### PR TITLE
fix: add settingSources to inline edit and instruction refine services

### DIFF
--- a/src/features/chat/services/InstructionRefineService.ts
+++ b/src/features/chat/services/InstructionRefineService.ts
@@ -97,6 +97,9 @@ export class InstructionRefineService {
       tools: [], // No tools needed for instruction refinement
       permissionMode: 'bypassPermissions',
       allowDangerouslySkipPermissions: true,
+      settingSources: this.plugin.settings.loadUserClaudeSettings
+        ? ['user', 'project']
+        : ['project'],
     };
 
     if (this.sessionId) {

--- a/src/features/inline-edit/InlineEditService.ts
+++ b/src/features/inline-edit/InlineEditService.ts
@@ -120,6 +120,9 @@ export class InlineEditService {
       tools: [...READ_ONLY_TOOLS], // Only read-only tools needed
       permissionMode: 'bypassPermissions',
       allowDangerouslySkipPermissions: true,
+      settingSources: this.plugin.settings.loadUserClaudeSettings
+        ? ['user', 'project']
+        : ['project'],
       hooks: {
         PreToolUse: [
           this.createReadOnlyHook(),


### PR DESCRIPTION
## Summary
- Add `settingSources` option to `InlineEditService` and `InstructionRefineService`
- Respects `loadUserClaudeSettings` setting to load `~/.claude/settings.json` where API keys may be configured
- Fixes exit code 1 errors when using inline edit or `#` instruction mode

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] All 2328 tests pass
- [x] Build succeeds
- [ ] Manual test: Enable "Load User Claude Settings", use inline edit with API key in `~/.claude/settings.json`
- [ ] Manual test: Use `#` instruction mode with same setup

Fixes #72