### PR TITLE
Add Codex custom model settings

### DIFF
--- a/src/providers/codex/env/CodexSettingsReconciler.ts
+++ b/src/providers/codex/env/CodexSettingsReconciler.ts
@@ -2,9 +2,9 @@ import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvir
 import type { ProviderSettingsReconciler } from '../../../core/providers/types';
 import type { Conversation } from '../../../core/types';
 import { parseEnvironmentVariables } from '../../../utils/env';
+import { resolveCodexModelSelection } from '../modelOptions';
 import { getCodexProviderSettings, updateCodexProviderSettings } from '../settings';
 import { getCodexState } from '../types';
-import { DEFAULT_CODEX_PRIMARY_MODEL } from '../types/models';
 import { codexChatUIConfig } from '../ui/CodexChatUIConfig';
 
 const ENV_HASH_KEYS = ['OPENAI_MODEL', 'OPENAI_BASE_URL', 'OPENAI_API_KEY'];
@@ -41,15 +41,10 @@ export const codexSettingsReconciler: ProviderSettingsReconciler = {
       }
     }
 
-    const envVars = parseEnvironmentVariables(envText || '');
-    if (envVars.OPENAI_MODEL) {
-      settings.model = envVars.OPENAI_MODEL;
-    } else if (
-      typeof settings.model === 'string'
-      && settings.model.length > 0
-      && !codexChatUIConfig.isDefaultModel(settings.model)
-    ) {
-      settings.model = codexChatUIConfig.getModelOptions({})[0]?.value ?? DEFAULT_CODEX_PRIMARY_MODEL;
+    const currentModel = typeof settings.model === 'string' ? settings.model : '';
+    const nextModel = resolveCodexModelSelection(settings, currentModel);
+    if (nextModel) {
+      settings.model = nextModel;
     }
 
     updateCodexProviderSettings(settings, { environmentHash: currentHash });

--- a/src/providers/codex/modelOptions.ts
+++ b/src/providers/codex/modelOptions.ts
@@ -1,0 +1,84 @@
+import { getRuntimeEnvironmentVariables } from '../../core/providers/providerEnvironment';
+import type { ProviderUIOption } from '../../core/providers/types';
+import { getCodexProviderSettings } from './settings';
+import {
+  DEFAULT_CODEX_MODEL_SET,
+  DEFAULT_CODEX_MODELS,
+  DEFAULT_CODEX_PRIMARY_MODEL,
+  formatCodexModelLabel,
+} from './types/models';
+
+function createCustomCodexModelOption(modelId: string, description: string): ProviderUIOption {
+  return {
+    value: modelId,
+    label: formatCodexModelLabel(modelId),
+    description,
+  };
+}
+
+function getConfiguredEnvModel(settings: Record<string, unknown>): string | null {
+  const modelId = getRuntimeEnvironmentVariables(settings, 'codex').OPENAI_MODEL?.trim();
+  return modelId ? modelId : null;
+}
+
+export function getConfiguredEnvCustomModel(settings: Record<string, unknown>): string | null {
+  const modelId = getConfiguredEnvModel(settings);
+  return modelId && !DEFAULT_CODEX_MODEL_SET.has(modelId) ? modelId : null;
+}
+
+export function parseConfiguredCustomModelIds(value: string): string[] {
+  const modelIds: string[] = [];
+  const seen = new Set<string>();
+
+  for (const line of value.split(/\r?\n/)) {
+    const modelId = line.trim();
+    if (!modelId || seen.has(modelId)) {
+      continue;
+    }
+
+    seen.add(modelId);
+    modelIds.push(modelId);
+  }
+
+  return modelIds;
+}
+
+export function getCodexModelOptions(settings: Record<string, unknown>): ProviderUIOption[] {
+  const models = [...DEFAULT_CODEX_MODELS];
+  const seenValues = new Set(models.map(model => model.value));
+
+  const envModel = getConfiguredEnvCustomModel(settings);
+  if (envModel) {
+    seenValues.add(envModel);
+    models.unshift(createCustomCodexModelOption(envModel, 'Custom (env)'));
+  }
+
+  const codexSettings = getCodexProviderSettings(settings);
+  for (const modelId of parseConfiguredCustomModelIds(codexSettings.customModels)) {
+    if (seenValues.has(modelId)) {
+      continue;
+    }
+
+    seenValues.add(modelId);
+    models.push(createCustomCodexModelOption(modelId, 'Custom model'));
+  }
+
+  return models;
+}
+
+export function resolveCodexModelSelection(
+  settings: Record<string, unknown>,
+  currentModel: string,
+): string | null {
+  const envModel = getConfiguredEnvModel(settings);
+  if (envModel) {
+    return envModel;
+  }
+
+  const modelOptions = getCodexModelOptions(settings);
+  if (currentModel && modelOptions.some(option => option.value === currentModel)) {
+    return currentModel;
+  }
+
+  return modelOptions[0]?.value ?? DEFAULT_CODEX_PRIMARY_MODEL;
+}

--- a/src/providers/codex/settings.ts
+++ b/src/providers/codex/settings.ts
@@ -21,6 +21,7 @@ export interface CodexProviderSettings {
   safeMode: CodexSafeMode;
   cliPath: string;
   cliPathsByHost: HostnameCliPaths;
+  customModels: string;
   reasoningSummary: CodexReasoningSummary;
   environmentVariables: string;
   environmentHash: string;
@@ -35,6 +36,7 @@ export const DEFAULT_CODEX_PROVIDER_SETTINGS: Readonly<CodexProviderSettings> = 
   safeMode: 'workspace-write',
   cliPath: '',
   cliPathsByHost: {},
+  customModels: '',
   reasoningSummary: 'detailed',
   environmentVariables: '',
   environmentHash: '',
@@ -95,6 +97,8 @@ export function getCodexProviderSettings(
       ?? (settings.codexCliPath as string | undefined)
       ?? DEFAULT_CODEX_PROVIDER_SETTINGS.cliPath,
     cliPathsByHost: normalizeHostnameCliPaths(config.cliPathsByHost ?? settings.codexCliPathsByHost),
+    customModels: (config.customModels as string | undefined)
+      ?? DEFAULT_CODEX_PROVIDER_SETTINGS.customModels,
     reasoningSummary: (config.reasoningSummary as CodexReasoningSummary | undefined)
       ?? (settings.codexReasoningSummary as CodexReasoningSummary | undefined)
       ?? DEFAULT_CODEX_PROVIDER_SETTINGS.reasoningSummary,
@@ -177,6 +181,7 @@ export function updateCodexProviderSettings(
     safeMode: next.safeMode,
     cliPath: next.cliPath,
     cliPathsByHost: next.cliPathsByHost,
+    customModels: next.customModels,
     reasoningSummary: next.reasoningSummary,
     environmentVariables: next.environmentVariables,
     environmentHash: next.environmentHash,

--- a/src/providers/codex/ui/CodexChatUIConfig.ts
+++ b/src/providers/codex/ui/CodexChatUIConfig.ts
@@ -1,4 +1,3 @@
-import { getRuntimeEnvironmentVariables } from '../../../core/providers/providerEnvironment';
 import type {
   ProviderChatUIConfig,
   ProviderIconSvg,
@@ -7,9 +6,9 @@ import type {
   ProviderServiceTierToggleConfig,
   ProviderUIOption,
 } from '../../../core/providers/types';
+import { getCodexModelOptions } from '../modelOptions';
 import {
   DEFAULT_CODEX_MODEL_SET,
-  DEFAULT_CODEX_MODELS,
   DEFAULT_CODEX_PRIMARY_MODEL,
   FAST_TIER_CODEX_DESCRIPTION,
   FAST_TIER_CODEX_MODEL,
@@ -52,17 +51,7 @@ function looksLikeCodexModel(model: string): boolean {
 
 export const codexChatUIConfig: ProviderChatUIConfig = {
   getModelOptions(settings: Record<string, unknown>): ProviderUIOption[] {
-    const envVars = getRuntimeEnvironmentVariables(settings, 'codex');
-    if (envVars.OPENAI_MODEL) {
-      const customModel = envVars.OPENAI_MODEL;
-      if (!DEFAULT_CODEX_MODEL_SET.has(customModel)) {
-        return [
-          { value: customModel, label: customModel, description: 'Custom (env)' },
-          ...DEFAULT_CODEX_MODELS,
-        ];
-      }
-    }
-    return [...DEFAULT_CODEX_MODELS];
+    return getCodexModelOptions(settings);
   },
 
   ownsModel(model: string, settings: Record<string, unknown>): boolean {
@@ -98,7 +87,7 @@ export const codexChatUIConfig: ProviderChatUIConfig = {
   },
 
   normalizeModelVariant(model: string, settings: Record<string, unknown>): string {
-    if (this.getModelOptions(settings).some((option) => option.value === model)) {
+    if (getCodexModelOptions(settings).some((option) => option.value === model)) {
       return model;
     }
 

--- a/src/providers/codex/ui/CodexSettingsTab.ts
+++ b/src/providers/codex/ui/CodexSettingsTab.ts
@@ -1,12 +1,14 @@
 import * as fs from 'fs';
 import { Setting } from 'obsidian';
 
+import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type { ProviderSettingsTabRenderer } from '../../../core/providers/types';
 import { renderEnvironmentSettingsSection } from '../../../features/settings/ui/EnvironmentSettingsSection';
 import { t } from '../../../i18n/i18n';
 import { getHostnameKey } from '../../../utils/env';
 import { expandHomePath } from '../../../utils/path';
 import { getCodexWorkspaceServices } from '../app/CodexWorkspaceServices';
+import { parseConfiguredCustomModelIds, resolveCodexModelSelection } from '../modelOptions';
 import { isWindowsStyleCliReference } from '../runtime/CodexBinaryLocator';
 import { getCodexProviderSettings, updateCodexProviderSettings } from '../settings';
 import { DEFAULT_CODEX_PRIMARY_MODEL } from '../types/models';
@@ -21,6 +23,21 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
     const hostnameKey = getHostnameKey();
     const isWindowsHost = process.platform === 'win32';
     let installationMethod = codexSettings.installationMethod;
+
+    const reconcileActiveCodexModelSelection = (): void => {
+      const activeProvider = settingsBag.settingsProvider;
+      if (activeProvider !== 'codex') {
+        return;
+      }
+
+      const currentModel = typeof settingsBag.model === 'string' ? settingsBag.model : '';
+      const nextModel = resolveCodexModelSelection(settingsBag, currentModel);
+      if (!nextModel || nextModel === currentModel) {
+        return;
+      }
+
+      settingsBag.model = nextModel;
+    };
 
     // --- Setup ---
 
@@ -245,6 +262,96 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
       { value: 'detailed', label: 'Detailed' },
       { value: 'none', label: 'Off' },
     ];
+
+    new Setting(container)
+      .setName('Custom models')
+      .setDesc('Append additional Codex model IDs to the picker, one per line. OPENAI_MODEL still takes precedence when set.')
+      .addTextArea((text) => {
+        let pendingCustomModels = codexSettings.customModels;
+        let savedCustomModels = codexSettings.customModels;
+
+        const reconcileInactiveCodexProjection = (
+          previousCustomModels: string,
+        ): boolean => {
+          if (settingsBag.settingsProvider === 'codex') {
+            return false;
+          }
+
+          const savedProviderModel = (
+            settingsBag.savedProviderModel
+            && typeof settingsBag.savedProviderModel === 'object'
+          )
+            ? settingsBag.savedProviderModel as Record<string, unknown>
+            : {};
+          const currentSavedModel = typeof savedProviderModel.codex === 'string'
+            ? savedProviderModel.codex
+            : '';
+          if (!currentSavedModel) {
+            return false;
+          }
+
+          const previousCustomModelIds = new Set(parseConfiguredCustomModelIds(previousCustomModels));
+          if (!previousCustomModelIds.has(currentSavedModel)) {
+            return false;
+          }
+
+          const nextSavedModel = resolveCodexModelSelection(settingsBag, currentSavedModel);
+          if (!nextSavedModel || nextSavedModel === currentSavedModel) {
+            return false;
+          }
+
+          settingsBag.savedProviderModel = {
+            ...savedProviderModel,
+            codex: nextSavedModel,
+          };
+          return true;
+        };
+
+        const commitCustomModels = async (): Promise<void> => {
+          const previousCustomModels = savedCustomModels;
+          const previousModel = typeof settingsBag.model === 'string' ? settingsBag.model : '';
+          const previousTitleModel = typeof settingsBag.titleGenerationModel === 'string'
+            ? settingsBag.titleGenerationModel
+            : '';
+
+          if (pendingCustomModels !== savedCustomModels) {
+            updateCodexProviderSettings(settingsBag, { customModels: pendingCustomModels });
+            savedCustomModels = pendingCustomModels;
+          }
+
+          reconcileActiveCodexModelSelection();
+          const didReconcileInactiveProjection = reconcileInactiveCodexProjection(previousCustomModels);
+          const didReconcileTitleModel = ProviderSettingsCoordinator
+            .reconcileTitleGenerationModelSelection(settingsBag);
+          const nextModel = typeof settingsBag.model === 'string' ? settingsBag.model : '';
+          const nextTitleModel = typeof settingsBag.titleGenerationModel === 'string'
+            ? settingsBag.titleGenerationModel
+            : '';
+          const didModelSelectionChange = previousModel !== nextModel;
+          const didCustomModelsChange = previousCustomModels !== savedCustomModels;
+
+          if (!didCustomModelsChange && !didModelSelectionChange && !didReconcileInactiveProjection
+            && !didReconcileTitleModel
+            && previousTitleModel === nextTitleModel) {
+            return;
+          }
+
+          await context.plugin.saveSettings();
+          context.refreshModelSelectors();
+        };
+
+        text
+          .setPlaceholder('gpt-5.6-preview\no4-mini\nmy-custom-model')
+          .setValue(codexSettings.customModels)
+          .onChange((value) => {
+            pendingCustomModels = value;
+          });
+        text.inputEl.rows = 4;
+        text.inputEl.cols = 40;
+        text.inputEl.addEventListener('blur', () => {
+          void commitCustomModels();
+        });
+      });
 
     new Setting(container)
       .setName('Reasoning summary')

--- a/tests/unit/core/providers/ProviderSettingsCoordinator.test.ts
+++ b/tests/unit/core/providers/ProviderSettingsCoordinator.test.ts
@@ -139,6 +139,23 @@ describe('ProviderSettingsCoordinator', () => {
       ).toBe(true);
       expect(settings.titleGenerationModel).toBe('');
     });
+
+    it('keeps Codex custom title models while they are still available', () => {
+      const settings: Record<string, unknown> = {
+        titleGenerationModel: 'my-custom-model',
+        providerConfigs: {
+          codex: {
+            enabled: true,
+            customModels: 'my-custom-model',
+          },
+        },
+      };
+
+      expect(
+        ProviderSettingsCoordinator.reconcileTitleGenerationModelSelection(settings),
+      ).toBe(false);
+      expect(settings.titleGenerationModel).toBe('my-custom-model');
+    });
   });
 
   describe('projectActiveProviderState', () => {

--- a/tests/unit/core/providers/modelRouting.test.ts
+++ b/tests/unit/core/providers/modelRouting.test.ts
@@ -38,6 +38,19 @@ describe('getProviderForModel', () => {
     expect(getProviderForModel('my-custom-model', settings)).toBe('codex');
   });
 
+  it('routes settings-defined custom Codex models to codex when settings are provided', () => {
+    const settings = {
+      providerConfigs: {
+        codex: {
+          enabled: true,
+          customModels: 'my-custom-model',
+        },
+      },
+    };
+
+    expect(getProviderForModel('my-custom-model', settings)).toBe('codex');
+  });
+
   it('routes custom OPENAI_MODEL to claude without settings (no context)', () => {
     expect(getProviderForModel('my-custom-model')).toBe('claude');
   });

--- a/tests/unit/providers/codex/env/CodexSettingsReconciler.test.ts
+++ b/tests/unit/providers/codex/env/CodexSettingsReconciler.test.ts
@@ -32,13 +32,48 @@ describe('codexSettingsReconciler', () => {
     expect(settings.model).toBe(DEFAULT_CODEX_PRIMARY_MODEL);
   });
 
-  it('restores a built-in model when OPENAI_MODEL is removed', () => {
+  it('preserves an active settings-defined custom model across non-model env changes', () => {
+    const conversation = {
+      providerId: 'codex',
+      sessionId: 'thread-123',
+      providerState: {
+        threadId: 'thread-123',
+        sessionFilePath: '/tmp/thread-123.jsonl',
+      },
+      messages: [],
+    } as unknown as Conversation;
+
     const settings: Record<string, unknown> = {
       model: 'my-custom-model',
       providerConfigs: {
         codex: {
-          environmentVariables: '',
-          environmentHash: 'OPENAI_MODEL=my-custom-model',
+          customModels: 'my-custom-model',
+          environmentVariables: 'OPENAI_BASE_URL=https://api.example.com/v1',
+          environmentHash: '',
+        },
+      },
+    };
+
+    const result = codexSettingsReconciler.reconcileModelWithEnvironment(settings, [conversation]);
+
+    expect(result.changed).toBe(true);
+    expect(result.invalidatedConversations).toEqual([conversation]);
+    expect(conversation.sessionId).toBeNull();
+    expect(conversation.providerState).toBeUndefined();
+    expect(settings.model).toBe('my-custom-model');
+    expect((settings.providerConfigs as any).codex.environmentHash).toBe(
+      'OPENAI_BASE_URL=https://api.example.com/v1',
+    );
+  });
+
+  it('restores a built-in model when a settings-defined custom model is removed', () => {
+    const settings: Record<string, unknown> = {
+      model: 'my-custom-model',
+      providerConfigs: {
+        codex: {
+          customModels: '',
+          environmentVariables: 'OPENAI_BASE_URL=https://api.example.com/v1',
+          environmentHash: '',
         },
       },
     };
@@ -47,6 +82,8 @@ describe('codexSettingsReconciler', () => {
 
     expect(result.changed).toBe(true);
     expect(settings.model).toBe('gpt-5.4-mini');
-    expect((settings.providerConfigs as any).codex.environmentHash).toBe('');
+    expect((settings.providerConfigs as any).codex.environmentHash).toBe(
+      'OPENAI_BASE_URL=https://api.example.com/v1',
+    );
   });
 });

--- a/tests/unit/providers/codex/settings.test.ts
+++ b/tests/unit/providers/codex/settings.test.ts
@@ -18,6 +18,7 @@ describe('codex settings', () => {
   it('defaults installationMethod to native-windows and leaves wslDistroOverride empty', () => {
     const settings = getCodexProviderSettings({});
 
+    expect(settings.customModels).toBe('');
     expect(settings.installationMethod).toBe('native-windows');
     expect(settings.wslDistroOverride).toBe('');
     expect(settings.installationMethod).toBe(DEFAULT_CODEX_PROVIDER_SETTINGS.installationMethod);

--- a/tests/unit/providers/codex/ui/CodexChatUIConfig.test.ts
+++ b/tests/unit/providers/codex/ui/CodexChatUIConfig.test.ts
@@ -10,6 +10,39 @@ describe('CodexChatUIConfig', () => {
       expect(options.map(o => o.value)).toContain('gpt-5.4-mini');
     });
 
+    it('appends settings-defined custom models after the built-in options', () => {
+      const options = codexChatUIConfig.getModelOptions({
+        providerConfigs: {
+          codex: {
+            customModels: 'gpt-5.6-preview\nmy-custom-model\nmy-custom-model',
+          },
+        },
+      });
+
+      expect(options).toEqual([
+        {
+          value: 'gpt-5.4-mini',
+          label: 'GPT-5.4 Mini',
+          description: 'Fast',
+        },
+        {
+          value: DEFAULT_CODEX_PRIMARY_MODEL,
+          label: 'GPT-5.5',
+          description: 'Latest',
+        },
+        {
+          value: 'gpt-5.6-preview',
+          label: 'GPT-5.6 Preview',
+          description: 'Custom model',
+        },
+        {
+          value: 'my-custom-model',
+          label: 'my-custom-model',
+          description: 'Custom model',
+        },
+      ]);
+    });
+
     it('should prepend custom model from OPENAI_MODEL env var', () => {
       const options = codexChatUIConfig.getModelOptions({
         environmentVariables: 'OPENAI_MODEL=my-custom-model',
@@ -17,6 +50,24 @@ describe('CodexChatUIConfig', () => {
       expect(options[0].value).toBe('my-custom-model');
       expect(options[0].description).toBe('Custom (env)');
       expect(options.length).toBe(3);
+    });
+
+    it('deduplicates env and settings-defined custom models', () => {
+      const options = codexChatUIConfig.getModelOptions({
+        providerConfigs: {
+          codex: {
+            customModels: 'my-custom-model\nsecond-custom-model',
+            environmentVariables: 'OPENAI_MODEL=my-custom-model',
+          },
+        },
+      });
+
+      expect(options.map(option => option.value)).toEqual([
+        'my-custom-model',
+        'gpt-5.4-mini',
+        DEFAULT_CODEX_PRIMARY_MODEL,
+        'second-custom-model',
+      ]);
     });
 
     it('should not duplicate when OPENAI_MODEL matches a default model', () => {
@@ -75,6 +126,13 @@ describe('CodexChatUIConfig', () => {
       expect(codexChatUIConfig.normalizeModelVariant('custom', {
         environmentVariables: 'OPENAI_MODEL=custom',
       })).toBe('custom');
+      expect(codexChatUIConfig.normalizeModelVariant('settings-custom', {
+        providerConfigs: {
+          codex: {
+            customModels: 'settings-custom',
+          },
+        },
+      })).toBe('settings-custom');
     });
   });
 

--- a/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
+++ b/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 
+import { DEFAULT_CODEX_PROVIDER_SETTINGS } from '@/providers/codex/settings';
 import { codexSettingsTabRenderer } from '@/providers/codex/ui/CodexSettingsTab';
 
 const mockGetHostnameKey = jest.fn(() => 'host-a');
@@ -8,12 +9,28 @@ const mockSaveSettings = jest.fn().mockResolvedValue(undefined);
 const mockBroadcastToAllTabs = jest.fn().mockResolvedValue(undefined);
 
 jest.mock('fs');
+jest.mock('@/core/providers/ProviderSettingsCoordinator', () => ({
+  ProviderSettingsCoordinator: {
+    reconcileTitleGenerationModelSelection: jest.fn((settings: Record<string, unknown>) => {
+      const titleGenerationModel = settings.titleGenerationModel;
+      const customModels = (
+        settings.providerConfigs as { codex?: { customModels?: string } } | undefined
+      )?.codex?.customModels ?? '';
+      if (titleGenerationModel === 'my-custom-model' && customModels !== 'my-custom-model') {
+        settings.titleGenerationModel = '';
+        return true;
+      }
+      return false;
+    }),
+  },
+}));
 jest.mock('obsidian', () => {
   class MockSetting {
     public name = '';
     public desc = '';
     public heading = false;
     public textComponents: MockTextComponent[] = [];
+    public textAreaComponents: MockTextAreaComponent[] = [];
     public dropdownComponents: MockDropdownComponent[] = [];
     public toggleComponents: MockToggleComponent[] = [];
     public settingEl = { style: {} };
@@ -40,6 +57,13 @@ jest.mock('obsidian', () => {
     addText(callback: (text: MockTextComponent) => void) {
       const component = createTextComponent();
       this.textComponents.push(component);
+      callback(component);
+      return this;
+    }
+
+    addTextArea(callback: (text: MockTextAreaComponent) => void) {
+      const component = createTextAreaComponent();
+      this.textAreaComponents.push(component);
       callback(component);
       return this;
     }
@@ -89,6 +113,7 @@ jest.mock('@/i18n/i18n', () => ({
 }));
 
 jest.mock('@/utils/env', () => ({
+  ...jest.requireActual('@/utils/env'),
   getHostnameKey: () => mockGetHostnameKey(),
 }));
 
@@ -99,11 +124,11 @@ interface MockTextComponent {
   setPlaceholder: jest.MockedFunction<(value: string) => MockTextComponent>;
   setValue: jest.MockedFunction<(value: string) => MockTextComponent>;
   onChange: jest.MockedFunction<(callback: (value: string) => Promise<void> | void) => MockTextComponent>;
-  inputEl: {
-    value: string;
-    style: Record<string, string>;
-    addClass: jest.Mock;
-  };
+  inputEl: MockInputEl;
+}
+
+interface MockTextAreaComponent extends MockTextComponent {
+  trigger: (event: string) => Promise<void>;
 }
 
 interface MockDropdownComponent {
@@ -127,20 +152,43 @@ const createdSettings: Array<{
   desc: string;
   heading: boolean;
   textComponents: MockTextComponent[];
+  textAreaComponents: MockTextAreaComponent[];
   dropdownComponents: MockDropdownComponent[];
   toggleComponents: MockToggleComponent[];
 }> = [];
+
+interface MockInputEl {
+  rows: number;
+  cols: number;
+  value: string;
+  style: Record<string, string>;
+  addClass: jest.Mock;
+  addEventListener: jest.Mock;
+}
+
+function createInputEl(): MockInputEl & { _listeners: Map<string, Array<() => void>> } {
+  const listeners = new Map<string, Array<() => void>>();
+  return {
+    rows: 0,
+    cols: 0,
+    value: '',
+    style: {},
+    addClass: jest.fn(),
+    addEventListener: jest.fn((event: string, handler: () => void) => {
+      const handlers = listeners.get(event) ?? [];
+      handlers.push(handler);
+      listeners.set(event, handlers);
+    }),
+    _listeners: listeners,
+  };
+}
 
 function createTextComponent(): MockTextComponent {
   const component = {} as MockTextComponent;
   component.value = '';
   component.placeholder = '';
   component.onChangeCallback = null;
-  component.inputEl = {
-    value: '',
-    style: {},
-    addClass: jest.fn(),
-  };
+  component.inputEl = createInputEl();
   component.setPlaceholder = jest.fn((value: string) => {
     component.placeholder = value;
     return component;
@@ -155,6 +203,18 @@ function createTextComponent(): MockTextComponent {
     return component;
   });
 
+  return component;
+}
+
+function createTextAreaComponent(): MockTextAreaComponent {
+  const component = createTextComponent() as MockTextAreaComponent;
+  component.trigger = async (event: string) => {
+    const handlers = (component.inputEl as ReturnType<typeof createInputEl>)._listeners.get(event) ?? [];
+    for (const handler of handlers) {
+      handler();
+    }
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  };
   return component;
 }
 
@@ -220,19 +280,14 @@ function createContainer(): any {
 function createPlugin(overrides: Record<string, unknown> = {}): any {
   return {
     settings: {
+      settingsProvider: 'codex',
+      model: 'my-custom-model',
+      titleGenerationModel: '',
       providerConfigs: {
         codex: {
+          ...DEFAULT_CODEX_PROVIDER_SETTINGS,
           enabled: true,
-          safeMode: 'workspace-write',
-          cliPath: '',
-          cliPathsByHost: {},
-          reasoningSummary: 'detailed',
-          environmentVariables: '',
-          environmentHash: '',
-          installationMethod: 'native-windows',
-          installationMethodsByHost: {},
-          wslDistroOverride: '',
-          wslDistroOverridesByHost: {},
+          customModels: 'my-custom-model',
         },
       },
       ...overrides,
@@ -372,19 +427,11 @@ describe('CodexSettingsTab', () => {
     const plugin = createPlugin({
       providerConfigs: {
         codex: {
+          ...DEFAULT_CODEX_PROVIDER_SETTINGS,
           enabled: true,
-          safeMode: 'workspace-write',
-          cliPath: '',
           cliPathsByHost: {
             'host-a': 'C:\\Users\\me\\AppData\\Roaming\\npm\\codex.exe',
           },
-          reasoningSummary: 'detailed',
-          environmentVariables: '',
-          environmentHash: '',
-          installationMethod: 'native-windows',
-          installationMethodsByHost: {},
-          wslDistroOverride: '',
-          wslDistroOverridesByHost: {},
         },
       },
     });
@@ -404,5 +451,73 @@ describe('CodexSettingsTab', () => {
       'C:\\Users\\me\\AppData\\Roaming\\npm\\codex.exe',
     );
     expect(mockBroadcastToAllTabs).toHaveBeenCalledTimes(0);
+  });
+
+  it('does not switch the active model while the custom models textarea is mid-edit', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const plugin = createPlugin();
+    const context = createContext(plugin);
+
+    codexSettingsTabRenderer.render(createContainer(), context);
+
+    const customModelsSetting = findSetting('Custom models');
+    const customModelsTextArea = customModelsSetting.textAreaComponents[0];
+
+    await customModelsTextArea.onChangeCallback?.('different-custom-model');
+
+    expect(plugin.settings.providerConfigs.codex.customModels).toBe('my-custom-model');
+    expect(plugin.settings.model).toBe('my-custom-model');
+    expect(mockSaveSettings).not.toHaveBeenCalled();
+    expect(context.refreshModelSelectors).not.toHaveBeenCalled();
+  });
+
+  it('reconciles removed custom models on blur and clears stale title model selections', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const plugin = createPlugin({
+      titleGenerationModel: 'my-custom-model',
+    });
+    const context = createContext(plugin);
+
+    codexSettingsTabRenderer.render(createContainer(), context);
+
+    const customModelsSetting = findSetting('Custom models');
+    const customModelsTextArea = customModelsSetting.textAreaComponents[0];
+
+    await customModelsTextArea.onChangeCallback?.('different-custom-model');
+    await customModelsTextArea.trigger('blur');
+
+    expect(plugin.settings.providerConfigs.codex.customModels).toBe('different-custom-model');
+    expect(plugin.settings.model).toBe('gpt-5.4-mini');
+    expect(plugin.settings.titleGenerationModel).toBe('');
+    expect(mockSaveSettings).toHaveBeenCalledTimes(1);
+    expect(context.refreshModelSelectors).toHaveBeenCalledTimes(1);
+  });
+
+  it('reconciles an inactive Codex saved model when a removed custom model was selected', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const plugin = createPlugin({
+      settingsProvider: 'claude',
+      model: 'haiku',
+      savedProviderModel: {
+        claude: 'haiku',
+        codex: 'my-custom-model',
+      },
+    });
+    const context = createContext(plugin);
+
+    codexSettingsTabRenderer.render(createContainer(), context);
+
+    const customModelsSetting = findSetting('Custom models');
+    const customModelsTextArea = customModelsSetting.textAreaComponents[0];
+
+    await customModelsTextArea.onChangeCallback?.('different-custom-model');
+    await customModelsTextArea.trigger('blur');
+
+    expect(plugin.settings.model).toBe('haiku');
+    expect(plugin.settings.savedProviderModel).toEqual({
+      claude: 'haiku',
+      codex: 'gpt-5.4-mini',
+    });
+    expect(mockSaveSettings).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
This branch adds provider-owned Codex custom model settings so users can append extra model IDs to the picker while keeping OPENAI_MODEL as the highest-priority override.

It centralizes Codex model option parsing and fallback selection, formats recognizable GPT-style custom labels, and reuses that logic in the UI config and environment reconciler.

The settings tab now commits custom model edits on blur and reconciles active and inactive Codex selections plus stale title-model state when a custom model is removed.

Verification: npm run typecheck, npm run lint, npm run test, npm run build.