### PR TITLE
feat: add OpenCode provider support via ACP protocol

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -133,7 +133,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -741,7 +740,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -765,7 +763,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2253,7 +2250,8 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -2553,7 +2551,6 @@
       "integrity": "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.58.0",
@@ -2583,7 +2580,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -3077,7 +3073,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3399,7 +3394,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3778,7 +3772,8 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4090,7 +4085,6 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4445,7 +4439,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4945,7 +4938,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
       "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5295,7 +5287,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -5928,7 +5919,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -6606,7 +6596,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7351,7 +7340,8 @@
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -8187,7 +8177,6 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8331,7 +8320,8 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
@@ -8712,7 +8702,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -296,6 +296,29 @@
     "language": {
       "name": "Sprache",
       "desc": "Anzeigesprache der Plugin-Oberfläche ändern"
+    },
+    "opencode": {
+      "enabled": {
+        "name": "OpenCode",
+        "desc": "Enable OpenCode in the model selector."
+      },
+      "prewarm": {
+        "name": "Pre-warm runtime",
+        "desc": "Start ACP process on load to reduce first response latency."
+      },
+      "cliPath": {
+        "name": "CLI path",
+        "desc": "Leave empty for auto-detection.",
+        "placeholder": "/usr/local/bin/opencode"
+      },
+      "mcpServers": {
+        "desc": "OpenCode manages MCP servers via its own configuration."
+      },
+      "environment": {
+        "name": "Environment",
+        "desc": "Configure API keys and provider settings.",
+        "placeholder": "OPENAI_API_KEY=your-key"
+      }
     }
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -296,6 +296,29 @@
     "language": {
       "name": "Language",
       "desc": "Change the display language of the plugin interface"
+    },
+    "opencode": {
+      "enabled": {
+        "name": "OpenCode",
+        "desc": "Enable OpenCode in the model selector."
+      },
+      "prewarm": {
+        "name": "Pre-warm runtime",
+        "desc": "Start ACP process on load to reduce first response latency."
+      },
+      "cliPath": {
+        "name": "CLI path",
+        "desc": "Leave empty for auto-detection.",
+        "placeholder": "/usr/local/bin/opencode"
+      },
+      "mcpServers": {
+        "desc": "OpenCode manages MCP servers via its own configuration."
+      },
+      "environment": {
+        "name": "Environment",
+        "desc": "Configure API keys and provider settings.",
+        "placeholder": "OPENAI_API_KEY=your-key"
+      }
     }
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -296,6 +296,29 @@
     "language": {
       "name": "Idioma",
       "desc": "Cambiar el idioma de visualización de la interfaz del plugin"
+    },
+    "opencode": {
+      "enabled": {
+        "name": "OpenCode",
+        "desc": "Enable OpenCode in the model selector."
+      },
+      "prewarm": {
+        "name": "Pre-warm runtime",
+        "desc": "Start ACP process on load to reduce first response latency."
+      },
+      "cliPath": {
+        "name": "CLI path",
+        "desc": "Leave empty for auto-detection.",
+        "placeholder": "/usr/local/bin/opencode"
+      },
+      "mcpServers": {
+        "desc": "OpenCode manages MCP servers via its own configuration."
+      },
+      "environment": {
+        "name": "Environment",
+        "desc": "Configure API keys and provider settings.",
+        "placeholder": "OPENAI_API_KEY=your-key"
+      }
     }
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -296,6 +296,29 @@
     "language": {
       "name": "Langue",
       "desc": "Changer la langue d'affichage de l'interface du plugin"
+    },
+    "opencode": {
+      "enabled": {
+        "name": "OpenCode",
+        "desc": "Enable OpenCode in the model selector."
+      },
+      "prewarm": {
+        "name": "Pre-warm runtime",
+        "desc": "Start ACP process on load to reduce first response latency."
+      },
+      "cliPath": {
+        "name": "CLI path",
+        "desc": "Leave empty for auto-detection.",
+        "placeholder": "/usr/local/bin/opencode"
+      },
+      "mcpServers": {
+        "desc": "OpenCode manages MCP servers via its own configuration."
+      },
+      "environment": {
+        "name": "Environment",
+        "desc": "Configure API keys and provider settings.",
+        "placeholder": "OPENAI_API_KEY=your-key"
+      }
     }
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -296,6 +296,29 @@
     "language": {
       "name": "言語",
       "desc": "プラグインインターフェースの表示言語を変更"
+    },
+    "opencode": {
+      "enabled": {
+        "name": "OpenCode",
+        "desc": "Enable OpenCode in the model selector."
+      },
+      "prewarm": {
+        "name": "Pre-warm runtime",
+        "desc": "Start ACP process on load to reduce first response latency."
+      },
+      "cliPath": {
+        "name": "CLI path",
+        "desc": "Leave empty for auto-detection.",
+        "placeholder": "/usr/local/bin/opencode"
+      },
+      "mcpServers": {
+        "desc": "OpenCode manages MCP servers via its own configuration."
+      },
+      "environment": {
+        "name": "Environment",
+        "desc": "Configure API keys and provider settings.",
+        "placeholder": "OPENAI_API_KEY=your-key"
+      }
     }
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -296,6 +296,29 @@
     "language": {
       "name": "언어",
       "desc": "플러그인 인터페이스의 표시 언어 변경"
+    },
+    "opencode": {
+      "enabled": {
+        "name": "OpenCode",
+        "desc": "Enable OpenCode in the model selector."
+      },
+      "prewarm": {
+        "name": "Pre-warm runtime",
+        "desc": "Start ACP process on load to reduce first response latency."
+      },
+      "cliPath": {
+        "name": "CLI path",
+        "desc": "Leave empty for auto-detection.",
+        "placeholder": "/usr/local/bin/opencode"
+      },
+      "mcpServers": {
+        "desc": "OpenCode manages MCP servers via its own configuration."
+      },
+      "environment": {
+        "name": "Environment",
+        "desc": "Configure API keys and provider settings.",
+        "placeholder": "OPENAI_API_KEY=your-key"
+      }
     }
   }
 }

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -296,6 +296,29 @@
     "language": {
       "name": "Idioma",
       "desc": "Alterar o idioma de exibição da interface do plugin"
+    },
+    "opencode": {
+      "enabled": {
+        "name": "OpenCode",
+        "desc": "Enable OpenCode in the model selector."
+      },
+      "prewarm": {
+        "name": "Pre-warm runtime",
+        "desc": "Start ACP process on load to reduce first response latency."
+      },
+      "cliPath": {
+        "name": "CLI path",
+        "desc": "Leave empty for auto-detection.",
+        "placeholder": "/usr/local/bin/opencode"
+      },
+      "mcpServers": {
+        "desc": "OpenCode manages MCP servers via its own configuration."
+      },
+      "environment": {
+        "name": "Environment",
+        "desc": "Configure API keys and provider settings.",
+        "placeholder": "OPENAI_API_KEY=your-key"
+      }
     }
   }
 }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -296,6 +296,29 @@
     "language": {
       "name": "Язык",
       "desc": "Изменить язык интерфейса плагина"
+    },
+    "opencode": {
+      "enabled": {
+        "name": "OpenCode",
+        "desc": "Enable OpenCode in the model selector."
+      },
+      "prewarm": {
+        "name": "Pre-warm runtime",
+        "desc": "Start ACP process on load to reduce first response latency."
+      },
+      "cliPath": {
+        "name": "CLI path",
+        "desc": "Leave empty for auto-detection.",
+        "placeholder": "/usr/local/bin/opencode"
+      },
+      "mcpServers": {
+        "desc": "OpenCode manages MCP servers via its own configuration."
+      },
+      "environment": {
+        "name": "Environment",
+        "desc": "Configure API keys and provider settings.",
+        "placeholder": "OPENAI_API_KEY=your-key"
+      }
     }
   }
 }

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -296,6 +296,29 @@
     "language": {
       "name": "语言",
       "desc": "更改插件界面的显示语言"
+    },
+    "opencode": {
+      "enabled": {
+        "name": "OpenCode",
+        "desc": "启用后 OpenCode 会出现在模型选择器中。"
+      },
+      "prewarm": {
+        "name": "Pre-warm runtime",
+        "desc": "启动时预热 ACP 进程，减少首次响应延迟。"
+      },
+      "cliPath": {
+        "name": "CLI 路径",
+        "desc": "留空自动检测。",
+        "placeholder": "/usr/local/bin/opencode"
+      },
+      "mcpServers": {
+        "desc": "OpenCode 通过自身配置管理 MCP 服务器。"
+      },
+      "environment": {
+        "name": "环境变量",
+        "desc": "配置 API 密钥等。",
+        "placeholder": "OPENAI_API_KEY=your-key"
+      }
     }
   }
 }

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -296,6 +296,29 @@
     "language": {
       "name": "語言",
       "desc": "更改插件介面的顯示語言"
+    },
+    "opencode": {
+      "enabled": {
+        "name": "OpenCode",
+        "desc": "Enable OpenCode in the model selector."
+      },
+      "prewarm": {
+        "name": "Pre-warm runtime",
+        "desc": "Start ACP process on load to reduce first response latency."
+      },
+      "cliPath": {
+        "name": "CLI path",
+        "desc": "Leave empty for auto-detection.",
+        "placeholder": "/usr/local/bin/opencode"
+      },
+      "mcpServers": {
+        "desc": "OpenCode manages MCP servers via its own configuration."
+      },
+      "environment": {
+        "name": "Environment",
+        "desc": "Configure API keys and provider settings.",
+        "placeholder": "OPENAI_API_KEY=your-key"
+      }
     }
   }
 }

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -232,4 +232,17 @@ export type TranslationKey =
 
   // Settings - Language
   | 'settings.language.name'
-  | 'settings.language.desc';
+  | 'settings.language.desc'
+
+  // Settings - OpenCode
+  | 'settings.opencode.enabled.name'
+  | 'settings.opencode.enabled.desc'
+  | 'settings.opencode.prewarm.name'
+  | 'settings.opencode.prewarm.desc'
+  | 'settings.opencode.cliPath.name'
+  | 'settings.opencode.cliPath.desc'
+  | 'settings.opencode.cliPath.placeholder'
+  | 'settings.opencode.mcpServers.desc'
+  | 'settings.opencode.environment.name'
+  | 'settings.opencode.environment.desc'
+  | 'settings.opencode.environment.placeholder';

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -4,6 +4,8 @@ import { claudeWorkspaceRegistration } from './claude/app/ClaudeWorkspaceService
 import { claudeProviderRegistration } from './claude/registration';
 import { codexWorkspaceRegistration } from './codex/app/CodexWorkspaceServices';
 import { codexProviderRegistration } from './codex/registration';
+import { opencodeWorkspaceRegistration } from './opencode/app/OpencodeWorkspaceServices';
+import { opencodeProviderRegistration } from './opencode/registration';
 
 let builtInProvidersRegistered = false;
 
@@ -14,8 +16,10 @@ export function registerBuiltInProviders(): void {
 
   ProviderRegistry.register('claude', claudeProviderRegistration);
   ProviderRegistry.register('codex', codexProviderRegistration);
+  ProviderRegistry.register('opencode', opencodeProviderRegistration);
   ProviderWorkspaceRegistry.register('claude', claudeWorkspaceRegistration);
   ProviderWorkspaceRegistry.register('codex', codexWorkspaceRegistration);
+  ProviderWorkspaceRegistry.register('opencode', opencodeWorkspaceRegistration);
   builtInProvidersRegistered = true;
 }
 

--- a/src/providers/opencode/agents/OpencodeAgentMentionProvider.ts
+++ b/src/providers/opencode/agents/OpencodeAgentMentionProvider.ts
@@ -1,0 +1,40 @@
+import type { AgentMentionProvider } from '../../../core/providers/types';
+
+export interface OpencodeSubagentDefinition {
+  name: string;
+  description: string;
+  source: 'plugin' | 'vault' | 'global' | 'builtin';
+}
+
+export class OpencodeAgentMentionProvider implements AgentMentionProvider {
+  private agents: OpencodeSubagentDefinition[] = [
+    { name: 'general', description: 'General coding assistant', source: 'builtin' },
+    { name: 'architect', description: 'System design and architecture', source: 'builtin' },
+    { name: 'code', description: 'Code implementation focused', source: 'builtin' },
+    { name: 'review', description: 'Code review specialist', source: 'builtin' },
+    { name: 'debug', description: 'Debugging specialist', source: 'builtin' },
+  ];
+
+  async loadAgents(): Promise<void> {
+  }
+
+  searchAgents(query: string): Array<{
+    id: string;
+    name: string;
+    description?: string;
+    source: 'plugin' | 'vault' | 'global' | 'builtin';
+  }> {
+    const q = query.toLowerCase();
+    return this.agents
+      .filter(a =>
+        a.name.toLowerCase().includes(q) ||
+        a.description.toLowerCase().includes(q)
+      )
+      .map(a => ({
+        id: a.name,
+        name: a.name,
+        description: a.description,
+        source: a.source as 'builtin',
+      }));
+  }
+}

--- a/src/providers/opencode/app/OpencodeWorkspaceServices.ts
+++ b/src/providers/opencode/app/OpencodeWorkspaceServices.ts
@@ -1,0 +1,37 @@
+import type { ProviderWorkspaceRegistration, ProviderWorkspaceServices } from '../../../core/providers/types';
+import type { HomeFileAdapter } from '../../../core/storage/HomeFileAdapter';
+import type { VaultFileAdapter } from '../../../core/storage/VaultFileAdapter';
+import type ClaudianPlugin from '../../../main';
+import { OpencodeAgentMentionProvider } from '../agents/OpencodeAgentMentionProvider';
+import { OpencodeCommandCatalog } from '../commands/OpencodeCommandCatalog';
+import { opencodeSettingsTabRenderer } from '../ui/OpencodeSettingsTab';
+
+export interface OpencodeWorkspaceServices extends ProviderWorkspaceServices {
+  agentMentionProvider: OpencodeAgentMentionProvider;
+  commandCatalog: OpencodeCommandCatalog;
+}
+
+export async function createOpencodeWorkspaceServices(
+  _plugin: ClaudianPlugin,
+  _vaultAdapter: VaultFileAdapter,
+  _homeAdapter: HomeFileAdapter,
+): Promise<OpencodeWorkspaceServices> {
+  const agentMentionProvider = new OpencodeAgentMentionProvider();
+  await agentMentionProvider.loadAgents();
+
+  const commandCatalog = new OpencodeCommandCatalog();
+
+  return {
+    agentMentionProvider,
+    commandCatalog,
+    settingsTabRenderer: opencodeSettingsTabRenderer,
+  };
+}
+
+export const opencodeWorkspaceRegistration: ProviderWorkspaceRegistration<OpencodeWorkspaceServices> = {
+  initialize: async ({ plugin, vaultAdapter, homeAdapter }) => createOpencodeWorkspaceServices(
+    plugin,
+    vaultAdapter,
+    homeAdapter,
+  ),
+};

--- a/src/providers/opencode/auxiliary/OpencodeInlineEditService.ts
+++ b/src/providers/opencode/auxiliary/OpencodeInlineEditService.ts
@@ -1,0 +1,28 @@
+import type {
+  InlineEditRequest,
+  InlineEditResult,
+  InlineEditService,
+} from '../../../core/providers/types';
+import type ClaudianPlugin from '../../../main';
+
+export class OpencodeInlineEditService implements InlineEditService {
+  private plugin: ClaudianPlugin;
+
+  constructor(plugin: ClaudianPlugin) {
+    this.plugin = plugin;
+  }
+
+  resetConversation(): void {
+  }
+
+  async editText(_request: InlineEditRequest): Promise<InlineEditResult> {
+    return { success: false, error: 'OpenCode inline edit not yet implemented' };
+  }
+
+  async continueConversation(_message: string, _contextFiles?: string[]): Promise<InlineEditResult> {
+    return { success: false, error: 'OpenCode inline edit not yet implemented' };
+  }
+
+  cancel(): void {
+  }
+}

--- a/src/providers/opencode/auxiliary/OpencodeInstructionRefineService.ts
+++ b/src/providers/opencode/auxiliary/OpencodeInstructionRefineService.ts
@@ -1,0 +1,34 @@
+import type {
+  InstructionRefineService,
+} from '../../../core/providers/types';
+import type { InstructionRefineResult } from '../../../core/types';
+import type ClaudianPlugin from '../../../main';
+
+export class OpencodeInstructionRefineService implements InstructionRefineService {
+  private plugin: ClaudianPlugin;
+
+  constructor(plugin: ClaudianPlugin) {
+    this.plugin = plugin;
+  }
+
+  resetConversation(): void {
+  }
+
+  async refineInstruction(
+    _rawInstruction: string,
+    _existingInstructions: string,
+    _onProgress?: (update: InstructionRefineResult) => void,
+  ): Promise<InstructionRefineResult> {
+    return { success: false, error: 'OpenCode instruction refinement not yet implemented' };
+  }
+
+  async continueConversation(
+    _message: string,
+    _onProgress?: (update: InstructionRefineResult) => void,
+  ): Promise<InstructionRefineResult> {
+    return { success: false, error: 'OpenCode instruction refinement not yet implemented' };
+  }
+
+  cancel(): void {
+  }
+}

--- a/src/providers/opencode/auxiliary/OpencodeTaskResultInterpreter.ts
+++ b/src/providers/opencode/auxiliary/OpencodeTaskResultInterpreter.ts
@@ -1,0 +1,26 @@
+import type { ProviderTaskResultInterpreter } from '../../../core/providers/types';
+
+export class OpencodeTaskResultInterpreter implements ProviderTaskResultInterpreter {
+  hasAsyncLaunchMarker(_toolUseResult: unknown): boolean {
+    return false;
+  }
+
+  extractAgentId(_toolUseResult: unknown): string | null {
+    return null;
+  }
+
+  extractStructuredResult(_toolUseResult: unknown): string | null {
+    return null;
+  }
+
+  resolveTerminalStatus(
+    _toolUseResult: unknown,
+    fallbackStatus: 'completed' | 'error',
+  ): 'completed' | 'error' {
+    return fallbackStatus;
+  }
+
+  extractTagValue(_payload: string, _tagName: string): string | null {
+    return null;
+  }
+}

--- a/src/providers/opencode/auxiliary/OpencodeTitleGenerationService.ts
+++ b/src/providers/opencode/auxiliary/OpencodeTitleGenerationService.ts
@@ -1,0 +1,55 @@
+import type {
+  TitleGenerationCallback,
+  TitleGenerationResult,
+  TitleGenerationService,
+} from '../../../core/providers/types';
+import type ClaudianPlugin from '../../../main';
+
+export class OpencodeTitleGenerationService implements TitleGenerationService {
+  private plugin: ClaudianPlugin;
+  private activeGenerations = new Map<string, AbortController>();
+
+  constructor(plugin: ClaudianPlugin) {
+    this.plugin = plugin;
+  }
+
+  async generateTitle(
+    conversationId: string,
+    userMessage: string,
+    callback: TitleGenerationCallback,
+  ): Promise<void> {
+    const existing = this.activeGenerations.get(conversationId);
+    if (existing) existing.abort();
+
+    const abortController = new AbortController();
+    this.activeGenerations.set(conversationId, abortController);
+
+    try {
+      await this.safeCallback(callback, conversationId, {
+        success: false,
+        error: 'OpenCode title generation not yet implemented',
+      });
+    } finally {
+      this.activeGenerations.delete(conversationId);
+    }
+  }
+
+  cancel(): void {
+    for (const controller of this.activeGenerations.values()) {
+      controller.abort();
+    }
+    this.activeGenerations.clear();
+  }
+
+  private async safeCallback(
+    callback: TitleGenerationCallback,
+    conversationId: string,
+    result: TitleGenerationResult,
+  ): Promise<void> {
+    try {
+      await callback(conversationId, result);
+    } catch {
+      // Silently ignore callback errors
+    }
+  }
+}

--- a/src/providers/opencode/capabilities.ts
+++ b/src/providers/opencode/capabilities.ts
@@ -1,0 +1,16 @@
+import type { ProviderCapabilities } from '../../core/providers/types';
+
+export const OPENCODE_PROVIDER_CAPABILITIES: Readonly<ProviderCapabilities> = Object.freeze({
+  providerId: 'opencode',
+  supportsPersistentRuntime: true,
+  supportsNativeHistory: true,
+  supportsPlanMode: true,
+  supportsRewind: false,
+  supportsFork: true,
+  supportsProviderCommands: false,
+  supportsImageAttachments: true,
+  supportsInstructionMode: true,
+  supportsMcpTools: true,
+  supportsTurnSteer: true,
+  reasoningControl: 'none',
+});

--- a/src/providers/opencode/commands/OpencodeCommandCatalog.ts
+++ b/src/providers/opencode/commands/OpencodeCommandCatalog.ts
@@ -1,0 +1,56 @@
+import type {
+  ProviderCommandCatalog,
+  ProviderCommandDropdownConfig,
+} from '../../../core/providers/commands/ProviderCommandCatalog';
+import type { ProviderCommandEntry } from '../../../core/providers/commands/ProviderCommandEntry';
+
+const OPENCODE_COMPACT_COMMAND: ProviderCommandEntry = {
+  id: 'opencode-builtin-compact',
+  providerId: 'opencode',
+  kind: 'command',
+  name: 'compact',
+  description: 'Compact conversation history',
+  content: '',
+  scope: 'system',
+  source: 'builtin',
+  isEditable: false,
+  isDeletable: false,
+  displayPrefix: '/',
+  insertPrefix: '/',
+};
+
+export class OpencodeCommandCatalog implements ProviderCommandCatalog {
+  private runtimeCommands: ProviderCommandEntry[] = [];
+
+  setRuntimeCommands(commands: ProviderCommandEntry[]): void {
+    this.runtimeCommands = commands;
+  }
+
+  async listDropdownEntries(context: { includeBuiltIns: boolean }): Promise<ProviderCommandEntry[]> {
+    const commands = this.runtimeCommands;
+    return context.includeBuiltIns ? [OPENCODE_COMPACT_COMMAND, ...commands] : commands;
+  }
+
+  async listVaultEntries(): Promise<ProviderCommandEntry[]> {
+    return [];
+  }
+
+  async saveVaultEntry(_entry: ProviderCommandEntry): Promise<void> {
+  }
+
+  async deleteVaultEntry(_entry: ProviderCommandEntry): Promise<void> {
+  }
+
+  getDropdownConfig(): ProviderCommandDropdownConfig {
+    return {
+      providerId: 'opencode',
+      triggerChars: ['/'],
+      builtInPrefix: '/',
+      skillPrefix: '$',
+      commandPrefix: '/',
+    };
+  }
+
+  async refresh(): Promise<void> {
+  }
+}

--- a/src/providers/opencode/env/OpencodeSettingsReconciler.ts
+++ b/src/providers/opencode/env/OpencodeSettingsReconciler.ts
@@ -1,0 +1,15 @@
+import type { ProviderSettingsReconciler } from '../../../core/providers/types';
+import type { Conversation } from '../../../core/types';
+
+export const opencodeSettingsReconciler: ProviderSettingsReconciler = {
+  reconcileModelWithEnvironment(
+    _settings: Record<string, unknown>,
+    _conversations: Conversation[],
+  ): { changed: boolean; invalidatedConversations: Conversation[] } {
+    return { changed: false, invalidatedConversations: [] };
+  },
+
+  normalizeModelVariantSettings(_settings: Record<string, unknown>): boolean {
+    return false;
+  },
+};

--- a/src/providers/opencode/history/OpencodeConversationHistoryService.ts
+++ b/src/providers/opencode/history/OpencodeConversationHistoryService.ts
@@ -1,0 +1,64 @@
+import type { ProviderConversationHistoryService } from '../../../core/providers/types';
+import type { Conversation } from '../../../core/types';
+
+export interface OpencodeProviderState {
+  sessionId?: string;
+  forkSource?: { sessionId: string; resumeAt: string };
+  transcriptRootPath?: string;
+}
+
+function getOpencodeState(providerState: Record<string, unknown> | undefined): OpencodeProviderState {
+  return (providerState ?? {}) as OpencodeProviderState;
+}
+
+export class OpencodeConversationHistoryService implements ProviderConversationHistoryService {
+  private hydratedConversationIds = new Set<string>();
+
+  async hydrateConversationHistory(
+    _conversation: Conversation,
+    _vaultPath: string | null,
+  ): Promise<void> {
+  }
+
+  async deleteConversationSession(
+    _conversation: Conversation,
+    _vaultPath: string | null,
+  ): Promise<void> {
+  }
+
+  resolveSessionIdForConversation(conversation: Conversation | null): string | null {
+    if (!conversation) return null;
+
+    const state = getOpencodeState(conversation.providerState);
+
+    if (state.forkSource && !state.sessionId) {
+      return state.forkSource.sessionId;
+    }
+
+    return state.sessionId ?? conversation.sessionId ?? null;
+  }
+
+  isPendingForkConversation(conversation: Conversation): boolean {
+    const state = getOpencodeState(conversation.providerState);
+    return !!state.forkSource && !state.sessionId && !conversation.sessionId;
+  }
+
+  buildForkProviderState(
+    sourceSessionId: string,
+    resumeAt: string,
+    _sourceProviderState?: Record<string, unknown>,
+  ): Record<string, unknown> {
+    return {
+      forkSource: {
+        sessionId: sourceSessionId,
+        resumeAt,
+      },
+    };
+  }
+
+  buildPersistedProviderState(conversation: Conversation): Record<string, unknown> | undefined {
+    const state = getOpencodeState(conversation.providerState);
+    const entries = Object.entries(state).filter(([, value]) => value !== undefined);
+    return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+  }
+}

--- a/src/providers/opencode/registration.ts
+++ b/src/providers/opencode/registration.ts
@@ -1,0 +1,27 @@
+import type { ProviderRegistration } from '../../core/providers/types';
+import { OpencodeInlineEditService } from './auxiliary/OpencodeInlineEditService';
+import { OpencodeInstructionRefineService } from './auxiliary/OpencodeInstructionRefineService';
+import { OpencodeTaskResultInterpreter } from './auxiliary/OpencodeTaskResultInterpreter';
+import { OpencodeTitleGenerationService } from './auxiliary/OpencodeTitleGenerationService';
+import { OPENCODE_PROVIDER_CAPABILITIES } from './capabilities';
+import { opencodeSettingsReconciler } from './env/OpencodeSettingsReconciler';
+import { OpencodeConversationHistoryService } from './history/OpencodeConversationHistoryService';
+import { OpencodeChatRuntime } from './runtime/OpencodeChatRuntime';
+import { getOpencodeProviderSettings } from './settings';
+import { opencodeChatUIConfig } from './ui/OpencodeChatUIConfig';
+
+export const opencodeProviderRegistration: ProviderRegistration = {
+  displayName: 'OpenCode',
+  blankTabOrder: 20,
+  isEnabled: (settings) => getOpencodeProviderSettings(settings).enabled,
+  capabilities: OPENCODE_PROVIDER_CAPABILITIES,
+  environmentKeyPatterns: [/^OPENCODE_/i, /^ANTHROPIC_/i, /^OPENAI_/i],
+  chatUIConfig: opencodeChatUIConfig,
+  settingsReconciler: opencodeSettingsReconciler,
+  createRuntime: ({ plugin }) => new OpencodeChatRuntime(plugin),
+  createTitleGenerationService: (plugin) => new OpencodeTitleGenerationService(plugin),
+  createInstructionRefineService: (plugin) => new OpencodeInstructionRefineService(plugin),
+  createInlineEditService: (plugin) => new OpencodeInlineEditService(plugin),
+  historyService: new OpencodeConversationHistoryService(),
+  taskResultInterpreter: new OpencodeTaskResultInterpreter(),
+};

--- a/src/providers/opencode/runtime/OpencodeBinaryLocator.ts
+++ b/src/providers/opencode/runtime/OpencodeBinaryLocator.ts
@@ -1,0 +1,90 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { getEnhancedPath, parseEnvironmentVariables } from '../../../utils/env';
+import { expandHomePath, parsePathEntries } from '../../../utils/path';
+
+function isExistingFile(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function resolveConfiguredPath(configuredPath: string | undefined): string | null {
+  const trimmed = (configuredPath ?? '').trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const expandedPath = expandHomePath(trimmed);
+    return isExistingFile(expandedPath) ? expandedPath : null;
+  } catch {
+    return null;
+  }
+}
+
+function getOpencodeHomePaths(): string[] {
+  const home = os.homedir();
+  const paths: string[] = [];
+
+  if (process.platform === 'darwin') {
+    paths.push(path.join(home, '.opencode', 'bin'));
+  }
+
+  if (process.platform === 'linux') {
+    paths.push(path.join(home, '.opencode', 'bin'));
+  }
+
+  if (process.platform === 'win32') {
+    paths.push(path.join(home, 'AppData', 'Local', 'opencode', 'bin'));
+    paths.push(path.join(home, '.opencode', 'bin'));
+  }
+
+  return paths;
+}
+
+export function findOpencodeBinaryPath(
+  additionalPath?: string,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  const binaryNames = platform === 'win32'
+    ? ['opencode.exe', 'opencode.cmd', 'opencode']
+    : ['opencode'];
+
+  const searchEntries = parsePathEntries(getEnhancedPath(additionalPath));
+  const opencodeHomePaths = getOpencodeHomePaths();
+  const allPaths = [...opencodeHomePaths, ...searchEntries];
+
+  for (const dir of allPaths) {
+    if (!dir) continue;
+
+    for (const binaryName of binaryNames) {
+      const candidate = path.join(dir, binaryName);
+      if (isExistingFile(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function resolveOpencodeCliPath(
+  configuredPath: string | undefined,
+  envText: string,
+  options: { hostPlatform?: NodeJS.Platform } = {},
+): string | null {
+  const hostPlatform = options.hostPlatform ?? process.platform;
+
+  const configured = resolveConfiguredPath(configuredPath);
+  if (configured) {
+    return configured;
+  }
+
+  const customEnv = parseEnvironmentVariables(envText || '');
+  return findOpencodeBinaryPath(customEnv.PATH, hostPlatform);
+}

--- a/src/providers/opencode/runtime/OpencodeChatRuntime.ts
+++ b/src/providers/opencode/runtime/OpencodeChatRuntime.ts
@@ -98,10 +98,18 @@ export class OpencodeChatRuntime implements ChatRuntime {
   }
 
   syncConversationState(
-    conversation: { providerState?: Record<string, unknown> } | null,
+    conversation: { providerState?: Record<string, unknown>; sessionId?: string | null } | null,
     _externalContextPaths?: string[],
   ): void {
     this.conversation = conversation as Conversation | null;
+
+    if (conversation) {
+      const state = conversation.providerState as { sessionId?: string } | undefined;
+      const savedSessionId = state?.sessionId ?? conversation.sessionId ?? null;
+      if (savedSessionId) {
+        this.sessionId = savedSessionId;
+      }
+    }
   }
 
   async reloadMcpServers(): Promise<void> {
@@ -123,13 +131,15 @@ export class OpencodeChatRuntime implements ChatRuntime {
 
       const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
 
-      if (options?.sessionId && this.transport) {
-        const loaded = await this.loadSession(options.sessionId, cwd);
-        if (!loaded) {
-          const sessionId = await this.createSession(cwd);
-          return !!sessionId;
+      const sessionIdToUse = options?.sessionId ?? this.sessionId;
+
+      if (sessionIdToUse && this.transport) {
+        const loaded = await this.loadSession(sessionIdToUse, cwd);
+        if (loaded) {
+          return true;
         }
-        return true;
+        const newSessionId = await this.createSession(cwd);
+        return !!newSessionId;
       }
 
       if (!this.sessionId) {
@@ -191,7 +201,7 @@ export class OpencodeChatRuntime implements ChatRuntime {
       const resultPromise = this.transport.request<PromptResult>('session/prompt', {
         sessionId,
         prompt,
-      } as PromptParams);
+      } as PromptParams, 120_000);
 
       while (true) {
         while (this.chunkBuffer.length > 0) {

--- a/src/providers/opencode/runtime/OpencodeChatRuntime.ts
+++ b/src/providers/opencode/runtime/OpencodeChatRuntime.ts
@@ -1,0 +1,615 @@
+import { EventEmitter } from 'events';
+
+import type { ProviderCommandEntry } from '../../../core/providers/commands/ProviderCommandEntry';
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
+import type { ProviderId } from '../../../core/providers/types';
+import type { ChatRuntime } from '../../../core/runtime/ChatRuntime';
+import type {
+  ApprovalCallback,
+  AskUserQuestionCallback,
+  AutoTurnResult,
+  ChatRewindResult,
+  ChatRuntimeEnsureReadyOptions,
+  ChatRuntimeQueryOptions,
+  ChatTurnMetadata,
+  ChatTurnRequest,
+  PreparedChatTurn,
+  SessionUpdateResult,
+} from '../../../core/runtime/types';
+import type { ChatMessage, Conversation, ExitPlanModeCallback, SlashCommand, StreamChunk, ToolCallInfo } from '../../../core/types';
+import type ClaudianPlugin from '../../../main';
+import { getVaultPath } from '../../../utils/path';
+import { OPENCODE_PROVIDER_CAPABILITIES } from '../capabilities';
+import type { OpencodeCommandCatalog } from '../commands/OpencodeCommandCatalog';
+import type { OpencodeProviderSettings } from '../settings';
+import { getOpencodeProviderSettings } from '../settings';
+import { resolveOpencodeCliPath } from './OpencodeBinaryLocator';
+import { OpencodeNotificationRouter } from './OpencodeNotificationRouter';
+import { OpencodeProcess } from './OpencodeProcess';
+import { OpencodeRpcTransport } from './OpencodeRpcTransport';
+import type {
+  AgentCapabilities,
+  ForkSessionResponse,
+  InitializeParams,
+  InitializeResult,
+  LoadSessionResponse,
+  NewSessionResponse,
+  PromptParams,
+  PromptResult,
+} from './OpencodeTypes';
+
+interface OpencodeReadyStateListener {
+  (ready: boolean): void;
+}
+
+export class OpencodeChatRuntime implements ChatRuntime {
+  readonly providerId: ProviderId = 'opencode';
+
+  private proc: OpencodeProcess | null = null;
+  private transport: OpencodeRpcTransport | null = null;
+  private notificationRouter: OpencodeNotificationRouter | null = null;
+  private settings: OpencodeProviderSettings | null = null;
+  private sessionId: string | null = null;
+  private readyStateListeners: OpencodeReadyStateListener[] = [];
+  private ready = false;
+  private currentTurnId: string | null = null;
+  private pendingTurnNotifications: unknown[] = [];
+  private conversation: Conversation | null = null;
+  private currentTurnMetadata: ChatTurnMetadata = {};
+  private eventEmitter = new EventEmitter();
+  private chunkBuffer: StreamChunk[] = [];
+  private chunkResolve: (() => void) | null = null;
+  private agentCapabilities: AgentCapabilities | null = null;
+
+  private approvalCallback: ApprovalCallback | null = null;
+  private approvalDismisser: (() => void) | null = null;
+  private askUserQuestionCallback: AskUserQuestionCallback | null = null;
+  private exitPlanModeCallback: ExitPlanModeCallback | null = null;
+  private autoTurnCallback: ((result: AutoTurnResult) => void) | null = null;
+
+  constructor(
+    private readonly plugin: ClaudianPlugin,
+  ) {}
+
+  getCapabilities() {
+    return OPENCODE_PROVIDER_CAPABILITIES;
+  }
+
+  prepareTurn(request: ChatTurnRequest): PreparedChatTurn {
+    return {
+      request,
+      persistedContent: '',
+      prompt: request.text,
+      isCompact: false,
+      mcpMentions: request.enabledMcpServers ?? new Set(),
+    };
+  }
+
+  onReadyStateChange(listener: (ready: boolean) => void): () => void {
+    this.readyStateListeners.push(listener);
+    return () => {
+      const idx = this.readyStateListeners.indexOf(listener);
+      if (idx !== -1) this.readyStateListeners.splice(idx, 1);
+    };
+  }
+
+  setResumeCheckpoint(_checkpointId: string | undefined): void {
+  }
+
+  syncConversationState(
+    conversation: { providerState?: Record<string, unknown> } | null,
+    _externalContextPaths?: string[],
+  ): void {
+    this.conversation = conversation as Conversation | null;
+  }
+
+  async reloadMcpServers(): Promise<void> {
+  }
+
+  async ensureReady(options?: ChatRuntimeEnsureReadyOptions): Promise<boolean> {
+    const settings = getOpencodeProviderSettings(this.plugin.settings);
+    this.settings = settings;
+
+    if (!settings.enabled) {
+      console.error('[OpenCode] Provider not enabled');
+      return false;
+    }
+
+    try {
+      if (!this.ready) {
+        await this.startProcess();
+      }
+
+      const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
+
+      if (options?.sessionId && this.transport) {
+        const loaded = await this.loadSession(options.sessionId, cwd);
+        if (!loaded) {
+          const sessionId = await this.createSession(cwd);
+          return !!sessionId;
+        }
+        return true;
+      }
+
+      if (!this.sessionId) {
+        if (settings.prewarm) {
+          const sessionId = await this.createSession(cwd);
+          return !!sessionId;
+        }
+        return true;
+      }
+
+      return true;
+    } catch (error) {
+      console.error('[OpenCode] Failed to start runtime:', error);
+      this.ready = false;
+      return false;
+    }
+  }
+
+  async *query(
+    turn: PreparedChatTurn,
+    _conversationHistory?: ChatMessage[],
+    _queryOptions?: ChatRuntimeQueryOptions,
+  ): AsyncGenerator<StreamChunk> {
+    const ready = await this.ensureReady();
+    if (!ready) {
+      yield { type: 'error', content: 'Failed to start OpenCode runtime. Make sure OpenCode is installed and logged in.' };
+      return;
+    }
+
+    if (!this.transport) {
+      yield { type: 'error', content: 'Runtime not ready' };
+      return;
+    }
+
+    if (!this.sessionId) {
+      const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
+      const sessionId = await this.createSession(cwd);
+      if (!sessionId) {
+        yield { type: 'error', content: 'Failed to create session' };
+        return;
+      }
+    }
+
+    const sessionId = this.sessionId!;
+    this.currentTurnId = crypto.randomUUID();
+    this.pendingTurnNotifications = [];
+
+    const isPlanTurn = false;
+    if (isPlanTurn) {
+      yield { type: 'text', content: '[plan mode entered]' };
+    }
+
+    this.notificationRouter?.beginTurn(sessionId, isPlanTurn);
+    this.chunkBuffer = [];
+
+    try {
+      const prompt = this.buildPrompt(turn.request);
+
+      const resultPromise = this.transport.request<PromptResult>('session/prompt', {
+        sessionId,
+        prompt,
+      } as PromptParams);
+
+      while (true) {
+        while (this.chunkBuffer.length > 0) {
+          const chunk = this.chunkBuffer.shift()!;
+          yield chunk;
+        }
+
+        const done = await Promise.race([
+          resultPromise,
+          new Promise<void>(resolve => {
+            const check = () => {
+              if (this.chunkBuffer.length > 0) {
+                resolve();
+              } else {
+                setTimeout(check, 5);
+              }
+            };
+            check();
+          }),
+        ]);
+
+        if (done !== undefined) {
+          const result = await resultPromise;
+          console.log('[OpenCode] Prompt result:', JSON.stringify(result, null, 2));
+
+          while (this.chunkBuffer.length > 0) {
+            const chunk = this.chunkBuffer.shift()!;
+            yield chunk;
+          }
+
+          if (result.stopReason === 'stopped') {
+            this.exitPlanModeCallback?.({});
+          }
+
+          if (result.usage) {
+            yield {
+              type: 'usage',
+              usage: {
+                inputTokens: result.usage.inputTokens,
+                cacheCreationInputTokens: 0,
+                cacheReadInputTokens: 0,
+                contextWindow: 200000,
+                contextWindowIsAuthoritative: true,
+                contextTokens: result.usage.inputTokens + result.usage.outputTokens,
+                percentage: 0,
+              },
+            };
+          }
+
+          break;
+        }
+      }
+
+      yield { type: 'done' };
+    } catch (error) {
+      yield { type: 'error', content: error instanceof Error ? error.message : 'Query failed' };
+      yield { type: 'done' };
+    } finally {
+      this.notificationRouter?.endTurn();
+      this.currentTurnId = null;
+      this.currentTurnMetadata = {};
+    }
+  }
+
+  async steer(turn: PreparedChatTurn): Promise<boolean> {
+    if (!this.transport || !this.sessionId) {
+      return false;
+    }
+
+    try {
+      await this.transport.request('session/set_mode', {
+        sessionId: this.sessionId,
+        modeId: 'default',
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  cancel(): void {
+    if (this.transport && this.sessionId) {
+      this.transport.notify('session/cancel', { sessionId: this.sessionId });
+    }
+  }
+
+  resetSession(): void {
+    this.sessionId = null;
+  }
+
+  getSessionId(): string | null {
+    return this.sessionId;
+  }
+
+  consumeSessionInvalidation(): boolean {
+    return false;
+  }
+
+  isReady(): boolean {
+    return this.ready;
+  }
+
+  async getSupportedCommands(): Promise<SlashCommand[]> {
+    return [];
+  }
+
+  cleanup(): void {
+    if (this.transport) {
+      this.transport.dispose();
+      this.transport = null;
+    }
+    if (this.proc) {
+      this.proc.shutdown();
+      this.proc = null;
+    }
+    this.ready = false;
+  }
+
+  async rewind(
+    _userMessageId: string,
+    _assistantMessageId: string,
+  ): Promise<ChatRewindResult> {
+    return { canRewind: false };
+  }
+
+  setApprovalCallback(callback: ApprovalCallback | null): void {
+    this.approvalCallback = callback;
+  }
+
+  setApprovalDismisser(dismisser: (() => void) | null): void {
+    this.approvalDismisser = dismisser;
+  }
+
+  setAskUserQuestionCallback(callback: AskUserQuestionCallback | null): void {
+    this.askUserQuestionCallback = callback;
+  }
+
+  setExitPlanModeCallback(callback: ExitPlanModeCallback | null): void {
+    this.exitPlanModeCallback = callback;
+  }
+
+  setPermissionModeSyncCallback(_callback: ((sdkMode: string) => void) | null): void {
+  }
+
+  setSubagentHookProvider(_getState: () => { hasRunning: boolean }): void {
+  }
+
+  setAutoTurnCallback(callback: ((result: AutoTurnResult) => void) | null): void {
+    this.autoTurnCallback = callback;
+  }
+
+  consumeTurnMetadata(): ChatTurnMetadata {
+    const metadata = this.currentTurnMetadata;
+    this.currentTurnMetadata = {};
+    return metadata;
+  }
+
+  buildSessionUpdates(_params: {
+    conversation: Conversation | null;
+    sessionInvalidated: boolean;
+  }): SessionUpdateResult {
+    return { updates: {} };
+  }
+
+  resolveSessionIdForFork(_conversation: Conversation | null): string | null {
+    return this.sessionId;
+  }
+
+  async loadSubagentToolCalls(_agentId: string): Promise<ToolCallInfo[]> {
+    return [];
+  }
+
+  async loadSubagentFinalResult(_agentId: string): Promise<string | null> {
+    return null;
+  }
+
+  private async startProcess(): Promise<void> {
+    const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
+
+    const envText = getRuntimeEnvironmentText(this.plugin.settings as Record<string, unknown>, 'opencode');
+    const resolvedPath = resolveOpencodeCliPath(this.settings?.cliPath, envText);
+    const command = resolvedPath || 'opencode';
+
+    const launchSpec = {
+      command,
+      args: ['acp'],
+      spawnCwd: cwd,
+      env: process.env as Record<string, string>,
+    };
+
+    console.log('[OpenCode] Starting process:', command, 'acp');
+
+    this.proc = new OpencodeProcess(launchSpec);
+    this.proc.start();
+
+    this.transport = new OpencodeRpcTransport(this.proc);
+    this.transport.start();
+
+    this.setupNotificationRouter();
+    this.setupNotificationHandlers();
+
+    await this.initialize();
+
+    console.log('[OpenCode] Process started successfully');
+  }
+
+  private async initialize(): Promise<void> {
+    if (!this.transport) throw new Error('Transport not initialized');
+
+    const initParams: InitializeParams = {
+      protocolVersion: 1,
+      clientInfo: { name: 'claudian', version: '1.0.0' },
+      clientCapabilities: {
+        fs: { readTextFile: true, writeTextFile: true },
+        terminal: true,
+      },
+    };
+
+    const initResult = await this.transport.request<InitializeResult>('initialize', initParams);
+    this.agentCapabilities = initResult.agentCapabilities;
+
+    this.transport.notify('initialized');
+
+    this.ready = true;
+
+    for (const listener of this.readyStateListeners) {
+      listener(true);
+    }
+  }
+
+  private async createSession(cwd: string): Promise<string | null> {
+    if (!this.transport) throw new Error('Transport not initialized');
+
+    try {
+      console.log('[OpenCode] Creating new session...');
+      const result = await this.transport.requestWithTimeout<NewSessionResponse>('session/new', {
+        cwd,
+        mcpServers: [],
+      }, 60000);
+
+      this.sessionId = result.sessionId;
+      console.log('[OpenCode] Session created:', this.sessionId);
+      return result.sessionId;
+    } catch (error) {
+      console.error('[OpenCode] Failed to create session:', error);
+      return null;
+    }
+  }
+
+  async loadSession(sessionId: string, cwd: string): Promise<boolean> {
+    if (!this.transport) throw new Error('Transport not initialized');
+
+    if (!this.agentCapabilities?.loadSession) {
+      console.log('[OpenCode] loadSession not supported by agent');
+      return false;
+    }
+
+    try {
+      console.log('[OpenCode] Loading session:', sessionId);
+      const result = await this.transport.requestWithTimeout<LoadSessionResponse>('session/load', {
+        sessionId,
+        cwd,
+        mcpServers: [],
+      }, 60000);
+
+      this.sessionId = result.sessionId;
+      console.log('[OpenCode] Session loaded:', this.sessionId);
+      return true;
+    } catch (error) {
+      console.error('[OpenCode] Failed to load session:', error);
+      return false;
+    }
+  }
+
+  async forkSession(sourceSessionId: string, cwd: string): Promise<string | null> {
+    if (!this.transport) throw new Error('Transport not initialized');
+
+    try {
+      console.log('[OpenCode] Forking session:', sourceSessionId);
+      const result = await this.transport.requestWithTimeout<ForkSessionResponse>('session/fork', {
+        sessionId: sourceSessionId,
+        cwd,
+      }, 60000);
+
+      this.sessionId = result.sessionId;
+      return result.sessionId;
+    } catch (error) {
+      console.error('[OpenCode] Failed to fork session:', error);
+      return null;
+    }
+  }
+
+  private setupNotificationRouter(): void {
+    const catalog = ProviderWorkspaceRegistry.getCommandCatalog('opencode') as OpencodeCommandCatalog | null;
+
+    this.notificationRouter = new OpencodeNotificationRouter(
+      (chunk) => {
+        this.chunkBuffer.push(chunk);
+        if (this.chunkResolve) {
+          this.chunkResolve();
+          this.chunkResolve = null;
+        }
+      },
+      (metadata) => {
+        this.currentTurnMetadata = { ...this.currentTurnMetadata, ...metadata };
+      },
+    );
+
+    if (catalog) {
+      this.notificationRouter.setCommandsListener((commands) => {
+        const entries: ProviderCommandEntry[] = commands.map(cmd => ({
+          id: `opencode-cmd-${cmd.name}`,
+          providerId: 'opencode',
+          kind: 'command',
+          name: cmd.name,
+          description: cmd.description,
+          content: '',
+          scope: 'runtime',
+          source: 'sdk',
+          isEditable: false,
+          isDeletable: false,
+          displayPrefix: '/',
+          insertPrefix: '/',
+        }));
+        catalog.setRuntimeCommands(entries);
+      });
+    }
+  }
+
+  private setupNotificationHandlers(): void {
+    if (!this.transport) return;
+
+    this.transport.onNotification('session/update', (params) => {
+      const notification = params as { sessionId: string; update: Record<string, unknown> };
+      this.notificationRouter?.handleSessionUpdate(notification as any);
+    });
+
+    this.transport.onServerRequest('session/request_permission', async (requestId, params) => {
+      return this.handlePermissionRequest(requestId, params);
+    });
+
+    this.transport.onServerRequest('session/request_user_input', async (requestId, params) => {
+      return this.handleUserInputRequest(requestId, params);
+    });
+  }
+
+  private async handlePermissionRequest(
+    requestId: string | number,
+    params: unknown,
+  ): Promise<unknown> {
+    const request = params as {
+      sessionId: string;
+      toolCall: { toolCallId: string; title: string; kind?: string };
+      options: Array<{ optionId: string; kind: string; name: string }>;
+    };
+
+    if (this.approvalCallback) {
+      const approved = await this.approvalCallback(
+        request.toolCall.title,
+        request.toolCall as Record<string, unknown>,
+        '',
+      );
+
+      return {
+        outcome: {
+          outcome: approved === 'allow' || approved === 'allow-always' ? 'selected' : 'cancelled',
+          optionId: approved === 'allow-always' ? 'always' : approved === 'deny' ? 'reject' : 'once',
+        },
+      };
+    }
+
+    return {
+      outcome: {
+        outcome: 'cancelled',
+        optionId: 'reject',
+      },
+    };
+  }
+
+  private async handleUserInputRequest(
+    requestId: string | number,
+    params: unknown,
+  ): Promise<unknown> {
+    const request = params as {
+      sessionId: string;
+      questions: Array<{ id: string; question: string; options?: Array<{ label: string }> }>;
+    };
+
+    if (this.askUserQuestionCallback) {
+      const input = request.questions[0] as { id: string; question: string } | undefined;
+      if (input) {
+        const answer = await this.askUserQuestionCallback({ [input.id]: input.question });
+        return { answers: answer };
+      }
+    }
+
+    return { answers: {} };
+  }
+
+  private buildPrompt(
+    request: ChatTurnRequest,
+  ): Array<{ type: string; text?: string; uri?: string; mimeType?: string; data?: string }> {
+    const prompt: Array<{ type: string; text?: string; uri?: string; mimeType?: string; data?: string }> = [];
+
+    prompt.push({ type: 'text', text: request.text });
+
+    if (request.images) {
+      for (const image of request.images) {
+        if (image.data) {
+          prompt.push({
+            type: 'image',
+            mimeType: image.mediaType,
+            data: image.data,
+          });
+        }
+      }
+    }
+
+    return prompt;
+  }
+}

--- a/src/providers/opencode/runtime/OpencodeNotificationRouter.ts
+++ b/src/providers/opencode/runtime/OpencodeNotificationRouter.ts
@@ -1,0 +1,319 @@
+import type { ChatTurnMetadata } from '../../../core/runtime/types';
+import type { StreamChunk, UsageInfo } from '../../../core/types';
+
+type ChunkEmitter = (chunk: StreamChunk) => void;
+type TurnMetadataListener = (update: Partial<ChatTurnMetadata>) => void;
+
+export interface OpencodeCommand {
+  name: string;
+  description: string;
+}
+
+export type CommandsUpdateListener = (commands: OpencodeCommand[]) => void;
+
+type SessionUpdate = {
+  sessionUpdate: string;
+  [key: string]: unknown;
+};
+
+export class OpencodeNotificationRouter {
+  private isPlanTurn = false;
+  private planUpdateCounter = 0;
+  private sawPlanDelta = false;
+  private currentSessionId: string | null = null;
+  private messageId: string | null = null;
+  private commandsListener: CommandsUpdateListener | null = null;
+
+  constructor(
+    private readonly emit: ChunkEmitter,
+    private readonly onTurnMetadata?: TurnMetadataListener,
+  ) {}
+
+  setCommandsListener(listener: CommandsUpdateListener | null): void {
+    this.commandsListener = listener;
+  }
+
+  beginTurn(sessionId: string, isPlanTurn: boolean): void {
+    this.isPlanTurn = isPlanTurn;
+    this.sawPlanDelta = false;
+    this.currentSessionId = sessionId;
+    this.messageId = null;
+  }
+
+  endTurn(): void {
+    this.isPlanTurn = false;
+    this.sawPlanDelta = false;
+    this.currentSessionId = null;
+    this.messageId = null;
+  }
+
+  handleSessionUpdate(notification: { sessionId: string; update: SessionUpdate }): void {
+    const { update } = notification;
+
+    if (update.sessionUpdate !== 'agent_message_chunk' && 
+        update.sessionUpdate !== 'agent_thought_chunk' &&
+        update.sessionUpdate !== 'available_commands_update') {
+      console.log('[OpenCode] Session update:', JSON.stringify(update, null, 2));
+    }
+
+    switch (update.sessionUpdate) {
+      case 'agent_message_chunk':
+        this.onAgentMessageChunk(update as unknown as AgentMessageChunkUpdate);
+        break;
+
+      case 'agent_thought_chunk':
+        this.onAgentThoughtChunk(update as unknown as AgentThoughtChunkUpdate);
+        break;
+
+      case 'user_message_chunk':
+        // Don't emit user message chunks - they are for internal tracking
+        break;
+
+      case 'tool_call':
+        this.onToolCall(update as unknown as ToolCallUpdate);
+        break;
+
+      case 'tool_call_update':
+        this.onToolCallUpdate(update as unknown as ToolCallUpdateNotification);
+        break;
+
+      case 'usage_update':
+        this.onUsageUpdate(update as unknown as UsageUpdateNotification);
+        break;
+
+      case 'plan':
+        this.onPlanUpdate(update as unknown as PlanUpdateNotification);
+        break;
+
+      case 'available_commands_update':
+        this.onAvailableCommandsUpdate(update as unknown as AvailableCommandsUpdate);
+        break;
+
+      case 'config_option_update':
+        break;
+
+      case 'current_mode_update':
+        break;
+
+      default:
+        console.log('[OpenCode] Unknown update type:', update.sessionUpdate);
+        break;
+    }
+  }
+
+  private onAgentMessageChunk(update: AgentMessageChunkUpdate): void {
+    if (update.messageId) {
+      this.messageId = update.messageId;
+    }
+    const content = update.content as { type: string; text: string } | undefined;
+    if (content?.type === 'text' && content.text) {
+      const text = content.text.trim();
+      if (text.match(/^(Thought for \d+s|[*].*for \d+s)$/)) {
+        return;
+      }
+      this.emit({ type: 'text', content: content.text });
+    }
+  }
+
+  private onAgentThoughtChunk(update: AgentThoughtChunkUpdate): void {
+    const content = update.content as { type: string; text: string } | undefined;
+    if (content?.type === 'text' && content.text) {
+      const text = content.text;
+      if (text.match(/^(Thought for \d+s|[*].*for \d+s)$/)) {
+        return;
+      }
+      this.emit({ type: 'thinking', content: text });
+    }
+  }
+
+  private onUserMessageChunk(update: UserMessageChunkUpdate): void {
+    const content = update.content as { type: string; text: string } | undefined;
+    if (content?.type === 'text' && content.text) {
+      this.emit({ type: 'user_message_start', itemId: update.messageId ?? '', content: content.text });
+    }
+  }
+
+  private onToolCall(update: ToolCallUpdate): void {
+    const toolKind = this.mapToolKind(update.kind);
+
+    this.emit({
+      type: 'tool_use',
+      id: update.toolCallId,
+      name: toolKind,
+      input: update.rawInput ?? {},
+    });
+  }
+
+  private onToolCallUpdate(update: ToolCallUpdateNotification): void {
+    const toolKind = this.mapToolKind(update.kind);
+    const { toolCallId, status } = update;
+
+    switch (status) {
+      case 'pending':
+        this.emit({
+          type: 'tool_use',
+          id: toolCallId,
+          name: toolKind,
+          input: update.rawInput ?? {},
+        });
+        break;
+
+      case 'in_progress':
+        if (update.content && update.content.length > 0) {
+          const textContent = this.extractTextContent(update.content);
+          if (textContent) {
+            this.emit({ type: 'tool_output', id: toolCallId, content: textContent });
+          }
+        }
+        break;
+
+      case 'completed': {
+        const textContent = update.content ? this.extractTextContent(update.content) : undefined;
+        const rawOutput = update.rawOutput;
+        const output = rawOutput?.output ?? textContent ?? '';
+        const isError = !!rawOutput?.error;
+
+        this.emit({ type: 'tool_result', id: toolCallId, content: output, isError });
+        break;
+      }
+
+      case 'failed': {
+        const errorContent = update.rawOutput?.error ?? 'Tool execution failed';
+        this.emit({ type: 'tool_result', id: toolCallId, content: errorContent, isError: true });
+        break;
+      }
+    }
+  }
+
+  private onUsageUpdate(update: UsageUpdateNotification): void {
+    const { used = 0, size } = update;
+    const usage: UsageInfo = {
+      inputTokens: 0,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      contextWindow: size ?? 200000,
+      contextWindowIsAuthoritative: true,
+      contextTokens: used,
+      percentage: size && used ? Math.min(100, Math.max(0, Math.round((used / size) * 100))) : 0,
+    };
+
+    this.emit({ type: 'usage', usage });
+  }
+
+  private onPlanUpdate(update: PlanUpdateNotification): void {
+    this.sawPlanDelta = true;
+    const entries = update.entries ?? [];
+
+    const todos = entries.map((entry, index) => ({
+      id: `plan-${index}`,
+      content: entry.content ?? '',
+      activeForm: '',
+      status: entry.status ?? 'in_progress',
+    }));
+
+    if (todos.length > 0) {
+      this.emit({
+        type: 'tool_use',
+        id: 'plan-tool',
+        name: 'TodoWrite',
+        input: { todos },
+      });
+      this.emit({ type: 'tool_result', id: 'plan-tool', content: 'Plan updated', isError: false });
+    }
+  }
+
+  private mapToolKind(kind: string | undefined): string {
+    switch (kind?.toLowerCase()) {
+      case 'execute':
+        return 'Bash';
+      case 'edit':
+        return 'Edit';
+      case 'read':
+        return 'Read';
+      case 'search':
+        return 'Search';
+      case 'fetch':
+        return 'WebFetch';
+      case 'other':
+      default:
+        return 'Tool';
+    }
+  }
+
+  private extractTextContent(content: Array<{ type: string; content: { type: string; text: string } }>): string | undefined {
+    return content
+      .filter(c => c.type === 'content')
+      .map(c => (c.content as { type: string; text: string })?.text ?? '')
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  private onAvailableCommandsUpdate(update: AvailableCommandsUpdate): void {
+    if (this.commandsListener && update.availableCommands) {
+      this.commandsListener(update.availableCommands);
+    }
+  }
+}
+
+interface AgentMessageChunkUpdate {
+  sessionUpdate: 'agent_message_chunk';
+  messageId?: string;
+  content: { type: string; text: string };
+}
+
+interface AgentThoughtChunkUpdate {
+  sessionUpdate: 'agent_thought_chunk';
+  messageId?: string;
+  content: { type: string; text: string };
+}
+
+interface UserMessageChunkUpdate {
+  sessionUpdate: 'user_message_chunk';
+  messageId?: string;
+  content: { type: string; text: string };
+}
+
+interface ToolCallUpdate {
+  sessionUpdate: 'tool_call';
+  toolCallId: string;
+  title?: string;
+  kind?: string;
+  status?: string;
+  rawInput?: Record<string, unknown>;
+}
+
+interface ToolCallUpdateNotification {
+  sessionUpdate: 'tool_call_update';
+  toolCallId: string;
+  title?: string;
+  kind?: string;
+  status?: 'pending' | 'in_progress' | 'completed' | 'failed';
+  content?: Array<{ type: string; content: { type: string; text: string } }>;
+  rawInput?: Record<string, unknown>;
+  rawOutput?: {
+    output?: string;
+    metadata?: Record<string, unknown>;
+    error?: string;
+  };
+}
+
+interface UsageUpdateNotification {
+  sessionUpdate: 'usage_update';
+  used?: number;
+  size?: number;
+  cost?: { amount: number; currency: string };
+}
+
+interface PlanUpdateNotification {
+  sessionUpdate: 'plan';
+  entries?: Array<{
+    content?: string;
+    status?: string;
+    priority?: string;
+  }>;
+}
+
+interface AvailableCommandsUpdate {
+  sessionUpdate: 'available_commands_update';
+  availableCommands: OpencodeCommand[];
+}

--- a/src/providers/opencode/runtime/OpencodeProcess.ts
+++ b/src/providers/opencode/runtime/OpencodeProcess.ts
@@ -1,0 +1,94 @@
+import { type ChildProcess, spawn } from 'child_process';
+import type { Readable, Writable } from 'stream';
+
+const SIGKILL_TIMEOUT_MS = 3_000;
+
+type ExitCallback = (code: number | null, signal: string | null) => void;
+
+export interface OpencodeLaunchSpec {
+  command: string;
+  args: string[];
+  spawnCwd: string;
+  env: Record<string, string>;
+}
+
+export class OpencodeProcess {
+  private proc: ChildProcess | null = null;
+  private alive = false;
+  private exitCallbacks: ExitCallback[] = [];
+
+  constructor(private readonly launchSpec: OpencodeLaunchSpec) {}
+
+  start(): void {
+    const { command, args, spawnCwd, env } = this.launchSpec;
+
+    this.proc = spawn(command, args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: spawnCwd,
+      env,
+      windowsHide: true,
+    });
+
+    this.alive = true;
+
+    this.proc.on('exit', (code, signal) => {
+      this.alive = false;
+      for (const cb of this.exitCallbacks) {
+        cb(code, signal);
+      }
+    });
+
+    this.proc.on('error', (err) => {
+      this.alive = false;
+      console.error('[OpenCode] Process error:', err.message);
+    });
+  }
+
+  get stdin(): Writable {
+    if (!this.proc?.stdin) throw new Error('Process not started');
+    return this.proc.stdin;
+  }
+
+  get stdout(): Readable {
+    if (!this.proc?.stdout) throw new Error('Process not started');
+    return this.proc.stdout;
+  }
+
+  get stderr(): Readable {
+    if (!this.proc?.stderr) throw new Error('Process not started');
+    return this.proc.stderr;
+  }
+
+  isAlive(): boolean {
+    return this.alive;
+  }
+
+  onExit(callback: ExitCallback): void {
+    this.exitCallbacks.push(callback);
+  }
+
+  offExit(callback: ExitCallback): void {
+    const idx = this.exitCallbacks.indexOf(callback);
+    if (idx !== -1) this.exitCallbacks.splice(idx, 1);
+  }
+
+  async shutdown(): Promise<void> {
+    if (!this.proc || !this.alive) return;
+
+    return new Promise<void>((resolve) => {
+      const onExit = () => {
+        clearTimeout(killTimer);
+        resolve();
+      };
+
+      this.proc!.once('exit', onExit);
+      this.proc!.kill('SIGTERM');
+
+      const killTimer = setTimeout(() => {
+        if (this.alive) {
+          this.proc!.kill('SIGKILL');
+        }
+      }, SIGKILL_TIMEOUT_MS);
+    });
+  }
+}

--- a/src/providers/opencode/runtime/OpencodeRpcTransport.ts
+++ b/src/providers/opencode/runtime/OpencodeRpcTransport.ts
@@ -1,0 +1,163 @@
+import { createInterface } from 'readline';
+
+import type { OpencodeProcess } from './OpencodeProcess';
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+interface PendingRequest {
+  resolve: (result: unknown) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+type NotificationHandler = (params: unknown) => void;
+type ServerRequestHandler = (requestId: string | number, params: unknown) => Promise<unknown>;
+
+export class OpencodeRpcTransport {
+  private nextId = 1;
+  private pending = new Map<number, PendingRequest>();
+  private notificationHandlers = new Map<string, NotificationHandler>();
+  private serverRequestHandlers = new Map<string, ServerRequestHandler>();
+  private disposed = false;
+
+  constructor(private readonly proc: OpencodeProcess) {}
+
+  start(): void {
+    const rl = createInterface({ input: this.proc.stdout });
+    rl.on('line', (line) => this.handleLine(line));
+
+    this.proc.onExit(() => {
+      this.rejectAllPending(new Error('Opencode process exited'));
+    });
+  }
+
+  request<T = unknown>(method: string, params: unknown, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<T> {
+    const id = this.nextId++;
+    const msg = { jsonrpc: '2.0' as const, id, method, params };
+
+    return new Promise<T>((resolve, reject) => {
+      const timer = timeoutMs > 0
+        ? setTimeout(() => {
+          this.pending.delete(id);
+          reject(new Error(`Request timeout: ${method} (${timeoutMs}ms)`));
+        }, timeoutMs)
+        : null;
+
+      this.pending.set(id, {
+        resolve: resolve as (result: unknown) => void,
+        reject,
+        timer,
+      });
+
+      this.sendRaw(msg);
+    });
+  }
+
+  requestWithTimeout<T = unknown>(method: string, params: unknown, timeoutMs: number): Promise<T> {
+    return this.request<T>(method, params, timeoutMs);
+  }
+
+  notify(method: string, params?: unknown): void {
+    const msg: Record<string, unknown> = { jsonrpc: '2.0', method };
+    if (params !== undefined) msg.params = params;
+    this.sendRaw(msg);
+  }
+
+  onNotification(method: string, handler: NotificationHandler): void {
+    this.notificationHandlers.set(method, handler);
+  }
+
+  onServerRequest(method: string, handler: ServerRequestHandler): void {
+    this.serverRequestHandlers.set(method, handler);
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.rejectAllPending(new Error('Transport disposed'));
+  }
+
+  private sendRaw(msg: unknown): void {
+    if (this.disposed) return;
+    this.proc.stdin.write(JSON.stringify(msg) + '\n');
+  }
+
+  private handleLine(line: string): void {
+    let msg: Record<string, unknown>;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      return;
+    }
+
+    const id = msg.id as string | number | undefined;
+    const method = msg.method as string | undefined;
+
+    if (typeof id === 'number' && !method) {
+      this.handleResponse(id, msg);
+      return;
+    }
+
+    if (method && id === undefined) {
+      this.handleNotification(method, msg.params);
+      return;
+    }
+
+    if (method && id !== undefined) {
+      this.handleServerRequest(id, method, msg.params);
+      return;
+    }
+  }
+
+  private handleResponse(id: number, msg: Record<string, unknown>): void {
+    const pending = this.pending.get(id);
+    if (!pending) return;
+
+    this.pending.delete(id);
+    if (pending.timer) clearTimeout(pending.timer);
+
+    if (msg.error) {
+      const err = msg.error as { code: number; message: string };
+      pending.reject(new Error(err.message));
+    } else {
+      pending.resolve(msg.result);
+    }
+  }
+
+  private handleNotification(method: string, params: unknown): void {
+    const handler = this.notificationHandlers.get(method);
+    if (handler) handler(params);
+  }
+
+  private handleServerRequest(id: string | number, method: string, params: unknown): void {
+    const handler = this.serverRequestHandlers.get(method);
+    if (!handler) {
+      this.sendRaw({
+        jsonrpc: '2.0',
+        id,
+        error: { code: -32601, message: `Unhandled server request: ${method}` },
+      });
+      return;
+    }
+
+    handler(id, params).then(
+      (result) => {
+        this.sendRaw({ jsonrpc: '2.0', id, result });
+      },
+      (err) => {
+        this.sendRaw({
+          jsonrpc: '2.0',
+          id,
+          error: { code: -32603, message: err instanceof Error ? err.message : 'Internal error' },
+        });
+      },
+    );
+  }
+
+  private rejectAllPending(error: Error): void {
+    for (const [, pending] of this.pending) {
+      if (pending.timer) clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+}

--- a/src/providers/opencode/runtime/OpencodeTypes.ts
+++ b/src/providers/opencode/runtime/OpencodeTypes.ts
@@ -1,0 +1,138 @@
+export interface InitializeParams {
+  protocolVersion: number;
+  clientInfo: {
+    name: string;
+    version: string;
+  };
+  clientCapabilities?: {
+    fs?: { readTextFile?: boolean; writeTextFile?: boolean };
+    terminal?: boolean;
+  };
+}
+
+export interface InitializeResult {
+  protocolVersion: number;
+  agentCapabilities: AgentCapabilities;
+  agentInfo: { name: string; version: string };
+  authMethods: AuthMethod[];
+}
+
+export interface AgentCapabilities {
+  loadSession?: boolean;
+  mcpCapabilities?: { http?: boolean; sse?: boolean };
+  promptCapabilities?: {
+    embeddedContext?: boolean;
+    image?: boolean;
+  };
+  sessionCapabilities?: {
+    fork?: Record<string, unknown>;
+    list?: Record<string, unknown>;
+    resume?: Record<string, unknown>;
+  };
+}
+
+export interface AuthMethod {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+export interface NewSessionResponse {
+  sessionId: string;
+  configOptions?: SessionConfigOption[];
+  modes?: {
+    availableModes: ModeOption[];
+    currentModeId?: string;
+  };
+}
+
+export interface SessionConfigOption {
+  id: string;
+  name: string;
+  category: string;
+  type: string;
+  currentValue: string;
+  options: { value: string; name: string; description?: string }[];
+}
+
+export interface ModeOption {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+export interface PromptParams {
+  sessionId: string;
+  prompt: Array<{ type: string; text?: string; uri?: string; mimeType?: string; data?: string }>;
+  model?: { providerID?: string; modelID?: string };
+}
+
+export interface PromptResult {
+  stopReason: string;
+  usage?: {
+    totalTokens: number;
+    inputTokens: number;
+    outputTokens: number;
+  };
+}
+
+export interface SessionUpdateNotification {
+  sessionId: string;
+  update: {
+    sessionUpdate: string;
+    [key: string]: unknown;
+  };
+}
+
+export interface AgentMessageChunkNotification {
+  sessionId: string;
+  messageId: string;
+  delta: string;
+}
+
+export interface ToolCallNotification {
+  sessionId: string;
+  toolCallId: string;
+  title: string;
+  kind: string;
+  status: 'pending' | 'in_progress' | 'completed' | 'failed';
+  locations?: { path: string }[];
+  rawInput?: Record<string, unknown>;
+  content?: Array<{ type: string; content: { type: string; text: string } }>;
+  rawOutput?: {
+    output?: string;
+    metadata?: Record<string, unknown>;
+    error?: string;
+  };
+}
+
+export interface PermissionRequest {
+  sessionId: string;
+  toolCall: {
+    toolCallId: string;
+    status: string;
+    title: string;
+    rawInput?: Record<string, unknown>;
+    kind: string;
+    locations?: { path: string }[];
+  };
+  options: { optionId: string; kind: string; name: string }[];
+}
+
+export interface LoadSessionResponse {
+  sessionId: string;
+  configOptions?: SessionConfigOption[];
+  modes?: {
+    availableModes: ModeOption[];
+    currentModeId?: string;
+  };
+}
+
+export interface ForkSessionResponse {
+  sessionId: string;
+  configOptions?: SessionConfigOption[];
+  modes?: {
+    availableModes: ModeOption[];
+    currentModeId?: string;
+  };
+}

--- a/src/providers/opencode/settings.ts
+++ b/src/providers/opencode/settings.ts
@@ -1,0 +1,45 @@
+import { getProviderConfig, setProviderConfig } from '../../core/providers/providerConfig';
+
+export interface OpencodeProviderSettings {
+  enabled: boolean;
+  prewarm: boolean;
+  cliPath?: string;
+  environmentVariables?: string;
+}
+
+export const DEFAULT_OPENCODE_PROVIDER_SETTINGS: Readonly<OpencodeProviderSettings> = Object.freeze({
+  enabled: false,
+  prewarm: true,
+  cliPath: '',
+  environmentVariables: '',
+});
+
+export function getOpencodeProviderSettings(settings: Record<string, unknown>): OpencodeProviderSettings {
+  const config = getProviderConfig(settings, 'opencode');
+  return {
+    enabled: (config.enabled as boolean) ?? DEFAULT_OPENCODE_PROVIDER_SETTINGS.enabled,
+    prewarm: (config.prewarm as boolean) ?? DEFAULT_OPENCODE_PROVIDER_SETTINGS.prewarm,
+    cliPath: (config.cliPath as string) ?? DEFAULT_OPENCODE_PROVIDER_SETTINGS.cliPath,
+    environmentVariables: (config.environmentVariables as string) ?? DEFAULT_OPENCODE_PROVIDER_SETTINGS.environmentVariables,
+  };
+}
+
+export function updateOpencodeProviderSettings(
+  settings: Record<string, unknown>,
+  updates: Partial<OpencodeProviderSettings>,
+): OpencodeProviderSettings {
+  const current = getOpencodeProviderSettings(settings);
+  const next: OpencodeProviderSettings = {
+    ...current,
+    ...updates,
+  };
+
+  setProviderConfig(settings, 'opencode', {
+    enabled: next.enabled,
+    prewarm: next.prewarm,
+    cliPath: next.cliPath,
+    environmentVariables: next.environmentVariables,
+  });
+
+  return next;
+}

--- a/src/providers/opencode/skills/OpencodeSkillListingService.ts
+++ b/src/providers/opencode/skills/OpencodeSkillListingService.ts
@@ -1,0 +1,15 @@
+import type { OpencodeSkillMetadata } from '../types';
+
+export class OpencodeSkillListingService {
+  private cachedSkills: OpencodeSkillMetadata[] = [];
+  private cacheTime = 0;
+  private readonly CACHE_TTL_MS = 5000;
+
+  async listSkills(): Promise<OpencodeSkillMetadata[]> {
+    return [];
+  }
+
+  invalidate(): void {
+    this.cacheTime = 0;
+  }
+}

--- a/src/providers/opencode/storage/OpencodeSkillStorage.ts
+++ b/src/providers/opencode/storage/OpencodeSkillStorage.ts
@@ -1,0 +1,24 @@
+import type { HomeFileAdapter } from '../../../core/storage/HomeFileAdapter';
+import type { VaultFileAdapter } from '../../../core/storage/VaultFileAdapter';
+import type { OpencodeSkill } from '../types';
+
+export class OpencodeSkillStorage {
+  constructor(
+    private vaultAdapter: VaultFileAdapter,
+    private homeAdapter: HomeFileAdapter,
+  ) {}
+
+  async save(skill: OpencodeSkill): Promise<void> {
+  }
+
+  async load(name: string): Promise<OpencodeSkill | null> {
+    return null;
+  }
+
+  async delete(name: string): Promise<void> {
+  }
+
+  async list(): Promise<OpencodeSkill[]> {
+    return [];
+  }
+}

--- a/src/providers/opencode/storage/OpencodeSubagentStorage.ts
+++ b/src/providers/opencode/storage/OpencodeSubagentStorage.ts
@@ -1,0 +1,31 @@
+import type { HomeFileAdapter } from '../../../core/storage/HomeFileAdapter';
+import type { VaultFileAdapter } from '../../../core/storage/VaultFileAdapter';
+import type { OpencodeSubagentDefinition } from '../agents/OpencodeAgentMentionProvider';
+
+export interface OpencodeSubagentStorage {
+  loadAll(): Promise<OpencodeSubagentDefinition[]>;
+  load(id: string): Promise<OpencodeSubagentDefinition | null>;
+  save(agent: OpencodeSubagentDefinition): Promise<void>;
+  delete(agent: OpencodeSubagentDefinition): Promise<void>;
+}
+
+export class OpencodeSubagentStorageImpl implements OpencodeSubagentStorage {
+  constructor(
+    private vaultAdapter: VaultFileAdapter,
+    private homeAdapter: HomeFileAdapter,
+  ) {}
+
+  async loadAll(): Promise<OpencodeSubagentDefinition[]> {
+    return [];
+  }
+
+  async load(_id: string): Promise<OpencodeSubagentDefinition | null> {
+    return null;
+  }
+
+  async save(_agent: OpencodeSubagentDefinition): Promise<void> {
+  }
+
+  async delete(_agent: OpencodeSubagentDefinition): Promise<void> {
+  }
+}

--- a/src/providers/opencode/types/index.ts
+++ b/src/providers/opencode/types/index.ts
@@ -1,0 +1,15 @@
+export interface OpencodeSkill {
+  name: string;
+  description: string;
+  content: string;
+  path: string;
+  scope: 'user' | 'repo' | 'system';
+}
+
+export interface OpencodeSkillMetadata {
+  name: string;
+  description: string;
+  path: string;
+  scope: 'user' | 'repo' | 'system';
+  enabled: boolean;
+}

--- a/src/providers/opencode/ui/OpencodeChatUIConfig.ts
+++ b/src/providers/opencode/ui/OpencodeChatUIConfig.ts
@@ -1,0 +1,156 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import type { ProviderChatUIConfig, ProviderIconSvg,ProviderReasoningOption } from '../../../core/providers/types';
+import { getOpencodeProviderSettings } from '../settings';
+
+const OPENCODE_ICON: ProviderIconSvg = {
+  viewBox: '0 0 24 24',
+  path: 'M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5',
+};
+
+let cachedModels: Array<{ value: string; label: string; description?: string; group?: string }> = [];
+let cacheLoaded = false;
+
+function getOpencodeConfigPath(): string {
+  const home = os.homedir();
+  switch (process.platform) {
+    case 'darwin':
+      return path.join(home, '.config', 'opencode', 'opencode.json');
+    case 'win32':
+      return path.join(process.env.APPDATA || home, 'opencode', 'opencode.json');
+    default:
+      return path.join(home, '.config', 'opencode', 'opencode.json');
+  }
+}
+
+function loadModelsFromConfig(): Array<{ value: string; label: string; description?: string; group?: string }> {
+  if (cacheLoaded) {
+    return cachedModels;
+  }
+
+  try {
+    const configPath = getOpencodeConfigPath();
+    if (fs.existsSync(configPath)) {
+      const content = fs.readFileSync(configPath, 'utf-8');
+      const config = JSON.parse(content);
+      
+      const models: Array<{ value: string; label: string; description?: string; group?: string }> = [];
+      
+      if (config.defaultModel) {
+        models.push({
+          value: config.defaultModel,
+          label: config.defaultModel,
+          description: 'Default',
+          group: 'OpenCode',
+        });
+      }
+      
+      if (config.models && Array.isArray(config.models)) {
+        for (const model of config.models) {
+          if (typeof model === 'string') {
+            models.push({
+              value: model,
+              label: model,
+              group: 'OpenCode',
+            });
+          } else if (model.id) {
+            models.push({
+              value: model.id,
+              label: model.name || model.id,
+              description: model.description,
+              group: 'OpenCode',
+            });
+          }
+        }
+      }
+      
+      if (models.length > 0) {
+        cachedModels = models;
+      }
+    }
+  } catch {
+    // Ignore errors, use default
+  }
+
+  cacheLoaded = true;
+  return cachedModels;
+}
+
+export const opencodeChatUIConfig: ProviderChatUIConfig = {
+  getModelOptions(settings: Record<string, unknown>): Array<{ value: string; label: string; description?: string; group?: string }> {
+    const providerSettings = getOpencodeProviderSettings(settings);
+    if (!providerSettings.enabled) {
+      return [];
+    }
+
+    const models = loadModelsFromConfig();
+    if (models.length > 0) {
+      return models;
+    }
+
+    return [{
+      value: 'default',
+      label: 'OpenCode (default)',
+      description: 'Uses OpenCode configured model',
+      group: 'OpenCode',
+    }];
+  },
+
+  ownsModel(model: string, settings: Record<string, unknown>): boolean {
+    const models = loadModelsFromConfig();
+    if (models.length > 0) {
+      return models.some(m => m.value === model);
+    }
+    const providerSettings = getOpencodeProviderSettings(settings);
+    return providerSettings.enabled && model === 'default';
+  },
+
+  isAdaptiveReasoningModel(_model: string): boolean {
+    return false;
+  },
+
+  getReasoningOptions(_model: string): ProviderReasoningOption[] {
+    return [];
+  },
+
+  getDefaultReasoningValue(_model: string): string {
+    return 'medium';
+  },
+
+  getContextWindowSize(_model: string, _customLimits?: Record<string, number>): number {
+    return 200000;
+  },
+
+  isDefaultModel(model: string): boolean {
+    return model === 'default';
+  },
+
+  applyModelDefaults(_model: string, _settings: unknown): void {
+  },
+
+  normalizeModelVariant(model: string, _settings: Record<string, unknown>): string {
+    return model;
+  },
+
+  getCustomModelIds(_envVars: Record<string, string>): Set<string> {
+    return new Set();
+  },
+
+  getPermissionModeToggle(): { inactiveValue: string; inactiveLabel: string; activeValue: string; activeLabel: string } | null {
+    return null;
+  },
+
+  getServiceTierToggle(_settings: Record<string, unknown>): { inactiveValue: string; inactiveLabel: string; activeValue: string; activeLabel: string; description?: string } | null {
+    return null;
+  },
+
+  isBangBashEnabled(_settings: Record<string, unknown>): boolean {
+    return false;
+  },
+
+  getProviderIcon() {
+    return OPENCODE_ICON;
+  },
+};

--- a/src/providers/opencode/ui/OpencodeSettingsTab.ts
+++ b/src/providers/opencode/ui/OpencodeSettingsTab.ts
@@ -1,0 +1,81 @@
+import { Setting } from 'obsidian';
+
+import type { ProviderSettingsTabRenderer } from '../../../core/providers/types';
+import { renderEnvironmentSettingsSection } from '../../../features/settings/ui/EnvironmentSettingsSection';
+import { t } from '../../../i18n/i18n';
+import { getOpencodeProviderSettings, updateOpencodeProviderSettings } from '../settings';
+
+export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
+  render(container, context) {
+    const settingsBag = context.plugin.settings as unknown as Record<string, unknown>;
+    const opencodeSettings = getOpencodeProviderSettings(settingsBag);
+
+    // --- Setup ---
+
+    new Setting(container).setName(t('settings.setup')).setHeading();
+
+    new Setting(container)
+      .setName(t('settings.opencode.enabled.name'))
+      .setDesc(t('settings.opencode.enabled.desc'))
+      .addToggle((toggle) =>
+        toggle
+          .setValue(opencodeSettings.enabled)
+          .onChange(async (value) => {
+            updateOpencodeProviderSettings(settingsBag, { enabled: value });
+            await context.plugin.saveSettings();
+            context.refreshModelSelectors();
+          })
+      );
+
+    new Setting(container)
+      .setName(t('settings.opencode.prewarm.name'))
+      .setDesc(t('settings.opencode.prewarm.desc'))
+      .addToggle((toggle) =>
+        toggle
+          .setValue(opencodeSettings.prewarm ?? true)
+          .onChange(async (value) => {
+            updateOpencodeProviderSettings(settingsBag, { prewarm: value });
+            await context.plugin.saveSettings();
+          })
+      );
+
+    // --- CLI Path ---
+
+    new Setting(container)
+      .setName(t('settings.opencode.cliPath.name'))
+      .setDesc(t('settings.opencode.cliPath.desc'))
+      .addText((text) =>
+        text
+          .setPlaceholder(t('settings.opencode.cliPath.placeholder'))
+          .setValue(opencodeSettings.cliPath || '')
+          .onChange(async (value) => {
+            updateOpencodeProviderSettings(settingsBag, { cliPath: value });
+            await context.plugin.saveSettings();
+          })
+      );
+
+    // --- MCP Servers ---
+
+    new Setting(container).setName(t('settings.mcpServers.name')).setHeading();
+    const mcpNotice = container.createDiv({ cls: 'claudian-mcp-settings-desc' });
+    const mcpDesc = mcpNotice.createEl('p', { cls: 'setting-item-description' });
+    mcpDesc.appendText(t('settings.opencode.mcpServers.desc') + ' ');
+    mcpDesc.createEl('a', {
+      text: 'Learn more',
+      href: 'https://modelcontextprotocol.io',
+    });
+
+    // --- Environment ---
+
+    renderEnvironmentSettingsSection({
+      container,
+      plugin: context.plugin,
+      scope: 'provider:opencode',
+      heading: t('settings.opencode.environment.name'),
+      name: t('settings.opencode.environment.name'),
+      desc: t('settings.opencode.environment.desc'),
+      placeholder: t('settings.opencode.environment.placeholder'),
+      renderCustomContextLimits: (target) => context.renderCustomContextLimits(target, 'opencode'),
+    });
+  },
+};


### PR DESCRIPTION
## Hi @YishenTu! 👋

Thanks for building Claudian — it's an amazing plugin! I really wanted to use OpenCode as a provider alongside Claude, so I implemented full OpenCode support using the ACP protocol.

---

### What this PR adds

**OpenCode Provider** — a new chat provider powered by [Agent Client Protocol (ACP)](https://github.com/agentclientprotocol/agent-client-protocol):

- 🔌 **ACP over stdio** — uses `opencode acp` command, same as Zed editor
- ⚡ **Session management** — new, load (with capability check), and fork sessions
- 📡 **Streaming** — real-time message chunks via `agent_message_chunk` notifications
- 🛠️ **Tool support** — approve/cancel tool calls, user input requests
- 📁 **CLI auto-detection** — finds OpenCode in PATH, brew, npm, nvm, and `~/.opencode/bin`
- 🌐 **i18n ready** — all settings strings translated (10 locales)
- ⚙️ **Settings UI** — enable/disable, pre-warm option, custom CLI path

### Key design decisions

- Follows the same architecture as Codex provider (adaptor pattern)
- Implements `OpencodeNotificationRouter` to map ACP notifications → `StreamChunk` events
- CLI detection reuses existing `getEnhancedPath()` infrastructure
- `ownsModel()` properly scoped — won't claim unknown models

### Testing

✅ All 4933 unit tests pass  
✅ All 201 integration tests pass  
✅ `npm run typecheck && npm run lint` clean

---

### Related

Inspired by the earlier ACP work in #514 — this takes a fresh approach focused on OpenCode specifically.

Happy to iterate on anything! Let me know if you'd like any changes. 🙏