### PR TITLE
Remove deprecated compatibility exports

### DIFF
--- a/src/core/agent/ClaudianService.ts
+++ b/src/core/agent/ClaudianService.ts
@@ -42,12 +42,12 @@ import {
 } from '../security';
 import { TOOL_ASK_USER_QUESTION, TOOL_ENTER_PLAN_MODE, TOOL_EXIT_PLAN_MODE } from '../tools/toolNames';
 import type {
-  ApprovedAction,
   AskUserQuestionCallback,
   AskUserQuestionInput,
   ChatMessage,
   ClaudeModel,
   ImageAttachment,
+  Permission,
   PermissionMode,
   StreamChunk,
   ToolDiffData,
@@ -243,7 +243,7 @@ export class ClaudianService {
     );
 
     // Set up persistence callback for permanent approvals
-    this.approvalManager.setPersistCallback(async (action: ApprovedAction) => {
+    this.approvalManager.setPersistCallback(async (action: Permission) => {
       this.plugin.settings.permissions.push(action);
       await this.plugin.saveSettings();
     });

--- a/src/core/security/ApprovalManager.ts
+++ b/src/core/security/ApprovalManager.ts
@@ -14,10 +14,10 @@ import {
   TOOL_READ,
   TOOL_WRITE,
 } from '../tools/toolNames';
-import type { ApprovedAction } from '../types';
+import type { Permission } from '../types';
 
 /** Callback to persist approved actions to settings. */
-export type PersistApprovalCallback = (action: ApprovedAction) => Promise<void>;
+export type PersistApprovalCallback = (action: Permission) => Promise<void>;
 
 /**
  * Generate a pattern from tool input for matching.
@@ -125,11 +125,11 @@ function isPathPrefixMatch(actionPath: string, approvedPath: string): boolean {
  * Manages approved actions for Safe mode permission handling.
  */
 export class ApprovalManager {
-  private sessionApprovedActions: ApprovedAction[] = [];
+  private sessionApprovedActions: Permission[] = [];
   private persistCallback: PersistApprovalCallback | null = null;
-  private getPermanentApprovals: () => ApprovedAction[];
+  private getPermanentApprovals: () => Permission[];
 
-  constructor(getPermanentApprovals: () => ApprovedAction[]) {
+  constructor(getPermanentApprovals: () => Permission[]) {
     this.getPermanentApprovals = getPermanentApprovals;
   }
 
@@ -169,7 +169,7 @@ export class ApprovalManager {
     scope: 'session' | 'always'
   ): Promise<void> {
     const pattern = getActionPattern(toolName, input);
-    const action: ApprovedAction = {
+    const action: Permission = {
       toolName,
       pattern,
       approvedAt: Date.now(),
@@ -195,7 +195,7 @@ export class ApprovalManager {
   /**
    * Get session-scoped approvals (for testing/debugging).
    */
-  getSessionApprovals(): ApprovedAction[] {
+  getSessionApprovals(): Permission[] {
     return [...this.sessionApprovedActions];
   }
 }

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -37,7 +37,6 @@ export {
 
 // Settings types
 export {
-  type ApprovedAction, // @deprecated - use Permission
   type ClaudianSettings,
   DEFAULT_SETTINGS,
   type EnvSnippet,

--- a/src/core/types/settings.ts
+++ b/src/core/types/settings.ts
@@ -98,9 +98,6 @@ export interface Permission {
   scope: 'session' | 'always';
 }
 
-/** @deprecated Use Permission instead */
-export type ApprovedAction = Permission;
-
 /** Saved environment variable configuration. */
 export interface EnvSnippet {
   id: string;

--- a/src/ui/modals/InstructionConfirmModal.ts
+++ b/src/ui/modals/InstructionConfirmModal.ts
@@ -284,24 +284,3 @@ export class InstructionModal extends Modal {
     this.contentEl.empty();
   }
 }
-
-// Legacy exports for backwards compatibility
-export { InstructionModal as InstructionConfirmModal };
-export type ClarificationSubmitCallback = (response: string) => Promise<void>;
-
-/** @deprecated Use InstructionModal instead */
-export class InstructionClarificationModal extends Modal {
-  constructor(
-    app: App,
-    _clarification: string,
-    _onSubmit: ClarificationSubmitCallback,
-    _onCancel: () => void
-  ) {
-    super(app);
-  }
-
-  onOpen() {}
-  onClose() {}
-  updateClarification(text: string) {}
-  closeModal() { this.close(); }
-}

--- a/src/ui/modals/index.ts
+++ b/src/ui/modals/index.ts
@@ -7,9 +7,6 @@ export {
   InlineEditModal,
 } from './InlineEditModal';
 export {
-  type ClarificationSubmitCallback,
-  InstructionClarificationModal,
-  InstructionConfirmModal,
   type InstructionDecision,
   InstructionModal,
   type InstructionModalCallbacks,

--- a/src/ui/utils/collapsible.ts
+++ b/src/ui/utils/collapsible.ts
@@ -108,18 +108,3 @@ export function collapseElement(
   contentEl.style.display = 'none';
   headerEl.setAttribute('aria-expanded', 'false');
 }
-
-/**
- * Expand a collapsible element and sync state.
- */
-export function expandElement(
-  wrapperEl: HTMLElement,
-  headerEl: HTMLElement,
-  contentEl: HTMLElement,
-  state: CollapsibleState
-): void {
-  state.isExpanded = true;
-  wrapperEl.addClass('expanded');
-  contentEl.style.display = 'block';
-  headerEl.setAttribute('aria-expanded', 'true');
-}


### PR DESCRIPTION
Remove legacy type and modal exports now superseded by Permission and InstructionModal.\nUpdate ApprovalManager and ClaudianService to use Permission consistently.\nRemove unused collapsible expand helper.