### PR TITLE
fix: remove duplicate tooltip on tab badge hover

### DIFF
--- a/src/features/chat/tabs/TabBar.ts
+++ b/src/features/chat/tabs/TabBar.ts
@@ -61,9 +61,8 @@ export class TabBar {
       text: String(item.index),
     });
 
-    // Tooltip with full title
+    // Tooltip with full title (aria-label only; adding title too causes double tooltip)
     badgeEl.setAttribute('aria-label', item.title);
-    badgeEl.setAttribute('title', item.title);
 
     // Click handler to switch tab
     badgeEl.addEventListener('click', () => {

--- a/tests/unit/features/chat/tabs/TabBar.test.ts
+++ b/tests/unit/features/chat/tabs/TabBar.test.ts
@@ -89,15 +89,16 @@ describe('TabBar', () => {
       expect(containerEl._children[0].textContent).toBe('5');
     });
 
-    it('should set title tooltip from item title', () => {
+    it('should set aria-label tooltip from item title', () => {
       const containerEl = createMockEl();
       const callbacks = createMockCallbacks();
       const tabBar = new TabBar(containerEl, callbacks);
 
       tabBar.update([createTabBarItem({ title: 'My Conversation' })]);
 
-      expect(containerEl._children[0].getAttribute('title')).toBe('My Conversation');
       expect(containerEl._children[0].getAttribute('aria-label')).toBe('My Conversation');
+      // title attribute is intentionally omitted to prevent double tooltip
+      expect(containerEl._children[0].getAttribute('title')).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

Tab badges show two overlapping tooltips on hover: a native browser tooltip (from `title`) and an Obsidian tooltip (from `aria-label`). This PR removes the redundant `title` attribute.

## Changes

`TabBar.ts:66`: removed `badgeEl.setAttribute('title', item.title)`. The `aria-label` attribute at line 65 is sufficient for both accessibility and Obsidian's tooltip rendering.

Updated the corresponding test to verify `title` is null and `aria-label` carries the value.

## Testing

All 5055 tests pass. Lint and typecheck clean.

Relates to #443

This contribution was developed with AI assistance (Claude Code).