### PR TITLE
Fix ACP prompt turn timeout

### DIFF
--- a/src/providers/acp/AcpClientConnection.ts
+++ b/src/providers/acp/AcpClientConnection.ts
@@ -1,4 +1,4 @@
-import type { AcpJsonRpcTransport } from './AcpJsonRpcTransport';
+import type { AcpJsonRpcTransport, JsonRpcRequestOptions } from './AcpJsonRpcTransport';
 import { JsonRpcErrorResponse } from './AcpJsonRpcTransport';
 import {
   ACP_SERVER_NOTIFICATION_ALIASES,
@@ -49,6 +49,9 @@ import type {
 type SessionNotificationListener = (
   notification: AcpSessionNotification,
 ) => void | Promise<void>;
+
+// ACP prompt turns are long-running RPCs; session/update notifications stream progress until the final response.
+const ACP_PROMPT_TURN_TIMEOUT_MS = 0;
 
 export interface AcpFileSystemDelegate {
   readTextFile?: (request: AcpReadTextFileRequest) => Promise<AcpReadTextFileResponse>;
@@ -160,7 +163,9 @@ export class AcpClientConnection {
   }
 
   prompt(request: AcpPromptRequest): Promise<AcpPromptResponse> {
-    return this.requestWithFallback<AcpPromptResponse>('prompt', request);
+    return this.requestWithFallback<AcpPromptResponse>('prompt', request, {
+      timeoutMs: ACP_PROMPT_TURN_TIMEOUT_MS,
+    });
   }
 
   cancel(notification: AcpCancelNotification): void {
@@ -281,10 +286,11 @@ export class AcpClientConnection {
   private async requestWithFallback<T>(
     logicalMethod: AcpLogicalMethod,
     params?: unknown,
+    requestOptions?: JsonRpcRequestOptions,
   ): Promise<T> {
     const cachedMethod = this.methodCache.get(logicalMethod);
     if (cachedMethod) {
-      return this.options.transport.request<T>(cachedMethod, params);
+      return this.options.transport.request<T>(cachedMethod, params, requestOptions);
     }
 
     const candidates = getAcpMethodCandidates(logicalMethod, this.options.methodOverrides);
@@ -292,7 +298,7 @@ export class AcpClientConnection {
 
     for (const methodName of candidates) {
       try {
-        const result = await this.options.transport.request<T>(methodName, params);
+        const result = await this.options.transport.request<T>(methodName, params, requestOptions);
         this.methodCache.set(logicalMethod, methodName);
         return result;
       } catch (error) {

--- a/tests/unit/providers/acp/AcpClientConnection.test.ts
+++ b/tests/unit/providers/acp/AcpClientConnection.test.ts
@@ -1,10 +1,14 @@
 import { createInterface } from 'node:readline';
 import { PassThrough } from 'node:stream';
 
-import type { AcpSessionNotification } from '../../../../src/providers/acp';
+import type {
+  AcpSessionNotification,
+  JsonRpcRequestOptions,
+} from '../../../../src/providers/acp';
 import {
   AcpClientConnection,
   AcpJsonRpcTransport,
+  JsonRpcErrorResponse,
 } from '../../../../src/providers/acp';
 
 interface ConnectionHarness {
@@ -174,6 +178,49 @@ describe('AcpClientConnection', () => {
       harness.transport.dispose();
       harness.close();
     }
+  });
+
+  it('disables request timeout for prompt turns across method fallback', async () => {
+    const promptRequest = {
+      prompt: [{ text: 'hi', type: 'text' as const }],
+      sessionId: 'session-1',
+    };
+    const requests: Array<{
+      method: string;
+      options?: JsonRpcRequestOptions;
+      params?: unknown;
+    }> = [];
+    const transport = {
+      notify: () => undefined,
+      onNotification: () => () => undefined,
+      onRequest: () => () => undefined,
+      request: async (method: string, params?: unknown, options?: JsonRpcRequestOptions) => {
+        requests.push({ method, options, params });
+        if (method === 'session/prompt') {
+          throw new JsonRpcErrorResponse(method, -32601, 'Method not found');
+        }
+        return { stopReason: 'end_turn' };
+      },
+      signal: new AbortController().signal,
+    } as unknown as AcpJsonRpcTransport;
+    const connection = new AcpClientConnection({ transport });
+
+    await expect(connection.prompt(promptRequest)).resolves.toEqual({
+      stopReason: 'end_turn',
+    });
+
+    expect(requests).toEqual([
+      {
+        method: 'session/prompt',
+        options: { timeoutMs: 0 },
+        params: promptRequest,
+      },
+      {
+        method: 'prompt',
+        options: { timeoutMs: 0 },
+        params: promptRequest,
+      },
+    ]);
   });
 
   it('sends cancel notifications to all known aliases when no working method is cached', async () => {


### PR DESCRIPTION
## Summary

- Disable the JSON-RPC request timeout specifically for ACP prompt turns.
- Keep the existing 30s default timeout for short ACP control-plane requests.
- Preserve ACP method fallback behavior while forwarding per-request options.

## Why

ACP `session/prompt` is a long-running turn RPC. Progress streams through `session/update` notifications, and the final response can legitimately take multiple minutes. Applying the generic 30s transport timeout to `session/prompt` caused OpenCode turns with tool calls or web search to fail with `Request timeout: session/prompt (30000ms)`.

## Tests

- `npm run test -- tests/unit/providers/acp/AcpClientConnection.test.ts`
- `npm run typecheck`
- `npx eslint src/providers/acp/AcpClientConnection.ts tests/unit/providers/acp/AcpClientConnection.test.ts`
- `npm run build`

Fixes #581
