### PR TITLE
fix(style): inherit Obsidian body font in chat container

### DIFF
--- a/src/style/base/container.css
+++ b/src/style/base/container.css
@@ -4,4 +4,5 @@
   height: 100%;
   padding: 0;
   overflow: hidden;
+  font-family: var(--font-text);
 }


### PR DESCRIPTION
## Summary
- Add `font-family: var(--font-text)` to `.claudian-container` so the chat UI respects the user's custom body font configured in Obsidian's Appearance settings
- Fix proposed by @Centerful in #402

## Test plan
- Set a custom body font in Obsidian → Appearance → Font → Body font
- Open Claudian sidebar and verify chat text uses the configured font

Closes #402