### PR TITLE
feat: register Switch to tab 1..9 commands

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -168,6 +168,33 @@ export default class ClaudianPlugin extends Plugin {
       },
     });
 
+    // `Switch to tab N` commands for N = 1..9. Exposed through Obsidian's
+    // addCommand so users can rebind in Settings → Hotkeys. No default
+    // chord is assigned; typical binding is ⌘/⌥ + digit but that varies
+    // by OS and user preference. checkCallback hides commands for slots
+    // that exceed the current tab count, keeping the command palette
+    // tidy.
+    for (let index = 1; index <= 9; index++) {
+      this.addCommand({
+        id: `switch-to-tab-${index}`,
+        name: `Switch to tab ${index}`,
+        checkCallback: (checking: boolean) => {
+          const leaf = this.app.workspace.getLeavesOfType(VIEW_TYPE_CLAUDIAN)[0];
+          if (!leaf) return false;
+          const view = leaf.view as ClaudianView;
+          const tabManager = view.getTabManager();
+          if (!tabManager) return false;
+          const tabs = tabManager.getAllTabs();
+          if (tabs.length < index) return false;
+
+          if (!checking) {
+            void tabManager.switchToTab(tabs[index - 1].id);
+          }
+          return true;
+        },
+      });
+    }
+
     this.addSettingTab(new ClaudianSettingTab(this.app, this));
   }
 

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -496,6 +496,66 @@ describe('ClaudianPlugin', () => {
     });
   });
 
+  describe('switch-to-tab-N commands', () => {
+    function leafWithTabs(tabs: Array<{ id: string }>) {
+      const switchToTab = jest.fn().mockResolvedValue(undefined);
+      const tabManager = {
+        getAllTabs: jest.fn().mockReturnValue(tabs),
+        switchToTab,
+      };
+      const mockView = { getTabManager: () => tabManager };
+      mockApp.workspace.getLeavesOfType = jest.fn().mockReturnValue([{ view: mockView }]);
+      return { tabManager, switchToTab };
+    }
+
+    it('registers commands for N = 1..9', async () => {
+      await plugin.onload();
+      for (let i = 1; i <= 9; i++) {
+        const command = getRegisteredCommand(`switch-to-tab-${i}`);
+        expect(command.name).toBe(`Switch to tab ${i}`);
+      }
+    });
+
+    it('switch-to-tab-1 switches to the first tab when any exists', async () => {
+      await plugin.onload();
+      const { switchToTab } = leafWithTabs([{ id: 'tab-a' }, { id: 'tab-b' }]);
+
+      const command = getRegisteredCommand('switch-to-tab-1');
+      expect(command.checkCallback(true)).toBe(true);
+      expect(command.checkCallback(false)).toBe(true);
+
+      expect(switchToTab).toHaveBeenCalledTimes(1);
+      expect(switchToTab).toHaveBeenCalledWith('tab-a');
+    });
+
+    it('switch-to-tab-3 is unavailable when only 2 tabs exist', async () => {
+      await plugin.onload();
+      const { switchToTab } = leafWithTabs([{ id: 'a' }, { id: 'b' }]);
+
+      const command = getRegisteredCommand('switch-to-tab-3');
+      expect(command.checkCallback(true)).toBe(false);
+      expect(switchToTab).not.toHaveBeenCalled();
+    });
+
+    it('is unavailable when no Claudian leaf is open', async () => {
+      await plugin.onload();
+      mockApp.workspace.getLeavesOfType = jest.fn().mockReturnValue([]);
+
+      const command = getRegisteredCommand('switch-to-tab-1');
+      expect(command.checkCallback(true)).toBe(false);
+    });
+
+    it('is unavailable when the leaf has no TabManager yet', async () => {
+      await plugin.onload();
+      mockApp.workspace.getLeavesOfType = jest.fn().mockReturnValue([
+        { view: { getTabManager: () => null } },
+      ]);
+
+      const command = getRegisteredCommand('switch-to-tab-1');
+      expect(command.checkCallback(true)).toBe(false);
+    });
+  });
+
   describe('createConversation', () => {
     it('should create a new conversation with unique ID', async () => {
       await plugin.onload();


### PR DESCRIPTION
Exposes nine Obsidian commands (switch-to-tab-1 .. switch-to-tab-9) that activate the Nth tab in the current Claudian view. Surfacing them through addCommand (rather than a view-scoped DOM keydown listener) means:

  - Users rebind in Settings → Hotkeys like any other command.
  - checkCallback hides slots above the current tab count so the command palette stays tidy.
  - Fires from anywhere in Obsidian, not only when the Claudian view has DOM focus.

No default chord is assigned. ⌘/⌥/Ctrl + digit all collide with common OS / browser bindings and the right choice varies per user, so we leave it to the user via Hotkeys. A README note would suggest ⌥1..9 on macOS and Alt+1..9 elsewhere.

Tests: +5 cases in tests/integration/main.test.ts
  - registers all nine commands with the expected names
  - switch-to-tab-1 calls TabManager.switchToTab(tabs[0].id)
  - switch-to-tab-3 is unavailable when only 2 tabs exist
  - unavailable when no Claudian leaf is open
  - unavailable when leaf has no TabManager yet