### PR TITLE
fix: scope ESC streaming interrupt to Claudian view

### DIFF
--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -489,8 +489,8 @@ export class ClaudianView extends ItemView {
       }
     });
 
-    // Document-level escape to cancel streaming
-    this.registerDomEvent(document, 'keydown', (e: KeyboardEvent) => {
+    // View-scoped escape to cancel streaming (only when Claudian has focus)
+    this.registerDomEvent(this.containerEl, 'keydown', (e: KeyboardEvent) => {
       if (e.key === 'Escape' && !e.isComposing) {
         const activeTab = this.tabManager?.getActiveTab();
         if (activeTab?.state.isStreaming) {


### PR DESCRIPTION
## Summary
- Scoped the ESC key handler from `document` to `this.containerEl` so pressing Escape outside the Claudian panel no longer interrupts streaming sessions
- Matches the existing pattern used by the Shift+Tab plan mode toggle handler

Fixes #265

## Test plan
- [x] Start a streaming session in Claudian
- [x] Press ESC while focused on the Claudian chat panel — streaming should be interrupted
- [x] Start another streaming session
- [x] Click into the main Obsidian editor or another pane and press ESC — streaming should NOT be interrupted
- [x] Verify ESC still works for closing dropdowns, modals, and other Claudian UI elements