### PR TITLE
feat: add ACP (Agent Client Protocol) provider

### DIFF
--- a/src/providers/acp/CLAUDE.md
+++ b/src/providers/acp/CLAUDE.md
@@ -1,0 +1,77 @@
+# ACP Provider
+
+Adaptor for Agent Client Protocol (ACP) agents via stdio JSON-RPC 2.0.
+
+## Protocol Overview
+
+ACP is a standardized JSON-RPC 2.0 protocol for agent-editor communication, similar to LSP for language servers. The ACP provider enables Claudian to connect to any ACP-compatible agent.
+
+The protocol uses:
+- **Startup handshake**: client sends `initialize`, receives server capabilities
+- **Client → Server** (request/response): `chat/send`, `tools/list`, `shutdown`
+- **Server → Client** (notifications): streaming deltas, tool events, `chat/messageStop`
+- **Server → Client → Server** (server requests): tool approval gates, user input requests
+
+## Design Decisions
+
+### Transport Layer
+
+The stdio transport (`AcpStdioTransport`) is adapted from `CodexRpcTransport` since both use JSON-RPC 2.0 over newline-delimited JSON. This provides a proven pattern for:
+- Request/response correlation
+- Timeout handling
+- Notification routing
+- Server request (bidi-rpc) handling
+
+### Provider State
+
+ACP agents are stateless from Claudian's perspective. The `providerState` only stores the `sessionId` for tracking active conversations. Agent-managed history and session persistence are handled by the agent itself.
+
+### MVP Scope
+
+The initial implementation (Phase 1) supports:
+- Text streaming via `chat/textDelta` notifications
+- Basic tool use (approval, execution, result)
+- stdio transport for local agents
+
+Future phases will add:
+- HTTP/WebSocket transport for remote agents
+- Multi-agent configuration
+- Agent capability discovery
+- Session persistence
+
+## Non-Obvious Behaviors
+
+### Agent Configuration
+
+ACP agents are configured in settings under `acp.agents`. Each agent has:
+- `id`: Unique identifier
+- `name`: Display name in UI
+- `transportType`: 'stdio' | 'http' | 'websocket'
+- `command`/`args`/`env`: For stdio agents
+- `url`/`headers`: For HTTP/WebSocket agents (future)
+
+The `defaultAgentId` setting determines which agent is active by default.
+
+### Chunk Buffering
+
+Similar to Codex, the runtime uses a chunk buffer pattern:
+- Notifications push chunks to `chunkBuffer`
+- The `query()` generator drains the buffer
+- `chunkResolve` unblocks the drain loop when new chunks arrive
+
+### Tool Approval Mapping
+
+ACP uses `allow`/`deny`/`allow-always` decisions. Claudian's `ApprovalDecision` is mapped as:
+- `allow` or `allow-always` → `allow`
+- `deny` or `cancel` → `deny`
+
+### User Input Questions
+
+ACP's `user/requestInput` uses question IDs. Claudian's `AskUserQuestionCallback` expects a `Record<string, unknown>`, so the router converts between formats.
+
+## Gotchas
+
+- `AcpChatRuntime` is a minimal MVP implementation—many `ChatRuntime` methods are no-ops or return stub values
+- Tool result interpretation is minimal—ACP doesn't have the same async agent pattern as Claude
+- The settings reconciler only invalidates conversations when the configured agent is removed
+- HTTP/WebSocket transport is stubbed for future implementation

--- a/src/providers/acp/auxiliary/AcpInlineEditService.ts
+++ b/src/providers/acp/auxiliary/AcpInlineEditService.ts
@@ -1,0 +1,42 @@
+import type { InlineEditService, InlineEditResult } from '../../../core/providers/types';
+import ClaudianPlugin from '../../../main';
+
+/**
+ * ACP inline edit service (stub for MVP).
+ */
+export class AcpInlineEditService implements InlineEditService {
+  constructor(private readonly plugin: ClaudianPlugin) {}
+
+  resetConversation(): void {
+    // No-op in MVP
+  }
+
+  async editText(_request: {
+    mode: 'selection' | 'cursor';
+    instruction: string;
+    notePath: string;
+    selectedText?: string;
+    cursorContext?: unknown;
+    contextFiles?: string[];
+  }): Promise<InlineEditResult> {
+    // For MVP, indicate that inline edit is not supported
+    return {
+      success: false,
+      error: 'ACP inline edit is not yet supported',
+    };
+  }
+
+  async continueConversation(
+    _message: string,
+    _contextFiles?: string[],
+  ): Promise<InlineEditResult> {
+    return {
+      success: false,
+      error: 'ACP inline edit is not yet supported',
+    };
+  }
+
+  cancel(): void {
+    // No-op in MVP
+  }
+}

--- a/src/providers/acp/auxiliary/AcpInstructionRefineService.ts
+++ b/src/providers/acp/auxiliary/AcpInstructionRefineService.ts
@@ -1,0 +1,34 @@
+import type { InstructionRefineService } from '../../../core/providers/types';
+import type { InstructionRefineResult } from '../../../core/types';
+import ClaudianPlugin from '../../../main';
+
+/**
+ * ACP instruction refine service (stub for MVP).
+ */
+export class AcpInstructionRefineService implements InstructionRefineService {
+  constructor(private readonly plugin: ClaudianPlugin) {}
+
+  resetConversation(): void {
+    // No-op in MVP
+  }
+
+  async refineInstruction(
+    rawInstruction: string,
+    _existingInstructions: string,
+    _onProgress?: (update: InstructionRefineResult) => void,
+  ): Promise<InstructionRefineResult> {
+    // For MVP, just return the raw instruction
+    return { success: true, refinedInstruction: rawInstruction };
+  }
+
+  async continueConversation(
+    _message: string,
+    _onProgress?: (update: InstructionRefineResult) => void,
+  ): Promise<InstructionRefineResult> {
+    return { success: true, refinedInstruction: '' };
+  }
+
+  cancel(): void {
+    // No-op in MVP
+  }
+}

--- a/src/providers/acp/auxiliary/AcpTaskResultInterpreter.ts
+++ b/src/providers/acp/auxiliary/AcpTaskResultInterpreter.ts
@@ -1,0 +1,43 @@
+import type { ProviderTaskResultInterpreter } from '../../../core/providers/types';
+import type { ToolCallInfo } from '../../../core/types';
+
+/**
+ * ACP task result interpreter.
+ * ACP doesn't use the same async agent pattern as Claude, so most methods are no-ops.
+ */
+export class AcpTaskResultInterpreter implements ProviderTaskResultInterpreter {
+  hasAsyncLaunchMarker(toolUseResult: unknown): boolean {
+    // ACP doesn't have async launch markers
+    return false;
+  }
+
+  extractAgentId(toolUseResult: unknown): string | null {
+    // ACP doesn't use agent IDs in the same way
+    return null;
+  }
+
+  extractStructuredResult(toolUseResult: unknown): string | null {
+    // Try to extract a structured result from the tool output
+    if (toolUseResult && typeof toolUseResult === 'object') {
+      const result = toolUseResult as Record<string, unknown>;
+      if (typeof result.result === 'string') {
+        return result.result;
+      }
+    }
+    return null;
+  }
+
+  resolveTerminalStatus(
+    _toolUseResult: unknown,
+    fallbackStatus: 'completed' | 'error',
+  ): 'completed' | 'error' {
+    return fallbackStatus;
+  }
+
+  extractTagValue(payload: string, tagName: string): string | null {
+    // Extract a tag value from the payload (e.g., <tag>value</tag>)
+    const regex = new RegExp(`<${tagName}>([^<]*)</${tagName}>`, 's');
+    const match = payload.match(regex);
+    return match ? match[1].trim() : null;
+  }
+}

--- a/src/providers/acp/auxiliary/AcpTitleGenerationService.ts
+++ b/src/providers/acp/auxiliary/AcpTitleGenerationService.ts
@@ -1,0 +1,24 @@
+import type { TitleGenerationService } from '../../../core/providers/types';
+import type ClaudianPlugin from '../../../main';
+
+/**
+ * ACP title generation service (stub for MVP).
+ * In a full implementation, this would use a separate ACP agent process.
+ */
+export class AcpTitleGenerationService implements TitleGenerationService {
+  constructor(private readonly plugin: ClaudianPlugin) {}
+
+  async generateTitle(
+    conversationId: string,
+    userMessage: string,
+    callback: (conversationId: string, result: { success: true; title: string } | { success: false; error: string }) => Promise<void>,
+  ): Promise<void> {
+    // For MVP, just use the first N characters of the user message
+    const title = userMessage.slice(0, 50).trim() + (userMessage.length > 50 ? '...' : '');
+    await callback(conversationId, { success: true, title });
+  }
+
+  cancel(): void {
+    // No-op in MVP
+  }
+}

--- a/src/providers/acp/capabilities.ts
+++ b/src/providers/acp/capabilities.ts
@@ -1,0 +1,16 @@
+import type { ProviderCapabilities } from '../../core/providers/types';
+
+export const ACP_PROVIDER_CAPABILITIES: Readonly<ProviderCapabilities> = Object.freeze({
+  providerId: 'acp',
+  supportsPersistentRuntime: false,  // Agent manages its own lifecycle
+  supportsNativeHistory: false,      // Depends on agent implementation
+  supportsPlanMode: false,           // Not in initial ACP spec
+  supportsRewind: false,             // Not in ACP spec
+  supportsFork: false,               // Not in ACP spec
+  supportsProviderCommands: false,   // Agent-specific commands handled differently
+  supportsImageAttachments: true,    // If agent supports it
+  supportsInstructionMode: false,    // Not in initial MVP
+  supportsMcpTools: false,           // ACP has its own tool system
+  supportsTurnSteer: false,          // Not in ACP spec
+  reasoningControl: 'none',          // Agent controls reasoning
+});

--- a/src/providers/acp/env/AcpSettingsReconciler.ts
+++ b/src/providers/acp/env/AcpSettingsReconciler.ts
@@ -1,0 +1,38 @@
+import type { ProviderSettingsReconciler } from '../../../core/providers/types';
+import type { Conversation } from '../../../core/types';
+import { getAcpProviderSettings, setAcpProviderSettings } from '../settings';
+
+/**
+ * ACP settings reconciler.
+ * Handles environment-based settings changes and session invalidation.
+ */
+export const acpSettingsReconciler: ProviderSettingsReconciler = {
+  reconcileModelWithEnvironment(
+    settings: Record<string, unknown>,
+    conversations: Conversation[],
+  ): { changed: boolean; invalidatedConversations: Conversation[] } {
+    const currentSettings = getAcpProviderSettings(settings);
+    const currentAgents = currentSettings.agents.map(a => a.id).join(',');
+
+    // Check if any agent configuration has changed
+    // For MVP, we just invalidate all ACP conversations if agents changed
+    const invalidations: Conversation[] = [];
+
+    for (const conv of conversations) {
+      if (conv.providerId === 'acp' && conv.sessionId) {
+        // Check if the agent for this conversation still exists
+        const agentExists = currentSettings.agents.some(a => a.id === conv.sessionId);
+        if (!agentExists) {
+          invalidations.push(conv);
+        }
+      }
+    }
+
+    return { changed: false, invalidatedConversations: invalidations };
+  },
+
+  normalizeModelVariantSettings(_settings: Record<string, unknown>): boolean {
+    // ACP doesn't have model variants in MVP
+    return false;
+  },
+};

--- a/src/providers/acp/history/AcpConversationHistoryService.ts
+++ b/src/providers/acp/history/AcpConversationHistoryService.ts
@@ -1,0 +1,47 @@
+import type { ProviderConversationHistoryService } from '../../../core/providers/types';
+import type { Conversation } from '../../../core/types';
+
+/**
+ * ACP conversation history service (stub for MVP).
+ * In a full implementation, this would hydrate history from ACP agent storage.
+ */
+export class AcpConversationHistoryService implements ProviderConversationHistoryService {
+  async hydrateConversationHistory(
+    _conversation: Conversation,
+    _vaultPath: string | null,
+  ): Promise<void> {
+    // No-op in MVP - ACP agents manage their own history
+  }
+
+  async deleteConversationSession(
+    _conversation: Conversation,
+    _vaultPath: string | null,
+  ): Promise<void> {
+    // No-op in MVP - ACP agents manage their own history
+  }
+
+  resolveSessionIdForConversation(conversation: Conversation | null): string | null {
+    if (!conversation) return null;
+    const providerState = conversation.providerState as Record<string, unknown> | undefined;
+    return (providerState?.sessionId as string) ?? null;
+  }
+
+  isPendingForkConversation(_conversation: Conversation): boolean {
+    // ACP doesn't support fork in MVP
+    return false;
+  }
+
+  buildForkProviderState(
+    _sourceSessionId: string,
+    _resumeAt: string,
+    _sourceProviderState?: Record<string, unknown>,
+  ): Record<string, unknown> {
+    // ACP doesn't support fork in MVP
+    return {};
+  }
+
+  buildPersistedProviderState(_conversation: Conversation): Record<string, unknown> | undefined {
+    // No additional persisted state for MVP
+    return undefined;
+  }
+}

--- a/src/providers/acp/protocol/acpProtocolTypes.ts
+++ b/src/providers/acp/protocol/acpProtocolTypes.ts
@@ -1,0 +1,197 @@
+// ACP (Agent Client Protocol) JSON-RPC types.
+// Based on the Agent Client Protocol specification.
+// Field names match the wire format (camelCase).
+
+// ---------------------------------------------------------------------------
+// JSON-RPC 2.0 base
+// ---------------------------------------------------------------------------
+
+export interface AcpJsonRpcRequest {
+  jsonrpc: '2.0';
+  id: number;
+  method: string;
+  params?: unknown;
+}
+
+export interface AcpJsonRpcNotification {
+  jsonrpc: '2.0';
+  method: string;
+  params?: unknown;
+}
+
+export interface AcpJsonRpcResponse {
+  jsonrpc: '2.0';
+  id: number;
+  result?: unknown;
+  error?: AcpJsonRpcError;
+}
+
+export interface AcpJsonRpcError {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Initialize
+// ---------------------------------------------------------------------------
+
+export interface AcpClientCapabilities {
+  chat?: boolean;
+  tools?: boolean;
+  agentLifecycle?: boolean;
+  streaming?: boolean;
+}
+
+export interface AcpInitializeParams {
+  clientInfo: { name: string; version: string };
+  capabilities: AcpClientCapabilities;
+}
+
+export interface AcpServerInfo {
+  name: string;
+  version: string;
+}
+
+export interface AcpServerCapabilities {
+  chat?: boolean;
+  tools?: boolean;
+  agentLifecycle?: boolean;
+  streaming?: boolean;
+}
+
+export interface AcpInitializeResult {
+  serverInfo: AcpServerInfo;
+  capabilities: AcpServerCapabilities;
+}
+
+// ---------------------------------------------------------------------------
+// Chat
+// ---------------------------------------------------------------------------
+
+export interface AcpTextContent {
+  type: 'text';
+  text: string;
+}
+
+export interface AcpToolUseContent {
+  type: 'tool_use';
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+export interface AcpToolResultContent {
+  type: 'tool_result';
+  toolUseId: string;
+  content?: string;
+  isError?: boolean;
+}
+
+export type AcpContentBlock = AcpTextContent | AcpToolUseContent | AcpToolResultContent;
+
+export interface AcpMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: string | AcpContentBlock[];
+}
+
+export interface AcpTool {
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export interface AcpChatParams {
+  messages: AcpMessage[];
+  stream?: boolean;
+  tools?: AcpTool[];
+  maxTokens?: number;
+}
+
+export interface AcpChatResult {
+  messageId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Chat streaming notifications
+// ---------------------------------------------------------------------------
+
+export interface AcpTextDeltaParams {
+  messageId: string;
+  delta: string;
+}
+
+export interface AcpToolUseStartParams {
+  messageId: string;
+  toolUseId: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+export interface AcpToolResultParams {
+  messageId: string;
+  toolUseId: string;
+  content?: string;
+  isError?: boolean;
+}
+
+export interface AcpMessageStopParams {
+  messageId: string;
+}
+
+export interface AcpErrorParams {
+  messageId: string;
+  error: string;
+}
+
+// ---------------------------------------------------------------------------
+// Tool approval (server request)
+// ---------------------------------------------------------------------------
+
+export interface AcpToolApprovalRequest {
+  messageId: string;
+  toolUseId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+  description?: string;
+}
+
+export type AcpToolApprovalDecision = 'allow' | 'deny' | 'allow-always';
+
+export interface AcpToolApprovalResponse {
+  decision: AcpToolApprovalDecision;
+}
+
+// ---------------------------------------------------------------------------
+// User input (server request)
+// ---------------------------------------------------------------------------
+
+export interface AcpUserInputQuestion {
+  id: string;
+  header: string;
+  question: string;
+  options?: Array<{ label: string; description: string }>;
+  isOther: boolean;
+  isSecret: boolean;
+}
+
+export interface AcpUserInputRequest {
+  messageId: string;
+  questions: AcpUserInputQuestion[];
+}
+
+export interface AcpUserInputResponse {
+  answers: Record<string, { answers: string[] }>;
+}
+
+// ---------------------------------------------------------------------------
+// Shutdown
+// ---------------------------------------------------------------------------
+
+export interface AcpShutdownParams {
+  reason?: string;
+}
+
+export interface AcpShutdownResult {
+  acknowledged: boolean;
+}

--- a/src/providers/acp/registration.ts
+++ b/src/providers/acp/registration.ts
@@ -1,0 +1,27 @@
+import type { ProviderRegistration } from '../../core/providers/types';
+import { AcpChatRuntime } from './runtime/AcpChatRuntime';
+import { AcpTitleGenerationService } from './auxiliary/AcpTitleGenerationService';
+import { AcpInstructionRefineService } from './auxiliary/AcpInstructionRefineService';
+import { AcpInlineEditService } from './auxiliary/AcpInlineEditService';
+import { AcpConversationHistoryService } from './history/AcpConversationHistoryService';
+import { AcpTaskResultInterpreter } from './auxiliary/AcpTaskResultInterpreter';
+import { ACP_PROVIDER_CAPABILITIES } from './capabilities';
+import { acpSettingsReconciler } from './env/AcpSettingsReconciler';
+import { acpChatUIConfig } from './ui/AcpChatUIConfig';
+import { getAcpProviderSettings } from './settings';
+
+export const acpProviderRegistration: ProviderRegistration = {
+  displayName: 'ACP',
+  blankTabOrder: 30,
+  isEnabled: (settings) => getAcpProviderSettings(settings).enabled,
+  capabilities: ACP_PROVIDER_CAPABILITIES,
+  environmentKeyPatterns: [/^ACP_/i],
+  chatUIConfig: acpChatUIConfig,
+  settingsReconciler: acpSettingsReconciler,
+  createRuntime: ({ plugin }) => new AcpChatRuntime(plugin),
+  createTitleGenerationService: (plugin) => new AcpTitleGenerationService(plugin),
+  createInstructionRefineService: (plugin) => new AcpInstructionRefineService(plugin),
+  createInlineEditService: (plugin) => new AcpInlineEditService(plugin),
+  historyService: new AcpConversationHistoryService(),
+  taskResultInterpreter: new AcpTaskResultInterpreter(),
+};

--- a/src/providers/acp/runtime/AcpChatRuntime.ts
+++ b/src/providers/acp/runtime/AcpChatRuntime.ts
@@ -1,0 +1,439 @@
+import type { ProviderCapabilities, ProviderId } from '../../../core/providers/types';
+import type { ChatRuntime } from '../../../core/runtime/ChatRuntime';
+import type {
+  ApprovalCallback,
+  AskUserQuestionCallback,
+  AutoTurnResult,
+  ChatRewindResult,
+  ChatRuntimeConversationState,
+  ChatRuntimeEnsureReadyOptions,
+  ChatRuntimeQueryOptions,
+  ChatTurnMetadata,
+  ChatTurnRequest,
+  ExitPlanModeCallback,
+  PreparedChatTurn,
+  SessionUpdateResult,
+  SubagentRuntimeState,
+} from '../../../core/runtime/types';
+import type { ChatMessage, Conversation, SlashCommand, StreamChunk } from '../../../core/types';
+import type ClaudianPlugin from '../../../main';
+import { getAcpProviderSettings, type AcpAgentConfig } from '../settings';
+import { ACP_PROVIDER_CAPABILITIES } from '../capabilities';
+import type { AcpChatParams, AcpInitializeResult, AcpMessage } from '../protocol/acpProtocolTypes';
+import { AcpProcessManager } from '../transport/AcpProcessManager';
+import { AcpNotificationRouter } from './AcpNotificationRouter';
+import { AcpServerRequestRouter } from './AcpServerRequestRouter';
+import { AcpStdioTransport } from '../transport/AcpStdioTransport';
+import type { AcpTransport } from '../transport/AcpTransport';
+
+export class AcpChatRuntime implements ChatRuntime {
+  readonly providerId: ProviderId = 'acp';
+
+  private plugin: ClaudianPlugin;
+  private transport: AcpTransport | null = null;
+  private processManager: AcpProcessManager | null = null;
+  private notificationRouter: AcpNotificationRouter | null = null;
+  private serverRequestRouter = new AcpServerRequestRouter();
+  private ready = false;
+  private readyListeners = new Set<(ready: boolean) => void>();
+  private sessionId: string | null = null;
+
+  // Chunk buffering for streaming
+  private chunkBuffer: StreamChunk[] = [];
+  private chunkResolve: (() => void) | null = null;
+
+  // Callbacks
+  private approvalCallback: ApprovalCallback | null = null;
+  private approvalDismisser: (() => void) | null = null;
+  private askUserCallback: AskUserQuestionCallback | null = null;
+  private exitPlanModeCallback: ExitPlanModeCallback | null = null;
+  private permissionModeSyncCallback: ((sdkMode: string) => void) | null = null;
+  private subagentHookProvider: (() => SubagentRuntimeState) | null = null;
+  private autoTurnCallback: ((result: AutoTurnResult) => void) | null = null;
+
+  // Cancellation
+  private canceled = false;
+  private currentMessageId: string | null = null;
+  private turnMetadata: ChatTurnMetadata = {};
+
+  constructor(plugin: ClaudianPlugin) {
+    this.plugin = plugin;
+  }
+
+  getCapabilities(): Readonly<ProviderCapabilities> {
+    return ACP_PROVIDER_CAPABILITIES;
+  }
+
+  prepareTurn(request: ChatTurnRequest): PreparedChatTurn {
+    // For ACP, we just need to prepare the text prompt
+    return {
+      request,
+      persistedContent: request.text,
+      prompt: request.text,
+      isCompact: false,
+      mcpMentions: new Set(),
+    };
+  }
+
+  consumeTurnMetadata(): ChatTurnMetadata {
+    const metadata = { ...this.turnMetadata };
+    this.turnMetadata = {};
+    return metadata;
+  }
+
+  onReadyStateChange(listener: (ready: boolean) => void): () => void {
+    this.readyListeners.add(listener);
+    return () => {
+      this.readyListeners.delete(listener);
+    };
+  }
+
+  setResumeCheckpoint(_checkpointId: string | undefined): void {
+    // ACP doesn't support resume checkpoints in MVP
+  }
+
+  syncConversationState(_conversation: ChatRuntimeConversationState | null): void {
+    // ACP doesn't persist conversation state in MVP
+    this.sessionId = null;
+  }
+
+  async reloadMcpServers(): Promise<void> {
+    // ACP doesn't use MCP in MVP
+  }
+
+  async ensureReady(options?: ChatRuntimeEnsureReadyOptions): Promise<boolean> {
+    if (this.ready && options?.force !== true) {
+      return true;
+    }
+
+    const settings = getAcpProviderSettings(this.plugin.settings);
+    if (!settings.enabled) {
+      return false;
+    }
+
+    const agentConfig = this.getActiveAgentConfig(settings);
+    if (!agentConfig) {
+      return false;
+    }
+
+    // Start the agent process and transport
+    if (!this.transport || !this.transport.isAlive()) {
+      await this.startAgent(agentConfig);
+    }
+
+    this.setReady(true);
+    return true;
+  }
+
+  async *query(
+    turn: PreparedChatTurn,
+    _conversationHistory?: ChatMessage[],
+    _queryOptions?: ChatRuntimeQueryOptions,
+  ): AsyncGenerator<StreamChunk> {
+    await this.ensureReady();
+
+    if (!this.transport) {
+      yield { type: 'error', content: 'ACP transport not available' };
+      yield { type: 'done' };
+      return;
+    }
+
+    this.canceled = false;
+    this.chunkBuffer = [];
+    this.chunkResolve = null;
+    this.currentMessageId = null;
+
+    const enqueueChunk = (chunk: StreamChunk): void => {
+      this.chunkBuffer.push(chunk);
+      if (this.chunkResolve) {
+        this.chunkResolve();
+        this.chunkResolve = null;
+      }
+    };
+
+    // Set up notification router
+    this.notificationRouter = new AcpNotificationRouter(enqueueChunk);
+    this.wireTransportHandlers();
+
+    try {
+      // Build ACP chat request
+      const acpRequest = this.buildAcpChatRequest(turn);
+
+      // Send chat request
+      const result = await this.transport.request<{ messageId: string }>('chat/send', acpRequest);
+      this.currentMessageId = result.messageId;
+      this.recordTurnMetadata({ userMessageId: result.messageId, wasSent: true });
+
+      // Yield chunks until done or canceled
+      while (true) {
+        if (this.canceled) {
+          // Drain remaining chunks before exiting
+          while (this.chunkBuffer.length > 0) {
+            const chunk = this.chunkBuffer.shift()!;
+            yield chunk;
+            if (chunk.type === 'done') return;
+          }
+          yield { type: 'done' };
+          return;
+        }
+
+        if (this.chunkBuffer.length === 0) {
+          await new Promise<void>((resolve) => {
+            this.chunkResolve = resolve;
+            if (this.chunkBuffer.length > 0 || this.canceled) {
+              resolve();
+              this.chunkResolve = null;
+            }
+          });
+        }
+
+        while (this.chunkBuffer.length > 0) {
+          const chunk = this.chunkBuffer.shift()!;
+          yield chunk;
+          if (chunk.type === 'done') {
+            return;
+          }
+        }
+      }
+    } catch (err: unknown) {
+      if (this.canceled) {
+        yield { type: 'done' };
+        return;
+      }
+      const message = err instanceof Error ? err.message : 'Unknown ACP error';
+      yield { type: 'error', content: message };
+      yield { type: 'done' };
+      return;
+    } finally {
+      this.currentMessageId = null;
+    }
+  }
+
+  cancel(): void {
+    this.canceled = true;
+    this.dismissAllPendingPrompts();
+
+    // Unblock the chunk-wait loop
+    if (this.chunkResolve) {
+      this.chunkResolve();
+      this.chunkResolve = null;
+    }
+  }
+
+  resetSession(): void {
+    this.sessionId = null;
+  }
+
+  getSessionId(): string | null {
+    return this.sessionId;
+  }
+
+  consumeSessionInvalidation(): boolean {
+    return false; // ACP doesn't have environment-based invalidation in MVP
+  }
+
+  isReady(): boolean {
+    return this.ready;
+  }
+
+  async getSupportedCommands(): Promise<SlashCommand[]> {
+    return []; // ACP doesn't have provider commands in MVP
+  }
+
+  cleanup(): void {
+    this.cancel();
+    this.readyListeners.clear();
+    this.shutdownTransport().catch(() => {});
+  }
+
+  async rewind(_userMessageId: string, _assistantMessageId: string): Promise<ChatRewindResult> {
+    return { canRewind: false, error: 'ACP does not support rewind' };
+  }
+
+  setApprovalCallback(callback: ApprovalCallback | null): void {
+    this.approvalCallback = callback;
+    this.serverRequestRouter.setApprovalCallback(callback);
+  }
+
+  setApprovalDismisser(dismisser: (() => void) | null): void {
+    this.approvalDismisser = dismisser;
+  }
+
+  setAskUserQuestionCallback(callback: AskUserQuestionCallback | null): void {
+    this.askUserCallback = callback;
+    this.serverRequestRouter.setAskUserCallback(callback);
+  }
+
+  setExitPlanModeCallback(callback: ExitPlanModeCallback | null): void {
+    this.exitPlanModeCallback = callback;
+  }
+
+  setPermissionModeSyncCallback(callback: ((sdkMode: string) => void) | null): void {
+    this.permissionModeSyncCallback = callback;
+  }
+
+  setSubagentHookProvider(getState: () => SubagentRuntimeState): void {
+    this.subagentHookProvider = getState;
+  }
+
+  setAutoTurnCallback(callback: ((result: AutoTurnResult) => void) | null): void {
+    this.autoTurnCallback = callback;
+  }
+
+  buildSessionUpdates(params: {
+    conversation: Conversation | null;
+    sessionInvalidated: boolean;
+  }): SessionUpdateResult {
+    const sessionId = this.sessionId;
+
+    const updates: Partial<Conversation> = {
+      sessionId,
+      providerState: sessionId ? { sessionId } : undefined,
+    };
+
+    if (params.sessionInvalidated && params.conversation) {
+      updates.sessionId = null;
+      updates.providerState = undefined;
+    }
+
+    return { updates };
+  }
+
+  resolveSessionIdForFork(conversation: Conversation | null): string | null {
+    return this.sessionId ?? conversation?.sessionId ?? null;
+  }
+
+  // -----------------------------------------------------------------------
+  // Private helpers
+  // -----------------------------------------------------------------------
+
+  private getActiveAgentConfig(settings: ReturnType<typeof getAcpProviderSettings>): AcpAgentConfig | null {
+    const defaultAgent = settings.agents.find(a => a.id === settings.defaultAgentId);
+    const agent = defaultAgent ?? settings.agents.find(a => a.enabled) ?? settings.agents[0];
+
+    if (!agent || !agent.enabled) {
+      return null;
+    }
+
+    return agent;
+  }
+
+  private async startAgent(agentConfig: AcpAgentConfig): Promise<void> {
+    this.shutdownTransport().catch(() => {});
+
+    this.processManager = new AcpProcessManager(agentConfig);
+    this.processManager.start();
+
+    this.transport = new AcpStdioTransport(
+      this.processManager.stdin,
+      this.processManager.stdout,
+      () => this.handleProcessExit(),
+    );
+    this.transport.start();
+
+    // Initialize handshake
+    const initResult = await this.transport.request<AcpInitializeResult>('initialize', {
+      clientInfo: { name: 'claudian', version: '1.0.0' },
+      capabilities: { chat: true, streaming: true },
+    });
+
+    if (initResult.capabilities.chat) {
+      // Chat is supported
+    }
+  }
+
+  private async shutdownTransport(): Promise<void> {
+    if (this.transport) {
+      this.transport.dispose();
+      this.transport = null;
+    }
+    if (this.processManager) {
+      await this.processManager.shutdown();
+      this.processManager = null;
+    }
+    this.setReady(false);
+  }
+
+  private handleProcessExit(): void {
+    this.setReady(false);
+    this.rejectAllPending(new Error('ACP agent process exited'));
+  }
+
+  private rejectAllPending(_error: Error): void {
+    if (this.chunkResolve) {
+      this.chunkResolve();
+      this.chunkResolve = null;
+    }
+  }
+
+  private setReady(ready: boolean): void {
+    this.ready = ready;
+    for (const listener of this.readyListeners) {
+      listener(ready);
+    }
+  }
+
+  private resetTurnMetadata(): void {
+    this.turnMetadata = {};
+  }
+
+  private recordTurnMetadata(update: Partial<ChatTurnMetadata>): void {
+    this.turnMetadata = {
+      ...this.turnMetadata,
+      ...update,
+    };
+  }
+
+  private buildAcpChatRequest(turn: PreparedChatTurn): AcpChatParams {
+    const messages: AcpMessage[] = [
+      { role: 'user', content: turn.prompt },
+    ];
+
+    return {
+      messages,
+      stream: true,
+    };
+  }
+
+  private wireTransportHandlers(): void {
+    if (!this.transport || !this.notificationRouter) return;
+
+    const router = this.notificationRouter;
+    const methods = [
+      'chat/textDelta',
+      'chat/toolUseStart',
+      'chat/toolResult',
+      'chat/messageStop',
+      'chat/error',
+    ];
+
+    for (const method of methods) {
+      this.transport.onNotification(method, (params) => {
+        router.handleNotification(method, params);
+      });
+    }
+
+    // Server requests (tool approval, user input)
+    const requestMethods = [
+      'tool/requestApproval',
+      'user/requestInput',
+    ];
+
+    for (const method of requestMethods) {
+      this.transport.onServerRequest(method, (requestId, params) => {
+        return this.serverRequestRouter.handleServerRequest(requestId, method, params);
+      });
+    }
+  }
+
+  private dismissApprovalUI(): void {
+    if (this.approvalDismisser) {
+      this.approvalDismisser();
+    }
+  }
+
+  private dismissAllPendingPrompts(): void {
+    this.dismissApprovalUI();
+    this.serverRequestRouter.abortPendingAskUser();
+  }
+}

--- a/src/providers/acp/runtime/AcpNotificationRouter.ts
+++ b/src/providers/acp/runtime/AcpNotificationRouter.ts
@@ -1,0 +1,70 @@
+import type { StreamChunk, UsageInfo } from '../../../core/types';
+import type {
+  AcpMessageStopParams,
+  AcpTextDeltaParams,
+  AcpToolResultParams,
+  AcpToolUseStartParams,
+} from '../protocol/acpProtocolTypes';
+
+type ChunkEmitter = (chunk: StreamChunk) => void;
+
+/**
+ * Maps ACP notifications to StreamChunk types.
+ * Adapted from CodexNotificationRouter for the ACP protocol.
+ */
+export class AcpNotificationRouter {
+  constructor(private readonly emit: ChunkEmitter) {}
+
+  handleNotification(method: string, params: unknown): void {
+    switch (method) {
+      case 'chat/textDelta':
+        this.onTextDelta(params as AcpTextDeltaParams);
+        break;
+      case 'chat/toolUseStart':
+        this.onToolUseStart(params as AcpToolUseStartParams);
+        break;
+      case 'chat/toolResult':
+        this.onToolResult(params as AcpToolResultParams);
+        break;
+      case 'chat/messageStop':
+        this.onMessageStop(params as AcpMessageStopParams);
+        break;
+      case 'chat/error':
+        this.onError(params as { error: string });
+        break;
+      default:
+        // Unknown notification - ignore
+        break;
+    }
+  }
+
+  private onTextDelta(params: AcpTextDeltaParams): void {
+    this.emit({ type: 'text', content: params.delta });
+  }
+
+  private onToolUseStart(params: AcpToolUseStartParams): void {
+    this.emit({
+      type: 'tool_use',
+      id: params.toolUseId,
+      name: params.name,
+      input: params.input,
+    });
+  }
+
+  private onToolResult(params: AcpToolResultParams): void {
+    this.emit({
+      type: 'tool_result',
+      id: params.toolUseId,
+      content: params.content ?? '',
+      isError: params.isError ?? false,
+    });
+  }
+
+  private onMessageStop(_params: AcpMessageStopParams): void {
+    this.emit({ type: 'done' });
+  }
+
+  private onError(params: { error: string }): void {
+    this.emit({ type: 'error', content: params.error });
+  }
+}

--- a/src/providers/acp/runtime/AcpServerRequestRouter.ts
+++ b/src/providers/acp/runtime/AcpServerRequestRouter.ts
@@ -1,0 +1,127 @@
+import type {
+  ApprovalCallback,
+  AskUserQuestionCallback,
+} from '../../../core/runtime/types';
+import type { ApprovalDecision } from '../../../core/types';
+import type {
+  AcpToolApprovalRequest,
+  AcpToolApprovalResponse,
+  AcpUserInputRequest,
+  AcpUserInputResponse,
+} from '../protocol/acpProtocolTypes';
+
+/**
+ * Handles server requests from ACP agents (tool approval, user input).
+ * Adapted from CodexServerRequestRouter for the ACP protocol.
+ */
+export class AcpServerRequestRouter {
+  private approvalCallback: ApprovalCallback | null = null;
+  private askUserCallback: AskUserQuestionCallback | null = null;
+  private pendingAskUserAbortController: AbortController | null = null;
+
+  setApprovalCallback(callback: ApprovalCallback | null): void {
+    this.approvalCallback = callback;
+  }
+
+  setAskUserCallback(callback: AskUserQuestionCallback | null): void {
+    this.askUserCallback = callback;
+  }
+
+  async handleServerRequest(
+    requestId: string | number,
+    method: string,
+    params: unknown,
+  ): Promise<unknown> {
+    switch (method) {
+      case 'tool/requestApproval':
+        return this.handleToolApproval(requestId, params as AcpToolApprovalRequest);
+      case 'user/requestInput':
+        return this.handleUserInput(requestId, params as AcpUserInputRequest);
+      default:
+        throw new Error(`Unsupported server request: ${method}`);
+    }
+  }
+
+  private async handleToolApproval(
+    _requestId: string | number,
+    params: AcpToolApprovalRequest,
+  ): Promise<AcpToolApprovalResponse> {
+    if (!this.approvalCallback) {
+      return { decision: 'deny' };
+    }
+
+    try {
+      const decision = await this.approvalCallback(
+        params.toolName,
+        params.input,
+        params.description ?? '',
+      );
+
+      // Map Claudian's approval decision to ACP's
+      const acpDecision: AcpToolApprovalResponse['decision'] =
+        decision === 'allow' || decision === 'allow-always' ? 'allow' :
+        decision === 'deny' || decision === 'cancel' ? 'deny' : 'allow-always';
+
+      return { decision: acpDecision };
+    } catch {
+      return { decision: 'deny' };
+    }
+  }
+
+  private async handleUserInput(
+    _requestId: string | number,
+    params: AcpUserInputRequest,
+  ): Promise<AcpUserInputResponse> {
+    if (!this.askUserCallback) {
+      throw new Error('No ask-user callback registered');
+    }
+
+    // Abort any pending ask-user request
+    this.abortPendingAskUser();
+
+    this.pendingAskUserAbortController = new AbortController();
+
+    try {
+      // Build input for the callback - convert questions to Record<string, unknown>
+      const input: Record<string, unknown> = {};
+      for (const q of params.questions) {
+        input[q.id] = {
+          question: q.question,
+          header: q.header,
+          options: q.options?.map(o => ({ label: o.label, description: o.description })) ?? [],
+          isOther: q.isOther,
+          isSecret: q.isSecret,
+        };
+      }
+
+      const answers = await this.askUserCallback(
+        input,
+        this.pendingAskUserAbortController.signal,
+      );
+
+      // Map answers back to ACP format
+      const answersRecord: Record<string, { answers: string[] }> = {};
+      if (answers) {
+        for (const [id, answer] of Object.entries(answers)) {
+          answersRecord[id] = { answers: Array.isArray(answer) ? answer : [answer] };
+        }
+      }
+
+      return { answers: answersRecord };
+    } finally {
+      this.pendingAskUserAbortController = null;
+    }
+  }
+
+  abortPendingAskUser(): void {
+    if (this.pendingAskUserAbortController) {
+      this.pendingAskUserAbortController.abort();
+      this.pendingAskUserAbortController = null;
+    }
+  }
+
+  hasPendingApprovalRequest(_requestId: string | number, _messageId: string): boolean {
+    // ACP doesn't have the same "auto-resolve" pattern as Codex
+    return false;
+  }
+}

--- a/src/providers/acp/settings.ts
+++ b/src/providers/acp/settings.ts
@@ -1,0 +1,68 @@
+import type { ProviderId } from '../../core/providers/types';
+
+export type AcpTransportType = 'stdio' | 'http' | 'websocket';
+
+export interface AcpAgentConfig {
+  id: string;
+  name: string;
+  transportType: AcpTransportType;
+  // For stdio
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  // For http/websocket (future use)
+  url?: string;
+  headers?: Record<string, string>;
+  // Common
+  enabled: boolean;
+}
+
+export interface AcpProviderSettings {
+  enabled: boolean;
+  agents: AcpAgentConfig[];
+  defaultAgentId?: string;
+}
+
+export const DEFAULT_ACP_SETTINGS: Readonly<AcpProviderSettings> = Object.freeze({
+  enabled: false,
+  agents: [],
+});
+
+export function getAcpProviderSettings(
+  settings: Record<string, unknown>,
+): AcpProviderSettings {
+  const acpSettings = settings.acp as Record<string, unknown> | undefined;
+  if (!acpSettings) {
+    return { ...DEFAULT_ACP_SETTINGS };
+  }
+
+  return {
+    enabled: acpSettings.enabled === true,
+    agents: Array.isArray(acpSettings.agents)
+      ? (acpSettings.agents as AcpAgentConfig[]).filter((agent): agent is AcpAgentConfig =>
+        agent && typeof agent.id === 'string' && typeof agent.name === 'string',
+      )
+      : [],
+    defaultAgentId: typeof acpSettings.defaultAgentId === 'string'
+      ? acpSettings.defaultAgentId
+      : undefined,
+  };
+}
+
+export function setAcpProviderSettings(
+  settings: Record<string, unknown>,
+  acpSettings: Partial<AcpProviderSettings>,
+): void {
+  const current = getAcpProviderSettings(settings);
+  const merged: AcpProviderSettings = {
+    ...current,
+    ...acpSettings,
+    agents: acpSettings.agents ?? current.agents,
+  };
+
+  (settings as Record<string, unknown>)[providerIdToKey('acp')] = merged;
+}
+
+export function providerIdToKey(providerId: ProviderId): string {
+  return providerId;
+}

--- a/src/providers/acp/transport/AcpProcessManager.ts
+++ b/src/providers/acp/transport/AcpProcessManager.ts
@@ -1,0 +1,84 @@
+import { spawn, type ChildProcess } from 'child_process';
+
+export interface AcpAgentConfig {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+}
+
+/**
+ * Manages an ACP agent subprocess.
+ * Similar to CodexAppServerProcess but for ACP agents.
+ */
+export class AcpProcessManager {
+  private proc: ChildProcess | null = null;
+  private exitPromise: Promise<void> | null = null;
+  private exitResolve: (() => void) | null = null;
+
+  constructor(private readonly config: AcpAgentConfig) {}
+
+  start(): void {
+    if (this.proc) {
+      throw new Error('ACP agent process already started');
+    }
+
+    this.proc = spawn(this.config.command, this.config.args ?? [], {
+      env: { ...process.env, ...this.config.env },
+      cwd: this.config.cwd ?? process.cwd(),
+      stdio: ['pipe', 'pipe', 'inherit'], // stdin, stdout, stderr
+    });
+
+    this.proc.on('exit', () => {
+      if (this.exitResolve) {
+        this.exitResolve();
+      }
+    });
+
+    this.exitPromise = new Promise((resolve) => {
+      this.exitResolve = resolve;
+    });
+  }
+
+  get stdin(): NodeJS.WritableStream {
+    if (!this.proc || !this.proc.stdin) {
+      throw new Error('ACP agent process not started or stdin not available');
+    }
+    return this.proc.stdin;
+  }
+
+  get stdout(): NodeJS.ReadableStream {
+    if (!this.proc || !this.proc.stdout) {
+      throw new Error('ACP agent process not started or stdout not available');
+    }
+    return this.proc.stdout;
+  }
+
+  isAlive(): boolean {
+    return this.proc !== null && this.proc.exitCode === null;
+  }
+
+  async shutdown(): Promise<void> {
+    if (!this.proc) return;
+
+    const proc = this.proc;
+    this.proc = null;
+
+    // Try graceful shutdown first
+    proc.kill('SIGTERM');
+
+    // Wait up to 5 seconds for graceful exit
+    const timeout = setTimeout(() => {
+      if (this.isAlive()) {
+        proc.kill('SIGKILL');
+      }
+    }, 5000);
+
+    await this.exitPromise;
+    clearTimeout(timeout);
+  }
+
+  onExit(callback: () => void): void {
+    this.exitPromise?.then(callback);
+  }
+}

--- a/src/providers/acp/transport/AcpStdioTransport.ts
+++ b/src/providers/acp/transport/AcpStdioTransport.ts
@@ -1,0 +1,174 @@
+import { createInterface } from 'readline';
+
+import type { AcpTransport } from './AcpTransport';
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+interface PendingRequest {
+  resolve: (result: unknown) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+type NotificationHandler = (params: unknown) => void;
+type ServerRequestHandler = (requestId: string | number, params: unknown) => Promise<unknown>;
+
+/**
+ * Stdio transport for ACP agents.
+ * Adapted from CodexRpcTransport for the ACP protocol.
+ */
+export class AcpStdioTransport implements AcpTransport {
+  private nextId = 1;
+  private pending = new Map<number, PendingRequest>();
+  private notificationHandlers = new Map<string, NotificationHandler>();
+  private serverRequestHandlers = new Map<string, ServerRequestHandler>();
+  private disposed = false;
+
+  constructor(
+    private readonly stdin: NodeJS.WritableStream,
+    private readonly stdout: NodeJS.ReadableStream,
+    private readonly onExit?: () => void,
+  ) {}
+
+  start(): void {
+    const rl = createInterface({ input: this.stdout });
+    rl.on('line', (line) => this.handleLine(line));
+  }
+
+  request<T = unknown>(method: string, params?: unknown, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<T> {
+    const id = this.nextId++;
+    const msg = { jsonrpc: '2.0' as const, id, method, params };
+
+    return new Promise<T>((resolve, reject) => {
+      const timer = timeoutMs > 0
+        ? setTimeout(() => {
+          this.pending.delete(id);
+          reject(new Error(`Request timeout: ${method} (${timeoutMs}ms)`));
+        }, timeoutMs)
+        : null;
+
+      this.pending.set(id, {
+        resolve: resolve as (result: unknown) => void,
+        reject,
+        timer,
+      });
+
+      this.sendRaw(msg);
+    });
+  }
+
+  notify(method: string, params?: unknown): void {
+    const msg: Record<string, unknown> = { jsonrpc: '2.0', method };
+    if (params !== undefined) msg.params = params;
+    this.sendRaw(msg);
+  }
+
+  onNotification(method: string, handler: NotificationHandler): void {
+    this.notificationHandlers.set(method, handler);
+  }
+
+  onServerRequest(method: string, handler: ServerRequestHandler): void {
+    this.serverRequestHandlers.set(method, handler);
+  }
+
+  isAlive(): boolean {
+    return !this.disposed;
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.rejectAllPending(new Error('Transport disposed'));
+  }
+
+  // -----------------------------------------------------------------------
+  // Private
+  // -----------------------------------------------------------------------
+
+  private sendRaw(msg: unknown): void {
+    if (this.disposed) return;
+    this.stdin.write(JSON.stringify(msg) + '\n');
+  }
+
+  private handleLine(line: string): void {
+    let msg: Record<string, unknown>;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      return; // malformed line
+    }
+
+    const id = msg.id as string | number | undefined;
+    const method = msg.method as string | undefined;
+
+    // Server response to our request
+    if (typeof id === 'number' && !method) {
+      this.handleResponse(id, msg);
+      return;
+    }
+
+    // Server notification (no id, has method)
+    if (method && id === undefined) {
+      this.handleNotification(method, msg.params);
+      return;
+    }
+
+    // Server-initiated request (has both id and method)
+    if (method && id !== undefined) {
+      this.handleServerRequest(id, method, msg.params);
+      return;
+    }
+  }
+
+  private handleResponse(id: number, msg: Record<string, unknown>): void {
+    const pending = this.pending.get(id);
+    if (!pending) return;
+
+    this.pending.delete(id);
+    if (pending.timer) clearTimeout(pending.timer);
+
+    if (msg.error) {
+      const err = msg.error as { code: number; message: string; data?: unknown };
+      pending.reject(new Error(err.message));
+    } else {
+      pending.resolve(msg.result);
+    }
+  }
+
+  private handleNotification(method: string, params: unknown): void {
+    const handler = this.notificationHandlers.get(method);
+    if (handler) handler(params);
+  }
+
+  private handleServerRequest(id: string | number, method: string, params: unknown): void {
+    const handler = this.serverRequestHandlers.get(method);
+    if (!handler) {
+      this.sendRaw({
+        jsonrpc: '2.0',
+        id,
+        error: { code: -32601, message: `Unhandled server request: ${method}` },
+      });
+      return;
+    }
+
+    handler(id, params).then(
+      (result) => {
+        this.sendRaw({ jsonrpc: '2.0', id, result });
+      },
+      (err) => {
+        this.sendRaw({
+          jsonrpc: '2.0',
+          id,
+          error: { code: -32603, message: err instanceof Error ? err.message : 'Internal error' },
+        });
+      },
+    );
+  }
+
+  private rejectAllPending(error: Error): void {
+    for (const [, pending] of this.pending) {
+      if (pending.timer) clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+}

--- a/src/providers/acp/transport/AcpTransport.ts
+++ b/src/providers/acp/transport/AcpTransport.ts
@@ -1,0 +1,44 @@
+// Base transport interface for ACP communication.
+// ACP can communicate over stdio (local agents) or HTTP/WebSocket (remote agents).
+
+type NotificationHandler = (params: unknown) => void;
+type ServerRequestHandler = (requestId: string | number, params: unknown) => Promise<unknown>;
+
+export interface AcpTransport {
+  /**
+   * Start the transport connection.
+   * For stdio: starts reading from stdout
+   * For HTTP/WebSocket: establishes connection
+   */
+  start(): void | Promise<void>;
+
+  /**
+   * Send a request and wait for response.
+   */
+  request<T = unknown>(method: string, params?: unknown, timeoutMs?: number): Promise<T>;
+
+  /**
+   * Send a notification (no response expected).
+   */
+  notify(method: string, params?: unknown): void | Promise<void>;
+
+  /**
+   * Register a handler for server notifications.
+   */
+  onNotification(method: string, handler: NotificationHandler): void;
+
+  /**
+   * Register a handler for server requests (bidi-rpc).
+   */
+  onServerRequest(method: string, handler: ServerRequestHandler): void;
+
+  /**
+   * Check if the transport is alive/connected.
+   */
+  isAlive(): boolean;
+
+  /**
+   * Clean up resources.
+   */
+  dispose(): void | Promise<void>;
+}

--- a/src/providers/acp/ui/AcpChatUIConfig.ts
+++ b/src/providers/acp/ui/AcpChatUIConfig.ts
@@ -1,0 +1,64 @@
+import type {
+  ProviderChatUIConfig,
+  ProviderUIOption,
+} from '../../../core/providers/types';
+import { getAcpProviderSettings } from '../settings';
+
+/**
+ * ACP chat UI configuration.
+ * Provides model options and other UI configuration for the ACP provider.
+ */
+export const acpChatUIConfig: ProviderChatUIConfig = {
+  getModelOptions(settings: Record<string, unknown>): ProviderUIOption[] {
+    const acpSettings = getAcpProviderSettings(settings);
+    // Return configured agents as "model" options
+    return acpSettings.agents
+      .filter(a => a.enabled)
+      .map(agent => ({
+        value: agent.id,
+        label: agent.name,
+        description: `${agent.transportType} agent`,
+      }));
+  },
+
+  ownsModel(model: string, settings: Record<string, unknown>): boolean {
+    const acpSettings = getAcpProviderSettings(settings);
+    return acpSettings.agents.some(a => a.id === model);
+  },
+
+  isAdaptiveReasoningModel(_model: string): boolean {
+    // ACP agents manage their own reasoning
+    return false;
+  },
+
+  getReasoningOptions(_model: string): import('../../../core/providers/types').ProviderReasoningOption[] {
+    // ACP agents manage their own reasoning
+    return [];
+  },
+
+  getDefaultReasoningValue(_model: string): string {
+    return 'medium';
+  },
+
+  getContextWindowSize(_model: string, _customLimits?: Record<string, number>): number {
+    // ACP agents manage their own context windows
+    return 200000;
+  },
+
+  isDefaultModel(_model: string): boolean {
+    // ACP doesn't have built-in models
+    return false;
+  },
+
+  applyModelDefaults(_model: string, _settings: unknown): void {
+    // No-op for ACP
+  },
+
+  normalizeModelVariant(model: string, _settings: Record<string, unknown>): string {
+    return model;
+  },
+
+  getCustomModelIds(_envVars: Record<string, string>): Set<string> {
+    return new Set();
+  },
+};

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -4,6 +4,7 @@ import { claudeWorkspaceRegistration } from './claude/app/ClaudeWorkspaceService
 import { claudeProviderRegistration } from './claude/registration';
 import { codexWorkspaceRegistration } from './codex/app/CodexWorkspaceServices';
 import { codexProviderRegistration } from './codex/registration';
+import { acpProviderRegistration } from './acp/registration';
 
 let builtInProvidersRegistered = false;
 
@@ -14,6 +15,7 @@ export function registerBuiltInProviders(): void {
 
   ProviderRegistry.register('claude', claudeProviderRegistration);
   ProviderRegistry.register('codex', codexProviderRegistration);
+  ProviderRegistry.register('acp', acpProviderRegistration);
   ProviderWorkspaceRegistry.register('claude', claudeWorkspaceRegistration);
   ProviderWorkspaceRegistry.register('codex', codexWorkspaceRegistration);
   builtInProvidersRegistered = true;


### PR DESCRIPTION
Add support for ACP, a standardized JSON-RPC 2.0 protocol for agent-editor communication. This enables Claudian to connect to any ACP-compatible agent.

Implementation includes:
- Protocol type definitions for ACP JSON-RPC messages
- Stdio transport for local ACP agents
- ChatRuntime implementation with text streaming
- Tool approval and user input server request handling
- Notification router mapping ACP events to StreamChunks
- Provider registration, settings, and UI configuration

Phase 1 MVP: supports text streaming and basic tool use via stdio. Future phases will add HTTP/WebSocket transport and multi-agent support.