### PR TITLE
Add coverage for agent core exports and tooling helpers

### DIFF
--- a/tests/helpers/mockElement.ts
+++ b/tests/helpers/mockElement.ts
@@ -145,6 +145,7 @@ export function createMockEl(tag = 'div'): any {
     },
     scrollIntoView() {},
     focus() {},
+    blur() {},
 
     setAttribute(name: string, value: string) { attributes.set(name, value); },
     getAttribute(name: string) { return attributes.get(name) ?? null; },

--- a/tests/unit/core/agent/index.test.ts
+++ b/tests/unit/core/agent/index.test.ts
@@ -1,0 +1,11 @@
+import { ClaudianService, MessageChannel, QueryOptionsBuilder, SessionManager } from '@/core/agent';
+
+describe('core/agent index', () => {
+  it('re-exports runtime symbols', () => {
+    expect(ClaudianService).toBeDefined();
+    expect(MessageChannel).toBeDefined();
+    expect(QueryOptionsBuilder).toBeDefined();
+    expect(SessionManager).toBeDefined();
+  });
+});
+

--- a/tests/unit/core/agents/index.test.ts
+++ b/tests/unit/core/agents/index.test.ts
@@ -1,0 +1,11 @@
+import { AgentManager } from '@/core/agents';
+import { buildAgentFromFrontmatter, parseAgentFile } from '@/core/agents';
+
+describe('core/agents index', () => {
+  it('re-exports runtime symbols', () => {
+    expect(AgentManager).toBeDefined();
+    expect(buildAgentFromFrontmatter).toBeDefined();
+    expect(parseAgentFile).toBeDefined();
+  });
+});
+

--- a/tests/unit/core/plugins/index.test.ts
+++ b/tests/unit/core/plugins/index.test.ts
@@ -1,0 +1,8 @@
+import { PluginManager } from '@/core/plugins';
+
+describe('core/plugins index', () => {
+  it('re-exports runtime symbols', () => {
+    expect(PluginManager).toBeDefined();
+  });
+});
+

--- a/tests/unit/core/tools/toolInput.test.ts
+++ b/tests/unit/core/tools/toolInput.test.ts
@@ -1,4 +1,27 @@
-import { getPathFromToolInput } from '@/core/tools/toolInput';
+import { extractResolvedAnswers, getPathFromToolInput } from '@/core/tools/toolInput';
+
+describe('extractResolvedAnswers', () => {
+  it('returns undefined when result is not an object', () => {
+    expect(extractResolvedAnswers('bad')).toBeUndefined();
+    expect(extractResolvedAnswers(123)).toBeUndefined();
+    expect(extractResolvedAnswers(undefined)).toBeUndefined();
+    expect(extractResolvedAnswers(null)).toBeUndefined();
+  });
+
+  it('returns undefined when answers is missing', () => {
+    expect(extractResolvedAnswers({})).toBeUndefined();
+  });
+
+  it('returns undefined when answers is not an object', () => {
+    expect(extractResolvedAnswers({ answers: 'bad' })).toBeUndefined();
+    expect(extractResolvedAnswers({ answers: null })).toBeUndefined();
+  });
+
+  it('returns answers when valid', () => {
+    const answers = { foo: 'bar', baz: 1 };
+    expect(extractResolvedAnswers({ answers })).toBe(answers);
+  });
+});
 
 describe('getPathFromToolInput', () => {
   describe('Read tool', () => {
@@ -19,6 +42,12 @@ describe('getPathFromToolInput', () => {
 
       expect(result).toBeNull();
     });
+
+    it('should fall back to notebook_path when file_path is empty', () => {
+      const result = getPathFromToolInput('Read', { file_path: '', notebook_path: '/path/to/notebook.ipynb' });
+
+      expect(result).toBe('/path/to/notebook.ipynb');
+    });
   });
 
   describe('Write tool', () => {
@@ -32,6 +61,12 @@ describe('getPathFromToolInput', () => {
       const result = getPathFromToolInput('Write', { content: 'some content' });
 
       expect(result).toBeNull();
+    });
+
+    it('should fall back to notebook_path when file_path is missing', () => {
+      const result = getPathFromToolInput('Write', { notebook_path: '/path/to/notebook.ipynb' });
+
+      expect(result).toBe('/path/to/notebook.ipynb');
     });
   });
 
@@ -53,6 +88,16 @@ describe('getPathFromToolInput', () => {
       });
 
       expect(result).toBeNull();
+    });
+
+    it('should fall back to notebook_path when file_path is missing', () => {
+      const result = getPathFromToolInput('Edit', {
+        notebook_path: '/path/to/notebook.ipynb',
+        old_string: 'old',
+        new_string: 'new',
+      });
+
+      expect(result).toBe('/path/to/notebook.ipynb');
     });
   });
 
@@ -98,6 +143,12 @@ describe('getPathFromToolInput', () => {
 
     it('should extract pattern as fallback from Glob tool input', () => {
       const result = getPathFromToolInput('Glob', { pattern: '**/*.ts' });
+
+      expect(result).toBe('**/*.ts');
+    });
+
+    it('should fall back to pattern when path is empty', () => {
+      const result = getPathFromToolInput('Glob', { path: '', pattern: '**/*.ts' });
 
       expect(result).toBe('**/*.ts');
     });

--- a/tests/unit/features/chat/controllers/index.test.ts
+++ b/tests/unit/features/chat/controllers/index.test.ts
@@ -1,0 +1,18 @@
+import {
+  ConversationController,
+  InputController,
+  NavigationController,
+  SelectionController,
+  StreamController,
+} from '@/features/chat/controllers';
+
+describe('features/chat/controllers index', () => {
+  it('re-exports runtime symbols', () => {
+    expect(ConversationController).toBeDefined();
+    expect(InputController).toBeDefined();
+    expect(NavigationController).toBeDefined();
+    expect(SelectionController).toBeDefined();
+    expect(StreamController).toBeDefined();
+  });
+});
+

--- a/tests/unit/features/chat/rendering/InlineExitPlanMode.test.ts
+++ b/tests/unit/features/chat/rendering/InlineExitPlanMode.test.ts
@@ -1,0 +1,160 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { createMockEl } from '@test/helpers/mockElement';
+
+import { InlineExitPlanMode } from '@/features/chat/rendering/InlineExitPlanMode';
+
+beforeAll(() => {
+  globalThis.requestAnimationFrame = (cb: FrameRequestCallback) => {
+    cb(0);
+    return 0;
+  };
+  (globalThis as any).document = { activeElement: null };
+});
+
+function fireKeyDown(root: any, key: string): void {
+  root.dispatchEvent({
+    type: 'keydown',
+    key,
+    preventDefault: jest.fn(),
+    stopPropagation: jest.fn(),
+  });
+}
+
+function findRoot(container: any): any {
+  return container.querySelector('.claudian-plan-approval-inline');
+}
+
+function findItems(root: any): any[] {
+  return root.querySelectorAll('claudian-ask-item');
+}
+
+describe('InlineExitPlanMode', () => {
+  it('resolves with approve-new-session and includes plan content when readable', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claudian-'));
+    const planFilePath = path.join(tmpDir, 'plan.md');
+    fs.writeFileSync(planFilePath, 'Step 1\nStep 2\n', 'utf8');
+
+    const container = createMockEl();
+    const resolve = jest.fn();
+    const renderContent = jest.fn().mockResolvedValue(undefined);
+
+    const widget = new InlineExitPlanMode(
+      container,
+      {
+        planFilePath,
+        allowedPrompts: [{ tool: 'Bash', prompt: 'Run bash commands' }],
+      },
+      resolve,
+      undefined,
+      renderContent,
+    );
+
+    widget.render();
+
+    const root = findRoot(container);
+    expect(root).toBeTruthy();
+    expect(root.getEventListenerCount('keydown')).toBe(1);
+    expect(container.querySelector('.claudian-plan-permissions-list')).toBeTruthy();
+    expect(renderContent).toHaveBeenCalled();
+
+    fireKeyDown(root, 'Enter');
+
+    expect(resolve).toHaveBeenCalledTimes(1);
+    expect(resolve).toHaveBeenCalledWith({
+      type: 'approve-new-session',
+      planContent: 'Implement this plan:\n\nStep 1\nStep 2',
+    });
+    expect(root.getEventListenerCount('keydown')).toBe(0);
+  });
+
+  it('shows a read error when plan file cannot be read', () => {
+    const container = createMockEl();
+    const resolve = jest.fn();
+
+    const widget = new InlineExitPlanMode(
+      container,
+      { planFilePath: '/path/does/not/exist.md' },
+      resolve,
+    );
+
+    widget.render();
+
+    const root = findRoot(container);
+    expect(root).toBeTruthy();
+    expect(container.querySelector('.claudian-plan-read-error')).toBeTruthy();
+
+    fireKeyDown(root, 'Enter');
+    expect(resolve).toHaveBeenCalledWith({
+      type: 'approve-new-session',
+      planContent: 'Implement the approved plan.',
+    });
+  });
+
+  it('supports keyboard navigation for approve/current-session', () => {
+    const container = createMockEl();
+    const resolve = jest.fn();
+
+    const widget = new InlineExitPlanMode(container, {}, resolve);
+    widget.render();
+
+    const root = findRoot(container);
+    expect(root).toBeTruthy();
+
+    fireKeyDown(root, 'ArrowDown');
+    fireKeyDown(root, 'Enter');
+
+    expect(resolve).toHaveBeenCalledWith({ type: 'approve' });
+  });
+
+  it('supports feedback flow and Escape when input is focused', () => {
+    const container = createMockEl();
+    const resolve = jest.fn();
+
+    const widget = new InlineExitPlanMode(container, {}, resolve);
+    widget.render();
+
+    const root = findRoot(container);
+    expect(root).toBeTruthy();
+
+    fireKeyDown(root, 'ArrowDown');
+    fireKeyDown(root, 'ArrowDown');
+    fireKeyDown(root, 'Enter');
+
+    const items = findItems(root);
+    const feedbackRow = items[2];
+    const feedbackInput = feedbackRow.querySelector('claudian-ask-custom-text');
+
+    expect(resolve).not.toHaveBeenCalled();
+
+    feedbackInput.dispatchEvent('focus');
+
+    fireKeyDown(root, 'Escape');
+    expect(resolve).not.toHaveBeenCalled();
+
+    feedbackInput.value = 'Please revise the plan';
+    feedbackInput.dispatchEvent('focus');
+
+    fireKeyDown(root, 'Enter');
+    expect(resolve).toHaveBeenCalledWith({ type: 'feedback', text: 'Please revise the plan' });
+  });
+
+  it('resolves null on abort and does not resolve twice', () => {
+    const container = createMockEl();
+    const resolve = jest.fn();
+    const controller = new AbortController();
+
+    const widget = new InlineExitPlanMode(container, {}, resolve, controller.signal);
+    widget.render();
+
+    controller.abort();
+
+    expect(resolve).toHaveBeenCalledTimes(1);
+    expect(resolve).toHaveBeenCalledWith(null);
+
+    widget.destroy();
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/features/chat/tabs/index.test.ts
+++ b/tests/unit/features/chat/tabs/index.test.ts
@@ -1,0 +1,9 @@
+import { TabBar, TabManager, createTab } from '@/features/chat/tabs';
+
+describe('features/chat/tabs index', () => {
+  it('re-exports runtime symbols', () => {
+    expect(createTab).toBeDefined();
+    expect(TabBar).toBeDefined();
+    expect(TabManager).toBeDefined();
+  });
+});

--- a/tests/unit/i18n/constants.test.ts
+++ b/tests/unit/i18n/constants.test.ts
@@ -1,0 +1,43 @@
+import { DEFAULT_LOCALE, getLocaleDisplayString, getLocaleInfo, SUPPORTED_LOCALES } from '@/i18n/constants';
+
+describe('i18n/constants', () => {
+  it('DEFAULT_LOCALE is en', () => {
+    expect(DEFAULT_LOCALE).toBe('en');
+  });
+
+  it('getLocaleInfo returns metadata for a supported locale', () => {
+    const info = getLocaleInfo('en');
+    expect(info).toBeDefined();
+    expect(info?.code).toBe('en');
+    expect(info?.name).toBe('English');
+    expect(info?.englishName).toBe('English');
+    expect(info?.flag).toBe('🇺🇸');
+  });
+
+  it('getLocaleInfo returns undefined for unknown locale', () => {
+    expect(getLocaleInfo('xx' as any)).toBeUndefined();
+  });
+
+  it('getLocaleDisplayString returns a string with a flag by default', () => {
+    expect(getLocaleDisplayString('en')).toBe('🇺🇸 English (English)');
+  });
+
+  it('getLocaleDisplayString can omit the flag', () => {
+    expect(getLocaleDisplayString('en', false)).toBe('English (English)');
+  });
+
+  it('getLocaleDisplayString returns code when locale is unknown', () => {
+    expect(getLocaleDisplayString('xx' as any)).toBe('xx');
+  });
+
+  it('getLocaleDisplayString omits the flag when metadata has no flag', () => {
+    const originalFlag = SUPPORTED_LOCALES[0]?.flag;
+    SUPPORTED_LOCALES[0].flag = undefined;
+    try {
+      expect(getLocaleDisplayString('en')).toBe('English (English)');
+    } finally {
+      SUPPORTED_LOCALES[0].flag = originalFlag;
+    }
+  });
+});
+

--- a/tests/unit/shared/index.test.ts
+++ b/tests/unit/shared/index.test.ts
@@ -1,0 +1,50 @@
+jest.mock('@/shared/components/SelectableDropdown', () => ({
+  SelectableDropdown: function SelectableDropdown() {},
+}));
+
+jest.mock('@/shared/components/SelectionHighlight', () => ({
+  hideSelectionHighlight: jest.fn(),
+  showSelectionHighlight: jest.fn(),
+}));
+
+jest.mock('@/shared/components/SlashCommandDropdown', () => ({
+  SlashCommandDropdown: function SlashCommandDropdown() {},
+}));
+
+jest.mock('@/shared/icons', () => ({
+  CHECK_ICON_SVG: '<svg />',
+  MCP_ICON_SVG: '<svg />',
+}));
+
+jest.mock('@/shared/mention/MentionDropdownController', () => ({
+  MentionDropdownController: function MentionDropdownController() {},
+}));
+
+jest.mock('@/shared/modals/InstructionConfirmModal', () => ({
+  InstructionModal: function InstructionModal() {},
+}));
+
+import {
+  CHECK_ICON_SVG,
+  hideSelectionHighlight,
+  InstructionModal,
+  MCP_ICON_SVG,
+  MentionDropdownController,
+  SelectableDropdown,
+  showSelectionHighlight,
+  SlashCommandDropdown,
+} from '@/shared';
+
+describe('shared index', () => {
+  it('re-exports runtime symbols', () => {
+    expect(SelectableDropdown).toBeDefined();
+    expect(showSelectionHighlight).toBeDefined();
+    expect(hideSelectionHighlight).toBeDefined();
+    expect(SlashCommandDropdown).toBeDefined();
+    expect(MentionDropdownController).toBeDefined();
+    expect(InstructionModal).toBeDefined();
+    expect(CHECK_ICON_SVG).toBe('<svg />');
+    expect(MCP_ICON_SVG).toBe('<svg />');
+  });
+});
+

--- a/tests/unit/shared/modals/ConfirmModal.test.ts
+++ b/tests/unit/shared/modals/ConfirmModal.test.ts
@@ -1,0 +1,111 @@
+import { createMockEl } from '@test/helpers/mockElement';
+
+let lastModalInstance: any;
+let createdButtons: any[] = [];
+
+jest.mock('obsidian', () => {
+  const actual = jest.requireActual('obsidian');
+
+  class MockModal {
+    app: any;
+    modalEl: any;
+    contentEl: any;
+
+    constructor(app: any) {
+      this.app = app;
+      this.modalEl = createMockEl();
+      this.contentEl = createMockEl();
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      lastModalInstance = this;
+    }
+
+    setTitle = jest.fn();
+
+    open() {
+      this.onOpen();
+    }
+
+    close() {
+      this.onClose();
+    }
+
+    onOpen() {
+      // Overridden by subclass
+    }
+
+    onClose() {
+      // Overridden by subclass
+    }
+  }
+
+  class MockSetting {
+    constructor(_containerEl: any) {}
+
+    addButton(cb: (btn: any) => void) {
+      const btn: any = {
+        _onClick: null as null | (() => void),
+        setButtonText: jest.fn().mockReturnThis(),
+        setWarning: jest.fn().mockReturnThis(),
+        onClick: jest.fn((handler: () => void) => {
+          btn._onClick = handler;
+          return btn;
+        }),
+      };
+      createdButtons.push(btn);
+      cb(btn);
+      return this;
+    }
+  }
+
+  return {
+    ...actual,
+    Modal: MockModal,
+    Setting: MockSetting,
+  };
+});
+
+import { confirm, confirmDelete } from '@/shared/modals/ConfirmModal';
+
+beforeEach(() => {
+  lastModalInstance = null;
+  createdButtons = [];
+});
+
+describe('ConfirmModal', () => {
+  const mockApp = {} as any;
+
+  it('confirmDelete resolves true when confirm button is clicked', async () => {
+    const p = confirmDelete(mockApp, 'Are you sure?');
+
+    expect(lastModalInstance).toBeTruthy();
+    expect(createdButtons).toHaveLength(2);
+
+    const confirmBtn = createdButtons[1];
+    confirmBtn._onClick();
+
+    await expect(p).resolves.toBe(true);
+    expect(lastModalInstance.contentEl.children).toHaveLength(0);
+  });
+
+  it('confirmDelete resolves false when closed without confirming', async () => {
+    const p = confirmDelete(mockApp, 'Are you sure?');
+
+    lastModalInstance.close();
+
+    await expect(p).resolves.toBe(false);
+    expect(lastModalInstance.contentEl.children).toHaveLength(0);
+  });
+
+  it('confirm resolves true when confirm button is clicked', async () => {
+    const p = confirm(mockApp, 'Proceed?', 'Confirm');
+
+    expect(createdButtons).toHaveLength(2);
+    const confirmBtn = createdButtons[1];
+    expect(confirmBtn.setButtonText).toHaveBeenLastCalledWith('Confirm');
+
+    confirmBtn._onClick();
+
+    await expect(p).resolves.toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add mock element blur support and extend tool input tests for resolved answers and fallback paths/patterns
- add re-export sanity tests for core agent, agents, plugins, chat controllers, tabs, shared helpers, and i18n constants
- add focused tests for inline exit plan mode interactions and confirm modal flows

## Testing
- Not run (not requested)