### PR TITLE
style: Use monospace font for tool headers and result text

### DIFF
--- a/src/style/components/toolcalls.css
+++ b/src/style/components/toolcalls.css
@@ -26,6 +26,7 @@
 
 .claudian-tool-label {
   flex: 1;
+  font-family: var(--font-monospace);
   font-size: 13px;
   font-weight: 500;
   color: var(--text-normal);
@@ -91,6 +92,7 @@
 }
 
 .claudian-tool-result-text {
+  font-family: var(--font-monospace);
   font-size: 12px;
   color: var(--text-muted);
   line-height: 1.4;


### PR DESCRIPTION
Apply monospace font styling to tool call headers and result text for improved readability and visual consistency with code-related content.

Changes:
- `.claudian-tool-label`: Added `font-family: var(--font-monospace)`
- `.claudian-tool-result-text`: Added `font-family: var(--font-monospace)`