### PR TITLE
feat: add switch-to-tab-N commands for quick tab navigation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -181,6 +181,31 @@ export default class ClaudianPlugin extends Plugin {
       },
     });
 
+    // Switch to tab 1-9 commands
+    for (let n = 1; n <= 9; n++) {
+      this.addCommand({
+        id: `switch-to-tab-${n}`,
+        name: `Switch to tab ${n}`,
+        checkCallback: (checking: boolean) => {
+          const leaf = this.app.workspace.getLeavesOfType(VIEW_TYPE_CLAUDIAN)[0];
+          if (!leaf) return false;
+
+          const view = leaf.view as ClaudianView;
+          const tabManager = view.getTabManager();
+          if (!tabManager) return false;
+
+          const tabs = tabManager.getAllTabs();
+          if (n > tabs.length) return false;
+
+          if (!checking) {
+            const targetTab = tabs[n - 1];
+            tabManager.switchToTab(targetTab.id);
+          }
+          return true;
+        },
+      });
+    }
+
     this.addSettingTab(new ClaudianSettingTab(this.app, this));
   }
 


### PR DESCRIPTION
Add 9 new commands (switch-to-tab-1 through switch-to-tab-9) that allow users to quickly switch between Claudian tabs using keyboard shortcuts.

Commands only appear when the target tab exists (e.g., switch-to-tab-3 won't show if there are only 2 tabs open).

Users can bind these to hotkeys like Cmd+1-9 or Fn+1-9 in Obsidian's hotkey settings.