### PR TITLE
Use bash date lookup in the main system prompt

### DIFF
--- a/src/core/prompt/mainAgent.ts
+++ b/src/core/prompt/mainAgent.ts
@@ -1,5 +1,3 @@
-import { getTodayDate } from '../../utils/date';
-
 export interface SystemPromptSettings {
   mediaFolder?: string;
   customPrompt?: string;
@@ -40,7 +38,7 @@ function getBaseSystemPrompt(
 
   return `${userContext}## Time Context
 
-- **Current Date**: ${getTodayDate()}
+- **Current Date**: Use \`bash: date\` to get the current date and time. Never guess or assume.
 - **Knowledge Status**: You possess extensive internal knowledge up to your training cutoff. You do not know the exact date of your cutoff, but you must assume that your internal weights are static and "past," while the Current Date is "present."
 
 ## Identity & Role

--- a/tests/unit/providers/claude/prompt/systemPrompt.test.ts
+++ b/tests/unit/providers/claude/prompt/systemPrompt.test.ts
@@ -28,7 +28,7 @@ describe('systemPrompt', () => {
 
     it('should include base system prompt elements', () => {
       const prompt = buildSystemPrompt();
-      expect(prompt).toContain('Mocked Date');
+      expect(prompt).toContain('Use `bash: date` to get the current date and time. Never guess or assume.');
       expect(prompt).toContain('Claudian');
       expect(prompt).toContain('## Path Conventions');
       expect(prompt).toContain('# User Message Format');

--- a/tests/unit/utils/date.test.ts
+++ b/tests/unit/utils/date.test.ts
@@ -3,7 +3,6 @@ import { formatDurationMmSs, getTodayDate } from '../../../src/utils/date';
 describe('getTodayDate', () => {
   it('returns readable date with ISO suffix', () => {
     const result = getTodayDate();
-    // Should end with ISO date in parentheses, e.g. "(2024-01-15)"
     expect(result).toMatch(/\(\d{4}-\d{2}-\d{2}\)$/);
   });
 


### PR DESCRIPTION
## Summary
- update the main system prompt to tell the agent to use `bash: date` for current time lookup
- align the system prompt unit test with the new time guidance
- remove an outdated comment from the date utility test

## Testing
- npm test -- --runInBand tests/unit/providers/claude/prompt/systemPrompt.test.ts tests/unit/utils/date.test.ts