### PR TITLE
Fix input box hidden state across overlapping inline prompts

### DIFF
--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -73,6 +73,7 @@ export class InputController {
   private pendingAskInline: InlineAskUserQuestion | null = null;
   private pendingExitPlanModeInline: InlineExitPlanMode | null = null;
   private activeResumeDropdown: ResumeSessionDropdown | null = null;
+  private inputContainerHideDepth = 0;
 
   constructor(deps: InputControllerDeps) {
     this.deps = deps;
@@ -820,8 +821,7 @@ export class InputController {
     config?: InlineAskQuestionConfig,
   ): Promise<Record<string, string> | null> {
     this.deps.streamController.hideThinkingIndicator();
-    const previousDisplay = inputContainerEl.style.display;
-    inputContainerEl.style.display = 'none';
+    this.hideInputContainer(inputContainerEl);
 
     return new Promise<Record<string, string> | null>((resolve, reject) => {
       const inline = new InlineAskUserQuestion(
@@ -829,7 +829,7 @@ export class InputController {
         input,
         (result: Record<string, string> | null) => {
           setPending(null);
-          inputContainerEl.style.display = previousDisplay;
+          this.restoreInputContainer(inputContainerEl);
           resolve(result);
         },
         signal,
@@ -840,7 +840,7 @@ export class InputController {
         inline.render();
       } catch (err) {
         setPending(null);
-        inputContainerEl.style.display = previousDisplay;
+        this.restoreInputContainer(inputContainerEl);
         reject(err);
       }
     });
@@ -858,7 +858,7 @@ export class InputController {
     }
 
     streamController.hideThinkingIndicator();
-    inputContainerEl.style.display = 'none';
+    this.hideInputContainer(inputContainerEl);
 
     const enrichedInput = state.planFilePath
       ? { ...input, planFilePath: state.planFilePath }
@@ -873,7 +873,7 @@ export class InputController {
         enrichedInput,
         (decision: ExitPlanModeDecision | null) => {
           this.pendingExitPlanModeInline = null;
-          inputContainerEl.style.display = '';
+          this.restoreInputContainer(inputContainerEl);
           resolve(decision);
         },
         signal,
@@ -884,7 +884,7 @@ export class InputController {
         inline.render();
       } catch (err) {
         this.pendingExitPlanModeInline = null;
-        inputContainerEl.style.display = '';
+        this.restoreInputContainer(inputContainerEl);
         reject(err);
       }
     });
@@ -902,6 +902,27 @@ export class InputController {
     if (this.pendingExitPlanModeInline) {
       this.pendingExitPlanModeInline.destroy();
       this.pendingExitPlanModeInline = null;
+    }
+    this.resetInputContainerVisibility();
+  }
+
+  private hideInputContainer(inputContainerEl: HTMLElement): void {
+    this.inputContainerHideDepth++;
+    inputContainerEl.style.display = 'none';
+  }
+
+  private restoreInputContainer(inputContainerEl: HTMLElement): void {
+    if (this.inputContainerHideDepth <= 0) return;
+    this.inputContainerHideDepth--;
+    if (this.inputContainerHideDepth === 0) {
+      inputContainerEl.style.display = '';
+    }
+  }
+
+  private resetInputContainerVisibility(): void {
+    if (this.inputContainerHideDepth > 0) {
+      this.inputContainerHideDepth = 0;
+      this.deps.getInputContainerEl().style.display = '';
     }
   }
 

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -1635,6 +1635,70 @@ describe('InputController - Message Queue', () => {
       controller.dismissPendingApproval();
       await approvalPromise;
     });
+
+    it('should restore input visibility after overlapping inline prompts are dismissed', async () => {
+      const parentEl = createMockEl();
+      const inputContainerEl = createMockEl();
+      (inputContainerEl as any).parentElement = parentEl;
+      deps.getInputContainerEl = () => inputContainerEl as any;
+
+      controller = new InputController(deps);
+
+      const approvalPromise = controller.handleApprovalRequest(
+        'bash',
+        { command: 'ls -la' },
+        'Run shell command',
+      );
+      const askPromise = controller.handleAskUserQuestion({
+        questions: [
+          {
+            question: 'Select one option',
+            options: ['Option A', 'Option B'],
+          },
+        ],
+      });
+
+      expect(inputContainerEl.style.display).toBe('none');
+
+      controller.dismissPendingApproval();
+
+      await expect(approvalPromise).resolves.toBe('cancel');
+      await expect(askPromise).resolves.toBeNull();
+      expect(inputContainerEl.style.display).toBe('');
+    });
+
+    it('should keep input hidden until overlapping exit-plan prompt is dismissed', async () => {
+      const parentEl = createMockEl();
+      const inputContainerEl = createMockEl();
+      (inputContainerEl as any).parentElement = parentEl;
+      deps.getInputContainerEl = () => inputContainerEl as any;
+
+      controller = new InputController(deps);
+
+      const approvalPromise = controller.handleApprovalRequest(
+        'bash',
+        { command: 'ls -la' },
+        'Run shell command',
+      );
+      const exitPlanPromise = controller.handleExitPlanMode({});
+
+      expect(inputContainerEl.style.display).toBe('none');
+
+      const items = parentEl.querySelectorAll('claudian-ask-item');
+      const allowOnceItem = items.find((item: any) => {
+        const label = item.querySelector('claudian-ask-item-label');
+        return label?.textContent === 'Allow once';
+      });
+      expect(allowOnceItem).toBeDefined();
+
+      allowOnceItem!.click();
+      await expect(approvalPromise).resolves.toBe('allow');
+      expect(inputContainerEl.style.display).toBe('none');
+
+      controller.dismissPendingApproval();
+      await expect(exitPlanPromise).resolves.toBeNull();
+      expect(inputContainerEl.style.display).toBe('');
+    });
   });
 
   describe('handleInstructionSubmit', () => {


### PR DESCRIPTION
## Summary
This branch fixes a race where overlapping inline prompts (approval, AskUserQuestion, ExitPlanMode) could leave the composer hidden after one prompt resolved.
Input visibility is now managed with a depth counter so the input is shown only when the last overlapping prompt is dismissed, and dismiss cleanup force-resets stale hide state.
The branch also adds focused unit tests covering overlapping approval+AskUserQuestion and approval+ExitPlanMode flows to prevent regressions.

## Validation
Ran: npm run typecheck && npm run lint && npm run test && npm run build.