### PR TITLE
feat: update context gauge warning message

### DIFF
--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -865,7 +865,10 @@ export class ContextUsageMeter {
     }
 
     // Set tooltip with detailed usage
-    const tooltip = `${this.formatTokens(usage.contextTokens)} / ${this.formatTokens(usage.contextWindow)}`;
+    let tooltip = `${this.formatTokens(usage.contextTokens)} / ${this.formatTokens(usage.contextWindow)}`;
+    if (usage.percentage > 80) {
+      tooltip += ' (Approaching limit, run `/compact` to continue)';
+    }
     this.container.setAttribute('data-tooltip', tooltip);
   }
 

--- a/tests/unit/features/chat/ui/InputToolbar.test.ts
+++ b/tests/unit/features/chat/ui/InputToolbar.test.ts
@@ -532,6 +532,18 @@ describe('ContextUsageMeter', () => {
     const container = parentEl.querySelector('.claudian-context-meter');
     expect(container?.getAttribute('data-tooltip')).toBe('500 / 200k');
   });
+
+  it('should add compact reminder to tooltip when usage > 80%', () => {
+    meter.update(makeUsage({ contextTokens: 170000, contextWindow: 200000, percentage: 85 }));
+    const container = parentEl.querySelector('.claudian-context-meter');
+    expect(container?.getAttribute('data-tooltip')).toBe('170k / 200k (Approaching limit, run `/compact` to continue)');
+  });
+
+  it('should not add compact reminder to tooltip when usage ≤ 80%', () => {
+    meter.update(makeUsage({ contextTokens: 160000, contextWindow: 200000, percentage: 80 }));
+    const container = parentEl.querySelector('.claudian-context-meter');
+    expect(container?.getAttribute('data-tooltip')).toBe('160k / 200k');
+  });
 });
 
 describe('McpServerSelector - toggle and badges', () => {


### PR DESCRIPTION
## Summary
Updated the context gauge warning message to be more actionable. When usage exceeds 80%, users are now prompted to run `/compact` to continue.

## Changes
- Modified tooltip in `ContextUsageMeter.update()` to show "Approaching limit, run `/compact` to continue" when usage > 80%
- Added test coverage for both warning and non-warning states

Fixes #209

Generated with [Claude Code](https://claude.ai/code)