### PR TITLE
fix: restrict node shebang detection to first line only

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -239,7 +239,9 @@ export function cliPathRequiresNode(cliPath: string): boolean {
       const buffer = Buffer.alloc(200);
       const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, 0);
       const header = buffer.slice(0, bytesRead).toString('utf8');
-      return header.startsWith('#!') && header.toLowerCase().includes('node');
+      if (!header.startsWith('#!')) return false;
+      const shebangLine = header.split(/\r?\n/)[0].toLowerCase();
+      return shebangLine.includes('node');
     } finally {
       if (fd !== null) {
         try {

--- a/tests/unit/utils/env.test.ts
+++ b/tests/unit/utils/env.test.ts
@@ -713,6 +713,30 @@ describe('cliPathRequiresNode', () => {
     expect(cliPathRequiresNode(scriptPath)).toBe(false);
   });
 
+  it('returns false for non-node shebang scripts that reference node in the body', () => {
+    const scriptPath = isWindows ? 'C:\\temp\\claude-wrapper' : '/tmp/claude-wrapper';
+    const script = [
+      '#!/usr/bin/env bash',
+      'set -euo pipefail',
+      'NODE_BIN="$(command -v node)"',
+      'exec "$NODE_BIN" /path/to/cli.js "$@"',
+      '',
+    ].join('\n');
+
+    jest.spyOn(fs, 'existsSync').mockImplementation(p => String(p) === scriptPath);
+    jest.spyOn(fs, 'statSync').mockImplementation(
+      p => ({ isFile: () => String(p) === scriptPath }) as fsType.Stats
+    );
+    jest.spyOn(fs, 'openSync').mockImplementation(() => 1 as any);
+    jest.spyOn(fs, 'readSync').mockImplementation((_, buffer: ArrayBufferView) => {
+      Buffer.from(buffer.buffer, buffer.byteOffset, buffer.byteLength).write(script);
+      return script.length;
+    });
+    jest.spyOn(fs, 'closeSync').mockImplementation(() => {});
+
+    expect(cliPathRequiresNode(scriptPath)).toBe(false);
+  });
+
   it('returns false for .cmd files', () => {
     expect(cliPathRequiresNode('/path/to/claude.cmd')).toBe(false);
   });


### PR DESCRIPTION
## Summary

- `cliPathRequiresNode()` previously checked the entire first 200 bytes of a CLI executable for the string `"node"`. This caused false positives for **bash wrapper scripts** that reference `node` in variable names (e.g. `NODE_BIN`) or paths within the first 200 bytes, even when their shebang line clearly indicates a non-Node interpreter like `#!/usr/bin/env bash`.
- The function now only checks the **shebang line** (first line) for `node`, which is the correct indicator of the intended interpreter.

## Problem

When users configure a custom CLI path pointing to a bash wrapper script (e.g. for custom Claude implementations), the wrapper script is incorrectly identified as a Node.js script if its body happens to contain the substring `node` within the first 200 bytes. This causes Claudian to spawn the script via `node` instead of executing it directly, resulting in a `SyntaxError` and `exit code 1`:

```
SyntaxError: Unexpected identifier 'pipefail'
    at wrapSafe (node:internal/modules/cjs/loader:1638:18)
    ...
```

### Example wrapper that triggers the bug

```bash
#!/usr/bin/env bash
set -euo pipefail
NODE_BIN="$(command -v node)"       # ← "node" in variable name
exec "$NODE_BIN" /path/to/cli.js "$@"
```

The shebang is `bash`, but `NODE_BIN` contains `node` within 200 bytes → `cliPathRequiresNode` returns `true` → Claudian runs `node /path/to/wrapper.sh ...` → crash.

## Fix

```diff
-      return header.startsWith('#!') && header.toLowerCase().includes('node');
+      if (!header.startsWith('#!')) return false;
+      const shebangLine = header.split(/\r?\n/)[0].toLowerCase();
+      return shebangLine.includes('node');
```

Only the shebang line is checked, which correctly distinguishes `#!/usr/bin/env bash` from `#!/usr/bin/env node`.

