### PR TITLE
Fix stop hook loop after foreground task completion

### DIFF
--- a/src/features/chat/services/SubagentManager.ts
+++ b/src/features/chat/services/SubagentManager.ts
@@ -604,39 +604,83 @@ export class SubagentManager {
     if (this.taskResultInterpreter.hasAsyncLaunchMarker(taskToolUseResult)) {
       return 'async';
     }
-    // Use strict async markers only; avoid broad ID heuristics.
+    // Only promote to async for launch-shaped payloads. Completed sync results
+    // can still contain agent metadata in the payload or final output text.
     return this.parseAgentIdStrict(taskResult) ? 'async' : 'sync';
   }
 
   private parseAgentIdStrict(result: string): string | null {
-    const fromRaw = this.extractAgentIdFromString(result);
-    if (fromRaw) return fromRaw;
-
-    const payload = this.unwrapTextPayload(result);
-    const fromPayload = this.extractAgentIdFromString(payload);
-    if (fromPayload) return fromPayload;
+    const payload = this.unwrapTextPayload(result).trim();
+    if (!payload) {
+      return null;
+    }
 
     try {
-      const parsed = JSON.parse(result);
+      const parsed = JSON.parse(payload);
 
-      if (Array.isArray(parsed)) {
-        for (const block of parsed) {
-          if (block && typeof block === 'object' && typeof (block as Record<string, unknown>).text === 'string') {
-            const fromText = this.extractAgentIdFromString((block as Record<string, unknown>).text as string);
-            if (fromText) return fromText;
-          }
-        }
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return null;
       }
 
-      const agentId = parsed.agent_id || parsed.agentId || parsed?.data?.agent_id;
-      if (typeof agentId === 'string' && agentId.length > 0) {
-        return agentId;
+      if (this.hasTerminalTaskStatus(parsed)) {
+        return null;
+      }
+
+      const directAgentId = this.extractAgentIdFromRecord(parsed as Record<string, unknown>);
+      if (directAgentId) {
+        return directAgentId;
+      }
+
+      const taskRecord = (parsed as Record<string, unknown>).task;
+      if (taskRecord && typeof taskRecord === 'object' && !Array.isArray(taskRecord)) {
+        return this.extractAgentIdFromRecord(taskRecord as Record<string, unknown>);
       }
     } catch {
       // Not JSON
     }
 
-    return null;
+    const xmlStatus = this.taskResultInterpreter.extractTagValue(payload, 'retrieval_status')
+      ?? this.taskResultInterpreter.extractTagValue(payload, 'status');
+    if (this.isTerminalTaskStatusValue(xmlStatus)) {
+      return null;
+    }
+
+    const exactLineMatch = payload.match(/^\s*(?:agent_id|agentId)\s*[=:]\s*"?([a-zA-Z0-9_-]+)"?\s*$/i);
+    return exactLineMatch?.[1] ?? null;
+  }
+
+  private hasTerminalTaskStatus(value: unknown): boolean {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return false;
+    }
+
+    const record = value as Record<string, unknown>;
+    const rawStatus = record.retrieval_status ?? record.status;
+    return this.isTerminalTaskStatusValue(rawStatus);
+  }
+
+  private isTerminalTaskStatusValue(rawStatus: unknown): boolean {
+    if (typeof rawStatus !== 'string') {
+      return false;
+    }
+
+    const normalized = rawStatus.toLowerCase();
+    return normalized === 'completed' || normalized === 'success' || normalized === 'error';
+  }
+
+  private extractAgentIdFromRecord(record: Record<string, unknown>): string | null {
+    const direct = record.agent_id ?? record.agentId;
+    if (typeof direct === 'string' && direct.length > 0) {
+      return direct;
+    }
+
+    const data = record.data;
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+      return null;
+    }
+
+    const nested = (data as Record<string, unknown>).agent_id ?? (data as Record<string, unknown>).agentId;
+    return typeof nested === 'string' && nested.length > 0 ? nested : null;
   }
 
   private extractAgentIdFromString(value: string): string | null {

--- a/src/providers/claude/runtime/ClaudeTaskResultInterpreter.ts
+++ b/src/providers/claude/runtime/ClaudeTaskResultInterpreter.ts
@@ -67,15 +67,13 @@ export class ClaudeTaskResultInterpreter implements ProviderTaskResultInterprete
       return true;
     }
 
-    if (this.extractAgentId(toolUseResult)) {
-      return true;
-    }
-
     const rawStatus = record.retrieval_status ?? record.status;
     if (typeof rawStatus === 'string' && rawStatus.toLowerCase() === 'async_launched') {
       return true;
     }
 
+    // Sync Task results can still carry agentId metadata, so only treat
+    // output files as async when an explicit async marker is otherwise absent.
     return typeof record.outputFile === 'string' && record.outputFile.length > 0;
   }
 

--- a/tests/unit/features/chat/services/SubagentManager.test.ts
+++ b/tests/unit/features/chat/services/SubagentManager.test.ts
@@ -6,6 +6,7 @@ import { join } from 'path';
 
 import type { SubagentInfo, ToolCallInfo } from '@/core/types';
 import { SubagentManager } from '@/features/chat/services/SubagentManager';
+import { createStopSubagentHook } from '@/providers/claude/hooks/SubagentHooks';
 
 jest.mock('@/features/chat/rendering/SubagentRenderer', () => ({
   createSubagentBlock: jest.fn().mockImplementation((_parentEl: any, toolId: string, input: any) => ({
@@ -1214,6 +1215,85 @@ Only this is the final result.
       expect(result?.mode).toBe('async');
     });
 
+    it('treats completed toolUseResult metadata with agentId as sync when mode is unknown', () => {
+      const { manager } = createManager();
+      const parentEl = createMockEl();
+
+      manager.handleTaskToolUse('task-1', { prompt: 'test' }, parentEl);
+      const result = manager.renderPendingTaskFromTaskResult(
+        'task-1',
+        '{}',
+        false,
+        parentEl,
+        {
+          status: 'completed',
+          agentId: 'agent-sync',
+          content: [
+            { type: 'text', text: 'Full sync result.' },
+            { type: 'text', text: 'agentId: agent-sync' },
+          ],
+        }
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.mode).toBe('sync');
+      expect(manager.getSyncSubagent('task-1')).toBeDefined();
+      expect(manager.isPendingAsyncTask('task-1')).toBe(false);
+      expect(manager.hasRunningSubagents()).toBe(false);
+    });
+
+    it('treats stringified completed task metadata with agentId as sync when mode is unknown', () => {
+      const { manager } = createManager();
+      const parentEl = createMockEl();
+      const completedToolUseResult = {
+        status: 'completed',
+        agentId: 'agent-sync',
+      };
+
+      manager.handleTaskToolUse('task-1', { prompt: 'test' }, parentEl);
+      const result = manager.renderPendingTaskFromTaskResult(
+        'task-1',
+        JSON.stringify(completedToolUseResult, null, 2),
+        false,
+        parentEl,
+        completedToolUseResult,
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.mode).toBe('sync');
+      expect(manager.getSyncSubagent('task-1')).toBeDefined();
+      expect(manager.isPendingAsyncTask('task-1')).toBe(false);
+      expect(manager.hasRunningSubagents()).toBe(false);
+    });
+
+    it('treats sync result text with agentId metadata as sync when mode is unknown', () => {
+      const { manager } = createManager();
+      const parentEl = createMockEl();
+      const completedToolUseResult = {
+        status: 'completed',
+        agentId: 'agent-sync',
+        content: [
+          { type: 'text', text: 'Full sync result.' },
+          { type: 'text', text: 'agentId: agent-sync\n<usage>total_tokens: 500</usage>' },
+        ],
+      };
+
+      manager.handleTaskToolUse('task-1', { prompt: 'test' }, parentEl);
+      const result = manager.renderPendingTaskFromTaskResult(
+        'task-1',
+        'Full sync result.\nagentId: agent-sync\n<usage>total_tokens: 500</usage>',
+        false,
+        parentEl,
+        completedToolUseResult,
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.mode).toBe('sync');
+      expect(manager.getSyncSubagent('task-1')).toBeDefined();
+      expect(manager.isPendingAsyncTask('task-1')).toBe(false);
+      expect(manager.hasRunningSubagents()).toBe(false);
+    });
+
     it('resolves to sync on errored task result when mode is unknown', () => {
       const { manager } = createManager();
       const parentEl = createMockEl();
@@ -1473,6 +1553,86 @@ Only this is the final result.
         );
 
         expect(manager.hasRunningSubagents()).toBe(false);
+      });
+
+      it('returns false after parallel foreground tasks resolve from completed task results', () => {
+        const { manager } = createManager();
+        const parentEl = createMockEl();
+        const syncToolUseResult1 = {
+          status: 'completed',
+          agentId: 'agent-sync-1',
+          content: [{ type: 'text', text: 'Foreground result 1.' }],
+        };
+        const syncToolUseResult2 = {
+          status: 'completed',
+          agentId: 'agent-sync-2',
+          content: [{ type: 'text', text: 'Foreground result 2.' }],
+        };
+
+        manager.handleTaskToolUse('task-1', { prompt: 'Foreground 1' }, parentEl);
+        manager.handleTaskToolUse('task-2', { prompt: 'Foreground 2' }, parentEl);
+
+        const first = manager.renderPendingTaskFromTaskResult(
+          'task-1',
+          '{}',
+          false,
+          parentEl,
+          syncToolUseResult1
+        );
+        const second = manager.renderPendingTaskFromTaskResult(
+          'task-2',
+          '{}',
+          false,
+          parentEl,
+          syncToolUseResult2
+        );
+
+        expect(first?.mode).toBe('sync');
+        expect(second?.mode).toBe('sync');
+
+        manager.finalizeSyncSubagent('task-1', '{}', false, syncToolUseResult1);
+        manager.finalizeSyncSubagent('task-2', '{}', false, syncToolUseResult2);
+
+        expect(manager.hasRunningSubagents()).toBe(false);
+      });
+
+      it('allows the Stop hook after a foreground task resolves from completed task metadata', async () => {
+        const { manager } = createManager();
+        const parentEl = createMockEl();
+        const completedToolUseResult = {
+          status: 'completed',
+          agentId: 'agent-sync',
+        };
+        const hook = createStopSubagentHook(() => ({
+          hasRunning: manager.hasRunningSubagents(),
+        }));
+
+        manager.handleTaskToolUse('task-1', { prompt: 'Foreground task' }, parentEl);
+        const rendered = manager.renderPendingTaskFromTaskResult(
+          'task-1',
+          JSON.stringify(completedToolUseResult, null, 2),
+          false,
+          parentEl,
+          completedToolUseResult,
+        );
+
+        expect(rendered?.mode).toBe('sync');
+
+        manager.finalizeSyncSubagent('task-1', '{}', false, completedToolUseResult);
+
+        const stopResult = await hook.hooks[0](
+          {
+            hook_event_name: 'Stop',
+            session_id: 'test-session',
+            transcript_path: '/tmp/transcript',
+            cwd: '/vault',
+            stop_hook_active: true,
+          },
+          undefined,
+          { signal: new AbortController().signal }
+        );
+
+        expect(stopResult).toEqual({});
       });
     });
   });

--- a/tests/unit/providers/claude/runtime/ClaudeTaskResultInterpreter.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudeTaskResultInterpreter.test.ts
@@ -1,0 +1,28 @@
+import { ClaudeTaskResultInterpreter } from '@/providers/claude/runtime/ClaudeTaskResultInterpreter';
+
+describe('ClaudeTaskResultInterpreter', () => {
+  describe('hasAsyncLaunchMarker', () => {
+    it('does not treat completed sync metadata with agentId as an async launch', () => {
+      const interpreter = new ClaudeTaskResultInterpreter();
+
+      expect(interpreter.hasAsyncLaunchMarker({
+        status: 'completed',
+        agentId: 'agent-sync',
+        content: [
+          { type: 'text', text: 'Final sync result.' },
+          { type: 'text', text: 'agentId: agent-sync' },
+        ],
+      })).toBe(false);
+    });
+
+    it('treats explicit async launch markers as async', () => {
+      const interpreter = new ClaudeTaskResultInterpreter();
+
+      expect(interpreter.hasAsyncLaunchMarker({
+        isAsync: true,
+        status: 'async_launched',
+        agentId: 'agent-async',
+      })).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Fixes the stop-hook loop triggered after foreground Task completions by stopping completed sync task results from being inferred as background launches while still honoring explicit async markers. It adds regressions for stringified completed task metadata, sync result text that carries agent metadata, parallel foreground completions, and a Stop-hook assertion that verifies the hook no longer blocks after a foreground task finishes. It also adds focused interpreter coverage for Claude task result async marker detection so completed sync metadata stays classified as sync. Verification: npm run typecheck, npm run lint, npm test, and npm run build all pass.

fix: #493 
