### PR TITLE
fix(selection): preserve selection when Claudian is in detached window or own tab

### DIFF
--- a/src/features/chat/controllers/SelectionController.ts
+++ b/src/features/chat/controllers/SelectionController.ts
@@ -17,6 +17,7 @@ export class SelectionController {
   private focusScopeEl: HTMLElement;
   private contextRowEl: HTMLElement;
   private onVisibilityChange: (() => void) | null;
+  private ownViewType: string | null;
   private storedSelection: StoredSelection | null = null;
   private inputHandoffGraceUntil: number | null = null;
   private pollInterval: ReturnType<typeof setInterval> | null = null;
@@ -31,7 +32,8 @@ export class SelectionController {
     inputEl: HTMLElement,
     contextRowEl: HTMLElement,
     onVisibilityChange?: () => void,
-    focusScopeEl?: HTMLElement
+    focusScopeEl?: HTMLElement,
+    ownViewType?: string
   ) {
     this.app = app;
     this.indicatorEl = indicatorEl;
@@ -39,6 +41,7 @@ export class SelectionController {
     this.focusScopeEl = focusScopeEl ?? inputEl;
     this.contextRowEl = contextRowEl;
     this.onVisibilityChange = onVisibilityChange ?? null;
+    this.ownViewType = ownViewType ?? null;
   }
 
   start(): void {
@@ -209,8 +212,18 @@ export class SelectionController {
 
   private isFocusWithinChatSidebar(): boolean {
     const activeElement = document.activeElement as Node | null;
-    return activeElement !== null
-      && (activeElement === this.focusScopeEl || this.focusScopeEl.contains(activeElement));
+    if (activeElement !== null
+      && (activeElement === this.focusScopeEl || this.focusScopeEl.contains(activeElement))) {
+      return true;
+    }
+    if (this.ownViewType) {
+      const activeLeaf = (this.app.workspace as any).activeLeaf
+        ?? this.app.workspace.getMostRecentLeaf?.();
+      if (activeLeaf?.view?.getViewType?.() === this.ownViewType) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private clearWhenMarkdownContextIsUnavailable(): void {

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -4,7 +4,7 @@ import { Notice } from 'obsidian';
 import { ClaudianService } from '../../../core/agent';
 import type { McpServerManager } from '../../../core/mcp';
 import type { ChatMessage, ClaudeModel, Conversation, EffortLevel, PermissionMode, SlashCommand, StreamChunk, ThinkingBudget } from '../../../core/types';
-import { DEFAULT_CLAUDE_MODELS, DEFAULT_EFFORT_LEVEL, DEFAULT_THINKING_BUDGET, getContextWindowSize, isAdaptiveThinkingModel } from '../../../core/types';
+import { DEFAULT_CLAUDE_MODELS, DEFAULT_EFFORT_LEVEL, DEFAULT_THINKING_BUDGET, getContextWindowSize, isAdaptiveThinkingModel,VIEW_TYPE_CLAUDIAN } from '../../../core/types';
 import { t } from '../../../i18n';
 import type ClaudianPlugin from '../../../main';
 import { SlashCommandDropdown } from '../../../shared/components/SlashCommandDropdown';
@@ -755,6 +755,7 @@ export function initializeTabControllers(
     dom.contextRowEl,
     () => autoResizeTextarea(dom.inputEl),
     dom.contentEl,
+    VIEW_TYPE_CLAUDIAN,
   );
 
   // Browser selection controller

--- a/tests/unit/features/chat/controllers/SelectionController.test.ts
+++ b/tests/unit/features/chat/controllers/SelectionController.test.ts
@@ -192,7 +192,28 @@ describe('SelectionController', () => {
     expect(indicatorEl.style.display).toBe('block');
   });
 
-  it('clears selection when focus leaves markdown and the chat sidebar is not focused', () => {
+  it('preserves selection when active leaf is the Claudian view (detached window / own tab)', () => {
+    const claudianLeaf = { view: { getViewType: () => 'claudian-view' } };
+    app.workspace.activeLeaf = claudianLeaf;
+    controller = new SelectionController(app, indicatorEl, inputEl, contextRowEl, undefined, focusScopeEl, 'claudian-view');
+
+    controller.start();
+    jest.advanceTimersByTime(250);
+    expect(controller.hasSelection()).toBe(true);
+
+    app.workspace.getActiveViewOfType.mockReturnValue(null);
+    (global as any).document.activeElement = null;
+    jest.advanceTimersByTime(250);
+
+    expect(controller.hasSelection()).toBe(true);
+    expect(indicatorEl.style.display).toBe('block');
+  });
+
+  it('clears selection when active leaf is a non-Claudian, non-markdown view', () => {
+    const settingsLeaf = { view: { getViewType: () => 'settings' } };
+    app.workspace.activeLeaf = settingsLeaf;
+    controller = new SelectionController(app, indicatorEl, inputEl, contextRowEl, undefined, focusScopeEl, 'claudian-view');
+
     controller.start();
     jest.advanceTimersByTime(250);
     expect(controller.hasSelection()).toBe(true);


### PR DESCRIPTION
## Summary

- Fixes #399 — editor text selection was lost when Claudian runs in a detached window or its own tab
- When the Claudian leaf is detached, clicking it deactivates the MarkdownView leaf and `document.activeElement` becomes `<body>`, which falls outside `focusScopeEl`. The sidebar focus guard now also checks whether the active leaf's view type is the Claudian view, so the selection is preserved.
- Added `ownViewType` parameter to `SelectionController` and updated tests

## Verification

- [x] Unit test: selection preserved when active leaf is the Claudian view (detached window / own tab)
- [x] Unit test: selection cleared when active leaf is a non-Claudian, non-markdown view
- [x] Manual: open Claudian in a detached window, select text in the editor, verify selection context appears in chat
- [x] Manual: open Claudian in its own tab, select text in the editor, verify selection context appears in chat
