### PR TITLE
Fix Windows path comparisons and environment variable expansion

### DIFF
--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -54,8 +54,9 @@ export function getCurrentPlatformBlockedCommands(commands: PlatformBlockedComma
 /**
  * Get blocked commands for the Bash tool.
  *
- * On Windows, the Bash tool runs in a Git Bash/MSYS2 environment,
- * so use Unix blocklist patterns.
+ * On Windows, the Bash tool runs in a Git Bash/MSYS2 environment but can still
+ * invoke Windows commands (e.g., via `cmd /c` or `powershell`), so both Unix
+ * and Windows blocklist patterns are merged.
  */
 export function getBashToolBlockedCommands(commands: PlatformBlockedCommands): string[] {
   if (process.platform === 'win32') {

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -58,7 +58,10 @@ export function getCurrentPlatformBlockedCommands(commands: PlatformBlockedComma
  * so use Unix blocklist patterns.
  */
 export function getBashToolBlockedCommands(commands: PlatformBlockedCommands): string[] {
-  return process.platform === 'win32' ? commands.unix : getCurrentPlatformBlockedCommands(commands);
+  if (process.platform === 'win32') {
+    return Array.from(new Set([...commands.unix, ...commands.windows]));
+  }
+  return getCurrentPlatformBlockedCommands(commands);
 }
 
 /** Permission mode for tool execution. */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,7 +72,7 @@ function getEnvValue(key: string): string | undefined {
 }
 
 function expandEnvironmentVariables(value: string): string {
-  if (!value.includes('%') && !value.includes('$')) {
+  if (!value.includes('%') && !value.includes('$') && !value.includes('!')) {
     return value;
   }
 
@@ -215,8 +215,16 @@ function normalizeWindowsPathPrefix(value: string): string {
 }
 
 function normalizePathForComparison(value: string): string {
-  const normalized = normalizeWindowsPathPrefix(path.normalize(value));
-  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+  if (!value || typeof value !== 'string') {
+    return '';
+  }
+  try {
+    const normalized = normalizeWindowsPathPrefix(path.normalize(value));
+    return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+  } catch {
+    // Fallback to input if normalization fails
+    return process.platform === 'win32' ? value.toLowerCase() : value;
+  }
 }
 
 /** Checks whether a candidate path is within the vault. */

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -250,18 +250,16 @@ describe('utils.ts', () => {
       expect(expandHomePath(braceStyle)).toBe(envValue);
     });
 
-    it('should expand Windows-specific environment variable formats on Windows', () => {
-      const isWindows = process.platform === 'win32';
+    it('should handle Windows-specific environment variable formats based on platform', () => {
       const powerShellStyle = `$env:${envKey}`;
       const cmdStyle = `!${envKey}!`;
 
-      if (isWindows) {
-        expect(expandHomePath(powerShellStyle)).toBe(envValue);
-        expect(expandHomePath(cmdStyle)).toBe(envValue);
-      } else {
-        expect(expandHomePath(powerShellStyle)).toBe(powerShellStyle);
-        expect(expandHomePath(cmdStyle)).toBe(cmdStyle);
-      }
+      // On Windows: expanded; on Unix: unchanged
+      const expectedPowerShell = process.platform === 'win32' ? envValue : powerShellStyle;
+      const expectedCmd = process.platform === 'win32' ? envValue : cmdStyle;
+
+      expect(expandHomePath(powerShellStyle)).toBe(expectedPowerShell);
+      expect(expandHomePath(cmdStyle)).toBe(expectedCmd);
     });
 
     it('should leave unknown environment variables untouched', () => {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -250,6 +250,20 @@ describe('utils.ts', () => {
       expect(expandHomePath(braceStyle)).toBe(envValue);
     });
 
+    it('should expand Windows-specific environment variable formats on Windows', () => {
+      const isWindows = process.platform === 'win32';
+      const powerShellStyle = `$env:${envKey}`;
+      const cmdStyle = `!${envKey}!`;
+
+      if (isWindows) {
+        expect(expandHomePath(powerShellStyle)).toBe(envValue);
+        expect(expandHomePath(cmdStyle)).toBe(envValue);
+      } else {
+        expect(expandHomePath(powerShellStyle)).toBe(powerShellStyle);
+        expect(expandHomePath(cmdStyle)).toBe(cmdStyle);
+      }
+    });
+
     it('should leave unknown environment variables untouched', () => {
       expect(expandHomePath('%CLAUDIAN_MISSING_VAR%')).toBe('%CLAUDIAN_MISSING_VAR%');
       expect(expandHomePath('$CLAUDIAN_MISSING_VAR')).toBe('$CLAUDIAN_MISSING_VAR');


### PR DESCRIPTION
### Motivation
- Resolve mismatches on Windows caused by `\\?\` path prefixes and case-insensitive filesystems.
- Support Windows-specific environment variable syntaxes (`$env:VAR`, `!VAR!`) during environment variable expansion.
- Ensure the Bash tool blocked-commands list covers both Unix and Windows patterns when running on Windows.
- Improve correctness of vault/context/export path checks across platforms.

### Description
- Added `normalizeWindowsPathPrefix` and `normalizePathForComparison` to strip `\\?\` prefixes and normalize path casing on Windows.
- Updated path-checking functions (`isPathWithinVault`, `isPathInAllowedExportPaths`, `isPathInAllowedContextPaths`, `getPathAccessType`) to use `normalizePathForComparison` around `resolveRealPath` results.
- Extended `expandEnvironmentVariables` to recognize `!VAR!` and PowerShell `$env:VAR` formats on Windows.
- Changed `getBashToolBlockedCommands` to return a merged set of `commands.unix` and `commands.windows` on Windows and added unit tests in `tests/utils.test.ts` for the env expansion behavior.

### Testing
- No automated test suite was executed as part of this change.
- Added unit tests in `tests/utils.test.ts` that validate Windows-specific env expansion formats and existing env expansion cases.
- All local changes were linted/compiled during development but no CI results are included here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f4e275ebc832cacf846cc0428214e)