### PR TITLE
fix: show free-text input in AskUserQuestion by default

### DIFF
--- a/src/features/chat/rendering/InlineAskUserQuestion.ts
+++ b/src/features/chat/rendering/InlineAskUserQuestion.ts
@@ -124,7 +124,7 @@ export class InlineAskUserQuestion {
           typeof q === 'object' &&
           q !== null &&
           typeof q.question === 'string' &&
-          ((Array.isArray(q.options) && q.options.length > 0) || q.isOther === true),
+          ((Array.isArray(q.options) && q.options.length > 0) || q.isOther === true || this.config.showCustomInput),
       )
       .map((q, idx) => ({
         question: q.question,
@@ -655,8 +655,8 @@ export class InlineAskUserQuestion {
     this.handleResolve(result);
   }
 
-  private canShowCustomInputForQuestion(question: AskUserQuestionItem): boolean {
-    return this.config.showCustomInput && question.isOther === true;
+  private canShowCustomInputForQuestion(_question: AskUserQuestionItem): boolean {
+    return this.config.showCustomInput;
   }
 
   private getOptionValue(option: AskUserQuestionOption): string {

--- a/tests/unit/features/chat/rendering/InlineAskUserQuestion.test.ts
+++ b/tests/unit/features/chat/rendering/InlineAskUserQuestion.test.ts
@@ -24,11 +24,14 @@ function makeInput(
 
 function renderWidget(
   input: Record<string, unknown>,
-  signal?: AbortSignal,
+  configOrSignal?: InlineAskQuestionConfig | AbortSignal,
 ): { container: any; resolve: jest.Mock; widget: InlineAskUserQuestion } {
   const container = createMockEl();
   const resolve = jest.fn();
-  const widget = new InlineAskUserQuestion(container, input, resolve, signal);
+  const isSignal = configOrSignal instanceof AbortSignal;
+  const signal = isSignal ? configOrSignal : undefined;
+  const config = isSignal ? undefined : configOrSignal;
+  const widget = new InlineAskUserQuestion(container, input, resolve, signal, config);
   widget.render();
   return { container, resolve, widget };
 }
@@ -83,13 +86,21 @@ describe('InlineAskUserQuestion', () => {
       expect(resolve).not.toHaveBeenCalled();
     });
 
-    it('resolves null when all questions have empty options', () => {
+    it('resolves null when all questions have empty options and custom input is disabled', () => {
       const input = makeInput([
         { question: 'Q1', options: [] },
         { question: 'Q2', options: [] },
       ]);
-      const { resolve } = renderWidget(input);
+      const { resolve } = renderWidget(input, { showCustomInput: false });
       expect(resolve).toHaveBeenCalledWith(null);
+    });
+
+    it('keeps questions with empty options when custom input is enabled', () => {
+      const input = makeInput([
+        { question: 'Q1', options: [] },
+      ]);
+      const { resolve } = renderWidget(input);
+      expect(resolve).not.toHaveBeenCalled();
     });
 
     it('keeps questions that only allow free-form input', () => {
@@ -379,18 +390,20 @@ describe('InlineAskUserQuestion', () => {
   });
 
   describe('question metadata', () => {
-    it('shows custom input only when the question allows "other"', () => {
-      const disallowOtherInput = {
-        questions: [{ question: 'Pick one', options: ['A', 'B'], isOther: false }],
+    it('shows custom input by default when showCustomInput is enabled', () => {
+      const input = {
+        questions: [{ question: 'Pick one', options: ['A', 'B'] }],
       };
-      const { container: noOther } = renderWidget(disallowOtherInput);
-      expect(noOther.querySelectorAll('claudian-ask-custom-item')).toHaveLength(0);
+      const { container: withCustom } = renderWidget(input);
+      expect(withCustom.querySelectorAll('claudian-ask-custom-item')).toHaveLength(1);
+    });
 
-      const allowOtherInput = {
-        questions: [{ question: 'Pick one', options: ['A', 'B'], isOther: true }],
+    it('hides custom input when showCustomInput is disabled', () => {
+      const input = {
+        questions: [{ question: 'Pick one', options: ['A', 'B'] }],
       };
-      const { container: withOther } = renderWidget(allowOtherInput);
-      expect(withOther.querySelectorAll('claudian-ask-custom-item')).toHaveLength(1);
+      const { container: noCustom } = renderWidget(input, { showCustomInput: false });
+      expect(noCustom.querySelectorAll('claudian-ask-custom-item')).toHaveLength(0);
     });
 
     it('renders secret free-form questions with password input', () => {


### PR DESCRIPTION
related: https://github.com/YishenTu/claudian/issues/487

show free-text input in AskUserQuestion by default

Remove the isOther gate from canShowCustomInputForQuestion() so the "Other" free-text row appears when showCustomInput is enabled (the default), matching Claude Code CLI behavior.