### PR TITLE
fix: use full vault path for @-mentioned files

### DIFF
--- a/src/shared/mention/MentionDropdownController.ts
+++ b/src/shared/mention/MentionDropdownController.ts
@@ -463,14 +463,15 @@ export class MentionDropdownController {
       this.inputEl.selectionStart = this.inputEl.selectionEnd = beforeAt.length + replacement.length;
     } else {
       const file = selectedItem.file;
-      if (file) {
-        const normalizedPath = this.callbacks.normalizePathForVault(file.path);
-        if (normalizedPath) {
-          this.callbacks.onAttachFile(normalizedPath);
-        }
-      } else if (selectedItem.path) {
-        const normalizedPath = this.callbacks.normalizePathForVault(selectedItem.path);
-        if (normalizedPath) {
+      const rawPath = file?.path ?? selectedItem.path;
+      const normalizedPath = this.callbacks.normalizePathForVault(rawPath);
+
+      if (normalizedPath) {
+        // Use display name (@filename) but map to full vault-relative path for transformation
+        const displayName = `@${selectedItem.name}`;
+        if (this.callbacks.onAttachContextFile) {
+          this.callbacks.onAttachContextFile(displayName, normalizedPath);
+        } else {
           this.callbacks.onAttachFile(normalizedPath);
         }
       }


### PR DESCRIPTION
## Summary
- When selecting vault files via `@`-mention, now maps display name (`@filename.md`) to full vault-relative path (`folder/file.md`)
- Claude's Read tool now succeeds on first attempt for nested files (no more glob fallback)

## Test plan
- [ ] Select a vault file in a subfolder via `@` mention
- [ ] Verify input still shows just `@filename.md`
- [ ] Verify Claude can Read the file on first attempt without glob

Fixes #80