### PR TITLE
fix: include local settings source so .claude/settings.local.json is loaded by SDK

### DIFF
--- a/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts
+++ b/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts
@@ -120,7 +120,7 @@ export class QueryOptionsBuilder {
       mcpServersKey: '', // Dynamic via setMcpServers, not tracked for restart
       pluginsKey,
       externalContextPaths: externalContextPaths || [],
-      settingSources: claudeSettings.loadUserSettings ? 'user,project' : 'project',
+      settingSources: claudeSettings.loadUserSettings ? 'user,project,local' : 'project,local',
       claudeCliPath: ctx.cliPath,
       enableChrome: claudeSettings.enableChrome,
     };
@@ -266,7 +266,7 @@ export class QueryOptionsBuilder {
       model,
       abortController,
       pathToClaudeCodeExecutable: ctx.cliPath,
-      settingSources: claudeSettings.loadUserSettings ? ['user', 'project'] : ['project'],
+      settingSources: claudeSettings.loadUserSettings ? ['user', 'project', 'local'] : ['project', 'local'],
       env: {
         ...process.env,
         ...ctx.customEnv,


### PR DESCRIPTION
## Summary

- `settingSources` was missing `'local'`, so the SDK never loaded `.claude/settings.local.json`
- Added `'local'` to both the SDK options array and the restart-detection key string in `buildPersistentQueryConfig`

## Test plan

- Add config to `.claude/settings.local.json` (e.g. `pluginConfigs`, `permissions.allow`)
- Start a conversation in Claudian — settings should now take effect