### PR TITLE
test: add comprehensive unit tests for chat features

### DIFF
--- a/tests/unit/features/chat/rendering/MessageRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/MessageRenderer.test.ts
@@ -1,7 +1,7 @@
 import { createMockEl } from '@test/helpers/mockElement';
 
-import { TOOL_AGENT_OUTPUT } from '@/core/tools/toolNames';
-import type { ChatMessage } from '@/core/types';
+import { TOOL_AGENT_OUTPUT, TOOL_TASK } from '@/core/tools/toolNames';
+import type { ChatMessage, ImageAttachment } from '@/core/types';
 import { MessageRenderer } from '@/features/chat/rendering/MessageRenderer';
 import { renderStoredAsyncSubagent, renderStoredSubagent } from '@/features/chat/rendering/SubagentRenderer';
 import { renderStoredThinkingBlock } from '@/features/chat/rendering/ThinkingBlockRenderer';
@@ -32,7 +32,25 @@ function createMockComponent() {
   };
 }
 
+function createRenderer(messagesEl?: any) {
+  const el = messagesEl ?? createMockEl();
+  const comp = createMockComponent();
+  const plugin = {
+    app: {},
+    settings: { mediaFolder: '' },
+  };
+  return { renderer: new MessageRenderer(plugin as any, comp as any, el), messagesEl: el };
+}
+
 describe('MessageRenderer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ============================================
+  // renderMessages
+  // ============================================
+
   it('renders welcome element and calls renderStoredMessage for each message', () => {
     const messagesEl = createMockEl();
     const emptySpy = jest.spyOn(messagesEl, 'empty');
@@ -51,6 +69,20 @@ describe('MessageRenderer', () => {
     expect(welcomeEl.hasClass('claudian-welcome')).toBe(true);
     expect(welcomeEl.children[0].textContent).toBe('Hello');
   });
+
+  it('renders empty messages list with just welcome element', () => {
+    const { renderer } = createRenderer();
+    const renderStoredSpy = jest.spyOn(renderer, 'renderStoredMessage').mockImplementation(() => {});
+
+    const welcomeEl = renderer.renderMessages([], () => 'Welcome!');
+
+    expect(renderStoredSpy).not.toHaveBeenCalled();
+    expect(welcomeEl.hasClass('claudian-welcome')).toBe(true);
+  });
+
+  // ============================================
+  // renderStoredMessage
+  // ============================================
 
   it('renders interrupt messages with interrupt styling instead of user bubble', () => {
     const messagesEl = createMockEl();
@@ -77,6 +109,111 @@ describe('MessageRenderer', () => {
     expect(textEl.innerHTML).toContain('claudian-interrupted');
     expect(textEl.innerHTML).toContain('Interrupted');
   });
+
+  it('skips rebuilt context messages', () => {
+    const messagesEl = createMockEl();
+    const { renderer } = createRenderer(messagesEl);
+
+    const msg: ChatMessage = {
+      id: 'rebuilt-1',
+      role: 'user',
+      content: 'rebuilt context',
+      timestamp: Date.now(),
+      isRebuiltContext: true,
+    };
+
+    renderer.renderStoredMessage(msg);
+
+    expect(messagesEl.children.length).toBe(0);
+  });
+
+  it('renders user message with text content', () => {
+    const messagesEl = createMockEl();
+    const { renderer } = createRenderer(messagesEl);
+    jest.spyOn(renderer, 'renderContent').mockResolvedValue(undefined);
+
+    const msg: ChatMessage = {
+      id: 'u1',
+      role: 'user',
+      content: 'Hello world',
+      timestamp: Date.now(),
+    };
+
+    renderer.renderStoredMessage(msg);
+
+    expect(messagesEl.children.length).toBe(1);
+    const msgEl = messagesEl.children[0];
+    expect(msgEl.hasClass('claudian-message-user')).toBe(true);
+  });
+
+  it('renders user message with displayContent instead of content', () => {
+    const messagesEl = createMockEl();
+    const { renderer } = createRenderer(messagesEl);
+    const renderContentSpy = jest.spyOn(renderer, 'renderContent').mockResolvedValue(undefined);
+
+    const msg: ChatMessage = {
+      id: 'u1',
+      role: 'user',
+      content: 'full prompt with context',
+      displayContent: 'user input only',
+      timestamp: Date.now(),
+    };
+
+    renderer.renderStoredMessage(msg);
+
+    expect(renderContentSpy).toHaveBeenCalledWith(expect.anything(), 'user input only');
+  });
+
+  it('skips empty user message bubble (image-only)', () => {
+    const messagesEl = createMockEl();
+    const { renderer } = createRenderer(messagesEl);
+    jest.spyOn(renderer, 'renderMessageImages').mockImplementation(() => {});
+
+    const msg: ChatMessage = {
+      id: 'u1',
+      role: 'user',
+      content: '',
+      timestamp: Date.now(),
+      images: [{ id: 'img-1', name: 'img.png', mediaType: 'image/png', data: 'abc', size: 100, source: 'paste' as const }],
+    };
+
+    renderer.renderStoredMessage(msg);
+
+    // Images should still be rendered, but no message bubble
+    expect(renderer.renderMessageImages).toHaveBeenCalled();
+    // Only the images container, no message bubble
+    const bubbles = messagesEl.children.filter(
+      (c: any) => c.hasClass('claudian-message')
+    );
+    expect(bubbles.length).toBe(0);
+  });
+
+  it('renders user message with images above bubble', () => {
+    const messagesEl = createMockEl();
+    const { renderer } = createRenderer(messagesEl);
+    jest.spyOn(renderer, 'renderContent').mockResolvedValue(undefined);
+    const renderImagesSpy = jest.spyOn(renderer, 'renderMessageImages').mockImplementation(() => {});
+
+    const images: ImageAttachment[] = [
+      { id: 'img-1', name: 'photo.png', mediaType: 'image/png', data: 'base64data', size: 200, source: 'file' },
+    ];
+
+    const msg: ChatMessage = {
+      id: 'u1',
+      role: 'user',
+      content: 'Check this image',
+      timestamp: Date.now(),
+      images,
+    };
+
+    renderer.renderStoredMessage(msg);
+
+    expect(renderImagesSpy).toHaveBeenCalledWith(messagesEl, images);
+  });
+
+  // ============================================
+  // renderAssistantContent
+  // ============================================
 
   it('renders assistant content blocks using specialized renderers', () => {
     const messagesEl = createMockEl();
@@ -120,12 +257,181 @@ describe('MessageRenderer', () => {
     expect(renderStoredSubagent).toHaveBeenCalled();
   });
 
+  it('skips empty or whitespace-only text blocks', () => {
+    const messagesEl = createMockEl();
+    const { renderer } = createRenderer(messagesEl);
+    const renderContentSpy = jest.spyOn(renderer, 'renderContent').mockResolvedValue(undefined);
+
+    const msg: ChatMessage = {
+      id: 'm1',
+      role: 'assistant',
+      content: '',
+      timestamp: Date.now(),
+      contentBlocks: [
+        { type: 'text', content: '' } as any,
+        { type: 'text', content: '   ' } as any,
+        { type: 'text', content: 'Real content' } as any,
+      ],
+    };
+
+    renderer.renderStoredMessage(msg);
+
+    // Only the non-empty text block should trigger renderContent
+    expect(renderContentSpy).toHaveBeenCalledTimes(1);
+    expect(renderContentSpy).toHaveBeenCalledWith(expect.anything(), 'Real content');
+  });
+
+  it('renders response duration footer when durationSeconds is present', () => {
+    const messagesEl = createMockEl();
+    const { renderer } = createRenderer(messagesEl);
+    jest.spyOn(renderer, 'renderContent').mockResolvedValue(undefined);
+
+    const msg: ChatMessage = {
+      id: 'm1',
+      role: 'assistant',
+      content: '',
+      timestamp: Date.now(),
+      contentBlocks: [
+        { type: 'text', content: 'Response text' } as any,
+      ],
+      durationSeconds: 65,
+      durationFlavorWord: 'Baked',
+    };
+
+    renderer.renderStoredMessage(msg);
+
+    // Find the footer element
+    const msgEl = messagesEl.children[0];
+    const contentEl = msgEl.children[0]; // claudian-message-content
+    const footerEl = contentEl.children.find((c: any) => c.hasClass('claudian-response-footer'));
+    expect(footerEl).toBeDefined();
+    const durationSpan = footerEl!.children[0];
+    expect(durationSpan.textContent).toContain('Baked');
+    expect(durationSpan.textContent).toContain('1m 5s');
+  });
+
+  it('does not render footer when durationSeconds is 0', () => {
+    const messagesEl = createMockEl();
+    const { renderer } = createRenderer(messagesEl);
+    jest.spyOn(renderer, 'renderContent').mockResolvedValue(undefined);
+
+    const msg: ChatMessage = {
+      id: 'm1',
+      role: 'assistant',
+      content: '',
+      timestamp: Date.now(),
+      contentBlocks: [
+        { type: 'text', content: 'Response' } as any,
+      ],
+      durationSeconds: 0,
+    };
+
+    renderer.renderStoredMessage(msg);
+
+    const msgEl = messagesEl.children[0];
+    const contentEl = msgEl.children[0];
+    const footerEl = contentEl.children.find((c: any) => c.hasClass('claudian-response-footer'));
+    expect(footerEl).toBeUndefined();
+  });
+
+  it('uses default flavor word "Baked" when durationFlavorWord is not set', () => {
+    const messagesEl = createMockEl();
+    const { renderer } = createRenderer(messagesEl);
+    jest.spyOn(renderer, 'renderContent').mockResolvedValue(undefined);
+
+    const msg: ChatMessage = {
+      id: 'm1',
+      role: 'assistant',
+      content: '',
+      timestamp: Date.now(),
+      contentBlocks: [
+        { type: 'text', content: 'Response' } as any,
+      ],
+      durationSeconds: 30,
+    };
+
+    renderer.renderStoredMessage(msg);
+
+    const msgEl = messagesEl.children[0];
+    const contentEl = msgEl.children[0];
+    const footerEl = contentEl.children.find((c: any) => c.hasClass('claudian-response-footer'));
+    expect(footerEl).toBeDefined();
+    expect(footerEl!.children[0].textContent).toContain('Baked');
+  });
+
+  it('renders fallback content for old conversations without contentBlocks', () => {
+    const messagesEl = createMockEl();
+    const { renderer } = createRenderer(messagesEl);
+    const renderContentSpy = jest.spyOn(renderer, 'renderContent').mockResolvedValue(undefined);
+    const addCopySpy = jest.spyOn(renderer, 'addTextCopyButton').mockImplementation(() => {});
+
+    const msg: ChatMessage = {
+      id: 'm1',
+      role: 'assistant',
+      content: 'Legacy response text',
+      timestamp: Date.now(),
+      toolCalls: [
+        { id: 'read-1', name: 'Read', input: { file_path: 'test.md' }, status: 'completed' } as any,
+      ],
+    };
+
+    renderer.renderStoredMessage(msg);
+
+    // Should render content text
+    expect(renderContentSpy).toHaveBeenCalledWith(expect.anything(), 'Legacy response text');
+    // Should add copy button for fallback text
+    expect(addCopySpy).toHaveBeenCalledWith(expect.anything(), 'Legacy response text');
+    // Should render tool call
+    expect(renderStoredToolCall).toHaveBeenCalled();
+  });
+
+  it('renders Task tool calls as subagents for backward compatibility', () => {
+    const messagesEl = createMockEl();
+    const { renderer } = createRenderer(messagesEl);
+
+    (renderStoredSubagent as jest.Mock).mockClear();
+
+    const msg: ChatMessage = {
+      id: 'm1',
+      role: 'assistant',
+      content: '',
+      timestamp: Date.now(),
+      toolCalls: [
+        {
+          id: 'task-1',
+          name: TOOL_TASK,
+          input: { description: 'Run tests' },
+          status: 'completed',
+          result: 'All passed',
+        } as any,
+      ],
+      contentBlocks: [
+        { type: 'tool_use', toolId: 'task-1' } as any,
+      ],
+    };
+
+    renderer.renderStoredMessage(msg);
+
+    expect(renderStoredSubagent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        id: 'task-1',
+        description: 'Run tests',
+        status: 'completed',
+        result: 'All passed',
+      })
+    );
+  });
+
+  // ============================================
+  // TaskOutput skipping
+  // ============================================
+
   it('should skip TaskOutput tool calls (internal async subagent communication)', () => {
     const messagesEl = createMockEl();
     const mockComponent = createMockComponent();
     const renderer = new MessageRenderer({} as any, mockComponent as any, messagesEl);
 
-    // Clear any previous calls
     (renderStoredToolCall as jest.Mock).mockClear();
 
     const msg: ChatMessage = {
@@ -143,7 +449,6 @@ describe('MessageRenderer', () => {
 
     renderer.renderStoredMessage(msg);
 
-    // renderStoredToolCall should NOT be called for TaskOutput
     expect(renderStoredToolCall).not.toHaveBeenCalled();
   });
 
@@ -152,7 +457,6 @@ describe('MessageRenderer', () => {
     const mockComponent = createMockComponent();
     const renderer = new MessageRenderer({} as any, mockComponent as any, messagesEl);
 
-    // Clear any previous calls
     (renderStoredToolCall as jest.Mock).mockClear();
 
     const msg: ChatMessage = {
@@ -174,7 +478,6 @@ describe('MessageRenderer', () => {
 
     renderer.renderStoredMessage(msg);
 
-    // renderStoredToolCall should be called twice (Read and Grep), but not for TaskOutput
     expect(renderStoredToolCall).toHaveBeenCalledTimes(2);
     expect(renderStoredToolCall).toHaveBeenCalledWith(
       expect.anything(),
@@ -184,5 +487,232 @@ describe('MessageRenderer', () => {
       expect.anything(),
       expect.objectContaining({ id: 'grep-1', name: 'Grep' })
     );
+  });
+
+  // ============================================
+  // addMessage (streaming)
+  // ============================================
+
+  it('addMessage creates user message bubble with text', () => {
+    const messagesEl = createMockEl();
+    const { renderer } = createRenderer(messagesEl);
+    jest.spyOn(renderer, 'renderContent').mockResolvedValue(undefined);
+
+    const msg: ChatMessage = {
+      id: 'u1',
+      role: 'user',
+      content: 'Hello',
+      timestamp: Date.now(),
+    };
+
+    const msgEl = renderer.addMessage(msg);
+
+    expect(msgEl.hasClass('claudian-message-user')).toBe(true);
+  });
+
+  it('addMessage renders images for user messages', () => {
+    const messagesEl = createMockEl();
+    const { renderer } = createRenderer(messagesEl);
+    jest.spyOn(renderer, 'renderContent').mockResolvedValue(undefined);
+    const renderImagesSpy = jest.spyOn(renderer, 'renderMessageImages').mockImplementation(() => {});
+
+    const images: ImageAttachment[] = [
+      { id: 'img-1', name: 'photo.png', mediaType: 'image/png', data: 'base64data', size: 200, source: 'file' },
+    ];
+
+    const msg: ChatMessage = {
+      id: 'u1',
+      role: 'user',
+      content: 'Look at this',
+      timestamp: Date.now(),
+      images,
+    };
+
+    renderer.addMessage(msg);
+
+    expect(renderImagesSpy).toHaveBeenCalledWith(messagesEl, images);
+  });
+
+  it('addMessage skips empty bubble for image-only user messages', () => {
+    const messagesEl = createMockEl();
+    const { renderer } = createRenderer(messagesEl);
+    jest.spyOn(renderer, 'renderMessageImages').mockImplementation(() => {});
+    const scrollSpy = jest.spyOn(renderer, 'scrollToBottom').mockImplementation(() => {});
+
+    const msg: ChatMessage = {
+      id: 'u1',
+      role: 'user',
+      content: '',
+      timestamp: Date.now(),
+      images: [{ id: 'img-1', name: 'img.png', mediaType: 'image/png', data: 'abc', size: 100, source: 'paste' as const }],
+    };
+
+    const result = renderer.addMessage(msg);
+
+    // Should still return an element (last child or messagesEl)
+    expect(result).toBeDefined();
+    expect(scrollSpy).toHaveBeenCalled();
+  });
+
+  it('addMessage creates assistant message element without user-specific rendering', () => {
+    const messagesEl = createMockEl();
+    const { renderer } = createRenderer(messagesEl);
+
+    const msg: ChatMessage = {
+      id: 'a1',
+      role: 'assistant',
+      content: '',
+      timestamp: Date.now(),
+    };
+
+    const msgEl = renderer.addMessage(msg);
+
+    expect(msgEl.hasClass('claudian-message-assistant')).toBe(true);
+  });
+
+  // ============================================
+  // setMessagesEl
+  // ============================================
+
+  it('setMessagesEl updates the container element', () => {
+    const messagesEl = createMockEl();
+    const { renderer } = createRenderer(messagesEl);
+    const newEl = createMockEl();
+
+    renderer.setMessagesEl(newEl);
+
+    // Verify by using scrollToBottom which references messagesEl
+    renderer.scrollToBottom();
+    // The new element should have been used (scrollTop set)
+    expect(newEl.scrollTop).toBe(newEl.scrollHeight);
+  });
+
+  // ============================================
+  // Image rendering
+  // ============================================
+
+  it('renderMessageImages creates image elements', () => {
+    const containerEl = createMockEl();
+    const { renderer } = createRenderer();
+    jest.spyOn(renderer, 'setImageSrc').mockImplementation(() => {});
+
+    const images: ImageAttachment[] = [
+      { id: 'img-1', name: 'photo.png', mediaType: 'image/png', data: 'base64data1', size: 200, source: 'file' },
+      { id: 'img-2', name: 'avatar.jpg', mediaType: 'image/jpeg', data: 'base64data2', size: 300, source: 'file' },
+    ];
+
+    renderer.renderMessageImages(containerEl, images);
+
+    // Should create images container with 2 image wrappers
+    expect(containerEl.children.length).toBe(1);
+    const imagesContainer = containerEl.children[0];
+    expect(imagesContainer.hasClass('claudian-message-images')).toBe(true);
+    expect(imagesContainer.children.length).toBe(2);
+  });
+
+  it('setImageSrc sets data URI on image element', () => {
+    const { renderer } = createRenderer();
+    const imgEl = createMockEl('img');
+
+    const image: ImageAttachment = {
+      id: 'img-1',
+      name: 'test.png',
+      mediaType: 'image/png',
+      data: 'abc123',
+      size: 100,
+      source: 'file',
+    };
+
+    renderer.setImageSrc(imgEl as any, image);
+
+    expect(imgEl.getAttribute('src')).toBe('data:image/png;base64,abc123');
+  });
+
+  it('showFullImage creates overlay with image', () => {
+    const { renderer } = createRenderer();
+    const image: ImageAttachment = {
+      id: 'img-1',
+      name: 'test.png',
+      mediaType: 'image/png',
+      data: 'abc123',
+      size: 100,
+      source: 'file',
+    };
+
+    // Mock document.body.createDiv (document may not exist in node env)
+    const overlayEl = createMockEl();
+    const mockBody = { createDiv: jest.fn().mockReturnValue(overlayEl) };
+    const origDocument = globalThis.document;
+    (globalThis as any).document = { body: mockBody, addEventListener: jest.fn(), removeEventListener: jest.fn() };
+
+    try {
+      renderer.showFullImage(image);
+      expect(mockBody.createDiv).toHaveBeenCalledWith({ cls: 'claudian-image-modal-overlay' });
+    } finally {
+      (globalThis as any).document = origDocument;
+    }
+  });
+
+  // ============================================
+  // Copy button
+  // ============================================
+
+  it('addTextCopyButton adds a copy button element', () => {
+    const textEl = createMockEl();
+    const { renderer } = createRenderer();
+
+    renderer.addTextCopyButton(textEl, 'some markdown');
+
+    expect(textEl.children.length).toBe(1);
+    const copyBtn = textEl.children[0];
+    expect(copyBtn.hasClass('claudian-text-copy-btn')).toBe(true);
+  });
+
+  // ============================================
+  // Scroll utilities
+  // ============================================
+
+  it('scrollToBottom sets scrollTop to scrollHeight', () => {
+    const messagesEl = createMockEl();
+    messagesEl.scrollHeight = 1000;
+    const { renderer } = createRenderer(messagesEl);
+
+    renderer.scrollToBottom();
+
+    expect(messagesEl.scrollTop).toBe(1000);
+  });
+
+  it('scrollToBottomIfNeeded scrolls when near bottom', () => {
+    const messagesEl = createMockEl();
+    messagesEl.scrollHeight = 1000;
+    messagesEl.scrollTop = 950;
+    Object.defineProperty(messagesEl, 'clientHeight', { value: 0, configurable: true });
+    const { renderer } = createRenderer(messagesEl);
+
+    // Mock requestAnimationFrame
+    const origRAF = globalThis.requestAnimationFrame;
+    (globalThis as any).requestAnimationFrame = (cb: () => void) => { cb(); return 0; };
+
+    try {
+      renderer.scrollToBottomIfNeeded();
+      // Near bottom (1000 - 950 - 0 = 50, < 100 threshold) → scrolls
+      expect(messagesEl.scrollTop).toBe(1000);
+    } finally {
+      (globalThis as any).requestAnimationFrame = origRAF;
+    }
+  });
+
+  it('scrollToBottomIfNeeded does not scroll when far from bottom', () => {
+    const messagesEl = createMockEl();
+    messagesEl.scrollHeight = 1000;
+    messagesEl.scrollTop = 100;
+    Object.defineProperty(messagesEl, 'clientHeight', { value: 0, configurable: true });
+    const { renderer } = createRenderer(messagesEl);
+
+    const originalScrollTop = messagesEl.scrollTop;
+    renderer.scrollToBottomIfNeeded();
+
+    // scrollTop should not change (900 > 100 threshold)
+    expect(messagesEl.scrollTop).toBe(originalScrollTop);
   });
 });

--- a/tests/unit/features/chat/rendering/SubagentRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/SubagentRenderer.test.ts
@@ -1,15 +1,18 @@
 import { createMockEl, type MockElement } from '@test/helpers/mockElement';
 import { setIcon } from 'obsidian';
 
-import type { SubagentInfo } from '@/core/types';
+import type { SubagentInfo, ToolCallInfo } from '@/core/types';
 import {
+  addSubagentToolCall,
   createAsyncSubagentBlock,
   createSubagentBlock,
   finalizeAsyncSubagent,
+  finalizeSubagentBlock,
   markAsyncSubagentOrphaned,
   renderStoredAsyncSubagent,
   renderStoredSubagent,
   updateAsyncSubagentRunning,
+  updateSubagentToolResult,
 } from '@/features/chat/rendering/SubagentRenderer';
 
 const getTextByClass = (el: MockElement, cls: string): string[] => {
@@ -478,5 +481,456 @@ describe('Async Subagent Renderer', () => {
       headerEl.click();
       expect((wrapperEl as any).hasClass('expanded')).toBe(false);
     });
+
+    it('renders error status correctly', () => {
+      const subagent: SubagentInfo = {
+        id: 'task-1',
+        description: 'Failed task',
+        status: 'error',
+        toolCalls: [],
+        isExpanded: false,
+        mode: 'async',
+        asyncStatus: 'error',
+      };
+
+      const wrapperEl = renderStoredAsyncSubagent(parentEl as any, subagent);
+
+      expect((wrapperEl as any).hasClass('error')).toBe(true);
+      const contentText = getTextByClass(wrapperEl as any, 'claudian-subagent-done-text')[0];
+      expect(contentText).toBe('ERROR');
+    });
+
+    it('renders orphaned status correctly', () => {
+      const subagent: SubagentInfo = {
+        id: 'task-1',
+        description: 'Lost task',
+        status: 'error',
+        toolCalls: [],
+        isExpanded: false,
+        mode: 'async',
+        asyncStatus: 'orphaned',
+      };
+
+      (setIcon as jest.Mock).mockClear();
+      const wrapperEl = renderStoredAsyncSubagent(parentEl as any, subagent);
+
+      expect((wrapperEl as any).hasClass('error')).toBe(true);
+      expect((wrapperEl as any).hasClass('orphaned')).toBe(true);
+      const contentText = getTextByClass(wrapperEl as any, 'claudian-subagent-done-text')[0];
+      expect(contentText).toContain('Task orphaned');
+      // Should use alert-circle icon
+      expect(setIcon).toHaveBeenCalledWith(expect.anything(), 'alert-circle');
+    });
+
+    it('renders running status with prompt', () => {
+      const subagent: SubagentInfo = {
+        id: 'task-1',
+        description: 'Running task',
+        status: 'running',
+        toolCalls: [],
+        isExpanded: false,
+        mode: 'async',
+        asyncStatus: 'running',
+        prompt: 'Do some work',
+      };
+
+      const wrapperEl = renderStoredAsyncSubagent(parentEl as any, subagent);
+
+      expect((wrapperEl as any).hasClass('running')).toBe(true);
+      const contentText = getTextByClass(wrapperEl as any, 'claudian-subagent-done-text')[0];
+      expect(contentText).toContain('Do some work');
+    });
+
+    it('renders pending status as running', () => {
+      const subagent: SubagentInfo = {
+        id: 'task-1',
+        description: 'Pending task',
+        status: 'running',
+        toolCalls: [],
+        isExpanded: false,
+        mode: 'async',
+        asyncStatus: 'pending',
+      };
+
+      const wrapperEl = renderStoredAsyncSubagent(parentEl as any, subagent);
+
+      // pending maps to running display status
+      expect((wrapperEl as any).hasClass('running')).toBe(true);
+    });
+  });
+});
+
+describe('addSubagentToolCall', () => {
+  let parentEl: MockElement;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    parentEl = createMockEl('div');
+  });
+
+  it('adds tool call to state and updates count', () => {
+    const state = createSubagentBlock(parentEl as any, 'task-1', { description: 'Test task' });
+
+    const toolCall: ToolCallInfo = {
+      id: 'tool-1',
+      name: 'Read',
+      input: { file_path: 'test.md' },
+      status: 'running',
+      isExpanded: false,
+    };
+
+    addSubagentToolCall(state, toolCall);
+
+    expect(state.info.toolCalls).toHaveLength(1);
+    expect(state.countEl.textContent).toBe('1 tool uses');
+  });
+
+  it('clears previous content and renders new tool item', () => {
+    const state = createSubagentBlock(parentEl as any, 'task-1', { description: 'Test task' });
+
+    const toolCall1: ToolCallInfo = {
+      id: 'tool-1',
+      name: 'Read',
+      input: { file_path: 'test.md' },
+      status: 'running',
+      isExpanded: false,
+    };
+    addSubagentToolCall(state, toolCall1);
+
+    const toolCall2: ToolCallInfo = {
+      id: 'tool-2',
+      name: 'Grep',
+      input: { pattern: 'test' },
+      status: 'running',
+      isExpanded: false,
+    };
+    addSubagentToolCall(state, toolCall2);
+
+    expect(state.info.toolCalls).toHaveLength(2);
+    expect(state.countEl.textContent).toBe('2 tool uses');
+    // currentResultEl should be cleared when new tool is added
+    expect(state.currentResultEl).toBeNull();
+  });
+
+  it('sets currentToolEl with tool id dataset', () => {
+    const state = createSubagentBlock(parentEl as any, 'task-1', { description: 'Test task' });
+
+    const toolCall: ToolCallInfo = {
+      id: 'tool-abc',
+      name: 'Read',
+      input: { file_path: 'test.md' },
+      status: 'running',
+      isExpanded: false,
+    };
+    addSubagentToolCall(state, toolCall);
+
+    expect(state.currentToolEl).not.toBeNull();
+    expect((state.currentToolEl as any).dataset.toolId).toBe('tool-abc');
+  });
+});
+
+describe('updateSubagentToolResult', () => {
+  let parentEl: MockElement;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    parentEl = createMockEl('div');
+  });
+
+  it('updates tool call status in state', () => {
+    const state = createSubagentBlock(parentEl as any, 'task-1', { description: 'Test task' });
+
+    const toolCall: ToolCallInfo = {
+      id: 'tool-1',
+      name: 'Read',
+      input: { file_path: 'test.md' },
+      status: 'running',
+      isExpanded: false,
+    };
+    addSubagentToolCall(state, toolCall);
+
+    const updatedToolCall: ToolCallInfo = {
+      ...toolCall,
+      status: 'completed',
+      result: 'File contents here',
+    };
+    updateSubagentToolResult(state, 'tool-1', updatedToolCall);
+
+    expect(state.info.toolCalls[0].status).toBe('completed');
+  });
+
+  it('creates result element when tool has result', () => {
+    const state = createSubagentBlock(parentEl as any, 'task-1', { description: 'Test task' });
+
+    const toolCall: ToolCallInfo = {
+      id: 'tool-1',
+      name: 'Read',
+      input: { file_path: 'test.md' },
+      status: 'running',
+      isExpanded: false,
+    };
+    addSubagentToolCall(state, toolCall);
+
+    const updatedToolCall: ToolCallInfo = {
+      ...toolCall,
+      status: 'completed',
+      result: 'File contents',
+    };
+    updateSubagentToolResult(state, 'tool-1', updatedToolCall);
+
+    expect(state.currentResultEl).not.toBeNull();
+  });
+
+  it('updates existing result element on subsequent calls', () => {
+    const state = createSubagentBlock(parentEl as any, 'task-1', { description: 'Test task' });
+
+    const toolCall: ToolCallInfo = {
+      id: 'tool-1',
+      name: 'Read',
+      input: { file_path: 'test.md' },
+      status: 'running',
+      isExpanded: false,
+    };
+    addSubagentToolCall(state, toolCall);
+
+    // First result
+    updateSubagentToolResult(state, 'tool-1', { ...toolCall, status: 'completed', result: 'First result' });
+    const firstResultEl = state.currentResultEl;
+
+    // Update result
+    updateSubagentToolResult(state, 'tool-1', { ...toolCall, status: 'completed', result: 'Updated result' });
+
+    // Should reuse the same result element
+    expect(state.currentResultEl).toBe(firstResultEl);
+  });
+
+  it('ignores update for non-matching tool ID', () => {
+    const state = createSubagentBlock(parentEl as any, 'task-1', { description: 'Test task' });
+
+    const toolCall: ToolCallInfo = {
+      id: 'tool-1',
+      name: 'Read',
+      input: { file_path: 'test.md' },
+      status: 'running',
+      isExpanded: false,
+    };
+    addSubagentToolCall(state, toolCall);
+
+    // Update with different ID - should not crash
+    updateSubagentToolResult(state, 'tool-999', { ...toolCall, id: 'tool-999', status: 'completed' });
+
+    // State should remain unchanged for the rendered tool
+    expect(state.currentResultEl).toBeNull();
+  });
+});
+
+describe('finalizeSubagentBlock', () => {
+  let parentEl: MockElement;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    parentEl = createMockEl('div');
+  });
+
+  it('sets status to completed and adds done class', () => {
+    const state = createSubagentBlock(parentEl as any, 'task-1', { description: 'Test task' });
+
+    (setIcon as jest.Mock).mockClear();
+    finalizeSubagentBlock(state, 'All done', false);
+
+    expect(state.info.status).toBe('completed');
+    expect(state.info.result).toBe('All done');
+    expect((state.wrapperEl as any).hasClass('done')).toBe(true);
+    expect(setIcon).toHaveBeenCalledWith(expect.anything(), 'check');
+  });
+
+  it('sets status to error and adds error class', () => {
+    const state = createSubagentBlock(parentEl as any, 'task-1', { description: 'Test task' });
+
+    (setIcon as jest.Mock).mockClear();
+    finalizeSubagentBlock(state, 'Something failed', true);
+
+    expect(state.info.status).toBe('error');
+    expect(state.info.result).toBe('Something failed');
+    expect((state.wrapperEl as any).hasClass('error')).toBe(true);
+    expect(setIcon).toHaveBeenCalledWith(expect.anything(), 'x');
+  });
+
+  it('clears content and shows DONE text', () => {
+    const state = createSubagentBlock(parentEl as any, 'task-1', { description: 'Test task' });
+
+    // Add a tool call first to populate content
+    addSubagentToolCall(state, {
+      id: 'tool-1',
+      name: 'Read',
+      input: { file_path: 'test.md' },
+      status: 'running',
+      isExpanded: false,
+    });
+
+    finalizeSubagentBlock(state, 'Done', false);
+
+    expect(state.currentToolEl).toBeNull();
+    expect(state.currentResultEl).toBeNull();
+    const doneText = getTextByClass(state.contentEl as any, 'claudian-subagent-done-text')[0];
+    expect(doneText).toBe('DONE');
+  });
+
+  it('shows ERROR text when isError is true', () => {
+    const state = createSubagentBlock(parentEl as any, 'task-1', { description: 'Test task' });
+
+    finalizeSubagentBlock(state, 'Error occurred', true);
+
+    const errorText = getTextByClass(state.contentEl as any, 'claudian-subagent-done-text')[0];
+    expect(errorText).toBe('ERROR');
+  });
+
+  it('updates tool count badge after finalization', () => {
+    const state = createSubagentBlock(parentEl as any, 'task-1', { description: 'Test task' });
+
+    addSubagentToolCall(state, {
+      id: 'tool-1',
+      name: 'Read',
+      input: {},
+      status: 'running',
+      isExpanded: false,
+    });
+    addSubagentToolCall(state, {
+      id: 'tool-2',
+      name: 'Grep',
+      input: {},
+      status: 'running',
+      isExpanded: false,
+    });
+
+    finalizeSubagentBlock(state, 'Done', false);
+
+    expect(state.countEl.textContent).toBe('2 tool uses');
+  });
+});
+
+describe('renderStoredSubagent status variants', () => {
+  let parentEl: MockElement;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    parentEl = createMockEl('div');
+  });
+
+  it('renders completed subagent with done class and check icon', () => {
+    const subagent: SubagentInfo = {
+      id: 'task-1',
+      description: 'Completed task',
+      status: 'completed',
+      toolCalls: [],
+      isExpanded: false,
+    };
+
+    (setIcon as jest.Mock).mockClear();
+    const wrapperEl = renderStoredSubagent(parentEl as any, subagent);
+
+    expect((wrapperEl as any).hasClass('done')).toBe(true);
+    expect(setIcon).toHaveBeenCalledWith(expect.anything(), 'check');
+    const doneText = getTextByClass(wrapperEl as any, 'claudian-subagent-done-text')[0];
+    expect(doneText).toBe('DONE');
+  });
+
+  it('renders error subagent with error class and x icon', () => {
+    const subagent: SubagentInfo = {
+      id: 'task-1',
+      description: 'Failed task',
+      status: 'error',
+      toolCalls: [],
+      isExpanded: false,
+    };
+
+    (setIcon as jest.Mock).mockClear();
+    const wrapperEl = renderStoredSubagent(parentEl as any, subagent);
+
+    expect((wrapperEl as any).hasClass('error')).toBe(true);
+    expect(setIcon).toHaveBeenCalledWith(expect.anything(), 'x');
+    const errorText = getTextByClass(wrapperEl as any, 'claudian-subagent-done-text')[0];
+    expect(errorText).toBe('ERROR');
+  });
+
+  it('renders running subagent with last tool call', () => {
+    const subagent: SubagentInfo = {
+      id: 'task-1',
+      description: 'Running task',
+      status: 'running',
+      toolCalls: [
+        { id: 'tool-1', name: 'Read', input: { file_path: 'test.md' }, status: 'completed', isExpanded: false },
+        { id: 'tool-2', name: 'Grep', input: { pattern: 'test' }, status: 'running', isExpanded: false },
+      ],
+      isExpanded: false,
+    };
+
+    const wrapperEl = renderStoredSubagent(parentEl as any, subagent);
+
+    // Should not have done or error class
+    expect((wrapperEl as any).hasClass('done')).toBe(false);
+    expect((wrapperEl as any).hasClass('error')).toBe(false);
+  });
+
+  it('renders running subagent tool call with result', () => {
+    const subagent: SubagentInfo = {
+      id: 'task-1',
+      description: 'Running task',
+      status: 'running',
+      toolCalls: [
+        {
+          id: 'tool-1',
+          name: 'Read',
+          input: { file_path: 'test.md' },
+          status: 'completed',
+          result: 'File contents here',
+          isExpanded: false,
+        },
+      ],
+      isExpanded: false,
+    };
+
+    const wrapperEl = renderStoredSubagent(parentEl as any, subagent);
+    const contentEl = (wrapperEl as any).children[1]; // content area
+
+    // Should show result text
+    const resultTexts = getTextByClass(contentEl, 'claudian-subagent-result-text');
+    expect(resultTexts.length).toBe(1);
+    expect(resultTexts[0]).toContain('File contents here');
+  });
+
+  it('shows correct tool count in badge', () => {
+    const subagent: SubagentInfo = {
+      id: 'task-1',
+      description: 'Task with tools',
+      status: 'completed',
+      toolCalls: [
+        { id: 'tool-1', name: 'Read', input: {}, status: 'completed', isExpanded: false },
+        { id: 'tool-2', name: 'Grep', input: {}, status: 'completed', isExpanded: false },
+        { id: 'tool-3', name: 'Edit', input: {}, status: 'completed', isExpanded: false },
+      ],
+      isExpanded: false,
+    };
+
+    const wrapperEl = renderStoredSubagent(parentEl as any, subagent);
+
+    const countTexts = getTextByClass(wrapperEl as any, 'claudian-subagent-count');
+    expect(countTexts[0]).toBe('3 tool uses');
+  });
+
+  it('truncates long descriptions', () => {
+    const longDesc = 'A'.repeat(50);
+    const subagent: SubagentInfo = {
+      id: 'task-1',
+      description: longDesc,
+      status: 'completed',
+      toolCalls: [],
+      isExpanded: false,
+    };
+
+    const wrapperEl = renderStoredSubagent(parentEl as any, subagent);
+
+    const labelTexts = getTextByClass(wrapperEl as any, 'claudian-subagent-label');
+    expect(labelTexts[0]).toBe('A'.repeat(40) + '...');
   });
 });

--- a/tests/unit/features/chat/rendering/ToolCallRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/ToolCallRenderer.test.ts
@@ -3,8 +3,19 @@ import { setIcon } from 'obsidian';
 
 import type { ToolCallInfo } from '@/core/types';
 import {
+  areAllTodosCompleted,
+  formatToolInput,
+  getCurrentTask,
+  getToolLabel,
+  isBlockedToolResult,
+  renderReadResult,
+  renderResultLines,
   renderStoredToolCall,
+  renderTodoWriteResult,
   renderToolCall,
+  renderWebSearchResult,
+  setToolIcon,
+  truncateResult,
   updateToolCallResult,
 } from '@/features/chat/rendering/ToolCallRenderer';
 
@@ -304,6 +315,400 @@ describe('ToolCallRenderer', () => {
 
       expect(tabEvent.preventDefault).not.toHaveBeenCalled();
       expect(toolEl.hasClass('expanded')).toBe(false);
+    });
+  });
+
+  describe('setToolIcon', () => {
+    it('should call setIcon with the resolved icon name', () => {
+      const el = createMockEl() as unknown as HTMLElement;
+      setToolIcon(el, 'Read');
+      expect(setIcon).toHaveBeenCalledWith(el, expect.any(String));
+    });
+
+    it('should set MCP SVG for MCP tools', () => {
+      const el = createMockEl();
+      setToolIcon(el as unknown as HTMLElement, 'mcp__server__tool');
+      // MCP tools get innerHTML set with the SVG
+      expect(el.innerHTML).toContain('svg');
+    });
+  });
+
+  describe('getToolLabel', () => {
+    it('should label Read tool with shortened path', () => {
+      expect(getToolLabel('Read', { file_path: '/a/b/c/d/e.ts' })).toBe('Read: .../d/e.ts');
+    });
+
+    it('should label Read with fallback for missing path', () => {
+      expect(getToolLabel('Read', {})).toBe('Read: file');
+    });
+
+    it('should label Write tool with path', () => {
+      expect(getToolLabel('Write', { file_path: 'short.ts' })).toBe('Write: short.ts');
+    });
+
+    it('should label Edit tool with path', () => {
+      expect(getToolLabel('Edit', { file_path: 'file.ts' })).toBe('Edit: file.ts');
+    });
+
+    it('should label Bash tool and truncate long commands', () => {
+      const shortCmd = 'npm test';
+      expect(getToolLabel('Bash', { command: shortCmd })).toBe('Bash: npm test');
+
+      const longCmd = 'a'.repeat(50);
+      expect(getToolLabel('Bash', { command: longCmd })).toBe(`Bash: ${'a'.repeat(40)}...`);
+    });
+
+    it('should label Bash with fallback for missing command', () => {
+      expect(getToolLabel('Bash', {})).toBe('Bash: command');
+    });
+
+    it('should label Glob tool', () => {
+      expect(getToolLabel('Glob', { pattern: '**/*.ts' })).toBe('Glob: **/*.ts');
+    });
+
+    it('should label Glob with fallback', () => {
+      expect(getToolLabel('Glob', {})).toBe('Glob: files');
+    });
+
+    it('should label Grep tool', () => {
+      expect(getToolLabel('Grep', { pattern: 'TODO' })).toBe('Grep: TODO');
+    });
+
+    it('should label WebSearch and truncate long queries', () => {
+      expect(getToolLabel('WebSearch', { query: 'short' })).toBe('WebSearch: short');
+
+      const longQuery = 'q'.repeat(50);
+      expect(getToolLabel('WebSearch', { query: longQuery })).toBe(`WebSearch: ${'q'.repeat(40)}...`);
+    });
+
+    it('should label WebFetch and truncate long URLs', () => {
+      expect(getToolLabel('WebFetch', { url: 'https://x.com' })).toBe('WebFetch: https://x.com');
+
+      const longUrl = 'https://' + 'x'.repeat(50);
+      expect(getToolLabel('WebFetch', { url: longUrl })).toBe(`WebFetch: ${longUrl.substring(0, 40)}...`);
+    });
+
+    it('should label LS tool with path', () => {
+      expect(getToolLabel('LS', { path: '/src' })).toBe('LS: /src');
+    });
+
+    it('should label LS with fallback', () => {
+      expect(getToolLabel('LS', {})).toBe('LS: .');
+    });
+
+    it('should label TodoWrite with completion count', () => {
+      const todos = [
+        { status: 'completed' },
+        { status: 'completed' },
+        { status: 'pending' },
+      ];
+      expect(getToolLabel('TodoWrite', { todos })).toBe('Tasks (2/3)');
+    });
+
+    it('should label TodoWrite without array', () => {
+      expect(getToolLabel('TodoWrite', {})).toBe('Tasks');
+    });
+
+    it('should label Skill tool', () => {
+      expect(getToolLabel('Skill', { skill: 'commit' })).toBe('Skill: commit');
+    });
+
+    it('should label Skill with fallback', () => {
+      expect(getToolLabel('Skill', {})).toBe('Skill: skill');
+    });
+
+    it('should return raw name for unknown tools', () => {
+      expect(getToolLabel('CustomTool', {})).toBe('CustomTool');
+    });
+  });
+
+  describe('formatToolInput', () => {
+    it('should return file_path for Read/Write/Edit', () => {
+      expect(formatToolInput('Read', { file_path: '/test.ts' })).toBe('/test.ts');
+      expect(formatToolInput('Write', { file_path: '/out.ts' })).toBe('/out.ts');
+      expect(formatToolInput('Edit', { file_path: '/edit.ts' })).toBe('/edit.ts');
+    });
+
+    it('should return command for Bash', () => {
+      expect(formatToolInput('Bash', { command: 'ls -la' })).toBe('ls -la');
+    });
+
+    it('should return pattern for Glob/Grep', () => {
+      expect(formatToolInput('Glob', { pattern: '*.ts' })).toBe('*.ts');
+      expect(formatToolInput('Grep', { pattern: 'TODO' })).toBe('TODO');
+    });
+
+    it('should return query for WebSearch', () => {
+      expect(formatToolInput('WebSearch', { query: 'test' })).toBe('test');
+    });
+
+    it('should return url for WebFetch', () => {
+      expect(formatToolInput('WebFetch', { url: 'https://example.com' })).toBe('https://example.com');
+    });
+
+    it('should return JSON for unknown tools', () => {
+      const input = { key: 'value' };
+      expect(formatToolInput('Unknown', input)).toBe(JSON.stringify(input, null, 2));
+    });
+
+    it('should fallback to JSON when expected field is missing', () => {
+      const input = { other: 'data' };
+      expect(formatToolInput('Bash', input)).toBe(JSON.stringify(input, null, 2));
+    });
+  });
+
+  describe('renderResultLines', () => {
+    it('should render up to maxLines lines', () => {
+      const container = createMockEl();
+      renderResultLines(container as unknown as HTMLElement, 'line1\nline2\nline3\nline4\nline5', 3);
+      // 3 lines + 1 "more" indicator
+      expect(container._children.length).toBe(4);
+      expect(container._children[3].textContent).toBe('2 more lines');
+    });
+
+    it('should strip line number prefixes', () => {
+      const container = createMockEl();
+      renderResultLines(container as unknown as HTMLElement, '  1\u2192const x = 1;', 3);
+      expect(container._children[0].textContent).toBe('const x = 1;');
+    });
+
+    it('should render all lines when within limit', () => {
+      const container = createMockEl();
+      renderResultLines(container as unknown as HTMLElement, 'a\nb', 5);
+      expect(container._children.length).toBe(2);
+    });
+  });
+
+  describe('truncateResult', () => {
+    it('should truncate by length', () => {
+      const long = 'x'.repeat(3000);
+      const result = truncateResult(long, 20, 2000);
+      expect(result.length).toBeLessThanOrEqual(2001); // 2000 chars + possible newline content
+    });
+
+    it('should truncate by line count', () => {
+      const lines = Array.from({ length: 30 }, (_, i) => `line ${i}`).join('\n');
+      const result = truncateResult(lines, 5, 100000);
+      expect(result).toContain('more lines');
+    });
+
+    it('should return original when within limits', () => {
+      const short = 'hello\nworld';
+      expect(truncateResult(short)).toBe(short);
+    });
+  });
+
+  describe('isBlockedToolResult', () => {
+    it('should detect "blocked by blocklist"', () => {
+      expect(isBlockedToolResult('Blocked by blocklist: /etc/passwd')).toBe(true);
+    });
+
+    it('should detect "outside the vault"', () => {
+      expect(isBlockedToolResult('Path is outside the vault')).toBe(true);
+    });
+
+    it('should detect "access denied"', () => {
+      expect(isBlockedToolResult('Access Denied for this file')).toBe(true);
+    });
+
+    it('should detect "user denied"', () => {
+      expect(isBlockedToolResult('User denied the action')).toBe(true);
+    });
+
+    it('should detect "approval"', () => {
+      expect(isBlockedToolResult('Requires approval from user')).toBe(true);
+    });
+
+    it('should detect "deny" only when isError is true', () => {
+      expect(isBlockedToolResult('deny permission', true)).toBe(true);
+      expect(isBlockedToolResult('deny permission', false)).toBe(false);
+      expect(isBlockedToolResult('deny permission')).toBe(false);
+    });
+
+    it('should return false for normal results', () => {
+      expect(isBlockedToolResult('File content here')).toBe(false);
+    });
+  });
+
+  describe('renderWebSearchResult', () => {
+    it('should render links from web search result', () => {
+      const container = createMockEl();
+      const result = 'Links: [{"title":"Result 1","url":"https://example.com"},{"title":"Result 2","url":"https://test.com"}]';
+      const rendered = renderWebSearchResult(container as unknown as HTMLElement, result, 3);
+      expect(rendered).toBe(true);
+      expect(container._children.length).toBe(2);
+    });
+
+    it('should show "more results" when exceeding maxItems', () => {
+      const container = createMockEl();
+      const links = Array.from({ length: 5 }, (_, i) => ({ title: `R${i}`, url: `https://${i}.com` }));
+      const result = `Links: ${JSON.stringify(links)}`;
+      renderWebSearchResult(container as unknown as HTMLElement, result, 2);
+      expect(container._children.length).toBe(3); // 2 items + 1 "more"
+      expect(container._children[2].textContent).toBe('3 more results');
+    });
+
+    it('should return false for non-web-search results', () => {
+      const container = createMockEl();
+      expect(renderWebSearchResult(container as unknown as HTMLElement, 'plain text')).toBe(false);
+    });
+
+    it('should return false for empty links array', () => {
+      const container = createMockEl();
+      expect(renderWebSearchResult(container as unknown as HTMLElement, 'Links: []')).toBe(false);
+    });
+
+    it('should return false for malformed JSON', () => {
+      const container = createMockEl();
+      expect(renderWebSearchResult(container as unknown as HTMLElement, 'Links: not-json')).toBe(false);
+    });
+  });
+
+  describe('renderReadResult', () => {
+    it('should show line count', () => {
+      const container = createMockEl();
+      renderReadResult(container as unknown as HTMLElement, 'line1\nline2\nline3');
+      expect(container._children[0].textContent).toBe('3 lines read');
+    });
+
+    it('should filter empty lines', () => {
+      const container = createMockEl();
+      renderReadResult(container as unknown as HTMLElement, 'line1\n\n\nline2');
+      expect(container._children[0].textContent).toBe('2 lines read');
+    });
+  });
+
+  describe('getCurrentTask', () => {
+    it('should return in_progress todo', () => {
+      const input = {
+        todos: [
+          { status: 'completed', content: 'done', activeForm: 'Done' },
+          { status: 'in_progress', content: 'working', activeForm: 'Working on it' },
+        ],
+      };
+      expect(getCurrentTask(input)?.activeForm).toBe('Working on it');
+    });
+
+    it('should return undefined when no in_progress todo', () => {
+      expect(getCurrentTask({ todos: [{ status: 'completed', content: 'a', activeForm: 'A' }] })).toBeUndefined();
+    });
+
+    it('should return undefined when no todos', () => {
+      expect(getCurrentTask({})).toBeUndefined();
+    });
+
+    it('should return undefined for non-array todos', () => {
+      expect(getCurrentTask({ todos: 'not an array' })).toBeUndefined();
+    });
+  });
+
+  describe('areAllTodosCompleted', () => {
+    it('should return true when all completed', () => {
+      const input = {
+        todos: [
+          { status: 'completed', content: 'a', activeForm: 'A' },
+          { status: 'completed', content: 'b', activeForm: 'B' },
+        ],
+      };
+      expect(areAllTodosCompleted(input)).toBe(true);
+    });
+
+    it('should return false when some not completed', () => {
+      const input = {
+        todos: [
+          { status: 'completed', content: 'a', activeForm: 'A' },
+          { status: 'pending', content: 'b', activeForm: 'B' },
+        ],
+      };
+      expect(areAllTodosCompleted(input)).toBe(false);
+    });
+
+    it('should return false when empty', () => {
+      expect(areAllTodosCompleted({ todos: [] })).toBe(false);
+    });
+
+    it('should return false when no todos', () => {
+      expect(areAllTodosCompleted({})).toBe(false);
+    });
+  });
+
+  describe('renderTodoWriteResult', () => {
+    it('should render todo items', () => {
+      const container = createMockEl();
+      const input = {
+        todos: [
+          { status: 'completed', content: 'Task 1', activeForm: 'Task 1' },
+          { status: 'pending', content: 'Task 2', activeForm: 'Task 2' },
+        ],
+      };
+      renderTodoWriteResult(container as unknown as HTMLElement, input);
+      expect(container.hasClass('claudian-todo-panel-content')).toBe(true);
+      expect(container.hasClass('claudian-todo-list-container')).toBe(true);
+    });
+
+    it('should show fallback text when no todos array', () => {
+      const container = createMockEl();
+      renderTodoWriteResult(container as unknown as HTMLElement, {});
+      expect(container._children[0].textContent).toBe('Tasks updated');
+    });
+
+    it('should show fallback text for non-array todos', () => {
+      const container = createMockEl();
+      renderTodoWriteResult(container as unknown as HTMLElement, { todos: 'invalid' });
+      expect(container._children[0].textContent).toBe('Tasks updated');
+    });
+  });
+
+  describe('updateToolCallResult for TodoWrite', () => {
+    it('should update todo status and content', () => {
+      const parentEl = createMockEl();
+      const toolCall = createToolCall({
+        id: 'todo-1',
+        name: 'TodoWrite',
+        input: {
+          todos: [
+            { status: 'in_progress', content: 'Task 1', activeForm: 'Working' },
+          ],
+        },
+      });
+      const toolCallElements = new Map<string, HTMLElement>();
+
+      renderToolCall(parentEl, toolCall, toolCallElements);
+
+      // Update with all completed
+      toolCall.input = {
+        todos: [
+          { status: 'completed', content: 'Task 1', activeForm: 'Done' },
+        ],
+      };
+      updateToolCallResult('todo-1', toolCall, toolCallElements);
+
+      const statusEl = parentEl.querySelector('.claudian-tool-status');
+      expect(statusEl?.hasClass('status-completed')).toBe(true);
+    });
+
+    it('should do nothing for non-existent tool id', () => {
+      const toolCallElements = new Map<string, HTMLElement>();
+      updateToolCallResult('nonexistent', createToolCall(), toolCallElements);
+      expect(toolCallElements.size).toBe(0);
+    });
+  });
+
+  describe('renderStoredToolCall for TodoWrite', () => {
+    it('should render stored TodoWrite with status', () => {
+      const parentEl = createMockEl();
+      const toolCall = createToolCall({
+        name: 'TodoWrite',
+        status: 'completed',
+        input: {
+          todos: [
+            { status: 'completed', content: 'Task 1', activeForm: 'Done' },
+          ],
+        },
+      });
+
+      const toolEl = renderStoredToolCall(parentEl, toolCall);
+      expect(toolEl).toBeDefined();
     });
   });
 });

--- a/tests/unit/features/chat/rendering/collapsible.test.ts
+++ b/tests/unit/features/chat/rendering/collapsible.test.ts
@@ -1,0 +1,204 @@
+import { createMockEl } from '@test/helpers/mockElement';
+
+import {
+  collapseElement,
+  type CollapsibleState,
+  setupCollapsible,
+} from '@/features/chat/rendering/collapsible';
+
+describe('collapsible', () => {
+  describe('setupCollapsible', () => {
+    it('should start collapsed by default', () => {
+      const wrapper = createMockEl();
+      const header = createMockEl();
+      const content = createMockEl();
+      const state: CollapsibleState = { isExpanded: false };
+
+      setupCollapsible(wrapper, header, content, state);
+
+      expect(state.isExpanded).toBe(false);
+      expect(content.style.display).toBe('none');
+      expect(header.getAttribute('aria-expanded')).toBe('false');
+      expect(wrapper.hasClass('expanded')).toBe(false);
+    });
+
+    it('should start expanded when initiallyExpanded is true', () => {
+      const wrapper = createMockEl();
+      const header = createMockEl();
+      const content = createMockEl();
+      const state: CollapsibleState = { isExpanded: false };
+
+      setupCollapsible(wrapper, header, content, state, { initiallyExpanded: true });
+
+      expect(state.isExpanded).toBe(true);
+      expect(content.style.display).toBe('block');
+      expect(header.getAttribute('aria-expanded')).toBe('true');
+      expect(wrapper.hasClass('expanded')).toBe(true);
+    });
+
+    it('should toggle on click', () => {
+      const wrapper = createMockEl();
+      const header = createMockEl();
+      const content = createMockEl();
+      const state: CollapsibleState = { isExpanded: false };
+
+      setupCollapsible(wrapper, header, content, state);
+
+      const clickHandlers = header._eventListeners.get('click') || [];
+      expect(clickHandlers.length).toBe(1);
+
+      // Expand
+      clickHandlers[0]();
+      expect(state.isExpanded).toBe(true);
+      expect(wrapper.hasClass('expanded')).toBe(true);
+      expect(content.style.display).toBe('block');
+      expect(header.getAttribute('aria-expanded')).toBe('true');
+
+      // Collapse
+      clickHandlers[0]();
+      expect(state.isExpanded).toBe(false);
+      expect(wrapper.hasClass('expanded')).toBe(false);
+      expect(content.style.display).toBe('none');
+      expect(header.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('should toggle on Enter key', () => {
+      const wrapper = createMockEl();
+      const header = createMockEl();
+      const content = createMockEl();
+      const state: CollapsibleState = { isExpanded: false };
+
+      setupCollapsible(wrapper, header, content, state);
+
+      const keydownHandlers = header._eventListeners.get('keydown') || [];
+      const event = { key: 'Enter', preventDefault: jest.fn() };
+      keydownHandlers[0](event);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(state.isExpanded).toBe(true);
+    });
+
+    it('should toggle on Space key', () => {
+      const wrapper = createMockEl();
+      const header = createMockEl();
+      const content = createMockEl();
+      const state: CollapsibleState = { isExpanded: false };
+
+      setupCollapsible(wrapper, header, content, state);
+
+      const keydownHandlers = header._eventListeners.get('keydown') || [];
+      const event = { key: ' ', preventDefault: jest.fn() };
+      keydownHandlers[0](event);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(state.isExpanded).toBe(true);
+    });
+
+    it('should not toggle on other keys', () => {
+      const wrapper = createMockEl();
+      const header = createMockEl();
+      const content = createMockEl();
+      const state: CollapsibleState = { isExpanded: false };
+
+      setupCollapsible(wrapper, header, content, state);
+
+      const keydownHandlers = header._eventListeners.get('keydown') || [];
+      const event = { key: 'Tab', preventDefault: jest.fn() };
+      keydownHandlers[0](event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(state.isExpanded).toBe(false);
+    });
+
+    it('should call onToggle callback with new state', () => {
+      const wrapper = createMockEl();
+      const header = createMockEl();
+      const content = createMockEl();
+      const state: CollapsibleState = { isExpanded: false };
+      const onToggle = jest.fn();
+
+      setupCollapsible(wrapper, header, content, state, { onToggle });
+
+      const clickHandlers = header._eventListeners.get('click') || [];
+
+      clickHandlers[0]();
+      expect(onToggle).toHaveBeenCalledWith(true);
+
+      clickHandlers[0]();
+      expect(onToggle).toHaveBeenCalledWith(false);
+    });
+
+    it('should set aria-label with baseAriaLabel', () => {
+      const wrapper = createMockEl();
+      const header = createMockEl();
+      const content = createMockEl();
+      const state: CollapsibleState = { isExpanded: false };
+
+      setupCollapsible(wrapper, header, content, state, { baseAriaLabel: 'Read: file.ts' });
+
+      expect(header.getAttribute('aria-label')).toBe('Read: file.ts - click to expand');
+
+      // Expand and check label changes
+      const clickHandlers = header._eventListeners.get('click') || [];
+      clickHandlers[0]();
+      expect(header.getAttribute('aria-label')).toBe('Read: file.ts - click to collapse');
+    });
+
+    it('should set aria-label for initially expanded with baseAriaLabel', () => {
+      const wrapper = createMockEl();
+      const header = createMockEl();
+      const content = createMockEl();
+      const state: CollapsibleState = { isExpanded: false };
+
+      setupCollapsible(wrapper, header, content, state, {
+        initiallyExpanded: true,
+        baseAriaLabel: 'Tool',
+      });
+
+      expect(header.getAttribute('aria-label')).toBe('Tool - click to collapse');
+    });
+
+    it('should not set aria-label without baseAriaLabel', () => {
+      const wrapper = createMockEl();
+      const header = createMockEl();
+      const content = createMockEl();
+      const state: CollapsibleState = { isExpanded: false };
+
+      setupCollapsible(wrapper, header, content, state);
+
+      expect(header.getAttribute('aria-label')).toBeNull();
+    });
+  });
+
+  describe('collapseElement', () => {
+    it('should collapse an expanded element', () => {
+      const wrapper = createMockEl();
+      const header = createMockEl();
+      const content = createMockEl();
+      const state: CollapsibleState = { isExpanded: true };
+
+      wrapper.addClass('expanded');
+      content.style.display = 'block';
+      header.setAttribute('aria-expanded', 'true');
+
+      collapseElement(wrapper, header, content, state);
+
+      expect(state.isExpanded).toBe(false);
+      expect(wrapper.hasClass('expanded')).toBe(false);
+      expect(content.style.display).toBe('none');
+      expect(header.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('should be safe to call on already collapsed element', () => {
+      const wrapper = createMockEl();
+      const header = createMockEl();
+      const content = createMockEl();
+      const state: CollapsibleState = { isExpanded: false };
+
+      collapseElement(wrapper, header, content, state);
+
+      expect(state.isExpanded).toBe(false);
+      expect(content.style.display).toBe('none');
+    });
+  });
+});

--- a/tests/unit/features/chat/rendering/todoUtils.test.ts
+++ b/tests/unit/features/chat/rendering/todoUtils.test.ts
@@ -1,0 +1,105 @@
+import { createMockEl } from '@test/helpers/mockElement';
+import { setIcon } from 'obsidian';
+
+import type { TodoItem } from '@/core/tools';
+import {
+  getTodoDisplayText,
+  getTodoStatusIcon,
+  renderTodoItems,
+} from '@/features/chat/rendering/todoUtils';
+
+jest.mock('obsidian', () => ({
+  setIcon: jest.fn(),
+}));
+
+describe('todoUtils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getTodoStatusIcon', () => {
+    it('should return "check" for completed', () => {
+      expect(getTodoStatusIcon('completed')).toBe('check');
+    });
+
+    it('should return "dot" for pending', () => {
+      expect(getTodoStatusIcon('pending')).toBe('dot');
+    });
+
+    it('should return "dot" for in_progress', () => {
+      expect(getTodoStatusIcon('in_progress')).toBe('dot');
+    });
+  });
+
+  describe('getTodoDisplayText', () => {
+    it('should return activeForm for in_progress', () => {
+      const todo: TodoItem = { status: 'in_progress', content: 'Fix bug', activeForm: 'Fixing bug' };
+      expect(getTodoDisplayText(todo)).toBe('Fixing bug');
+    });
+
+    it('should return content for completed', () => {
+      const todo: TodoItem = { status: 'completed', content: 'Fix bug', activeForm: 'Fixing bug' };
+      expect(getTodoDisplayText(todo)).toBe('Fix bug');
+    });
+
+    it('should return content for pending', () => {
+      const todo: TodoItem = { status: 'pending', content: 'Fix bug', activeForm: 'Fixing bug' };
+      expect(getTodoDisplayText(todo)).toBe('Fix bug');
+    });
+  });
+
+  describe('renderTodoItems', () => {
+    it('should render todo items with status icons and text', () => {
+      const container = createMockEl();
+      const todos: TodoItem[] = [
+        { status: 'completed', content: 'Task 1', activeForm: 'Doing Task 1' },
+        { status: 'in_progress', content: 'Task 2', activeForm: 'Doing Task 2' },
+        { status: 'pending', content: 'Task 3', activeForm: 'Doing Task 3' },
+      ];
+
+      renderTodoItems(container as unknown as HTMLElement, todos);
+
+      expect(container._children.length).toBe(3);
+      expect(setIcon).toHaveBeenCalledTimes(3);
+
+      // First item: completed
+      expect(container._children[0].hasClass('claudian-todo-completed')).toBe(true);
+      expect(setIcon).toHaveBeenCalledWith(expect.anything(), 'check');
+
+      // Second item: in_progress shows activeForm
+      expect(container._children[1].hasClass('claudian-todo-in_progress')).toBe(true);
+
+      // Third item: pending
+      expect(container._children[2].hasClass('claudian-todo-pending')).toBe(true);
+    });
+
+    it('should clear container before rendering', () => {
+      const container = createMockEl();
+      container.createDiv({ text: 'old content' });
+
+      renderTodoItems(container as unknown as HTMLElement, [
+        { status: 'completed', content: 'New', activeForm: 'New' },
+      ]);
+
+      // Should have exactly 1 child (old cleared, new added)
+      expect(container._children.length).toBe(1);
+    });
+
+    it('should handle empty todos array', () => {
+      const container = createMockEl();
+      renderTodoItems(container as unknown as HTMLElement, []);
+      expect(container._children.length).toBe(0);
+    });
+
+    it('should set aria-hidden on status icon', () => {
+      const container = createMockEl();
+      renderTodoItems(container as unknown as HTMLElement, [
+        { status: 'completed', content: 'Task', activeForm: 'Task' },
+      ]);
+
+      const item = container._children[0];
+      const icon = item._children[0];
+      expect(icon.getAttribute('aria-hidden')).toBe('true');
+    });
+  });
+});

--- a/tests/unit/features/chat/state/ChatState.test.ts
+++ b/tests/unit/features/chat/state/ChatState.test.ts
@@ -1,0 +1,488 @@
+import { ChatState, createInitialState } from '@/features/chat/state/ChatState';
+import type { ChatStateCallbacks } from '@/features/chat/state/types';
+
+describe('ChatState', () => {
+  describe('createInitialState', () => {
+    it('returns correct default values', () => {
+      const state = createInitialState();
+
+      expect(state.messages).toEqual([]);
+      expect(state.isStreaming).toBe(false);
+      expect(state.cancelRequested).toBe(false);
+      expect(state.streamGeneration).toBe(0);
+      expect(state.isCreatingConversation).toBe(false);
+      expect(state.isSwitchingConversation).toBe(false);
+      expect(state.currentConversationId).toBeNull();
+      expect(state.queuedMessage).toBeNull();
+      expect(state.currentContentEl).toBeNull();
+      expect(state.currentTextEl).toBeNull();
+      expect(state.currentTextContent).toBe('');
+      expect(state.currentThinkingState).toBeNull();
+      expect(state.thinkingEl).toBeNull();
+      expect(state.queueIndicatorEl).toBeNull();
+      expect(state.thinkingIndicatorTimeout).toBeNull();
+      expect(state.toolCallElements).toBeInstanceOf(Map);
+      expect(state.writeEditStates).toBeInstanceOf(Map);
+      expect(state.pendingTools).toBeInstanceOf(Map);
+      expect(state.usage).toBeNull();
+      expect(state.ignoreUsageUpdates).toBe(false);
+      expect(state.currentTodos).toBeNull();
+      expect(state.needsAttention).toBe(false);
+      expect(state.autoScrollEnabled).toBe(true);
+      expect(state.responseStartTime).toBeNull();
+      expect(state.flavorTimerInterval).toBeNull();
+    });
+  });
+
+  describe('messages', () => {
+    it('returns a copy of messages', () => {
+      const chatState = new ChatState();
+      const msg = { id: '1', role: 'user' as const, content: 'hi', timestamp: 1 };
+      chatState.addMessage(msg);
+
+      const msgs = chatState.messages;
+      msgs.push({ id: '2', role: 'user' as const, content: 'bye', timestamp: 2 });
+
+      expect(chatState.messages).toHaveLength(1);
+    });
+
+    it('fires onMessagesChanged when setting messages', () => {
+      const onMessagesChanged = jest.fn();
+      const chatState = new ChatState({ onMessagesChanged });
+
+      chatState.messages = [{ id: '1', role: 'user', content: 'hi', timestamp: 1 }];
+
+      expect(onMessagesChanged).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires onMessagesChanged when adding a message', () => {
+      const onMessagesChanged = jest.fn();
+      const chatState = new ChatState({ onMessagesChanged });
+
+      chatState.addMessage({ id: '1', role: 'user', content: 'hi', timestamp: 1 });
+
+      expect(onMessagesChanged).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires onMessagesChanged when clearing messages', () => {
+      const onMessagesChanged = jest.fn();
+      const chatState = new ChatState({ onMessagesChanged });
+      chatState.addMessage({ id: '1', role: 'user', content: 'hi', timestamp: 1 });
+
+      chatState.clearMessages();
+
+      expect(chatState.messages).toHaveLength(0);
+      expect(onMessagesChanged).toHaveBeenCalledTimes(2); // once for add, once for clear
+    });
+  });
+
+  describe('streaming control', () => {
+    it('fires onStreamingStateChanged when isStreaming changes', () => {
+      const onStreamingStateChanged = jest.fn();
+      const chatState = new ChatState({ onStreamingStateChanged });
+
+      chatState.isStreaming = true;
+
+      expect(onStreamingStateChanged).toHaveBeenCalledWith(true);
+    });
+
+    it('bumpStreamGeneration increments and returns the new value', () => {
+      const chatState = new ChatState();
+
+      expect(chatState.streamGeneration).toBe(0);
+      const gen1 = chatState.bumpStreamGeneration();
+      expect(gen1).toBe(1);
+      expect(chatState.streamGeneration).toBe(1);
+
+      const gen2 = chatState.bumpStreamGeneration();
+      expect(gen2).toBe(2);
+    });
+
+    it('stores cancelRequested', () => {
+      const chatState = new ChatState();
+      chatState.cancelRequested = true;
+      expect(chatState.cancelRequested).toBe(true);
+    });
+
+    it('stores isCreatingConversation', () => {
+      const chatState = new ChatState();
+      chatState.isCreatingConversation = true;
+      expect(chatState.isCreatingConversation).toBe(true);
+    });
+
+    it('stores isSwitchingConversation', () => {
+      const chatState = new ChatState();
+      chatState.isSwitchingConversation = true;
+      expect(chatState.isSwitchingConversation).toBe(true);
+    });
+  });
+
+  describe('conversation', () => {
+    it('fires onConversationChanged when currentConversationId changes', () => {
+      const onConversationChanged = jest.fn();
+      const chatState = new ChatState({ onConversationChanged });
+
+      chatState.currentConversationId = 'conv-1';
+
+      expect(onConversationChanged).toHaveBeenCalledWith('conv-1');
+    });
+
+    it('fires onConversationChanged with null', () => {
+      const onConversationChanged = jest.fn();
+      const chatState = new ChatState({ onConversationChanged });
+      chatState.currentConversationId = 'conv-1';
+
+      chatState.currentConversationId = null;
+
+      expect(onConversationChanged).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe('queued message', () => {
+    it('stores and retrieves queued message', () => {
+      const chatState = new ChatState();
+      const queued = { content: 'queued', editorContext: null };
+
+      chatState.queuedMessage = queued;
+
+      expect(chatState.queuedMessage).toBe(queued);
+    });
+  });
+
+  describe('streaming DOM state', () => {
+    it('stores currentContentEl', () => {
+      const chatState = new ChatState();
+      const el = {} as HTMLElement;
+      chatState.currentContentEl = el;
+      expect(chatState.currentContentEl).toBe(el);
+    });
+
+    it('stores currentTextEl', () => {
+      const chatState = new ChatState();
+      const el = {} as HTMLElement;
+      chatState.currentTextEl = el;
+      expect(chatState.currentTextEl).toBe(el);
+    });
+
+    it('stores currentTextContent', () => {
+      const chatState = new ChatState();
+      chatState.currentTextContent = 'hello';
+      expect(chatState.currentTextContent).toBe('hello');
+    });
+
+    it('stores currentThinkingState', () => {
+      const chatState = new ChatState();
+      const state = { content: 'thinking' } as any;
+      chatState.currentThinkingState = state;
+      expect(chatState.currentThinkingState).toBe(state);
+    });
+
+    it('stores thinkingEl', () => {
+      const chatState = new ChatState();
+      const el = {} as HTMLElement;
+      chatState.thinkingEl = el;
+      expect(chatState.thinkingEl).toBe(el);
+    });
+
+    it('stores queueIndicatorEl', () => {
+      const chatState = new ChatState();
+      const el = {} as HTMLElement;
+      chatState.queueIndicatorEl = el;
+      expect(chatState.queueIndicatorEl).toBe(el);
+    });
+
+    it('stores thinkingIndicatorTimeout', () => {
+      const chatState = new ChatState();
+      const timeout = setTimeout(() => {}, 100);
+      chatState.thinkingIndicatorTimeout = timeout;
+      expect(chatState.thinkingIndicatorTimeout).toBe(timeout);
+      clearTimeout(timeout);
+    });
+  });
+
+  describe('tool tracking maps', () => {
+    it('returns mutable toolCallElements map', () => {
+      const chatState = new ChatState();
+      const el = {} as HTMLElement;
+      chatState.toolCallElements.set('tool-1', el);
+      expect(chatState.toolCallElements.get('tool-1')).toBe(el);
+    });
+
+    it('returns mutable writeEditStates map', () => {
+      const chatState = new ChatState();
+      const state = {} as any;
+      chatState.writeEditStates.set('we-1', state);
+      expect(chatState.writeEditStates.get('we-1')).toBe(state);
+    });
+
+    it('returns mutable pendingTools map', () => {
+      const chatState = new ChatState();
+      const pt = { toolCall: {} as any, parentEl: null };
+      chatState.pendingTools.set('pt-1', pt);
+      expect(chatState.pendingTools.get('pt-1')).toBe(pt);
+    });
+  });
+
+  describe('usage', () => {
+    it('fires onUsageChanged when usage changes', () => {
+      const onUsageChanged = jest.fn();
+      const chatState = new ChatState({ onUsageChanged });
+      const usage = { inputTokens: 100, outputTokens: 50 } as any;
+
+      chatState.usage = usage;
+
+      expect(onUsageChanged).toHaveBeenCalledWith(usage);
+    });
+
+    it('fires onUsageChanged with null', () => {
+      const onUsageChanged = jest.fn();
+      const chatState = new ChatState({ onUsageChanged });
+      chatState.usage = { inputTokens: 100, outputTokens: 50 } as any;
+
+      chatState.usage = null;
+
+      expect(onUsageChanged).toHaveBeenCalledWith(null);
+    });
+
+    it('stores ignoreUsageUpdates', () => {
+      const chatState = new ChatState();
+      chatState.ignoreUsageUpdates = true;
+      expect(chatState.ignoreUsageUpdates).toBe(true);
+    });
+  });
+
+  describe('currentTodos', () => {
+    it('fires onTodosChanged when todos change', () => {
+      const onTodosChanged = jest.fn();
+      const chatState = new ChatState({ onTodosChanged });
+      const todos = [{ content: 'Test', status: 'pending' as const, activeForm: 'Testing' }];
+
+      chatState.currentTodos = todos;
+
+      expect(onTodosChanged).toHaveBeenCalledWith(todos);
+    });
+
+    it('normalizes empty array to null', () => {
+      const onTodosChanged = jest.fn();
+      const chatState = new ChatState({ onTodosChanged });
+
+      chatState.currentTodos = [];
+
+      expect(onTodosChanged).toHaveBeenCalledWith(null);
+    });
+
+    it('returns a copy of todos', () => {
+      const chatState = new ChatState();
+      const todos = [{ content: 'Test', status: 'pending' as const, activeForm: 'Testing' }];
+      chatState.currentTodos = todos;
+
+      const retrieved = chatState.currentTodos!;
+      retrieved.push({ content: 'Other', status: 'pending' as const, activeForm: 'Othering' });
+
+      expect(chatState.currentTodos).toHaveLength(1);
+    });
+
+    it('returns null when not set', () => {
+      const chatState = new ChatState();
+      expect(chatState.currentTodos).toBeNull();
+    });
+  });
+
+  describe('needsAttention', () => {
+    it('fires onAttentionChanged when value changes', () => {
+      const onAttentionChanged = jest.fn();
+      const chatState = new ChatState({ onAttentionChanged });
+
+      chatState.needsAttention = true;
+
+      expect(onAttentionChanged).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('autoScrollEnabled', () => {
+    it('fires onAutoScrollChanged when value changes', () => {
+      const onAutoScrollChanged = jest.fn();
+      const chatState = new ChatState({ onAutoScrollChanged });
+      // Default is true, so set to false to trigger change
+      chatState.autoScrollEnabled = false;
+
+      expect(onAutoScrollChanged).toHaveBeenCalledWith(false);
+    });
+
+    it('does not fire onAutoScrollChanged when value is the same', () => {
+      const onAutoScrollChanged = jest.fn();
+      const chatState = new ChatState({ onAutoScrollChanged });
+      // Default is true, set to true again
+      chatState.autoScrollEnabled = true;
+
+      expect(onAutoScrollChanged).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('response timer', () => {
+    it('stores responseStartTime', () => {
+      const chatState = new ChatState();
+      chatState.responseStartTime = 12345;
+      expect(chatState.responseStartTime).toBe(12345);
+    });
+
+    it('stores flavorTimerInterval', () => {
+      const chatState = new ChatState();
+      const interval = setInterval(() => {}, 1000);
+      chatState.flavorTimerInterval = interval;
+      expect(chatState.flavorTimerInterval).toBe(interval);
+      clearInterval(interval);
+    });
+  });
+
+  describe('clearFlavorTimerInterval', () => {
+    it('clears active interval', () => {
+      const chatState = new ChatState();
+      const clearSpy = jest.spyOn(global, 'clearInterval');
+      const interval = setInterval(() => {}, 1000);
+      chatState.flavorTimerInterval = interval;
+
+      chatState.clearFlavorTimerInterval();
+
+      expect(clearSpy).toHaveBeenCalledWith(interval);
+      expect(chatState.flavorTimerInterval).toBeNull();
+      clearSpy.mockRestore();
+    });
+
+    it('is a no-op when no interval is active', () => {
+      const chatState = new ChatState();
+      const clearSpy = jest.spyOn(global, 'clearInterval');
+
+      chatState.clearFlavorTimerInterval();
+
+      expect(clearSpy).not.toHaveBeenCalled();
+      clearSpy.mockRestore();
+    });
+  });
+
+  describe('resetStreamingState', () => {
+    it('resets all streaming-related state', () => {
+      const chatState = new ChatState();
+      chatState.currentContentEl = {} as HTMLElement;
+      chatState.currentTextEl = {} as HTMLElement;
+      chatState.currentTextContent = 'text';
+      chatState.currentThinkingState = {} as any;
+      chatState.isStreaming = true;
+      chatState.cancelRequested = true;
+      const timeout = setTimeout(() => {}, 1000);
+      chatState.thinkingIndicatorTimeout = timeout;
+      const interval = setInterval(() => {}, 1000);
+      chatState.flavorTimerInterval = interval;
+      chatState.responseStartTime = 12345;
+
+      chatState.resetStreamingState();
+
+      expect(chatState.currentContentEl).toBeNull();
+      expect(chatState.currentTextEl).toBeNull();
+      expect(chatState.currentTextContent).toBe('');
+      expect(chatState.currentThinkingState).toBeNull();
+      expect(chatState.isStreaming).toBe(false);
+      expect(chatState.cancelRequested).toBe(false);
+      expect(chatState.thinkingIndicatorTimeout).toBeNull();
+      expect(chatState.flavorTimerInterval).toBeNull();
+      expect(chatState.responseStartTime).toBeNull();
+    });
+  });
+
+  describe('clearMaps', () => {
+    it('clears all tracking maps', () => {
+      const chatState = new ChatState();
+      chatState.toolCallElements.set('a', {} as HTMLElement);
+      chatState.writeEditStates.set('b', {} as any);
+      chatState.pendingTools.set('c', { toolCall: {} as any, parentEl: null });
+
+      chatState.clearMaps();
+
+      expect(chatState.toolCallElements.size).toBe(0);
+      expect(chatState.writeEditStates.size).toBe(0);
+      expect(chatState.pendingTools.size).toBe(0);
+    });
+  });
+
+  describe('resetForNewConversation', () => {
+    it('resets all conversation state', () => {
+      const onMessagesChanged = jest.fn();
+      const onUsageChanged = jest.fn();
+      const onTodosChanged = jest.fn();
+      const onAutoScrollChanged = jest.fn();
+      const chatState = new ChatState({
+        onMessagesChanged,
+        onUsageChanged,
+        onTodosChanged,
+        onAutoScrollChanged,
+      });
+
+      // Set up some state
+      chatState.addMessage({ id: '1', role: 'user', content: 'hi', timestamp: 1 });
+      chatState.isStreaming = true;
+      chatState.cancelRequested = true;
+      chatState.currentContentEl = {} as HTMLElement;
+      chatState.toolCallElements.set('a', {} as HTMLElement);
+      chatState.queuedMessage = { content: 'queued', editorContext: null };
+      chatState.usage = { inputTokens: 100, outputTokens: 50 } as any;
+      chatState.currentTodos = [{ content: 'Test', status: 'pending' as const, activeForm: 'Testing' }];
+      // autoScrollEnabled defaults to true, set to false first so reset triggers change
+      chatState.autoScrollEnabled = false;
+
+      // Reset all tracking
+      jest.clearAllMocks();
+
+      chatState.resetForNewConversation();
+
+      expect(chatState.messages).toHaveLength(0);
+      expect(chatState.isStreaming).toBe(false);
+      expect(chatState.cancelRequested).toBe(false);
+      expect(chatState.currentContentEl).toBeNull();
+      expect(chatState.toolCallElements.size).toBe(0);
+      expect(chatState.writeEditStates.size).toBe(0);
+      expect(chatState.pendingTools.size).toBe(0);
+      expect(chatState.queuedMessage).toBeNull();
+      expect(chatState.usage).toBeNull();
+      expect(chatState.currentTodos).toBeNull();
+      expect(chatState.autoScrollEnabled).toBe(true);
+
+      // Verify callbacks were fired
+      expect(onMessagesChanged).toHaveBeenCalled();
+      expect(onUsageChanged).toHaveBeenCalledWith(null);
+      expect(onTodosChanged).toHaveBeenCalledWith(null);
+      expect(onAutoScrollChanged).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('getPersistedMessages', () => {
+    it('returns messages as-is', () => {
+      const chatState = new ChatState();
+      const msg = { id: '1', role: 'user' as const, content: 'test', timestamp: 1 };
+      chatState.addMessage(msg);
+
+      const persisted = chatState.getPersistedMessages();
+
+      expect(persisted).toHaveLength(1);
+      expect(persisted[0]).toEqual(msg);
+    });
+  });
+
+  describe('callbacks property', () => {
+    it('allows getting callbacks', () => {
+      const callbacks: ChatStateCallbacks = { onMessagesChanged: jest.fn() };
+      const chatState = new ChatState(callbacks);
+
+      expect(chatState.callbacks).toBe(callbacks);
+    });
+
+    it('allows setting callbacks', () => {
+      const chatState = new ChatState();
+      const newCallbacks: ChatStateCallbacks = { onMessagesChanged: jest.fn() };
+
+      chatState.callbacks = newCallbacks;
+      chatState.addMessage({ id: '1', role: 'user', content: 'hi', timestamp: 1 });
+
+      expect(newCallbacks.onMessagesChanged).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/features/chat/ui/file-context/state/FileContextState.test.ts
+++ b/tests/unit/features/chat/ui/file-context/state/FileContextState.test.ts
@@ -1,0 +1,195 @@
+import { FileContextState } from '@/features/chat/ui/file-context/state/FileContextState';
+
+describe('FileContextState', () => {
+  let state: FileContextState;
+
+  beforeEach(() => {
+    state = new FileContextState();
+  });
+
+  describe('initial state', () => {
+    it('should start with no attached files', () => {
+      expect(state.getAttachedFiles().size).toBe(0);
+    });
+
+    it('should start with session not started', () => {
+      expect(state.isSessionStarted()).toBe(false);
+    });
+
+    it('should start with current note not sent', () => {
+      expect(state.hasSentCurrentNote()).toBe(false);
+    });
+
+    it('should start with no MCP mentions', () => {
+      expect(state.getMentionedMcpServers().size).toBe(0);
+    });
+  });
+
+  describe('session lifecycle', () => {
+    it('should mark session as started', () => {
+      state.startSession();
+      expect(state.isSessionStarted()).toBe(true);
+    });
+
+    it('should mark current note as sent', () => {
+      state.markCurrentNoteSent();
+      expect(state.hasSentCurrentNote()).toBe(true);
+    });
+  });
+
+  describe('resetForNewConversation', () => {
+    it('should reset all state', () => {
+      state.startSession();
+      state.markCurrentNoteSent();
+      state.attachFile('file1.md');
+      state.attachContextFile('ctx/file.ts', '/abs/ctx/file.ts');
+      state.addMentionedMcpServer('server1');
+
+      state.resetForNewConversation();
+
+      expect(state.isSessionStarted()).toBe(false);
+      expect(state.hasSentCurrentNote()).toBe(false);
+      expect(state.getAttachedFiles().size).toBe(0);
+      expect(state.getMentionedMcpServers().size).toBe(0);
+    });
+  });
+
+  describe('resetForLoadedConversation', () => {
+    it('should set state based on whether conversation has messages', () => {
+      state.attachFile('file1.md');
+      state.attachContextFile('ctx/file.ts', '/abs/ctx/file.ts');
+      state.addMentionedMcpServer('server1');
+
+      state.resetForLoadedConversation(true);
+
+      expect(state.isSessionStarted()).toBe(true);
+      expect(state.hasSentCurrentNote()).toBe(true);
+      expect(state.getAttachedFiles().size).toBe(0);
+      expect(state.getMentionedMcpServers().size).toBe(0);
+    });
+
+    it('should not mark as started when no messages', () => {
+      state.resetForLoadedConversation(false);
+
+      expect(state.isSessionStarted()).toBe(false);
+      expect(state.hasSentCurrentNote()).toBe(false);
+    });
+  });
+
+  describe('file attachments', () => {
+    it('should attach a file', () => {
+      state.attachFile('test.md');
+      expect(state.getAttachedFiles().has('test.md')).toBe(true);
+    });
+
+    it('should return a copy of attached files (not the internal set)', () => {
+      state.attachFile('test.md');
+      const files = state.getAttachedFiles();
+      files.add('other.md');
+      expect(state.getAttachedFiles().has('other.md')).toBe(false);
+    });
+
+    it('should detach a file', () => {
+      state.attachFile('test.md');
+      state.detachFile('test.md');
+      expect(state.getAttachedFiles().has('test.md')).toBe(false);
+    });
+
+    it('should set attached files replacing existing', () => {
+      state.attachFile('old.md');
+      state.setAttachedFiles(['new1.md', 'new2.md']);
+      const files = state.getAttachedFiles();
+      expect(files.has('old.md')).toBe(false);
+      expect(files.has('new1.md')).toBe(true);
+      expect(files.has('new2.md')).toBe(true);
+    });
+
+    it('should clear all attachments', () => {
+      state.attachFile('a.md');
+      state.attachContextFile('ctx/b.ts', '/abs/b.ts');
+      state.clearAttachments();
+      expect(state.getAttachedFiles().size).toBe(0);
+    });
+  });
+
+  describe('context file attachments', () => {
+    it('should attach a context file with path mapping', () => {
+      state.attachContextFile('ctx/file.ts', '/absolute/path/file.ts');
+      expect(state.getAttachedFiles().has('/absolute/path/file.ts')).toBe(true);
+    });
+
+    it('should transform context mentions in text', () => {
+      state.attachContextFile('ctx/file.ts', '/absolute/path/file.ts');
+      const result = state.transformContextMentions('Look at ctx/file.ts for details');
+      expect(result).toBe('Look at /absolute/path/file.ts for details');
+    });
+
+    it('should replace multiple occurrences of the same mention', () => {
+      state.attachContextFile('ctx/a.ts', '/abs/a.ts');
+      const result = state.transformContextMentions('ctx/a.ts and ctx/a.ts');
+      expect(result).toBe('/abs/a.ts and /abs/a.ts');
+    });
+
+    it('should handle multiple different context files', () => {
+      state.attachContextFile('ctx/a.ts', '/abs/a.ts');
+      state.attachContextFile('ctx/b.ts', '/abs/b.ts');
+      const result = state.transformContextMentions('ctx/a.ts and ctx/b.ts');
+      expect(result).toBe('/abs/a.ts and /abs/b.ts');
+    });
+
+    it('should return text unchanged when no context files', () => {
+      const text = 'no mentions here';
+      expect(state.transformContextMentions(text)).toBe(text);
+    });
+
+    it('should handle regex special characters in display names', () => {
+      state.attachContextFile('file (1).ts', '/abs/file (1).ts');
+      const result = state.transformContextMentions('See file (1).ts');
+      expect(result).toBe('See /abs/file (1).ts');
+    });
+  });
+
+  describe('MCP server mentions', () => {
+    it('should add a mentioned MCP server', () => {
+      state.addMentionedMcpServer('server1');
+      expect(state.getMentionedMcpServers().has('server1')).toBe(true);
+    });
+
+    it('should return a copy of mentioned servers', () => {
+      state.addMentionedMcpServer('server1');
+      const servers = state.getMentionedMcpServers();
+      servers.add('server2');
+      expect(state.getMentionedMcpServers().has('server2')).toBe(false);
+    });
+
+    it('should clear MCP mentions', () => {
+      state.addMentionedMcpServer('server1');
+      state.clearMcpMentions();
+      expect(state.getMentionedMcpServers().size).toBe(0);
+    });
+
+    it('should set mentioned MCP servers and return true when changed', () => {
+      const changed = state.setMentionedMcpServers(new Set(['a', 'b']));
+      expect(changed).toBe(true);
+      expect(state.getMentionedMcpServers()).toEqual(new Set(['a', 'b']));
+    });
+
+    it('should return false when setting same servers', () => {
+      state.setMentionedMcpServers(new Set(['a', 'b']));
+      const changed = state.setMentionedMcpServers(new Set(['a', 'b']));
+      expect(changed).toBe(false);
+    });
+
+    it('should return true when sizes differ', () => {
+      state.setMentionedMcpServers(new Set(['a']));
+      const changed = state.setMentionedMcpServers(new Set(['a', 'b']));
+      expect(changed).toBe(true);
+    });
+
+    it('should return true when same size but different contents', () => {
+      state.setMentionedMcpServers(new Set(['a', 'b']));
+      const changed = state.setMentionedMcpServers(new Set(['a', 'c']));
+      expect(changed).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Add unit tests covering message rendering, subagent rendering, tool calls, services, chat state, file context state, and UI utilities.

Tests ensure proper rendering of welcome screens, message content, thinking blocks, attachments, and error handling across the chat interface.

This PR adds 2600+ lines of test coverage to improve code quality and reliability.