### PR TITLE
feat: add Cursor Agent as third chat provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ yarn-error.log*
 # IDE
 .idea/
 .vscode/
+.cursor/
 *.swp
 *.swo
 *~

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -94,6 +94,7 @@ const context = await esbuild.context({
     '@lezer/lr',
     ...builtins,
     ...builtins.map(m => `node:${m}`),
+    'node:sqlite',
   ],
   format: 'cjs',
   target: 'es2018',

--- a/package-lock.json
+++ b/package-lock.json
@@ -133,7 +133,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -741,7 +740,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -765,7 +763,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2253,7 +2250,8 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -2553,7 +2551,6 @@
       "integrity": "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.58.0",
@@ -2583,7 +2580,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -3077,7 +3073,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3399,7 +3394,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3778,7 +3772,8 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4090,7 +4085,6 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4445,7 +4439,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4945,7 +4938,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
       "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5295,7 +5287,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -5928,7 +5919,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -6606,7 +6596,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7351,7 +7340,8 @@
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -8187,7 +8177,6 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8331,7 +8320,8 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
@@ -8712,7 +8702,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/settings/ClaudianSettingsStorage.ts
+++ b/src/app/settings/ClaudianSettingsStorage.ts
@@ -27,6 +27,10 @@ import {
   getCodexProviderSettings,
   updateCodexProviderSettings,
 } from '../../providers/codex/settings';
+import {
+  getCursorProviderSettings,
+  updateCursorProviderSettings,
+} from '../../providers/cursor/settings';
 import { DEFAULT_CLAUDIAN_SETTINGS } from './defaultSettings';
 
 export {
@@ -225,6 +229,10 @@ export class ClaudianSettingsStorage {
     updateCodexProviderSettings(
       merged as unknown as Record<string, unknown>,
       getCodexProviderSettings(legacyProviderSettings),
+    );
+    updateCursorProviderSettings(
+      merged as unknown as Record<string, unknown>,
+      getCursorProviderSettings(legacyProviderSettings),
     );
 
     if (

--- a/src/app/settings/defaultSettings.ts
+++ b/src/app/settings/defaultSettings.ts
@@ -2,6 +2,7 @@ import { getDefaultHiddenProviderCommands } from '../../core/providers/commands/
 import { type ClaudianSettings } from '../../core/types/settings';
 import { DEFAULT_CLAUDE_PROVIDER_SETTINGS } from '../../providers/claude/settings';
 import { DEFAULT_CODEX_PROVIDER_SETTINGS } from '../../providers/codex/settings';
+import { DEFAULT_CURSOR_PROVIDER_SETTINGS } from '../../providers/cursor/settings';
 
 export const DEFAULT_CLAUDIAN_SETTINGS: ClaudianSettings = {
   userName: '',
@@ -35,6 +36,7 @@ export const DEFAULT_CLAUDIAN_SETTINGS: ClaudianSettings = {
   providerConfigs: {
     claude: { ...DEFAULT_CLAUDE_PROVIDER_SETTINGS },
     codex: { ...DEFAULT_CODEX_PROVIDER_SETTINGS },
+    cursor: { ...DEFAULT_CURSOR_PROVIDER_SETTINGS },
   },
 
   settingsProvider: 'claude',

--- a/src/providers/cursor/app/CursorWorkspaceServices.ts
+++ b/src/providers/cursor/app/CursorWorkspaceServices.ts
@@ -1,0 +1,38 @@
+import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
+import type {
+  ProviderCliResolver,
+  ProviderWorkspaceRegistration,
+  ProviderWorkspaceServices,
+} from '../../../core/providers/types';
+import type { HomeFileAdapter } from '../../../core/storage/HomeFileAdapter';
+import type { VaultFileAdapter } from '../../../core/storage/VaultFileAdapter';
+import type ClaudianPlugin from '../../../main';
+import { CursorCliResolver } from '../runtime/CursorCliResolver';
+import { cursorSettingsTabRenderer } from '../ui/CursorSettingsTab';
+
+function createCursorCliResolver(): ProviderCliResolver {
+  return new CursorCliResolver();
+}
+
+export async function createCursorWorkspaceServices(
+  _plugin: ClaudianPlugin,
+  _vaultAdapter: VaultFileAdapter,
+  _homeAdapter: HomeFileAdapter,
+): Promise<ProviderWorkspaceServices> {
+  return {
+    cliResolver: createCursorCliResolver(),
+    settingsTabRenderer: cursorSettingsTabRenderer,
+  };
+}
+
+export const cursorWorkspaceRegistration: ProviderWorkspaceRegistration = {
+  initialize: async ({ plugin, vaultAdapter, homeAdapter }) => createCursorWorkspaceServices(
+    plugin,
+    vaultAdapter,
+    homeAdapter,
+  ),
+};
+
+export function getCursorWorkspaceServices(): ProviderWorkspaceServices | null {
+  return ProviderWorkspaceRegistry.getServices('cursor');
+}

--- a/src/providers/cursor/auxiliary/CursorInlineEditService.ts
+++ b/src/providers/cursor/auxiliary/CursorInlineEditService.ts
@@ -1,0 +1,73 @@
+import {
+  buildInlineEditPrompt,
+  getInlineEditSystemPrompt,
+  parseInlineEditResponse,
+} from '../../../core/prompt/inlineEdit';
+import type {
+  InlineEditRequest,
+  InlineEditResult,
+  InlineEditService,
+} from '../../../core/providers/types';
+import type ClaudianPlugin from '../../../main';
+import { appendContextFiles } from '../../../utils/context';
+import { CursorAuxCliRunner } from '../runtime/CursorAuxCliRunner';
+
+export class CursorInlineEditService implements InlineEditService {
+  private plugin: ClaudianPlugin;
+  private runner: CursorAuxCliRunner;
+  private abortController: AbortController | null = null;
+  private hasThread = false;
+
+  constructor(plugin: ClaudianPlugin) {
+    this.plugin = plugin;
+    this.runner = new CursorAuxCliRunner(plugin);
+  }
+
+  resetConversation(): void {
+    this.runner.reset();
+    this.hasThread = false;
+  }
+
+  async editText(request: InlineEditRequest): Promise<InlineEditResult> {
+    this.resetConversation();
+    const prompt = buildInlineEditPrompt(request);
+    return this.sendMessage(prompt);
+  }
+
+  async continueConversation(message: string, contextFiles?: string[]): Promise<InlineEditResult> {
+    if (!this.hasThread) {
+      return { success: false, error: 'No active conversation to continue' };
+    }
+    let prompt = message;
+    if (contextFiles && contextFiles.length > 0) {
+      prompt = appendContextFiles(message, contextFiles);
+    }
+    return this.sendMessage(prompt);
+  }
+
+  cancel(): void {
+    if (this.abortController) {
+      this.abortController.abort();
+      this.abortController = null;
+    }
+  }
+
+  private async sendMessage(prompt: string): Promise<InlineEditResult> {
+    this.abortController = new AbortController();
+
+    try {
+      const text = await this.runner.query({
+        systemPrompt: getInlineEditSystemPrompt(),
+        abortController: this.abortController,
+      }, prompt);
+
+      this.hasThread = true;
+      return parseInlineEditResponse(text);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      return { success: false, error: msg };
+    } finally {
+      this.abortController = null;
+    }
+  }
+}

--- a/src/providers/cursor/auxiliary/CursorInstructionRefineService.ts
+++ b/src/providers/cursor/auxiliary/CursorInstructionRefineService.ts
@@ -1,0 +1,90 @@
+import { buildRefineSystemPrompt } from '../../../core/prompt/instructionRefine';
+import type {
+  InstructionRefineService,
+  RefineProgressCallback,
+} from '../../../core/providers/types';
+import type { InstructionRefineResult } from '../../../core/types';
+import type ClaudianPlugin from '../../../main';
+import { CursorAuxCliRunner } from '../runtime/CursorAuxCliRunner';
+
+export class CursorInstructionRefineService implements InstructionRefineService {
+  private runner: CursorAuxCliRunner;
+  private abortController: AbortController | null = null;
+  private existingInstructions = '';
+  private hasThread = false;
+
+  constructor(plugin: ClaudianPlugin) {
+    this.runner = new CursorAuxCliRunner(plugin);
+  }
+
+  resetConversation(): void {
+    this.runner.reset();
+    this.hasThread = false;
+  }
+
+  async refineInstruction(
+    rawInstruction: string,
+    existingInstructions: string,
+    onProgress?: RefineProgressCallback,
+  ): Promise<InstructionRefineResult> {
+    this.resetConversation();
+    this.existingInstructions = existingInstructions;
+    const prompt = `Please refine this instruction: "${rawInstruction}"`;
+    return this.sendMessage(prompt, onProgress);
+  }
+
+  async continueConversation(
+    message: string,
+    onProgress?: RefineProgressCallback,
+  ): Promise<InstructionRefineResult> {
+    if (!this.hasThread) {
+      return { success: false, error: 'No active conversation to continue' };
+    }
+    return this.sendMessage(message, onProgress);
+  }
+
+  cancel(): void {
+    if (this.abortController) {
+      this.abortController.abort();
+      this.abortController = null;
+    }
+  }
+
+  private async sendMessage(
+    prompt: string,
+    onProgress?: RefineProgressCallback,
+  ): Promise<InstructionRefineResult> {
+    this.abortController = new AbortController();
+
+    try {
+      const text = await this.runner.query({
+        systemPrompt: buildRefineSystemPrompt(this.existingInstructions),
+        abortController: this.abortController,
+      }, prompt);
+
+      this.hasThread = true;
+      const parsed = this.parseResponse(text);
+      onProgress?.(parsed);
+      return parsed;
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      return { success: false, error: msg };
+    } finally {
+      this.abortController = null;
+    }
+  }
+
+  private parseResponse(text: string): InstructionRefineResult {
+    const match = text.match(/<instruction>([\s\S]*?)<\/instruction>/);
+    if (match) {
+      return { success: true, refinedInstruction: match[1].trim() };
+    }
+
+    const trimmed = text.trim();
+    if (trimmed) {
+      return { success: true, clarification: trimmed };
+    }
+
+    return { success: false, error: 'Empty response' };
+  }
+}

--- a/src/providers/cursor/auxiliary/CursorTaskResultInterpreter.ts
+++ b/src/providers/cursor/auxiliary/CursorTaskResultInterpreter.ts
@@ -1,0 +1,29 @@
+import type {
+  ProviderTaskResultInterpreter,
+  ProviderTaskTerminalStatus,
+} from '../../../core/providers/types';
+
+export class CursorTaskResultInterpreter implements ProviderTaskResultInterpreter {
+  hasAsyncLaunchMarker(_toolUseResult: unknown): boolean {
+    return false;
+  }
+
+  extractAgentId(_toolUseResult: unknown): string | null {
+    return null;
+  }
+
+  extractStructuredResult(_toolUseResult: unknown): string | null {
+    return null;
+  }
+
+  resolveTerminalStatus(
+    _toolUseResult: unknown,
+    fallbackStatus: ProviderTaskTerminalStatus,
+  ): ProviderTaskTerminalStatus {
+    return fallbackStatus;
+  }
+
+  extractTagValue(_payload: string, _tagName: string): string | null {
+    return null;
+  }
+}

--- a/src/providers/cursor/auxiliary/CursorTitleGenerationService.ts
+++ b/src/providers/cursor/auxiliary/CursorTitleGenerationService.ts
@@ -1,0 +1,99 @@
+import { TITLE_GENERATION_SYSTEM_PROMPT } from '../../../core/prompt/titleGeneration';
+import type {
+  TitleGenerationCallback,
+  TitleGenerationResult,
+  TitleGenerationService,
+} from '../../../core/providers/types';
+import type ClaudianPlugin from '../../../main';
+import { CursorAuxCliRunner } from '../runtime/CursorAuxCliRunner';
+
+export class CursorTitleGenerationService implements TitleGenerationService {
+  private plugin: ClaudianPlugin;
+  private activeGenerations = new Map<string, AbortController>();
+
+  constructor(plugin: ClaudianPlugin) {
+    this.plugin = plugin;
+  }
+
+  async generateTitle(
+    conversationId: string,
+    userMessage: string,
+    callback: TitleGenerationCallback,
+  ): Promise<void> {
+    const existing = this.activeGenerations.get(conversationId);
+    if (existing) existing.abort();
+
+    const abortController = new AbortController();
+    this.activeGenerations.set(conversationId, abortController);
+
+    const truncated = userMessage.length > 500
+      ? userMessage.substring(0, 500) + '...'
+      : userMessage;
+    const prompt = `User's request:\n"""\n${truncated}\n"""\n\nGenerate a title for this conversation:`;
+
+    const runner = new CursorAuxCliRunner(this.plugin);
+
+    try {
+      const text = await runner.query({
+        systemPrompt: TITLE_GENERATION_SYSTEM_PROMPT,
+        model: this.resolveTitleModel(),
+        abortController,
+      }, prompt);
+
+      const title = this.parseTitle(text);
+      if (title) {
+        await this.safeCallback(callback, conversationId, { success: true, title });
+      } else {
+        await this.safeCallback(callback, conversationId, {
+          success: false,
+          error: 'Failed to parse title from response',
+        });
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      await this.safeCallback(callback, conversationId, { success: false, error: msg });
+    } finally {
+      runner.reset();
+      this.activeGenerations.delete(conversationId);
+    }
+  }
+
+  cancel(): void {
+    for (const controller of this.activeGenerations.values()) {
+      controller.abort();
+    }
+    this.activeGenerations.clear();
+  }
+
+  private resolveTitleModel(): string | undefined {
+    return this.plugin.settings.titleGenerationModel || undefined;
+  }
+
+  private parseTitle(responseText: string): string | null {
+    const trimmed = responseText.trim();
+    if (!trimmed) return null;
+
+    let title = trimmed;
+    if (
+      (title.startsWith('"') && title.endsWith('"')) ||
+      (title.startsWith("'") && title.endsWith("'"))
+    ) {
+      title = title.slice(1, -1);
+    }
+    const oneLine = title.split('\n')[0]?.trim() ?? '';
+    if (!oneLine) return null;
+    return oneLine.length > 120 ? `${oneLine.slice(0, 117)}...` : oneLine;
+  }
+
+  private async safeCallback(
+    callback: TitleGenerationCallback,
+    conversationId: string,
+    result: TitleGenerationResult,
+  ): Promise<void> {
+    try {
+      await callback(conversationId, result);
+    } catch {
+      // ignore
+    }
+  }
+}

--- a/src/providers/cursor/capabilities.ts
+++ b/src/providers/cursor/capabilities.ts
@@ -1,0 +1,15 @@
+import type { ProviderCapabilities } from '../../core/providers/types';
+
+export const CURSOR_PROVIDER_CAPABILITIES: Readonly<ProviderCapabilities> = Object.freeze({
+  providerId: 'cursor',
+  supportsPersistentRuntime: false,
+  supportsNativeHistory: true,
+  supportsPlanMode: true,
+  supportsRewind: false,
+  supportsFork: false,
+  supportsProviderCommands: false,
+  supportsImageAttachments: true,
+  supportsInstructionMode: true,
+  supportsMcpTools: false,
+  reasoningControl: 'none',
+});

--- a/src/providers/cursor/env/CursorSettingsReconciler.ts
+++ b/src/providers/cursor/env/CursorSettingsReconciler.ts
@@ -1,0 +1,61 @@
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import type { ProviderSettingsReconciler } from '../../../core/providers/types';
+import type { Conversation } from '../../../core/types';
+import { parseEnvironmentVariables } from '../../../utils/env';
+import { getCursorProviderSettings, updateCursorProviderSettings } from '../settings';
+import { getCursorState } from '../types';
+import { cursorChatUIConfig } from '../ui/CursorChatUIConfig';
+
+const ENV_HASH_KEYS = ['CURSOR_API_KEY', 'CURSOR_BASE_URL'];
+
+function computeCursorEnvHash(envText: string): string {
+  const envVars = parseEnvironmentVariables(envText || '');
+  return ENV_HASH_KEYS
+    .filter(key => envVars[key])
+    .map(key => `${key}=${envVars[key]}`)
+    .sort()
+    .join('|');
+}
+
+export const cursorSettingsReconciler: ProviderSettingsReconciler = {
+  reconcileModelWithEnvironment(
+    settings: Record<string, unknown>,
+    conversations: Conversation[],
+  ): { changed: boolean; invalidatedConversations: Conversation[] } {
+    const envText = getRuntimeEnvironmentText(settings, 'cursor');
+    const currentHash = computeCursorEnvHash(envText);
+    const savedHash = getCursorProviderSettings(settings).environmentHash;
+
+    if (currentHash === savedHash) {
+      return { changed: false, invalidatedConversations: [] };
+    }
+
+    const invalidatedConversations: Conversation[] = [];
+    for (const conv of conversations) {
+      const state = getCursorState(conv.providerState);
+      if (conv.providerId === 'cursor' && (conv.sessionId || state.chatSessionId)) {
+        conv.sessionId = null;
+        conv.providerState = undefined;
+        invalidatedConversations.push(conv);
+      }
+    }
+
+    const envVars = parseEnvironmentVariables(envText || '');
+    if (envVars.CURSOR_MODEL) {
+      settings.model = envVars.CURSOR_MODEL;
+    } else if (
+      typeof settings.model === 'string'
+      && settings.model.length > 0
+      && !cursorChatUIConfig.isDefaultModel(settings.model)
+    ) {
+      settings.model = cursorChatUIConfig.getModelOptions({})[0]?.value ?? 'auto';
+    }
+
+    updateCursorProviderSettings(settings, { environmentHash: currentHash });
+    return { changed: true, invalidatedConversations };
+  },
+
+  normalizeModelVariantSettings(): boolean {
+    return false;
+  },
+};

--- a/src/providers/cursor/history/CursorConversationHistoryService.ts
+++ b/src/providers/cursor/history/CursorConversationHistoryService.ts
@@ -1,0 +1,97 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import type { ProviderConversationHistoryService } from '../../../core/providers/types';
+import type { Conversation } from '../../../core/types';
+import { getCursorState, resolveCursorSessionId } from '../types';
+import { cursorWorkspaceHash, loadCursorChatMessagesFromStore, resolveCursorStoreDbPath } from './cursorHistoryStore';
+
+export class CursorConversationHistoryService implements ProviderConversationHistoryService {
+  private hydratedConversationKeys = new Map<string, string>();
+
+  async hydrateConversationHistory(
+    conversation: Conversation,
+    vaultPath: string | null,
+  ): Promise<void> {
+    const sessionId = resolveCursorSessionId(conversation);
+    if (!sessionId || !vaultPath) {
+      this.hydratedConversationKeys.delete(conversation.id);
+      return;
+    }
+
+    const dbPath = resolveCursorStoreDbPath(vaultPath, sessionId);
+    if (!dbPath) {
+      this.hydratedConversationKeys.delete(conversation.id);
+      return;
+    }
+
+    const hydrationKey = `${sessionId}::${dbPath}`;
+    if (
+      conversation.messages.length > 0
+      && this.hydratedConversationKeys.get(conversation.id) === hydrationKey
+    ) {
+      return;
+    }
+
+    const loaded = loadCursorChatMessagesFromStore(dbPath);
+    if (loaded.length === 0) {
+      this.hydratedConversationKeys.delete(conversation.id);
+      return;
+    }
+
+    conversation.messages = loaded;
+    this.hydratedConversationKeys.set(conversation.id, hydrationKey);
+  }
+
+  async deleteConversationSession(
+    conversation: Conversation,
+    vaultPath: string | null,
+  ): Promise<void> {
+    const sessionId = resolveCursorSessionId(conversation);
+    if (!sessionId || !vaultPath) {
+      return;
+    }
+
+    const hash = cursorWorkspaceHash(vaultPath);
+    const chatDir = path.join(os.homedir(), '.cursor', 'chats', hash, sessionId);
+    if (!chatDir.startsWith(path.join(os.homedir(), '.cursor', 'chats'))) {
+      return;
+    }
+
+    try {
+      fs.rmSync(chatDir, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  }
+
+  resolveSessionIdForConversation(conversation: Conversation | null): string | null {
+    return resolveCursorSessionId(conversation);
+  }
+
+  isPendingForkConversation(_conversation: Conversation): boolean {
+    return false;
+  }
+
+  buildForkProviderState(
+    _sourceSessionId: string,
+    _resumeAt: string,
+    _sourceProviderState?: Record<string, unknown>,
+  ): Record<string, unknown> {
+    return {};
+  }
+
+  buildPersistedProviderState(
+    conversation: Conversation,
+  ): Record<string, unknown> | undefined {
+    const state = getCursorState(conversation.providerState);
+    const sid = state.chatSessionId ?? conversation.sessionId ?? undefined;
+    const merged: Record<string, unknown> = { ...state };
+    if (sid) {
+      merged.chatSessionId = sid;
+    }
+    const entries = Object.entries(merged).filter(([, value]) => value !== undefined);
+    return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+  }
+}

--- a/src/providers/cursor/history/cursorHistoryStore.ts
+++ b/src/providers/cursor/history/cursorHistoryStore.ts
@@ -1,0 +1,184 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import type { ChatMessage, ToolCallInfo } from '../../../core/types';
+
+export function cursorWorkspaceHash(absoluteVaultPath: string): string {
+  return crypto.createHash('md5').update(absoluteVaultPath).digest('hex');
+}
+
+export function resolveCursorStoreDbPath(
+  absoluteVaultPath: string,
+  sessionId: string,
+): string | null {
+  const hash = cursorWorkspaceHash(absoluteVaultPath);
+  const candidate = path.join(os.homedir(), '.cursor', 'chats', hash, sessionId, 'store.db');
+  return fs.existsSync(candidate) ? candidate : null;
+}
+
+function isIdeBootstrapUser(content: string): boolean {
+  return content.includes('<user_info>');
+}
+
+function parseAssistantBlob(record: Record<string, unknown>): { text: string; toolCalls: ToolCallInfo[] } {
+  const content = record.content;
+  if (typeof content === 'string') {
+    return { text: content, toolCalls: [] };
+  }
+  if (!Array.isArray(content)) {
+    return { text: '', toolCalls: [] };
+  }
+
+  let text = '';
+  const toolCalls: ToolCallInfo[] = [];
+
+  for (const block of content) {
+    if (!block || typeof block !== 'object') {
+      continue;
+    }
+    const b = block as Record<string, unknown>;
+    if (b.type === 'redacted-reasoning') {
+      continue;
+    }
+    if (b.type === 'text' && typeof b.text === 'string') {
+      text += b.text;
+    }
+    if (b.type === 'tool-call') {
+      const id = typeof b.toolCallId === 'string' ? b.toolCallId : '';
+      const name = typeof b.toolName === 'string' ? b.toolName : 'tool';
+      const args = b.args && typeof b.args === 'object' && !Array.isArray(b.args)
+        ? b.args as Record<string, unknown>
+        : {};
+      if (id) {
+        toolCalls.push({
+          id,
+          name,
+          input: args,
+          status: 'running',
+        });
+      }
+    }
+  }
+
+  return { text, toolCalls };
+}
+
+function applyToolBlob(record: Record<string, unknown>, messages: ChatMessage[]): void {
+  const content = record.content;
+  if (!Array.isArray(content)) {
+    return;
+  }
+
+  for (const block of content) {
+    if (!block || typeof block !== 'object') {
+      continue;
+    }
+    const b = block as Record<string, unknown>;
+    if (b.type !== 'tool-result') {
+      continue;
+    }
+    const toolCallId = typeof b.toolCallId === 'string' ? b.toolCallId : '';
+    if (!toolCallId) {
+      continue;
+    }
+    const result = b.result;
+    const resultStr = typeof result === 'string' ? result : JSON.stringify(result);
+
+    const assistant = [...messages].reverse().find(
+      m => m.role === 'assistant' && m.toolCalls?.some(t => t.id === toolCallId),
+    );
+    if (!assistant?.toolCalls) {
+      continue;
+    }
+    const tc = assistant.toolCalls.find(t => t.id === toolCallId);
+    if (tc) {
+      tc.result = resultStr;
+      tc.status = 'completed';
+    }
+  }
+}
+
+function openCursorSqliteReadonly(dbPath: string):
+  | { prepare: (sql: string) => { all: () => unknown[] } }
+  | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/consistent-type-imports
+    const { DatabaseSync } = require('node:sqlite') as typeof import('node:sqlite');
+    const db = new DatabaseSync(dbPath, { readOnly: true });
+    return db;
+  } catch {
+    return null;
+  }
+}
+
+export function loadCursorChatMessagesFromStore(dbPath: string): ChatMessage[] {
+  const db = openCursorSqliteReadonly(dbPath);
+  if (!db) {
+    return [];
+  }
+
+  let rows: Array<{ rowid: number; id: string; data: Buffer | Uint8Array }>;
+  try {
+    const stmt = db.prepare('SELECT rowid, id, data FROM blobs ORDER BY rowid');
+    rows = stmt.all() as Array<{ rowid: number; id: string; data: Buffer | Uint8Array }>;
+  } catch {
+    return [];
+  }
+
+  const messages: ChatMessage[] = [];
+
+  for (const row of rows) {
+    const buf = Buffer.isBuffer(row.data) ? row.data : Buffer.from(row.data);
+    const raw = buf.toString('utf8');
+    if (!raw.startsWith('{')) {
+      continue;
+    }
+
+    let record: Record<string, unknown>;
+    try {
+      record = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+
+    const role = record.role;
+    if (role === 'system') {
+      continue;
+    }
+
+    if (role === 'user') {
+      const c = record.content;
+      const text = typeof c === 'string' ? c : '';
+      if (isIdeBootstrapUser(text)) {
+        continue;
+      }
+      messages.push({
+        id: `cursor-${row.id.slice(0, 12)}`,
+        role: 'user',
+        content: text,
+        timestamp: Date.now(),
+      });
+      continue;
+    }
+
+    if (role === 'assistant') {
+      const { text, toolCalls } = parseAssistantBlob(record);
+      messages.push({
+        id: `cursor-${row.id.slice(0, 12)}`,
+        role: 'assistant',
+        content: text,
+        timestamp: Date.now(),
+        toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+      });
+      continue;
+    }
+
+    if (role === 'tool') {
+      applyToolBlob(record, messages);
+    }
+  }
+
+  return messages;
+}

--- a/src/providers/cursor/prompt/encodeCursorTurn.ts
+++ b/src/providers/cursor/prompt/encodeCursorTurn.ts
@@ -1,0 +1,63 @@
+import type { ChatTurnRequest, PreparedChatTurn } from '../../../core/runtime/types';
+
+function isCompactCommand(text: string): boolean {
+  return /^\/compact(\s|$)/i.test(text);
+}
+
+export function encodeCursorTurn(request: ChatTurnRequest): PreparedChatTurn {
+  const isCompact = isCompactCommand(request.text);
+
+  if (isCompact) {
+    return {
+      request,
+      persistedContent: request.text,
+      prompt: request.text,
+      isCompact: true,
+      mcpMentions: new Set(),
+    };
+  }
+
+  const sections: string[] = [];
+  sections.push(request.text);
+
+  if (request.images?.length) {
+    sections.push(
+      `\n[The user attached ${request.images.length} image(s) in Claudian. Use vault paths or ask which files to read if you need the image bytes.]`,
+    );
+  }
+
+  if (request.currentNotePath) {
+    sections.push(`\n[Current note: ${request.currentNotePath}]`);
+  }
+
+  if (request.editorSelection?.selectedText) {
+    sections.push(
+      `\n[Editor selection from ${request.editorSelection.notePath || 'current note'}:\n${request.editorSelection.selectedText}\n]`,
+    );
+  }
+
+  if (request.browserSelection?.selectedText) {
+    sections.push(
+      `\n[Browser selection from ${request.browserSelection.url ?? 'unknown page'}:\n${request.browserSelection.selectedText}\n]`,
+    );
+  }
+
+  if (request.canvasSelection) {
+    const nodeList = request.canvasSelection.nodeIds.join(', ');
+    if (nodeList) {
+      sections.push(
+        `\n[Canvas selection from ${request.canvasSelection.canvasPath}:\n${nodeList}\n]`,
+      );
+    }
+  }
+
+  const prompt = sections.join('');
+
+  return {
+    request,
+    persistedContent: request.text,
+    prompt,
+    isCompact: false,
+    mcpMentions: new Set(),
+  };
+}

--- a/src/providers/cursor/registration.ts
+++ b/src/providers/cursor/registration.ts
@@ -1,0 +1,27 @@
+import type { ProviderRegistration } from '../../core/providers/types';
+import { CursorInlineEditService } from './auxiliary/CursorInlineEditService';
+import { CursorInstructionRefineService } from './auxiliary/CursorInstructionRefineService';
+import { CursorTaskResultInterpreter } from './auxiliary/CursorTaskResultInterpreter';
+import { CursorTitleGenerationService } from './auxiliary/CursorTitleGenerationService';
+import { CURSOR_PROVIDER_CAPABILITIES } from './capabilities';
+import { cursorSettingsReconciler } from './env/CursorSettingsReconciler';
+import { CursorConversationHistoryService } from './history/CursorConversationHistoryService';
+import { CursorChatRuntime } from './runtime/CursorChatRuntime';
+import { getCursorProviderSettings } from './settings';
+import { cursorChatUIConfig } from './ui/CursorChatUIConfig';
+
+export const cursorProviderRegistration: ProviderRegistration = {
+  displayName: 'Cursor Agent',
+  blankTabOrder: 8,
+  isEnabled: (settings) => getCursorProviderSettings(settings).enabled,
+  capabilities: CURSOR_PROVIDER_CAPABILITIES,
+  environmentKeyPatterns: [/^CURSOR_/i],
+  chatUIConfig: cursorChatUIConfig,
+  settingsReconciler: cursorSettingsReconciler,
+  createRuntime: ({ plugin }) => new CursorChatRuntime(plugin),
+  createTitleGenerationService: (plugin) => new CursorTitleGenerationService(plugin),
+  createInstructionRefineService: (plugin) => new CursorInstructionRefineService(plugin),
+  createInlineEditService: (plugin) => new CursorInlineEditService(plugin),
+  historyService: new CursorConversationHistoryService(),
+  taskResultInterpreter: new CursorTaskResultInterpreter(),
+};

--- a/src/providers/cursor/runtime/CursorAuxCliRunner.ts
+++ b/src/providers/cursor/runtime/CursorAuxCliRunner.ts
@@ -1,0 +1,153 @@
+import { spawn } from 'child_process';
+
+import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
+import type ClaudianPlugin from '../../../main';
+import { getVaultPath } from '../../../utils/path';
+import { buildCursorAgentEnvironment } from './cursorAgentEnv';
+import { resolveCursorModelForCli } from './cursorCliModel';
+import { buildCursorAgentJsonModeFlagArgs, type CursorPermissionMode } from './cursorLaunchArgs';
+
+export interface CursorAuxQueryConfig {
+  systemPrompt: string;
+  model?: string;
+  abortController?: AbortController;
+}
+
+interface CursorJsonResult {
+  type?: string;
+  subtype?: string;
+  result?: string;
+  session_id?: string;
+  is_error?: boolean;
+}
+
+export class CursorAuxCliRunner {
+  private sessionId: string | null = null;
+
+  constructor(private readonly plugin: ClaudianPlugin) {}
+
+  reset(): void {
+    this.sessionId = null;
+  }
+
+  async query(config: CursorAuxQueryConfig, prompt: string): Promise<string> {
+    const cli = this.plugin.getResolvedProviderCliPath('cursor');
+    if (!cli) {
+      throw new Error('Cursor Agent CLI not found. Install the Cursor CLI and configure its path in settings.');
+    }
+
+    const workspaceDir = getVaultPath(this.plugin.app) ?? process.cwd();
+    const permissionMode = this.plugin.settings.permissionMode as CursorPermissionMode;
+    const model = resolveCursorModelForCli(
+      config.model ?? this.resolveProviderModel(),
+    );
+
+    const flagArgs = buildCursorAgentJsonModeFlagArgs({
+      workspaceDir,
+      model,
+      permissionMode,
+      resumeSessionId: this.sessionId,
+    });
+
+    const fullPrompt = config.systemPrompt
+      ? `${config.systemPrompt}\n\n${prompt}`
+      : prompt;
+
+    const env = buildCursorAgentEnvironment(this.plugin);
+    const { stdout, stderr, code, signal } = await this.spawnOnce(
+      cli,
+      [...flagArgs, fullPrompt],
+      { cwd: workspaceDir, env },
+      config.abortController?.signal,
+    );
+
+    if (signal === 'SIGTERM' || config.abortController?.signal.aborted) {
+      throw new Error('Cancelled');
+    }
+
+    if (code !== 0) {
+      throw new Error(stderr.trim() || `Cursor Agent exited with code ${code}`);
+    }
+
+    const trimmed = stdout.trim();
+    if (!trimmed) {
+      throw new Error('Empty response from Cursor Agent');
+    }
+
+    let parsed: CursorJsonResult;
+    try {
+      parsed = JSON.parse(trimmed) as CursorJsonResult;
+    } catch {
+      throw new Error('Failed to parse Cursor Agent JSON output');
+    }
+
+    if (typeof parsed.session_id === 'string' && parsed.session_id) {
+      this.sessionId = parsed.session_id;
+    }
+
+    if (parsed.is_error === true) {
+      throw new Error(parsed.result?.trim() || 'Cursor Agent reported an error');
+    }
+
+    return typeof parsed.result === 'string' ? parsed.result : '';
+  }
+
+  private resolveProviderModel(): string | undefined {
+    const providerSettings = ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+      this.plugin.settings as unknown as Record<string, unknown>,
+      'cursor',
+    );
+    const m = providerSettings.model;
+    return typeof m === 'string' && m.trim() ? m.trim() : undefined;
+  }
+
+  private spawnOnce(
+    command: string,
+    args: string[],
+    options: { cwd: string; env: Record<string, string> },
+    signal?: AbortSignal,
+  ): Promise<{ stdout: string; stderr: string; code: number | null; signal: NodeJS.Signals | null }> {
+    return new Promise((resolve, reject) => {
+      const child = spawn(command, args, {
+        cwd: options.cwd,
+        env: options.env,
+        windowsHide: true,
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout?.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString('utf8');
+      });
+      child.stderr?.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString('utf8');
+      });
+
+      const onAbort = (): void => {
+        child.kill('SIGTERM');
+      };
+      if (signal) {
+        if (signal.aborted) {
+          onAbort();
+        } else {
+          signal.addEventListener('abort', onAbort, { once: true });
+        }
+      }
+
+      child.on('error', (err) => {
+        if (signal) {
+          signal.removeEventListener('abort', onAbort);
+        }
+        reject(err);
+      });
+
+      child.on('close', (code, killSignal) => {
+        if (signal) {
+          signal.removeEventListener('abort', onAbort);
+        }
+        resolve({ stdout, stderr, code, signal: killSignal });
+      });
+    });
+  }
+}

--- a/src/providers/cursor/runtime/CursorBinaryLocator.ts
+++ b/src/providers/cursor/runtime/CursorBinaryLocator.ts
@@ -1,0 +1,70 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { getEnhancedPath, parseEnvironmentVariables } from '../../../utils/env';
+import { expandHomePath, parsePathEntries } from '../../../utils/path';
+
+function isExistingFile(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function resolveConfiguredPath(configuredPath: string | undefined): string | null {
+  const trimmed = (configuredPath ?? '').trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const expandedPath = expandHomePath(trimmed);
+    return isExistingFile(expandedPath) ? expandedPath : null;
+  } catch {
+    return null;
+  }
+}
+
+export function findCursorAgentBinaryPath(
+  additionalPath?: string,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  const binaryNames = platform === 'win32'
+    ? ['agent.exe', 'agent']
+    : ['agent'];
+  const searchEntries = parsePathEntries(getEnhancedPath(additionalPath));
+
+  for (const dir of searchEntries) {
+    if (!dir) continue;
+
+    for (const binaryName of binaryNames) {
+      const candidate = path.join(dir, binaryName);
+      if (isExistingFile(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function resolveCursorCliPath(
+  hostnamePath: string | undefined,
+  legacyPath: string | undefined,
+  envText: string,
+  hostPlatform: NodeJS.Platform = process.platform,
+): string | null {
+  const configuredHostnamePath = resolveConfiguredPath(hostnamePath);
+  if (configuredHostnamePath) {
+    return configuredHostnamePath;
+  }
+
+  const configuredLegacyPath = resolveConfiguredPath(legacyPath);
+  if (configuredLegacyPath) {
+    return configuredLegacyPath;
+  }
+
+  const customEnv = parseEnvironmentVariables(envText || '');
+  return findCursorAgentBinaryPath(customEnv.PATH, hostPlatform);
+}

--- a/src/providers/cursor/runtime/CursorChatRuntime.ts
+++ b/src/providers/cursor/runtime/CursorChatRuntime.ts
@@ -1,0 +1,298 @@
+import { spawn } from 'child_process';
+import * as readline from 'readline';
+
+import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
+import type { ProviderCapabilities, ProviderId } from '../../../core/providers/types';
+import type { ChatRuntime } from '../../../core/runtime/ChatRuntime';
+import type {
+  ApprovalCallback,
+  AskUserQuestionCallback,
+  AutoTurnResult,
+  ChatRewindResult,
+  ChatRuntimeConversationState,
+  ChatRuntimeEnsureReadyOptions,
+  ChatRuntimeQueryOptions,
+  ChatTurnMetadata,
+  ChatTurnRequest,
+  ExitPlanModeCallback,
+  PreparedChatTurn,
+  SessionUpdateResult,
+  SubagentRuntimeState,
+} from '../../../core/runtime/types';
+import type { ChatMessage, Conversation, SlashCommand, StreamChunk } from '../../../core/types';
+import type ClaudianPlugin from '../../../main';
+import { getVaultPath } from '../../../utils/path';
+import { CURSOR_PROVIDER_CAPABILITIES } from '../capabilities';
+import { encodeCursorTurn } from '../prompt/encodeCursorTurn';
+import { getCursorState, resolveCursorSessionId } from '../types';
+import { buildCursorAgentEnvironment } from './cursorAgentEnv';
+import { resolveCursorModelForCli } from './cursorCliModel';
+import { buildCursorAgentFlagArgs, type CursorPermissionMode } from './cursorLaunchArgs';
+import { CursorNdjsonStreamReducer } from './cursorStreamMapper';
+
+export class CursorChatRuntime implements ChatRuntime {
+  readonly providerId: ProviderId = 'cursor';
+
+  private plugin: ClaudianPlugin;
+  private ready = false;
+  private readyListeners = new Set<(ready: boolean) => void>();
+  private canceled = false;
+  private child: ReturnType<typeof spawn> | null = null;
+  private lastSessionId: string | null = null;
+  private activeResumeId: string | null = null;
+  private turnMetadata: ChatTurnMetadata = {};
+
+  constructor(plugin: ClaudianPlugin) {
+    this.plugin = plugin;
+  }
+
+  getCapabilities(): Readonly<ProviderCapabilities> {
+    return CURSOR_PROVIDER_CAPABILITIES;
+  }
+
+  prepareTurn(request: ChatTurnRequest): PreparedChatTurn {
+    return encodeCursorTurn(request);
+  }
+
+  consumeTurnMetadata(): ChatTurnMetadata {
+    const metadata = { ...this.turnMetadata };
+    this.turnMetadata = {};
+    return metadata;
+  }
+
+  onReadyStateChange(listener: (ready: boolean) => void): () => void {
+    this.readyListeners.add(listener);
+    return () => {
+      this.readyListeners.delete(listener);
+    };
+  }
+
+  setResumeCheckpoint(_checkpointId: string | undefined): void {}
+
+  syncConversationState(conversation: ChatRuntimeConversationState | null): void {
+    if (!conversation) {
+      this.activeResumeId = null;
+      return;
+    }
+    this.activeResumeId = resolveCursorSessionId(conversation);
+  }
+
+  async reloadMcpServers(): Promise<void> {}
+
+  async ensureReady(_options?: ChatRuntimeEnsureReadyOptions): Promise<boolean> {
+    const cli = this.plugin.getResolvedProviderCliPath('cursor');
+    const nextReady = !!cli;
+    if (this.ready !== nextReady) {
+      this.ready = nextReady;
+      for (const listener of this.readyListeners) {
+        listener(nextReady);
+      }
+    }
+    return nextReady;
+  }
+
+  async *query(
+    turn: PreparedChatTurn,
+    _conversationHistory?: ChatMessage[],
+    queryOptions?: ChatRuntimeQueryOptions,
+  ): AsyncGenerator<StreamChunk> {
+    this.turnMetadata = {};
+    this.canceled = false;
+
+    const cli = this.plugin.getResolvedProviderCliPath('cursor');
+    if (!cli) {
+      yield { type: 'error', content: 'Cursor Agent CLI not found. Configure it in Cursor settings.' };
+      yield { type: 'done' };
+      return;
+    }
+
+    const workspaceDir = getVaultPath(this.plugin.app) ?? process.cwd();
+    const permissionMode = this.plugin.settings.permissionMode as CursorPermissionMode;
+    const model = resolveCursorModelForCli(
+      queryOptions?.model ?? this.resolveProviderModel(),
+    );
+    const resumeId = this.activeResumeId;
+
+    yield {
+      type: 'user_message_start',
+      content: turn.persistedContent,
+    };
+    yield { type: 'assistant_message_start' };
+
+    const flagArgs = buildCursorAgentFlagArgs({
+      workspaceDir,
+      model,
+      permissionMode,
+      resumeSessionId: resumeId,
+      approveMcps: (turn.request.enabledMcpServers?.size ?? 0) > 0,
+    });
+
+    const env = buildCursorAgentEnvironment(this.plugin);
+    const reducer = new CursorNdjsonStreamReducer();
+    let sawDone = false;
+    const child = spawn(cli, [...flagArgs, turn.prompt], {
+      cwd: workspaceDir,
+      env,
+      windowsHide: true,
+    });
+    this.child = child;
+
+    let stderrAcc = '';
+    child.stderr?.on('data', (d: Buffer) => {
+      stderrAcc += d.toString('utf8');
+    });
+
+    const rl = readline.createInterface({ input: child.stdout });
+
+    try {
+      for await (const line of rl) {
+        if (this.canceled) {
+          break;
+        }
+        const { chunks, sessionId } = reducer.reduceLine(line);
+        if (sessionId) {
+          this.lastSessionId = sessionId;
+        }
+        for (const chunk of chunks) {
+          if (chunk.type === 'done') {
+            sawDone = true;
+          }
+          yield chunk;
+        }
+      }
+    } finally {
+      rl.close();
+    }
+
+    const exitCode = await new Promise<number | null>((resolve) => {
+      child.on('close', (code) => resolve(code));
+    });
+
+    const stderrText = stderrAcc;
+    this.child = null;
+
+    if (this.canceled) {
+      if (!sawDone) {
+        yield { type: 'done' };
+      }
+      return;
+    }
+
+    if (exitCode !== 0) {
+      if (!sawDone) {
+        const msg = stderrText.trim() || `Cursor Agent exited with code ${exitCode}`;
+        yield { type: 'error', content: msg };
+        yield { type: 'done' };
+      }
+      return;
+    }
+
+    if (!sawDone) {
+      yield {
+        type: 'error',
+        content: stderrText.trim() || 'Cursor Agent finished without a terminal result event',
+      };
+      yield { type: 'done' };
+    }
+
+    if (this.lastSessionId) {
+      this.activeResumeId = this.lastSessionId;
+    }
+  }
+
+  cancel(): void {
+    this.canceled = true;
+    if (this.child) {
+      this.child.kill('SIGTERM');
+      this.child = null;
+    }
+  }
+
+  resetSession(): void {
+    this.lastSessionId = null;
+    this.activeResumeId = null;
+  }
+
+  getSessionId(): string | null {
+    return this.lastSessionId;
+  }
+
+  consumeSessionInvalidation(): boolean {
+    return false;
+  }
+
+  isReady(): boolean {
+    return this.ready;
+  }
+
+  async getSupportedCommands(): Promise<SlashCommand[]> {
+    return [];
+  }
+
+  cleanup(): void {
+    this.cancel();
+    this.readyListeners.clear();
+  }
+
+  async rewind(
+    _userMessageId: string,
+    _assistantMessageId: string,
+  ): Promise<ChatRewindResult> {
+    return { canRewind: false, error: 'Cursor Agent does not support rewind' };
+  }
+
+  setApprovalCallback(_callback: ApprovalCallback | null): void {}
+
+  setApprovalDismisser(_dismisser: (() => void) | null): void {}
+
+  setAskUserQuestionCallback(_callback: AskUserQuestionCallback | null): void {}
+
+  setExitPlanModeCallback(_callback: ExitPlanModeCallback | null): void {}
+
+  setPermissionModeSyncCallback(_callback: ((sdkMode: string) => void) | null): void {}
+
+  setSubagentHookProvider(_getState: () => SubagentRuntimeState): void {}
+
+  setAutoTurnCallback(_callback: ((result: AutoTurnResult) => void) | null): void {}
+
+  buildSessionUpdates(params: {
+    conversation: Conversation | null;
+    sessionInvalidated: boolean;
+  }): SessionUpdateResult {
+    if (params.sessionInvalidated && params.conversation) {
+      return {
+        updates: {
+          sessionId: null,
+          providerState: undefined,
+        },
+      };
+    }
+
+    const sid = this.lastSessionId;
+    const existing = params.conversation ? getCursorState(params.conversation.providerState) : {};
+    const providerState: Record<string, unknown> = { ...existing };
+    if (sid) {
+      providerState.chatSessionId = sid;
+    }
+
+    return {
+      updates: {
+        sessionId: sid,
+        providerState: Object.keys(providerState).length > 0 ? providerState : undefined,
+      },
+    };
+  }
+
+  resolveSessionIdForFork(_conversation: Conversation | null): string | null {
+    return null;
+  }
+
+  private resolveProviderModel(): string | undefined {
+    const providerSettings = ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+      this.plugin.settings as unknown as Record<string, unknown>,
+      'cursor',
+    );
+    const m = providerSettings.model;
+    return typeof m === 'string' && m.trim() ? m.trim() : undefined;
+  }
+}

--- a/src/providers/cursor/runtime/CursorCliResolver.ts
+++ b/src/providers/cursor/runtime/CursorCliResolver.ts
@@ -1,0 +1,53 @@
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import type { HostnameCliPaths } from '../../../core/types/settings';
+import { getHostnameKey } from '../../../utils/env';
+import { getCursorProviderSettings } from '../settings';
+import { resolveCursorCliPath } from './CursorBinaryLocator';
+
+export class CursorCliResolver {
+  private resolvedPath: string | null = null;
+  private lastHostnamePath = '';
+  private lastLegacyPath = '';
+  private lastEnvText = '';
+  private readonly cachedHostname = getHostnameKey();
+
+  resolveFromSettings(settings: Record<string, unknown>): string | null {
+    const cursorSettings = getCursorProviderSettings(settings);
+    const hostnamePath = (cursorSettings.cliPathsByHost[this.cachedHostname] ?? '').trim();
+    const legacyPath = cursorSettings.cliPath.trim();
+    const envText = getRuntimeEnvironmentText(settings, 'cursor');
+
+    if (
+      this.resolvedPath
+      && hostnamePath === this.lastHostnamePath
+      && legacyPath === this.lastLegacyPath
+      && envText === this.lastEnvText
+    ) {
+      return this.resolvedPath;
+    }
+
+    this.lastHostnamePath = hostnamePath;
+    this.lastLegacyPath = legacyPath;
+    this.lastEnvText = envText;
+
+    this.resolvedPath = resolveCursorCliPath(hostnamePath, legacyPath, envText);
+    return this.resolvedPath;
+  }
+
+  resolve(
+    hostnamePaths: HostnameCliPaths | undefined,
+    legacyPath: string | undefined,
+    envText: string,
+  ): string | null {
+    const hostnamePath = (hostnamePaths?.[this.cachedHostname] ?? '').trim();
+    const normalizedLegacyPath = (legacyPath ?? '').trim();
+    return resolveCursorCliPath(hostnamePath, normalizedLegacyPath, envText);
+  }
+
+  reset(): void {
+    this.resolvedPath = null;
+    this.lastHostnamePath = '';
+    this.lastLegacyPath = '';
+    this.lastEnvText = '';
+  }
+}

--- a/src/providers/cursor/runtime/cursorAgentEnv.ts
+++ b/src/providers/cursor/runtime/cursorAgentEnv.ts
@@ -1,0 +1,16 @@
+import type ClaudianPlugin from '../../../main';
+import { getEnhancedPath, parseEnvironmentVariables } from '../../../utils/env';
+
+export function buildCursorAgentEnvironment(plugin: ClaudianPlugin): Record<string, string> {
+  const customEnv = parseEnvironmentVariables(plugin.getActiveEnvironmentVariables('cursor'));
+  const baseEnv = Object.fromEntries(
+    Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+  );
+  const enhancedPath = getEnhancedPath(customEnv.PATH);
+
+  return {
+    ...baseEnv,
+    ...customEnv,
+    PATH: enhancedPath,
+  };
+}

--- a/src/providers/cursor/runtime/cursorCliModel.ts
+++ b/src/providers/cursor/runtime/cursorCliModel.ts
@@ -1,0 +1,10 @@
+export function resolveCursorModelForCli(model: string | undefined): string | undefined {
+  if (!model?.trim()) {
+    return undefined;
+  }
+  const m = model.trim();
+  if (m === 'composer-1') {
+    return 'auto';
+  }
+  return m;
+}

--- a/src/providers/cursor/runtime/cursorLaunchArgs.ts
+++ b/src/providers/cursor/runtime/cursorLaunchArgs.ts
@@ -1,0 +1,103 @@
+export type CursorPermissionMode = 'yolo' | 'plan' | 'normal';
+
+export interface BuildCursorAgentFlagArgsOptions {
+  workspaceDir: string;
+  model?: string | null;
+  permissionMode: CursorPermissionMode;
+  resumeSessionId?: string | null;
+  approveMcps?: boolean;
+}
+
+export function buildCursorAgentFlagArgs(options: BuildCursorAgentFlagArgsOptions): string[] {
+  const args: string[] = [
+    '-p',
+    '--output-format', 'stream-json',
+    '--stream-partial-output',
+    '--workspace', options.workspaceDir,
+    '--trust',
+  ];
+
+  if (options.permissionMode === 'yolo') {
+    args.push('--force', '--sandbox', 'disabled');
+  } else if (options.permissionMode === 'plan') {
+    args.push('--mode', 'plan', '--sandbox', 'enabled');
+  } else {
+    args.push('--sandbox', 'enabled');
+  }
+
+  if (options.model) {
+    args.push('--model', options.model);
+  }
+
+  if (options.resumeSessionId) {
+    args.push('--resume', options.resumeSessionId);
+  }
+
+  if (options.approveMcps) {
+    args.push('--approve-mcps');
+  }
+
+  return args;
+}
+
+export function buildCursorAgentJsonModeFlagArgs(
+  options: BuildCursorAgentFlagArgsOptions,
+): string[] {
+  const args: string[] = [
+    '-p',
+    '--output-format', 'json',
+    '--workspace', options.workspaceDir,
+    '--trust',
+  ];
+
+  if (options.permissionMode === 'yolo') {
+    args.push('--force', '--sandbox', 'disabled');
+  } else if (options.permissionMode === 'plan') {
+    args.push('--mode', 'plan', '--sandbox', 'enabled');
+  } else {
+    args.push('--sandbox', 'enabled');
+  }
+
+  if (options.model) {
+    args.push('--model', options.model);
+  }
+
+  if (options.resumeSessionId) {
+    args.push('--resume', options.resumeSessionId);
+  }
+
+  if (options.approveMcps) {
+    args.push('--approve-mcps');
+  }
+
+  return args;
+}
+
+export function buildCursorAgentTextModeFlagArgs(
+  options: Omit<BuildCursorAgentFlagArgsOptions, never>,
+): string[] {
+  const args: string[] = [
+    '-p',
+    '--output-format', 'text',
+    '--workspace', options.workspaceDir,
+    '--trust',
+  ];
+
+  if (options.permissionMode === 'yolo') {
+    args.push('--force', '--sandbox', 'disabled');
+  } else if (options.permissionMode === 'plan') {
+    args.push('--mode', 'plan', '--sandbox', 'enabled');
+  } else {
+    args.push('--sandbox', 'enabled');
+  }
+
+  if (options.model) {
+    args.push('--model', options.model);
+  }
+
+  if (options.resumeSessionId) {
+    args.push('--resume', options.resumeSessionId);
+  }
+
+  return args;
+}

--- a/src/providers/cursor/runtime/cursorStreamMapper.ts
+++ b/src/providers/cursor/runtime/cursorStreamMapper.ts
@@ -1,0 +1,184 @@
+import type { StreamChunk } from '../../../core/types';
+
+export interface CursorReduceResult {
+  chunks: StreamChunk[];
+  sessionId?: string;
+}
+
+function extractAssistantText(record: Record<string, unknown>): string {
+  const msg = record.message;
+  if (!msg || typeof msg !== 'object') {
+    return '';
+  }
+  const content = (msg as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return '';
+  }
+  let out = '';
+  for (const block of content) {
+    if (!block || typeof block !== 'object') {
+      continue;
+    }
+    const b = block as Record<string, unknown>;
+    if (b.type === 'text' && typeof b.text === 'string') {
+      out += b.text;
+    }
+  }
+  return out;
+}
+
+function parseToolStart(record: Record<string, unknown>): {
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+} | null {
+  const callId = typeof record.call_id === 'string' ? record.call_id : '';
+  if (!callId) {
+    return null;
+  }
+
+  const tc = record.tool_call;
+  if (!tc || typeof tc !== 'object') {
+    return null;
+  }
+  const t = tc as Record<string, unknown>;
+
+  const read = t.readToolCall;
+  if (read && typeof read === 'object') {
+    const args = (read as { args?: Record<string, unknown> }).args ?? {};
+    return { id: callId, name: 'read_file', input: { ...args } };
+  }
+
+  const write = t.writeToolCall;
+  if (write && typeof write === 'object') {
+    const w = write as { args?: Record<string, unknown> };
+    const args = w.args ?? {};
+    return { id: callId, name: 'write_file', input: { ...args } };
+  }
+
+  const fn = t.function;
+  if (fn && typeof fn === 'object') {
+    const f = fn as { name?: string; arguments?: string };
+    const name = typeof f.name === 'string' ? f.name : 'function';
+    let input: Record<string, unknown> = {};
+    if (typeof f.arguments === 'string' && f.arguments.trim()) {
+      try {
+        input = JSON.parse(f.arguments) as Record<string, unknown>;
+      } catch {
+        input = { raw: f.arguments };
+      }
+    }
+    return { id: callId, name, input };
+  }
+
+  return { id: callId, name: 'tool', input: { tool_call: tc } };
+}
+
+function stringifyToolResult(record: Record<string, unknown>): string {
+  const tc = record.tool_call;
+  if (tc && typeof tc === 'object') {
+    try {
+      return JSON.stringify(tc);
+    } catch {
+      return String(tc);
+    }
+  }
+  return JSON.stringify(record);
+}
+
+export class CursorNdjsonStreamReducer {
+  private assistantAcc = '';
+
+  reset(): void {
+    this.assistantAcc = '';
+  }
+
+  reduceLine(line: string): CursorReduceResult {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      return { chunks: [] };
+    }
+
+    let rec: Record<string, unknown>;
+    try {
+      rec = JSON.parse(trimmed) as Record<string, unknown>;
+    } catch {
+      return { chunks: [] };
+    }
+
+    const sessionId = typeof rec.session_id === 'string' ? rec.session_id : undefined;
+    const type = rec.type;
+
+    if (type === 'system' || type === 'user') {
+      return { chunks: [], sessionId };
+    }
+
+    if (type === 'assistant') {
+      const full = extractAssistantText(rec);
+      const delta = full.startsWith(this.assistantAcc)
+        ? full.slice(this.assistantAcc.length)
+        : full;
+      this.assistantAcc = full;
+      const chunks: StreamChunk[] = delta ? [{ type: 'text', content: delta }] : [];
+      return { chunks, sessionId };
+    }
+
+    if (type === 'tool_call') {
+      const subtype = rec.subtype;
+      if (subtype === 'started') {
+        this.assistantAcc = '';
+        const tool = parseToolStart(rec);
+        if (!tool) {
+          return { chunks: [], sessionId };
+        }
+        return {
+          chunks: [{ type: 'tool_use', id: tool.id, name: tool.name, input: tool.input }],
+          sessionId,
+        };
+      }
+
+      if (subtype === 'completed') {
+        const callId = typeof rec.call_id === 'string' ? rec.call_id : '';
+        if (!callId) {
+          return { chunks: [], sessionId };
+        }
+        const content = stringifyToolResult(rec);
+        return {
+          chunks: [{ type: 'tool_result', id: callId, content }],
+          sessionId,
+        };
+      }
+
+      return { chunks: [], sessionId };
+    }
+
+    if (type === 'result') {
+      this.assistantAcc = '';
+      if (rec.is_error === true) {
+        const msg = typeof rec.result === 'string'
+          ? rec.result
+          : 'Cursor Agent run failed';
+        return {
+          chunks: [{ type: 'error', content: msg }, { type: 'done' }],
+          sessionId,
+        };
+      }
+      const chunks: StreamChunk[] = [
+        {
+          type: 'usage',
+          usage: {
+            inputTokens: 0,
+            contextWindow: 200_000,
+            contextTokens: 0,
+            percentage: 0,
+          },
+          sessionId: sessionId ?? null,
+        },
+        { type: 'done' },
+      ];
+      return { chunks, sessionId };
+    }
+
+    return { chunks: [], sessionId };
+  }
+}

--- a/src/providers/cursor/settings.ts
+++ b/src/providers/cursor/settings.ts
@@ -1,0 +1,70 @@
+import { getProviderConfig, setProviderConfig } from '../../core/providers/providerConfig';
+import { getProviderEnvironmentVariables } from '../../core/providers/providerEnvironment';
+import type { HostnameCliPaths } from '../../core/types/settings';
+function normalizeHostnameCliPaths(value: unknown): HostnameCliPaths {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  const result: HostnameCliPaths = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry === 'string' && entry.trim()) {
+      result[key] = entry.trim();
+    }
+  }
+  return result;
+}
+
+export interface CursorProviderSettings {
+  enabled: boolean;
+  cliPath: string;
+  cliPathsByHost: HostnameCliPaths;
+  environmentVariables: string;
+  environmentHash: string;
+}
+
+export const DEFAULT_CURSOR_PROVIDER_SETTINGS: Readonly<CursorProviderSettings> = Object.freeze({
+  enabled: false,
+  cliPath: '',
+  cliPathsByHost: {},
+  environmentVariables: '',
+  environmentHash: '',
+});
+
+export function getCursorProviderSettings(settings: Record<string, unknown>): CursorProviderSettings {
+  const config = getProviderConfig(settings, 'cursor');
+
+  return {
+    enabled: (config.enabled as boolean | undefined) ?? DEFAULT_CURSOR_PROVIDER_SETTINGS.enabled,
+    cliPath: (config.cliPath as string | undefined) ?? DEFAULT_CURSOR_PROVIDER_SETTINGS.cliPath,
+    cliPathsByHost: normalizeHostnameCliPaths(config.cliPathsByHost),
+    environmentVariables: (config.environmentVariables as string | undefined)
+      ?? getProviderEnvironmentVariables(settings, 'cursor')
+      ?? DEFAULT_CURSOR_PROVIDER_SETTINGS.environmentVariables,
+    environmentHash: (config.environmentHash as string | undefined)
+      ?? DEFAULT_CURSOR_PROVIDER_SETTINGS.environmentHash,
+  };
+}
+
+export function updateCursorProviderSettings(
+  settings: Record<string, unknown>,
+  updates: Partial<CursorProviderSettings>,
+): CursorProviderSettings {
+  const current = getCursorProviderSettings(settings);
+  const next: CursorProviderSettings = {
+    ...current,
+    ...updates,
+    cliPathsByHost: updates.cliPathsByHost
+      ? normalizeHostnameCliPaths(updates.cliPathsByHost)
+      : { ...current.cliPathsByHost },
+  };
+
+  setProviderConfig(settings, 'cursor', {
+    enabled: next.enabled,
+    cliPath: next.cliPath,
+    cliPathsByHost: next.cliPathsByHost,
+    environmentVariables: next.environmentVariables,
+    environmentHash: next.environmentHash,
+  });
+  return next;
+}

--- a/src/providers/cursor/types.ts
+++ b/src/providers/cursor/types.ts
@@ -1,0 +1,31 @@
+import type { Conversation } from '../../core/types';
+
+export interface CursorProviderState {
+  /** Cursor Agent chat / session id (folder name under ~/.cursor/chats/<workspaceHash>/). */
+  chatSessionId?: string;
+}
+
+export function getCursorState(providerState: Record<string, unknown> | undefined): CursorProviderState {
+  if (!providerState) {
+    return {};
+  }
+  const chatSessionId = providerState.chatSessionId;
+  return {
+    ...(typeof chatSessionId === 'string' && chatSessionId.trim()
+      ? { chatSessionId: chatSessionId.trim() }
+      : {}),
+  };
+}
+
+export function resolveCursorSessionId(
+  conversation: Pick<Conversation, 'sessionId' | 'providerState'> | null,
+): string | null {
+  if (!conversation) {
+    return null;
+  }
+  const fromState = getCursorState(conversation.providerState).chatSessionId;
+  if (fromState) {
+    return fromState;
+  }
+  return conversation.sessionId;
+}

--- a/src/providers/cursor/ui/CursorChatUIConfig.ts
+++ b/src/providers/cursor/ui/CursorChatUIConfig.ts
@@ -1,0 +1,96 @@
+import { getRuntimeEnvironmentVariables } from '../../../core/providers/providerEnvironment';
+import type {
+  ProviderChatUIConfig,
+  ProviderPermissionModeToggleConfig,
+  ProviderReasoningOption,
+  ProviderUIOption,
+} from '../../../core/providers/types';
+
+const CURSOR_MODELS: ProviderUIOption[] = [
+  { value: 'auto', label: 'Auto' },
+  { value: 'composer-2-fast', label: 'Composer 2 Fast' },
+  { value: 'composer-2', label: 'Composer 2' },
+  { value: 'composer-1.5', label: 'Composer 1.5' },
+];
+
+const CURSOR_MODEL_SET = new Set(CURSOR_MODELS.map(m => m.value));
+
+const CURSOR_PERMISSION_MODE_TOGGLE: ProviderPermissionModeToggleConfig = {
+  inactiveValue: 'normal',
+  inactiveLabel: 'Safe',
+  activeValue: 'yolo',
+  activeLabel: 'YOLO',
+  planValue: 'plan',
+  planLabel: 'Plan',
+};
+
+const DEFAULT_CONTEXT_WINDOW = 200_000;
+
+const REASONING_OFF: ProviderReasoningOption[] = [
+  { value: 'off', label: 'Off' },
+];
+
+export const cursorChatUIConfig: ProviderChatUIConfig = {
+  getModelOptions(settings: Record<string, unknown>): ProviderUIOption[] {
+    const envVars = getRuntimeEnvironmentVariables(settings, 'cursor');
+    if (envVars.CURSOR_MODEL && !CURSOR_MODEL_SET.has(envVars.CURSOR_MODEL)) {
+      return [
+        { value: envVars.CURSOR_MODEL, label: envVars.CURSOR_MODEL, description: 'Custom (env)' },
+        ...CURSOR_MODELS,
+      ];
+    }
+    return [...CURSOR_MODELS];
+  },
+
+  ownsModel(model: string, settings: Record<string, unknown>): boolean {
+    if (this.getModelOptions(settings).some((option: ProviderUIOption) => option.value === model)) {
+      return true;
+    }
+    return /^composer-/i.test(model);
+  },
+
+  isAdaptiveReasoningModel(): boolean {
+    return false;
+  },
+
+  getReasoningOptions(): ProviderReasoningOption[] {
+    return [...REASONING_OFF];
+  },
+
+  getDefaultReasoningValue(): string {
+    return 'off';
+  },
+
+  getContextWindowSize(): number {
+    return DEFAULT_CONTEXT_WINDOW;
+  },
+
+  isDefaultModel(model: string): boolean {
+    return CURSOR_MODEL_SET.has(model);
+  },
+
+  applyModelDefaults(): void {},
+
+  normalizeModelVariant(model: string): string {
+    if (model === 'composer-1') {
+      return 'auto';
+    }
+    return model;
+  },
+
+  getCustomModelIds(envVars: Record<string, string>): Set<string> {
+    const ids = new Set<string>();
+    if (envVars.CURSOR_MODEL && !CURSOR_MODEL_SET.has(envVars.CURSOR_MODEL)) {
+      ids.add(envVars.CURSOR_MODEL);
+    }
+    return ids;
+  },
+
+  getPermissionModeToggle(): ProviderPermissionModeToggleConfig {
+    return CURSOR_PERMISSION_MODE_TOGGLE;
+  },
+
+  isBangBashEnabled(): boolean {
+    return false;
+  },
+};

--- a/src/providers/cursor/ui/CursorSettingsTab.ts
+++ b/src/providers/cursor/ui/CursorSettingsTab.ts
@@ -1,0 +1,137 @@
+import * as fs from 'fs';
+import { Setting } from 'obsidian';
+
+import type { ProviderSettingsTabRenderer } from '../../../core/providers/types';
+import { renderEnvironmentSettingsSection } from '../../../features/settings/ui/EnvironmentSettingsSection';
+import { t } from '../../../i18n/i18n';
+import type { TranslationKey } from '../../../i18n/types';
+import { getHostnameKey } from '../../../utils/env';
+import { expandHomePath } from '../../../utils/path';
+import { getCursorProviderSettings, updateCursorProviderSettings } from '../settings';
+
+export const cursorSettingsTabRenderer: ProviderSettingsTabRenderer = {
+  render(container, context) {
+    const settingsBag = context.plugin.settings as unknown as Record<string, unknown>;
+    const cursorSettings = getCursorProviderSettings(settingsBag);
+    const hostnameKey = getHostnameKey();
+
+    new Setting(container).setName(t('settings.setup')).setHeading();
+
+    new Setting(container)
+      .setName('Enable Cursor Agent provider')
+      .setDesc(
+        'When enabled, Cursor Agent appears as a provider. Requires the Cursor CLI (`agent`) and authentication (for example CURSOR_API_KEY). Headless mode uses --trust; review permission mode and sandbox settings carefully.',
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(cursorSettings.enabled)
+          .onChange(async (value) => {
+            updateCursorProviderSettings(settingsBag, { enabled: value });
+            await context.plugin.saveSettings();
+            context.refreshModelSelectors();
+          })
+      );
+
+    const cliPathSetting = new Setting(container)
+      .setName(`Cursor Agent CLI path (${hostnameKey})`)
+      .setDesc('Path to the `agent` binary, or leave empty to search PATH.');
+
+    const validationEl = container.createDiv({ cls: 'claudian-cli-path-validation' });
+    validationEl.style.color = 'var(--text-error)';
+    validationEl.style.fontSize = '0.85em';
+    validationEl.style.marginTop = '-0.5em';
+    validationEl.style.marginBottom = '0.5em';
+    validationEl.style.display = 'none';
+
+    const validatePath = (value: string): string | null => {
+      const trimmed = value.trim();
+      if (!trimmed) return null;
+
+      const expandedPath = expandHomePath(trimmed);
+
+      if (!fs.existsSync(expandedPath)) {
+        return t('settings.cliPath.validation.notExist' as TranslationKey);
+      }
+      const stat = fs.statSync(expandedPath);
+      if (!stat.isFile()) {
+        return t('settings.cliPath.validation.isDirectory' as TranslationKey);
+      }
+      return null;
+    };
+
+    const updateCliPathValidation = (value: string, inputEl?: HTMLInputElement): boolean => {
+      const error = validatePath(value);
+      if (error) {
+        validationEl.setText(error);
+        validationEl.style.display = 'block';
+        if (inputEl) {
+          inputEl.style.borderColor = 'var(--text-error)';
+        }
+        return false;
+      }
+
+      validationEl.style.display = 'none';
+      if (inputEl) {
+        inputEl.style.borderColor = '';
+      }
+      return true;
+    };
+
+    const cliPathsByHost = { ...cursorSettings.cliPathsByHost };
+
+    const persistCliPath = async (value: string, inputEl?: HTMLInputElement): Promise<boolean> => {
+      const isValid = updateCliPathValidation(value, inputEl);
+      if (!isValid) {
+        return false;
+      }
+
+      const trimmed = value.trim();
+      if (trimmed) {
+        cliPathsByHost[hostnameKey] = trimmed;
+      } else {
+        delete cliPathsByHost[hostnameKey];
+      }
+
+      updateCursorProviderSettings(settingsBag, { cliPathsByHost: { ...cliPathsByHost } });
+      await context.plugin.saveSettings();
+      const view = context.plugin.getView();
+      await view?.getTabManager()?.broadcastToAllTabs(
+        (service) => Promise.resolve(service.cleanup()),
+      );
+      return true;
+    };
+
+    const currentValue = cursorSettings.cliPathsByHost[hostnameKey] || '';
+
+    cliPathSetting.addText((text) => {
+      text
+        .setPlaceholder('agent')
+        .setValue(currentValue)
+        .onChange(async (value) => {
+          await persistCliPath(value, text.inputEl);
+        });
+      text.inputEl.addClass('claudian-settings-cli-path-input');
+      text.inputEl.style.width = '100%';
+
+      updateCliPathValidation(currentValue, text.inputEl);
+    });
+
+    new Setting(container).setName(t('settings.safety')).setHeading();
+
+    const safety = container.createDiv({ cls: 'setting-item-description' });
+    safety.createEl('p', {
+      text: 'Claudian maps toolbar permission mode to Cursor CLI flags: YOLO uses --force and sandbox disabled; Plan uses plan mode with sandbox enabled; Normal uses sandbox enabled without --force. All runs use --trust so the agent can complete non-interactively.',
+    });
+
+    renderEnvironmentSettingsSection({
+      container,
+      plugin: context.plugin,
+      scope: 'provider:cursor',
+      heading: t('settings.environment'),
+      name: 'Cursor Agent environment',
+      desc: 'Variables such as CURSOR_API_KEY. Chats are stored under ~/.cursor/chats/<workspace-hash>/<session-id>/.',
+      placeholder: 'CURSOR_API_KEY=your-key',
+      renderCustomContextLimits: (target) => context.renderCustomContextLimits(target, 'cursor'),
+    });
+  },
+};

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -4,6 +4,8 @@ import { claudeWorkspaceRegistration } from './claude/app/ClaudeWorkspaceService
 import { claudeProviderRegistration } from './claude/registration';
 import { codexWorkspaceRegistration } from './codex/app/CodexWorkspaceServices';
 import { codexProviderRegistration } from './codex/registration';
+import { cursorWorkspaceRegistration } from './cursor/app/CursorWorkspaceServices';
+import { cursorProviderRegistration } from './cursor/registration';
 
 let builtInProvidersRegistered = false;
 
@@ -14,8 +16,10 @@ export function registerBuiltInProviders(): void {
 
   ProviderRegistry.register('claude', claudeProviderRegistration);
   ProviderRegistry.register('codex', codexProviderRegistration);
+  ProviderRegistry.register('cursor', cursorProviderRegistration);
   ProviderWorkspaceRegistry.register('claude', claudeWorkspaceRegistration);
   ProviderWorkspaceRegistry.register('codex', codexWorkspaceRegistration);
+  ProviderWorkspaceRegistry.register('cursor', cursorWorkspaceRegistration);
   builtInProvidersRegistered = true;
 }
 

--- a/tests/unit/core/providers/ProviderRegistry.test.ts
+++ b/tests/unit/core/providers/ProviderRegistry.test.ts
@@ -75,6 +75,7 @@ describe('ProviderRegistry', () => {
     const ids = ProviderRegistry.getRegisteredProviderIds();
     expect(ids).toContain('claude');
     expect(ids).toContain('codex');
+    expect(ids).toContain('cursor');
   });
 
   it('filters enabled provider ids using registration metadata', () => {
@@ -88,10 +89,33 @@ describe('ProviderRegistry', () => {
         codex: { enabled: true },
       },
     })).toEqual(['codex', 'claude']);
+    expect(ProviderRegistry.getEnabledProviderIds({
+      providerConfigs: {
+        codex: { enabled: true },
+        cursor: { enabled: true },
+      },
+    })).toEqual(['cursor', 'codex', 'claude']);
   });
 
   it('returns the display name from provider registration metadata', () => {
     expect(ProviderRegistry.getProviderDisplayName('claude')).toBe('Claude');
     expect(ProviderRegistry.getProviderDisplayName('codex')).toBe('Codex');
+    expect(ProviderRegistry.getProviderDisplayName('cursor')).toBe('Cursor Agent');
+  });
+
+  it('creates a Cursor runtime', () => {
+    const runtime = ProviderRegistry.createChatRuntime({
+      providerId: 'cursor',
+      plugin: {} as any,
+    });
+    expect(runtime.providerId).toBe('cursor');
+  });
+
+  it('returns Cursor capabilities', () => {
+    const caps = ProviderRegistry.getCapabilities('cursor');
+    expect(caps.providerId).toBe('cursor');
+    expect(caps.supportsNativeHistory).toBe(true);
+    expect(caps.supportsFork).toBe(false);
+    expect(caps.supportsRewind).toBe(false);
   });
 });

--- a/tests/unit/providers/cursor/history/cursorHistoryStore.test.ts
+++ b/tests/unit/providers/cursor/history/cursorHistoryStore.test.ts
@@ -1,9 +1,12 @@
+import * as crypto from 'crypto';
+
 import { cursorWorkspaceHash } from '@/providers/cursor/history/cursorHistoryStore';
 
 describe('cursorHistoryStore', () => {
   it('hashes workspace path with md5 hex like Cursor CLI', () => {
-    expect(cursorWorkspaceHash('/Users/darmawan01/Labs/claudian')).toBe(
-      '482a9f0bc2c8bac86641b6841c2dbec1',
+    const vaultPath = '/tmp/claudian-test-vault-path';
+    expect(cursorWorkspaceHash(vaultPath)).toBe(
+      crypto.createHash('md5').update(vaultPath).digest('hex'),
     );
   });
 });

--- a/tests/unit/providers/cursor/history/cursorHistoryStore.test.ts
+++ b/tests/unit/providers/cursor/history/cursorHistoryStore.test.ts
@@ -1,0 +1,9 @@
+import { cursorWorkspaceHash } from '@/providers/cursor/history/cursorHistoryStore';
+
+describe('cursorHistoryStore', () => {
+  it('hashes workspace path with md5 hex like Cursor CLI', () => {
+    expect(cursorWorkspaceHash('/Users/darmawan01/Labs/claudian')).toBe(
+      '482a9f0bc2c8bac86641b6841c2dbec1',
+    );
+  });
+});

--- a/tests/unit/providers/cursor/runtime/cursorCliModel.test.ts
+++ b/tests/unit/providers/cursor/runtime/cursorCliModel.test.ts
@@ -1,0 +1,17 @@
+import { resolveCursorModelForCli } from '@/providers/cursor/runtime/cursorCliModel';
+
+describe('resolveCursorModelForCli', () => {
+  it('maps deprecated composer-1 to auto', () => {
+    expect(resolveCursorModelForCli('composer-1')).toBe('auto');
+  });
+
+  it('passes through current model ids', () => {
+    expect(resolveCursorModelForCli('composer-2-fast')).toBe('composer-2-fast');
+    expect(resolveCursorModelForCli('auto')).toBe('auto');
+  });
+
+  it('returns undefined for empty input', () => {
+    expect(resolveCursorModelForCli(undefined)).toBeUndefined();
+    expect(resolveCursorModelForCli('')).toBeUndefined();
+  });
+});

--- a/tests/unit/providers/cursor/runtime/cursorLaunchArgs.test.ts
+++ b/tests/unit/providers/cursor/runtime/cursorLaunchArgs.test.ts
@@ -1,0 +1,67 @@
+import {
+  buildCursorAgentFlagArgs,
+  buildCursorAgentJsonModeFlagArgs,
+} from '@/providers/cursor/runtime/cursorLaunchArgs';
+
+describe('cursorLaunchArgs', () => {
+  const workspace = '/vault';
+
+  it('builds stream-json argv with trust and sandbox for normal mode', () => {
+    const args = buildCursorAgentFlagArgs({
+      workspaceDir: workspace,
+      permissionMode: 'normal',
+      resumeSessionId: null,
+    });
+    expect(args).toContain('-p');
+    expect(args).toContain('--output-format');
+    expect(args).toContain('stream-json');
+    expect(args).toContain('--stream-partial-output');
+    expect(args).toContain('--workspace');
+    expect(args).toContain(workspace);
+    expect(args).toContain('--trust');
+    expect(args).toContain('--sandbox');
+    expect(args).toContain('enabled');
+  });
+
+  it('adds force and disabled sandbox for yolo', () => {
+    const args = buildCursorAgentFlagArgs({
+      workspaceDir: workspace,
+      permissionMode: 'yolo',
+    });
+    expect(args).toContain('--force');
+    expect(args).toContain('disabled');
+  });
+
+  it('adds plan mode for plan permission', () => {
+    const args = buildCursorAgentFlagArgs({
+      workspaceDir: workspace,
+      permissionMode: 'plan',
+    });
+    expect(args).toContain('--mode');
+    expect(args).toContain('plan');
+  });
+
+  it('appends resume and model when provided', () => {
+    const args = buildCursorAgentFlagArgs({
+      workspaceDir: workspace,
+      permissionMode: 'normal',
+      model: 'composer-2-fast',
+      resumeSessionId: 'sess-1',
+    });
+    expect(args).toContain('--resume');
+    expect(args).toContain('sess-1');
+    expect(args).toContain('--model');
+    expect(args).toContain('composer-2-fast');
+  });
+
+  it('json mode omits stream partial flags', () => {
+    const args = buildCursorAgentJsonModeFlagArgs({
+      workspaceDir: workspace,
+      permissionMode: 'normal',
+    });
+    expect(args).toContain('--output-format');
+    expect(args).toContain('json');
+    expect(args).not.toContain('stream-json');
+    expect(args).not.toContain('--stream-partial-output');
+  });
+});

--- a/tests/unit/providers/cursor/runtime/cursorStreamMapper.test.ts
+++ b/tests/unit/providers/cursor/runtime/cursorStreamMapper.test.ts
@@ -1,0 +1,60 @@
+import { CursorNdjsonStreamReducer } from '@/providers/cursor/runtime/cursorStreamMapper';
+
+describe('CursorNdjsonStreamReducer', () => {
+  it('emits text deltas for cumulative assistant output', () => {
+    const r = new CursorNdjsonStreamReducer();
+    const a = r.reduceLine(JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hel' }] },
+      session_id: 's1',
+    }));
+    expect(a.chunks).toEqual([{ type: 'text', content: 'hel' }]);
+    expect(a.sessionId).toBe('s1');
+
+    const b = r.reduceLine(JSON.stringify({
+      type: 'assistant',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
+      session_id: 's1',
+    }));
+    expect(b.chunks).toEqual([{ type: 'text', content: 'lo' }]);
+  });
+
+  it('emits tool_use on started and tool_result on completed', () => {
+    const r = new CursorNdjsonStreamReducer();
+    const start = r.reduceLine(JSON.stringify({
+      type: 'tool_call',
+      subtype: 'started',
+      call_id: 'c1',
+      tool_call: { readToolCall: { args: { path: 'a.md' } } },
+    }));
+    expect(start.chunks).toEqual([{
+      type: 'tool_use',
+      id: 'c1',
+      name: 'read_file',
+      input: { path: 'a.md' },
+    }]);
+
+    const done = r.reduceLine(JSON.stringify({
+      type: 'tool_call',
+      subtype: 'completed',
+      call_id: 'c1',
+      tool_call: { readToolCall: { args: { path: 'a.md' }, result: { success: { content: 'x' } } } },
+    }));
+    expect(done.chunks[0]).toMatchObject({
+      type: 'tool_result',
+      id: 'c1',
+      content: expect.stringContaining('readToolCall'),
+    });
+  });
+
+  it('ends with usage and done on result success', () => {
+    const r = new CursorNdjsonStreamReducer();
+    const out = r.reduceLine(JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      session_id: 's9',
+    }));
+    expect(out.chunks.map(c => c.type)).toEqual(['usage', 'done']);
+  });
+});


### PR DESCRIPTION
## Summary
Adds **Cursor Agent** as a third chat provider.

## Key changes
- Register Cursor provider via subprocess Cursor CLI (`agent -p`, `stream-json`)
- Session resume via `--resume`; workspace keyed by vault path (md5)
- Hydrate history from `~/.cursor/chats` SQLite store when `node:sqlite` is available
- Adds settings tab, env reconciler, and title/refine/inline auxiliary runners
- Model presets aligned with current Cursor CLI (`auto`, `composer-2`, etc.)
- Maps legacy `composer-1` to `auto` for CLI compatibility
- Fix unit test to avoid developer-specific absolute path + MD5 assertion
- Ignore local Cursor IDE `.cursor/` directory

## Screenshots
_TBD — will add screenshot in a follow-up._

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`
- [x] Manual smoke: select Cursor provider → send message → verify streaming + cancel/resume + history load

## Notes
- History hydration requires SQLite support (`node:sqlite`) to be available; otherwise Cursor history load is skipped gracefully.