### PR TITLE
feat: Add Ultra (32k token) thinking budget option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ await MarkdownRenderer.renderMarkdown(markdown, container, sourcePath, component
 interface ClaudianSettings {
   model: string;                     // 'claude-haiku-4-5' | 'claude-sonnet-4-5' | 'claude-opus-4-5' | custom
   titleGenerationModel: string;      // Model for auto titles (empty = auto)
-  thinkingBudget: 'off' | 'low' | 'medium' | 'high';  // 0 | 4k | 8k | 16k tokens
+  thinkingBudget: 'off' | 'low' | 'medium' | 'high' | 'xhigh';  // 0 | 4k | 8k | 16k | 32k tokens
   permissionMode: 'yolo' | 'normal';
   enableBlocklist: boolean;
   blockedCommands: { unix: string[], windows: string[] };  // Platform-keyed blocklist

--- a/src/core/types/models.ts
+++ b/src/core/types/models.ts
@@ -13,7 +13,7 @@ export const DEFAULT_CLAUDE_MODELS: { value: ClaudeModel; label: string; descrip
 ];
 
 /** Extended thinking token budget levels. */
-export type ThinkingBudget = 'off' | 'low' | 'medium' | 'high';
+export type ThinkingBudget = 'off' | 'low' | 'medium' | 'high' | 'xhigh';
 
 /** Thinking budget configuration with token counts. */
 export const THINKING_BUDGETS: { value: ThinkingBudget; label: string; tokens: number }[] = [
@@ -21,6 +21,7 @@ export const THINKING_BUDGETS: { value: ThinkingBudget; label: string; tokens: n
   { value: 'low', label: 'Low', tokens: 4000 },
   { value: 'medium', label: 'Med', tokens: 8000 },
   { value: 'high', label: 'High', tokens: 16000 },
+  { value: 'xhigh', label: 'Ultra', tokens: 32000 },
 ];
 
 /** Default thinking budget per model tier. */


### PR DESCRIPTION
Adds a new xhigh/Ultra thinking budget tier with 32k tokens for extended thinking workflows.

This expands the thinking budget options from off/low/medium/high to off/low/medium/high/xhigh, providing users with maximum extended thinking capacity when needed.

The new option is automatically available in the UI via THINKING_BUDGETS without requiring additional component changes.