### PR TITLE
Fix Codex provider refresh when enabling it in settings

### DIFF
--- a/src/features/settings/ClaudianSettings.ts
+++ b/src/features/settings/ClaudianSettings.ts
@@ -149,6 +149,10 @@ export class ClaudianSettingTab extends PluginSettingTab {
         ) => this.renderHiddenProviderCommandSetting(target, targetProviderId, copy),
         refreshModelSelectors: () => {
           for (const view of this.plugin.getAllViews()) {
+            const tabManager = view.getTabManager();
+            for (const tab of tabManager?.getAllTabs() ?? []) {
+              tab.onProviderAvailabilityChanged?.();
+            }
             view.refreshModelSelector();
           }
         },

--- a/src/providers/codex/ui/CodexSettingsTab.ts
+++ b/src/providers/codex/ui/CodexSettingsTab.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { Setting } from 'obsidian';
+import { Notice, Setting } from 'obsidian';
 
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type { ProviderSettingsTabRenderer } from '../../../core/providers/types';
@@ -45,7 +45,7 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
 
     new Setting(container)
       .setName('Enable Codex provider')
-      .setDesc('When enabled, Codex models appear in the model selector for new conversations. Existing Codex sessions are preserved.')
+      .setDesc('When enabled, Codex models appear in the model selector for new conversations. Existing chats stay on their current provider, so open a new tab to switch to Codex.')
       .addToggle((toggle) =>
         toggle
           .setValue(codexSettings.enabled)
@@ -53,6 +53,9 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
             updateCodexProviderSettings(settingsBag, { enabled: value });
             await context.plugin.saveSettings();
             context.refreshModelSelectors();
+            if (value) {
+              new Notice('Codex enabled. Existing chats stay on their current provider. Open a new tab to switch to Codex.');
+            }
           })
       );
 

--- a/src/providers/codex/ui/CodexSettingsTab.ts
+++ b/src/providers/codex/ui/CodexSettingsTab.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { Notice, Setting } from 'obsidian';
+import { Setting } from 'obsidian';
 
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type { ProviderSettingsTabRenderer } from '../../../core/providers/types';
@@ -45,7 +45,7 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
 
     new Setting(container)
       .setName('Enable Codex provider')
-      .setDesc('When enabled, Codex models appear in the model selector for new conversations. Existing chats stay on their current provider, so open a new tab to switch to Codex.')
+      .setDesc('When enabled, Codex models appear in the model selector for new conversations. Existing Codex sessions are preserved.')
       .addToggle((toggle) =>
         toggle
           .setValue(codexSettings.enabled)
@@ -53,9 +53,6 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
             updateCodexProviderSettings(settingsBag, { enabled: value });
             await context.plugin.saveSettings();
             context.refreshModelSelectors();
-            if (value) {
-              new Notice('Codex enabled. Existing chats stay on their current provider. Open a new tab to switch to Codex.');
-            }
           })
       );
 

--- a/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
+++ b/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
@@ -84,6 +84,7 @@ jest.mock('obsidian', () => {
   }
 
   return {
+    Notice: jest.fn(),
     Setting: MockSetting,
   };
 });
@@ -363,6 +364,29 @@ describe('CodexSettingsTab', () => {
 
     expect(findOptionalSetting('Installation method')).toBeUndefined();
     expect(findOptionalSetting('WSL distro override')).toBeUndefined();
+  });
+
+  it('refreshes existing chat views after enabling Codex', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const plugin = createPlugin({
+      providerConfigs: {
+        codex: {
+          ...DEFAULT_CODEX_PROVIDER_SETTINGS,
+          enabled: false,
+          customModels: '',
+        },
+      },
+    });
+    const context = createContext(plugin);
+
+    codexSettingsTabRenderer.render(createContainer(), context);
+
+    const enableSetting = findSetting('Enable Codex provider');
+    await enableSetting.toggleComponents[0].onChangeCallback?.(true);
+
+    expect(plugin.settings.providerConfigs.codex.enabled).toBe(true);
+    expect(mockSaveSettings).toHaveBeenCalledTimes(1);
+    expect(context.refreshModelSelectors).toHaveBeenCalledTimes(1);
   });
 
   it('uses host-native CLI path behavior on non-Windows even when WSL is saved', async () => {


### PR DESCRIPTION
## Bug

When enabling the Codex provider in settings, the model switcher did not immediately reflect the provider availability clearly enough in the current UI flow.

Users often had to open a new chat tab before they could actually switch to a Codex model, which made it feel like Codex had not been enabled successfully.

## Fix

- refresh existing chat views after enabling Codex
- re-run provider availability handling for already open tabs before re-rendering model selectors
- add a regression test covering the refresh path when Codex is enabled