### PR TITLE
Fix New tab when Claudian view is closed

### DIFF
--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -250,7 +250,7 @@ export class ClaudianView extends ItemView {
     this.tabBar = new TabBar(this.tabBarContainerEl, {
       onTabClick: (tabId) => this.handleTabClick(tabId),
       onTabClose: (tabId) => this.handleTabClose(tabId),
-      onNewTab: () => this.handleNewTab(),
+      onNewTab: () => this.createNewTab(),
     });
     fragment.appendChild(this.tabBarContainerEl);
 
@@ -263,7 +263,7 @@ export class ClaudianView extends ItemView {
     setIcon(newTabBtn, 'square-plus');
     newTabBtn.setAttribute('aria-label', 'New tab');
     newTabBtn.addEventListener('click', async () => {
-      await this.handleNewTab();
+      await this.createNewTab();
     });
 
     // New conversation button (square-pen icon - new conversation in current tab)
@@ -367,7 +367,7 @@ export class ClaudianView extends ItemView {
     this.updateTabBarVisibility();
   }
 
-  private async handleNewTab(): Promise<void> {
+  async createNewTab(): Promise<void> {
     const tab = await this.tabManager?.createTab();
     if (!tab) {
       const maxTabs = this.plugin.settings.maxTabs ?? 3;
@@ -623,7 +623,7 @@ export class ClaudianView extends ItemView {
       this.pendingPersist = null;
       if (!this.tabManager) return;
       const state = this.tabManager.getPersistedState();
-      this.plugin.storage.setTabManagerState(state).catch(() => {
+      this.plugin.persistTabManagerState(state).catch(() => {
         // Silently ignore persistence errors
       });
     }, 300);
@@ -638,7 +638,7 @@ export class ClaudianView extends ItemView {
     }
     if (!this.tabManager) return;
     const state = this.tabManager.getPersistedState();
-    await this.plugin.storage.setTabManagerState(state);
+    await this.plugin.persistTabManagerState(state);
   }
 
   // ============================================

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import { ProviderRegistry } from './core/providers/ProviderRegistry';
 import { ProviderSettingsCoordinator } from './core/providers/ProviderSettingsCoordinator';
 import { ProviderWorkspaceRegistry } from './core/providers/ProviderWorkspaceRegistry';
 import type { ProviderId } from './core/providers/types';
+import type { AppTabManagerState } from './core/providers/types';
 import { DEFAULT_CHAT_PROVIDER_ID } from './core/providers/types';
 import type {
   ClaudianSettings,
@@ -41,6 +42,7 @@ export default class ClaudianPlugin extends Plugin {
   settings!: ClaudianSettings;
   storage!: SharedAppStorage;
   private conversations: Conversation[] = [];
+  private lastKnownTabManagerState: AppTabManagerState | null = null;
 
   async onload() {
     await this.loadSettings();
@@ -113,17 +115,10 @@ export default class ClaudianPlugin extends Plugin {
       id: 'new-tab',
       name: 'New tab',
       checkCallback: (checking: boolean) => {
-        const leaf = this.app.workspace.getLeavesOfType(VIEW_TYPE_CLAUDIAN)[0];
-        if (!leaf) return false;
-
-        const view = leaf.view as ClaudianView;
-        const tabManager = view.getTabManager();
-        if (!tabManager) return false;
-
-        if (!tabManager.canCreateTab()) return false;
+        if (!this.canCreateNewTab()) return false;
 
         if (!checking) {
-          tabManager.createTab();
+          void this.openNewTab();
         }
         return true;
       },
@@ -182,7 +177,7 @@ export default class ClaudianPlugin extends Plugin {
       const tabManager = view.getTabManager();
       if (tabManager) {
         const state = tabManager.getPersistedState();
-        await this.storage.setTabManagerState(state);
+        await this.persistTabManagerState(state);
       }
     }
   }
@@ -209,9 +204,57 @@ export default class ClaudianPlugin extends Plugin {
     }
   }
 
+  private canCreateNewTab(): boolean {
+    const view = this.getView();
+    const tabManager = view?.getTabManager();
+
+    if (tabManager) {
+      return tabManager.canCreateTab();
+    }
+
+    if (view) {
+      return false;
+    }
+
+    return this.getLastKnownOpenTabCount() < this.getMaxTabsLimit();
+  }
+
+  private async ensureViewOpen(): Promise<ClaudianView | null> {
+    const existingView = this.getView();
+    if (existingView) {
+      return existingView;
+    }
+
+    await this.activateView();
+    return this.getView();
+  }
+
+  private async openNewTab(): Promise<void> {
+    const existingView = this.getView();
+    if (existingView) {
+      await existingView.createNewTab();
+      return;
+    }
+
+    const restoredTabCount = this.getLastKnownOpenTabCount();
+    const view = await this.ensureViewOpen();
+    if (!view) {
+      return;
+    }
+
+    // A cold-open view creates its initial tab during restore. Avoid stacking
+    // an extra blank tab on top when there was no prior layout to restore.
+    if (restoredTabCount === 0) {
+      return;
+    }
+
+    await view.createNewTab();
+  }
+
   async loadSettings() {
     this.storage = new SharedStorageService(this);
     const { claudian } = await this.storage.initialize();
+    this.lastKnownTabManagerState = await this.storage.getTabManagerState();
 
     this.settings = {
       ...DEFAULT_CLAUDIAN_SETTINGS,
@@ -622,6 +665,11 @@ export default class ClaudianPlugin extends Plugin {
     }));
   }
 
+  async persistTabManagerState(state: AppTabManagerState): Promise<void> {
+    this.lastKnownTabManagerState = state;
+    await this.storage.setTabManagerState(state);
+  }
+
   getView(): ClaudianView | null {
     const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_CLAUDIAN);
     if (leaves.length > 0) {
@@ -648,6 +696,15 @@ export default class ClaudianPlugin extends Plugin {
       }
     }
     return null;
+  }
+
+  private getLastKnownOpenTabCount(): number {
+    return this.lastKnownTabManagerState?.openTabs.length ?? 0;
+  }
+
+  private getMaxTabsLimit(): number {
+    const maxTabs = this.settings.maxTabs ?? 3;
+    return Math.max(3, Math.min(10, maxTabs));
   }
 
 }

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -15,6 +15,18 @@ describe('ClaudianPlugin', () => {
   let mockApp: any;
   let mockManifest: any;
 
+  function getRegisteredCommand(commandId: string) {
+    const call = (plugin.addCommand as jest.Mock).mock.calls.find(
+      ([config]) => config.id === commandId,
+    );
+
+    if (!call) {
+      throw new Error(`Command ${commandId} was not registered`);
+    }
+
+    return call[0];
+  }
+
   beforeEach(() => {
     // Reset mocks
     jest.clearAllMocks();
@@ -379,6 +391,108 @@ describe('ClaudianPlugin', () => {
       await commandConfig.callback();
 
       expect(mockApp.workspace.revealLeaf).toHaveBeenCalledWith(mockLeaf);
+    });
+  });
+
+  describe('new-tab command', () => {
+    it('opens the view without creating a duplicate tab when no tab layout is persisted', async () => {
+      await plugin.onload();
+
+      const createNewTab = jest.fn().mockResolvedValue(undefined);
+      const mockView = {
+        createNewTab,
+      };
+
+      let viewOpened = false;
+      jest.spyOn(plugin, 'activateView').mockImplementation(async () => {
+        viewOpened = true;
+      });
+      jest.spyOn(plugin, 'getView').mockImplementation(() => (
+        viewOpened ? mockView as any : null
+      ));
+
+      const command = getRegisteredCommand('new-tab');
+
+      expect(command.checkCallback(true)).toBe(true);
+      expect(command.checkCallback(false)).toBe(true);
+
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(plugin.activateView).toHaveBeenCalledTimes(1);
+      expect(createNewTab).not.toHaveBeenCalled();
+    });
+
+    it('creates a new tab after reopening a persisted tab layout', async () => {
+      (plugin.loadData as jest.Mock).mockResolvedValue({
+        tabManagerState: {
+          openTabs: [
+            { tabId: 'tab-1', conversationId: null },
+          ],
+          activeTabId: 'tab-1',
+        },
+      });
+
+      await plugin.onload();
+
+      const createNewTab = jest.fn().mockResolvedValue(undefined);
+      const mockView = {
+        createNewTab,
+      };
+
+      let viewOpened = false;
+      jest.spyOn(plugin, 'activateView').mockImplementation(async () => {
+        viewOpened = true;
+      });
+      jest.spyOn(plugin, 'getView').mockImplementation(() => (
+        viewOpened ? mockView as any : null
+      ));
+
+      const command = getRegisteredCommand('new-tab');
+
+      expect(command.checkCallback(true)).toBe(true);
+      expect(command.checkCallback(false)).toBe(true);
+
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(plugin.activateView).toHaveBeenCalledTimes(1);
+      expect(createNewTab).toHaveBeenCalledTimes(1);
+    });
+
+    it('stays unavailable when the open view is already at the tab limit', async () => {
+      await plugin.onload();
+
+      const mockView = {
+        getTabManager: jest.fn().mockReturnValue({
+          canCreateTab: jest.fn().mockReturnValue(false),
+        }),
+      };
+
+      jest.spyOn(plugin, 'getView').mockReturnValue(mockView as any);
+
+      const command = getRegisteredCommand('new-tab');
+
+      expect(command.checkCallback(true)).toBe(false);
+    });
+
+    it('stays unavailable when reopening the persisted layout would already hit the tab limit', async () => {
+      (plugin.loadData as jest.Mock).mockResolvedValue({
+        tabManagerState: {
+          openTabs: [
+            { tabId: 'tab-1', conversationId: null },
+            { tabId: 'tab-2', conversationId: null },
+            { tabId: 'tab-3', conversationId: null },
+          ],
+          activeTabId: 'tab-3',
+        },
+      });
+
+      await plugin.onload();
+
+      jest.spyOn(plugin, 'getView').mockReturnValue(null);
+
+      const command = getRegisteredCommand('new-tab');
+
+      expect(command.checkCallback(true)).toBe(false);
     });
   });
 


### PR DESCRIPTION
When `Claudian: New tab` runs with the chat view closed, the plugin now opens the view first and preserves the expected one-step behavior.

The plugin also tracks the last persisted tab layout so reopening from a closed state avoids creating a duplicate blank tab on a cold open while still adding a tab when a prior layout exists.

This branch routes tab-manager persistence through the plugin for that availability check and adds integration coverage for the closed-view, restored-layout, and max-tab-limit scenarios.

Testing: `npm run typecheck`, `npm run lint`, `npm run test`, and `npm run build`.