### PR TITLE
fix: normalize structured tool_result content in Codex/MCP paths

### DIFF
--- a/src/core/tools/toolResultContent.ts
+++ b/src/core/tools/toolResultContent.ts
@@ -1,0 +1,26 @@
+export interface ToolResultContentOptions {
+  fallbackIndent?: number;
+}
+
+export function extractToolResultContent(
+  content: unknown,
+  options?: ToolResultContentOptions,
+): string {
+  if (typeof content === 'string') return content;
+  if (content == null) return '';
+
+  if (Array.isArray(content)) {
+    const textParts = content.filter(isTextBlock).map((block) => block.text);
+    if (textParts.length > 0) return textParts.join('\n');
+    if (content.length > 0) return JSON.stringify(content, null, options?.fallbackIndent);
+    return '';
+  }
+
+  return JSON.stringify(content, null, options?.fallbackIndent);
+}
+
+function isTextBlock(block: unknown): block is { type: 'text'; text: string } {
+  if (!block || typeof block !== 'object') return false;
+  const record = block as Record<string, unknown>;
+  return record.type === 'text' && typeof record.text === 'string';
+}

--- a/src/features/chat/controllers/StreamController.ts
+++ b/src/features/chat/controllers/StreamController.ts
@@ -21,6 +21,7 @@ import {
   TOOL_TODO_WRITE,
   TOOL_WRITE,
 } from '../../../core/tools/toolNames';
+import { extractToolResultContent } from '../../../core/tools/toolResultContent';
 import type { ChatMessage, StreamChunk, SubagentInfo, ToolCallInfo } from '../../../core/types';
 import type { SDKToolUseResult } from '../../../core/types/diff';
 import type ClaudianPlugin from '../../../main';
@@ -87,6 +88,10 @@ export class StreamController {
 
   private getSubagentLifecycleAdapter(toolName?: string): ProviderSubagentLifecycleAdapter | null {
     return resolveSubagentLifecycleAdapter(this.getActiveProviderId(), toolName);
+  }
+
+  private normalizeToolResultContent(content: unknown): string {
+    return extractToolResultContent(content, { fallbackIndent: 2 });
   }
 
   // ============================================
@@ -455,15 +460,16 @@ export class StreamController {
   ): boolean {
     const existingToolCall = msg.toolCalls?.find(tc => tc.id === chunk.id);
     if (!existingToolCall) return false;
+    const normalizedContent = this.normalizeToolResultContent(chunk.content);
 
     const adapter = this.getSubagentLifecycleAdapter(existingToolCall.name);
     if (!adapter) return false;
 
     if (adapter.isSpawnTool(existingToolCall.name)) {
       existingToolCall.status = chunk.isError ? 'error' : 'completed';
-      existingToolCall.result = chunk.content;
+      existingToolCall.result = normalizedContent;
 
-      const spawnResult = adapter.extractSpawnResult(chunk.content);
+      const spawnResult = adapter.extractSpawnResult(normalizedContent);
       if (spawnResult.agentId) {
         this.lifecycleAgentIdToSpawnId.set(spawnResult.agentId, chunk.id);
       }
@@ -482,7 +488,7 @@ export class StreamController {
 
       if (chunk.isError) {
         if (subagentState) {
-          finalizeSubagentBlock(subagentState, chunk.content || 'Error', true);
+          finalizeSubagentBlock(subagentState, normalizedContent || 'Error', true);
         }
       }
       return true;
@@ -490,7 +496,7 @@ export class StreamController {
 
     if (adapter.isWaitTool(existingToolCall.name)) {
       existingToolCall.status = chunk.isError ? 'error' : 'completed';
-      existingToolCall.result = chunk.content;
+      existingToolCall.result = normalizedContent;
 
       for (const spawnId of adapter.resolveSpawnToolIds(
         existingToolCall,
@@ -517,7 +523,7 @@ export class StreamController {
 
     if (adapter.isCloseTool(existingToolCall.name)) {
       existingToolCall.status = chunk.isError ? 'error' : 'completed';
-      existingToolCall.result = chunk.content;
+      existingToolCall.result = normalizedContent;
       return true;
     }
 
@@ -529,6 +535,7 @@ export class StreamController {
     msg: ChatMessage
   ): Promise<void> {
     const { state, subagentManager } = this.deps;
+    const normalizedContent = this.normalizeToolResultContent(chunk.content);
 
     // Resolve pending Task before processing result.
     if (subagentManager.hasPendingTask(chunk.id)) {
@@ -567,7 +574,7 @@ export class StreamController {
     const existingToolCall = msg.toolCalls?.find(tc => tc.id === chunk.id);
 
     // Regular tool result
-    const isBlocked = isBlockedToolResult(chunk.content, chunk.isError);
+    const isBlocked = isBlockedToolResult(normalizedContent, chunk.isError);
 
     if (existingToolCall) {
       // Tools that resolve via dedicated callbacks (not content-based) skip
@@ -579,12 +586,12 @@ export class StreamController {
       } else {
         existingToolCall.status = 'completed';
       }
-      existingToolCall.result = chunk.content;
+      existingToolCall.result = normalizedContent;
 
       if (existingToolCall.name === TOOL_ASK_USER_QUESTION) {
         const answers =
           extractResolvedAnswers(chunk.toolUseResult) ??
-          extractResolvedAnswersFromResultText(chunk.content);
+          extractResolvedAnswersFromResultText(normalizedContent);
         if (answers) existingToolCall.resolvedAnswers = answers;
       }
 
@@ -808,9 +815,10 @@ export class StreamController {
       case 'subagent_tool_result': {
         const toolCall = subagentState.info.toolCalls.find((tc: ToolCallInfo) => tc.id === chunk.id);
         if (toolCall) {
-          const isBlocked = isBlockedToolResult(chunk.content, chunk.isError);
+          const normalizedContent = this.normalizeToolResultContent(chunk.content);
+          const isBlocked = isBlockedToolResult(normalizedContent, chunk.isError);
           toolCall.status = isBlocked ? 'blocked' : (chunk.isError ? 'error' : 'completed');
-          toolCall.result = chunk.content;
+          toolCall.result = normalizedContent;
           subagentManager.updateSyncToolResult(parentToolUseId, chunk.id, toolCall);
         }
         break;
@@ -827,11 +835,12 @@ export class StreamController {
     msg: ChatMessage
   ): void {
     const isError = chunk.isError || false;
+    const normalizedContent = this.normalizeToolResultContent(chunk.content);
     const finalized = this.deps.subagentManager.finalizeSyncSubagent(
       chunk.id, chunk.content, isError, chunk.toolUseResult
     );
 
-    const extractedResult = finalized?.result ?? chunk.content;
+    const extractedResult = finalized?.result ?? normalizedContent;
 
     const taskToolCall = this.ensureTaskToolCall(msg, chunk.id);
     taskToolCall.status = isError ? 'error' : 'completed';

--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -7,6 +7,7 @@ import {
   isWriteEditTool,
   TOOL_AGENT_OUTPUT,
 } from '../../../core/tools/toolNames';
+import { extractToolResultContent } from '../../../core/tools/toolResultContent';
 import type { ChatMessage, ImageAttachment, SubagentInfo, ToolCallInfo } from '../../../core/types';
 import { t } from '../../../i18n/i18n';
 import type ClaudianPlugin from '../../../main';
@@ -482,7 +483,7 @@ export class MessageRenderer {
     if (toolCall.status === 'error' || toolCall.status === 'blocked') return 'error';
     if (toolCall.status === 'running') return 'running';
 
-    const lowerResult = (toolCall.result || '').toLowerCase();
+    const lowerResult = extractToolResultContent(toolCall.result, { fallbackIndent: 2 }).toLowerCase();
     if (
       lowerResult.includes('not_ready') ||
       lowerResult.includes('not ready') ||

--- a/src/features/chat/rendering/ToolCallRenderer.ts
+++ b/src/features/chat/rendering/ToolCallRenderer.ts
@@ -23,6 +23,7 @@ import {
   TOOL_WRITE,
   TOOL_WRITE_STDIN,
 } from '../../../core/tools/toolNames';
+import { extractToolResultContent } from '../../../core/tools/toolResultContent';
 import type { AskUserQuestionItem, AskUserQuestionOption, ToolCallInfo } from '../../../core/types';
 import { MCP_ICON_SVG } from '../../../shared/icons';
 import { parseApplyPatchDiffs } from '../../../utils/diff';
@@ -723,8 +724,8 @@ export function renderTodoWriteResult(
   renderTodoItems(container, todos);
 }
 
-export function isBlockedToolResult(content: string, isError?: boolean): boolean {
-  const lower = content.toLowerCase();
+export function isBlockedToolResult(content: unknown, isError?: boolean): boolean {
+  const lower = extractToolResultContent(content, { fallbackIndent: 2 }).toLowerCase();
   if (lower.includes('outside the vault')) return true;
   if (lower.includes('access denied')) return true;
   if (lower.includes('user denied')) return true;

--- a/src/features/chat/services/SubagentManager.ts
+++ b/src/features/chat/services/SubagentManager.ts
@@ -5,6 +5,7 @@ import { isAbsolute, sep } from 'path';
 import { ProviderRegistry } from '../../../core/providers/ProviderRegistry';
 import type { ProviderTaskResultInterpreter } from '../../../core/providers/types';
 import { TOOL_TASK } from '../../../core/tools/toolNames';
+import { extractToolResultContent } from '../../../core/tools/toolResultContent';
 import type {
   SubagentInfo,
   SubagentMode,
@@ -214,7 +215,7 @@ export class SubagentManager {
    */
   public renderPendingTaskFromTaskResult(
     toolId: string,
-    taskResult: string,
+    taskResult: unknown,
     isError: boolean,
     parentElOverride?: HTMLElement | null,
     taskToolUseResult?: unknown
@@ -227,8 +228,9 @@ export class SubagentManager {
     if (!targetEl) return null;
 
     const explicitMode = this.resolveTaskMode(input);
+    const taskResultText = extractToolResultContent(taskResult, { fallbackIndent: 2 });
     const inferredMode = explicitMode
-      ?? this.inferModeFromTaskResult(taskResult, isError, taskToolUseResult);
+      ?? this.inferModeFromTaskResult(taskResultText, isError, taskToolUseResult);
 
     this.pendingTasks.delete(toolId);
 
@@ -279,14 +281,15 @@ export class SubagentManager {
 
   public finalizeSyncSubagent(
     toolId: string,
-    result: string,
+    result: unknown,
     isError: boolean,
     toolUseResult?: unknown
   ): SubagentInfo | null {
     const subagentState = this.syncSubagents.get(toolId);
     if (!subagentState) return null;
 
-    const extractedResult = this.extractAgentResult(result, '', toolUseResult);
+    const resultText = extractToolResultContent(result, { fallbackIndent: 2 });
+    const extractedResult = this.extractAgentResult(resultText, '', toolUseResult);
     finalizeSubagentBlock(subagentState, extractedResult, isError);
     this.syncSubagents.delete(toolId);
 
@@ -299,22 +302,23 @@ export class SubagentManager {
 
   public handleTaskToolResult(
     taskToolId: string,
-    result: string,
+    result: unknown,
     isError?: boolean,
     toolUseResult?: unknown
   ): void {
     const subagent = this.pendingAsyncSubagents.get(taskToolId);
     if (!subagent) return;
+    const resultText = extractToolResultContent(result, { fallbackIndent: 2 });
 
     if (isError) {
-      this.transitionToError(subagent, taskToolId, result || 'Task failed to start');
+      this.transitionToError(subagent, taskToolId, resultText || 'Task failed to start');
       return;
     }
 
-    const agentId = this.taskResultInterpreter.extractAgentId(toolUseResult) ?? this.parseAgentId(result);
+    const agentId = this.taskResultInterpreter.extractAgentId(toolUseResult) ?? this.parseAgentId(resultText);
 
     if (!agentId) {
-      const truncatedResult = result.length > 100 ? result.substring(0, 100) + '...' : result;
+      const truncatedResult = resultText.length > 100 ? resultText.substring(0, 100) + '...' : resultText;
       this.transitionToError(subagent, taskToolId, `Failed to parse agent_id. Result: ${truncatedResult}`);
       return;
     }
@@ -344,15 +348,16 @@ export class SubagentManager {
 
   public handleAgentOutputToolResult(
     toolId: string,
-    result: string,
+    result: unknown,
     isError: boolean,
     toolUseResult?: unknown
   ): SubagentInfo | undefined {
+    const resultText = extractToolResultContent(result, { fallbackIndent: 2 });
     let agentId = this.outputToolIdToAgentId.get(toolId);
     let subagent = agentId ? this.activeAsyncSubagents.get(agentId) : undefined;
 
     if (!subagent) {
-      const inferredAgentId = this.inferAgentIdFromResult(result);
+      const inferredAgentId = this.inferAgentIdFromResult(resultText);
       if (inferredAgentId) {
         agentId = inferredAgentId;
         subagent = this.activeAsyncSubagents.get(inferredAgentId);
@@ -370,13 +375,13 @@ export class SubagentManager {
       return undefined;
     }
 
-    const stillRunning = this.isStillRunningResult(result, isError);
+    const stillRunning = this.isStillRunningResult(resultText, isError);
     if (stillRunning) {
       this.outputToolIdToAgentId.delete(toolId);
       return subagent;
     }
 
-    const extractedResult = this.extractAgentResult(result, agentId ?? '', toolUseResult);
+    const extractedResult = this.extractAgentResult(resultText, agentId ?? '', toolUseResult);
 
     // The chunk's is_error flag can be unreliable for async subagent results
     // (SDK may set is_error on the content block even when the agent succeeded).

--- a/src/providers/claude/sdk/toolResultContent.ts
+++ b/src/providers/claude/sdk/toolResultContent.ts
@@ -1,24 +1,4 @@
-interface ToolResultContentOptions {
-  fallbackIndent?: number;
-}
-
-export function extractToolResultContent(
-  content: unknown,
-  options?: ToolResultContentOptions
-): string {
-  if (typeof content === 'string') return content;
-  if (content == null) return '';
-  if (Array.isArray(content)) {
-    const textParts = content.filter(isTextBlock).map((block) => block.text);
-    if (textParts.length > 0) return textParts.join('\n');
-    if (content.length > 0) return JSON.stringify(content, null, options?.fallbackIndent);
-    return '';
-  }
-  return JSON.stringify(content, null, options?.fallbackIndent);
-}
-
-function isTextBlock(block: unknown): block is { type: 'text'; text: string } {
-  if (!block || typeof block !== 'object') return false;
-  const record = block as Record<string, unknown>;
-  return record.type === 'text' && typeof record.text === 'string';
-}
+export {
+  extractToolResultContent,
+  type ToolResultContentOptions,
+} from '../../../core/tools/toolResultContent';

--- a/tests/unit/features/chat/controllers/StreamController.test.ts
+++ b/tests/unit/features/chat/controllers/StreamController.test.ts
@@ -1827,6 +1827,33 @@ describe('StreamController - Text Content', () => {
         structured
       );
     });
+
+    it('normalizes structured tool_result content before storing it on tool calls', async () => {
+      const { updateToolCallResult } = jest.requireMock('@/features/chat/rendering/ToolCallRenderer');
+      const msg = createTestMessage();
+      msg.toolCalls = [
+        {
+          id: 'mcp-1',
+          name: 'mcp__stitch__create_project',
+          input: {},
+          status: 'running',
+          isExpanded: false,
+        } as any,
+      ];
+
+      await controller.handleStreamChunk(
+        {
+          type: 'tool_result',
+          id: 'mcp-1',
+          content: [{ type: 'text', text: 'Created project successfully' }],
+        } as any,
+        msg,
+      );
+
+      expect(msg.toolCalls[0].status).toBe('completed');
+      expect(msg.toolCalls[0].result).toBe('Created project successfully');
+      expect(updateToolCallResult).toHaveBeenCalled();
+    });
   });
 
   describe('showThinkingIndicator - timer disconnection cleanup', () => {

--- a/tests/unit/features/chat/rendering/MessageRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/MessageRenderer.test.ts
@@ -667,6 +667,42 @@ describe('MessageRenderer', () => {
     expect(renderStoredSubagent).not.toHaveBeenCalled();
   });
 
+  it('infers async running state from structured Task result content', () => {
+    const messagesEl = createMockEl();
+    const { renderer } = createRenderer(messagesEl);
+
+    (renderStoredAsyncSubagent as jest.Mock).mockClear();
+
+    const msg: ChatMessage = {
+      id: 'm-task-async-structured',
+      role: 'assistant',
+      content: '',
+      timestamp: Date.now(),
+      toolCalls: [
+        {
+          id: 'task-async-structured-1',
+          name: TOOL_TASK,
+          input: { description: 'Background task', run_in_background: true },
+          status: 'completed',
+          result: [{ type: 'text', text: '{"status":"running"}' }] as any,
+        } as any,
+      ],
+      contentBlocks: [
+        { type: 'tool_use', toolId: 'task-async-structured-1' } as any,
+      ],
+    };
+
+    renderer.renderStoredMessage(msg);
+
+    expect(renderStoredAsyncSubagent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        id: 'task-async-structured-1',
+        asyncStatus: 'running',
+      })
+    );
+  });
+
   it('uses subagent block mode hint when linked subagent mode is missing', () => {
     const messagesEl = createMockEl();
     const { renderer } = createRenderer(messagesEl);

--- a/tests/unit/features/chat/rendering/ToolCallRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/ToolCallRenderer.test.ts
@@ -620,6 +620,12 @@ describe('ToolCallRenderer', () => {
     it('should return false for normal results', () => {
       expect(isBlockedToolResult('File content here')).toBe(false);
     });
+
+    it('extracts text from structured content blocks before blocked detection', () => {
+      expect(isBlockedToolResult([
+        { type: 'text', text: 'Requires approval from user' },
+      ])).toBe(true);
+    });
   });
 
   describe('renderTodoWriteResult', () => {

--- a/tests/unit/features/chat/services/SubagentManager.test.ts
+++ b/tests/unit/features/chat/services/SubagentManager.test.ts
@@ -100,6 +100,23 @@ describe('SubagentManager', () => {
       expect(manager.isPendingAsyncTask('task-structured')).toBe(false);
     });
 
+    it('transitions from pending to running when structured content carries agent_id', () => {
+      const { manager, updates } = createManager();
+      const parentEl = createMockEl();
+
+      manager.handleTaskToolUse('task-array', { description: 'Background', run_in_background: true }, parentEl);
+      manager.handleTaskToolResult(
+        'task-array',
+        [{ type: 'text', text: '{"agent_id":"agent-array-1"}' }] as any,
+      );
+
+      const running = manager.getByTaskId('task-array');
+      expect(running?.asyncStatus).toBe('running');
+      expect(running?.agentId).toBe('agent-array-1');
+      expect(updates[updates.length - 1].agentId).toBe('agent-array-1');
+      expect(manager.isPendingAsyncTask('task-array')).toBe(false);
+    });
+
     it('moves to error when Task tool_result parsing fails', () => {
       const { manager, updates } = createManager();
       const parentEl = createMockEl();
@@ -759,7 +776,9 @@ ${inlineOutput}
       const { manager } = createManager();
       setupLinkedAgentOutput(manager, 'task-1', 'agent-untrusted-output', 'out-1');
 
-      const fullOutputFile = join(process.cwd(), 'agent-untrusted.output');
+      const homeDir = process.env.HOME ?? process.cwd();
+      const untrustedDir = mkdtempSync(join(homeDir, '.claudian-untrusted-'));
+      const fullOutputFile = join(untrustedDir, 'agent-untrusted.output');
       const fullOutput = [
         JSON.stringify({
           type: 'assistant',
@@ -783,7 +802,7 @@ ${inlineOutput}
         const result = manager.handleAgentOutputToolResult('out-1', xmlPayload, false);
         expect(result?.result).toBe(inlineOutput);
       } finally {
-        rmSync(fullOutputFile, { force: true });
+        rmSync(untrustedDir, { recursive: true, force: true });
       }
     });
 
@@ -1150,6 +1169,22 @@ Only this is the final result.
       const result = manager.renderPendingTaskFromTaskResult(
         'task-1',
         '{"agent_id":"agent-123"}',
+        false
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.mode).toBe('async');
+      expect(manager.hasPendingTask('task-1')).toBe(false);
+    });
+
+    it('infers async from structured task-result content when mode is still unknown', () => {
+      const { manager } = createManager();
+      const parentEl = createMockEl();
+
+      manager.handleTaskToolUse('task-1', { prompt: 'test' }, parentEl);
+      const result = manager.renderPendingTaskFromTaskResult(
+        'task-1',
+        [{ type: 'text', text: '{"agent_id":"agent-structured"}' }] as any,
         false
       );
 


### PR DESCRIPTION
## Summary

Closes #534.

This fixes a crash when `tool_result.content` is structured data instead of a plain string.

A real-world trigger is Codex MCP tools such as Stitch `create_project`, which can return structured content blocks like:

```json
[{ "type": "text", "text": "Created project ..." }]
```

Several Codex/MCP/UI paths were still assuming string-only tool results and calling string methods directly.

## What changed

- moved `extractToolResultContent(content: unknown)` into a shared helper
- reused that helper before blocked-result detection
- reused it before async Task status inference in message rendering
- normalized stored tool results in `StreamController`
- normalized async/subagent Task and AgentOutput parsing in `SubagentManager`
- added regression coverage for structured content arrays
- made the untrusted output-file regression test independent of the repo checkout location

## Why this is minimal

Claude-side parsing already had the right normalization logic. This PR just applies the same boundary consistently to the remaining Codex/MCP-facing paths instead of introducing a new parsing model.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test -- --runInBand --selectProjects unit tests/unit/features/chat/rendering/ToolCallRenderer.test.ts tests/unit/features/chat/rendering/MessageRenderer.test.ts tests/unit/features/chat/services/SubagentManager.test.ts tests/unit/features/chat/controllers/StreamController.test.ts`
