### PR TITLE
Update Codex model defaults for GPT-5.5

### DIFF
--- a/src/core/providers/ProviderSettingsCoordinator.ts
+++ b/src/core/providers/ProviderSettingsCoordinator.ts
@@ -68,6 +68,17 @@ function normalizeReasoningValue(
   return uiConfig.getDefaultReasoningValue(model);
 }
 
+function normalizeProviderModel(
+  uiConfig: ProviderChatUIConfig,
+  settings: Record<string, unknown>,
+  model: string | undefined,
+): string | undefined {
+  if (!model) {
+    return undefined;
+  }
+  return uiConfig.normalizeModelVariant(model, settings);
+}
+
 export class ProviderSettingsCoordinator {
   static reconcileTitleGenerationModelSelection(settings: Record<string, unknown>): boolean {
     const currentModel = typeof settings.titleGenerationModel === 'string'
@@ -133,16 +144,23 @@ export class ProviderSettingsCoordinator {
     const savedEffort = ensureProjectionMap(settings, 'savedProviderEffort');
     const savedServiceTier = ensureProjectionMap(settings, 'savedProviderServiceTier');
     const savedBudget = ensureProjectionMap(settings, 'savedProviderThinkingBudget');
+    const uiConfig = ProviderRegistry.getChatUIConfig(providerId);
+    const normalizedModel = normalizeProviderModel(
+      uiConfig,
+      settings,
+      typeof settings.model === 'string' ? settings.model : undefined,
+    );
+    const projectedSettings = normalizedModel && normalizedModel !== settings.model
+      ? { ...settings, model: normalizedModel }
+      : settings;
 
-    if (typeof settings.model === 'string') {
-      savedModel[providerId] = settings.model;
+    if (normalizedModel) {
+      savedModel[providerId] = normalizedModel;
     }
     if (typeof settings.effortLevel === 'string') {
       savedEffort[providerId] = settings.effortLevel;
     }
-    const serviceTierToggle = ProviderRegistry
-      .getChatUIConfig(providerId)
-      .getServiceTierToggle?.(settings) ?? null;
+    const serviceTierToggle = uiConfig.getServiceTierToggle?.(projectedSettings) ?? null;
     if (serviceTierToggle && typeof settings.serviceTier === 'string') {
       savedServiceTier[providerId] = settings.serviceTier;
     }
@@ -161,12 +179,15 @@ export class ProviderSettingsCoordinator {
     const savedServiceTier = settings.savedProviderServiceTier as ProviderProjectionMap | undefined;
     const savedBudget = settings.savedProviderThinkingBudget as ProviderProjectionMap | undefined;
 
-    const currentModel = typeof settings.model === 'string' ? settings.model : '';
+    const shouldPreferCurrentProjection = providerId === getSettingsProviderId(settings);
+    const currentModelRaw = typeof settings.model === 'string' ? settings.model : '';
+    const currentModel = shouldPreferCurrentProjection
+      ? (normalizeProviderModel(uiConfig, settings, currentModelRaw) ?? '')
+      : currentModelRaw;
     const currentEffort = typeof settings.effortLevel === 'string' ? settings.effortLevel : undefined;
     const currentServiceTier = typeof settings.serviceTier === 'string' ? settings.serviceTier : undefined;
     const currentBudget = typeof settings.thinkingBudget === 'string' ? settings.thinkingBudget : undefined;
     const modelOptions = uiConfig.getModelOptions(settings);
-    const shouldPreferCurrentProjection = providerId === getSettingsProviderId(settings);
     const isDefaultModelOfAnotherProvider = currentModel.length > 0
       && ProviderRegistry.getRegisteredProviderIds()
         .filter(id => id !== providerId)
@@ -180,7 +201,7 @@ export class ProviderSettingsCoordinator {
     const fallbackModel = canReuseCurrentModel
       ? currentModel
       : (modelOptions[0]?.value ?? currentModel);
-    const savedModelValue = savedModel?.[providerId];
+    const savedModelValue = normalizeProviderModel(uiConfig, settings, savedModel?.[providerId]);
     const isSavedModelValid = savedModelValue !== undefined
       && modelOptions.some(option => option.value === savedModelValue);
     const model = (isSavedModelValid ? savedModelValue : undefined) ?? fallbackModel;

--- a/src/providers/codex/env/CodexSettingsReconciler.ts
+++ b/src/providers/codex/env/CodexSettingsReconciler.ts
@@ -4,6 +4,7 @@ import type { Conversation } from '../../../core/types';
 import { parseEnvironmentVariables } from '../../../utils/env';
 import { getCodexProviderSettings, updateCodexProviderSettings } from '../settings';
 import { getCodexState } from '../types';
+import { DEFAULT_CODEX_PRIMARY_MODEL, normalizeCodexModelVariant } from '../types/models';
 import { codexChatUIConfig } from '../ui/CodexChatUIConfig';
 
 const ENV_HASH_KEYS = ['OPENAI_MODEL', 'OPENAI_BASE_URL', 'OPENAI_API_KEY'];
@@ -48,14 +49,25 @@ export const codexSettingsReconciler: ProviderSettingsReconciler = {
       && settings.model.length > 0
       && !codexChatUIConfig.isDefaultModel(settings.model)
     ) {
-      settings.model = codexChatUIConfig.getModelOptions({})[0]?.value ?? 'gpt-5.4';
+      settings.model = codexChatUIConfig.getModelOptions({})[0]?.value ?? DEFAULT_CODEX_PRIMARY_MODEL;
     }
 
     updateCodexProviderSettings(settings, { environmentHash: currentHash });
     return { changed: true, invalidatedConversations };
   },
 
-  normalizeModelVariantSettings(): boolean {
-    return false;
+  normalizeModelVariantSettings(settings: Record<string, unknown>): boolean {
+    const model = settings.model as string;
+    if (!model) {
+      return false;
+    }
+
+    const normalizedModel = normalizeCodexModelVariant(model);
+    if (normalizedModel === model) {
+      return false;
+    }
+
+    settings.model = normalizedModel;
+    return true;
   },
 };

--- a/src/providers/codex/env/CodexSettingsReconciler.ts
+++ b/src/providers/codex/env/CodexSettingsReconciler.ts
@@ -4,7 +4,7 @@ import type { Conversation } from '../../../core/types';
 import { parseEnvironmentVariables } from '../../../utils/env';
 import { getCodexProviderSettings, updateCodexProviderSettings } from '../settings';
 import { getCodexState } from '../types';
-import { DEFAULT_CODEX_PRIMARY_MODEL, normalizeCodexModelVariant } from '../types/models';
+import { DEFAULT_CODEX_PRIMARY_MODEL } from '../types/models';
 import { codexChatUIConfig } from '../ui/CodexChatUIConfig';
 
 const ENV_HASH_KEYS = ['OPENAI_MODEL', 'OPENAI_BASE_URL', 'OPENAI_API_KEY'];
@@ -62,7 +62,7 @@ export const codexSettingsReconciler: ProviderSettingsReconciler = {
       return false;
     }
 
-    const normalizedModel = normalizeCodexModelVariant(model);
+    const normalizedModel = codexChatUIConfig.normalizeModelVariant(model, settings);
     if (normalizedModel === model) {
       return false;
     }

--- a/src/providers/codex/runtime/CodexAuxQueryRunner.ts
+++ b/src/providers/codex/runtime/CodexAuxQueryRunner.ts
@@ -1,5 +1,6 @@
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type ClaudianPlugin from '../../../main';
+import { DEFAULT_CODEX_PRIMARY_MODEL } from '../types/models';
 import { CodexAppServerProcess } from './CodexAppServerProcess';
 import { resolveCodexAppServerLaunchSpec } from './codexAppServerSupport';
 import type {
@@ -155,7 +156,7 @@ export class CodexAuxQueryRunner {
       this.plugin.settings as unknown as Record<string, unknown>,
       'codex',
     );
-    return (providerSettings.model as string) ?? 'gpt-5.4';
+    return (providerSettings.model as string) ?? DEFAULT_CODEX_PRIMARY_MODEL;
   }
 
   private async startProcess(): Promise<void> {

--- a/src/providers/codex/runtime/CodexChatRuntime.ts
+++ b/src/providers/codex/runtime/CodexChatRuntime.ts
@@ -42,6 +42,7 @@ import {
   findPreferredCodexSkillByName,
 } from '../skills/CodexSkillListingService';
 import { type CodexProviderState, getCodexState } from '../types';
+import { DEFAULT_CODEX_PRIMARY_MODEL, FAST_TIER_CODEX_MODEL } from '../types/models';
 import { CodexAppServerProcess } from './CodexAppServerProcess';
 import {
   initializeCodexAppServerTransport,
@@ -85,7 +86,7 @@ function resolveCodexSandboxConfig(
 }
 
 function resolveCodexServiceTier(serviceTier: unknown, model: string | undefined): string | null {
-  if (model !== 'gpt-5.4') {
+  if (model !== FAST_TIER_CODEX_MODEL) {
     return null;
   }
   return serviceTier === 'fast' ? 'fast' : null;
@@ -403,10 +404,10 @@ export class CodexChatRuntime implements ChatRuntime {
         const permissionMode = this.resolveSandboxConfig();
         await this.transport!.request<ThreadResumeResult>('thread/resume', {
           threadId,
-          model: model ?? 'gpt-5.4',
+          model: model ?? DEFAULT_CODEX_PRIMARY_MODEL,
           approvalPolicy: permissionMode.approvalPolicy,
           sandbox: permissionMode.sandbox,
-          serviceTier: resolveCodexServiceTier(this.getProviderSettings().serviceTier, model ?? 'gpt-5.4'),
+          serviceTier: resolveCodexServiceTier(this.getProviderSettings().serviceTier, model ?? DEFAULT_CODEX_PRIMARY_MODEL),
           baseInstructions: promptText,
           persistExtendedHistory: true,
         });
@@ -442,10 +443,10 @@ export class CodexChatRuntime implements ChatRuntime {
         const permissionMode = this.resolveSandboxConfig();
         const resumeResult = await this.transport!.request<ThreadResumeResult>('thread/resume', {
           threadId: existingThreadId,
-          model: model ?? 'gpt-5.4',
+          model: model ?? DEFAULT_CODEX_PRIMARY_MODEL,
           approvalPolicy: permissionMode.approvalPolicy,
           sandbox: permissionMode.sandbox,
-          serviceTier: resolveCodexServiceTier(this.getProviderSettings().serviceTier, model ?? 'gpt-5.4'),
+          serviceTier: resolveCodexServiceTier(this.getProviderSettings().serviceTier, model ?? DEFAULT_CODEX_PRIMARY_MODEL),
           baseInstructions: promptText,
           persistExtendedHistory: true,
         });
@@ -460,11 +461,11 @@ export class CodexChatRuntime implements ChatRuntime {
         // New thread
         const permissionMode = this.resolveSandboxConfig();
         const startResult = await this.transport!.request<ThreadStartResult>('thread/start', {
-          model: model ?? 'gpt-5.4',
+          model: model ?? DEFAULT_CODEX_PRIMARY_MODEL,
           cwd: this.launchSpec?.targetCwd ?? getVaultPath(this.plugin.app) ?? undefined,
           approvalPolicy: permissionMode.approvalPolicy,
           sandbox: permissionMode.sandbox,
-          serviceTier: resolveCodexServiceTier(this.getProviderSettings().serviceTier, model ?? 'gpt-5.4'),
+          serviceTier: resolveCodexServiceTier(this.getProviderSettings().serviceTier, model ?? DEFAULT_CODEX_PRIMARY_MODEL),
           baseInstructions: promptText,
           experimentalRawEvents: false,
           persistExtendedHistory: true,
@@ -517,7 +518,7 @@ export class CodexChatRuntime implements ChatRuntime {
         // Start turn
         const providerSettings = this.getProviderSettings();
         const effort = EFFORT_MAP[providerSettings.effortLevel as string] ?? 'medium';
-        const resolvedModel = model ?? 'gpt-5.4';
+        const resolvedModel = model ?? DEFAULT_CODEX_PRIMARY_MODEL;
         const isPlanMode = providerSettings.permissionMode === 'plan';
         const externalContextPaths = this.resolveExternalContextPaths(turn, queryOptions);
         const permissionMode = this.resolveSandboxConfig();

--- a/src/providers/codex/types/models.ts
+++ b/src/providers/codex/types/models.ts
@@ -1,0 +1,54 @@
+import type { ProviderUIOption } from '../../../core/providers/types';
+
+export type CodexModel = string;
+
+export const DEFAULT_CODEX_MINI_MODEL: CodexModel = 'gpt-5.4-mini';
+export const DEFAULT_CODEX_PRIMARY_MODEL: CodexModel = 'gpt-5.5';
+export const FAST_TIER_CODEX_MODEL = DEFAULT_CODEX_PRIMARY_MODEL;
+export const LEGACY_CODEX_PRIMARY_MODELS: readonly CodexModel[] = ['gpt-5.4'];
+
+const LEGACY_CODEX_MODEL_MIGRATIONS = new Map<CodexModel, CodexModel>(
+  LEGACY_CODEX_PRIMARY_MODELS.map(model => [model, DEFAULT_CODEX_PRIMARY_MODEL]),
+);
+
+function formatCodexModelSuffix(suffix: string): string {
+  return suffix
+    .split('-')
+    .filter(Boolean)
+    .map(segment => segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase())
+    .join(' ');
+}
+
+export function formatCodexModelLabel(model: string): string {
+  const match = model.match(/^gpt-([^-]+)(?:-(.+))?$/i);
+  if (!match) {
+    return model;
+  }
+
+  const [, version, suffix] = match;
+  return `GPT-${version}${suffix ? ` ${formatCodexModelSuffix(suffix)}` : ''}`;
+}
+
+export function normalizeCodexModelVariant(model: string): string {
+  return LEGACY_CODEX_MODEL_MIGRATIONS.get(model) ?? model;
+}
+
+function createCodexModelOption(model: CodexModel, description: string): ProviderUIOption {
+  return {
+    value: model,
+    label: formatCodexModelLabel(model),
+    description,
+  };
+}
+
+export const DEFAULT_CODEX_MINI_MODEL_LABEL = formatCodexModelLabel(DEFAULT_CODEX_MINI_MODEL);
+export const DEFAULT_CODEX_PRIMARY_MODEL_LABEL = formatCodexModelLabel(DEFAULT_CODEX_PRIMARY_MODEL);
+export const FAST_TIER_CODEX_MODEL_LABEL = formatCodexModelLabel(FAST_TIER_CODEX_MODEL);
+export const FAST_TIER_CODEX_DESCRIPTION = `Enable ${FAST_TIER_CODEX_MODEL_LABEL} fast mode for this conversation. Faster responses use more credits.`;
+
+export const DEFAULT_CODEX_MODELS: ProviderUIOption[] = [
+  createCodexModelOption(DEFAULT_CODEX_MINI_MODEL, 'Fast'),
+  createCodexModelOption(DEFAULT_CODEX_PRIMARY_MODEL, 'Latest'),
+];
+
+export const DEFAULT_CODEX_MODEL_SET = new Set(DEFAULT_CODEX_MODELS.map(model => model.value));

--- a/src/providers/codex/types/models.ts
+++ b/src/providers/codex/types/models.ts
@@ -5,11 +5,6 @@ export type CodexModel = string;
 export const DEFAULT_CODEX_MINI_MODEL: CodexModel = 'gpt-5.4-mini';
 export const DEFAULT_CODEX_PRIMARY_MODEL: CodexModel = 'gpt-5.5';
 export const FAST_TIER_CODEX_MODEL = DEFAULT_CODEX_PRIMARY_MODEL;
-export const LEGACY_CODEX_PRIMARY_MODELS: readonly CodexModel[] = ['gpt-5.4'];
-
-const LEGACY_CODEX_MODEL_MIGRATIONS = new Map<CodexModel, CodexModel>(
-  LEGACY_CODEX_PRIMARY_MODELS.map(model => [model, DEFAULT_CODEX_PRIMARY_MODEL]),
-);
 
 function formatCodexModelSuffix(suffix: string): string {
   return suffix
@@ -27,10 +22,6 @@ export function formatCodexModelLabel(model: string): string {
 
   const [, version, suffix] = match;
   return `GPT-${version}${suffix ? ` ${formatCodexModelSuffix(suffix)}` : ''}`;
-}
-
-export function normalizeCodexModelVariant(model: string): string {
-  return LEGACY_CODEX_MODEL_MIGRATIONS.get(model) ?? model;
 }
 
 function createCodexModelOption(model: CodexModel, description: string): ProviderUIOption {

--- a/src/providers/codex/ui/CodexChatUIConfig.ts
+++ b/src/providers/codex/ui/CodexChatUIConfig.ts
@@ -10,9 +10,9 @@ import type {
 import {
   DEFAULT_CODEX_MODEL_SET,
   DEFAULT_CODEX_MODELS,
+  DEFAULT_CODEX_PRIMARY_MODEL,
   FAST_TIER_CODEX_DESCRIPTION,
   FAST_TIER_CODEX_MODEL,
-  normalizeCodexModelVariant,
 } from '../types/models';
 
 const OPENAI_ICON: ProviderIconSvg = {
@@ -97,8 +97,12 @@ export const codexChatUIConfig: ProviderChatUIConfig = {
     // No-op for Codex
   },
 
-  normalizeModelVariant(model: string): string {
-    return normalizeCodexModelVariant(model);
+  normalizeModelVariant(model: string, settings: Record<string, unknown>): string {
+    if (this.getModelOptions(settings).some((option) => option.value === model)) {
+      return model;
+    }
+
+    return DEFAULT_CODEX_PRIMARY_MODEL;
   },
 
   getCustomModelIds(envVars: Record<string, string>): Set<string> {

--- a/src/providers/codex/ui/CodexChatUIConfig.ts
+++ b/src/providers/codex/ui/CodexChatUIConfig.ts
@@ -7,18 +7,18 @@ import type {
   ProviderServiceTierToggleConfig,
   ProviderUIOption,
 } from '../../../core/providers/types';
+import {
+  DEFAULT_CODEX_MODEL_SET,
+  DEFAULT_CODEX_MODELS,
+  FAST_TIER_CODEX_DESCRIPTION,
+  FAST_TIER_CODEX_MODEL,
+  normalizeCodexModelVariant,
+} from '../types/models';
 
 const OPENAI_ICON: ProviderIconSvg = {
   viewBox: '-1 -.1 949.1 959.8',
   path: 'm925.8 456.3c10.4 23.2 17 48 19.7 73.3 2.6 25.3 1.3 50.9-4.1 75.8-5.3 24.9-14.5 48.8-27.3 70.8-8.4 14.7-18.3 28.5-29.7 41.2-11.3 12.6-23.9 24-37.6 34-13.8 10-28.5 18.4-44.1 25.3-15.5 6.8-31.7 12-48.3 15.4-7.8 24.2-19.4 47.1-34.4 67.7-14.9 20.6-33 38.7-53.6 53.6-20.6 15-43.4 26.6-67.6 34.4-24.2 7.9-49.5 11.8-75 11.8-16.9.1-33.9-1.7-50.5-5.1-16.5-3.5-32.7-8.8-48.2-15.7s-30.2-15.5-43.9-25.5c-13.6-10-26.2-21.5-37.4-34.2-25 5.4-50.6 6.7-75.9 4.1-25.3-2.7-50.1-9.3-73.4-19.7-23.2-10.3-44.7-24.3-63.6-41.4s-35-37.1-47.7-59.1c-8.5-14.7-15.5-30.2-20.8-46.3s-8.8-32.7-10.6-49.6c-1.8-16.8-1.7-33.8.1-50.7 1.8-16.8 5.5-33.4 10.8-49.5-17-18.9-31-40.4-41.4-63.6-10.3-23.3-17-48-19.6-73.3-2.7-25.3-1.3-50.9 4-75.8s14.5-48.8 27.3-70.8c8.4-14.7 18.3-28.6 29.6-41.2s24-24 37.7-34 28.5-18.5 44-25.3c15.6-6.9 31.8-12 48.4-15.4 7.8-24.3 19.4-47.1 34.3-67.7 15-20.6 33.1-38.7 53.7-53.7 20.6-14.9 43.4-26.5 67.6-34.4 24.2-7.8 49.5-11.8 75-11.7 16.9-.1 33.9 1.6 50.5 5.1s32.8 8.7 48.3 15.6c15.5 7 30.2 15.5 43.9 25.5 13.7 10.1 26.3 21.5 37.5 34.2 24.9-5.3 50.5-6.6 75.8-4s50 9.3 73.3 19.6c23.2 10.4 44.7 24.3 63.6 41.4 18.9 17 35 36.9 47.7 59 8.5 14.6 15.5 30.1 20.8 46.3 5.3 16.1 8.9 32.7 10.6 49.6 1.8 16.9 1.8 33.9-.1 50.8-1.8 16.9-5.5 33.5-10.8 49.6 17.1 18.9 31 40.3 41.4 63.6zm-333.2 426.9c21.8-9 41.6-22.3 58.3-39s30-36.5 39-58.4c9-21.8 13.7-45.2 13.7-68.8v-223q-.1-.3-.2-.7-.1-.3-.3-.6-.2-.3-.5-.5-.3-.3-.6-.4l-80.7-46.6v269.4c0 2.7-.4 5.5-1.1 8.1-.7 2.7-1.7 5.2-3.1 7.6s-3 4.6-5 6.5a32.1 32.1 0 0 1-6.5 5l-191.1 110.3c-1.6 1-4.3 2.4-5.7 3.2 7.9 6.7 16.5 12.6 25.5 17.8 9.1 5.2 18.5 9.6 28.3 13.2 9.8 3.5 19.9 6.2 30.1 8 10.3 1.8 20.7 2.7 31.1 2.7 23.6 0 47-4.7 68.8-13.8zm-455.1-151.4c11.9 20.5 27.6 38.3 46.3 52.7 18.8 14.4 40.1 24.9 62.9 31s46.6 7.7 70 4.6 45.9-10.7 66.4-22.5l193.2-111.5.5-.5q.2-.2.3-.6.2-.3.3-.6v-94l-233.2 134.9c-2.4 1.4-4.9 2.4-7.5 3.2-2.7.7-5.4 1-8.2 1-2.7 0-5.4-.3-8.1-1-2.6-.8-5.2-1.8-7.6-3.2l-191.1-110.4c-1.7-1-4.2-2.5-5.6-3.4-1.8 10.3-2.7 20.7-2.7 31.1s1 20.8 2.8 31.1c1.8 10.2 4.6 20.3 8.1 30.1 3.6 9.8 8 19.2 13.2 28.2zm-50.2-417c-11.8 20.5-19.4 43.1-22.5 66.5s-1.5 47.1 4.6 70c6.1 22.8 16.6 44.1 31 62.9 14.4 18.7 32.3 34.4 52.7 46.2l193.1 111.6q.3.1.7.2h.7q.4 0 .7-.2.3-.1.6-.3l81-46.8-233.2-134.6c-2.3-1.4-4.5-3.1-6.5-5a32.1 32.1 0 0 1-5-6.5c-1.3-2.4-2.4-4.9-3.1-7.6-.7-2.6-1.1-5.3-1-8.1v-227.1c-9.8 3.6-19.3 8-28.3 13.2-9 5.3-17.5 11.3-25.5 18-7.9 6.7-15.3 14.1-22 22.1-6.7 7.9-12.6 16.5-17.8 25.5zm663.3 154.4c2.4 1.4 4.6 3 6.6 5 1.9 1.9 3.6 4.1 5 6.5 1.3 2.4 2.4 5 3.1 7.6.6 2.7 1 5.4.9 8.2v227.1c32.1-11.8 60.1-32.5 80.8-59.7 20.8-27.2 33.3-59.7 36.2-93.7s-3.9-68.2-19.7-98.5-39.9-55.5-69.5-72.5l-193.1-111.6q-.3-.1-.7-.2h-.7q-.3.1-.7.2-.3.1-.6.3l-80.6 46.6 233.2 134.7zm80.5-121h-.1v.1zm-.1-.1c5.8-33.6 1.9-68.2-11.3-99.7-13.1-31.5-35-58.6-63-78.2-28-19.5-61-30.7-95.1-32.2-34.2-1.4-68 6.9-97.6 23.9l-193.1 111.5q-.3.2-.5.5l-.4.6q-.1.3-.2.7-.1.3-.1.7v93.2l233.2-134.7c2.4-1.4 5-2.4 7.6-3.2 2.7-.7 5.4-1 8.1-1 2.8 0 5.5.3 8.2 1 2.6.8 5.1 1.8 7.5 3.2l191.1 110.4c1.7 1 4.2 2.4 5.6 3.3zm-505.3-103.2c0-2.7.4-5.4 1.1-8.1.7-2.6 1.7-5.2 3.1-7.6 1.4-2.3 3-4.5 5-6.5 1.9-1.9 4.1-3.6 6.5-4.9l191.1-110.3c1.8-1.1 4.3-2.5 5.7-3.2-26.2-21.9-58.2-35.9-92.1-40.2-33.9-4.4-68.3 1-99.2 15.5-31 14.5-57.2 37.6-75.5 66.4-18.3 28.9-28 62.3-28 96.5v223q.1.4.2.7.1.3.3.6.2.3.5.6.2.2.6.4l80.7 46.6zm43.8 294.7 103.9 60 103.9-60v-119.9l-103.8-60-103.9 60z',
 };
-
-const CODEX_MODELS: ProviderUIOption[] = [
-  { value: 'gpt-5.4-mini', label: 'GPT-5.4 Mini', description: 'Fast' },
-  { value: 'gpt-5.4', label: 'GPT-5.4', description: 'Latest' },
-];
-
-const CODEX_MODEL_SET = new Set(CODEX_MODELS.map(m => m.value));
 
 const EFFORT_LEVELS: ProviderReasoningOption[] = [
   { value: 'low', label: 'Low' },
@@ -41,7 +41,7 @@ const CODEX_SERVICE_TIER_TOGGLE: ProviderServiceTierToggleConfig = {
   inactiveLabel: 'Standard',
   activeValue: 'fast',
   activeLabel: 'Fast',
-  description: 'Enable GPT-5.4 fast mode for this conversation. Faster responses use more credits.',
+  description: FAST_TIER_CODEX_DESCRIPTION,
 };
 
 const DEFAULT_CONTEXT_WINDOW = 200_000;
@@ -55,14 +55,14 @@ export const codexChatUIConfig: ProviderChatUIConfig = {
     const envVars = getRuntimeEnvironmentVariables(settings, 'codex');
     if (envVars.OPENAI_MODEL) {
       const customModel = envVars.OPENAI_MODEL;
-      if (!CODEX_MODEL_SET.has(customModel)) {
+      if (!DEFAULT_CODEX_MODEL_SET.has(customModel)) {
         return [
           { value: customModel, label: customModel, description: 'Custom (env)' },
-          ...CODEX_MODELS,
+          ...DEFAULT_CODEX_MODELS,
         ];
       }
     }
-    return [...CODEX_MODELS];
+    return [...DEFAULT_CODEX_MODELS];
   },
 
   ownsModel(model: string, settings: Record<string, unknown>): boolean {
@@ -90,7 +90,7 @@ export const codexChatUIConfig: ProviderChatUIConfig = {
   },
 
   isDefaultModel(model: string): boolean {
-    return CODEX_MODEL_SET.has(model);
+    return DEFAULT_CODEX_MODEL_SET.has(model);
   },
 
   applyModelDefaults(): void {
@@ -98,12 +98,12 @@ export const codexChatUIConfig: ProviderChatUIConfig = {
   },
 
   normalizeModelVariant(model: string): string {
-    return model;
+    return normalizeCodexModelVariant(model);
   },
 
   getCustomModelIds(envVars: Record<string, string>): Set<string> {
     const ids = new Set<string>();
-    if (envVars.OPENAI_MODEL && !CODEX_MODEL_SET.has(envVars.OPENAI_MODEL)) {
+    if (envVars.OPENAI_MODEL && !DEFAULT_CODEX_MODEL_SET.has(envVars.OPENAI_MODEL)) {
       ids.add(envVars.OPENAI_MODEL);
     }
     return ids;
@@ -114,7 +114,7 @@ export const codexChatUIConfig: ProviderChatUIConfig = {
   },
 
   getServiceTierToggle(settings): ProviderServiceTierToggleConfig | null {
-    return settings.model === 'gpt-5.4' ? CODEX_SERVICE_TIER_TOGGLE : null;
+    return settings.model === FAST_TIER_CODEX_MODEL ? CODEX_SERVICE_TIER_TOGGLE : null;
   },
 
   getProviderIcon() {

--- a/src/providers/codex/ui/CodexSettingsTab.ts
+++ b/src/providers/codex/ui/CodexSettingsTab.ts
@@ -9,6 +9,7 @@ import { expandHomePath } from '../../../utils/path';
 import { getCodexWorkspaceServices } from '../app/CodexWorkspaceServices';
 import { isWindowsStyleCliReference } from '../runtime/CodexBinaryLocator';
 import { getCodexProviderSettings, updateCodexProviderSettings } from '../settings';
+import { DEFAULT_CODEX_PRIMARY_MODEL } from '../types/models';
 import { CodexSkillSettings } from './CodexSkillSettings';
 import { CodexSubagentSettings } from './CodexSubagentSettings';
 
@@ -321,7 +322,7 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
       heading: t('settings.environment'),
       name: 'Codex environment',
       desc: 'Codex-owned runtime variables only. Use this for OPENAI_* and CODEX_* settings. If Codex auto-detection needs help, add its install directory to shared PATH instead of this provider section.',
-      placeholder: 'OPENAI_API_KEY=your-key\nOPENAI_BASE_URL=https://api.openai.com/v1\nOPENAI_MODEL=gpt-5.4\nCODEX_SANDBOX=workspace-write',
+      placeholder: `OPENAI_API_KEY=your-key\nOPENAI_BASE_URL=https://api.openai.com/v1\nOPENAI_MODEL=${DEFAULT_CODEX_PRIMARY_MODEL}\nCODEX_SANDBOX=workspace-write`,
       renderCustomContextLimits: (target) => context.renderCustomContextLimits(target, 'codex'),
     });
   },

--- a/src/providers/codex/ui/CodexSubagentSettings.ts
+++ b/src/providers/codex/ui/CodexSubagentSettings.ts
@@ -3,6 +3,7 @@ import { Modal, Notice, setIcon, Setting } from 'obsidian';
 
 import { confirmDelete } from '../../../shared/modals/ConfirmModal';
 import type { CodexSubagentStorage } from '../storage/CodexSubagentStorage';
+import { DEFAULT_CODEX_PRIMARY_MODEL } from '../types/models';
 import type { CodexSubagentDefinition } from '../types/subagent';
 
 const REASONING_EFFORT_OPTIONS = [
@@ -137,7 +138,7 @@ class CodexSubagentModal extends Modal {
       .addText(text => {
         this._modelInput = text.inputEl;
         text.setValue(this.existing?.model ?? '')
-          .setPlaceholder('gpt-5.4');
+          .setPlaceholder(DEFAULT_CODEX_PRIMARY_MODEL);
       });
 
     new Setting(details)

--- a/tests/unit/core/providers/ProviderSettingsCoordinator.test.ts
+++ b/tests/unit/core/providers/ProviderSettingsCoordinator.test.ts
@@ -4,6 +4,7 @@ import { ProviderRegistry } from '@/core/providers/ProviderRegistry';
 import { ProviderSettingsCoordinator } from '@/core/providers/ProviderSettingsCoordinator';
 import type { Conversation } from '@/core/types';
 import { DEFAULT_CLAUDE_PROVIDER_SETTINGS } from '@/providers/claude/settings';
+import { DEFAULT_CODEX_PRIMARY_MODEL } from '@/providers/codex/types/models';
 
 describe('ProviderSettingsCoordinator', () => {
   describe('normalizeProviderSelection', () => {
@@ -87,6 +88,21 @@ describe('ProviderSettingsCoordinator', () => {
       const result = ProviderSettingsCoordinator.normalizeAllModelVariants(settings);
       expect(typeof result).toBe('boolean');
     });
+
+    it('migrates the active Codex primary model when an older built-in value is persisted', () => {
+      const settings: Record<string, unknown> = {
+        settingsProvider: 'codex',
+        model: 'gpt-5.4',
+        providerConfigs: {
+          codex: { enabled: true },
+        },
+        savedProviderModel: { codex: 'gpt-5.4' },
+      };
+
+      expect(ProviderSettingsCoordinator.normalizeAllModelVariants(settings)).toBe(true);
+      expect(settings.model).toBe(DEFAULT_CODEX_PRIMARY_MODEL);
+      expect(settings.savedProviderModel).toEqual({ codex: DEFAULT_CODEX_PRIMARY_MODEL });
+    });
   });
 
   describe('reconcileTitleGenerationModelSelection', () => {
@@ -136,7 +152,7 @@ describe('ProviderSettingsCoordinator', () => {
         effortLevel: 'high',
         serviceTier: 'default',
         thinkingBudget: 'off',
-        savedProviderModel: { codex: 'gpt-5.4', claude: 'haiku' },
+        savedProviderModel: { codex: DEFAULT_CODEX_PRIMARY_MODEL, claude: 'haiku' },
         savedProviderEffort: { codex: 'medium', claude: 'high' },
         savedProviderServiceTier: { codex: 'fast', claude: 'default' },
         savedProviderThinkingBudget: { codex: '1024', claude: 'off' },
@@ -144,10 +160,32 @@ describe('ProviderSettingsCoordinator', () => {
 
       ProviderSettingsCoordinator.projectActiveProviderState(settings);
 
-      expect(settings.model).toBe('gpt-5.4');
+      expect(settings.model).toBe(DEFAULT_CODEX_PRIMARY_MODEL);
       expect(settings.effortLevel).toBe('medium');
       expect(settings.serviceTier).toBe('fast');
       expect(settings.thinkingBudget).toBe('1024');
+    });
+
+    it('migrates a saved legacy Codex model before projecting provider state', () => {
+      const settings: Record<string, unknown> = {
+        settingsProvider: 'claude',
+        model: 'haiku',
+        effortLevel: 'high',
+        serviceTier: 'default',
+        thinkingBudget: 'off',
+        providerConfigs: {
+          codex: { enabled: true },
+        },
+        savedProviderModel: { claude: 'haiku', codex: 'gpt-5.4' },
+        savedProviderEffort: { claude: 'high', codex: 'medium' },
+        savedProviderServiceTier: { claude: 'default', codex: 'fast' },
+        savedProviderThinkingBudget: { claude: 'off', codex: 'off' },
+      };
+
+      const snapshot = ProviderSettingsCoordinator.getProviderSettingsSnapshot(settings, 'codex');
+
+      expect(snapshot.model).toBe(DEFAULT_CODEX_PRIMARY_MODEL);
+      expect(snapshot.serviceTier).toBe('fast');
     });
 
     it('defaults to claude when settingsProvider is not set', () => {
@@ -232,7 +270,7 @@ describe('ProviderSettingsCoordinator', () => {
         providerConfigs: {
           codex: { enabled: true },
         },
-        model: 'gpt-5.4',
+        model: DEFAULT_CODEX_PRIMARY_MODEL,
         effortLevel: 'low',
         serviceTier: 'fast',
         thinkingBudget: 'off',
@@ -246,7 +284,7 @@ describe('ProviderSettingsCoordinator', () => {
 
       expect(settings.savedProviderModel).toEqual({
         claude: 'haiku',
-        codex: 'gpt-5.4',
+        codex: DEFAULT_CODEX_PRIMARY_MODEL,
       });
       expect(settings.savedProviderEffort).toEqual({
         claude: 'high',
@@ -325,14 +363,14 @@ describe('ProviderSettingsCoordinator', () => {
         providerConfigs: {
           codex: {
             enabled: true,
-            environmentVariables: 'OPENAI_MODEL=gpt-5.4',
+            environmentVariables: `OPENAI_MODEL=${DEFAULT_CODEX_PRIMARY_MODEL}`,
           },
         },
         model: 'haiku',
         effortLevel: 'high',
         serviceTier: 'default',
         thinkingBudget: 'off',
-        savedProviderModel: { claude: 'haiku', codex: 'gpt-5.4' },
+        savedProviderModel: { claude: 'haiku', codex: DEFAULT_CODEX_PRIMARY_MODEL },
         savedProviderEffort: { claude: 'high', codex: 'medium' },
         savedProviderServiceTier: { claude: 'default', codex: 'fast' },
         savedProviderThinkingBudget: { claude: 'off', codex: 'off' },
@@ -346,7 +384,7 @@ describe('ProviderSettingsCoordinator', () => {
       expect(settings.model).toBe('haiku');
       expect(settings.savedProviderModel).toEqual({
         claude: 'haiku',
-        codex: 'gpt-5.4',
+        codex: DEFAULT_CODEX_PRIMARY_MODEL,
       });
       expect(settings.savedProviderServiceTier).toEqual({
         claude: 'default',

--- a/tests/unit/core/providers/modelRouting.test.ts
+++ b/tests/unit/core/providers/modelRouting.test.ts
@@ -1,6 +1,7 @@
 import '@/providers';
 
 import { getEnabledProviderForModel, getProviderForModel } from '@/core/providers/modelRouting';
+import { DEFAULT_CODEX_PRIMARY_MODEL } from '@/providers/codex/types/models';
 
 describe('getProviderForModel', () => {
   it('routes Claude default models to claude', () => {
@@ -15,7 +16,7 @@ describe('getProviderForModel', () => {
   });
 
   it('routes Codex default models to codex', () => {
-    expect(getProviderForModel('gpt-5.4')).toBe('codex');
+    expect(getProviderForModel(DEFAULT_CODEX_PRIMARY_MODEL)).toBe('codex');
   });
 
   it('routes unknown models to claude (default)', () => {
@@ -46,7 +47,7 @@ describe('getProviderForModel', () => {
       settingsProvider: 'claude',
       providerConfigs: {
         claude: {
-          environmentVariables: 'ANTHROPIC_MODEL=gpt-5.4',
+          environmentVariables: `ANTHROPIC_MODEL=${DEFAULT_CODEX_PRIMARY_MODEL}`,
         },
         codex: {
           enabled: false,
@@ -54,7 +55,7 @@ describe('getProviderForModel', () => {
       },
     };
 
-    expect(getProviderForModel('gpt-5.4', settings)).toBe('codex');
-    expect(getEnabledProviderForModel('gpt-5.4', settings)).toBe('claude');
+    expect(getProviderForModel(DEFAULT_CODEX_PRIMARY_MODEL, settings)).toBe('codex');
+    expect(getEnabledProviderForModel(DEFAULT_CODEX_PRIMARY_MODEL, settings)).toBe('claude');
   });
 });

--- a/tests/unit/core/providers/tabLifecycle.test.ts
+++ b/tests/unit/core/providers/tabLifecycle.test.ts
@@ -14,6 +14,7 @@ import '@/providers';
  * - provider lock after bind
  */
 import { getProviderForModel } from '@/core/providers/modelRouting';
+import { DEFAULT_CODEX_PRIMARY_MODEL } from '@/providers/codex/types/models';
 
 describe('Tab Lifecycle - Model-Driven Provider Routing', () => {
   describe('getProviderForModel', () => {
@@ -25,7 +26,7 @@ describe('Tab Lifecycle - Model-Driven Provider Routing', () => {
     });
 
     it('derives codex from Codex model names', () => {
-      expect(getProviderForModel('gpt-5.4')).toBe('codex');
+      expect(getProviderForModel(DEFAULT_CODEX_PRIMARY_MODEL)).toBe('codex');
       expect(getProviderForModel('gpt-4o')).toBe('codex');
       expect(getProviderForModel('o3')).toBe('codex');
       expect(getProviderForModel('o4-mini')).toBe('codex');
@@ -61,12 +62,12 @@ describe('Tab Lifecycle - Blank Tab Behavior', () => {
   });
 
   it('blank tabs derive provider from draft model selection', () => {
-    expect(getProviderForModel('gpt-5.4')).toBe('codex');
+    expect(getProviderForModel(DEFAULT_CODEX_PRIMARY_MODEL)).toBe('codex');
     expect(getProviderForModel('sonnet')).toBe('claude');
   });
 
   it('blank tab with Codex draft model should fall back when Codex is disabled', () => {
-    const draftModel = 'gpt-5.4';
+    const draftModel = DEFAULT_CODEX_PRIMARY_MODEL;
     const draftProvider = getProviderForModel(draftModel);
 
     // Verify the draft is Codex
@@ -82,7 +83,7 @@ describe('Tab Lifecycle - Blank Tab Behavior', () => {
 describe('Tab Lifecycle - Provider Lock After Bind', () => {
   it('cross-provider model change should be rejected on bound sessions', () => {
     const boundProvider = 'claude';
-    const requestedModel = 'gpt-5.4';
+    const requestedModel = DEFAULT_CODEX_PRIMARY_MODEL;
     const requestedProvider = getProviderForModel(requestedModel);
 
     // Provider mismatch should be detected
@@ -197,7 +198,7 @@ describe('Tab Lifecycle - Codex Disable Fallback', () => {
   it('blank tab with Codex draft falls back to Claude default when Codex disabled', () => {
     const tab = {
       lifecycleState: 'blank' as const,
-      draftModel: 'gpt-5.4',
+      draftModel: DEFAULT_CODEX_PRIMARY_MODEL,
       providerId: 'codex' as const,
     };
 

--- a/tests/unit/features/chat/controllers/StreamController.test.ts
+++ b/tests/unit/features/chat/controllers/StreamController.test.ts
@@ -13,6 +13,7 @@ import {
 import type { ChatMessage } from '@/core/types';
 import { StreamController, type StreamControllerDeps } from '@/features/chat/controllers/StreamController';
 import { ChatState } from '@/features/chat/state/ChatState';
+import { DEFAULT_CODEX_PRIMARY_MODEL } from '@/providers/codex/types/models';
 
 jest.mock('@/core/tools/todo', () => ({
   parseTodoInput: jest.fn(),
@@ -310,12 +311,12 @@ describe('StreamController - Text Content', () => {
       const msg = createTestMessage();
       const usage = createMockUsage({ model: undefined });
       const providerSettingsSpy = jest.spyOn(ProviderSettingsCoordinator, 'getProviderSettingsSnapshot');
-      providerSettingsSpy.mockReturnValue({ model: 'gpt-5.4' } as any);
+      providerSettingsSpy.mockReturnValue({ model: DEFAULT_CODEX_PRIMARY_MODEL } as any);
       (deps.getAgentService!() as any).providerId = 'codex';
 
       await controller.handleStreamChunk({ type: 'usage', usage, sessionId: 'session-1' }, msg);
 
-      expect(deps.state.usage).toEqual({ ...usage, model: 'gpt-5.4' });
+      expect(deps.state.usage).toEqual({ ...usage, model: DEFAULT_CODEX_PRIMARY_MODEL });
 
       providerSettingsSpy.mockRestore();
     });
@@ -863,7 +864,7 @@ describe('StreamController - Text Content', () => {
     it('uses authoritative usage chunks directly', async () => {
       const msg = createTestMessage();
       const usage = createMockUsage({
-        model: 'gpt-5.4',
+        model: DEFAULT_CODEX_PRIMARY_MODEL,
         contextWindow: 258400,
         contextWindowIsAuthoritative: true,
         contextTokens: 129200,

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -21,6 +21,10 @@ import {
   type TabCreateOptions,
   wireTabInputEvents,
 } from '@/features/chat/tabs/Tab';
+import {
+  DEFAULT_CODEX_PRIMARY_MODEL,
+  DEFAULT_CODEX_PRIMARY_MODEL_LABEL,
+} from '@/providers/codex/types/models';
 import * as envUtils from '@/utils/env';
 
 // Mock ResizeObserver (not available in jsdom)
@@ -552,12 +556,12 @@ describe('Tab - Creation', () => {
 
     it('should derive the blank-tab provider from the default draft model', () => {
       const plugin = createMockPlugin();
-      plugin.settings.model = 'gpt-5.4';
+      plugin.settings.model = DEFAULT_CODEX_PRIMARY_MODEL;
 
       const tab = createTab(createMockOptions({ plugin }));
 
       expect(tab.lifecycleState).toBe('blank');
-      expect(tab.draftModel).toBe('gpt-5.4');
+      expect(tab.draftModel).toBe(DEFAULT_CODEX_PRIMARY_MODEL);
       expect(tab.providerId).toBe('codex');
     });
 
@@ -566,12 +570,12 @@ describe('Tab - Creation', () => {
       // Top-level model is Claude, but Codex has its own saved model
       plugin.settings.model = 'claude-sonnet-4-5';
       plugin.settings.settingsProvider = 'claude';
-      plugin.settings.savedProviderModel = { claude: 'claude-sonnet-4-5', codex: 'gpt-5.4' };
+      plugin.settings.savedProviderModel = { claude: 'claude-sonnet-4-5', codex: DEFAULT_CODEX_PRIMARY_MODEL };
 
       const tab = createTab(createMockOptions({ plugin, defaultProviderId: 'codex' }));
 
       expect(tab.lifecycleState).toBe('blank');
-      expect(tab.draftModel).toBe('gpt-5.4');
+      expect(tab.draftModel).toBe(DEFAULT_CODEX_PRIMARY_MODEL);
       expect(tab.providerId).toBe('codex');
     });
 
@@ -603,10 +607,10 @@ describe('Tab - Creation', () => {
     it('should keep a Claude custom gpt model on Claude when Codex is disabled', () => {
       const plugin = createMockPlugin();
       plugin.settings.settingsProvider = 'claude';
-      plugin.settings.model = 'gpt-5.4';
+      plugin.settings.model = DEFAULT_CODEX_PRIMARY_MODEL;
       plugin.settings.providerConfigs = {
         claude: {
-          environmentVariables: 'ANTHROPIC_MODEL=gpt-5.4',
+          environmentVariables: `ANTHROPIC_MODEL=${DEFAULT_CODEX_PRIMARY_MODEL}`,
         },
         codex: {
           enabled: false,
@@ -616,7 +620,7 @@ describe('Tab - Creation', () => {
       const tab = createTab(createMockOptions({ plugin }));
 
       expect(tab.lifecycleState).toBe('blank');
-      expect(tab.draftModel).toBe('gpt-5.4');
+      expect(tab.draftModel).toBe(DEFAULT_CODEX_PRIMARY_MODEL);
       expect(tab.providerId).toBe('claude');
     });
 
@@ -632,7 +636,7 @@ describe('Tab - Creation', () => {
       };
       plugin.settings.savedProviderModel = {
         claude: 'opus',
-        codex: 'gpt-5.4',
+        codex: DEFAULT_CODEX_PRIMARY_MODEL,
       };
 
       const tab = createTab(createMockOptions({ plugin, defaultProviderId: 'codex' }));
@@ -887,7 +891,7 @@ describe('Tab - Service Initialization', () => {
       initializeTabUI(tab, plugin);
 
       // Simulate blank tab with Codex draft model
-      tab.draftModel = 'gpt-5.4';
+      tab.draftModel = DEFAULT_CODEX_PRIMARY_MODEL;
       tab.providerId = 'codex';
       tab.lifecycleState = 'blank';
 
@@ -916,10 +920,10 @@ describe('Tab - Service Initialization', () => {
 
       const plugin = createMockPlugin();
       plugin.settings.settingsProvider = 'claude';
-      plugin.settings.model = 'gpt-5.4';
+      plugin.settings.model = DEFAULT_CODEX_PRIMARY_MODEL;
       plugin.settings.providerConfigs = {
         claude: {
-          environmentVariables: 'ANTHROPIC_MODEL=gpt-5.4',
+          environmentVariables: `ANTHROPIC_MODEL=${DEFAULT_CODEX_PRIMARY_MODEL}`,
         },
         codex: {
           enabled: false,
@@ -929,7 +933,7 @@ describe('Tab - Service Initialization', () => {
       const tab = createTab(createMockOptions({ plugin }));
       initializeTabUI(tab, plugin);
 
-      expect(tab.draftModel).toBe('gpt-5.4');
+      expect(tab.draftModel).toBe(DEFAULT_CODEX_PRIMARY_MODEL);
       expect(tab.providerId).toBe('claude');
 
       plugin.settings.providerConfigs = {
@@ -964,7 +968,7 @@ describe('Tab - Service Initialization', () => {
           codexEnabled: true,
           savedProviderModel: {
             claude: 'claude-sonnet-4-5',
-            codex: 'gpt-5.4',
+            codex: DEFAULT_CODEX_PRIMARY_MODEL,
           },
           savedProviderEffort: {
             claude: 'high',
@@ -998,16 +1002,16 @@ describe('Tab - Service Initialization', () => {
       const toolbarCallbacks = toolbarModule.createInputToolbar.mock.calls.at(-1)?.[1];
 
       expect(toolbarCallbacks.getSettings()).toEqual(expect.objectContaining({
-        model: 'gpt-5.4',
+        model: DEFAULT_CODEX_PRIMARY_MODEL,
         effortLevel: 'medium',
       }));
 
-      await toolbarCallbacks.onModelChange('gpt-5.4');
+      await toolbarCallbacks.onModelChange(DEFAULT_CODEX_PRIMARY_MODEL);
 
       expect(plugin.settings.model).toBe('claude-sonnet-4-5');
       expect(plugin.settings.savedProviderModel).toEqual(expect.objectContaining({
         claude: 'claude-sonnet-4-5',
-        codex: 'gpt-5.4',
+        codex: DEFAULT_CODEX_PRIMARY_MODEL,
       }));
       expect(plugin.saveSettings).toHaveBeenCalled();
     });
@@ -1048,7 +1052,7 @@ describe('Tab - Service Initialization', () => {
       jest.spyOn(ProviderRegistry, 'getTaskResultInterpreter').mockReturnValue({} as any);
 
       const plugin = createMockPlugin();
-      plugin.settings.savedProviderModel = { claude: 'claude-sonnet-4-5', codex: 'gpt-5.4' };
+      plugin.settings.savedProviderModel = { claude: 'claude-sonnet-4-5', codex: DEFAULT_CODEX_PRIMARY_MODEL };
       const tab = createTab(createMockOptions({ plugin }));
       initializeTabUI(tab, plugin);
       initializeTabControllers(tab, plugin, {} as any, createMockMcpManager());
@@ -1066,7 +1070,7 @@ describe('Tab - Service Initialization', () => {
       callback();
 
       expect(tab.lifecycleState).toBe('blank');
-      expect(tab.draftModel).toBe('gpt-5.4');
+      expect(tab.draftModel).toBe(DEFAULT_CODEX_PRIMARY_MODEL);
       expect(tab.providerId).toBe('codex');
     });
 
@@ -1076,7 +1080,7 @@ describe('Tab - Service Initialization', () => {
       jest.spyOn(ProviderRegistry, 'getTaskResultInterpreter').mockReturnValue({} as any);
 
       const plugin = createMockPlugin();
-      plugin.settings.savedProviderModel = { claude: 'claude-sonnet-4-5', codex: 'gpt-5.4' };
+      plugin.settings.savedProviderModel = { claude: 'claude-sonnet-4-5', codex: DEFAULT_CODEX_PRIMARY_MODEL };
       const tab = createTab(createMockOptions({ plugin }));
       initializeTabUI(tab, plugin);
       initializeTabControllers(tab, plugin, {} as any, createMockMcpManager());
@@ -1100,7 +1104,7 @@ describe('Tab - Service Initialization', () => {
       expect(tab.serviceInitialized).toBe(false);
       expect(tab.lifecycleState).toBe('blank');
       expect(tab.providerId).toBe('codex');
-      expect(tab.draftModel).toBe('gpt-5.4');
+      expect(tab.draftModel).toBe(DEFAULT_CODEX_PRIMARY_MODEL);
     });
   });
 });
@@ -2367,7 +2371,7 @@ describe('Tab - UI Callback Wiring', () => {
       const plugin = createMockPlugin({
         settings: {
           excludedTags: [],
-          model: 'gpt-5.4',
+          model: DEFAULT_CODEX_PRIMARY_MODEL,
           thinkingBudget: 'low',
           effortLevel: 'high',
           permissionMode: 'yolo',
@@ -2381,7 +2385,7 @@ describe('Tab - UI Callback Wiring', () => {
           codexEnabled: true,
           savedProviderModel: {
             claude: 'claude-sonnet-4-5',
-            codex: 'gpt-5.4',
+            codex: DEFAULT_CODEX_PRIMARY_MODEL,
           },
           savedProviderEffort: {
             claude: 'high',
@@ -3238,7 +3242,7 @@ describe('Tab - Blank Tab Model Selector', () => {
       { value: 'sonnet', label: 'Sonnet' },
     ];
     const codexModels = [
-      { value: 'gpt-5.4', label: 'GPT-5.4' },
+      { value: DEFAULT_CODEX_PRIMARY_MODEL, label: DEFAULT_CODEX_PRIMARY_MODEL_LABEL },
     ];
 
     jest.spyOn(ProviderRegistry, 'getEnabledProviderIds').mockReturnValue(['codex', 'claude']);
@@ -3281,7 +3285,7 @@ describe('Tab - Cross-Provider Model Rejection', () => {
     expect(toolbarCallbacks).toBeDefined();
 
     // Attempt cross-provider model change (Claude -> Codex)
-    await toolbarCallbacks.onModelChange('gpt-5.4');
+    await toolbarCallbacks.onModelChange(DEFAULT_CODEX_PRIMARY_MODEL);
 
     // Should show a Notice rejecting it
     expect(Notice).toHaveBeenCalledWith(expect.stringContaining('Cannot switch provider'));
@@ -3360,9 +3364,9 @@ describe('Tab - Blank Tab Draft Model Change', () => {
     const toolbarCallbacks = toolbarModule.createInputToolbar.mock.calls.at(-1)?.[1];
 
     // Switch to Codex model on blank tab
-    await toolbarCallbacks.onModelChange('gpt-5.4');
+    await toolbarCallbacks.onModelChange(DEFAULT_CODEX_PRIMARY_MODEL);
 
-    expect(tab.draftModel).toBe('gpt-5.4');
+    expect(tab.draftModel).toBe(DEFAULT_CODEX_PRIMARY_MODEL);
     expect(tab.providerId).toBe('codex');
     // No runtime should have been created
     expect(tab.service).toBeNull();
@@ -3398,7 +3402,7 @@ describe('Tab - Blank Tab Draft Model Change', () => {
 
     mockServiceTierToggle.updateDisplay.mockClear();
 
-    await toolbarCallbacks.onModelChange('gpt-5.4');
+    await toolbarCallbacks.onModelChange(DEFAULT_CODEX_PRIMARY_MODEL);
 
     expect(mockServiceTierToggle.updateDisplay).toHaveBeenCalled();
   });
@@ -3410,12 +3414,12 @@ describe('Tab - Blank Tab Draft Model Change', () => {
 
     const plugin = createMockPlugin();
     plugin.settings.settingsProvider = 'codex';
-    plugin.settings.model = 'gpt-5.4';
+    plugin.settings.model = DEFAULT_CODEX_PRIMARY_MODEL;
     plugin.settings.effortLevel = 'medium';
     plugin.settings.serviceTier = 'fast';
     plugin.settings.savedProviderModel = {
       claude: 'claude-sonnet-4-5',
-      codex: 'gpt-5.4',
+      codex: DEFAULT_CODEX_PRIMARY_MODEL,
     };
     plugin.settings.savedProviderEffort = {
       claude: 'high',
@@ -3441,7 +3445,7 @@ describe('Tab - Blank Tab Draft Model Change', () => {
     await toolbarCallbacks.onModelChange('gpt-5.4-mini');
     expect(plugin.settings.savedProviderServiceTier.codex).toBe('fast');
 
-    await toolbarCallbacks.onModelChange('gpt-5.4');
+    await toolbarCallbacks.onModelChange(DEFAULT_CODEX_PRIMARY_MODEL);
     expect(plugin.settings.savedProviderServiceTier.codex).toBe('fast');
   });
 
@@ -3517,7 +3521,7 @@ describe('Tab - Blank Tab Draft Model Change', () => {
     const toolbarCallbacks = toolbarModule.createInputToolbar.mock.calls.at(-1)?.[1];
 
     // Switch to Codex model → should swap catalog
-    await toolbarCallbacks.onModelChange('gpt-5.4');
+    await toolbarCallbacks.onModelChange(DEFAULT_CODEX_PRIMARY_MODEL);
 
     expect(setProviderCatalogSpy).toHaveBeenCalledTimes(1);
     const [config, getEntries] = setProviderCatalogSpy.mock.calls[0];
@@ -3580,7 +3584,7 @@ describe('Tab - Blank Tab Draft Model Change', () => {
         codexEnabled: true,
         savedProviderModel: {
           claude: 'claude-sonnet-4-5',
-          codex: 'gpt-5.4',
+          codex: DEFAULT_CODEX_PRIMARY_MODEL,
         },
         savedProviderEffort: {
           claude: 'high',
@@ -3609,7 +3613,7 @@ describe('Tab - Blank Tab Draft Model Change', () => {
     };
     const toolbarCallbacks = toolbarModule.createInputToolbar.mock.calls.at(-1)?.[1];
 
-    await toolbarCallbacks.onModelChange('gpt-5.4');
+    await toolbarCallbacks.onModelChange(DEFAULT_CODEX_PRIMARY_MODEL);
 
     expect(setHiddenCommandsSpy).toHaveBeenCalledWith(new Set(['analyze']));
   });
@@ -3649,7 +3653,7 @@ describe('Tab - Blank Tab Draft Model Change', () => {
     const initialInstructionCalls = createInstructionRefineServiceSpy.mock.calls.length;
     const initialTitleCalls = createTitleGenerationServiceSpy.mock.calls.length;
 
-    await toolbarCallbacks.onModelChange('gpt-5.4');
+    await toolbarCallbacks.onModelChange(DEFAULT_CODEX_PRIMARY_MODEL);
     await toolbarCallbacks.onModelChange('opus');
 
     expect(staleService.cleanup).toHaveBeenCalledTimes(1);
@@ -3691,7 +3695,7 @@ describe('Tab - First Send Binding', () => {
     const plugin = createMockPlugin();
     const tab = createTab(createMockOptions({ plugin }));
 
-    tab.draftModel = 'gpt-5.4';
+    tab.draftModel = DEFAULT_CODEX_PRIMARY_MODEL;
     tab.providerId = 'codex';
     tab.lifecycleState = 'blank';
 
@@ -3792,7 +3796,7 @@ describe('Tab - History Bind Without Runtime', () => {
         codexEnabled: true,
         savedProviderModel: {
           claude: 'claude-sonnet-4-5',
-          codex: 'gpt-5.4',
+          codex: DEFAULT_CODEX_PRIMARY_MODEL,
         },
         savedProviderEffort: {
           claude: 'high',

--- a/tests/unit/features/chat/tabs/TabManager.test.ts
+++ b/tests/unit/features/chat/tabs/TabManager.test.ts
@@ -7,6 +7,7 @@ import {
   type PersistedTabManagerState,
   type TabManagerCallbacks,
 } from '@/features/chat/tabs/types';
+import { DEFAULT_CODEX_PRIMARY_MODEL } from '@/providers/codex/types/models';
 
 // Mock Tab module functions
 const mockCreateTab = jest.fn();
@@ -907,7 +908,7 @@ describe('TabManager - SDK Commands', () => {
       tabFactory: (n) => createMockTabData({
         id: `tab-${n}`,
         lifecycleState: n === 2 ? 'blank' : 'bound_cold',
-        draftModel: n === 2 ? 'gpt-5.4' : null,
+        draftModel: n === 2 ? DEFAULT_CODEX_PRIMARY_MODEL : null,
         providerId: 'claude',
         service: n === 1 ? readyClaudeService : null,
       }),
@@ -1025,7 +1026,7 @@ describe('TabManager - Provider Command Catalog', () => {
       tabFactory: () => createMockTabData({
         id: 'tab-1',
         lifecycleState: 'blank',
-        draftModel: 'gpt-5.4',
+        draftModel: DEFAULT_CODEX_PRIMARY_MODEL,
         providerId: 'claude',
       }),
     });

--- a/tests/unit/features/chat/ui/InputToolbar.test.ts
+++ b/tests/unit/features/chat/ui/InputToolbar.test.ts
@@ -10,6 +10,10 @@ import {
   ServiceTierToggle,
   ThinkingBudgetSelector,
 } from '@/features/chat/ui/InputToolbar';
+import {
+  DEFAULT_CODEX_PRIMARY_MODEL,
+  DEFAULT_CODEX_PRIMARY_MODEL_LABEL,
+} from '@/providers/codex/types/models';
 
 jest.mock('obsidian', () => ({
   Notice: jest.fn(),
@@ -119,7 +123,7 @@ function createMockUIConfig() {
       planLabel: 'PLAN',
     }),
     getServiceTierToggle: jest.fn().mockImplementation((settings: Record<string, unknown>) =>
-      settings.model === 'gpt-5.4'
+      settings.model === DEFAULT_CODEX_PRIMARY_MODEL
         ? {
           inactiveValue: 'default',
           inactiveLabel: 'Standard',
@@ -280,7 +284,7 @@ describe('ModelSelector', () => {
     const groupedModels = [
       { value: 'opus', label: 'Opus', group: 'Claude' },
       { value: 'sonnet', label: 'Sonnet', group: 'Claude' },
-      { value: 'gpt-5.4', label: 'GPT-5.4', group: 'Codex' },
+      { value: DEFAULT_CODEX_PRIMARY_MODEL, label: DEFAULT_CODEX_PRIMARY_MODEL_LABEL, group: 'Codex' },
     ];
     const uiConfig = createMockUIConfig();
     uiConfig.getModelOptions.mockReturnValue(groupedModels);
@@ -297,7 +301,7 @@ describe('ModelSelector', () => {
 
     const dropdown = parentEl.querySelector('.claudian-model-dropdown');
     const children = dropdown?.children || [];
-    // Reversed: [Codex group, gpt-5.4, Claude group, Sonnet, Opus]
+    // Reversed: [Codex group, built-in Codex model, Claude group, Sonnet, Opus]
     const groups = children.filter((c: any) => c.hasClass('claudian-model-group'));
     expect(groups.length).toBe(2);
     expect(groups[0]?.textContent).toBe('Codex');
@@ -587,7 +591,7 @@ describe('ServiceTierToggle', () => {
     callbacks = createMockCallbacks({
       getUIConfig: jest.fn().mockReturnValue(uiConfig),
       getSettings: jest.fn().mockReturnValue({
-        model: 'gpt-5.4',
+        model: DEFAULT_CODEX_PRIMARY_MODEL,
         thinkingBudget: 'off',
         effortLevel: 'medium',
         serviceTier: 'default',
@@ -614,7 +618,7 @@ describe('ServiceTierToggle', () => {
 
   it('renders the icon button in the active state when fast mode is on', () => {
     callbacks.getSettings.mockReturnValue({
-      model: 'gpt-5.4',
+      model: DEFAULT_CODEX_PRIMARY_MODEL,
       thinkingBudget: 'off',
       effortLevel: 'medium',
       serviceTier: 'fast',
@@ -637,7 +641,7 @@ describe('ServiceTierToggle', () => {
 
   it('toggles from Fast to Standard on click', async () => {
     callbacks.getSettings.mockReturnValue({
-      model: 'gpt-5.4',
+      model: DEFAULT_CODEX_PRIMARY_MODEL,
       thinkingBudget: 'off',
       effortLevel: 'medium',
       serviceTier: 'fast',

--- a/tests/unit/features/chat/utils/usageInfo.test.ts
+++ b/tests/unit/features/chat/utils/usageInfo.test.ts
@@ -1,4 +1,5 @@
 import { calculateUsagePercentage, recalculateUsageForModel } from '@/features/chat/utils/usageInfo';
+import { DEFAULT_CODEX_PRIMARY_MODEL } from '@/providers/codex/types/models';
 
 describe('usageInfo', () => {
   describe('calculateUsagePercentage', () => {
@@ -12,7 +13,7 @@ describe('usageInfo', () => {
   describe('recalculateUsageForModel', () => {
     it('preserves an authoritative context window for the same model', () => {
       const usage = {
-        model: 'gpt-5.4',
+        model: DEFAULT_CODEX_PRIMARY_MODEL,
         inputTokens: 1000,
         cacheCreationInputTokens: 0,
         cacheReadInputTokens: 0,
@@ -22,9 +23,9 @@ describe('usageInfo', () => {
         percentage: 50,
       };
 
-      expect(recalculateUsageForModel(usage, 'gpt-5.4', 200000)).toEqual({
+      expect(recalculateUsageForModel(usage, DEFAULT_CODEX_PRIMARY_MODEL, 200000)).toEqual({
         ...usage,
-        model: 'gpt-5.4',
+        model: DEFAULT_CODEX_PRIMARY_MODEL,
         contextWindow: 258400,
         contextWindowIsAuthoritative: true,
         percentage: 50,
@@ -33,7 +34,7 @@ describe('usageInfo', () => {
 
     it('falls back to the UI context window when the model changes', () => {
       const usage = {
-        model: 'gpt-5.4',
+        model: DEFAULT_CODEX_PRIMARY_MODEL,
         inputTokens: 1000,
         cacheCreationInputTokens: 0,
         cacheReadInputTokens: 0,

--- a/tests/unit/providers/codex/env/CodexSettingsReconciler.test.ts
+++ b/tests/unit/providers/codex/env/CodexSettingsReconciler.test.ts
@@ -1,5 +1,6 @@
 import type { Conversation } from '@/core/types';
 import { codexSettingsReconciler } from '@/providers/codex/env/CodexSettingsReconciler';
+import { DEFAULT_CODEX_PRIMARY_MODEL } from '@/providers/codex/types/models';
 
 describe('codexSettingsReconciler', () => {
   it('invalidates both sessionId and providerState when the Codex env hash changes', () => {
@@ -14,10 +15,10 @@ describe('codexSettingsReconciler', () => {
     } as unknown as Conversation;
 
     const settings: Record<string, unknown> = {
-      model: 'gpt-5.4',
+      model: DEFAULT_CODEX_PRIMARY_MODEL,
       providerConfigs: {
         codex: {
-          environmentVariables: 'OPENAI_MODEL=gpt-5.4',
+          environmentVariables: `OPENAI_MODEL=${DEFAULT_CODEX_PRIMARY_MODEL}`,
           environmentHash: '',
         },
       },
@@ -28,7 +29,7 @@ describe('codexSettingsReconciler', () => {
     expect(result.changed).toBe(true);
     expect(conversation.sessionId).toBeNull();
     expect(conversation.providerState).toBeUndefined();
-    expect(settings.model).toBe('gpt-5.4');
+    expect(settings.model).toBe(DEFAULT_CODEX_PRIMARY_MODEL);
   });
 
   it('restores a built-in model when OPENAI_MODEL is removed', () => {

--- a/tests/unit/providers/codex/runtime/CodexChatRuntime.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexChatRuntime.test.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 
 import type { PreparedChatTurn } from '@/core/runtime/types';
 import type { StreamChunk } from '@/core/types/chat';
+import { DEFAULT_CODEX_PRIMARY_MODEL } from '@/providers/codex/types/models';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -118,7 +119,7 @@ async function emitServerRequest(
 function createMockPlugin(overrides: Record<string, unknown> = {}): any {
   return {
     settings: {
-      model: 'gpt-5.4',
+      model: DEFAULT_CODEX_PRIMARY_MODEL,
       effortLevel: 'medium',
       systemPrompt: '',
       mediaFolder: '',
@@ -245,7 +246,7 @@ function threadStartResponse(threadId = 'thread-001') {
       gitInfo: null,
       name: null,
     },
-    model: 'gpt-5.4',
+    model: DEFAULT_CODEX_PRIMARY_MODEL,
     modelProvider: 'openai_http',
     serviceTier: null,
     cwd: '/test/vault',
@@ -467,7 +468,7 @@ describe('CodexChatRuntime', () => {
       expect(mockTransportRequest).toHaveBeenCalledWith(
         'thread/start',
         expect.objectContaining({
-          model: 'gpt-5.4',
+          model: DEFAULT_CODEX_PRIMARY_MODEL,
           cwd: '/test/vault',
           persistExtendedHistory: true,
           experimentalRawEvents: false,
@@ -1331,7 +1332,7 @@ describe('CodexChatRuntime', () => {
     });
 
     it('sends serviceTier on thread/resume when fast mode is enabled', async () => {
-      const plugin = createMockPlugin({ model: 'gpt-5.4', serviceTier: 'fast' });
+      const plugin = createMockPlugin({ model: DEFAULT_CODEX_PRIMARY_MODEL, serviceTier: 'fast' });
       const rt = new CodexChatRuntime(plugin);
 
       rt.syncConversationState({
@@ -1745,7 +1746,7 @@ describe('CodexChatRuntime', () => {
       expect(turnStartCall[1].collaborationMode).toEqual({
         mode: 'plan',
         settings: {
-          model: 'gpt-5.4',
+          model: DEFAULT_CODEX_PRIMARY_MODEL,
           reasoning_effort: 'medium',
           developer_instructions: null,
         },

--- a/tests/unit/providers/codex/storage/CodexSubagentStorage.test.ts
+++ b/tests/unit/providers/codex/storage/CodexSubagentStorage.test.ts
@@ -7,6 +7,7 @@ import {
   parseSubagentToml,
   serializeSubagentToml,
 } from '@/providers/codex/storage/CodexSubagentStorage';
+import { DEFAULT_CODEX_PRIMARY_MODEL } from '@/providers/codex/types/models';
 import type { CodexSubagentDefinition } from '@/providers/codex/types/subagent';
 
 function createMockAdapter(files: Record<string, string> = {}): VaultFileAdapter {
@@ -51,7 +52,7 @@ Stay in exploration mode.
 Trace the real execution path.
 """
 nickname_candidates = ["Atlas", "Delta", "Echo"]
-model = "gpt-5.4"
+model = "${DEFAULT_CODEX_PRIMARY_MODEL}"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 `;
@@ -74,7 +75,7 @@ describe('parseSubagentToml', () => {
 
     expect(result).not.toBeNull();
     expect(result!.nicknameCandidates).toEqual(['Atlas', 'Delta', 'Echo']);
-    expect(result!.model).toBe('gpt-5.4');
+    expect(result!.model).toBe(DEFAULT_CODEX_PRIMARY_MODEL);
     expect(result!.modelReasoningEffort).toBe('high');
     expect(result!.sandboxMode).toBe('read-only');
   });
@@ -140,7 +141,7 @@ describe('serializeSubagentToml', () => {
       description: 'Explores code.',
       developerInstructions: 'Explore.',
       nicknameCandidates: ['Atlas', 'Delta'],
-      model: 'gpt-5.4',
+      model: DEFAULT_CODEX_PRIMARY_MODEL,
       modelReasoningEffort: 'high',
       sandboxMode: 'read-only',
     };
@@ -149,7 +150,7 @@ describe('serializeSubagentToml', () => {
 
     expect(toml).toContain('nickname_candidates');
     expect(toml).toContain('Atlas');
-    expect(toml).toContain('model = "gpt-5.4"');
+    expect(toml).toContain(`model = "${DEFAULT_CODEX_PRIMARY_MODEL}"`);
     expect(toml).toContain('model_reasoning_effort = "high"');
     expect(toml).toContain('sandbox_mode = "read-only"');
   });

--- a/tests/unit/providers/codex/ui/CodexChatUIConfig.test.ts
+++ b/tests/unit/providers/codex/ui/CodexChatUIConfig.test.ts
@@ -1,3 +1,7 @@
+import {
+  DEFAULT_CODEX_PRIMARY_MODEL,
+  LEGACY_CODEX_PRIMARY_MODELS,
+} from '@/providers/codex/types/models';
 import { codexChatUIConfig } from '@/providers/codex/ui/CodexChatUIConfig';
 
 describe('CodexChatUIConfig', () => {
@@ -5,7 +9,7 @@ describe('CodexChatUIConfig', () => {
     it('should return default models when no env vars', () => {
       const options = codexChatUIConfig.getModelOptions({});
       expect(options).toHaveLength(2);
-      expect(options.map(o => o.value)).toContain('gpt-5.4');
+      expect(options.map(o => o.value)).toContain(DEFAULT_CODEX_PRIMARY_MODEL);
       expect(options.map(o => o.value)).toContain('gpt-5.4-mini');
     });
 
@@ -20,7 +24,7 @@ describe('CodexChatUIConfig', () => {
 
     it('should not duplicate when OPENAI_MODEL matches a default model', () => {
       const options = codexChatUIConfig.getModelOptions({
-        environmentVariables: 'OPENAI_MODEL=gpt-5.4',
+        environmentVariables: `OPENAI_MODEL=${DEFAULT_CODEX_PRIMARY_MODEL}`,
       });
       expect(options.length).toBe(2);
     });
@@ -28,14 +32,14 @@ describe('CodexChatUIConfig', () => {
 
   describe('isAdaptiveReasoningModel', () => {
     it('should return true for all models', () => {
-      expect(codexChatUIConfig.isAdaptiveReasoningModel('gpt-5.4')).toBe(true);
+      expect(codexChatUIConfig.isAdaptiveReasoningModel(DEFAULT_CODEX_PRIMARY_MODEL)).toBe(true);
       expect(codexChatUIConfig.isAdaptiveReasoningModel('unknown-model')).toBe(true);
     });
   });
 
   describe('getReasoningOptions', () => {
     it('should return effort levels', () => {
-      const options = codexChatUIConfig.getReasoningOptions('gpt-5.4');
+      const options = codexChatUIConfig.getReasoningOptions(DEFAULT_CODEX_PRIMARY_MODEL);
       expect(options).toHaveLength(4);
       expect(options.map(o => o.value)).toEqual(['low', 'medium', 'high', 'xhigh']);
     });
@@ -43,19 +47,19 @@ describe('CodexChatUIConfig', () => {
 
   describe('getDefaultReasoningValue', () => {
     it('should return medium for all models', () => {
-      expect(codexChatUIConfig.getDefaultReasoningValue('gpt-5.4')).toBe('medium');
+      expect(codexChatUIConfig.getDefaultReasoningValue(DEFAULT_CODEX_PRIMARY_MODEL)).toBe('medium');
     });
   });
 
   describe('getContextWindowSize', () => {
     it('should return 200000 for all models', () => {
-      expect(codexChatUIConfig.getContextWindowSize('gpt-5.4')).toBe(200_000);
+      expect(codexChatUIConfig.getContextWindowSize(DEFAULT_CODEX_PRIMARY_MODEL)).toBe(200_000);
     });
   });
 
   describe('isDefaultModel', () => {
     it('should return true for built-in models', () => {
-      expect(codexChatUIConfig.isDefaultModel('gpt-5.4')).toBe(true);
+      expect(codexChatUIConfig.isDefaultModel(DEFAULT_CODEX_PRIMARY_MODEL)).toBe(true);
       expect(codexChatUIConfig.isDefaultModel('gpt-5.4-mini')).toBe(true);
     });
 
@@ -65,8 +69,12 @@ describe('CodexChatUIConfig', () => {
   });
 
   describe('normalizeModelVariant', () => {
-    it('should return model as-is', () => {
-      expect(codexChatUIConfig.normalizeModelVariant('gpt-5.4', {})).toBe('gpt-5.4');
+    it('migrates legacy built-in models to the current primary model', () => {
+      expect(codexChatUIConfig.normalizeModelVariant(LEGACY_CODEX_PRIMARY_MODELS[0], {})).toBe(DEFAULT_CODEX_PRIMARY_MODEL);
+    });
+
+    it('should return other models as-is', () => {
+      expect(codexChatUIConfig.normalizeModelVariant(DEFAULT_CODEX_PRIMARY_MODEL, {})).toBe(DEFAULT_CODEX_PRIMARY_MODEL);
       expect(codexChatUIConfig.normalizeModelVariant('custom', {})).toBe('custom');
     });
   });
@@ -78,7 +86,7 @@ describe('CodexChatUIConfig', () => {
     });
 
     it('should not include default models', () => {
-      const ids = codexChatUIConfig.getCustomModelIds({ OPENAI_MODEL: 'gpt-5.4' });
+      const ids = codexChatUIConfig.getCustomModelIds({ OPENAI_MODEL: DEFAULT_CODEX_PRIMARY_MODEL });
       expect(ids.size).toBe(0);
     });
 

--- a/tests/unit/providers/codex/ui/CodexChatUIConfig.test.ts
+++ b/tests/unit/providers/codex/ui/CodexChatUIConfig.test.ts
@@ -1,7 +1,4 @@
-import {
-  DEFAULT_CODEX_PRIMARY_MODEL,
-  LEGACY_CODEX_PRIMARY_MODELS,
-} from '@/providers/codex/types/models';
+import { DEFAULT_CODEX_PRIMARY_MODEL } from '@/providers/codex/types/models';
 import { codexChatUIConfig } from '@/providers/codex/ui/CodexChatUIConfig';
 
 describe('CodexChatUIConfig', () => {
@@ -69,13 +66,15 @@ describe('CodexChatUIConfig', () => {
   });
 
   describe('normalizeModelVariant', () => {
-    it('migrates legacy built-in models to the current primary model', () => {
-      expect(codexChatUIConfig.normalizeModelVariant(LEGACY_CODEX_PRIMARY_MODELS[0], {})).toBe(DEFAULT_CODEX_PRIMARY_MODEL);
+    it('falls back unavailable Codex models to the current primary model', () => {
+      expect(codexChatUIConfig.normalizeModelVariant('gpt-5.4', {})).toBe(DEFAULT_CODEX_PRIMARY_MODEL);
     });
 
-    it('should return other models as-is', () => {
+    it('keeps visible models as-is', () => {
       expect(codexChatUIConfig.normalizeModelVariant(DEFAULT_CODEX_PRIMARY_MODEL, {})).toBe(DEFAULT_CODEX_PRIMARY_MODEL);
-      expect(codexChatUIConfig.normalizeModelVariant('custom', {})).toBe('custom');
+      expect(codexChatUIConfig.normalizeModelVariant('custom', {
+        environmentVariables: 'OPENAI_MODEL=custom',
+      })).toBe('custom');
     });
   });
 


### PR DESCRIPTION
## Summary
- centralize built-in Codex model ids, labels, fast-tier copy, and runtime fallbacks in `src/providers/codex/types/models.ts`
- switch Codex runtime, settings, and UI defaults to the shared GPT-5.5 primary model instead of scattered hardcoded strings
- migrate persisted legacy `gpt-5.4` Codex selections and saved provider projections to `gpt-5.5` so upgraded users keep aligned UI, runtime, and fast-tier behavior

## Testing
- npm run typecheck
- npm run lint
- npm run test
- npm run build