### PR TITLE
fix: clear stale session IDs after hydration to prevent 'No conversation found' error on restart

### DIFF
--- a/src/providers/claude/history/ClaudeConversationHistoryService.ts
+++ b/src/providers/claude/history/ClaudeConversationHistoryService.ts
@@ -430,12 +430,16 @@ export class ClaudeConversationHistoryService implements ProviderConversationHis
     conversation.messages = merged;
     this.hydratedConversationIds.add(conversation.id);
 
-    // Clear provider session IDs so the runtime starts a fresh Claude Code process
-    // instead of trying to resume an old (dead) session. The loaded history messages
-    // are preserved and will be injected as context via the noSessionButHasHistory path.
-    conversation.sessionId = null;
-    delete state.providerSessionId;
-    delete state.previousProviderSessionIds;
+    // If we successfully loaded messages from old SDK sessions, clear the stale
+    // provider session IDs. This prevents the runtime from trying to resume an
+    // old (dead) session via --session-id, and instead falls through to the
+    // noSessionButHasHistory cold-start path which injects the loaded history
+    // messages as context into a fresh session.
+    if (successCount > 0) {
+      conversation.sessionId = null;
+      delete state.providerSessionId;
+      delete state.previousProviderSessionIds;
+    }
   }
 
   async deleteConversationSession(

--- a/src/providers/claude/history/ClaudeConversationHistoryService.ts
+++ b/src/providers/claude/history/ClaudeConversationHistoryService.ts
@@ -429,6 +429,13 @@ export class ClaudeConversationHistoryService implements ProviderConversationHis
 
     conversation.messages = merged;
     this.hydratedConversationIds.add(conversation.id);
+
+    // Clear provider session IDs so the runtime starts a fresh Claude Code process
+    // instead of trying to resume an old (dead) session. The loaded history messages
+    // are preserved and will be injected as context via the noSessionButHasHistory path.
+    conversation.sessionId = null;
+    delete state.providerSessionId;
+    delete state.previousProviderSessionIds;
   }
 
   async deleteConversationSession(


### PR DESCRIPTION
## Problem
When Obsidian restarts, Claudian restores tabs and calls `hydrateConversationHistory()`, which successfully loads old conversation history from disk. However, the conversation object still retains the old `providerSessionId`. When the user sends a new message, Claudian passes this stale session ID as `--session-id` to the new Claude Code process, which fails with:

> Error: No conversation found with session ID: xxxxxxxx

## Root Cause
In `ClaudeConversationHistoryService.hydrateConversationHistory()`, after loading messages from the old JSONL files, both `conversation.sessionId` and `state.providerSessionId` remain set to the old (dead) session ID. The runtime then tries to resume this session via `options.resume` when starting the new Claude Code process.

Claudian already has a `noSessionButHasHistory` cold-start path designed exactly for this scenario — it builds conversation context from loaded history messages and starts a fresh session. The problem is that the stale session ID prevents this path from being reached.

## Fix
After successful hydration in `hydrateConversationHistory()`, clear:
- `conversation.sessionId`
- `state.providerSessionId`
- `state.previousProviderSessionIds`

This allows the runtime to fall through to the `noSessionButHasHistory` cold-start path, which injects the loaded history messages as context into a brand new session — no more 'No conversation found' errors.

### Impact
- ✅ History messages are still displayed in the UI
- ✅ New Claude Code process starts fresh with history as context  
- ✅ No 'No conversation found' error on restart
- ✅ Fork/rewind operations unaffected
- ✅ Normal in-session continuations unaffected (already hydrated, skip on second call)

## Related issues
Fixes #615