### PR TITLE
Support Claude auto mode

### DIFF
--- a/src/providers/claude/commands/probeRuntimeCommands.ts
+++ b/src/providers/claude/commands/probeRuntimeCommands.ts
@@ -43,6 +43,10 @@ export async function probeRuntimeCommands(plugin: ClaudianPlugin): Promise<Slas
 
   const abortController = new AbortController();
   let commands: SlashCommand[] = [];
+  const extraArgs = {
+    ...(claudeSettings.safeMode === 'auto' ? { 'enable-auto-mode': null } : {}),
+    ...(claudeSettings.enableChrome ? { chrome: null } : {}),
+  };
 
   try {
     const conversation = agentQuery({
@@ -55,7 +59,7 @@ export async function probeRuntimeCommands(plugin: ClaudianPlugin): Promise<Slas
         permissionMode: 'bypassPermissions',
         allowDangerouslySkipPermissions: true,
         settingSources: claudeSettings.loadUserSettings ? ['user', 'project'] : ['project'],
-        ...(claudeSettings.enableChrome ? { extraArgs: { chrome: null } } : {}),
+        ...(Object.keys(extraArgs).length > 0 ? { extraArgs } : {}),
         spawnClaudeCodeProcess: createCustomSpawnFunction(enhancedPath),
         persistSession: false,
       },

--- a/src/providers/claude/runtime/ClaudeDynamicUpdates.ts
+++ b/src/providers/claude/runtime/ClaudeDynamicUpdates.ts
@@ -119,7 +119,11 @@ export async function applyClaudeDynamicUpdates(
   if (configBeforePermissionUpdate) {
     const sdkMode = deps.resolveSDKPermissionMode(permissionMode);
     const currentSdkMode = configBeforePermissionUpdate.sdkPermissionMode ?? null;
-    if (sdkMode !== currentSdkMode) {
+    const requiresAutoModeRestart = sdkMode === 'auto' && !configBeforePermissionUpdate.enableAutoMode;
+    if (requiresAutoModeRestart) {
+      // The Claude Code auto-mode opt-in is a startup flag. The restart path below
+      // will rebuild the query with that capability before auto becomes active.
+    } else if (sdkMode !== currentSdkMode) {
       try {
         await persistentQuery.setPermissionMode(sdkMode);
         deps.mutateCurrentConfig(config => {

--- a/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts
+++ b/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts
@@ -80,6 +80,7 @@ export class QueryOptionsBuilder {
     // Since allowDangerouslySkipPermissions is always true, both directions work without restart.
 
     if (currentConfig.enableChrome !== newConfig.enableChrome) return true;
+    if (currentConfig.enableAutoMode !== newConfig.enableAutoMode) return true;
 
     // External context paths require restart (additionalDirectories can't be updated dynamically)
     if (QueryOptionsBuilder.pathsChanged(currentConfig.externalContextPaths, newConfig.externalContextPaths)) {
@@ -123,6 +124,7 @@ export class QueryOptionsBuilder {
       settingSources: claudeSettings.loadUserSettings ? 'user,project' : 'project',
       claudeCliPath: ctx.cliPath,
       enableChrome: claudeSettings.enableChrome,
+      enableAutoMode: claudeSettings.safeMode === 'auto',
     };
   }
 
@@ -242,8 +244,15 @@ export class QueryOptionsBuilder {
     );
   }
 
-  private static applyExtraArgs(options: Options, enableChrome: boolean): void {
-    if (enableChrome) {
+  private static applyExtraArgs(
+    options: Options,
+    settings: { enableChrome: boolean; safeMode: ClaudeSafeMode },
+  ): void {
+    if (settings.safeMode === 'auto') {
+      options.extraArgs = { ...options.extraArgs, 'enable-auto-mode': null };
+    }
+
+    if (settings.enableChrome) {
       options.extraArgs = { ...options.extraArgs, chrome: null };
     }
   }
@@ -275,7 +284,7 @@ export class QueryOptionsBuilder {
       includePartialMessages: true,
     };
 
-    QueryOptionsBuilder.applyExtraArgs(options, claudeSettings.enableChrome);
+    QueryOptionsBuilder.applyExtraArgs(options, claudeSettings);
     options.spawnClaudeCodeProcess = createCustomSpawnFunction(ctx.enhancedPath);
 
     return { options, claudeSettings };

--- a/src/providers/claude/runtime/claudeColdStartQuery.ts
+++ b/src/providers/claude/runtime/claudeColdStartQuery.ts
@@ -110,6 +110,10 @@ export async function runColdStartQuery(
     options.resume = config.resumeSessionId;
   }
 
+  if (claudeSettings.safeMode === 'auto') {
+    options.extraArgs = { ...options.extraArgs, 'enable-auto-mode': null };
+  }
+
   if (!config.thinking?.disabled) {
     const effortLevel = resolveAdaptiveEffortLevel(selectedModel, settings.effortLevel);
     if (effortLevel !== null) {

--- a/src/providers/claude/runtime/types.ts
+++ b/src/providers/claude/runtime/types.ts
@@ -109,6 +109,7 @@ export interface PersistentQueryConfig {
   settingSources: string;
   claudeCliPath: string;
   enableChrome: boolean;
+  enableAutoMode: boolean;
 }
 
 export interface SessionState {

--- a/src/providers/claude/settings.ts
+++ b/src/providers/claude/settings.ts
@@ -2,7 +2,8 @@ import { getProviderConfig, setProviderConfig } from '../../core/providers/provi
 import { getProviderEnvironmentVariables } from '../../core/providers/providerEnvironment';
 import type { HostnameCliPaths } from '../../core/types/settings';
 
-export type ClaudeSafeMode = 'acceptEdits' | 'default';
+export const CLAUDE_SAFE_MODES = ['acceptEdits', 'auto', 'default'] as const;
+export type ClaudeSafeMode = typeof CLAUDE_SAFE_MODES[number];
 
 export interface ClaudeProviderSettings {
   safeMode: ClaudeSafeMode;
@@ -48,14 +49,20 @@ function normalizeHostnameCliPaths(value: unknown): HostnameCliPaths {
   return result;
 }
 
+function normalizeClaudeSafeMode(value: unknown): ClaudeSafeMode | undefined {
+  return (CLAUDE_SAFE_MODES as readonly unknown[]).includes(value)
+    ? value as ClaudeSafeMode
+    : undefined;
+}
+
 export function getClaudeProviderSettings(
   settings: Record<string, unknown>,
 ): ClaudeProviderSettings {
   const config = getProviderConfig(settings, 'claude');
 
   return {
-    safeMode: (config.safeMode as ClaudeSafeMode | undefined)
-      ?? (settings.claudeSafeMode as ClaudeSafeMode | undefined)
+    safeMode: normalizeClaudeSafeMode(config.safeMode)
+      ?? normalizeClaudeSafeMode(settings.claudeSafeMode)
       ?? DEFAULT_CLAUDE_PROVIDER_SETTINGS.safeMode,
     cliPath: (config.cliPath as string | undefined)
       ?? (settings.claudeCliPath as string | undefined)
@@ -94,9 +101,13 @@ export function updateClaudeProviderSettings(
   settings: Record<string, unknown>,
   updates: Partial<ClaudeProviderSettings>,
 ): ClaudeProviderSettings {
+  const current = getClaudeProviderSettings(settings);
   const next = {
-    ...getClaudeProviderSettings(settings),
+    ...current,
     ...updates,
+    safeMode: 'safeMode' in updates
+      ? normalizeClaudeSafeMode(updates.safeMode) ?? current.safeMode
+      : current.safeMode,
   };
   setProviderConfig(settings, 'claude', next);
   return next;

--- a/src/providers/claude/types/agent.ts
+++ b/src/providers/claude/types/agent.ts
@@ -1,2 +1,2 @@
-export const AGENT_PERMISSION_MODES = ['default', 'acceptEdits', 'dontAsk', 'bypassPermissions', 'plan', 'delegate'] as const;
+export const AGENT_PERMISSION_MODES = ['default', 'acceptEdits', 'auto', 'dontAsk', 'bypassPermissions', 'plan', 'delegate'] as const;
 export type AgentPermissionMode = typeof AGENT_PERMISSION_MODES[number];

--- a/src/providers/claude/types/settings.ts
+++ b/src/providers/claude/types/settings.ts
@@ -29,7 +29,7 @@ export interface CCPermissions {
   /** Rules that always prompt for confirmation */
   ask?: PermissionRule[];
   /** Default permission mode */
-  defaultMode?: 'acceptEdits' | 'bypassPermissions' | 'default' | 'plan';
+  defaultMode?: 'acceptEdits' | 'auto' | 'bypassPermissions' | 'default' | 'dontAsk' | 'plan';
   /** Additional directories to include in permission scope */
   additionalDirectories?: string[];
 }

--- a/src/providers/claude/ui/ClaudeSettingsTab.ts
+++ b/src/providers/claude/ui/ClaudeSettingsTab.ts
@@ -10,7 +10,12 @@ import { getHostnameKey } from '../../../utils/env';
 import { expandHomePath } from '../../../utils/path';
 import { getClaudeWorkspaceServices } from '../app/ClaudeWorkspaceServices';
 import { resolveClaudeModelSelection } from '../modelOptions';
-import { getClaudeProviderSettings, updateClaudeProviderSettings } from '../settings';
+import {
+  CLAUDE_SAFE_MODES,
+  type ClaudeSafeMode,
+  getClaudeProviderSettings,
+  updateClaudeProviderSettings,
+} from '../settings';
 import { AgentSettings } from './AgentSettings';
 import { claudeChatUIConfig } from './ClaudeChatUIConfig';
 import { PluginSettingsManager } from './PluginSettingsManager';
@@ -146,14 +151,15 @@ export const claudeSettingsTabRenderer: ProviderSettingsTabRenderer = {
       .setName(t('settings.claudeSafeMode.name'))
       .setDesc(t('settings.claudeSafeMode.desc'))
       .addDropdown((dropdown) => {
+        for (const mode of CLAUDE_SAFE_MODES) {
+          dropdown.addOption(mode, mode);
+        }
         dropdown
-          .addOption('acceptEdits', 'acceptEdits')
-          .addOption('default', 'default')
           .setValue(claudeSettings.safeMode)
           .onChange(async (value) => {
             updateClaudeProviderSettings(
               settingsBag,
-              { safeMode: value as 'acceptEdits' | 'default' },
+              { safeMode: value as ClaudeSafeMode },
             );
             await context.plugin.saveSettings();
           });

--- a/tests/__mocks__/claude-agent-sdk.ts
+++ b/tests/__mocks__/claude-agent-sdk.ts
@@ -85,7 +85,7 @@ export type PermissionRuleValue = {
 
 export type PermissionUpdateDestination = 'userSettings' | 'projectSettings' | 'localSettings' | 'session' | 'cliArg';
 
-export type PermissionMode = 'acceptEdits' | 'bypassPermissions' | 'default' | 'delegate' | 'dontAsk' | 'plan';
+export type PermissionMode = 'acceptEdits' | 'auto' | 'bypassPermissions' | 'default' | 'delegate' | 'dontAsk' | 'plan';
 
 export type PermissionUpdate =
   | { type: 'addRules'; rules: PermissionRuleValue[]; behavior: PermissionBehavior; destination: PermissionUpdateDestination }

--- a/tests/unit/providers/claude/agents/AgentStorage.test.ts
+++ b/tests/unit/providers/claude/agents/AgentStorage.test.ts
@@ -339,6 +339,10 @@ describe('parsePermissionMode', () => {
     expect(parsePermissionMode('acceptEdits')).toBe('acceptEdits');
   });
 
+  it('returns auto for valid input', () => {
+    expect(parsePermissionMode('auto')).toBe('auto');
+  });
+
   it('returns dontAsk for valid input', () => {
     expect(parsePermissionMode('dontAsk')).toBe('dontAsk');
   });

--- a/tests/unit/providers/claude/commands/probeRuntimeCommands.test.ts
+++ b/tests/unit/providers/claude/commands/probeRuntimeCommands.test.ts
@@ -72,4 +72,21 @@ describe('probeRuntimeCommands', () => {
     expect(options?.settingSources).toEqual(['user', 'project']);
     expect(options?.extraArgs).toEqual({ chrome: null });
   });
+
+  it('passes auto mode opt-in when Claude safe mode is auto', async () => {
+    sdkMock.setMockMessages([
+      { type: 'system', subtype: 'init', session_id: 'probe-session' },
+    ], { appendResult: false });
+    sdkMock.setMockSupportedCommands([]);
+
+    await probeRuntimeCommands(createMockPlugin({
+      providerConfigs: {
+        claude: {
+          safeMode: 'auto',
+        },
+      },
+    }));
+
+    expect(sdkMock.getLastOptions()?.extraArgs).toEqual({ 'enable-auto-mode': null });
+  });
 });

--- a/tests/unit/providers/claude/runtime/ClaudianService.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudianService.test.ts
@@ -1643,6 +1643,50 @@ describe('ClaudianService', () => {
       expect((service as any).currentConfig.sdkPermissionMode).toBe('acceptEdits');
     });
 
+    it('should restart before applying auto mode when auto opt-in was not enabled', async () => {
+      (mockPlugin as any).settings.permissionMode = 'normal';
+      (mockPlugin as any).settings.claudeSafeMode = 'acceptEdits';
+      (service as any).currentConfig = (service as any).buildPersistentQueryConfig(
+        '/mock/vault/path',
+        '/usr/local/bin/claude',
+        [],
+      );
+
+      mockPersistentQuery.setPermissionMode.mockClear();
+      (service as any).startPersistentQuery.mockClear();
+      (mockPlugin as any).settings.claudeSafeMode = 'auto';
+
+      await (service as any).applyDynamicUpdates({});
+
+      expect(mockPersistentQuery.setPermissionMode).not.toHaveBeenCalled();
+      expect((service as any).startPersistentQuery).toHaveBeenCalledTimes(1);
+      expect((service as any).currentConfig.permissionMode).toBe('normal');
+      expect((service as any).currentConfig.sdkPermissionMode).toBe('auto');
+      expect((service as any).currentConfig.enableAutoMode).toBe(true);
+    });
+
+    it('should update permission mode to auto dynamically when auto opt-in is already enabled', async () => {
+      (mockPlugin as any).settings.permissionMode = 'yolo';
+      (mockPlugin as any).settings.claudeSafeMode = 'auto';
+      (service as any).currentConfig = (service as any).buildPersistentQueryConfig(
+        '/mock/vault/path',
+        '/usr/local/bin/claude',
+        [],
+      );
+
+      mockPersistentQuery.setPermissionMode.mockClear();
+      (service as any).startPersistentQuery.mockClear();
+      (mockPlugin as any).settings.permissionMode = 'normal';
+
+      await (service as any).applyDynamicUpdates({});
+
+      expect(mockPersistentQuery.setPermissionMode).toHaveBeenCalledWith('auto');
+      expect((service as any).startPersistentQuery).not.toHaveBeenCalled();
+      expect((service as any).currentConfig.permissionMode).toBe('normal');
+      expect((service as any).currentConfig.sdkPermissionMode).toBe('auto');
+      expect((service as any).currentConfig.enableAutoMode).toBe(true);
+    });
+
     it('should update MCP servers when changed', async () => {
       mockMcpManager.getActiveServers.mockReturnValue({
         'test-server': { command: 'test', args: [] },

--- a/tests/unit/providers/claude/runtime/QueryOptionsBuilder.test.ts
+++ b/tests/unit/providers/claude/runtime/QueryOptionsBuilder.test.ts
@@ -77,6 +77,7 @@ function createMockPersistentQueryConfig(
     settingSources: 'project',
     claudeCliPath: '/mock/claude',
     enableChrome: false,
+    enableAutoMode: false,
     ...overrides,
   };
 }
@@ -161,6 +162,12 @@ describe('QueryOptionsBuilder', () => {
       expect(QueryOptionsBuilder.needsRestart(currentConfig, newConfig)).toBe(true);
     });
 
+    it('returns true when enableAutoMode changes', () => {
+      const currentConfig = createMockPersistentQueryConfig();
+      const newConfig = { ...currentConfig, enableAutoMode: true };
+      expect(QueryOptionsBuilder.needsRestart(currentConfig, newConfig)).toBe(true);
+    });
+
     it('returns true when externalContextPaths changes', () => {
       const currentConfig = createMockPersistentQueryConfig();
       const newConfig = { ...currentConfig, externalContextPaths: ['/external/path'] };
@@ -208,6 +215,28 @@ describe('QueryOptionsBuilder', () => {
 
       expect(config.permissionMode).toBe('normal');
       expect(config.sdkPermissionMode).toBe('default');
+    });
+
+    it('tracks auto sdkPermissionMode for Claude safe mode', () => {
+      const ctx = createMockContext({
+        settings: createMockSettings({ permissionMode: 'normal', claudeSafeMode: 'auto' }),
+      });
+      const config = QueryOptionsBuilder.buildPersistentQueryConfig(ctx);
+
+      expect(config.permissionMode).toBe('normal');
+      expect(config.sdkPermissionMode).toBe('auto');
+      expect(config.enableAutoMode).toBe(true);
+    });
+
+    it('enables auto mode startup capability whenever Claude safe mode is auto', () => {
+      const ctx = createMockContext({
+        settings: createMockSettings({ permissionMode: 'yolo', claudeSafeMode: 'auto' }),
+      });
+      const config = QueryOptionsBuilder.buildPersistentQueryConfig(ctx);
+
+      expect(config.permissionMode).toBe('yolo');
+      expect(config.sdkPermissionMode).toBe('bypassPermissions');
+      expect(config.enableAutoMode).toBe(true);
     });
 
     it('includes thinking tokens when budget is set', () => {
@@ -334,6 +363,35 @@ describe('QueryOptionsBuilder', () => {
       expect(options.allowDangerouslySkipPermissions).toBe(true);
     });
 
+    it('resolves claudeSafeMode "auto" when permissionMode is normal', () => {
+      const ctx = {
+        ...createMockContext({
+          settings: createMockSettings({ permissionMode: 'normal', claudeSafeMode: 'auto' }),
+        }),
+        abortController: new AbortController(),
+        hooks: {},
+      };
+      const options = QueryOptionsBuilder.buildPersistentQueryOptions(ctx);
+
+      expect(options.permissionMode).toBe('auto');
+      expect(options.allowDangerouslySkipPermissions).toBe(true);
+      expect(options.extraArgs).toEqual({ 'enable-auto-mode': null });
+    });
+
+    it('passes auto mode opt-in whenever Claude safe mode is auto', () => {
+      const ctx = {
+        ...createMockContext({
+          settings: createMockSettings({ permissionMode: 'yolo', claudeSafeMode: 'auto' }),
+        }),
+        abortController: new AbortController(),
+        hooks: {},
+      };
+      const options = QueryOptionsBuilder.buildPersistentQueryOptions(ctx);
+
+      expect(options.permissionMode).toBe('bypassPermissions');
+      expect(options.extraArgs).toEqual({ 'enable-auto-mode': null });
+    });
+
     it('ignores claudeSafeMode when permissionMode is yolo', () => {
       const ctx = {
         ...createMockContext({
@@ -431,6 +489,19 @@ describe('QueryOptionsBuilder', () => {
 
       expect(options.extraArgs).toBeDefined();
       expect(options.extraArgs).toEqual({ chrome: null });
+    });
+
+    it('sets extraArgs with chrome and auto mode flags when both are enabled', () => {
+      const ctx = {
+        ...createMockContext({
+          settings: createMockSettings({ enableChrome: true, claudeSafeMode: 'auto' }),
+        }),
+        abortController: new AbortController(),
+        hooks: {},
+      };
+      const options = QueryOptionsBuilder.buildPersistentQueryOptions(ctx);
+
+      expect(options.extraArgs).toEqual({ 'enable-auto-mode': null, chrome: null });
     });
 
     it('does not set extraArgs when enableChrome is disabled', () => {
@@ -628,6 +699,20 @@ describe('QueryOptionsBuilder', () => {
 
       expect(options.extraArgs).toBeDefined();
       expect(options.extraArgs).toEqual({ chrome: null });
+    });
+
+    it('sets extraArgs with auto mode flag when Claude safe mode is auto', () => {
+      const ctx = {
+        ...createMockContext({
+          settings: createMockSettings({ claudeSafeMode: 'auto' }),
+        }),
+        abortController: new AbortController(),
+        hooks: {},
+        hasEditorContext: false,
+      };
+      const options = QueryOptionsBuilder.buildColdStartQueryOptions(ctx);
+
+      expect(options.extraArgs).toEqual({ 'enable-auto-mode': null });
     });
 
     it('does not set extraArgs when enableChrome is disabled', () => {

--- a/tests/unit/providers/claude/runtime/claudeColdStartQuery.test.ts
+++ b/tests/unit/providers/claude/runtime/claudeColdStartQuery.test.ts
@@ -149,6 +149,29 @@ describe('runColdStartQuery', () => {
       expect(opts?.hooks).toBe(hooks);
     });
 
+    it('passes auto mode opt-in when Claude safe mode is auto', async () => {
+      sdkMock.setMockMessages([]);
+
+      await runColdStartQuery(
+        createConfig({
+          providerSettings: {
+            model: 'claude-sonnet-4-5',
+            thinkingBudget: 'off',
+            effortLevel: 'medium',
+            loadUserClaudeSettings: false,
+            providerConfigs: {
+              claude: {
+                safeMode: 'auto',
+              },
+            },
+          },
+        }),
+        'hi',
+      );
+
+      expect(sdkMock.getLastOptions()?.extraArgs).toEqual({ 'enable-auto-mode': null });
+    });
+
     it('sets persistSession false when configured', async () => {
       sdkMock.setMockMessages([]);
 

--- a/tests/unit/providers/claude/ui/ClaudeSettingsTab.test.ts
+++ b/tests/unit/providers/claude/ui/ClaudeSettingsTab.test.ts
@@ -371,6 +371,27 @@ describe('ClaudeSettingsTab', () => {
     expect(context.refreshModelSelectors).not.toHaveBeenCalled();
   });
 
+  it('offers auto as a Claude safe mode and persists it', async () => {
+    const plugin = createPlugin();
+    const context = createContext(plugin);
+
+    claudeSettingsTabRenderer.render(createContainer(), context);
+
+    const safeModeSetting = findSetting('settings.claudeSafeMode.name');
+    const safeModeDropdown = safeModeSetting.dropdownComponents[0];
+
+    expect(safeModeDropdown.options).toEqual([
+      { value: 'acceptEdits', label: 'acceptEdits' },
+      { value: 'auto', label: 'auto' },
+      { value: 'default', label: 'default' },
+    ]);
+
+    await safeModeDropdown.onChangeCallback?.('auto');
+
+    expect(plugin.settings.providerConfigs.claude.safeMode).toBe('auto');
+    expect(mockSaveSettings).toHaveBeenCalledTimes(1);
+  });
+
   it('reconciles removed custom models on blur and clears stale title model selections', async () => {
     const plugin = createPlugin({
       titleGenerationModel: 'claude-opus-4-6',


### PR DESCRIPTION
Adds Claude auto safe-mode support across provider settings, the settings dropdown, SDK permission mapping, and Claude Code-compatible permission types. When Claude Safe mode is set to auto, SDK launches pass --enable-auto-mode across persistent runtime, cold-start, and command-probe paths, while dynamic updates restart once only if the existing persistent query lacks the auto opt-in. Includes regression coverage for settings normalization, UI persistence, launch args, dynamic permission updates, and agent/frontmatter parsing. Validation: npm run typecheck; npm run lint; npm run test; npm run build.