### PR TITLE
fix: apply permission mode changes live

### DIFF
--- a/src/core/runtime/ChatRuntime.ts
+++ b/src/core/runtime/ChatRuntime.ts
@@ -29,6 +29,7 @@ export interface ChatRuntime {
   ): void;
   reloadMcpServers(): Promise<void>;
   ensureReady(options?: ChatRuntimeEnsureReadyOptions): Promise<boolean>;
+  updatePermissionMode(mode: string): Promise<void>;
   query(
     turn: PreparedChatTurn,
     conversationHistory?: ChatMessage[],

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -826,12 +826,7 @@ function initializeInputToolbar(
       tab.ui.serviceTierToggle?.updateDisplay();
     },
     onPermissionModeChange: async (mode: string) => {
-      (plugin.settings as unknown as Record<string, unknown>).permissionMode = mode;
-      await plugin.saveSettings();
-      dom.inputWrapper.toggleClass(
-        'claudian-input-plan-mode',
-        mode === 'plan' && getTabCapabilities(tab, plugin).supportsPlanMode,
-      );
+      await updateTabPermissionMode(tab, plugin, mode);
     },
   });
 
@@ -1688,11 +1683,19 @@ function renderAutoTriggeredTurn(tab: TabData, result: AutoTurnResult): void {
 }
 
 export function updatePlanModeUI(tab: TabData, plugin: ClaudianPlugin, mode: string): void {
+  void updateTabPermissionMode(tab, plugin, mode);
+}
+
+async function updateTabPermissionMode(tab: TabData, plugin: ClaudianPlugin, mode: string): Promise<void> {
   (plugin.settings as unknown as Record<string, unknown>).permissionMode = mode;
-  void plugin.saveSettings();
   tab.ui.permissionToggle?.updateDisplay();
   tab.dom.inputWrapper.toggleClass(
     'claudian-input-plan-mode',
     mode === 'plan' && getTabCapabilities(tab, plugin).supportsPlanMode,
   );
+
+  await Promise.all([
+    plugin.saveSettings(),
+    tab.service?.updatePermissionMode(mode) ?? Promise.resolve(),
+  ]);
 }

--- a/src/providers/claude/runtime/ClaudeChatRuntime.ts
+++ b/src/providers/claude/runtime/ClaudeChatRuntime.ts
@@ -1729,6 +1729,31 @@ export class ClaudianService implements ChatRuntime {
     });
   }
 
+  async updatePermissionMode(mode: string): Promise<void> {
+    if (mode !== 'normal' && mode !== 'yolo' && mode !== 'plan') {
+      return;
+    }
+
+    const sdkMode = this.resolveSDKPermissionMode(mode);
+    if (!this.persistentQuery) {
+      if (this.currentConfig) {
+        this.currentConfig.permissionMode = mode;
+        this.currentConfig.sdkPermissionMode = sdkMode;
+      }
+      return;
+    }
+
+    try {
+      await this.persistentQuery.setPermissionMode(sdkMode);
+      if (this.currentConfig) {
+        this.currentConfig.permissionMode = mode;
+        this.currentConfig.sdkPermissionMode = sdkMode;
+      }
+    } catch {
+      new Notice('Failed to update permission mode');
+    }
+  }
+
   setApprovalCallback(callback: ApprovalCallback | null) {
     this.approvalCallback = callback;
   }

--- a/src/providers/codex/runtime/CodexChatRuntime.ts
+++ b/src/providers/codex/runtime/CodexChatRuntime.ts
@@ -209,6 +209,10 @@ export class CodexChatRuntime implements ChatRuntime {
     // No-op: Codex handles MCP internally
   }
 
+  async updatePermissionMode(_mode: string): Promise<void> {
+    // Codex reads permission settings when starting or resuming a turn.
+  }
+
   async ensureReady(options?: ChatRuntimeEnsureReadyOptions): Promise<boolean> {
     const promptSettings = this.getSystemPromptSettings();
     const promptKey = computeSystemPromptKey(promptSettings);

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -45,6 +45,7 @@ global.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
 jest.mock('@/providers/claude/runtime/ClaudeChatRuntime', () => ({
   ClaudianService: jest.fn().mockImplementation(() => ({
     ensureReady: jest.fn().mockResolvedValue(true),
+    updatePermissionMode: jest.fn().mockResolvedValue(undefined),
     cleanup: jest.fn(),
     isReady: jest.fn().mockReturnValue(false),
     syncConversationState: jest.fn(),
@@ -122,6 +123,7 @@ const createMockClaudianService = (overrides?: {
 }) => ({
   providerId: overrides?.providerId ?? 'claude',
   ensureReady: overrides?.ensureReady ?? jest.fn().mockResolvedValue(true),
+  updatePermissionMode: jest.fn().mockResolvedValue(undefined),
   cleanup: jest.fn(),
   isReady: jest.fn().mockReturnValue(false),
   getCapabilities: jest.fn().mockReturnValue({
@@ -3330,6 +3332,33 @@ describe('Tab - Cross-Provider Model Rejection', () => {
 
     expect(Notice).not.toHaveBeenCalled();
     expect(plugin.saveSettings).toHaveBeenCalled();
+  });
+
+  it('pushes permission mode changes to the active runtime immediately', async () => {
+    jest.spyOn(ProviderRegistry, 'createInstructionRefineService').mockReturnValue({ cancel: jest.fn(), resetConversation: jest.fn() } as any);
+    jest.spyOn(ProviderRegistry, 'createTitleGenerationService').mockReturnValue({ cancel: jest.fn() } as any);
+    jest.spyOn(ProviderRegistry, 'getTaskResultInterpreter').mockReturnValue({} as any);
+
+    const plugin = createMockPlugin();
+    const tab = createTab(createMockOptions({ plugin }));
+    initializeTabUI(tab, plugin);
+    const service = createMockClaudianService();
+    tab.service = service as any;
+
+    const toolbarModule = jest.requireMock('@/features/chat/ui/InputToolbar') as {
+      createInputToolbar: jest.Mock;
+    };
+    const toolbarCallbacks = toolbarModule.createInputToolbar.mock.calls.at(-1)?.[1];
+
+    await toolbarCallbacks.onPermissionModeChange('yolo');
+    await toolbarCallbacks.onPermissionModeChange('plan');
+    await toolbarCallbacks.onPermissionModeChange('normal');
+
+    expect(plugin.settings.permissionMode).toBe('normal');
+    expect(plugin.saveSettings).toHaveBeenCalled();
+    expect(service.updatePermissionMode).toHaveBeenCalledWith('yolo');
+    expect(service.updatePermissionMode).toHaveBeenCalledWith('plan');
+    expect(service.updatePermissionMode).toHaveBeenCalledWith('normal');
   });
 });
 

--- a/tests/unit/providers/claude/runtime/ClaudianService.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudianService.test.ts
@@ -1605,6 +1605,46 @@ describe('ClaudianService', () => {
       expect(mockPersistentQuery.setPermissionMode).toHaveBeenCalledWith('bypassPermissions');
     });
 
+    it('should immediately update permission mode on the active persistent query', async () => {
+      await service.updatePermissionMode('yolo');
+
+      expect(mockPersistentQuery.setPermissionMode).toHaveBeenCalledWith('bypassPermissions');
+      expect((service as any).currentConfig.permissionMode).toBe('yolo');
+      expect((service as any).currentConfig.sdkPermissionMode).toBe('bypassPermissions');
+    });
+
+    it('should immediately update permission mode to plan', async () => {
+      await service.updatePermissionMode('plan');
+
+      expect(mockPersistentQuery.setPermissionMode).toHaveBeenCalledWith('plan');
+      expect((service as any).currentConfig.permissionMode).toBe('plan');
+      expect((service as any).currentConfig.sdkPermissionMode).toBe('plan');
+    });
+
+    it('should immediately update permission mode from yolo back to safe', async () => {
+      (mockPlugin as any).settings.claudeSafeMode = 'acceptEdits';
+      await service.updatePermissionMode('yolo');
+      mockPersistentQuery.setPermissionMode.mockClear();
+
+      await service.updatePermissionMode('normal');
+
+      expect(mockPersistentQuery.setPermissionMode).toHaveBeenCalledWith('acceptEdits');
+      expect((service as any).currentConfig.permissionMode).toBe('normal');
+      expect((service as any).currentConfig.sdkPermissionMode).toBe('acceptEdits');
+    });
+
+    it('should immediately restore the configured safe SDK mode', async () => {
+      (mockPlugin as any).settings.claudeSafeMode = 'default';
+      await service.updatePermissionMode('yolo');
+      mockPersistentQuery.setPermissionMode.mockClear();
+
+      await service.updatePermissionMode('normal');
+
+      expect(mockPersistentQuery.setPermissionMode).toHaveBeenCalledWith('default');
+      expect((service as any).currentConfig.permissionMode).toBe('normal');
+      expect((service as any).currentConfig.sdkPermissionMode).toBe('default');
+    });
+
     it('should update permission mode when claudeSafeMode changes within normal mode', async () => {
       (mockPlugin as any).settings.permissionMode = 'normal';
       (mockPlugin as any).settings.claudeSafeMode = 'acceptEdits';


### PR DESCRIPTION
## Summary

This fixes permission mode changes made from the chat toolbar so they take effect immediately in the active conversation instead of only affecting later runtime setup.

- Adds `updatePermissionMode(mode)` to the shared chat runtime interface.
- Routes toolbar permission-mode changes through the active tab runtime after saving settings and updating UI state.
- Implements Claude live permission updates with `persistentQuery.setPermissionMode(...)`, preserving Claudian's existing mode mapping (`yolo -> bypassPermissions`, `plan -> plan`, Safe/normal -> configured Claude safe mode).
- Adds a Codex runtime no-op implementation because Codex reads permission settings when starting or resuming a turn.
- Covers switching into YOLO, into plan, and back from YOLO to Safe during an active persistent Claude query.

## Tested

- `npx jest --selectProjects unit --runTestsByPath tests/unit/providers/claude/runtime/ClaudianService.test.ts tests/unit/features/chat/tabs/Tab.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Manual Obsidian smoke test: switched permission mode mid-conversation and confirmed the updated mode took effect live.