### PR TITLE
Reset auto-scroll when switching conversations

### DIFF
--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -117,6 +117,7 @@ export class ConversationController {
       state.clearMessages();
       state.usage = null;
       state.currentTodos = null;
+      state.autoScrollEnabled = true;
 
       // Reset agent service session (no session ID for entry point)
       // Pass persistent paths to prevent stale external contexts
@@ -174,6 +175,7 @@ export class ConversationController {
       state.clearMessages();
       state.usage = null;
       state.currentTodos = null;
+      state.autoScrollEnabled = true;
 
       // Pass persistent paths to prevent stale external contexts
       this.getAgentService()?.setSessionId(
@@ -207,6 +209,7 @@ export class ConversationController {
     state.currentConversationId = conversation.id;
     state.messages = [...conversation.messages];
     state.usage = conversation.usage ?? null;
+    state.autoScrollEnabled = true;
 
     const hasMessages = state.messages.length > 0;
 
@@ -278,6 +281,7 @@ export class ConversationController {
       state.currentConversationId = conversation.id;
       state.messages = [...conversation.messages];
       state.usage = conversation.usage ?? null;
+      state.autoScrollEnabled = true;
 
       const hasMessages = state.messages.length > 0;
 

--- a/src/features/chat/state/ChatState.ts
+++ b/src/features/chat/state/ChatState.ts
@@ -363,6 +363,7 @@ export class ChatState {
     this.state.queuedMessage = null;
     this.usage = null;
     this.currentTodos = null;
+    this.autoScrollEnabled = true;
   }
 
   /** Gets messages for persistence. */


### PR DESCRIPTION
This resets auto-scroll to enabled when starting, loading, or switching conversations. It also ensures new conversation resets re-enable auto-scroll.