### PR TITLE
Fix vim navigation mapping persistence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,11 @@ interface ClaudianSettings {
   allowedExportPaths: string[];      // Write-only paths outside vault
   allowedContextPaths: string[];     // Read-only paths outside vault
   slashCommands: SlashCommand[];     // Loaded from .claude/commands/*.md
+  keyboardNavigation: {             // Vim-style navigation key bindings
+    scrollUpKey: string;
+    scrollDownKey: string;
+    focusInputKey: string;
+  };
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ An Obsidian plugin that embeds Claude Agent (using Claude Agent SDK) as a sideba
 - **Plan Mode**: Toggle read-only exploration with Shift+Tab before implementation. Agent explores codebase, presents a plan, then implements after approval.
 
 - **Robust Security**: Implement permission modes (YOLO/Safe), a safety blocklist, and vault confinement with symlink-safe checks.
+- **Vim-style Navigation**: Press Escape to focus the chat panel, then use `w/s` (configurable) to scroll and `i` to focus input.
 
 ## Requirements
 
@@ -116,6 +117,7 @@ Use it like Claude Code—read, write, edit, search files in your vault.
 - **Environment variables**: Custom environment variables for Claude SDK (KEY=VALUE format)
 - **Environment snippets**: Save and restore environment variable configurations
 - **MCP Servers**: Add/edit/test/delete MCP server configurations with context-saving mode
+- **Vim-style navigation mappings**: Configure key bindings with lines like `map w scrollUp`, `map s scrollDown`, `map i focusInput`
 
 ### Safety and permissions
 

--- a/src/features/settings/keyboardNavigation.ts
+++ b/src/features/settings/keyboardNavigation.ts
@@ -1,0 +1,60 @@
+import type { KeyboardNavigationSettings } from '@/core/types/settings';
+
+const NAV_ACTIONS = ['scrollUp', 'scrollDown', 'focusInput'] as const;
+type NavAction = (typeof NAV_ACTIONS)[number];
+
+export const buildNavMappingText = (settings: KeyboardNavigationSettings): string => {
+  return [
+    `map ${settings.scrollUpKey} scrollUp`,
+    `map ${settings.scrollDownKey} scrollDown`,
+    `map ${settings.focusInputKey} focusInput`,
+  ].join('\n');
+};
+
+export const parseNavMappings = (
+  value: string
+): { settings?: Record<NavAction, string>; error?: string } => {
+  const parsed: Partial<Record<NavAction, string>> = {};
+  const usedKeys = new Map<string, string>();
+  const lines = value.split('\n');
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    const parts = line.split(/\s+/);
+    if (parts.length !== 3 || parts[0] !== 'map') {
+      return { error: 'Each line must follow "map <key> <action>"' };
+    }
+
+    const key = parts[1];
+    const action = parts[2] as NavAction;
+
+    if (!NAV_ACTIONS.includes(action)) {
+      return { error: `Unknown action: ${parts[2]}` };
+    }
+
+    if (key.length !== 1) {
+      return { error: `Key must be a single character for ${action}` };
+    }
+
+    const normalizedKey = key.toLowerCase();
+    if (usedKeys.has(normalizedKey)) {
+      return { error: 'Navigation keys must be unique' };
+    }
+
+    if (parsed[action]) {
+      return { error: `Duplicate mapping for ${action}` };
+    }
+
+    usedKeys.set(normalizedKey, action);
+    parsed[action] = key;
+  }
+
+  const missing = NAV_ACTIONS.filter((action) => !parsed[action]);
+  if (missing.length > 0) {
+    return { error: `Missing mapping for ${missing.join(', ')}` };
+  }
+
+  return { settings: parsed as Record<NavAction, string> };
+};

--- a/tests/unit/features/settings/keyboardNavigation.test.ts
+++ b/tests/unit/features/settings/keyboardNavigation.test.ts
@@ -1,0 +1,73 @@
+import { buildNavMappingText, parseNavMappings } from '@/features/settings/keyboardNavigation';
+
+describe('keyboardNavigation', () => {
+  describe('buildNavMappingText', () => {
+    it('should build mapping lines in order', () => {
+      const result = buildNavMappingText({
+        scrollUpKey: 'w',
+        scrollDownKey: 's',
+        focusInputKey: 'i',
+      });
+
+      expect(result).toBe('map w scrollUp\nmap s scrollDown\nmap i focusInput');
+    });
+  });
+
+  describe('parseNavMappings', () => {
+    it('should parse valid mappings', () => {
+      const result = parseNavMappings('map w scrollUp\nmap s scrollDown\nmap i focusInput');
+
+      expect(result.settings).toEqual({
+        scrollUp: 'w',
+        scrollDown: 's',
+        focusInput: 'i',
+      });
+    });
+
+    it('should ignore empty lines', () => {
+      const result = parseNavMappings('\nmap w scrollUp\n\nmap s scrollDown\nmap i focusInput\n');
+
+      expect(result.settings).toEqual({
+        scrollUp: 'w',
+        scrollDown: 's',
+        focusInput: 'i',
+      });
+    });
+
+    it('should reject invalid formats', () => {
+      const result = parseNavMappings('map w scrollUp extra');
+
+      expect(result.error).toBe('Each line must follow "map <key> <action>"');
+    });
+
+    it('should reject unknown actions', () => {
+      const result = parseNavMappings('map w jump\nmap s scrollDown\nmap i focusInput');
+
+      expect(result.error).toBe('Unknown action: jump');
+    });
+
+    it('should reject multi-character keys', () => {
+      const result = parseNavMappings('map ww scrollUp\nmap s scrollDown\nmap i focusInput');
+
+      expect(result.error).toBe('Key must be a single character for scrollUp');
+    });
+
+    it('should reject duplicate action mappings', () => {
+      const result = parseNavMappings('map w scrollUp\nmap s scrollDown\nmap i scrollDown');
+
+      expect(result.error).toBe('Duplicate mapping for scrollDown');
+    });
+
+    it('should reject duplicate keys case-insensitively', () => {
+      const result = parseNavMappings('map W scrollUp\nmap w scrollDown\nmap i focusInput');
+
+      expect(result.error).toBe('Navigation keys must be unique');
+    });
+
+    it('should reject missing mappings', () => {
+      const result = parseNavMappings('map w scrollUp\nmap s scrollDown');
+
+      expect(result.error).toBe('Missing mapping for focusInput');
+    });
+  });
+});


### PR DESCRIPTION
This updates the settings UI to save vim navigation mappings reliably and extracts parsing helpers for reuse. It adds unit tests for mapping parsing and formatting.