### PR TITLE
fix: handle Claude background task notifications

### DIFF
--- a/src/core/runtime/ChatRuntime.ts
+++ b/src/core/runtime/ChatRuntime.ts
@@ -3,7 +3,7 @@ import type { ChatMessage, Conversation, SlashCommand, StreamChunk, ToolCallInfo
 import type {
   ApprovalCallback,
   AskUserQuestionCallback,
-  AutoTurnResult,
+  AutoTurnCallback,
   ChatRewindResult,
   ChatRuntimeConversationState,
   ChatRuntimeEnsureReadyOptions,
@@ -50,7 +50,7 @@ export interface ChatRuntime {
   setExitPlanModeCallback(callback: ExitPlanModeCallback | null): void;
   setPermissionModeSyncCallback(callback: ((sdkMode: string) => void) | null): void;
   setSubagentHookProvider(getState: () => SubagentRuntimeState): void;
-  setAutoTurnCallback(callback: ((result: AutoTurnResult) => void) | null): void;
+  setAutoTurnCallback(callback: AutoTurnCallback | null): void;
   consumeTurnMetadata(): ChatTurnMetadata;
 
   buildSessionUpdates(params: {

--- a/src/core/runtime/types.ts
+++ b/src/core/runtime/types.ts
@@ -108,6 +108,8 @@ export interface AutoTurnResult {
   metadata: ChatTurnMetadata;
 }
 
+export type AutoTurnCallback = (result: AutoTurnResult) => void | Promise<void>;
+
 export type {
   ApprovalDecision,
   ExitPlanModeCallback,

--- a/src/core/types/chat.ts
+++ b/src/core/types/chat.ts
@@ -147,6 +147,7 @@ export type StreamChunk =
   | { type: 'done' }
   | { type: 'usage'; usage: UsageInfo; sessionId?: string | null }
   | { type: 'context_compacted' }
+  | { type: 'async_subagent_result'; agentId: string; status: 'completed' | 'error'; result?: string }
   | { type: 'subagent_tool_use'; subagentId: string; id: string; name: string; input: Record<string, unknown> }
   | { type: 'subagent_tool_result'; subagentId: string; id: string; content: string; isError?: boolean; toolUseResult?: SDKToolUseResult };
 

--- a/src/features/chat/controllers/StreamController.ts
+++ b/src/features/chat/controllers/StreamController.ts
@@ -178,6 +178,10 @@ export class StreamController {
         await this.handleSubagentChunk(chunk, msg);
         break;
 
+      case 'async_subagent_result':
+        await this.handleAsyncSubagentResult(chunk);
+        break;
+
       case 'tool_output':
         this.handleToolOutput(chunk, msg);
         break;
@@ -1137,6 +1141,21 @@ export class StreamController {
     await this.hydrateAsyncSubagentToolCalls(handled);
 
     return isLinked || handled !== undefined;
+  }
+
+  private async handleAsyncSubagentResult(
+    chunk: Extract<StreamChunk, { type: 'async_subagent_result' }>
+  ): Promise<void> {
+    const handled = this.deps.subagentManager.handleAsyncSubagentResult(
+      chunk.agentId,
+      chunk.status,
+      chunk.result
+    );
+
+    await this.hydrateAsyncSubagentToolCalls(handled);
+    if (handled) {
+      this.showThinkingIndicator();
+    }
   }
 
   private async hydrateAsyncSubagentToolCalls(subagent: SubagentInfo | undefined): Promise<void> {

--- a/src/features/chat/services/SubagentManager.ts
+++ b/src/features/chat/services/SubagentManager.ts
@@ -404,6 +404,34 @@ export class SubagentManager {
     return subagent;
   }
 
+  public handleAsyncSubagentResult(
+    agentId: string,
+    status: 'completed' | 'error',
+    result?: string
+  ): SubagentInfo | undefined {
+    const subagent = this.activeAsyncSubagents.get(agentId);
+    if (!subagent || subagent.asyncStatus !== 'running') {
+      return undefined;
+    }
+
+    subagent.agentId = subagent.agentId || agentId;
+    subagent.asyncStatus = status;
+    subagent.status = status;
+    subagent.result = result?.trim() || (status === 'error' ? 'Background task failed.' : 'Background task completed.');
+    subagent.completedAt = Date.now();
+
+    this.activeAsyncSubagents.delete(agentId);
+    for (const [toolId, mappedAgentId] of this.outputToolIdToAgentId.entries()) {
+      if (mappedAgentId === agentId) {
+        this.outputToolIdToAgentId.delete(toolId);
+      }
+    }
+
+    this.updateAsyncDomState(subagent);
+    this.onStateChange(subagent);
+    return subagent;
+  }
+
   public isPendingAsyncTask(taskToolId: string): boolean {
     return this.pendingAsyncSubagents.has(taskToolId);
   }

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -19,7 +19,8 @@ import {
 } from '../../../core/providers/types';
 import type { ChatRuntime } from '../../../core/runtime/ChatRuntime';
 import type { AutoTurnResult } from '../../../core/runtime/types';
-import type { ChatMessage, Conversation } from '../../../core/types';
+import { TOOL_AGENT_OUTPUT } from '../../../core/tools/toolNames';
+import type { ChatMessage, Conversation, StreamChunk } from '../../../core/types';
 import { t } from '../../../i18n/i18n';
 import type ClaudianPlugin from '../../../main';
 import { SlashCommandDropdown } from '../../../shared/components/SlashCommandDropdown';
@@ -1671,9 +1672,7 @@ export function setupServiceCallbacks(tab: TabData, plugin: ClaudianPlugin): voi
         hasRunning: tab.services.subagentManager.hasRunningSubagents(),
       })
     );
-    tab.service.setAutoTurnCallback((result: AutoTurnResult) => {
-      renderAutoTriggeredTurn(tab, result);
-    });
+    tab.service.setAutoTurnCallback((result: AutoTurnResult) => renderAutoTriggeredTurn(tab, result));
     tab.service.setPermissionModeSyncCallback((sdkMode) => {
       const mode = sdkMode === 'bypassPermissions' || sdkMode === 'yolo'
         ? 'yolo'
@@ -1701,39 +1700,108 @@ function generateMessageId(): string {
  * Renders an auto-triggered turn (e.g., agent response to task-notification)
  * that arrives after the main handler has completed.
  */
-function renderAutoTriggeredTurn(tab: TabData, result: AutoTurnResult): void {
+function isVisibleAutoTurnChunk(chunk: StreamChunk, hiddenToolIds: Set<string>): boolean {
+  switch (chunk.type) {
+    case 'text':
+      return chunk.content.trim().length > 0;
+    case 'thinking':
+    case 'notice':
+    case 'error':
+    case 'tool_output':
+    case 'context_compacted':
+    case 'subagent_tool_use':
+    case 'subagent_tool_result':
+      return true;
+    case 'tool_use':
+      return chunk.name !== TOOL_AGENT_OUTPUT;
+    case 'tool_result':
+      return !hiddenToolIds.has(chunk.id);
+    default:
+      return false;
+  }
+}
+
+function hasVisibleAutoTurnMessageContent(msg: ChatMessage): boolean {
+  if (msg.content.trim().length > 0) return true;
+  if (msg.toolCalls && msg.toolCalls.length > 0) return true;
+  return msg.contentBlocks?.some(block =>
+    block.type !== 'text' || block.content.trim().length > 0
+  ) ?? false;
+}
+
+async function renderAutoTriggeredTurn(tab: TabData, result: AutoTurnResult): Promise<void> {
   if (!tab.dom.contentEl.isConnected) {
     return;
   }
 
   const { chunks, metadata } = result;
-  const hasToolActivity = chunks.some(
-    chunk => chunk.type === 'tool_use' || chunk.type === 'tool_result'
+  if (chunks.length === 0) return;
+
+  const hiddenToolIds = new Set(
+    chunks
+      .filter((chunk): chunk is Extract<StreamChunk, { type: 'tool_use' }> =>
+        chunk.type === 'tool_use' && chunk.name === TOOL_AGENT_OUTPUT
+      )
+      .map(chunk => chunk.id)
   );
-  let textContent = '';
-
-  for (const chunk of chunks) {
-    if (chunk.type === 'text') {
-      textContent += chunk.content;
-    }
-  }
-
-  if (!textContent.trim() && !hasToolActivity) return;
-
-  const content = textContent.trim() || '(background task completed)';
+  const hasVisibleContent = chunks.some(chunk => isVisibleAutoTurnChunk(chunk, hiddenToolIds));
 
   const assistantMsg: ChatMessage = {
     id: metadata.assistantMessageId ?? generateMessageId(),
     role: 'assistant',
-    content,
+    content: '',
     timestamp: Date.now(),
-    contentBlocks: [{ type: 'text', content }],
+    toolCalls: [],
+    contentBlocks: [],
     ...(metadata.assistantMessageId && { assistantMessageId: metadata.assistantMessageId }),
   };
 
-  tab.state.addMessage(assistantMsg);
-  tab.renderer?.renderStoredMessage(assistantMsg);
-  tab.renderer?.scrollToBottom();
+  const previousContentEl = tab.state.currentContentEl;
+  const previousTextEl = tab.state.currentTextEl;
+  const previousTextContent = tab.state.currentTextContent;
+  const previousThinkingState = tab.state.currentThinkingState;
+
+  if (hasVisibleContent) {
+    tab.state.addMessage(assistantMsg);
+    const msgEl = tab.renderer?.addMessage?.(assistantMsg);
+    const contentEl = msgEl?.querySelector('.claudian-message-content') as HTMLElement | null | undefined;
+    if (contentEl) {
+      if (!previousContentEl) {
+        tab.state.toolCallElements.clear();
+      }
+      tab.state.currentContentEl = contentEl;
+      tab.state.currentTextEl = null;
+      tab.state.currentTextContent = '';
+      tab.state.currentThinkingState = null;
+    }
+  }
+
+  try {
+    for (const chunk of chunks) {
+      await tab.controllers.streamController?.handleStreamChunk(chunk, assistantMsg);
+    }
+
+    if (hasVisibleContent && !hasVisibleAutoTurnMessageContent(assistantMsg)) {
+      const placeholder = '(background task completed)';
+      assistantMsg.content = placeholder;
+      await tab.controllers.streamController?.appendText(placeholder);
+    }
+
+    if (hasVisibleContent) {
+      await tab.controllers.streamController?.finalizeCurrentThinkingBlock(assistantMsg);
+      await tab.controllers.streamController?.finalizeCurrentTextBlock(assistantMsg);
+    }
+  } finally {
+    if (hasVisibleContent) {
+      tab.controllers.streamController?.hideThinkingIndicator();
+      tab.services.subagentManager.resetStreamingState?.();
+      tab.state.currentContentEl = previousContentEl;
+      tab.state.currentTextEl = previousTextEl;
+      tab.state.currentTextContent = previousTextContent;
+      tab.state.currentThinkingState = previousThinkingState;
+      tab.renderer?.scrollToBottom();
+    }
+  }
 }
 
 export function updatePlanModeUI(tab: TabData, plugin: ClaudianPlugin, mode: string): void {

--- a/src/providers/claude/history/sdkAsyncSubagent.ts
+++ b/src/providers/claude/history/sdkAsyncSubagent.ts
@@ -36,7 +36,7 @@ export function resolveToolUseResultStatus(
   const rawStatus = record.retrieval_status ?? record.status;
   const status = typeof rawStatus === 'string' ? rawStatus.toLowerCase() : '';
 
-  if (status === 'error') {
+  if (status === 'error' || status === 'failed' || status === 'stopped' || status === 'killed') {
     return 'error';
   }
   if (status === 'completed' || status === 'success') {

--- a/src/providers/claude/runtime/ClaudeChatRuntime.ts
+++ b/src/providers/claude/runtime/ClaudeChatRuntime.ts
@@ -34,7 +34,7 @@ import type { ChatRuntime } from '../../../core/runtime/ChatRuntime';
 import type {
   ApprovalCallback,
   AskUserQuestionCallback,
-  AutoTurnResult,
+  AutoTurnCallback,
   ChatRewindResult,
   ChatRuntimeConversationState,
   ChatRuntimeQueryOptions,
@@ -179,7 +179,7 @@ export class ClaudianService implements ChatRuntime {
   private _autoTurnBuffer: StreamChunk[] = [];
   private _autoTurnSawStreamText = false;
   private _autoTurnSawStreamThinking = false;
-  private _autoTurnCallback: ((result: AutoTurnResult) => void) | null = null;
+  private _autoTurnCallback: AutoTurnCallback | null = null;
   private turnMetadata: ChatTurnMetadata = {};
   private bufferedUsageChunk: StreamChunk & { type: 'usage' } | null = null;
   private streamTransformState = createTransformStreamState();
@@ -831,6 +831,7 @@ export class ClaudianService implements ChatRuntime {
 
     // Safe to use last handler - design guarantees single handler at a time
     const handler = this.responseHandlers[this.responseHandlers.length - 1];
+    const autoTurnBufferStartLength = this._autoTurnBuffer.length;
 
     // Transform SDK message to StreamChunks
     for (const event of transformSDKMessage(message, this.getTransformOptions())) {
@@ -920,6 +921,15 @@ export class ClaudianService implements ChatRuntime {
       }
     }
 
+    if (
+      !handler
+      && message.type === 'system'
+      && message.subtype === 'task_notification'
+      && this._autoTurnBuffer.length > autoTurnBufferStartLength
+    ) {
+      await this.flushAutoTurnBuffer();
+    }
+
     if (message.type === 'assistant' && message.uuid) {
       this.recordTurnMetadata({ assistantMessageId: message.uuid });
     }
@@ -935,22 +945,26 @@ export class ClaudianService implements ChatRuntime {
         handler.resetStreamThinking();
         handler.onDone();
       } else {
-        this._autoTurnSawStreamText = false;
-        this._autoTurnSawStreamThinking = false;
-        if (this._autoTurnBuffer.length === 0) {
-          return;
-        }
-
-        // Flush buffered chunks from auto-triggered turn (no handler was registered)
-        const chunks = [...this._autoTurnBuffer];
-        const metadata = this.consumeTurnMetadata();
-        this._autoTurnBuffer = [];
-        try {
-          this._autoTurnCallback?.({ chunks, metadata });
-        } catch {
-          new Notice('Background task completed, but the result could not be rendered.');
-        }
+        await this.flushAutoTurnBuffer();
       }
+    }
+  }
+
+  private async flushAutoTurnBuffer(): Promise<void> {
+    this._autoTurnSawStreamText = false;
+    this._autoTurnSawStreamThinking = false;
+    if (this._autoTurnBuffer.length === 0) {
+      return;
+    }
+
+    // Flush buffered chunks from auto-triggered turn (no handler was registered)
+    const chunks = [...this._autoTurnBuffer];
+    const metadata = this.consumeTurnMetadata();
+    this._autoTurnBuffer = [];
+    try {
+      await this._autoTurnCallback?.({ chunks, metadata });
+    } catch {
+      new Notice('Background task completed, but the result could not be rendered.');
     }
   }
 
@@ -1766,7 +1780,7 @@ export class ClaudianService implements ChatRuntime {
     this._subagentStateProvider = getState;
   }
 
-  setAutoTurnCallback(callback: ((result: AutoTurnResult) => void) | null): void {
+  setAutoTurnCallback(callback: AutoTurnCallback | null): void {
     this._autoTurnCallback = callback;
   }
 

--- a/src/providers/claude/stream/transformClaudeMessage.ts
+++ b/src/providers/claude/stream/transformClaudeMessage.ts
@@ -9,6 +9,7 @@ import { createTransformStreamState, type TransformStreamState } from './toolInp
 
 type ToolUseFields = { id: string; name: string; input: Record<string, unknown> };
 type ToolResultFields = { id: string; content: string; isError?: boolean; toolUseResult?: SDKToolUseResult };
+type AsyncSubagentResultStatus = Extract<StreamChunk, { type: 'async_subagent_result' }>['status'];
 
 export { createTransformStreamState };
 
@@ -31,6 +32,37 @@ function emitToolResult(parentToolUseId: string | null, fields: ToolResultFields
     return { type: 'tool_result', ...fields };
   }
   return { type: 'subagent_tool_result', subagentId: parentToolUseId, ...fields };
+}
+
+function normalizeTaskNotificationStatus(status: unknown): AsyncSubagentResultStatus {
+  return status === 'completed' ? 'completed' : 'error';
+}
+
+function normalizeTaskNotificationResult(status: AsyncSubagentResultStatus, summary: unknown): string {
+  if (typeof summary === 'string' && summary.trim().length > 0) {
+    return summary.trim();
+  }
+  return status === 'completed' ? 'Background task completed.' : 'Background task failed.';
+}
+
+function transformTaskNotification(message: SDKMessage): StreamChunk | null {
+  if (message.type !== 'system' || message.subtype !== 'task_notification') {
+    return null;
+  }
+
+  const record = message as unknown as Record<string, unknown>;
+  const taskId = record.task_id;
+  if (typeof taskId !== 'string' || taskId.length === 0) {
+    return null;
+  }
+
+  const status = normalizeTaskNotificationStatus(record.status);
+  return {
+    type: 'async_subagent_result',
+    agentId: taskId,
+    status,
+    result: normalizeTaskNotificationResult(status, record.summary),
+  };
 }
 
 export interface TransformOptions {
@@ -352,6 +384,11 @@ export function* transformSDKMessage(
         };
       } else if (message.subtype === 'compact_boundary') {
         yield { type: 'context_compacted' };
+      } else if (message.subtype === 'task_notification') {
+        const notification = transformTaskNotification(message);
+        if (notification) {
+          yield notification;
+        }
       }
       break;
 

--- a/src/providers/codex/runtime/CodexChatRuntime.ts
+++ b/src/providers/codex/runtime/CodexChatRuntime.ts
@@ -13,7 +13,7 @@ import type { ChatRuntime } from '../../../core/runtime/ChatRuntime';
 import type {
   ApprovalCallback,
   AskUserQuestionCallback,
-  AutoTurnResult,
+  AutoTurnCallback,
   ChatRewindResult,
   ChatRuntimeConversationState,
   ChatRuntimeEnsureReadyOptions,
@@ -133,7 +133,7 @@ export class CodexChatRuntime implements ChatRuntime {
   private exitPlanModeCallback: ExitPlanModeCallback | null = null;
   private permissionModeSyncCallback: ((sdkMode: string) => void) | null = null;
   private subagentHookProvider: (() => SubagentRuntimeState) | null = null;
-  private autoTurnCallback: ((result: AutoTurnResult) => void) | null = null;
+  private autoTurnCallback: AutoTurnCallback | null = null;
   private resumeCheckpoint: string | undefined;
   private activeInputBundles = new Set<CodexInputBundle>();
 
@@ -779,7 +779,7 @@ export class CodexChatRuntime implements ChatRuntime {
     this.subagentHookProvider = getState;
   }
 
-  setAutoTurnCallback(callback: ((result: AutoTurnResult) => void) | null): void {
+  setAutoTurnCallback(callback: AutoTurnCallback | null): void {
     this.autoTurnCallback = callback;
   }
 

--- a/src/providers/opencode/runtime/OpencodeChatRuntime.ts
+++ b/src/providers/opencode/runtime/OpencodeChatRuntime.ts
@@ -16,7 +16,7 @@ import type {
   ApprovalCallback,
   ApprovalDecisionOption,
   AskUserQuestionCallback,
-  AutoTurnResult,
+  AutoTurnCallback,
   ChatRewindResult,
   ChatRuntimeEnsureReadyOptions,
   ChatRuntimeQueryOptions,
@@ -483,7 +483,7 @@ export class OpencodeChatRuntime implements ChatRuntime {
 
   setSubagentHookProvider(_getState: () => SubagentRuntimeState): void {}
 
-  setAutoTurnCallback(_callback: ((result: AutoTurnResult) => void) | null): void {}
+  setAutoTurnCallback(_callback: AutoTurnCallback | null): void {}
 
   consumeTurnMetadata(): ChatTurnMetadata {
     const metadata = this.currentTurnMetadata;

--- a/tests/unit/features/chat/controllers/StreamController.test.ts
+++ b/tests/unit/features/chat/controllers/StreamController.test.ts
@@ -105,6 +105,7 @@ function createMockDeps(): StreamControllerDeps {
       isLinkedAgentOutputTool: jest.fn().mockReturnValue(false),
       handleAgentOutputToolResult: jest.fn().mockReturnValue(undefined),
       handleAgentOutputToolUse: jest.fn(),
+      handleAsyncSubagentResult: jest.fn().mockReturnValue(undefined),
       handleTaskToolUse: jest.fn().mockReturnValue({ action: 'buffered' }),
       handleTaskToolResult: jest.fn(),
       refreshAsyncSubagent: jest.fn(),
@@ -1670,6 +1671,47 @@ describe('StreamController - Text Content', () => {
         { foo: 'bar' }
       );
       expect(updateToolCallResult).not.toHaveBeenCalled();
+    });
+
+    it('async_subagent_result finalizes and hydrates the matching background subagent', async () => {
+      const runtime = deps.getAgentService!() as any;
+      const msg = createTestMessage();
+      deps.state.currentContentEl = createMockEl();
+      const completedSubagent = {
+        id: 'task-1',
+        description: 'Background task',
+        prompt: 'Do work',
+        mode: 'async',
+        status: 'completed',
+        toolCalls: [],
+        isExpanded: false,
+        asyncStatus: 'completed',
+        agentId: 'agent-1',
+        result: 'Notification summary',
+      };
+
+      (deps.subagentManager.handleAsyncSubagentResult as jest.Mock).mockReturnValueOnce(completedSubagent);
+      runtime.loadSubagentFinalResult.mockResolvedValueOnce('Recovered final result');
+
+      await controller.handleStreamChunk(
+        {
+          type: 'async_subagent_result',
+          agentId: 'agent-1',
+          status: 'completed',
+          result: 'Notification summary',
+        } as any,
+        msg
+      );
+
+      expect(deps.subagentManager.handleAsyncSubagentResult).toHaveBeenCalledWith(
+        'agent-1',
+        'completed',
+        'Notification summary'
+      );
+      expect(runtime.loadSubagentToolCalls).toHaveBeenCalledWith('agent-1');
+      expect(runtime.loadSubagentFinalResult).toHaveBeenCalledWith('agent-1');
+      expect(completedSubagent.result).toBe('Recovered final result');
+      expect(deps.subagentManager.refreshAsyncSubagent).toHaveBeenCalledWith(completedSubagent);
     });
 
     it('hydrates async subagent tool calls from sidecar during streaming completion', async () => {

--- a/tests/unit/features/chat/services/SubagentManager.test.ts
+++ b/tests/unit/features/chat/services/SubagentManager.test.ts
@@ -1590,6 +1590,33 @@ Only this is the final result.
         expect(manager.hasRunningSubagents()).toBe(false);
       });
 
+      it('returns false after a live task notification completes an active async subagent', () => {
+        const { manager, updates } = createManager();
+        const parentEl = createMockEl();
+        manager.handleTaskToolUse('task-1', { description: 'Background', run_in_background: true }, parentEl);
+        manager.handleTaskToolResult('task-1', JSON.stringify({ agent_id: 'agent-123' }));
+
+        expect(manager.hasRunningSubagents()).toBe(true);
+
+        const completed = manager.handleAsyncSubagentResult(
+          'agent-123',
+          'completed',
+          'Background agent finished.'
+        );
+
+        expect(completed?.asyncStatus).toBe('completed');
+        expect(completed?.status).toBe('completed');
+        expect(completed?.result).toBe('Background agent finished.');
+        expect(manager.hasRunningSubagents()).toBe(false);
+        expect(updates[updates.length - 1]).toEqual(
+          expect.objectContaining({
+            agentId: 'agent-123',
+            asyncStatus: 'completed',
+            result: 'Background agent finished.',
+          })
+        );
+      });
+
       it('returns false after parallel foreground tasks resolve from completed task results', () => {
         const { manager } = createManager();
         const parentEl = createMockEl();

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -1393,8 +1393,13 @@ describe('Tab - Service Callbacks', () => {
       const plugin = createMockPlugin();
       const tab = createTab(createMockOptions({ plugin }));
       const addMessageSpy = jest.spyOn(tab.state, 'addMessage');
-      const renderStoredMessage = jest.fn();
+      const addMessage = jest.fn(() => {
+        const msgEl = createMockEl();
+        msgEl.createDiv({ cls: 'claudian-message-content' });
+        return msgEl;
+      });
       const scrollToBottom = jest.fn();
+      const handleStreamChunk = jest.fn().mockResolvedValue(undefined);
 
       Object.defineProperty(tab.dom.contentEl, 'isConnected', {
         value: true,
@@ -1402,7 +1407,19 @@ describe('Tab - Service Callbacks', () => {
         configurable: true,
       });
 
-      tab.renderer = { renderStoredMessage, scrollToBottom } as any;
+      tab.renderer = {
+        addMessage,
+        renderContent: jest.fn(),
+        addTextCopyButton: jest.fn(),
+        scrollToBottom,
+      } as any;
+      tab.controllers.streamController = {
+        handleStreamChunk,
+        appendText: jest.fn().mockResolvedValue(undefined),
+        finalizeCurrentThinkingBlock: jest.fn().mockResolvedValue(undefined),
+        finalizeCurrentTextBlock: jest.fn().mockResolvedValue(undefined),
+        hideThinkingIndicator: jest.fn(),
+      } as any;
       tab.controllers.inputController = {
         handleApprovalRequest: jest.fn(),
         dismissPendingApproval: jest.fn(),
@@ -1411,6 +1428,7 @@ describe('Tab - Service Callbacks', () => {
       } as any;
       tab.services.subagentManager = {
         hasRunningSubagents: jest.fn().mockReturnValue(false),
+        resetStreamingState: jest.fn(),
       } as any;
 
       const service = {
@@ -1427,13 +1445,13 @@ describe('Tab - Service Callbacks', () => {
       setupServiceCallbacks(tab, plugin);
 
       const autoTurnCallback = service.setAutoTurnCallback.mock.calls[0][0];
-      return { tab, addMessageSpy, renderStoredMessage, scrollToBottom, autoTurnCallback };
+      return { tab, addMessageSpy, addMessage, handleStreamChunk, scrollToBottom, autoTurnCallback };
     }
 
-    it('renders tool-only auto-triggered turns with a placeholder assistant message', () => {
-      const { addMessageSpy, renderStoredMessage, scrollToBottom, autoTurnCallback } = setupAutoTurnTest();
+    it('renders tool-only auto-triggered turns with a placeholder assistant message', async () => {
+      const { addMessageSpy, addMessage, handleStreamChunk, scrollToBottom, autoTurnCallback } = setupAutoTurnTest();
 
-      autoTurnCallback({
+      await autoTurnCallback({
         chunks: [
           { type: 'tool_result', id: 'task-1', content: 'done' },
         ],
@@ -1446,15 +1464,48 @@ describe('Tab - Service Callbacks', () => {
           content: '(background task completed)',
         })
       );
-      expect(renderStoredMessage).toHaveBeenCalled();
+      expect(addMessage).toHaveBeenCalled();
+      expect(handleStreamChunk).toHaveBeenCalledWith(
+        { type: 'tool_result', id: 'task-1', content: 'done' },
+        expect.objectContaining({ role: 'assistant' })
+      );
       expect(scrollToBottom).toHaveBeenCalled();
     });
 
-    it('skips auto-triggered rendering after the tab DOM is detached', () => {
-      const { tab, addMessageSpy, renderStoredMessage, scrollToBottom, autoTurnCallback } = setupAutoTurnTest();
+    it('routes hidden async subagent auto-turn chunks without adding a placeholder message', async () => {
+      const { addMessageSpy, addMessage, handleStreamChunk, scrollToBottom, autoTurnCallback } = setupAutoTurnTest();
+
+      await autoTurnCallback({
+        chunks: [
+          {
+            type: 'async_subagent_result',
+            agentId: 'agent-1',
+            status: 'completed',
+            result: 'Done',
+          },
+        ],
+        metadata: {},
+      });
+
+      expect(handleStreamChunk).toHaveBeenCalledWith(
+        {
+          type: 'async_subagent_result',
+          agentId: 'agent-1',
+          status: 'completed',
+          result: 'Done',
+        },
+        expect.objectContaining({ role: 'assistant' })
+      );
+      expect(addMessageSpy).not.toHaveBeenCalled();
+      expect(addMessage).not.toHaveBeenCalled();
+      expect(scrollToBottom).not.toHaveBeenCalled();
+    });
+
+    it('skips auto-triggered rendering after the tab DOM is detached', async () => {
+      const { tab, addMessageSpy, addMessage, handleStreamChunk, scrollToBottom, autoTurnCallback } = setupAutoTurnTest();
 
       (tab.dom.contentEl as any).isConnected = false;
-      autoTurnCallback({
+      await autoTurnCallback({
         chunks: [
           { type: 'text', content: 'Background result' },
         ],
@@ -1462,7 +1513,8 @@ describe('Tab - Service Callbacks', () => {
       });
 
       expect(addMessageSpy).not.toHaveBeenCalled();
-      expect(renderStoredMessage).not.toHaveBeenCalled();
+      expect(addMessage).not.toHaveBeenCalled();
+      expect(handleStreamChunk).not.toHaveBeenCalled();
       expect(scrollToBottom).not.toHaveBeenCalled();
     });
   });

--- a/tests/unit/providers/claude/runtime/ClaudianService.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudianService.test.ts
@@ -1170,6 +1170,55 @@ describe('ClaudianService', () => {
       expect(onChunk).toHaveBeenCalled();
     });
 
+    it('should route task_notification completion to the active handler', async () => {
+      await (service as any).routeMessage({
+        type: 'system',
+        subtype: 'task_notification',
+        task_id: 'agent-123',
+        status: 'completed',
+        output_file: '/tmp/agent-123.output',
+        summary: 'Agent completed successfully.',
+        uuid: 'notification-1',
+        session_id: 'session-1',
+      });
+
+      expect(onChunk).toHaveBeenCalledWith({
+        type: 'async_subagent_result',
+        agentId: 'agent-123',
+        status: 'completed',
+        result: 'Agent completed successfully.',
+      });
+    });
+
+    it('should flush task_notification completion through auto-turn callback without waiting for a result message', async () => {
+      (service as any).responseHandlers = [];
+      const autoTurnCallback = jest.fn();
+      service.setAutoTurnCallback(autoTurnCallback);
+
+      await (service as any).routeMessage({
+        type: 'system',
+        subtype: 'task_notification',
+        task_id: 'agent-456',
+        status: 'completed',
+        output_file: '/tmp/agent-456.output',
+        summary: 'Background agent finished.',
+        uuid: 'notification-2',
+        session_id: 'session-1',
+      });
+
+      expect(autoTurnCallback).toHaveBeenCalledWith({
+        chunks: [
+          {
+            type: 'async_subagent_result',
+            agentId: 'agent-456',
+            status: 'completed',
+            result: 'Background agent finished.',
+          },
+        ],
+        metadata: {},
+      });
+    });
+
     it('should route tool input deltas as tool_use updates', async () => {
       await (service as any).routeMessage({
         type: 'stream_event',

--- a/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
+++ b/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
@@ -92,6 +92,50 @@ describe('transformSDKMessage', () => {
         permissionMode: 'plan',
       });
     });
+
+    it('normalizes task_notification completion into async subagent result', () => {
+      const message = msg({
+        type: 'system',
+        subtype: 'task_notification',
+        task_id: 'agent-123',
+        status: 'completed',
+        output_file: '/tmp/agent-123.output',
+        summary: 'Agent completed successfully.',
+      } as any);
+
+      const results = [...transformSDKMessage(message)];
+
+      expect(results).toEqual([
+        {
+          type: 'async_subagent_result',
+          agentId: 'agent-123',
+          status: 'completed',
+          result: 'Agent completed successfully.',
+        },
+      ]);
+    });
+
+    it('maps non-completed task_notification statuses to async subagent errors', () => {
+      const message = msg({
+        type: 'system',
+        subtype: 'task_notification',
+        task_id: 'agent-failed',
+        status: 'failed',
+        output_file: '/tmp/agent-failed.output',
+        summary: 'Agent failed.',
+      } as any);
+
+      const results = [...transformSDKMessage(message)];
+
+      expect(results).toEqual([
+        {
+          type: 'async_subagent_result',
+          agentId: 'agent-failed',
+          status: 'error',
+          result: 'Agent failed.',
+        },
+      ]);
+    });
   });
 
   describe('assistant messages', () => {

--- a/tests/unit/utils/sdkSession.test.ts
+++ b/tests/unit/utils/sdkSession.test.ts
@@ -2140,6 +2140,12 @@ describe('sdkSession', () => {
       expect(resolveToolUseResultStatus(undefined, 'orphaned')).toBe('orphaned');
       expect(resolveToolUseResultStatus({ status: 'unknown' }, 'orphaned')).toBe('orphaned');
     });
+
+    it('maps task notification failure statuses to error', () => {
+      expect(resolveToolUseResultStatus({ status: 'failed' }, 'completed')).toBe('error');
+      expect(resolveToolUseResultStatus({ status: 'stopped' }, 'completed')).toBe('error');
+      expect(resolveToolUseResultStatus({ status: 'killed' }, 'completed')).toBe('error');
+    });
   });
 
   describe('loadSDKSessionMessages - async subagent hydration', () => {


### PR DESCRIPTION
## Summary
- Fixes #624 by normalizing Claude system/task_notification events into async subagent result chunks
- Routes auto-triggered Claude turn chunks through StreamController so completed background tasks clear active async-subagent state
- Adds coverage across Claude stream/runtime handling, StreamController, SubagentManager, Tab auto-turns, and history normalization

## Validation
- npx tsx .context/repro-gh-624-task-notification.ts
- npm run typecheck
- npm run lint -- --quiet
- npm test -- --selectProjects unit --runInBand
- npm run build
- git diff --check