### PR TITLE
Fix Claude Code npm cjs wrapper detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,15 +101,15 @@ npm run build
 
 If you encounter `spawn claude ENOENT` or `Claude CLI not found`, the plugin can't auto-detect your Claude installation. Common with Node version managers (nvm, fnm, volta).
 
-**Solution**: Find your CLI path and set it in Settings → Advanced → Claude CLI path.
+**Solution**: Leave the setting empty first so Claudian can auto-detect Claude Code. If auto-detection fails, find your CLI path and set it in Settings → Advanced → Claude CLI path.
 
 | Platform | Command | Example Path |
 |----------|---------|--------------|
 | macOS/Linux | `which claude` | `/Users/you/.volta/bin/claude` |
 | Windows (native) | `where.exe claude` | `C:\Users\you\AppData\Local\Claude\claude.exe` |
-| Windows (npm) | `npm root -g` | `{root}\@anthropic-ai\claude-code\cli.js` |
+| Windows (npm) | `npm root -g` | `{root}\@anthropic-ai\claude-code\cli-wrapper.cjs` |
 
-> **Note**: On Windows, avoid `.cmd` wrappers. Use `claude.exe` or `cli.js`.
+> **Note**: On Windows, avoid `.cmd` and `.ps1` wrappers. Use `claude.exe` for native installs, or `cli-wrapper.cjs` for package-manager installs. `cli.js` is only a legacy fallback for older Claude Code npm packages.
 
 **Alternative**: Add your Node.js bin directory to PATH in Settings → Environment → Custom variables.
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -286,7 +286,7 @@
     "cliPath": {
       "name": "Claude CLI-Pfad",
       "desc": "Benutzerdefinierter Pfad zum Claude Code CLI. Leer lassen für automatische Erkennung.",
-      "descWindows": "Für den nativen Installer verwenden Sie claude.exe. Für npm/pnpm/yarn oder andere Paketmanager-Installationen verwenden Sie den cli.js-Pfad (nicht claude.cmd).",
+      "descWindows": "Für den nativen Installer verwenden Sie claude.exe. Für npm/pnpm/yarn oder andere Paketmanager-Installationen verwenden Sie den cli-wrapper.cjs-Pfad (nicht claude.cmd).",
       "descUnix": "Fügen Sie die Ausgabe von \"which claude\" ein — funktioniert sowohl für native als auch npm/pnpm/yarn-Installationen.",
       "validation": {
         "notExist": "Pfad existiert nicht",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -286,7 +286,7 @@
     "cliPath": {
       "name": "Claude CLI path",
       "desc": "Custom path to Claude Code CLI. Leave empty for auto-detection.",
-      "descWindows": "For the native installer, use claude.exe. For npm/pnpm/yarn or other package manager installs, use the cli.js path (not claude.cmd).",
+      "descWindows": "For the native installer, use claude.exe. For npm/pnpm/yarn or other package manager installs, use the cli-wrapper.cjs path (not claude.cmd).",
       "descUnix": "Paste the output of \"which claude\" — works for both native and npm/pnpm/yarn installs.",
       "validation": {
         "notExist": "Path does not exist",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -286,7 +286,7 @@
     "cliPath": {
       "name": "Ruta CLI Claude",
       "desc": "Ruta personalizada a Claude Code CLI. Dejar vacío para detección automática.",
-      "descWindows": "Para el instalador nativo, use claude.exe. Para instalaciones con npm/pnpm/yarn u otros gestores de paquetes, use la ruta cli.js (no claude.cmd).",
+      "descWindows": "Para el instalador nativo, use claude.exe. Para instalaciones con npm/pnpm/yarn u otros gestores de paquetes, use la ruta cli-wrapper.cjs (no claude.cmd).",
       "descUnix": "Pegue la salida de \"which claude\" — funciona tanto para instalaciones nativas como npm/pnpm/yarn.",
       "validation": {
         "notExist": "La ruta no existe",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -286,7 +286,7 @@
     "cliPath": {
       "name": "Chemin CLI Claude",
       "desc": "Chemin personnalisé vers Claude Code CLI. Laisser vide pour la détection automatique.",
-      "descWindows": "Pour l'installateur natif, utilisez claude.exe. Pour les installations npm/pnpm/yarn ou autres gestionnaires de paquets, utilisez le chemin cli.js (pas claude.cmd).",
+      "descWindows": "Pour l'installateur natif, utilisez claude.exe. Pour les installations npm/pnpm/yarn ou autres gestionnaires de paquets, utilisez le chemin cli-wrapper.cjs (pas claude.cmd).",
       "descUnix": "Collez la sortie de \"which claude\" — fonctionne pour les installations natives et npm/pnpm/yarn.",
       "validation": {
         "notExist": "Le chemin n'existe pas",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -286,7 +286,7 @@
     "cliPath": {
       "name": "Claude CLI パス",
       "desc": "Claude Code CLI のカスタムパス。空欄で自動検出を使用。",
-      "descWindows": "ネイティブインストーラーの場合は claude.exe を使用。npm/pnpm/yarn やその他のパッケージマネージャーでのインストールの場合は cli.js パスを使用（claude.cmd ではない）。",
+      "descWindows": "ネイティブインストーラーの場合は claude.exe を使用。npm/pnpm/yarn やその他のパッケージマネージャーでのインストールの場合は cli-wrapper.cjs パスを使用（claude.cmd ではない）。",
       "descUnix": "\"which claude\" の出力を貼り付けてください - ネイティブと npm/pnpm/yarn インストールの両方で動作します。",
       "validation": {
         "notExist": "パスが存在しません",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -286,7 +286,7 @@
     "cliPath": {
       "name": "Claude CLI 경로",
       "desc": "Claude Code CLI의 사용자 정의 경로. 비워두면 자동 감지 사용.",
-      "descWindows": "네이티브 설치 프로그램의 경우 claude.exe를 사용하세요. npm/pnpm/yarn 또는 기타 패키지 관리자 설치의 경우 cli.js 경로를 사용하세요 (claude.cmd가 아님).",
+      "descWindows": "네이티브 설치 프로그램의 경우 claude.exe를 사용하세요. npm/pnpm/yarn 또는 기타 패키지 관리자 설치의 경우 cli-wrapper.cjs 경로를 사용하세요 (claude.cmd가 아님).",
       "descUnix": "\"which claude\"의 출력을 붙여넣으세요 - 네이티브 및 npm/pnpm/yarn 설치 모두에서 작동합니다.",
       "validation": {
         "notExist": "경로가 존재하지 않습니다",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -286,7 +286,7 @@
     "cliPath": {
       "name": "Caminho CLI Claude",
       "desc": "Caminho personalizado para Claude Code CLI. Deixe vazio para detecção automática.",
-      "descWindows": "Para o instalador nativo, use claude.exe. Para instalações com npm/pnpm/yarn ou outros gerenciadores de pacotes, use o caminho cli.js (não claude.cmd).",
+      "descWindows": "Para o instalador nativo, use claude.exe. Para instalações com npm/pnpm/yarn ou outros gerenciadores de pacotes, use o caminho cli-wrapper.cjs (não claude.cmd).",
       "descUnix": "Cole a saída de \"which claude\" — funciona tanto para instalações nativas quanto npm/pnpm/yarn.",
       "validation": {
         "notExist": "Caminho não existe",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -286,7 +286,7 @@
     "cliPath": {
       "name": "Путь к CLI Claude",
       "desc": "Пользовательский путь к Claude Code CLI. Оставьте пустым для автоматического определения.",
-      "descWindows": "Для нативного установщика используйте claude.exe. Для установок через npm/pnpm/yarn или другие менеджеры пакетов используйте путь к cli.js (не claude.cmd).",
+      "descWindows": "Для нативного установщика используйте claude.exe. Для установок через npm/pnpm/yarn или другие менеджеры пакетов используйте путь к cli-wrapper.cjs (не claude.cmd).",
       "descUnix": "Вставьте вывод команды \"which claude\" — работает как для нативных установок, так и для npm/pnpm/yarn.",
       "validation": {
         "notExist": "Путь не существует",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -286,7 +286,7 @@
     "cliPath": {
       "name": "Claude CLI 路径",
       "desc": "Claude Code CLI 的自定义路径。留空使用自动检测。",
-      "descWindows": "对于原生安装程序，使用 claude.exe。对于 npm/pnpm/yarn 或其他包管理器安装，使用 cli.js 路径（不是 claude.cmd）。",
+      "descWindows": "对于原生安装程序，使用 claude.exe。对于 npm/pnpm/yarn 或其他包管理器安装，使用 cli-wrapper.cjs 路径（不是 claude.cmd）。",
       "descUnix": "粘贴 \"which claude\" 的输出 - 适用于原生安装和 npm/pnpm/yarn 安装。",
       "validation": {
         "notExist": "路径不存在",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -286,7 +286,7 @@
     "cliPath": {
       "name": "Claude CLI 路徑",
       "desc": "Claude Code CLI 的自訂路徑。留空使用自動檢測。",
-      "descWindows": "對於原生安裝程式，使用 claude.exe。對於 npm/pnpm/yarn 或其他套件管理器安裝，使用 cli.js 路徑（不是 claude.cmd）。",
+      "descWindows": "對於原生安裝程式，使用 claude.exe。對於 npm/pnpm/yarn 或其他套件管理器安裝，使用 cli-wrapper.cjs 路徑（不是 claude.cmd）。",
       "descUnix": "貼上 \"which claude\" 的輸出 - 適用於原生安裝和 npm/pnpm/yarn 安裝。",
       "validation": {
         "notExist": "路徑不存在",

--- a/src/providers/claude/cli/findClaudeCLIPath.ts
+++ b/src/providers/claude/cli/findClaudeCLIPath.ts
@@ -4,6 +4,9 @@ import * as path from 'path';
 
 import { parsePathEntries, resolveNvmDefaultBin } from '../../../utils/path';
 
+const CLAUDE_CODE_PACKAGE_SEGMENTS = ['node_modules', '@anthropic-ai', 'claude-code'];
+const CLAUDE_CODE_NODE_ENTRYPOINTS = ['cli-wrapper.cjs', 'cli.js'];
+
 function getEnvValue(name: string): string | undefined {
   return process.env[name];
 }
@@ -43,18 +46,9 @@ function isExistingFile(filePath: string): boolean {
   return false;
 }
 
-function resolveCliJsNearPathEntry(entry: string, isWindows: boolean): string | null {
-  const directCandidate = path.join(entry, 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js');
-  if (isExistingFile(directCandidate)) {
-    return directCandidate;
-  }
-
-  const baseName = path.basename(entry).toLowerCase();
-  if (baseName === 'bin') {
-    const prefix = path.dirname(entry);
-    const candidate = isWindows
-      ? path.join(prefix, 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js')
-      : path.join(prefix, 'lib', 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js');
+function findClaudeCodeNodeEntrypoint(packageRoot: string): string | null {
+  for (const entrypoint of CLAUDE_CODE_NODE_ENTRYPOINTS) {
+    const candidate = path.join(packageRoot, entrypoint);
     if (isExistingFile(candidate)) {
       return candidate;
     }
@@ -63,9 +57,32 @@ function resolveCliJsNearPathEntry(entry: string, isWindows: boolean): string | 
   return null;
 }
 
-function resolveCliJsFromPathEntries(entries: string[], isWindows: boolean): string | null {
+function resolveClaudeCodeEntrypointNearPathEntry(entry: string, isWindows: boolean): string | null {
+  const directCandidate = findClaudeCodeNodeEntrypoint(
+    path.join(entry, ...CLAUDE_CODE_PACKAGE_SEGMENTS)
+  );
+  if (directCandidate) {
+    return directCandidate;
+  }
+
+  const baseName = path.basename(entry).toLowerCase();
+  if (baseName === 'bin') {
+    const prefix = path.dirname(entry);
+    const packageParent = isWindows ? prefix : path.join(prefix, 'lib');
+    const candidate = findClaudeCodeNodeEntrypoint(
+      path.join(packageParent, ...CLAUDE_CODE_PACKAGE_SEGMENTS)
+    );
+    if (candidate) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function resolveClaudeCodeEntrypointFromPathEntries(entries: string[], isWindows: boolean): string | null {
   for (const entry of entries) {
-    const candidate = resolveCliJsNearPathEntry(entry, isWindows);
+    const candidate = resolveClaudeCodeEntrypointNearPathEntry(entry, isWindows);
     if (candidate) {
       return candidate;
     }
@@ -91,9 +108,9 @@ function resolveClaudeFromPathEntries(
     return exeCandidate;
   }
 
-  const cliJsCandidate = resolveCliJsFromPathEntries(entries, isWindows);
-  if (cliJsCandidate) {
-    return cliJsCandidate;
+  const packageEntrypoint = resolveClaudeCodeEntrypointFromPathEntries(entries, isWindows);
+  if (packageEntrypoint) {
+    return packageEntrypoint;
   }
 
   return null;
@@ -116,49 +133,43 @@ function getNpmGlobalPrefix(): string | null {
   return null;
 }
 
-function getNpmCliJsPaths(): string[] {
+function addClaudeCodeEntrypointPaths(paths: string[], packageParent: string): void {
+  const packageRoot = path.join(packageParent, ...CLAUDE_CODE_PACKAGE_SEGMENTS);
+  for (const entrypoint of CLAUDE_CODE_NODE_ENTRYPOINTS) {
+    paths.push(path.join(packageRoot, entrypoint));
+  }
+}
+
+function getNpmClaudeCodeEntrypointPaths(): string[] {
   const homeDir = os.homedir();
   const isWindows = process.platform === 'win32';
-  const cliJsPaths: string[] = [];
+  const entrypointPaths: string[] = [];
 
   if (isWindows) {
-    cliJsPaths.push(
-      path.join(homeDir, 'AppData', 'Roaming', 'npm', 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js')
-    );
+    addClaudeCodeEntrypointPaths(entrypointPaths, path.join(homeDir, 'AppData', 'Roaming', 'npm'));
 
     const npmPrefix = getNpmGlobalPrefix();
     if (npmPrefix) {
-      cliJsPaths.push(
-        path.join(npmPrefix, 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js')
-      );
+      addClaudeCodeEntrypointPaths(entrypointPaths, npmPrefix);
     }
 
     const programFiles = process.env.ProgramFiles || 'C:\\Program Files';
     const programFilesX86 = process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)';
 
-    cliJsPaths.push(
-      path.join(programFiles, 'nodejs', 'node_global', 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js'),
-      path.join(programFilesX86, 'nodejs', 'node_global', 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js')
-    );
-
-    cliJsPaths.push(
-      path.join('D:', 'Program Files', 'nodejs', 'node_global', 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js')
-    );
+    addClaudeCodeEntrypointPaths(entrypointPaths, path.join(programFiles, 'nodejs', 'node_global'));
+    addClaudeCodeEntrypointPaths(entrypointPaths, path.join(programFilesX86, 'nodejs', 'node_global'));
+    addClaudeCodeEntrypointPaths(entrypointPaths, path.join('D:', 'Program Files', 'nodejs', 'node_global'));
   } else {
-    cliJsPaths.push(
-      path.join(homeDir, '.npm-global', 'lib', 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js'),
-      '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js',
-      '/usr/lib/node_modules/@anthropic-ai/claude-code/cli.js'
-    );
+    addClaudeCodeEntrypointPaths(entrypointPaths, path.join(homeDir, '.npm-global', 'lib'));
+    addClaudeCodeEntrypointPaths(entrypointPaths, '/usr/local/lib');
+    addClaudeCodeEntrypointPaths(entrypointPaths, '/usr/lib');
 
     if (process.env.npm_config_prefix) {
-      cliJsPaths.push(
-        path.join(process.env.npm_config_prefix, 'lib', 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js')
-      );
+      addClaudeCodeEntrypointPaths(entrypointPaths, path.join(process.env.npm_config_prefix, 'lib'));
     }
   }
 
-  return cliJsPaths;
+  return entrypointPaths;
 }
 
 export function findClaudeCLIPath(pathValue?: string): string | null {
@@ -174,7 +185,7 @@ export function findClaudeCLIPath(pathValue?: string): string | null {
     }
   }
 
-  // On Windows, prefer native .exe, then cli.js. Avoid .cmd fallback
+  // On Windows, prefer native .exe, then Node-backed package entrypoints. Avoid .cmd fallback
   // because it requires shell: true and breaks SDK stdio streaming.
   if (isWindows) {
     const exePaths: string[] = [
@@ -191,8 +202,8 @@ export function findClaudeCLIPath(pathValue?: string): string | null {
       }
     }
 
-    const cliJsPaths = getNpmCliJsPaths();
-    for (const p of cliJsPaths) {
+    const packageEntrypointPaths = getNpmClaudeCodeEntrypointPaths();
+    for (const p of packageEntrypointPaths) {
       if (isExistingFile(p)) {
         return p;
       }
@@ -230,8 +241,8 @@ export function findClaudeCLIPath(pathValue?: string): string | null {
   }
 
   if (!isWindows) {
-    const cliJsPaths = getNpmCliJsPaths();
-    for (const p of cliJsPaths) {
+    const packageEntrypointPaths = getNpmClaudeCodeEntrypointPaths();
+    for (const p of packageEntrypointPaths) {
       if (isExistingFile(p)) {
         return p;
       }

--- a/src/providers/claude/runtime/customSpawn.ts
+++ b/src/providers/claude/runtime/customSpawn.ts
@@ -1,21 +1,28 @@
 import type { SpawnedProcess, SpawnOptions } from '@anthropic-ai/claude-agent-sdk';
 import { spawn } from 'child_process';
 
-import { findNodeExecutable } from '../../../utils/env';
+import { cliPathRequiresNode, findNodeExecutable } from '../../../utils/env';
 
 export function createCustomSpawnFunction(
   enhancedPath: string
 ): (options: SpawnOptions) => SpawnedProcess {
   return (options: SpawnOptions): SpawnedProcess => {
     let { command } = options;
-    const { args, cwd, env, signal } = options;
+    let { args } = options;
+    const { cwd, env, signal } = options;
     const shouldPipeStderr = !!env?.DEBUG_CLAUDE_AGENT_SDK;
 
-    // Resolve full path to avoid PATH lookup issues in GUI apps
-    if (command === 'node') {
+    // The SDK only routes some script extensions through `node`; normalize the
+    // remaining Node-backed paths here before Electron spawns with shell=false.
+    if (command === 'node' || cliPathRequiresNode(command)) {
       const nodeFullPath = findNodeExecutable(enhancedPath);
-      if (nodeFullPath) {
-        command = nodeFullPath;
+      if (command === 'node') {
+        if (nodeFullPath) {
+          command = nodeFullPath;
+        }
+      } else {
+        args = [command, ...args];
+        command = nodeFullPath ?? 'node';
       }
     }
 

--- a/src/providers/claude/ui/ClaudeSettingsTab.ts
+++ b/src/providers/claude/ui/ClaudeSettingsTab.ts
@@ -127,8 +127,8 @@ export const claudeSettingsTabRenderer: ProviderSettingsTabRenderer = {
 
     cliPathSetting.addText((text) => {
       const placeholder = process.platform === 'win32'
-        ? 'D:\\nodejs\\node_global\\node_modules\\@anthropic-ai\\claude-code\\cli.js'
-        : '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js';
+        ? 'D:\\nodejs\\node_global\\node_modules\\@anthropic-ai\\claude-code\\cli-wrapper.cjs'
+        : '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli-wrapper.cjs';
 
       text
         .setPlaceholder(placeholder)

--- a/tests/unit/providers/claude/runtime/customSpawn.test.ts
+++ b/tests/unit/providers/claude/runtime/customSpawn.test.ts
@@ -58,6 +58,53 @@ describe('createCustomSpawnFunction', () => {
     expect(result).toBe(mockProcess);
   });
 
+  it('launches Node-backed script commands through node when SDK passes them directly', () => {
+    const mockProcess = createMockProcess();
+    spawnMock.mockReturnValue(mockProcess as unknown as ReturnType<typeof spawn>);
+
+    const findNodeExecutable = jest
+      .spyOn(env, 'findNodeExecutable')
+      .mockReturnValue('/custom/node');
+
+    const spawnFn = createCustomSpawnFunction('/enhanced/path');
+    const signal = new AbortController().signal;
+    spawnFn({
+      command: '/npm/node_modules/@anthropic-ai/claude-code/cli-wrapper.cjs',
+      args: ['--output-format', 'stream-json'],
+      cwd: '/tmp',
+      env: {},
+      signal,
+    });
+
+    expect(findNodeExecutable).toHaveBeenCalledWith('/enhanced/path');
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/custom/node',
+      ['/npm/node_modules/@anthropic-ai/claude-code/cli-wrapper.cjs', '--output-format', 'stream-json'],
+      expect.objectContaining({ cwd: '/tmp' })
+    );
+  });
+
+  it('falls back to node command for Node-backed scripts when node path resolution fails', () => {
+    const mockProcess = createMockProcess();
+    spawnMock.mockReturnValue(mockProcess as unknown as ReturnType<typeof spawn>);
+
+    jest.spyOn(env, 'findNodeExecutable').mockReturnValue(null);
+
+    const spawnFn = createCustomSpawnFunction('/enhanced/path');
+    spawnFn({
+      command: '/npm/node_modules/@anthropic-ai/claude-code/cli-wrapper.cjs',
+      args: ['--output-format', 'stream-json'],
+      cwd: '/tmp',
+      env: {},
+    } as SpawnOptions);
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'node',
+      ['/npm/node_modules/@anthropic-ai/claude-code/cli-wrapper.cjs', '--output-format', 'stream-json'],
+      expect.any(Object)
+    );
+  });
+
   it('pipes stderr only when DEBUG_CLAUDE_AGENT_SDK is set', () => {
     const mockProcess = createMockProcess();
     spawnMock.mockReturnValue(mockProcess as unknown as ReturnType<typeof spawn>);

--- a/tests/unit/providers/claude/ui/ClaudeSettingsTab.test.ts
+++ b/tests/unit/providers/claude/ui/ClaudeSettingsTab.test.ts
@@ -354,6 +354,19 @@ describe('ClaudeSettingsTab', () => {
     mockedStatSync.mockReturnValue({ isFile: () => true } as fs.Stats);
   });
 
+  it('uses the current npm package wrapper path as the CLI placeholder', () => {
+    const plugin = createPlugin();
+    const context = createContext(plugin);
+
+    claudeSettingsTabRenderer.render(createContainer(), context);
+
+    const cliPathSetting = findSetting('settings.cliPath.name (host-a)');
+    const cliPathInput = cliPathSetting.textComponents[0];
+
+    expect(cliPathInput.placeholder).toContain('cli-wrapper.cjs');
+    expect(cliPathInput.placeholder).not.toContain('cli.js');
+  });
+
   it('does not switch the active model while the custom models textarea is mid-edit', async () => {
     const plugin = createPlugin();
     const context = createContext(plugin);

--- a/tests/unit/utils/env.test.ts
+++ b/tests/unit/utils/env.test.ts
@@ -720,6 +720,7 @@ describe('cliPathRequiresNode', () => {
   it('is case-insensitive', () => {
     expect(cliPathRequiresNode('/path/to/CLI.JS')).toBe(true);
     expect(cliPathRequiresNode('/path/to/cli.MJS')).toBe(true);
+    expect(cliPathRequiresNode('/path/to/cli-wrapper.CJS')).toBe(true);
   });
 });
 

--- a/tests/unit/utils/path.test.ts
+++ b/tests/unit/utils/path.test.ts
@@ -450,21 +450,38 @@ describe('findClaudeCLIPath', () => {
     expect(result).toBe(commonPath);
   });
 
-  it('falls back to npm cli.js paths when binary not found', () => {
-    const cliJsPath = path.join(
+  it('falls back to npm cli-wrapper.cjs paths when binary not found', () => {
+    const cliWrapperPath = path.join(
+      os.homedir(), '.npm-global', 'lib', 'node_modules',
+      '@anthropic-ai', 'claude-code', 'cli-wrapper.cjs'
+    );
+
+    jest.spyOn(fs, 'existsSync').mockImplementation(
+      p => String(p) === cliWrapperPath
+    );
+    jest.spyOn(fs, 'statSync').mockImplementation(
+      p => ({ isFile: () => String(p) === cliWrapperPath }) as fsType.Stats
+    );
+
+    const result = findClaudeCLIPath();
+    expect(result).toBe(cliWrapperPath);
+  });
+
+  it('keeps legacy npm cli.js fallback when cli-wrapper.cjs is absent', () => {
+    const legacyCliPath = path.join(
       os.homedir(), '.npm-global', 'lib', 'node_modules',
       '@anthropic-ai', 'claude-code', 'cli.js'
     );
 
     jest.spyOn(fs, 'existsSync').mockImplementation(
-      p => String(p) === cliJsPath
+      p => String(p) === legacyCliPath
     );
     jest.spyOn(fs, 'statSync').mockImplementation(
-      p => ({ isFile: () => String(p) === cliJsPath }) as fsType.Stats
+      p => ({ isFile: () => String(p) === legacyCliPath }) as fsType.Stats
     );
 
     const result = findClaudeCLIPath();
-    expect(result).toBe(cliJsPath);
+    expect(result).toBe(legacyCliPath);
   });
 
   it('falls back to PATH environment when common and npm paths fail', () => {

--- a/tests/unit/utils/utils.test.ts
+++ b/tests/unit/utils/utils.test.ts
@@ -499,11 +499,11 @@ describe('utils.ts', () => {
         expect(findClaudeCLIPath()).toBeNull();
       });
 
-      it('should check cli.js paths as fallback on Unix', () => {
+      it('should check cli-wrapper.cjs paths as fallback on Unix', () => {
         jest.spyOn(os, 'homedir').mockReturnValue('/home/test');
-        mockExistingFile('/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js');
+        mockExistingFile('/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli-wrapper.cjs');
 
-        expect(findClaudeCLIPath()).toBe('/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js');
+        expect(findClaudeCLIPath()).toBe('/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli-wrapper.cjs');
       });
 
       it('should resolve Claude CLI from custom PATH', () => {
@@ -549,37 +549,35 @@ describe('utils.ts', () => {
         }) as fsType.Stats);
       }
 
-      it('should prefer .exe when both .exe and cli.js exist', () => {
+      it('should prefer .exe when both .exe and cli-wrapper.cjs exist', () => {
         jest.spyOn(os, 'homedir').mockReturnValue('C:\\Users\\test');
         const exePath = path.join('C:\\Users\\test', '.claude', 'local', 'claude.exe');
-        const cliJsPath = path.join('C:\\Users\\test', 'AppData', 'Roaming', 'npm', 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js');
-        mockExistingFile(exePath, cliJsPath);
+        const cliWrapperPath = path.join('C:\\Users\\test', 'AppData', 'Roaming', 'npm', 'node_modules', '@anthropic-ai', 'claude-code', 'cli-wrapper.cjs');
+        mockExistingFile(exePath, cliWrapperPath);
 
         expect(findClaudeCLIPath()).toBe(exePath);
       });
 
-      it('should prioritize cli.js over .cmd files on Windows', () => {
+      it('should prioritize cli-wrapper.cjs over .cmd files on Windows', () => {
         jest.spyOn(os, 'homedir').mockReturnValue('C:\\Users\\test');
         // Note: path.join uses actual platform separator, so we match against that
-        const cliJsPath = path.join('C:\\Users\\test', 'AppData', 'Roaming', 'npm', 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js');
+        const cliWrapperPath = path.join('C:\\Users\\test', 'AppData', 'Roaming', 'npm', 'node_modules', '@anthropic-ai', 'claude-code', 'cli-wrapper.cjs');
         const cmdPath = path.join('C:\\Users\\test', 'AppData', 'Roaming', 'npm', 'claude.cmd');
-        // Both .cmd and cli.js exist, but cli.js should be returned (cmd is ignored entirely)
-        mockExistingFile(cmdPath, cliJsPath);
+        mockExistingFile(cmdPath, cliWrapperPath);
 
-        // Should return cli.js, not claude.cmd
-        expect(findClaudeCLIPath()).toBe(cliJsPath);
+        expect(findClaudeCLIPath()).toBe(cliWrapperPath);
       });
 
-      it('should find cli.js in custom npm global path via npm_config_prefix', () => {
+      it('should find cli-wrapper.cjs in custom npm global path via npm_config_prefix', () => {
         jest.spyOn(os, 'homedir').mockReturnValue('C:\\Users\\test');
         process.env.npm_config_prefix = 'D:\\nodejs\\node_global';
-        const expectedPath = path.join('D:\\nodejs\\node_global', 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js');
+        const expectedPath = path.join('D:\\nodejs\\node_global', 'node_modules', '@anthropic-ai', 'claude-code', 'cli-wrapper.cjs');
         mockExistingFile(expectedPath);
 
         expect(findClaudeCLIPath()).toBe(expectedPath);
       });
 
-      it('should fall back to .exe if cli.js not found', () => {
+      it('should fall back to .exe if package entrypoint is not found', () => {
         jest.spyOn(os, 'homedir').mockReturnValue('C:\\Users\\test');
         const expectedPath = path.join('C:\\Users\\test', '.claude', 'local', 'claude.exe');
         mockExistingFile(expectedPath);
@@ -602,13 +600,13 @@ describe('utils.ts', () => {
         expect(findClaudeCLIPath()).toBeNull();
       });
 
-      it('should resolve cli.js from custom PATH npm prefix', () => {
+      it('should resolve cli-wrapper.cjs from custom PATH npm prefix', () => {
         const npmBin = 'C:\\Users\\test\\AppData\\Roaming\\npm';
-        const cliJsPath = path.join(npmBin, 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js');
-        mockExistingFile(cliJsPath);
+        const cliWrapperPath = path.join(npmBin, 'node_modules', '@anthropic-ai', 'claude-code', 'cli-wrapper.cjs');
+        mockExistingFile(cliWrapperPath);
 
         const customPath = `${npmBin};C:\\Windows\\System32`;
-        expect(findClaudeCLIPath(customPath)).toBe(cliJsPath);
+        expect(findClaudeCLIPath(customPath)).toBe(cliWrapperPath);
       });
 
       it('should not return a directory path even if it exists', () => {


### PR DESCRIPTION
## Summary
- Detect Claude Code npm `cli-wrapper.cjs` entrypoints before legacy `cli.js`.
- Normalize direct Node-backed script launches in the Claude custom spawn adapter so `.cjs` runs through Node.
- Update CLI path settings text, README guidance, locale copy, and regression tests.

## Tests
- `npm run test -- tests/unit/providers/claude/runtime/customSpawn.test.ts tests/unit/utils/path.test.ts tests/unit/utils/utils.test.ts tests/unit/utils/env.test.ts tests/unit/providers/claude/ui/ClaudeSettingsTab.test.ts`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run build`
- `git diff --check`

fix #584