### PR TITLE
feat: add send/stop button to input toolbar

### DIFF
--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -41,7 +41,7 @@ import { ChatState } from '../state/ChatState';
 import { BangBashModeManager as BangBashModeManagerClass } from '../ui/BangBashModeManager';
 import { FileContextManager } from '../ui/FileContext';
 import { ImageContextManager } from '../ui/ImageContext';
-import { createInputToolbar } from '../ui/InputToolbar';
+import { createInputToolbar, SendStopButton } from '../ui/InputToolbar';
 import { InstructionModeManager as InstructionModeManagerClass } from '../ui/InstructionModeManager';
 import { NavigationSidebar } from '../ui/NavigationSidebar';
 import { StatusPanel } from '../ui/StatusPanel';
@@ -396,6 +396,7 @@ export function createTab(options: TabCreateOptions): TabData {
       mcpServerSelector: null,
       permissionToggle: null,
       serviceTierToggle: null,
+      sendStopButton: null,
       slashCommandDropdown: null,
       instructionModeManager: null,
       bangBashModeManager: null,
@@ -842,6 +843,11 @@ function initializeInputToolbar(
   tab.ui.mcpServerSelector = toolbarComponents.mcpServerSelector;
   tab.ui.permissionToggle = toolbarComponents.permissionToggle;
   tab.ui.serviceTierToggle = toolbarComponents.serviceTierToggle;
+
+  tab.ui.sendStopButton = new SendStopButton(inputToolbar, {
+    onSend: () => { void tab.controllers.inputController?.sendMessage(); },
+    onStop: () => { tab.controllers.inputController?.cancelStreaming(); },
+  });
 
   tab.ui.mcpServerSelector.setMcpManager(getProviderMcpManager(getTabProviderId(tab, plugin)));
 

--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -146,6 +146,7 @@ export class TabManager implements TabManagerInterface {
       tabId,
       defaultProviderId,
       onStreamingChanged: (isStreaming) => {
+        tab.ui?.sendStopButton?.setStreaming(isStreaming);
         this.callbacks.onTabStreamingChanged?.(tab.id, isStreaming);
       },
       onTitleChanged: (title) => {

--- a/src/features/chat/tabs/types.ts
+++ b/src/features/chat/tabs/types.ts
@@ -22,6 +22,7 @@ import type {
   McpServerSelector,
   ModelSelector,
   PermissionToggle,
+  SendStopButton,
   ServiceTierToggle,
   ThinkingBudgetSelector,
 } from '../ui/InputToolbar';
@@ -130,6 +131,7 @@ export interface TabUIComponents {
   mcpServerSelector: McpServerSelector | null;
   permissionToggle: PermissionToggle | null;
   serviceTierToggle: ServiceTierToggle | null;
+  sendStopButton: SendStopButton | null;
   slashCommandDropdown: SlashCommandDropdown | null;
   instructionModeManager: InstructionModeManager | null;
   bangBashModeManager: BangBashModeManager | null;

--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -1063,6 +1063,43 @@ export class ContextUsageMeter {
   }
 }
 
+export interface SendStopCallbacks {
+  onSend: () => void;
+  onStop: () => void;
+}
+
+export class SendStopButton {
+  private container: HTMLElement;
+  private btnEl: HTMLElement;
+  private streaming = false;
+  private callbacks: SendStopCallbacks;
+
+  constructor(parentEl: HTMLElement, callbacks: SendStopCallbacks) {
+    this.callbacks = callbacks;
+    this.container = parentEl.createDiv({ cls: 'claudian-send-stop-container' });
+    this.btnEl = this.container.createDiv({ cls: 'claudian-send-stop-btn' });
+    setIcon(this.btnEl, 'arrow-up');
+    this.btnEl.addEventListener('click', () => {
+      if (this.streaming) {
+        this.callbacks.onStop();
+      } else {
+        this.callbacks.onSend();
+      }
+    });
+  }
+
+  setStreaming(streaming: boolean): void {
+    this.streaming = streaming;
+    if (streaming) {
+      this.btnEl.addClass('claudian-send-stop-btn--streaming');
+      setIcon(this.btnEl, 'square');
+    } else {
+      this.btnEl.removeClass('claudian-send-stop-btn--streaming');
+      setIcon(this.btnEl, 'arrow-up');
+    }
+  }
+}
+
 export function createInputToolbar(
   parentEl: HTMLElement,
   callbacks: ToolbarCallbacks

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -27,6 +27,7 @@
 @import "./toolbar/service-tier-toggle.css";
 @import "./toolbar/external-context.css";
 @import "./toolbar/mcp-selector.css";
+@import "./toolbar/send-stop-button.css";
 
 /* Features */
 @import "./features/file-context.css";

--- a/src/style/toolbar/send-stop-button.css
+++ b/src/style/toolbar/send-stop-button.css
@@ -1,0 +1,30 @@
+.claudian-send-stop-container {
+  flex-shrink: 0;
+}
+
+.claudian-send-stop-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: var(--claudian-brand);
+  color: #fff;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.claudian-send-stop-btn:hover {
+  opacity: 0.85;
+}
+
+.claudian-send-stop-btn svg {
+  width: 14px;
+  height: 14px;
+  pointer-events: none;
+}
+
+.claudian-send-stop-btn--streaming {
+  /* Same brand color, icon switches to square — no extra color change needed */
+}

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -274,6 +274,9 @@ jest.mock('@/features/chat/ui/InputToolbar', () => ({
       serviceTierToggle: mockServiceTierToggle,
     };
   }),
+  SendStopButton: jest.fn().mockImplementation(() => ({
+    setStreaming: jest.fn(),
+  })),
 }));
 
 jest.mock('@/shared/components/SlashCommandDropdown', () => ({

--- a/tests/unit/features/chat/ui/InputToolbar.test.ts
+++ b/tests/unit/features/chat/ui/InputToolbar.test.ts
@@ -7,6 +7,7 @@ import {
   McpServerSelector,
   ModelSelector,
   PermissionToggle,
+  SendStopButton,
   ServiceTierToggle,
   ThinkingBudgetSelector,
 } from '@/features/chat/ui/InputToolbar';
@@ -1008,5 +1009,63 @@ describe('createInputToolbar', () => {
     expect(toolbar.mcpServerSelector).toBeInstanceOf(McpServerSelector);
     expect(toolbar.permissionToggle).toBeInstanceOf(PermissionToggle);
     expect(toolbar.serviceTierToggle).toBeInstanceOf(ServiceTierToggle);
+  });
+});
+
+describe('SendStopButton', () => {
+  let parentEl: any;
+  let onSend: jest.Mock;
+  let onStop: jest.Mock;
+  let button: SendStopButton;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    parentEl = createMockEl();
+    onSend = jest.fn();
+    onStop = jest.fn();
+    button = new SendStopButton(parentEl, { onSend, onStop });
+  });
+
+  it('renders send icon by default', () => {
+    const btn = parentEl.querySelector('.claudian-send-stop-btn');
+    expect(btn).toBeTruthy();
+    expect(btn?.hasClass('claudian-send-stop-btn--streaming')).toBe(false);
+  });
+
+  it('calls onSend when clicked in idle state', async () => {
+    const btn = parentEl.querySelector('.claudian-send-stop-btn');
+    await btn?.dispatchEvent('click');
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(onStop).not.toHaveBeenCalled();
+  });
+
+  it('switches to streaming state when setStreaming(true) is called', () => {
+    button.setStreaming(true);
+    const btn = parentEl.querySelector('.claudian-send-stop-btn');
+    expect(btn?.hasClass('claudian-send-stop-btn--streaming')).toBe(true);
+  });
+
+  it('calls onStop when clicked in streaming state', async () => {
+    button.setStreaming(true);
+    const btn = parentEl.querySelector('.claudian-send-stop-btn');
+    await btn?.dispatchEvent('click');
+    expect(onStop).toHaveBeenCalledTimes(1);
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('reverts to idle state when setStreaming(false) is called', () => {
+    button.setStreaming(true);
+    button.setStreaming(false);
+    const btn = parentEl.querySelector('.claudian-send-stop-btn');
+    expect(btn?.hasClass('claudian-send-stop-btn--streaming')).toBe(false);
+  });
+
+  it('calls onSend again after reverting from streaming state', async () => {
+    button.setStreaming(true);
+    button.setStreaming(false);
+    const btn = parentEl.querySelector('.claudian-send-stop-btn');
+    await btn?.dispatchEvent('click');
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(onStop).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Replaces keyboard-only Esc interrupt with a visible send/stop button in the input toolbar
- Shows arrow-up (send) when idle and square (stop) when streaming
- Uses brand color for visual consistency

## Test plan

- [ ] Send button submits message when input has text
- [ ] Stop button appears during streaming and cancels on click
- [ ] Button state reverts to send after stream completes or is cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)