### PR TITLE
fix(selection): preserve selection when Claudian is in detached window or own tab

### DIFF
--- a/src/features/chat/controllers/SelectionController.ts
+++ b/src/features/chat/controllers/SelectionController.ts
@@ -23,6 +23,7 @@ export class SelectionController {
   private focusScopeEl: HTMLElement;
   private contextRowEl: HTMLElement;
   private onVisibilityChange: (() => void) | null;
+  private ownViewType: string | null;
   private storedSelection: StoredSelection | null = null;
   private inputHandoffGraceUntil: number | null = null;
   private pollInterval: number | null = null;
@@ -37,7 +38,8 @@ export class SelectionController {
     inputEl: HTMLElement,
     contextRowEl: HTMLElement,
     onVisibilityChange?: () => void,
-    focusScopeEl?: HTMLElement
+    focusScopeEl?: HTMLElement,
+    ownViewType?: string
   ) {
     this.app = app;
     this.indicatorEl = indicatorEl;
@@ -45,6 +47,7 @@ export class SelectionController {
     this.focusScopeEl = focusScopeEl ?? inputEl;
     this.contextRowEl = contextRowEl;
     this.onVisibilityChange = onVisibilityChange ?? null;
+    this.ownViewType = ownViewType ?? null;
   }
 
   start(): void {
@@ -245,8 +248,18 @@ export class SelectionController {
 
   private isFocusWithinChatSidebar(): boolean {
     const activeElement = this.getActiveElement(this.focusScopeEl.ownerDocument) as Node | null;
-    return activeElement !== null
-      && (activeElement === this.focusScopeEl || this.focusScopeEl.contains(activeElement));
+    if (activeElement !== null
+      && (activeElement === this.focusScopeEl || this.focusScopeEl.contains(activeElement))) {
+      return true;
+    }
+    if (this.ownViewType) {
+      const activeLeaf = (this.app.workspace as any).activeLeaf
+        ?? this.app.workspace.getMostRecentLeaf?.();
+      if (activeLeaf?.view?.getViewType?.() === this.ownViewType) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private isNativeEditorSelectionVisible(sel: StoredSelection): boolean {

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -21,6 +21,7 @@ import type { ChatRuntime } from '../../../core/runtime/ChatRuntime';
 import type { AutoTurnResult } from '../../../core/runtime/types';
 import { TOOL_AGENT_OUTPUT } from '../../../core/tools/toolNames';
 import type { ChatMessage, ClaudianSettings, Conversation, StreamChunk } from '../../../core/types';
+import { VIEW_TYPE_CLAUDIAN } from '../../../core/types';
 import { t } from '../../../i18n/i18n';
 import type ClaudianPlugin from '../../../main';
 import { SlashCommandDropdown } from '../../../shared/components/SlashCommandDropdown';
@@ -1226,6 +1227,7 @@ export function initializeTabControllers(
     dom.contextRowEl,
     () => autoResizeTextarea(dom.inputEl),
     dom.contentEl,
+    VIEW_TYPE_CLAUDIAN,
   );
 
   tab.controllers.browserSelectionController = new BrowserSelectionController(

--- a/tests/unit/features/chat/controllers/SelectionController.test.ts
+++ b/tests/unit/features/chat/controllers/SelectionController.test.ts
@@ -212,7 +212,29 @@ describe('SelectionController', () => {
     expect(hideSelectionHighlight).not.toHaveBeenCalled();
   });
 
-  it('clears selection when focus leaves markdown and the chat sidebar is not focused', () => {
+  it('preserves selection when active leaf is the Claudian view (detached window / own tab)', () => {
+    const claudianLeaf = { view: { getViewType: () => 'claudian-view' } };
+    app.workspace.activeLeaf = claudianLeaf;
+    controller = new SelectionController(app, indicatorEl, inputEl, contextRowEl, undefined, focusScopeEl, 'claudian-view');
+
+    controller.start();
+    jest.advanceTimersByTime(250);
+    expect(controller.hasSelection()).toBe(true);
+
+    app.workspace.getActiveViewOfType.mockReturnValue(null);
+    (global as any).document.activeElement = null;
+    jest.advanceTimersByTime(250);
+
+    expect(controller.hasSelection()).toBe(true);
+    expect(indicatorEl.style.display).toBe('block');
+  });
+
+  it('clears selection when active leaf is a non-Claudian, non-markdown view', () => {
+    const settingsLeaf = { view: { getViewType: () => 'settings' } };
+    app.workspace.activeLeaf = settingsLeaf;
+    controller = new SelectionController(app, indicatorEl, inputEl, contextRowEl, undefined, focusScopeEl, 'claudian-view');
+
+
     controller.start();
     jest.advanceTimersByTime(250);
     expect(controller.hasSelection()).toBe(true);


### PR DESCRIPTION
## Summary

- Fixes #399 — editor text selection was lost when Claudian runs in a detached window or its own tab
- When the Claudian leaf is detached, clicking it deactivates the MarkdownView leaf and `document.activeElement` becomes `<body>`, which falls outside `focusScopeEl`. The sidebar focus guard now also checks whether the active leaf's view type is the Claudian view, so the selection is preserved.
- Added `ownViewType` parameter to `SelectionController` and updated tests
- Rebased on current `main` (replaces #431)

## Root Cause

1. Text selected in editor → poll detects it → indicator shows ✓
2. User clicks anywhere in Claudian (detached window or own tab) → editor's MarkdownView becomes inactive
3. Next poll cycle (~250ms): `getActiveViewOfType(MarkdownView)` returns `null`
4. `clearWhenMarkdownContextIsUnavailable()` fires
5. `isFocusWithinChatSidebar()` → `false` (`document.activeElement` is `<body>`, not inside `focusScopeEl`)
6. Selection cleared ✗

## Fix

`isFocusWithinChatSidebar()` now has a secondary check: if the active leaf's view type matches the Claudian view type, treat it as "focus within sidebar."

## Verification

- [x] Unit test: selection preserved when active leaf is the Claudian view (detached window / own tab)
- [x] Unit test: selection cleared when active leaf is a non-Claudian, non-markdown view
- [x] Manual: open Claudian in a detached window, select text in the editor, verify selection context appears in chat
- [x] Manual: open Claudian in its own tab, select text in the editor, verify selection context appears in chat