### PR TITLE
fix: enable dynamic permission mode switching without restart

### DIFF
--- a/src/core/agent/ClaudianService.ts
+++ b/src/core/agent/ClaudianService.ts
@@ -946,26 +946,13 @@ export class ClaudianService {
       }
     }
 
-    // Update permission mode if changed (except YOLO toggle which requires restart)
-    // Note: Switching from normal to YOLO requires restart (allowDangerouslySkipPermissions)
-    // Switching from YOLO to normal can use setPermissionMode
+    // Update permission mode if changed
+    // Since we always start with allowDangerouslySkipPermissions: true,
+    // we can dynamically switch between modes without restarting
     if (this.currentConfig && permissionMode !== this.currentConfig.permissionMode) {
-      if (permissionMode === 'yolo' && this.currentConfig.permissionMode !== 'yolo') {
-        // Switching TO YOLO requires restart
-        if (!allowRestart) {
-          return;
-        }
-        await this.restartPersistentQuery('permission mode change to YOLO', restartOptions);
-        if (allowRestart && this.persistentQuery) {
-          await this.applyDynamicUpdates(queryOptions, restartOptions, false);
-        }
-        return;
-      } else if (permissionMode !== 'yolo') {
-        // Can update via setPermissionMode (normal mode uses 'default')
-        await this.persistentQuery.setPermissionMode('default');
-        this.currentConfig.permissionMode = permissionMode;
-        this.currentConfig.allowDangerouslySkip = false;
-      }
+      const sdkMode = permissionMode === 'yolo' ? 'bypassPermissions' : 'default';
+      await this.persistentQuery.setPermissionMode(sdkMode);
+      this.currentConfig.permissionMode = permissionMode;
     }
 
     // Update MCP servers if changed

--- a/src/core/agent/types.ts
+++ b/src/core/agent/types.ts
@@ -142,7 +142,6 @@ export interface PersistentQueryConfig {
   model: string | null;
   thinkingTokens: number | null;
   permissionMode: PermissionMode | null;
-  allowDangerouslySkip: boolean;
   systemPromptKey: string;
   disallowedToolsKey: string;
   mcpServersKey: string;

--- a/tests/integration/core/agent/ClaudianService.test.ts
+++ b/tests/integration/core/agent/ClaudianService.test.ts
@@ -2437,6 +2437,25 @@ describe('ClaudianService', () => {
       expect(response?.setPermissionMode).toHaveBeenCalledWith('default');
     });
 
+    it('updates permission mode via setPermissionMode when going from normal to YOLO', async () => {
+      // Start in normal mode
+      mockPlugin.settings.permissionMode = 'normal';
+      service = new ClaudianService(mockPlugin, createMockMcpManager());
+
+      const chunks1: any[] = [];
+      for await (const c of service.query('first')) chunks1.push(c);
+
+      // Switch to YOLO mode
+      mockPlugin.settings.permissionMode = 'yolo';
+
+      const chunks2: any[] = [];
+      for await (const c of service.query('second')) chunks2.push(c);
+
+      const response = getLastResponse();
+      // Should call setPermissionMode for normal -> YOLO transition (no restart needed)
+      expect(response?.setPermissionMode).toHaveBeenCalledWith('bypassPermissions');
+    });
+
     it('updates MCP servers on the active persistent query', async () => {
       const chunks1: any[] = [];
       for await (const c of service.query('first', undefined, undefined, {

--- a/tests/unit/core/agent/QueryOptionsBuilder.test.ts
+++ b/tests/unit/core/agent/QueryOptionsBuilder.test.ts
@@ -86,7 +86,6 @@ describe('QueryOptionsBuilder', () => {
         model: 'claude-sonnet-4-5',
         thinkingTokens: null,
         permissionMode: 'yolo',
-        allowDangerouslySkip: true,
         systemPromptKey: 'key1',
         disallowedToolsKey: '',
         mcpServersKey: '',
@@ -105,7 +104,6 @@ describe('QueryOptionsBuilder', () => {
         model: 'claude-sonnet-4-5',
         thinkingTokens: null,
         permissionMode: 'yolo',
-        allowDangerouslySkip: true,
         systemPromptKey: 'key1',
         disallowedToolsKey: '',
         mcpServersKey: '',
@@ -124,7 +122,6 @@ describe('QueryOptionsBuilder', () => {
         model: 'claude-sonnet-4-5',
         thinkingTokens: null,
         permissionMode: 'yolo',
-        allowDangerouslySkip: true,
         systemPromptKey: 'key1',
         disallowedToolsKey: '',
         mcpServersKey: '',
@@ -144,7 +141,6 @@ describe('QueryOptionsBuilder', () => {
         model: 'claude-sonnet-4-5',
         thinkingTokens: null,
         permissionMode: 'yolo',
-        allowDangerouslySkip: true,
         systemPromptKey: 'key1',
         disallowedToolsKey: '',
         mcpServersKey: '',
@@ -164,7 +160,6 @@ describe('QueryOptionsBuilder', () => {
         model: 'claude-sonnet-4-5',
         thinkingTokens: null,
         permissionMode: 'yolo',
-        allowDangerouslySkip: true,
         systemPromptKey: 'key1',
         disallowedToolsKey: '',
         mcpServersKey: '',
@@ -184,7 +179,6 @@ describe('QueryOptionsBuilder', () => {
         model: 'claude-sonnet-4-5',
         thinkingTokens: null,
         permissionMode: 'yolo',
-        allowDangerouslySkip: true,
         systemPromptKey: 'key1',
         disallowedToolsKey: '',
         mcpServersKey: '',
@@ -204,7 +198,6 @@ describe('QueryOptionsBuilder', () => {
         model: 'claude-sonnet-4-5',
         thinkingTokens: null,
         permissionMode: 'yolo',
-        allowDangerouslySkip: true,
         systemPromptKey: 'key1',
         disallowedToolsKey: '',
         mcpServersKey: '',
@@ -224,7 +217,6 @@ describe('QueryOptionsBuilder', () => {
         model: 'claude-sonnet-4-5',
         thinkingTokens: null,
         permissionMode: 'yolo',
-        allowDangerouslySkip: true,
         systemPromptKey: 'key1',
         disallowedToolsKey: '',
         mcpServersKey: '',
@@ -244,7 +236,6 @@ describe('QueryOptionsBuilder', () => {
         model: 'claude-sonnet-4-5',
         thinkingTokens: null,
         permissionMode: 'yolo',
-        allowDangerouslySkip: true,
         systemPromptKey: 'key1',
         disallowedToolsKey: '',
         mcpServersKey: '',
@@ -268,7 +259,6 @@ describe('QueryOptionsBuilder', () => {
       expect(config.model).toBe('claude-sonnet-4-5');
       expect(config.thinkingTokens).toBeNull();
       expect(config.permissionMode).toBe('yolo');
-      expect(config.allowDangerouslySkip).toBe(true);
       expect(config.settingSources).toBe('project');
       expect(config.claudeCliPath).toBe('/mock/claude');
     });
@@ -318,6 +308,8 @@ describe('QueryOptionsBuilder', () => {
       const options = QueryOptionsBuilder.buildPersistentQueryOptions(ctx);
 
       expect(options.permissionMode).toBe('default');
+      // Always true to enable dynamic switching to bypassPermissions without restart
+      expect(options.allowDangerouslySkipPermissions).toBe(true);
       expect(options.canUseTool).toBe(canUseTool);
     });
 


### PR DESCRIPTION
## Summary
- Enable bidirectional permission mode switching (safe↔yolo) without process restart
- Always set `allowDangerouslySkipPermissions: true` at init to enable dynamic switching via `setPermissionMode()`
- Remove unused `allowDangerouslySkip` field from `PersistentQueryConfig`

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] Unit tests pass (1999 tests)
- [x] Integration tests pass (253 tests)
- [x] Added new integration test for normal→YOLO transition
- [ ] Manual test: toggle permission mode in sidebar while streaming