### PR TITLE
Fix blank-tab routing when Codex is disabled

### DIFF
--- a/src/core/providers/ProviderRegistry.ts
+++ b/src/core/providers/ProviderRegistry.ts
@@ -134,9 +134,25 @@ export class ProviderRegistry {
   static resolveProviderForModel(
     model: string,
     settings: Record<string, unknown> = {},
+    options: {
+      onlyEnabledProviders?: boolean;
+      fallbackProviderId?: ProviderId;
+    } = {},
   ): ProviderId {
-    for (const providerId of this.getRegisteredProviderIds()) {
-      if (providerId === DEFAULT_CHAT_PROVIDER_ID) {
+    const providerIds = options.onlyEnabledProviders
+      ? this.getEnabledProviderIds(settings)
+      : this.getRegisteredProviderIds();
+    const fallbackProviderId = (
+      options.fallbackProviderId
+      && (!options.onlyEnabledProviders || this.isEnabled(options.fallbackProviderId, settings))
+    )
+      ? options.fallbackProviderId
+      : (options.onlyEnabledProviders
+        ? this.resolveSettingsProviderId(settings)
+        : DEFAULT_CHAT_PROVIDER_ID);
+
+    for (const providerId of providerIds) {
+      if (providerId === fallbackProviderId) {
         continue;
       }
 
@@ -145,7 +161,7 @@ export class ProviderRegistry {
       }
     }
 
-    return DEFAULT_CHAT_PROVIDER_ID;
+    return fallbackProviderId;
   }
 
   static getCustomModelIds(envVars: Record<string, string>): Set<string> {

--- a/src/core/providers/modelRouting.ts
+++ b/src/core/providers/modelRouting.ts
@@ -4,3 +4,14 @@ import type { ProviderId } from './types';
 export function getProviderForModel(model: string, settings?: Record<string, unknown>): ProviderId {
   return ProviderRegistry.resolveProviderForModel(model, settings);
 }
+
+export function getEnabledProviderForModel(
+  model: string,
+  settings: Record<string, unknown>,
+  fallbackProviderId?: ProviderId,
+): ProviderId {
+  return ProviderRegistry.resolveProviderForModel(model, settings, {
+    onlyEnabledProviders: true,
+    fallbackProviderId,
+  });
+}

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -4,7 +4,7 @@ import { Notice } from 'obsidian';
 import { getHiddenProviderCommandSet } from '../../../core/providers/commands/hiddenCommands';
 import type { ProviderCommandDropdownConfig } from '../../../core/providers/commands/ProviderCommandCatalog';
 import type { ProviderCommandEntry } from '../../../core/providers/commands/ProviderCommandEntry';
-import { getProviderForModel } from '../../../core/providers/modelRouting';
+import { getEnabledProviderForModel, getProviderForModel } from '../../../core/providers/modelRouting';
 import { ProviderRegistry } from '../../../core/providers/ProviderRegistry';
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
@@ -87,11 +87,15 @@ function resolveBlankTabModel(
   providerId?: ProviderId,
 ): string {
   const settings = plugin.settings as unknown as Record<string, unknown>;
-  if (providerId) {
-    const snapshot = ProviderSettingsCoordinator.getProviderSettingsSnapshot(settings, providerId);
-    return snapshot.model as string;
+  if (!providerId) {
+    return settings.model as string;
   }
-  return settings.model as string;
+
+  const targetProviderId = ProviderRegistry.isEnabled(providerId, settings)
+    ? providerId
+    : ProviderRegistry.resolveSettingsProviderId(settings);
+  const snapshot = ProviderSettingsCoordinator.getProviderSettingsSnapshot(settings, targetProviderId);
+  return snapshot.model as string;
 }
 
 export interface TabCreateOptions {
@@ -282,20 +286,31 @@ export function onProviderAvailabilityChanged(tab: TabData, plugin: ClaudianPlug
 
   const settingsSnapshot = plugin.settings as unknown as Record<string, unknown>;
   const enabledProviderIds = ProviderRegistry.getEnabledProviderIds(settingsSnapshot);
+  let nextProviderId = tab.providerId;
 
   if (tab.draftModel) {
-    const draftProvider = getProviderForModel(tab.draftModel, settingsSnapshot);
-    if (!enabledProviderIds.includes(draftProvider)) {
+    const draftProvider = getEnabledProviderForModel(tab.draftModel, settingsSnapshot);
+    const draftProviderOwnsModel = ProviderRegistry
+      .getChatUIConfig(draftProvider)
+      .ownsModel(tab.draftModel, settingsSnapshot);
+    if (!enabledProviderIds.includes(draftProvider) || !draftProviderOwnsModel) {
       const fallbackProviderId = enabledProviderIds[0] ?? DEFAULT_CHAT_PROVIDER_ID;
       const fallbackModels = ProviderRegistry.getChatUIConfig(fallbackProviderId)
         .getModelOptions(settingsSnapshot);
       tab.draftModel = fallbackModels[0]?.value ?? tab.draftModel;
-      tab.providerId = fallbackProviderId;
+      nextProviderId = fallbackProviderId;
+    } else {
+      nextProviderId = draftProvider;
     }
   }
 
+  tab.providerId = nextProviderId;
+
   // Clean up stale service if provider changed
-  if (tab.service && tab.draftModel && tab.service.providerId !== getProviderForModel(tab.draftModel, plugin.settings as unknown as Record<string, unknown>)) {
+  if (
+    tab.service
+    && tab.service.providerId !== nextProviderId
+  ) {
     tab.service.cleanup();
     tab.service = null;
     tab.serviceInitialized = false;
@@ -346,7 +361,7 @@ export function createTab(options: TabCreateOptions): TabData {
   const draftModel = isBound ? null : resolveBlankTabModel(plugin, options.defaultProviderId);
   const initialProviderId = conversation?.providerId
     ?? (draftModel
-      ? getProviderForModel(draftModel, plugin.settings as unknown as Record<string, unknown>)
+      ? getEnabledProviderForModel(draftModel, plugin.settings as unknown as Record<string, unknown>)
       : DEFAULT_CHAT_PROVIDER_ID);
 
   const tab: TabData = {
@@ -711,7 +726,7 @@ function initializeInputToolbar(
   // Blank-tab UI config wrapper that returns mixed model options
   const blankTabUIConfigProxy = (): ProviderChatUIConfig => {
     const draftProvider = tab.draftModel
-      ? getProviderForModel(tab.draftModel, plugin.settings as unknown as Record<string, unknown>)
+      ? getEnabledProviderForModel(tab.draftModel, plugin.settings as unknown as Record<string, unknown>)
       : DEFAULT_CHAT_PROVIDER_ID;
     const baseConfig = ProviderRegistry.getChatUIConfig(draftProvider);
     return {
@@ -736,7 +751,10 @@ function initializeInputToolbar(
       if (tab.lifecycleState === 'blank') {
         const previousProvider = tab.providerId;
         tab.draftModel = model;
-        const newProvider = getProviderForModel(model, plugin.settings as unknown as Record<string, unknown>);
+        const newProvider = getEnabledProviderForModel(
+          model,
+          plugin.settings as unknown as Record<string, unknown>,
+        );
         if (tab.service) {
           cleanupTabRuntime(tab);
         }
@@ -1293,7 +1311,10 @@ export function initializeTabControllers(
       try {
         // For blank tabs on first send: derive provider from draft model
         if (tab.lifecycleState === 'blank' && tab.draftModel) {
-          const derivedProvider = getProviderForModel(tab.draftModel, plugin.settings as unknown as Record<string, unknown>);
+          const derivedProvider = getEnabledProviderForModel(
+            tab.draftModel,
+            plugin.settings as unknown as Record<string, unknown>,
+          );
           tab.providerId = derivedProvider;
         }
 

--- a/src/features/chat/tabs/providerResolution.ts
+++ b/src/features/chat/tabs/providerResolution.ts
@@ -1,4 +1,4 @@
-import { getProviderForModel } from '../../../core/providers/modelRouting';
+import { getEnabledProviderForModel } from '../../../core/providers/modelRouting';
 import type { ProviderId } from '../../../core/providers/types';
 import type { Conversation } from '../../../core/types';
 import type ClaudianPlugin from '../../../main';
@@ -16,7 +16,7 @@ function getStoredConversationProviderId(
   }
 
   if (tab.lifecycleState === 'blank' && tab.draftModel) {
-    return getProviderForModel(
+    return getEnabledProviderForModel(
       tab.draftModel,
       plugin.settings as unknown as Record<string, unknown>,
     );

--- a/tests/unit/core/providers/modelRouting.test.ts
+++ b/tests/unit/core/providers/modelRouting.test.ts
@@ -1,6 +1,6 @@
 import '@/providers';
 
-import { getProviderForModel } from '@/core/providers/modelRouting';
+import { getEnabledProviderForModel, getProviderForModel } from '@/core/providers/modelRouting';
 
 describe('getProviderForModel', () => {
   it('routes Claude default models to claude', () => {
@@ -39,5 +39,22 @@ describe('getProviderForModel', () => {
 
   it('routes custom OPENAI_MODEL to claude without settings (no context)', () => {
     expect(getProviderForModel('my-custom-model')).toBe('claude');
+  });
+
+  it('can resolve blank-tab routing within enabled providers only', () => {
+    const settings = {
+      settingsProvider: 'claude',
+      providerConfigs: {
+        claude: {
+          environmentVariables: 'ANTHROPIC_MODEL=gpt-5.4',
+        },
+        codex: {
+          enabled: false,
+        },
+      },
+    };
+
+    expect(getProviderForModel('gpt-5.4', settings)).toBe('codex');
+    expect(getEnabledProviderForModel('gpt-5.4', settings)).toBe('claude');
   });
 });

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -599,6 +599,48 @@ describe('Tab - Creation', () => {
       expect(tab.draftModel).toBe('opus');
       expect(tab.providerId).toBe('claude');
     });
+
+    it('should keep a Claude custom gpt model on Claude when Codex is disabled', () => {
+      const plugin = createMockPlugin();
+      plugin.settings.settingsProvider = 'claude';
+      plugin.settings.model = 'gpt-5.4';
+      plugin.settings.providerConfigs = {
+        claude: {
+          environmentVariables: 'ANTHROPIC_MODEL=gpt-5.4',
+        },
+        codex: {
+          enabled: false,
+        },
+      };
+
+      const tab = createTab(createMockOptions({ plugin }));
+
+      expect(tab.lifecycleState).toBe('blank');
+      expect(tab.draftModel).toBe('gpt-5.4');
+      expect(tab.providerId).toBe('claude');
+    });
+
+    it('should fall back to an enabled provider when defaultProviderId is disabled', () => {
+      const plugin = createMockPlugin();
+      plugin.settings.settingsProvider = 'claude';
+      plugin.settings.model = 'claude-sonnet-4-5';
+      plugin.settings.providerConfigs = {
+        claude: {},
+        codex: {
+          enabled: false,
+        },
+      };
+      plugin.settings.savedProviderModel = {
+        claude: 'opus',
+        codex: 'gpt-5.4',
+      };
+
+      const tab = createTab(createMockOptions({ plugin, defaultProviderId: 'codex' }));
+
+      expect(tab.lifecycleState).toBe('blank');
+      expect(tab.draftModel).toBe('opus');
+      expect(tab.providerId).toBe('claude');
+    });
   });
 });
 
@@ -863,6 +905,45 @@ describe('Tab - Service Initialization', () => {
       expect(tab.service).toBeNull();
       expect(tab.serviceInitialized).toBe(false);
       expect(mockSlashCommandDropdown.resetSdkSkillsCache).toHaveBeenCalled();
+    });
+
+    it('rebinds blank-tab helper services when a newly enabled provider takes over the draft model', () => {
+      const createInstructionRefineServiceSpy = jest.spyOn(ProviderRegistry, 'createInstructionRefineService')
+        .mockReturnValue({ cancel: jest.fn(), resetConversation: jest.fn() } as any);
+      const createTitleGenerationServiceSpy = jest.spyOn(ProviderRegistry, 'createTitleGenerationService')
+        .mockReturnValue({ cancel: jest.fn() } as any);
+      jest.spyOn(ProviderRegistry, 'getTaskResultInterpreter').mockReturnValue({} as any);
+
+      const plugin = createMockPlugin();
+      plugin.settings.settingsProvider = 'claude';
+      plugin.settings.model = 'gpt-5.4';
+      plugin.settings.providerConfigs = {
+        claude: {
+          environmentVariables: 'ANTHROPIC_MODEL=gpt-5.4',
+        },
+        codex: {
+          enabled: false,
+        },
+      };
+
+      const tab = createTab(createMockOptions({ plugin }));
+      initializeTabUI(tab, plugin);
+
+      expect(tab.draftModel).toBe('gpt-5.4');
+      expect(tab.providerId).toBe('claude');
+
+      plugin.settings.providerConfigs = {
+        ...plugin.settings.providerConfigs,
+        codex: {
+          enabled: true,
+        },
+      };
+
+      onProviderAvailabilityChanged(tab, plugin);
+
+      expect(tab.providerId).toBe('codex');
+      expect(createInstructionRefineServiceSpy).toHaveBeenLastCalledWith(plugin, 'codex');
+      expect(createTitleGenerationServiceSpy).toHaveBeenLastCalledWith(plugin, 'codex');
     });
 
     it('surfaces provider-scoped model settings for inactive-provider tabs and saves back to that provider snapshot', async () => {


### PR DESCRIPTION
## Summary
- Route blank and new-tab provider selection through enabled providers only, so a Claude-side custom `gpt-5.4` model no longer binds conversations to disabled Codex.
- Fall back to the active enabled provider snapshot when inheriting a disabled provider's draft model, and rebind blank-tab helper services when provider availability changes.
- Add regression coverage for disabled-provider routing and provider re-enable transitions in model-routing and tab tests.

## Verification
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`

Closes #497.
