### PR TITLE
Fix disappearing Obsidian chat wikilinks

### DIFF
--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -580,13 +580,18 @@ export class MessageRenderer {
     el.empty();
 
     try {
-      // Replace image embeds with HTML img tags before rendering
+      // Normalize embeds before MarkdownRenderer consumes them.
       const processedMarkdown = replaceImageEmbedsWithHtml(
         markdown,
         this.app,
         this.plugin.settings.mediaFolder
       );
-      await MarkdownRenderer.renderMarkdown(processedMarkdown, el, '', this.component);
+      await MarkdownRenderer.renderMarkdown(
+        processedMarkdown,
+        el,
+        '',
+        this.component
+      );
 
       // Wrap pre elements and move buttons outside scroll area
       el.querySelectorAll('pre').forEach((pre) => {

--- a/src/utils/fileLink.ts
+++ b/src/utils/fileLink.ts
@@ -33,6 +33,23 @@ interface WikilinkMatch {
   displayText: string;
 }
 
+function buildWikilinkMatch(
+  fullMatch: string,
+  linkPath: string,
+  index: number
+): WikilinkMatch {
+  const pipeIndex = fullMatch.lastIndexOf('|');
+  const displayText = pipeIndex > 0 ? fullMatch.slice(pipeIndex + 1, -2) : linkPath;
+
+  return {
+    index,
+    fullMatch,
+    linkPath,
+    linkTarget: extractLinkTarget(fullMatch),
+    displayText,
+  };
+}
+
 export function extractLinkTarget(fullMatch: string): string {
   const inner = fullMatch.slice(2, -2);
   const pipeIndex = inner.indexOf('|');
@@ -51,14 +68,10 @@ function findWikilinks(app: App, text: string): WikilinkMatch[] {
   while ((match = pattern.exec(text)) !== null) {
     const fullMatch = match[0];
     const linkPath = match[1];
-    const linkTarget = extractLinkTarget(fullMatch);
 
     if (!fileExistsInVault(app, linkPath)) continue;
 
-    const pipeIndex = fullMatch.lastIndexOf('|');
-    const displayText = pipeIndex > 0 ? fullMatch.slice(pipeIndex + 1, -2) : linkPath;
-
-    matches.push({ index: match.index, fullMatch, linkPath, linkTarget, displayText });
+    matches.push(buildWikilinkMatch(fullMatch, linkPath, match.index));
   }
 
   return matches.sort((a, b) => b.index - a.index);
@@ -85,6 +98,11 @@ function fileExistsInVault(app: App, linkPath: string): boolean {
   return false;
 }
 
+function extractLinkPathFromTarget(linkTarget: string): string {
+  const subpathIndex = linkTarget.search(/[#^]/);
+  return subpathIndex >= 0 ? linkTarget.slice(0, subpathIndex) : linkTarget;
+}
+
 /**
  * Creates a link element for a wikilink.
  * Click handling is done via event delegation in registerFileLinkHandler.
@@ -99,6 +117,22 @@ function createWikilink(
   link.setAttribute('data-href', linkTarget);
   link.setAttribute('href', linkTarget);
   return link;
+}
+
+function repairEmptyInternalLink(app: App, link: HTMLAnchorElement): void {
+  if ((link.textContent || '').trim()) return;
+
+  const linkTarget = link.dataset.href || link.getAttribute('data-href') || link.getAttribute('href');
+  if (!linkTarget) return;
+
+  const linkPath = extractLinkPathFromTarget(linkTarget);
+  if (!linkPath || !fileExistsInVault(app, linkPath)) return;
+
+  link.classList.add('claudian-file-link');
+  if (!link.dataset.href) {
+    link.setAttribute('data-href', linkTarget);
+  }
+  link.textContent = linkTarget;
 }
 
 /**
@@ -167,10 +201,15 @@ function processTextNode(app: App, node: Text): boolean {
 
 /**
  * Call after MarkdownRenderer.renderMarkdown().
- * Catches wikilinks that Obsidian's renderer doesn't process (e.g., in code blocks).
+ * Catches wikilinks that remain as raw text after rendering, especially inline code spans.
  */
 export function processFileLinks(app: App, container: HTMLElement): void {
   if (!app || !container) return;
+
+  // Repair resolved internal links that rendered as empty anchors.
+  container.querySelectorAll('a.internal-link').forEach((linkEl) => {
+    repairEmptyInternalLink(app, linkEl as HTMLAnchorElement);
+  });
 
   // Wikilinks in inline code aren't rendered by Obsidian's MarkdownRenderer
   container.querySelectorAll('code').forEach((codeEl) => {

--- a/tests/unit/features/chat/rendering/MessageRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/MessageRenderer.test.ts
@@ -1521,6 +1521,33 @@ describe('MessageRenderer', () => {
   // ============================================
 
   describe('renderContent - code block wrapping', () => {
+    it('passes image-processed markdown directly to MarkdownRenderer', async () => {
+      const { MarkdownRenderer } = await import('obsidian');
+      const { replaceImageEmbedsWithHtml } = await import('@/utils/imageEmbed');
+      const { processFileLinks } = await import('@/utils/fileLink');
+      const { renderer } = createRenderer();
+      const el = createMockEl();
+
+      (replaceImageEmbedsWithHtml as jest.Mock).mockReturnValueOnce(
+        '<span title="[[note.md]]">raw html</span>\n    [[note.md]]'
+      );
+
+      await renderer.renderContent(el, 'before-images ![[image.png]] [[note.md]]');
+
+      expect(replaceImageEmbedsWithHtml).toHaveBeenCalledWith(
+        'before-images ![[image.png]] [[note.md]]',
+        expect.anything(),
+        ''
+      );
+      expect(MarkdownRenderer.renderMarkdown).toHaveBeenCalledWith(
+        '<span title="[[note.md]]">raw html</span>\n    [[note.md]]',
+        el,
+        '',
+        expect.anything()
+      );
+      expect(processFileLinks).toHaveBeenCalledWith(expect.anything(), el);
+    });
+
     it('should wrap pre elements in code wrapper divs', async () => {
       const { MarkdownRenderer } = await import('obsidian');
       const { renderer } = createRenderer();

--- a/tests/unit/utils/fileLink.dom.test.ts
+++ b/tests/unit/utils/fileLink.dom.test.ts
@@ -214,6 +214,20 @@ describe('processFileLinks', () => {
       expect(links.length).toBe(0);
     });
 
+    it('repairs empty resolved internal-link anchors while leaving missing wikilinks visible', () => {
+      const app = createMockApp(['note.md']);
+      const container = document.createElement('div');
+      container.innerHTML = '<a class="internal-link" href="note"></a> and [[missing.md]]';
+
+      processFileLinks(app, container);
+
+      const internalLink = container.querySelector('a.internal-link');
+      expect(internalLink).not.toBeNull();
+      expect(internalLink!.textContent).toBe('note');
+      expect(internalLink!.classList.contains('claudian-file-link')).toBe(true);
+      expect(container.textContent).toBe('note and [[missing.md]]');
+    });
+
     it('processes text nodes in regular elements', () => {
       const app = createMockApp(['note.md']);
       const container = document.createElement('div');


### PR DESCRIPTION
## Summary
- keep chat markdown rendering limited to image embed normalization before `MarkdownRenderer`
- repair empty resolved `.internal-link` anchors during post-render file-link processing so existing note links stay visible and clickable while missing wikilinks remain plain text
- add regression coverage for raw HTML and indented code passthrough plus the consumed-existing-link case

## Verification
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run build`
