### PR TITLE
feat: support concurrent title generation per conversation

### DIFF
--- a/src/core/prompts/titleGeneration.ts
+++ b/src/core/prompts/titleGeneration.ts
@@ -1,0 +1,19 @@
+/**
+ * Claudian - Title Generation System Prompt
+ *
+ * System prompt for generating conversation titles.
+ */
+
+/** System prompt for AI-powered conversation title generation. */
+export const TITLE_GENERATION_SYSTEM_PROMPT = `You generate concise conversation titles.
+
+Given the user's first message and the AI's first response, generate a short title (max 50 characters) that captures the essence of the conversation.
+
+Guidelines:
+- Be specific about the topic, not generic
+- Use sentence case (capitalize first word only, unless proper nouns)
+- Don't use quotes or punctuation at the end
+- Focus on what the user is trying to accomplish
+- If code-related, mention the language/framework
+
+Output ONLY the title text, nothing else. No quotes, no explanation.`;

--- a/src/core/storage/SessionStorage.ts
+++ b/src/core/storage/SessionStorage.ts
@@ -37,6 +37,7 @@ interface SessionMetaRecord {
   usage?: UsageInfo;
   approvedPlan?: string;
   pendingPlanContent?: string;
+  titleGenerationStatus?: 'pending' | 'success' | 'failed';
 }
 
 /** Message record stored as subsequent lines. */
@@ -190,6 +191,7 @@ export class SessionStorage {
         lastResponseAt: record.lastResponseAt,
         messageCount,
         preview,
+        titleGenerationStatus: record.titleGenerationStatus,
       };
     } catch {
       return null;
@@ -233,6 +235,7 @@ export class SessionStorage {
       usage: meta.usage,
       approvedPlan: meta.approvedPlan,
       pendingPlanContent: meta.pendingPlanContent,
+      titleGenerationStatus: meta.titleGenerationStatus,
     };
   }
 
@@ -253,6 +256,7 @@ export class SessionStorage {
       usage: conversation.usage,
       approvedPlan: conversation.approvedPlan,
       pendingPlanContent: conversation.pendingPlanContent,
+      titleGenerationStatus: conversation.titleGenerationStatus,
     };
     lines.push(JSON.stringify(meta));
 

--- a/src/core/types/chat.ts
+++ b/src/core/types/chat.ts
@@ -72,6 +72,8 @@ export interface Conversation {
   approvedPlan?: string;
   /** Pending plan content awaiting user approval. */
   pendingPlanContent?: string;
+  /** Status of AI title generation. */
+  titleGenerationStatus?: 'pending' | 'success' | 'failed';
 }
 
 /** Lightweight conversation metadata for the history dropdown. */
@@ -84,6 +86,8 @@ export interface ConversationMeta {
   lastResponseAt?: number;
   messageCount: number;
   preview: string;
+  /** Status of AI title generation. */
+  titleGenerationStatus?: 'pending' | 'success' | 'failed';
 }
 
 /** Normalized stream chunk from the Claude Agent SDK. */

--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -39,6 +39,7 @@ import {
 import { MessageRenderer } from './rendering';
 import { AsyncSubagentManager } from './services/AsyncSubagentManager';
 import { InstructionRefineService } from './services/InstructionRefineService';
+import { TitleGenerationService } from './services/TitleGenerationService';
 import { ChatState } from './state';
 
 /** Main sidebar chat view for interacting with Claude. */
@@ -60,6 +61,7 @@ export class ClaudianView extends ItemView {
   // Services
   private asyncSubagentManager: AsyncSubagentManager;
   private instructionRefineService: InstructionRefineService | null = null;
+  private titleGenerationService: TitleGenerationService | null = null;
 
   // DOM Elements
   private messagesEl: HTMLElement | null = null;
@@ -176,6 +178,8 @@ export class ClaudianView extends ItemView {
     this.instructionModeManager = null;
     this.instructionRefineService?.cancel();
     this.instructionRefineService = null;
+    this.titleGenerationService?.cancel();
+    this.titleGenerationService = null;
 
     // Cleanup async subagents
     this.asyncSubagentManager.orphanAllActive();
@@ -286,6 +290,7 @@ export class ClaudianView extends ItemView {
 
     // Instruction mode manager
     this.instructionRefineService = new InstructionRefineService(this.plugin);
+    this.titleGenerationService = new TitleGenerationService(this.plugin);
     this.instructionModeManager = new InstructionModeManagerClass(
       this.inputEl,
       {
@@ -396,6 +401,7 @@ export class ClaudianView extends ItemView {
         showPlanBanner: (content) => { void this.planBanner?.show(content); },
         hidePlanBanner: () => this.planBanner?.hide(),
         triggerPendingPlanApproval: (content) => this.inputController?.restorePendingPlanApproval(content),
+        getTitleGenerationService: () => this.titleGenerationService,
       },
       {}
     );
@@ -417,6 +423,7 @@ export class ClaudianView extends ItemView {
       getMcpServerSelector: () => this.mcpServerSelector,
       getInstructionModeManager: () => this.instructionModeManager,
       getInstructionRefineService: () => this.instructionRefineService,
+      getTitleGenerationService: () => this.titleGenerationService,
       getComponent: () => this,
       setPlanModeActive: (active) => {
         this.permissionToggle?.setPlanModeActive(active);

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -328,7 +328,11 @@ export class ConversationController {
         regenerateBtn.setAttribute('aria-label', 'Regenerate title');
         regenerateBtn.addEventListener('click', async (e) => {
           e.stopPropagation();
-          await this.regenerateTitle(conv.id);
+          try {
+            await this.regenerateTitle(conv.id);
+          } catch (error) {
+            console.error('[ConversationController] Failed to regenerate title:', error);
+          }
         });
       }
 

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -12,6 +12,7 @@ import type ClaudianPlugin from '../../../main';
 import type { FileContextManager, ImageContextManager, McpServerSelector } from '../../../ui';
 import type { MessageRenderer } from '../rendering/MessageRenderer';
 import type { AsyncSubagentManager } from '../services/AsyncSubagentManager';
+import type { TitleGenerationService } from '../services/TitleGenerationService';
 import type { ChatState } from '../state/ChatState';
 
 /** Callbacks for conversation events. */
@@ -46,6 +47,8 @@ export interface ConversationControllerDeps {
   hidePlanBanner: () => void;
   /** Trigger pending plan approval panel (for restore on load). */
   triggerPendingPlanApproval: (content: string) => void;
+  /** Get title generation service. */
+  getTitleGenerationService: () => TitleGenerationService | null;
 }
 
 /**
@@ -314,6 +317,21 @@ export class ConversationController {
 
       const actions = item.createDiv({ cls: 'claudian-history-item-actions' });
 
+      // Show regenerate button if title generation failed, or loading indicator if pending
+      if (conv.titleGenerationStatus === 'pending') {
+        const loadingEl = actions.createEl('span', { cls: 'claudian-action-btn claudian-action-loading' });
+        setIcon(loadingEl, 'loader-2');
+        loadingEl.setAttribute('aria-label', 'Generating title...');
+      } else if (conv.titleGenerationStatus === 'failed') {
+        const regenerateBtn = actions.createEl('button', { cls: 'claudian-action-btn' });
+        setIcon(regenerateBtn, 'refresh-cw');
+        regenerateBtn.setAttribute('aria-label', 'Regenerate title');
+        regenerateBtn.addEventListener('click', async (e) => {
+          e.stopPropagation();
+          await this.regenerateTitle(conv.id);
+        });
+      }
+
       const renameBtn = actions.createEl('button', { cls: 'claudian-action-btn' });
       setIcon(renameBtn, 'pencil');
       renameBtn.setAttribute('aria-label', 'Rename');
@@ -466,12 +484,77 @@ export class ConversationController {
   // Utilities
   // ============================================
 
-  /** Generates a title from the first message. */
-  generateTitle(firstMessage: string): string {
+  /** Generates a fallback title from the first message (used when AI fails). */
+  generateFallbackTitle(firstMessage: string): string {
     const firstSentence = firstMessage.split(/[.!?\n]/)[0].trim();
     const autoTitle = firstSentence.substring(0, 50);
     const suffix = firstSentence.length > 50 ? '...' : '';
     return `${autoTitle}${suffix}`;
+  }
+
+  /** Regenerates AI title for a conversation. */
+  async regenerateTitle(conversationId: string): Promise<void> {
+    const { plugin } = this.deps;
+    const titleService = this.deps.getTitleGenerationService();
+    if (!titleService) return;
+
+    // Get the full conversation from cache
+    const fullConv = plugin.getConversationById(conversationId);
+    if (!fullConv || fullConv.messages.length < 2) return;
+
+    // Find first user and assistant messages by role (not by index)
+    const firstUserMsg = fullConv.messages.find(m => m.role === 'user');
+    const firstAssistantMsg = fullConv.messages.find(m => m.role === 'assistant');
+    if (!firstUserMsg || !firstAssistantMsg) return;
+
+    const userContent = firstUserMsg.displayContent || firstUserMsg.content;
+
+    // Extract text from assistant response
+    const assistantText = firstAssistantMsg.content ||
+      firstAssistantMsg.contentBlocks
+        ?.filter((b): b is { type: 'text'; content: string } => b.type === 'text')
+        .map(b => b.content)
+        .join('\n') || '';
+
+    if (!assistantText) return;
+
+    // Check if it's a plan conversation (title starts with [Plan])
+    const isPlan = fullConv.title.startsWith('[Plan]');
+
+    // Store current title to check if user renames during generation
+    const expectedTitle = fullConv.title;
+
+    // Set pending status before starting generation
+    await plugin.updateConversation(conversationId, { titleGenerationStatus: 'pending' });
+    this.updateHistoryDropdown();
+
+    // Fire async AI title generation
+    await titleService.generateTitle(
+      conversationId,
+      userContent,
+      assistantText,
+      async (convId, result) => {
+        // Check if conversation still exists and user hasn't manually renamed
+        const currentConv = plugin.getConversationById(convId);
+        if (!currentConv) return;
+
+        // Only apply AI title if user hasn't manually renamed (title still matches expected)
+        const userManuallyRenamed = currentConv.title !== expectedTitle;
+
+        if (result.success && result.title && !userManuallyRenamed) {
+          const newTitle = isPlan ? `[Plan] ${result.title}` : result.title;
+          await plugin.renameConversation(convId, newTitle);
+          await plugin.updateConversation(convId, { titleGenerationStatus: 'success' });
+        } else if (!userManuallyRenamed) {
+          // Keep existing title, mark as failed (only if user hasn't renamed)
+          await plugin.updateConversation(convId, { titleGenerationStatus: 'failed' });
+        } else {
+          // User manually renamed, clear the status (user's choice takes precedence)
+          await plugin.updateConversation(convId, { titleGenerationStatus: undefined });
+        }
+        this.updateHistoryDropdown();
+      }
+    );
   }
 
   /** Formats a timestamp for display. */

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -32,6 +32,7 @@ import { appendMarkdownSnippet } from '../../../utils/markdown';
 import { formatSlashCommandWarnings } from '../../../utils/slashCommandWarnings';
 import type { MessageRenderer } from '../rendering/MessageRenderer';
 import type { InstructionRefineService } from '../services/InstructionRefineService';
+import type { TitleGenerationService } from '../services/TitleGenerationService';
 import type { ChatState } from '../state/ChatState';
 import type { QueryOptions } from '../state/types';
 import type { ConversationController } from './ConversationController';
@@ -58,6 +59,7 @@ export interface InputControllerDeps {
   getMcpServerSelector: () => McpServerSelector | null;
   getInstructionModeManager: () => InstructionModeManager | null;
   getInstructionRefineService: () => InstructionRefineService | null;
+  getTitleGenerationService: () => TitleGenerationService | null;
   getComponent: () => Component;
   setPlanModeActive: (active: boolean) => void;
   getPlanBanner: () => PlanBanner | null;
@@ -247,11 +249,6 @@ export class InputController {
       renderer.addMessage(userMsg);
     }
 
-    if (state.messages.length === 1 && state.currentConversationId) {
-      const title = conversationController.generateTitle(displayContent);
-      await plugin.renameConversation(state.currentConversationId, title);
-    }
-
     const assistantMsg: ChatMessage = {
       id: this.deps.generateId(),
       role: 'assistant',
@@ -326,6 +323,65 @@ export class InputController {
             void this.sendMessageWithPlanMode({ ...resendPayload, skipUserMessage: true });
           }, 100);
           scheduledPlanModeResend = true;
+        }
+      }
+
+      // Generate AI title after first complete exchange (user + assistant)
+      if (state.messages.length === 2 && state.currentConversationId) {
+        // Find first user and assistant messages by role (not by index)
+        const firstUserMsg = state.messages.find(m => m.role === 'user');
+        const firstAssistantMsg = state.messages.find(m => m.role === 'assistant');
+
+        if (firstUserMsg && firstAssistantMsg) {
+          const userContent = firstUserMsg.displayContent || firstUserMsg.content;
+
+          // Extract text from assistant response
+          const assistantText = firstAssistantMsg.content ||
+            firstAssistantMsg.contentBlocks
+              ?.filter((b): b is { type: 'text'; content: string } => b.type === 'text')
+              .map(b => b.content)
+              .join('\n') || '';
+
+          // Set immediate fallback title
+          const fallbackTitle = conversationController.generateFallbackTitle(userContent);
+          await plugin.renameConversation(state.currentConversationId, fallbackTitle);
+
+          // Fire async AI title generation only if service and content available
+          const titleService = this.deps.getTitleGenerationService();
+          if (titleService && assistantText) {
+            // Mark as pending only when we're actually starting generation
+            await plugin.updateConversation(state.currentConversationId, { titleGenerationStatus: 'pending' });
+            conversationController.updateHistoryDropdown();
+
+            const convId = state.currentConversationId;
+            const expectedTitle = fallbackTitle; // Store to check if user renamed during generation
+            void titleService.generateTitle(
+              convId,
+              userContent,
+              assistantText,
+              async (conversationId, result) => {
+                // Check if conversation still exists and user hasn't manually renamed
+                const currentConv = plugin.getConversationById(conversationId);
+                if (!currentConv) return;
+
+                // Only apply AI title if user hasn't manually renamed (title still matches fallback)
+                const userManuallyRenamed = currentConv.title !== expectedTitle;
+
+                if (result.success && result.title && !userManuallyRenamed) {
+                  await plugin.renameConversation(conversationId, result.title);
+                  await plugin.updateConversation(conversationId, { titleGenerationStatus: 'success' });
+                } else if (!userManuallyRenamed) {
+                  // Keep fallback title, mark as failed (only if user hasn't renamed)
+                  await plugin.updateConversation(conversationId, { titleGenerationStatus: 'failed' });
+                } else {
+                  // User manually renamed, clear the status (user's choice takes precedence)
+                  await plugin.updateConversation(conversationId, { titleGenerationStatus: undefined });
+                }
+                conversationController.updateHistoryDropdown();
+              }
+            );
+          }
+          // If no titleService or no assistantText, just keep the fallback title with no status
         }
       }
 
@@ -510,12 +566,7 @@ ${content}
       state.addMessage(userMsg);
       renderer.addMessage(userMsg);
 
-      if (state.messages.length === 1 && state.currentConversationId) {
-        const title = conversationController.generateTitle(displayContent);
-        await plugin.renameConversation(state.currentConversationId, title);
-      }
     }
-
     const assistantMsg: ChatMessage = {
       id: this.deps.generateId(),
       role: 'assistant',
@@ -575,6 +626,66 @@ ${content}
       state.activeSubagents.clear();
 
       await conversationController.save(true);
+
+      // Generate AI title after first complete plan mode exchange
+      if (state.messages.length === 2 && state.currentConversationId) {
+        // Find first user and assistant messages by role (not by index)
+        const firstUserMsg = state.messages.find(m => m.role === 'user');
+        const firstAssistantMsg = state.messages.find(m => m.role === 'assistant');
+
+        if (firstUserMsg && firstAssistantMsg) {
+          const userContent = firstUserMsg.displayContent || firstUserMsg.content;
+
+          // Extract text from assistant response
+          const assistantText = firstAssistantMsg.content ||
+            firstAssistantMsg.contentBlocks
+              ?.filter((b): b is { type: 'text'; content: string } => b.type === 'text')
+              .map(b => b.content)
+              .join('\n') || '';
+
+          // Set immediate fallback title with [Plan] prefix
+          const fallbackTitle = conversationController.generateFallbackTitle(userContent);
+          const fullFallbackTitle = `[Plan] ${fallbackTitle}`;
+          await plugin.renameConversation(state.currentConversationId, fullFallbackTitle);
+
+          // Fire async AI title generation only if service and content available
+          const titleService = this.deps.getTitleGenerationService();
+          if (titleService && assistantText) {
+            // Mark as pending only when we're actually starting generation
+            await plugin.updateConversation(state.currentConversationId, { titleGenerationStatus: 'pending' });
+            conversationController.updateHistoryDropdown();
+
+            const convId = state.currentConversationId;
+            const expectedTitle = fullFallbackTitle; // Store to check if user renamed during generation
+            void titleService.generateTitle(
+              convId,
+              userContent,
+              assistantText,
+              async (conversationId, result) => {
+                // Check if conversation still exists and user hasn't manually renamed
+                const currentConv = plugin.getConversationById(conversationId);
+                if (!currentConv) return;
+
+                // Only apply AI title if user hasn't manually renamed (title still matches fallback)
+                const userManuallyRenamed = currentConv.title !== expectedTitle;
+
+                if (result.success && result.title && !userManuallyRenamed) {
+                  await plugin.renameConversation(conversationId, `[Plan] ${result.title}`);
+                  await plugin.updateConversation(conversationId, { titleGenerationStatus: 'success' });
+                } else if (!userManuallyRenamed) {
+                  // Keep fallback title, mark as failed (only if user hasn't renamed)
+                  await plugin.updateConversation(conversationId, { titleGenerationStatus: 'failed' });
+                } else {
+                  // User manually renamed, clear the status (user's choice takes precedence)
+                  await plugin.updateConversation(conversationId, { titleGenerationStatus: undefined });
+                }
+                conversationController.updateHistoryDropdown();
+              }
+            );
+          }
+          // If no titleService or no assistantText, just keep the fallback title with no status
+        }
+      }
 
       this.processQueuedMessage();
     }

--- a/src/features/chat/services/TitleGenerationService.ts
+++ b/src/features/chat/services/TitleGenerationService.ts
@@ -1,0 +1,214 @@
+/**
+ * Claudian - Title generation service
+ *
+ * Lightweight Claude query service for generating conversation titles
+ * based on first user message and first AI response.
+ */
+
+import type { Options } from '@anthropic-ai/claude-agent-sdk';
+import { query as agentQuery } from '@anthropic-ai/claude-agent-sdk';
+
+import { TITLE_GENERATION_SYSTEM_PROMPT } from '../../../core/prompts/titleGeneration';
+import type ClaudianPlugin from '../../../main';
+import { parseEnvironmentVariables } from '../../../utils/env';
+import { findClaudeCLIPath, getVaultPath } from '../../../utils/path';
+
+/** Result of title generation. */
+export interface TitleGenerationResult {
+  success: boolean;
+  title?: string;
+  error?: string;
+}
+
+/** Callback when title generation completes. */
+export type TitleGenerationCallback = (
+  conversationId: string,
+  result: TitleGenerationResult
+) => Promise<void>;
+
+/** Service for generating conversation titles with AI. */
+export class TitleGenerationService {
+  private plugin: ClaudianPlugin;
+  private resolvedClaudePath: string | null = null;
+  /** Map of conversationId to AbortController for concurrent generation support. */
+  private activeGenerations: Map<string, AbortController> = new Map();
+
+  constructor(plugin: ClaudianPlugin) {
+    this.plugin = plugin;
+  }
+
+  /**
+   * Generates a title for a conversation based on first messages.
+   * Non-blocking: calls callback when complete.
+   */
+  async generateTitle(
+    conversationId: string,
+    userMessage: string,
+    assistantResponse: string,
+    callback: TitleGenerationCallback
+  ): Promise<void> {
+    const vaultPath = getVaultPath(this.plugin.app);
+    if (!vaultPath) {
+      await callback(conversationId, {
+        success: false,
+        error: 'Could not determine vault path',
+      });
+      return;
+    }
+
+    if (!this.resolvedClaudePath) {
+      this.resolvedClaudePath = findClaudeCLIPath();
+    }
+
+    if (!this.resolvedClaudePath) {
+      await callback(conversationId, {
+        success: false,
+        error: 'Claude CLI not found',
+      });
+      return;
+    }
+
+    // Get the appropriate model: ANTHROPIC_DEFAULT_HAIKU_MODEL or fallback to claude-haiku-4-5
+    const envVars = parseEnvironmentVariables(
+      this.plugin.getActiveEnvironmentVariables()
+    );
+    const titleModel = envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL || 'claude-haiku-4-5';
+
+    // Cancel any existing generation for this conversation
+    const existingController = this.activeGenerations.get(conversationId);
+    if (existingController) {
+      existingController.abort();
+    }
+
+    // Create a new local AbortController for this generation
+    const abortController = new AbortController();
+    this.activeGenerations.set(conversationId, abortController);
+
+    // Truncate messages if too long (save tokens)
+    const truncatedUser = this.truncateText(userMessage, 500);
+    const truncatedAssistant = this.truncateText(assistantResponse, 500);
+
+    const prompt = `User's first message:
+"""
+${truncatedUser}
+"""
+
+AI's response:
+"""
+${truncatedAssistant}
+"""
+
+Generate a title for this conversation:`;
+
+    // Parse custom environment variables
+    const customEnv = parseEnvironmentVariables(
+      this.plugin.getActiveEnvironmentVariables()
+    );
+
+    const options: Options = {
+      cwd: vaultPath,
+      systemPrompt: TITLE_GENERATION_SYSTEM_PROMPT,
+      model: titleModel,
+      abortController,
+      pathToClaudeCodeExecutable: this.resolvedClaudePath,
+      env: {
+        ...process.env,
+        ...customEnv,
+      },
+      allowedTools: [], // No tools needed for title generation
+      permissionMode: 'bypassPermissions',
+      allowDangerouslySkipPermissions: true,
+    };
+
+    try {
+      const response = agentQuery({ prompt, options });
+      let responseText = '';
+
+      for await (const message of response) {
+        if (abortController.signal.aborted) {
+          await callback(conversationId, {
+            success: false,
+            error: 'Cancelled',
+          });
+          return;
+        }
+
+        const text = this.extractTextFromMessage(message);
+        if (text) {
+          responseText += text;
+        }
+      }
+
+      const title = this.parseTitle(responseText);
+      if (title) {
+        await callback(conversationId, { success: true, title });
+      } else {
+        await callback(conversationId, {
+          success: false,
+          error: 'Failed to parse title from response',
+        });
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      await callback(conversationId, { success: false, error: msg });
+    } finally {
+      // Clean up the controller for this conversation
+      this.activeGenerations.delete(conversationId);
+    }
+  }
+
+  /** Cancels all ongoing title generations. */
+  cancel(): void {
+    for (const controller of this.activeGenerations.values()) {
+      controller.abort();
+    }
+    this.activeGenerations.clear();
+  }
+
+  /** Truncates text to a maximum length with ellipsis. */
+  private truncateText(text: string, maxLength: number): string {
+    if (text.length <= maxLength) return text;
+    return text.substring(0, maxLength) + '...';
+  }
+
+  /** Extracts text content from SDK message. */
+  private extractTextFromMessage(
+    message: { type: string; message?: { content?: Array<{ type: string; text?: string }> } }
+  ): string {
+    if (message.type !== 'assistant' || !message.message?.content) {
+      return '';
+    }
+
+    return message.message.content
+      .filter((block): block is { type: 'text'; text: string } =>
+        block.type === 'text' && !!block.text
+      )
+      .map((block) => block.text)
+      .join('');
+  }
+
+  /** Parses and cleans the title from response. */
+  private parseTitle(responseText: string): string | null {
+    const trimmed = responseText.trim();
+    if (!trimmed) return null;
+
+    // Remove surrounding quotes if present
+    let title = trimmed;
+    if (
+      (title.startsWith('"') && title.endsWith('"')) ||
+      (title.startsWith("'") && title.endsWith("'"))
+    ) {
+      title = title.slice(1, -1);
+    }
+
+    // Remove trailing punctuation
+    title = title.replace(/[.!?:;,]+$/, '');
+
+    // Truncate to max 50 characters
+    if (title.length > 50) {
+      title = title.substring(0, 47) + '...';
+    }
+
+    return title || null;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -444,6 +444,11 @@ export default class ClaudianPlugin extends Plugin {
     return this.conversations.find(c => c.id === this.activeConversationId) || null;
   }
 
+  /** Gets a conversation by ID from the in-memory cache. */
+  getConversationById(id: string): Conversation | null {
+    return this.conversations.find(c => c.id === id) || null;
+  }
+
   /** Returns conversation metadata list for the history dropdown. */
   getConversationList(): ConversationMeta[] {
     return this.conversations.map(c => ({
@@ -454,6 +459,7 @@ export default class ClaudianPlugin extends Plugin {
       lastResponseAt: c.lastResponseAt,
       messageCount: c.messages.length,
       preview: this.getConversationPreview(c),
+      titleGenerationStatus: c.titleGenerationStatus,
     }));
   }
 

--- a/src/style/base/animations.css
+++ b/src/style/base/animations.css
@@ -66,13 +66,3 @@
   }
 }
 
-/* History title generation spinner */
-@keyframes claudian-spin {
-  from {
-    transform: rotate(0deg);
-  }
-
-  to {
-    transform: rotate(360deg);
-  }
-}

--- a/src/style/base/animations.css
+++ b/src/style/base/animations.css
@@ -65,3 +65,14 @@
     transform: rotate(360deg);
   }
 }
+
+/* History title generation spinner */
+@keyframes claudian-spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/style/components/history.css
+++ b/src/style/components/history.css
@@ -169,3 +169,22 @@
   outline: none;
   box-shadow: 0 0 0 2px var(--interactive-accent-hover);
 }
+
+/* Loading indicator for title generation */
+.claudian-action-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: claudian-spin 1s linear infinite;
+  opacity: 0.6;
+  cursor: default;
+}
+
+@keyframes claudian-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/style/components/history.css
+++ b/src/style/components/history.css
@@ -175,7 +175,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  animation: claudian-spin 1s linear infinite;
+  animation: spin 1s linear infinite;
   opacity: 0.6;
   cursor: default;
 }

--- a/src/style/components/history.css
+++ b/src/style/components/history.css
@@ -179,12 +179,3 @@
   opacity: 0.6;
   cursor: default;
 }
-
-@keyframes claudian-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}

--- a/tests/InputController.test.ts
+++ b/tests/InputController.test.ts
@@ -73,6 +73,8 @@ function createMockDeps(overrides: Partial<InputControllerDeps> = {}): InputCont
         extractMentions: jest.fn().mockReturnValue(new Set()),
       },
       renameConversation: jest.fn(),
+      updateConversation: jest.fn(),
+      getConversationById: jest.fn().mockReturnValue(null),
     } as any,
     state,
     renderer: {
@@ -93,7 +95,8 @@ function createMockDeps(overrides: Partial<InputControllerDeps> = {}): InputCont
     } as any,
     conversationController: {
       save: jest.fn(),
-      generateTitle: jest.fn().mockReturnValue('Test Title'),
+      generateFallbackTitle: jest.fn().mockReturnValue('Test Title'),
+      updateHistoryDropdown: jest.fn(),
     } as any,
     getInputEl: () => inputEl,
     getWelcomeEl: () => null,
@@ -110,6 +113,7 @@ function createMockDeps(overrides: Partial<InputControllerDeps> = {}): InputCont
     getMcpServerSelector: () => null,
     getInstructionModeManager: () => null,
     getInstructionRefineService: () => null,
+    getTitleGenerationService: () => null,
     getComponent: () => ({} as any),
     setPlanModeActive: jest.fn(),
     getPlanBanner: () => null,
@@ -373,6 +377,286 @@ describe('InputController - Message Queue', () => {
       expect(deps.setPlanModeActive).toHaveBeenCalledWith(false);
       expect(deps.plugin.agentService.setCurrentPlanFilePath).toHaveBeenCalledTimes(2);
       expect(deps.state.planModeState).toBeNull();
+    });
+  });
+
+  describe('Title generation', () => {
+    it('should set pending status and fallback title after first exchange', async () => {
+      const mockTitleService = {
+        generateTitle: jest.fn(),
+        cancel: jest.fn(),
+      };
+      const welcomeEl = { style: { display: '' } } as any;
+      const fileContextManager = {
+        startSession: jest.fn(),
+        getAttachedFiles: jest.fn().mockReturnValue(new Set()),
+        hasFilesChanged: jest.fn().mockReturnValue(false),
+        markFilesSent: jest.fn(),
+      };
+      const imageContextManager = createMockImageContextManager();
+
+      deps = createMockDeps({
+        getWelcomeEl: () => welcomeEl,
+        getFileContextManager: () => fileContextManager as any,
+        getImageContextManager: () => imageContextManager as any,
+        getTitleGenerationService: () => mockTitleService as any,
+      });
+      deps.state.currentConversationId = 'conv-1';
+
+      // Mock the agent query to return a text response
+      (deps.plugin.agentService.query as jest.Mock).mockReturnValue(
+        createMockStream([
+          { type: 'text', content: 'Hello, how can I help?' },
+          { type: 'done' },
+        ])
+      );
+
+      // Mock handleStreamChunk to populate assistant content
+      (deps.streamController.handleStreamChunk as jest.Mock).mockImplementation(async (chunk, msg) => {
+        if (chunk.type === 'text') {
+          msg.content = chunk.content;
+        }
+      });
+
+      inputEl = deps.getInputEl() as ReturnType<typeof createMockInputEl>;
+      inputEl.value = 'Hello world';
+      controller = new InputController(deps);
+
+      await controller.sendMessage();
+
+      // After first exchange (2 messages), should set pending status (only when titleService available and content exists)
+      expect(deps.plugin.updateConversation).toHaveBeenCalledWith('conv-1', { titleGenerationStatus: 'pending' });
+      expect(deps.plugin.renameConversation).toHaveBeenCalledWith('conv-1', 'Test Title');
+    });
+
+    it('should find messages by role, not by index', async () => {
+      const welcomeEl = { style: { display: '' } } as any;
+      const fileContextManager = {
+        startSession: jest.fn(),
+        getAttachedFiles: jest.fn().mockReturnValue(new Set()),
+        hasFilesChanged: jest.fn().mockReturnValue(false),
+        markFilesSent: jest.fn(),
+      };
+      const imageContextManager = createMockImageContextManager();
+
+      deps = createMockDeps({
+        getWelcomeEl: () => welcomeEl,
+        getFileContextManager: () => fileContextManager as any,
+        getImageContextManager: () => imageContextManager as any,
+      });
+      deps.state.currentConversationId = 'conv-1';
+
+      (deps.plugin.agentService.query as jest.Mock).mockReturnValue(
+        createMockStream([{ type: 'done' }])
+      );
+
+      inputEl = deps.getInputEl() as ReturnType<typeof createMockInputEl>;
+      inputEl.value = 'Test message';
+      controller = new InputController(deps);
+
+      await controller.sendMessage();
+
+      // Verify messages are found by role
+      const userMsg = deps.state.messages.find(m => m.role === 'user');
+      const assistantMsg = deps.state.messages.find(m => m.role === 'assistant');
+      expect(userMsg).toBeDefined();
+      expect(assistantMsg).toBeDefined();
+    });
+
+    it('should call title generation service when available', async () => {
+      const mockTitleService = {
+        generateTitle: jest.fn(),
+        cancel: jest.fn(),
+      };
+      const welcomeEl = { style: { display: '' } } as any;
+      const fileContextManager = {
+        startSession: jest.fn(),
+        getAttachedFiles: jest.fn().mockReturnValue(new Set()),
+        hasFilesChanged: jest.fn().mockReturnValue(false),
+        markFilesSent: jest.fn(),
+      };
+      const imageContextManager = createMockImageContextManager();
+
+      deps = createMockDeps({
+        getWelcomeEl: () => welcomeEl,
+        getFileContextManager: () => fileContextManager as any,
+        getImageContextManager: () => imageContextManager as any,
+        getTitleGenerationService: () => mockTitleService as any,
+      });
+      deps.state.currentConversationId = 'conv-1';
+
+      (deps.plugin.agentService.query as jest.Mock).mockReturnValue(
+        createMockStream([
+          { type: 'text', content: 'Response text' },
+          { type: 'done' },
+        ])
+      );
+
+      // Mock handleStreamChunk to populate assistant content
+      (deps.streamController.handleStreamChunk as jest.Mock).mockImplementation(async (chunk, msg) => {
+        if (chunk.type === 'text') {
+          msg.content = chunk.content;
+        }
+      });
+
+      inputEl = deps.getInputEl() as ReturnType<typeof createMockInputEl>;
+      inputEl.value = 'Hello world';
+      controller = new InputController(deps);
+
+      await controller.sendMessage();
+
+      // Title service should be called with user and assistant content
+      expect(mockTitleService.generateTitle).toHaveBeenCalled();
+      const callArgs = mockTitleService.generateTitle.mock.calls[0];
+      expect(callArgs[0]).toBe('conv-1'); // conversationId
+      expect(callArgs[1]).toContain('Hello world'); // user content
+    });
+
+    it('should not overwrite user-renamed title in callback', async () => {
+      const mockTitleService = {
+        generateTitle: jest.fn(),
+        cancel: jest.fn(),
+      };
+      const welcomeEl = { style: { display: '' } } as any;
+      const fileContextManager = {
+        startSession: jest.fn(),
+        getAttachedFiles: jest.fn().mockReturnValue(new Set()),
+        hasFilesChanged: jest.fn().mockReturnValue(false),
+        markFilesSent: jest.fn(),
+      };
+      const imageContextManager = createMockImageContextManager();
+
+      deps = createMockDeps({
+        getWelcomeEl: () => welcomeEl,
+        getFileContextManager: () => fileContextManager as any,
+        getImageContextManager: () => imageContextManager as any,
+        getTitleGenerationService: () => mockTitleService as any,
+      });
+      deps.state.currentConversationId = 'conv-1';
+
+      (deps.plugin.agentService.query as jest.Mock).mockReturnValue(
+        createMockStream([
+          { type: 'text', content: 'Response' },
+          { type: 'done' },
+        ])
+      );
+
+      (deps.streamController.handleStreamChunk as jest.Mock).mockImplementation(async (chunk, msg) => {
+        if (chunk.type === 'text') {
+          msg.content = chunk.content;
+        }
+      });
+
+      // Mock getConversationById to return a conversation with different title (user renamed)
+      (deps.plugin.getConversationById as jest.Mock).mockReturnValue({
+        id: 'conv-1',
+        title: 'User Custom Title', // User renamed it
+      });
+
+      inputEl = deps.getInputEl() as ReturnType<typeof createMockInputEl>;
+      inputEl.value = 'Test';
+      controller = new InputController(deps);
+
+      await controller.sendMessage();
+
+      // Get the callback and simulate it being called
+      const callback = mockTitleService.generateTitle.mock.calls[0][3];
+      await callback('conv-1', { success: true, title: 'AI Generated Title' });
+
+      // Should clear status since user manually renamed (not apply AI title)
+      expect(deps.plugin.updateConversation).toHaveBeenCalledWith('conv-1', { titleGenerationStatus: undefined });
+    });
+
+    it('should not set pending status when titleService is null', async () => {
+      const welcomeEl = { style: { display: '' } } as any;
+      const fileContextManager = {
+        startSession: jest.fn(),
+        getAttachedFiles: jest.fn().mockReturnValue(new Set()),
+        hasFilesChanged: jest.fn().mockReturnValue(false),
+        markFilesSent: jest.fn(),
+      };
+      const imageContextManager = createMockImageContextManager();
+
+      deps = createMockDeps({
+        getWelcomeEl: () => welcomeEl,
+        getFileContextManager: () => fileContextManager as any,
+        getImageContextManager: () => imageContextManager as any,
+        getTitleGenerationService: () => null, // No title service
+      });
+      deps.state.currentConversationId = 'conv-1';
+
+      (deps.plugin.agentService.query as jest.Mock).mockReturnValue(
+        createMockStream([
+          { type: 'text', content: 'Response' },
+          { type: 'done' },
+        ])
+      );
+
+      (deps.streamController.handleStreamChunk as jest.Mock).mockImplementation(async (chunk, msg) => {
+        if (chunk.type === 'text') {
+          msg.content = chunk.content;
+        }
+      });
+
+      inputEl = deps.getInputEl() as ReturnType<typeof createMockInputEl>;
+      inputEl.value = 'Test message';
+      controller = new InputController(deps);
+
+      await controller.sendMessage();
+
+      // Should NOT set pending status when no titleService
+      const updateCalls = (deps.plugin.updateConversation as jest.Mock).mock.calls;
+      const pendingCall = updateCalls.find((call: [string, { titleGenerationStatus?: string }]) =>
+        call[1]?.titleGenerationStatus === 'pending'
+      );
+      expect(pendingCall).toBeUndefined();
+    });
+
+    it('should not set pending status when assistantText is empty', async () => {
+      const mockTitleService = {
+        generateTitle: jest.fn(),
+        cancel: jest.fn(),
+      };
+      const welcomeEl = { style: { display: '' } } as any;
+      const fileContextManager = {
+        startSession: jest.fn(),
+        getAttachedFiles: jest.fn().mockReturnValue(new Set()),
+        hasFilesChanged: jest.fn().mockReturnValue(false),
+        markFilesSent: jest.fn(),
+      };
+      const imageContextManager = createMockImageContextManager();
+
+      deps = createMockDeps({
+        getWelcomeEl: () => welcomeEl,
+        getFileContextManager: () => fileContextManager as any,
+        getImageContextManager: () => imageContextManager as any,
+        getTitleGenerationService: () => mockTitleService as any,
+      });
+      deps.state.currentConversationId = 'conv-1';
+
+      // Return empty stream - no text content
+      (deps.plugin.agentService.query as jest.Mock).mockReturnValue(
+        createMockStream([{ type: 'done' }])
+      );
+
+      // Don't populate assistant content (leave it empty)
+      (deps.streamController.handleStreamChunk as jest.Mock).mockImplementation(async () => {});
+
+      inputEl = deps.getInputEl() as ReturnType<typeof createMockInputEl>;
+      inputEl.value = 'Test message';
+      controller = new InputController(deps);
+
+      await controller.sendMessage();
+
+      // Should NOT call title service when assistantText is empty
+      expect(mockTitleService.generateTitle).not.toHaveBeenCalled();
+
+      // Should NOT set pending status when assistantText is empty
+      const updateCalls = (deps.plugin.updateConversation as jest.Mock).mock.calls;
+      const pendingCall = updateCalls.find((call: [string, { titleGenerationStatus?: string }]) =>
+        call[1]?.titleGenerationStatus === 'pending'
+      );
+      expect(pendingCall).toBeUndefined();
     });
   });
 });

--- a/tests/InputController.test.ts
+++ b/tests/InputController.test.ts
@@ -383,7 +383,7 @@ describe('InputController - Message Queue', () => {
   describe('Title generation', () => {
     it('should set pending status and fallback title after first exchange', async () => {
       const mockTitleService = {
-        generateTitle: jest.fn(),
+        generateTitle: jest.fn().mockResolvedValue(undefined),
         cancel: jest.fn(),
       };
       const welcomeEl = { style: { display: '' } } as any;
@@ -465,7 +465,7 @@ describe('InputController - Message Queue', () => {
 
     it('should call title generation service when available', async () => {
       const mockTitleService = {
-        generateTitle: jest.fn(),
+        generateTitle: jest.fn().mockResolvedValue(undefined),
         cancel: jest.fn(),
       };
       const welcomeEl = { style: { display: '' } } as any;
@@ -514,7 +514,7 @@ describe('InputController - Message Queue', () => {
 
     it('should not overwrite user-renamed title in callback', async () => {
       const mockTitleService = {
-        generateTitle: jest.fn(),
+        generateTitle: jest.fn().mockResolvedValue(undefined),
         cancel: jest.fn(),
       };
       const welcomeEl = { style: { display: '' } } as any;
@@ -614,7 +614,7 @@ describe('InputController - Message Queue', () => {
 
     it('should not set pending status when assistantText is empty', async () => {
       const mockTitleService = {
-        generateTitle: jest.fn(),
+        generateTitle: jest.fn().mockResolvedValue(undefined),
         cancel: jest.fn(),
       };
       const welcomeEl = { style: { display: '' } } as any;

--- a/tests/TitleGenerationService.test.ts
+++ b/tests/TitleGenerationService.test.ts
@@ -1,0 +1,408 @@
+/**
+ * Tests for TitleGenerationService - Generating conversation titles with AI
+ */
+
+import { type TitleGenerationResult, TitleGenerationService } from '../src/features/chat/services/TitleGenerationService';
+import * as pathUtils from '../src/utils/path';
+// eslint-disable-next-line jest/no-mocks-import
+import {
+  getLastOptions,
+  resetMockMessages,
+  setMockMessages,
+} from './__mocks__/claude-agent-sdk';
+
+// Mock findClaudeCLIPath for controlled testing
+jest.spyOn(pathUtils, 'findClaudeCLIPath');
+
+function createMockPlugin(settings = {}) {
+  return {
+    settings: {
+      model: 'sonnet',
+      thinkingBudget: 'off',
+      ...settings,
+    },
+    app: {
+      vault: {
+        adapter: {
+          basePath: '/test/vault/path',
+        },
+      },
+    },
+    getActiveEnvironmentVariables: jest.fn().mockReturnValue(''),
+  } as any;
+}
+
+describe('TitleGenerationService', () => {
+  let service: TitleGenerationService;
+  let mockPlugin: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetMockMessages();
+    mockPlugin = createMockPlugin();
+    service = new TitleGenerationService(mockPlugin);
+    (service as any).resolvedClaudePath = '/fake/claude';
+  });
+
+  describe('generateTitle', () => {
+    it('should generate a title from user and assistant messages', async () => {
+      setMockMessages([
+        { type: 'system', subtype: 'init', session_id: 'test-session' },
+        {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'text', text: 'Setting Up React Project' }],
+          },
+        },
+        { type: 'result' },
+      ]);
+
+      const callback = jest.fn();
+      await service.generateTitle(
+        'conv-123',
+        'How do I set up a React project?',
+        'You can use create-react-app...',
+        callback
+      );
+
+      expect(callback).toHaveBeenCalledWith('conv-123', {
+        success: true,
+        title: 'Setting Up React Project',
+      });
+    });
+
+    it('should use no tools for title generation', async () => {
+      setMockMessages([
+        { type: 'system', subtype: 'init', session_id: 'test-session' },
+        {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'text', text: 'Test Title' }],
+          },
+        },
+        { type: 'result' },
+      ]);
+
+      const callback = jest.fn();
+      await service.generateTitle('conv-123', 'test', 'response', callback);
+
+      const options = getLastOptions();
+      expect(options?.allowedTools).toEqual([]);
+      expect(options?.permissionMode).toBe('bypassPermissions');
+    });
+
+    it('should use ANTHROPIC_DEFAULT_HAIKU_MODEL when set', async () => {
+      mockPlugin.getActiveEnvironmentVariables.mockReturnValue(
+        'ANTHROPIC_DEFAULT_HAIKU_MODEL=custom-haiku'
+      );
+
+      setMockMessages([
+        { type: 'system', subtype: 'init', session_id: 'test-session' },
+        {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'text', text: 'Title' }],
+          },
+        },
+        { type: 'result' },
+      ]);
+
+      const callback = jest.fn();
+      await service.generateTitle('conv-123', 'test', 'response', callback);
+
+      const options = getLastOptions();
+      expect(options?.model).toBe('custom-haiku');
+    });
+
+    it('should fallback to claude-haiku-4-5 model', async () => {
+      setMockMessages([
+        { type: 'system', subtype: 'init', session_id: 'test-session' },
+        {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'text', text: 'Title' }],
+          },
+        },
+        { type: 'result' },
+      ]);
+
+      const callback = jest.fn();
+      await service.generateTitle('conv-123', 'test', 'response', callback);
+
+      const options = getLastOptions();
+      expect(options?.model).toBe('claude-haiku-4-5');
+    });
+
+    it('should strip surrounding quotes from title', async () => {
+      setMockMessages([
+        { type: 'system', subtype: 'init', session_id: 'test-session' },
+        {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'text', text: '"Quoted Title"' }],
+          },
+        },
+        { type: 'result' },
+      ]);
+
+      const callback = jest.fn();
+      await service.generateTitle('conv-123', 'test', 'response', callback);
+
+      expect(callback).toHaveBeenCalledWith('conv-123', {
+        success: true,
+        title: 'Quoted Title',
+      });
+    });
+
+    it('should strip trailing punctuation from title', async () => {
+      setMockMessages([
+        { type: 'system', subtype: 'init', session_id: 'test-session' },
+        {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'text', text: 'Title With Punctuation...' }],
+          },
+        },
+        { type: 'result' },
+      ]);
+
+      const callback = jest.fn();
+      await service.generateTitle('conv-123', 'test', 'response', callback);
+
+      expect(callback).toHaveBeenCalledWith('conv-123', {
+        success: true,
+        title: 'Title With Punctuation',
+      });
+    });
+
+    it('should truncate titles longer than 50 characters', async () => {
+      const longTitle = 'A'.repeat(60);
+      setMockMessages([
+        { type: 'system', subtype: 'init', session_id: 'test-session' },
+        {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'text', text: longTitle }],
+          },
+        },
+        { type: 'result' },
+      ]);
+
+      const callback = jest.fn();
+      await service.generateTitle('conv-123', 'test', 'response', callback);
+
+      expect(callback).toHaveBeenCalledWith('conv-123', {
+        success: true,
+        title: 'A'.repeat(47) + '...',
+      });
+    });
+
+    it('should fail gracefully when response is empty', async () => {
+      setMockMessages([
+        { type: 'system', subtype: 'init', session_id: 'test-session' },
+        {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'text', text: '' }],
+          },
+        },
+        { type: 'result' },
+      ]);
+
+      const callback = jest.fn();
+      await service.generateTitle('conv-123', 'test', 'response', callback);
+
+      expect(callback).toHaveBeenCalledWith('conv-123', {
+        success: false,
+        error: 'Failed to parse title from response',
+      });
+    });
+
+    it('should fail when vault path cannot be determined', async () => {
+      mockPlugin.app.vault.adapter.basePath = undefined;
+
+      const callback = jest.fn();
+      await service.generateTitle('conv-123', 'test', 'response', callback);
+
+      expect(callback).toHaveBeenCalledWith('conv-123', {
+        success: false,
+        error: 'Could not determine vault path',
+      });
+    });
+
+    it('should fail when Claude CLI is not found', async () => {
+      (service as any).resolvedClaudePath = null;
+      (pathUtils.findClaudeCLIPath as jest.Mock).mockReturnValue(null);
+
+      const callback = jest.fn();
+      await service.generateTitle('conv-123', 'test', 'response', callback);
+
+      expect(callback).toHaveBeenCalledWith('conv-123', {
+        success: false,
+        error: 'Claude CLI not found',
+      });
+    });
+
+    it('should truncate long user messages', async () => {
+      const longMessage = 'x'.repeat(1000);
+      setMockMessages([
+        { type: 'system', subtype: 'init', session_id: 'test-session' },
+        {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'text', text: 'Title' }],
+          },
+        },
+        { type: 'result' },
+      ]);
+
+      const callback = jest.fn();
+      await service.generateTitle('conv-123', longMessage, 'response', callback);
+
+      // Service should still complete successfully with truncated message
+      expect(callback).toHaveBeenCalledWith('conv-123', {
+        success: true,
+        title: 'Title',
+      });
+    });
+  });
+
+  describe('concurrent generation', () => {
+    it('should support multiple concurrent generations', async () => {
+      setMockMessages([
+        { type: 'system', subtype: 'init', session_id: 'test-session' },
+        {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'text', text: 'Title' }],
+          },
+        },
+        { type: 'result' },
+      ]);
+
+      const callback1 = jest.fn();
+      const callback2 = jest.fn();
+
+      // Start two generations concurrently
+      const promise1 = service.generateTitle('conv-1', 'msg1', 'resp1', callback1);
+      const promise2 = service.generateTitle('conv-2', 'msg2', 'resp2', callback2);
+
+      await Promise.all([promise1, promise2]);
+
+      expect(callback1).toHaveBeenCalledWith('conv-1', { success: true, title: 'Title' });
+      expect(callback2).toHaveBeenCalledWith('conv-2', { success: true, title: 'Title' });
+    });
+
+    it('should cancel previous generation for same conversation', async () => {
+      // First call will be aborted when second call starts
+      const callback1 = jest.fn();
+      const callback2 = jest.fn();
+
+      // Mock a slow first generation
+      setMockMessages([
+        { type: 'system', subtype: 'init', session_id: 'test-session' },
+        {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'text', text: 'Title 1' }],
+          },
+        },
+        { type: 'result' },
+      ]);
+
+      // Start first generation (won't await it)
+      const promise1 = service.generateTitle('conv-1', 'msg1', 'resp1', callback1);
+
+      // Immediately start second generation for same conversation
+      setMockMessages([
+        { type: 'system', subtype: 'init', session_id: 'test-session-2' },
+        {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'text', text: 'Title 2' }],
+          },
+        },
+        { type: 'result' },
+      ]);
+      const promise2 = service.generateTitle('conv-1', 'msg2', 'resp2', callback2);
+
+      await Promise.all([promise1, promise2]);
+
+      // Second generation should complete with new title
+      expect(callback2).toHaveBeenCalledWith('conv-1', { success: true, title: 'Title 2' });
+    });
+  });
+
+  describe('cancel', () => {
+    it('should cancel all active generations', async () => {
+      setMockMessages([
+        { type: 'system', subtype: 'init', session_id: 'test-session' },
+        {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'text', text: 'Title' }],
+          },
+        },
+        { type: 'result' },
+      ]);
+
+      const callback = jest.fn();
+
+      // Start generation then cancel immediately
+      const promise = service.generateTitle('conv-1', 'msg', 'resp', callback);
+      service.cancel();
+
+      await promise;
+
+      // Should have been called with cancelled error or completed
+      expect(callback).toHaveBeenCalled();
+    });
+  });
+
+  describe('safeCallback', () => {
+    it('should catch errors thrown by callback', async () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      setMockMessages([
+        { type: 'system', subtype: 'init', session_id: 'test-session' },
+        {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'text', text: 'Title' }],
+          },
+        },
+        { type: 'result' },
+      ]);
+
+      const throwingCallback = jest.fn().mockRejectedValue(new Error('Callback error'));
+
+      // Should not throw
+      await expect(
+        service.generateTitle('conv-123', 'test', 'response', throwingCallback)
+      ).resolves.not.toThrow();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[TitleGeneration] Error in callback:',
+        'Callback error'
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
+});
+
+describe('TitleGenerationResult type', () => {
+  it('should be a discriminated union for success', () => {
+    const success: TitleGenerationResult = { success: true, title: 'Test Title' };
+    expect(success.success).toBe(true);
+    // TypeScript narrows the type based on success: true
+    expect(success).toEqual({ success: true, title: 'Test Title' });
+  });
+
+  it('should be a discriminated union for failure', () => {
+    const failure: TitleGenerationResult = { success: false, error: 'Some error' };
+    expect(failure.success).toBe(false);
+    // TypeScript narrows the type based on success: false
+    expect(failure).toEqual({ success: false, error: 'Some error' });
+  });
+});


### PR DESCRIPTION
## Summary
- Support concurrent title generation for multiple conversations simultaneously
- Changed from single global AbortController to per-conversation tracking with Map
- Automatically update history dropdown when title generation starts
- Add comprehensive tests for edge cases (no titleService, empty assistant response)

## Test Plan
- Run `npm test` to verify all tests pass
- Manual testing: Start typing in multiple conversation tabs and verify titles generate independently