### PR TITLE
fix: avoid passing AbortSignal to spawn() for Electron compatibility

### DIFF
--- a/src/core/agent/customSpawn.ts
+++ b/src/core/agent/customSpawn.ts
@@ -27,13 +27,23 @@ export function createCustomSpawnFunction(
       }
     }
 
+    // Do not pass `signal` directly to spawn() — Obsidian's Electron runtime
+    // uses a different realm for AbortSignal, causing `instanceof EventTarget`
+    // checks inside Node's internals to fail. Handle abort manually instead.
     const child = spawn(command, args, {
       cwd,
       env: env as NodeJS.ProcessEnv,
-      signal,
       stdio: ['pipe', 'pipe', shouldPipeStderr ? 'pipe' : 'ignore'],
       windowsHide: true,
     });
+
+    if (signal) {
+      if (signal.aborted) {
+        child.kill();
+      } else {
+        signal.addEventListener('abort', () => child.kill(), { once: true });
+      }
+    }
 
     if (shouldPipeStderr && child.stderr && typeof child.stderr.on === 'function') {
       child.stderr.on('data', () => {});


### PR DESCRIPTION
## Summary

- Remove `signal` from `child_process.spawn()` options in `createCustomSpawnFunction` to fix cross-realm `AbortSignal` incompatibility in Obsidian's Electron runtime
- Handle abort manually via `signal.addEventListener('abort', ...)` instead

## Problem

Obsidian's Electron uses a different realm for `AbortSignal` than Node.js's internals expect. When `signal` is passed to `spawn()`, Node validates it with `instanceof EventTarget`, which fails across realms:

```
Error: The "eventTargets" argument must be an instance of EventEmitter
or EventTarget. Received an instance of AbortSignal
```

## Note

This PR fixes the `customSpawn.ts` part of the issue. There is also a similar problem in the upstream SDK (`@anthropic-ai/claude-agent-sdk`) where `events.setMaxListeners(n, abortSignal)` triggers the same cross-realm error — that would need to be fixed in the SDK itself.

Fixes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)