### PR TITLE
fix: add thinking content dedup to prevent duplicate thinking blocks

### DIFF
--- a/src/providers/claude/runtime/ClaudeChatRuntime.ts
+++ b/src/providers/claude/runtime/ClaudeChatRuntime.ts
@@ -170,6 +170,7 @@ export class ClaudianService implements ChatRuntime {
   // Auto-triggered turn handling (e.g., task-notification delivery by the SDK)
   private _autoTurnBuffer: StreamChunk[] = [];
   private _autoTurnSawStreamText = false;
+  private _autoTurnSawStreamThinking = false;
   private _autoTurnCallback: ((result: AutoTurnResult) => void) | null = null;
   private turnMetadata: ChatTurnMetadata = {};
   private bufferedUsageChunk: StreamChunk & { type: 'usage' } | null = null;
@@ -584,6 +585,7 @@ export class ClaudianService implements ChatRuntime {
     this.currentConfig = null;
     this._autoTurnBuffer = [];
     this._autoTurnSawStreamText = false;
+    this._autoTurnSawStreamThinking = false;
     if (!preserveHandlers) {
       this.responseHandlers = [];
       this.currentAllowedTools = null;
@@ -816,6 +818,13 @@ export class ClaudianService implements ChatRuntime {
         this._autoTurnSawStreamText = true;
       }
     }
+    if (this.isStreamThinkingEvent(message)) {
+      if (handler) {
+        handler.markStreamThinkingSeen();
+      } else {
+        this._autoTurnSawStreamThinking = true;
+      }
+    }
 
     // Transform SDK message to StreamChunks
     for (const event of transformSDKMessage(message, this.getTransformOptions())) {
@@ -849,6 +858,11 @@ export class ClaudianService implements ChatRuntime {
         // (complete). Skip the assistant message text if stream text was already seen.
         if (message.type === 'assistant' && event.type === 'text') {
           if (handler?.sawStreamText || (!handler && this._autoTurnSawStreamText)) {
+            continue;
+          }
+        }
+        if (message.type === 'assistant' && event.type === 'thinking') {
+          if (handler?.sawStreamThinking || (!handler && this._autoTurnSawStreamThinking)) {
             continue;
           }
         }
@@ -891,9 +905,11 @@ export class ClaudianService implements ChatRuntime {
       // Notify handler
       if (handler) {
         handler.resetStreamText();
+        handler.resetStreamThinking();
         handler.onDone();
       } else {
         this._autoTurnSawStreamText = false;
+        this._autoTurnSawStreamThinking = false;
         if (this._autoTurnBuffer.length === 0) {
           return;
         }
@@ -1428,6 +1444,16 @@ export class ClaudianService implements ChatRuntime {
     return false;
   }
 
+  private isStreamThinkingEvent(message: SDKMessage): boolean {
+    if (message.type !== 'stream_event') return false;
+    const event = message.event;
+    if (!event) return false;
+    if (event.type === 'content_block_delta') {
+      return event.delta?.type === 'thinking_delta';
+    }
+    return false;
+  }
+
   private buildPromptWithImages(prompt: string, images?: ImageAttachment[]): string | AsyncGenerator<any> {
     return buildClaudePromptWithImages(prompt, images);
   }
@@ -1474,6 +1500,7 @@ export class ClaudianService implements ChatRuntime {
     const options = QueryOptionsBuilder.buildColdStartQueryOptions(ctx);
 
     let sawStreamText = false;
+    let sawStreamThinking = false;
     try {
       const response = agentQuery({ prompt: queryPrompt, options });
       this.recordTurnMetadata({ wasSent: true });
@@ -1482,6 +1509,9 @@ export class ClaudianService implements ChatRuntime {
       for await (const message of response) {
         if (this.isStreamTextEvent(message)) {
           sawStreamText = true;
+        }
+        if (this.isStreamThinkingEvent(message)) {
+          sawStreamThinking = true;
         }
         if (this.abortController?.signal.aborted) {
           await response.interrupt();
@@ -1501,6 +1531,9 @@ export class ClaudianService implements ChatRuntime {
             if (message.type === 'assistant' && sawStreamText && event.type === 'text') {
               continue;
             }
+            if (message.type === 'assistant' && sawStreamThinking && event.type === 'thinking') {
+              continue;
+            }
             if (event.type === 'usage') {
               yield this.bufferUsageChunk({ ...event, sessionId: streamSessionId });
             } else {
@@ -1515,6 +1548,7 @@ export class ClaudianService implements ChatRuntime {
 
         if (message.type === 'result') {
           sawStreamText = false;
+          sawStreamThinking = false;
         }
       }
     } catch (error) {

--- a/src/providers/claude/runtime/ClaudeChatRuntime.ts
+++ b/src/providers/claude/runtime/ClaudeChatRuntime.ts
@@ -1446,10 +1446,24 @@ export class ClaudianService implements ChatRuntime {
 
   private isStreamThinkingEvent(message: SDKMessage): boolean {
     if (message.type !== 'stream_event') return false;
+    // transformSDKMessage only emits visible thinking when parent_tool_use_id
+    // is null, so subagent stream_events must not arm the main-turn dedup
+    // flag — otherwise the following main assistant thinking gets skipped.
+    if (message.parent_tool_use_id != null) return false;
     const event = message.event;
     if (!event) return false;
     if (event.type === 'content_block_delta') {
       return event.delta?.type === 'thinking_delta';
+    }
+    // transformSDKMessage also emits thinking from content_block_start when
+    // content_block.thinking is non-empty, so dedup must see that case too.
+    if (
+      event.type === 'content_block_start' &&
+      event.content_block?.type === 'thinking' &&
+      typeof event.content_block.thinking === 'string' &&
+      event.content_block.thinking.length > 0
+    ) {
+      return true;
     }
     return false;
   }

--- a/src/providers/claude/runtime/types.ts
+++ b/src/providers/claude/runtime/types.ts
@@ -51,9 +51,12 @@ export interface ResponseHandler {
   onDone: () => void;
   onError: (error: Error) => void;
   readonly sawStreamText: boolean;
+  readonly sawStreamThinking: boolean;
   readonly sawAnyChunk: boolean;
   markStreamTextSeen(): void;
+  markStreamThinkingSeen(): void;
   resetStreamText(): void;
+  resetStreamThinking(): void;
   markChunkSeen(): void;
 }
 
@@ -66,6 +69,7 @@ export interface ResponseHandlerOptions {
 
 export function createResponseHandler(options: ResponseHandlerOptions): ResponseHandler {
   let _sawStreamText = false;
+  let _sawStreamThinking = false;
   let _sawAnyChunk = false;
 
   return {
@@ -74,9 +78,12 @@ export function createResponseHandler(options: ResponseHandlerOptions): Response
     onDone: options.onDone,
     onError: options.onError,
     get sawStreamText() { return _sawStreamText; },
+    get sawStreamThinking() { return _sawStreamThinking; },
     get sawAnyChunk() { return _sawAnyChunk; },
     markStreamTextSeen() { _sawStreamText = true; },
+    markStreamThinkingSeen() { _sawStreamThinking = true; },
     resetStreamText() { _sawStreamText = false; },
+    resetStreamThinking() { _sawStreamThinking = false; },
     markChunkSeen() { _sawAnyChunk = true; },
   };
 }

--- a/tests/unit/providers/claude/runtime/ClaudianService.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudianService.test.ts
@@ -829,11 +829,25 @@ describe('ClaudianService', () => {
       expect((service as any).isStreamThinkingEvent({ type: 'assistant' })).toBe(false);
     });
 
-    it('should return false for content_block_start with thinking type', () => {
+    it('should return false for content_block_start with thinking type and no thinking payload', () => {
       expect((service as any).isStreamThinkingEvent({
         type: 'stream_event',
         event: { type: 'content_block_start', content_block: { type: 'thinking' } },
       })).toBe(false);
+    });
+
+    it('should return false for content_block_start with empty thinking', () => {
+      expect((service as any).isStreamThinkingEvent({
+        type: 'stream_event',
+        event: { type: 'content_block_start', content_block: { type: 'thinking', thinking: '' } },
+      })).toBe(false);
+    });
+
+    it('should return true for content_block_start with non-empty thinking', () => {
+      expect((service as any).isStreamThinkingEvent({
+        type: 'stream_event',
+        event: { type: 'content_block_start', content_block: { type: 'thinking', thinking: 'hmm' } },
+      })).toBe(true);
     });
 
     it('should return true for content_block_delta with thinking_delta', () => {
@@ -847,6 +861,24 @@ describe('ClaudianService', () => {
       expect((service as any).isStreamThinkingEvent({
         type: 'stream_event',
         event: { type: 'content_block_delta', delta: { type: 'text_delta' } },
+      })).toBe(false);
+    });
+
+    it('should return false for subagent stream events with thinking_delta', () => {
+      // Subagent stream events carry parent_tool_use_id; transformSDKMessage
+      // does not emit visible thinking for them, so dedup must stay off.
+      expect((service as any).isStreamThinkingEvent({
+        type: 'stream_event',
+        parent_tool_use_id: 'toolu_01ABC',
+        event: { type: 'content_block_delta', delta: { type: 'thinking_delta', thinking: 'sub' } },
+      })).toBe(false);
+    });
+
+    it('should return false for subagent stream events with content_block_start thinking', () => {
+      expect((service as any).isStreamThinkingEvent({
+        type: 'stream_event',
+        parent_tool_use_id: 'toolu_01ABC',
+        event: { type: 'content_block_start', content_block: { type: 'thinking', thinking: 'sub' } },
       })).toBe(false);
     });
   });

--- a/tests/unit/providers/claude/runtime/ClaudianService.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudianService.test.ts
@@ -824,6 +824,33 @@ describe('ClaudianService', () => {
     });
   });
 
+  describe('isStreamThinkingEvent', () => {
+    it('should return false for non-stream_event messages', () => {
+      expect((service as any).isStreamThinkingEvent({ type: 'assistant' })).toBe(false);
+    });
+
+    it('should return false for content_block_start with thinking type', () => {
+      expect((service as any).isStreamThinkingEvent({
+        type: 'stream_event',
+        event: { type: 'content_block_start', content_block: { type: 'thinking' } },
+      })).toBe(false);
+    });
+
+    it('should return true for content_block_delta with thinking_delta', () => {
+      expect((service as any).isStreamThinkingEvent({
+        type: 'stream_event',
+        event: { type: 'content_block_delta', delta: { type: 'thinking_delta', thinking: 'hmm' } },
+      })).toBe(true);
+    });
+
+    it('should return false for content_block_delta with text_delta', () => {
+      expect((service as any).isStreamThinkingEvent({
+        type: 'stream_event',
+        event: { type: 'content_block_delta', delta: { type: 'text_delta' } },
+      })).toBe(false);
+    });
+  });
+
   describe('buildSDKUserMessage', () => {
     it('should build text-only message', () => {
       const message = (service as any).buildSDKUserMessage('Hello Claude');


### PR DESCRIPTION
## Summary

Thinking blocks are displayed 2-3 times when using third-party models with extended thinking. The SDK delivers thinking content via both stream events and the final assistant message. Text already had dedup via `sawStreamText`, but thinking had no equivalent.

## Root cause

`transformClaudeMessage.ts` yields `{ type: 'thinking' }` from both `content_block_delta` stream events (lines 258-259) and from the assistant message content blocks (lines 156-158). Text avoids this duplication through `sawStreamText` tracking in `ClaudeChatRuntime.ts`, but no equivalent `sawStreamThinking` tracking existed for thinking blocks.

## Changes

Added `sawStreamThinking` tracking parallel to `sawStreamText`:

- `types.ts`: Extended `ResponseHandler` interface with `sawStreamThinking`, `markStreamThinkingSeen()`, `resetStreamThinking()`
- `ClaudeChatRuntime.ts`: Added `isStreamThinkingEvent()` that detects `content_block_delta` with `thinking_delta`
- `ClaudeChatRuntime.ts`: Wired thinking dedup into both `routeMessage()` (persistent query path) and `queryViaSDK()` (cold start path)
- Added 4 unit tests for `isStreamThinkingEvent()`

## Testing

All 5059 tests pass. Lint and typecheck clean.

Fixes #406

This contribution was developed with AI assistance (Codex).