### PR TITLE
feat: make wikilinks clickable to open files in Obsidian

### DIFF
--- a/src/core/prompts/mainAgent.ts
+++ b/src/core/prompts/mainAgent.ts
@@ -78,6 +78,16 @@ User's question or request here
 - **Dataview**: You may encounter Dataview queries (in \`\`\`dataview\`\`\` blocks). Do not break them unless asked.
 - **Vault Config**: \`.obsidian/\` contains internal config. Touch only if you know what you are doing.
 
+**File References in Responses:**
+When mentioning vault files in your responses, use wikilink format so users can click to open them:
+- ✓ Use: \`[[folder/note.md]]\` or \`[[note]]\`
+- ✗ Avoid: plain paths like \`folder/note.md\` (not clickable)
+
+Examples:
+- "I found your notes in [[30.areas/finance/Investment lessons/2024.Current trading lessons.md]]"
+- "See [[daily notes/2024-01-15]] for more details"
+- "The config is in [[.obsidian/plugins/my-plugin/data.json]]"
+
 ## Tool Usage Guidelines
 
 Standard tools (Read, Write, Edit, Glob, Grep, LS, Bash, WebSearch, WebFetch, Skills, AskUserQuestion) work as expected.

--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -19,6 +19,7 @@ import {
   renderStoredToolCall,
   renderStoredWriteEdit,
 } from '../../../ui';
+import { processFileLinks, registerFileLinkHandler } from '../../../utils/fileLink';
 
 /** Render content function type for callbacks. */
 export type RenderContentFn = (el: HTMLElement, markdown: string) => Promise<void>;
@@ -41,6 +42,9 @@ export class MessageRenderer {
     this.app = app;
     this.component = component;
     this.messagesEl = messagesEl;
+
+    // Register delegated click handler for file links
+    registerFileLinkHandler(this.app, this.messagesEl, this.component);
   }
 
   /** Sets the messages container element. */
@@ -407,6 +411,9 @@ export class MessageRenderer {
         wrapper.appendChild(copyBtn);
       }
     });
+
+    // Process file paths to make them clickable links
+    processFileLinks(this.app, el);
   }
 
   // ============================================

--- a/src/style/features/file-link.css
+++ b/src/style/features/file-link.css
@@ -1,0 +1,22 @@
+/* Clickable file links that open files in Obsidian */
+.claudian-file-link {
+  color: var(--text-accent);
+  text-decoration: none;
+  cursor: pointer;
+  border-radius: 3px;
+  transition: color 0.15s ease;
+}
+
+.claudian-file-link:hover {
+  color: var(--text-accent-hover);
+  text-decoration: underline;
+}
+
+/* File link inside inline code */
+code .claudian-file-link {
+  color: var(--text-accent);
+}
+
+code .claudian-file-link:hover {
+  color: var(--text-accent-hover);
+}

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -29,6 +29,7 @@
 
 /* Features */
 @import "./features/file-context.css";
+@import "./features/file-link.css";
 @import "./features/image-context.css";
 @import "./features/image-modal.css";
 @import "./features/inline-edit.css";

--- a/src/utils/fileLink.ts
+++ b/src/utils/fileLink.ts
@@ -1,0 +1,312 @@
+/**
+ * Claudian - File Link Utilities
+ *
+ * Detects Obsidian wikilinks [[path/to/file]] in rendered content and makes
+ * them clickable to open the file in Obsidian.
+ */
+
+import type { App, Component } from 'obsidian';
+import { TFile } from 'obsidian';
+
+/**
+ * Regex pattern to match Obsidian wikilinks in text content.
+ *
+ * Matches:
+ * - Standard wikilinks: [[note]] or [[folder/note]]
+ * - Wikilinks with display text: [[note|display text]]
+ * - Wikilinks with headings: [[note#heading]]
+ * - Wikilinks with block references: [[note^block]]
+ *
+ * Does NOT match image embeds ![[image.png]] (those are handled separately).
+ */
+const WIKILINK_PATTERN = /(?<!!)\[\[([^\]|#^]+)(?:#[^\]|]+)?(?:\^[^\]|]+)?(?:\|[^\]]+)?\]\]/g;
+
+/**
+ * Checks if a file exists in the vault.
+ */
+function fileExistsInVault(app: App, linkPath: string): boolean {
+  // Try to find the file using metadataCache (handles aliases, partial matches)
+  const file = app.metadataCache.getFirstLinkpathDest(linkPath, '');
+  if (file) {
+    return true;
+  }
+
+  // Also try direct path lookup
+  const directFile = app.vault.getFileByPath(linkPath);
+  if (directFile) {
+    return true;
+  }
+
+  // Try with .md extension if not present
+  if (!linkPath.endsWith('.md')) {
+    const withExt = app.vault.getFileByPath(linkPath + '.md');
+    if (withExt) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Creates a link element for a wikilink.
+ * Click handling is done via event delegation in registerFileLinkHandler.
+ */
+function createWikilink(
+  linkPath: string,
+  displayText: string
+): HTMLElement {
+  const link = document.createElement('a');
+  link.className = 'claudian-file-link internal-link';
+  link.textContent = displayText;
+  link.setAttribute('data-href', linkPath);
+  link.setAttribute('href', linkPath);
+  return link;
+}
+
+/**
+ * Registers a delegated click handler for file links on a container.
+ * Should be called once on the messages container.
+ * Handles both our custom .claudian-file-link and Obsidian's .internal-link.
+ */
+export function registerFileLinkHandler(
+  app: App,
+  container: HTMLElement,
+  component: Component
+): void {
+  component.registerDomEvent(container, 'click', (event: MouseEvent) => {
+    const target = event.target as HTMLElement;
+    // Handle both our links and Obsidian's internal links
+    const link = target.closest('.claudian-file-link, .internal-link') as HTMLAnchorElement;
+
+    if (link) {
+      event.preventDefault();
+      const linkPath = link.dataset.href || link.getAttribute('href');
+      if (linkPath) {
+        // Open the file using Obsidian's API
+        const file = app.metadataCache.getFirstLinkpathDest(linkPath, '');
+        if (file instanceof TFile) {
+          const leaf = app.workspace.getLeaf('tab');
+          void leaf.openFile(file);
+        } else {
+          void app.workspace.openLinkText(linkPath, '', 'tab');
+        }
+      }
+    }
+  });
+}
+
+/**
+ * Processes a text node and replaces wikilinks with clickable links.
+ * Returns true if any replacements were made.
+ */
+function processTextNode(app: App, node: Text): boolean {
+  const text = node.textContent;
+  if (!text || !text.includes('[[')) return false;
+
+  // Reset regex state
+  WIKILINK_PATTERN.lastIndex = 0;
+
+  const matches: Array<{
+    index: number;
+    fullMatch: string;
+    linkPath: string;
+    displayText: string;
+  }> = [];
+
+  let match: RegExpExecArray | null;
+  while ((match = WIKILINK_PATTERN.exec(text)) !== null) {
+    const fullMatch = match[0];
+    const linkPath = match[1];
+
+    // Extract display text (after | if present, otherwise use link path)
+    const pipeIndex = fullMatch.lastIndexOf('|');
+    const displayText = pipeIndex > 0
+      ? fullMatch.slice(pipeIndex + 1, -2)
+      : linkPath;
+
+    // Only create link if file exists in vault
+    if (!fileExistsInVault(app, linkPath)) continue;
+
+    matches.push({
+      index: match.index,
+      fullMatch,
+      linkPath,
+      displayText,
+    });
+  }
+
+  if (matches.length === 0) return false;
+
+  // Sort matches by index (descending) to replace from end to start
+  matches.sort((a, b) => b.index - a.index);
+
+  // Create a document fragment to hold the result
+  const fragment = document.createDocumentFragment();
+  const remaining = text;
+  let currentIndex = text.length;
+
+  // Process matches from end to start
+  for (const { index, fullMatch, linkPath, displayText } of matches) {
+    const endIndex = index + fullMatch.length;
+
+    // Add text after this match
+    if (endIndex < currentIndex) {
+      fragment.insertBefore(
+        document.createTextNode(remaining.slice(endIndex, currentIndex)),
+        fragment.firstChild
+      );
+    }
+
+    // Create the link
+    const link = createWikilink(linkPath, displayText);
+    fragment.insertBefore(link, fragment.firstChild);
+
+    currentIndex = index;
+  }
+
+  // Add remaining text at the beginning
+  if (currentIndex > 0) {
+    fragment.insertBefore(
+      document.createTextNode(remaining.slice(0, currentIndex)),
+      fragment.firstChild
+    );
+  }
+
+  // Replace the original text node
+  node.parentNode?.replaceChild(fragment, node);
+  return true;
+}
+
+/**
+ * Processes rendered content to make wikilinks clickable.
+ * This should be called after MarkdownRenderer.renderMarkdown().
+ *
+ * Obsidian's MarkdownRenderer may not process wikilinks in code blocks
+ * or certain contexts, so this function catches those cases.
+ *
+ * @param app Obsidian App instance
+ * @param container The container element with rendered markdown
+ */
+export function processFileLinks(app: App, container: HTMLElement): void {
+  // Skip if no app or container
+  if (!app || !container) return;
+
+  // Process text within inline code elements
+  // (wikilinks in inline code aren't rendered by Obsidian's MarkdownRenderer)
+  container.querySelectorAll('code').forEach((codeEl) => {
+    // Skip code blocks (they have a parent <pre>)
+    if (codeEl.parentElement?.tagName === 'PRE') return;
+
+    const text = codeEl.textContent;
+    if (!text || !text.includes('[[')) return;
+
+    // Find all wikilink matches
+    WIKILINK_PATTERN.lastIndex = 0;
+    const matches: Array<{
+      index: number;
+      fullMatch: string;
+      linkPath: string;
+      displayText: string;
+    }> = [];
+
+    let match: RegExpExecArray | null;
+    while ((match = WIKILINK_PATTERN.exec(text)) !== null) {
+      const fullMatch = match[0];
+      const linkPath = match[1];
+
+      // Only include if file exists in vault
+      if (!fileExistsInVault(app, linkPath)) continue;
+
+      // Extract display text (after | if present, otherwise use link path)
+      const pipeIndex = fullMatch.lastIndexOf('|');
+      const displayText = pipeIndex > 0
+        ? fullMatch.slice(pipeIndex + 1, -2)
+        : linkPath;
+
+      matches.push({
+        index: match.index,
+        fullMatch,
+        linkPath,
+        displayText,
+      });
+    }
+
+    if (matches.length === 0) return;
+
+    // Sort matches by index (descending) to replace from end to start
+    matches.sort((a, b) => b.index - a.index);
+
+    // Create a document fragment to hold the rebuilt content
+    const fragment = document.createDocumentFragment();
+    let currentIndex = text.length;
+
+    // Process matches from end to start
+    for (const { index, fullMatch, linkPath, displayText } of matches) {
+      const endIndex = index + fullMatch.length;
+
+      // Add text after this match
+      if (endIndex < currentIndex) {
+        fragment.insertBefore(
+          document.createTextNode(text.slice(endIndex, currentIndex)),
+          fragment.firstChild
+        );
+      }
+
+      // Create the link
+      const link = createWikilink(linkPath, displayText);
+      fragment.insertBefore(link, fragment.firstChild);
+
+      currentIndex = index;
+    }
+
+    // Add remaining text at the beginning
+    if (currentIndex > 0) {
+      fragment.insertBefore(
+        document.createTextNode(text.slice(0, currentIndex)),
+        fragment.firstChild
+      );
+    }
+
+    // Replace the code element's content
+    codeEl.textContent = '';
+    codeEl.appendChild(fragment);
+  });
+
+  // Process regular text nodes (not in code blocks or already-rendered links)
+  const walker = document.createTreeWalker(
+    container,
+    NodeFilter.SHOW_TEXT,
+    {
+      acceptNode(node) {
+        // Skip nodes inside <pre>, <code>, <a>, or already processed links
+        const parent = node.parentElement;
+        if (!parent) return NodeFilter.FILTER_REJECT;
+
+        const tagName = parent.tagName.toUpperCase();
+        if (tagName === 'PRE' || tagName === 'CODE' || tagName === 'A') {
+          return NodeFilter.FILTER_REJECT;
+        }
+
+        // Skip if parent or ancestor is a code block or link
+        if (parent.closest('pre, code, a, .claudian-file-link, .internal-link')) {
+          return NodeFilter.FILTER_REJECT;
+        }
+
+        return NodeFilter.FILTER_ACCEPT;
+      },
+    }
+  );
+
+  // Collect text nodes first (modifying while walking causes issues)
+  const textNodes: Text[] = [];
+  let node: Node | null;
+  while ((node = walker.nextNode())) {
+    textNodes.push(node as Text);
+  }
+
+  // Process each text node
+  for (const textNode of textNodes) {
+    processTextNode(app, textNode);
+  }
+}

--- a/tests/unit/features/chat/rendering/MessageRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/MessageRenderer.test.ts
@@ -70,10 +70,21 @@ function createMockElement() {
   return element;
 }
 
+function createMockComponent() {
+  return {
+    registerDomEvent: jest.fn(),
+    register: jest.fn(),
+    addChild: jest.fn(),
+    load: jest.fn(),
+    unload: jest.fn(),
+  };
+}
+
 describe('MessageRenderer', () => {
   it('renders welcome element and calls renderStoredMessage for each message', () => {
     const messagesEl = createMockElement();
-    const renderer = new MessageRenderer({} as any, {} as any, messagesEl);
+    const mockComponent = createMockComponent();
+    const renderer = new MessageRenderer({} as any, mockComponent as any, messagesEl);
     const renderStoredSpy = jest.spyOn(renderer, 'renderStoredMessage').mockImplementation(() => {});
 
     const messages: ChatMessage[] = [
@@ -90,7 +101,8 @@ describe('MessageRenderer', () => {
 
   it('renders assistant content blocks using specialized renderers', () => {
     const messagesEl = createMockElement();
-    const renderer = new MessageRenderer({} as any, {} as any, messagesEl);
+    const mockComponent = createMockComponent();
+    const renderer = new MessageRenderer({} as any, mockComponent as any, messagesEl);
     const renderContentSpy = jest.spyOn(renderer, 'renderContent').mockResolvedValue(undefined);
 
     const msg: ChatMessage = {

--- a/tests/unit/utils/fileLink.test.ts
+++ b/tests/unit/utils/fileLink.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for fileLink utility - wikilink pattern matching
+ *
+ * Focuses on testing the regex pattern logic, which is the core value.
+ * DOM manipulation is tested manually in Obsidian.
+ */
+
+// Extract the pattern from the module for testing
+// This matches the pattern in src/utils/fileLink.ts
+const WIKILINK_PATTERN = /(?<!!)\[\[([^\]|#^]+)(?:#[^\]|]+)?(?:\^[^\]|]+)?(?:\|[^\]]+)?\]\]/g;
+
+interface WikilinkMatch {
+  fullMatch: string;
+  linkPath: string;
+  index: number;
+}
+
+function findWikilinks(text: string): WikilinkMatch[] {
+  WIKILINK_PATTERN.lastIndex = 0;
+  const matches: WikilinkMatch[] = [];
+
+  let match: RegExpExecArray | null;
+  while ((match = WIKILINK_PATTERN.exec(text)) !== null) {
+    matches.push({
+      fullMatch: match[0],
+      linkPath: match[1],
+      index: match.index,
+    });
+  }
+
+  return matches;
+}
+
+function extractDisplayText(fullMatch: string, linkPath: string): string {
+  const pipeIndex = fullMatch.lastIndexOf('|');
+  return pipeIndex > 0 ? fullMatch.slice(pipeIndex + 1, -2) : linkPath;
+}
+
+describe('wikilink pattern matching', () => {
+  describe('basic wikilinks', () => {
+    it('matches simple wikilink', () => {
+      const matches = findWikilinks('[[note.md]]');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].linkPath).toBe('note.md');
+    });
+
+    it('matches wikilink without extension', () => {
+      const matches = findWikilinks('[[note]]');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].linkPath).toBe('note');
+    });
+
+    it('matches wikilink with folder path', () => {
+      const matches = findWikilinks('[[folder/subfolder/note.md]]');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].linkPath).toBe('folder/subfolder/note.md');
+    });
+
+    it('matches wikilink in surrounding text', () => {
+      const matches = findWikilinks('Check [[note.md]] for info');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].linkPath).toBe('note.md');
+      expect(matches[0].index).toBe(6);
+    });
+  });
+
+  describe('wikilinks with display text', () => {
+    it('matches wikilink with pipe alias', () => {
+      const matches = findWikilinks('[[note.md|My Note]]');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].linkPath).toBe('note.md');
+      expect(matches[0].fullMatch).toBe('[[note.md|My Note]]');
+    });
+
+    it('extracts display text correctly', () => {
+      const fullMatch = '[[note.md|My Display Text]]';
+      const displayText = extractDisplayText(fullMatch, 'note.md');
+      expect(displayText).toBe('My Display Text');
+    });
+
+    it('uses link path when no display text', () => {
+      const fullMatch = '[[note.md]]';
+      const displayText = extractDisplayText(fullMatch, 'note.md');
+      expect(displayText).toBe('note.md');
+    });
+  });
+
+  describe('wikilinks with headings and blocks', () => {
+    it('matches wikilink with heading reference', () => {
+      const matches = findWikilinks('[[note.md#section]]');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].linkPath).toBe('note.md');
+    });
+
+    it('matches wikilink with block reference', () => {
+      const matches = findWikilinks('[[note.md^blockid]]');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].linkPath).toBe('note.md');
+    });
+
+    it('matches wikilink with heading and display text', () => {
+      const matches = findWikilinks('[[note.md#section|Section Link]]');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].linkPath).toBe('note.md');
+    });
+  });
+
+  describe('multiple wikilinks', () => {
+    it('matches multiple wikilinks in text', () => {
+      const matches = findWikilinks('See [[note1.md]] and [[note2.md]]');
+      expect(matches).toHaveLength(2);
+      expect(matches[0].linkPath).toBe('note1.md');
+      expect(matches[1].linkPath).toBe('note2.md');
+    });
+
+    it('matches consecutive wikilinks', () => {
+      const matches = findWikilinks('[[a.md]][[b.md]]');
+      expect(matches).toHaveLength(2);
+    });
+
+    it('captures correct indices for multiple matches', () => {
+      const text = '[[first.md]] middle [[second.md]]';
+      const matches = findWikilinks(text);
+      expect(matches[0].index).toBe(0);
+      expect(matches[1].index).toBe(20);
+    });
+  });
+
+  describe('image embeds (should NOT match)', () => {
+    it('does not match image embed', () => {
+      const matches = findWikilinks('![[image.png]]');
+      expect(matches).toHaveLength(0);
+    });
+
+    it('does not match image embed with alt text', () => {
+      const matches = findWikilinks('![[image.png|alt text]]');
+      expect(matches).toHaveLength(0);
+    });
+
+    it('matches file link but not image embed', () => {
+      const matches = findWikilinks('[[note.md]] and ![[image.png]]');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].linkPath).toBe('note.md');
+    });
+
+    it('handles mixed file links and image embeds', () => {
+      const text = '![[img1.png]] [[file.md]] ![[img2.png]] [[other.md]]';
+      const matches = findWikilinks(text);
+      expect(matches).toHaveLength(2);
+      expect(matches[0].linkPath).toBe('file.md');
+      expect(matches[1].linkPath).toBe('other.md');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles empty text', () => {
+      const matches = findWikilinks('');
+      expect(matches).toHaveLength(0);
+    });
+
+    it('handles text without wikilinks', () => {
+      const matches = findWikilinks('Just plain text here');
+      expect(matches).toHaveLength(0);
+    });
+
+    it('handles incomplete wikilink syntax', () => {
+      const matches = findWikilinks('[[incomplete');
+      expect(matches).toHaveLength(0);
+    });
+
+    it('matches wikilink at start of text', () => {
+      const matches = findWikilinks('[[note.md]] is first');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].index).toBe(0);
+    });
+
+    it('matches wikilink at end of text', () => {
+      const matches = findWikilinks('last is [[note.md]]');
+      expect(matches).toHaveLength(1);
+    });
+
+    it('handles special characters in path', () => {
+      const matches = findWikilinks('[[folder/my note (2024).md]]');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].linkPath).toBe('folder/my note (2024).md');
+    });
+
+    it('handles spaces in filename', () => {
+      const matches = findWikilinks('[[my long filename.md]]');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].linkPath).toBe('my long filename.md');
+    });
+
+    it('handles deep folder paths', () => {
+      const matches = findWikilinks('[[a/b/c/d/e/note.md]]');
+      expect(matches).toHaveLength(1);
+      expect(matches[0].linkPath).toBe('a/b/c/d/e/note.md');
+    });
+  });
+
+  describe('real-world examples', () => {
+    it('matches typical vault path from screenshot', () => {
+      const text = 'Found in [[30.areas/a.finance/Investment lessons/2024.Current trading lessons.md]]';
+      const matches = findWikilinks(text);
+      expect(matches).toHaveLength(1);
+      expect(matches[0].linkPath).toBe('30.areas/a.finance/Investment lessons/2024.Current trading lessons.md');
+    });
+
+    it('matches multiple paths in a list', () => {
+      const text = `
+1. [[30.areas/finance/note1.md]] - First
+2. [[30.areas/finance/note2.md]] - Second
+      `;
+      const matches = findWikilinks(text);
+      expect(matches).toHaveLength(2);
+    });
+
+    it('handles markdown formatting around links', () => {
+      const text = 'Check **[[important.md]]** for *[[details.md]]*';
+      const matches = findWikilinks(text);
+      expect(matches).toHaveLength(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

When Claude outputs wikilinks like `[[folder/note.md]]` in responses, they are now converted to clickable links that open the file in Obsidian.

**Changes:**
- Add `fileLink.ts` utility to detect and process `[[wikilink]]` format
- Add CSS styles for clickable file links (uses Obsidian's accent colors)
- Integrate link processing into `MessageRenderer.renderContent()`
- Update system prompt to instruct Claude to use wikilinks when referencing vault files
- Add 28 unit tests for wikilink pattern matching

**How it works:**
1. Claude is instructed to output file references as wikilinks: `[[30.areas/finance/notes.md]]`
2. After markdown rendering, the utility detects `[[...]]` patterns
3. If the file exists in the vault, it becomes a clickable link
4. Clicking opens the file in Obsidian via `app.workspace.openLinkText()`

**Not matched:** Image embeds `![[image.png]]` are correctly ignored.

## Test plan

- [x] Lint passes
- [x] Build passes  
- [x] All 45 test suites pass (1109 tests)
- [x] Manual test: Ask Claude to find files, verify wikilinks are clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)