### PR TITLE
fix: skip syncConversationState during active streaming in switchToTab

### DIFF
--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -226,15 +226,20 @@ export class TabManager implements TabManagerInterface {
       if (tab.conversationId && tab.state.messages.length === 0) {
         await tab.controllers.conversationController?.switchTo(tab.conversationId);
       } else if (tab.conversationId && tab.state.messages.length > 0 && tab.service) {
-        // Tab already has messages loaded and runtime exists — passive sync only
-        const conversation = this.plugin.getConversationSync(tab.conversationId);
-        if (conversation) {
-          const hasMessages = conversation.messages.length > 0;
-          const externalContextPaths = hasMessages
-            ? conversation.externalContextPaths || []
-            : (this.plugin.settings.persistentExternalContextPaths || []);
+        // Tab already has messages loaded and runtime exists — passive sync only.
+        // Skip sync if the tab is actively streaming to avoid killing the CLI process.
+        // syncConversationState → setSessionId → closePersistentQuery("session switch")
+        // would terminate the running persistent query when session IDs diverge.
+        if (!tab.state.isStreaming) {
+          const conversation = this.plugin.getConversationSync(tab.conversationId);
+          if (conversation) {
+            const hasMessages = conversation.messages.length > 0;
+            const externalContextPaths = hasMessages
+              ? conversation.externalContextPaths || []
+              : (this.plugin.settings.persistentExternalContextPaths || []);
 
-          tab.service.syncConversationState(conversation, externalContextPaths);
+            tab.service.syncConversationState(conversation, externalContextPaths);
+          }
         }
       } else if (!tab.conversationId && tab.state.messages.length === 0) {
         // New tab with no conversation - initialize welcome greeting


### PR DESCRIPTION
## Summary

Fixes #437, fixes #449

When switching back to a tab that is actively streaming, `switchToTab()` unconditionally calls `syncConversationState()`, which calls `setSessionId()`. If the resolved session ID differs from the current one (e.g. after a forced restart from `applyDynamicUpdates`), it calls `closePersistentQuery("session switch")` — killing the CLI child process and terminating the active stream.

This adds an `isStreaming` guard so that tabs with active streams are left untouched during tab switches. The sync runs normally for idle tabs.

## Debug Evidence

Added `console.warn` to `closePersistentQuery`, `handler.onDone/onError`, `cancel()`, and `switchToTab` in the bundled `main.js`. Reproduction: start a streaming conversation in Tab A → switch to Tab B → switch back to Tab A.

```
switchToTab { from: "tab-A", to: "tab-B" }
closePersistentQuery { reason: "forced restart", handlerCount: 0 }
responseConsumer: iterator exhausted (normal end)

switchToTab { from: "tab-B", to: "tab-A" }
closePersistentQuery { reason: "session switch", handlerCount: 1 }  ← kills active stream
handler.onDone()
responseConsumer: iterator exhausted (normal end)
```

Call stack for the killing call:
```
ClaudianService.closePersistentQuery
  ← ClaudianService.setSessionId
  ← ClaudianService.syncConversationState
  ← TabManager.switchToTab
  ← ClaudianView.handleTabClick
```

## Change

```diff
// TabManager.ts — switchToTab()
 } else if (tab.conversationId && tab.state.messages.length > 0 && tab.service) {
+  if (!tab.state.isStreaming) {
     const conversation = this.plugin.getConversationSync(tab.conversationId);
     ...
     tab.service.syncConversationState(conversation, externalContextPaths);
+  }
 }
```

## Test plan

- [ ] Start a streaming conversation in Tab A
- [ ] Switch to Tab B while Tab A is streaming
- [ ] Switch back to Tab A — streaming should continue uninterrupted
- [ ] Verify idle tab switching still syncs conversation state correctly
- [ ] Verify `(background task completed)` no longer appears after tab switch

Tested on v2.0.2 by patching the bundled `main.js` directly — confirmed the fix resolves both #437 and #449.