### PR TITLE
Fix tab session sync during thinking and pending saves

### DIFF
--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -126,6 +126,7 @@ export class ConversationController {
       state.planFilePath = null;
       state.prePlanPermissionMode = null;
       state.autoScrollEnabled = plugin.settings.enableAutoScroll ?? true;
+      state.hasPendingConversationSave = false;
 
       // Reset agent service session (no session ID for entry point)
       // Pass persistent paths to prevent stale external contexts
@@ -187,6 +188,7 @@ export class ConversationController {
       state.planFilePath = null;
       state.prePlanPermissionMode = null;
       state.autoScrollEnabled = plugin.settings.enableAutoScroll ?? true;
+      state.hasPendingConversationSave = false;
 
       // Pass persistent paths to prevent stale external contexts
       this.getAgentService()?.syncConversationState(
@@ -413,6 +415,7 @@ export class ConversationController {
     }
 
     await plugin.updateConversation(state.currentConversationId!, updates);
+    state.hasPendingConversationSave = false;
   }
 
   /**
@@ -429,6 +432,7 @@ export class ConversationController {
     state.messages = [...conversation.messages];
     state.usage = conversation.usage ?? null;
     state.autoScrollEnabled = plugin.settings.enableAutoScroll ?? true;
+    state.hasPendingConversationSave = false;
 
     // Clear status panels (auto-hide: panels reappear when agent creates new todos)
     state.currentTodos = null;

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -279,6 +279,7 @@ export class InputController {
       images: imagesForMessage,
     };
     state.addMessage(userMsg);
+    state.hasPendingConversationSave = true;
     renderer.addMessage(userMsg);
 
     await this.triggerTitleGeneration();

--- a/src/features/chat/state/ChatState.ts
+++ b/src/features/chat/state/ChatState.ts
@@ -18,6 +18,7 @@ function createInitialState(): ChatStateData {
     streamGeneration: 0,
     isCreatingConversation: false,
     isSwitchingConversation: false,
+    hasPendingConversationSave: false,
     currentConversationId: null,
     queuedMessage: null,
     currentContentEl: null,
@@ -136,6 +137,14 @@ export class ChatState {
 
   set isSwitchingConversation(value: boolean) {
     this.state.isSwitchingConversation = value;
+  }
+
+  get hasPendingConversationSave(): boolean {
+    return this.state.hasPendingConversationSave;
+  }
+
+  set hasPendingConversationSave(value: boolean) {
+    this.state.hasPendingConversationSave = value;
   }
 
   // ============================================

--- a/src/features/chat/state/types.ts
+++ b/src/features/chat/state/types.ts
@@ -55,6 +55,8 @@ export interface ChatStateData {
   isCreatingConversation: boolean;
   /** Guards against concurrent operations during conversation switching. */
   isSwitchingConversation: boolean;
+  /** Local tab state is ahead of persisted conversation metadata. */
+  hasPendingConversationSave: boolean;
 
   // Conversation identity
   currentConversationId: string | null;

--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -225,8 +225,14 @@ export class TabManager implements TabManagerInterface {
       // Load conversation if not already loaded
       if (tab.conversationId && tab.state.messages.length === 0) {
         await tab.controllers.conversationController?.switchTo(tab.conversationId);
-      } else if (tab.conversationId && tab.state.messages.length > 0 && tab.service) {
-        // Tab already has messages loaded and runtime exists — passive sync only
+      } else if (
+        tab.conversationId
+        && tab.state.messages.length > 0
+        && tab.service
+        && !tab.state.isStreaming
+        && !tab.state.hasPendingConversationSave
+      ) {
+        // Passive sync is only safe once local tab state has been persisted.
         const conversation = this.plugin.getConversationSync(tab.conversationId);
         if (conversation) {
           const hasMessages = conversation.messages.length > 0;

--- a/tests/unit/features/chat/controllers/ConversationController.test.ts
+++ b/tests/unit/features/chat/controllers/ConversationController.test.ts
@@ -482,6 +482,16 @@ describe('ConversationController', () => {
       const updates = call[1];
       expect(updates).not.toHaveProperty('resumeAtMessageId');
     });
+
+    it('should clear pending conversation save state after persisting', async () => {
+      deps.state.currentConversationId = 'conv-1';
+      deps.state.messages = [{ id: '1', role: 'user', content: 'test', timestamp: Date.now() }];
+      deps.state.hasPendingConversationSave = true;
+
+      await controller.save();
+
+      expect(deps.state.hasPendingConversationSave).toBe(false);
+    });
   });
 
   describe('loadActive with existing conversation', () => {

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -1828,6 +1828,7 @@ describe('InputController - Message Queue', () => {
       expect(mockNotice).toHaveBeenCalledWith('Failed to initialize agent service. Please try again.');
       expect(deps.streamController.hideThinkingIndicator).toHaveBeenCalled();
       expect(deps.state.isStreaming).toBe(false);
+      expect(deps.state.hasPendingConversationSave).toBe(true);
       expect((deps as any).mockAgentService.query).not.toHaveBeenCalled();
     });
   });
@@ -1849,6 +1850,7 @@ describe('InputController - Message Queue', () => {
       await controller.sendMessage();
 
       expect(mockNotice).toHaveBeenCalledWith('Agent service not available. Please reload the plugin.');
+      expect(deps.state.hasPendingConversationSave).toBe(true);
       expect((deps as any).mockAgentService.query).not.toHaveBeenCalled();
     });
   });

--- a/tests/unit/features/chat/tabs/TabManager.test.ts
+++ b/tests/unit/features/chat/tabs/TabManager.test.ts
@@ -115,6 +115,7 @@ function createMockView(): any {
 function createMockTabData(overrides: Record<string, any> = {}): any {
   const defaultState = {
     isStreaming: false,
+    hasPendingConversationSave: false,
     needsAttention: false,
     messages: [],
     currentConversationId: null,
@@ -1728,6 +1729,114 @@ describe('TabManager - switchToTab Session Sync', () => {
       expect.objectContaining({ id: 'conv-empty', sessionId: 'session-abc' }),
       ['/persistent/path'],
     );
+  });
+
+  it('should not sync service session for an already-loaded streaming tab', async () => {
+    jest.clearAllMocks();
+
+    const mockSyncConversationState = jest.fn();
+    const mockService = {
+      syncConversationState: mockSyncConversationState,
+    };
+
+    let tabCounter = 0;
+    mockCreateTab.mockImplementation(() => {
+      tabCounter++;
+
+      if (tabCounter === 1) {
+        return createMockTabData({ id: 'tab-1' });
+      }
+
+      return createMockTabData({
+        id: 'tab-2',
+        conversationId: 'conv-streaming',
+        service: mockService,
+        serviceInitialized: true,
+        state: {
+          isStreaming: true,
+          messages: [{ id: 'msg-1', role: 'user', content: 'test' }],
+        },
+      });
+    });
+
+    const plugin = createMockPlugin();
+    plugin.getConversationSync = jest.fn().mockReturnValue({
+      id: 'conv-streaming',
+      messages: [{ id: 'msg-1', role: 'user', content: 'test' }],
+      sessionId: 'session-stream',
+      externalContextPaths: ['/some/path'],
+    });
+
+    const manager = new TabManager(
+      plugin,
+      createMockMcpManager(),
+      createMockEl(),
+      createMockView()
+    );
+
+    await manager.createTab();
+    const backgroundStreamingTab = await manager.createTab(undefined, undefined, { activate: false });
+
+    jest.clearAllMocks();
+
+    await manager.switchToTab(backgroundStreamingTab!.id);
+
+    expect(plugin.getConversationSync).not.toHaveBeenCalled();
+    expect(mockSyncConversationState).not.toHaveBeenCalled();
+  });
+
+  it('should not sync service session when local conversation state is pending save', async () => {
+    jest.clearAllMocks();
+
+    const mockSyncConversationState = jest.fn();
+    const mockService = {
+      syncConversationState: mockSyncConversationState,
+    };
+
+    let tabCounter = 0;
+    mockCreateTab.mockImplementation(() => {
+      tabCounter++;
+
+      if (tabCounter === 1) {
+        return createMockTabData({ id: 'tab-1' });
+      }
+
+      return createMockTabData({
+        id: 'tab-2',
+        conversationId: 'conv-pending-save',
+        service: mockService,
+        serviceInitialized: true,
+        state: {
+          hasPendingConversationSave: true,
+          messages: [{ id: 'msg-1', role: 'user', content: 'test' }],
+        },
+      });
+    });
+
+    const plugin = createMockPlugin();
+    plugin.getConversationSync = jest.fn().mockReturnValue({
+      id: 'conv-pending-save',
+      messages: [],
+      sessionId: null,
+      externalContextPaths: [],
+    });
+
+    const manager = new TabManager(
+      plugin,
+      createMockMcpManager(),
+      createMockEl(),
+      createMockView()
+    );
+
+    await manager.createTab();
+    const pendingSaveTab = await manager.createTab(undefined, undefined, { activate: false });
+
+    jest.clearAllMocks();
+
+    await manager.switchToTab(pendingSaveTab!.id);
+
+    expect(plugin.getConversationSync).not.toHaveBeenCalled();
+    expect(mockSyncConversationState).not.toHaveBeenCalled();
   });
 
   it('should initialize welcome for new tab without conversation', async () => {


### PR DESCRIPTION
This prevents passive runtime session sync when a tab is already streaming or when its local conversation state is ahead of persisted storage. It adds a pending conversation save flag to chat state, marks the tab dirty as soon as a user message is appended, and clears the flag after conversation load, creation, and save. That avoids switching an active Claude session back to stale persisted session metadata during the pre-response thinking window or before the conversation save completes. It also adds regression tests for the new dirty-state lifecycle and the tab-switch guards.