### PR TITLE
fix: improve code comment contrast in light mode

### DIFF
--- a/src/style/components/code.css
+++ b/src/style/components/code.css
@@ -14,6 +14,12 @@
   margin: 0;
 }
 
+/* Light mode: use a lighter background so hljs comment colors stay readable */
+body.theme-light .claudian-code-wrapper pre,
+body.theme-light .claudian-message-content pre {
+  background: rgba(0, 0, 0, 0.08);
+}
+
 /* Code blocks without language - wrap content */
 .claudian-code-wrapper:not(.has-language) pre {
   white-space: pre-wrap;


### PR DESCRIPTION
## Summary
- Use a lighter code block background (`rgba(0,0,0,0.08)`) in light mode instead of the default `0.2` opacity
- This preserves hljs comment readability without overriding individual token colors
- Dark mode remains unchanged at `0.2`

Closes #277

## Test plan
- [ ] Open Obsidian in light mode (moonstone theme)
- [ ] Send a message that produces a code block with comments (e.g., HTML or JS with `//` or `<!-- -->`)
- [ ] Verify comments are readable against the code block background
- [ ] Switch to dark mode and verify code blocks still look correct (unchanged)
- [ ] Test with different community themes (e.g., Cupertino) in light mode