### PR TITLE
Disable Spark reasoning summaries

### DIFF
--- a/src/providers/codex/runtime/CodexChatRuntime.ts
+++ b/src/providers/codex/runtime/CodexChatRuntime.ts
@@ -36,7 +36,11 @@ import {
   findCodexSessionFile,
 } from '../history/CodexHistoryStore';
 import { encodeCodexTurn } from '../prompt/encodeCodexTurn';
-import { type CodexSafeMode, getCodexProviderSettings } from '../settings';
+import {
+  type CodexSafeMode,
+  getCodexProviderSettings,
+  getEffectiveCodexReasoningSummary,
+} from '../settings';
 import {
   extractExplicitCodexSkillNames,
   findPreferredCodexSkillByName,
@@ -543,7 +547,7 @@ export class CodexChatRuntime implements ChatRuntime {
             }
           : undefined;
 
-        const summary = getCodexProviderSettings(providerSettings).reasoningSummary;
+        const summary = getEffectiveCodexReasoningSummary(providerSettings, resolvedModel);
         const serviceTier = resolveCodexServiceTier(providerSettings.serviceTier, resolvedModel);
 
         // Configure router plan state before turn/start so buffered notifications

--- a/src/providers/codex/settings.ts
+++ b/src/providers/codex/settings.ts
@@ -2,6 +2,7 @@ import { getProviderConfig, setProviderConfig } from '../../core/providers/provi
 import { getProviderEnvironmentVariables } from '../../core/providers/providerEnvironment';
 import type { HostnameCliPaths } from '../../core/types/settings';
 import { getHostnameKey } from '../../utils/env';
+import { CODEX_SPARK_MODEL } from './types/models';
 
 export type CodexSafeMode = 'workspace-write' | 'read-only';
 export type CodexReasoningSummary = 'auto' | 'concise' | 'detailed' | 'none';
@@ -45,6 +46,30 @@ export const DEFAULT_CODEX_PROVIDER_SETTINGS: Readonly<CodexProviderSettings> = 
   wslDistroOverride: '',
   wslDistroOverridesByHost: {},
 });
+
+export function shouldDisableCodexReasoningSummary(model: string | undefined): boolean {
+  return model === CODEX_SPARK_MODEL;
+}
+
+export function getEffectiveCodexReasoningSummary(
+  settings: Record<string, unknown>,
+  model: string | undefined,
+): CodexReasoningSummary {
+  if (shouldDisableCodexReasoningSummary(model)) {
+    return 'none';
+  }
+
+  return getCodexProviderSettings(settings).reasoningSummary;
+}
+
+export function applyCodexModelDefaults(
+  model: string,
+  settings: Record<string, unknown>,
+): void {
+  if (shouldDisableCodexReasoningSummary(model)) {
+    updateCodexProviderSettings(settings, { reasoningSummary: 'none' });
+  }
+}
 
 function normalizeHostnameCliPaths(value: unknown): HostnameCliPaths {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {

--- a/src/providers/codex/types/models.ts
+++ b/src/providers/codex/types/models.ts
@@ -2,6 +2,7 @@ import type { ProviderUIOption } from '../../../core/providers/types';
 
 export type CodexModel = string;
 
+export const CODEX_SPARK_MODEL: CodexModel = 'gpt-5.3-codex-spark';
 export const DEFAULT_CODEX_MINI_MODEL: CodexModel = 'gpt-5.4-mini';
 export const DEFAULT_CODEX_PRIMARY_MODEL: CodexModel = 'gpt-5.5';
 export const FAST_TIER_CODEX_MODEL = DEFAULT_CODEX_PRIMARY_MODEL;

--- a/src/providers/codex/ui/CodexChatUIConfig.ts
+++ b/src/providers/codex/ui/CodexChatUIConfig.ts
@@ -7,6 +7,7 @@ import type {
 } from '../../../core/providers/types';
 import { OPENAI_PROVIDER_ICON } from '../../../shared/icons';
 import { getCodexModelOptions } from '../modelOptions';
+import { applyCodexModelDefaults } from '../settings';
 import {
   DEFAULT_CODEX_MODEL_SET,
   DEFAULT_CODEX_PRIMARY_MODEL,
@@ -77,8 +78,12 @@ export const codexChatUIConfig: ProviderChatUIConfig = {
     return DEFAULT_CODEX_MODEL_SET.has(model);
   },
 
-  applyModelDefaults(): void {
-    // No-op for Codex
+  applyModelDefaults(model: string, settings: unknown): void {
+    if (!settings || typeof settings !== 'object') {
+      return;
+    }
+
+    applyCodexModelDefaults(model, settings as Record<string, unknown>);
   },
 
   normalizeModelVariant(model: string, settings: Record<string, unknown>): string {

--- a/src/providers/codex/ui/CodexSettingsTab.ts
+++ b/src/providers/codex/ui/CodexSettingsTab.ts
@@ -341,7 +341,7 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
         };
 
         text
-          .setPlaceholder('gpt-5.6-preview\no4-mini\nmy-custom-model')
+          .setPlaceholder('gpt-5.4\ngpt-5.3-codex-spark')
           .setValue(codexSettings.customModels)
           .onChange((value) => {
             pendingCustomModels = value;

--- a/tests/unit/providers/codex/runtime/CodexChatRuntime.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexChatRuntime.test.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 
 import type { PreparedChatTurn } from '@/core/runtime/types';
 import type { StreamChunk } from '@/core/types/chat';
-import { DEFAULT_CODEX_PRIMARY_MODEL } from '@/providers/codex/types/models';
+import { CODEX_SPARK_MODEL, DEFAULT_CODEX_PRIMARY_MODEL } from '@/providers/codex/types/models';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -514,6 +514,46 @@ describe('CodexChatRuntime', () => {
       expect(chunks).toContainEqual({ type: 'text', content: 'Hello!' });
       expect(chunks).toContainEqual({ type: 'done' });
       expect(findCall('thread/start')).toBeDefined();
+    });
+
+    it('sends reasoning summary off for GPT-5.3 Codex Spark turns', async () => {
+      runtime.cleanup();
+      runtime = new CodexChatRuntime(createMockPlugin({
+        model: CODEX_SPARK_MODEL,
+        providerConfigs: {
+          codex: {
+            customModels: CODEX_SPARK_MODEL,
+            reasoningSummary: 'detailed',
+          },
+        },
+      }));
+
+      await collectChunks(runtime.query(createTurn('hi')));
+
+      const turnStartCall = findCall('turn/start');
+      expect(turnStartCall[1]).toMatchObject({
+        model: CODEX_SPARK_MODEL,
+        summary: 'none',
+      });
+    });
+
+    it('sends the configured reasoning summary for other Codex models', async () => {
+      runtime.cleanup();
+      runtime = new CodexChatRuntime(createMockPlugin({
+        providerConfigs: {
+          codex: {
+            reasoningSummary: 'concise',
+          },
+        },
+      }));
+
+      await collectChunks(runtime.query(createTurn('hi')));
+
+      const turnStartCall = findCall('turn/start');
+      expect(turnStartCall[1]).toMatchObject({
+        model: DEFAULT_CODEX_PRIMARY_MODEL,
+        summary: 'concise',
+      });
     });
 
     it('derives WSL transcript and memories roots from thread paths when initialize omits codexHome', async () => {

--- a/tests/unit/providers/codex/settings.test.ts
+++ b/tests/unit/providers/codex/settings.test.ts
@@ -1,8 +1,11 @@
 import {
+  applyCodexModelDefaults,
   DEFAULT_CODEX_PROVIDER_SETTINGS,
   getCodexProviderSettings,
+  getEffectiveCodexReasoningSummary,
   updateCodexProviderSettings,
 } from '@/providers/codex/settings';
+import { CODEX_SPARK_MODEL } from '@/providers/codex/types/models';
 
 const mockGetHostnameKey = jest.fn(() => 'host-a');
 
@@ -111,5 +114,32 @@ describe('codex settings', () => {
     expect(next.wslDistroOverridesByHost).toEqual({
       'host-b': 'Debian',
     });
+  });
+
+  it('forces reasoning summary off for GPT-5.3 Codex Spark', () => {
+    const settingsBag: Record<string, unknown> = {
+      providerConfigs: {
+        codex: {
+          reasoningSummary: 'detailed',
+        },
+      },
+    };
+
+    expect(getEffectiveCodexReasoningSummary(settingsBag, CODEX_SPARK_MODEL)).toBe('none');
+    expect(getEffectiveCodexReasoningSummary(settingsBag, 'gpt-5.5')).toBe('detailed');
+  });
+
+  it('sets reasoning summary off when applying GPT-5.3 Codex Spark model defaults', () => {
+    const settingsBag: Record<string, unknown> = {
+      providerConfigs: {
+        codex: {
+          reasoningSummary: 'detailed',
+        },
+      },
+    };
+
+    applyCodexModelDefaults(CODEX_SPARK_MODEL, settingsBag);
+
+    expect(getCodexProviderSettings(settingsBag).reasoningSummary).toBe('none');
   });
 });

--- a/tests/unit/providers/codex/ui/CodexChatUIConfig.test.ts
+++ b/tests/unit/providers/codex/ui/CodexChatUIConfig.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_CODEX_PRIMARY_MODEL } from '@/providers/codex/types/models';
+import { CODEX_SPARK_MODEL, DEFAULT_CODEX_PRIMARY_MODEL } from '@/providers/codex/types/models';
 import { codexChatUIConfig } from '@/providers/codex/ui/CodexChatUIConfig';
 
 describe('CodexChatUIConfig', () => {
@@ -102,6 +102,48 @@ describe('CodexChatUIConfig', () => {
   describe('getContextWindowSize', () => {
     it('should return 200000 for all models', () => {
       expect(codexChatUIConfig.getContextWindowSize(DEFAULT_CODEX_PRIMARY_MODEL)).toBe(200_000);
+    });
+  });
+
+  describe('applyModelDefaults', () => {
+    it('sets reasoning summary off for GPT-5.3 Codex Spark', () => {
+      const settings: Record<string, unknown> = {
+        providerConfigs: {
+          codex: {
+            reasoningSummary: 'detailed',
+          },
+        },
+      };
+
+      codexChatUIConfig.applyModelDefaults(CODEX_SPARK_MODEL, settings);
+
+      expect(settings).toMatchObject({
+        providerConfigs: {
+          codex: {
+            reasoningSummary: 'none',
+          },
+        },
+      });
+    });
+
+    it('leaves reasoning summary unchanged for other Codex models', () => {
+      const settings: Record<string, unknown> = {
+        providerConfigs: {
+          codex: {
+            reasoningSummary: 'detailed',
+          },
+        },
+      };
+
+      codexChatUIConfig.applyModelDefaults(DEFAULT_CODEX_PRIMARY_MODEL, settings);
+
+      expect(settings).toMatchObject({
+        providerConfigs: {
+          codex: {
+            reasoningSummary: 'detailed',
+          },
+        },
+      });
     });
   });
 

--- a/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
+++ b/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
@@ -471,6 +471,18 @@ describe('CodexSettingsTab', () => {
     expect(context.refreshModelSelectors).not.toHaveBeenCalled();
   });
 
+  it('shows current Codex custom model examples in the custom models textarea', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const plugin = createPlugin();
+
+    codexSettingsTabRenderer.render(createContainer(), createContext(plugin));
+
+    const customModelsSetting = findSetting('Custom models');
+    expect(customModelsSetting.textAreaComponents[0].placeholder).toBe(
+      'gpt-5.4\ngpt-5.3-codex-spark',
+    );
+  });
+
   it('reconciles removed custom models on blur and clears stale title model selections', async () => {
     Object.defineProperty(process, 'platform', { value: 'darwin' });
     const plugin = createPlugin({


### PR DESCRIPTION
Disables reasoning summaries for `gpt-5.3-codex-spark` at the Codex provider boundary, including model-default selection and every `turn/start` payload.

Updates the Codex custom model input example to show `gpt-5.4` and `gpt-5.3-codex-spark`.

Adds unit coverage for settings resolution, UI defaults, settings placeholder text, and runtime request payloads.

Verification run: `npm run typecheck`, `npm run lint`, `npm run test`, and `npm run build`.