### PR TITLE
fix: support late prompt usage in Claude streams

### DIFF
--- a/src/providers/claude/runtime/ClaudeChatRuntime.ts
+++ b/src/providers/claude/runtime/ClaudeChatRuntime.ts
@@ -72,7 +72,11 @@ import { encodeClaudeTurn } from '../prompt/ClaudeTurnEncoder';
 import { isContextWindowEvent, isSessionInitEvent, isStreamChunk } from '../sdk/typeGuards';
 import type { TransformEvent } from '../sdk/types';
 import { getClaudeProviderSettings } from '../settings';
-import { createTransformStreamState, transformSDKMessage } from '../stream/transformClaudeMessage';
+import {
+  createTransformStreamState,
+  createTransformUsageState,
+  transformSDKMessage,
+} from '../stream/transformClaudeMessage';
 import { type ClaudeProviderState, getClaudeState } from '../types/providerState';
 import { createClaudeApprovalCallback } from './ClaudeApprovalHandler';
 import { applyClaudeDynamicUpdates } from './ClaudeDynamicUpdates';
@@ -179,6 +183,7 @@ export class ClaudianService implements ChatRuntime {
   private turnMetadata: ChatTurnMetadata = {};
   private bufferedUsageChunk: StreamChunk & { type: 'usage' } | null = null;
   private streamTransformState = createTransformStreamState();
+  private usageTransformState = createTransformUsageState();
 
   private getLegacyPluginDeps(): ClaudianPlugin & {
     agentManager?: Pick<AppAgentManager, 'setBuiltinAgentNames'>;
@@ -251,6 +256,7 @@ export class ClaudianService implements ChatRuntime {
   private resetTurnMetadata(): void {
     this.turnMetadata = {};
     this.bufferedUsageChunk = null;
+    this.usageTransformState.clear();
   }
 
   private recordTurnMetadata(update: Partial<ChatTurnMetadata>): void {
@@ -590,6 +596,7 @@ export class ClaudianService implements ChatRuntime {
     this.currentConfig = null;
     this.cachedSdkCommands = [];
     this.streamTransformState.clearAll();
+    this.usageTransformState.clear();
     this._autoTurnBuffer = [];
     this._autoTurnSawStreamText = false;
     this._autoTurnSawStreamThinking = false;
@@ -796,12 +803,17 @@ export class ClaudianService implements ChatRuntime {
   }
 
   /** @param modelOverride - Optional model override for cold-start queries */
-  private getTransformOptions(modelOverride?: string, streamState = this.streamTransformState) {
+  private getTransformOptions(
+    modelOverride?: string,
+    streamState = this.streamTransformState,
+    usageState = this.usageTransformState,
+  ) {
     const settings = this.getScopedSettings();
     return {
       intendedModel: modelOverride ?? settings.model,
       customContextLimits: settings.customContextLimits,
       streamState,
+      usageState,
     };
   }
 
@@ -1513,6 +1525,7 @@ export class ClaudianService implements ChatRuntime {
     let sawStreamText = false;
     let sawStreamThinking = false;
     const streamState = createTransformStreamState();
+    const usageState = createTransformUsageState();
     try {
       const response = agentQuery({ prompt: queryPrompt, options });
       this.recordTurnMetadata({ wasSent: true });
@@ -1524,7 +1537,7 @@ export class ClaudianService implements ChatRuntime {
           break;
         }
 
-        for (const event of transformSDKMessage(message, this.getTransformOptions(selectedModel, streamState))) {
+        for (const event of transformSDKMessage(message, this.getTransformOptions(selectedModel, streamState, usageState))) {
           this.noteVisibleStreamContent(message, event, {
             onText: () => {
               sawStreamText = true;

--- a/src/providers/claude/stream/transformClaudeMessage.ts
+++ b/src/providers/claude/stream/transformClaudeMessage.ts
@@ -40,12 +40,30 @@ export interface TransformOptions {
   customContextLimits?: Record<string, number>;
   /** Tracks active streamed tool blocks so input_json_delta can be normalized. */
   streamState?: TransformStreamState;
+  /** Tracks prompt-token usage across Anthropic-compatible stream events. */
+  usageState?: TransformUsageState;
 }
 
-interface MessageUsage {
+export interface MessageUsage {
   input_tokens?: number;
+  output_tokens?: number;
   cache_creation_input_tokens?: number;
   cache_read_input_tokens?: number;
+}
+
+interface PromptUsageSnapshot {
+  inputTokens: number;
+  cacheCreationInputTokens: number;
+  cacheReadInputTokens: number;
+  contextTokens: number;
+}
+
+export interface TransformUsageState {
+  clear(): void;
+  mergePromptUsage(usage: MessageUsage): PromptUsageSnapshot;
+  getPromptUsage(): PromptUsageSnapshot;
+  hasEmitted(promptUsage: PromptUsageSnapshot): boolean;
+  markEmitted(promptUsage: PromptUsageSnapshot): void;
 }
 
 interface ContextWindowEntry {
@@ -194,6 +212,127 @@ function selectContextWindowEntry(
   );
 }
 
+const EMPTY_PROMPT_USAGE: PromptUsageSnapshot = {
+  inputTokens: 0,
+  cacheCreationInputTokens: 0,
+  cacheReadInputTokens: 0,
+  contextTokens: 0,
+};
+
+function normalizeTokenCount(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function hasPromptUsageField(usage: unknown): usage is MessageUsage {
+  if (!usage || typeof usage !== 'object' || Array.isArray(usage)) {
+    return false;
+  }
+
+  const record = usage as Record<string, unknown>;
+  return typeof record.input_tokens === 'number'
+    || typeof record.cache_creation_input_tokens === 'number'
+    || typeof record.cache_read_input_tokens === 'number';
+}
+
+function toPromptUsageSnapshot(usage: MessageUsage): PromptUsageSnapshot {
+  const inputTokens = normalizeTokenCount(usage.input_tokens);
+  const cacheCreationInputTokens = normalizeTokenCount(usage.cache_creation_input_tokens);
+  const cacheReadInputTokens = normalizeTokenCount(usage.cache_read_input_tokens);
+  return {
+    inputTokens,
+    cacheCreationInputTokens,
+    cacheReadInputTokens,
+    contextTokens: inputTokens + cacheCreationInputTokens + cacheReadInputTokens,
+  };
+}
+
+function mergePromptUsage(
+  current: PromptUsageSnapshot,
+  usage: MessageUsage,
+): PromptUsageSnapshot {
+  const next = toPromptUsageSnapshot(usage);
+  const inputTokens = Math.max(current.inputTokens, next.inputTokens);
+  const cacheCreationInputTokens = Math.max(current.cacheCreationInputTokens, next.cacheCreationInputTokens);
+  const cacheReadInputTokens = Math.max(current.cacheReadInputTokens, next.cacheReadInputTokens);
+  return {
+    inputTokens,
+    cacheCreationInputTokens,
+    cacheReadInputTokens,
+    contextTokens: inputTokens + cacheCreationInputTokens + cacheReadInputTokens,
+  };
+}
+
+function samePromptUsage(a: PromptUsageSnapshot, b: PromptUsageSnapshot): boolean {
+  return a.inputTokens === b.inputTokens
+    && a.cacheCreationInputTokens === b.cacheCreationInputTokens
+    && a.cacheReadInputTokens === b.cacheReadInputTokens
+    && a.contextTokens === b.contextTokens;
+}
+
+function buildUsageInfo(promptUsage: PromptUsageSnapshot, options?: TransformOptions): UsageInfo {
+  const model = options?.intendedModel ?? 'sonnet';
+  const contextWindow = getContextWindowSize(model, options?.customContextLimits);
+  const percentage = Math.min(100, Math.max(0, Math.round((promptUsage.contextTokens / contextWindow) * 100)));
+
+  return {
+    model,
+    inputTokens: promptUsage.inputTokens,
+    cacheCreationInputTokens: promptUsage.cacheCreationInputTokens,
+    cacheReadInputTokens: promptUsage.cacheReadInputTokens,
+    contextWindow,
+    contextTokens: promptUsage.contextTokens,
+    percentage,
+  };
+}
+
+export function createTransformUsageState(): TransformUsageState {
+  let promptUsage: PromptUsageSnapshot = { ...EMPTY_PROMPT_USAGE };
+  let lastEmittedPromptUsage: PromptUsageSnapshot | null = null;
+
+  return {
+    clear(): void {
+      promptUsage = { ...EMPTY_PROMPT_USAGE };
+      lastEmittedPromptUsage = null;
+    },
+
+    mergePromptUsage(usage: MessageUsage): PromptUsageSnapshot {
+      promptUsage = mergePromptUsage(promptUsage, usage);
+      return promptUsage;
+    },
+
+    getPromptUsage(): PromptUsageSnapshot {
+      return { ...promptUsage };
+    },
+
+    hasEmitted(nextPromptUsage: PromptUsageSnapshot): boolean {
+      return lastEmittedPromptUsage !== null && samePromptUsage(lastEmittedPromptUsage, nextPromptUsage);
+    },
+
+    markEmitted(nextPromptUsage: PromptUsageSnapshot): void {
+      lastEmittedPromptUsage = { ...nextPromptUsage };
+    },
+  };
+}
+
+function maybeEmitUsageFromPromptUsage(
+  promptUsage: PromptUsageSnapshot,
+  options?: TransformOptions,
+  behavior: { emitZeroUsage?: boolean } = {},
+): StreamChunk | null {
+  if (promptUsage.contextTokens <= 0) {
+    return behavior.emitZeroUsage
+      ? { type: 'usage', usage: buildUsageInfo(promptUsage, options) }
+      : null;
+  }
+
+  if (options?.usageState?.hasEmitted(promptUsage)) {
+    return null;
+  }
+
+  options?.usageState?.markEmitted(promptUsage);
+  return { type: 'usage', usage: buildUsageInfo(promptUsage, options) };
+}
+
 /**
  * Transform SDK message to StreamChunk format.
  * One SDK message can yield multiple chunks (e.g., text + tool_use blocks).
@@ -250,25 +389,15 @@ export function* transformSDKMessage(
       // This gives accurate per-turn context usage without subagent token pollution
       const usage = (message.message as { usage?: MessageUsage } | undefined)?.usage;
       if (parentToolUseId === null && usage) {
-        const inputTokens = usage.input_tokens ?? 0;
-        const cacheCreationInputTokens = usage.cache_creation_input_tokens ?? 0;
-        const cacheReadInputTokens = usage.cache_read_input_tokens ?? 0;
-        const contextTokens = inputTokens + cacheCreationInputTokens + cacheReadInputTokens;
-
-        const model = options?.intendedModel ?? 'sonnet';
-        const contextWindow = getContextWindowSize(model, options?.customContextLimits);
-        const percentage = Math.min(100, Math.max(0, Math.round((contextTokens / contextWindow) * 100)));
-
-        const usageInfo: UsageInfo = {
-          model,
-          inputTokens,
-          cacheCreationInputTokens,
-          cacheReadInputTokens,
-          contextWindow,
-          contextTokens,
-          percentage,
-        };
-        yield { type: 'usage', usage: usageInfo };
+        if (options?.usageState) {
+          const promptUsage = options.usageState.mergePromptUsage(usage);
+          const usageChunk = maybeEmitUsageFromPromptUsage(promptUsage, options, { emitZeroUsage: true });
+          if (usageChunk) {
+            yield usageChunk;
+          }
+        } else {
+          yield { type: 'usage', usage: buildUsageInfo(toPromptUsageSnapshot(usage), options) };
+        }
       }
       break;
     }
@@ -315,7 +444,38 @@ export function* transformSDKMessage(
     case 'stream_event': {
       const parentToolUseId = message.parent_tool_use_id ?? null;
       const event = message.event;
-      if (event?.type === 'content_block_start' && event.content_block?.type === 'tool_use') {
+      if (parentToolUseId === null && event?.type === 'message_start') {
+        options?.usageState?.clear();
+        const usage = (event.message as { usage?: MessageUsage } | undefined)?.usage;
+        if (usage && hasPromptUsageField(usage)) {
+          if (options?.usageState) {
+            options.usageState.mergePromptUsage(usage);
+          } else {
+            const usageChunk = maybeEmitUsageFromPromptUsage(toPromptUsageSnapshot(usage), options);
+            if (usageChunk) {
+              yield usageChunk;
+            }
+          }
+        }
+      } else if (parentToolUseId === null && event?.type === 'message_delta' && hasPromptUsageField(event.usage)) {
+        if (options?.usageState) {
+          const previousPromptUsage = options.usageState.getPromptUsage();
+          const promptUsage = options.usageState.mergePromptUsage(event.usage);
+          const shouldEmitDeltaUsage = previousPromptUsage.contextTokens <= 0
+            || options.usageState.hasEmitted(previousPromptUsage);
+          if (shouldEmitDeltaUsage) {
+            const usageChunk = maybeEmitUsageFromPromptUsage(promptUsage, options);
+            if (usageChunk) {
+              yield usageChunk;
+            }
+          }
+        } else {
+          const usageChunk = maybeEmitUsageFromPromptUsage(toPromptUsageSnapshot(event.usage), options);
+          if (usageChunk) {
+            yield usageChunk;
+          }
+        }
+      } else if (event?.type === 'content_block_start' && event.content_block?.type === 'tool_use') {
         const toolUseFields: ToolUseFields = {
           id: event.content_block.id || `tool-${Date.now()}`,
           name: event.content_block.name || 'unknown',
@@ -356,6 +516,13 @@ export function* transformSDKMessage(
 
     case 'result':
       options?.streamState?.clearAll();
+      if (options?.usageState) {
+        const usageChunk = maybeEmitUsageFromPromptUsage(options.usageState.getPromptUsage(), options);
+        if (usageChunk) {
+          yield usageChunk;
+        }
+        options.usageState.clear();
+      }
       if (isResultError(message)) {
         const content = message.errors.filter((e) => e.trim().length > 0).join('\n');
         yield {

--- a/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
+++ b/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
@@ -1,6 +1,10 @@
 import { buildSDKMessage } from '@test/helpers/sdkMessages';
 
-import { createTransformStreamState, transformSDKMessage } from '@/providers/claude/stream/transformClaudeMessage';
+import {
+  createTransformStreamState,
+  createTransformUsageState,
+  transformSDKMessage,
+} from '@/providers/claude/stream/transformClaudeMessage';
 
 const msg = buildSDKMessage;
 
@@ -821,6 +825,255 @@ describe('transformSDKMessage', () => {
 
       expect(results).toEqual([]);
     });
+
+    it('yields usage when Anthropic-compatible message_delta carries prompt tokens', () => {
+      const usageState = createTransformUsageState();
+      const startMessage = msg({
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: {
+            usage: {
+              input_tokens: 0,
+              output_tokens: 0,
+            },
+          },
+        },
+      });
+      const deltaMessage = msg({
+        type: 'stream_event',
+        event: {
+          type: 'message_delta',
+          delta: { stop_reason: 'end_turn' },
+          usage: {
+            input_tokens: 16,
+            output_tokens: 6,
+            cache_read_input_tokens: 0,
+          },
+        },
+      });
+
+      expect([...transformSDKMessage(startMessage, {
+        intendedModel: 'glm-5.1',
+        usageState,
+      })]).toEqual([]);
+
+      const results = [...transformSDKMessage(deltaMessage, {
+        intendedModel: 'glm-5.1',
+        usageState,
+      })];
+
+      expect(results).toEqual([
+        {
+          type: 'usage',
+          usage: {
+            model: 'glm-5.1',
+            inputTokens: 16,
+            cacheCreationInputTokens: 0,
+            cacheReadInputTokens: 0,
+            contextWindow: 200000,
+            contextTokens: 16,
+            percentage: 0,
+          },
+        },
+      ]);
+    });
+
+    it('keeps standard message_start prompt usage on the final assistant usage path', () => {
+      const usageState = createTransformUsageState();
+      const startMessage = msg({
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: {
+            usage: {
+              input_tokens: 10,
+              output_tokens: 0,
+              cache_creation_input_tokens: 0,
+              cache_read_input_tokens: 0,
+            },
+          },
+        },
+      });
+      const deltaMessage = msg({
+        type: 'stream_event',
+        event: {
+          type: 'message_delta',
+          delta: { stop_reason: 'end_turn' },
+          usage: {
+            input_tokens: 10,
+            output_tokens: 4,
+          },
+        },
+      });
+      const assistantMessage = msg({
+        type: 'assistant',
+        parent_tool_use_id: null,
+        message: {
+          content: [{ type: 'text', text: 'Hello' }],
+          usage: {
+            input_tokens: 10,
+            output_tokens: 4,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          },
+        },
+      });
+
+      const startResults = [...transformSDKMessage(startMessage, {
+        intendedModel: 'sonnet',
+        usageState,
+      })];
+      const deltaResults = [...transformSDKMessage(deltaMessage, {
+        intendedModel: 'sonnet',
+        usageState,
+      })];
+      const assistantResults = [...transformSDKMessage(assistantMessage, {
+        intendedModel: 'sonnet',
+        usageState,
+      })];
+
+      expect(startResults).toEqual([]);
+      expect(deltaResults).toEqual([]);
+      expect(assistantResults).toEqual([
+        { type: 'text', content: 'Hello' },
+        {
+          type: 'usage',
+          usage: {
+            model: 'sonnet',
+            inputTokens: 10,
+            cacheCreationInputTokens: 0,
+            cacheReadInputTokens: 0,
+            contextWindow: 200000,
+            contextTokens: 10,
+            percentage: 0,
+          },
+        },
+      ]);
+    });
+
+    it('emits message_start prompt usage at result when no assistant usage arrives', () => {
+      const usageState = createTransformUsageState();
+      const startMessage = msg({
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: {
+            usage: {
+              input_tokens: 10,
+              output_tokens: 0,
+              cache_creation_input_tokens: 0,
+              cache_read_input_tokens: 0,
+            },
+          },
+        },
+      });
+      const deltaMessage = msg({
+        type: 'stream_event',
+        event: {
+          type: 'message_delta',
+          delta: { stop_reason: 'end_turn' },
+          usage: {
+            output_tokens: 4,
+          },
+        },
+      });
+      const resultMessage = msg({
+        type: 'result',
+        subtype: 'success',
+        modelUsage: undefined,
+      });
+
+      expect([...transformSDKMessage(startMessage, {
+        intendedModel: 'sonnet',
+        usageState,
+      })]).toEqual([]);
+      expect([...transformSDKMessage(deltaMessage, {
+        intendedModel: 'sonnet',
+        usageState,
+      })]).toEqual([]);
+
+      expect([...transformSDKMessage(resultMessage, {
+        intendedModel: 'sonnet',
+        usageState,
+      })]).toEqual([
+        {
+          type: 'usage',
+          usage: {
+            model: 'sonnet',
+            inputTokens: 10,
+            cacheCreationInputTokens: 0,
+            cacheReadInputTokens: 0,
+            contextWindow: 200000,
+            contextTokens: 10,
+            percentage: 0,
+          },
+        },
+      ]);
+    });
+
+    it('ignores standard message_delta usage that only contains output tokens', () => {
+      const usageState = createTransformUsageState();
+      const message = msg({
+        type: 'stream_event',
+        event: {
+          type: 'message_delta',
+          delta: { stop_reason: 'end_turn' },
+          usage: {
+            output_tokens: 6,
+          },
+        },
+      });
+
+      const results = [...transformSDKMessage(message, { usageState })];
+
+      expect(results).toEqual([]);
+    });
+
+    it('ignores subagent stream usage deltas', () => {
+      const usageState = createTransformUsageState();
+      const message = msg({
+        type: 'stream_event',
+        parent_tool_use_id: 'subagent-parent',
+        event: {
+          type: 'message_delta',
+          usage: {
+            input_tokens: 16,
+            output_tokens: 6,
+          },
+        },
+      });
+
+      const results = [...transformSDKMessage(message, { usageState })];
+
+      expect(results).toEqual([]);
+    });
+
+    it('ignores subagent message_start usage', () => {
+      const usageState = createTransformUsageState();
+      const message = msg({
+        type: 'stream_event',
+        parent_tool_use_id: 'subagent-parent',
+        event: {
+          type: 'message_start',
+          message: {
+            usage: {
+              input_tokens: 16,
+              output_tokens: 0,
+            },
+          },
+        },
+      });
+
+      const results = [...transformSDKMessage(message, { usageState })];
+
+      expect(results).toEqual([]);
+      expect([...transformSDKMessage(msg({
+        type: 'result',
+        subtype: 'success',
+        modelUsage: undefined,
+      }), { usageState })]).toEqual([]);
+    });
   });
 
   describe('result messages', () => {
@@ -1152,6 +1405,40 @@ describe('transformSDKMessage', () => {
       expect(usage.percentage).toBe(1); // 1500 / 200000 * 100 rounded
     });
 
+    it('yields usage from assistant message when usage state has no stream prompt usage', () => {
+      const usageState = createTransformUsageState();
+      const message = msg({
+        type: 'assistant',
+        parent_tool_use_id: null,
+        message: {
+          content: [{ type: 'text', text: 'Hello' }],
+          usage: {
+            input_tokens: 1000,
+            output_tokens: 500,
+            cache_creation_input_tokens: 300,
+            cache_read_input_tokens: 200,
+          },
+        },
+      });
+
+      const results = [...transformSDKMessage(message, {
+        intendedModel: 'sonnet',
+        usageState,
+      })];
+
+      const usageResults = results.filter(r => r.type === 'usage');
+      expect(usageResults).toHaveLength(1);
+      expect((usageResults[0] as any).usage).toEqual({
+        model: 'sonnet',
+        inputTokens: 1000,
+        cacheCreationInputTokens: 300,
+        cacheReadInputTokens: 200,
+        contextWindow: 200000,
+        contextTokens: 1500,
+        percentage: 1,
+      });
+    });
+
     it('skips usage extraction for subagent messages', () => {
       const message = msg({
         type: 'assistant',
@@ -1264,6 +1551,81 @@ describe('transformSDKMessage', () => {
       expect(usage.cacheCreationInputTokens).toBe(0);
       expect(usage.cacheReadInputTokens).toBe(0);
       expect(usage.contextTokens).toBe(0);
+    });
+
+    it('emits final zero usage with usage state when no stream prompt usage exists', () => {
+      const usageState = createTransformUsageState();
+      const message = msg({
+        type: 'assistant',
+        parent_tool_use_id: null,
+        message: {
+          content: [{ type: 'text', text: 'Hello' }],
+          usage: {
+            input_tokens: 0,
+            output_tokens: 6,
+          },
+        },
+      });
+
+      const results = [...transformSDKMessage(message, {
+        intendedModel: 'sonnet',
+        usageState,
+      })];
+
+      expect(results).toEqual([
+        { type: 'text', content: 'Hello' },
+        {
+          type: 'usage',
+          usage: {
+            model: 'sonnet',
+            inputTokens: 0,
+            cacheCreationInputTokens: 0,
+            cacheReadInputTokens: 0,
+            contextWindow: 200000,
+            contextTokens: 0,
+            percentage: 0,
+          },
+        },
+      ]);
+    });
+
+    it('does not let final zero assistant usage overwrite positive stream usage', () => {
+      const usageState = createTransformUsageState();
+      const deltaMessage = msg({
+        type: 'stream_event',
+        event: {
+          type: 'message_delta',
+          usage: {
+            input_tokens: 16,
+            output_tokens: 6,
+          },
+        },
+      });
+      const assistantMessage = msg({
+        type: 'assistant',
+        parent_tool_use_id: null,
+        message: {
+          content: [{ type: 'text', text: 'Hello' }],
+          usage: {
+            input_tokens: 0,
+            output_tokens: 6,
+          },
+        },
+      });
+
+      const streamResults = [...transformSDKMessage(deltaMessage, {
+        intendedModel: 'glm-5.1',
+        usageState,
+      })];
+      const assistantResults = [...transformSDKMessage(assistantMessage, {
+        intendedModel: 'glm-5.1',
+        usageState,
+      })];
+
+      expect(streamResults.filter(r => r.type === 'usage')).toHaveLength(1);
+      expect(assistantResults).toEqual([
+        { type: 'text', content: 'Hello' },
+      ]);
     });
   });
 


### PR DESCRIPTION
## Summary
- normalize Anthropic-compatible stream usage so prompt tokens can be read from `message_delta.usage` when providers report them late
- keep standard Claude behavior on the assistant/final usage path and avoid emitting output-only delta usage
- prevent later zero-valued assistant usage from hiding a prior positive stream usage chunk
- reset usage transform state at turn/runtime boundaries and flush message_start usage at result when no assistant usage arrives

Fixes #560.

## Verification
- Real GLM stream through the updated transformer: `real_glm=inputTokens:16,contextTokens:16`
- Synthetic transformer verification for GLM-style and standard Anthropic-style usage
- `npm run test -- tests/unit/providers/claude/stream/transformSDKMessage.test.ts --runInBand`
- `npm run test -- tests/unit/providers/claude/runtime/ClaudianService.test.ts --runInBand`
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run build`
- `git diff --check`
