### PR TITLE
feat(opencode): add streaming diff support and usage tracking

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,118 @@
+# Copilot Instructions
+
+## Commands
+
+```bash
+npm run dev          # Watch mode
+npm run build        # Production build
+npm run typecheck    # Type checking
+npm run lint         # Lint
+npm run lint:fix     # Lint and fix
+npm run test         # Run all tests
+npm run test:watch   # Watch mode tests
+npm run test:coverage
+```
+
+### Running specific tests
+
+```bash
+npm run test -- --selectProjects unit           # Unit tests only
+npm run test -- --selectProjects integration    # Integration tests only
+npm run test -- path/to/file.test.ts            # Single test file
+npm run test -- -t "test name pattern"          # By test name
+```
+
+### Validation before committing
+
+```bash
+npm run typecheck && npm run lint && npm run test && npm run build
+```
+
+## Architecture
+
+Claudian is an Obsidian plugin embedding AI chat runtimes (Claude, Codex) in a sidebar and inline-edit flow.
+
+### Layer Structure
+
+| Layer | Purpose |
+|-------|---------|
+| `app/` | Shared settings defaults and plugin-level storage helpers |
+| `core/` | Provider-neutral runtime contracts, registries, tool types |
+| `providers/claude/` | Claude SDK adaptor — runtime, prompt encoding, MCP, plugins |
+| `providers/codex/` | Codex app-server adaptor — JSON-RPC transport, JSONL history |
+| `features/chat/` | Sidebar chat — tabs, controllers, renderers |
+| `features/inline-edit/` | Inline edit modal and provider edit services |
+| `features/settings/` | Settings shell with provider tabs |
+| `shared/` | Reusable UI components |
+| `i18n/` | 10 locales |
+| `utils/` | Cross-cutting utilities |
+| `style/` | Modular CSS |
+
+### Provider Boundary
+
+- `ChatRuntime` is the provider-neutral interface in `core/runtime/`
+- `ProviderRegistry` creates runtimes and auxiliary services
+- `ProviderWorkspaceRegistry` owns command catalogs, agent mentions, CLI resolution, MCP managers
+- `Conversation.providerState` is opaque in feature code — provider-specific fields stay behind typed helpers
+- Claude state: `ClaudeProviderState`; Codex state: `CodexProviderState`
+
+### Data Flow
+
+```
+User Input → InputController → ChatRuntime.prepareTurn() → ChatRuntime.query() → StreamController → MessageRenderer
+```
+
+Feature code consumes provider-neutral `StreamChunk` values. Providers own prompt encoding and history hydration.
+
+## Key Conventions
+
+### TDD Workflow
+
+Write the failing test first in the mirrored `tests/` path, make it pass, then refactor. Tests mirror `src/` layout under `tests/unit/` and `tests/integration/`.
+
+### Provider-Native First
+
+Prefer official Claude SDK and Codex app-server behavior over reimplementing locally. Adapt to provider capabilities instead of shadowing them.
+
+### Runtime Exploration
+
+For provider integrations, inspect real runtime output first. Claude data: `~/.claude/`. Codex data: `~/.codex/`. Real transcripts beat guessed event shapes.
+
+### Comments
+
+Comment why, not what. Avoid narration and redundant JSDoc.
+
+### No Console Logging
+
+No `console.*` in production code.
+
+### Throwaway Scripts
+
+Put non-committed notes and throwaway scripts in `.context/`.
+
+## Storage Locations
+
+| Path | Contents |
+|------|----------|
+| `.claude/settings.json` | Claude Code project settings and permissions |
+| `.claudian/claudian-settings.json` | Claudian app settings |
+| `.claude/mcp.json` | Claudian-managed MCP servers |
+| `.claude/commands/**/*.md` | Claude slash commands |
+| `.claude/skills/*/SKILL.md` | Claude skills |
+| `.codex/skills/*/SKILL.md` | Codex vault skills |
+| `~/.claude/projects/{vault}/*.jsonl` | Claude transcripts |
+| `~/.codex/sessions/**/*.jsonl` | Codex transcripts |
+
+## Provider-Specific Patterns
+
+### Claude
+
+- Persistent query stays alive across turns; dynamic updates via SDK API calls
+- SDK session files are tree-structured; `sdkBranchFilter` finds the canonical branch
+- MCP dual-namespace: `mcpServers` (CC-compatible) and `_claudian.servers` (Claudian metadata)
+
+### Codex
+
+- JSON-RPC 2.0 over stdio with `initialize` → `initialized` handshake
+- Dual tool source: transcript mode (session JSONL polling) vs fallback mode (live RPC)
+- `thread/resume` required before any operation on existing thread in new daemon process

--- a/package-lock.json
+++ b/package-lock.json
@@ -133,7 +133,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -741,7 +740,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -765,7 +763,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2253,7 +2250,8 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -2553,7 +2551,6 @@
       "integrity": "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.58.0",
@@ -2583,7 +2580,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -3077,7 +3073,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3399,7 +3394,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3778,7 +3772,8 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4090,7 +4085,6 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4445,7 +4439,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4945,7 +4938,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
       "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5295,7 +5287,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -5928,7 +5919,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -6606,7 +6596,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7351,7 +7340,8 @@
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -8187,7 +8177,6 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8331,7 +8320,8 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
@@ -8712,7 +8702,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/settings/ClaudianSettingsStorage.ts
+++ b/src/app/settings/ClaudianSettingsStorage.ts
@@ -27,6 +27,10 @@ import {
   getCodexProviderSettings,
   updateCodexProviderSettings,
 } from '../../providers/codex/settings';
+import {
+  getOpenCodeProviderSettings,
+  updateOpenCodeProviderSettings,
+} from '../../providers/opencode/settings';
 import { DEFAULT_CLAUDIAN_SETTINGS } from './defaultSettings';
 
 export {
@@ -213,9 +217,15 @@ export class ClaudianSettingsStorage {
       providerConfigs,
     };
 
+    const defaults = this.getDefaults();
     const merged = {
-      ...this.getDefaults(),
+      ...defaults,
       ...legacyNormalized,
+      // Deep-merge providerConfigs to preserve defaults for new providers
+      providerConfigs: {
+        ...defaults.providerConfigs,
+        ...providerConfigs,
+      },
     } as StoredClaudianSettings;
 
     updateClaudeProviderSettings(
@@ -225,6 +235,10 @@ export class ClaudianSettingsStorage {
     updateCodexProviderSettings(
       merged as unknown as Record<string, unknown>,
       getCodexProviderSettings(legacyProviderSettings),
+    );
+    updateOpenCodeProviderSettings(
+      merged as unknown as Record<string, unknown>,
+      getOpenCodeProviderSettings(legacyProviderSettings),
     );
 
     if (

--- a/src/app/settings/defaultSettings.ts
+++ b/src/app/settings/defaultSettings.ts
@@ -2,6 +2,7 @@ import { getDefaultHiddenProviderCommands } from '../../core/providers/commands/
 import { type ClaudianSettings } from '../../core/types/settings';
 import { DEFAULT_CLAUDE_PROVIDER_SETTINGS } from '../../providers/claude/settings';
 import { DEFAULT_CODEX_PROVIDER_SETTINGS } from '../../providers/codex/settings';
+import { DEFAULT_OPENCODE_PROVIDER_SETTINGS } from '../../providers/opencode/settings';
 
 export const DEFAULT_CLAUDIAN_SETTINGS: ClaudianSettings = {
   userName: '',
@@ -35,6 +36,7 @@ export const DEFAULT_CLAUDIAN_SETTINGS: ClaudianSettings = {
   providerConfigs: {
     claude: { ...DEFAULT_CLAUDE_PROVIDER_SETTINGS },
     codex: { ...DEFAULT_CODEX_PROVIDER_SETTINGS },
+    opencode: { ...DEFAULT_OPENCODE_PROVIDER_SETTINGS },
   },
 
   settingsProvider: 'claude',

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -4,6 +4,8 @@ import { claudeWorkspaceRegistration } from './claude/app/ClaudeWorkspaceService
 import { claudeProviderRegistration } from './claude/registration';
 import { codexWorkspaceRegistration } from './codex/app/CodexWorkspaceServices';
 import { codexProviderRegistration } from './codex/registration';
+import { openCodeWorkspaceRegistration } from './opencode/app/OpenCodeWorkspaceServices';
+import { openCodeProviderRegistration } from './opencode/registration';
 
 let builtInProvidersRegistered = false;
 
@@ -14,8 +16,10 @@ export function registerBuiltInProviders(): void {
 
   ProviderRegistry.register('claude', claudeProviderRegistration);
   ProviderRegistry.register('codex', codexProviderRegistration);
+  ProviderRegistry.register('opencode', openCodeProviderRegistration);
   ProviderWorkspaceRegistry.register('claude', claudeWorkspaceRegistration);
   ProviderWorkspaceRegistry.register('codex', codexWorkspaceRegistration);
+  ProviderWorkspaceRegistry.register('opencode', openCodeWorkspaceRegistration);
   builtInProvidersRegistered = true;
 }
 

--- a/src/providers/opencode/CLAUDE.md
+++ b/src/providers/opencode/CLAUDE.md
@@ -1,0 +1,67 @@
+# OpenCode Provider
+
+Adaptor for OpenCode CLI via JSON-RPC 2.0 over stdio.
+
+## Protocol Overview
+
+OpenCode speaks JSON-RPC 2.0 over stdio (newline-delimited JSON) similar to Codex:
+- **Startup**: `opencode stdio` spawns the CLI in stdio mode
+- **Handshake**: client sends `initialize`, then notifies `initialized`
+- **Client → Server**: `thread/*`, `turn/*`, `skills/list`
+- **Server → Client**: streaming deltas, turn events, completion notifications
+- **Server → Client → Server**: approval gates, user input requests
+
+## Design Decisions
+
+### Model Agnostic
+
+OpenCode supports 75+ LLM providers (Claude, GPT, Gemini, local models via Ollama). The model selector shows common models but users can configure custom models via environment variables.
+
+### Opt-In by Default
+
+Like Codex, OpenCode is disabled by default. Users must explicitly enable it in settings.
+
+### Skill Discovery via Filesystem
+
+Unlike Codex which uses runtime `skills/list` RPC, OpenCode skill discovery scans `.opencode/skills/` and `.agents/skills/` directories directly.
+
+## Storage Paths
+
+| Path | Contents |
+|------|----------|
+| `.opencode/skills/*/SKILL.md` | OpenCode vault skills |
+| `.agents/skills/*/SKILL.md` | Alternate vault skill root |
+| `.opencode/agents/*.toml` | OpenCode vault subagent definitions |
+| `~/.opencode/sessions/**/*.jsonl` | OpenCode transcripts |
+
+## Implementation Status
+
+**Implemented:**
+- Provider registration and capabilities
+- Settings UI (enable toggle, CLI path, safe mode)
+- Skill catalog with filesystem discovery
+- Agent mention provider
+- History service skeleton
+- Auxiliary services (title, refine, inline edit)
+- RPC transport layer
+
+**Pending (requires live OpenCode validation):**
+- Full ChatRuntime query implementation
+- Approval and ask-user handling
+- Session management (resume, fork)
+- Streaming notification routing
+- Session file parsing format validation
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `OPENCODE_MODEL` | Override default model |
+| `OPENCODE_API_KEY` | API key for the configured provider |
+| `OPENCODE_BASE_URL` | Custom API endpoint |
+
+## Gotchas
+
+- OpenCode protocol details may differ from Codex — validate against running instance
+- Session file format needs validation against real OpenCode transcripts
+- Model list is approximate — actual available models depend on user's configured providers

--- a/src/providers/opencode/agents/OpenCodeAgentMentionProvider.ts
+++ b/src/providers/opencode/agents/OpenCodeAgentMentionProvider.ts
@@ -1,0 +1,33 @@
+import type { AgentMentionProvider } from '../../../core/providers/types';
+import type { OpenCodeSubagentStorage } from '../storage/OpenCodeSubagentStorage';
+import type { OpenCodeSubagentDefinition } from '../types/subagent';
+
+export class OpenCodeAgentMentionProvider implements AgentMentionProvider {
+  private agents: OpenCodeSubagentDefinition[] = [];
+
+  constructor(private storage: OpenCodeSubagentStorage) {}
+
+  async loadAgents(): Promise<void> {
+    this.agents = await this.storage.loadAll();
+  }
+
+  searchAgents(query: string): Array<{
+    id: string;
+    name: string;
+    description?: string;
+    source: 'plugin' | 'vault' | 'global' | 'builtin';
+  }> {
+    const q = query.toLowerCase();
+    return this.agents
+      .filter(a =>
+        a.name.toLowerCase().includes(q) ||
+        a.description.toLowerCase().includes(q)
+      )
+      .map(a => ({
+        id: a.name,
+        name: a.name,
+        description: a.description,
+        source: 'vault' as const,
+      }));
+  }
+}

--- a/src/providers/opencode/app/OpenCodeWorkspaceServices.ts
+++ b/src/providers/opencode/app/OpenCodeWorkspaceServices.ts
@@ -1,0 +1,75 @@
+import type { ProviderCommandCatalog } from '../../../core/providers/commands/ProviderCommandCatalog';
+import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
+import type {
+  ProviderCliResolver,
+  ProviderWorkspaceRegistration,
+  ProviderWorkspaceServices,
+} from '../../../core/providers/types';
+import type { HomeFileAdapter } from '../../../core/storage/HomeFileAdapter';
+import type { VaultFileAdapter } from '../../../core/storage/VaultFileAdapter';
+import type ClaudianPlugin from '../../../main';
+import { getVaultPath } from '../../../utils/path';
+import { OpenCodeAgentMentionProvider } from '../agents/OpenCodeAgentMentionProvider';
+import { OpenCodeSkillCatalog } from '../commands/OpenCodeSkillCatalog';
+import { OpenCodeCliResolver } from '../runtime/OpenCodeCliResolver';
+import { OpenCodeSkillListingService } from '../skills/OpenCodeSkillListingService';
+import { OpenCodeSkillStorage } from '../storage/OpenCodeSkillStorage';
+import { OpenCodeSubagentStorage } from '../storage/OpenCodeSubagentStorage';
+import { openCodeSettingsTabRenderer } from '../ui/OpenCodeSettingsTab';
+
+export interface OpenCodeWorkspaceServices extends ProviderWorkspaceServices {
+  subagentStorage: OpenCodeSubagentStorage;
+  commandCatalog: ProviderCommandCatalog;
+  agentMentionProvider: OpenCodeAgentMentionProvider;
+  cliResolver: ProviderCliResolver;
+}
+
+function createOpenCodeCliResolver(): ProviderCliResolver {
+  return new OpenCodeCliResolver();
+}
+
+export async function createOpenCodeWorkspaceServices(
+  plugin: ClaudianPlugin,
+  vaultAdapter: VaultFileAdapter,
+  homeAdapter: HomeFileAdapter,
+): Promise<OpenCodeWorkspaceServices> {
+  const vaultPath = getVaultPath(plugin.app);
+
+  const subagentStorage = new OpenCodeSubagentStorage(vaultAdapter);
+  const agentMentionProvider = new OpenCodeAgentMentionProvider(subagentStorage);
+  await agentMentionProvider.loadAgents();
+
+  const skillListProvider = new OpenCodeSkillListingService(vaultPath);
+  const commandCatalog = new OpenCodeSkillCatalog(
+    new OpenCodeSkillStorage(vaultAdapter, homeAdapter),
+    skillListProvider,
+    vaultPath,
+  );
+
+  return {
+    subagentStorage,
+    commandCatalog,
+    agentMentionProvider,
+    cliResolver: createOpenCodeCliResolver(),
+    settingsTabRenderer: openCodeSettingsTabRenderer,
+    refreshAgentMentions: async () => {
+      await agentMentionProvider.loadAgents();
+    },
+  };
+}
+
+export const openCodeWorkspaceRegistration: ProviderWorkspaceRegistration<OpenCodeWorkspaceServices> = {
+  initialize: async ({ plugin, vaultAdapter, homeAdapter }) => createOpenCodeWorkspaceServices(
+    plugin,
+    vaultAdapter,
+    homeAdapter,
+  ),
+};
+
+export function maybeGetOpenCodeWorkspaceServices(): OpenCodeWorkspaceServices | null {
+  return ProviderWorkspaceRegistry.getServices('opencode') as OpenCodeWorkspaceServices | null;
+}
+
+export function getOpenCodeWorkspaceServices(): OpenCodeWorkspaceServices {
+  return ProviderWorkspaceRegistry.requireServices('opencode') as OpenCodeWorkspaceServices;
+}

--- a/src/providers/opencode/auxiliary/OpenCodeInlineEditService.ts
+++ b/src/providers/opencode/auxiliary/OpenCodeInlineEditService.ts
@@ -1,0 +1,73 @@
+import {
+  buildInlineEditPrompt,
+  getInlineEditSystemPrompt,
+  parseInlineEditResponse,
+} from '../../../core/prompt/inlineEdit';
+import type {
+  InlineEditRequest,
+  InlineEditResult,
+  InlineEditService,
+} from '../../../core/providers/types';
+import type ClaudianPlugin from '../../../main';
+import { appendContextFiles } from '../../../utils/context';
+import { OpenCodeAuxQueryRunner } from '../runtime/OpenCodeAuxQueryRunner';
+
+export class OpenCodeInlineEditService implements InlineEditService {
+  private plugin: ClaudianPlugin;
+  private runner: OpenCodeAuxQueryRunner;
+  private abortController: AbortController | null = null;
+  private hasThread = false;
+
+  constructor(plugin: ClaudianPlugin) {
+    this.plugin = plugin;
+    this.runner = new OpenCodeAuxQueryRunner(plugin);
+  }
+
+  resetConversation(): void {
+    this.runner.reset();
+    this.hasThread = false;
+  }
+
+  async editText(request: InlineEditRequest): Promise<InlineEditResult> {
+    this.resetConversation();
+    const prompt = buildInlineEditPrompt(request);
+    return this.sendMessage(prompt);
+  }
+
+  async continueConversation(message: string, contextFiles?: string[]): Promise<InlineEditResult> {
+    if (!this.hasThread) {
+      return { success: false, error: 'No active conversation to continue' };
+    }
+    let prompt = message;
+    if (contextFiles && contextFiles.length > 0) {
+      prompt = appendContextFiles(message, contextFiles);
+    }
+    return this.sendMessage(prompt);
+  }
+
+  cancel(): void {
+    if (this.abortController) {
+      this.abortController.abort();
+      this.abortController = null;
+    }
+  }
+
+  private async sendMessage(prompt: string): Promise<InlineEditResult> {
+    this.abortController = new AbortController();
+
+    try {
+      const text = await this.runner.query({
+        systemPrompt: getInlineEditSystemPrompt(),
+        abortController: this.abortController,
+      }, prompt);
+
+      this.hasThread = true;
+      return parseInlineEditResponse(text);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      return { success: false, error: msg };
+    } finally {
+      this.abortController = null;
+    }
+  }
+}

--- a/src/providers/opencode/auxiliary/OpenCodeInstructionRefineService.ts
+++ b/src/providers/opencode/auxiliary/OpenCodeInstructionRefineService.ts
@@ -1,0 +1,91 @@
+import { buildRefineSystemPrompt } from '../../../core/prompt/instructionRefine';
+import type {
+  InstructionRefineService,
+  RefineProgressCallback,
+} from '../../../core/providers/types';
+import type { InstructionRefineResult } from '../../../core/types';
+import type ClaudianPlugin from '../../../main';
+import { OpenCodeAuxQueryRunner } from '../runtime/OpenCodeAuxQueryRunner';
+
+export class OpenCodeInstructionRefineService implements InstructionRefineService {
+  private runner: OpenCodeAuxQueryRunner;
+  private abortController: AbortController | null = null;
+  private existingInstructions = '';
+  private hasThread = false;
+
+  constructor(plugin: ClaudianPlugin) {
+    this.runner = new OpenCodeAuxQueryRunner(plugin);
+  }
+
+  resetConversation(): void {
+    this.runner.reset();
+    this.hasThread = false;
+  }
+
+  async refineInstruction(
+    rawInstruction: string,
+    existingInstructions: string,
+    onProgress?: RefineProgressCallback,
+  ): Promise<InstructionRefineResult> {
+    this.resetConversation();
+    this.existingInstructions = existingInstructions;
+    const prompt = `Please refine this instruction: "${rawInstruction}"`;
+    return this.sendMessage(prompt, onProgress);
+  }
+
+  async continueConversation(
+    message: string,
+    onProgress?: RefineProgressCallback,
+  ): Promise<InstructionRefineResult> {
+    if (!this.hasThread) {
+      return { success: false, error: 'No active conversation to continue' };
+    }
+    return this.sendMessage(message, onProgress);
+  }
+
+  cancel(): void {
+    if (this.abortController) {
+      this.abortController.abort();
+      this.abortController = null;
+    }
+  }
+
+  private async sendMessage(
+    prompt: string,
+    onProgress?: RefineProgressCallback,
+  ): Promise<InstructionRefineResult> {
+    this.abortController = new AbortController();
+
+    try {
+      const text = await this.runner.query({
+        systemPrompt: buildRefineSystemPrompt(this.existingInstructions),
+        abortController: this.abortController,
+        onTextChunk: onProgress
+          ? (accumulated: string) => onProgress(this.parseResponse(accumulated))
+          : undefined,
+      }, prompt);
+
+      this.hasThread = true;
+      return this.parseResponse(text);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      return { success: false, error: msg };
+    } finally {
+      this.abortController = null;
+    }
+  }
+
+  private parseResponse(text: string): InstructionRefineResult {
+    const match = text.match(/<instruction>([\s\S]*?)<\/instruction>/);
+    if (match) {
+      return { success: true, refinedInstruction: match[1].trim() };
+    }
+
+    const trimmed = text.trim();
+    if (trimmed) {
+      return { success: true, clarification: trimmed };
+    }
+
+    return { success: false, error: 'Empty response' };
+  }
+}

--- a/src/providers/opencode/auxiliary/OpenCodeTaskResultInterpreter.ts
+++ b/src/providers/opencode/auxiliary/OpenCodeTaskResultInterpreter.ts
@@ -1,0 +1,29 @@
+import type {
+  ProviderTaskResultInterpreter,
+  ProviderTaskTerminalStatus,
+} from '../../../core/providers/types';
+
+export class OpenCodeTaskResultInterpreter implements ProviderTaskResultInterpreter {
+  hasAsyncLaunchMarker(_toolUseResult: unknown): boolean {
+    return false;
+  }
+
+  extractAgentId(_toolUseResult: unknown): string | null {
+    return null;
+  }
+
+  extractStructuredResult(_toolUseResult: unknown): string | null {
+    return null;
+  }
+
+  resolveTerminalStatus(
+    _toolUseResult: unknown,
+    fallbackStatus: ProviderTaskTerminalStatus,
+  ): ProviderTaskTerminalStatus {
+    return fallbackStatus;
+  }
+
+  extractTagValue(_payload: string, _tagName: string): string | null {
+    return null;
+  }
+}

--- a/src/providers/opencode/auxiliary/OpenCodeTitleGenerationService.ts
+++ b/src/providers/opencode/auxiliary/OpenCodeTitleGenerationService.ts
@@ -1,0 +1,104 @@
+import { TITLE_GENERATION_SYSTEM_PROMPT } from '../../../core/prompt/titleGeneration';
+import type {
+  TitleGenerationCallback,
+  TitleGenerationResult,
+  TitleGenerationService,
+} from '../../../core/providers/types';
+import type ClaudianPlugin from '../../../main';
+import { OpenCodeAuxQueryRunner } from '../runtime/OpenCodeAuxQueryRunner';
+
+export class OpenCodeTitleGenerationService implements TitleGenerationService {
+  private plugin: ClaudianPlugin;
+  private activeGenerations = new Map<string, AbortController>();
+
+  constructor(plugin: ClaudianPlugin) {
+    this.plugin = plugin;
+  }
+
+  async generateTitle(
+    conversationId: string,
+    userMessage: string,
+    callback: TitleGenerationCallback,
+  ): Promise<void> {
+    const existing = this.activeGenerations.get(conversationId);
+    if (existing) existing.abort();
+
+    const abortController = new AbortController();
+    this.activeGenerations.set(conversationId, abortController);
+
+    const truncated = userMessage.length > 500
+      ? userMessage.substring(0, 500) + '...'
+      : userMessage;
+    const prompt = `User's request:\n"""\n${truncated}\n"""\n\nGenerate a title for this conversation:`;
+
+    const runner = new OpenCodeAuxQueryRunner(this.plugin);
+
+    try {
+      const text = await runner.query({
+        systemPrompt: TITLE_GENERATION_SYSTEM_PROMPT,
+        model: this.resolveTitleModel(),
+        abortController,
+      }, prompt);
+
+      const title = this.parseTitle(text);
+      if (title) {
+        await this.safeCallback(callback, conversationId, { success: true, title });
+      } else {
+        await this.safeCallback(callback, conversationId, {
+          success: false,
+          error: 'Failed to parse title from response',
+        });
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      await this.safeCallback(callback, conversationId, { success: false, error: msg });
+    } finally {
+      runner.reset();
+      this.activeGenerations.delete(conversationId);
+    }
+  }
+
+  cancel(): void {
+    for (const controller of this.activeGenerations.values()) {
+      controller.abort();
+    }
+    this.activeGenerations.clear();
+  }
+
+  private resolveTitleModel(): string | undefined {
+    return this.plugin.settings.titleGenerationModel || undefined;
+  }
+
+  private parseTitle(responseText: string): string | null {
+    const trimmed = responseText.trim();
+    if (!trimmed) return null;
+
+    let title = trimmed;
+    if (
+      (title.startsWith('"') && title.endsWith('"')) ||
+      (title.startsWith("'") && title.endsWith("'"))
+    ) {
+      title = title.slice(1, -1);
+    }
+
+    title = title.replace(/[.!?:;,]+$/, '');
+
+    if (title.length > 50) {
+      title = title.substring(0, 47) + '...';
+    }
+
+    return title || null;
+  }
+
+  private async safeCallback(
+    callback: TitleGenerationCallback,
+    conversationId: string,
+    result: TitleGenerationResult,
+  ): Promise<void> {
+    try {
+      await callback(conversationId, result);
+    } catch {
+      // Silently ignore callback errors
+    }
+  }
+}

--- a/src/providers/opencode/capabilities.ts
+++ b/src/providers/opencode/capabilities.ts
@@ -1,0 +1,16 @@
+import type { ProviderCapabilities } from '../../core/providers/types';
+
+export const OPENCODE_PROVIDER_CAPABILITIES: Readonly<ProviderCapabilities> = Object.freeze({
+  providerId: 'opencode',
+  supportsPersistentRuntime: true,
+  supportsNativeHistory: true,
+  supportsPlanMode: true,
+  supportsRewind: false,
+  supportsFork: true,
+  supportsProviderCommands: false,
+  supportsImageAttachments: true,
+  supportsInstructionMode: true,
+  supportsMcpTools: false,
+  supportsTurnSteer: true,
+  reasoningControl: 'effort',
+});

--- a/src/providers/opencode/commands/OpenCodeSkillCatalog.ts
+++ b/src/providers/opencode/commands/OpenCodeSkillCatalog.ts
@@ -1,0 +1,168 @@
+import type {
+  ProviderCommandCatalog,
+  ProviderCommandDropdownConfig,
+} from '../../../core/providers/commands/ProviderCommandCatalog';
+import type { ProviderCommandEntry } from '../../../core/providers/commands/ProviderCommandEntry';
+import type { SlashCommand } from '../../../core/types';
+import {
+  type OpenCodeSkillListProvider,
+  type OpenCodeSkillMetadata,
+} from '../skills/OpenCodeSkillListingService';
+import {
+  createOpenCodeSkillPersistenceKey,
+  type OpenCodeSkillStorage,
+  parseOpenCodeSkillPersistenceKey,
+  resolveOpenCodeSkillLocationFromPath,
+} from '../storage/OpenCodeSkillStorage';
+
+const OPENCODE_SKILL_ID_PREFIX = 'opencode-skill-';
+
+const OPENCODE_COMPACT_COMMAND: ProviderCommandEntry = {
+  id: 'opencode-builtin-compact',
+  providerId: 'opencode',
+  kind: 'command',
+  name: 'compact',
+  description: 'Compact conversation history',
+  content: '',
+  scope: 'system',
+  source: 'builtin',
+  isEditable: false,
+  isDeletable: false,
+  displayPrefix: '/',
+  insertPrefix: '/',
+};
+
+function buildSkillId(skill: OpenCodeSkillMetadata): string {
+  const encodedPath = encodeURIComponent(skill.path);
+  return `${OPENCODE_SKILL_ID_PREFIX}${skill.scope}-${encodedPath}`;
+}
+
+function listedSkillToProviderEntry(
+  skill: OpenCodeSkillMetadata,
+  vaultPath: string | null,
+): ProviderCommandEntry {
+  const location = vaultPath ? resolveOpenCodeSkillLocationFromPath(skill.path, vaultPath) : null;
+  const isVault = skill.scope === 'repo' && location !== null;
+
+  return {
+    id: buildSkillId(skill),
+    providerId: 'opencode',
+    kind: 'skill',
+    name: skill.name,
+    description: skill.description,
+    content: '',
+    scope: isVault ? 'vault' : 'user',
+    source: 'user',
+    isEditable: isVault,
+    isDeletable: isVault,
+    displayPrefix: '$',
+    insertPrefix: '$',
+    ...(isVault && location
+      ? {
+          persistenceKey: createOpenCodeSkillPersistenceKey({
+            rootId: location.rootId,
+            currentName: location.name,
+          }),
+        }
+      : {}),
+  };
+}
+
+export class OpenCodeSkillCatalog implements ProviderCommandCatalog {
+  constructor(
+    private storage: OpenCodeSkillStorage,
+    private listProvider: OpenCodeSkillListProvider,
+    private vaultPath: string | null,
+  ) {}
+
+  setRuntimeCommands(_commands: SlashCommand[]): void {
+    // OpenCode dropdown entries come from filesystem discovery; runtime commands are ignored.
+  }
+
+  async listDropdownEntries(context: { includeBuiltIns: boolean }): Promise<ProviderCommandEntry[]> {
+    const skills = await this.listProvider.listSkills();
+    const entries = skills.map(skill => listedSkillToProviderEntry(skill, this.vaultPath));
+    return context.includeBuiltIns ? [OPENCODE_COMPACT_COMMAND, ...entries] : entries;
+  }
+
+  async listVaultEntries(): Promise<ProviderCommandEntry[]> {
+    if (!this.vaultPath) {
+      return [];
+    }
+
+    const listedSkills = (await this.listProvider.listSkills())
+      .filter(skill => skill.scope === 'repo');
+    const entries: ProviderCommandEntry[] = [];
+
+    for (const listedSkill of listedSkills) {
+      const location = resolveOpenCodeSkillLocationFromPath(listedSkill.path, this.vaultPath);
+      if (!location) {
+        continue;
+      }
+
+      const storedSkill = await this.storage.load(location);
+      if (!storedSkill) {
+        continue;
+      }
+
+      entries.push({
+        id: `${OPENCODE_SKILL_ID_PREFIX}${location.rootId}-${storedSkill.name}`,
+        providerId: 'opencode',
+        kind: 'skill',
+        name: storedSkill.name,
+        description: storedSkill.description ?? listedSkill.description,
+        content: storedSkill.content,
+        scope: 'vault',
+        source: 'user',
+        isEditable: true,
+        isDeletable: true,
+        displayPrefix: '$',
+        insertPrefix: '$',
+        persistenceKey: createOpenCodeSkillPersistenceKey({
+          rootId: location.rootId,
+          currentName: location.name,
+        }),
+      });
+    }
+
+    return entries;
+  }
+
+  async saveVaultEntry(entry: ProviderCommandEntry): Promise<void> {
+    const persistenceState = parseOpenCodeSkillPersistenceKey(entry.persistenceKey);
+    await this.storage.save({
+      name: entry.name,
+      description: entry.description,
+      content: entry.content,
+      rootId: persistenceState?.rootId,
+      previousLocation: persistenceState?.currentName
+        ? { rootId: persistenceState.rootId, name: persistenceState.currentName }
+        : undefined,
+    });
+    this.listProvider.invalidate();
+  }
+
+  async deleteVaultEntry(entry: ProviderCommandEntry): Promise<void> {
+    const persistenceState = parseOpenCodeSkillPersistenceKey(entry.persistenceKey);
+    await this.storage.delete({
+      name: persistenceState?.currentName ?? entry.name,
+      rootId: persistenceState?.rootId ?? 'vault-opencode',
+    });
+    this.listProvider.invalidate();
+  }
+
+  getDropdownConfig(): ProviderCommandDropdownConfig {
+    return {
+      providerId: 'opencode',
+      triggerChars: ['/', '$'],
+      builtInPrefix: '/',
+      skillPrefix: '$',
+      commandPrefix: '/',
+    };
+  }
+
+  async refresh(): Promise<void> {
+    this.listProvider.invalidate();
+    await this.listProvider.listSkills({ forceReload: true });
+  }
+}

--- a/src/providers/opencode/env/OpenCodeSettingsReconciler.ts
+++ b/src/providers/opencode/env/OpenCodeSettingsReconciler.ts
@@ -1,0 +1,75 @@
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import type { ProviderSettingsReconciler } from '../../../core/providers/types';
+import type { Conversation } from '../../../core/types';
+import { parseEnvironmentVariables } from '../../../utils/env';
+import { getOpenCodeProviderSettings } from '../settings';
+import { getOpenCodeState } from '../types';
+import { openCodeChatUIConfig } from '../ui/OpenCodeChatUIConfig';
+
+interface OpenCodeProviderSettingsWithHash {
+  environmentHash?: string;
+}
+
+const ENV_HASH_KEYS = ['OPENCODE_MODEL', 'OPENCODE_BASE_URL', 'OPENCODE_API_KEY'];
+
+function computeOpenCodeEnvHash(envText: string): string {
+  const envVars = parseEnvironmentVariables(envText || '');
+  return ENV_HASH_KEYS
+    .filter(key => envVars[key])
+    .map(key => `${key}=${envVars[key]}`)
+    .sort()
+    .join('|');
+}
+
+function getEnvironmentHash(settings: Record<string, unknown>): string | undefined {
+  const opencode = settings.opencode as OpenCodeProviderSettingsWithHash | undefined;
+  return opencode?.environmentHash;
+}
+
+function setEnvironmentHash(settings: Record<string, unknown>, hash: string): void {
+  const current = getOpenCodeProviderSettings(settings);
+  settings.opencode = { ...current, environmentHash: hash };
+}
+
+export const openCodeSettingsReconciler: ProviderSettingsReconciler = {
+  reconcileModelWithEnvironment(
+    settings: Record<string, unknown>,
+    conversations: Conversation[],
+  ): { changed: boolean; invalidatedConversations: Conversation[] } {
+    const envText = getRuntimeEnvironmentText(settings, 'opencode');
+    const currentHash = computeOpenCodeEnvHash(envText);
+    const savedHash = getEnvironmentHash(settings);
+
+    if (currentHash === savedHash) {
+      return { changed: false, invalidatedConversations: [] };
+    }
+
+    const invalidatedConversations: Conversation[] = [];
+    for (const conv of conversations) {
+      const state = getOpenCodeState(conv);
+      if (conv.providerId === 'opencode' && (conv.sessionId || state.threadId)) {
+        conv.sessionId = null;
+        conv.providerState = undefined;
+        invalidatedConversations.push(conv);
+      }
+    }
+
+    const envVars = parseEnvironmentVariables(envText || '');
+    if (envVars.OPENCODE_MODEL) {
+      settings.model = envVars.OPENCODE_MODEL;
+    } else if (
+      typeof settings.model === 'string'
+      && settings.model.length > 0
+      && !openCodeChatUIConfig.isDefaultModel(settings.model)
+    ) {
+      settings.model = openCodeChatUIConfig.getModelOptions({})[0]?.value ?? 'claude-sonnet-4';
+    }
+
+    setEnvironmentHash(settings, currentHash);
+    return { changed: true, invalidatedConversations };
+  },
+
+  normalizeModelVariantSettings(): boolean {
+    return false;
+  },
+};

--- a/src/providers/opencode/history/OpenCodeConversationHistoryService.ts
+++ b/src/providers/opencode/history/OpenCodeConversationHistoryService.ts
@@ -1,0 +1,151 @@
+import type { ProviderConversationHistoryService } from '../../../core/providers/types';
+import type { Conversation } from '../../../core/types';
+import type { OpenCodeProviderState } from '../types';
+import { getOpenCodeState } from '../types';
+import {
+  findOpenCodeSessionFile,
+  type OpenCodeParsedTurn,
+  parseOpenCodeSessionFile,
+  parseOpenCodeSessionTurns,
+} from './OpenCodeHistoryStore';
+
+function readSessionTurns(sessionFilePath: string): OpenCodeParsedTurn[] {
+  let content: string;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    content = require('fs').readFileSync(sessionFilePath, 'utf-8');
+  } catch {
+    return [];
+  }
+  return parseOpenCodeSessionTurns(content);
+}
+
+export class OpenCodeConversationHistoryService implements ProviderConversationHistoryService {
+  private hydratedConversationPaths = new Map<string, string>();
+
+  async hydrateConversationHistory(
+    conversation: Conversation,
+    _vaultPath: string | null,
+  ): Promise<void> {
+    const state = getOpenCodeState(conversation);
+
+    // Pending fork with existing in-memory messages: keep them as-is
+    if (this.isPendingForkConversation(conversation) && conversation.messages.length > 0) {
+      return;
+    }
+
+    // Pending fork without messages: hydrate from source transcript truncated at resumeAt
+    if (this.isPendingForkConversation(conversation)) {
+      const sourceSessionFile = this.resolveSourceSessionFile(state);
+      if (!sourceSessionFile) return;
+
+      const turns = readSessionTurns(sourceSessionFile);
+      const resumeAt = state.forkSource!.resumeAtMessageId;
+      const truncated = this.truncateTurnsAtCheckpoint(turns, resumeAt);
+      if (!truncated) {
+        this.hydratedConversationPaths.delete(conversation.id);
+        return;
+      }
+      conversation.messages = truncated.flatMap(t => t.messages);
+      return;
+    }
+
+    // Normal hydration
+    const threadId = state.threadId ?? conversation.sessionId ?? null;
+    const sessionFilePath = state.sessionFilePath ?? (
+      threadId
+        ? findOpenCodeSessionFile(threadId)
+        : null
+    );
+
+    if (!sessionFilePath) {
+      this.hydratedConversationPaths.delete(conversation.id);
+      return;
+    }
+
+    const hydrationKey = `${threadId ?? ''}::${sessionFilePath}`;
+    if (
+      conversation.messages.length > 0
+      && this.hydratedConversationPaths.get(conversation.id) === hydrationKey
+    ) {
+      return;
+    }
+
+    if (sessionFilePath !== state.sessionFilePath) {
+      conversation.providerState = {
+        ...(conversation.providerState ?? {}),
+        ...(threadId ? { threadId } : {}),
+        sessionFilePath,
+      };
+    }
+
+    const sdkMessages = parseOpenCodeSessionFile(sessionFilePath);
+    if (sdkMessages.length === 0) {
+      this.hydratedConversationPaths.delete(conversation.id);
+      return;
+    }
+
+    conversation.messages = sdkMessages;
+    this.hydratedConversationPaths.set(conversation.id, hydrationKey);
+  }
+
+  async deleteConversationSession(
+    _conversation: Conversation,
+    _vaultPath: string | null,
+  ): Promise<void> {
+    // Never delete ~/.opencode transcripts
+  }
+
+  resolveSessionIdForConversation(conversation: Conversation | null): string | null {
+    if (!conversation) return null;
+    const state = getOpenCodeState(conversation);
+    return state.threadId ?? conversation.sessionId ?? state.forkSource?.sourceThreadId ?? null;
+  }
+
+  isPendingForkConversation(conversation: Conversation): boolean {
+    const state = getOpenCodeState(conversation);
+    return !!state.forkSource && !state.threadId && !conversation.sessionId;
+  }
+
+  buildForkProviderState(
+    sourceSessionId: string,
+    resumeAt: string,
+    sourceProviderState?: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const sourceState = sourceProviderState as OpenCodeProviderState | undefined;
+    const providerState: OpenCodeProviderState = {
+      forkSource: { sourceThreadId: sourceSessionId, resumeAtMessageId: resumeAt },
+      ...(sourceState?.sessionFilePath ? { sessionFilePath: sourceState.sessionFilePath } : {}),
+    };
+    return providerState as Record<string, unknown>;
+  }
+
+  buildPersistedProviderState(
+    conversation: Conversation,
+  ): Record<string, unknown> | undefined {
+    const entries = Object.entries(getOpenCodeState(conversation))
+      .filter(([, value]) => value !== undefined);
+    return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private resolveSourceSessionFile(state: OpenCodeProviderState): string | null {
+    if (!state.forkSource) return null;
+    return state.sessionFilePath ?? findOpenCodeSessionFile(state.forkSource.sourceThreadId);
+  }
+
+  private truncateTurnsAtCheckpoint(
+    turns: OpenCodeParsedTurn[],
+    resumeAt: string,
+  ): OpenCodeParsedTurn[] | null {
+    const checkpointIndex = turns.findIndex(turn => turn.turnId === resumeAt);
+    if (checkpointIndex < 0) {
+      return null;
+    }
+
+    return turns.slice(0, checkpointIndex + 1);
+  }
+}

--- a/src/providers/opencode/history/OpenCodeHistoryStore.ts
+++ b/src/providers/opencode/history/OpenCodeHistoryStore.ts
@@ -1,0 +1,128 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import type { ChatMessage } from '../../../core/types';
+
+export interface OpenCodeParsedTurn {
+  turnId: string | null;
+  messages: ChatMessage[];
+}
+
+const OPENCODE_HOME_DIR = path.join(os.homedir(), '.opencode', 'sessions');
+
+export function findOpenCodeSessionFile(
+  threadId: string,
+  customRootPath?: string,
+): string | null {
+  const rootPath = customRootPath || OPENCODE_HOME_DIR;
+
+  try {
+    if (!fs.existsSync(rootPath)) {
+      return null;
+    }
+
+    // Try direct match: {threadId}.jsonl
+    const directPath = path.join(rootPath, `${threadId}.jsonl`);
+    if (fs.existsSync(directPath)) {
+      return directPath;
+    }
+
+    // Try with date prefix: {date}-{threadId}.jsonl
+    const files = fs.readdirSync(rootPath);
+    for (const file of files) {
+      if (file.endsWith(`-${threadId}.jsonl`) || file === `${threadId}.jsonl`) {
+        return path.join(rootPath, file);
+      }
+    }
+
+    // Search subdirectories
+    for (const entry of files) {
+      const entryPath = path.join(rootPath, entry);
+      const stat = fs.statSync(entryPath);
+      if (stat.isDirectory()) {
+        const found = findOpenCodeSessionFile(threadId, entryPath);
+        if (found) return found;
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+export function parseOpenCodeSessionFile(sessionFilePath: string): ChatMessage[] {
+  try {
+    const content = fs.readFileSync(sessionFilePath, 'utf-8');
+    const turns = parseOpenCodeSessionTurns(content);
+    return turns.flatMap(turn => turn.messages);
+  } catch {
+    return [];
+  }
+}
+
+export function parseOpenCodeSessionTurns(content: string): OpenCodeParsedTurn[] {
+  const lines = content.split('\n').filter(line => line.trim());
+  const turns: OpenCodeParsedTurn[] = [];
+  let currentTurn: OpenCodeParsedTurn | null = null;
+
+  for (const line of lines) {
+    try {
+      const record = JSON.parse(line);
+
+      if (record.type === 'turn_start' || record.type === 'turn') {
+        if (currentTurn) {
+          turns.push(currentTurn);
+        }
+        currentTurn = {
+          turnId: record.turnId ?? record.id ?? null,
+          messages: [],
+        };
+      }
+
+      if (record.type === 'user_message' || record.role === 'user') {
+        const message: ChatMessage = {
+          id: record.id ?? `user-${Date.now()}`,
+          role: 'user',
+          content: record.content ?? record.text ?? '',
+          timestamp: record.timestamp ?? Date.now(),
+        };
+        if (currentTurn) {
+          currentTurn.messages.push(message);
+        } else {
+          currentTurn = { turnId: null, messages: [message] };
+        }
+      }
+
+      if (record.type === 'assistant_message' || record.role === 'assistant') {
+        const message: ChatMessage = {
+          id: record.id ?? `assistant-${Date.now()}`,
+          role: 'assistant',
+          content: record.content ?? record.text ?? '',
+          timestamp: record.timestamp ?? Date.now(),
+        };
+        if (currentTurn) {
+          currentTurn.messages.push(message);
+        } else {
+          currentTurn = { turnId: null, messages: [message] };
+        }
+      }
+
+      if (record.type === 'turn_complete' || record.type === 'turn_end') {
+        if (currentTurn) {
+          turns.push(currentTurn);
+          currentTurn = null;
+        }
+      }
+    } catch {
+      // Skip malformed lines
+    }
+  }
+
+  if (currentTurn && currentTurn.messages.length > 0) {
+    turns.push(currentTurn);
+  }
+
+  return turns;
+}

--- a/src/providers/opencode/prompt/encodeOpenCodeTurn.ts
+++ b/src/providers/opencode/prompt/encodeOpenCodeTurn.ts
@@ -1,0 +1,61 @@
+import type { ChatTurnRequest, PreparedChatTurn } from '../../../core/runtime/types';
+
+function isCompactCommand(text: string): boolean {
+  return /^\/compact(\s|$)/i.test(text);
+}
+
+/**
+ * Encode a chat turn request into the format expected by OpenCode.
+ * Similar to Codex encoding but may diverge as we learn OpenCode's specific requirements.
+ */
+export function encodeOpenCodeTurn(request: ChatTurnRequest): PreparedChatTurn {
+  const isCompact = isCompactCommand(request.text);
+
+  if (isCompact) {
+    return {
+      request,
+      persistedContent: request.text,
+      prompt: request.text,
+      isCompact: true,
+      mcpMentions: new Set(),
+    };
+  }
+
+  const sections: string[] = [];
+  sections.push(request.text);
+
+  if (request.currentNotePath) {
+    sections.push(`\n[Current note: ${request.currentNotePath}]`);
+  }
+
+  if (request.editorSelection?.selectedText) {
+    sections.push(
+      `\n[Editor selection from ${request.editorSelection.notePath || 'current note'}:\n${request.editorSelection.selectedText}\n]`,
+    );
+  }
+
+  if (request.browserSelection?.selectedText) {
+    sections.push(
+      `\n[Browser selection from ${request.browserSelection.url ?? 'unknown page'}:\n${request.browserSelection.selectedText}\n]`,
+    );
+  }
+
+  if (request.canvasSelection) {
+    const nodeList = request.canvasSelection.nodeIds.join(', ');
+    if (nodeList) {
+      sections.push(
+        `\n[Canvas selection from ${request.canvasSelection.canvasPath}:\n${nodeList}\n]`,
+      );
+    }
+  }
+
+  const prompt = sections.join('');
+
+  return {
+    request,
+    persistedContent: request.text,
+    prompt,
+    isCompact: false,
+    mcpMentions: new Set(),
+  };
+}

--- a/src/providers/opencode/registration.ts
+++ b/src/providers/opencode/registration.ts
@@ -1,0 +1,27 @@
+import type { ProviderRegistration } from '../../core/providers/types';
+import { OpenCodeInlineEditService } from './auxiliary/OpenCodeInlineEditService';
+import { OpenCodeInstructionRefineService } from './auxiliary/OpenCodeInstructionRefineService';
+import { OpenCodeTaskResultInterpreter } from './auxiliary/OpenCodeTaskResultInterpreter';
+import { OpenCodeTitleGenerationService } from './auxiliary/OpenCodeTitleGenerationService';
+import { OPENCODE_PROVIDER_CAPABILITIES } from './capabilities';
+import { openCodeSettingsReconciler } from './env/OpenCodeSettingsReconciler';
+import { OpenCodeConversationHistoryService } from './history/OpenCodeConversationHistoryService';
+import { OpenCodeChatRuntime } from './runtime/OpenCodeChatRuntime';
+import { getOpenCodeProviderSettings } from './settings';
+import { openCodeChatUIConfig } from './ui/OpenCodeChatUIConfig';
+
+export const openCodeProviderRegistration: ProviderRegistration = {
+  displayName: 'OpenCode',
+  blankTabOrder: 5,
+  isEnabled: (settings) => getOpenCodeProviderSettings(settings).enabled,
+  capabilities: OPENCODE_PROVIDER_CAPABILITIES,
+  environmentKeyPatterns: [/^OPENCODE_/i],
+  chatUIConfig: openCodeChatUIConfig,
+  settingsReconciler: openCodeSettingsReconciler,
+  createRuntime: ({ plugin }) => new OpenCodeChatRuntime(plugin),
+  createTitleGenerationService: (plugin) => new OpenCodeTitleGenerationService(plugin),
+  createInstructionRefineService: (plugin) => new OpenCodeInstructionRefineService(plugin),
+  createInlineEditService: (plugin) => new OpenCodeInlineEditService(plugin),
+  historyService: new OpenCodeConversationHistoryService(),
+  taskResultInterpreter: new OpenCodeTaskResultInterpreter(),
+};

--- a/src/providers/opencode/runtime/OpenCodeAppServerProcess.ts
+++ b/src/providers/opencode/runtime/OpenCodeAppServerProcess.ts
@@ -1,0 +1,87 @@
+import { type ChildProcess, spawn } from 'child_process';
+import type { Readable, Writable } from 'stream';
+
+import type { OpenCodeLaunchSpec } from './openCodeLaunchTypes';
+
+const SIGKILL_TIMEOUT_MS = 3_000;
+
+type ExitCallback = (code: number | null, signal: string | null) => void;
+
+export class OpenCodeAppServerProcess {
+  private proc: ChildProcess | null = null;
+  private alive = false;
+  private exitCallbacks: ExitCallback[] = [];
+
+  constructor(
+    private readonly launchSpec: Pick<OpenCodeLaunchSpec, 'command' | 'args' | 'spawnCwd' | 'env'>,
+  ) {}
+
+  start(): void {
+    this.proc = spawn(this.launchSpec.command, this.launchSpec.args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: this.launchSpec.spawnCwd,
+      env: this.launchSpec.env,
+    });
+
+    this.alive = true;
+
+    this.proc.on('exit', (code, signal) => {
+      this.alive = false;
+      for (const cb of this.exitCallbacks) {
+        cb(code, signal);
+      }
+    });
+
+    this.proc.on('error', () => {
+      this.alive = false;
+    });
+  }
+
+  get stdin(): Writable {
+    if (!this.proc?.stdin) throw new Error('Process not started');
+    return this.proc.stdin;
+  }
+
+  get stdout(): Readable {
+    if (!this.proc?.stdout) throw new Error('Process not started');
+    return this.proc.stdout;
+  }
+
+  get stderr(): Readable {
+    if (!this.proc?.stderr) throw new Error('Process not started');
+    return this.proc.stderr;
+  }
+
+  isAlive(): boolean {
+    return this.alive;
+  }
+
+  onExit(callback: ExitCallback): void {
+    this.exitCallbacks.push(callback);
+  }
+
+  offExit(callback: ExitCallback): void {
+    const idx = this.exitCallbacks.indexOf(callback);
+    if (idx !== -1) this.exitCallbacks.splice(idx, 1);
+  }
+
+  async shutdown(): Promise<void> {
+    if (!this.proc || !this.alive) return;
+
+    return new Promise<void>((resolve) => {
+      const onExit = () => {
+        clearTimeout(killTimer);
+        resolve();
+      };
+
+      this.proc!.once('exit', onExit);
+      this.proc!.kill('SIGTERM');
+
+      const killTimer = setTimeout(() => {
+        if (this.alive) {
+          this.proc!.kill('SIGKILL');
+        }
+      }, SIGKILL_TIMEOUT_MS);
+    });
+  }
+}

--- a/src/providers/opencode/runtime/OpenCodeAuxQueryRunner.ts
+++ b/src/providers/opencode/runtime/OpenCodeAuxQueryRunner.ts
@@ -1,0 +1,167 @@
+import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
+import type ClaudianPlugin from '../../../main';
+import { OpenCodeAppServerProcess } from './OpenCodeAppServerProcess';
+import { resolveOpenCodeAppServerLaunchSpec } from './openCodeAppServerSupport';
+import type {
+  InitializeResult,
+  StreamDeltaNotification,
+  ThreadStartResult,
+  TurnStartResult,
+} from './openCodeAppServerTypes';
+import type { OpenCodeLaunchSpec } from './openCodeLaunchTypes';
+import { OpenCodeRpcTransport } from './OpenCodeRpcTransport';
+
+export interface OpenCodeAuxQueryConfig {
+  systemPrompt: string;
+  model?: string;
+  abortController?: AbortController;
+  onTextChunk?: (accumulatedText: string) => void;
+}
+
+/**
+ * Runs ephemeral OpenCode queries for auxiliary tasks
+ * (title generation, instruction refinement, inline edit).
+ * Manages its own process lifecycle, separate from the main chat runtime.
+ * Supports multi-turn conversations within a single thread.
+ */
+export class OpenCodeAuxQueryRunner {
+  private process: OpenCodeAppServerProcess | null = null;
+  private transport: OpenCodeRpcTransport | null = null;
+  private threadId: string | null = null;
+  private launchSpec: OpenCodeLaunchSpec | null = null;
+
+  constructor(private readonly plugin: ClaudianPlugin) {}
+
+  async query(config: OpenCodeAuxQueryConfig, prompt: string): Promise<string> {
+    if (!this.process || !this.transport) {
+      await this.startProcess();
+    }
+
+    if (!this.threadId) {
+      const model = config.model ?? this.resolveProviderModel();
+      const result = await this.transport!.request<ThreadStartResult>('thread/start', {
+        model,
+        cwd: this.launchSpec?.spawnCwd ?? process.cwd(),
+        approvalPolicy: 'never',
+        sandbox: 'read-only',
+        baseInstructions: config.systemPrompt,
+      });
+      this.threadId = result.thread.id;
+    }
+
+    let accumulatedText = '';
+    let turnError: string | null = null;
+    let resolveWait: (() => void) | null = null;
+
+    const donePromise = new Promise<void>((resolve) => {
+      resolveWait = resolve;
+    });
+
+    this.transport!.onNotification('stream/delta', (params) => {
+      const p = params as StreamDeltaNotification;
+      if (p.delta.type === 'text' && p.delta.content) {
+        accumulatedText += p.delta.content;
+        config.onTextChunk?.(accumulatedText);
+      }
+    });
+
+    this.transport!.onNotification('turn/completed', (_params) => {
+      resolveWait?.();
+    });
+
+    this.transport!.onNotification('error', (params) => {
+      const p = params as { message?: string };
+      turnError = p.message ?? 'Unknown error';
+      resolveWait?.();
+    });
+
+    // Resolve if process dies unexpectedly to avoid hanging forever
+    const exitHandler = (): void => {
+      if (!turnError) turnError = 'OpenCode process exited unexpectedly';
+      resolveWait?.();
+    };
+    this.process!.onExit(exitHandler);
+
+    // Register abort handler before turn/start to avoid race condition
+    let turnId: string | null = null;
+    const abortHandler = (): void => {
+      if (this.transport && this.threadId && turnId) {
+        this.transport.request('turn/cancel', {
+          threadId: this.threadId,
+          turnId,
+        }).catch(() => {});
+      }
+      resolveWait?.();
+    };
+
+    config.abortController?.signal.addEventListener('abort', abortHandler, { once: true });
+
+    // Check if already aborted before starting the turn
+    if (config.abortController?.signal.aborted) {
+      config.abortController.signal.removeEventListener('abort', abortHandler);
+      this.process?.offExit(exitHandler);
+      throw new Error('Cancelled');
+    }
+
+    const turnResult = await this.transport!.request<TurnStartResult>('turn/start', {
+      threadId: this.threadId,
+      input: [{ type: 'text', text: prompt }],
+      model: config.model,
+    });
+    turnId = turnResult.turn.id;
+
+    try {
+      await donePromise;
+    } finally {
+      config.abortController?.signal.removeEventListener('abort', abortHandler);
+      this.process?.offExit(exitHandler);
+    }
+
+    if (config.abortController?.signal.aborted) {
+      throw new Error('Cancelled');
+    }
+
+    if (turnError) {
+      throw new Error(turnError);
+    }
+
+    return accumulatedText;
+  }
+
+  reset(): void {
+    this.threadId = null;
+    this.launchSpec = null;
+    if (this.transport) {
+      this.transport.dispose();
+      this.transport = null;
+    }
+    if (this.process) {
+      this.process.shutdown().catch(() => {});
+      this.process = null;
+    }
+  }
+
+  private resolveProviderModel(): string {
+    const providerSettings = ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+      this.plugin.settings as unknown as Record<string, unknown>,
+      'opencode',
+    );
+    return (providerSettings.model as string) ?? 'claude-sonnet-4';
+  }
+
+  private async startProcess(): Promise<void> {
+    this.launchSpec = resolveOpenCodeAppServerLaunchSpec(this.plugin);
+    this.process = new OpenCodeAppServerProcess(this.launchSpec);
+    this.process.start();
+
+    this.transport = new OpenCodeRpcTransport(this.process);
+    this.transport.start();
+
+    await this.transport.request<InitializeResult>('initialize', {
+      clientInfo: { name: 'claudian-aux', version: '1.0.0' },
+      capabilities: {},
+    });
+
+    this.transport.notify('initialized');
+  }
+}

--- a/src/providers/opencode/runtime/OpenCodeBinaryLocator.ts
+++ b/src/providers/opencode/runtime/OpenCodeBinaryLocator.ts
@@ -1,0 +1,64 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { getEnhancedPath, parseEnvironmentVariables } from '../../../utils/env';
+import { expandHomePath, parsePathEntries } from '../../../utils/path';
+
+function isExistingFile(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function resolveConfiguredPath(configuredPath: string | undefined): string | null {
+  const trimmed = (configuredPath ?? '').trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const expandedPath = expandHomePath(trimmed);
+    return isExistingFile(expandedPath) ? expandedPath : null;
+  } catch {
+    return null;
+  }
+}
+
+export function findOpenCodeBinaryPath(
+  additionalPath?: string,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  const binaryNames = platform === 'win32'
+    ? ['opencode.cmd', 'opencode.exe', 'opencode.bat', 'opencode']
+    : ['opencode'];
+  const searchEntries = parsePathEntries(getEnhancedPath(additionalPath));
+
+  for (const dir of searchEntries) {
+    if (!dir) continue;
+
+    for (const binaryName of binaryNames) {
+      const candidate = path.join(dir, binaryName);
+      if (isExistingFile(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function resolveOpenCodeCliPath(
+  customCliPath: string | undefined,
+  envText: string,
+  hostPlatform: NodeJS.Platform = process.platform,
+): string | null {
+  const configuredPath = resolveConfiguredPath(customCliPath);
+  if (configuredPath) {
+    return configuredPath;
+  }
+
+  const customEnv = parseEnvironmentVariables(envText || '');
+  return findOpenCodeBinaryPath(customEnv.PATH, hostPlatform);
+}

--- a/src/providers/opencode/runtime/OpenCodeChatRuntime.ts
+++ b/src/providers/opencode/runtime/OpenCodeChatRuntime.ts
@@ -20,6 +20,7 @@ import type {
   SubagentRuntimeState,
 } from '../../../core/runtime/types';
 import type { ChatMessage, Conversation, SlashCommand, StreamChunk, ToolCallInfo } from '../../../core/types';
+import type { StructuredPatchHunk } from '../../../core/types/diff';
 import type ClaudianPlugin from '../../../main';
 import { getVaultPath } from '../../../utils/path';
 import { OPENCODE_PROVIDER_CAPABILITIES } from '../capabilities';
@@ -29,17 +30,72 @@ import { getOpenCodeState } from '../types';
 import { resolveOpenCodeCliPath } from './OpenCodeBinaryLocator';
 import { OpenCodeSessionManager } from './OpenCodeSessionManager';
 
+/** Diff information from OpenCode edit tool metadata. */
+interface OpenCodeFileDiff {
+  file: string;
+  patch: string;
+  additions: number;
+  deletions: number;
+}
+
+/** Tool state embedded in OpenCode tool_use events. */
+interface OpenCodeToolState {
+  status: 'pending' | 'running' | 'completed' | 'error';
+  input?: Record<string, unknown>;
+  output?: string;
+  error?: string;
+  metadata?: {
+    diff?: string;
+    filediff?: OpenCodeFileDiff;
+    filepath?: string;
+    exists?: boolean;
+    truncated?: boolean;
+    diagnostics?: Record<string, unknown>;
+    preview?: string;
+    loaded?: string[];
+  };
+  title?: string;
+  time?: {
+    start: number;
+    end: number;
+  };
+}
+
+/** OpenCode JSON event structure from `opencode run --format json`. */
 interface OpenCodeEvent {
   type: string;
+  timestamp?: number;
   sessionID?: string;
   part?: {
     type: string;
+    id?: string;
+    messageID?: string;
+    sessionID?: string;
+    // Text event fields
     text?: string;
+    // Tool event fields
+    tool?: string;
+    callID?: string;
+    state?: OpenCodeToolState;
+    // Legacy/simple fields
     name?: string;
     input?: unknown;
     output?: string;
     error?: string;
     reason?: string;
+    // Step finish fields
+    snapshot?: string;
+    tokens?: {
+      total: number;
+      input: number;
+      output: number;
+      reasoning: number;
+      cache?: {
+        write: number;
+        read: number;
+      };
+    };
+    cost?: number;
   };
 }
 
@@ -264,22 +320,52 @@ export class OpenCodeChatRuntime implements ChatRuntime {
         }
         break;
 
-      case 'tool_use':
-        if (event.part?.name) {
+      case 'tool_use': {
+        // OpenCode embeds tool state (including result) directly in tool_use events
+        const part = event.part;
+        if (!part) break;
+
+        const toolName = part.tool ?? part.name ?? 'unknown';
+        const callId = part.callID ?? part.id ?? toolName;
+        const state = part.state;
+
+        // Get input from state or legacy field and normalize field names
+        const rawInput = (state?.input ?? part.input ?? {}) as Record<string, unknown>;
+        const input = this.normalizeToolInput(rawInput);
+
+        // Emit tool_use chunk
+        enqueue({
+          type: 'tool_use',
+          id: callId,
+          name: this.normalizeToolName(toolName),
+          input,
+        });
+
+        // If tool has completed, emit tool_result with diff data if available
+        if (state?.status === 'completed' || state?.status === 'error') {
+          const isError = state.status === 'error';
+          const content = state.output ?? state.error ?? '';
+
+          // Build SDKToolUseResult with structuredPatch if diff data is available
+          const toolUseResult = this.buildToolUseResult(toolName, state, input);
+
           enqueue({
-            type: 'tool_use',
-            id: event.part.name,
-            name: event.part.name,
-            input: (event.part.input ?? {}) as Record<string, unknown>,
+            type: 'tool_result',
+            id: callId,
+            content,
+            isError,
+            toolUseResult,
           });
         }
         break;
+      }
 
       case 'tool_result':
+        // Legacy format - simple tool result without embedded state
         if (event.part?.output !== undefined) {
           enqueue({
             type: 'tool_result',
-            id: event.part.name ?? 'unknown',
+            id: event.part.name ?? event.part.callID ?? 'unknown',
             content: event.part.output,
           });
         }
@@ -291,13 +377,169 @@ export class OpenCodeChatRuntime implements ChatRuntime {
         }
         break;
 
-      case 'step_finish':
-        // Turn completed
-        if (event.part?.reason === 'stop') {
+      case 'step_finish': {
+        // Extract usage information from step_finish
+        const tokens = event.part?.tokens;
+        if (tokens && event.part?.reason === 'stop') {
+          this.turnMetadata.assistantMessageId = event.sessionID;
+
+          // Emit usage chunk with token information
+          const cacheWrite = tokens.cache?.write ?? 0;
+          const cacheRead = tokens.cache?.read ?? 0;
+          const inputTokens = tokens.input + cacheWrite + cacheRead;
+
+          enqueue({
+            type: 'usage',
+            usage: {
+              inputTokens,
+              cacheCreationInputTokens: cacheWrite,
+              cacheReadInputTokens: cacheRead,
+              contextWindow: 200000, // Default context window, could be model-specific
+              contextTokens: tokens.total,
+              percentage: Math.min(100, (tokens.total / 200000) * 100),
+            },
+            sessionId: event.sessionID,
+          });
+        } else if (event.part?.reason === 'stop') {
           this.turnMetadata.assistantMessageId = event.sessionID;
         }
         break;
+      }
     }
+  }
+
+  /**
+   * Normalize OpenCode tool names to match the expected format for renderers.
+   * OpenCode uses lowercase names like 'write', 'edit', 'read'.
+   * The renderer expects capitalized names like 'Write', 'Edit', 'Read'.
+   */
+  private normalizeToolName(toolName: string): string {
+    const nameMap: Record<string, string> = {
+      'write': 'Write',
+      'edit': 'Edit',
+      'read': 'Read',
+      'bash': 'Bash',
+      'glob': 'Glob',
+      'grep': 'Grep',
+      'task': 'Task',
+      'todowrite': 'TodoWrite',
+      'webfetch': 'WebFetch',
+      'question': 'Question',
+      'skill': 'Skill',
+    };
+    return nameMap[toolName.toLowerCase()] ?? toolName;
+  }
+
+  /**
+   * Normalize tool input field names from OpenCode format to the format expected by renderers.
+   * OpenCode uses camelCase (filePath, oldString, newString).
+   * Renderers expect snake_case (file_path, old_string, new_string).
+   */
+  private normalizeToolInput(input: Record<string, unknown>): Record<string, unknown> {
+    const normalized: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(input)) {
+      // Convert camelCase to snake_case for known fields
+      const normalizedKey = this.camelToSnakeCase(key);
+      normalized[normalizedKey] = value;
+
+      // Also keep original key for compatibility
+      if (normalizedKey !== key) {
+        normalized[key] = value;
+      }
+    }
+
+    return normalized;
+  }
+
+  /**
+   * Convert camelCase to snake_case.
+   */
+  private camelToSnakeCase(str: string): string {
+    return str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+  }
+
+  /**
+   * Build SDKToolUseResult with structuredPatch from OpenCode metadata.
+   * This enables the WriteEditRenderer to show proper diffs.
+   */
+  private buildToolUseResult(
+    toolName: string,
+    state: OpenCodeToolState,
+    input: Record<string, unknown>,
+  ): Record<string, unknown> | undefined {
+    const metadata = state.metadata;
+    if (!metadata) return undefined;
+
+    const result: Record<string, unknown> = {};
+
+    // Extract file path
+    const filePath = metadata.filepath ?? (input.filePath as string) ?? (input.file_path as string);
+    if (filePath) {
+      result.filePath = filePath;
+    }
+
+    // Parse unified diff into structuredPatch format for the diff renderer
+    if (metadata.filediff?.patch || metadata.diff) {
+      const patchText = metadata.filediff?.patch ?? metadata.diff ?? '';
+      const hunks = this.parseUnifiedDiffToStructuredPatch(patchText);
+      if (hunks.length > 0) {
+        result.structuredPatch = hunks;
+      }
+    }
+
+    return Object.keys(result).length > 0 ? result : undefined;
+  }
+
+  /**
+   * Parse a unified diff string into StructuredPatchHunk format.
+   * This converts OpenCode's diff format to the format expected by the diff renderer.
+   */
+  private parseUnifiedDiffToStructuredPatch(patchText: string): StructuredPatchHunk[] {
+    const hunks: StructuredPatchHunk[] = [];
+    const lines = patchText.split(/\r?\n/);
+
+    let currentHunk: StructuredPatchHunk | null = null;
+
+    for (const line of lines) {
+      // Match hunk header: @@ -oldStart,oldLines +newStart,newLines @@
+      const hunkMatch = line.match(/^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/);
+      if (hunkMatch) {
+        if (currentHunk) {
+          hunks.push(currentHunk);
+        }
+        currentHunk = {
+          oldStart: parseInt(hunkMatch[1], 10),
+          oldLines: parseInt(hunkMatch[2] ?? '1', 10),
+          newStart: parseInt(hunkMatch[3], 10),
+          newLines: parseInt(hunkMatch[4] ?? '1', 10),
+          lines: [],
+        };
+        continue;
+      }
+
+      // Skip header lines
+      if (line.startsWith('Index:') || line.startsWith('===') ||
+          line.startsWith('---') || line.startsWith('+++')) {
+        continue;
+      }
+
+      // Skip "No newline at end of file" markers
+      if (line.startsWith('\\ No newline')) {
+        continue;
+      }
+
+      // Add diff lines to current hunk
+      if (currentHunk && (line.startsWith('+') || line.startsWith('-') || line.startsWith(' '))) {
+        currentHunk.lines.push(line);
+      }
+    }
+
+    if (currentHunk) {
+      hunks.push(currentHunk);
+    }
+
+    return hunks;
   }
 
   async steer(_turn: PreparedChatTurn): Promise<boolean> {

--- a/src/providers/opencode/runtime/OpenCodeChatRuntime.ts
+++ b/src/providers/opencode/runtime/OpenCodeChatRuntime.ts
@@ -1,0 +1,431 @@
+import { spawn, type ChildProcess } from 'child_process';
+import { createInterface } from 'readline';
+
+import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
+import type { ProviderCapabilities, ProviderId } from '../../../core/providers/types';
+import type { ChatRuntime } from '../../../core/runtime/ChatRuntime';
+import type {
+  ApprovalCallback,
+  AskUserQuestionCallback,
+  AutoTurnResult,
+  ChatRewindResult,
+  ChatRuntimeConversationState,
+  ChatRuntimeEnsureReadyOptions,
+  ChatRuntimeQueryOptions,
+  ChatTurnMetadata,
+  ChatTurnRequest,
+  ExitPlanModeCallback,
+  PreparedChatTurn,
+  SessionUpdateResult,
+  SubagentRuntimeState,
+} from '../../../core/runtime/types';
+import type { ChatMessage, Conversation, SlashCommand, StreamChunk, ToolCallInfo } from '../../../core/types';
+import type ClaudianPlugin from '../../../main';
+import { getVaultPath } from '../../../utils/path';
+import { OPENCODE_PROVIDER_CAPABILITIES } from '../capabilities';
+import { encodeOpenCodeTurn } from '../prompt/encodeOpenCodeTurn';
+import { getOpenCodeProviderSettings } from '../settings';
+import { getOpenCodeState } from '../types';
+import { resolveOpenCodeCliPath } from './OpenCodeBinaryLocator';
+import { OpenCodeSessionManager } from './OpenCodeSessionManager';
+
+interface OpenCodeEvent {
+  type: string;
+  sessionID?: string;
+  part?: {
+    type: string;
+    text?: string;
+    name?: string;
+    input?: unknown;
+    output?: string;
+    error?: string;
+    reason?: string;
+  };
+}
+
+/**
+ * OpenCode ChatRuntime implementation.
+ * Uses `opencode run --format json` to send messages and stream responses.
+ */
+export class OpenCodeChatRuntime implements ChatRuntime {
+  readonly providerId: ProviderId = 'opencode';
+
+  private plugin: ClaudianPlugin;
+  private ready = false;
+  private readyListeners: Array<(ready: boolean) => void> = [];
+  private sessionManager = new OpenCodeSessionManager();
+  private turnMetadata: ChatTurnMetadata = {};
+
+  private currentProcess: ChildProcess | null = null;
+  private canceled = false;
+
+  private approvalCallback: ApprovalCallback | null = null;
+  private askUserCallback: AskUserQuestionCallback | null = null;
+  private exitPlanModeCallback: ExitPlanModeCallback | null = null;
+  private permissionModeSyncCallback: ((sdkMode: string) => void) | null = null;
+  private subagentHookProvider: (() => SubagentRuntimeState) | null = null;
+  private autoTurnCallback: ((result: AutoTurnResult) => void) | null = null;
+
+  constructor(plugin: ClaudianPlugin) {
+    this.plugin = plugin;
+  }
+
+  getCapabilities(): Readonly<ProviderCapabilities> {
+    return OPENCODE_PROVIDER_CAPABILITIES;
+  }
+
+  prepareTurn(request: ChatTurnRequest): PreparedChatTurn {
+    return encodeOpenCodeTurn(request);
+  }
+
+  onReadyStateChange(listener: (ready: boolean) => void): () => void {
+    this.readyListeners.push(listener);
+    return () => {
+      const idx = this.readyListeners.indexOf(listener);
+      if (idx !== -1) this.readyListeners.splice(idx, 1);
+    };
+  }
+
+  setResumeCheckpoint(_checkpointId: string | undefined): void {
+    // OpenCode doesn't support checkpoint-based resume yet
+  }
+
+  syncConversationState(
+    conversation: ChatRuntimeConversationState | null,
+    _externalContextPaths?: string[],
+  ): void {
+    if (!conversation) {
+      this.sessionManager.reset();
+      return;
+    }
+
+    const state = getOpenCodeState({ providerState: conversation.providerState } as Conversation);
+    if (state.threadId) {
+      this.sessionManager.setThread(state.threadId, state.sessionFilePath ?? undefined);
+    }
+  }
+
+  async reloadMcpServers(): Promise<void> {
+    // OpenCode manages its own MCP configuration
+  }
+
+  async ensureReady(_options?: ChatRuntimeEnsureReadyOptions): Promise<boolean> {
+    // Verify CLI is available
+    const settings = this.plugin.settings as unknown as Record<string, unknown>;
+    const openCodeSettings = getOpenCodeProviderSettings(settings);
+    const cliPath = resolveOpenCodeCliPath(openCodeSettings.customCliPath, '');
+    
+    if (!cliPath) {
+      throw new Error('OpenCode CLI not found. Please install OpenCode or configure the CLI path in settings.');
+    }
+
+    this.ready = true;
+    this.notifyReadyState(true);
+    return true;
+  }
+
+  async *query(
+    turn: PreparedChatTurn,
+    _conversationHistory?: ChatMessage[],
+    queryOptions?: ChatRuntimeQueryOptions,
+  ): AsyncGenerator<StreamChunk> {
+    await this.ensureReady();
+    
+    this.canceled = false;
+    const settings = this.plugin.settings as unknown as Record<string, unknown>;
+    const openCodeSettings = getOpenCodeProviderSettings(settings);
+    const cliPath = resolveOpenCodeCliPath(openCodeSettings.customCliPath, '');
+    
+    if (!cliPath) {
+      yield { type: 'error', content: 'OpenCode CLI not found' };
+      yield { type: 'done' };
+      return;
+    }
+
+    const model = this.resolveModel(queryOptions);
+    const vaultPath = getVaultPath(this.plugin.app) ?? process.cwd();
+    const sessionId = this.sessionManager.getThreadId();
+
+    // Build command arguments
+    // Replace newlines with spaces to avoid shell parsing issues on Windows
+    const message = turn.prompt.replace(/\r?\n/g, ' ');
+    const args = ['run', '--format', 'json', '-m', model];
+    
+    // Continue session if we have one
+    if (sessionId) {
+      args.push('-s', sessionId);
+    }
+    
+    // Add the message
+    args.push(message);
+
+    // Spawn the process
+    // On Windows, spawn may not properly pipe stdout with .cmd files,
+    // so wrap with cmd.exe for better compatibility.
+    const proc = spawn(
+      process.platform === 'win32' ? 'cmd.exe' : cliPath,
+      process.platform === 'win32' ? ['/c', cliPath, ...args] : args,
+      {
+        cwd: vaultPath,
+        env: { ...process.env },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }
+    );
+    this.currentProcess = proc;
+
+    const chunkBuffer: StreamChunk[] = [];
+    let resolveChunk: (() => void) | null = null;
+    let processEnded = false;
+
+    const enqueue = (chunk: StreamChunk): void => {
+      chunkBuffer.push(chunk);
+      if (resolveChunk) {
+        resolveChunk();
+        resolveChunk = null;
+      }
+    };
+
+    // Parse JSON events from stdout
+    if (!proc.stdout) {
+      yield { type: 'error', content: 'Failed to capture OpenCode output' };
+      yield { type: 'done' };
+      return;
+    }
+    
+    const rl = createInterface({ input: proc.stdout });
+    rl.on('line', (line) => {
+      if (this.canceled) {
+        return;
+      }
+      
+      let event: OpenCodeEvent;
+      try {
+        event = JSON.parse(line) as OpenCodeEvent;
+      } catch {
+        // Skip non-JSON lines
+        return;
+      }
+      
+      this.handleEvent(event, enqueue);
+    });
+
+    // Collect stderr for errors
+    let stderrOutput = '';
+    proc.stderr?.on('data', (data) => {
+      stderrOutput += data.toString();
+    });
+
+    // Handle process end
+    proc.on('close', (code) => {
+      processEnded = true;
+      if (code !== 0 && stderrOutput) {
+        enqueue({ type: 'error', content: stderrOutput.trim() });
+      }
+      enqueue({ type: 'done' });
+    });
+
+    proc.on('error', (err) => {
+      processEnded = true;
+      enqueue({ type: 'error', content: err.message });
+      enqueue({ type: 'done' });
+    });
+
+    // Yield chunks as they arrive
+    while (true) {
+      if (chunkBuffer.length > 0) {
+        const chunk = chunkBuffer.shift()!;
+        yield chunk;
+        if (chunk.type === 'done') {
+          break;
+        }
+      } else if (processEnded) {
+        yield { type: 'done' };
+        break;
+      } else {
+        await new Promise<void>((resolve) => {
+          resolveChunk = resolve;
+        });
+      }
+    }
+
+    this.currentProcess = null;
+  }
+
+  private handleEvent(event: OpenCodeEvent, enqueue: (chunk: StreamChunk) => void): void {
+    // Extract session ID for future continuation
+    if (event.sessionID && !this.sessionManager.getThreadId()) {
+      this.sessionManager.setThread(event.sessionID);
+    }
+
+    switch (event.type) {
+      case 'text':
+        if (event.part?.text) {
+          enqueue({ type: 'text', content: event.part.text });
+        }
+        break;
+
+      case 'tool_use':
+        if (event.part?.name) {
+          enqueue({
+            type: 'tool_use',
+            id: event.part.name,
+            name: event.part.name,
+            input: (event.part.input ?? {}) as Record<string, unknown>,
+          });
+        }
+        break;
+
+      case 'tool_result':
+        if (event.part?.output !== undefined) {
+          enqueue({
+            type: 'tool_result',
+            id: event.part.name ?? 'unknown',
+            content: event.part.output,
+          });
+        }
+        break;
+
+      case 'error':
+        if (event.part?.error) {
+          enqueue({ type: 'error', content: event.part.error });
+        }
+        break;
+
+      case 'step_finish':
+        // Turn completed
+        if (event.part?.reason === 'stop') {
+          this.turnMetadata.assistantMessageId = event.sessionID;
+        }
+        break;
+    }
+  }
+
+  async steer(_turn: PreparedChatTurn): Promise<boolean> {
+    return false;
+  }
+
+  cancel(): void {
+    console.log('[OpenCode] cancel() called', new Error().stack);
+    this.canceled = true;
+    if (this.currentProcess) {
+      this.currentProcess.kill('SIGTERM');
+      this.currentProcess = null;
+    }
+  }
+
+  resetSession(): void {
+    console.log('[OpenCode] resetSession() called', new Error().stack);
+    this.sessionManager.reset();
+    this.cancel();
+    this.ready = false;
+    this.notifyReadyState(false);
+  }
+
+  getSessionId(): string | null {
+    return this.sessionManager.getThreadId();
+  }
+
+  consumeSessionInvalidation(): boolean {
+    return this.sessionManager.consumeInvalidation();
+  }
+
+  isReady(): boolean {
+    return this.ready;
+  }
+
+  async getSupportedCommands(): Promise<SlashCommand[]> {
+    return [];
+  }
+
+  cleanup(): void {
+    this.resetSession();
+  }
+
+  async rewind(_userMessageId: string, _assistantMessageId: string): Promise<ChatRewindResult> {
+    return { canRewind: false, error: 'Rewind not supported by OpenCode provider' };
+  }
+
+  setApprovalCallback(callback: ApprovalCallback | null): void {
+    this.approvalCallback = callback;
+  }
+
+  setApprovalDismisser(_dismisser: (() => void) | null): void {
+    // Will be implemented with approval handling
+  }
+
+  setAskUserQuestionCallback(callback: AskUserQuestionCallback | null): void {
+    this.askUserCallback = callback;
+  }
+
+  setExitPlanModeCallback(callback: ExitPlanModeCallback | null): void {
+    this.exitPlanModeCallback = callback;
+  }
+
+  setPermissionModeSyncCallback(callback: ((sdkMode: string) => void) | null): void {
+    this.permissionModeSyncCallback = callback;
+  }
+
+  setSubagentHookProvider(getState: () => SubagentRuntimeState): void {
+    this.subagentHookProvider = getState;
+  }
+
+  setAutoTurnCallback(callback: ((result: AutoTurnResult) => void) | null): void {
+    this.autoTurnCallback = callback;
+  }
+
+  consumeTurnMetadata(): ChatTurnMetadata {
+    const metadata = this.turnMetadata;
+    this.turnMetadata = {};
+    return metadata;
+  }
+
+  buildSessionUpdates(params: {
+    conversation: Conversation | null;
+    sessionInvalidated: boolean;
+  }): SessionUpdateResult {
+    const threadId = this.sessionManager.getThreadId();
+    const sessionFilePath = this.sessionManager.getSessionFilePath();
+
+    const providerState: Record<string, unknown> = {
+      ...(params.conversation?.providerState as Record<string, unknown> | undefined),
+      threadId: threadId ?? undefined,
+      sessionFilePath: sessionFilePath ?? undefined,
+    };
+
+    return {
+      updates: {
+        sessionId: threadId ?? undefined,
+        providerState,
+      },
+    };
+  }
+
+  resolveSessionIdForFork(_conversation: Conversation | null): string | null {
+    return this.sessionManager.getThreadId();
+  }
+
+  async loadSubagentToolCalls(_agentId: string): Promise<ToolCallInfo[]> {
+    return [];
+  }
+
+  async loadSubagentFinalResult(_agentId: string): Promise<string | null> {
+    return null;
+  }
+
+  private notifyReadyState(ready: boolean): void {
+    for (const listener of this.readyListeners) {
+      listener(ready);
+    }
+  }
+
+  private resolveModel(queryOptions?: ChatRuntimeQueryOptions): string {
+    if (queryOptions?.model) {
+      return queryOptions.model;
+    }
+    const providerSettings = ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+      this.plugin.settings as unknown as Record<string, unknown>,
+      'opencode',
+    );
+    return (providerSettings.model as string) || 'github-copilot/claude-sonnet-4.5';
+  }
+}

--- a/src/providers/opencode/runtime/OpenCodeCliResolver.ts
+++ b/src/providers/opencode/runtime/OpenCodeCliResolver.ts
@@ -1,0 +1,36 @@
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import type { ProviderCliResolver } from '../../../core/providers/types';
+import { getOpenCodeProviderSettings } from '../settings';
+import { resolveOpenCodeCliPath } from './OpenCodeBinaryLocator';
+
+export class OpenCodeCliResolver implements ProviderCliResolver {
+  private resolvedPath: string | null = null;
+  private lastCustomPath = '';
+  private lastEnvText = '';
+
+  resolveFromSettings(settings: Record<string, unknown>): string | null {
+    const openCodeSettings = getOpenCodeProviderSettings(settings);
+    const customPath = openCodeSettings.customCliPath.trim();
+    const envText = getRuntimeEnvironmentText(settings, 'opencode');
+
+    if (
+      this.resolvedPath &&
+      customPath === this.lastCustomPath &&
+      envText === this.lastEnvText
+    ) {
+      return this.resolvedPath;
+    }
+
+    this.lastCustomPath = customPath;
+    this.lastEnvText = envText;
+
+    this.resolvedPath = resolveOpenCodeCliPath(customPath, envText);
+    return this.resolvedPath;
+  }
+
+  reset(): void {
+    this.resolvedPath = null;
+    this.lastCustomPath = '';
+    this.lastEnvText = '';
+  }
+}

--- a/src/providers/opencode/runtime/OpenCodeNotificationRouter.ts
+++ b/src/providers/opencode/runtime/OpenCodeNotificationRouter.ts
@@ -1,0 +1,437 @@
+import type { ChatTurnMetadata } from '../../../core/runtime/types';
+import type { StreamChunk, UsageInfo } from '../../../core/types';
+import type {
+  AgentMessageDeltaNotification,
+  AgentMessageItem,
+  CommandExecutionItem,
+  ContextCompactionItem,
+  ErrorNotification,
+  FileChangeItem,
+  ImageViewItem,
+  ItemCompletedNotification,
+  ItemStartedNotification,
+  McpToolCallItem,
+  PlanDeltaNotification,
+  ReasoningSummaryTextDeltaNotification,
+  ReasoningTextDeltaNotification,
+  TokenUsageUpdatedNotification,
+  TurnCompletedNotification,
+  TurnPlanUpdatedNotification,
+  UserInput,
+  UserMessageItem,
+  WebSearchItem,
+} from './openCodeAppServerTypes';
+
+type ChunkEmitter = (chunk: StreamChunk) => void;
+type TurnMetadataListener = (update: Partial<ChatTurnMetadata>) => void;
+
+/**
+ * Routes OpenCode server notifications to appropriate stream chunks.
+ * Adapted from CodexNotificationRouter for the OpenCode protocol.
+ */
+export class OpenCodeNotificationRouter {
+  private seenWebSearchIds = new Set<string>();
+  private planUpdateCounter = 0;
+  private isPlanTurn = false;
+  private sawPlanDelta = false;
+  private startedUserMessageIds = new Set<string>();
+  private startedAgentMessageIds = new Set<string>();
+  private agentMessageDeltaIds = new Set<string>();
+
+  constructor(
+    private readonly emit: ChunkEmitter,
+    private readonly onTurnMetadata?: TurnMetadataListener,
+  ) {}
+
+  beginTurn(params: { isPlanTurn: boolean }): void {
+    this.isPlanTurn = params.isPlanTurn;
+    this.sawPlanDelta = false;
+    this.startedUserMessageIds.clear();
+    this.startedAgentMessageIds.clear();
+    this.agentMessageDeltaIds.clear();
+  }
+
+  endTurn(): void {
+    this.isPlanTurn = false;
+    this.sawPlanDelta = false;
+    this.startedUserMessageIds.clear();
+    this.startedAgentMessageIds.clear();
+    this.agentMessageDeltaIds.clear();
+  }
+
+  handleNotification(method: string, params: unknown): void {
+    switch (method) {
+      case 'item/agentMessage/delta':
+        this.onAgentMessageDelta(params as AgentMessageDeltaNotification);
+        break;
+      case 'item/started':
+        this.onItemStarted(params as ItemStartedNotification);
+        break;
+      case 'item/completed':
+        this.onItemCompleted(params as ItemCompletedNotification);
+        break;
+      case 'item/reasoning/summaryTextDelta':
+        this.onReasoningSummaryDelta(params as ReasoningSummaryTextDeltaNotification);
+        break;
+      case 'item/reasoning/textDelta':
+        this.onReasoningTextDelta(params as ReasoningTextDeltaNotification);
+        break;
+      case 'item/reasoning/summaryPartAdded':
+        break;
+      case 'item/plan/delta':
+        this.onPlanDelta(params as PlanDeltaNotification);
+        break;
+      case 'item/commandExecution/outputDelta':
+      case 'item/fileChange/outputDelta':
+        this.onOutputDelta(params as { itemId: string; delta: string });
+        break;
+      case 'thread/tokenUsage/updated':
+        this.onTokenUsageUpdated(params as TokenUsageUpdatedNotification);
+        break;
+      case 'turn/plan/updated':
+        this.onPlanUpdated(params as TurnPlanUpdatedNotification);
+        break;
+      case 'turn/completed':
+        this.onTurnCompleted(params as TurnCompletedNotification);
+        break;
+      case 'error':
+        this.onError(params as ErrorNotification);
+        break;
+      default:
+        break;
+    }
+  }
+
+  private onAgentMessageDelta(params: AgentMessageDeltaNotification): void {
+    this.agentMessageDeltaIds.add(params.itemId);
+    this.emit({ type: 'text', content: params.delta });
+  }
+
+  private onReasoningSummaryDelta(params: ReasoningSummaryTextDeltaNotification): void {
+    this.emit({ type: 'thinking', content: params.delta });
+  }
+
+  private onReasoningTextDelta(params: ReasoningTextDeltaNotification): void {
+    this.emit({ type: 'thinking', content: params.delta });
+  }
+
+  private onPlanDelta(params: PlanDeltaNotification): void {
+    this.sawPlanDelta = true;
+    this.emit({ type: 'text', content: params.delta });
+  }
+
+  private onItemStarted(params: ItemStartedNotification): void {
+    const item = params.item;
+
+    switch (item.type) {
+      case 'userMessage':
+        this.emitUserMessageBoundary(item as UserMessageItem);
+        break;
+
+      case 'agentMessage':
+        this.emitAgentMessageBoundary(item as AgentMessageItem);
+        break;
+
+      case 'reasoning':
+        break;
+
+      case 'commandExecution':
+        this.emitToolUseFromCommand(item as CommandExecutionItem);
+        break;
+
+      case 'fileChange':
+        this.emitToolUseFromFileChange(item as FileChangeItem);
+        break;
+
+      case 'imageView':
+        this.emitToolUseFromImageView(item as ImageViewItem);
+        break;
+
+      case 'webSearch':
+        this.emitToolUseFromWebSearch(item as WebSearchItem);
+        break;
+
+      case 'mcpToolCall':
+        this.emitToolUseFromMcp(item as McpToolCallItem);
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  private onItemCompleted(params: ItemCompletedNotification): void {
+    const item = params.item;
+
+    switch (item.type) {
+      case 'userMessage':
+        if (!this.startedUserMessageIds.has(item.id)) {
+          this.emitUserMessageBoundary(item as UserMessageItem);
+        }
+        break;
+
+      case 'agentMessage':
+        this.completeAgentMessage(item as AgentMessageItem);
+        break;
+
+      case 'commandExecution':
+        this.emitToolResultFromCommand(item as CommandExecutionItem);
+        break;
+
+      case 'fileChange':
+        this.emitToolResultFromFileChange(item as FileChangeItem);
+        break;
+
+      case 'imageView':
+        this.emitToolResultFromImageView(item as ImageViewItem);
+        break;
+
+      case 'webSearch':
+        this.emitToolResultFromWebSearch(item as WebSearchItem);
+        break;
+
+      case 'mcpToolCall':
+        this.emitToolResultFromMcp(item as McpToolCallItem);
+        break;
+
+      case 'contextCompaction':
+        this.emitContextCompactionBoundary(item as ContextCompactionItem);
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  // -- commandExecution -------------------------------------------------------
+
+  private emitToolUseFromCommand(item: CommandExecutionItem): void {
+    const rawAction = item.commandActions?.[0]?.command ?? item.command;
+
+    this.emit({
+      type: 'tool_use',
+      id: item.id,
+      name: 'command_execution',
+      input: { command: rawAction },
+    });
+  }
+
+  private emitToolResultFromCommand(item: CommandExecutionItem): void {
+    const output = item.aggregatedOutput ?? '';
+    const isError = item.exitCode !== null && item.exitCode !== 0;
+
+    this.emit({ type: 'tool_result', id: item.id, content: output, isError });
+  }
+
+  // -- fileChange -------------------------------------------------------------
+
+  private emitToolUseFromFileChange(item: FileChangeItem): void {
+    this.emit({
+      type: 'tool_use',
+      id: item.id,
+      name: 'file_change',
+      input: { changes: item.changes ?? [] },
+    });
+  }
+
+  private emitToolResultFromFileChange(item: FileChangeItem): void {
+    const paths = (item.changes ?? []).map(c => c.path).join(', ');
+    this.emit({
+      type: 'tool_result',
+      id: item.id,
+      content: paths || 'File change completed',
+      isError: false,
+    });
+  }
+
+  // -- imageView --------------------------------------------------------------
+
+  private emitToolUseFromImageView(item: ImageViewItem): void {
+    this.emit({
+      type: 'tool_use',
+      id: item.id,
+      name: 'view_image',
+      input: { path: item.path },
+    });
+  }
+
+  private emitToolResultFromImageView(item: ImageViewItem): void {
+    this.emit({ type: 'tool_result', id: item.id, content: item.path, isError: false });
+  }
+
+  // -- webSearch --------------------------------------------------------------
+
+  private emitToolUseFromWebSearch(item: WebSearchItem): void {
+    if (this.seenWebSearchIds.has(item.id)) return;
+    this.seenWebSearchIds.add(item.id);
+
+    this.emit({
+      type: 'tool_use',
+      id: item.id,
+      name: 'WebSearch',
+      input: {
+        query: item.query ?? '',
+        queries: item.queries ?? [],
+        url: item.url ?? '',
+        pattern: item.pattern ?? '',
+        action: item.action ?? {},
+      },
+    });
+  }
+
+  private emitToolResultFromWebSearch(item: WebSearchItem): void {
+    this.emit({
+      type: 'tool_result',
+      id: item.id,
+      content: 'Search complete',
+      isError: item.status === 'failed' || item.status === 'error',
+    });
+  }
+
+  // -- mcpToolCall ------------------------------------------------------------
+
+  private emitToolUseFromMcp(item: McpToolCallItem): void {
+    this.emit({
+      type: 'tool_use',
+      id: item.id,
+      name: `mcp__${item.server}__${item.tool}`,
+      input: item.arguments ?? {},
+    });
+  }
+
+  private emitToolResultFromMcp(item: McpToolCallItem): void {
+    let content = '';
+    if (item.error) {
+      content = item.error;
+    } else if (item.result?.content) {
+      content = item.result.content
+        .map(c => c.text ?? '')
+        .filter(Boolean)
+        .join('\n');
+    }
+    if (!content) {
+      content = item.status === 'completed' ? 'Completed' : 'Failed';
+    }
+
+    this.emit({
+      type: 'tool_result',
+      id: item.id,
+      content,
+      isError: item.status === 'failed' || item.status === 'error',
+    });
+  }
+
+  private emitContextCompactionBoundary(_item: ContextCompactionItem): void {
+    this.emit({ type: 'context_compacted' });
+  }
+
+  private emitUserMessageBoundary(item: UserMessageItem): void {
+    if (this.startedUserMessageIds.has(item.id)) {
+      return;
+    }
+
+    this.startedUserMessageIds.add(item.id);
+    this.emit({
+      type: 'user_message_start',
+      itemId: item.id,
+      content: this.extractUserMessageText(item.content),
+    });
+  }
+
+  private emitAgentMessageBoundary(item: AgentMessageItem): void {
+    if (this.startedAgentMessageIds.has(item.id)) {
+      return;
+    }
+
+    this.startedAgentMessageIds.add(item.id);
+    this.emit({ type: 'assistant_message_start', itemId: item.id });
+  }
+
+  private completeAgentMessage(item: AgentMessageItem): void {
+    if (!this.startedAgentMessageIds.has(item.id)) {
+      this.emitAgentMessageBoundary(item);
+    }
+
+    if (this.agentMessageDeltaIds.has(item.id) || !item.text) {
+      return;
+    }
+
+    this.emit({ type: 'text', content: item.text });
+  }
+
+  private extractUserMessageText(content: UserInput[]): string {
+    return content
+      .map((part) => (part.type === 'text' ? part.text : ''))
+      .filter((text) => text.length > 0)
+      .join('\n\n');
+  }
+
+  // -- turn/plan/updated (update_plan) ----------------------------------------
+
+  private onPlanUpdated(params: TurnPlanUpdatedNotification): void {
+    this.planUpdateCounter += 1;
+    const syntheticId = `plan-update-${params.turnId ?? this.planUpdateCounter}`;
+    const PLAN_STATUS_MAP: Record<string, string> = {
+      inProgress: 'in_progress',
+      in_progress: 'in_progress',
+    };
+
+    const todos = params.plan.map(item => ({
+      id: '',
+      content: item.step,
+      activeForm: item.step,
+      status: PLAN_STATUS_MAP[item.status] ?? item.status,
+    }));
+
+    this.emit({ type: 'tool_use', id: syntheticId, name: 'TodoWrite', input: { todos } });
+    this.emit({ type: 'tool_result', id: syntheticId, content: 'Plan updated', isError: false });
+  }
+
+  // -- outputDelta (commandExecution + fileChange) ----------------------------
+
+  private onOutputDelta(params: { itemId: string; delta: string }): void {
+    this.emit({ type: 'tool_output', id: params.itemId, content: params.delta });
+  }
+
+  // -- tokenUsage / turnCompleted / error -------------------------------------
+
+  private onTokenUsageUpdated(params: TokenUsageUpdatedNotification): void {
+    const last = params.tokenUsage.last;
+    const contextTokens = last.inputTokens;
+    const contextWindow = params.tokenUsage.modelContextWindow;
+
+    const usage: UsageInfo = {
+      inputTokens: last.inputTokens,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: last.cachedInputTokens,
+      contextWindow,
+      contextWindowIsAuthoritative: contextWindow > 0,
+      contextTokens,
+      percentage: contextWindow > 0 ? Math.min(100, Math.max(0, Math.round((contextTokens / contextWindow) * 100))) : 0,
+    };
+
+    this.emit({ type: 'usage', usage, sessionId: params.threadId });
+  }
+
+  private onTurnCompleted(params: TurnCompletedNotification): void {
+    const turn = params.turn;
+
+    if (turn.status === 'failed' && turn.error) {
+      this.emit({ type: 'error', content: turn.error.message });
+    }
+
+    if (turn.status === 'completed') {
+      this.onTurnMetadata?.({
+        assistantMessageId: turn.id,
+        ...(this.isPlanTurn && this.sawPlanDelta ? { planCompleted: true } : {}),
+      });
+    }
+
+    this.emit({ type: 'done' });
+  }
+
+  private onError(params: ErrorNotification): void {
+    if (params.willRetry) return;
+    this.emit({ type: 'error', content: params.error.message });
+  }
+}

--- a/src/providers/opencode/runtime/OpenCodeRpcTransport.ts
+++ b/src/providers/opencode/runtime/OpenCodeRpcTransport.ts
@@ -1,0 +1,172 @@
+import { createInterface } from 'readline';
+
+import type { OpenCodeAppServerProcess } from './OpenCodeAppServerProcess';
+import type { JsonRpcError } from './openCodeAppServerTypes';
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+interface PendingRequest {
+  resolve: (result: unknown) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+type NotificationHandler = (params: unknown) => void;
+type ServerRequestHandler = (requestId: string | number, params: unknown) => Promise<unknown>;
+
+export class OpenCodeRpcTransport {
+  private nextId = 1;
+  private pending = new Map<number, PendingRequest>();
+  private notificationHandlers = new Map<string, NotificationHandler>();
+  private serverRequestHandlers = new Map<string, ServerRequestHandler>();
+  private disposed = false;
+
+  constructor(private readonly proc: OpenCodeAppServerProcess) {}
+
+  start(): void {
+    const rl = createInterface({ input: this.proc.stdout });
+    rl.on('line', (line) => this.handleLine(line));
+
+    this.proc.onExit(() => {
+      this.rejectAllPending(new Error('App-server process exited'));
+    });
+  }
+
+  request<T = unknown>(method: string, params: unknown, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<T> {
+    const id = this.nextId++;
+    const msg = { jsonrpc: '2.0' as const, id, method, params };
+
+    return new Promise<T>((resolve, reject) => {
+      const timer = timeoutMs > 0
+        ? setTimeout(() => {
+          this.pending.delete(id);
+          reject(new Error(`Request timeout: ${method} (${timeoutMs}ms)`));
+        }, timeoutMs)
+        : null;
+
+      this.pending.set(id, {
+        resolve: resolve as (result: unknown) => void,
+        reject,
+        timer,
+      });
+
+      this.sendRaw(msg);
+    });
+  }
+
+  notify(method: string, params?: unknown): void {
+    const msg: Record<string, unknown> = { jsonrpc: '2.0', method };
+    if (params !== undefined) msg.params = params;
+    this.sendRaw(msg);
+  }
+
+  onNotification(method: string, handler: NotificationHandler): () => void {
+    this.notificationHandlers.set(method, handler);
+    return () => {
+      if (this.notificationHandlers.get(method) === handler) {
+        this.notificationHandlers.delete(method);
+      }
+    };
+  }
+
+  onServerRequest(method: string, handler: ServerRequestHandler): void {
+    this.serverRequestHandlers.set(method, handler);
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.rejectAllPending(new Error('Transport disposed'));
+  }
+
+  // -------------------------------------------------------------------------
+  // Private
+  // -------------------------------------------------------------------------
+
+  private sendRaw(msg: unknown): void {
+    if (this.disposed) return;
+    this.proc.stdin.write(JSON.stringify(msg) + '\n');
+  }
+
+  private handleLine(line: string): void {
+    let msg: Record<string, unknown>;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      return; // malformed line
+    }
+
+    const id = msg.id as string | number | undefined;
+    const method = msg.method as string | undefined;
+
+    // Server response to our request
+    if (typeof id === 'number' && !method) {
+      this.handleResponse(id, msg);
+      return;
+    }
+
+    // Server notification (no id, has method)
+    if (method && id === undefined) {
+      this.handleNotification(method, msg.params);
+      return;
+    }
+
+    // Server-initiated request (has both id and method)
+    if (method && id !== undefined) {
+      this.handleServerRequest(id, method, msg.params);
+      return;
+    }
+  }
+
+  private handleResponse(id: number, msg: Record<string, unknown>): void {
+    const pending = this.pending.get(id);
+    if (!pending) return;
+
+    this.pending.delete(id);
+    if (pending.timer) clearTimeout(pending.timer);
+
+    if (msg.error) {
+      const err = msg.error as JsonRpcError;
+      pending.reject(new Error(err.message));
+    } else {
+      pending.resolve(msg.result);
+    }
+  }
+
+  private handleNotification(method: string, params: unknown): void {
+    const handler = this.notificationHandlers.get(method);
+    if (handler) handler(params);
+  }
+
+  private handleServerRequest(id: string | number, method: string, params: unknown): void {
+    const handler = this.serverRequestHandlers.get(method);
+    if (!handler) {
+      this.sendRaw({
+        jsonrpc: '2.0',
+        id,
+        error: { code: -32601, message: `Unhandled server request: ${method}` },
+      });
+      return;
+    }
+
+    handler(id, params).then(
+      (result) => {
+        this.sendRaw({ jsonrpc: '2.0', id, result });
+      },
+      (err) => {
+        this.sendRaw({
+          jsonrpc: '2.0',
+          id,
+          error: { code: -32603, message: err instanceof Error ? err.message : 'Internal error' },
+        });
+      },
+    );
+  }
+
+  private rejectAllPending(error: Error): void {
+    for (const [, pending] of this.pending) {
+      if (pending.timer) clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+}

--- a/src/providers/opencode/runtime/OpenCodeSessionManager.ts
+++ b/src/providers/opencode/runtime/OpenCodeSessionManager.ts
@@ -1,0 +1,42 @@
+/**
+ * Manages OpenCode session state (thread ID, session file path, invalidation).
+ */
+export class OpenCodeSessionManager {
+  private threadId: string | null = null;
+  private sessionFilePath: string | null = null;
+  private sessionInvalidated = false;
+
+  getThreadId(): string | null {
+    return this.threadId;
+  }
+
+  getSessionFilePath(): string | null {
+    return this.sessionFilePath;
+  }
+
+  setThread(threadId: string, sessionFilePath?: string): void {
+    const threadChanged = this.threadId !== threadId;
+    this.threadId = threadId;
+    if (sessionFilePath) {
+      this.sessionFilePath = sessionFilePath;
+    } else if (threadChanged) {
+      this.sessionFilePath = null;
+    }
+  }
+
+  reset(): void {
+    this.threadId = null;
+    this.sessionFilePath = null;
+    this.sessionInvalidated = false;
+  }
+
+  invalidateSession(): void {
+    this.sessionInvalidated = true;
+  }
+
+  consumeInvalidation(): boolean {
+    const was = this.sessionInvalidated;
+    this.sessionInvalidated = false;
+    return was;
+  }
+}

--- a/src/providers/opencode/runtime/openCodeAppServerSupport.ts
+++ b/src/providers/opencode/runtime/openCodeAppServerSupport.ts
@@ -1,0 +1,35 @@
+import { getRuntimeEnvironmentVariables } from '../../../core/providers/providerEnvironment';
+import type ClaudianPlugin from '../../../main';
+import { getVaultPath } from '../../../utils/path';
+import { getOpenCodeProviderSettings } from '../settings';
+import { resolveOpenCodeCliPath } from './OpenCodeBinaryLocator';
+import type { OpenCodeLaunchSpec } from './openCodeLaunchTypes';
+
+export function resolveOpenCodeAppServerLaunchSpec(
+  plugin: ClaudianPlugin,
+): OpenCodeLaunchSpec {
+  const settings = plugin.settings as unknown as Record<string, unknown>;
+  const openCodeSettings = getOpenCodeProviderSettings(settings);
+  const envVars = getRuntimeEnvironmentVariables(settings, 'opencode');
+
+  const cliPath = resolveOpenCodeCliPath(
+    openCodeSettings.customCliPath,
+    envVars.PATH ?? '',
+  );
+
+  if (!cliPath) {
+    throw new Error('OpenCode CLI not found. Please install OpenCode or configure the CLI path.');
+  }
+
+  const vaultPath = getVaultPath(plugin.app) ?? process.cwd();
+
+  return {
+    command: cliPath,
+    args: ['run', '--format', 'json'],
+    spawnCwd: vaultPath,
+    env: {
+      ...process.env,
+      ...envVars,
+    },
+  };
+}

--- a/src/providers/opencode/runtime/openCodeAppServerTypes.ts
+++ b/src/providers/opencode/runtime/openCodeAppServerTypes.ts
@@ -1,0 +1,689 @@
+// Local protocol subset for OpenCode app-server stdio JSON-RPC.
+// Field names match the wire format (camelCase).
+// Based on OpenCode protocol, adapted from Codex types.
+
+// ---------------------------------------------------------------------------
+// JSON-RPC base
+// ---------------------------------------------------------------------------
+
+export interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id: number;
+  method: string;
+  params?: unknown;
+}
+
+export interface JsonRpcNotification {
+  jsonrpc: '2.0';
+  method: string;
+  params?: unknown;
+}
+
+export interface JsonRpcResponse {
+  jsonrpc: '2.0';
+  id: number;
+  result?: unknown;
+  error?: JsonRpcError;
+}
+
+export interface JsonRpcError {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Initialize
+// ---------------------------------------------------------------------------
+
+export interface InitializeParams {
+  clientInfo: { name: string; version: string };
+  capabilities: { experimentalApi?: boolean };
+}
+
+export interface InitializeResult {
+  userAgent: string;
+  openCodeHome: string;
+  platformFamily: string;
+  platformOs: string;
+}
+
+// ---------------------------------------------------------------------------
+// Thread
+// ---------------------------------------------------------------------------
+
+export interface Thread {
+  id: string;
+  preview: string;
+  ephemeral: boolean;
+  path: string;
+  cwd: string;
+  cliVersion: string;
+  status: ThreadStatus;
+  turns: Turn[];
+  createdAt: number;
+  updatedAt: number;
+  name: string | null;
+  modelProvider: string;
+  source: string;
+  agentNickname: string | null;
+  agentRole: string | null;
+  gitInfo: GitInfo | null;
+}
+
+export interface ThreadStatus {
+  type: 'idle' | 'active' | 'systemError';
+  activeFlags?: string[];
+}
+
+export interface GitInfo {
+  sha: string;
+  branch: string;
+  originUrl: string;
+}
+
+export interface Turn {
+  id: string;
+  items: ThreadItem[];
+  status: 'inProgress' | 'completed' | 'failed' | 'interrupted';
+  error: TurnError | null;
+}
+
+export interface TurnError {
+  message: string;
+  errorInfo: string | Record<string, unknown>;
+  additionalDetails: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Thread items
+// ---------------------------------------------------------------------------
+
+export type ThreadItem =
+  | UserMessageItem
+  | AgentMessageItem
+  | PlanItem
+  | ReasoningItem
+  | CommandExecutionItem
+  | FileChangeItem
+  | ImageViewItem
+  | WebSearchItem
+  | McpToolCallItem
+  | ContextCompactionItem;
+
+export interface UserMessageItem {
+  type: 'userMessage';
+  id: string;
+  content: UserInput[];
+}
+
+export interface AgentMessageItem {
+  type: 'agentMessage';
+  id: string;
+  text: string;
+  phase: string;
+  memoryCitation: unknown | null;
+}
+
+export interface PlanItem {
+  type: 'plan';
+  id: string;
+  text: string;
+}
+
+export interface ReasoningItem {
+  type: 'reasoning';
+  id: string;
+  summary: string[];
+  content: string[];
+}
+
+export interface CommandExecutionItem {
+  type: 'commandExecution';
+  id: string;
+  command: string;
+  cwd: string;
+  processId: string;
+  source: string;
+  status: string;
+  commandActions: CommandAction[];
+  aggregatedOutput: string | null;
+  exitCode: number | null;
+  durationMs: number | null;
+}
+
+export interface CommandAction {
+  type: string;
+  command: string;
+}
+
+export interface FileChangeItem {
+  type: 'fileChange';
+  id: string;
+  changes: FileChangeEntry[];
+}
+
+export interface FileChangeEntry {
+  path: string;
+  type: string;
+}
+
+export interface ImageViewItem {
+  type: 'imageView';
+  id: string;
+  path: string;
+}
+
+export interface WebSearchItem {
+  type: 'webSearch';
+  id: string;
+  query?: string;
+  queries?: string[];
+  url?: string;
+  pattern?: string;
+  action?: {
+    type?: string;
+    query?: string;
+    queries?: string[];
+    url?: string;
+    pattern?: string;
+  };
+  status?: string;
+}
+
+export interface McpToolCallItem {
+  type: 'mcpToolCall';
+  id: string;
+  server: string;
+  tool: string;
+  status?: string;
+  arguments?: Record<string, unknown>;
+  result?: { content?: Array<{ type?: string; text?: string }> } | null;
+  error?: string | null;
+  durationMs?: number | null;
+}
+
+export interface ContextCompactionItem {
+  type: 'contextCompaction';
+  id: string;
+}
+
+// ---------------------------------------------------------------------------
+// User input
+// ---------------------------------------------------------------------------
+
+export interface TextInput {
+  type: 'text';
+  text: string;
+  text_elements?: unknown[];
+}
+
+export interface LocalImageInput {
+  type: 'localImage';
+  path: string;
+}
+
+export interface SkillInput {
+  type: 'skill';
+  name: string;
+  path: string;
+}
+
+export interface MentionInput {
+  type: 'mention';
+  name: string;
+  path: string;
+}
+
+export type UserInput = TextInput | LocalImageInput | SkillInput | MentionInput;
+
+// ---------------------------------------------------------------------------
+// skills/list
+// ---------------------------------------------------------------------------
+
+export type SkillScope = 'user' | 'repo' | 'system' | 'admin';
+
+export interface SkillInterface {
+  displayName?: string;
+  shortDescription?: string;
+}
+
+export interface SkillMetadata {
+  name: string;
+  description: string;
+  shortDescription?: string;
+  interface?: SkillInterface;
+  path: string;
+  scope: SkillScope;
+  enabled: boolean;
+}
+
+export interface SkillErrorInfo {
+  path: string;
+  message: string;
+}
+
+export interface SkillsListEntry {
+  cwd: string;
+  skills: SkillMetadata[];
+  errors: SkillErrorInfo[];
+}
+
+export interface SkillsListParams {
+  cwds?: string[];
+  forceReload?: boolean;
+  perCwdExtraUserRoots?: Array<{
+    cwd: string;
+    extraUserRoots: string[];
+  }> | null;
+}
+
+export interface SkillsListResult {
+  data: SkillsListEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// thread/start
+// ---------------------------------------------------------------------------
+
+export interface ThreadStartParams {
+  model: string;
+  cwd: string;
+  approvalPolicy: string;
+  sandbox: string;
+  serviceTier?: string | null;
+  baseInstructions?: string;
+  experimentalRawEvents?: boolean;
+  persistExtendedHistory?: boolean;
+  sandboxPolicy?: SandboxPolicy;
+}
+
+export interface ThreadStartResult {
+  thread: Thread;
+  model: string;
+  modelProvider: string;
+  serviceTier: string | null;
+  cwd: string;
+  approvalPolicy: string;
+  approvalsReviewer: string;
+  sandbox: SandboxPolicy;
+  reasoningEffort: string;
+}
+
+export type SandboxPolicy =
+  | { type: 'dangerFullAccess' }
+  | {
+    type: 'workspaceWrite';
+    writableRoots: string[];
+    readOnlyAccess: { type: string };
+    networkAccess: boolean;
+    excludeTmpdirEnvVar: boolean;
+    excludeSlashTmp: boolean;
+  }
+  | {
+    type: 'readOnly';
+    access: { type: string };
+    networkAccess: boolean;
+  }
+  | {
+    type: 'externalSandbox';
+    networkAccess: string;
+  };
+
+// ---------------------------------------------------------------------------
+// thread/resume
+// ---------------------------------------------------------------------------
+
+export interface ThreadResumeParams {
+  threadId: string;
+  model?: string;
+  approvalPolicy?: string;
+  sandbox?: string;
+  serviceTier?: string | null;
+  baseInstructions?: string;
+  persistExtendedHistory?: boolean;
+}
+
+export type ThreadResumeResult = ThreadStartResult;
+
+// ---------------------------------------------------------------------------
+// thread/fork
+// ---------------------------------------------------------------------------
+
+export interface ThreadForkParams {
+  threadId: string;
+}
+
+export type ThreadForkResult = ThreadStartResult;
+
+// ---------------------------------------------------------------------------
+// thread/rollback
+// ---------------------------------------------------------------------------
+
+export interface ThreadRollbackParams {
+  threadId: string;
+  numTurns: number;
+}
+
+export interface ThreadRollbackResult {
+  thread: Thread;
+}
+
+// ---------------------------------------------------------------------------
+// thread/compact/start
+// ---------------------------------------------------------------------------
+
+export interface ThreadCompactStartParams {
+  threadId: string;
+}
+
+export type ThreadCompactStartResult = Record<string, never>;
+
+// ---------------------------------------------------------------------------
+// turn/start
+// ---------------------------------------------------------------------------
+
+export interface CollaborationModeSettings {
+  model: string;
+  reasoning_effort: string | null;
+  developer_instructions: string | null;
+}
+
+export interface CollaborationMode {
+  mode: 'plan' | 'default';
+  settings: CollaborationModeSettings;
+}
+
+export interface TurnStartParams {
+  threadId: string;
+  input: UserInput[];
+  cwd?: string;
+  approvalPolicy?: string;
+  approvalsReviewer?: string;
+  model?: string;
+  serviceTier?: string | null;
+  effort?: string;
+  summary?: 'auto' | 'concise' | 'detailed' | 'none';
+  sandboxPolicy?: SandboxPolicy | null;
+  personality?: string;
+  outputSchema?: unknown;
+  collaborationMode?: CollaborationMode;
+}
+
+export interface TurnStartResult {
+  turn: Turn;
+}
+
+// ---------------------------------------------------------------------------
+// turn/steer
+// ---------------------------------------------------------------------------
+
+export interface TurnSteerParams {
+  threadId: string;
+  input: UserInput[];
+  expectedTurnId: string;
+}
+
+export interface TurnSteerResult {
+  turnId: string;
+}
+
+// ---------------------------------------------------------------------------
+// turn/interrupt
+// ---------------------------------------------------------------------------
+
+export interface TurnInterruptParams {
+  threadId: string;
+  turnId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Server notifications
+// ---------------------------------------------------------------------------
+
+export interface ThreadStartedNotification {
+  thread: Thread;
+}
+
+export interface ThreadStatusChangedNotification {
+  threadId: string;
+  status: ThreadStatus;
+}
+
+export interface TurnStartedNotification {
+  threadId: string;
+  turn: Turn;
+}
+
+export interface TurnCompletedNotification {
+  threadId: string;
+  turn: Turn;
+}
+
+export interface ItemStartedNotification {
+  item: ThreadItem;
+  threadId: string;
+  turnId: string;
+}
+
+export interface ItemCompletedNotification {
+  item: ThreadItem;
+  threadId: string;
+  turnId: string;
+}
+
+export interface AgentMessageDeltaNotification {
+  threadId: string;
+  turnId: string;
+  itemId: string;
+  delta: string;
+}
+
+export interface TokenUsage {
+  totalTokens: number;
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+  reasoningOutputTokens: number;
+}
+
+export interface TokenUsageUpdatedNotification {
+  threadId: string;
+  turnId: string;
+  tokenUsage: {
+    total: TokenUsage;
+    last: TokenUsage;
+    modelContextWindow: number;
+  };
+}
+
+export interface PlanStep {
+  step: string;
+  status: string;
+}
+
+export interface TurnPlanUpdatedNotification {
+  threadId: string;
+  turnId: string;
+  explanation: string | null;
+  plan: PlanStep[];
+}
+
+export interface ErrorNotification {
+  error: TurnError;
+  willRetry: boolean;
+  threadId: string;
+  turnId: string;
+}
+
+export interface ReasoningSummaryPartAddedNotification {
+  threadId: string;
+  turnId: string;
+  itemId: string;
+  summaryIndex: number;
+}
+
+export interface ReasoningSummaryTextDeltaNotification {
+  threadId: string;
+  turnId: string;
+  itemId: string;
+  summaryIndex: number;
+  delta: string;
+}
+
+export interface ReasoningTextDeltaNotification {
+  threadId: string;
+  turnId: string;
+  itemId: string;
+  contentIndex: number;
+  delta: string;
+}
+
+export interface PlanDeltaNotification {
+  threadId: string;
+  turnId: string;
+  itemId: string;
+  delta: string;
+}
+
+export type RequestId = string | number;
+
+export interface ServerRequestResolvedNotification {
+  threadId: string;
+  requestId: RequestId;
+}
+
+// Backward compatibility (deprecated, use StreamDeltaNotification name)
+export interface StreamDeltaNotification {
+  turnId: string;
+  delta: {
+    type: 'text' | 'tool_use' | 'tool_result' | 'thinking';
+    content?: string;
+    toolName?: string;
+    toolCallId?: string;
+    input?: unknown;
+    output?: string;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Server requests (require client response)
+// ---------------------------------------------------------------------------
+
+export interface CommandApprovalRequest {
+  threadId: string;
+  turnId: string;
+  itemId: string;
+  command: string | null;
+  cwd: string | null;
+  reason?: string | null;
+  commandActions?: CommandAction[] | null;
+  approvalId?: string | null;
+  networkApprovalContext?: {
+    host: string;
+    protocol: string;
+  } | null;
+  additionalPermissions?: AdditionalPermissionProfile | null;
+  skillMetadata?: { pathToSkillsMd: string } | null;
+  proposedExecpolicyAmendment?: string[] | null;
+  proposedNetworkPolicyAmendments?: Array<{
+    host: string;
+    action: 'allow' | 'deny';
+  }> | null;
+  availableDecisions?: CommandExecutionApprovalDecision[] | null;
+}
+
+export type CommandExecutionApprovalDecision =
+  | 'accept'
+  | 'acceptForSession'
+  | { acceptWithExecpolicyAmendment: { execpolicy_amendment: string[] } }
+  | { applyNetworkPolicyAmendment: { network_policy_amendment: { host: string; action: 'allow' | 'deny' } } }
+  | 'decline'
+  | 'cancel';
+
+export interface CommandExecutionApprovalResponse {
+  decision: CommandExecutionApprovalDecision;
+}
+
+export interface FileChangeApprovalRequest {
+  threadId: string;
+  turnId: string;
+  itemId: string;
+  reason?: string | null;
+  grantRoot?: string | null;
+}
+
+export type FileChangeApprovalDecision =
+  | 'accept'
+  | 'acceptForSession'
+  | 'decline'
+  | 'cancel';
+
+export interface FileChangeApprovalResponse {
+  decision: FileChangeApprovalDecision;
+}
+
+export interface AdditionalFileSystemPermissions {
+  read?: string[] | null;
+  write?: string[] | null;
+}
+
+export interface AdditionalNetworkPermissions {
+  enabled?: boolean | null;
+}
+
+export interface AdditionalPermissionProfile {
+  fileSystem?: AdditionalFileSystemPermissions | null;
+  network?: AdditionalNetworkPermissions | null;
+  macos?: Record<string, unknown> | null;
+}
+
+export interface RequestPermissionProfile {
+  fileSystem?: AdditionalFileSystemPermissions | null;
+  network?: AdditionalNetworkPermissions | null;
+}
+
+export interface GrantedPermissionProfile {
+  fileSystem?: AdditionalFileSystemPermissions | null;
+  network?: AdditionalNetworkPermissions | null;
+}
+
+export type PermissionGrantScope = 'turn' | 'session';
+
+export interface PermissionsApprovalRequest {
+  threadId: string;
+  turnId: string;
+  itemId: string;
+  permissions: RequestPermissionProfile;
+  reason?: string | null;
+}
+
+export interface PermissionsApprovalResponse {
+  permissions: GrantedPermissionProfile;
+  scope?: PermissionGrantScope;
+}
+
+export interface UserInputQuestionOption {
+  label: string;
+  description: string;
+}
+
+export interface UserInputQuestion {
+  id: string;
+  header: string;
+  question: string;
+  options: UserInputQuestionOption[] | null;
+  isOther: boolean;
+  isSecret: boolean;
+}
+
+export interface UserInputRequest {
+  threadId: string;
+  turnId: string;
+  itemId: string;
+  questions: UserInputQuestion[];
+}
+
+export interface UserInputResponse {
+  answers: Record<string, { answers: string[] }>;
+}

--- a/src/providers/opencode/runtime/openCodeLaunchTypes.ts
+++ b/src/providers/opencode/runtime/openCodeLaunchTypes.ts
@@ -1,0 +1,6 @@
+export interface OpenCodeLaunchSpec {
+  command: string;
+  args: string[];
+  spawnCwd: string;
+  env: NodeJS.ProcessEnv;
+}

--- a/src/providers/opencode/settings.ts
+++ b/src/providers/opencode/settings.ts
@@ -1,0 +1,50 @@
+export interface OpenCodeProviderSettings {
+  enabled: boolean;
+  model: string;
+  customCliPath: string;
+  safeMode: OpenCodeSafeMode;
+}
+
+export type OpenCodeSafeMode = 'workspace-write' | 'workspace-read' | 'none';
+
+export const DEFAULT_OPENCODE_PROVIDER_SETTINGS: OpenCodeProviderSettings = {
+  enabled: false,
+  model: '',
+  customCliPath: '',
+  safeMode: 'workspace-write',
+};
+
+export function getOpenCodeProviderSettings(settings: Record<string, unknown>): OpenCodeProviderSettings {
+  const providerConfigs = settings.providerConfigs as Record<string, unknown> | undefined;
+  const opencode = providerConfigs?.opencode as Partial<OpenCodeProviderSettings> | undefined;
+  return {
+    enabled: opencode?.enabled ?? DEFAULT_OPENCODE_PROVIDER_SETTINGS.enabled,
+    model: opencode?.model ?? DEFAULT_OPENCODE_PROVIDER_SETTINGS.model,
+    customCliPath: opencode?.customCliPath ?? DEFAULT_OPENCODE_PROVIDER_SETTINGS.customCliPath,
+    safeMode: opencode?.safeMode ?? DEFAULT_OPENCODE_PROVIDER_SETTINGS.safeMode,
+  };
+}
+
+export function setOpenCodeProviderSettings(
+  settings: Record<string, unknown>,
+  updates: Partial<OpenCodeProviderSettings>,
+): void {
+  const current = getOpenCodeProviderSettings(settings);
+  const providerConfigs = (settings.providerConfigs ?? {}) as Record<string, unknown>;
+  providerConfigs.opencode = { ...current, ...updates };
+  settings.providerConfigs = providerConfigs;
+}
+
+export function updateOpenCodeProviderSettings(
+  settings: Record<string, unknown>,
+  updates: Partial<OpenCodeProviderSettings>,
+): OpenCodeProviderSettings {
+  const next = {
+    ...getOpenCodeProviderSettings(settings),
+    ...updates,
+  };
+  const providerConfigs = (settings.providerConfigs ?? {}) as Record<string, unknown>;
+  providerConfigs.opencode = next;
+  settings.providerConfigs = providerConfigs;
+  return next;
+}

--- a/src/providers/opencode/skills/OpenCodeSkillListingService.ts
+++ b/src/providers/opencode/skills/OpenCodeSkillListingService.ts
@@ -1,0 +1,142 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import type { SlashCommand } from '../../../core/types';
+
+export interface OpenCodeSkillMetadata {
+  name: string;
+  description?: string;
+  path: string;
+  scope: 'repo' | 'user';
+}
+
+export interface OpenCodeSkillListProvider {
+  listSkills(options?: { forceReload?: boolean }): Promise<OpenCodeSkillMetadata[]>;
+  invalidate(): void;
+}
+
+const OPENCODE_SKILL_DIRS = [
+  '.opencode/skills',
+  '.agents/skills',
+];
+
+export function extractExplicitOpenCodeSkillNames(text: string): string[] {
+  const matches = text.matchAll(/(^|\s)\$([A-Za-z0-9_-]+)/g);
+  const names: string[] = [];
+  const seen = new Set<string>();
+
+  for (const match of matches) {
+    const name = match[2];
+    if (!name) continue;
+
+    const normalized = name.toLowerCase();
+    if (seen.has(normalized)) continue;
+
+    seen.add(normalized);
+    names.push(name);
+  }
+
+  return names;
+}
+
+export function findPreferredOpenCodeSkillByName(
+  skills: OpenCodeSkillMetadata[],
+  name: string,
+): OpenCodeSkillMetadata | undefined {
+  const normalizedName = name.toLowerCase();
+  return skills.find(skill => skill.name.toLowerCase() === normalizedName);
+}
+
+export class OpenCodeSkillListingService implements OpenCodeSkillListProvider {
+  private cachedSkills: OpenCodeSkillMetadata[] | null = null;
+  private cacheTimestamp = 0;
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+
+  constructor(
+    private readonly vaultPath: string | null,
+    options: { ttlMs?: number; now?: () => number } = {},
+  ) {
+    this.ttlMs = options.ttlMs ?? 5_000;
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  async listSkills(options?: { forceReload?: boolean }): Promise<OpenCodeSkillMetadata[]> {
+    const currentTime = this.now();
+
+    if (
+      !options?.forceReload
+      && this.cachedSkills
+      && currentTime - this.cacheTimestamp < this.ttlMs
+    ) {
+      return this.cachedSkills;
+    }
+
+    this.cachedSkills = await this.discoverSkills();
+    this.cacheTimestamp = currentTime;
+    return this.cachedSkills;
+  }
+
+  invalidate(): void {
+    this.cachedSkills = null;
+    this.cacheTimestamp = 0;
+  }
+
+  private async discoverSkills(): Promise<OpenCodeSkillMetadata[]> {
+    const skills: OpenCodeSkillMetadata[] = [];
+
+    if (!this.vaultPath) return skills;
+
+    for (const skillDir of OPENCODE_SKILL_DIRS) {
+      const fullPath = path.join(this.vaultPath, skillDir);
+
+      try {
+        if (!fs.existsSync(fullPath)) continue;
+
+        const entries = fs.readdirSync(fullPath, { withFileTypes: true });
+        for (const entry of entries) {
+          if (!entry.isDirectory()) continue;
+
+          const skillMdPath = path.join(fullPath, entry.name, 'SKILL.md');
+          if (!fs.existsSync(skillMdPath)) continue;
+
+          const content = fs.readFileSync(skillMdPath, 'utf-8');
+          const description = this.extractDescription(content);
+
+          skills.push({
+            name: entry.name,
+            description,
+            path: skillMdPath,
+            scope: 'repo',
+          });
+        }
+      } catch {
+        // Ignore errors reading skill directories
+      }
+    }
+
+    return skills;
+  }
+
+  private extractDescription(content: string): string | undefined {
+    const lines = content.split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed && !trimmed.startsWith('#')) {
+        return trimmed.slice(0, 100);
+      }
+    }
+    return undefined;
+  }
+}
+
+export function openCodeSkillToSlashCommand(skill: OpenCodeSkillMetadata): SlashCommand {
+  return {
+    id: skill.name,
+    name: skill.name,
+    description: skill.description ?? '',
+    content: '',
+    source: 'user',
+    kind: 'skill',
+  };
+}

--- a/src/providers/opencode/storage/OpenCodeSkillStorage.ts
+++ b/src/providers/opencode/storage/OpenCodeSkillStorage.ts
@@ -1,0 +1,250 @@
+import * as path from 'path';
+
+import type { VaultFileAdapter } from '../../../core/storage/VaultFileAdapter';
+import { parseSlashCommandContent, serializeSlashCommandMarkdown } from '../../../utils/slashCommand';
+
+export const OPENCODE_VAULT_SKILLS_PATH = '.opencode/skills';
+export const AGENTS_VAULT_SKILLS_PATH = '.agents/skills';
+
+export type OpenCodeSkillRootId = 'vault-opencode' | 'vault-agents';
+
+export const OPENCODE_SKILL_ROOT_OPTIONS = [
+  { id: 'vault-opencode' as const, label: OPENCODE_VAULT_SKILLS_PATH },
+  { id: 'vault-agents' as const, label: AGENTS_VAULT_SKILLS_PATH },
+];
+
+const ROOT_PATH_BY_ID: Record<OpenCodeSkillRootId, string> = {
+  'vault-opencode': OPENCODE_VAULT_SKILLS_PATH,
+  'vault-agents': AGENTS_VAULT_SKILLS_PATH,
+};
+
+const ROOT_ID_BY_PATH = new Map<string, OpenCodeSkillRootId>(
+  Object.entries(ROOT_PATH_BY_ID).map(([rootId, rootPath]) => [rootPath, rootId as OpenCodeSkillRootId]),
+);
+
+const ALL_SCAN_ROOTS: OpenCodeSkillRootId[] = ['vault-opencode', 'vault-agents'];
+const SKILL_PERSISTENCE_PREFIX = 'opencode-skill';
+
+export type OpenCodeSkillStorageAdapter = Pick<
+  VaultFileAdapter,
+  'read' | 'write' | 'delete' | 'deleteFolder' | 'listFolders' | 'ensureFolder'
+>;
+
+export interface OpenCodeSkillEntry {
+  name: string;
+  description?: string;
+  content: string;
+  provenance: 'vault' | 'home';
+  rootId: OpenCodeSkillRootId;
+}
+
+export interface OpenCodeSkillLocation {
+  name: string;
+  rootId: OpenCodeSkillRootId;
+}
+
+export interface OpenCodeSkillSaveInput {
+  name: string;
+  description?: string;
+  content: string;
+  rootId?: OpenCodeSkillRootId;
+  previousLocation?: OpenCodeSkillLocation;
+}
+
+export interface OpenCodeSkillPersistenceState {
+  rootId: OpenCodeSkillRootId;
+  currentName?: string;
+}
+
+export function createOpenCodeSkillPersistenceKey(
+  state: OpenCodeSkillPersistenceState,
+): string {
+  const parts = [SKILL_PERSISTENCE_PREFIX, state.rootId];
+  if (state.currentName) {
+    parts.push(encodeURIComponent(state.currentName));
+  }
+  return parts.join(':');
+}
+
+export function parseOpenCodeSkillPersistenceKey(
+  persistenceKey?: string,
+): OpenCodeSkillPersistenceState | null {
+  if (!persistenceKey) {
+    return null;
+  }
+
+  const legacyRootId = ROOT_ID_BY_PATH.get(persistenceKey);
+  if (legacyRootId) {
+    return { rootId: legacyRootId };
+  }
+
+  const [prefix, rootId, encodedName] = persistenceKey.split(':');
+  if (prefix !== SKILL_PERSISTENCE_PREFIX) {
+    return null;
+  }
+  if (rootId !== 'vault-opencode' && rootId !== 'vault-agents') {
+    return null;
+  }
+
+  return {
+    rootId,
+    ...(encodedName ? { currentName: decodeURIComponent(encodedName) } : {}),
+  };
+}
+
+export function resolveOpenCodeSkillLocationFromPath(
+  skillPath: string,
+  vaultPath: string,
+): OpenCodeSkillLocation | null {
+  const usesWindowsPathSemantics = (
+    /^[A-Za-z]:[\\/]/.test(skillPath)
+    || /^[A-Za-z]:[\\/]/.test(vaultPath)
+    || skillPath.startsWith('\\\\')
+    || vaultPath.startsWith('\\\\')
+  );
+  const pathApi = usesWindowsPathSemantics ? path.win32 : path.posix;
+  const normalizedSkillPath = pathApi.normalize(skillPath);
+  const normalizedVaultPath = pathApi.normalize(vaultPath);
+
+  for (const [rootId, rootPath] of Object.entries(ROOT_PATH_BY_ID) as Array<[OpenCodeSkillRootId, string]>) {
+    const rootDir = pathApi.normalize(pathApi.join(normalizedVaultPath, rootPath));
+    const relative = pathApi.relative(rootDir, normalizedSkillPath);
+
+    if (
+      !relative
+      || relative.startsWith(`..${pathApi.sep}`)
+      || relative === '..'
+    ) {
+      continue;
+    }
+
+    const parts = relative.split(pathApi.sep);
+    if (parts.length !== 2 || parts[1] !== 'SKILL.md' || !parts[0]) {
+      continue;
+    }
+
+    return {
+      name: parts[0],
+      rootId,
+    };
+  }
+
+  return null;
+}
+
+export class OpenCodeSkillStorage {
+  constructor(
+    private vaultAdapter: OpenCodeSkillStorageAdapter,
+    private homeAdapter?: OpenCodeSkillStorageAdapter,
+  ) {}
+
+  async scanAll(): Promise<OpenCodeSkillEntry[]> {
+    const vaultSkills = await this.scanRoots(this.vaultAdapter, ALL_SCAN_ROOTS, 'vault');
+    const homeSkills = this.homeAdapter
+      ? await this.scanRoots(this.homeAdapter, ALL_SCAN_ROOTS, 'home')
+      : [];
+
+    // Deduplicate: vault takes priority over home
+    const seen = new Set(vaultSkills.map(s => s.name.toLowerCase()));
+    const deduped = homeSkills.filter(s => !seen.has(s.name.toLowerCase()));
+
+    return [...vaultSkills, ...deduped];
+  }
+
+  async scanVault(): Promise<OpenCodeSkillEntry[]> {
+    return this.scanRoots(this.vaultAdapter, ALL_SCAN_ROOTS, 'vault');
+  }
+
+  async save(input: OpenCodeSkillSaveInput): Promise<void> {
+    const targetRootId = input.rootId ?? 'vault-opencode';
+    const targetLocation = { rootId: targetRootId, name: input.name };
+    const { dirPath, filePath } = this.buildLocationPaths(targetLocation);
+    const previousLocation = input.previousLocation;
+
+    await this.vaultAdapter.ensureFolder(dirPath);
+    const markdown = serializeSlashCommandMarkdown(
+      { name: input.name, description: input.description },
+      input.content,
+    );
+    await this.vaultAdapter.write(filePath, markdown);
+
+    if (
+      previousLocation
+      && (previousLocation.rootId !== targetRootId || previousLocation.name !== input.name)
+    ) {
+      await this.delete(previousLocation);
+    }
+  }
+
+  async delete(location: OpenCodeSkillLocation): Promise<void> {
+    const { dirPath, filePath } = this.buildLocationPaths(location);
+    await this.vaultAdapter.delete(filePath);
+    await this.vaultAdapter.deleteFolder(dirPath);
+  }
+
+  async load(location: OpenCodeSkillLocation): Promise<OpenCodeSkillEntry | null> {
+    const { filePath } = this.buildLocationPaths(location);
+
+    try {
+      const content = await this.vaultAdapter.read(filePath);
+      const parsed = parseSlashCommandContent(content);
+
+      return {
+        name: location.name,
+        description: parsed.description,
+        content: parsed.promptContent,
+        provenance: 'vault',
+        rootId: location.rootId,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private async scanRoots(
+    adapter: OpenCodeSkillStorageAdapter,
+    roots: OpenCodeSkillRootId[],
+    provenance: 'vault' | 'home',
+  ): Promise<OpenCodeSkillEntry[]> {
+    const results: OpenCodeSkillEntry[] = [];
+
+    for (const rootId of roots) {
+      const rootPath = ROOT_PATH_BY_ID[rootId];
+      try {
+        const folders = await adapter.listFolders(rootPath);
+        for (const folder of folders) {
+          const skillName = folder.split('/').pop()!;
+          const skillPath = `${rootPath}/${skillName}/SKILL.md`;
+
+          try {
+            const content = await adapter.read(skillPath);
+            const parsed = parseSlashCommandContent(content);
+
+            results.push({
+              name: skillName,
+              description: parsed.description,
+              content: parsed.promptContent,
+              provenance,
+              rootId,
+            });
+          } catch {
+            // Skip malformed files
+          }
+        }
+      } catch {
+        // Root doesn't exist or can't be read
+      }
+    }
+
+    return results;
+  }
+
+  private buildLocationPaths(location: OpenCodeSkillLocation): { dirPath: string; filePath: string } {
+    const rootPath = ROOT_PATH_BY_ID[location.rootId];
+    const dirPath = `${rootPath}/${location.name}`;
+    return {
+      dirPath,
+      filePath: `${dirPath}/SKILL.md`,
+    };
+  }
+}

--- a/src/providers/opencode/storage/OpenCodeSubagentStorage.ts
+++ b/src/providers/opencode/storage/OpenCodeSubagentStorage.ts
@@ -1,0 +1,212 @@
+import { parse as parseToml, stringify as stringifyToml } from 'smol-toml';
+
+import type { VaultFileAdapter } from '../../../core/storage/VaultFileAdapter';
+import {
+  OPENCODE_SUBAGENT_KNOWN_KEYS,
+  type OpenCodeSubagentDefinition,
+} from '../types/subagent';
+
+export const OPENCODE_AGENTS_PATH = '.opencode/agents';
+const SUBAGENT_PERSISTENCE_PREFIX = 'opencode-subagent';
+
+export interface OpenCodeSubagentLocation {
+  fileName: string;
+}
+
+export function createOpenCodeSubagentPersistenceKey(
+  location: OpenCodeSubagentLocation,
+): string {
+  return `${SUBAGENT_PERSISTENCE_PREFIX}:${encodeURIComponent(location.fileName)}`;
+}
+
+export function parseOpenCodeSubagentPersistenceKey(
+  persistenceKey?: string,
+): OpenCodeSubagentLocation | null {
+  if (!persistenceKey) {
+    return null;
+  }
+
+  if (persistenceKey.startsWith(`${OPENCODE_AGENTS_PATH}/`) && persistenceKey.endsWith('.toml')) {
+    return { fileName: persistenceKey.slice(OPENCODE_AGENTS_PATH.length + 1) };
+  }
+
+  const [prefix, encodedFileName] = persistenceKey.split(':');
+  if (prefix !== SUBAGENT_PERSISTENCE_PREFIX || !encodedFileName) {
+    return null;
+  }
+
+  const fileName = decodeURIComponent(encodedFileName);
+  return fileName.endsWith('.toml') ? { fileName } : null;
+}
+
+export class OpenCodeSubagentStorage {
+  constructor(
+    private vaultAdapter: Pick<VaultFileAdapter, 'exists' | 'read' | 'write' | 'delete' | 'listFiles' | 'ensureFolder'>,
+  ) {}
+
+  async loadAll(): Promise<OpenCodeSubagentDefinition[]> {
+    return this.scanAdapter(this.vaultAdapter);
+  }
+
+  async load(agent: OpenCodeSubagentDefinition): Promise<OpenCodeSubagentDefinition | null> {
+    const filePath = this.resolveCurrentPath(agent);
+    try {
+      if (!(await this.vaultAdapter.exists(filePath))) return null;
+      const content = await this.vaultAdapter.read(filePath);
+      return parseSubagentToml(content, filePath);
+    } catch {
+      return null;
+    }
+  }
+
+  async save(agent: OpenCodeSubagentDefinition, previous?: OpenCodeSubagentDefinition | null): Promise<void> {
+    const filePath = this.resolveTargetPath(agent, previous);
+    const previousPath = previous ? this.resolveCurrentPath(previous) : null;
+    await this.vaultAdapter.ensureFolder(OPENCODE_AGENTS_PATH);
+    const content = serializeSubagentToml(agent);
+    await this.vaultAdapter.write(filePath, content);
+
+    if (previousPath && previousPath !== filePath) {
+      await this.vaultAdapter.delete(previousPath);
+    }
+  }
+
+  async delete(agent: OpenCodeSubagentDefinition): Promise<void> {
+    const filePath = this.resolveCurrentPath(agent);
+    await this.vaultAdapter.delete(filePath);
+  }
+
+  private resolveCurrentPath(agent: OpenCodeSubagentDefinition): string {
+    const persistedLocation = parseOpenCodeSubagentPersistenceKey(agent.persistenceKey);
+    if (persistedLocation) {
+      return `${OPENCODE_AGENTS_PATH}/${persistedLocation.fileName}`;
+    }
+
+    return `${OPENCODE_AGENTS_PATH}/${agent.name}.toml`;
+  }
+
+  private resolveTargetPath(
+    agent: OpenCodeSubagentDefinition,
+    previous?: OpenCodeSubagentDefinition | null,
+  ): string {
+    if (previous && previous.name === agent.name) {
+      return this.resolveCurrentPath(previous);
+    }
+
+    return `${OPENCODE_AGENTS_PATH}/${agent.name}.toml`;
+  }
+
+  private async scanAdapter(
+    adapter: Pick<VaultFileAdapter, 'read' | 'listFiles'>,
+  ): Promise<OpenCodeSubagentDefinition[]> {
+    const results: OpenCodeSubagentDefinition[] = [];
+
+    try {
+      const files = await adapter.listFiles(OPENCODE_AGENTS_PATH);
+      for (const filePath of files) {
+        if (!filePath.endsWith('.toml')) continue;
+        try {
+          const content = await adapter.read(filePath);
+          const agent = parseSubagentToml(content, filePath);
+          if (agent) results.push(agent);
+        } catch {
+          // Skip malformed files
+        }
+      }
+    } catch {
+      // Directory doesn't exist yet
+    }
+
+    return results;
+  }
+}
+
+export function parseSubagentToml(
+  content: string,
+  filePath: string,
+): OpenCodeSubagentDefinition | null {
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = parseToml(content) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  const name = typeof parsed.name === 'string' ? parsed.name : undefined;
+  const description =
+    typeof parsed.description === 'string' ? parsed.description : undefined;
+  const developerInstructions =
+    typeof parsed.developer_instructions === 'string'
+      ? parsed.developer_instructions
+      : undefined;
+
+  if (!name || !description || !developerInstructions) return null;
+
+  const result: OpenCodeSubagentDefinition = {
+    name,
+    description,
+    developerInstructions,
+    persistenceKey: createOpenCodeSubagentPersistenceKey({
+      fileName: filePath.startsWith(`${OPENCODE_AGENTS_PATH}/`)
+        ? filePath.slice(OPENCODE_AGENTS_PATH.length + 1)
+        : filePath.split('/').pop() ?? filePath,
+    }),
+  };
+
+  if (typeof parsed.model === 'string') {
+    result.model = parsed.model;
+  }
+  if (typeof parsed.model_reasoning_effort === 'string') {
+    result.modelReasoningEffort = parsed.model_reasoning_effort;
+  }
+  if (typeof parsed.sandbox_mode === 'string') {
+    result.sandboxMode = parsed.sandbox_mode;
+  }
+  if (Array.isArray(parsed.nickname_candidates)) {
+    const candidates = parsed.nickname_candidates.filter(
+      (v): v is string => typeof v === 'string',
+    );
+    if (candidates.length > 0) result.nicknameCandidates = candidates;
+  }
+
+  const extraFields: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    if (!OPENCODE_SUBAGENT_KNOWN_KEYS.has(key)) {
+      extraFields[key] = value;
+    }
+  }
+  if (Object.keys(extraFields).length > 0) {
+    result.extraFields = extraFields;
+  }
+
+  return result;
+}
+
+export function serializeSubagentToml(agent: OpenCodeSubagentDefinition): string {
+  const doc: Record<string, unknown> = {
+    name: agent.name,
+    description: agent.description,
+    developer_instructions: agent.developerInstructions,
+  };
+
+  if (agent.nicknameCandidates && agent.nicknameCandidates.length > 0) {
+    doc.nickname_candidates = agent.nicknameCandidates;
+  }
+  if (agent.model) {
+    doc.model = agent.model;
+  }
+  if (agent.modelReasoningEffort) {
+    doc.model_reasoning_effort = agent.modelReasoningEffort;
+  }
+  if (agent.sandboxMode) {
+    doc.sandbox_mode = agent.sandboxMode;
+  }
+
+  if (agent.extraFields) {
+    for (const [key, value] of Object.entries(agent.extraFields)) {
+      doc[key] = value;
+    }
+  }
+
+  return stringifyToml(doc);
+}

--- a/src/providers/opencode/types/index.ts
+++ b/src/providers/opencode/types/index.ts
@@ -1,0 +1,29 @@
+import type { Conversation } from '../../../core/types';
+
+export interface OpenCodeProviderState {
+  threadId?: string;
+  sessionFilePath?: string;
+  forkSource?: OpenCodeForkSource;
+}
+
+export interface OpenCodeForkSource {
+  sourceThreadId: string;
+  resumeAtMessageId: string;
+}
+
+export function getOpenCodeState(conversation: Conversation | null): OpenCodeProviderState {
+  if (!conversation || conversation.providerId !== 'opencode') {
+    return {};
+  }
+  return (conversation.providerState ?? {}) as OpenCodeProviderState;
+}
+
+export function setOpenCodeState(
+  conversation: Conversation,
+  state: Partial<OpenCodeProviderState>,
+): void {
+  conversation.providerState = {
+    ...getOpenCodeState(conversation),
+    ...state,
+  };
+}

--- a/src/providers/opencode/types/subagent.ts
+++ b/src/providers/opencode/types/subagent.ts
@@ -1,0 +1,23 @@
+export interface OpenCodeSubagentDefinition {
+  name: string;
+  description: string;
+  developerInstructions: string;
+  nicknameCandidates?: string[];
+  model?: string;
+  modelReasoningEffort?: string;
+  sandboxMode?: string;
+  /** Opaque storage token preserved across edits/deletes. */
+  persistenceKey?: string;
+  /** Preserves unrecognized TOML keys for round-trip fidelity. */
+  extraFields?: Record<string, unknown>;
+}
+
+export const OPENCODE_SUBAGENT_KNOWN_KEYS = new Set([
+  'name',
+  'description',
+  'developer_instructions',
+  'nickname_candidates',
+  'model',
+  'model_reasoning_effort',
+  'sandbox_mode',
+]);

--- a/src/providers/opencode/ui/OpenCodeChatUIConfig.ts
+++ b/src/providers/opencode/ui/OpenCodeChatUIConfig.ts
@@ -1,0 +1,121 @@
+import { getRuntimeEnvironmentVariables } from '../../../core/providers/providerEnvironment';
+import type {
+  ProviderChatUIConfig,
+  ProviderIconSvg,
+  ProviderPermissionModeToggleConfig,
+  ProviderReasoningOption,
+  ProviderServiceTierToggleConfig,
+  ProviderUIOption,
+} from '../../../core/providers/types';
+
+const OPENCODE_ICON: ProviderIconSvg = {
+  viewBox: '0 0 24 24',
+  path: 'M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z',
+};
+
+const OPENCODE_MODELS: ProviderUIOption[] = [
+  // GitHub Copilot models (primary supported backend)
+  { value: 'github-copilot/claude-sonnet-4.5', label: 'Claude Sonnet 4.5', description: 'GitHub Copilot' },
+  { value: 'github-copilot/claude-sonnet-4.6', label: 'Claude Sonnet 4.6', description: 'GitHub Copilot' },
+  { value: 'github-copilot/claude-sonnet-4', label: 'Claude Sonnet 4', description: 'GitHub Copilot' },
+  { value: 'github-copilot/gpt-5.4', label: 'GPT-5.4', description: 'GitHub Copilot' },
+  { value: 'github-copilot/gpt-5-mini', label: 'GPT-5 Mini', description: 'GitHub Copilot' },
+  // Use custom model (via env var) for direct API access
+];
+
+const OPENCODE_MODEL_SET = new Set(OPENCODE_MODELS.map(m => m.value));
+
+const EFFORT_LEVELS: ProviderReasoningOption[] = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+];
+
+const OPENCODE_PERMISSION_MODE_TOGGLE: ProviderPermissionModeToggleConfig = {
+  inactiveValue: 'normal',
+  inactiveLabel: 'Safe',
+  activeValue: 'yolo',
+  activeLabel: 'YOLO',
+  planValue: 'plan',
+  planLabel: 'Plan',
+};
+
+const DEFAULT_CONTEXT_WINDOW = 200_000;
+
+export const openCodeChatUIConfig: ProviderChatUIConfig = {
+  getModelOptions(settings: Record<string, unknown>): ProviderUIOption[] {
+    const envVars = getRuntimeEnvironmentVariables(settings, 'opencode');
+    if (envVars.OPENCODE_MODEL) {
+      const customModel = envVars.OPENCODE_MODEL;
+      if (!OPENCODE_MODEL_SET.has(customModel)) {
+        return [
+          { value: customModel, label: customModel, description: 'Custom (env)' },
+          ...OPENCODE_MODELS,
+        ];
+      }
+    }
+    return [...OPENCODE_MODELS];
+  },
+
+  ownsModel(model: string, settings: Record<string, unknown>): boolean {
+    if (this.getModelOptions(settings).some((option: ProviderUIOption) => option.value === model)) {
+      return true;
+    }
+    return false;
+  },
+
+  isAdaptiveReasoningModel(): boolean {
+    return true;
+  },
+
+  getReasoningOptions(): ProviderReasoningOption[] {
+    return EFFORT_LEVELS;
+  },
+
+  getDefaultReasoningValue(): string {
+    return 'medium';
+  },
+
+  getContextWindowSize(_model: string, customLimits?: Record<string, number>): number {
+    if (customLimits?.[_model]) {
+      return customLimits[_model];
+    }
+    return DEFAULT_CONTEXT_WINDOW;
+  },
+
+  isDefaultModel(model: string): boolean {
+    return OPENCODE_MODEL_SET.has(model);
+  },
+
+  applyModelDefaults(): void {
+    // No-op for OpenCode
+  },
+
+  normalizeModelVariant(model: string): string {
+    return model;
+  },
+
+  getCustomModelIds(envVars: Record<string, string>): Set<string> {
+    const ids = new Set<string>();
+    if (envVars.OPENCODE_MODEL && !OPENCODE_MODEL_SET.has(envVars.OPENCODE_MODEL)) {
+      ids.add(envVars.OPENCODE_MODEL);
+    }
+    return ids;
+  },
+
+  getPermissionModeToggle(): ProviderPermissionModeToggleConfig | null {
+    return OPENCODE_PERMISSION_MODE_TOGGLE;
+  },
+
+  getServiceTierToggle(): ProviderServiceTierToggleConfig | null {
+    return null;
+  },
+
+  isBangBashEnabled(): boolean {
+    return true;
+  },
+
+  getProviderIcon(): ProviderIconSvg | null {
+    return OPENCODE_ICON;
+  },
+};

--- a/src/providers/opencode/ui/OpenCodeSettingsTab.ts
+++ b/src/providers/opencode/ui/OpenCodeSettingsTab.ts
@@ -1,0 +1,125 @@
+import * as fs from 'fs';
+import { Setting } from 'obsidian';
+
+import type { ProviderSettingsTabRenderer } from '../../../core/providers/types';
+import { renderEnvironmentSettingsSection } from '../../../features/settings/ui/EnvironmentSettingsSection';
+import { t } from '../../../i18n/i18n';
+import { expandHomePath } from '../../../utils/path';
+import { getOpenCodeProviderSettings, setOpenCodeProviderSettings } from '../settings';
+
+export const openCodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
+  render(container, context) {
+    const settingsBag = context.plugin.settings as unknown as Record<string, unknown>;
+    const openCodeSettings = getOpenCodeProviderSettings(settingsBag);
+
+    // --- Setup ---
+
+    new Setting(container).setName(t('settings.setup')).setHeading();
+
+    new Setting(container)
+      .setName('Enable OpenCode provider')
+      .setDesc('When enabled, OpenCode models appear in the model selector for new conversations.')
+      .addToggle((toggle) =>
+        toggle
+          .setValue(openCodeSettings.enabled)
+          .onChange(async (value) => {
+            setOpenCodeProviderSettings(settingsBag, { enabled: value });
+            await context.plugin.saveSettings();
+            context.refreshModelSelectors();
+          })
+      );
+
+    const cliPathSetting = new Setting(container)
+      .setName('OpenCode CLI path')
+      .setDesc('Custom path to the local OpenCode CLI. Leave empty for auto-detection from PATH.');
+
+    const validationEl = container.createDiv({ cls: 'claudian-cli-path-validation' });
+    validationEl.style.color = 'var(--text-error)';
+    validationEl.style.fontSize = '0.85em';
+    validationEl.style.marginTop = '-0.5em';
+    validationEl.style.marginBottom = '0.5em';
+    validationEl.style.display = 'none';
+
+    const validatePath = (value: string): string | null => {
+      const trimmed = value.trim();
+      if (!trimmed) return null;
+
+      try {
+        const expandedPath = expandHomePath(trimmed);
+        if (!fs.existsSync(expandedPath)) {
+          return `File not found: ${expandedPath}`;
+        }
+        if (!fs.statSync(expandedPath).isFile()) {
+          return 'Path exists but is not a file.';
+        }
+      } catch (error) {
+        return `Failed to validate path: ${error instanceof Error ? error.message : 'Unknown error'}`;
+      }
+
+      return null;
+    };
+
+    const updateValidationUI = (value: string): void => {
+      const error = validatePath(value);
+      if (error) {
+        validationEl.textContent = error;
+        validationEl.style.display = 'block';
+      } else {
+        validationEl.style.display = 'none';
+      }
+    };
+
+    cliPathSetting.addText((text) => {
+      text
+        .setPlaceholder(process.platform === 'win32'
+          ? 'C:\\Users\\you\\.opencode\\bin\\opencode.exe'
+          : '/usr/local/bin/opencode')
+        .setValue(openCodeSettings.customCliPath)
+        .onChange(async (value) => {
+          updateValidationUI(value);
+          setOpenCodeProviderSettings(settingsBag, { customCliPath: value.trim() });
+          await context.plugin.saveSettings();
+        });
+    });
+
+    // --- Safe Mode ---
+
+    new Setting(container)
+      .setName('Safe mode')
+      .setDesc('Default sandbox level for OpenCode sessions. Controls what file/system access the AI agent has.')
+      .addDropdown((dropdown) => {
+        dropdown
+          .addOption('workspace-write', 'Workspace Write (default)')
+          .addOption('workspace-read', 'Workspace Read Only')
+          .addOption('none', 'None (full access)')
+          .setValue(openCodeSettings.safeMode)
+          .onChange(async (value) => {
+            setOpenCodeProviderSettings(settingsBag, {
+              safeMode: value as 'workspace-write' | 'workspace-read' | 'none',
+            });
+            await context.plugin.saveSettings();
+          });
+      });
+
+    // --- Environment Variables ---
+
+    renderEnvironmentSettingsSection({
+      container,
+      plugin: context.plugin,
+      scope: 'provider:opencode',
+      heading: t('settings.environment'),
+      name: 'OpenCode environment',
+      desc: 'Configure environment variables for the OpenCode CLI process (e.g., OPENCODE_MODEL, OPENCODE_API_KEY, custom PATH).',
+      placeholder: 'OPENCODE_MODEL=claude-sonnet-4\nOPENCODE_API_KEY=your-key\nOPENCODE_BASE_URL=https://api.anthropic.com',
+      renderCustomContextLimits: (target) => context.renderCustomContextLimits(target, 'opencode'),
+    });
+
+    // --- Hidden Provider Commands ---
+
+    context.renderHiddenProviderCommandSetting(container, 'opencode', {
+      name: 'Hidden skills',
+      desc: 'Skills to hide from the dropdown. Separate multiple names with commas.',
+      placeholder: 'skill-name-1, skill-name-2',
+    });
+  },
+};


### PR DESCRIPTION
## Summary

This PR enhances the OpenCode provider to properly display file diffs and track usage, bringing it closer to feature parity with the Claude provider.

## Changes

- **Parse OpenCode JSON events**: Updated OpenCodeEvent interface to match actual OpenCode CLI output format with embedded tool state
- **Extract diff data**: Parse metadata.filediff from tool_use events and convert to structuredPatch format for the diff renderer
- **Normalize tool names**: Map OpenCode lowercase names (write, edit, read) to capitalized names (Write, Edit, Read) expected by renderers
- **Normalize input fields**: Convert camelCase field names to snake_case for compatibility with existing diff extraction logic
- **Usage tracking**: Extract token usage from step_finish events and emit proper usage chunks

## Testing

Tested with opencode run commands that produce proper JSON events with diff metadata.

## Related

This is Phase 1 of the OpenCode feature parity work. Phase 2 will add inline editor accept/reject UI.