### PR TITLE
Stream incremental Claude tool input updates

### DIFF
--- a/src/features/chat/rendering/SubagentRenderer.ts
+++ b/src/features/chat/rendering/SubagentRenderer.ts
@@ -290,6 +290,31 @@ export function addSubagentToolCall(
   state: SubagentState,
   toolCall: ToolCallInfo
 ): void {
+  const existingIndex = state.info.toolCalls.findIndex(tc => tc.id === toolCall.id);
+  if (existingIndex >= 0) {
+    const existingToolCall = state.info.toolCalls[existingIndex]!;
+    const mergedToolCall: ToolCallInfo = {
+      ...existingToolCall,
+      ...toolCall,
+      input: {
+        ...existingToolCall.input,
+        ...toolCall.input,
+      },
+      result: toolCall.result ?? existingToolCall.result,
+      isExpanded: toolCall.isExpanded ?? existingToolCall.isExpanded,
+    };
+
+    state.info.toolCalls[existingIndex] = mergedToolCall;
+
+    const existingView = state.toolElements.get(toolCall.id);
+    if (existingView) {
+      updateSubagentToolView(existingView, mergedToolCall);
+    }
+
+    updateSyncHeaderAria(state);
+    return;
+  }
+
   state.info.toolCalls.push(toolCall);
 
   const toolCount = state.info.toolCalls.length;

--- a/src/providers/claude/runtime/ClaudeChatRuntime.ts
+++ b/src/providers/claude/runtime/ClaudeChatRuntime.ts
@@ -72,7 +72,7 @@ import { createStopSubagentHook, type SubagentHookState } from '../hooks/Subagen
 import { encodeClaudeTurn } from '../prompt/ClaudeTurnEncoder';
 import { isContextWindowEvent, isSessionInitEvent, isStreamChunk } from '../sdk/typeGuards';
 import { getClaudeProviderSettings } from '../settings';
-import { transformSDKMessage } from '../stream/transformClaudeMessage';
+import { createTransformStreamState, transformSDKMessage } from '../stream/transformClaudeMessage';
 import { type ClaudeProviderState, getClaudeState } from '../types/providerState';
 import { createClaudeApprovalCallback } from './ClaudeApprovalHandler';
 import { applyClaudeDynamicUpdates } from './ClaudeDynamicUpdates';
@@ -176,6 +176,7 @@ export class ClaudianService implements ChatRuntime {
   private _autoTurnCallback: ((result: AutoTurnResult) => void) | null = null;
   private turnMetadata: ChatTurnMetadata = {};
   private bufferedUsageChunk: StreamChunk & { type: 'usage' } | null = null;
+  private streamTransformState = createTransformStreamState();
 
   private getLegacyPluginDeps(): ClaudianPlugin & {
     agentManager?: Pick<AppAgentManager, 'setBuiltinAgentNames'>;
@@ -586,6 +587,7 @@ export class ClaudianService implements ChatRuntime {
     this.responseConsumerPromise = null;
     this.currentConfig = null;
     this.cachedSdkCommands = [];
+    this.streamTransformState.clearAll();
     this._autoTurnBuffer = [];
     this._autoTurnSawStreamText = false;
     if (!preserveHandlers) {
@@ -791,11 +793,12 @@ export class ClaudianService implements ChatRuntime {
   }
 
   /** @param modelOverride - Optional model override for cold-start queries */
-  private getTransformOptions(modelOverride?: string) {
+  private getTransformOptions(modelOverride?: string, streamState = this.streamTransformState) {
     const settings = this.getScopedSettings();
     return {
       intendedModel: modelOverride ?? settings.model,
       customContextLimits: settings.customContextLimits,
+      streamState,
     };
   }
 
@@ -1482,6 +1485,7 @@ export class ClaudianService implements ChatRuntime {
     const options = QueryOptionsBuilder.buildColdStartQueryOptions(ctx);
 
     let sawStreamText = false;
+    const streamState = createTransformStreamState();
     try {
       const response = agentQuery({ prompt: queryPrompt, options });
       this.recordTurnMetadata({ wasSent: true });
@@ -1496,7 +1500,7 @@ export class ClaudianService implements ChatRuntime {
           break;
         }
 
-        for (const event of transformSDKMessage(message, this.getTransformOptions(selectedModel))) {
+        for (const event of transformSDKMessage(message, this.getTransformOptions(selectedModel, streamState))) {
           if (isSessionInitEvent(event)) {
             this.sessionManager.captureSession(event.sessionId);
             streamSessionId = event.sessionId;

--- a/src/providers/claude/stream/toolInputStreamState.ts
+++ b/src/providers/claude/stream/toolInputStreamState.ts
@@ -1,0 +1,318 @@
+type JsonTokenType = 'brace' | 'bracket' | 'separator' | 'delimiter' | 'string' | 'number' | 'name';
+
+type JsonToken = {
+  type: JsonTokenType;
+  value: string;
+};
+
+type ToolUseSnapshot = {
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+  partialJson: string;
+};
+
+type ToolUseFields = {
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+};
+
+export interface TransformStreamState {
+  registerToolUse(parentToolUseId: string | null, index: number, toolUse: ToolUseFields): void;
+  applyInputJsonDelta(parentToolUseId: string | null, index: number, partialJson: string): ToolUseFields | null;
+  clearContentBlock(parentToolUseId: string | null, index: number): void;
+  clearParent(parentToolUseId: string | null): void;
+  clearAll(): void;
+}
+
+const MAIN_AGENT_STREAM = '__main__';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeToolInput(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+function getContentBlockKey(parentToolUseId: string | null, index: number): string {
+  return `${parentToolUseId ?? MAIN_AGENT_STREAM}:${index}`;
+}
+
+function getParentPrefix(parentToolUseId: string | null): string {
+  return `${parentToolUseId ?? MAIN_AGENT_STREAM}:`;
+}
+
+function findClosingTokenIndex(tokens: JsonToken[], value: string): number {
+  for (let index = tokens.length - 1; index >= 0; index -= 1) {
+    if (tokens[index]?.value === value) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function tokenizePartialJson(input: string): JsonToken[] {
+  const tokens: JsonToken[] = [];
+  let index = 0;
+
+  while (index < input.length) {
+    let char = input[index] ?? '';
+
+    if (char === '\\') {
+      index += 1;
+      continue;
+    }
+
+    if (char === '{' || char === '}') {
+      tokens.push({ type: 'brace', value: char });
+      index += 1;
+      continue;
+    }
+
+    if (char === '[' || char === ']') {
+      tokens.push({ type: 'bracket', value: char });
+      index += 1;
+      continue;
+    }
+
+    if (char === ':') {
+      tokens.push({ type: 'separator', value: char });
+      index += 1;
+      continue;
+    }
+
+    if (char === ',') {
+      tokens.push({ type: 'delimiter', value: char });
+      index += 1;
+      continue;
+    }
+
+    if (char === '"') {
+      let value = '';
+      let isDanglingString = false;
+      index += 1;
+      char = input[index] ?? '';
+
+      while (char !== '"') {
+        if (index === input.length) {
+          isDanglingString = true;
+          break;
+        }
+
+        if (char === '\\') {
+          index += 1;
+          if (index === input.length) {
+            isDanglingString = true;
+            break;
+          }
+          value += char + (input[index] ?? '');
+          index += 1;
+          char = input[index] ?? '';
+          continue;
+        }
+
+        value += char;
+        index += 1;
+        char = input[index] ?? '';
+      }
+
+      index += 1;
+      if (!isDanglingString) {
+        tokens.push({ type: 'string', value });
+      }
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      index += 1;
+      continue;
+    }
+
+    if (/[0-9]/.test(char) || char === '-' || char === '.') {
+      let value = '';
+
+      if (char === '-') {
+        value += char;
+        index += 1;
+        char = input[index] ?? '';
+      }
+
+      while (/[0-9]/.test(char) || char === '.') {
+        value += char;
+        index += 1;
+        char = input[index] ?? '';
+      }
+
+      tokens.push({ type: 'number', value });
+      continue;
+    }
+
+    if (/[a-z]/i.test(char)) {
+      let value = '';
+
+      while (/[a-z]/i.test(char)) {
+        value += char;
+        index += 1;
+        char = input[index] ?? '';
+      }
+
+      if (value === 'true' || value === 'false' || value === 'null') {
+        tokens.push({ type: 'name', value });
+      } else {
+        index += 1;
+      }
+      continue;
+    }
+
+    index += 1;
+  }
+
+  return tokens;
+}
+
+function stripIncompleteTail(tokens: JsonToken[]): JsonToken[] {
+  if (tokens.length === 0) {
+    return tokens;
+  }
+
+  const lastToken = tokens[tokens.length - 1];
+  if (!lastToken) {
+    return tokens;
+  }
+
+  switch (lastToken.type) {
+    case 'separator':
+    case 'delimiter':
+      return stripIncompleteTail(tokens.slice(0, -1));
+    case 'number': {
+      const lastChar = lastToken.value[lastToken.value.length - 1];
+      return lastChar === '.' || lastChar === '-'
+        ? stripIncompleteTail(tokens.slice(0, -1))
+        : tokens;
+    }
+    case 'string': {
+      const previousToken = tokens[tokens.length - 2];
+      if (previousToken?.type === 'delimiter') {
+        return stripIncompleteTail(tokens.slice(0, -1));
+      }
+      if (previousToken?.type === 'brace' && previousToken.value === '{') {
+        return stripIncompleteTail(tokens.slice(0, -1));
+      }
+      return tokens;
+    }
+    default:
+      return tokens;
+  }
+}
+
+function closeOpenContainers(tokens: JsonToken[]): JsonToken[] {
+  const completedTokens = [...tokens];
+  const closingTokens: JsonToken[] = [];
+
+  for (const token of completedTokens) {
+      if (token.type === 'brace') {
+        if (token.value === '{') {
+          closingTokens.push({ type: 'brace', value: '}' });
+        } else {
+          const closingIndex = findClosingTokenIndex(closingTokens, '}');
+          if (closingIndex >= 0) {
+            closingTokens.splice(closingIndex, 1);
+          }
+        }
+        continue;
+    }
+
+    if (token.type === 'bracket') {
+      if (token.value === '[') {
+        closingTokens.push({ type: 'bracket', value: ']' });
+      } else {
+        const closingIndex = findClosingTokenIndex(closingTokens, ']');
+        if (closingIndex >= 0) {
+          closingTokens.splice(closingIndex, 1);
+        }
+      }
+    }
+  }
+
+  for (let index = closingTokens.length - 1; index >= 0; index -= 1) {
+    const token = closingTokens[index];
+    if (token) {
+      completedTokens.push(token);
+    }
+  }
+
+  return completedTokens;
+}
+
+function renderJson(tokens: JsonToken[]): string {
+  return tokens
+    .map((token) => token.type === 'string' ? `"${token.value}"` : token.value)
+    .join('');
+}
+
+function parsePartialToolInput(input: string): Record<string, unknown> | null {
+  const tokens = tokenizePartialJson(input);
+  if (tokens.length === 0) {
+    return {};
+  }
+
+  try {
+    const repairedJson = renderJson(closeOpenContainers(stripIncompleteTail(tokens)));
+    return normalizeToolInput(JSON.parse(repairedJson));
+  } catch {
+    return null;
+  }
+}
+
+export function createTransformStreamState(): TransformStreamState {
+  const activeToolUses = new Map<string, ToolUseSnapshot>();
+
+  return {
+    registerToolUse(parentToolUseId, index, toolUse) {
+      activeToolUses.set(getContentBlockKey(parentToolUseId, index), {
+        ...toolUse,
+        input: { ...toolUse.input },
+        partialJson: '',
+      });
+    },
+    applyInputJsonDelta(parentToolUseId, index, partialJson) {
+      const snapshot = activeToolUses.get(getContentBlockKey(parentToolUseId, index));
+      if (!snapshot) {
+        return null;
+      }
+
+      snapshot.partialJson += partialJson;
+      const parsedInput = parsePartialToolInput(snapshot.partialJson);
+      if (parsedInput === null) {
+        return null;
+      }
+
+      snapshot.input = {
+        ...snapshot.input,
+        ...parsedInput,
+      };
+
+      return {
+        id: snapshot.id,
+        name: snapshot.name,
+        input: { ...snapshot.input },
+      };
+    },
+    clearContentBlock(parentToolUseId, index) {
+      activeToolUses.delete(getContentBlockKey(parentToolUseId, index));
+    },
+    clearParent(parentToolUseId) {
+      const parentPrefix = getParentPrefix(parentToolUseId);
+      for (const key of activeToolUses.keys()) {
+        if (key.startsWith(parentPrefix)) {
+          activeToolUses.delete(key);
+        }
+      }
+    },
+    clearAll() {
+      activeToolUses.clear();
+    },
+  };
+}

--- a/src/providers/claude/stream/transformClaudeMessage.ts
+++ b/src/providers/claude/stream/transformClaudeMessage.ts
@@ -5,9 +5,12 @@ import { isBlockedMessage } from '../sdk/messages';
 import { extractToolResultContent } from '../sdk/toolResultContent';
 import type { TransformEvent } from '../sdk/types';
 import { getContextWindowSize } from '../types/models';
+import { createTransformStreamState, type TransformStreamState } from './toolInputStreamState';
 
 type ToolUseFields = { id: string; name: string; input: Record<string, unknown> };
 type ToolResultFields = { id: string; content: string; isError?: boolean; toolUseResult?: SDKToolUseResult };
+
+export { createTransformStreamState };
 
 function getToolInput(input: unknown): Record<string, unknown> {
   if (!input || typeof input !== 'object' || Array.isArray(input)) {
@@ -35,6 +38,8 @@ export interface TransformOptions {
   intendedModel?: string;
   /** Custom context limits from settings (model ID → tokens). */
   customContextLimits?: Record<string, number>;
+  /** Tracks active streamed tool blocks so input_json_delta can be normalized. */
+  streamState?: TransformStreamState;
 }
 
 interface MessageUsage {
@@ -171,6 +176,8 @@ export function* transformSDKMessage(
         }
       }
 
+      options?.streamState?.clearParent(parentToolUseId);
+
       // Extract usage from main agent assistant messages only (not subagent)
       // This gives accurate per-turn context usage without subagent token pollution
       const usage = (message.message as { usage?: MessageUsage } | undefined)?.usage;
@@ -241,11 +248,15 @@ export function* transformSDKMessage(
       const parentToolUseId = message.parent_tool_use_id ?? null;
       const event = message.event;
       if (event?.type === 'content_block_start' && event.content_block?.type === 'tool_use') {
-        yield emitToolUse(parentToolUseId, {
+        const toolUseFields: ToolUseFields = {
           id: event.content_block.id || `tool-${Date.now()}`,
           name: event.content_block.name || 'unknown',
           input: getToolInput(event.content_block.input),
-        });
+        };
+        if (typeof event.index === 'number') {
+          options?.streamState?.registerToolUse(parentToolUseId, event.index, toolUseFields);
+        }
+        yield emitToolUse(parentToolUseId, toolUseFields);
       } else if (event?.type === 'content_block_start' && event.content_block?.type === 'thinking') {
         if (parentToolUseId === null && event.content_block.thinking) {
           yield { type: 'thinking', content: event.content_block.thinking };
@@ -255,16 +266,28 @@ export function* transformSDKMessage(
           yield { type: 'text', content: event.content_block.text };
         }
       } else if (event?.type === 'content_block_delta') {
-        if (parentToolUseId === null && event.delta?.type === 'thinking_delta' && event.delta.thinking) {
+        if (event.delta?.type === 'input_json_delta' && typeof event.index === 'number') {
+          const toolUseFields = options?.streamState?.applyInputJsonDelta(
+            parentToolUseId,
+            event.index,
+            event.delta.partial_json,
+          );
+          if (toolUseFields) {
+            yield emitToolUse(parentToolUseId, toolUseFields);
+          }
+        } else if (parentToolUseId === null && event.delta?.type === 'thinking_delta' && event.delta.thinking) {
           yield { type: 'thinking', content: event.delta.thinking };
         } else if (parentToolUseId === null && event.delta?.type === 'text_delta' && event.delta.text) {
           yield { type: 'text', content: event.delta.text };
         }
+      } else if (event?.type === 'content_block_stop' && typeof event.index === 'number') {
+        options?.streamState?.clearContentBlock(parentToolUseId, event.index);
       }
       break;
     }
 
     case 'result':
+      options?.streamState?.clearAll();
       if (isResultError(message)) {
         const content = message.errors.filter((e) => e.trim().length > 0).join('\n');
         yield {

--- a/tests/unit/features/chat/rendering/SubagentRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/SubagentRenderer.test.ts
@@ -627,6 +627,37 @@ describe('addSubagentToolCall', () => {
     expect(state.info.toolCalls).toHaveLength(2);
     expect(state.countEl.textContent).toBe('2 tool uses');
   });
+
+  it('merges repeated tool IDs instead of duplicating tool rows', () => {
+    const state = createSubagentBlock(parentEl as any, 'task-1', { description: 'Test task' });
+
+    addSubagentToolCall(state, {
+      id: 'tool-1',
+      name: 'Write',
+      input: {},
+      status: 'running',
+      isExpanded: false,
+    });
+
+    addSubagentToolCall(state, {
+      id: 'tool-1',
+      name: 'Write',
+      input: { file_path: 'notes.md' },
+      status: 'running',
+      isExpanded: false,
+    });
+
+    expect(state.info.toolCalls).toHaveLength(1);
+    expect(state.info.toolCalls[0]).toEqual(
+      expect.objectContaining({
+        id: 'tool-1',
+        input: { file_path: 'notes.md' },
+      })
+    );
+    expect(state.countEl.textContent).toBe('1 tool uses');
+    expect(getTextByClass(state.toolsContainerEl as any, 'claudian-subagent-tool-name')).toEqual(['Write']);
+    expect(getTextByClass(state.toolsContainerEl as any, 'claudian-subagent-tool-summary')).toEqual(['notes.md']);
+  });
 });
 
 describe('updateSubagentToolResult', () => {

--- a/tests/unit/providers/claude/runtime/ClaudianService.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudianService.test.ts
@@ -1217,6 +1217,52 @@ describe('ClaudianService', () => {
       expect(onChunk).toHaveBeenCalled();
     });
 
+    it('should route tool input deltas as tool_use updates', async () => {
+      await (service as any).routeMessage({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: {
+            type: 'tool_use',
+            id: 'stream-tool-1',
+            name: 'Write',
+            input: {},
+          },
+        },
+      });
+      await (service as any).routeMessage({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: {
+            type: 'input_json_delta',
+            partial_json: '{"file_path":"notes.md"',
+          },
+        },
+      });
+
+      const toolChunks = onChunk.mock.calls
+        .map(([chunk]) => chunk)
+        .filter((chunk: any) => chunk.type === 'tool_use');
+
+      expect(toolChunks).toEqual([
+        {
+          type: 'tool_use',
+          id: 'stream-tool-1',
+          name: 'Write',
+          input: {},
+        },
+        {
+          type: 'tool_use',
+          id: 'stream-tool-1',
+          name: 'Write',
+          input: { file_path: 'notes.md' },
+        },
+      ]);
+    });
+
     it('should signal turn complete on result message', async () => {
       const message = { type: 'result', subtype: 'success', result: 'completed' };
 
@@ -3053,6 +3099,74 @@ describe('ClaudianService', () => {
 
       // Stream text was seen, so duplicate text from assistant message should be skipped
       // Verify query completed successfully
+      expect(chunks.some(c => c.type === 'done')).toBe(true);
+    });
+
+    it('should stream cumulative tool input updates during cold-start query', async () => {
+      sdkMock.setMockMessages([
+        { type: 'system', subtype: 'init', session_id: 'stream-tool-input' },
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_start',
+            index: 0,
+            content_block: {
+              type: 'tool_use',
+              id: 'stream-tool-1',
+              name: 'Write',
+              input: {},
+            },
+          },
+        },
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: {
+              type: 'input_json_delta',
+              partial_json: '{"file_path":"notes.md"',
+            },
+          },
+        },
+        {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: {
+              type: 'input_json_delta',
+              partial_json: ',"content":"Hello"',
+            },
+          },
+        },
+      ], { appendResult: true });
+
+      const chunks = await collectChunks(
+        service.query('hello', undefined, undefined, { forceColdStart: true })
+      );
+
+      const toolChunks = chunks.filter(c => c.type === 'tool_use');
+      expect(toolChunks).toEqual([
+        {
+          type: 'tool_use',
+          id: 'stream-tool-1',
+          name: 'Write',
+          input: {},
+        },
+        {
+          type: 'tool_use',
+          id: 'stream-tool-1',
+          name: 'Write',
+          input: { file_path: 'notes.md' },
+        },
+        {
+          type: 'tool_use',
+          id: 'stream-tool-1',
+          name: 'Write',
+          input: { file_path: 'notes.md', content: 'Hello' },
+        },
+      ]);
       expect(chunks.some(c => c.type === 'done')).toBe(true);
     });
 

--- a/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
+++ b/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
@@ -1,6 +1,6 @@
 import { buildSDKMessage } from '@test/helpers/sdkMessages';
 
-import { transformSDKMessage } from '@/providers/claude/stream/transformClaudeMessage';
+import { createTransformStreamState, transformSDKMessage } from '@/providers/claude/stream/transformClaudeMessage';
 
 const msg = buildSDKMessage;
 
@@ -584,6 +584,70 @@ describe('transformSDKMessage', () => {
 
       expect(results.length).toBe(1);
       expect((results[0] as any).id).toMatch(/^tool-\d+$/);
+    });
+
+    it('yields cumulative tool_use updates for input_json_delta', () => {
+      const streamState = createTransformStreamState();
+      const startMessage = msg({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: {
+            type: 'tool_use',
+            id: 'stream-tool-1',
+            name: 'Write',
+            input: {},
+          },
+        },
+      });
+      const firstDeltaMessage = msg({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: {
+            type: 'input_json_delta',
+            partial_json: '{"file_path":"notes.md"',
+          },
+        },
+      });
+      const secondDeltaMessage = msg({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: {
+            type: 'input_json_delta',
+            partial_json: ',"content":"Hello"',
+          },
+        },
+      });
+
+      expect([...transformSDKMessage(startMessage, { streamState })]).toEqual([
+        {
+          type: 'tool_use',
+          id: 'stream-tool-1',
+          name: 'Write',
+          input: {},
+        },
+      ]);
+      expect([...transformSDKMessage(firstDeltaMessage, { streamState })]).toEqual([
+        {
+          type: 'tool_use',
+          id: 'stream-tool-1',
+          name: 'Write',
+          input: { file_path: 'notes.md' },
+        },
+      ]);
+      expect([...transformSDKMessage(secondDeltaMessage, { streamState })]).toEqual([
+        {
+          type: 'tool_use',
+          id: 'stream-tool-1',
+          name: 'Write',
+          input: { file_path: 'notes.md', content: 'Hello' },
+        },
+      ]);
     });
 
     it('yields thinking for content_block_start with thinking', () => {


### PR DESCRIPTION
## Summary
- stream Claude `input_json_delta` events into cumulative `tool_use` updates in both persistent and cold-start runtime paths
- add tracked tool-input state so partial JSON can be merged across stream events and cleared at the right boundaries
- merge repeated subagent tool IDs so progressive updates refresh existing rows instead of duplicating them

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run build`