### PR TITLE
fix: load local Claude settings in all SDK calls

### DIFF
--- a/src/providers/claude/commands/probeRuntimeCommands.ts
+++ b/src/providers/claude/commands/probeRuntimeCommands.ts
@@ -6,7 +6,10 @@ import type ClaudianPlugin from '../../../main';
 import { getEnhancedPath, parseEnvironmentVariables } from '../../../utils/env';
 import { getVaultPath } from '../../../utils/path';
 import { createCustomSpawnFunction } from '../runtime/customSpawn';
-import { getClaudeProviderSettings } from '../settings';
+import {
+  getClaudeProviderSettings,
+  resolveClaudeSettingSources,
+} from '../settings';
 
 function mapSdkCommands(sdkCommands: SDKSlashCommand[]): SlashCommand[] {
   return sdkCommands.map((cmd) => ({
@@ -58,7 +61,7 @@ export async function probeRuntimeCommands(plugin: ClaudianPlugin): Promise<Slas
         env: { ...process.env, ...customEnv, PATH: enhancedPath },
         permissionMode: 'bypassPermissions',
         allowDangerouslySkipPermissions: true,
-        settingSources: claudeSettings.loadUserSettings ? ['user', 'project'] : ['project'],
+        settingSources: resolveClaudeSettingSources(claudeSettings.loadUserSettings),
         ...(Object.keys(extraArgs).length > 0 ? { extraArgs } : {}),
         spawnClaudeCodeProcess: createCustomSpawnFunction(enhancedPath),
         persistSession: false,

--- a/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts
+++ b/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts
@@ -15,6 +15,7 @@ import type { ClaudianSettings, PermissionMode } from '../../../core/types/setti
 import {
   type ClaudeSafeMode,
   getClaudeProviderSettings,
+  resolveClaudeSettingSources,
 } from '../settings';
 import {
   resolveAdaptiveEffortLevel,
@@ -110,6 +111,8 @@ export class QueryOptionsBuilder {
     const disallowedToolsKey = ctx.mcpManager.getAllDisallowedMcpTools().join('|');
     const pluginsKey = ctx.pluginManager.getPluginsKey();
 
+    const settingSources = resolveClaudeSettingSources(claudeSettings.loadUserSettings);
+
     return {
       model: ctx.settings.model,
       thinkingTokens: resolveThinkingTokens(ctx.settings.model, ctx.settings.thinkingBudget),
@@ -121,7 +124,7 @@ export class QueryOptionsBuilder {
       mcpServersKey: '', // Dynamic via setMcpServers, not tracked for restart
       pluginsKey,
       externalContextPaths: externalContextPaths || [],
-      settingSources: claudeSettings.loadUserSettings ? 'user,project' : 'project',
+      settingSources: settingSources.join(','),
       claudeCliPath: ctx.cliPath,
       enableChrome: claudeSettings.enableChrome,
       enableAutoMode: claudeSettings.safeMode === 'auto',
@@ -275,7 +278,7 @@ export class QueryOptionsBuilder {
       model,
       abortController,
       pathToClaudeCodeExecutable: ctx.cliPath,
-      settingSources: claudeSettings.loadUserSettings ? ['user', 'project'] : ['project'],
+      settingSources: resolveClaudeSettingSources(claudeSettings.loadUserSettings),
       env: {
         ...process.env,
         ...ctx.customEnv,

--- a/src/providers/claude/runtime/claudeColdStartQuery.ts
+++ b/src/providers/claude/runtime/claudeColdStartQuery.ts
@@ -6,7 +6,10 @@ import type ClaudianPlugin from '../../../main';
 import { getEnhancedPath, getMissingNodeError, parseEnvironmentVariables } from '../../../utils/env';
 import { getVaultPath } from '../../../utils/path';
 import { extractAssistantText } from '../auxiliary/extractAssistantText';
-import { getClaudeProviderSettings } from '../settings';
+import {
+  getClaudeProviderSettings,
+  resolveClaudeSettingSources,
+} from '../settings';
 import {
   resolveAdaptiveEffortLevel,
   resolveThinkingTokens,
@@ -88,9 +91,7 @@ export async function runColdStartQuery(
     },
     permissionMode: 'bypassPermissions',
     allowDangerouslySkipPermissions: true,
-    settingSources: claudeSettings.loadUserSettings
-      ? ['user', 'project']
-      : ['project'],
+    settingSources: resolveClaudeSettingSources(claudeSettings.loadUserSettings),
     spawnClaudeCodeProcess: createCustomSpawnFunction(enhancedPath),
   };
 

--- a/src/providers/claude/settings.ts
+++ b/src/providers/claude/settings.ts
@@ -4,6 +4,7 @@ import type { HostnameCliPaths } from '../../core/types/settings';
 
 export const CLAUDE_SAFE_MODES = ['acceptEdits', 'auto', 'default'] as const;
 export type ClaudeSafeMode = typeof CLAUDE_SAFE_MODES[number];
+export type ClaudeSettingSource = 'user' | 'project' | 'local';
 
 export interface ClaudeProviderSettings {
   safeMode: ClaudeSafeMode;
@@ -95,6 +96,14 @@ export function getClaudeProviderSettings(
       ?? (settings.lastEnvHash as string | undefined)
       ?? DEFAULT_CLAUDE_PROVIDER_SETTINGS.environmentHash,
   };
+}
+
+export function resolveClaudeSettingSources(
+  loadUserSettings: boolean,
+): ClaudeSettingSource[] {
+  return loadUserSettings
+    ? ['user', 'project', 'local']
+    : ['project', 'local'];
 }
 
 export function updateClaudeProviderSettings(

--- a/tests/unit/features/chat/services/InstructionRefineService.test.ts
+++ b/tests/unit/features/chat/services/InstructionRefineService.test.ts
@@ -79,7 +79,7 @@ describe('InstructionRefineService', () => {
       await service.refineInstruction('be concise', '');
 
       const options = getLastOptions();
-      expect(options?.settingSources).toEqual(['project']);
+      expect(options?.settingSources).toEqual(['project', 'local']);
     });
 
     it('should set settingSources to include user when loadUserClaudeSettings is true', async () => {
@@ -98,7 +98,7 @@ describe('InstructionRefineService', () => {
       await service.refineInstruction('be concise', '');
 
       const options = getLastOptions();
-      expect(options?.settingSources).toEqual(['user', 'project']);
+      expect(options?.settingSources).toEqual(['user', 'project', 'local']);
     });
 
     it('should include existing instructions and allow markdown blocks', async () => {

--- a/tests/unit/features/chat/services/TitleGenerationService.test.ts
+++ b/tests/unit/features/chat/services/TitleGenerationService.test.ts
@@ -300,7 +300,7 @@ describe('TitleGenerationService', () => {
       await service.generateTitle('conv-123', 'test', callback);
 
       const options = getLastOptions();
-      expect(options?.settingSources).toEqual(['project']);
+      expect(options?.settingSources).toEqual(['project', 'local']);
     });
 
     it('should set settingSources to include user when loadUserClaudeSettings is true', async () => {
@@ -321,7 +321,7 @@ describe('TitleGenerationService', () => {
       await service.generateTitle('conv-123', 'test', callback);
 
       const options = getLastOptions();
-      expect(options?.settingSources).toEqual(['user', 'project']);
+      expect(options?.settingSources).toEqual(['user', 'project', 'local']);
     });
 
     it('should truncate long user messages', async () => {

--- a/tests/unit/features/inline-edit/InlineEditService.test.ts
+++ b/tests/unit/features/inline-edit/InlineEditService.test.ts
@@ -361,7 +361,7 @@ describe('InlineEditService', () => {
       });
 
       const options = getLastOptions();
-      expect(options?.settingSources).toEqual(['project']);
+      expect(options?.settingSources).toEqual(['project', 'local']);
     });
 
     it('should set settingSources to include user when loadUserClaudeSettings is true', async () => {
@@ -385,7 +385,7 @@ describe('InlineEditService', () => {
       });
 
       const options = getLastOptions();
-      expect(options?.settingSources).toEqual(['user', 'project']);
+      expect(options?.settingSources).toEqual(['user', 'project', 'local']);
     });
 
     it('should set adaptive thinking for Claude models', async () => {

--- a/tests/unit/providers/claude/commands/probeRuntimeCommands.test.ts
+++ b/tests/unit/providers/claude/commands/probeRuntimeCommands.test.ts
@@ -54,7 +54,7 @@ describe('probeRuntimeCommands', () => {
       content: '',
       source: 'sdk',
     }]);
-    expect(sdkMock.getLastOptions()?.settingSources).toEqual(['project']);
+    expect(sdkMock.getLastOptions()?.settingSources).toEqual(['project', 'local']);
   });
 
   it('includes user settings in the probe when the runtime would include them', async () => {
@@ -69,7 +69,7 @@ describe('probeRuntimeCommands', () => {
     }));
 
     const options = sdkMock.getLastOptions();
-    expect(options?.settingSources).toEqual(['user', 'project']);
+    expect(options?.settingSources).toEqual(['user', 'project', 'local']);
     expect(options?.extraArgs).toEqual({ chrome: null });
   });
 

--- a/tests/unit/providers/claude/runtime/QueryOptionsBuilder.test.ts
+++ b/tests/unit/providers/claude/runtime/QueryOptionsBuilder.test.ts
@@ -74,7 +74,7 @@ function createMockPersistentQueryConfig(
     mcpServersKey: '',
     pluginsKey: '',
     externalContextPaths: [],
-    settingSources: 'project',
+    settingSources: 'project,local',
     claudeCliPath: '/mock/claude',
     enableChrome: false,
     enableAutoMode: false,
@@ -128,7 +128,7 @@ describe('QueryOptionsBuilder', () => {
 
     it('returns true when settingSources changes', () => {
       const currentConfig = createMockPersistentQueryConfig();
-      const newConfig = { ...currentConfig, settingSources: 'user,project' };
+      const newConfig = { ...currentConfig, settingSources: 'user,project,local' };
       expect(QueryOptionsBuilder.needsRestart(currentConfig, newConfig)).toBe(true);
     });
 
@@ -203,7 +203,7 @@ describe('QueryOptionsBuilder', () => {
       expect(config.thinkingTokens).toBeNull();
       expect(config.permissionMode).toBe('yolo');
       expect(config.sdkPermissionMode).toBe('bypassPermissions');
-      expect(config.settingSources).toBe('project');
+      expect(config.settingSources).toBe('project,local');
       expect(config.claudeCliPath).toBe('/mock/claude');
     });
 
@@ -294,13 +294,13 @@ describe('QueryOptionsBuilder', () => {
       expect(config.enableChrome).toBe(true);
     });
 
-    it('sets settingSources to user,project when loadUserClaudeSettings is true', () => {
+    it('sets settingSources to user,project,local when loadUserClaudeSettings is true', () => {
       const ctx = createMockContext({
         settings: createMockSettings({ loadUserClaudeSettings: true }),
       });
       const config = QueryOptionsBuilder.buildPersistentQueryConfig(ctx);
 
-      expect(config.settingSources).toBe('user,project');
+      expect(config.settingSources).toBe('user,project,local');
     });
   });
 

--- a/tests/unit/providers/claude/runtime/claudeColdStartQuery.test.ts
+++ b/tests/unit/providers/claude/runtime/claudeColdStartQuery.test.ts
@@ -216,6 +216,42 @@ describe('runColdStartQuery', () => {
       expect(opts?.model).toBe('claude-sonnet-4-5');
     });
 
+    it('loads project and local settings when user settings are disabled', async () => {
+      sdkMock.setMockMessages([]);
+
+      await runColdStartQuery(
+        createConfig({
+          providerSettings: {
+            model: 'claude-sonnet-4-5',
+            thinkingBudget: 'off',
+            effortLevel: 'medium',
+            loadUserClaudeSettings: false,
+          },
+        }),
+        'hi',
+      );
+
+      expect(sdkMock.getLastOptions()?.settingSources).toEqual(['project', 'local']);
+    });
+
+    it('loads user, project, and local settings when user settings are enabled', async () => {
+      sdkMock.setMockMessages([]);
+
+      await runColdStartQuery(
+        createConfig({
+          providerSettings: {
+            model: 'claude-sonnet-4-5',
+            thinkingBudget: 'off',
+            effortLevel: 'medium',
+            loadUserClaudeSettings: true,
+          },
+        }),
+        'hi',
+      );
+
+      expect(sdkMock.getLastOptions()?.settingSources).toEqual(['user', 'project', 'local']);
+    });
+
     it('clamps unsupported xhigh effort before calling the SDK', async () => {
       sdkMock.setMockMessages([]);
 


### PR DESCRIPTION
## Summary

- centralize Claude SDK `settingSources` so `local` is always included with project settings
- reuse the helper across persistent chat, cold-start auxiliary queries, and runtime command probing
- update tests for main chat, title generation, instruction refine, inline edit, command probing, and cold-start queries

## Test plan

- `npm run test -- tests/unit/providers/claude/runtime/QueryOptionsBuilder.test.ts tests/unit/providers/claude/runtime/claudeColdStartQuery.test.ts tests/unit/providers/claude/commands/probeRuntimeCommands.test.ts tests/unit/features/chat/services/TitleGenerationService.test.ts tests/unit/features/chat/services/InstructionRefineService.test.ts tests/unit/features/inline-edit/InlineEditService.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run build`

Supersedes #588.
