### PR TITLE
feat: add current time to system prompt context

### DIFF
--- a/src/core/prompt/mainAgent.ts
+++ b/src/core/prompt/mainAgent.ts
@@ -1,4 +1,4 @@
-import { getTodayDate } from '../../utils/date';
+import { getTodayDate, getCurrentTime } from '../../utils/date';
 
 export interface SystemPromptSettings {
   mediaFolder?: string;
@@ -41,6 +41,7 @@ function getBaseSystemPrompt(
   return `${userContext}## Time Context
 
 - **Current Date**: ${getTodayDate()}
+- **Current Time**: ${getCurrentTime()}
 - **Knowledge Status**: You possess extensive internal knowledge up to your training cutoff. You do not know the exact date of your cutoff, but you must assume that your internal weights are static and "past," while the Current Date is "present."
 
 ## Identity & Role

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -17,6 +17,14 @@ export function getTodayDate(): string {
   return `${readable} (${iso})`;
 }
 
+/**
+ * Returns the current local time in en-US format (e.g. "02:23 PM").
+ * Uses the system clock of the user's machine.
+ */
+export function getCurrentTime(): string {
+  return new Date().toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
+}
+
 /** Formats a duration in seconds as "1m 23s" or "45s". */
 export function formatDurationMmSs(seconds: number): string {
   if (!Number.isFinite(seconds) || seconds < 0) {


### PR DESCRIPTION
## Summary
- Adds `getCurrentTime()` utility to `src/utils/date.ts` that returns the 
  current local time in en-US format (e.g. "02:23 PM") using the user's system clock
- Imports and adds `getCurrentTime()` to the Time Context section of the 
  system prompt in `src/core/prompt/mainAgent.ts`

## Why
The system prompt already provides the current date as context. Adding the 
current time allows the AI to be aware of time-sensitive situations within 
the same day and give more precise time-aware responses.

The time is read from the user's local system clock via `new Date()` — 
no external calls, no hardcoded timezone.

## Test
Open a new chat and ask "what time is it?" — it should respond with the 
current local time.