### PR TITLE
fix: use CSS variables for scroll-to-bottom button colors

### DIFF
--- a/src/style/components/scroll-to-bottom.css
+++ b/src/style/components/scroll-to-bottom.css
@@ -11,7 +11,7 @@
   align-items: center;
   justify-content: center;
   gap: 6px;
-  background: rgba(0, 0, 0, 0.85) !important;
+  background: var(--background-secondary) !important;
   border: 1px solid var(--background-modifier-border) !important;
   border-radius: 6px;
   cursor: pointer;
@@ -30,7 +30,7 @@
 }
 
 .claudian-scroll-to-bottom:hover {
-  background: rgba(0, 0, 0, 0.95) !important;
+  background: var(--background-modifier-hover) !important;
   color: var(--text-normal);
   border-color: var(--background-modifier-border-hover) !important;
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded `rgba(0, 0, 0, 0.85)` background with `var(--background-secondary)`
- Replace hardcoded `rgba(0, 0, 0, 0.95)` hover background with `var(--background-modifier-hover)`
- Button now adapts properly to both light and dark themes

## Test plan
- [ ] Toggle between light and dark themes in Obsidian
- [ ] Verify scroll-to-bottom button is visible and readable in both modes
- [ ] Verify hover state works correctly in both modes