### PR TITLE
fix(opencode): rename `opencode/aux` → `opencode/auxiliary` to avoid Windows reserved name

### DIFF
--- a/src/providers/opencode/runtime/OpencodeAuxQueryRunner.ts
+++ b/src/providers/opencode/runtime/OpencodeAuxQueryRunner.ts
@@ -172,7 +172,7 @@ export class OpencodeAuxQueryRunner implements AuxQueryRunner {
     const runtimeEnv = buildOpencodeRuntimeEnv(settings, resolvedCliPath);
     const auxAgentId = OPENCODE_AUX_AGENT_IDS[this.options.agentProfile];
     const artifacts = await prepareOpencodeLaunchArtifacts({
-      artifactsSubdir: `opencode/aux/${this.options.artifactPurpose}`,
+      artifactsSubdir: `opencode/auxiliary/${this.options.artifactPurpose}`,
       defaultAgentId: auxAgentId,
       managedAgents: [buildOpencodeAuxAgentConfig(this.options.agentProfile)],
       runtimeEnv,

--- a/tests/unit/providers/opencode/OpencodeAuxQueryRunner.test.ts
+++ b/tests/unit/providers/opencode/OpencodeAuxQueryRunner.test.ts
@@ -149,7 +149,7 @@ describe('OpencodeAuxQueryRunner', () => {
     }, 'Generate a title')).resolves.toBe('Fix title now');
 
     expect(mockPrepareOpencodeLaunchArtifacts).toHaveBeenCalledWith(expect.objectContaining({
-      artifactsSubdir: 'opencode/aux/title-gen',
+      artifactsSubdir: 'opencode/auxiliary/title-gen',
       defaultAgentId: 'claudian-aux-passive',
       managedAgents: [expect.objectContaining({ id: 'claudian-aux-passive' })],
       systemPromptKey: 'Use this custom system prompt.',

--- a/tests/unit/providers/opencode/OpencodeLaunchArtifacts.test.ts
+++ b/tests/unit/providers/opencode/OpencodeLaunchArtifacts.test.ts
@@ -48,7 +48,7 @@ describe('buildOpencodeManagedConfig', () => {
   it('can create a dedicated aux agent and default it for the process', () => {
     expect(buildOpencodeManagedConfig(
       {},
-      '/vault/.claudian/opencode/aux/system.md',
+      '/vault/.claudian/opencode/auxiliary/system.md',
       undefined,
       [{
         definition: {
@@ -70,7 +70,7 @@ describe('buildOpencodeManagedConfig', () => {
             '*': 'deny',
             read: 'allow',
           },
-          prompt: '{file:/vault/.claudian/opencode/aux/system.md}',
+          prompt: '{file:/vault/.claudian/opencode/auxiliary/system.md}',
         },
       },
       default_agent: 'claudian-aux-readonly',


### PR DESCRIPTION
## Summary

`AUX` is a [reserved DOS device name on Windows](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions) (along with `CON`, `PRN`, `NUL`, `COM1-9`, `LPT1-9`). When a path component is exactly `aux` (case-insensitive), Win32 APIs such as `CreateFile` / `_wopen` interpret the name as the **AUX device** rather than a directory, and fail to open it as a file/folder.

Tools that route through the long-path `\?\` prefix (Explorer, PowerShell `Get-ChildItem`, parts of Node.js `fs`) bypass this. **Plain Win32 callers — including Git for Windows — do not.**

`OpencodeAuxQueryRunner` writes its artifacts to `<vault>/.claudian/opencode/aux/<purpose>/`, which means as soon as a Windows user triggers any opencode auxiliary task (e.g. title generation), files land in a path that Git physically cannot open.

## Reproduction (Windows)

```bash
$ git add ".claudian/opencode/aux/title-gen/config.json"
error: open(".claudian/opencode/aux/title-gen/config.json"): No such file or directory
error: unable to index file '.claudian/opencode/aux/title-gen/config.json'
fatal: adding files failed
```

`git check-ignore` returns nothing (the path is not ignored), the file is plainly readable from PowerShell / `cat`, but `git add` cannot open it. The same failure happens for `git stash -u`, `git update-index --add`, etc.

This breaks the [obsidian-git](https://github.com/Vinzent03/obsidian-git) plugin's auto backup as soon as the artifact is created — the entire `git add -A` aborts with `fatal: adding files failed` and no further files get committed until the user manually intervenes.

## Fix

Rename the artifact subdirectory from `opencode/aux/<purpose>` to `opencode/auxiliary/<purpose>`. The new name matches the existing source-tree convention (`src/providers/.../auxiliary/`).

| File | Change |
|------|--------|
| `src/providers/opencode/runtime/OpencodeAuxQueryRunner.ts` | template literal at line 175 |
| `tests/unit/providers/opencode/OpencodeAuxQueryRunner.test.ts` | expected `artifactsSubdir` |
| `tests/unit/providers/opencode/OpencodeLaunchArtifacts.test.ts` | path strings in two assertions |

Diff is **3 files, +4/-4 lines**.

## Out of scope (intentionally left as-is)

Internal identifiers `claudian-aux`, `claudian-aux-passive`, `claudian-aux-readonly`, `OPENCODE_AUX_AGENT_IDS`, `OpencodeAuxQueryRunner` (class), `auxAgentId` (variable), etc. are **not** filesystem paths — they're agent IDs and TS symbols — so they don't need to change for this issue. Renaming them too would be a much larger churn for no functional benefit.

## Migration / compatibility

- Existing `.claudian/opencode/aux/` folders on user vaults become orphaned (empty or with stale config). Users can simply delete them; Windows users will need PowerShell with the long-path prefix to do so:
  ```powershell
  Remove-Item -LiteralPath "\?\C:\path\to\vault\.claudian\opencode\aux" -Recurse -Force
  ```
- New artifacts will be created under `.claudian/opencode/auxiliary/` automatically on next run.
- No config-file format change, no API change.

## Test plan

- [x] `npm run build` succeeds (`main.js` diff is exactly +6 bytes — the literal length difference)
- [x] Modified unit tests pass (`OpencodeAuxQueryRunner.test.ts` and `OpencodeLaunchArtifacts.test.ts` — only failures on my Windows machine were pre-existing path-separator issues unrelated to this PR)
- [x] Manually verified on Windows: `git add` of files inside `opencode/auxiliary/title-gen/` succeeds where the old `opencode/aux/title-gen/` failed
- [x] obsidian-git auto backup now completes without `adding files failed`