### PR TITLE
fix: send Codex default mode after plan mode

### DIFF
--- a/src/providers/codex/runtime/CodexChatRuntime.ts
+++ b/src/providers/codex/runtime/CodexChatRuntime.ts
@@ -536,16 +536,14 @@ export class CodexChatRuntime implements ChatRuntime {
           threadPath ?? transcriptSessionFilePath,
         );
 
-        const collaborationMode = isPlanMode
-          ? {
-              mode: 'plan' as const,
-              settings: {
-                model: resolvedModel,
-                reasoning_effort: effort,
-                developer_instructions: null,
-              },
-            }
-          : undefined;
+        const collaborationMode = {
+          mode: isPlanMode ? 'plan' as const : 'default' as const,
+          settings: {
+            model: resolvedModel,
+            reasoning_effort: effort,
+            developer_instructions: null,
+          },
+        };
 
         const summary = getEffectiveCodexReasoningSummary(providerSettings, resolvedModel);
         const serviceTier = resolveCodexServiceTier(providerSettings.serviceTier, resolvedModel);
@@ -563,7 +561,7 @@ export class CodexChatRuntime implements ChatRuntime {
           effort,
           summary,
           sandboxPolicy,
-          ...(collaborationMode ? { collaborationMode } : {}),
+          collaborationMode,
         });
         this.currentTurnId = turnResult.turn.id;
         this.recordTurnMetadata({

--- a/tests/unit/providers/codex/runtime/CodexChatRuntime.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexChatRuntime.test.ts
@@ -1795,7 +1795,7 @@ describe('CodexChatRuntime', () => {
       rt.cleanup();
     });
 
-    it('does not include collaborationMode when permissionMode is normal', async () => {
+    it('includes default collaborationMode when permissionMode is normal', async () => {
       const plugin = createMockPlugin({ permissionMode: 'normal' });
       const rt = new CodexChatRuntime(plugin);
       captureHandlers();
@@ -1805,12 +1805,19 @@ describe('CodexChatRuntime', () => {
 
       const turnStartCall = findCall('turn/start');
       expect(turnStartCall).toBeDefined();
-      expect(turnStartCall[1].collaborationMode).toBeUndefined();
+      expect(turnStartCall[1].collaborationMode).toEqual({
+        mode: 'default',
+        settings: {
+          model: DEFAULT_CODEX_PRIMARY_MODEL,
+          reasoning_effort: 'medium',
+          developer_instructions: null,
+        },
+      });
 
       rt.cleanup();
     });
 
-    it('does not include collaborationMode when permissionMode is yolo', async () => {
+    it('includes default collaborationMode when permissionMode is yolo', async () => {
       const plugin = createMockPlugin({ permissionMode: 'yolo' });
       const rt = new CodexChatRuntime(plugin);
       captureHandlers();
@@ -1820,7 +1827,49 @@ describe('CodexChatRuntime', () => {
 
       const turnStartCall = findCall('turn/start');
       expect(turnStartCall).toBeDefined();
-      expect(turnStartCall[1].collaborationMode).toBeUndefined();
+      expect(turnStartCall[1].collaborationMode).toEqual({
+        mode: 'default',
+        settings: {
+          model: DEFAULT_CODEX_PRIMARY_MODEL,
+          reasoning_effort: 'medium',
+          developer_instructions: null,
+        },
+      });
+
+      rt.cleanup();
+    });
+
+    it('sends default collaborationMode after switching out of plan mode on the same thread', async () => {
+      const plugin = createMockPlugin({ permissionMode: 'plan' });
+      const rt = new CodexChatRuntime(plugin);
+      captureHandlers();
+      setupDefaultRequestMock();
+
+      await collectChunks(rt.query(createTurn('plan this')));
+
+      plugin.settings.permissionMode = 'normal';
+      await collectChunks(rt.query(createTurn('now edit')));
+
+      const turnStartCalls = mockTransportRequest.mock.calls.filter(
+        (call: any[]) => call[0] === 'turn/start',
+      );
+      expect(turnStartCalls).toHaveLength(2);
+      expect(turnStartCalls[0][1].collaborationMode).toEqual({
+        mode: 'plan',
+        settings: {
+          model: DEFAULT_CODEX_PRIMARY_MODEL,
+          reasoning_effort: 'medium',
+          developer_instructions: null,
+        },
+      });
+      expect(turnStartCalls[1][1].collaborationMode).toEqual({
+        mode: 'default',
+        settings: {
+          model: DEFAULT_CODEX_PRIMARY_MODEL,
+          reasoning_effort: 'medium',
+          developer_instructions: null,
+        },
+      });
 
       rt.cleanup();
     });


### PR DESCRIPTION
## Summary

- Always send Codex app-server `collaborationMode` on normal turns, using native `mode: "default"` outside Plan Mode.
- Keep Plan Mode turns on native `mode: "plan"` and use `developer_instructions: null` so Codex applies its built-in preset instructions.
- Add regression coverage for normal/yolo turns and the same-thread Plan Mode -> normal transition.

Fixes #600.

## Verification

- `npm run test -- --selectProjects unit --testPathPatterns CodexChatRuntime.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run build`
- `npx tsx .context/codex-plan-mode-e2e.ts`
- `npx tsx .context/codex-plan-mode-live-e2e.ts`
