### PR TITLE
fix: lock focus during streaming, release after response completes

### DIFF
--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -511,12 +511,13 @@ export class ClaudianView extends ItemView {
       this.plugin.app.vault.on('modify', markDirty)
     );
 
-    // File open event
+    // File open event — locked while streaming, released after
     this.registerEvent(
       this.plugin.app.workspace.on('file-open', (file) => {
-        if (file) {
-          this.tabManager?.getActiveTab()?.ui.fileContextManager?.handleFileOpen(file);
-        }
+        if (!file) return;
+        const tab = this.tabManager?.getActiveTab();
+        if (tab?.state.isStreaming) return;
+        tab?.ui.fileContextManager?.handleFileOpen(file);
       })
     );
 

--- a/src/features/chat/ui/FileContext.ts
+++ b/src/features/chat/ui/FileContext.ts
@@ -171,16 +171,23 @@ export class FileContextManager {
     const normalizedPath = this.normalizePathForVault(file.path);
     if (!normalizedPath) return;
 
+    const isExcluded = this.hasExcludedTag(file);
+
     if (!this.state.isSessionStarted()) {
+      // Before session: replace all attachments with the new file
       this.state.clearAttachments();
-      if (!this.hasExcludedTag(file)) {
+      if (!isExcluded) {
         this.currentNotePath = normalizedPath;
         this.state.attachFile(normalizedPath);
       } else {
         this.currentNotePath = null;
       }
-      this.refreshCurrentNoteChip();
+    } else {
+      // During active session: update focus indicator without clearing attachments
+      this.currentNotePath = isExcluded ? null : normalizedPath;
     }
+
+    this.refreshCurrentNoteChip();
   }
 
   markFilesCacheDirty() {

--- a/tests/unit/features/chat/ui/FileContextManager.test.ts
+++ b/tests/unit/features/chat/ui/FileContextManager.test.ts
@@ -376,8 +376,8 @@ describe('FileContextManager', () => {
       manager.destroy();
     });
 
-    it('should not update current note when session is started', () => {
-      const app = createMockApp({ files: ['notes/a.md'] });
+    it('should update current note focus indicator when session is started', () => {
+      const app = createMockApp({ files: ['notes/a.md', 'notes/b.md'] });
       const manager = new FileContextManager(
         app, containerEl as any, inputEl, createMockCallbacks()
       );
@@ -387,8 +387,24 @@ describe('FileContextManager', () => {
 
       const fileB = createMockTFile('notes/b.md');
       manager.handleFileOpen(fileB);
-      // Should NOT update because session is started
-      expect(manager.getCurrentNotePath()).toBe('notes/a.md');
+      // Focus indicator should follow active file even during session
+      expect(manager.getCurrentNotePath()).toBe('notes/b.md');
+      manager.destroy();
+    });
+
+    it('should not clear attachments when switching files after session starts', () => {
+      const app = createMockApp({ files: ['notes/a.md', 'notes/b.md'] });
+      const manager = new FileContextManager(
+        app, containerEl as any, inputEl, createMockCallbacks()
+      );
+
+      manager.setCurrentNote('notes/a.md');
+      manager.startSession();
+
+      const fileB = createMockTFile('notes/b.md');
+      manager.handleFileOpen(fileB);
+      // Original attachment (a.md) should remain — don't clear during active session
+      expect(manager.getAttachedFiles().has('notes/a.md')).toBe(true);
       manager.destroy();
     });
 


### PR DESCRIPTION
## Summary

- Focus indicator (current note chip) was permanently locked after the first message because `handleFileOpen` was gated on `sessionStarted`, which never resets during a conversation
- Now the lock is based on streaming state: file-open events are skipped while `isStreaming` is true in `ClaudianView` and resume once the response finishes
- During an active session (between messages), the focus chip follows file switches without clearing manual @-mention attachments

## Test plan

- [ ] Open sidebar, switch files before sending any message — focus chip should follow
- [ ] Send a message, while AI is responding switch files — focus chip should stay locked
- [ ] After AI finishes responding, switch files — focus chip should follow again
- [ ] Verify @-mentioned files are not cleared when switching files mid-session