### PR TITLE
fix: patch renderer timers and thinking sync

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -10,6 +10,12 @@ import {
   readFileSync,
   rmSync,
 } from 'fs';
+import rendererSafeUnrefHelpers from './scripts/rendererSafeUnref.js';
+
+const {
+  findUnsafeTimerUnrefSites,
+  patchRendererUnsafeUnrefSites,
+} = rendererSafeUnrefHelpers;
 
 // Load .env.local if it exists
 if (existsSync('.env.local')) {
@@ -37,6 +43,35 @@ const patchCodexSdkImportMeta = {
         };
       },
     );
+  },
+};
+
+const patchRendererUnsafeUnref = {
+  name: 'patch-renderer-unsafe-unref',
+  setup(build) {
+    build.onEnd(async (result) => {
+      if (result.errors.length > 0 || !existsSync('main.js')) return;
+
+      const bundlePath = path.join(process.cwd(), 'main.js');
+      const originalContents = await fsPromises.readFile(bundlePath, 'utf8');
+      const patchedBundle = patchRendererUnsafeUnrefSites(originalContents);
+
+      if (patchedBundle.contents !== originalContents) {
+        await fsPromises.writeFile(bundlePath, patchedBundle.contents, 'utf8');
+      }
+
+      const unsafeMatches = findUnsafeTimerUnrefSites(patchedBundle.contents);
+      if (unsafeMatches.length > 0) {
+        const details = unsafeMatches
+          .slice(0, 5)
+          .map((match) => `line ${match.line}: ${match.snippet}`)
+          .join('\n');
+
+        throw new Error(
+          `Renderer-unsafe timer .unref() calls remain in main.js:\n${details}`,
+        );
+      }
+    });
   },
 };
 
@@ -77,7 +112,7 @@ const copyToObsidian = {
 const context = await esbuild.context({
   entryPoints: ['src/main.ts'],
   bundle: true,
-  plugins: [patchCodexSdkImportMeta, copyToObsidian],
+  plugins: [patchCodexSdkImportMeta, patchRendererUnsafeUnref, copyToObsidian],
   external: [
     'obsidian',
     'electron',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,16 @@ export default defineConfig([
     ignores: ['dist/**', 'node_modules/**', 'coverage/**', 'main.js'],
   },
   js.configs.recommended,
+  {
+    files: ['esbuild.config.mjs', 'scripts/**/*.js', 'scripts/**/*.mjs'],
+    languageOptions: {
+      globals: {
+        console: 'readonly',
+        module: 'readonly',
+        process: 'readonly',
+      },
+    },
+  },
   ...tseslint.configs['flat/recommended'],
   {
     files: ['src/**/*.ts', 'tests/**/*.ts'],

--- a/scripts/rendererSafeUnref.js
+++ b/scripts/rendererSafeUnref.js
@@ -1,0 +1,148 @@
+const UNSAFE_TIMER_UNREF_PATTERNS = [
+  {
+    name: 'claude-sdk-process-transport-close',
+    pattern: /if \(\$ && !\$\.killed && \$\.exitCode === null\) setTimeout\(\(X\) => \{\s*if \(X\.killed \|\| X\.exitCode !== null\) return;\s*X\.kill\("SIGTERM"\), setTimeout\(\(J\) => \{\s*if \(J\.exitCode === null\) J\.kill\("SIGKILL"\);\s*\}, 5e3, X\)\.unref\(\);\s*\}, M2, \$\)\.unref\(\), \$\.once\("exit", \(\) => mJ\.delete\(\$\)\);/g,
+    replacement:
+      'if ($ && !$.killed && $.exitCode === null) {' +
+      '\n      const processKillTimer = setTimeout((X) => {' +
+      '\n        if (X.killed || X.exitCode !== null) return;' +
+      '\n        X.kill("SIGTERM");' +
+      '\n        const forceKillTimer = setTimeout((J) => {' +
+      '\n          if (J.exitCode === null) J.kill("SIGKILL");' +
+      '\n        }, 5e3, X);' +
+      '\n        forceKillTimer.unref?.();' +
+      '\n      }, M2, $);' +
+      '\n      processKillTimer.unref?.();' +
+      '\n      $.once("exit", () => mJ.delete($));' +
+      '\n    }',
+  },
+  {
+    name: 'mcp-sdk-stdio-close-wait',
+    pattern: /new Promise\(\(resolve5\) => setTimeout\(resolve5, 2e3\)\.unref\(\)\)/g,
+    replacement:
+      'new Promise((resolve5) => {' +
+      '\n        const closeTimeout = setTimeout(resolve5, 2e3);' +
+      '\n        closeTimeout.unref?.();' +
+      '\n      })',
+  },
+];
+
+const TIMER_CALL_PREFIXES = ['setTimeout(', 'setInterval('];
+
+function patchRendererUnsafeUnrefSites(contents) {
+  let nextContents = contents;
+  const appliedPatches = [];
+
+  for (const patch of UNSAFE_TIMER_UNREF_PATTERNS) {
+    const matchCount = [...nextContents.matchAll(patch.pattern)].length;
+    if (matchCount === 0) {
+      continue;
+    }
+    nextContents = nextContents.replace(patch.pattern, patch.replacement);
+    appliedPatches.push({ name: patch.name, count: matchCount });
+  }
+
+  return {
+    contents: nextContents,
+    appliedPatches,
+  };
+}
+
+function findUnsafeTimerUnrefSites(contents) {
+  const matches = [];
+
+  let searchIndex = 0;
+  while (searchIndex < contents.length) {
+    const timerStart = findNextTimerCall(contents, searchIndex);
+    if (!timerStart) {
+      break;
+    }
+
+    const callEnd = findMatchingParen(contents, timerStart.openParenIndex);
+    if (callEnd === -1) {
+      searchIndex = timerStart.startIndex + timerStart.prefix.length;
+      continue;
+    }
+
+    const unrefMatch = contents.slice(callEnd + 1).match(/^\s*\.unref\(\)/);
+    if (unrefMatch) {
+      const startIndex = timerStart.startIndex;
+      const endIndex = callEnd + 1 + unrefMatch[0].length;
+      const line = contents.slice(0, startIndex).split('\n').length;
+      matches.push({
+        line,
+        snippet: contents.slice(startIndex, endIndex),
+      });
+      searchIndex = endIndex;
+      continue;
+    }
+
+    searchIndex = callEnd + 1;
+  }
+
+  return matches;
+}
+
+function findNextTimerCall(contents, startIndex) {
+  let nextMatch = null;
+
+  for (const prefix of TIMER_CALL_PREFIXES) {
+    const index = contents.indexOf(prefix, startIndex);
+    if (index === -1) {
+      continue;
+    }
+    if (!nextMatch || index < nextMatch.startIndex) {
+      nextMatch = {
+        prefix,
+        startIndex: index,
+        openParenIndex: index + prefix.length - 1,
+      };
+    }
+  }
+
+  return nextMatch;
+}
+
+function findMatchingParen(contents, openParenIndex) {
+  let depth = 1;
+  let quote = null;
+
+  for (let index = openParenIndex + 1; index < contents.length; index += 1) {
+    const char = contents[index];
+
+    if (quote) {
+      if (char === '\\') {
+        index += 1;
+        continue;
+      }
+      if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === '\'' || char === '`') {
+      quote = char;
+      continue;
+    }
+
+    if (char === '(') {
+      depth += 1;
+      continue;
+    }
+
+    if (char === ')') {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+
+  return -1;
+}
+
+module.exports = {
+  findUnsafeTimerUnrefSites,
+  patchRendererUnsafeUnrefSites,
+};

--- a/src/providers/claude/runtime/ClaudeDynamicUpdates.ts
+++ b/src/providers/claude/runtime/ClaudeDynamicUpdates.ts
@@ -11,9 +11,8 @@ import type {
 } from '../../../core/runtime/types';
 import type { ClaudianSettings, PermissionMode } from '../../../core/types/settings';
 import {
-  isAdaptiveThinkingModel,
-  normalizeEffortLevel,
-  THINKING_BUDGETS,
+  resolveAdaptiveEffortLevel,
+  resolveThinkingTokens,
 } from '../types/models';
 import type {
   ClosePersistentQueryOptions,
@@ -78,32 +77,25 @@ export async function applyClaudeDynamicUpdates(
     }
   }
 
-  if (!isAdaptiveThinkingModel(selectedModel)) {
-    deps.mutateCurrentConfig(config => {
-      config.effortLevel = null;
-    });
-
-    const budgetConfig = THINKING_BUDGETS.find(b => b.value === settings.thinkingBudget);
-    const thinkingTokens = budgetConfig?.tokens ?? null;
-    const currentThinking = deps.getCurrentConfig()?.thinkingTokens ?? null;
-    if (thinkingTokens !== currentThinking) {
-      try {
-        await persistentQuery.setMaxThinkingTokens(thinkingTokens);
-        deps.mutateCurrentConfig(config => {
-          config.thinkingTokens = thinkingTokens;
-        });
-      } catch {
-        deps.notifyFailure('Failed to update thinking budget');
-      }
+  const thinkingTokens = resolveThinkingTokens(selectedModel, settings.thinkingBudget);
+  const currentThinking = deps.getCurrentConfig()?.thinkingTokens ?? null;
+  if (thinkingTokens !== currentThinking) {
+    try {
+      await persistentQuery.setMaxThinkingTokens(thinkingTokens);
+      deps.mutateCurrentConfig(config => {
+        config.thinkingTokens = thinkingTokens;
+      });
+    } catch {
+      deps.notifyFailure('Failed to update thinking budget');
     }
+  } else {
+    deps.mutateCurrentConfig(config => {
+      config.thinkingTokens = thinkingTokens;
+    });
   }
 
-  if (isAdaptiveThinkingModel(selectedModel)) {
-    deps.mutateCurrentConfig(config => {
-      config.thinkingTokens = null;
-    });
-
-    const effortLevel = normalizeEffortLevel(selectedModel, settings.effortLevel);
+  const effortLevel = resolveAdaptiveEffortLevel(selectedModel, settings.effortLevel);
+  if (effortLevel !== null) {
     const currentEffort = deps.getCurrentConfig()?.effortLevel ?? null;
     if (effortLevel !== currentEffort) {
       try {
@@ -117,6 +109,10 @@ export async function applyClaudeDynamicUpdates(
         deps.notifyFailure('Failed to update effort level');
       }
     }
+  } else {
+    deps.mutateCurrentConfig(config => {
+      config.effortLevel = null;
+    });
   }
 
   const configBeforePermissionUpdate = deps.getCurrentConfig();

--- a/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts
+++ b/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts
@@ -17,10 +17,8 @@ import {
   getClaudeProviderSettings,
 } from '../settings';
 import {
-  type EffortLevel,
-  isAdaptiveThinkingModel,
-  normalizeEffortLevel,
-  THINKING_BUDGETS,
+  resolveAdaptiveEffortLevel,
+  resolveThinkingTokens,
 } from '../types/models';
 import { createCustomSpawnFunction } from './customSpawn';
 import {
@@ -103,9 +101,6 @@ export class QueryOptionsBuilder {
       userName: ctx.settings.userName,
     };
 
-    const budgetSetting = ctx.settings.thinkingBudget;
-    const budgetConfig = THINKING_BUDGETS.find(b => b.value === budgetSetting);
-    const thinkingTokens = budgetConfig?.tokens ?? null;
     const sdkPermissionMode = QueryOptionsBuilder.resolveClaudeSdkPermissionMode(
       ctx.settings.permissionMode,
       claudeSettings.safeMode,
@@ -116,10 +111,8 @@ export class QueryOptionsBuilder {
 
     return {
       model: ctx.settings.model,
-      thinkingTokens: thinkingTokens && thinkingTokens > 0 ? thinkingTokens : null,
-      effortLevel: isAdaptiveThinkingModel(ctx.settings.model)
-        ? normalizeEffortLevel(ctx.settings.model, ctx.settings.effortLevel)
-        : null,
+      thinkingTokens: resolveThinkingTokens(ctx.settings.model, ctx.settings.thinkingBudget),
+      effortLevel: resolveAdaptiveEffortLevel(ctx.settings.model, ctx.settings.effortLevel),
       permissionMode: ctx.settings.permissionMode,
       sdkPermissionMode,
       systemPromptKey: computeSystemPromptKey(systemPromptSettings),
@@ -293,14 +286,16 @@ export class QueryOptionsBuilder {
     settings: ClaudianSettings,
     model: string
   ): void {
-    if (isAdaptiveThinkingModel(model)) {
+    const effortLevel = resolveAdaptiveEffortLevel(model, settings.effortLevel);
+    if (effortLevel !== null) {
       options.thinking = { type: 'adaptive' };
-      options.effort = normalizeEffortLevel(model, settings.effortLevel) as EffortLevel;
-    } else {
-      const budgetConfig = THINKING_BUDGETS.find(b => b.value === settings.thinkingBudget);
-      if (budgetConfig && budgetConfig.tokens > 0) {
-        options.maxThinkingTokens = budgetConfig.tokens;
-      }
+      options.effort = effortLevel;
+      return;
+    }
+
+    const thinkingTokens = resolveThinkingTokens(model, settings.thinkingBudget);
+    if (thinkingTokens !== null) {
+      options.maxThinkingTokens = thinkingTokens;
     }
   }
 

--- a/src/providers/claude/runtime/claudeColdStartQuery.ts
+++ b/src/providers/claude/runtime/claudeColdStartQuery.ts
@@ -8,9 +8,8 @@ import { getVaultPath } from '../../../utils/path';
 import { extractAssistantText } from '../auxiliary/extractAssistantText';
 import { getClaudeProviderSettings } from '../settings';
 import {
-  isAdaptiveThinkingModel,
-  normalizeEffortLevel,
-  THINKING_BUDGETS,
+  resolveAdaptiveEffortLevel,
+  resolveThinkingTokens,
 } from '../types/models';
 import { createCustomSpawnFunction } from './customSpawn';
 
@@ -112,15 +111,14 @@ export async function runColdStartQuery(
   }
 
   if (!config.thinking?.disabled) {
-    if (isAdaptiveThinkingModel(selectedModel)) {
+    const effortLevel = resolveAdaptiveEffortLevel(selectedModel, settings.effortLevel);
+    if (effortLevel !== null) {
       options.thinking = { type: 'adaptive' };
-      options.effort = normalizeEffortLevel(selectedModel, settings.effortLevel);
+      options.effort = effortLevel;
     } else {
-      const budgetConfig = THINKING_BUDGETS.find(
-        b => b.value === settings.thinkingBudget
-      );
-      if (budgetConfig && budgetConfig.tokens > 0) {
-        options.maxThinkingTokens = budgetConfig.tokens;
+      const thinkingTokens = resolveThinkingTokens(selectedModel, settings.thinkingBudget);
+      if (thinkingTokens !== null) {
+        options.maxThinkingTokens = thinkingTokens;
       }
     }
   }

--- a/src/providers/claude/types/models.ts
+++ b/src/providers/claude/types/models.ts
@@ -86,6 +86,30 @@ export function normalizeEffortLevel(
   return DEFAULT_EFFORT_LEVEL[model] ?? 'high';
 }
 
+export function resolveThinkingTokens(
+  model: string,
+  thinkingBudget: unknown,
+): number | null {
+  if (isAdaptiveThinkingModel(model)) {
+    return null;
+  }
+
+  const budgetConfig = THINKING_BUDGETS.find((budget) => budget.value === thinkingBudget);
+  const thinkingTokens = budgetConfig?.tokens ?? null;
+  return thinkingTokens && thinkingTokens > 0 ? thinkingTokens : null;
+}
+
+export function resolveAdaptiveEffortLevel(
+  model: string,
+  effortLevel: unknown,
+): EffortLevel | null {
+  if (!isAdaptiveThinkingModel(model)) {
+    return null;
+  }
+
+  return normalizeEffortLevel(model, effortLevel);
+}
+
 export const CONTEXT_WINDOW_STANDARD = 200_000;
 export const CONTEXT_WINDOW_1M = 1_000_000;
 

--- a/tests/unit/providers/claude/runtime/ClaudianService.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudianService.test.ts
@@ -1548,6 +1548,55 @@ describe('ClaudianService', () => {
       expect(mockPersistentQuery.applyFlagSettings).not.toHaveBeenCalled();
     });
 
+    it('should clear thinking tokens when switching from budgeted to adaptive models', async () => {
+      (mockPlugin as any).settings.model = 'custom-model';
+      (mockPlugin as any).settings.thinkingBudget = 'high';
+      (service as any).currentConfig = (service as any).buildPersistentQueryConfig(
+        '/mock/vault/path',
+        '/usr/local/bin/claude',
+        [],
+      );
+
+      mockPersistentQuery.setModel.mockClear();
+      mockPersistentQuery.setMaxThinkingTokens.mockClear();
+      mockPersistentQuery.applyFlagSettings.mockClear();
+
+      (mockPlugin as any).settings.model = 'sonnet';
+      (mockPlugin as any).settings.effortLevel = 'max';
+
+      await (service as any).applyDynamicUpdates({});
+
+      expect(mockPersistentQuery.setModel).toHaveBeenCalledWith('sonnet');
+      expect(mockPersistentQuery.setMaxThinkingTokens).toHaveBeenCalledWith(null);
+      expect(mockPersistentQuery.applyFlagSettings).toHaveBeenCalledWith({ effortLevel: 'max' });
+      expect((service as any).currentConfig.thinkingTokens).toBeNull();
+      expect((service as any).currentConfig.effortLevel).toBe('max');
+    });
+
+    it('should restore thinking tokens when switching from adaptive to budgeted models', async () => {
+      (mockPlugin as any).settings.model = 'sonnet';
+      (mockPlugin as any).settings.thinkingBudget = 'high';
+      (mockPlugin as any).settings.effortLevel = 'max';
+      (service as any).currentConfig = (service as any).buildPersistentQueryConfig(
+        '/mock/vault/path',
+        '/usr/local/bin/claude',
+        [],
+      );
+
+      mockPersistentQuery.setModel.mockClear();
+      mockPersistentQuery.setMaxThinkingTokens.mockClear();
+      mockPersistentQuery.applyFlagSettings.mockClear();
+
+      (mockPlugin as any).settings.model = 'custom-model';
+
+      await (service as any).applyDynamicUpdates({});
+
+      expect(mockPersistentQuery.setModel).toHaveBeenCalledWith('custom-model');
+      expect(mockPersistentQuery.setMaxThinkingTokens).toHaveBeenCalledWith(16000);
+      expect((service as any).currentConfig.thinkingTokens).toBe(16000);
+      expect((service as any).currentConfig.effortLevel).toBeNull();
+    });
+
     it('should update permission mode when changed', async () => {
       (mockPlugin as any).settings.permissionMode = 'yolo';
 

--- a/tests/unit/providers/claude/runtime/QueryOptionsBuilder.test.ts
+++ b/tests/unit/providers/claude/runtime/QueryOptionsBuilder.test.ts
@@ -212,7 +212,7 @@ describe('QueryOptionsBuilder', () => {
 
     it('includes thinking tokens when budget is set', () => {
       const ctx = createMockContext({
-        settings: createMockSettings({ thinkingBudget: 'high' }),
+        settings: createMockSettings({ model: 'custom-model', thinkingBudget: 'high' }),
       });
       const config = QueryOptionsBuilder.buildPersistentQueryConfig(ctx);
 
@@ -225,6 +225,16 @@ describe('QueryOptionsBuilder', () => {
       });
       const config = QueryOptionsBuilder.buildPersistentQueryConfig(ctx);
 
+      expect(config.effortLevel).toBe('max');
+    });
+
+    it('clears thinkingTokens for adaptive models even when a budget is configured', () => {
+      const ctx = createMockContext({
+        settings: createMockSettings({ model: 'sonnet', thinkingBudget: 'high', effortLevel: 'max' }),
+      });
+      const config = QueryOptionsBuilder.buildPersistentQueryConfig(ctx);
+
+      expect(config.thinkingTokens).toBeNull();
       expect(config.effortLevel).toBe('max');
     });
 

--- a/tests/unit/scripts/rendererSafeUnref.test.ts
+++ b/tests/unit/scripts/rendererSafeUnref.test.ts
@@ -1,0 +1,46 @@
+import * as rendererSafeUnrefHelpers from '../../../scripts/rendererSafeUnref.js';
+
+const {
+  findUnsafeTimerUnrefSites,
+  patchRendererUnsafeUnrefSites,
+} = rendererSafeUnrefHelpers;
+
+describe('rendererSafeUnref helpers', () => {
+  it('patches the known unsafe timer .unref() bundle sites', () => {
+    const input = [
+      'if ($ && !$.killed && $.exitCode === null) setTimeout((X) => {',
+      '  if (X.killed || X.exitCode !== null) return;',
+      '  X.kill("SIGTERM"), setTimeout((J) => {',
+      '    if (J.exitCode === null) J.kill("SIGKILL");',
+      '  }, 5e3, X).unref();',
+      '}, M2, $).unref(), $.once("exit", () => mJ.delete($));',
+      'await Promise.race([closePromise, new Promise((resolve5) => setTimeout(resolve5, 2e3).unref())]);',
+    ].join('\n');
+
+    const result = patchRendererUnsafeUnrefSites(input);
+
+    expect(result.appliedPatches).toEqual([
+      { name: 'claude-sdk-process-transport-close', count: 1 },
+      { name: 'mcp-sdk-stdio-close-wait', count: 1 },
+    ]);
+    expect(result.contents).toContain('processKillTimer.unref?.();');
+    expect(result.contents).toContain('forceKillTimer.unref?.();');
+    expect(result.contents).toContain('closeTimeout.unref?.();');
+    expect(findUnsafeTimerUnrefSites(result.contents)).toEqual([]);
+  });
+
+  it('reports remaining direct timer .unref() calls but ignores guarded usage', () => {
+    const input = [
+      'const timer = setTimeout(run, 1000);',
+      'timer.unref?.();',
+      'if (timer.unref) timer.unref();',
+      'setTimeout(run, 1000).unref();',
+      'setInterval(run, 1000).unref();',
+    ].join('\n');
+
+    expect(findUnsafeTimerUnrefSites(input)).toEqual([
+      { line: 4, snippet: 'setTimeout(run, 1000).unref()' },
+      { line: 5, snippet: 'setInterval(run, 1000).unref()' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- patch bundled dependency timer `.unref()` sites at build time and fail the build if unsafe direct timer `.unref()` chains remain in `main.js`
- add regression coverage for the renderer-safe unref sanitizer and keep the helper tracked in git
- unify Claude thinking-state resolution so adaptive models clear fixed budgets on live persistent queries and non-adaptive models restore configured token budgets
- add unit coverage for adaptive/non-adaptive thinking transitions in the Claude runtime

## Testing
- npm run typecheck
- npm run lint
- npm run test
- npm run build

## Context
- fixes the Obsidian renderer `.unref()` compatibility issue tracked in #525
- addresses the follow-up Claude persistent-query thinking-state regression found during review