### PR TITLE
fix: handle missing codexHome in Codex app-server initialize response

### DIFF
--- a/src/providers/codex/history/CodexConversationHistoryService.ts
+++ b/src/providers/codex/history/CodexConversationHistoryService.ts
@@ -4,6 +4,7 @@ import type { CodexProviderState } from '../types';
 import { getCodexState } from '../types';
 import {
   type CodexParsedTurn,
+  deriveCodexSessionsRootFromSessionPath,
   findCodexSessionFile,
   parseCodexSessionFile,
   parseCodexSessionTurns,
@@ -28,6 +29,8 @@ export class CodexConversationHistoryService implements ProviderConversationHist
     _vaultPath: string | null,
   ): Promise<void> {
     const state = getCodexState(conversation.providerState);
+    const transcriptRootPath = state.transcriptRootPath
+      ?? deriveCodexSessionsRootFromSessionPath(state.sessionFilePath);
 
     // Pending fork with existing in-memory messages: keep them as-is
     if (this.isPendingForkConversation(conversation) && conversation.messages.length > 0) {
@@ -55,7 +58,7 @@ export class CodexConversationHistoryService implements ProviderConversationHist
       const sourceSessionFile = this.resolveSourceSessionFile(state);
       const forkSessionFile = state.sessionFilePath ?? (
         state.threadId
-          ? findCodexSessionFile(state.threadId, state.transcriptRootPath)
+          ? findCodexSessionFile(state.threadId, transcriptRootPath ?? undefined)
           : null
       );
 
@@ -92,9 +95,11 @@ export class CodexConversationHistoryService implements ProviderConversationHist
     const threadId = state.threadId ?? conversation.sessionId ?? null;
     const sessionFilePath = state.sessionFilePath ?? (
       threadId
-        ? findCodexSessionFile(threadId, state.transcriptRootPath)
+        ? findCodexSessionFile(threadId, transcriptRootPath ?? undefined)
         : null
     );
+    const resolvedTranscriptRootPath = transcriptRootPath
+      ?? deriveCodexSessionsRootFromSessionPath(sessionFilePath);
 
     if (!sessionFilePath) {
       this.hydratedConversationPaths.delete(conversation.id);
@@ -114,6 +119,13 @@ export class CodexConversationHistoryService implements ProviderConversationHist
         ...(conversation.providerState ?? {}),
         ...(threadId ? { threadId } : {}),
         sessionFilePath,
+        ...(resolvedTranscriptRootPath ? { transcriptRootPath: resolvedTranscriptRootPath } : {}),
+      };
+    } else if (resolvedTranscriptRootPath && resolvedTranscriptRootPath !== state.transcriptRootPath) {
+      conversation.providerState = {
+        ...(conversation.providerState ?? {}),
+        ...(threadId ? { threadId } : {}),
+        transcriptRootPath: resolvedTranscriptRootPath,
       };
     }
 
@@ -151,12 +163,14 @@ export class CodexConversationHistoryService implements ProviderConversationHist
     sourceProviderState?: Record<string, unknown>,
   ): Record<string, unknown> {
     const sourceState = getCodexState(sourceProviderState);
+    const sourceTranscriptRootPath = sourceState.transcriptRootPath
+      ?? deriveCodexSessionsRootFromSessionPath(sourceState.sessionFilePath);
     const providerState: CodexProviderState = {
       forkSource: { sessionId: sourceSessionId, resumeAt },
       ...(sourceState.sessionFilePath ? { forkSourceSessionFilePath: sourceState.sessionFilePath } : {}),
       ...(
-        sourceState.transcriptRootPath
-          ? { forkSourceTranscriptRootPath: sourceState.transcriptRootPath }
+        sourceTranscriptRootPath
+          ? { forkSourceTranscriptRootPath: sourceTranscriptRootPath }
           : {}
       ),
     };
@@ -177,8 +191,10 @@ export class CodexConversationHistoryService implements ProviderConversationHist
 
   private resolveSourceSessionFile(state: CodexProviderState): string | null {
     if (!state.forkSource) return null;
+    const sourceTranscriptRootPath = state.forkSourceTranscriptRootPath
+      ?? deriveCodexSessionsRootFromSessionPath(state.forkSourceSessionFilePath);
     return state.forkSourceSessionFilePath
-      ?? findCodexSessionFile(state.forkSource.sessionId, state.forkSourceTranscriptRootPath);
+      ?? findCodexSessionFile(state.forkSource.sessionId, sourceTranscriptRootPath ?? undefined);
   }
 
   private truncateTurnsAtCheckpoint(

--- a/src/providers/codex/history/CodexHistoryStore.ts
+++ b/src/providers/codex/history/CodexHistoryStore.ts
@@ -1044,6 +1044,45 @@ function flushBubbleTurnMessages(
 
 const SAFE_SESSION_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
 
+function getPathModuleForSessionPath(sessionPath: string): typeof path.posix | typeof path.win32 {
+  return sessionPath.includes('\\') || /^[A-Za-z]:/.test(sessionPath)
+    ? path.win32
+    : path.posix;
+}
+
+export function deriveCodexSessionsRootFromSessionPath(
+  sessionFilePath: string | null | undefined,
+): string | null {
+  if (!sessionFilePath) {
+    return null;
+  }
+
+  const pathModule = getPathModuleForSessionPath(sessionFilePath);
+  let current = pathModule.dirname(pathModule.normalize(sessionFilePath));
+  let previous: string | null = null;
+
+  while (current && current !== previous) {
+    if (pathModule.basename(current).toLowerCase() === 'sessions') {
+      return current;
+    }
+    previous = current;
+    current = pathModule.dirname(current);
+  }
+
+  return null;
+}
+
+export function deriveCodexMemoriesDirFromSessionsRoot(
+  sessionsDir: string | null | undefined,
+): string | null {
+  if (!sessionsDir) {
+    return null;
+  }
+
+  const pathModule = getPathModuleForSessionPath(sessionsDir);
+  return pathModule.join(pathModule.dirname(sessionsDir), 'memories');
+}
+
 export function findCodexSessionFile(
   threadId: string,
   root: string = path.join(os.homedir(), '.codex', 'sessions'),

--- a/src/providers/codex/runtime/CodexChatRuntime.ts
+++ b/src/providers/codex/runtime/CodexChatRuntime.ts
@@ -30,7 +30,11 @@ import type ClaudianPlugin from '../../../main';
 import { getVaultPath } from '../../../utils/path';
 import { buildContextFromHistory } from '../../../utils/session';
 import { CODEX_PROVIDER_CAPABILITIES } from '../capabilities';
-import { findCodexSessionFile } from '../history/CodexHistoryStore';
+import {
+  deriveCodexMemoriesDirFromSessionsRoot,
+  deriveCodexSessionsRootFromSessionPath,
+  findCodexSessionFile,
+} from '../history/CodexHistoryStore';
 import { encodeCodexTurn } from '../prompt/encodeCodexTurn';
 import { type CodexSafeMode, getCodexProviderSettings } from '../settings';
 import {
@@ -61,7 +65,7 @@ import type {
 import type { CodexLaunchSpec } from './codexLaunchTypes';
 import { CodexNotificationRouter } from './CodexNotificationRouter';
 import { CodexRpcTransport } from './CodexRpcTransport';
-import { type CodexRuntimeContext,createCodexRuntimeContext } from './CodexRuntimeContext';
+import { type CodexRuntimeContext, createCodexRuntimeContext } from './CodexRuntimeContext';
 import { CodexServerRequestRouter } from './CodexServerRequestRouter';
 import { CodexFileTailEngine } from './CodexSessionFileTail';
 import { CodexSessionManager } from './CodexSessionManager';
@@ -373,6 +377,7 @@ export class CodexChatRuntime implements ChatRuntime {
       const existingThreadId = this.session.getThreadId();
       let threadId: string;
       let threadPath: string | null = null;
+      let threadTargetPath: string | null = null;
       let completedPendingFork = false;
 
       if (this.pendingFork) {
@@ -383,7 +388,8 @@ export class CodexChatRuntime implements ChatRuntime {
           threadId: fork.sessionId,
         });
         threadId = forkResult.thread.id;
-        threadPath = this.toHostSessionPath(forkResult.thread.path);
+        threadTargetPath = forkResult.thread.path ?? null;
+        threadPath = this.toHostSessionPath(threadTargetPath);
 
         // Compute rollback: count turns after the resumeAt checkpoint
         const forkTurns = forkResult.thread.turns ?? [];
@@ -444,7 +450,8 @@ export class CodexChatRuntime implements ChatRuntime {
           persistExtendedHistory: true,
         });
         threadId = resumeResult.thread.id;
-        threadPath = this.toHostSessionPath(resumeResult.thread.path);
+        threadTargetPath = resumeResult.thread.path ?? null;
+        threadPath = this.toHostSessionPath(threadTargetPath);
         this.loadedThreadId = threadId;
       } else if (existingThreadId && existingThreadId === this.loadedThreadId) {
         // Thread already loaded — just start a new turn
@@ -463,7 +470,8 @@ export class CodexChatRuntime implements ChatRuntime {
           persistExtendedHistory: true,
         });
         threadId = startResult.thread.id;
-        threadPath = this.toHostSessionPath(startResult.thread.path);
+        threadTargetPath = startResult.thread.path ?? null;
+        threadPath = this.toHostSessionPath(threadTargetPath);
         this.loadedThreadId = threadId;
       }
 
@@ -488,7 +496,7 @@ export class CodexChatRuntime implements ChatRuntime {
       } else {
         // --- Normal turn path ---
         tailEngine = new CodexFileTailEngine(
-          this.runtimeContext?.sessionsDirHost ?? path.join(os.homedir(), '.codex', 'sessions'),
+          this.resolveTranscriptRootHost(threadPath) ?? path.join(os.homedir(), '.codex', 'sessions'),
           200_000,
         );
         tailEngine.resetForNewTurn();
@@ -513,7 +521,15 @@ export class CodexChatRuntime implements ChatRuntime {
         const isPlanMode = providerSettings.permissionMode === 'plan';
         const externalContextPaths = this.resolveExternalContextPaths(turn, queryOptions);
         const permissionMode = this.resolveSandboxConfig();
-        const sandboxPolicy = this.buildTurnSandboxPolicy(externalContextPaths, permissionMode.sandbox);
+        const transcriptRootTarget = this.runtimeContext?.sessionsDirTarget
+          ?? deriveCodexSessionsRootFromSessionPath(threadTargetPath)
+          ?? this.resolveTranscriptRootTarget(threadPath ?? transcriptSessionFilePath);
+        const sandboxPolicy = this.buildTurnSandboxPolicy(
+          externalContextPaths,
+          permissionMode.sandbox,
+          transcriptRootTarget,
+          threadPath ?? transcriptSessionFilePath,
+        );
 
         const collaborationMode = isPlanMode
           ? {
@@ -624,7 +640,7 @@ export class CodexChatRuntime implements ChatRuntime {
         if (threadId) {
           const sessionFilePath = findCodexSessionFile(
             threadId,
-            this.runtimeContext?.sessionsDirHost ?? undefined,
+            this.resolveTranscriptRootHost(this.session.getSessionFilePath() ?? this.currentThreadPath) ?? undefined,
           );
           if (sessionFilePath) {
             this.session.setThread(threadId, sessionFilePath);
@@ -770,6 +786,7 @@ export class CodexChatRuntime implements ChatRuntime {
   }): SessionUpdateResult {
     const threadId = this.session.getThreadId();
     const sessionFilePath = this.session.getSessionFilePath() ?? this.currentThreadPath;
+    const transcriptRootPath = this.resolveTranscriptRootHost(sessionFilePath);
 
     // Preserve forkSource from existing conversation state
     const existingState = params.conversation
@@ -780,8 +797,8 @@ export class CodexChatRuntime implements ChatRuntime {
       ...(threadId ? { threadId } : {}),
       ...(sessionFilePath ? { sessionFilePath } : {}),
       ...(
-        this.runtimeContext?.sessionsDirHost || existingState?.transcriptRootPath
-          ? { transcriptRootPath: this.runtimeContext?.sessionsDirHost ?? existingState?.transcriptRootPath }
+        transcriptRootPath || existingState?.transcriptRootPath
+          ? { transcriptRootPath: transcriptRootPath ?? existingState?.transcriptRootPath }
           : {}
       ),
       ...(existingState?.forkSource ? { forkSource: existingState.forkSource } : {}),
@@ -1001,6 +1018,8 @@ export class CodexChatRuntime implements ChatRuntime {
   private buildTurnSandboxPolicy(
     externalContextPaths: string[],
     sandboxMode: string,
+    transcriptRootTargetHint?: string | null,
+    sessionFilePathHint?: string | null,
   ): SandboxPolicy | undefined {
     if (sandboxMode === 'danger-full-access') {
       return { type: 'dangerFullAccess' };
@@ -1022,11 +1041,18 @@ export class CodexChatRuntime implements ChatRuntime {
       externalContextPaths,
       'external context path',
     );
+    const memoriesDirTarget = deriveCodexMemoriesDirFromSessionsRoot(transcriptRootTargetHint)
+      ?? this.resolveMemoriesDirTarget(sessionFilePathHint)
+      ?? (
+        this.launchSpec?.target.method === 'wsl'
+          ? null
+          : path.join(os.homedir(), '.codex', 'memories')
+      );
 
     const writableRoots = [
       this.launchSpec?.targetCwd ?? getVaultPath(this.plugin.app),
       ...mappedExternalContextPaths,
-      this.runtimeContext?.memoriesDirTarget ?? path.join(os.homedir(), '.codex', 'memories'),
+      memoriesDirTarget,
       this.mapHostPathToTarget(os.tmpdir()),
       this.launchSpec?.target.platformFamily === 'unix' ? '/tmp' : null,
       this.mapHostPathToTarget(process.env.TMPDIR),
@@ -1253,6 +1279,29 @@ export class CodexChatRuntime implements ChatRuntime {
     return this.launchSpec?.pathMapper.toHostPath(targetPath) ?? targetPath;
   }
 
+  private toTargetSessionPath(sessionPath: string | null | undefined): string | null {
+    if (!sessionPath) {
+      return null;
+    }
+
+    if (!this.launchSpec) {
+      return sessionPath;
+    }
+
+    if (this.launchSpec.target.platformFamily === 'unix' && sessionPath.startsWith('/')) {
+      return sessionPath;
+    }
+
+    if (
+      this.launchSpec.target.platformFamily === 'windows'
+      && (/^[A-Za-z]:[\\/]/.test(sessionPath) || sessionPath.startsWith('\\\\'))
+    ) {
+      return sessionPath;
+    }
+
+    return this.launchSpec.pathMapper.toTargetPath(sessionPath) ?? sessionPath;
+  }
+
   private mapHostPathToTarget(hostPath: string | null | undefined): string | null {
     if (!hostPath) {
       return null;
@@ -1273,6 +1322,34 @@ export class CodexChatRuntime implements ChatRuntime {
       }
       return targetPath;
     });
+  }
+
+  private resolveTranscriptRootHost(sessionFilePath?: string | null): string | null {
+    return this.runtimeContext?.sessionsDirHost
+      ?? deriveCodexSessionsRootFromSessionPath(
+        sessionFilePath ?? this.session.getSessionFilePath() ?? this.currentThreadPath,
+      );
+  }
+
+  private resolveTranscriptRootTarget(sessionFilePath?: string | null): string | null {
+    if (this.runtimeContext?.sessionsDirTarget) {
+      return this.runtimeContext.sessionsDirTarget;
+    }
+
+    const targetSessionPath = this.toTargetSessionPath(
+      sessionFilePath ?? this.session.getSessionFilePath() ?? this.currentThreadPath,
+    );
+    return deriveCodexSessionsRootFromSessionPath(targetSessionPath);
+  }
+
+  private resolveMemoriesDirTarget(sessionFilePath?: string | null): string | null {
+    if (this.runtimeContext?.memoriesDirTarget) {
+      return this.runtimeContext.memoriesDirTarget;
+    }
+
+    return deriveCodexMemoriesDirFromSessionsRoot(
+      this.resolveTranscriptRootTarget(sessionFilePath),
+    );
   }
 }
 

--- a/src/providers/codex/runtime/CodexRuntimeContext.ts
+++ b/src/providers/codex/runtime/CodexRuntimeContext.ts
@@ -6,11 +6,11 @@ import type { CodexLaunchSpec } from './codexLaunchTypes';
 export interface CodexRuntimeContext {
   launchSpec: CodexLaunchSpec;
   initializeResult: InitializeResult;
-  codexHomeTarget: string;
+  codexHomeTarget: string | null;
   codexHomeHost: string | null;
-  sessionsDirTarget: string;
+  sessionsDirTarget: string | null;
   sessionsDirHost: string | null;
-  memoriesDirTarget: string;
+  memoriesDirTarget: string | null;
 }
 
 function normalizeTargetPath(launchSpec: CodexLaunchSpec, value: string): string {
@@ -23,6 +23,47 @@ function joinTargetPath(launchSpec: CodexLaunchSpec, ...parts: string[]): string
   return launchSpec.target.platformFamily === 'windows'
     ? path.win32.join(...parts)
     : path.posix.join(...parts.map(part => part.replace(/\\/g, '/')));
+}
+
+function normalizeOptionalTargetPath(
+  launchSpec: CodexLaunchSpec,
+  value: string | null | undefined,
+): string | null {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  return trimmed ? normalizeTargetPath(launchSpec, trimmed) : null;
+}
+
+function resolveFallbackCodexHomeTarget(launchSpec: CodexLaunchSpec): string | null {
+  const rawCodexHome = typeof launchSpec.env.CODEX_HOME === 'string'
+    ? launchSpec.env.CODEX_HOME.trim()
+    : '';
+  const envCodexHome = launchSpec.target.method === 'wsl'
+    ? normalizeOptionalTargetPath(
+        launchSpec,
+        rawCodexHome.startsWith('/') ? rawCodexHome : launchSpec.pathMapper.toTargetPath(rawCodexHome),
+      )
+    : normalizeOptionalTargetPath(launchSpec, rawCodexHome);
+  if (envCodexHome) {
+    return envCodexHome;
+  }
+
+  if (launchSpec.target.method === 'wsl') {
+    return null;
+  }
+
+  const homeVar = launchSpec.target.platformFamily === 'windows'
+    ? launchSpec.env.USERPROFILE
+    : launchSpec.env.HOME;
+  const homeDir = normalizeOptionalTargetPath(launchSpec, homeVar);
+  return homeDir ? joinTargetPath(launchSpec, homeDir, '.codex') : null;
+}
+
+function resolveCodexHomeTarget(
+  launchSpec: CodexLaunchSpec,
+  initializeResult: InitializeResult,
+): string | null {
+  return normalizeOptionalTargetPath(launchSpec, initializeResult.codexHome)
+    ?? resolveFallbackCodexHomeTarget(launchSpec);
 }
 
 function validateInitializeTarget(
@@ -48,17 +89,21 @@ export function createCodexRuntimeContext(
 ): CodexRuntimeContext {
   validateInitializeTarget(launchSpec, initializeResult);
 
-  const codexHomeTarget = normalizeTargetPath(launchSpec, initializeResult.codexHome);
-  const sessionsDirTarget = joinTargetPath(launchSpec, codexHomeTarget, 'sessions');
-  const memoriesDirTarget = joinTargetPath(launchSpec, codexHomeTarget, 'memories');
+  const codexHomeTarget = resolveCodexHomeTarget(launchSpec, initializeResult);
+  const sessionsDirTarget = codexHomeTarget
+    ? joinTargetPath(launchSpec, codexHomeTarget, 'sessions')
+    : null;
+  const memoriesDirTarget = codexHomeTarget
+    ? joinTargetPath(launchSpec, codexHomeTarget, 'memories')
+    : null;
 
   return {
     launchSpec,
     initializeResult,
     codexHomeTarget,
-    codexHomeHost: launchSpec.pathMapper.toHostPath(codexHomeTarget),
+    codexHomeHost: codexHomeTarget ? launchSpec.pathMapper.toHostPath(codexHomeTarget) : null,
     sessionsDirTarget,
-    sessionsDirHost: launchSpec.pathMapper.toHostPath(sessionsDirTarget),
+    sessionsDirHost: sessionsDirTarget ? launchSpec.pathMapper.toHostPath(sessionsDirTarget) : null,
     memoriesDirTarget,
   };
 }

--- a/src/providers/codex/runtime/codexAppServerTypes.ts
+++ b/src/providers/codex/runtime/codexAppServerTypes.ts
@@ -43,7 +43,7 @@ export interface InitializeParams {
 
 export interface InitializeResult {
   userAgent: string;
-  codexHome: string;
+  codexHome?: string;
   platformFamily: string;
   platformOs: string;
 }

--- a/tests/unit/providers/codex/history/CodexConversationHistoryService.test.ts
+++ b/tests/unit/providers/codex/history/CodexConversationHistoryService.test.ts
@@ -195,6 +195,55 @@ describe('CodexConversationHistoryService', () => {
     expect((conversation.providerState as Record<string, unknown>).sessionFilePath).toBe(transcriptPath);
   });
 
+  it('backfills transcriptRootPath from sessionFilePath when only the session path is known', async () => {
+    const threadId = 'thread-backfill-root';
+    const sessionsDir = path.join(tempHome, 'custom-codex-root', 'sessions', '2026', '03', '28');
+    fs.mkdirSync(sessionsDir, { recursive: true });
+
+    const transcriptPath = path.join(
+      sessionsDir,
+      `rollout-2026-03-28T00-00-00-${threadId}.jsonl`,
+    );
+
+    fs.writeFileSync(
+      transcriptPath,
+      [
+        JSON.stringify({
+          timestamp: '2026-03-28T00:00:00.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Recovered from session path.' }],
+          },
+        }),
+      ].join('\n'),
+      'utf-8',
+    );
+
+    const conversation: Conversation = {
+      id: 'conv-backfill-root',
+      providerId: 'codex',
+      title: 'Backfill Transcript Root',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      sessionId: threadId,
+      providerState: {
+        threadId,
+        sessionFilePath: transcriptPath,
+      },
+      messages: [],
+    };
+
+    const service = new CodexConversationHistoryService();
+    await service.hydrateConversationHistory(conversation, null);
+
+    expect(conversation.messages).toHaveLength(1);
+    expect((conversation.providerState as Record<string, unknown>).transcriptRootPath).toBe(
+      path.join(tempHome, 'custom-codex-root', 'sessions'),
+    );
+  });
+
   describe('buildForkProviderState', () => {
     it('stores forkSource with sessionId and resumeAt in providerState', () => {
       const service = new CodexConversationHistoryService();
@@ -213,6 +262,23 @@ describe('CodexConversationHistoryService', () => {
         {
           sessionFilePath: '\\\\wsl$\\Ubuntu\\home\\user\\.codex\\sessions\\2026\\03\\27\\rollout-thread.jsonl',
           transcriptRootPath: '\\\\wsl$\\Ubuntu\\home\\user\\.codex\\sessions',
+        },
+      );
+
+      expect(result).toEqual({
+        forkSource: { sessionId: 'source-thread-id', resumeAt: 'turn-uuid-2' },
+        forkSourceSessionFilePath: '\\\\wsl$\\Ubuntu\\home\\user\\.codex\\sessions\\2026\\03\\27\\rollout-thread.jsonl',
+        forkSourceTranscriptRootPath: '\\\\wsl$\\Ubuntu\\home\\user\\.codex\\sessions',
+      });
+    });
+
+    it('derives the source transcript root from sessionFilePath when only the session path is stored', () => {
+      const service = new CodexConversationHistoryService();
+      const result = service.buildForkProviderState(
+        'source-thread-id',
+        'turn-uuid-2',
+        {
+          sessionFilePath: '\\\\wsl$\\Ubuntu\\home\\user\\.codex\\sessions\\2026\\03\\27\\rollout-thread.jsonl',
         },
       );
 

--- a/tests/unit/providers/codex/history/CodexHistoryStore.test.ts
+++ b/tests/unit/providers/codex/history/CodexHistoryStore.test.ts
@@ -1,10 +1,38 @@
 import * as path from 'path';
 
-import { parseCodexSessionContent, parseCodexSessionFile, parseCodexSessionTurns } from '@/providers/codex/history/CodexHistoryStore';
+import {
+  deriveCodexMemoriesDirFromSessionsRoot,
+  deriveCodexSessionsRootFromSessionPath,
+  parseCodexSessionContent,
+  parseCodexSessionFile,
+  parseCodexSessionTurns,
+} from '@/providers/codex/history/CodexHistoryStore';
 
 const FIXTURES_DIR = path.join(__dirname, '..', 'fixtures');
 
 describe('CodexHistoryStore', () => {
+  describe('path helpers', () => {
+    it('derives transcript and memories roots from POSIX session paths', () => {
+      const sessionFilePath = '/home/user/.codex/sessions/2026/04/14/rollout-thread.jsonl';
+
+      expect(deriveCodexSessionsRootFromSessionPath(sessionFilePath)).toBe('/home/user/.codex/sessions');
+      expect(deriveCodexMemoriesDirFromSessionsRoot('/home/user/.codex/sessions')).toBe(
+        '/home/user/.codex/memories',
+      );
+    });
+
+    it('derives transcript and memories roots from WSL UNC session paths', () => {
+      const sessionFilePath = '\\\\wsl$\\Ubuntu\\home\\user\\.codex\\sessions\\2026\\04\\14\\rollout-thread.jsonl';
+
+      expect(deriveCodexSessionsRootFromSessionPath(sessionFilePath)).toBe(
+        '\\\\wsl$\\Ubuntu\\home\\user\\.codex\\sessions',
+      );
+      expect(deriveCodexMemoriesDirFromSessionsRoot('\\\\wsl$\\Ubuntu\\home\\user\\.codex\\sessions')).toBe(
+        '\\\\wsl$\\Ubuntu\\home\\user\\.codex\\memories',
+      );
+    });
+  });
+
   describe('parseCodexSessionFile - simple session', () => {
     it('should parse a simple session with reasoning and agent message', () => {
       const filePath = path.join(FIXTURES_DIR, 'codex-session-simple.jsonl');

--- a/tests/unit/providers/codex/runtime/CodexChatRuntime.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexChatRuntime.test.ts
@@ -175,11 +175,20 @@ function createWslLaunchSpec(overrides: Record<string, unknown> = {}) {
         distroName: 'Ubuntu',
       },
       toTargetPath: jest.fn((value: string) => {
+        if (!value) {
+          return null;
+        }
+        if (value.startsWith('/home/') || value.startsWith('/mnt/')) {
+          return null;
+        }
         if (value.startsWith('/tmp/')) {
           return value.replace('/tmp/', '/mnt/c/tmp/');
         }
         if (value.startsWith('/external/')) {
           return value.replace('/external/', '/mnt/d/external/');
+        }
+        if (value.startsWith('\\\\wsl$\\Ubuntu\\')) {
+          return `/${value.slice('\\\\wsl$\\Ubuntu\\'.length).replace(/\\/g, '/')}`;
         }
         return `/mnt/c/${value.replace(/^\/+/, '').replace(/\\/g, '/')}`;
       }),
@@ -471,7 +480,7 @@ describe('CodexChatRuntime', () => {
       expect(chunks).toContainEqual({ type: 'done' });
     });
 
-    it('handles initialize responses that omit codexHome', async () => {
+    it('handles host-native initialize responses that omit codexHome', async () => {
       mockTransportRequest.mockImplementation(async (method: string) => {
         switch (method) {
           case 'initialize':
@@ -504,6 +513,59 @@ describe('CodexChatRuntime', () => {
       expect(chunks).toContainEqual({ type: 'text', content: 'Hello!' });
       expect(chunks).toContainEqual({ type: 'done' });
       expect(findCall('thread/start')).toBeDefined();
+    });
+
+    it('derives WSL transcript and memories roots from thread paths when initialize omits codexHome', async () => {
+      mockResolveLaunchSpec.mockReturnValue(createWslLaunchSpec());
+      mockTransportRequest.mockImplementation(async (method: string) => {
+        if (method === 'initialize') {
+          return {
+            userAgent: 'test/0.1',
+            platformFamily: 'unix',
+            platformOs: 'linux',
+          };
+        }
+
+        if (method === 'thread/start') {
+          return {
+            ...threadStartResponse('thread-wsl-no-home'),
+            thread: {
+              ...threadStartResponse('thread-wsl-no-home').thread,
+              path: '/home/user/.codex/sessions/2026/04/14/thread-wsl-no-home.jsonl',
+            },
+          };
+        }
+
+        if (method === 'turn/start') {
+          setTimeout(() => {
+            emitNotification('turn/completed', {
+              threadId: 'thread-wsl-no-home',
+              turn: { id: 'turn-wsl-no-home', items: [], status: 'completed', error: null },
+            });
+          }, 0);
+          return turnStartResponse('turn-wsl-no-home');
+        }
+
+        return {};
+      });
+
+      await collectChunks(runtime.query(createTurn('hi')));
+
+      const turnStartCall = findCall('turn/start');
+      expect(turnStartCall[1].sandboxPolicy).toMatchObject({
+        type: 'workspaceWrite',
+        writableRoots: expect.arrayContaining([
+          '/mnt/c/vault',
+          '/home/user/.codex/memories',
+        ]),
+      });
+
+      const result = runtime.buildSessionUpdates({ conversation: null, sessionInvalidated: false });
+      expect((result.updates.providerState as any)).toMatchObject({
+        threadId: 'thread-wsl-no-home',
+        sessionFilePath: '\\\\wsl$\\Ubuntu\\home\\user\\.codex\\sessions\\2026\\04\\14\\thread-wsl-no-home.jsonl',
+        transcriptRootPath: '\\\\wsl$\\Ubuntu\\home\\user\\.codex\\sessions',
+      });
     });
 
     it('uses the launch spec target cwd when starting a WSL-backed thread', async () => {

--- a/tests/unit/providers/codex/runtime/CodexChatRuntime.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexChatRuntime.test.ts
@@ -471,6 +471,41 @@ describe('CodexChatRuntime', () => {
       expect(chunks).toContainEqual({ type: 'done' });
     });
 
+    it('handles initialize responses that omit codexHome', async () => {
+      mockTransportRequest.mockImplementation(async (method: string) => {
+        switch (method) {
+          case 'initialize':
+            return { userAgent: 'test/0.1', platformFamily: 'unix', platformOs: 'macos' };
+          case 'thread/start':
+            return threadStartResponse('thread-no-home');
+          case 'turn/start':
+            setTimeout(() => {
+              emitNotification('item/agentMessage/delta', {
+                threadId: 'thread-no-home',
+                turnId: 'turn-no-home',
+                itemId: 'msg1',
+                delta: 'Hello!',
+              });
+              emitNotification('turn/completed', {
+                threadId: 'thread-no-home',
+                turn: { id: 'turn-no-home', items: [], status: 'completed', error: null },
+              });
+            }, 0);
+            return turnStartResponse('turn-no-home');
+          case 'turn/interrupt':
+            return {};
+          default:
+            throw new Error(`Unexpected request: ${method}`);
+        }
+      });
+
+      const chunks = await collectChunks(runtime.query(createTurn('hi')));
+
+      expect(chunks).toContainEqual({ type: 'text', content: 'Hello!' });
+      expect(chunks).toContainEqual({ type: 'done' });
+      expect(findCall('thread/start')).toBeDefined();
+    });
+
     it('uses the launch spec target cwd when starting a WSL-backed thread', async () => {
       mockResolveLaunchSpec.mockReturnValue(createWslLaunchSpec());
       mockTransportRequest.mockImplementation(async (method: string) => {

--- a/tests/unit/providers/codex/runtime/CodexRuntimeContext.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexRuntimeContext.test.ts
@@ -22,6 +22,25 @@ function createLaunchSpec(overrides: Partial<CodexLaunchSpec> = {}): CodexLaunch
   };
 }
 
+function createHostLaunchSpec(overrides: Partial<CodexLaunchSpec> = {}): CodexLaunchSpec {
+  const target = {
+    method: 'host-native' as const,
+    platformFamily: 'unix' as const,
+    platformOs: 'macos' as const,
+  };
+
+  return {
+    target,
+    command: 'codex',
+    args: ['app-server', '--listen', 'stdio://'],
+    spawnCwd: '/Users/test/repo',
+    targetCwd: '/Users/test/repo',
+    env: { HOME: '/Users/test' },
+    pathMapper: createCodexPathMapper(target),
+    ...overrides,
+  };
+}
+
 describe('createCodexRuntimeContext', () => {
   it('derives host-readable transcript roots from initialize.codexHome for WSL targets', () => {
     const context = createCodexRuntimeContext(
@@ -50,5 +69,39 @@ describe('createCodexRuntimeContext', () => {
         platformOs: 'windows',
       },
     )).toThrow('Codex target mismatch');
+  });
+
+  it('falls back to HOME when initialize omits codexHome for host-native targets', () => {
+    const context = createCodexRuntimeContext(
+      createHostLaunchSpec(),
+      {
+        userAgent: 'test/0.1',
+        platformFamily: 'unix',
+        platformOs: 'macos',
+      },
+    );
+
+    expect(context.codexHomeTarget).toBe('/Users/test/.codex');
+    expect(context.codexHomeHost).toBe('/Users/test/.codex');
+    expect(context.sessionsDirTarget).toBe('/Users/test/.codex/sessions');
+    expect(context.sessionsDirHost).toBe('/Users/test/.codex/sessions');
+    expect(context.memoriesDirTarget).toBe('/Users/test/.codex/memories');
+  });
+
+  it('keeps transcript roots nullable when initialize omits codexHome for WSL targets', () => {
+    const context = createCodexRuntimeContext(
+      createLaunchSpec(),
+      {
+        userAgent: 'test/0.1',
+        platformFamily: 'unix',
+        platformOs: 'linux',
+      },
+    );
+
+    expect(context.codexHomeTarget).toBeNull();
+    expect(context.codexHomeHost).toBeNull();
+    expect(context.sessionsDirTarget).toBeNull();
+    expect(context.sessionsDirHost).toBeNull();
+    expect(context.memoriesDirTarget).toBeNull();
   });
 });


### PR DESCRIPTION
#463 

fix: handle missing codexHome in Codex app-server initialize response

Make codexHome optional in the initialize payload and fall back safely
when deriving Codex runtime paths, preventing replace() crashes in Obsidian.
