### PR TITLE
feat: add nvm4w (Node Version Manager for Windows) support

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -43,6 +43,13 @@ function getExtraBinaryPaths(): string[] {
     paths.push(path.join(programFiles, 'nodejs'));
     paths.push(path.join(programFilesX86, 'nodejs'));
 
+    // nvm4w (Node Version Manager for Windows)
+    // Default: C:\nvm4w\nodejs, but support all drive letters
+    const drives = ['C', 'D', 'E', 'F', 'G', 'H'];
+    for (const drive of drives) {
+      paths.push(path.join(drive + ':', 'nvm4w', 'nodejs'));
+    }
+
     // Docker
     paths.push(path.join(programFiles, 'Docker', 'Docker', 'resources', 'bin'));
 

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -178,6 +178,15 @@ function getNpmCliJsPaths(): string[] {
     cliJsPaths.push(
       path.join('D:', 'Program Files', 'nodejs', 'node_global', 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js')
     );
+
+    // nvm4w (Node Version Manager for Windows)
+    // Default: C:\nvm4w\nodejs, but support all drive letters
+    const drives = ['C', 'D', 'E', 'F', 'G', 'H'];
+    for (const drive of drives) {
+      cliJsPaths.push(
+        path.join(drive + ':', 'nvm4w', 'nodejs', 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js')
+      );
+    }
   } else {
     // Unix/macOS npm global paths
     cliJsPaths.push(


### PR DESCRIPTION
## Summary
- Add nvm4w paths to `getExtraBinaryPaths()` in `env.ts`
- Add nvm4w paths to `getNpmCliJsPaths()` in `path.ts`
- Supports C-H drive letters for flexibility

## Problem
Users who installed Node.js via nvm4w (Node Version Manager for Windows) could not use the plugin because:
1. The CLI path `C:\nvm4w\nodejs\node_modules\@anthropic-ai\claude-code\cli.js` was not auto-detected
2. The PATH environment variable did not include `C:\nvm4w\nodejs`, causing `spawn node ENOENT` errors

## Solution
Added nvm4w installation paths to both the PATH search and CLI auto-detection logic.

## Changes
- `src/utils/env.ts`: Added nvm4w nodejs path to getExtraBinaryPaths()
- `src/utils/path.ts`: Added nvm4w cli.js path to getNpmCliJsPaths()