### PR TITLE
fix: entries is not iterable

### DIFF
--- a/src/core/plugins/PluginManager.ts
+++ b/src/core/plugins/PluginManager.ts
@@ -93,7 +93,8 @@ export class PluginManager {
       for (const [pluginId, entries] of Object.entries(installedPlugins.plugins)) {
         if (!entries || entries.length === 0) continue;
 
-        const entry = selectInstalledPluginEntry(entries, normalizedVaultPath);
+        const entriesArray = Array.isArray(entries) ? entries : [entries];
+        const entry = selectInstalledPluginEntry(entriesArray, normalizedVaultPath);
         if (!entry) continue;
 
         const scope: PluginScope = entry.scope === 'project' ? 'project' : 'user';


### PR DESCRIPTION
开启插件时报错：

<img width="1050" height="476" alt="image" src="https://github.com/user-attachments/assets/1fe417e3-e85f-476a-8f1d-c6ab282cd3b0" />

提示："claudian" 加载失败。修复后编译测试能正常开启插件。
