### PR TITLE
fix: handle missing codexHome in Codex runtime context

### DIFF
--- a/src/providers/codex/runtime/CodexRuntimeContext.ts
+++ b/src/providers/codex/runtime/CodexRuntimeContext.ts
@@ -14,15 +14,19 @@ export interface CodexRuntimeContext {
 }
 
 function normalizeTargetPath(launchSpec: CodexLaunchSpec, value: string): string {
+  const rawValue = typeof value === 'string' ? value : String(value ?? '');
   return launchSpec.target.platformFamily === 'windows'
-    ? path.win32.normalize(value)
-    : path.posix.normalize(value.replace(/\\/g, '/'));
+    ? path.win32.normalize(rawValue)
+    : path.posix.normalize(rawValue.replace(/\\/g, '/'));
 }
 
 function joinTargetPath(launchSpec: CodexLaunchSpec, ...parts: string[]): string {
+  const normalizedParts = parts
+    .filter(part => part != null && part !== '')
+    .map(part => (typeof part === 'string' ? part : String(part)));
   return launchSpec.target.platformFamily === 'windows'
-    ? path.win32.join(...parts)
-    : path.posix.join(...parts.map(part => part.replace(/\\/g, '/')));
+    ? path.win32.join(...normalizedParts)
+    : path.posix.join(...normalizedParts.map(part => part.replace(/\\/g, '/')));
 }
 
 function validateInitializeTarget(
@@ -48,7 +52,18 @@ export function createCodexRuntimeContext(
 ): CodexRuntimeContext {
   validateInitializeTarget(launchSpec, initializeResult);
 
-  const codexHomeTarget = normalizeTargetPath(launchSpec, initializeResult.codexHome);
+  const fallbackHomeBase = launchSpec.target.platformFamily === 'windows'
+    ? process.env.USERPROFILE || process.env.HOME || ''
+    : process.env.HOME || '';
+  const fallbackCodexHome = fallbackHomeBase
+    ? joinTargetPath(launchSpec, fallbackHomeBase, '.codex')
+    : '.codex';
+  const codexHomeTarget = normalizeTargetPath(
+    launchSpec,
+    typeof initializeResult.codexHome === 'string' && initializeResult.codexHome.trim()
+      ? initializeResult.codexHome
+      : fallbackCodexHome,
+  );
   const sessionsDirTarget = joinTargetPath(launchSpec, codexHomeTarget, 'sessions');
   const memoriesDirTarget = joinTargetPath(launchSpec, codexHomeTarget, 'memories');
 

--- a/tests/unit/providers/codex/runtime/CodexRuntimeContext.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexRuntimeContext.test.ts
@@ -51,4 +51,27 @@ describe('createCodexRuntimeContext', () => {
       },
     )).toThrow('Codex target mismatch');
   });
+
+  it('falls back to ~/.codex when initialize does not include codexHome', () => {
+    const previousHome = process.env.HOME;
+    process.env.HOME = '/home/fallback-user';
+
+    try {
+      const context = createCodexRuntimeContext(
+        createLaunchSpec(),
+        {
+          userAgent: 'test/0.1',
+          codexHome: undefined as unknown as string,
+          platformFamily: 'unix',
+          platformOs: 'linux',
+        },
+      );
+
+      expect(context.codexHomeTarget).toBe('/home/fallback-user/.codex');
+      expect(context.sessionsDirTarget).toBe('/home/fallback-user/.codex/sessions');
+      expect(context.memoriesDirTarget).toBe('/home/fallback-user/.codex/memories');
+    } finally {
+      process.env.HOME = previousHome;
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Handle missing `initialize.codexHome` in the Codex runtime context setup.

## Why

Some Codex CLI setups appear to return an initialize payload without `codexHome`. Claudian currently assumes that field is always present and crashes during path normalization with:

`Cannot read properties of undefined (reading 'replace')`

## What changed

- Made `normalizeTargetPath()` resilient to non-string input.
- Made `joinTargetPath()` skip null/empty path segments before normalizing.
- Added a fallback to `~/.codex` when `initializeResult.codexHome` is missing or blank.
- Added a unit test that covers the missing-`codexHome` path.

## Verification

Ran:

`npm test -- --runTestsByPath tests/unit/providers/codex/runtime/CodexRuntimeContext.test.ts`

Result:

- 1 test suite passed
- 3 tests passed

## User-visible impact

Claudian no longer crashes with a generic TypeError during Codex startup when `codexHome` is absent from the initialize payload.