### PR TITLE
Add Google Gemini API provider

### DIFF
--- a/src/app/settings/defaultSettings.ts
+++ b/src/app/settings/defaultSettings.ts
@@ -2,6 +2,7 @@ import { getDefaultHiddenProviderCommands } from '../../core/providers/commands/
 import { type ClaudianSettings } from '../../core/types/settings';
 import { DEFAULT_CLAUDE_PROVIDER_SETTINGS } from '../../providers/claude/settings';
 import { DEFAULT_CODEX_PROVIDER_SETTINGS } from '../../providers/codex/settings';
+import { DEFAULT_GEMINI_PROVIDER_SETTINGS } from '../../providers/gemini/settings';
 
 export const DEFAULT_CLAUDIAN_SETTINGS: ClaudianSettings = {
   userName: '',
@@ -35,6 +36,7 @@ export const DEFAULT_CLAUDIAN_SETTINGS: ClaudianSettings = {
   providerConfigs: {
     claude: { ...DEFAULT_CLAUDE_PROVIDER_SETTINGS },
     codex: { ...DEFAULT_CODEX_PROVIDER_SETTINGS },
+    gemini: { ...DEFAULT_GEMINI_PROVIDER_SETTINGS },
   },
 
   settingsProvider: 'claude',

--- a/src/providers/gemini/app/GeminiWorkspaceServices.ts
+++ b/src/providers/gemini/app/GeminiWorkspaceServices.ts
@@ -1,0 +1,13 @@
+import type {
+  ProviderWorkspaceRegistration,
+  ProviderWorkspaceServices,
+} from '../../../core/providers/types';
+import { geminiSettingsTabRenderer } from '../ui/GeminiSettingsTab';
+
+export type GeminiWorkspaceServices = ProviderWorkspaceServices;
+
+export const geminiWorkspaceRegistration: ProviderWorkspaceRegistration<GeminiWorkspaceServices> = {
+  initialize: async () => ({
+    settingsTabRenderer: geminiSettingsTabRenderer,
+  }),
+};

--- a/src/providers/gemini/auxiliary/GeminiInlineEditService.ts
+++ b/src/providers/gemini/auxiliary/GeminiInlineEditService.ts
@@ -1,0 +1,65 @@
+import {
+  buildInlineEditPrompt,
+  getInlineEditSystemPrompt,
+  parseInlineEditResponse,
+} from '../../../core/prompt/inlineEdit';
+import type {
+  InlineEditRequest,
+  InlineEditResult,
+  InlineEditService,
+} from '../../../core/providers/types';
+import type ClaudianPlugin from '../../../main';
+import { appendContextFiles } from '../../../utils/context';
+import { GeminiAuxQueryRunner } from '../runtime/GeminiAuxQueryRunner';
+
+export class GeminiInlineEditService implements InlineEditService {
+  private runner: GeminiAuxQueryRunner;
+  private abortController: AbortController | null = null;
+  private hasThread = false;
+
+  constructor(plugin: ClaudianPlugin) {
+    this.runner = new GeminiAuxQueryRunner(plugin);
+  }
+
+  resetConversation(): void {
+    this.runner.reset();
+    this.hasThread = false;
+  }
+
+  async editText(request: InlineEditRequest): Promise<InlineEditResult> {
+    this.resetConversation();
+    return this.sendMessage(buildInlineEditPrompt(request));
+  }
+
+  async continueConversation(message: string, contextFiles?: string[]): Promise<InlineEditResult> {
+    if (!this.hasThread) {
+      return { success: false, error: 'No active conversation to continue' };
+    }
+    const prompt = contextFiles && contextFiles.length > 0
+      ? appendContextFiles(message, contextFiles)
+      : message;
+    return this.sendMessage(prompt);
+  }
+
+  cancel(): void {
+    this.abortController?.abort();
+    this.abortController = null;
+  }
+
+  private async sendMessage(prompt: string): Promise<InlineEditResult> {
+    this.abortController = new AbortController();
+    try {
+      const text = await this.runner.query({
+        systemPrompt: getInlineEditSystemPrompt(),
+        abortController: this.abortController,
+      }, prompt);
+      this.hasThread = true;
+      return parseInlineEditResponse(text);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      return { success: false, error: msg };
+    } finally {
+      this.abortController = null;
+    }
+  }
+}

--- a/src/providers/gemini/auxiliary/GeminiInstructionRefineService.ts
+++ b/src/providers/gemini/auxiliary/GeminiInstructionRefineService.ts
@@ -1,0 +1,80 @@
+import { buildRefineSystemPrompt } from '../../../core/prompt/instructionRefine';
+import type {
+  InstructionRefineService,
+  RefineProgressCallback,
+} from '../../../core/providers/types';
+import type { InstructionRefineResult } from '../../../core/types';
+import type ClaudianPlugin from '../../../main';
+import { GeminiAuxQueryRunner } from '../runtime/GeminiAuxQueryRunner';
+
+export class GeminiInstructionRefineService implements InstructionRefineService {
+  private runner: GeminiAuxQueryRunner;
+  private abortController: AbortController | null = null;
+  private existingInstructions = '';
+  private hasThread = false;
+
+  constructor(plugin: ClaudianPlugin) {
+    this.runner = new GeminiAuxQueryRunner(plugin);
+  }
+
+  resetConversation(): void {
+    this.runner.reset();
+    this.hasThread = false;
+  }
+
+  async refineInstruction(
+    rawInstruction: string,
+    existingInstructions: string,
+    onProgress?: RefineProgressCallback,
+  ): Promise<InstructionRefineResult> {
+    this.resetConversation();
+    this.existingInstructions = existingInstructions;
+    return this.sendMessage(`Please refine this instruction: "${rawInstruction}"`, onProgress);
+  }
+
+  async continueConversation(
+    message: string,
+    onProgress?: RefineProgressCallback,
+  ): Promise<InstructionRefineResult> {
+    if (!this.hasThread) {
+      return { success: false, error: 'No active conversation to continue' };
+    }
+    return this.sendMessage(message, onProgress);
+  }
+
+  cancel(): void {
+    this.abortController?.abort();
+    this.abortController = null;
+  }
+
+  private async sendMessage(
+    prompt: string,
+    onProgress?: RefineProgressCallback,
+  ): Promise<InstructionRefineResult> {
+    this.abortController = new AbortController();
+    try {
+      const text = await this.runner.query({
+        systemPrompt: buildRefineSystemPrompt(this.existingInstructions),
+        abortController: this.abortController,
+      }, prompt);
+      this.hasThread = true;
+      const parsed = this.parseResponse(text);
+      onProgress?.(parsed);
+      return parsed;
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      return { success: false, error: msg };
+    } finally {
+      this.abortController = null;
+    }
+  }
+
+  private parseResponse(text: string): InstructionRefineResult {
+    const match = text.match(/<instruction>([\s\S]*?)<\/instruction>/);
+    if (match) {
+      return { success: true, refinedInstruction: match[1].trim() };
+    }
+    const trimmed = text.trim();
+    return trimmed ? { success: true, clarification: trimmed } : { success: false, error: 'Empty response' };
+  }
+}

--- a/src/providers/gemini/auxiliary/GeminiTaskResultInterpreter.ts
+++ b/src/providers/gemini/auxiliary/GeminiTaskResultInterpreter.ts
@@ -1,0 +1,29 @@
+import type {
+  ProviderTaskResultInterpreter,
+  ProviderTaskTerminalStatus,
+} from '../../../core/providers/types';
+
+export class GeminiTaskResultInterpreter implements ProviderTaskResultInterpreter {
+  hasAsyncLaunchMarker(_toolUseResult: unknown): boolean {
+    return false;
+  }
+
+  extractAgentId(_toolUseResult: unknown): string | null {
+    return null;
+  }
+
+  extractStructuredResult(_toolUseResult: unknown): string | null {
+    return null;
+  }
+
+  resolveTerminalStatus(
+    _toolUseResult: unknown,
+    fallbackStatus: ProviderTaskTerminalStatus,
+  ): ProviderTaskTerminalStatus {
+    return fallbackStatus;
+  }
+
+  extractTagValue(_payload: string, _tagName: string): string | null {
+    return null;
+  }
+}

--- a/src/providers/gemini/auxiliary/GeminiTitleGenerationService.ts
+++ b/src/providers/gemini/auxiliary/GeminiTitleGenerationService.ts
@@ -1,0 +1,82 @@
+import { TITLE_GENERATION_SYSTEM_PROMPT } from '../../../core/prompt/titleGeneration';
+import type {
+  TitleGenerationCallback,
+  TitleGenerationResult,
+  TitleGenerationService,
+} from '../../../core/providers/types';
+import type ClaudianPlugin from '../../../main';
+import { GeminiAuxQueryRunner } from '../runtime/GeminiAuxQueryRunner';
+
+export class GeminiTitleGenerationService implements TitleGenerationService {
+  private plugin: ClaudianPlugin;
+  private activeGenerations = new Map<string, AbortController>();
+
+  constructor(plugin: ClaudianPlugin) {
+    this.plugin = plugin;
+  }
+
+  async generateTitle(
+    conversationId: string,
+    userMessage: string,
+    callback: TitleGenerationCallback,
+  ): Promise<void> {
+    const existing = this.activeGenerations.get(conversationId);
+    if (existing) existing.abort();
+
+    const abortController = new AbortController();
+    this.activeGenerations.set(conversationId, abortController);
+
+    const truncated = userMessage.length > 500
+      ? userMessage.substring(0, 500) + '...'
+      : userMessage;
+    const prompt = `User's request:\n"""\n${truncated}\n"""\n\nGenerate a title for this conversation:`;
+    const runner = new GeminiAuxQueryRunner(this.plugin);
+
+    try {
+      const text = await runner.query({
+        systemPrompt: TITLE_GENERATION_SYSTEM_PROMPT,
+        model: this.plugin.settings.titleGenerationModel || undefined,
+        abortController,
+      }, prompt);
+      const title = this.parseTitle(text);
+      await this.safeCallback(callback, conversationId, title
+        ? { success: true, title }
+        : { success: false, error: 'Failed to parse title from response' });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      await this.safeCallback(callback, conversationId, { success: false, error: msg });
+    } finally {
+      runner.reset();
+      this.activeGenerations.delete(conversationId);
+    }
+  }
+
+  cancel(): void {
+    for (const controller of this.activeGenerations.values()) {
+      controller.abort();
+    }
+    this.activeGenerations.clear();
+  }
+
+  private parseTitle(responseText: string): string | null {
+    let title = responseText.trim();
+    if (!title) return null;
+    if ((title.startsWith('"') && title.endsWith('"')) || (title.startsWith("'") && title.endsWith("'"))) {
+      title = title.slice(1, -1);
+    }
+    title = title.replace(/[.!?:;,]+$/, '');
+    return title.length > 50 ? `${title.substring(0, 47)}...` : title;
+  }
+
+  private async safeCallback(
+    callback: TitleGenerationCallback,
+    conversationId: string,
+    result: TitleGenerationResult,
+  ): Promise<void> {
+    try {
+      await callback(conversationId, result);
+    } catch {
+      // Ignore callback errors.
+    }
+  }
+}

--- a/src/providers/gemini/capabilities.ts
+++ b/src/providers/gemini/capabilities.ts
@@ -1,0 +1,16 @@
+import type { ProviderCapabilities } from '../../core/providers/types';
+
+export const GEMINI_PROVIDER_CAPABILITIES: ProviderCapabilities = {
+  providerId: 'gemini',
+  supportsPersistentRuntime: false,
+  supportsNativeHistory: false,
+  supportsPlanMode: false,
+  supportsRewind: false,
+  supportsFork: false,
+  supportsProviderCommands: false,
+  supportsImageAttachments: true,
+  supportsInstructionMode: true,
+  supportsMcpTools: false,
+  supportsTurnSteer: false,
+  reasoningControl: 'none',
+};

--- a/src/providers/gemini/env/GeminiSettingsReconciler.ts
+++ b/src/providers/gemini/env/GeminiSettingsReconciler.ts
@@ -1,0 +1,64 @@
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import type { ProviderSettingsReconciler } from '../../../core/providers/types';
+import type { Conversation } from '../../../core/types';
+import { parseEnvironmentVariables } from '../../../utils/env';
+import { resolveGeminiModelSelection } from '../modelOptions';
+import { getGeminiProviderSettings, updateGeminiProviderSettings } from '../settings';
+import { geminiChatUIConfig } from '../ui/GeminiChatUIConfig';
+
+const ENV_HASH_KEYS = [
+  'GEMINI_API_KEY',
+  'GOOGLE_API_KEY',
+  'GEMINI_MODEL',
+  'GOOGLE_GEMINI_MODEL',
+  'GEMINI_API_BASE_URL',
+  'GOOGLE_GEMINI_BASE_URL',
+];
+
+function computeGeminiEnvHash(envText: string): string {
+  const envVars = parseEnvironmentVariables(envText || '');
+  return ENV_HASH_KEYS
+    .filter(key => envVars[key])
+    .map(key => `${key}=${envVars[key]}`)
+    .sort()
+    .join('|');
+}
+
+export const geminiSettingsReconciler: ProviderSettingsReconciler = {
+  reconcileModelWithEnvironment(
+    settings: Record<string, unknown>,
+    _conversations: Conversation[],
+  ): { changed: boolean; invalidatedConversations: Conversation[] } {
+    const envText = getRuntimeEnvironmentText(settings, 'gemini');
+    const currentHash = computeGeminiEnvHash(envText);
+    const savedHash = getGeminiProviderSettings(settings).environmentHash;
+
+    if (currentHash === savedHash) {
+      return { changed: false, invalidatedConversations: [] };
+    }
+
+    const currentModel = typeof settings.model === 'string' ? settings.model : '';
+    const nextModel = resolveGeminiModelSelection(settings, currentModel);
+    if (nextModel) {
+      settings.model = nextModel;
+    }
+
+    updateGeminiProviderSettings(settings, { environmentHash: currentHash });
+    return { changed: true, invalidatedConversations: [] };
+  },
+
+  normalizeModelVariantSettings(settings: Record<string, unknown>): boolean {
+    const model = settings.model as string;
+    if (!model) {
+      return false;
+    }
+
+    const normalizedModel = geminiChatUIConfig.normalizeModelVariant(model, settings);
+    if (normalizedModel === model) {
+      return false;
+    }
+
+    settings.model = normalizedModel;
+    return true;
+  },
+};

--- a/src/providers/gemini/history/GeminiConversationHistoryService.ts
+++ b/src/providers/gemini/history/GeminiConversationHistoryService.ts
@@ -1,0 +1,41 @@
+import type { ProviderConversationHistoryService } from '../../../core/providers/types';
+import type { Conversation } from '../../../core/types';
+
+export class GeminiConversationHistoryService implements ProviderConversationHistoryService {
+  async hydrateConversationHistory(
+    _conversation: Conversation,
+    _vaultPath: string | null,
+  ): Promise<void> {
+    // Gemini API conversations are persisted by Claudian's shared conversation store.
+  }
+
+  async deleteConversationSession(
+    _conversation: Conversation,
+    _vaultPath: string | null,
+  ): Promise<void> {
+    // No provider-native session artifacts to delete.
+  }
+
+  resolveSessionIdForConversation(conversation: Conversation | null): string | null {
+    return conversation?.sessionId ?? null;
+  }
+
+  isPendingForkConversation(_conversation: Conversation): boolean {
+    return false;
+  }
+
+  buildForkProviderState(
+    sourceSessionId: string,
+    resumeAt: string,
+    sourceProviderState?: Record<string, unknown>,
+  ): Record<string, unknown> {
+    return {
+      ...(sourceProviderState ?? {}),
+      forkSource: { sessionId: sourceSessionId, resumeAt },
+    };
+  }
+
+  buildPersistedProviderState(conversation: Conversation): Record<string, unknown> | undefined {
+    return conversation.providerState;
+  }
+}

--- a/src/providers/gemini/modelOptions.ts
+++ b/src/providers/gemini/modelOptions.ts
@@ -1,0 +1,85 @@
+import { getRuntimeEnvironmentVariables } from '../../core/providers/providerEnvironment';
+import type { ProviderUIOption } from '../../core/providers/types';
+import { getGeminiProviderSettings } from './settings';
+import {
+  DEFAULT_GEMINI_MODEL_SET,
+  DEFAULT_GEMINI_MODELS,
+  DEFAULT_GEMINI_PRIMARY_MODEL,
+  formatGeminiModelLabel,
+} from './types/models';
+
+function createCustomGeminiModelOption(modelId: string, description: string): ProviderUIOption {
+  return {
+    value: modelId,
+    label: formatGeminiModelLabel(modelId),
+    description,
+  };
+}
+
+function getConfiguredEnvModel(settings: Record<string, unknown>): string | null {
+  const env = getRuntimeEnvironmentVariables(settings, 'gemini');
+  const modelId = env.GEMINI_MODEL?.trim() || env.GOOGLE_GEMINI_MODEL?.trim();
+  return modelId ? modelId : null;
+}
+
+export function getConfiguredEnvCustomGeminiModel(settings: Record<string, unknown>): string | null {
+  const modelId = getConfiguredEnvModel(settings);
+  return modelId && !DEFAULT_GEMINI_MODEL_SET.has(modelId) ? modelId : null;
+}
+
+export function parseConfiguredCustomGeminiModelIds(value: string): string[] {
+  const modelIds: string[] = [];
+  const seen = new Set<string>();
+
+  for (const line of value.split(/\r?\n/)) {
+    const modelId = line.trim();
+    if (!modelId || seen.has(modelId)) {
+      continue;
+    }
+
+    seen.add(modelId);
+    modelIds.push(modelId);
+  }
+
+  return modelIds;
+}
+
+export function getGeminiModelOptions(settings: Record<string, unknown>): ProviderUIOption[] {
+  const models = [...DEFAULT_GEMINI_MODELS];
+  const seenValues = new Set(models.map(model => model.value));
+
+  const envModel = getConfiguredEnvCustomGeminiModel(settings);
+  if (envModel) {
+    seenValues.add(envModel);
+    models.unshift(createCustomGeminiModelOption(envModel, 'Custom (env)'));
+  }
+
+  const geminiSettings = getGeminiProviderSettings(settings);
+  for (const modelId of parseConfiguredCustomGeminiModelIds(geminiSettings.customModels)) {
+    if (seenValues.has(modelId)) {
+      continue;
+    }
+
+    seenValues.add(modelId);
+    models.push(createCustomGeminiModelOption(modelId, 'Custom model'));
+  }
+
+  return models;
+}
+
+export function resolveGeminiModelSelection(
+  settings: Record<string, unknown>,
+  currentModel: string,
+): string | null {
+  const envModel = getConfiguredEnvModel(settings);
+  if (envModel) {
+    return envModel;
+  }
+
+  const modelOptions = getGeminiModelOptions(settings);
+  if (currentModel && modelOptions.some(option => option.value === currentModel)) {
+    return currentModel;
+  }
+
+  return modelOptions[0]?.value ?? DEFAULT_GEMINI_PRIMARY_MODEL;
+}

--- a/src/providers/gemini/prompt/encodeGeminiTurn.ts
+++ b/src/providers/gemini/prompt/encodeGeminiTurn.ts
@@ -1,0 +1,55 @@
+import type { ChatTurnRequest, PreparedChatTurn } from '../../../core/runtime/types';
+
+function isCompactCommand(text: string): boolean {
+  return /^\/compact(\s|$)/i.test(text);
+}
+
+export function encodeGeminiTurn(request: ChatTurnRequest): PreparedChatTurn {
+  const isCompact = isCompactCommand(request.text);
+
+  if (isCompact) {
+    return {
+      request,
+      persistedContent: request.text,
+      prompt: request.text,
+      isCompact: true,
+      mcpMentions: new Set(),
+    };
+  }
+
+  const sections: string[] = [];
+  sections.push(request.text);
+
+  if (request.currentNotePath) {
+    sections.push(`\n[Current note: ${request.currentNotePath}]`);
+  }
+
+  if (request.editorSelection?.selectedText) {
+    sections.push(
+      `\n[Editor selection from ${request.editorSelection.notePath || 'current note'}:\n${request.editorSelection.selectedText}\n]`,
+    );
+  }
+
+  if (request.browserSelection?.selectedText) {
+    sections.push(
+      `\n[Browser selection from ${request.browserSelection.url ?? 'unknown page'}:\n${request.browserSelection.selectedText}\n]`,
+    );
+  }
+
+  if (request.canvasSelection) {
+    const nodeList = request.canvasSelection.nodeIds.join(', ');
+    if (nodeList) {
+      sections.push(
+        `\n[Canvas selection from ${request.canvasSelection.canvasPath}:\n${nodeList}\n]`,
+      );
+    }
+  }
+
+  return {
+    request,
+    persistedContent: request.text,
+    prompt: sections.join(''),
+    isCompact: false,
+    mcpMentions: new Set(),
+  };
+}

--- a/src/providers/gemini/registration.ts
+++ b/src/providers/gemini/registration.ts
@@ -1,0 +1,27 @@
+import type { ProviderRegistration } from '../../core/providers/types';
+import { GeminiInlineEditService } from './auxiliary/GeminiInlineEditService';
+import { GeminiInstructionRefineService } from './auxiliary/GeminiInstructionRefineService';
+import { GeminiTaskResultInterpreter } from './auxiliary/GeminiTaskResultInterpreter';
+import { GeminiTitleGenerationService } from './auxiliary/GeminiTitleGenerationService';
+import { GEMINI_PROVIDER_CAPABILITIES } from './capabilities';
+import { geminiSettingsReconciler } from './env/GeminiSettingsReconciler';
+import { GeminiConversationHistoryService } from './history/GeminiConversationHistoryService';
+import { GeminiChatRuntime } from './runtime/GeminiChatRuntime';
+import { getGeminiProviderSettings } from './settings';
+import { geminiChatUIConfig } from './ui/GeminiChatUIConfig';
+
+export const geminiProviderRegistration: ProviderRegistration = {
+  displayName: 'Gemini',
+  blankTabOrder: 20,
+  isEnabled: (settings) => getGeminiProviderSettings(settings).enabled,
+  capabilities: GEMINI_PROVIDER_CAPABILITIES,
+  environmentKeyPatterns: [/^GEMINI_/i, /^GOOGLE_(API_KEY|GEMINI_)/i],
+  chatUIConfig: geminiChatUIConfig,
+  settingsReconciler: geminiSettingsReconciler,
+  createRuntime: ({ plugin }) => new GeminiChatRuntime(plugin),
+  createTitleGenerationService: (plugin) => new GeminiTitleGenerationService(plugin),
+  createInstructionRefineService: (plugin) => new GeminiInstructionRefineService(plugin),
+  createInlineEditService: (plugin) => new GeminiInlineEditService(plugin),
+  historyService: new GeminiConversationHistoryService(),
+  taskResultInterpreter: new GeminiTaskResultInterpreter(),
+};

--- a/src/providers/gemini/runtime/GeminiApiClient.ts
+++ b/src/providers/gemini/runtime/GeminiApiClient.ts
@@ -1,0 +1,263 @@
+interface GeminiTextPart {
+  text: string;
+  thought?: boolean;
+}
+
+export interface GeminiInlineDataPart {
+  inlineData: {
+    mimeType: string;
+    data: string;
+  };
+}
+
+export interface GeminiFunctionCallPart {
+  functionCall: {
+    id?: string;
+    name: string;
+    args?: Record<string, unknown>;
+  };
+}
+
+export interface GeminiFunctionResponsePart {
+  functionResponse: {
+    id?: string;
+    name: string;
+    response: Record<string, unknown>;
+  };
+}
+
+export type GeminiPart = GeminiTextPart
+  | GeminiInlineDataPart
+  | GeminiFunctionCallPart
+  | GeminiFunctionResponsePart;
+
+export interface GeminiContent {
+  role: 'user' | 'model';
+  parts: GeminiPart[];
+}
+
+export interface GeminiFunctionDeclaration {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+}
+
+export interface GeminiUsageMetadata {
+  promptTokenCount?: number;
+  candidatesTokenCount?: number;
+  totalTokenCount?: number;
+  cachedContentTokenCount?: number;
+  thoughtsTokenCount?: number;
+}
+
+export interface GeminiFunctionCall {
+  id?: string;
+  name: string;
+  args: Record<string, unknown>;
+}
+
+export interface GeminiStreamDelta {
+  text?: string;
+  thought?: string;
+  functionCalls?: GeminiFunctionCall[];
+  usageMetadata?: GeminiUsageMetadata;
+}
+
+interface GeminiGenerateParams {
+  model: string;
+  contents: GeminiContent[];
+  systemInstruction?: string;
+  temperature?: number;
+  tools?: GeminiFunctionDeclaration[];
+  signal?: AbortSignal;
+}
+
+interface GeminiClientOptions {
+  apiKey: string;
+  baseUrl?: string;
+}
+
+function extractTextFromParts(parts: GeminiPart[] | undefined, thought: boolean): string {
+  if (!parts) return '';
+  return parts
+    .map((part) => {
+      if (!('text' in part)) return '';
+      if (!!part.thought !== thought) return '';
+      return part.text;
+    })
+    .join('');
+}
+
+function extractFunctionCalls(parts: GeminiPart[] | undefined): GeminiFunctionCall[] {
+  if (!parts) return [];
+  const calls: GeminiFunctionCall[] = [];
+  for (const part of parts) {
+    if ('functionCall' in part && part.functionCall?.name) {
+      calls.push({
+        id: part.functionCall.id,
+        name: part.functionCall.name,
+        args: part.functionCall.args ?? {},
+      });
+    }
+  }
+  return calls;
+}
+
+function parseGeminiResponseChunk(chunk: any): GeminiStreamDelta {
+  const parts = chunk?.candidates?.[0]?.content?.parts as GeminiPart[] | undefined;
+  const text = extractTextFromParts(parts, false);
+  const thought = extractTextFromParts(parts, true);
+  const functionCalls = extractFunctionCalls(parts);
+  const usageMetadata = chunk?.usageMetadata as GeminiUsageMetadata | undefined;
+
+  return {
+    ...(text ? { text } : {}),
+    ...(thought ? { thought } : {}),
+    ...(functionCalls.length > 0 ? { functionCalls } : {}),
+    ...(usageMetadata ? { usageMetadata } : {}),
+  };
+}
+
+export class GeminiApiClient {
+  private apiKey: string;
+  private baseUrl: string;
+
+  constructor(options: GeminiClientOptions) {
+    this.apiKey = options.apiKey;
+    this.baseUrl = (options.baseUrl || 'https://generativelanguage.googleapis.com/v1beta')
+      .replace(/\/+$/, '');
+  }
+
+  async generateText(params: GeminiGenerateParams): Promise<{
+    text: string;
+    usageMetadata?: GeminiUsageMetadata;
+  }> {
+    const response = await fetch(this.buildUrl(params.model, 'generateContent'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(this.buildRequestBody(params)),
+      signal: params.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(await this.extractErrorMessage(response));
+    }
+
+    const json = await response.json();
+    const parts = json?.candidates?.[0]?.content?.parts as GeminiPart[] | undefined;
+    return {
+      text: extractTextFromParts(parts, false),
+      usageMetadata: json?.usageMetadata,
+    };
+  }
+
+  async *streamGenerateContent(params: GeminiGenerateParams): AsyncGenerator<GeminiStreamDelta> {
+    const response = await fetch(this.buildUrl(params.model, 'streamGenerateContent', 'alt=sse'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(this.buildRequestBody(params)),
+      signal: params.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(await this.extractErrorMessage(response));
+    }
+
+    if (!response.body) {
+      const fallback = await response.json();
+      yield parseGeminiResponseChunk(fallback);
+      return;
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      let boundary = this.findSseBoundary(buffer);
+      while (boundary) {
+        const event = buffer.slice(0, boundary.index);
+        buffer = buffer.slice(boundary.index + boundary.length);
+        const data = this.extractSseData(event);
+        if (data && data !== '[DONE]') {
+          yield parseGeminiResponseChunk(JSON.parse(data));
+        }
+        boundary = this.findSseBoundary(buffer);
+      }
+    }
+
+    const remaining = buffer.trim();
+    if (remaining) {
+      const data = this.extractSseData(remaining);
+      if (data && data !== '[DONE]') {
+        yield parseGeminiResponseChunk(JSON.parse(data));
+      }
+    }
+  }
+
+  private buildRequestBody(params: GeminiGenerateParams): Record<string, unknown> {
+    const body: Record<string, unknown> = {
+      contents: params.contents,
+      generationConfig: {
+        ...(typeof params.temperature === 'number' ? { temperature: params.temperature } : {}),
+      },
+    };
+
+    if (params.systemInstruction?.trim()) {
+      body.systemInstruction = {
+        parts: [{ text: params.systemInstruction }],
+      };
+    }
+
+    if (params.tools && params.tools.length > 0) {
+      body.tools = [{ functionDeclarations: params.tools }];
+    }
+
+    return body;
+  }
+
+  private buildUrl(model: string, method: string, query?: string): string {
+    const normalizedModel = model.replace(/^models\//, '');
+    const sep = query ? `&${query}` : '';
+    return `${this.baseUrl}/models/${encodeURIComponent(normalizedModel)}:${method}?key=${encodeURIComponent(this.apiKey)}${sep}`;
+  }
+
+  private extractSseData(event: string): string | null {
+    const dataLines = event
+      .split(/\r?\n/)
+      .map(line => line.trim())
+      .filter(line => line.startsWith('data:'))
+      .map(line => line.slice('data:'.length).trim());
+
+    return dataLines.length > 0 ? dataLines.join('\n') : null;
+  }
+
+  private findSseBoundary(buffer: string): { index: number; length: number } | null {
+    const candidates = [
+      { index: buffer.indexOf('\r\n\r\n'), length: 4 },
+      { index: buffer.indexOf('\n\n'), length: 2 },
+      { index: buffer.indexOf('\r\r'), length: 2 },
+    ].filter(candidate => candidate.index >= 0);
+
+    if (candidates.length === 0) {
+      return null;
+    }
+
+    candidates.sort((a, b) => a.index - b.index);
+    return candidates[0];
+  }
+
+  private async extractErrorMessage(response: Response): Promise<string> {
+    try {
+      const json = await response.json();
+      const message = json?.error?.message || JSON.stringify(json);
+      return `Gemini API error (${response.status}): ${message}`;
+    } catch {
+      return `Gemini API error (${response.status}): ${await response.text()}`;
+    }
+  }
+}

--- a/src/providers/gemini/runtime/GeminiAuxQueryRunner.ts
+++ b/src/providers/gemini/runtime/GeminiAuxQueryRunner.ts
@@ -1,0 +1,67 @@
+import { getRuntimeEnvironmentVariables } from '../../../core/providers/providerEnvironment';
+import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
+import type ClaudianPlugin from '../../../main';
+import { getGeminiProviderSettings } from '../settings';
+import { DEFAULT_GEMINI_PRIMARY_MODEL } from '../types/models';
+import { GeminiApiClient, type GeminiContent } from './GeminiApiClient';
+
+export interface GeminiAuxQueryConfig {
+  systemPrompt: string;
+  model?: string;
+  abortController?: AbortController;
+}
+
+export class GeminiAuxQueryRunner {
+  private plugin: ClaudianPlugin;
+  private history: GeminiContent[] = [];
+
+  constructor(plugin: ClaudianPlugin) {
+    this.plugin = plugin;
+  }
+
+  async query(config: GeminiAuxQueryConfig, prompt: string): Promise<string> {
+    const env = getRuntimeEnvironmentVariables(
+      this.plugin.settings as unknown as Record<string, unknown>,
+      'gemini',
+    );
+    const apiKey = env.GEMINI_API_KEY || env.GOOGLE_API_KEY;
+    if (!apiKey) {
+      throw new Error('Gemini API key is missing. Add GEMINI_API_KEY or GOOGLE_API_KEY in Gemini provider environment settings.');
+    }
+
+    const providerSettings = ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+      this.plugin.settings as unknown as Record<string, unknown>,
+      'gemini',
+    );
+    const geminiSettings = getGeminiProviderSettings(providerSettings);
+    const model = config.model || (providerSettings.model as string | undefined) || DEFAULT_GEMINI_PRIMARY_MODEL;
+    const client = new GeminiApiClient({
+      apiKey,
+      baseUrl: env.GEMINI_API_BASE_URL || env.GOOGLE_GEMINI_BASE_URL,
+    });
+
+    const contents = [
+      ...this.history,
+      { role: 'user' as const, parts: [{ text: prompt }] },
+    ];
+
+    const response = await client.generateText({
+      model,
+      contents,
+      systemInstruction: config.systemPrompt,
+      temperature: geminiSettings.temperature,
+      signal: config.abortController?.signal,
+    });
+
+    this.history = [
+      ...contents,
+      { role: 'model' as const, parts: [{ text: response.text }] },
+    ];
+
+    return response.text;
+  }
+
+  reset(): void {
+    this.history = [];
+  }
+}

--- a/src/providers/gemini/runtime/GeminiChatRuntime.ts
+++ b/src/providers/gemini/runtime/GeminiChatRuntime.ts
@@ -1,0 +1,481 @@
+import { randomUUID } from 'crypto';
+
+import { buildSystemPrompt, computeSystemPromptKey, type SystemPromptSettings } from '../../../core/prompt/mainAgent';
+import { getRuntimeEnvironmentVariables } from '../../../core/providers/providerEnvironment';
+import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
+import type { ProviderCapabilities } from '../../../core/providers/types';
+import type { ChatRuntime } from '../../../core/runtime/ChatRuntime';
+import type {
+  ApprovalCallback,
+  AskUserQuestionCallback,
+  AutoTurnResult,
+  ChatRewindResult,
+  ChatRuntimeConversationState,
+  ChatRuntimeEnsureReadyOptions,
+  ChatRuntimeQueryOptions,
+  ChatTurnMetadata,
+  ChatTurnRequest,
+  ExitPlanModeCallback,
+  PreparedChatTurn,
+  SessionUpdateResult,
+  SubagentRuntimeState,
+} from '../../../core/runtime/types';
+import type { ChatMessage, Conversation, StreamChunk, ToolCallInfo } from '../../../core/types';
+import type ClaudianPlugin from '../../../main';
+import { getVaultPath } from '../../../utils/path';
+import { GEMINI_PROVIDER_CAPABILITIES } from '../capabilities';
+import { encodeGeminiTurn } from '../prompt/encodeGeminiTurn';
+import { getGeminiProviderSettings } from '../settings';
+import {
+  describeGeminiWriteTool,
+  executeGeminiVaultTool,
+  GEMINI_VAULT_TOOL_APPENDIX,
+  GEMINI_VAULT_TOOL_DECLARATIONS,
+  isGeminiWriteTool,
+} from '../tools/GeminiVaultTools';
+import { DEFAULT_GEMINI_CONTEXT_WINDOW, DEFAULT_GEMINI_PRIMARY_MODEL } from '../types/models';
+import {
+  GeminiApiClient,
+  type GeminiContent,
+  type GeminiFunctionCall,
+  type GeminiFunctionResponsePart,
+  type GeminiPart,
+  type GeminiUsageMetadata,
+} from './GeminiApiClient';
+
+const MAX_TOOL_ROUNDS = 8;
+const GEMINI_SUPPORTED_IMAGE_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
+
+
+export class GeminiChatRuntime implements ChatRuntime {
+  readonly providerId = 'gemini';
+
+  private plugin: ClaudianPlugin;
+  private ready = false;
+  private readyListeners = new Set<(ready: boolean) => void>();
+  private sessionId: string | null = null;
+  private abortController: AbortController | null = null;
+  private approvalCallback: ApprovalCallback | null = null;
+  private turnMetadata: ChatTurnMetadata = {};
+  private clientConfigKey = '';
+
+  constructor(plugin: ClaudianPlugin) {
+    this.plugin = plugin;
+  }
+
+  getCapabilities(): Readonly<ProviderCapabilities> {
+    return GEMINI_PROVIDER_CAPABILITIES;
+  }
+
+  prepareTurn(request: ChatTurnRequest): PreparedChatTurn {
+    return encodeGeminiTurn(request);
+  }
+
+  onReadyStateChange(listener: (ready: boolean) => void): () => void {
+    this.readyListeners.add(listener);
+    return () => this.readyListeners.delete(listener);
+  }
+
+  setResumeCheckpoint(_checkpointId: string | undefined): void {}
+
+  syncConversationState(
+    conversation: ChatRuntimeConversationState | null,
+    _externalContextPaths?: string[],
+  ): void {
+    this.sessionId = conversation?.sessionId ?? null;
+  }
+
+  async reloadMcpServers(): Promise<void> {}
+
+  async ensureReady(options?: ChatRuntimeEnsureReadyOptions): Promise<boolean> {
+    if (options?.sessionId) {
+      this.sessionId = options.sessionId;
+    }
+
+    const nextKey = computeSystemPromptKey(this.getSystemPromptSettings());
+    const rebuilt = options?.force === true || this.clientConfigKey !== nextKey;
+    this.clientConfigKey = nextKey;
+    this.setReady(true);
+    return rebuilt;
+  }
+
+  async *query(
+    turn: PreparedChatTurn,
+    conversationHistory: ChatMessage[] = [],
+    queryOptions?: ChatRuntimeQueryOptions,
+  ): AsyncGenerator<StreamChunk> {
+    this.resetTurnMetadata();
+    this.abortController = new AbortController();
+    this.turnMetadata.wasSent = true;
+
+    if (!this.sessionId) {
+      this.sessionId = randomUUID();
+    }
+
+    const env = getRuntimeEnvironmentVariables(
+      this.plugin.settings as unknown as Record<string, unknown>,
+      this.providerId,
+    );
+    const apiKey = env.GEMINI_API_KEY || env.GOOGLE_API_KEY;
+    if (!apiKey) {
+      yield {
+        type: 'error',
+        content: 'Gemini API key is missing. Add GEMINI_API_KEY or GOOGLE_API_KEY in the Gemini provider environment settings.',
+      };
+      yield { type: 'done' };
+      return;
+    }
+
+    const model = queryOptions?.model ?? this.resolveModel();
+    const providerSettings = getGeminiProviderSettings(this.getProviderSettings());
+    const client = new GeminiApiClient({
+      apiKey,
+      baseUrl: env.GEMINI_API_BASE_URL || env.GOOGLE_GEMINI_BASE_URL,
+    });
+    const contents = this.buildContents(conversationHistory, turn);
+    const systemPrompt = buildSystemPrompt(
+      this.getSystemPromptSettings(),
+      { appendices: [GEMINI_VAULT_TOOL_APPENDIX] },
+    );
+
+    let lastUsageMetadata: GeminiUsageMetadata | undefined;
+
+    try {
+      for (let round = 0; round < MAX_TOOL_ROUNDS; round += 1) {
+        const modelToolParts: GeminiPart[] = [];
+        const functionCalls: GeminiFunctionCall[] = [];
+
+        for await (const delta of client.streamGenerateContent({
+          model,
+          contents,
+          systemInstruction: systemPrompt,
+          temperature: providerSettings.temperature,
+          tools: GEMINI_VAULT_TOOL_DECLARATIONS,
+          signal: this.abortController.signal,
+        })) {
+          if (this.abortController.signal.aborted) {
+            break;
+          }
+
+          if (delta.text) {
+            yield { type: 'text', content: delta.text };
+          }
+          if (delta.thought) {
+            yield { type: 'thinking', content: delta.thought };
+          }
+          if (delta.usageMetadata) {
+            lastUsageMetadata = delta.usageMetadata;
+          }
+          if (delta.functionCalls) {
+            functionCalls.push(...delta.functionCalls);
+            for (const call of delta.functionCalls) {
+              modelToolParts.push({
+                functionCall: {
+                  id: call.id,
+                  name: call.name,
+                  args: call.args,
+                },
+              });
+            }
+          }
+        }
+
+        if (this.abortController.signal.aborted) {
+          break;
+        }
+
+        if (functionCalls.length === 0) {
+          break;
+        }
+
+        contents.push({ role: 'model', parts: modelToolParts });
+        const toolResponseParts: GeminiFunctionResponsePart[] = [];
+
+        for (const call of functionCalls) {
+          const id = call.id || `gemini-tool-${randomUUID()}`;
+          yield {
+            type: 'tool_use',
+            id,
+            name: call.name,
+            input: call.args,
+          };
+
+          const approvalResult = await this.ensureToolApproved(call);
+          const result = approvalResult ?? await executeGeminiVaultTool(this.plugin, call.name, call.args);
+          yield {
+            type: 'tool_result',
+            id,
+            content: result.content,
+            isError: result.isError,
+          };
+
+          toolResponseParts.push({
+            functionResponse: {
+              id: call.id,
+              name: call.name,
+              response: {
+                result: result.content,
+                ...(result.isError ? { error: true } : {}),
+              },
+            },
+          });
+        }
+
+        contents.push({ role: 'user', parts: toolResponseParts });
+      }
+
+      if (lastUsageMetadata) {
+        yield {
+          type: 'usage',
+          usage: this.toUsageInfo(model, lastUsageMetadata),
+          sessionId: this.sessionId,
+        };
+      }
+
+      yield { type: 'done' };
+    } catch (error) {
+      if (!this.abortController.signal.aborted) {
+        yield {
+          type: 'error',
+          content: error instanceof Error ? error.message : String(error),
+        };
+      }
+      yield { type: 'done' };
+    } finally {
+      this.abortController = null;
+    }
+  }
+
+  async steer(_turn: PreparedChatTurn): Promise<boolean> {
+    return false;
+  }
+
+  cancel(): void {
+    this.abortController?.abort();
+  }
+
+  resetSession(): void {
+    this.sessionId = null;
+    this.abortController?.abort();
+    this.abortController = null;
+  }
+
+  getSessionId(): string | null {
+    return this.sessionId;
+  }
+
+  consumeSessionInvalidation(): boolean {
+    return false;
+  }
+
+  isReady(): boolean {
+    return this.ready;
+  }
+
+  async getSupportedCommands() {
+    return [];
+  }
+
+  cleanup(): void {
+    this.cancel();
+    this.setReady(false);
+  }
+
+  async rewind(_userMessageId: string, _assistantMessageId: string): Promise<ChatRewindResult> {
+    return { canRewind: false, error: 'Gemini API provider does not support rewind yet.' };
+  }
+
+  setApprovalCallback(callback: ApprovalCallback | null): void {
+    this.approvalCallback = callback;
+  }
+  setApprovalDismisser(_dismisser: (() => void) | null): void {}
+  setAskUserQuestionCallback(_callback: AskUserQuestionCallback | null): void {}
+  setExitPlanModeCallback(_callback: ExitPlanModeCallback | null): void {}
+  setPermissionModeSyncCallback(_callback: ((sdkMode: string) => void) | null): void {}
+  setSubagentHookProvider(_getState: () => SubagentRuntimeState): void {}
+  setAutoTurnCallback(_callback: ((result: AutoTurnResult) => void) | null): void {}
+
+  consumeTurnMetadata(): ChatTurnMetadata {
+    const metadata = this.turnMetadata;
+    this.resetTurnMetadata();
+    return metadata;
+  }
+
+  buildSessionUpdates(params: {
+    conversation: Conversation | null;
+    sessionInvalidated: boolean;
+  }): SessionUpdateResult {
+    return {
+      updates: {
+        sessionId: params.sessionInvalidated ? null : this.sessionId,
+      },
+    };
+  }
+
+  resolveSessionIdForFork(_conversation: Conversation | null): string | null {
+    return null;
+  }
+
+  async loadSubagentToolCalls(_agentId: string): Promise<ToolCallInfo[]> {
+    return [];
+  }
+
+  async loadSubagentFinalResult(_agentId: string): Promise<string | null> {
+    return null;
+  }
+
+  private buildContents(conversationHistory: ChatMessage[], turn: PreparedChatTurn): GeminiContent[] {
+    const contents: GeminiContent[] = [];
+
+    for (const message of conversationHistory) {
+      if (message.isRebuiltContext || message.isInterrupt) {
+        continue;
+      }
+      const parts = this.buildMessageParts(message.content, message.images);
+      if (parts.length === 0) {
+        continue;
+      }
+      contents.push({
+        role: message.role === 'assistant' ? 'model' : 'user',
+        parts,
+      });
+    }
+
+    const currentParts = this.buildMessageParts(turn.prompt, turn.request.images);
+    if (currentParts.length > 0) {
+      contents.push({ role: 'user', parts: currentParts });
+    }
+
+    return contents;
+  }
+
+  private buildMessageParts(content: string, images?: ChatMessage['images']): GeminiPart[] {
+    const parts: GeminiPart[] = [];
+    if (content.trim()) {
+      parts.push({ text: content });
+    }
+    for (const image of images ?? []) {
+      const imagePart = this.buildImagePart(image);
+      if (imagePart) {
+        parts.push(imagePart);
+      }
+    }
+    return parts;
+  }
+
+  private buildImagePart(image: NonNullable<ChatMessage['images']>[number]): GeminiPart | null {
+    const mediaType = image.mediaType === 'image/jpeg' ? 'image/jpeg' : image.mediaType;
+    const rawData = typeof image.data === 'string' ? image.data.trim() : '';
+    const base64Data = rawData.startsWith('data:') && rawData.includes(',')
+      ? rawData.slice(rawData.indexOf(',') + 1)
+      : rawData;
+
+    if (!base64Data) {
+      return {
+        text: `[Image attachment omitted: ${image.name || 'unnamed image'} had no image data.]`,
+      };
+    }
+
+    if (!GEMINI_SUPPORTED_IMAGE_TYPES.has(mediaType)) {
+      return {
+        text: `[Image attachment omitted: Gemini currently supports PNG, JPEG, and WebP inputs; ${image.name || 'unnamed image'} was ${image.mediaType}.]`,
+      };
+    }
+
+    return {
+      inlineData: {
+        mimeType: mediaType,
+        data: base64Data,
+      },
+    };
+  }
+
+  private toUsageInfo(model: string, usage: GeminiUsageMetadata) {
+    const inputTokens = usage.promptTokenCount ?? 0;
+    const contextWindow = DEFAULT_GEMINI_CONTEXT_WINDOW;
+    const contextTokens = inputTokens;
+    return {
+      model,
+      inputTokens,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: usage.cachedContentTokenCount ?? 0,
+      contextWindow,
+      contextWindowIsAuthoritative: false,
+      contextTokens,
+      percentage: contextWindow > 0 ? Math.min(100, (contextTokens / contextWindow) * 100) : 0,
+    };
+  }
+
+  private resetTurnMetadata(): void {
+    this.turnMetadata = {};
+  }
+
+  private setReady(ready: boolean): void {
+    this.ready = ready;
+    for (const listener of this.readyListeners) {
+      listener(ready);
+    }
+  }
+
+  private getSystemPromptSettings(): SystemPromptSettings {
+    const settings = this.plugin.settings;
+    return {
+      mediaFolder: settings.mediaFolder,
+      customPrompt: settings.systemPrompt,
+      vaultPath: getVaultPath(this.plugin.app) ?? undefined,
+      userName: settings.userName,
+    };
+  }
+
+  private getProviderSettings(): Record<string, unknown> {
+    return ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+      this.plugin.settings as unknown as Record<string, unknown>,
+      this.providerId,
+    );
+  }
+
+  private resolveModel(): string {
+    const providerSettings = this.getProviderSettings();
+    return typeof providerSettings.model === 'string' && providerSettings.model
+      ? providerSettings.model
+      : DEFAULT_GEMINI_PRIMARY_MODEL;
+  }
+
+  private async ensureToolApproved(
+    call: GeminiFunctionCall,
+  ): Promise<{ content: string; isError?: boolean } | null> {
+    if (!isGeminiWriteTool(call.name)) {
+      return null;
+    }
+
+    const settings = this.getProviderSettings();
+    if (settings.permissionMode === 'yolo') {
+      return null;
+    }
+
+    if (!this.approvalCallback) {
+      return {
+        content: 'Write denied: no approval handler is available.',
+        isError: true,
+      };
+    }
+
+    const description = describeGeminiWriteTool(call.name, call.args);
+    const decision = await this.approvalCallback(
+      call.name,
+      call.args,
+      description,
+    );
+
+    if (decision === 'allow' || decision === 'allow-always') {
+      return null;
+    }
+
+    return {
+      content: decision === 'cancel'
+        ? 'Write cancelled by user.'
+        : 'Write denied by user.',
+      isError: true,
+    };
+  }
+}

--- a/src/providers/gemini/settings.ts
+++ b/src/providers/gemini/settings.ts
@@ -1,0 +1,65 @@
+import { getProviderConfig, setProviderConfig } from '../../core/providers/providerConfig';
+import { getProviderEnvironmentVariables } from '../../core/providers/providerEnvironment';
+
+export interface GeminiProviderSettings {
+  enabled: boolean;
+  customModels: string;
+  environmentVariables: string;
+  environmentHash: string;
+  temperature: number;
+}
+
+export const DEFAULT_GEMINI_PROVIDER_SETTINGS: Readonly<GeminiProviderSettings> = Object.freeze({
+  enabled: false,
+  customModels: '',
+  environmentVariables: '',
+  environmentHash: '',
+  temperature: 1.0,
+});
+
+function normalizeTemperature(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DEFAULT_GEMINI_PROVIDER_SETTINGS.temperature;
+  }
+  return Math.max(0, Math.min(2, value));
+}
+
+export function getGeminiProviderSettings(
+  settings: Record<string, unknown>,
+): GeminiProviderSettings {
+  const config = getProviderConfig(settings, 'gemini');
+  return {
+    enabled: (config.enabled as boolean | undefined)
+      ?? DEFAULT_GEMINI_PROVIDER_SETTINGS.enabled,
+    customModels: (config.customModels as string | undefined)
+      ?? DEFAULT_GEMINI_PROVIDER_SETTINGS.customModels,
+    environmentVariables: (config.environmentVariables as string | undefined)
+      ?? getProviderEnvironmentVariables(settings, 'gemini')
+      ?? DEFAULT_GEMINI_PROVIDER_SETTINGS.environmentVariables,
+    environmentHash: (config.environmentHash as string | undefined)
+      ?? DEFAULT_GEMINI_PROVIDER_SETTINGS.environmentHash,
+    temperature: normalizeTemperature(
+      config.temperature ?? DEFAULT_GEMINI_PROVIDER_SETTINGS.temperature,
+    ),
+  };
+}
+
+export function updateGeminiProviderSettings(
+  settings: Record<string, unknown>,
+  updates: Partial<GeminiProviderSettings>,
+): GeminiProviderSettings {
+  const next: GeminiProviderSettings = {
+    ...getGeminiProviderSettings(settings),
+    ...updates,
+  };
+
+  setProviderConfig(settings, 'gemini', {
+    enabled: next.enabled,
+    customModels: next.customModels,
+    environmentVariables: next.environmentVariables,
+    environmentHash: next.environmentHash,
+    temperature: normalizeTemperature(next.temperature),
+  });
+
+  return next;
+}

--- a/src/providers/gemini/tools/GeminiVaultTools.ts
+++ b/src/providers/gemini/tools/GeminiVaultTools.ts
@@ -1,0 +1,516 @@
+import { normalizePath, TFile, TFolder } from 'obsidian';
+
+import type ClaudianPlugin from '../../../main';
+import type { GeminiFunctionDeclaration } from '../runtime/GeminiApiClient';
+
+export interface GeminiToolExecutionResult {
+  content: string;
+  isError?: boolean;
+}
+
+const MAX_FILE_READ_CHARS = 80_000;
+const DEFAULT_MAX_RESULTS = 200;
+
+export const GEMINI_VAULT_TOOL_APPENDIX = `## Gemini Provider Tools
+
+This Gemini API provider exposes Obsidian vault tools for reading and writing text/markdown notes. Use these tools when you need vault context not already supplied in the user message, or when the user explicitly asks you to create or edit notes. All paths must be relative to the vault root. Hidden/system folders are intentionally excluded from these tools for safety. Write tools should be used carefully and only when the user asks for a vault change.
+
+No image-generation or binary-file-generation tool is currently available in this Gemini provider. If the user asks you to draw, generate, create, or insert an image asset, do not fabricate markdown image links, broken placeholder image syntax, or claim that an image file was created. Instead, either create a text-only/ASCII sketch or written image description in a note if that satisfies the request, or clearly say that Gemini image generation is not wired into Claudian yet.`;
+
+export const GEMINI_VAULT_TOOL_DECLARATIONS: GeminiFunctionDeclaration[] = [
+  {
+    name: 'list_vault_files',
+    description: 'List markdown files under a vault folder. Hidden/system folders are excluded.',
+    parameters: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Folder path relative to the vault root. Use "." for the vault root.',
+        },
+        recursive: {
+          type: 'boolean',
+          description: 'Whether to include files in nested folders.',
+        },
+        maxResults: {
+          type: 'number',
+          description: 'Maximum number of file paths to return. Default 200.',
+        },
+      },
+    },
+  },
+  {
+    name: 'read_vault_file',
+    description: 'Read a markdown/text file from the vault. Hidden/system folders are excluded.',
+    parameters: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'File path relative to the vault root.',
+        },
+      },
+      required: ['path'],
+    },
+  },
+  {
+    name: 'search_vault_files',
+    description: 'Search markdown file paths by a case-insensitive substring.',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Substring to search for in file paths.',
+        },
+        maxResults: {
+          type: 'number',
+          description: 'Maximum number of file paths to return. Default 200.',
+        },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'grep_vault',
+    description: 'Search text file contents for a case-insensitive substring. Returns matching file paths and line previews.',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Substring to search for in file contents.',
+        },
+        maxResults: {
+          type: 'number',
+          description: 'Maximum number of matches to return. Default 50.',
+        },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'write_vault_file',
+    description: 'Create a new text/markdown file, or overwrite an existing file only when overwrite is true. Hidden/system folders are excluded.',
+    parameters: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'File path relative to the vault root.',
+        },
+        content: {
+          type: 'string',
+          description: 'Complete file contents to write.',
+        },
+        overwrite: {
+          type: 'boolean',
+          description: 'Set true to overwrite an existing file. Defaults to false.',
+        },
+      },
+      required: ['path', 'content'],
+    },
+  },
+  {
+    name: 'append_vault_file',
+    description: 'Append text to an existing text/markdown file. Can create the file when createIfMissing is true. Hidden/system folders are excluded.',
+    parameters: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'File path relative to the vault root.',
+        },
+        content: {
+          type: 'string',
+          description: 'Text to append.',
+        },
+        createIfMissing: {
+          type: 'boolean',
+          description: 'Create the file if it does not exist. Defaults to true.',
+        },
+      },
+      required: ['path', 'content'],
+    },
+  },
+  {
+    name: 'replace_in_vault_file',
+    description: 'Replace exact text in an existing text/markdown file. Hidden/system folders are excluded.',
+    parameters: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'File path relative to the vault root.',
+        },
+        search: {
+          type: 'string',
+          description: 'Exact text to find.',
+        },
+        replacement: {
+          type: 'string',
+          description: 'Replacement text.',
+        },
+        replaceAll: {
+          type: 'boolean',
+          description: 'Replace every exact match. Defaults to false.',
+        },
+      },
+      required: ['path', 'search', 'replacement'],
+    },
+  },
+  {
+    name: 'create_vault_folder',
+    description: 'Create a folder in the vault, including missing parent folders. Hidden/system folders are excluded.',
+    parameters: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Folder path relative to the vault root.',
+        },
+      },
+      required: ['path'],
+    },
+  },
+];
+
+export const GEMINI_WRITE_TOOL_NAMES = new Set([
+  'write_vault_file',
+  'append_vault_file',
+  'replace_in_vault_file',
+  'create_vault_folder',
+]);
+
+export function isGeminiWriteTool(name: string): boolean {
+  return GEMINI_WRITE_TOOL_NAMES.has(name);
+}
+
+export function describeGeminiWriteTool(
+  name: string,
+  input: Record<string, unknown>,
+): string {
+  const path = typeof input.path === 'string' ? input.path : '(missing path)';
+  switch (name) {
+    case 'write_vault_file':
+      return input.overwrite === true
+        ? `Overwrite vault file: ${path}`
+        : `Create vault file: ${path}`;
+    case 'append_vault_file':
+      return `Append to vault file: ${path}`;
+    case 'replace_in_vault_file':
+      return `Replace text in vault file: ${path}`;
+    case 'create_vault_folder':
+      return `Create vault folder: ${path}`;
+    default:
+      return `Modify vault path: ${path}`;
+  }
+}
+
+function isBlockedPath(path: string): boolean {
+  const normalized = normalizePath(path || '.');
+  if (normalized === '.') return false;
+  if (normalized.startsWith('/') || normalized.includes('..')) return true;
+  return normalized
+    .split('/')
+    .some(part => part.startsWith('.'));
+}
+
+function normalizeVaultPath(value: unknown): string {
+  const raw = typeof value === 'string' && value.trim() ? value.trim() : '.';
+  return normalizePath(raw);
+}
+
+function requireString(value: unknown, name: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`Missing ${name}`);
+  }
+  return value;
+}
+
+function validateWritablePath(path: string): string | null {
+  if (!path || path === '.') {
+    return 'Path must be a file or folder path relative to the vault root.';
+  }
+  if (isBlockedPath(path)) {
+    return `Blocked system path: ${path}`;
+  }
+  return null;
+}
+
+function normalizeMaxResults(value: unknown, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+  return Math.max(1, Math.min(1000, Math.floor(value)));
+}
+
+function getReadableTextFiles(plugin: ClaudianPlugin): TFile[] {
+  return plugin.app.vault.getFiles()
+    .filter(file => !isBlockedPath(file.path))
+    .filter(file => /\.(md|txt|json|yaml|yml|csv|ts|tsx|js|jsx|css|scss|html|xml)$/i.test(file.path));
+}
+
+function formatJson(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+export async function executeGeminiVaultTool(
+  plugin: ClaudianPlugin,
+  name: string,
+  input: Record<string, unknown>,
+): Promise<GeminiToolExecutionResult> {
+  try {
+    switch (name) {
+      case 'list_vault_files':
+        return listVaultFiles(plugin, input);
+      case 'read_vault_file':
+        return readVaultFile(plugin, input);
+      case 'search_vault_files':
+        return searchVaultFiles(plugin, input);
+      case 'grep_vault':
+        return grepVault(plugin, input);
+      case 'write_vault_file':
+        return writeVaultFile(plugin, input);
+      case 'append_vault_file':
+        return appendVaultFile(plugin, input);
+      case 'replace_in_vault_file':
+        return replaceInVaultFile(plugin, input);
+      case 'create_vault_folder':
+        return createVaultFolder(plugin, input);
+      default:
+        return { content: `Unknown Gemini tool: ${name}`, isError: true };
+    }
+  } catch (error) {
+    return {
+      content: error instanceof Error ? error.message : String(error),
+      isError: true,
+    };
+  }
+}
+
+async function listVaultFiles(
+  plugin: ClaudianPlugin,
+  input: Record<string, unknown>,
+): Promise<GeminiToolExecutionResult> {
+  const folder = normalizeVaultPath(input.path);
+  const recursive = input.recursive === true;
+  const maxResults = normalizeMaxResults(input.maxResults, DEFAULT_MAX_RESULTS);
+
+  if (isBlockedPath(folder)) {
+    return { content: `Blocked system path: ${folder}`, isError: true };
+  }
+
+  const prefix = folder === '.' ? '' : `${folder.replace(/\/$/, '')}/`;
+  const files = getReadableTextFiles(plugin)
+    .map(file => file.path)
+    .filter(path => {
+      if (!prefix) return true;
+      if (!path.startsWith(prefix)) return false;
+      if (recursive) return true;
+      return !path.slice(prefix.length).includes('/');
+    })
+    .slice(0, maxResults);
+
+  return { content: formatJson({ files, truncated: files.length >= maxResults }) };
+}
+
+async function readVaultFile(
+  plugin: ClaudianPlugin,
+  input: Record<string, unknown>,
+): Promise<GeminiToolExecutionResult> {
+  const path = normalizeVaultPath(input.path);
+  if (isBlockedPath(path)) {
+    return { content: `Blocked system path: ${path}`, isError: true };
+  }
+
+  const file = plugin.app.vault.getAbstractFileByPath(path);
+  if (!(file instanceof TFile)) {
+    return { content: `File not found: ${path}`, isError: true };
+  }
+
+  const content = await plugin.app.vault.read(file);
+  const truncated = content.length > MAX_FILE_READ_CHARS;
+  return {
+    content: formatJson({
+      path,
+      content: truncated ? content.slice(0, MAX_FILE_READ_CHARS) : content,
+      truncated,
+    }),
+  };
+}
+
+async function searchVaultFiles(
+  plugin: ClaudianPlugin,
+  input: Record<string, unknown>,
+): Promise<GeminiToolExecutionResult> {
+  const query = typeof input.query === 'string' ? input.query.trim().toLowerCase() : '';
+  if (!query) return { content: 'Missing query', isError: true };
+  const maxResults = normalizeMaxResults(input.maxResults, DEFAULT_MAX_RESULTS);
+
+  const files = getReadableTextFiles(plugin)
+    .map(file => file.path)
+    .filter(path => path.toLowerCase().includes(query))
+    .slice(0, maxResults);
+
+  return { content: formatJson({ files, truncated: files.length >= maxResults }) };
+}
+
+async function grepVault(
+  plugin: ClaudianPlugin,
+  input: Record<string, unknown>,
+): Promise<GeminiToolExecutionResult> {
+  const query = typeof input.query === 'string' ? input.query.trim() : '';
+  if (!query) return { content: 'Missing query', isError: true };
+  const lowerQuery = query.toLowerCase();
+  const maxResults = normalizeMaxResults(input.maxResults, 50);
+  const matches: Array<{ path: string; line: number; preview: string }> = [];
+
+  for (const file of getReadableTextFiles(plugin)) {
+    if (matches.length >= maxResults) break;
+    const content = await plugin.app.vault.cachedRead(file);
+    const lines = content.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i += 1) {
+      if (lines[i].toLowerCase().includes(lowerQuery)) {
+        matches.push({
+          path: file.path,
+          line: i + 1,
+          preview: lines[i].slice(0, 300),
+        });
+        if (matches.length >= maxResults) break;
+      }
+    }
+  }
+
+  return { content: formatJson({ matches, truncated: matches.length >= maxResults }) };
+}
+
+async function ensureParentFolder(plugin: ClaudianPlugin, path: string): Promise<void> {
+  const parts = path.split('/');
+  parts.pop();
+  let current = '';
+
+  for (const part of parts) {
+    current = current ? `${current}/${part}` : part;
+    const existing = plugin.app.vault.getAbstractFileByPath(current);
+    if (existing instanceof TFolder) {
+      continue;
+    }
+    if (existing) {
+      throw new Error(`Cannot create folder ${current}; a file exists at that path.`);
+    }
+    await plugin.app.vault.createFolder(current);
+  }
+}
+
+async function writeVaultFile(
+  plugin: ClaudianPlugin,
+  input: Record<string, unknown>,
+): Promise<GeminiToolExecutionResult> {
+  const path = normalizeVaultPath(input.path);
+  const content = requireString(input.content, 'content');
+  const blocked = validateWritablePath(path);
+  if (blocked) return { content: blocked, isError: true };
+
+  const existing = plugin.app.vault.getAbstractFileByPath(path);
+  if (existing && !(existing instanceof TFile)) {
+    return { content: `Cannot write file; path is a folder: ${path}`, isError: true };
+  }
+  if (existing && input.overwrite !== true) {
+    return { content: `File already exists: ${path}. Set overwrite=true to replace it.`, isError: true };
+  }
+
+  await ensureParentFolder(plugin, path);
+  if (existing instanceof TFile) {
+    await plugin.app.vault.modify(existing, content);
+    return { content: formatJson({ path, action: 'overwritten', bytes: content.length }) };
+  }
+
+  await plugin.app.vault.create(path, content);
+  return { content: formatJson({ path, action: 'created', bytes: content.length }) };
+}
+
+async function appendVaultFile(
+  plugin: ClaudianPlugin,
+  input: Record<string, unknown>,
+): Promise<GeminiToolExecutionResult> {
+  const path = normalizeVaultPath(input.path);
+  const content = requireString(input.content, 'content');
+  const createIfMissing = input.createIfMissing !== false;
+  const blocked = validateWritablePath(path);
+  if (blocked) return { content: blocked, isError: true };
+
+  const existing = plugin.app.vault.getAbstractFileByPath(path);
+  if (existing && !(existing instanceof TFile)) {
+    return { content: `Cannot append file; path is a folder: ${path}`, isError: true };
+  }
+
+  if (!existing) {
+    if (!createIfMissing) {
+      return { content: `File not found: ${path}`, isError: true };
+    }
+    await ensureParentFolder(plugin, path);
+    await plugin.app.vault.create(path, content);
+    return { content: formatJson({ path, action: 'created', bytes: content.length }) };
+  }
+
+  await plugin.app.vault.append(existing, content);
+  return { content: formatJson({ path, action: 'appended', bytes: content.length }) };
+}
+
+async function replaceInVaultFile(
+  plugin: ClaudianPlugin,
+  input: Record<string, unknown>,
+): Promise<GeminiToolExecutionResult> {
+  const path = normalizeVaultPath(input.path);
+  const search = requireString(input.search, 'search');
+  const replacement = requireString(input.replacement, 'replacement');
+  const replaceAll = input.replaceAll === true;
+  const blocked = validateWritablePath(path);
+  if (blocked) return { content: blocked, isError: true };
+  if (!search) return { content: 'Search text cannot be empty.', isError: true };
+
+  const file = plugin.app.vault.getAbstractFileByPath(path);
+  if (!(file instanceof TFile)) {
+    return { content: `File not found: ${path}`, isError: true };
+  }
+
+  const original = await plugin.app.vault.read(file);
+  if (!original.includes(search)) {
+    return { content: `Search text not found in ${path}`, isError: true };
+  }
+
+  const occurrences = original.split(search).length - 1;
+  const updated = replaceAll
+    ? original.split(search).join(replacement)
+    : original.replace(search, replacement);
+  await plugin.app.vault.modify(file, updated);
+  return {
+    content: formatJson({
+      path,
+      action: 'replaced',
+      replacements: replaceAll ? occurrences : 1,
+    }),
+  };
+}
+
+async function createVaultFolder(
+  plugin: ClaudianPlugin,
+  input: Record<string, unknown>,
+): Promise<GeminiToolExecutionResult> {
+  const path = normalizeVaultPath(input.path);
+  const blocked = validateWritablePath(path);
+  if (blocked) return { content: blocked, isError: true };
+
+  const existing = plugin.app.vault.getAbstractFileByPath(path);
+  if (existing instanceof TFolder) {
+    return { content: formatJson({ path, action: 'already_exists' }) };
+  }
+  if (existing) {
+    return { content: `Cannot create folder; a file exists at ${path}`, isError: true };
+  }
+
+  await ensureParentFolder(plugin, `${path}/placeholder`);
+  if (!plugin.app.vault.getAbstractFileByPath(path)) {
+    await plugin.app.vault.createFolder(path);
+  }
+  return { content: formatJson({ path, action: 'created' }) };
+}

--- a/src/providers/gemini/types/models.ts
+++ b/src/providers/gemini/types/models.ts
@@ -1,0 +1,38 @@
+import type { ProviderUIOption } from '../../../core/providers/types';
+
+export const DEFAULT_GEMINI_PRIMARY_MODEL = 'gemini-2.5-pro';
+export const DEFAULT_GEMINI_CONTEXT_WINDOW = 1_000_000;
+
+export const DEFAULT_GEMINI_MODELS: ProviderUIOption[] = [
+  {
+    value: 'gemini-2.5-pro',
+    label: 'Gemini 2.5 Pro',
+    description: 'Highest quality',
+  },
+  {
+    value: 'gemini-2.5-flash',
+    label: 'Gemini 2.5 Flash',
+    description: 'Fast, balanced',
+  },
+  {
+    value: 'gemini-2.5-flash-lite',
+    label: 'Gemini 2.5 Flash Lite',
+    description: 'Fastest, low cost',
+  },
+];
+
+export const DEFAULT_GEMINI_MODEL_SET = new Set(
+  DEFAULT_GEMINI_MODELS.map((model) => model.value),
+);
+
+export function formatGeminiModelLabel(modelId: string): string {
+  return modelId
+    .replace(/^models\//, '')
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((part) => {
+      if (/^\d+(\.\d+)?$/.test(part)) return part;
+      return part.charAt(0).toUpperCase() + part.slice(1);
+    })
+    .join(' ');
+}

--- a/src/providers/gemini/ui/GeminiChatUIConfig.ts
+++ b/src/providers/gemini/ui/GeminiChatUIConfig.ts
@@ -1,0 +1,96 @@
+import type {
+  ProviderChatUIConfig,
+  ProviderIconSvg,
+  ProviderPermissionModeToggleConfig,
+  ProviderReasoningOption,
+  ProviderUIOption,
+} from '../../../core/providers/types';
+import { getGeminiModelOptions } from '../modelOptions';
+import {
+  DEFAULT_GEMINI_CONTEXT_WINDOW,
+  DEFAULT_GEMINI_MODEL_SET,
+  DEFAULT_GEMINI_PRIMARY_MODEL,
+} from '../types/models';
+
+const GEMINI_ICON: ProviderIconSvg = {
+  viewBox: '0 0 24 24',
+  path: 'M12 2l1.7 5.2L19 9l-5.3 1.8L12 16l-1.7-5.2L5 9l5.3-1.8L12 2zm6 10l.9 2.6 2.6.9-2.6.9L18 19l-.9-2.6-2.6-.9 2.6-.9L18 12zM6 14l.7 2.1 2.1.7-2.1.7L6 20l-.7-2.5-2.1-.7 2.1-.7L6 14z',
+};
+
+const HIDDEN_REASONING_OPTIONS: ProviderReasoningOption[] = [
+  { value: 'none', label: 'None' },
+];
+
+const GEMINI_PERMISSION_MODE_TOGGLE: ProviderPermissionModeToggleConfig = {
+  inactiveValue: 'normal',
+  inactiveLabel: 'Ask',
+  activeValue: 'yolo',
+  activeLabel: 'YOLO',
+};
+
+function looksLikeGeminiModel(model: string): boolean {
+  return /^gemini-/i.test(model) || /^models\/gemini-/i.test(model);
+}
+
+export const geminiChatUIConfig: ProviderChatUIConfig = {
+  getModelOptions(settings: Record<string, unknown>): ProviderUIOption[] {
+    return getGeminiModelOptions(settings);
+  },
+
+  ownsModel(model: string, settings: Record<string, unknown>): boolean {
+    if (this.getModelOptions(settings).some((option: ProviderUIOption) => option.value === model)) {
+      return true;
+    }
+
+    return looksLikeGeminiModel(model);
+  },
+
+  isAdaptiveReasoningModel(): boolean {
+    return false;
+  },
+
+  getReasoningOptions(): ProviderReasoningOption[] {
+    return [...HIDDEN_REASONING_OPTIONS];
+  },
+
+  getDefaultReasoningValue(): string {
+    return 'none';
+  },
+
+  getContextWindowSize(model: string, customLimits?: Record<string, number>): number {
+    return customLimits?.[model] ?? DEFAULT_GEMINI_CONTEXT_WINDOW;
+  },
+
+  isDefaultModel(model: string): boolean {
+    return DEFAULT_GEMINI_MODEL_SET.has(model);
+  },
+
+  applyModelDefaults(): void {
+    // No-op for Gemini API models.
+  },
+
+  normalizeModelVariant(model: string, settings: Record<string, unknown>): string {
+    if (getGeminiModelOptions(settings).some((option) => option.value === model)) {
+      return model;
+    }
+
+    return DEFAULT_GEMINI_PRIMARY_MODEL;
+  },
+
+  getCustomModelIds(envVars: Record<string, string>): Set<string> {
+    const ids = new Set<string>();
+    const envModel = envVars.GEMINI_MODEL || envVars.GOOGLE_GEMINI_MODEL;
+    if (envModel && !DEFAULT_GEMINI_MODEL_SET.has(envModel)) {
+      ids.add(envModel);
+    }
+    return ids;
+  },
+
+  getPermissionModeToggle(): ProviderPermissionModeToggleConfig {
+    return GEMINI_PERMISSION_MODE_TOGGLE;
+  },
+
+  getProviderIcon() {
+    return GEMINI_ICON;
+  },
+};

--- a/src/providers/gemini/ui/GeminiSettingsTab.ts
+++ b/src/providers/gemini/ui/GeminiSettingsTab.ts
@@ -1,0 +1,153 @@
+import { Setting } from 'obsidian';
+
+import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
+import type { ProviderSettingsTabRenderer } from '../../../core/providers/types';
+import { renderEnvironmentSettingsSection } from '../../../features/settings/ui/EnvironmentSettingsSection';
+import { t } from '../../../i18n/i18n';
+import { parseConfiguredCustomGeminiModelIds, resolveGeminiModelSelection } from '../modelOptions';
+import { getGeminiProviderSettings, updateGeminiProviderSettings } from '../settings';
+import { DEFAULT_GEMINI_PRIMARY_MODEL } from '../types/models';
+
+export const geminiSettingsTabRenderer: ProviderSettingsTabRenderer = {
+  render(container, context) {
+    const settingsBag = context.plugin.settings as unknown as Record<string, unknown>;
+    const geminiSettings = getGeminiProviderSettings(settingsBag);
+
+    const reconcileActiveGeminiModelSelection = (): void => {
+      if (settingsBag.settingsProvider !== 'gemini') {
+        return;
+      }
+      const currentModel = typeof settingsBag.model === 'string' ? settingsBag.model : '';
+      const nextModel = resolveGeminiModelSelection(settingsBag, currentModel);
+      if (nextModel && nextModel !== currentModel) {
+        settingsBag.model = nextModel;
+      }
+    };
+
+    new Setting(container).setName(t('settings.setup')).setHeading();
+
+    new Setting(container)
+      .setName('Enable Gemini provider')
+      .setDesc('When enabled, Gemini API models appear in the model selector for new conversations.')
+      .addToggle((toggle) =>
+        toggle
+          .setValue(geminiSettings.enabled)
+          .onChange(async (value) => {
+            updateGeminiProviderSettings(settingsBag, { enabled: value });
+            await context.plugin.saveSettings();
+            context.refreshModelSelectors();
+          })
+      );
+
+    new Setting(container).setName(t('settings.models')).setHeading();
+
+    new Setting(container)
+      .setName('Custom models')
+      .setDesc('Append additional Gemini model IDs to the picker, one per line. GEMINI_MODEL still takes precedence when set.')
+      .addTextArea((text) => {
+        let pendingCustomModels = geminiSettings.customModels;
+        let savedCustomModels = geminiSettings.customModels;
+
+        const reconcileInactiveGeminiProjection = (previousCustomModels: string): boolean => {
+          if (settingsBag.settingsProvider === 'gemini') {
+            return false;
+          }
+
+          const savedProviderModel = (
+            settingsBag.savedProviderModel
+            && typeof settingsBag.savedProviderModel === 'object'
+          )
+            ? settingsBag.savedProviderModel as Record<string, unknown>
+            : {};
+          const currentSavedModel = typeof savedProviderModel.gemini === 'string'
+            ? savedProviderModel.gemini
+            : '';
+          if (!currentSavedModel) {
+            return false;
+          }
+
+          const previousCustomModelIds = new Set(parseConfiguredCustomGeminiModelIds(previousCustomModels));
+          if (!previousCustomModelIds.has(currentSavedModel)) {
+            return false;
+          }
+
+          const nextSavedModel = resolveGeminiModelSelection(settingsBag, currentSavedModel);
+          if (!nextSavedModel || nextSavedModel === currentSavedModel) {
+            return false;
+          }
+
+          settingsBag.savedProviderModel = {
+            ...savedProviderModel,
+            gemini: nextSavedModel,
+          };
+          return true;
+        };
+
+        const commitCustomModels = async (): Promise<void> => {
+          const previousCustomModels = savedCustomModels;
+          const previousModel = typeof settingsBag.model === 'string' ? settingsBag.model : '';
+
+          if (pendingCustomModels !== savedCustomModels) {
+            updateGeminiProviderSettings(settingsBag, { customModels: pendingCustomModels });
+            savedCustomModels = pendingCustomModels;
+          }
+
+          reconcileActiveGeminiModelSelection();
+          const didReconcileInactiveProjection = reconcileInactiveGeminiProjection(previousCustomModels);
+          const didReconcileTitleModel = ProviderSettingsCoordinator
+            .reconcileTitleGenerationModelSelection(settingsBag);
+          const nextModel = typeof settingsBag.model === 'string' ? settingsBag.model : '';
+
+          if (
+            previousCustomModels === savedCustomModels
+            && previousModel === nextModel
+            && !didReconcileInactiveProjection
+            && !didReconcileTitleModel
+          ) {
+            return;
+          }
+
+          await context.plugin.saveSettings();
+          context.refreshModelSelectors();
+        };
+
+        text
+          .setPlaceholder('gemini-2.5-pro-preview\ngemini-3-pro-preview')
+          .setValue(geminiSettings.customModels)
+          .onChange((value) => {
+            pendingCustomModels = value;
+          });
+        text.inputEl.rows = 4;
+        text.inputEl.cols = 40;
+        text.inputEl.addEventListener('blur', () => {
+          void commitCustomModels();
+        });
+      });
+
+    new Setting(container)
+      .setName('Temperature')
+      .setDesc('Gemini generation temperature for chat and auxiliary requests. Range: 0.0–2.0.')
+      .addText((text) => {
+        text
+          .setPlaceholder('1.0')
+          .setValue(String(geminiSettings.temperature))
+          .onChange(async (value) => {
+            const parsed = Number(value);
+            if (!Number.isFinite(parsed)) return;
+            updateGeminiProviderSettings(settingsBag, { temperature: parsed });
+            await context.plugin.saveSettings();
+          });
+      });
+
+    renderEnvironmentSettingsSection({
+      container,
+      plugin: context.plugin,
+      scope: 'provider:gemini',
+      heading: t('settings.environment'),
+      name: 'Gemini environment',
+      desc: 'Gemini API variables. Add a Gemini API key from Google AI Studio. GEMINI_MODEL can override the selected model.',
+      placeholder: `GEMINI_API_KEY=your-key\nGEMINI_MODEL=${DEFAULT_GEMINI_PRIMARY_MODEL}\nGEMINI_API_BASE_URL=https://generativelanguage.googleapis.com/v1beta`,
+      renderCustomContextLimits: (target) => context.renderCustomContextLimits(target, 'gemini'),
+    });
+  },
+};

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -4,6 +4,8 @@ import { claudeWorkspaceRegistration } from './claude/app/ClaudeWorkspaceService
 import { claudeProviderRegistration } from './claude/registration';
 import { codexWorkspaceRegistration } from './codex/app/CodexWorkspaceServices';
 import { codexProviderRegistration } from './codex/registration';
+import { geminiWorkspaceRegistration } from './gemini/app/GeminiWorkspaceServices';
+import { geminiProviderRegistration } from './gemini/registration';
 
 let builtInProvidersRegistered = false;
 
@@ -14,8 +16,10 @@ export function registerBuiltInProviders(): void {
 
   ProviderRegistry.register('claude', claudeProviderRegistration);
   ProviderRegistry.register('codex', codexProviderRegistration);
+  ProviderRegistry.register('gemini', geminiProviderRegistration);
   ProviderWorkspaceRegistry.register('claude', claudeWorkspaceRegistration);
   ProviderWorkspaceRegistry.register('codex', codexWorkspaceRegistration);
+  ProviderWorkspaceRegistry.register('gemini', geminiWorkspaceRegistration);
   builtInProvidersRegistered = true;
 }
 


### PR DESCRIPTION
## Summary

Adds a third Claudian provider, `gemini`, backed by Google Gemini's REST `generateContent` / streaming API. The provider sits alongside Claude and Codex without adding a new runtime dependency.

## What changed

- Registers a new built-in `gemini` provider.
- Adds Gemini provider settings, model selection, and environment-variable reconciliation.
- Supports `GEMINI_API_KEY` / `GOOGLE_API_KEY`, optional model overrides, and optional base URL overrides.
- Adds default Gemini model options:
  - `gemini-2.5-pro`
  - `gemini-2.5-flash`
  - `gemini-2.5-flash-lite`
- Implements streamed chat turns over `streamGenerateContent?alt=sse`.
- Adds auxiliary Gemini services for title generation, instruction refinement, and inline edits.
- Adds Obsidian vault read/search tools and guarded vault write tools.
- Keeps Gemini write tools approval-gated in normal mode and executable directly in YOLO mode.
- Blocks absolute paths, parent traversal, and hidden/system folders for Gemini vault tools.
- Handles image attachments defensively by sending supported PNG/JPEG/WebP inputs and converting unsupported/empty attachments into explanatory text.
- Adds system-prompt guidance that Gemini cannot currently generate binary/image assets in Claudian, avoiding fabricated/broken image links.

## Privacy / credentials

No user API key or local Gemini account information is included. The code only contains placeholder environment-variable names such as `GEMINI_API_KEY=your-key`.

## Validation

- `npm ci`
- `npm run typecheck`
- `npm run build`
- `node --check main.js`
- Verified the patch contains no Gemini API key prefix.

## Known limitations / follow-ups

- Gemini provider does not yet implement persistent provider-native history, fork, rewind, plan mode, MCP tools, provider commands, or subagents.
- Gemini image generation is not wired into Claudian yet; this provider supports image input/vision attachments only.
- The model list is hardcoded. A future improvement could query Google model metadata or add richer custom-model configuration.
- The provider uses direct REST calls rather than `@google/genai` to avoid adding a dependency; happy to switch to the official SDK if preferred.
