### PR TITLE
Fix Codex settings on non-Windows hosts

### DIFF
--- a/src/providers/codex/ui/CodexSettingsTab.ts
+++ b/src/providers/codex/ui/CodexSettingsTab.ts
@@ -18,6 +18,7 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
     const settingsBag = context.plugin.settings as unknown as Record<string, unknown>;
     const codexSettings = getCodexProviderSettings(settingsBag);
     const hostnameKey = getHostnameKey();
+    const isWindowsHost = process.platform === 'win32';
     let installationMethod = codexSettings.installationMethod;
 
     // --- Setup ---
@@ -37,23 +38,32 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
           })
       );
 
-    new Setting(container)
-      .setName('Installation method')
-      .setDesc('How Claudian should launch Codex on Windows. Native Windows uses a Windows executable path. WSL launches the Linux CLI inside a selected distro.')
-      .addDropdown((dropdown) => {
-        dropdown
-          .addOption('native-windows', 'Native Windows')
-          .addOption('wsl', 'WSL')
-          .setValue(installationMethod)
-          .onChange(async (value) => {
-            installationMethod = value === 'wsl' ? 'wsl' : 'native-windows';
-            updateCodexProviderSettings(settingsBag, { installationMethod });
-            refreshInstallationMethodUI();
-            await context.plugin.saveSettings();
-          });
-      });
+    if (isWindowsHost) {
+      new Setting(container)
+        .setName('Installation method')
+        .setDesc('How Claudian should launch Codex on Windows. Native Windows uses a Windows executable path. WSL launches the Linux CLI inside a selected distro.')
+        .addDropdown((dropdown) => {
+          dropdown
+            .addOption('native-windows', 'Native Windows')
+            .addOption('wsl', 'WSL')
+            .setValue(installationMethod)
+            .onChange(async (value) => {
+              installationMethod = value === 'wsl' ? 'wsl' : 'native-windows';
+              updateCodexProviderSettings(settingsBag, { installationMethod });
+              refreshInstallationMethodUI();
+              await context.plugin.saveSettings();
+            });
+        });
+    }
 
     const getCliPathCopy = (): { desc: string; placeholder: string } => {
+      if (!isWindowsHost) {
+        return {
+          desc: 'Custom path to the local Codex CLI. Leave empty for auto-detection from PATH.',
+          placeholder: '/usr/local/bin/codex',
+        };
+      }
+
       if (installationMethod === 'wsl') {
         return {
           desc: 'Linux-side Codex command or absolute path to run inside WSL. Leave empty for PATH lookup inside the selected distro.',
@@ -67,7 +77,7 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
       };
     };
 
-    const shouldValidateCliPathAsFile = (): boolean => installationMethod !== 'wsl';
+    const shouldValidateCliPathAsFile = (): boolean => !isWindowsHost || installationMethod !== 'wsl';
 
     const cliPathSetting = new Setting(container)
       .setName(`Codex CLI path (${hostnameKey})`)
@@ -179,25 +189,27 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
       updateCliPathValidation(currentValue, text.inputEl);
     });
 
-    const wslDistroSetting = new Setting(container)
-      .setName('WSL distro override')
-      .setDesc('Optional advanced override. Leave empty to infer the distro from a \\\\wsl$ workspace path when possible, otherwise use the default WSL distro.');
+    if (isWindowsHost) {
+      const wslDistroSetting = new Setting(container)
+        .setName('WSL distro override')
+        .setDesc('Optional advanced override. Leave empty to infer the distro from a \\\\wsl$ workspace path when possible, otherwise use the default WSL distro.');
 
-    wslDistroSettingEl = wslDistroSetting.settingEl;
-    wslDistroSetting.addText((text) => {
-      text
-        .setPlaceholder('Ubuntu')
-        .setValue(codexSettings.wslDistroOverride)
-        .onChange(async (value) => {
-          updateCodexProviderSettings(settingsBag, { wslDistroOverride: value });
-          await context.plugin.saveSettings();
-        });
+      wslDistroSettingEl = wslDistroSetting.settingEl;
+      wslDistroSetting.addText((text) => {
+        text
+          .setPlaceholder('Ubuntu')
+          .setValue(codexSettings.wslDistroOverride)
+          .onChange(async (value) => {
+            updateCodexProviderSettings(settingsBag, { wslDistroOverride: value });
+            await context.plugin.saveSettings();
+          });
 
-      text.inputEl.addClass('claudian-settings-cli-path-input');
-      text.inputEl.style.width = '100%';
-      text.inputEl.disabled = installationMethod !== 'wsl';
-      wslDistroInputEl = text.inputEl;
-    });
+        text.inputEl.addClass('claudian-settings-cli-path-input');
+        text.inputEl.style.width = '100%';
+        text.inputEl.disabled = installationMethod !== 'wsl';
+        wslDistroInputEl = text.inputEl;
+      });
+    }
 
     refreshInstallationMethodUI();
 

--- a/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
+++ b/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
@@ -270,9 +270,18 @@ function findSetting(name: string) {
   return setting;
 }
 
+function findOptionalSetting(name: string) {
+  return createdSettings.find(candidate => candidate.name === name);
+}
+
 describe('CodexSettingsTab', () => {
   const mockedExistsSync = fs.existsSync as jest.MockedFunction<typeof fs.existsSync>;
   const mockedStatSync = fs.statSync as jest.MockedFunction<typeof fs.statSync>;
+  const originalPlatform = process.platform;
+
+  afterAll(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
 
   beforeEach(() => {
     createdSettings.length = 0;
@@ -281,7 +290,8 @@ describe('CodexSettingsTab', () => {
     mockedStatSync.mockReturnValue({ isFile: () => true } as fs.Stats);
   });
 
-  it('renders installation method and WSL distro override controls', () => {
+  it('renders installation method and WSL distro override controls on Windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
     const plugin = createPlugin();
 
     codexSettingsTabRenderer.render(createContainer(), createContext(plugin));
@@ -290,7 +300,55 @@ describe('CodexSettingsTab', () => {
     expect(findSetting('WSL distro override').textComponents).toHaveLength(1);
   });
 
+  it('hides Windows-only installation controls on non-Windows platforms', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const plugin = createPlugin();
+
+    codexSettingsTabRenderer.render(createContainer(), createContext(plugin));
+
+    expect(findOptionalSetting('Installation method')).toBeUndefined();
+    expect(findOptionalSetting('WSL distro override')).toBeUndefined();
+  });
+
+  it('uses host-native CLI path behavior on non-Windows even when WSL is saved', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const plugin = createPlugin({
+      providerConfigs: {
+        codex: {
+          enabled: true,
+          safeMode: 'workspace-write',
+          cliPath: '',
+          cliPathsByHost: {},
+          reasoningSummary: 'detailed',
+          environmentVariables: '',
+          environmentHash: '',
+          installationMethod: 'wsl',
+          installationMethodsByHost: {
+            'host-a': 'wsl',
+          },
+          wslDistroOverride: 'Ubuntu',
+          wslDistroOverridesByHost: {
+            'host-a': 'Ubuntu',
+          },
+        },
+      },
+    });
+
+    codexSettingsTabRenderer.render(createContainer(), createContext(plugin));
+
+    const cliPathSetting = findSetting('Codex CLI path (host-a)');
+    expect(cliPathSetting.desc).toBe('Custom path to the local Codex CLI. Leave empty for auto-detection from PATH.');
+    expect(cliPathSetting.textComponents[0].placeholder).toBe('/usr/local/bin/codex');
+
+    await cliPathSetting.textComponents[0].onChangeCallback?.('codex');
+
+    expect(plugin.settings.providerConfigs.codex.cliPathsByHost['host-a']).toBeUndefined();
+    expect(mockSaveSettings).toHaveBeenCalledTimes(0);
+    expect(mockBroadcastToAllTabs).toHaveBeenCalledTimes(0);
+  });
+
   it('accepts a Linux-side CLI command when installation method is WSL', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
     const plugin = createPlugin();
 
     codexSettingsTabRenderer.render(createContainer(), createContext(plugin));
@@ -310,6 +368,7 @@ describe('CodexSettingsTab', () => {
   });
 
   it('rejects a Windows-native CLI path when installation method is WSL', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
     const plugin = createPlugin({
       providerConfigs: {
         codex: {


### PR DESCRIPTION
Hide the Windows-only Codex installation method and WSL distro settings on non-Windows hosts.
Use host-native CLI copy and file-path validation outside Windows even if synced settings still contain a saved WSL installation method.
Add unit coverage for Windows-only rendering and the non-Windows fallback behavior.

Testing: npm test -- --runInBand --selectProjects unit tests/unit/providers/codex/ui/CodexSettingsTab.test.ts