### PR TITLE
fix: use full vault-relative path for @-mentioned files

### DIFF
--- a/src/features/chat/ui/file-context/state/FileContextState.ts
+++ b/src/features/chat/ui/file-context/state/FileContextState.ts
@@ -12,7 +12,7 @@ export class FileContextState {
   private sessionStarted = false;
   private mentionedMcpServers: Set<string> = new Set();
   private currentNoteSent = false;
-  /** Maps display name (e.g., "@folder/file.ts") to absolute path for context files. */
+  /** Maps display name to absolute path for external context files only. */
   private contextFileMap: Map<string, string> = new Map();
 
   getAttachedFiles(): Set<string> {
@@ -62,7 +62,7 @@ export class FileContextState {
     this.attachedFiles.add(path);
   }
 
-  /** Attach a context file with display name to absolute path mapping. */
+  /** Attach an external context file with display name to absolute path mapping. */
   attachContextFile(displayName: string, absolutePath: string): void {
     this.attachedFiles.add(absolutePath);
     this.contextFileMap.set(displayName, absolutePath);
@@ -77,11 +77,11 @@ export class FileContextState {
     this.contextFileMap.clear();
   }
 
-  /** Transform text by replacing context file display names with absolute paths. */
+  /** Transform text by replacing external context file display names with absolute paths. */
   transformContextMentions(text: string): string {
     let result = text;
     for (const [displayName, absolutePath] of this.contextFileMap) {
-      // Replace @folder/file.ts with absolute path
+      // Replace @contextFolder/file.ts with absolute path
       result = result.replace(new RegExp(escapeRegExp(displayName), 'g'), absolutePath);
     }
     return result;

--- a/src/shared/mention/MentionDropdownController.ts
+++ b/src/shared/mention/MentionDropdownController.ts
@@ -467,16 +467,12 @@ export class MentionDropdownController {
       const normalizedPath = this.callbacks.normalizePathForVault(rawPath);
 
       if (normalizedPath) {
-        // Use display name (@filename) but map to full vault-relative path for transformation
-        const displayName = `@${selectedItem.name}`;
-        if (this.callbacks.onAttachContextFile) {
-          this.callbacks.onAttachContextFile(displayName, normalizedPath);
-        } else {
-          this.callbacks.onAttachFile(normalizedPath);
-        }
+        // Use full vault-relative path directly - no mapping needed
+        this.callbacks.onAttachFile(normalizedPath);
       }
 
-      const replacement = `@${selectedItem.name} `;
+      // Insert full path so what user sees is what Claude gets
+      const replacement = `@${normalizedPath ?? selectedItem.name} `;
       this.inputEl.value = beforeAt + replacement + afterCursor;
       this.inputEl.selectionStart = this.inputEl.selectionEnd = beforeAt.length + replacement.length;
     }

--- a/tests/unit/features/chat/ui/FileContextManager.test.ts
+++ b/tests/unit/features/chat/ui/FileContextManager.test.ts
@@ -338,7 +338,7 @@ describe('FileContextManager', () => {
     manager.destroy();
   });
 
-  it('shows vault-relative path in @ dropdown and inserts filename on selection', () => {
+  it('shows vault-relative path in @ dropdown and inserts full path on selection', () => {
     const app = createMockApp({
       files: ['clipping/file.md'],
     });
@@ -359,7 +359,8 @@ describe('FileContextManager', () => {
 
     manager.handleMentionKeydown({ key: 'Enter', preventDefault: jest.fn() } as any);
 
-    expect(inputEl.value).toBe('@file.md ');
+    // Now inserts full vault-relative path (WYSIWYG)
+    expect(inputEl.value).toBe('@clipping/file.md ');
     const attached = (manager as any).state.getAttachedFiles();
     expect(attached.has('clipping/file.md')).toBe(true);
 


### PR DESCRIPTION
## Summary
- Vault file mentions now insert full path (`@folder/file.md`) instead of just filename
- Eliminates stale mapping bugs when files are renamed or user edits the mention text
- External context files unchanged (still map display name to absolute path)

## Context
Follow-up to #81 based on [Codex review feedback](https://github.com/YishenTu/claudian/pull/81#discussion_r2679416087) about `contextFileMap` getting out of sync on vault renames.

This fix takes a simpler approach: don't use mapping for vault files at all. What user sees is what Claude gets (WYSIWYG).

## Test plan
- [x] Select a vault file in a subfolder via `@` mention
- [x] Verify input shows full path `@folder/file.md`
- [x] Verify Claude can Read the file directly
- [x] All tests pass