### PR TITLE
fix: add isComposing checks for IME keyboard support

### DIFF
--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -483,7 +483,8 @@ export class ClaudianView extends ItemView {
     });
 
     this.registerDomEvent(document, 'keydown', (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && this.state.isStreaming) {
+      // Check !e.isComposing for IME support (Chinese, Japanese, Korean, etc.)
+      if (e.key === 'Escape' && !e.isComposing && this.state.isStreaming) {
         e.preventDefault();
         this.inputController?.cancelStreaming();
       }
@@ -530,7 +531,8 @@ export class ClaudianView extends ItemView {
         return;
       }
 
-      if (e.key === 'Escape' && this.state.isStreaming) {
+      // Check !e.isComposing for IME support (Chinese, Japanese, Korean, etc.)
+      if (e.key === 'Escape' && !e.isComposing && this.state.isStreaming) {
         e.preventDefault();
         this.inputController?.cancelStreaming();
         return;

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -427,9 +427,10 @@ export class ConversationController {
 
     input.addEventListener('blur', finishRename);
     input.addEventListener('keydown', async (e) => {
-      if (e.key === 'Enter') {
+      // Check !e.isComposing for IME support (Chinese, Japanese, Korean, etc.)
+      if (e.key === 'Enter' && !e.isComposing) {
         input.blur();
-      } else if (e.key === 'Escape') {
+      } else if (e.key === 'Escape' && !e.isComposing) {
         input.value = currentTitle;
         input.blur();
       }

--- a/src/features/chat/controllers/NavigationController.ts
+++ b/src/features/chat/controllers/NavigationController.ts
@@ -149,6 +149,9 @@ export class NavigationController {
   private handleInputKeydown(e: KeyboardEvent): void {
     if (e.key !== 'Escape') return;
 
+    // Ignore if composing (IME support for Chinese, Japanese, Korean, etc.)
+    if (e.isComposing) return;
+
     // If streaming, let existing handler interrupt (don't interfere)
     if (this.deps.isStreaming()) {
       return;

--- a/src/features/chat/ui/InstructionModeManager.ts
+++ b/src/features/chat/ui/InstructionModeManager.ts
@@ -93,7 +93,8 @@ export class InstructionModeManager {
   handleKeydown(e: KeyboardEvent): boolean {
     if (!this.state.active) return false;
 
-    if (e.key === 'Enter' && !e.shiftKey) {
+    // Check !e.isComposing for IME support (Chinese, Japanese, Korean, etc.)
+    if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
       // Don't handle if instruction is empty
       if (!this.state.rawInstruction.trim()) {
         return false;
@@ -104,7 +105,8 @@ export class InstructionModeManager {
       return true;
     }
 
-    if (e.key === 'Escape') {
+    // Check !e.isComposing for IME support (Chinese, Japanese, Korean, etc.)
+    if (e.key === 'Escape' && !e.isComposing) {
       e.preventDefault();
       this.cancel();
       return true;

--- a/src/features/inline-edit/ui/InlineEditModal.ts
+++ b/src/features/inline-edit/ui/InlineEditModal.ts
@@ -339,9 +339,9 @@ class InlineEditController {
       this.attachSelectionListeners();
     }
 
-    // Escape handler
+    // Escape handler (check !e.isComposing for IME support)
     this.escHandler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
+      if (e.key === 'Escape' && !e.isComposing) {
         this.reject();
       }
     };

--- a/src/features/settings/ui/EnvSnippetManager.ts
+++ b/src/features/settings/ui/EnvSnippetManager.ts
@@ -36,11 +36,12 @@ export class EnvSnippetModal extends Modal {
     let envVarsEl: HTMLTextAreaElement;
 
     // Add keyboard shortcuts for name/description fields
+    // Check !e.isComposing for IME support (Chinese, Japanese, Korean, etc.)
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Enter') {
+      if (e.key === 'Enter' && !e.isComposing) {
         e.preventDefault();
         saveSnippet();
-      } else if (e.key === 'Escape') {
+      } else if (e.key === 'Escape' && !e.isComposing) {
         e.preventDefault();
         this.close();
       }

--- a/src/features/settings/ui/McpServerModal.ts
+++ b/src/features/settings/ui/McpServerModal.ts
@@ -251,10 +251,11 @@ export class McpServerModal extends Modal {
   }
 
   private handleKeyDown(e: KeyboardEvent) {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    // Check !e.isComposing for IME support (Chinese, Japanese, Korean, etc.)
+    if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
       e.preventDefault();
       this.save();
-    } else if (e.key === 'Escape') {
+    } else if (e.key === 'Escape' && !e.isComposing) {
       e.preventDefault();
       this.close();
     }

--- a/src/shared/modals/InstructionConfirmModal.ts
+++ b/src/shared/modals/InstructionConfirmModal.ts
@@ -94,7 +94,8 @@ export class InstructionModal extends Modal {
     this.responseTextarea.inputEl.placeholder = 'Provide more details...';
 
     this.responseTextarea.inputEl.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter' && !e.shiftKey && !this.isSubmitting) {
+      // Check !e.isComposing for IME support (Chinese, Japanese, Korean, etc.)
+      if (e.key === 'Enter' && !e.shiftKey && !e.isComposing && !this.isSubmitting) {
         e.preventDefault();
         this.submitClarification();
       }


### PR DESCRIPTION
## Summary
- Adds `isComposing` checks to ESC and Enter keyboard handlers to fix conflicts with Chinese/Japanese/Korean input methods
- When composing characters (e.g., selecting from pinyin candidates), ESC/Enter should only affect the IME, not trigger app actions like aborting streaming or submitting forms

## Files Changed
- `ClaudianView.ts` - Document-level and input area ESC handlers
- `NavigationController.ts` - Input blur ESC handler
- `InstructionModeManager.ts` - Enter/ESC for instruction mode
- `InlineEditModal.ts` - ESC during input phase
- `ConversationController.ts` - Title editing Enter/ESC
- `EnvSnippetManager.ts` - Modal Enter/ESC
- `McpServerModal.ts` - Modal Enter/ESC
- `InstructionConfirmModal.ts` - Submit clarification Enter

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [x] `npm run test` - all 2022 tests pass
- [ ] Manual test with Chinese IME: ESC during pinyin composition should cancel the composition, not abort Claude streaming
- [ ] Manual test with Chinese IME: Enter during pinyin composition should select character, not submit message

Closes #84