### PR TITLE
fix: detect haiku 1M models in getModelUsageSignature()

### DIFF
--- a/src/providers/claude/stream/transformClaudeMessage.ts
+++ b/src/providers/claude/stream/transformClaudeMessage.ts
@@ -69,7 +69,7 @@ function getBuiltInModelSignature(model: string): { family: 'haiku' | 'sonnet' |
 function getModelUsageSignature(model: string): { family: 'haiku' | 'sonnet' | 'opus'; is1M: boolean } | null {
   const normalized = model.trim().toLowerCase();
   if (normalized.includes('haiku')) {
-    return { family: 'haiku', is1M: false };
+    return { family: 'haiku', is1M: normalized.endsWith('[1m]') };
   }
   if (normalized.includes('sonnet')) {
     return { family: 'sonnet', is1M: normalized.endsWith('[1m]') };


### PR DESCRIPTION
Closes #461

## Problem
`getModelUsageSignature()` hardcodes `is1M: false` for haiku models, even when the model name ends with `[1m]`. This means haiku 1M users never see context window usage events.

## Fix
Changed `is1M: false` to `is1M: normalized.endsWith("[1m]")` for haiku, consistent with sonnet/opus detection logic.