### PR TITLE
Simplify command panel display

### DIFF
--- a/src/features/chat/ui/StatusPanel.ts
+++ b/src/features/chat/ui/StatusPanel.ts
@@ -624,7 +624,7 @@ export class StatusPanel {
     const entryIconEl = document.createElement('span');
     entryIconEl.className = 'claudian-tool-icon';
     entryIconEl.setAttribute('aria-hidden', 'true');
-    setIcon(entryIconEl, 'terminal');
+    setIcon(entryIconEl, 'dollar-sign');
     entryHeaderEl.appendChild(entryIconEl);
 
     const entryLabelEl = document.createElement('span');

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -55,7 +55,7 @@
       "commandPanel": "Command panel",
       "copyAriaLabel": "Copy latest command output",
       "clearAriaLabel": "Clear bash output",
-      "commandLabel": "Command: {command}",
+      "commandLabel": "{command}",
       "statusLabel": "Status: {status}",
       "collapseOutput": "Collapse command output",
       "expandOutput": "Expand command output",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -55,7 +55,7 @@
       "commandPanel": "Command panel",
       "copyAriaLabel": "Copy latest command output",
       "clearAriaLabel": "Clear bash output",
-      "commandLabel": "Command: {command}",
+      "commandLabel": "{command}",
       "statusLabel": "Status: {status}",
       "collapseOutput": "Collapse command output",
       "expandOutput": "Expand command output",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -55,7 +55,7 @@
       "commandPanel": "Command panel",
       "copyAriaLabel": "Copy latest command output",
       "clearAriaLabel": "Clear bash output",
-      "commandLabel": "Command: {command}",
+      "commandLabel": "{command}",
       "statusLabel": "Status: {status}",
       "collapseOutput": "Collapse command output",
       "expandOutput": "Expand command output",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -55,7 +55,7 @@
       "commandPanel": "Command panel",
       "copyAriaLabel": "Copy latest command output",
       "clearAriaLabel": "Clear bash output",
-      "commandLabel": "Command: {command}",
+      "commandLabel": "{command}",
       "statusLabel": "Status: {status}",
       "collapseOutput": "Collapse command output",
       "expandOutput": "Expand command output",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -55,7 +55,7 @@
       "commandPanel": "Command panel",
       "copyAriaLabel": "Copy latest command output",
       "clearAriaLabel": "Clear bash output",
-      "commandLabel": "Command: {command}",
+      "commandLabel": "{command}",
       "statusLabel": "Status: {status}",
       "collapseOutput": "Collapse command output",
       "expandOutput": "Expand command output",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -55,7 +55,7 @@
       "commandPanel": "Command panel",
       "copyAriaLabel": "Copy latest command output",
       "clearAriaLabel": "Clear bash output",
-      "commandLabel": "Command: {command}",
+      "commandLabel": "{command}",
       "statusLabel": "Status: {status}",
       "collapseOutput": "Collapse command output",
       "expandOutput": "Expand command output",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -55,7 +55,7 @@
       "commandPanel": "Command panel",
       "copyAriaLabel": "Copy latest command output",
       "clearAriaLabel": "Clear bash output",
-      "commandLabel": "Command: {command}",
+      "commandLabel": "{command}",
       "statusLabel": "Status: {status}",
       "collapseOutput": "Collapse command output",
       "expandOutput": "Expand command output",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -55,7 +55,7 @@
       "commandPanel": "Command panel",
       "copyAriaLabel": "Copy latest command output",
       "clearAriaLabel": "Clear bash output",
-      "commandLabel": "Command: {command}",
+      "commandLabel": "{command}",
       "statusLabel": "Status: {status}",
       "collapseOutput": "Collapse command output",
       "expandOutput": "Expand command output",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -55,7 +55,7 @@
       "commandPanel": "命令面板",
       "copyAriaLabel": "复制最新命令输出",
       "clearAriaLabel": "清除命令输出",
-      "commandLabel": "命令: {command}",
+      "commandLabel": "{command}",
       "statusLabel": "状态: {status}",
       "collapseOutput": "折叠命令输出",
       "expandOutput": "展开命令输出",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -55,7 +55,7 @@
       "commandPanel": "Command panel",
       "copyAriaLabel": "Copy latest command output",
       "clearAriaLabel": "Clear bash output",
-      "commandLabel": "Command: {command}",
+      "commandLabel": "{command}",
       "statusLabel": "Status: {status}",
       "collapseOutput": "Collapse command output",
       "expandOutput": "Expand command output",

--- a/src/style/components/status-panel.css
+++ b/src/style/components/status-panel.css
@@ -231,6 +231,13 @@
   margin: 4px 0;
 }
 
+.claudian-status-panel-bash-entry .claudian-tool-icon svg {
+  width: 14px;
+  height: 14px;
+  position: relative;
+  top: -1px;
+}
+
 .claudian-status-panel-bash-entry .claudian-tool-call {
   margin: 0;
 }


### PR DESCRIPTION
Changes the command panel entry format from "[>_] Command: {command}" to "[$] {command}" for a cleaner, more terminal-like appearance.

- Icon changed from terminal (>_) to dollar sign ($)
- Removed "Command:" prefix in all 10 locales
- Icon sized to 14px and positioned 1px up for visual alignment