### PR TITLE
Fix Claude context meter for custom 1M models

### DIFF
--- a/src/providers/claude/stream/transformClaudeMessage.ts
+++ b/src/providers/claude/stream/transformClaudeMessage.ts
@@ -4,7 +4,7 @@ import type { SDKToolUseResult, StreamChunk, UsageInfo } from '../../../core/typ
 import { isBlockedMessage } from '../sdk/messages';
 import { extractToolResultContent } from '../sdk/toolResultContent';
 import type { TransformEvent } from '../sdk/types';
-import { getContextWindowSize } from '../types/models';
+import { getContextWindowSize, isDefaultClaudeModel } from '../types/models';
 import { createTransformStreamState, type TransformStreamState } from './toolInputStreamState';
 
 type ToolUseFields = { id: string; name: string; input: Record<string, unknown> };
@@ -53,36 +53,85 @@ interface ContextWindowEntry {
   contextWindow: number;
 }
 
+interface ClaudeModelSignature {
+  normalizedModel: string;
+  family: 'haiku' | 'sonnet' | 'opus';
+  is1M: boolean;
+  major?: string;
+  minor?: string;
+  date?: string;
+}
+
 function isResultError(message: { type: 'result'; subtype: string }): message is SDKResultError {
   return !!message.subtype && message.subtype !== 'success';
 }
 
-function getBuiltInModelSignature(model: string): { family: 'haiku' | 'sonnet' | 'opus'; is1M: boolean } | null {
+function normalizeClaudeModelId(model: string): string {
   const normalized = model.trim().toLowerCase();
+  const claudeIndex = normalized.indexOf('claude-');
+  return claudeIndex >= 0 ? normalized.slice(claudeIndex) : normalized;
+}
+
+function parseClaudeModelSignature(model: string): ClaudeModelSignature | null {
+  const normalized = normalizeClaudeModelId(model);
   if (normalized === 'haiku') {
-    return { family: 'haiku', is1M: false };
+    return { normalizedModel: normalized, family: 'haiku', is1M: false };
   }
   if (normalized === 'sonnet' || normalized === 'sonnet[1m]') {
-    return { family: 'sonnet', is1M: normalized.endsWith('[1m]') };
+    return { normalizedModel: normalized, family: 'sonnet', is1M: normalized.endsWith('[1m]') };
   }
   if (normalized === 'opus' || normalized === 'opus[1m]') {
-    return { family: 'opus', is1M: normalized.endsWith('[1m]') };
+    return { normalizedModel: normalized, family: 'opus', is1M: normalized.endsWith('[1m]') };
   }
+
+  const versionedMatch = normalized.match(
+    /^claude-(haiku|sonnet|opus)-(\d+)(?:-(\d+))?(?:-(\d{8}))?(?:-v\d+:\d+)?(\[1m\])?$/,
+  );
+  if (versionedMatch) {
+    const [, familyMatch, major, minor, date, oneMillionSuffix] = versionedMatch;
+    const family = familyMatch as ClaudeModelSignature['family'];
+    return {
+      normalizedModel: normalized,
+      family,
+      is1M: oneMillionSuffix === '[1m]',
+      major,
+      minor,
+      date,
+    };
+  }
+
   return null;
 }
 
-function getModelUsageSignature(model: string): { family: 'haiku' | 'sonnet' | 'opus'; is1M: boolean } | null {
-  const normalized = model.trim().toLowerCase();
-  if (normalized.includes('haiku')) {
-    return { family: 'haiku', is1M: false };
+function findUniqueEntry(
+  entries: ContextWindowEntry[],
+  predicate: (entry: ContextWindowEntry) => boolean,
+): ContextWindowEntry | null {
+  const matches = entries.filter(predicate);
+  return matches.length === 1 ? matches[0] : null;
+}
+
+function matchClaudeModelSignature(
+  entrySignature: ClaudeModelSignature | null,
+  intendedSignature: ClaudeModelSignature,
+  options?: { ignoreIs1M?: boolean },
+): boolean {
+  if (!entrySignature || entrySignature.family !== intendedSignature.family) {
+    return false;
   }
-  if (normalized.includes('sonnet')) {
-    return { family: 'sonnet', is1M: normalized.endsWith('[1m]') };
+  if (!options?.ignoreIs1M && entrySignature.is1M !== intendedSignature.is1M) {
+    return false;
   }
-  if (normalized.includes('opus')) {
-    return { family: 'opus', is1M: normalized.endsWith('[1m]') };
+  if (intendedSignature.major && entrySignature.major !== intendedSignature.major) {
+    return false;
   }
-  return null;
+  if (intendedSignature.minor && entrySignature.minor !== intendedSignature.minor) {
+    return false;
+  }
+  if (intendedSignature.date && entrySignature.date !== intendedSignature.date) {
+    return false;
+  }
+  return true;
 }
 
 function selectContextWindowEntry(
@@ -108,22 +157,41 @@ function selectContextWindowEntry(
     return null;
   }
 
-  const exactMatches = entries.filter((entry) => entry.model === intendedModel);
-  if (exactMatches.length === 1) {
-    return exactMatches[0];
+  const literalExactMatch = entries.find((entry) => entry.model === intendedModel);
+  if (literalExactMatch) {
+    return literalExactMatch;
   }
 
-  const intendedSignature = getBuiltInModelSignature(intendedModel);
+  const normalizedIntendedModel = normalizeClaudeModelId(intendedModel);
+  const exactMatch = findUniqueEntry(entries, (entry) => normalizeClaudeModelId(entry.model) === normalizedIntendedModel);
+  if (exactMatch) {
+    return exactMatch;
+  }
+
+  if (!isDefaultClaudeModel(intendedModel)) {
+    return null;
+  }
+
+  const intendedSignature = parseClaudeModelSignature(intendedModel);
   if (!intendedSignature) {
     return null;
   }
 
-  const signatureMatches = entries.filter((entry) => {
-    const entrySignature = getModelUsageSignature(entry.model);
-    return entrySignature?.family === intendedSignature.family && entrySignature.is1M === intendedSignature.is1M;
-  });
+  const strictSignatureMatch = findUniqueEntry(entries, (entry) =>
+    matchClaudeModelSignature(parseClaudeModelSignature(entry.model), intendedSignature),
+  );
+  if (strictSignatureMatch) {
+    return strictSignatureMatch;
+  }
 
-  return signatureMatches.length === 1 ? signatureMatches[0] : null;
+  const hasVersionedTarget = Boolean(intendedSignature.major || intendedSignature.date);
+  if (!hasVersionedTarget) {
+    return null;
+  }
+
+  return findUniqueEntry(entries, (entry) =>
+    matchClaudeModelSignature(parseClaudeModelSignature(entry.model), intendedSignature, { ignoreIs1M: true }),
+  );
 }
 
 /**

--- a/src/providers/claude/types/models.ts
+++ b/src/providers/claude/types/models.ts
@@ -52,12 +52,56 @@ export const DEFAULT_THINKING_BUDGET: Record<string, ThinkingBudget> = {
   'opus[1m]': 'medium',
 };
 
-const DEFAULT_MODEL_VALUES = new Set(DEFAULT_CLAUDE_MODELS.map(m => m.value));
+const ONE_M_SUFFIX = '[1m]';
+const DEFAULT_MODEL_VALUES = new Set(DEFAULT_CLAUDE_MODELS.map(m => m.value.toLowerCase()));
+
+function normalizeModelId(model: string): string {
+  return model.trim().toLowerCase();
+}
+
+function has1MContextSuffix(model: string): boolean {
+  return normalizeModelId(model).endsWith(ONE_M_SUFFIX);
+}
+
+function isBuiltInFamilyVariant(model: string, family: 'sonnet' | 'opus'): boolean {
+  const normalized = normalizeModelId(model);
+  return normalized === family || normalized === `${family}${ONE_M_SUFFIX}`;
+}
+
+function isValidContextLimit(limit: unknown): limit is number {
+  return typeof limit === 'number' && limit > 0 && !isNaN(limit) && isFinite(limit);
+}
+
+function resolveCustomContextLimit(
+  model: string,
+  customLimits?: Record<string, number>,
+): number | null {
+  if (!customLimits) {
+    return null;
+  }
+
+  const exactLimit = customLimits[model];
+  if (isValidContextLimit(exactLimit)) {
+    return exactLimit;
+  }
+
+  const normalizedModel = normalizeModelId(model);
+  const matchingLimits = Object.entries(customLimits)
+    .filter(([key, limit]) => key !== model && normalizeModelId(key) === normalizedModel && isValidContextLimit(limit))
+    .map(([, limit]) => limit);
+
+  return matchingLimits.length === 1 ? matchingLimits[0] : null;
+}
 
 /** Whether the model is a known Claude model that supports adaptive thinking. */
 export function isAdaptiveThinkingModel(model: string): boolean {
-  if (DEFAULT_MODEL_VALUES.has(model)) return true;
-  return /claude-(haiku|sonnet|opus)-/.test(model);
+  const normalized = normalizeModelId(model);
+  if (DEFAULT_MODEL_VALUES.has(normalized)) return true;
+  return /claude-(haiku|sonnet|opus)-/.test(normalized);
+}
+
+export function isDefaultClaudeModel(model: string): boolean {
+  return DEFAULT_MODEL_VALUES.has(normalizeModelId(model));
 }
 
 /**
@@ -65,8 +109,9 @@ export function isAdaptiveThinkingModel(model: string): boolean {
  * silently falls back to `high` on other models.
  */
 export function supportsXHighEffort(model: string): boolean {
-  if (model === 'opus' || model === 'opus[1m]') return true;
-  return /claude-opus-(4-[7-9]|[5-9])/.test(model);
+  const normalized = normalizeModelId(model);
+  if (isBuiltInFamilyVariant(normalized, 'opus')) return true;
+  return /claude-opus-(4-[7-9]|[5-9])/.test(normalized);
 }
 
 /** Clamp stored effort values to what the selected model actually supports. */
@@ -83,7 +128,7 @@ export function normalizeEffortLevel(
     return effortLevel as EffortLevel;
   }
 
-  return DEFAULT_EFFORT_LEVEL[model] ?? 'high';
+  return DEFAULT_EFFORT_LEVEL[normalizeModelId(model)] ?? 'high';
 }
 
 export function resolveThinkingTokens(
@@ -119,12 +164,12 @@ export function filterVisibleModelOptions<T extends { value: string }>(
   enableSonnet1M: boolean
 ): T[] {
   return models.filter((model) => {
-    if (model.value === 'opus' || model.value === 'opus[1m]') {
-      return enableOpus1M ? model.value === 'opus[1m]' : model.value === 'opus';
+    if (isBuiltInFamilyVariant(model.value, 'opus')) {
+      return enableOpus1M ? has1MContextSuffix(model.value) : normalizeModelId(model.value) === 'opus';
     }
 
-    if (model.value === 'sonnet' || model.value === 'sonnet[1m]') {
-      return enableSonnet1M ? model.value === 'sonnet[1m]' : model.value === 'sonnet';
+    if (isBuiltInFamilyVariant(model.value, 'sonnet')) {
+      return enableSonnet1M ? has1MContextSuffix(model.value) : normalizeModelId(model.value) === 'sonnet';
     }
 
     return true;
@@ -136,11 +181,11 @@ export function normalizeVisibleModelVariant(
   enableOpus1M: boolean,
   enableSonnet1M: boolean
 ): string {
-  if (model === 'opus' || model === 'opus[1m]') {
+  if (isBuiltInFamilyVariant(model, 'opus')) {
     return enableOpus1M ? 'opus[1m]' : 'opus';
   }
 
-  if (model === 'sonnet' || model === 'sonnet[1m]') {
+  if (isBuiltInFamilyVariant(model, 'sonnet')) {
     return enableSonnet1M ? 'sonnet[1m]' : 'sonnet';
   }
 
@@ -151,14 +196,12 @@ export function getContextWindowSize(
   model: string,
   customLimits?: Record<string, number>
 ): number {
-  if (customLimits && model in customLimits) {
-    const limit = customLimits[model];
-    if (typeof limit === 'number' && limit > 0 && !isNaN(limit) && isFinite(limit)) {
-      return limit;
-    }
+  const customLimit = resolveCustomContextLimit(model, customLimits);
+  if (customLimit !== null) {
+    return customLimit;
   }
 
-  if (model.endsWith('[1m]')) {
+  if (has1MContextSuffix(model)) {
     return CONTEXT_WINDOW_1M;
   }
 

--- a/tests/unit/providers/claude/env/claudeModelEnv.test.ts
+++ b/tests/unit/providers/claude/env/claudeModelEnv.test.ts
@@ -98,6 +98,11 @@ describe('getModelsFromEnvironment', () => {
     expect(result[0].label).toBe('Opus 4.6 (1M)');
   });
 
+  it('formats uppercase 1M suffixes into friendly labels', () => {
+    const result = getModelsFromEnvironment({ ANTHROPIC_MODEL: 'claude-opus-4-6[1M]' });
+    expect(result[0].label).toBe('Opus 4.6 (1M)');
+  });
+
   it('formats label from slash-separated model name', () => {
     const result = getModelsFromEnvironment({ ANTHROPIC_MODEL: 'org/custom-model' });
     expect(result[0].label).toBe('custom-model');

--- a/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
+++ b/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
@@ -955,6 +955,140 @@ describe('transformSDKMessage', () => {
       ]);
     });
 
+    it('matches provider-qualified custom model ids against SDK modelUsage keys', () => {
+      const message = msg({
+        type: 'result',
+        modelUsage: {
+          'claude-haiku-4-5-20251001': {
+            inputTokens: 1000,
+            outputTokens: 300,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            webSearchRequests: 0,
+            costUSD: 0.01,
+            contextWindow: 200000,
+            maxOutputTokens: 32000,
+          },
+          'claude-opus-4-6[1m]': {
+            inputTokens: 1000,
+            outputTokens: 300,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            webSearchRequests: 0,
+            costUSD: 0.01,
+            contextWindow: 1000000,
+            maxOutputTokens: 32000,
+          },
+        },
+      });
+
+      const results = [...transformSDKMessage(message, { intendedModel: 'anthropic/claude-opus-4-6[1m]' })];
+
+      expect(results).toEqual([
+        { type: 'context_window', contextWindow: 1000000 },
+      ]);
+    });
+
+    it('preserves literal exact matches when provider-qualified entries normalize to the same Claude id', () => {
+      const message = msg({
+        type: 'result',
+        modelUsage: {
+          'eu.anthropic.claude-opus-4-6[1m]': {
+            inputTokens: 1000,
+            outputTokens: 300,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            webSearchRequests: 0,
+            costUSD: 0.01,
+            contextWindow: 1000000,
+            maxOutputTokens: 32000,
+          },
+          'us.anthropic.claude-opus-4-6[1m]': {
+            inputTokens: 1000,
+            outputTokens: 300,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            webSearchRequests: 0,
+            costUSD: 0.01,
+            contextWindow: 500000,
+            maxOutputTokens: 32000,
+          },
+        },
+      });
+
+      const results = [...transformSDKMessage(message, { intendedModel: 'eu.anthropic.claude-opus-4-6[1m]' })];
+
+      expect(results).toEqual([
+        { type: 'context_window', contextWindow: 1000000 },
+      ]);
+    });
+
+    it('matches provider-qualified custom model ids with uppercase 1M suffixes', () => {
+      const message = msg({
+        type: 'result',
+        modelUsage: {
+          'claude-haiku-4-5-20251001': {
+            inputTokens: 1000,
+            outputTokens: 300,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            webSearchRequests: 0,
+            costUSD: 0.01,
+            contextWindow: 200000,
+            maxOutputTokens: 32000,
+          },
+          'claude-opus-4-6[1m]': {
+            inputTokens: 1000,
+            outputTokens: 300,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            webSearchRequests: 0,
+            costUSD: 0.01,
+            contextWindow: 1000000,
+            maxOutputTokens: 32000,
+          },
+        },
+      });
+
+      const results = [...transformSDKMessage(message, { intendedModel: 'anthropic/claude-opus-4-6[1M]' })];
+
+      expect(results).toEqual([
+        { type: 'context_window', contextWindow: 1000000 },
+      ]);
+    });
+
+    it('does not heuristically match different custom model ids', () => {
+      const message = msg({
+        type: 'result',
+        modelUsage: {
+          'claude-haiku-4-5-20251001': {
+            inputTokens: 1000,
+            outputTokens: 300,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            webSearchRequests: 0,
+            costUSD: 0.01,
+            contextWindow: 200000,
+            maxOutputTokens: 32000,
+          },
+          'claude-opus-4-6[1m]': {
+            inputTokens: 1000,
+            outputTokens: 300,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            webSearchRequests: 0,
+            costUSD: 0.01,
+            contextWindow: 1000000,
+            maxOutputTokens: 32000,
+          },
+        },
+      });
+
+      const results = [...transformSDKMessage(message, { intendedModel: 'anthropic/claude-opus-4-6' })];
+
+      expect(results).toEqual([]);
+    });
+
     it('does not override the heuristic when multi-model result usage is ambiguous', () => {
       const message = msg({
         type: 'result',

--- a/tests/unit/providers/claude/types/types.test.ts
+++ b/tests/unit/providers/claude/types/types.test.ts
@@ -598,6 +598,12 @@ describe('types.ts', () => {
         expect(getContextWindowSize('sonnet[1m]')).toBe(CONTEXT_WINDOW_1M);
       });
 
+      it('should treat [1M] and [1m] suffixes equivalently', () => {
+        expect(getContextWindowSize('opus[1M]')).toBe(CONTEXT_WINDOW_1M);
+        expect(getContextWindowSize('claude-opus-4-6[1M]')).toBe(CONTEXT_WINDOW_1M);
+        expect(getContextWindowSize('claude-sonnet-4-6[1M]')).toBe(CONTEXT_WINDOW_1M);
+      });
+
       it('should return 1M for full model IDs with [1m] suffix', () => {
         expect(getContextWindowSize('claude-opus-4-6[1m]')).toBe(CONTEXT_WINDOW_1M);
         expect(getContextWindowSize('claude-sonnet-4-6[1m]')).toBe(CONTEXT_WINDOW_1M);
@@ -606,6 +612,11 @@ describe('types.ts', () => {
       it('should prefer custom limits over [1m] suffix', () => {
         const customLimits = { 'opus[1m]': 500000 };
         expect(getContextWindowSize('opus[1m]', customLimits)).toBe(500000);
+      });
+
+      it('should match custom limits case-insensitively for [1M] suffixes', () => {
+        const customLimits = { 'claude-opus-4-6[1m]': 500000 };
+        expect(getContextWindowSize('claude-opus-4-6[1M]', customLimits)).toBe(500000);
       });
 
       it('should return standard for models without [1m] suffix', () => {
@@ -644,6 +655,11 @@ describe('types.ts', () => {
         expect(normalizeVisibleModelVariant('opus[1m]', false, true)).toBe('opus');
       });
 
+      it('should normalize built-in variants regardless of 1M suffix casing', () => {
+        expect(normalizeVisibleModelVariant('sonnet[1M]', false, false)).toBe('sonnet');
+        expect(normalizeVisibleModelVariant('opus[1M]', true, false)).toBe('opus[1m]');
+      });
+
       it('should leave unrelated model ids unchanged', () => {
         expect(normalizeVisibleModelVariant('', true, true)).toBe('');
         expect(normalizeVisibleModelVariant('haiku', true, true)).toBe('haiku');
@@ -659,6 +675,7 @@ describe('types.ts', () => {
       expect(isAdaptiveThinkingModel('sonnet[1m]')).toBe(true);
       expect(isAdaptiveThinkingModel('opus')).toBe(true);
       expect(isAdaptiveThinkingModel('opus[1m]')).toBe(true);
+      expect(isAdaptiveThinkingModel('opus[1M]')).toBe(true);
     });
 
     it('should return true for full Claude model IDs', () => {
@@ -688,6 +705,7 @@ describe('types.ts', () => {
     it('should return true for full versioned 1M model IDs', () => {
       expect(isAdaptiveThinkingModel('claude-opus-4-6[1m]')).toBe(true);
       expect(isAdaptiveThinkingModel('claude-sonnet-4-6[1m]')).toBe(true);
+      expect(isAdaptiveThinkingModel('claude-opus-4-6[1M]')).toBe(true);
     });
   });
 
@@ -695,6 +713,7 @@ describe('types.ts', () => {
     it('returns true for opus aliases and 4.7+ opus ids', () => {
       expect(supportsXHighEffort('opus')).toBe(true);
       expect(supportsXHighEffort('opus[1m]')).toBe(true);
+      expect(supportsXHighEffort('opus[1M]')).toBe(true);
       expect(supportsXHighEffort('claude-opus-4-7')).toBe(true);
       expect(supportsXHighEffort('claude-opus-5')).toBe(true);
     });


### PR DESCRIPTION
This branch fixes Claude context-window selection so custom models use the selected model ID to match SDK usage data, while built-in aliases keep their explicit fallback mapping. It also normalizes `[1M]` and `[1m]` handling across Claude model helpers so custom 1M models, labels, and context-limit lookups behave consistently. The tests add regression coverage for provider-qualified custom model IDs, uppercase 1M suffixes, exact-match precedence, and ambiguous multi-model result handling.