### PR TITLE
fix: resolve Obsidian review errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Open the chat sidebar from the ribbon icon or command palette. Select text and u
 
 - **Claude provider**: [Claude Code CLI](https://code.claude.com/docs/en/overview) installed (native install recommended). Claude subscription/API or compatible provider ([Openrouter](https://openrouter.ai/docs/guides/guides/claude-code-integration), [Kimi](https://platform.moonshot.ai/docs/guide/agent-support), etc.).
 - **Optional providers**: [Codex CLI](https://github.com/openai/codex), [Opencode](https://opencode.ai/).
-- Obsidian v1.4.5+
+- Obsidian v1.7.2+
 - Desktop only (macOS, Linux, Windows)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Open the chat sidebar from the ribbon icon or command palette. Select text and u
 
 - **Claude provider**: [Claude Code CLI](https://code.claude.com/docs/en/overview) installed (native install recommended). Claude subscription/API or compatible provider ([Openrouter](https://openrouter.ai/docs/guides/guides/claude-code-integration), [Kimi](https://platform.moonshot.ai/docs/guide/agent-support), etc.).
 - **Optional providers**: [Codex CLI](https://github.com/openai/codex), [Opencode](https://opencode.ai/).
-- Obsidian v1.7.2+
+- Obsidian v1.4.5+
 - Desktop only (macOS, Linux, Windows)
 
 ## Installation

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "realclaudian",
   "name": "Claudian",
   "version": "2.0.12",
-  "minAppVersion": "1.7.2",
+  "minAppVersion": "1.4.5",
   "description": "Embeds Claude Code/Codex as an AI collaborator in your vault. Your vault becomes agent's working directory, giving it full agentic capabilities: file read/write, search, bash commands, and multi-step workflows.",
   "author": "Yishen Tu",
   "authorUrl": "https://github.com/YishenTu",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "realclaudian",
   "name": "Claudian",
   "version": "2.0.12",
-  "minAppVersion": "1.4.5",
+  "minAppVersion": "1.7.2",
   "description": "Embeds Claude Code/Codex as an AI collaborator in your vault. Your vault becomes agent's working directory, giving it full agentic capabilities: file read/write, search, bash commands, and multi-step workflows.",
   "author": "Yishen Tu",
   "authorUrl": "https://github.com/YishenTu",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,6 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.112",
-        "@codemirror/state": "^6.6.0",
-        "@codemirror/view": "^6.42.1",
         "@modelcontextprotocol/sdk": "~1.29.0",
         "smol-toml": "^1.6.1",
         "tslib": "^2.8.1"
@@ -631,21 +629,25 @@
       "license": "MIT"
     },
     "node_modules/@codemirror/state": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
-      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
+      "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.42.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.42.1.tgz",
-      "integrity": "sha512-ToN3oFc0nsxNUYVF5P0ztLgbC4UPPjPtA9aKYhkOKQaZASpOUo6ISXyQLP66ctVwlDc+j6Jv0uK5IFALkiXztg==",
+      "version": "6.38.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
+      "integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@codemirror/state": "^6.6.0",
+        "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
@@ -2250,6 +2252,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -3774,6 +3777,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -7346,6 +7350,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/supports-color": {
@@ -8325,6 +8330,7 @@
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.112",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.42.1",
         "@modelcontextprotocol/sdk": "~1.29.0",
         "smol-toml": "^1.6.1",
         "tslib": "^2.8.1"
@@ -629,25 +631,21 @@
       "license": "MIT"
     },
     "node_modules/@codemirror/state": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
-      "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
-      "dev": true,
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.38.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
-      "integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
-      "dev": true,
+      "version": "6.42.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.42.1.tgz",
+      "integrity": "sha512-ToN3oFc0nsxNUYVF5P0ztLgbC4UPPjPtA9aKYhkOKQaZASpOUo6ISXyQLP66ctVwlDc+j6Jv0uK5IFALkiXztg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@codemirror/state": "^6.5.0",
+        "@codemirror/state": "^6.6.0",
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
@@ -2252,7 +2250,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -3777,7 +3774,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -7350,7 +7346,6 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/supports-color": {
@@ -8330,7 +8325,6 @@
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.112",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/view": "^6.42.1",
     "@modelcontextprotocol/sdk": "~1.29.0",
     "smol-toml": "^1.6.1",
     "tslib": "^2.8.1"

--- a/package.json
+++ b/package.json
@@ -45,8 +45,6 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.112",
-    "@codemirror/state": "^6.6.0",
-    "@codemirror/view": "^6.42.1",
     "@modelcontextprotocol/sdk": "~1.29.0",
     "smol-toml": "^1.6.1",
     "tslib": "^2.8.1"

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -183,14 +183,27 @@ export interface ProviderPathIconSvg {
   path: string;
 }
 
-export interface ProviderMarkupIconSvg {
-  kind: 'markup';
+export interface ProviderSvgPathChild {
+  tag: 'path';
+  attributes: Record<string, string>;
+}
+
+export interface ProviderSvgGroupChild {
+  tag: 'g';
+  attributes: Record<string, string>;
+  children: ProviderSvgPathChild[];
+}
+
+export type ProviderSvgChild = ProviderSvgGroupChild | ProviderSvgPathChild;
+
+export interface ProviderCompositeIconSvg {
+  kind: 'composite';
   viewBox: string;
-  markup: string;
+  children: ProviderSvgChild[];
 }
 
 /** SVG icon descriptor for provider branding in selectors and headers. */
-export type ProviderIconSvg = ProviderPathIconSvg | ProviderMarkupIconSvg;
+export type ProviderIconSvg = ProviderPathIconSvg | ProviderCompositeIconSvg;
 
 /** Extended option with token count for budget-based reasoning controls. */
 export interface ProviderReasoningOption extends ProviderUIOption {

--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -1,5 +1,5 @@
 import type { EventRef, WorkspaceLeaf } from 'obsidian';
-import { ItemView, Notice, Scope, setIcon } from 'obsidian';
+import { ItemView, Notice, setIcon } from 'obsidian';
 
 import { getHiddenProviderCommandSet } from '../../core/providers/commands/hiddenCommands';
 import { ProviderRegistry } from '../../core/providers/ProviderRegistry';
@@ -244,8 +244,7 @@ export class ClaudianView extends ItemView {
     this.titleTextEl = this.titleSlotEl.createEl('h4', { text: 'Claudian', cls: 'claudian-title-text' });
 
     // Header actions container (for header mode - initially hidden)
-    this.headerActionsEl = header.createDiv({ cls: 'claudian-header-actions claudian-header-actions-slot' });
-    this.headerActionsEl.style.display = 'none';
+    this.headerActionsEl = header.createDiv({ cls: 'claudian-header-actions claudian-header-actions-slot claudian-hidden' });
   }
 
   /**
@@ -304,7 +303,7 @@ export class ClaudianView extends ItemView {
 
     // Create a wrapper div to hold the fragment (for input mode nav row)
     const wrapper = document.createElement('div');
-    wrapper.style.display = 'contents';
+    wrapper.className = 'claudian-visible-contents';
     wrapper.appendChild(fragment);
     return wrapper;
   }
@@ -326,7 +325,7 @@ export class ClaudianView extends ItemView {
       }
       if (this.headerActionsEl) {
         this.headerActionsEl.appendChild(this.headerActionsContent);
-        this.headerActionsEl.style.display = 'flex';
+        this.headerActionsEl.removeClass('claudian-hidden');
       }
     } else {
       // Input mode: Both go to active tab's navRowEl via the wrapper
@@ -339,7 +338,7 @@ export class ClaudianView extends ItemView {
       }
       // Hide header actions slot when in input mode
       if (this.headerActionsEl) {
-        this.headerActionsEl.style.display = 'none';
+        this.headerActionsEl.addClass('claudian-hidden');
       }
     }
   }
@@ -415,16 +414,16 @@ export class ClaudianView extends ItemView {
     const isHeaderMode = this.plugin.settings.tabBarPosition === 'header';
 
     // Hide tab badges when only 1 tab, show when 2+
-    this.tabBarContainerEl.style.display = showTabBar ? 'flex' : 'none';
+    this.tabBarContainerEl.toggleClass('claudian-hidden', !showTabBar);
 
     // In header mode, badges replace logo/title in the same location
     // In input mode, keep logo/title visible (badges are in nav row)
     const hideBranding = showTabBar && isHeaderMode;
     if (this.logoEl) {
-      this.logoEl.style.display = hideBranding ? 'none' : '';
+      this.logoEl.toggleClass('claudian-hidden', hideBranding);
     }
     if (this.titleTextEl) {
-      this.titleTextEl.style.display = hideBranding ? 'none' : '';
+      this.titleTextEl.toggleClass('claudian-hidden', hideBranding);
     }
   }
 
@@ -558,17 +557,21 @@ export class ClaudianView extends ItemView {
       }
     });
 
-    // Register Escape on the view's Obsidian Scope to prevent Obsidian from
-    // navigating away when Claudian is open as a main-area tab.
-    // Returning false consumes the event (preventDefault + stops scope propagation).
-    this.scope = new Scope(this.app.scope);
-    this.scope.register([], 'Escape', () => {
+    // Capture Escape while focus is inside the view so Obsidian does not handle
+    // it as pane navigation before Claudian can cancel streaming.
+    const activeDocument = this.containerEl.ownerDocument;
+    this.registerDomEvent(activeDocument, 'keydown', (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' || e.isComposing) return;
+      const activeElement = activeDocument.activeElement;
+      if (!activeElement || !this.containerEl.contains(activeElement)) return;
+
+      e.preventDefault();
+      e.stopPropagation();
       const activeTab = this.tabManager?.getActiveTab();
       if (activeTab?.state.isStreaming) {
         activeTab.controllers.inputController?.cancelStreaming();
       }
-      return false;
-    });
+    }, { capture: true });
 
     // Vault events - forward to active tab's file context manager
     const markCacheDirty = (includesFolders: boolean): void => {

--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -44,7 +44,7 @@ export class ClaudianView extends ItemView {
   private pendingTabBarUpdate: number | null = null;
 
   // Debouncing for tab state persistence
-  private pendingPersist: ReturnType<typeof setTimeout> | null = null;
+  private pendingPersist: number | null = null;
 
   constructor(leaf: WorkspaceLeaf, plugin: ClaudianPlugin) {
     super(leaf);
@@ -208,7 +208,8 @@ export class ClaudianView extends ItemView {
 
   async onClose() {
     if (this.pendingTabBarUpdate !== null) {
-      cancelAnimationFrame(this.pendingTabBarUpdate);
+      const activeWindow = this.containerEl.ownerDocument.defaultView ?? window;
+      activeWindow.cancelAnimationFrame(this.pendingTabBarUpdate);
       this.pendingTabBarUpdate = null;
     }
 
@@ -252,38 +253,46 @@ export class ClaudianView extends ItemView {
    * This is called once and the content is moved between locations.
    */
   private buildNavRowContent(): HTMLElement {
+    const activeDocument = this.containerEl.ownerDocument;
+
     // Create a fragment to hold nav row content
-    const fragment = document.createDocumentFragment();
+    const fragment = activeDocument.createDocumentFragment();
 
     // Tab badges (left side in nav row, or in title slot for header mode)
-    this.tabBarContainerEl = document.createElement('div');
+    this.tabBarContainerEl = activeDocument.createElement('div');
     this.tabBarContainerEl.className = 'claudian-tab-bar-container';
     this.tabBar = new TabBar(this.tabBarContainerEl, {
       onTabClick: (tabId) => this.handleTabClick(tabId),
-      onTabClose: (tabId) => this.handleTabClose(tabId),
-      onNewTab: () => this.createNewTab(),
+      onTabClose: (tabId) => {
+        void this.handleTabClose(tabId);
+      },
+      onNewTab: () => {
+        void this.createNewTab().catch(() => new Notice('Failed to create tab'));
+      },
     });
     fragment.appendChild(this.tabBarContainerEl);
 
     // Header actions (right side)
-    this.headerActionsContent = document.createElement('div');
+    this.headerActionsContent = activeDocument.createElement('div');
     this.headerActionsContent.className = 'claudian-header-actions';
 
     // New tab button (plus icon)
     const newTabBtn = this.headerActionsContent.createDiv({ cls: 'claudian-header-btn claudian-new-tab-btn' });
     setIcon(newTabBtn, 'square-plus');
     newTabBtn.setAttribute('aria-label', 'New tab');
-    newTabBtn.addEventListener('click', async () => {
-      await this.createNewTab();
+    newTabBtn.addEventListener('click', () => {
+      void this.createNewTab().catch(() => new Notice('Failed to create tab'));
     });
 
     // New conversation button (square-pen icon - new conversation in current tab)
     const newBtn = this.headerActionsContent.createDiv({ cls: 'claudian-header-btn' });
     setIcon(newBtn, 'square-pen');
     newBtn.setAttribute('aria-label', 'New conversation');
-    newBtn.addEventListener('click', async () => {
-      await this.tabManager?.createNewConversation();
-      this.updateHistoryDropdown();
+    newBtn.addEventListener('click', () => {
+      void (async () => {
+        await this.tabManager?.createNewConversation();
+        this.updateHistoryDropdown();
+      })().catch(() => new Notice('Failed to create conversation'));
     });
 
     // History dropdown
@@ -302,7 +311,7 @@ export class ClaudianView extends ItemView {
     fragment.appendChild(this.headerActionsContent);
 
     // Create a wrapper div to hold the fragment (for input mode nav row)
-    const wrapper = document.createElement('div');
+    const wrapper = activeDocument.createElement('div');
     wrapper.className = 'claudian-visible-contents';
     wrapper.appendChild(fragment);
     return wrapper;
@@ -367,15 +376,22 @@ export class ClaudianView extends ItemView {
   // ============================================
 
   private handleTabClick(tabId: TabId): void {
-    this.tabManager?.switchToTab(tabId);
+    const switched = this.tabManager?.switchToTab(tabId);
+    if (switched) {
+      void switched.catch(() => new Notice('Failed to switch tab'));
+    }
   }
 
   private async handleTabClose(tabId: TabId): Promise<void> {
-    const tab = this.tabManager?.getTab(tabId);
-    // If streaming, treat close like user interrupt (force close cancels the stream)
-    const force = tab?.state.isStreaming ?? false;
-    await this.tabManager?.closeTab(tabId, force);
-    this.updateTabBarVisibility();
+    try {
+      const tab = this.tabManager?.getTab(tabId);
+      // If streaming, treat close like user interrupt (force close cancels the stream)
+      const force = tab?.state.isStreaming ?? false;
+      await this.tabManager?.closeTab(tabId, force);
+      this.updateTabBarVisibility();
+    } catch {
+      new Notice('Failed to close tab');
+    }
   }
 
   async createNewTab(): Promise<void> {
@@ -392,11 +408,12 @@ export class ClaudianView extends ItemView {
     if (!this.tabManager || !this.tabBar) return;
 
     // Debounce tab bar updates using requestAnimationFrame
+    const activeWindow = this.containerEl.ownerDocument.defaultView ?? window;
     if (this.pendingTabBarUpdate !== null) {
-      cancelAnimationFrame(this.pendingTabBarUpdate);
+      activeWindow.cancelAnimationFrame(this.pendingTabBarUpdate);
     }
 
-    this.pendingTabBarUpdate = requestAnimationFrame(() => {
+    this.pendingTabBarUpdate = activeWindow.requestAnimationFrame(() => {
       this.pendingTabBarUpdate = null;
       if (!this.tabManager || !this.tabBar) return;
 
@@ -529,8 +546,10 @@ export class ClaudianView extends ItemView {
   // ============================================
 
   private wireEventHandlers(): void {
+    const activeDocument = this.containerEl.ownerDocument;
+
     // Document-level click to close dropdowns
-    this.registerDomEvent(document, 'click', () => {
+    this.registerDomEvent(activeDocument, 'click', () => {
       this.historyDropdown?.removeClass('visible');
     });
 
@@ -559,7 +578,6 @@ export class ClaudianView extends ItemView {
 
     // Capture Escape while focus is inside the view so Obsidian does not handle
     // it as pane navigation before Claudian can cancel streaming.
-    const activeDocument = this.containerEl.ownerDocument;
     this.registerDomEvent(activeDocument, 'keydown', (e: KeyboardEvent) => {
       if (e.key !== 'Escape' || e.isComposing) return;
       const activeElement = activeDocument.activeElement;
@@ -597,7 +615,7 @@ export class ClaudianView extends ItemView {
     );
 
     // Click outside to close mention dropdown
-    this.registerDomEvent(document, 'click', (e) => {
+    this.registerDomEvent(activeDocument, 'click', (e) => {
       const activeTab = this.tabManager?.getActiveTab();
       if (activeTab) {
         const fcm = activeTab.ui.fileContextManager;
@@ -627,11 +645,13 @@ export class ClaudianView extends ItemView {
   }
 
   private persistTabState(): void {
+    const activeWindow = this.containerEl.ownerDocument.defaultView ?? window;
+
     // Debounce persistence to avoid rapid writes (300ms delay)
     if (this.pendingPersist !== null) {
-      clearTimeout(this.pendingPersist);
+      activeWindow.clearTimeout(this.pendingPersist);
     }
-    this.pendingPersist = setTimeout(() => {
+    this.pendingPersist = activeWindow.setTimeout(() => {
       this.pendingPersist = null;
       if (!this.tabManager) return;
       const state = this.tabManager.getPersistedState();
@@ -645,7 +665,8 @@ export class ClaudianView extends ItemView {
   private async persistTabStateImmediate(): Promise<void> {
     // Cancel any pending debounced persist
     if (this.pendingPersist !== null) {
-      clearTimeout(this.pendingPersist);
+      const activeWindow = this.containerEl.ownerDocument.defaultView ?? window;
+      activeWindow.clearTimeout(this.pendingPersist);
       this.pendingPersist = null;
     }
     if (!this.tabManager) return;

--- a/src/features/chat/controllers/BrowserSelectionController.ts
+++ b/src/features/chat/controllers/BrowserSelectionController.ts
@@ -250,9 +250,9 @@ export class BrowserSelectionController {
       const lineLabel = lineCount === 1 ? 'line' : 'lines';
       this.indicatorEl.textContent = `${lineCount} ${lineLabel} selected`;
       this.indicatorEl.setAttribute('title', this.buildIndicatorTitle());
-      this.indicatorEl.style.display = 'block';
+      this.indicatorEl.removeClass('claudian-hidden');
     } else {
-      this.indicatorEl.style.display = 'none';
+      this.indicatorEl.addClass('claudian-hidden');
       this.indicatorEl.textContent = '';
       this.indicatorEl.removeAttribute('title');
     }

--- a/src/features/chat/controllers/BrowserSelectionController.ts
+++ b/src/features/chat/controllers/BrowserSelectionController.ts
@@ -16,7 +16,7 @@ export class BrowserSelectionController {
   private contextRowEl: HTMLElement;
   private onVisibilityChange: (() => void) | null;
   private storedSelection: BrowserSelectionContext | null = null;
-  private pollInterval: ReturnType<typeof setInterval> | null = null;
+  private pollInterval: number | null = null;
   private pollInFlight = false;
 
   constructor(
@@ -35,14 +35,16 @@ export class BrowserSelectionController {
 
   start(): void {
     if (this.pollInterval) return;
-    this.pollInterval = setInterval(() => {
+    const activeWindow = this.inputEl.ownerDocument.defaultView ?? window;
+    this.pollInterval = activeWindow.setInterval(() => {
       void this.poll();
     }, BROWSER_SELECTION_POLL_INTERVAL);
   }
 
   stop(): void {
     if (this.pollInterval) {
-      clearInterval(this.pollInterval);
+      const activeWindow = this.inputEl.ownerDocument.defaultView ?? window;
+      activeWindow.clearInterval(this.pollInterval);
       this.pollInterval = null;
     }
     this.clear();
@@ -76,7 +78,7 @@ export class BrowserSelectionController {
   }
 
   private getActiveBrowserView(): { view: ItemView; viewType: string; containerEl: HTMLElement } | null {
-    const activeLeaf = (this.app.workspace as any).activeLeaf ?? this.app.workspace.getMostRecentLeaf?.();
+    const activeLeaf = this.app.workspace.activeLeaf ?? this.app.workspace.getMostRecentLeaf?.();
     const activeView = activeLeaf?.view as ItemView | undefined;
     const containerEl = (activeView as unknown as { containerEl?: HTMLElement }).containerEl;
     if (!activeView || !containerEl) return null;
@@ -129,7 +131,7 @@ export class BrowserSelectionController {
     const activeEl = doc.activeElement;
     if (!activeEl || !scopeEl.contains(activeEl)) return null;
 
-    if (activeEl instanceof HTMLTextAreaElement || activeEl instanceof HTMLInputElement) {
+    if (activeEl.instanceOf(HTMLTextAreaElement) || activeEl.instanceOf(HTMLInputElement)) {
       const { value, selectionStart, selectionEnd } = activeEl;
       if (typeof selectionStart !== 'number' || typeof selectionEnd !== 'number' || selectionStart === selectionEnd) return null;
       return value.slice(selectionStart, selectionEnd).trim() || null;
@@ -235,7 +237,7 @@ export class BrowserSelectionController {
   }
 
   private clearWhenInputIsNotFocused(): void {
-    if (document.activeElement === this.inputEl) return;
+    if (this.inputEl.ownerDocument.activeElement === this.inputEl) return;
     if (this.storedSelection) {
       this.storedSelection = null;
       this.updateIndicator();

--- a/src/features/chat/controllers/CanvasSelectionController.ts
+++ b/src/features/chat/controllers/CanvasSelectionController.ts
@@ -5,6 +5,17 @@ import { updateContextRowHasContent } from './contextRowVisibility';
 
 const CANVAS_POLL_INTERVAL = 250;
 
+type CanvasSelectionNode = { id?: unknown };
+
+type CanvasViewLike = ItemView & {
+  canvas?: {
+    selection?: Set<CanvasSelectionNode>;
+  };
+  file?: {
+    path?: unknown;
+  };
+};
+
 export class CanvasSelectionController {
   private app: App;
   private indicatorEl: HTMLElement;
@@ -12,7 +23,7 @@ export class CanvasSelectionController {
   private contextRowEl: HTMLElement;
   private onVisibilityChange: (() => void) | null;
   private storedSelection: CanvasSelectionContext | null = null;
-  private pollInterval: ReturnType<typeof setInterval> | null = null;
+  private pollInterval: number | null = null;
 
   constructor(
     app: App,
@@ -30,12 +41,14 @@ export class CanvasSelectionController {
 
   start(): void {
     if (this.pollInterval) return;
-    this.pollInterval = setInterval(() => this.poll(), CANVAS_POLL_INTERVAL);
+    const activeWindow = this.inputEl.ownerDocument.defaultView ?? window;
+    this.pollInterval = activeWindow.setInterval(() => this.poll(), CANVAS_POLL_INTERVAL);
   }
 
   stop(): void {
     if (this.pollInterval) {
-      clearInterval(this.pollInterval);
+      const activeWindow = this.inputEl.ownerDocument.defaultView ?? window;
+      activeWindow.clearInterval(this.pollInterval);
       this.pollInterval = null;
     }
     this.clear();
@@ -45,14 +58,16 @@ export class CanvasSelectionController {
     const canvasView = this.getCanvasView();
     if (!canvasView) return;
 
-    const canvas = (canvasView as any).canvas;
+    const canvas = canvasView.canvas;
     if (!canvas?.selection) return;
 
-    const selection: Set<{ id: string }> = canvas.selection;
-    const canvasPath = (canvasView as any).file?.path;
-    if (!canvasPath) return;
+    const selection = canvas.selection;
+    const canvasPath = canvasView.file?.path;
+    if (typeof canvasPath !== 'string' || !canvasPath) return;
 
-    const nodeIds = [...selection].map(node => node.id).filter(Boolean);
+    const nodeIds = [...selection]
+      .map(node => node.id)
+      .filter((id): id is string => typeof id === 'string' && id.length > 0);
 
     if (nodeIds.length > 0) {
       const sameSelection = this.storedSelection
@@ -64,7 +79,7 @@ export class CanvasSelectionController {
         this.storedSelection = { canvasPath, nodeIds };
         this.updateIndicator();
       }
-    } else if (document.activeElement !== this.inputEl) {
+    } else if (this.getActiveElement() !== this.inputEl) {
       if (this.storedSelection) {
         this.storedSelection = null;
         this.updateIndicator();
@@ -72,17 +87,22 @@ export class CanvasSelectionController {
     }
   }
 
-  private getCanvasView(): ItemView | null {
-    const activeLeaf = (this.app.workspace as any).activeLeaf ?? this.app.workspace.getMostRecentLeaf?.();
-    const activeView = activeLeaf?.view as ItemView | undefined;
-    if (activeView?.getViewType?.() === 'canvas' && (activeView as any).file) {
+  private getActiveElement(): Element | null {
+    return this.inputEl.ownerDocument?.activeElement
+      ?? (typeof document === 'undefined' ? null : document.activeElement);
+  }
+
+  private getCanvasView(): CanvasViewLike | null {
+    const activeLeaf = this.app.workspace.activeLeaf ?? this.app.workspace.getMostRecentLeaf?.();
+    const activeView = activeLeaf?.view as CanvasViewLike | undefined;
+    if (activeView?.getViewType?.() === 'canvas' && activeView.file) {
       return activeView;
     }
 
     const leaves = this.app.workspace.getLeavesOfType('canvas');
     if (leaves.length === 0) return null;
-    const leaf = leaves.find(l => (l.view as any).file);
-    return leaf ? (leaf.view as ItemView) : null;
+    const leaf = leaves.find(l => (l.view as CanvasViewLike).file);
+    return leaf ? (leaf.view as CanvasViewLike) : null;
   }
 
   private updateIndicator(): void {

--- a/src/features/chat/controllers/CanvasSelectionController.ts
+++ b/src/features/chat/controllers/CanvasSelectionController.ts
@@ -93,9 +93,9 @@ export class CanvasSelectionController {
       this.indicatorEl.textContent = nodeIds.length === 1
         ? `node "${nodeIds[0]}" selected`
         : `${nodeIds.length} nodes selected`;
-      this.indicatorEl.style.display = 'block';
+      this.indicatorEl.removeClass('claudian-hidden');
     } else {
-      this.indicatorEl.style.display = 'none';
+      this.indicatorEl.addClass('claudian-hidden');
     }
     this.updateContextRowVisibility();
   }

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -839,9 +839,9 @@ export class ConversationController {
     if (!welcomeEl) return;
 
     if (this.deps.state.messages.length === 0) {
-      welcomeEl.style.display = '';
+      welcomeEl.removeClass('claudian-hidden');
     } else {
-      welcomeEl.style.display = 'none';
+      welcomeEl.addClass('claudian-hidden');
     }
   }
 

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -16,6 +16,12 @@ import type { ImageContextManager } from '../ui/ImageContext';
 import type { ExternalContextSelector, McpServerSelector } from '../ui/InputToolbar';
 import type { StatusPanel } from '../ui/StatusPanel';
 
+function runConversationAction(action: () => Promise<void>, failureMessage: string): void {
+  void action().catch(() => {
+    new Notice(failureMessage);
+  });
+}
+
 export interface ConversationCallbacks {
   onNewConversation?: () => void;
   onConversationLoaded?: () => void;
@@ -571,30 +577,39 @@ export class ConversationController {
       });
 
       if (!isCurrent) {
-        content.addEventListener('click', async (e) => {
+        content.addEventListener('click', (e) => {
           e.stopPropagation();
           if (this.isHistoryNewTabModifierClick(e) && options.onOpenConversationInNewTab) {
             e.preventDefault();
-            await this.runHistoryAction(
-              () => options.onOpenConversationInNewTab?.(conv.id, true),
+            runConversationAction(
+              () => this.runHistoryAction(
+                () => options.onOpenConversationInNewTab?.(conv.id, true),
+                'Failed to load conversation',
+              ),
               'Failed to load conversation',
             );
             return;
           }
 
-          await this.runHistoryAction(
-            () => options.onSelectConversation(conv.id),
+          runConversationAction(
+            () => this.runHistoryAction(
+              () => options.onSelectConversation(conv.id),
+              'Failed to load conversation',
+            ),
             'Failed to load conversation',
           );
         });
 
         if (options.onOpenConversationInNewTab) {
-          content.addEventListener('auxclick', async (e) => {
+          content.addEventListener('auxclick', (e) => {
             if (e.button !== 1) return;
             e.preventDefault();
             e.stopPropagation();
-            await this.runHistoryAction(
-              () => options.onOpenConversationInNewTab?.(conv.id, true),
+            runConversationAction(
+              () => this.runHistoryAction(
+                () => options.onOpenConversationInNewTab?.(conv.id, true),
+                'Failed to load conversation',
+              ),
               'Failed to load conversation',
             );
           });
@@ -618,13 +633,12 @@ export class ConversationController {
         const regenerateBtn = actions.createEl('button', { cls: 'claudian-action-btn' });
         setIcon(regenerateBtn, 'refresh-cw');
         regenerateBtn.setAttribute('aria-label', 'Regenerate title');
-        regenerateBtn.addEventListener('click', async (e) => {
+        regenerateBtn.addEventListener('click', (e) => {
           e.stopPropagation();
-          try {
-            await this.regenerateTitle(conv.id);
-          } catch {
-            new Notice('Failed to regenerate response');
-          }
+          runConversationAction(
+            () => this.regenerateTitle(conv.id),
+            'Failed to regenerate response',
+          );
         });
       }
 
@@ -639,10 +653,13 @@ export class ConversationController {
       const deleteBtn = actions.createEl('button', { cls: 'claudian-action-btn claudian-delete-btn' });
       setIcon(deleteBtn, 'trash-2');
       deleteBtn.setAttribute('aria-label', 'Delete');
-      deleteBtn.addEventListener('click', async (e) => {
+      deleteBtn.addEventListener('click', (e) => {
         e.stopPropagation();
-        await this.runHistoryAction(
-          () => this.deleteHistoryConversation(conv.id, options),
+        runConversationAction(
+          () => this.runHistoryAction(
+            () => this.deleteHistoryConversation(conv.id, options),
+            'Failed to delete conversation',
+          ),
           'Failed to delete conversation',
         );
       });
@@ -761,8 +778,10 @@ export class ConversationController {
       }
     };
 
-    input.addEventListener('blur', finishRename);
-    input.addEventListener('keydown', async (e) => {
+    input.addEventListener('blur', () => {
+      runConversationAction(finishRename, 'Failed to rename conversation');
+    });
+    input.addEventListener('keydown', (e) => {
       // Check !e.isComposing for IME support (Chinese, Japanese, Korean, etc.)
       if (e.key === 'Enter' && !e.isComposing) {
         input.blur();

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -62,6 +62,10 @@ const DEFAULT_APPROVAL_DECISION_OPTIONS: ApprovalDecisionOption[] =
     decision,
   }));
 
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
 export interface InputControllerDeps {
   plugin: ClaudianPlugin;
   state: ChatState;
@@ -1096,7 +1100,8 @@ export class InputController {
     if (!(plugin.settings.enableAutoScroll ?? true)) return;
     if (!state.autoScrollEnabled) return;
 
-    requestAnimationFrame(() => {
+    const activeWindow = this.deps.getMessagesEl().ownerDocument.defaultView ?? window;
+    activeWindow.requestAnimationFrame(() => {
       if (!(this.deps.plugin.settings.enableAutoScroll ?? true)) return;
       if (!this.deps.state.autoScrollEnabled) return;
 
@@ -1341,7 +1346,7 @@ export class InputController {
       } catch (err) {
         setPending(null);
         this.restoreInputContainer(inputContainerEl);
-        reject(err);
+        reject(toError(err));
       }
     });
   }
@@ -1388,7 +1393,7 @@ export class InputController {
       } catch (err) {
         this.pendingExitPlanModeInline = null;
         this.restoreInputContainer(inputContainerEl);
-        reject(err);
+        reject(toError(err));
       }
     });
   }
@@ -1442,7 +1447,7 @@ export class InputController {
         this.pendingPlanApproval = null;
         this.pendingPlanApprovalInvalidated = false;
         this.restoreInputContainer(inputContainerEl);
-        reject(err);
+        reject(toError(err));
       }
     });
   }

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -257,7 +257,7 @@ export class InputController {
     // Hide welcome message when sending first message
     const welcomeEl = this.deps.getWelcomeEl();
     if (welcomeEl) {
-      welcomeEl.style.display = 'none';
+      welcomeEl.addClass('claudian-hidden');
     }
 
     fileContextManager?.startSession();
@@ -566,11 +566,13 @@ export class InputController {
         }
       }
 
-      indicatorEl.style.display = 'flex';
+      indicatorEl.addClass('claudian-visible-flex');
+      indicatorEl.removeClass('claudian-hidden');
       return;
     }
 
-    indicatorEl.style.display = 'none';
+    indicatorEl.removeClass('claudian-visible-flex');
+    indicatorEl.addClass('claudian-hidden');
   }
 
   clearQueuedMessage(): void {
@@ -1459,21 +1461,21 @@ export class InputController {
 
   private hideInputContainer(inputContainerEl: HTMLElement): void {
     this.inputContainerHideDepth++;
-    inputContainerEl.style.display = 'none';
+    inputContainerEl.addClass('claudian-hidden');
   }
 
   private restoreInputContainer(inputContainerEl: HTMLElement): void {
     if (this.inputContainerHideDepth <= 0) return;
     this.inputContainerHideDepth--;
     if (this.inputContainerHideDepth === 0) {
-      inputContainerEl.style.display = '';
+      inputContainerEl.removeClass('claudian-hidden');
     }
   }
 
   private resetInputContainerVisibility(): void {
     if (this.inputContainerHideDepth > 0) {
       this.inputContainerHideDepth = 0;
-      this.deps.getInputContainerEl().style.display = '';
+      this.deps.getInputContainerEl().removeClass('claudian-hidden');
     }
   }
 

--- a/src/features/chat/controllers/NavigationController.ts
+++ b/src/features/chat/controllers/NavigationController.ts
@@ -16,6 +16,7 @@ export class NavigationController {
   private deps: NavigationControllerDeps;
   private scrollDirection: 'up' | 'down' | null = null;
   private animationFrameId: number | null = null;
+  private keyboardDocument: Document | null = null;
   private initialized = false;
   private disposed = false;
 
@@ -46,7 +47,8 @@ export class NavigationController {
 
     // Attach event listeners
     messagesEl.addEventListener('keydown', this.boundMessagesKeydown);
-    document.addEventListener('keyup', this.boundKeyup);
+    this.keyboardDocument = messagesEl.ownerDocument;
+    this.keyboardDocument.addEventListener('keyup', this.boundKeyup);
 
     // Use capture phase to run before other handlers
     inputEl.addEventListener('keydown', this.boundInputKeydown, { capture: true });
@@ -62,7 +64,8 @@ export class NavigationController {
     this.stopScrolling();
 
     // Always clean up document listener first (most important for preventing leaks)
-    document.removeEventListener('keyup', this.boundKeyup);
+    this.keyboardDocument?.removeEventListener('keyup', this.boundKeyup);
+    this.keyboardDocument = null;
 
     // Element cleanup - may already be destroyed during view teardown
     const messagesEl = this.deps.getMessagesEl();
@@ -161,7 +164,8 @@ export class NavigationController {
   private stopScrolling(): void {
     this.scrollDirection = null;
     if (this.animationFrameId !== null) {
-      cancelAnimationFrame(this.animationFrameId);
+      const activeWindow = this.deps.getMessagesEl()?.ownerDocument.defaultView ?? window;
+      activeWindow.cancelAnimationFrame(this.animationFrameId);
       this.animationFrameId = null;
     }
   }
@@ -179,7 +183,8 @@ export class NavigationController {
     const scrollAmount = this.scrollDirection === 'up' ? -SCROLL_SPEED : SCROLL_SPEED;
     messagesEl.scrollTop += scrollAmount;
 
-    this.animationFrameId = requestAnimationFrame(this.scrollLoop);
+    const activeWindow = messagesEl.ownerDocument.defaultView ?? window;
+    this.animationFrameId = activeWindow.requestAnimationFrame(this.scrollLoop);
   };
 
   // ============================================

--- a/src/features/chat/controllers/SelectionController.ts
+++ b/src/features/chat/controllers/SelectionController.ts
@@ -320,9 +320,9 @@ export class SelectionController {
     if (this.storedSelection) {
       const lineText = this.storedSelection.lineCount === 1 ? 'line' : 'lines';
       this.indicatorEl.textContent = `${this.storedSelection.lineCount} ${lineText} selected`;
-      this.indicatorEl.style.display = 'block';
+      this.indicatorEl.removeClass('claudian-hidden');
     } else {
-      this.indicatorEl.style.display = 'none';
+      this.indicatorEl.addClass('claudian-hidden');
     }
     this.updateContextRowVisibility();
   }

--- a/src/features/chat/controllers/SelectionController.ts
+++ b/src/features/chat/controllers/SelectionController.ts
@@ -19,7 +19,7 @@ export class SelectionController {
   private onVisibilityChange: (() => void) | null;
   private storedSelection: StoredSelection | null = null;
   private inputHandoffGraceUntil: number | null = null;
-  private pollInterval: ReturnType<typeof setInterval> | null = null;
+  private pollInterval: number | null = null;
   private readonly focusScopePointerDownHandler = () => {
     if (!this.storedSelection) return;
     this.inputHandoffGraceUntil = Date.now() + INPUT_HANDOFF_GRACE_MS;
@@ -47,12 +47,14 @@ export class SelectionController {
     if (this.focusScopeEl !== this.inputEl) {
       this.focusScopeEl.addEventListener('pointerdown', this.focusScopePointerDownHandler);
     }
-    this.pollInterval = setInterval(() => this.poll(), SELECTION_POLL_INTERVAL);
+    const activeWindow = this.inputEl.ownerDocument.defaultView ?? window;
+    this.pollInterval = activeWindow.setInterval(() => this.poll(), SELECTION_POLL_INTERVAL);
   }
 
   stop(): void {
     if (this.pollInterval) {
-      clearInterval(this.pollInterval);
+      const activeWindow = this.inputEl.ownerDocument.defaultView ?? window;
+      activeWindow.clearInterval(this.pollInterval);
       this.pollInterval = null;
     }
     this.inputEl.removeEventListener('pointerdown', this.focusScopePointerDownHandler);
@@ -135,7 +137,7 @@ export class SelectionController {
       return;
     }
 
-    const selection = document.getSelection();
+    const selection = this.getDocumentSelection(containerEl.ownerDocument);
     const selectedText = selection?.toString() ?? '';
 
     if (selectedText.trim()) {
@@ -207,8 +209,25 @@ export class SelectionController {
     return ranges;
   }
 
+  private getDocumentSelection(ownerDocument?: Document | null): Selection | null {
+    if (ownerDocument && typeof ownerDocument.getSelection === 'function') {
+      return ownerDocument.getSelection();
+    }
+
+    if (typeof document !== 'undefined' && typeof document.getSelection === 'function') {
+      return document.getSelection();
+    }
+
+    return null;
+  }
+
+  private getActiveElement(ownerDocument?: Document | null): Element | null {
+    return ownerDocument?.activeElement
+      ?? (typeof document === 'undefined' ? null : document.activeElement);
+  }
+
   private isFocusWithinChatSidebar(): boolean {
-    const activeElement = document.activeElement as Node | null;
+    const activeElement = this.getActiveElement(this.focusScopeEl.ownerDocument) as Node | null;
     return activeElement !== null
       && (activeElement === this.focusScopeEl || this.focusScopeEl.contains(activeElement));
   }
@@ -218,7 +237,7 @@ export class SelectionController {
       return false;
     }
 
-    const activeElement = document.activeElement as Node | null;
+    const activeElement = this.getActiveElement(sel.editorView.dom.ownerDocument) as Node | null;
     if (activeElement === null || !sel.editorView.dom.contains(activeElement)) {
       return false;
     }
@@ -232,7 +251,7 @@ export class SelectionController {
       return false;
     }
 
-    return this.selectionMatchesRanges(document.getSelection(), ranges);
+    return this.selectionMatchesRanges(this.getDocumentSelection(this.focusScopeEl.ownerDocument), ranges);
   }
 
   private clearWhenMarkdownContextIsUnavailable(): void {

--- a/src/features/chat/controllers/StreamController.ts
+++ b/src/features/chat/controllers/StreamController.ts
@@ -706,7 +706,7 @@ export class StreamController {
       this.pendingTextRenderFrame = scheduleAnimationFrame(() => {
         this.pendingTextRenderFrame = null;
         void this.renderPendingText();
-      });
+      }, this.getStreamingRenderWindow());
     }
 
     return this.pendingTextRenderPromise;
@@ -753,7 +753,7 @@ export class StreamController {
       this.pendingTextRenderFrame = scheduleAnimationFrame(() => {
         this.pendingTextRenderFrame = null;
         void this.renderPendingText();
-      });
+      }, this.getStreamingRenderWindow());
       return;
     }
 
@@ -782,7 +782,7 @@ export class StreamController {
       this.pendingToolOutputFrames.delete(toolId);
       updateToolCallResult(toolId, toolCall, this.deps.state.toolCallElements);
       this.scrollToBottom();
-    });
+    }, this.getMessagesWindow());
     this.pendingToolOutputFrames.set(toolId, frame);
   }
 
@@ -856,7 +856,7 @@ export class StreamController {
       this.pendingThinkingRenderFrame = scheduleAnimationFrame(() => {
         this.pendingThinkingRenderFrame = null;
         void this.renderPendingThinking();
-      });
+      }, this.getThinkingRenderWindow());
     }
 
     return this.pendingThinkingRenderPromise;
@@ -903,7 +903,7 @@ export class StreamController {
       this.pendingThinkingRenderFrame = scheduleAnimationFrame(() => {
         this.pendingThinkingRenderFrame = null;
         void this.renderPendingThinking();
-      });
+      }, this.getThinkingRenderWindow());
       return;
     }
 
@@ -1228,7 +1228,8 @@ export class StreamController {
     if (attempt >= StreamController.ASYNC_SUBAGENT_RESULT_RETRY_DELAYS_MS.length) return;
 
     const delay = StreamController.ASYNC_SUBAGENT_RESULT_RETRY_DELAYS_MS[attempt];
-    setTimeout(() => {
+    const activeWindow = this.deps.getMessagesEl().ownerDocument.defaultView ?? window;
+    activeWindow.setTimeout(() => {
       void this.retryAsyncSubagentResult(subagent, runtime, attempt);
     }, delay);
   }
@@ -1340,8 +1341,8 @@ export class StreamController {
 
     // Clear any existing timeout
     if (state.thinkingIndicatorTimeout) {
-      clearTimeout(state.thinkingIndicatorTimeout);
-      state.thinkingIndicatorTimeout = null;
+      const activeWindow = state.currentContentEl.ownerDocument.defaultView ?? window;
+      state.clearThinkingIndicatorTimeout(activeWindow);
     }
 
     // Don't show flavor text while model thinking block is active
@@ -1357,8 +1358,9 @@ export class StreamController {
     }
 
     // Schedule showing the indicator after a delay
-    state.thinkingIndicatorTimeout = setTimeout(() => {
-      state.thinkingIndicatorTimeout = null;
+    const activeWindow = state.currentContentEl.ownerDocument.defaultView ?? window;
+    state.setThinkingIndicatorTimeout(activeWindow.setTimeout(() => {
+      state.setThinkingIndicatorTimeout(null, null);
       // Double-check we still have a content element, no indicator exists, and no thinking block
       if (!state.currentContentEl || state.thinkingEl || state.currentThinkingState) return;
 
@@ -1376,8 +1378,7 @@ export class StreamController {
         // Check if element is still connected to DOM (prevents orphaned interval updates)
         if (!timerSpan.isConnected) {
           if (state.flavorTimerInterval) {
-            clearInterval(state.flavorTimerInterval);
-            state.flavorTimerInterval = null;
+            state.clearFlavorTimerInterval();
           }
           return;
         }
@@ -1388,11 +1389,11 @@ export class StreamController {
 
       // Start interval to update timer every second
       if (state.flavorTimerInterval) {
-        clearInterval(state.flavorTimerInterval);
+        state.clearFlavorTimerInterval();
       }
-      state.flavorTimerInterval = setInterval(updateTimer, 1000);
+      state.setFlavorTimerInterval(activeWindow.setInterval(updateTimer, 1000), activeWindow);
 
-    }, StreamController.THINKING_INDICATOR_DELAY);
+    }, StreamController.THINKING_INDICATOR_DELAY), activeWindow);
   }
 
   /** Hides the thinking indicator and cancels any pending show timeout. */
@@ -1401,8 +1402,8 @@ export class StreamController {
 
     // Cancel any pending show timeout
     if (state.thinkingIndicatorTimeout) {
-      clearTimeout(state.thinkingIndicatorTimeout);
-      state.thinkingIndicatorTimeout = null;
+      const activeWindow = this.deps.getMessagesEl().ownerDocument.defaultView ?? window;
+      state.clearThinkingIndicatorTimeout(activeWindow);
     }
 
     // Clear timer interval (but preserve responseStartTime for duration capture)
@@ -1436,12 +1437,14 @@ export class StreamController {
    * FSWatcher often misses the event.
    */
   private notifyVaultFileChange(input: Record<string, unknown>): void {
-    const rawPath = (input.file_path ?? input.notebook_path) as string | undefined;
+    const rawPathValue = input.file_path ?? input.notebook_path;
+    const rawPath = typeof rawPathValue === 'string' ? rawPathValue : undefined;
     const vaultPath = getVaultPath(this.deps.plugin.app);
     const relativePath = normalizePathForVault(rawPath, vaultPath);
     if (!relativePath || relativePath.startsWith('/')) return;
 
-    setTimeout(() => {
+    const activeWindow = this.deps.getMessagesEl().ownerDocument.defaultView ?? window;
+    activeWindow.setTimeout(() => {
       const { vault } = this.deps.plugin.app;
       const file = vault.getAbstractFileByPath(relativePath);
       if (file instanceof TFile) {
@@ -1491,7 +1494,7 @@ export class StreamController {
     this.pendingScrollFrame = scheduleAnimationFrame(() => {
       this.pendingScrollFrame = null;
       this.applyScrollToBottom();
-    });
+    }, this.getMessagesWindow());
   }
 
   private applyScrollToBottom(): void {
@@ -1508,6 +1511,24 @@ export class StreamController {
 
     cancelScheduledAnimationFrame(this.pendingScrollFrame);
     this.pendingScrollFrame = null;
+  }
+
+  private getMessagesWindow(): Window | null {
+    return this.deps.getMessagesEl().ownerDocument.defaultView ?? null;
+  }
+
+  private getStreamingRenderWindow(): Window | null {
+    const { state } = this.deps;
+    return state.currentTextEl?.ownerDocument?.defaultView
+      ?? state.currentContentEl?.ownerDocument?.defaultView
+      ?? this.getMessagesWindow();
+  }
+
+  private getThinkingRenderWindow(): Window | null {
+    const { state } = this.deps;
+    return state.currentThinkingState?.contentEl.ownerDocument?.defaultView
+      ?? state.currentContentEl?.ownerDocument?.defaultView
+      ?? this.getMessagesWindow();
   }
 
   resetStreamingState(): void {

--- a/src/features/chat/controllers/contextRowVisibility.ts
+++ b/src/features/chat/controllers/contextRowVisibility.ts
@@ -5,11 +5,11 @@ export function updateContextRowHasContent(contextRowEl: HTMLElement): void {
   const fileIndicator = contextRowEl.querySelector('.claudian-file-indicator') as HTMLElement | null;
   const imagePreview = contextRowEl.querySelector('.claudian-image-preview') as HTMLElement | null;
 
-  const hasEditorSelection = editorIndicator?.style.display === 'block';
-  const hasBrowserSelection = browserIndicator !== null && browserIndicator.style.display === 'block';
-  const hasCanvasSelection = canvasIndicator?.style.display === 'block';
-  const hasFileChips = fileIndicator?.style.display === 'flex';
-  const hasImageChips = imagePreview?.style.display === 'flex';
+  const hasEditorSelection = !!editorIndicator && !editorIndicator.hasClass('claudian-hidden');
+  const hasBrowserSelection = !!browserIndicator && !browserIndicator.hasClass('claudian-hidden');
+  const hasCanvasSelection = !!canvasIndicator && !canvasIndicator.hasClass('claudian-hidden');
+  const hasFileChips = !!fileIndicator && fileIndicator.hasClass('claudian-visible-flex');
+  const hasImageChips = !!imagePreview && imagePreview.hasClass('claudian-visible-flex');
 
   contextRowEl.classList.toggle(
     'has-content',

--- a/src/features/chat/rendering/InlineAskUserQuestion.ts
+++ b/src/features/chat/rendering/InlineAskUserQuestion.ts
@@ -91,7 +91,8 @@ export class InlineAskUserQuestion {
     this.rootEl.addEventListener('keydown', this.boundKeyDown);
 
     // Defer focus to after the element is in the DOM and laid out
-    requestAnimationFrame(() => {
+    const activeWindow = this.rootEl.ownerDocument.defaultView ?? window;
+    activeWindow.requestAnimationFrame(() => {
       this.rootEl.focus();
       this.rootEl.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
     });
@@ -485,7 +486,7 @@ export class InlineAskUserQuestion {
 
         if (item.hasClass('claudian-ask-custom-item')) {
           const input = item.querySelector('.claudian-ask-custom-text') as HTMLInputElement;
-          if (input && document.activeElement === input) {
+          if (input && this.rootEl.ownerDocument.activeElement === input) {
             input.blur();
             this.isInputFocused = false;
           }
@@ -556,7 +557,7 @@ export class InlineAskUserQuestion {
         e.preventDefault();
         e.stopPropagation();
         this.isInputFocused = false;
-        (document.activeElement as HTMLElement)?.blur();
+        (this.rootEl.ownerDocument.activeElement as HTMLElement | null)?.blur();
         this.rootEl.focus();
         return;
       }
@@ -564,7 +565,7 @@ export class InlineAskUserQuestion {
         e.preventDefault();
         e.stopPropagation();
         this.isInputFocused = false;
-        (document.activeElement as HTMLElement)?.blur();
+        (this.rootEl.ownerDocument.activeElement as HTMLElement | null)?.blur();
         if (e.key === 'Tab' && e.shiftKey) {
           this.switchTab(this.activeTabIndex - 1);
         } else {

--- a/src/features/chat/rendering/InlineExitPlanMode.ts
+++ b/src/features/chat/rendering/InlineExitPlanMode.ts
@@ -122,7 +122,8 @@ export class InlineExitPlanMode {
     this.rootEl.setAttribute('tabindex', '0');
     this.rootEl.addEventListener('keydown', this.boundKeyDown);
 
-    requestAnimationFrame(() => {
+    const activeWindow = this.rootEl.ownerDocument.defaultView ?? window;
+    activeWindow.requestAnimationFrame(() => {
       this.rootEl.focus();
       this.rootEl.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
     });
@@ -239,7 +240,7 @@ export class InlineExitPlanMode {
 
         if (item.hasClass('claudian-ask-custom-item')) {
           const input = item.querySelector('.claudian-ask-custom-text') as HTMLInputElement;
-          if (input && document.activeElement === input) {
+          if (input && this.rootEl.ownerDocument.activeElement === input) {
             input.blur();
             this.isInputFocused = false;
           }

--- a/src/features/chat/rendering/InlineExitPlanMode.ts
+++ b/src/features/chat/rendering/InlineExitPlanMode.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as nodePath from 'path';
 
 import type { ExitPlanModeDecision } from '../../../core/types/tools';
@@ -147,9 +148,7 @@ export class InlineExitPlanMode {
     }
 
     try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const fs = require('fs');
-      const content = fs.readFileSync(planFilePath, 'utf-8') as string;
+      const content = fs.readFileSync(planFilePath, 'utf-8');
       return content.trim() || null;
     } catch (err) {
       this.planReadError = err instanceof Error ? err.message : 'unknown error';

--- a/src/features/chat/rendering/InlinePlanApproval.ts
+++ b/src/features/chat/rendering/InlinePlanApproval.ts
@@ -80,7 +80,8 @@ export class InlinePlanApproval {
     this.rootEl.setAttribute('tabindex', '0');
     this.rootEl.addEventListener('keydown', this.boundKeyDown);
 
-    requestAnimationFrame(() => {
+    const activeWindow = this.rootEl.ownerDocument.defaultView ?? window;
+    activeWindow.requestAnimationFrame(() => {
       this.rootEl.focus();
       this.rootEl.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
     });

--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -1,5 +1,5 @@
 import type { App, Component } from 'obsidian';
-import { MarkdownRenderer, Notice } from 'obsidian';
+import { MarkdownRenderer, Notice, setIcon } from 'obsidian';
 
 import { DEFAULT_CHAT_PROVIDER_ID, type ProviderCapabilities } from '../../../core/providers/types';
 import {
@@ -44,10 +44,6 @@ export class MessageRenderer {
   private getCapabilities: () => ProviderCapabilities;
   private forkCallback?: (messageId: string) => Promise<void>;
   private liveMessageEls = new Map<string, HTMLElement>();
-
-  private static readonly REWIND_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/></svg>`;
-
-  private static readonly FORK_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><circle cx="18" cy="6" r="3"/><path d="M18 9v2c0 .6-.4 1-1 1H7c-.6 0-1-.4-1-1V9"/><path d="M12 12v3"/></svg>`;
 
   constructor(
     plugin: ClaudianPlugin,
@@ -297,7 +293,12 @@ export class MessageRenderer {
 
   private appendInterruptIndicator(contentEl: HTMLElement): void {
     const textEl = contentEl.createDiv({ cls: 'claudian-text-block' });
-    textEl.innerHTML = '<span class="claudian-interrupted">Interrupted</span> <span class="claudian-interrupted-hint">· What should Claudian do instead?</span>';
+    textEl.createSpan({ cls: 'claudian-interrupted', text: 'Interrupted' });
+    textEl.appendText(' ');
+    textEl.createSpan({
+      cls: 'claudian-interrupted-hint',
+      text: '\u00B7 What should Claudian do instead?',
+    });
   }
 
   /**
@@ -666,9 +667,6 @@ export class MessageRenderer {
   // Copy Button
   // ============================================
 
-  /** Clipboard icon SVG for copy button. */
-  private static readonly COPY_ICON = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>`;
-
   /**
    * Adds a copy button to a text block.
    * Button shows clipboard icon on hover, changes to "copied!" on click.
@@ -677,7 +675,7 @@ export class MessageRenderer {
    */
   addTextCopyButton(textEl: HTMLElement, markdown: string): void {
     const copyBtn = textEl.createSpan({ cls: 'claudian-text-copy-btn' });
-    copyBtn.innerHTML = MessageRenderer.COPY_ICON;
+    setIcon(copyBtn, 'copy');
 
     let feedbackTimeout: ReturnType<typeof setTimeout> | null = null;
 
@@ -697,12 +695,13 @@ export class MessageRenderer {
       }
 
       // Show "copied!" feedback
-      copyBtn.innerHTML = '';
+      copyBtn.empty();
       copyBtn.setText('copied!');
       copyBtn.classList.add('copied');
 
       feedbackTimeout = setTimeout(() => {
-        copyBtn.innerHTML = MessageRenderer.COPY_ICON;
+        copyBtn.empty();
+        setIcon(copyBtn, 'copy');
         copyBtn.classList.remove('copied');
         feedbackTimeout = null;
       }, 1500);
@@ -741,7 +740,7 @@ export class MessageRenderer {
   private addUserCopyButton(msgEl: HTMLElement, content: string): void {
     const toolbar = this.getOrCreateActionsToolbar(msgEl);
     const copyBtn = toolbar.createSpan({ cls: 'claudian-user-msg-copy-btn' });
-    copyBtn.innerHTML = MessageRenderer.COPY_ICON;
+    setIcon(copyBtn, 'copy');
     copyBtn.setAttribute('aria-label', 'Copy message');
 
     let feedbackTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -754,11 +753,12 @@ export class MessageRenderer {
         return;
       }
       if (feedbackTimeout) clearTimeout(feedbackTimeout);
-      copyBtn.innerHTML = '';
+      copyBtn.empty();
       copyBtn.setText('copied!');
       copyBtn.classList.add('copied');
       feedbackTimeout = setTimeout(() => {
-        copyBtn.innerHTML = MessageRenderer.COPY_ICON;
+        copyBtn.empty();
+        setIcon(copyBtn, 'copy');
         copyBtn.classList.remove('copied');
         feedbackTimeout = null;
       }, 1500);
@@ -770,7 +770,7 @@ export class MessageRenderer {
     const toolbar = this.getOrCreateActionsToolbar(msgEl);
     const btn = toolbar.createSpan({ cls: 'claudian-message-rewind-btn' });
     if (toolbar.firstChild !== btn) toolbar.insertBefore(btn, toolbar.firstChild);
-    btn.innerHTML = MessageRenderer.REWIND_ICON;
+    setIcon(btn, 'rotate-ccw');
     btn.setAttribute('aria-label', t('chat.rewind.ariaLabel'));
     btn.addEventListener('click', async (e) => {
       e.stopPropagation();
@@ -787,7 +787,7 @@ export class MessageRenderer {
     const toolbar = this.getOrCreateActionsToolbar(msgEl);
     const btn = toolbar.createSpan({ cls: 'claudian-message-fork-btn' });
     if (toolbar.firstChild !== btn) toolbar.insertBefore(btn, toolbar.firstChild);
-    btn.innerHTML = MessageRenderer.FORK_ICON;
+    setIcon(btn, 'git-fork');
     btn.setAttribute('aria-label', t('chat.fork.ariaLabel'));
     btn.addEventListener('click', async (e) => {
       e.stopPropagation();

--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -35,6 +35,12 @@ export type RenderContentFn = (
   options?: RenderContentOptions
 ) => Promise<void>;
 
+function runRendererAction(action: () => Promise<void>): void {
+  void action().catch(() => {
+    // UI actions already surface expected failures locally.
+  });
+}
+
 export class MessageRenderer {
   private app: App;
   private plugin: ClaudianPlugin;
@@ -632,14 +638,20 @@ export class MessageRenderer {
               text: match[1],
             });
             wrapper.appendChild(label);
-            label.addEventListener('click', async () => {
-              try {
-                await navigator.clipboard.writeText(code.textContent || '');
-                label.setText('copied!');
-                setTimeout(() => label.setText(match[1]), 1500);
-              } catch {
-                // Clipboard API may fail in non-secure contexts
-              }
+            label.addEventListener('click', () => {
+              runRendererAction(async () => {
+                const activeWindow = label.ownerDocument.defaultView ?? window;
+                const originalLabel = match[1];
+                if (!originalLabel) return;
+
+                try {
+                  await navigator.clipboard.writeText(code.textContent || '');
+                  label.setText('copied!');
+                  activeWindow.setTimeout(() => label.setText(originalLabel), 1500);
+                } catch {
+                  // Clipboard API may fail in non-secure contexts
+                }
+              });
             });
           }
         }
@@ -677,34 +689,37 @@ export class MessageRenderer {
     const copyBtn = textEl.createSpan({ cls: 'claudian-text-copy-btn' });
     setIcon(copyBtn, 'copy');
 
-    let feedbackTimeout: ReturnType<typeof setTimeout> | null = null;
+    let feedbackTimeout: number | null = null;
 
-    copyBtn.addEventListener('click', async (e) => {
+    copyBtn.addEventListener('click', (e) => {
       e.stopPropagation();
+      runRendererAction(async () => {
+        const activeWindow = copyBtn.ownerDocument.defaultView ?? window;
 
-      try {
-        await navigator.clipboard.writeText(markdown);
-      } catch {
-        // Clipboard API may fail in non-secure contexts
-        return;
-      }
+        try {
+          await navigator.clipboard.writeText(markdown);
+        } catch {
+          // Clipboard API may fail in non-secure contexts
+          return;
+        }
 
-      // Clear any pending timeout from rapid clicks
-      if (feedbackTimeout) {
-        clearTimeout(feedbackTimeout);
-      }
+        // Clear any pending timeout from rapid clicks
+        if (feedbackTimeout) {
+          activeWindow.clearTimeout(feedbackTimeout);
+        }
 
-      // Show "copied!" feedback
-      copyBtn.empty();
-      copyBtn.setText('copied!');
-      copyBtn.classList.add('copied');
-
-      feedbackTimeout = setTimeout(() => {
+        // Show "copied!" feedback
         copyBtn.empty();
-        setIcon(copyBtn, 'copy');
-        copyBtn.classList.remove('copied');
-        feedbackTimeout = null;
-      }, 1500);
+        copyBtn.setText('copied!');
+        copyBtn.classList.add('copied');
+
+        feedbackTimeout = activeWindow.setTimeout(() => {
+          copyBtn.empty();
+          setIcon(copyBtn, 'copy');
+          copyBtn.classList.remove('copied');
+          feedbackTimeout = null;
+        }, 1500);
+      });
     });
   }
 
@@ -743,25 +758,28 @@ export class MessageRenderer {
     setIcon(copyBtn, 'copy');
     copyBtn.setAttribute('aria-label', 'Copy message');
 
-    let feedbackTimeout: ReturnType<typeof setTimeout> | null = null;
+    let feedbackTimeout: number | null = null;
 
-    copyBtn.addEventListener('click', async (e) => {
+    copyBtn.addEventListener('click', (e) => {
       e.stopPropagation();
-      try {
-        await navigator.clipboard.writeText(content);
-      } catch {
-        return;
-      }
-      if (feedbackTimeout) clearTimeout(feedbackTimeout);
-      copyBtn.empty();
-      copyBtn.setText('copied!');
-      copyBtn.classList.add('copied');
-      feedbackTimeout = setTimeout(() => {
+      runRendererAction(async () => {
+        const activeWindow = copyBtn.ownerDocument.defaultView ?? window;
+        try {
+          await navigator.clipboard.writeText(content);
+        } catch {
+          return;
+        }
+        if (feedbackTimeout) activeWindow.clearTimeout(feedbackTimeout);
         copyBtn.empty();
-        setIcon(copyBtn, 'copy');
-        copyBtn.classList.remove('copied');
-        feedbackTimeout = null;
-      }, 1500);
+        copyBtn.setText('copied!');
+        copyBtn.classList.add('copied');
+        feedbackTimeout = activeWindow.setTimeout(() => {
+          copyBtn.empty();
+          setIcon(copyBtn, 'copy');
+          copyBtn.classList.remove('copied');
+          feedbackTimeout = null;
+        }, 1500);
+      });
     });
   }
 
@@ -772,13 +790,15 @@ export class MessageRenderer {
     if (toolbar.firstChild !== btn) toolbar.insertBefore(btn, toolbar.firstChild);
     setIcon(btn, 'rotate-ccw');
     btn.setAttribute('aria-label', t('chat.rewind.ariaLabel'));
-    btn.addEventListener('click', async (e) => {
+    btn.addEventListener('click', (e) => {
       e.stopPropagation();
-      try {
-        await this.rewindCallback?.(messageId);
-      } catch (err) {
-        new Notice(t('chat.rewind.failed', { error: err instanceof Error ? err.message : 'Unknown error' }));
-      }
+      runRendererAction(async () => {
+        try {
+          await this.rewindCallback?.(messageId);
+        } catch (err) {
+          new Notice(t('chat.rewind.failed', { error: err instanceof Error ? err.message : 'Unknown error' }));
+        }
+      });
     });
   }
 
@@ -789,13 +809,15 @@ export class MessageRenderer {
     if (toolbar.firstChild !== btn) toolbar.insertBefore(btn, toolbar.firstChild);
     setIcon(btn, 'git-fork');
     btn.setAttribute('aria-label', t('chat.fork.ariaLabel'));
-    btn.addEventListener('click', async (e) => {
+    btn.addEventListener('click', (e) => {
       e.stopPropagation();
-      try {
-        await this.forkCallback?.(messageId);
-      } catch (err) {
-        new Notice(t('chat.fork.failed', { error: err instanceof Error ? err.message : 'Unknown error' }));
-      }
+      runRendererAction(async () => {
+        try {
+          await this.forkCallback?.(messageId);
+        } catch (err) {
+          new Notice(t('chat.fork.failed', { error: err instanceof Error ? err.message : 'Unknown error' }));
+        }
+      });
     });
   }
 
@@ -813,7 +835,8 @@ export class MessageRenderer {
     const { scrollTop, scrollHeight, clientHeight } = this.messagesEl;
     const isNearBottom = scrollHeight - scrollTop - clientHeight < threshold;
     if (isNearBottom) {
-      requestAnimationFrame(() => {
+      const activeWindow = this.messagesEl.ownerDocument.defaultView ?? window;
+      activeWindow.requestAnimationFrame(() => {
         this.messagesEl.scrollTop = this.messagesEl.scrollHeight;
       });
     }

--- a/src/features/chat/rendering/ThinkingBlockRenderer.ts
+++ b/src/features/chat/rendering/ThinkingBlockRenderer.ts
@@ -8,7 +8,7 @@ export interface ThinkingBlockState {
   labelEl: HTMLElement;
   content: string;
   startTime: number;
-  timerInterval: ReturnType<typeof setInterval> | null;
+  timerInterval: number | null;
   isExpanded: boolean;
 }
 
@@ -29,9 +29,10 @@ export function createThinkingBlock(
   const labelEl = header.createSpan({ cls: 'claudian-thinking-label' });
   const startTime = Date.now();
   labelEl.setText('Thinking 0s...');
+  const activeWindow = parentEl.ownerDocument.defaultView ?? window;
 
   // Start timer interval to update label every second
-  const timerInterval = setInterval(() => {
+  const timerInterval = activeWindow.setInterval(() => {
     const elapsed = Math.floor((Date.now() - startTime) / 1000);
     labelEl.setText(`Thinking ${elapsed}s...`);
   }, 1000);
@@ -68,7 +69,8 @@ export async function appendThinkingContent(
 export function finalizeThinkingBlock(state: ThinkingBlockState): number {
   // Stop the timer
   if (state.timerInterval) {
-    clearInterval(state.timerInterval);
+    const activeWindow = state.wrapperEl.ownerDocument.defaultView ?? window;
+    activeWindow.clearInterval(state.timerInterval);
     state.timerInterval = null;
   }
 
@@ -89,7 +91,8 @@ export function finalizeThinkingBlock(state: ThinkingBlockState): number {
 
 export function cleanupThinkingBlock(state: ThinkingBlockState | null) {
   if (state?.timerInterval) {
-    clearInterval(state.timerInterval);
+    const activeWindow = state.wrapperEl.ownerDocument.defaultView ?? window;
+    activeWindow.clearInterval(state.timerInterval);
   }
 }
 
@@ -114,7 +117,9 @@ export function renderStoredThinkingBlock(
 
   // Collapsible content
   const contentEl = wrapperEl.createDiv({ cls: 'claudian-thinking-content' });
-  renderContent(contentEl, content);
+  void renderContent(contentEl, content).catch(() => {
+    contentEl.setText(content);
+  });
 
   // Setup collapsible behavior (handles click, keyboard, ARIA, CSS)
   const state = { isExpanded: false };

--- a/src/features/chat/rendering/ToolCallRenderer.ts
+++ b/src/features/chat/rendering/ToolCallRenderer.ts
@@ -25,7 +25,7 @@ import {
 } from '../../../core/tools/toolNames';
 import { extractToolResultContent } from '../../../core/tools/toolResultContent';
 import type { AskUserQuestionItem, AskUserQuestionOption, ToolCallInfo } from '../../../core/types';
-import { MCP_ICON_SVG } from '../../../shared/icons';
+import { appendMcpIcon } from '../../../shared/icons';
 import { parseApplyPatchDiffs } from '../../../utils/diff';
 import { setupCollapsible } from './collapsible';
 import { renderDiffContent } from './DiffRenderer';
@@ -34,7 +34,7 @@ import { renderTodoItems } from './todoUtils';
 export function setToolIcon(el: HTMLElement, name: string): void {
   const icon = getToolIcon(name);
   if (icon === MCP_ICON_MARKER) {
-    el.innerHTML = MCP_ICON_SVG;
+    appendMcpIcon(el);
   } else {
     setIcon(el, icon);
   }
@@ -498,9 +498,7 @@ function renderToolSearchExpanded(container: HTMLElement, result: string): void 
 function renderWebFetchExpanded(container: HTMLElement, result: string): void {
   const maxChars = 500;
   const linesEl = container.createDiv({ cls: 'claudian-tool-lines' });
-  const lineEl = linesEl.createDiv({ cls: 'claudian-tool-line' });
-  lineEl.style.whiteSpace = 'pre-wrap';
-  lineEl.style.wordBreak = 'break-word';
+  const lineEl = linesEl.createDiv({ cls: 'claudian-tool-line claudian-tool-line-wrap' });
 
   if (result.length > maxChars) {
     lineEl.setText(result.slice(0, maxChars));
@@ -932,10 +930,10 @@ function createTodoToggleHandler(
   return (expanded: boolean) => {
     if (onExpandChange) onExpandChange(expanded);
     if (currentTaskEl) {
-      currentTaskEl.style.display = expanded ? 'none' : '';
+      currentTaskEl.toggleClass('claudian-hidden', expanded);
     }
     if (statusEl) {
-      statusEl.style.display = expanded ? 'none' : '';
+      statusEl.toggleClass('claudian-hidden', expanded);
     }
   };
 }

--- a/src/features/chat/rendering/ToolCallRenderer.ts
+++ b/src/features/chat/rendering/ToolCallRenderer.ts
@@ -40,6 +40,22 @@ export function setToolIcon(el: HTMLElement, name: string): void {
   }
 }
 
+function stringifyToolValue(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (value === null || value === undefined) return '';
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '';
+  }
+}
+
+function getInputText(input: Record<string, unknown>, key: string, fallback = ''): string {
+  return stringifyToolValue(input[key]) || fallback;
+}
+
 export function getToolName(name: string, input: Record<string, unknown>): string {
   switch (name) {
     case TOOL_TODO_WRITE: {
@@ -64,26 +80,26 @@ export function getToolSummary(name: string, input: Record<string, unknown>): st
     case TOOL_READ:
     case TOOL_WRITE:
     case TOOL_EDIT: {
-      const filePath = (input.file_path as string) || '';
+      const filePath = getInputText(input, 'file_path');
       return fileNameOnly(filePath);
     }
     case TOOL_BASH: {
-      const cmd = (input.command as string) || '';
+      const cmd = getInputText(input, 'command');
       return truncateText(cmd, 60);
     }
     case TOOL_GLOB:
     case TOOL_GREP:
-      return (input.pattern as string) || '';
+      return getInputText(input, 'pattern');
     case TOOL_WEB_SEARCH:
       return getWebSearchSummary(input, 60);
     case TOOL_WEB_FETCH:
-      return truncateText((input.url as string) || '', 60);
+      return truncateText(getInputText(input, 'url'), 60);
     case TOOL_LS:
-      return fileNameOnly((input.path as string) || '.');
+      return fileNameOnly(getInputText(input, 'path', '.'));
     case TOOL_SKILL:
-      return (input.skill as string) || '';
+      return getInputText(input, 'skill');
     case TOOL_TOOL_SEARCH:
-      return truncateText(parseToolSearchQuery(input.query as string | undefined), 60);
+      return truncateText(parseToolSearchQuery(getInputText(input, 'query')), 60);
     case TOOL_TODO_WRITE:
       return '';
     case TOOL_APPLY_PATCH:
@@ -102,28 +118,28 @@ export function getToolSummary(name: string, input: Record<string, unknown>): st
 export function getToolLabel(name: string, input: Record<string, unknown>): string {
   switch (name) {
     case TOOL_READ:
-      return `Read: ${shortenPath(input.file_path as string) || 'file'}`;
+      return `Read: ${shortenPath(getInputText(input, 'file_path')) || 'file'}`;
     case TOOL_WRITE:
-      return `Write: ${shortenPath(input.file_path as string) || 'file'}`;
+      return `Write: ${shortenPath(getInputText(input, 'file_path')) || 'file'}`;
     case TOOL_EDIT:
-      return `Edit: ${shortenPath(input.file_path as string) || 'file'}`;
+      return `Edit: ${shortenPath(getInputText(input, 'file_path')) || 'file'}`;
     case TOOL_BASH: {
-      const cmd = (input.command as string) || 'command';
+      const cmd = getInputText(input, 'command', 'command');
       return `Bash: ${cmd.length > 40 ? cmd.substring(0, 40) + '...' : cmd}`;
     }
     case TOOL_GLOB:
-      return `Glob: ${input.pattern || 'files'}`;
+      return `Glob: ${getInputText(input, 'pattern', 'files')}`;
     case TOOL_GREP:
-      return `Grep: ${input.pattern || 'pattern'}`;
+      return `Grep: ${getInputText(input, 'pattern', 'pattern')}`;
     case TOOL_WEB_SEARCH: {
       return getWebSearchLabel(input, 40);
     }
     case TOOL_WEB_FETCH: {
-      const url = (input.url as string) || 'url';
+      const url = getInputText(input, 'url', 'url');
       return `WebFetch: ${url.length > 40 ? url.substring(0, 40) + '...' : url}`;
     }
     case TOOL_LS:
-      return `LS: ${shortenPath(input.path as string) || '.'}`;
+      return `LS: ${shortenPath(getInputText(input, 'path')) || '.'}`;
     case TOOL_TODO_WRITE: {
       const todos = input.todos as Array<{ status: string }> | undefined;
       if (todos && Array.isArray(todos)) {
@@ -133,11 +149,11 @@ export function getToolLabel(name: string, input: Record<string, unknown>): stri
       return 'Tasks';
     }
     case TOOL_SKILL: {
-      const skillName = (input.skill as string) || 'skill';
+      const skillName = getInputText(input, 'skill', 'skill');
       return `Skill: ${skillName}`;
     }
     case TOOL_TOOL_SEARCH: {
-      const tools = parseToolSearchQuery(input.query as string | undefined);
+      const tools = parseToolSearchQuery(getInputText(input, 'query'));
       return `ToolSearch: ${tools || 'tools'}`;
     }
     case TOOL_ENTER_PLAN_MODE:
@@ -188,13 +204,13 @@ function getApplyPatchSummary(input: Record<string, unknown>): string {
 }
 
 function getWriteStdinSummary(input: Record<string, unknown>): string {
-  const sessionId = input.session_id ?? input.sessionId;
+  const sessionId = stringifyToolValue(input.session_id ?? input.sessionId);
   const chars = typeof input.chars === 'string' ? input.chars.replace(/\n/g, '\\n') : '';
   if (chars) {
     const preview = chars.length > 24 ? `${chars.slice(0, 24)}...` : chars;
-    return sessionId ? `#${String(sessionId)} ${preview}` : preview;
+    return sessionId ? `#${sessionId} ${preview}` : preview;
   }
-  return sessionId ? `#${String(sessionId)}` : '';
+  return sessionId ? `#${sessionId}` : '';
 }
 
 function getAgentLifecycleSummary(name: string, input: Record<string, unknown>): string {

--- a/src/features/chat/rendering/collapsible.ts
+++ b/src/features/chat/rendering/collapsible.ts
@@ -48,10 +48,10 @@ export function setupCollapsible(
   state.isExpanded = initiallyExpanded;
   if (initiallyExpanded) {
     wrapperEl.addClass('expanded');
-    contentEl.style.display = 'block';
+    contentEl.removeClass('claudian-hidden');
     headerEl.setAttribute('aria-expanded', 'true');
   } else {
-    contentEl.style.display = 'none';
+    contentEl.addClass('claudian-hidden');
     headerEl.setAttribute('aria-expanded', 'false');
   }
   updateAriaLabel(initiallyExpanded);
@@ -61,11 +61,11 @@ export function setupCollapsible(
     state.isExpanded = !state.isExpanded;
     if (state.isExpanded) {
       wrapperEl.addClass('expanded');
-      contentEl.style.display = 'block';
+      contentEl.removeClass('claudian-hidden');
       headerEl.setAttribute('aria-expanded', 'true');
     } else {
       wrapperEl.removeClass('expanded');
-      contentEl.style.display = 'none';
+      contentEl.addClass('claudian-hidden');
       headerEl.setAttribute('aria-expanded', 'false');
     }
     updateAriaLabel(state.isExpanded);
@@ -96,6 +96,6 @@ export function collapseElement(
 ): void {
   state.isExpanded = false;
   wrapperEl.removeClass('expanded');
-  contentEl.style.display = 'none';
+  contentEl.addClass('claudian-hidden');
   headerEl.setAttribute('aria-expanded', 'false');
 }

--- a/src/features/chat/state/ChatState.ts
+++ b/src/features/chat/state/ChatState.ts
@@ -47,6 +47,8 @@ function createInitialState(): ChatStateData {
 export class ChatState {
   private state: ChatStateData;
   private _callbacks: ChatStateCallbacks;
+  private thinkingIndicatorTimeoutWindow: Window | null = null;
+  private flavorTimerIntervalWindow: Window | null = null;
 
   constructor(callbacks: ChatStateCallbacks = {}) {
     this.state = createInitialState();
@@ -224,12 +226,13 @@ export class ChatState {
     this.state.queueIndicatorEl = value;
   }
 
-  get thinkingIndicatorTimeout(): ReturnType<typeof setTimeout> | null {
+  get thinkingIndicatorTimeout(): number | null {
     return this.state.thinkingIndicatorTimeout;
   }
 
-  set thinkingIndicatorTimeout(value: ReturnType<typeof setTimeout> | null) {
+  set thinkingIndicatorTimeout(value: number | null) {
     this.state.thinkingIndicatorTimeout = value;
+    this.thinkingIndicatorTimeoutWindow = value === null ? null : this.getDefaultTimerWindow();
   }
 
   // ============================================
@@ -325,12 +328,13 @@ export class ChatState {
     this.state.responseStartTime = value;
   }
 
-  get flavorTimerInterval(): ReturnType<typeof setInterval> | null {
+  get flavorTimerInterval(): number | null {
     return this.state.flavorTimerInterval;
   }
 
-  set flavorTimerInterval(value: ReturnType<typeof setInterval> | null) {
+  set flavorTimerInterval(value: number | null) {
     this.state.flavorTimerInterval = value;
+    this.flavorTimerIntervalWindow = value === null ? null : this.getDefaultTimerWindow();
   }
 
   get pendingNewSessionPlan(): string | null {
@@ -361,10 +365,31 @@ export class ChatState {
   // Reset Methods
   // ============================================
 
+  setThinkingIndicatorTimeout(value: number | null, ownerWindow: Window | null): void {
+    this.state.thinkingIndicatorTimeout = value;
+    this.thinkingIndicatorTimeoutWindow = value === null ? null : ownerWindow;
+  }
+
+  clearThinkingIndicatorTimeout(fallbackWindow: Window | null = null): void {
+    if (this.state.thinkingIndicatorTimeout) {
+      const ownerWindow = this.thinkingIndicatorTimeoutWindow ?? fallbackWindow ?? this.getDefaultTimerWindow();
+      ownerWindow?.clearTimeout(this.state.thinkingIndicatorTimeout);
+      this.state.thinkingIndicatorTimeout = null;
+      this.thinkingIndicatorTimeoutWindow = null;
+    }
+  }
+
+  setFlavorTimerInterval(value: number | null, ownerWindow: Window | null): void {
+    this.state.flavorTimerInterval = value;
+    this.flavorTimerIntervalWindow = value === null ? null : ownerWindow;
+  }
+
   clearFlavorTimerInterval(): void {
     if (this.state.flavorTimerInterval) {
-      clearInterval(this.state.flavorTimerInterval);
+      const ownerWindow = this.flavorTimerIntervalWindow ?? this.getDefaultTimerWindow();
+      ownerWindow?.clearInterval(this.state.flavorTimerInterval);
       this.state.flavorTimerInterval = null;
+      this.flavorTimerIntervalWindow = null;
     }
   }
 
@@ -376,10 +401,7 @@ export class ChatState {
     this.state.isStreaming = false;
     this.state.cancelRequested = false;
     // Clear thinking indicator timeout
-    if (this.state.thinkingIndicatorTimeout) {
-      clearTimeout(this.state.thinkingIndicatorTimeout);
-      this.state.thinkingIndicatorTimeout = null;
-    }
+    this.clearThinkingIndicatorTimeout();
     // Clear response timer
     this.clearFlavorTimerInterval();
     this.state.responseStartTime = null;
@@ -404,6 +426,10 @@ export class ChatState {
   getPersistedMessages(): ChatMessage[] {
     // Return messages as-is - image data is single source of truth
     return this.state.messages;
+  }
+
+  private getDefaultTimerWindow(): Window | null {
+    return typeof window === 'undefined' ? null : window;
   }
 }
 

--- a/src/features/chat/state/types.ts
+++ b/src/features/chat/state/types.ts
@@ -72,7 +72,7 @@ export interface ChatStateData {
   thinkingEl: HTMLElement | null;
   queueIndicatorEl: HTMLElement | null;
   /** Debounce timeout for showing thinking indicator after inactivity. */
-  thinkingIndicatorTimeout: ReturnType<typeof setTimeout> | null;
+  thinkingIndicatorTimeout: number | null;
 
   // Tool tracking maps
   toolCallElements: Map<string, HTMLElement>;
@@ -96,7 +96,7 @@ export interface ChatStateData {
 
   // Response timer state
   responseStartTime: number | null;
-  flavorTimerInterval: ReturnType<typeof setInterval> | null;
+  flavorTimerInterval: number | null;
 
   // Pending plan content for approve-new-session (auto-sends in new session after stream ends)
   pendingNewSessionPlan: string | null;

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -358,8 +358,7 @@ export function createTab(options: TabCreateOptions): TabData {
 
   const id = tabId ?? generateTabId();
 
-  const contentEl = containerEl.createDiv({ cls: 'claudian-tab-content' });
-  contentEl.style.display = 'none';
+  const contentEl = containerEl.createDiv({ cls: 'claudian-tab-content claudian-hidden' });
 
   const state = new ChatState({
     onStreamingStateChanged: onStreamingChanged,
@@ -445,9 +444,6 @@ export function createTab(options: TabCreateOptions): TabData {
  * - Max height is capped at 55% of view height (minimum 150px)
  */
 function autoResizeTextarea(textarea: HTMLTextAreaElement): void {
-  // Clear inline min-height to let flexbox compute natural allocation
-  textarea.style.minHeight = '';
-
   // Calculate max height: 55% of view height, minimum 150px
   const viewHeight = textarea.closest('.claudian-container')?.clientHeight ?? window.innerHeight;
   const maxHeight = Math.max(TEXTAREA_MIN_MAX_HEIGHT, viewHeight * TEXTAREA_MAX_HEIGHT_PERCENT);
@@ -460,12 +456,11 @@ function autoResizeTextarea(textarea: HTMLTextAreaElement): void {
 
   // Only set min-height if content exceeds flex allocation
   // This forces the wrapper to grow while letting it shrink when content reduces
-  if (contentHeight > flexAllocatedHeight) {
-    textarea.style.minHeight = `${contentHeight}px`;
-  }
-
-  // Always set max-height to enforce the cap
-  textarea.style.maxHeight = `${maxHeight}px`;
+  const minHeight = contentHeight > flexAllocatedHeight ? contentHeight : 60;
+  textarea.setCssProps({
+    '--claudian-textarea-min-height': `${minHeight}px`,
+    '--claudian-textarea-max-height': `${maxHeight}px`,
+  });
 }
 
 /**
@@ -939,14 +934,11 @@ export function initializeTabUI(
   initializeContextManagers(tab, plugin);
 
   // Selection indicator - add to contextRowEl
-  dom.selectionIndicatorEl = dom.contextRowEl.createDiv({ cls: 'claudian-selection-indicator' });
-  dom.selectionIndicatorEl.style.display = 'none';
+  dom.selectionIndicatorEl = dom.contextRowEl.createDiv({ cls: 'claudian-selection-indicator claudian-hidden' });
 
-  dom.browserIndicatorEl = dom.contextRowEl.createDiv({ cls: 'claudian-browser-selection-indicator' });
-  dom.browserIndicatorEl.style.display = 'none';
+  dom.browserIndicatorEl = dom.contextRowEl.createDiv({ cls: 'claudian-browser-selection-indicator claudian-hidden' });
 
-  dom.canvasIndicatorEl = dom.contextRowEl.createDiv({ cls: 'claudian-canvas-indicator' });
-  dom.canvasIndicatorEl.style.display = 'none';
+  dom.canvasIndicatorEl = dom.contextRowEl.createDiv({ cls: 'claudian-canvas-indicator claudian-hidden' });
 
   const catalogInfo = options.getProviderCatalogConfig?.() ?? null;
   initializeSlashCommands(
@@ -1547,7 +1539,7 @@ export function wireTabInputEvents(tab: TabData, plugin: ClaudianPlugin): void {
  * Activates a tab (shows it and starts services).
  */
 export function activateTab(tab: TabData): void {
-  tab.dom.contentEl.style.display = 'flex';
+  tab.dom.contentEl.removeClass('claudian-hidden');
   tab.controllers.selectionController?.start();
   tab.controllers.browserSelectionController?.start();
   tab.controllers.canvasSelectionController?.start();
@@ -1559,7 +1551,7 @@ export function activateTab(tab: TabData): void {
  * Deactivates a tab (hides it and stops services).
  */
 export function deactivateTab(tab: TabData): void {
-  tab.dom.contentEl.style.display = 'none';
+  tab.dom.contentEl.addClass('claudian-hidden');
   tab.controllers.selectionController?.stop();
   tab.controllers.browserSelectionController?.stop();
   tab.controllers.canvasSelectionController?.stop();

--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -13,6 +13,7 @@ import type { Conversation, SlashCommand } from '../../../core/types';
 import { t } from '../../../i18n/i18n';
 import type ClaudianPlugin from '../../../main';
 import { chooseForkTarget } from '../../../shared/modals/ForkTargetModal';
+import { focusWorkspaceLeaf } from '../../../utils/obsidianCompat';
 import { getTabProviderId } from './providerResolution';
 import {
   activateTab,
@@ -446,7 +447,7 @@ export class TabManager implements TabManagerInterface {
     const isSameView = crossViewResult?.view === this.view;
     if (crossViewResult && !isSameView) {
       // Focus the other view and switch to its tab instead of opening duplicate
-      this.plugin.app.workspace.revealLeaf(crossViewResult.view.leaf);
+      focusWorkspaceLeaf(this.plugin.app.workspace, crossViewResult.view.leaf);
       await crossViewResult.view.getTabManager()?.switchToTab(crossViewResult.tabId);
       return;
     }

--- a/src/features/chat/ui/ImageContext.ts
+++ b/src/features/chat/ui/ImageContext.ts
@@ -248,11 +248,13 @@ export class ImageContextManager {
     this.imagePreviewEl.empty();
 
     if (this.attachedImages.size === 0) {
-      this.imagePreviewEl.style.display = 'none';
+      this.imagePreviewEl.removeClass('claudian-visible-flex');
+      this.imagePreviewEl.addClass('claudian-hidden');
       return;
     }
 
-    this.imagePreviewEl.style.display = 'flex';
+    this.imagePreviewEl.addClass('claudian-visible-flex');
+    this.imagePreviewEl.removeClass('claudian-hidden');
 
     for (const [id, image] of this.attachedImages) {
       this.renderImagePreview(id, image);

--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -1,4 +1,5 @@
 import { Notice, setIcon } from 'obsidian';
+import * as os from 'os';
 import * as path from 'path';
 
 import type { McpServerManager } from '../../../core/mcp/McpServerManager';
@@ -15,7 +16,7 @@ import type {
   ManagedMcpServer,
   UsageInfo,
 } from '../../../core/types';
-import { CHECK_ICON_SVG, createProviderIconSvg, MCP_ICON_SVG } from '../../../shared/icons';
+import { appendCheckIcon, appendMcpIcon, createProviderIconSvg } from '../../../shared/icons';
 import { filterValidPaths, findConflictingPath, isDuplicatePath, isValidDirectoryPath, validateDirectoryPath } from '../../../utils/externalContext';
 import { expandHomePath, normalizePathForFilesystem } from '../../../utils/path';
 
@@ -175,11 +176,11 @@ export class ModeSelector {
 
     const selectorConfig = this.getSelectorConfig();
     if (!selectorConfig || selectorConfig.options.length !== 2) {
-      this.container.style.display = 'none';
+      this.container.addClass('claudian-hidden');
       return;
     }
 
-    this.container.style.display = '';
+    this.container.removeClass('claudian-hidden');
     const { active, inactive } = this.resolveOptionPair(selectorConfig);
     const currentOption = selectorConfig.options.find((option) => option.value === selectorConfig.value)
       ?? selectorConfig.options[0];
@@ -318,8 +319,8 @@ export class ThinkingBudgetSelector {
   updateDisplay() {
     const capabilities = this.callbacks.getCapabilities();
     if (capabilities.reasoningControl === 'none') {
-      if (this.effortEl) this.effortEl.style.display = 'none';
-      if (this.budgetEl) this.budgetEl.style.display = 'none';
+      this.effortEl?.addClass('claudian-hidden');
+      this.budgetEl?.addClass('claudian-hidden');
       return;
     }
 
@@ -332,18 +333,18 @@ export class ThinkingBudgetSelector {
       || (options.length === 1 && options[0]?.value === defaultValue);
 
     if (shouldHide) {
-      if (this.effortEl) this.effortEl.style.display = 'none';
-      if (this.budgetEl) this.budgetEl.style.display = 'none';
+      this.effortEl?.addClass('claudian-hidden');
+      this.budgetEl?.addClass('claudian-hidden');
       return;
     }
 
     const adaptive = uiConfig.isAdaptiveReasoningModel(model, settings);
 
     if (this.effortEl) {
-      this.effortEl.style.display = adaptive ? '' : 'none';
+      this.effortEl.toggleClass('claudian-hidden', !adaptive);
     }
     if (this.budgetEl) {
-      this.budgetEl.style.display = adaptive ? 'none' : '';
+      this.budgetEl.toggleClass('claudian-hidden', adaptive);
     }
 
     if (adaptive) {
@@ -394,22 +395,22 @@ export class PermissionToggle {
     const toggleConfig = this.getToggleConfig();
     const capabilities = this.callbacks.getCapabilities();
     if (!this.visible || !toggleConfig) {
-      this.container.style.display = 'none';
+      this.container.addClass('claudian-hidden');
       return;
     }
 
-    this.container.style.display = '';
+    this.container.removeClass('claudian-hidden');
     const mode = this.callbacks.getSettings().permissionMode;
     const planValue = toggleConfig.planValue;
     const planLabel = toggleConfig.planLabel ?? 'PLAN';
     const canShowPlan = Boolean(planValue) && capabilities.supportsPlanMode;
 
     if (canShowPlan && planValue && mode === planValue) {
-      this.toggleEl.style.display = 'none';
+      this.toggleEl.addClass('claudian-hidden');
       this.labelEl.setText(planLabel);
       this.labelEl.addClass('plan-active');
     } else {
-      this.toggleEl.style.display = '';
+      this.toggleEl.removeClass('claudian-hidden');
       this.labelEl.removeClass('plan-active');
       if (mode === toggleConfig.activeValue) {
         this.toggleEl.addClass('active');
@@ -468,11 +469,11 @@ export class ServiceTierToggle {
 
     const toggleConfig = this.getToggleConfig();
     if (!toggleConfig) {
-      this.container.style.display = 'none';
+      this.container.addClass('claudian-hidden');
       return;
     }
 
-    this.container.style.display = '';
+    this.container.removeClass('claudian-hidden');
     const current = this.callbacks.getSettings().serviceTier;
     const isActive = current === toggleConfig.activeValue;
     if (isActive) {
@@ -705,7 +706,7 @@ export class ExternalContextSelector {
   private async openFolderPicker() {
     try {
       // Access Electron's dialog through remote
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- Electron remote is exposed only at runtime in Obsidian's renderer.
       const { remote } = require('electron');
       const result = await remote.dialog.showOpenDialog({
         properties: ['openDirectory'],
@@ -799,8 +800,6 @@ export class ExternalContextSelector {
   /** Shorten path for display (replace home dir with ~) */
   private shortenPath(fullPath: string): string {
     try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const os = require('os');
       const homeDir = os.homedir();
       const normalize = (value: string) => value.replace(/\\/g, '/');
       const normalizedFull = normalize(fullPath);
@@ -864,7 +863,7 @@ export class McpServerSelector {
   setVisible(visible: boolean): void {
     this.visible = visible;
     if (!visible) {
-      this.container.style.display = 'none';
+      this.container.addClass('claudian-hidden');
     } else {
       this.updateDisplay();
     }
@@ -937,7 +936,7 @@ export class McpServerSelector {
     const iconWrapper = this.container.createDiv({ cls: 'claudian-mcp-selector-icon-wrapper' });
 
     this.iconEl = iconWrapper.createDiv({ cls: 'claudian-mcp-selector-icon' });
-    this.iconEl.innerHTML = MCP_ICON_SVG;
+    appendMcpIcon(this.iconEl);
 
     this.badgeEl = iconWrapper.createDiv({ cls: 'claudian-mcp-selector-badge' });
 
@@ -990,7 +989,7 @@ export class McpServerSelector {
     // Checkbox
     const checkEl = itemEl.createDiv({ cls: 'claudian-mcp-selector-check' });
     if (isEnabled) {
-      checkEl.innerHTML = CHECK_ICON_SVG;
+      appendCheckIcon(checkEl);
     }
 
     // Info
@@ -1027,10 +1026,10 @@ export class McpServerSelector {
 
     if (isEnabled) {
       itemEl.addClass('enabled');
-      if (checkEl) checkEl.innerHTML = CHECK_ICON_SVG;
+      if (checkEl) appendCheckIcon(checkEl);
     } else {
       itemEl.removeClass('enabled');
-      if (checkEl) checkEl.innerHTML = '';
+      if (checkEl) checkEl.empty();
     }
 
     this.updateDisplay();
@@ -1046,10 +1045,10 @@ export class McpServerSelector {
 
     // Show/hide container based on whether there are servers and visibility
     if (!hasServers || !this.visible) {
-      this.container.style.display = 'none';
+      this.container.addClass('claudian-hidden');
       return;
     }
-    this.container.style.display = '';
+    this.container.removeClass('claudian-hidden');
 
     if (count > 0) {
       this.iconEl.addClass('active');
@@ -1080,11 +1079,11 @@ export class ContextUsageMeter {
     this.container = parentEl.createDiv({ cls: 'claudian-context-meter' });
     this.render();
     // Initially hidden
-    this.container.style.display = 'none';
+    this.container.addClass('claudian-hidden');
   }
 
   setVisible(visible: boolean): void {
-    this.container.style.display = visible ? '' : 'none';
+    this.container.toggleClass('claudian-hidden', !visible);
   }
 
   private render() {
@@ -1109,31 +1108,45 @@ export class ContextUsageMeter {
     const y2 = cy + radius * Math.sin(endRad);
 
     const gaugeEl = this.container.createDiv({ cls: 'claudian-context-meter-gauge' });
-    gaugeEl.innerHTML = `
-      <svg width="${size}" height="${size}" viewBox="0 0 ${size} ${size}">
-        <path class="claudian-meter-bg"
-          d="M ${x1} ${y1} A ${radius} ${radius} 0 1 1 ${x2} ${y2}"
-          fill="none" stroke-width="${strokeWidth}" stroke-linecap="round"/>
-        <path class="claudian-meter-fill"
-          d="M ${x1} ${y1} A ${radius} ${radius} 0 1 1 ${x2} ${y2}"
-          fill="none" stroke-width="${strokeWidth}" stroke-linecap="round"
-          stroke-dasharray="${this.circumference}" stroke-dashoffset="${this.circumference}"/>
-      </svg>
-    `;
-    this.fillPath = gaugeEl.querySelector('.claudian-meter-fill');
+    const svg = gaugeEl.ownerDocument.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('width', String(size));
+    svg.setAttribute('height', String(size));
+    svg.setAttribute('viewBox', `0 0 ${size} ${size}`);
+
+    const pathData = `M ${x1} ${y1} A ${radius} ${radius} 0 1 1 ${x2} ${y2}`;
+    const backgroundPath = gaugeEl.ownerDocument.createElementNS('http://www.w3.org/2000/svg', 'path');
+    backgroundPath.classList.add('claudian-meter-bg');
+    backgroundPath.setAttribute('d', pathData);
+    backgroundPath.setAttribute('fill', 'none');
+    backgroundPath.setAttribute('stroke-width', String(strokeWidth));
+    backgroundPath.setAttribute('stroke-linecap', 'round');
+
+    const fillPath = gaugeEl.ownerDocument.createElementNS('http://www.w3.org/2000/svg', 'path');
+    fillPath.classList.add('claudian-meter-fill');
+    fillPath.setAttribute('d', pathData);
+    fillPath.setAttribute('fill', 'none');
+    fillPath.setAttribute('stroke-width', String(strokeWidth));
+    fillPath.setAttribute('stroke-linecap', 'round');
+    fillPath.setAttribute('stroke-dasharray', String(this.circumference));
+    fillPath.setAttribute('stroke-dashoffset', String(this.circumference));
+
+    svg.appendChild(backgroundPath);
+    svg.appendChild(fillPath);
+    gaugeEl.appendChild(svg);
+    this.fillPath = fillPath;
 
     this.percentEl = this.container.createSpan({ cls: 'claudian-context-meter-percent' });
   }
 
   update(usage: UsageInfo | null): void {
     if (!usage || usage.contextTokens <= 0) {
-      this.container.style.display = 'none';
+      this.container.addClass('claudian-hidden');
       return;
     }
-    this.container.style.display = 'flex';
+    this.container.removeClass('claudian-hidden');
     const fillLength = (usage.percentage / 100) * this.circumference;
     if (this.fillPath) {
-      this.fillPath.style.strokeDashoffset = String(this.circumference - fillLength);
+      this.fillPath.setAttribute('stroke-dashoffset', String(this.circumference - fillLength));
     }
 
     if (this.percentEl) {

--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -20,6 +20,23 @@ import { appendCheckIcon, appendMcpIcon, createProviderIconSvg } from '../../../
 import { filterValidPaths, findConflictingPath, isDuplicatePath, isValidDirectoryPath, validateDirectoryPath } from '../../../utils/externalContext';
 import { expandHomePath, normalizePathForFilesystem } from '../../../utils/path';
 
+interface ElectronOpenDialogResult {
+  canceled: boolean;
+  filePaths: string[];
+}
+
+interface ElectronRemoteApi {
+  dialog: {
+    showOpenDialog(options: { properties: string[]; title: string }): Promise<ElectronOpenDialogResult>;
+  };
+}
+
+function runToolbarAction(action: () => Promise<void>, failureMessage: string): void {
+  void action().catch(() => {
+    new Notice(failureMessage);
+  });
+}
+
 export interface ToolbarSettings {
   model: string;
   thinkingBudget: string;
@@ -120,11 +137,13 @@ export class ModelSelector {
         option.setAttribute('title', model.description);
       }
 
-      option.addEventListener('click', async (e) => {
+      option.addEventListener('click', (e) => {
         e.stopPropagation();
-        await this.callbacks.onModelChange(model.value);
-        this.updateDisplay();
-        this.renderOptions();
+        runToolbarAction(async () => {
+          await this.callbacks.onModelChange(model.value);
+          this.updateDisplay();
+          this.renderOptions();
+        }, 'Failed to change model');
       });
     }
   }
@@ -152,7 +171,9 @@ export class ModeSelector {
     this.labelEl = this.container.createSpan({ cls: 'claudian-mode-label' });
     this.toggleEl = this.container.createDiv({ cls: 'claudian-toggle-switch' });
 
-    this.toggleEl.addEventListener('click', () => this.toggle());
+    this.toggleEl.addEventListener('click', () => {
+      runToolbarAction(() => this.toggle(), 'Failed to change mode');
+    });
 
     this.updateDisplay();
   }
@@ -274,10 +295,12 @@ export class ThinkingBudgetSelector {
         gearEl.addClass('selected');
       }
 
-      gearEl.addEventListener('click', async (e) => {
+      gearEl.addEventListener('click', (e) => {
         e.stopPropagation();
-        await this.callbacks.onEffortLevelChange(effort.value);
-        this.updateDisplay();
+        runToolbarAction(async () => {
+          await this.callbacks.onEffortLevelChange(effort.value);
+          this.updateDisplay();
+        }, 'Failed to change effort level');
       });
     }
   }
@@ -308,10 +331,12 @@ export class ThinkingBudgetSelector {
         gearEl.addClass('selected');
       }
 
-      gearEl.addEventListener('click', async (e) => {
+      gearEl.addEventListener('click', (e) => {
         e.stopPropagation();
-        await this.callbacks.onThinkingBudgetChange(budget.value);
-        this.updateDisplay();
+        runToolbarAction(async () => {
+          await this.callbacks.onThinkingBudgetChange(budget.value);
+          this.updateDisplay();
+        }, 'Failed to change thinking budget');
       });
     }
   }
@@ -381,7 +406,9 @@ export class PermissionToggle {
 
     this.updateDisplay();
 
-    this.toggleEl.addEventListener('click', () => this.toggle());
+    this.toggleEl.addEventListener('click', () => {
+      runToolbarAction(() => this.toggle(), 'Failed to change permission mode');
+    });
   }
 
   private getToggleConfig(): ProviderPermissionModeToggleConfig | null {
@@ -456,7 +483,9 @@ export class ServiceTierToggle {
 
     this.updateDisplay();
 
-    this.buttonEl.addEventListener('click', () => this.toggle());
+    this.buttonEl.addEventListener('click', () => {
+      runToolbarAction(() => this.toggle(), 'Failed to change service tier');
+    });
   }
 
   private getToggleConfig(): ProviderServiceTierToggleConfig | null {
@@ -696,7 +725,7 @@ export class ExternalContextSelector {
     // Click to open native folder picker
     iconWrapper.addEventListener('click', (e) => {
       e.stopPropagation();
-      this.openFolderPicker();
+      void this.openFolderPicker();
     });
 
     this.dropdownEl = this.container.createDiv({ cls: 'claudian-external-context-dropdown' });
@@ -707,7 +736,10 @@ export class ExternalContextSelector {
     try {
       // Access Electron's dialog through remote
       // eslint-disable-next-line @typescript-eslint/no-require-imports -- Electron remote is exposed only at runtime in Obsidian's renderer.
-      const { remote } = require('electron');
+      const { remote } = require('electron') as { remote?: ElectronRemoteApi };
+      if (!remote) {
+        throw new Error('Electron remote API is unavailable');
+      }
       const result = await remote.dialog.showOpenDialog({
         properties: ['openDirectory'],
         title: 'Select External Context',

--- a/src/features/chat/ui/NavigationSidebar.ts
+++ b/src/features/chat/ui/NavigationSidebar.ts
@@ -70,7 +70,7 @@ export class NavigationSidebar {
     this.pendingVisibilityFrame = scheduleAnimationFrame(() => {
       this.pendingVisibilityFrame = null;
       this.applyVisibility();
-    });
+    }, this.messagesEl.ownerDocument.defaultView ?? null);
   }
 
   private applyVisibility(): void {

--- a/src/features/chat/ui/StatusPanel.ts
+++ b/src/features/chat/ui/StatusPanel.ts
@@ -121,8 +121,7 @@ export class StatusPanel {
 
     // Bash output container - hidden by default
     this.bashOutputContainerEl = document.createElement('div');
-    this.bashOutputContainerEl.className = 'claudian-status-panel-bash';
-    this.bashOutputContainerEl.style.display = 'none';
+    this.bashOutputContainerEl.className = 'claudian-status-panel-bash claudian-hidden';
 
     this.bashHeaderEl = document.createElement('div');
     this.bashHeaderEl.className = 'claudian-tool-header claudian-status-panel-bash-header';
@@ -148,8 +147,7 @@ export class StatusPanel {
 
     // Todo container
     this.todoContainerEl = document.createElement('div');
-    this.todoContainerEl.className = 'claudian-status-panel-todos';
-    this.todoContainerEl.style.display = 'none';
+    this.todoContainerEl.className = 'claudian-status-panel-todos claudian-hidden';
     this.panelEl.appendChild(this.todoContainerEl);
 
     // Todo header (collapsed view)
@@ -172,8 +170,7 @@ export class StatusPanel {
 
     // Todo content (expanded list)
     this.todoContentEl = document.createElement('div');
-    this.todoContentEl.className = 'claudian-status-panel-content claudian-todo-list-container';
-    this.todoContentEl.style.display = 'none';
+    this.todoContentEl.className = 'claudian-status-panel-content claudian-todo-list-container claudian-hidden';
     this.todoContainerEl.appendChild(this.todoContentEl);
 
     this.containerEl.appendChild(this.panelEl);
@@ -194,13 +191,13 @@ export class StatusPanel {
     this.currentTodos = todos;
 
     if (!todos || todos.length === 0) {
-      this.todoContainerEl.style.display = 'none';
+      this.todoContainerEl.addClass('claudian-hidden');
       this.todoHeaderEl.empty();
       this.todoContentEl.empty();
       return;
     }
 
-    this.todoContainerEl.style.display = 'block';
+    this.todoContainerEl.removeClass('claudian-hidden');
 
     // Count completed and find current task
     const completedCount = todos.filter(t => t.status === 'completed').length;
@@ -282,7 +279,7 @@ export class StatusPanel {
     if (!this.todoContentEl || !this.todoHeaderEl) return;
 
     // Show/hide content
-    this.todoContentEl.style.display = this.isTodoExpanded ? 'block' : 'none';
+    this.todoContentEl.toggleClass('claudian-hidden', !this.isTodoExpanded);
 
     // Re-render header to update current task visibility
     if (this.currentTodos && this.currentTodos.length > 0) {
@@ -357,11 +354,11 @@ export class StatusPanel {
     const scroll = options.scroll ?? true;
 
     if (this.currentBashOutputs.size === 0) {
-      this.bashOutputContainerEl.style.display = 'none';
+      this.bashOutputContainerEl.addClass('claudian-hidden');
       return;
     }
 
-    this.bashOutputContainerEl.style.display = 'block';
+    this.bashOutputContainerEl.removeClass('claudian-hidden');
     this.bashHeaderEl.empty();
     this.bashContentEl.empty();
 
@@ -384,7 +381,7 @@ export class StatusPanel {
 
     const previewEl = document.createElement('span');
     previewEl.className = 'claudian-tool-current';
-    previewEl.style.display = this.isBashExpanded ? '' : 'none';
+    previewEl.classList.toggle('claudian-hidden', !this.isBashExpanded);
     this.bashHeaderEl.appendChild(previewEl);
 
     const summaryStatusEl = document.createElement('span');
@@ -395,7 +392,7 @@ export class StatusPanel {
       if (latest.status === 'completed') setIcon(summaryStatusEl, 'check');
       if (latest.status === 'error') setIcon(summaryStatusEl, 'x');
     } else {
-      summaryStatusEl.style.display = 'none';
+      summaryStatusEl.classList.add('claudian-hidden');
     }
     this.bashHeaderEl.appendChild(summaryStatusEl);
 
@@ -411,7 +408,7 @@ export class StatusPanel {
     });
     this.bashHeaderEl.appendChild(actionsEl);
 
-    this.bashContentEl.style.display = this.isBashExpanded ? 'block' : 'none';
+    this.bashContentEl.toggleClass('claudian-hidden', !this.isBashExpanded);
 
     if (!this.isBashExpanded) {
       return;
@@ -460,7 +457,7 @@ export class StatusPanel {
     const contentEl = document.createElement('div');
     contentEl.className = 'claudian-tool-content';
     const isEntryExpanded = this.bashEntryExpanded.get(info.id) ?? true;
-    contentEl.style.display = isEntryExpanded ? 'block' : 'none';
+    contentEl.classList.toggle('claudian-hidden', !isEntryExpanded);
     entryHeaderEl.setAttribute('aria-expanded', String(isEntryExpanded));
     entryHeaderEl.setAttribute('aria-label', isEntryExpanded ? t('chat.bangBash.collapseOutput') : t('chat.bangBash.expandOutput'));
     entryHeaderEl.addEventListener('click', () => {

--- a/src/features/chat/ui/file-context/view/FileChipsView.ts
+++ b/src/features/chat/ui/file-context/view/FileChipsView.ts
@@ -29,11 +29,13 @@ export class FileChipsView {
     this.fileIndicatorEl.empty();
 
     if (!filePath) {
-      this.fileIndicatorEl.style.display = 'none';
+      this.fileIndicatorEl.removeClass('claudian-visible-flex');
+      this.fileIndicatorEl.addClass('claudian-hidden');
       return;
     }
 
-    this.fileIndicatorEl.style.display = 'flex';
+    this.fileIndicatorEl.addClass('claudian-visible-flex');
+    this.fileIndicatorEl.removeClass('claudian-hidden');
     this.renderFileChip(filePath, () => {
       this.callbacks.onRemoveAttachment(filePath);
     });

--- a/src/features/inline-edit/ui/InlineEditModal.ts
+++ b/src/features/inline-edit/ui/InlineEditModal.ts
@@ -24,7 +24,7 @@ import {
 import { type CursorContext, getEditorView } from '../../../utils/editor';
 import { buildExternalContextDisplayEntries } from '../../../utils/externalContext';
 import { externalContextScanner } from '../../../utils/externalContextScanner';
-import { escapeHtml, normalizeInsertionText } from '../../../utils/inlineEdit';
+import { normalizeInsertionText } from '../../../utils/inlineEdit';
 import { getVaultPath, normalizePathForVault as normalizePathForVaultUtil } from '../../../utils/path';
 
 export type InlineEditContext =
@@ -41,12 +41,12 @@ const showInlineEdit = StateEffect.define<{
 const showDiff = StateEffect.define<{
   from: number;
   to: number;
-  diffHtml: string;
+  diffOps: DiffOp[];
   widget: InlineEditController;
 }>();
 const showInsertion = StateEffect.define<{
   pos: number;
-  diffHtml: string;
+  diffOps: DiffOp[];
   widget: InlineEditController;
 }>();
 const hideInlineEdit = StateEffect.define<null>();
@@ -54,13 +54,13 @@ const hideInlineEdit = StateEffect.define<null>();
 let activeController: InlineEditController | null = null;
 
 class DiffWidget extends WidgetType {
-  constructor(private diffHtml: string, private controller: InlineEditController) {
+  constructor(private diffOps: DiffOp[], private controller: InlineEditController) {
     super();
   }
   toDOM(): HTMLElement {
     const span = document.createElement('span');
     span.className = 'claudian-inline-diff-replace';
-    span.innerHTML = this.diffHtml;
+    appendDiffOps(span, this.diffOps);
 
     const btns = document.createElement('span');
     btns.className = 'claudian-inline-diff-buttons';
@@ -84,7 +84,7 @@ class DiffWidget extends WidgetType {
     return span;
   }
   eq(other: DiffWidget): boolean {
-    return this.diffHtml === other.diffHtml;
+    return diffOpsEqual(this.diffOps, other.diffOps);
   }
   ignoreEvent(): boolean {
     return true;
@@ -124,13 +124,13 @@ const inlineEditField = StateField.define<DecorationSet>({
       } else if (e.is(showDiff)) {
         const builder = new RangeSetBuilder<Decoration>();
         builder.add(e.value.from, e.value.to, Decoration.replace({
-          widget: new DiffWidget(e.value.diffHtml, e.value.widget),
+          widget: new DiffWidget(e.value.diffOps, e.value.widget),
         }));
         deco = builder.finish();
       } else if (e.is(showInsertion)) {
         const builder = new RangeSetBuilder<Decoration>();
         builder.add(e.value.pos, e.value.pos, Decoration.widget({
-          widget: new DiffWidget(e.value.diffHtml, e.value.widget),
+          widget: new DiffWidget(e.value.diffOps, e.value.widget),
           side: 1, // After the position
         }));
         deco = builder.finish();
@@ -189,15 +189,27 @@ function computeDiff(oldText: string, newText: string): DiffOp[] {
   return ops;
 }
 
-function diffToHtml(ops: DiffOp[]): string {
-  return ops.map(op => {
-    const escaped = escapeHtml(op.text);
+function appendDiffOps(container: HTMLElement, ops: DiffOp[]): void {
+  for (const op of ops) {
     switch (op.type) {
-      case 'delete': return `<span class="claudian-diff-del">${escaped}</span>`;
-      case 'insert': return `<span class="claudian-diff-ins">${escaped}</span>`;
-      default: return escaped;
+      case 'delete':
+        container.createSpan({ cls: 'claudian-diff-del', text: op.text });
+        break;
+      case 'insert':
+        container.createSpan({ cls: 'claudian-diff-ins', text: op.text });
+        break;
+      default:
+        container.appendText(op.text);
     }
-  }).join('');
+  }
+}
+
+function diffOpsEqual(left: DiffOp[], right: DiffOp[]): boolean {
+  if (left.length !== right.length) return false;
+  return left.every((op, index) => {
+    const other = right[index];
+    return op.type === other.type && op.text === other.text;
+  });
 }
 
 export type InlineEditDecision = 'accept' | 'edit' | 'reject';
@@ -417,8 +429,7 @@ class InlineEditController {
     this.containerEl = container;
 
     this.agentReplyEl = document.createElement('div');
-    this.agentReplyEl.className = 'claudian-inline-agent-reply';
-    this.agentReplyEl.style.display = 'none';
+    this.agentReplyEl.className = 'claudian-inline-agent-reply claudian-hidden';
     container.appendChild(this.agentReplyEl);
 
     const inputWrap = document.createElement('div');
@@ -433,8 +444,7 @@ class InlineEditController {
     inputWrap.appendChild(this.inputEl);
 
     this.spinnerEl = document.createElement('div');
-    this.spinnerEl.className = 'claudian-inline-spinner';
-    this.spinnerEl.style.display = 'none';
+    this.spinnerEl.className = 'claudian-inline-spinner claudian-hidden';
     inputWrap.appendChild(this.spinnerEl);
 
     const inlineCatalog = ProviderWorkspaceRegistry.getCommandCatalog(this.resolvedProviderId);
@@ -490,7 +500,7 @@ class InlineEditController {
     this.removeSelectionListeners();
 
     this.inputEl.disabled = true;
-    this.spinnerEl.style.display = 'block';
+    this.spinnerEl.removeClass('claudian-hidden');
 
     const contextFiles = this.resolveContextFilesFromMessage(userMessage);
 
@@ -520,7 +530,7 @@ class InlineEditController {
       }
     }
 
-    this.spinnerEl.style.display = 'none';
+    this.spinnerEl.addClass('claudian-hidden');
 
     if (result.success) {
       if (result.editedText !== undefined) {
@@ -546,7 +556,7 @@ class InlineEditController {
 
   private showAgentReply(message: string) {
     if (!this.agentReplyEl || !this.containerEl) return;
-    this.agentReplyEl.style.display = 'block';
+    this.agentReplyEl.removeClass('claudian-hidden');
     this.agentReplyEl.textContent = message;
     this.containerEl.classList.add('has-agent-reply');
   }
@@ -567,13 +577,12 @@ class InlineEditController {
     hideSelectionHighlight(this.editorView);
 
     const diffOps = computeDiff(this.selectedText, this.editedText);
-    const diffHtml = diffToHtml(diffOps);
 
     this.editorView.dispatch({
       effects: showDiff.of({
         from: this.selFrom,
         to: this.selTo,
-        diffHtml,
+        diffOps,
         widget: this,
       }),
     });
@@ -589,13 +598,12 @@ class InlineEditController {
     const trimmedText = normalizeInsertionText(this.insertedText);
     this.insertedText = trimmedText;
 
-    const escaped = escapeHtml(trimmedText);
-    const diffHtml = `<span class="claudian-diff-ins">${escaped}</span>`;
+    const diffOps: DiffOp[] = [{ type: 'insert', text: trimmedText }];
 
     this.editorView.dispatch({
       effects: showInsertion.of({
         pos: this.selFrom,
-        diffHtml,
+        diffOps,
         widget: this,
       }),
     });

--- a/src/features/settings/ClaudianSettings.ts
+++ b/src/features/settings/ClaudianSettings.ts
@@ -1,5 +1,5 @@
 import type { App } from 'obsidian';
-import { Notice, PluginSettingTab, Setting } from 'obsidian';
+import { Notice, Platform, PluginSettingTab, Setting } from 'obsidian';
 
 import {
   getHiddenProviderCommands,
@@ -19,7 +19,7 @@ import { renderEnvironmentSettingsSection } from './ui/EnvironmentSettingsSectio
 type SettingsTabId = 'general' | ProviderId;
 
 function formatHotkey(hotkey: { modifiers: string[]; key: string }): string {
-  const isMac = navigator.platform.includes('Mac');
+  const isMac = Platform.isMacOS;
   const modMap: Record<string, string> = isMac
     ? { Mod: '⌘', Ctrl: '⌃', Alt: '⌥', Shift: '⇧', Meta: '⌘' }
     : { Mod: 'Ctrl', Ctrl: 'Ctrl', Alt: 'Alt', Shift: 'Shift', Meta: 'Win' };
@@ -206,16 +206,13 @@ export class ClaudianSettingTab extends PluginSettingTab {
       .setName(t('settings.maxTabs.name'))
       .setDesc(t('settings.maxTabs.desc'));
 
-    const maxTabsWarningEl = container.createDiv({ cls: 'claudian-max-tabs-warning' });
-    maxTabsWarningEl.style.color = 'var(--text-warning)';
-    maxTabsWarningEl.style.fontSize = '0.85em';
-    maxTabsWarningEl.style.marginTop = '-0.5em';
-    maxTabsWarningEl.style.marginBottom = '0.5em';
-    maxTabsWarningEl.style.display = 'none';
+    const maxTabsWarningEl = container.createDiv({
+      cls: 'claudian-max-tabs-warning claudian-setting-validation claudian-setting-validation-warning claudian-hidden',
+    });
     maxTabsWarningEl.setText(t('settings.maxTabs.warning'));
 
     const updateMaxTabsWarning = (value: number): void => {
-      maxTabsWarningEl.style.display = value > 5 ? 'block' : 'none';
+      maxTabsWarningEl.toggleClass('claudian-hidden', value <= 5);
     };
 
     maxTabsSetting.addSlider((slider) => {
@@ -537,7 +534,7 @@ export class ClaudianSettingTab extends PluginSettingTab {
         value: currentValue ? formatContextLimit(currentValue) : '',
       });
 
-      const validationEl = inputWrapper.createDiv({ cls: 'claudian-context-limit-validation' });
+      const validationEl = inputWrapper.createDiv({ cls: 'claudian-context-limit-validation claudian-hidden' });
 
       inputEl.addEventListener('input', async () => {
         const trimmed = inputEl.value.trim();
@@ -548,19 +545,19 @@ export class ClaudianSettingTab extends PluginSettingTab {
 
         if (!trimmed) {
           delete this.plugin.settings.customContextLimits[modelId];
-          validationEl.style.display = 'none';
+          validationEl.toggleClass('claudian-hidden', true);
           inputEl.classList.remove('claudian-input-error');
         } else {
           const parsed = parseContextLimit(trimmed);
           if (parsed === null) {
             validationEl.setText(t('settings.customContextLimits.invalid'));
-            validationEl.style.display = 'block';
+            validationEl.toggleClass('claudian-hidden', false);
             inputEl.classList.add('claudian-input-error');
             return;
           }
 
           this.plugin.settings.customContextLimits[modelId] = parsed;
-          validationEl.style.display = 'none';
+          validationEl.toggleClass('claudian-hidden', true);
           inputEl.classList.remove('claudian-input-error');
         }
 

--- a/src/features/settings/ui/EnvSnippetManager.ts
+++ b/src/features/settings/ui/EnvSnippetManager.ts
@@ -98,11 +98,11 @@ export class EnvSnippetModal extends Modal {
       const uniqueModelIds = ProviderRegistry.getCustomModelIds(envVars);
 
       if (uniqueModelIds.size === 0) {
-        contextLimitsContainer.style.display = 'none';
+        contextLimitsContainer.addClass('claudian-hidden');
         return;
       }
 
-      contextLimitsContainer.style.display = 'block';
+      contextLimitsContainer.removeClass('claudian-hidden');
 
       const existingLimits = this.snippet?.contextLimits ?? this.plugin.settings.customContextLimits ?? {};
 

--- a/src/features/settings/ui/EnvironmentSettingsSection.ts
+++ b/src/features/settings/ui/EnvironmentSettingsSection.ts
@@ -35,23 +35,20 @@ export function renderEnvironmentSettingsSection(
   }
 
   let envTextarea: HTMLTextAreaElement | null = null;
-  const reviewEl = container.createDiv({ cls: 'claudian-env-review-warning' });
-  reviewEl.style.color = 'var(--text-warning)';
-  reviewEl.style.fontSize = '0.85em';
-  reviewEl.style.marginTop = '-0.5em';
-  reviewEl.style.marginBottom = '0.5em';
-  reviewEl.style.display = 'none';
+  const reviewEl = container.createDiv({
+    cls: 'claudian-env-review-warning claudian-setting-validation claudian-setting-validation-warning claudian-hidden',
+  });
 
   const updateReviewWarning = () => {
     const reviewKeys = getEnvironmentReviewKeysForScope(envTextarea?.value ?? '', scope);
     if (reviewKeys.length === 0) {
-      reviewEl.style.display = 'none';
+      reviewEl.toggleClass('claudian-hidden', true);
       reviewEl.empty();
       return;
     }
 
     reviewEl.setText(`Review environment ownership for: ${reviewKeys.join(', ')}`);
-    reviewEl.style.display = 'block';
+    reviewEl.toggleClass('claudian-hidden', false);
   };
 
   new Setting(container)

--- a/src/features/settings/ui/McpTestModal.ts
+++ b/src/features/settings/ui/McpTestModal.ts
@@ -19,6 +19,25 @@ function formatToggleError(error: unknown): string {
   return error.message || 'Failed to update tool setting';
 }
 
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+function appendSpinnerSvg(container: HTMLElement): void {
+  const svg = container.ownerDocument.createElementNS(SVG_NS, 'svg');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('stroke-width', '2');
+
+  const path = container.ownerDocument.createElementNS(SVG_NS, 'path');
+  path.setAttribute(
+    'd',
+    'M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83'
+  );
+  svg.appendChild(path);
+
+  container.appendChild(svg);
+}
+
 export class McpTestModal extends Modal {
   private serverName: string;
   private result: McpTestResult | null = null;
@@ -77,9 +96,7 @@ export class McpTestModal extends Modal {
     const loadingEl = this.contentEl_.createDiv({ cls: 'claudian-mcp-test-loading' });
 
     const spinnerEl = loadingEl.createDiv({ cls: 'claudian-mcp-test-spinner' });
-    spinnerEl.innerHTML = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/>
-    </svg>`;
+    appendSpinnerSvg(spinnerEl);
 
     loadingEl.createSpan({ text: 'Connecting to MCP server...' });
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,7 @@ import { setLocale } from './i18n/i18n';
 import type { Locale } from './i18n/types';
 import { OPENCODE_PLAN_MODE_ID, OPENCODE_SAFE_MODE_ID } from './providers/opencode/modes';
 import { buildCursorContext } from './utils/editor';
+import { focusWorkspaceLeaf } from './utils/obsidianCompat';
 import { getVaultPath } from './utils/path';
 
 function isClaudianView(value: unknown): value is ClaudianView {
@@ -203,7 +204,7 @@ export default class ClaudianPlugin extends Plugin {
     }
 
     if (leaf) {
-      workspace.revealLeaf(leaf);
+      focusWorkspaceLeaf(workspace, leaf);
     }
   }
 

--- a/src/providers/claude/CLAUDE.md
+++ b/src/providers/claude/CLAUDE.md
@@ -6,7 +6,7 @@ SDK adaptor wrapping `@anthropic-ai/claude-agent-sdk` behind `ChatRuntime`, with
 
 ### Persistent Query — Why Not Restart
 
-The persistent query stays alive across turns. Model, thinking budget, permission mode, MCP servers, and effort level are updated dynamically via SDK API calls (`setModel`, `setMaxThinkingTokens`, `setPermissionMode`, `setMcpServers`, `applyFlagSettings`). Restart is still required when the effective system prompt, disabled-tool set, plugin set, settings source set, CLI path, Chrome enablement, or external context paths change. This eliminates cold-start latency for turns that only change dynamic knobs.
+The persistent query stays alive across turns. Model, permission mode, MCP servers, and effort level are updated dynamically via SDK API calls (`setModel`, `setPermissionMode`, `setMcpServers`, `applyFlagSettings`). Fixed thinking budgets are startup query options and require a query rebuild when they change. Restart is also required when the effective system prompt, disabled-tool set, plugin set, settings source set, CLI path, Chrome enablement, or external context paths change.
 
 ### Text Deduplication
 

--- a/src/providers/claude/runtime/ClaudeDynamicUpdates.ts
+++ b/src/providers/claude/runtime/ClaudeDynamicUpdates.ts
@@ -11,7 +11,6 @@ import type {
 import type { ClaudianSettings, PermissionMode } from '../../../core/types/settings';
 import {
   resolveAdaptiveEffortLevel,
-  resolveThinkingTokens,
 } from '../types/models';
 import type {
   ClaudeEnsureReadyOptions,
@@ -75,23 +74,6 @@ export async function applyClaudeDynamicUpdates(
     } catch {
       deps.notifyFailure('Failed to update model');
     }
-  }
-
-  const thinkingTokens = resolveThinkingTokens(selectedModel, settings.thinkingBudget);
-  const currentThinking = deps.getCurrentConfig()?.thinkingTokens ?? null;
-  if (thinkingTokens !== currentThinking) {
-    try {
-      await persistentQuery.setMaxThinkingTokens(thinkingTokens);
-      deps.mutateCurrentConfig(config => {
-        config.thinkingTokens = thinkingTokens;
-      });
-    } catch {
-      deps.notifyFailure('Failed to update thinking budget');
-    }
-  } else {
-    deps.mutateCurrentConfig(config => {
-      config.thinkingTokens = thinkingTokens;
-    });
   }
 
   const effortLevel = resolveAdaptiveEffortLevel(selectedModel, settings.effortLevel);

--- a/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts
+++ b/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts
@@ -80,6 +80,10 @@ export class QueryOptionsBuilder {
     // Note: Permission mode is handled dynamically via setPermissionMode() in ClaudianService.
     // Since allowDangerouslySkipPermissions is always true, both directions work without restart.
 
+    // Fixed thinking budgets are startup query options. Adaptive effort remains
+    // dynamic via applyFlagSettings(), but fixed budgets require query rebuilds.
+    if (currentConfig.thinkingTokens !== newConfig.thinkingTokens) return true;
+
     if (currentConfig.enableChrome !== newConfig.enableChrome) return true;
     if (currentConfig.enableAutoMode !== newConfig.enableAutoMode) return true;
 
@@ -309,7 +313,7 @@ export class QueryOptionsBuilder {
 
     const thinkingTokens = resolveThinkingTokens(model, settings.thinkingBudget);
     if (thinkingTokens !== null) {
-      options.maxThinkingTokens = thinkingTokens;
+      options.thinking = { type: 'enabled', budgetTokens: thinkingTokens };
     }
   }
 

--- a/src/providers/claude/runtime/claudeColdStartQuery.ts
+++ b/src/providers/claude/runtime/claudeColdStartQuery.ts
@@ -125,7 +125,7 @@ export async function runColdStartQuery(
     } else {
       const thinkingTokens = resolveThinkingTokens(selectedModel, settings.thinkingBudget);
       if (thinkingTokens !== null) {
-        options.maxThinkingTokens = thinkingTokens;
+        options.thinking = { type: 'enabled', budgetTokens: thinkingTokens };
       }
     }
   }

--- a/src/providers/claude/ui/ClaudeSettingsTab.ts
+++ b/src/providers/claude/ui/ClaudeSettingsTab.ts
@@ -57,12 +57,9 @@ export const claudeSettingsTabRenderer: ProviderSettingsTabRenderer = {
       .setName(`${t('settings.cliPath.name')} (${hostnameKey})`)
       .setDesc(cliPathDescription);
 
-    const validationEl = container.createDiv({ cls: 'claudian-cli-path-validation' });
-    validationEl.style.color = 'var(--text-error)';
-    validationEl.style.fontSize = '0.85em';
-    validationEl.style.marginTop = '-0.5em';
-    validationEl.style.marginBottom = '0.5em';
-    validationEl.style.display = 'none';
+    const validationEl = container.createDiv({
+      cls: 'claudian-cli-path-validation claudian-setting-validation claudian-setting-validation-error claudian-hidden',
+    });
 
     const validatePath = (value: string): string | null => {
       const trimmed = value.trim();
@@ -84,16 +81,16 @@ export const claudeSettingsTabRenderer: ProviderSettingsTabRenderer = {
       const error = validatePath(value);
       if (error) {
         validationEl.setText(error);
-        validationEl.style.display = 'block';
+        validationEl.toggleClass('claudian-hidden', false);
         if (inputEl) {
-          inputEl.style.borderColor = 'var(--text-error)';
+          inputEl.toggleClass('claudian-input-error', true);
         }
         return false;
       }
 
-      validationEl.style.display = 'none';
+      validationEl.toggleClass('claudian-hidden', true);
       if (inputEl) {
-        inputEl.style.borderColor = '';
+        inputEl.toggleClass('claudian-input-error', false);
       }
       return true;
     };
@@ -137,7 +134,6 @@ export const claudeSettingsTabRenderer: ProviderSettingsTabRenderer = {
           await persistCliPath(value);
         });
       text.inputEl.addClass('claudian-settings-cli-path-input');
-      text.inputEl.style.width = '100%';
       cliPathInputEl = text.inputEl;
 
       updateCliPathValidation(currentValue, text.inputEl);
@@ -388,13 +384,13 @@ export const claudeSettingsTabRenderer: ProviderSettingsTabRenderer = {
         toggle
           .setValue(claudeSettings.enableBangBash)
           .onChange(async (value) => {
-            bangBashValidationEl.style.display = 'none';
+            bangBashValidationEl.toggleClass('claudian-hidden', true);
             if (value) {
               const { findNodeExecutable, getEnhancedPath } = await import('../../../utils/env');
               const nodePath = findNodeExecutable(getEnhancedPath());
               if (!nodePath) {
                 bangBashValidationEl.setText(t('settings.enableBangBash.validation.noNode'));
-                bangBashValidationEl.style.display = 'block';
+                bangBashValidationEl.toggleClass('claudian-hidden', false);
                 toggle.setValue(false);
                 return;
               }
@@ -404,11 +400,8 @@ export const claudeSettingsTabRenderer: ProviderSettingsTabRenderer = {
           })
       );
 
-    const bangBashValidationEl = container.createDiv({ cls: 'claudian-bang-bash-validation' });
-    bangBashValidationEl.style.color = 'var(--text-error)';
-    bangBashValidationEl.style.fontSize = '0.85em';
-    bangBashValidationEl.style.marginTop = '-0.5em';
-    bangBashValidationEl.style.marginBottom = '0.5em';
-    bangBashValidationEl.style.display = 'none';
+    const bangBashValidationEl = container.createDiv({
+      cls: 'claudian-bang-bash-validation claudian-setting-validation claudian-setting-validation-error claudian-hidden',
+    });
   },
 };

--- a/src/providers/claude/ui/SlashCommandSettings.ts
+++ b/src/providers/claude/ui/SlashCommandSettings.ts
@@ -59,14 +59,14 @@ export class SlashCommandModal extends Modal {
     let contextValue: 'fork' | '' = this.existingEntry?.context ?? '';
     let agentInput: HTMLInputElement;
 
-    /* eslint-disable prefer-const -- assigned in Setting callbacks */
-    let disableUserSetting!: Setting;
-    let disableUserToggle!: ToggleComponent;
-    /* eslint-enable prefer-const */
+    let disableUserSetting: Setting | null = null;
+    let disableUserToggle: ToggleComponent | null = null;
 
     const updateSkillOnlyFields = () => {
+      if (!disableUserSetting || !disableUserToggle) return;
+
       const isSkillType = selectedType === 'skill';
-      disableUserSetting.settingEl.style.display = isSkillType ? '' : 'none';
+      disableUserSetting.settingEl.toggleClass('claudian-hidden', !isSkillType);
       if (!isSkillType) {
         disableUserInvocation = false;
         disableUserToggle.setValue(false);
@@ -176,7 +176,7 @@ export class SlashCommandModal extends Modal {
         toggle.setValue(contextValue === 'fork')
           .onChange(value => {
             contextValue = value ? 'fork' : '';
-            agentSetting.settingEl.style.display = value ? '' : 'none';
+            agentSetting.settingEl.toggleClass('claudian-hidden', !value);
           });
       });
 
@@ -188,7 +188,7 @@ export class SlashCommandModal extends Modal {
         text.setValue(this.existingEntry?.agent || '')
           .setPlaceholder('code-reviewer');
       });
-    agentSetting.settingEl.style.display = contextValue === 'fork' ? '' : 'none';
+    agentSetting.settingEl.toggleClass('claudian-hidden', contextValue !== 'fork');
 
     new Setting(contentEl)
       .setName('Prompt template')

--- a/src/providers/codex/history/CodexConversationHistoryService.ts
+++ b/src/providers/codex/history/CodexConversationHistoryService.ts
@@ -1,3 +1,5 @@
+import * as fs from 'fs';
+
 import type { ProviderConversationHistoryService } from '../../../core/providers/types';
 import type { Conversation } from '../../../core/types';
 import type { CodexProviderState } from '../types';
@@ -13,8 +15,7 @@ import {
 function readSessionTurns(sessionFilePath: string): CodexParsedTurn[] {
   let content: string;
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    content = require('fs').readFileSync(sessionFilePath, 'utf-8');
+    content = fs.readFileSync(sessionFilePath, 'utf-8');
   } catch {
     return [];
   }

--- a/src/providers/codex/normalization/codexToolNormalization.ts
+++ b/src/providers/codex/normalization/codexToolNormalization.ts
@@ -64,7 +64,7 @@ export function normalizeCodexToolInput(
     case 'view_image':
       return {
         ...input,
-        file_path: (input.path ?? input.file_path ?? '') as string,
+        file_path: stringifyCodexValue(input.path ?? input.file_path),
       };
 
     case 'web_search':
@@ -86,12 +86,12 @@ function normalizeUpdatePlanTodos(input: Record<string, unknown>): Array<Record<
   return plan.map((entry: unknown) => {
     if (!entry || typeof entry !== 'object') return { id: '', title: '', status: 'pending' };
     const item = entry as Record<string, unknown>;
-    const text = String(item.step ?? item.title ?? item.content ?? '');
+    const text = stringifyCodexValue(item.step ?? item.title ?? item.content);
     return {
-      id: String(item.id ?? ''),
+      id: stringifyCodexValue(item.id),
       content: text,
       activeForm: text,
-      status: String(item.status ?? 'pending'),
+      status: stringifyCodexValue(item.status) || 'pending',
     };
   });
 }
@@ -129,8 +129,8 @@ function normalizeQuestions(input: Record<string, unknown>): Array<Record<string
       : [];
 
     return {
-      question: String(item.question ?? `Question ${index + 1}`),
-      ...(item.id ? { id: String(item.id) } : {}),
+      question: stringifyCodexValue(item.question) || `Question ${index + 1}`,
+      ...(item.id ? { id: stringifyCodexValue(item.id) } : {}),
       header: typeof item.header === 'string' && item.header.trim()
         ? String(item.header)
         : `Q${index + 1}`,
@@ -144,11 +144,24 @@ function normalizeCommandValue(value: unknown): string {
   if (typeof value === 'string') return value;
   if (Array.isArray(value)) {
     return value
-      .map(entry => (typeof entry === 'string' ? entry : String(entry)))
+      .map(stringifyCodexValue)
+      .filter(Boolean)
       .join(' ')
       .trim();
   }
-  return value == null ? '' : String(value);
+  return stringifyCodexValue(value);
+}
+
+function stringifyCodexValue(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (value === null || value === undefined) return '';
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '';
+  }
 }
 
 function normalizeWebSearchInput(input: Record<string, unknown>): Record<string, unknown> {

--- a/src/providers/codex/ui/CodexSettingsTab.ts
+++ b/src/providers/codex/ui/CodexSettingsTab.ts
@@ -101,12 +101,9 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
       .setName(`Codex CLI path (${hostnameKey})`)
       .setDesc(getCliPathCopy().desc);
 
-    const validationEl = container.createDiv({ cls: 'claudian-cli-path-validation' });
-    validationEl.style.color = 'var(--text-error)';
-    validationEl.style.fontSize = '0.85em';
-    validationEl.style.marginTop = '-0.5em';
-    validationEl.style.marginBottom = '0.5em';
-    validationEl.style.display = 'none';
+    const validationEl = container.createDiv({
+      cls: 'claudian-cli-path-validation claudian-setting-validation claudian-setting-validation-error claudian-hidden',
+    });
 
     const validatePath = (value: string): string | null => {
       const trimmed = value.trim();
@@ -135,16 +132,16 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
       const error = validatePath(value);
       if (error) {
         validationEl.setText(error);
-        validationEl.style.display = 'block';
+        validationEl.toggleClass('claudian-hidden', false);
         if (inputEl) {
-          inputEl.style.borderColor = 'var(--text-error)';
+          inputEl.toggleClass('claudian-input-error', true);
         }
         return false;
       }
 
-      validationEl.style.display = 'none';
+      validationEl.toggleClass('claudian-hidden', true);
       if (inputEl) {
-        inputEl.style.borderColor = '';
+        inputEl.toggleClass('claudian-input-error', false);
       }
       return true;
     };
@@ -162,7 +159,7 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
         updateCliPathValidation(cliPathInputEl.value, cliPathInputEl);
       }
       if (wslDistroSettingEl) {
-        wslDistroSettingEl.style.display = installationMethod === 'wsl' ? '' : 'none';
+        wslDistroSettingEl.toggleClass('claudian-hidden', installationMethod !== 'wsl');
       }
       if (wslDistroInputEl) {
         wslDistroInputEl.disabled = installationMethod !== 'wsl';
@@ -201,7 +198,6 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
           await persistCliPath(value);
         });
       text.inputEl.addClass('claudian-settings-cli-path-input');
-      text.inputEl.style.width = '100%';
       cliPathInputEl = text.inputEl;
 
       updateCliPathValidation(currentValue, text.inputEl);
@@ -223,7 +219,6 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
           });
 
         text.inputEl.addClass('claudian-settings-cli-path-input');
-        text.inputEl.style.width = '100%';
         text.inputEl.disabled = installationMethod !== 'wsl';
         wslDistroInputEl = text.inputEl;
       });

--- a/src/providers/opencode/ui/OpencodeSettingsTab.ts
+++ b/src/providers/opencode/ui/OpencodeSettingsTab.ts
@@ -58,12 +58,9 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
       .setName(`CLI Path (${hostnameKey})`)
       .setDesc('Optional absolute path to the OpenCode CLI for this computer. Leave empty to use `opencode` from PATH.');
 
-    const validationEl = container.createDiv({ cls: 'claudian-cli-path-validation' });
-    validationEl.style.color = 'var(--text-error)';
-    validationEl.style.fontSize = '0.85em';
-    validationEl.style.marginTop = '-0.5em';
-    validationEl.style.marginBottom = '0.5em';
-    validationEl.style.display = 'none';
+    const validationEl = container.createDiv({
+      cls: 'claudian-cli-path-validation claudian-setting-validation claudian-setting-validation-error claudian-hidden',
+    });
 
     const validatePath = (value: string): string | null => {
       const trimmed = value.trim();
@@ -88,16 +85,16 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
       const error = validatePath(value);
       if (error) {
         validationEl.setText(error);
-        validationEl.style.display = 'block';
+        validationEl.toggleClass('claudian-hidden', false);
         if (inputEl) {
-          inputEl.style.borderColor = 'var(--text-error)';
+          inputEl.toggleClass('claudian-input-error', true);
         }
         return false;
       }
 
-      validationEl.style.display = 'none';
+      validationEl.toggleClass('claudian-hidden', true);
       if (inputEl) {
-        inputEl.style.borderColor = '';
+        inputEl.toggleClass('claudian-input-error', false);
       }
       return true;
     };
@@ -153,7 +150,6 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
         });
 
       text.inputEl.addClass('claudian-settings-cli-path-input');
-      text.inputEl.style.width = '100%';
       cliPathInputEl = text.inputEl;
 
       updateCliPathValidation(currentValue, text.inputEl);
@@ -285,11 +281,11 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
       selectedEl.empty();
       const current = getOpencodeProviderSettings(settingsBag);
       if (current.visibleModels.length === 0) {
-        selectedEl.style.display = 'none';
+        selectedEl.toggleClass('claudian-hidden', true);
         return;
       }
 
-      selectedEl.style.display = '';
+      selectedEl.toggleClass('claudian-hidden', false);
       const enrichedByRawId = new Map(
         getEnrichedModels().map((model) => [model.rawId, model] as const),
       );

--- a/src/shared/components/SlashCommandDropdown.ts
+++ b/src/shared/components/SlashCommandDropdown.ts
@@ -373,12 +373,11 @@ export class SlashCommandDropdown {
     if (!this.dropdownEl || !this.isFixed) return;
 
     const inputRect = this.inputEl.getBoundingClientRect();
-    this.dropdownEl.style.position = 'fixed';
-    this.dropdownEl.style.bottom = `${window.innerHeight - inputRect.top + 4}px`;
-    this.dropdownEl.style.left = `${inputRect.left}px`;
-    this.dropdownEl.style.right = 'auto';
-    this.dropdownEl.style.width = `${Math.max(inputRect.width, 280)}px`;
-    this.dropdownEl.style.zIndex = '10001';
+    this.dropdownEl.setCssProps({
+      '--claudian-fixed-dropdown-bottom': `${window.innerHeight - inputRect.top + 4}px`,
+      '--claudian-fixed-dropdown-left': `${inputRect.left}px`,
+      '--claudian-fixed-dropdown-width': `${Math.max(inputRect.width, 280)}px`,
+    });
   }
 
   private navigate(direction: number): void {

--- a/src/shared/icons.ts
+++ b/src/shared/icons.ts
@@ -1,8 +1,61 @@
-import type { ProviderIconSvg } from '../core/providers/types';
+import type { ProviderIconSvg, ProviderSvgChild } from '../core/providers/types';
 
 export const MCP_ICON_SVG = `<svg fill="currentColor" fill-rule="evenodd" height="1em" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>MCP</title><path d="M15.688 2.343a2.588 2.588 0 00-3.61 0l-9.626 9.44a.863.863 0 01-1.203 0 .823.823 0 010-1.18l9.626-9.44a4.313 4.313 0 016.016 0 4.116 4.116 0 011.204 3.54 4.3 4.3 0 013.609 1.18l.05.05a4.115 4.115 0 010 5.9l-8.706 8.537a.274.274 0 000 .393l1.788 1.754a.823.823 0 010 1.18.863.863 0 01-1.203 0l-1.788-1.753a1.92 1.92 0 010-2.754l8.706-8.538a2.47 2.47 0 000-3.54l-.05-.049a2.588 2.588 0 00-3.607-.003l-7.172 7.034-.002.002-.098.097a.863.863 0 01-1.204 0 .823.823 0 010-1.18l7.273-7.133a2.47 2.47 0 00-.003-3.537z"></path><path d="M14.485 4.703a.823.823 0 000-1.18.863.863 0 00-1.204 0l-7.119 6.982a4.115 4.115 0 000 5.9 4.314 4.314 0 006.016 0l7.12-6.982a.823.823 0 000-1.18.863.863 0 00-1.204 0l-7.119 6.982a2.588 2.588 0 01-3.61 0 2.47 2.47 0 010-3.54l7.12-6.982z"></path></svg>`;
 
 export const CHECK_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>`;
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+const MCP_ICON_PATHS = [
+  'M15.688 2.343a2.588 2.588 0 00-3.61 0l-9.626 9.44a.863.863 0 01-1.203 0 .823.823 0 010-1.18l9.626-9.44a4.313 4.313 0 016.016 0 4.116 4.116 0 011.204 3.54 4.3 4.3 0 013.609 1.18l.05.05a4.115 4.115 0 010 5.9l-8.706 8.537a.274.274 0 000 .393l1.788 1.754a.823.823 0 010 1.18.863.863 0 01-1.203 0l-1.788-1.753a1.92 1.92 0 010-2.754l8.706-8.538a2.47 2.47 0 000-3.54l-.05-.049a2.588 2.588 0 00-3.607-.003l-7.172 7.034-.002.002-.098.097a.863.863 0 01-1.204 0 .823.823 0 010-1.18l7.273-7.133a2.47 2.47 0 00-.003-3.537z',
+  'M14.485 4.703a.823.823 0 000-1.18.863.863 0 00-1.204 0l-7.119 6.982a4.115 4.115 0 000 5.9 4.314 4.314 0 006.016 0l7.12-6.982a.823.823 0 000-1.18.863.863 0 00-1.204 0l-7.119 6.982a2.588 2.588 0 01-3.61 0 2.47 2.47 0 010-3.54l7.12-6.982z',
+];
+
+function createSvgElement(ownerDocument: Document, tagName: string): SVGElement {
+  return ownerDocument.createElementNS(SVG_NS, tagName) as SVGElement;
+}
+
+export function appendMcpIcon(container: HTMLElement): void {
+  container.empty();
+
+  const svg = createSvgElement(container.ownerDocument, 'svg');
+  svg.setAttribute('fill', 'currentColor');
+  svg.setAttribute('fill-rule', 'evenodd');
+  svg.setAttribute('height', '1em');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('width', '1em');
+
+  const title = createSvgElement(container.ownerDocument, 'title');
+  title.textContent = 'MCP';
+  svg.appendChild(title);
+
+  for (const pathData of MCP_ICON_PATHS) {
+    const path = createSvgElement(container.ownerDocument, 'path');
+    path.setAttribute('d', pathData);
+    svg.appendChild(path);
+  }
+
+  container.appendChild(svg);
+}
+
+export function appendCheckIcon(container: HTMLElement): void {
+  container.empty();
+
+  const svg = createSvgElement(container.ownerDocument, 'svg');
+  svg.setAttribute('width', '12');
+  svg.setAttribute('height', '12');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('stroke-width', '3');
+  svg.setAttribute('stroke-linecap', 'round');
+  svg.setAttribute('stroke-linejoin', 'round');
+
+  const polyline = createSvgElement(container.ownerDocument, 'polyline');
+  polyline.setAttribute('points', '20 6 9 17 4 12');
+  svg.appendChild(polyline);
+
+  container.appendChild(svg);
+}
 
 export const OPENAI_PROVIDER_ICON: ProviderIconSvg = {
   viewBox: '-1 -.1 949.1 959.8',
@@ -15,18 +68,32 @@ export const CLAUDE_PROVIDER_ICON: ProviderIconSvg = {
 };
 
 export const OPENCODE_PROVIDER_ICON: ProviderIconSvg = {
-  kind: 'markup',
+  kind: 'composite',
   viewBox: '0 0 300 300',
-  markup: `
-    <g class="claudian-provider-icon-variant claudian-provider-icon-variant--light" transform="translate(30 0)">
-      <path d="M180 240H60V120H180V240Z" fill="#CFCECD"></path>
-      <path d="M180 60H60V240H180V60ZM240 300H0V0H240V300Z" fill="#211E1E"></path>
-    </g>
-    <g class="claudian-provider-icon-variant claudian-provider-icon-variant--dark" transform="translate(30 0)">
-      <path d="M180 240H60V120H180V240Z" fill="#4B4646"></path>
-      <path d="M180 60H60V240H180V60ZM240 300H0V0H240V300Z" fill="#F1ECEC"></path>
-    </g>
-  `,
+  children: [
+    {
+      tag: 'g',
+      attributes: {
+        class: 'claudian-provider-icon-variant claudian-provider-icon-variant--light',
+        transform: 'translate(30 0)',
+      },
+      children: [
+        { tag: 'path', attributes: { d: 'M180 240H60V120H180V240Z', fill: '#CFCECD' } },
+        { tag: 'path', attributes: { d: 'M180 60H60V240H180V60ZM240 300H0V0H240V300Z', fill: '#211E1E' } },
+      ],
+    },
+    {
+      tag: 'g',
+      attributes: {
+        class: 'claudian-provider-icon-variant claudian-provider-icon-variant--dark',
+        transform: 'translate(30 0)',
+      },
+      children: [
+        { tag: 'path', attributes: { d: 'M180 240H60V120H180V240Z', fill: '#4B4646' } },
+        { tag: 'path', attributes: { d: 'M180 60H60V240H180V60ZM240 300H0V0H240V300Z', fill: '#F1ECEC' } },
+      ],
+    },
+  ],
 };
 
 export interface CreateProviderIconSvgOptions {
@@ -40,8 +107,7 @@ export function createProviderIconSvg(
   icon: ProviderIconSvg,
   options: CreateProviderIconSvgOptions = {},
 ): SVGElement {
-  const NS = 'http://www.w3.org/2000/svg';
-  const svg = document.createElementNS(NS, 'svg');
+  const svg = document.createElementNS(SVG_NS, 'svg');
   svg.setAttribute('viewBox', icon.viewBox);
   svg.setAttribute('fill', 'none');
   svg.setAttribute('aria-hidden', 'true');
@@ -60,14 +126,31 @@ export function createProviderIconSvg(
     svg.setAttribute('data-provider', options.dataProvider);
   }
 
-  if (icon.kind === 'markup') {
-    svg.innerHTML = icon.markup.trim();
+  if (icon.kind === 'composite') {
+    for (const child of icon.children) {
+      svg.appendChild(createProviderSvgChild(child));
+    }
     return svg;
   }
 
-  const path = document.createElementNS(NS, 'path');
+  const path = document.createElementNS(SVG_NS, 'path');
   path.setAttribute('d', icon.path);
   path.setAttribute('fill', 'currentColor');
   svg.appendChild(path);
   return svg;
+}
+
+function createProviderSvgChild(child: ProviderSvgChild): SVGElement {
+  const element = document.createElementNS(SVG_NS, child.tag);
+  for (const [name, value] of Object.entries(child.attributes)) {
+    element.setAttribute(name, value);
+  }
+
+  if (child.tag === 'g') {
+    for (const nestedChild of child.children) {
+      element.appendChild(createProviderSvgChild(nestedChild));
+    }
+  }
+
+  return element;
 }

--- a/src/shared/mention/MentionDropdownController.ts
+++ b/src/shared/mention/MentionDropdownController.ts
@@ -5,7 +5,7 @@ import { buildExternalContextDisplayEntries } from '../../utils/externalContext'
 import { type ExternalContextFile, externalContextScanner } from '../../utils/externalContextScanner';
 import { extractMcpMentions } from '../../utils/mcp';
 import { SelectableDropdown } from '../components/SelectableDropdown';
-import { MCP_ICON_SVG } from '../icons';
+import { appendMcpIcon } from '../icons';
 import {
   type AgentMentionProvider,
   type FolderMentionItem,
@@ -436,7 +436,7 @@ export class MentionDropdownController {
         const iconEl = itemEl.createSpan({ cls: 'claudian-mention-icon' });
         switch (item.type) {
           case 'mcp-server':
-            iconEl.innerHTML = MCP_ICON_SVG;
+            appendMcpIcon(iconEl);
             break;
           case 'agent':
           case 'agent-folder':
@@ -517,12 +517,11 @@ export class MentionDropdownController {
     if (!dropdownEl) return;
 
     const inputRect = this.inputEl.getBoundingClientRect();
-    dropdownEl.style.position = 'fixed';
-    dropdownEl.style.bottom = `${window.innerHeight - inputRect.top + 4}px`;
-    dropdownEl.style.left = `${inputRect.left}px`;
-    dropdownEl.style.right = 'auto';
-    dropdownEl.style.width = `${Math.max(inputRect.width, 280)}px`;
-    dropdownEl.style.zIndex = '10001';
+    dropdownEl.setCssProps({
+      '--claudian-fixed-dropdown-bottom': `${window.innerHeight - inputRect.top + 4}px`,
+      '--claudian-fixed-dropdown-left': `${inputRect.left}px`,
+      '--claudian-fixed-dropdown-width': `${Math.max(inputRect.width, 280)}px`,
+    });
   }
 
   private insertReplacement(beforeAt: string, replacement: string, afterCursor: string): void {

--- a/src/shared/modals/InstructionConfirmModal.ts
+++ b/src/shared/modals/InstructionConfirmModal.ts
@@ -78,7 +78,7 @@ export class InstructionModal extends Modal {
 
     // Clarification state (hidden initially)
     this.clarificationEl = this.contentSectionEl.createDiv({ cls: 'claudian-instruction-clarification-section' });
-    this.clarificationEl.style.display = 'none';
+    this.clarificationEl.addClass('claudian-hidden');
     this.clarificationTextEl = this.clarificationEl.createDiv({ cls: 'claudian-instruction-clarification' });
 
     const responseSection = this.clarificationEl.createDiv({ cls: 'claudian-instruction-section' });
@@ -100,7 +100,7 @@ export class InstructionModal extends Modal {
 
     // Confirmation state (hidden initially)
     this.confirmationEl = this.contentSectionEl.createDiv({ cls: 'claudian-instruction-confirmation-section' });
-    this.confirmationEl.style.display = 'none';
+    this.confirmationEl.addClass('claudian-hidden');
 
     // Refined instruction display/edit
     const refinedSection = this.confirmationEl.createDiv({ cls: 'claudian-instruction-section' });
@@ -109,7 +109,7 @@ export class InstructionModal extends Modal {
 
     this.refinedDisplayEl = refinedSection.createDiv({ cls: 'claudian-instruction-refined' });
     this.editContainerEl = refinedSection.createDiv({ cls: 'claudian-instruction-edit-container' });
-    this.editContainerEl.style.display = 'none';
+    this.editContainerEl.addClass('claudian-hidden');
 
     this.editTextarea = new TextAreaComponent(this.editContainerEl);
     this.editTextarea.inputEl.addClass('claudian-instruction-edit-textarea');
@@ -167,13 +167,13 @@ export class InstructionModal extends Modal {
     this.state = state;
 
     if (this.loadingEl) {
-      this.loadingEl.style.display = state === 'loading' ? 'flex' : 'none';
+      this.loadingEl.toggleClass('claudian-hidden', state !== 'loading');
     }
     if (this.clarificationEl) {
-      this.clarificationEl.style.display = state === 'clarification' ? 'block' : 'none';
+      this.clarificationEl.toggleClass('claudian-hidden', state !== 'clarification');
     }
     if (this.confirmationEl) {
-      this.confirmationEl.style.display = state === 'confirmation' ? 'block' : 'none';
+      this.confirmationEl.toggleClass('claudian-hidden', state !== 'confirmation');
     }
 
     this.updateButtons();
@@ -234,8 +234,8 @@ export class InstructionModal extends Modal {
     this.isEditing = !this.isEditing;
 
     if (this.isEditing) {
-      if (this.refinedDisplayEl) this.refinedDisplayEl.style.display = 'none';
-      if (this.editContainerEl) this.editContainerEl.style.display = 'block';
+      this.refinedDisplayEl?.addClass('claudian-hidden');
+      this.editContainerEl?.removeClass('claudian-hidden');
       if (this.editBtnEl) this.editBtnEl.setText('Preview');
       this.editTextarea?.inputEl.focus();
     } else {
@@ -243,9 +243,9 @@ export class InstructionModal extends Modal {
       this.refinedInstruction = edited;
       if (this.refinedDisplayEl) {
         this.refinedDisplayEl.setText(edited);
-        this.refinedDisplayEl.style.display = 'block';
+        this.refinedDisplayEl.removeClass('claudian-hidden');
       }
-      if (this.editContainerEl) this.editContainerEl.style.display = 'none';
+      this.editContainerEl?.addClass('claudian-hidden');
       if (this.editBtnEl) this.editBtnEl.setText('Edit');
     }
   }

--- a/src/style/base/container.css
+++ b/src/style/base/container.css
@@ -7,6 +7,22 @@
   font-family: var(--font-text);
 }
 
+.claudian-hidden {
+  display: none !important;
+}
+
+.claudian-visible-block {
+  display: block !important;
+}
+
+.claudian-visible-flex {
+  display: flex !important;
+}
+
+.claudian-visible-contents {
+  display: contents !important;
+}
+
 .claudian-provider-icon-variant--dark {
   display: none;
 }

--- a/src/style/components/input.css
+++ b/src/style/components/input.css
@@ -72,8 +72,8 @@
 .claudian-input {
   width: 100%;
   flex: 1 1 0;
-  min-height: 60px;
-  /* max-height dynamically set by JS: max(150px, 55% of view height) */
+  min-height: var(--claudian-textarea-min-height, 60px);
+  max-height: var(--claudian-textarea-max-height, none);
   resize: none;
   padding: 8px 10px 10px 10px;
   border: none !important;

--- a/src/style/components/toolcalls.css
+++ b/src/style/components/toolcalls.css
@@ -145,6 +145,11 @@
   white-space: pre;
 }
 
+.claudian-tool-line-wrap {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 /* Hover highlight for file search results */
 .claudian-tool-line.hoverable:hover {
   background: var(--background-modifier-hover);

--- a/src/style/features/file-context.css
+++ b/src/style/features/file-context.css
@@ -24,6 +24,10 @@
 /* Fixed positioning for inline editor */
 .claudian-mention-dropdown-fixed {
   position: fixed;
+  bottom: var(--claudian-fixed-dropdown-bottom);
+  left: var(--claudian-fixed-dropdown-left);
+  right: auto;
+  width: var(--claudian-fixed-dropdown-width);
   z-index: 10001;
 }
 

--- a/src/style/features/slash-commands.css
+++ b/src/style/features/slash-commands.css
@@ -24,6 +24,10 @@
 /* Fixed positioning for inline editor */
 .claudian-slash-dropdown-fixed {
   position: fixed;
+  bottom: var(--claudian-fixed-dropdown-bottom);
+  left: var(--claudian-fixed-dropdown-left);
+  right: auto;
+  width: var(--claudian-fixed-dropdown-width);
   z-index: 10001;
 }
 

--- a/src/style/settings/base.css
+++ b/src/style/settings/base.css
@@ -107,6 +107,28 @@
   color: var(--text-error);
 }
 
+.claudian-setting-validation {
+  font-size: var(--font-ui-smaller);
+  margin-top: -0.5em;
+  margin-bottom: 0.5em;
+}
+
+.claudian-setting-validation-error {
+  color: var(--text-error);
+}
+
+.claudian-setting-validation-warning {
+  color: var(--text-warning);
+}
+
+.claudian-settings-cli-path-input {
+  width: 100%;
+}
+
+.claudian-settings-cli-path-input.claudian-input-error {
+  border-color: var(--text-error);
+}
+
 /* Hotkey grid - 3 columns */
 .claudian-hotkey-grid {
   display: grid;

--- a/src/style/settings/env-snippets.css
+++ b/src/style/settings/env-snippets.css
@@ -83,7 +83,6 @@
 }
 
 .claudian-context-limit-validation {
-  display: none;
   font-size: var(--font-ui-smaller);
   color: var(--text-error);
   margin-top: 4px;

--- a/src/utils/animationFrame.ts
+++ b/src/utils/animationFrame.ts
@@ -1,27 +1,46 @@
 export interface ScheduledAnimationFrame {
   kind: 'raf' | 'timeout';
-  id: number | ReturnType<typeof setTimeout>;
+  id: number;
+  ownerWindow: Window | null;
 }
 
-export function scheduleAnimationFrame(callback: () => void): ScheduledAnimationFrame {
-  if (typeof globalThis.requestAnimationFrame === 'function') {
+function getRendererWindow(): Window | null {
+  return typeof window === 'undefined' ? null : window;
+}
+
+export function scheduleAnimationFrame(
+  callback: () => void,
+  ownerWindow: Window | null = getRendererWindow(),
+): ScheduledAnimationFrame {
+  const activeWindow = ownerWindow ?? getRendererWindow();
+  if (!activeWindow) {
+    callback();
+    return { kind: 'timeout', id: 0, ownerWindow: null };
+  }
+
+  if (typeof activeWindow.requestAnimationFrame === 'function') {
     return {
       kind: 'raf',
-      id: globalThis.requestAnimationFrame(() => callback()),
+      id: activeWindow.requestAnimationFrame(() => callback()),
+      ownerWindow: activeWindow,
     };
   }
 
   return {
     kind: 'timeout',
-    id: globalThis.setTimeout(callback, 16),
+    id: activeWindow.setTimeout(callback, 16),
+    ownerWindow: activeWindow,
   };
 }
 
 export function cancelScheduledAnimationFrame(frame: ScheduledAnimationFrame): void {
-  if (frame.kind === 'raf' && typeof globalThis.cancelAnimationFrame === 'function') {
-    globalThis.cancelAnimationFrame(frame.id as number);
+  const activeWindow = frame.ownerWindow ?? getRendererWindow();
+  if (!activeWindow) return;
+
+  if (frame.kind === 'raf' && typeof activeWindow.cancelAnimationFrame === 'function') {
+    activeWindow.cancelAnimationFrame(frame.id);
     return;
   }
 
-  globalThis.clearTimeout(frame.id as ReturnType<typeof setTimeout>);
+  activeWindow.clearTimeout(frame.id);
 }

--- a/src/utils/electronCompat.ts
+++ b/src/utils/electronCompat.ts
@@ -19,7 +19,7 @@ function isAbortSignalLike(target: unknown): boolean {
  * See: #143, #239, #284, #339, #342, #370, #374, #387
  */
 export function patchSetMaxListenersForElectron(): void {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- Patch the shared CommonJS events module before SDK imports run.
   const events = require('events');
 
   if (events.setMaxListeners.__electronPatched) return;

--- a/src/utils/fileLink.ts
+++ b/src/utils/fileLink.ts
@@ -7,6 +7,8 @@
 
 import type { App, Component } from 'obsidian';
 
+import { getVaultFileByPath } from './obsidianCompat';
+
 /**
  * Regex pattern to match Obsidian wikilinks in text content.
  *
@@ -83,13 +85,13 @@ function fileExistsInVault(app: App, linkPath: string): boolean {
     return true;
   }
 
-  const directFile = app.vault.getFileByPath(linkPath);
+  const directFile = getVaultFileByPath(app, linkPath);
   if (directFile) {
     return true;
   }
 
   if (!linkPath.endsWith('.md')) {
-    const withExt = app.vault.getFileByPath(linkPath + '.md');
+    const withExt = getVaultFileByPath(app, linkPath + '.md');
     if (withExt) {
       return true;
     }

--- a/src/utils/imageEmbed.ts
+++ b/src/utils/imageEmbed.ts
@@ -10,6 +10,7 @@
 import type { App, TFile } from 'obsidian';
 
 import { escapeHtml } from './inlineEdit';
+import { getVaultFileByPath } from './obsidianCompat';
 
 const IMAGE_EXTENSIONS = new Set([
   'png',
@@ -34,12 +35,12 @@ function resolveImageFile(
   imagePath: string,
   mediaFolder: string
 ): TFile | null {
-  let file = app.vault.getFileByPath(imagePath);
+  let file = getVaultFileByPath(app, imagePath);
   if (file) return file;
 
   if (mediaFolder) {
     const withFolder = `${mediaFolder}/${imagePath}`;
-    file = app.vault.getFileByPath(withFolder);
+    file = getVaultFileByPath(app, withFolder);
     if (file) return file;
   }
 

--- a/src/utils/obsidianCompat.ts
+++ b/src/utils/obsidianCompat.ts
@@ -1,0 +1,23 @@
+import type { App, TFile, Workspace, WorkspaceLeaf } from 'obsidian';
+
+export function getVaultFileByPath(app: App, filePath: string): TFile | null {
+  const file = app.vault.getAbstractFileByPath(filePath);
+  if (isVaultFile(file)) {
+    return file;
+  }
+  return null;
+}
+
+export function focusWorkspaceLeaf(workspace: Workspace, leaf: WorkspaceLeaf): void {
+  workspace.setActiveLeaf(leaf, { focus: true });
+}
+
+function isVaultFile(value: unknown): value is TFile {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Partial<TFile>;
+  return typeof candidate.path === 'string'
+    && typeof candidate.basename === 'string';
+}

--- a/src/utils/obsidianCompat.ts
+++ b/src/utils/obsidianCompat.ts
@@ -9,6 +9,12 @@ export function getVaultFileByPath(app: App, filePath: string): TFile | null {
 }
 
 export function focusWorkspaceLeaf(workspace: Workspace, leaf: WorkspaceLeaf): void {
+  const revealLeaf = (workspace as unknown as Record<string, unknown>)['revealLeaf'];
+  if (typeof revealLeaf === 'function') {
+    (revealLeaf as (leaf: WorkspaceLeaf) => void).call(workspace, leaf);
+    return;
+  }
+
   workspace.setActiveLeaf(leaf, { focus: true });
 }
 

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -63,6 +63,10 @@ export class ItemView {
 
 export class WorkspaceLeaf {}
 
+export const Platform = {
+  isMacOS: true,
+};
+
 export class App {
   vault: any = {
     adapter: {
@@ -80,6 +84,7 @@ export class App {
     getLeaf: jest.fn().mockReturnValue({
       setViewState: jest.fn().mockResolvedValue(undefined),
     }),
+    setActiveLeaf: jest.fn(),
     revealLeaf: jest.fn(),
   };
 }

--- a/tests/helpers/mockElement.ts
+++ b/tests/helpers/mockElement.ts
@@ -43,6 +43,14 @@ export interface MockElement {
   appendText: (text: string) => void;
   setCssProps: (props: Record<string, string>) => void;
   ownerDocument: {
+    defaultView: {
+      requestAnimationFrame: (callback: FrameRequestCallback) => number;
+      cancelAnimationFrame: (handle: number) => void;
+      setTimeout: (callback: () => void, timeout: number) => number;
+      clearTimeout: (handle: number) => void;
+      setInterval: (callback: () => void, timeout: number) => number;
+      clearInterval: (handle: number) => void;
+    };
     createElement: (tagName: string) => MockElement;
     createElementNS: (namespace: string, tagName: string) => MockElement;
   };
@@ -125,7 +133,40 @@ export function createMockEl(tag = 'div'): any {
     }
   };
 
+  const defaultView = {
+    requestAnimationFrame: (callback: FrameRequestCallback): number => {
+      const requestFrame =
+        (globalThis as { window?: Window }).window?.requestAnimationFrame
+        ?? (globalThis as { requestAnimationFrame?: typeof requestAnimationFrame }).requestAnimationFrame;
+      if (typeof requestFrame === 'function') {
+        return requestFrame(callback);
+      }
+      return globalThis.setTimeout(() => callback(performance.now()), 16) as unknown as number;
+    },
+    cancelAnimationFrame: (handle: number): void => {
+      const cancelFrame =
+        (globalThis as { window?: Window }).window?.cancelAnimationFrame
+        ?? (globalThis as { cancelAnimationFrame?: typeof cancelAnimationFrame }).cancelAnimationFrame;
+      if (typeof cancelFrame === 'function') {
+        cancelFrame(handle);
+        return;
+      }
+      globalThis.clearTimeout(handle as unknown as ReturnType<typeof setTimeout>);
+    },
+    setTimeout: (callback: () => void, timeout: number): number =>
+      globalThis.setTimeout(callback, timeout) as unknown as number,
+    clearTimeout: (handle: number): void => {
+      globalThis.clearTimeout(handle as unknown as ReturnType<typeof setTimeout>);
+    },
+    setInterval: (callback: () => void, timeout: number): number =>
+      globalThis.setInterval(callback, timeout) as unknown as number,
+    clearInterval: (handle: number): void => {
+      globalThis.clearInterval(handle as unknown as ReturnType<typeof setInterval>);
+    },
+  };
+
   const ownerDocument = {
+    defaultView,
     createElement: (tagName: string) => createMockEl(tagName),
     createElementNS: (_namespace: string, tagName: string) => createMockEl(tagName),
   };

--- a/tests/helpers/mockElement.ts
+++ b/tests/helpers/mockElement.ts
@@ -30,6 +30,7 @@ export interface MockElement {
   scrollIntoView: () => void;
   setAttribute: (name: string, value: string) => void;
   getAttribute: (name: string) => string | undefined | null;
+  removeAttribute: (name: string) => void;
   addEventListener: (event: string, handler: (...args: any[]) => void) => void;
   removeEventListener: (event: string, handler: (...args: any[]) => void) => void;
   dispatchEvent: (eventOrType: string | { type: string; [key: string]: any }, extraArg?: any) => void;
@@ -39,6 +40,12 @@ export interface MockElement {
   querySelectorAll: (selector: string) => MockElement[];
   getBoundingClientRect: () => { top: number; left: number; width: number; height: number; right: number; bottom: number; x: number; y: number; toJSON: () => void };
   setText: (text: string) => void;
+  appendText: (text: string) => void;
+  setCssProps: (props: Record<string, string>) => void;
+  ownerDocument: {
+    createElement: (tagName: string) => MockElement;
+    createElementNS: (namespace: string, tagName: string) => MockElement;
+  };
   _classes: Set<string>;
   _classList: Set<string>;
   _attributes: Map<string, string>;
@@ -46,6 +53,35 @@ export interface MockElement {
   _children: MockElement[];
   [key: string]: any;
 }
+
+const CLASS_DISPLAY: Record<string, string> = {
+  'claudian-browser-selection-indicator': 'block',
+  'claudian-canvas-indicator': 'block',
+  'claudian-context-meter': 'flex',
+  'claudian-file-indicator': 'none',
+  'claudian-image-preview': 'none',
+  'claudian-mcp-selector': 'flex',
+  'claudian-mode-selector': 'flex',
+  'claudian-permission-toggle': 'flex',
+  'claudian-selection-indicator': 'block',
+  'claudian-service-tier-toggle': 'flex',
+  'claudian-status-panel-bash': 'block',
+  'claudian-status-panel-bash-content': 'block',
+  'claudian-status-panel-bash-entry-content': 'block',
+  'claudian-status-panel-content': 'block',
+  'claudian-status-panel-todos': 'block',
+  'claudian-tab-content': 'flex',
+  'claudian-thinking-budget': 'flex',
+  'claudian-thinking-effort': 'flex',
+};
+
+const DISPLAY_CLASSES = new Set([
+  'claudian-hidden',
+  'claudian-visible-block',
+  'claudian-visible-contents',
+  'claudian-visible-flex',
+  ...Object.keys(CLASS_DISPLAY),
+]);
 
 export function createMockEl(tag = 'div'): any {
   const children: MockElement[] = [];
@@ -55,6 +91,44 @@ export function createMockEl(tag = 'div'): any {
   const dataset: Record<string, string> = {};
   const style: Record<string, string> = {};
   let textContent = '';
+
+  const resolveDisplay = (): string | null => {
+    if (classes.has('claudian-hidden')) return 'none';
+    if (classes.has('claudian-visible-flex')) return 'flex';
+    if (classes.has('claudian-visible-block')) return 'block';
+    if (classes.has('claudian-visible-contents')) return 'contents';
+
+    for (const [cls, display] of Object.entries(CLASS_DISPLAY)) {
+      if (classes.has(cls)) return display;
+    }
+
+    return null;
+  };
+
+  const syncDisplay = () => {
+    const display = resolveDisplay();
+    if (display === null) {
+      style.display = '';
+      return;
+    }
+    style.display = display;
+  };
+
+  const updateClass = (cls: string, enabled: boolean) => {
+    if (enabled) {
+      classes.add(cls);
+    } else {
+      classes.delete(cls);
+    }
+    if (DISPLAY_CLASSES.has(cls)) {
+      syncDisplay();
+    }
+  };
+
+  const ownerDocument = {
+    createElement: (tagName: string) => createMockEl(tagName),
+    createElementNS: (_namespace: string, tagName: string) => createMockEl(tagName),
+  };
 
   const element: MockElement = {
     tagName: tag.toUpperCase(),
@@ -80,29 +154,33 @@ export function createMockEl(tag = 'div'): any {
       if (value) {
         value.split(' ').filter(Boolean).forEach(c => classes.add(c));
       }
+      syncDisplay();
     },
 
     classList: {
-      add: (cls: string) => classes.add(cls),
-      remove: (cls: string) => classes.delete(cls),
+      add: (cls: string) => updateClass(cls, true),
+      remove: (cls: string) => updateClass(cls, false),
       contains: (cls: string) => classes.has(cls),
       toggle: (cls: string, force?: boolean) => {
         if (force === undefined) {
-          if (classes.has(cls)) { classes.delete(cls); return false; }
-          classes.add(cls);
+          if (classes.has(cls)) {
+            updateClass(cls, false);
+            return false;
+          }
+          updateClass(cls, true);
           return true;
         }
-        if (force) { classes.add(cls); } else { classes.delete(cls); }
+        updateClass(cls, force);
         return force;
       },
     },
 
     addClass(cls: string) {
-      cls.split(/\s+/).filter(Boolean).forEach(c => classes.add(c));
+      cls.split(/\s+/).filter(Boolean).forEach(c => updateClass(c, true));
       return element;
     },
     removeClass(cls: string) {
-      cls.split(/\s+/).filter(Boolean).forEach(c => classes.delete(c));
+      cls.split(/\s+/).filter(Boolean).forEach(c => updateClass(c, false));
       return element;
     },
     hasClass: (cls: string) => classes.has(cls),
@@ -126,6 +204,11 @@ export function createMockEl(tag = 'div'): any {
       const child = createMockEl(tagName);
       if (opts?.cls) child.addClass(opts.cls);
       if (opts?.text) child.textContent = opts.text;
+      if (opts?.attr) {
+        for (const [name, value] of Object.entries(opts.attr)) {
+          child.setAttribute(name, value);
+        }
+      }
       children.push(child);
       return child;
     },
@@ -147,8 +230,30 @@ export function createMockEl(tag = 'div'): any {
     focus() {},
     blur() {},
 
-    setAttribute(name: string, value: string) { attributes.set(name, value); },
-    getAttribute(name: string) { return attributes.get(name) ?? null; },
+    setAttribute(name: string, value: string) {
+      if (name === 'class') {
+        element.className = value;
+      } else {
+        attributes.set(name, value);
+      }
+      if (name.startsWith('data-')) {
+        dataset[name.slice(5).replace(/-([a-z])/g, (_, char: string) => char.toUpperCase())] = value;
+      }
+    },
+    getAttribute(name: string) {
+      if (name === 'class') return element.className;
+      return attributes.get(name) ?? null;
+    },
+    removeAttribute(name: string) {
+      if (name === 'class') {
+        element.className = '';
+      } else {
+        attributes.delete(name);
+      }
+      if (name.startsWith('data-')) {
+        delete dataset[name.slice(5).replace(/-([a-z])/g, (_, char: string) => char.toUpperCase())];
+      }
+    },
 
     addEventListener(event: string, handler: (...args: any[]) => void) {
       if (!eventListeners.has(event)) eventListeners.set(event, []);
@@ -206,13 +311,20 @@ export function createMockEl(tag = 'div'): any {
     },
 
     setText(text: string) { textContent = text; },
-    setAttr(name: string, value: string) { attributes.set(name, value); },
+    appendText(text: string) { textContent += text; },
+    setCssProps(props: Record<string, string>) {
+      for (const [name, value] of Object.entries(props)) {
+        style[name] = value;
+      }
+    },
+    setAttr(name: string, value: string) { element.setAttribute(name, value); },
     toggleClass(cls: string, force: boolean) {
-      if (force) { classes.add(cls); } else { classes.delete(cls); }
+      updateClass(cls, force);
     },
     value: '',
     closest() { return { clientHeight: 600 }; },
     getEventListeners() { return eventListeners; },
+    ownerDocument,
 
     _classes: classes,
     _classList: classes,

--- a/tests/integration/core/agent/ClaudianService.test.ts
+++ b/tests/integration/core/agent/ClaudianService.test.ts
@@ -1530,7 +1530,7 @@ describe('ClaudianService', () => {
   });
 
   describe('persistent query dynamic updates', () => {
-    it('updates thinking tokens on the active persistent query when budget changes (custom model)', async () => {
+    it('rebuilds the persistent query when a fixed thinking budget changes', async () => {
       // Use a custom model so the legacy budget path is used
       mockPlugin.settings.model = 'custom-model';
       mockPlugin.settings.thinkingBudget = 'off';
@@ -1538,15 +1538,14 @@ describe('ClaudianService', () => {
       const chunks1: any[] = [];
       for await (const c of service.query('first')) chunks1.push(c);
 
-      // Change thinking budget - this should trigger setMaxThinkingTokens on next query
+      // Change thinking budget - this should rebuild the query with startup thinking options.
       mockPlugin.settings.thinkingBudget = 'high';
 
       const chunks2: any[] = [];
       for await (const c of service.query('second')) chunks2.push(c);
 
       const response = getLastResponse();
-      // setMaxThinkingTokens should be called with the new budget value (16000 for 'high')
-      expect(response?.setMaxThinkingTokens).toHaveBeenCalledWith(16000);
+      expect(response?.setMaxThinkingTokens).not.toHaveBeenCalled();
     });
 
     it('does not call setMaxThinkingTokens for adaptive models when budget changes', async () => {

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -131,7 +131,7 @@ describe('ClaudianPlugin', () => {
       await plugin.onload();
       await plugin.activateView();
 
-      expect(mockApp.workspace.setActiveLeaf).toHaveBeenCalledWith(mockLeaf, { focus: true });
+      expect(mockApp.workspace.revealLeaf).toHaveBeenCalledWith(mockLeaf);
     });
 
     it('should create new leaf in right sidebar by default if view does not exist', async () => {
@@ -484,7 +484,7 @@ describe('ClaudianPlugin', () => {
       const ribbonCallback = (plugin.addRibbonIcon as jest.Mock).mock.calls[0][2];
       await ribbonCallback();
 
-      expect(mockApp.workspace.setActiveLeaf).toHaveBeenCalledWith(mockLeaf, { focus: true });
+      expect(mockApp.workspace.revealLeaf).toHaveBeenCalledWith(mockLeaf);
     });
   });
 
@@ -497,7 +497,7 @@ describe('ClaudianPlugin', () => {
       const commandConfig = (plugin.addCommand as jest.Mock).mock.calls[0][0];
       await commandConfig.callback();
 
-      expect(mockApp.workspace.setActiveLeaf).toHaveBeenCalledWith(mockLeaf, { focus: true });
+      expect(mockApp.workspace.revealLeaf).toHaveBeenCalledWith(mockLeaf);
     });
   });
 

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -56,6 +56,7 @@ describe('ClaudianPlugin', () => {
         getLeaf: jest.fn().mockReturnValue({
           setViewState: jest.fn().mockResolvedValue(undefined),
         }),
+        setActiveLeaf: jest.fn(),
         revealLeaf: jest.fn(),
       },
     };
@@ -130,7 +131,7 @@ describe('ClaudianPlugin', () => {
       await plugin.onload();
       await plugin.activateView();
 
-      expect(mockApp.workspace.revealLeaf).toHaveBeenCalledWith(mockLeaf);
+      expect(mockApp.workspace.setActiveLeaf).toHaveBeenCalledWith(mockLeaf, { focus: true });
     });
 
     it('should create new leaf in right sidebar by default if view does not exist', async () => {
@@ -483,7 +484,7 @@ describe('ClaudianPlugin', () => {
       const ribbonCallback = (plugin.addRibbonIcon as jest.Mock).mock.calls[0][2];
       await ribbonCallback();
 
-      expect(mockApp.workspace.revealLeaf).toHaveBeenCalledWith(mockLeaf);
+      expect(mockApp.workspace.setActiveLeaf).toHaveBeenCalledWith(mockLeaf, { focus: true });
     });
   });
 
@@ -496,7 +497,7 @@ describe('ClaudianPlugin', () => {
       const commandConfig = (plugin.addCommand as jest.Mock).mock.calls[0][0];
       await commandConfig.callback();
 
-      expect(mockApp.workspace.revealLeaf).toHaveBeenCalledWith(mockLeaf);
+      expect(mockApp.workspace.setActiveLeaf).toHaveBeenCalledWith(mockLeaf, { focus: true });
     });
   });
 

--- a/tests/unit/features/chat/controllers/BrowserSelectionController.test.ts
+++ b/tests/unit/features/chat/controllers/BrowserSelectionController.test.ts
@@ -1,30 +1,42 @@
 /** @jest-environment jsdom */
 
+import { createMockEl } from '@test/helpers/mockElement';
+
 import { BrowserSelectionController } from '@/features/chat/controllers/BrowserSelectionController';
 
 function createMockIndicator() {
-  const indicatorEl = document.createElement('div');
-  indicatorEl.style.display = 'none';
+  const indicatorEl = createMockEl();
+  indicatorEl.addClass('claudian-browser-selection-indicator');
+  indicatorEl.addClass('claudian-hidden');
   return indicatorEl;
 }
 
 function createMockContextRow(browserIndicator: HTMLElement) {
-  const fileIndicator = { style: { display: 'none' } };
-  const imagePreview = { style: { display: 'none' } };
+  const editorIndicator = createMockEl();
+  editorIndicator.addClass('claudian-selection-indicator');
+  editorIndicator.addClass('claudian-hidden');
+  const canvasIndicator = createMockEl();
+  canvasIndicator.addClass('claudian-canvas-indicator');
+  canvasIndicator.addClass('claudian-hidden');
+  const fileIndicator = createMockEl();
+  fileIndicator.addClass('claudian-file-indicator');
+  fileIndicator.addClass('claudian-hidden');
+  const imagePreview = createMockEl();
+  imagePreview.addClass('claudian-image-preview');
+  imagePreview.addClass('claudian-hidden');
   const elements: Record<string, any> = {
-    '.claudian-selection-indicator': { style: { display: 'none' } },
+    '.claudian-selection-indicator': editorIndicator,
     '.claudian-browser-selection-indicator': browserIndicator,
-    '.claudian-canvas-indicator': { style: { display: 'none' } },
+    '.claudian-canvas-indicator': canvasIndicator,
     '.claudian-file-indicator': fileIndicator,
     '.claudian-image-preview': imagePreview,
   };
+  const contextRow = createMockEl();
+  const toggle = contextRow.classList.toggle;
+  contextRow.classList.toggle = jest.fn((cls: string, force?: boolean) => toggle(cls, force));
 
-  return {
-    classList: {
-      toggle: jest.fn(),
-    },
-    querySelector: jest.fn((selector: string) => elements[selector] ?? null),
-  } as any;
+  contextRow.querySelector = jest.fn((selector: string) => elements[selector] ?? null);
+  return contextRow as any;
 }
 
 async function flushMicrotasks(): Promise<void> {

--- a/tests/unit/features/chat/controllers/CanvasSelectionController.test.ts
+++ b/tests/unit/features/chat/controllers/CanvasSelectionController.test.ts
@@ -1,26 +1,30 @@
+import { createMockEl } from '@test/helpers/mockElement';
+
 import { CanvasSelectionController } from '@/features/chat/controllers/CanvasSelectionController';
 
 function createMockIndicator() {
-  return {
-    textContent: '',
-    style: { display: 'none' },
-  } as any;
+  const indicator = createMockEl();
+  indicator.addClass('claudian-canvas-indicator');
+  indicator.addClass('claudian-hidden');
+  return indicator;
 }
 
 function createMockContextRow() {
   const elements: Record<string, any> = {
-    '.claudian-selection-indicator': { style: { display: 'none' } },
-    '.claudian-canvas-indicator': { style: { display: 'none' } },
+    '.claudian-selection-indicator': createMockEl(),
+    '.claudian-canvas-indicator': createMockIndicator(),
     '.claudian-file-indicator': null,
     '.claudian-image-preview': null,
   };
+  elements['.claudian-selection-indicator'].addClass('claudian-selection-indicator');
+  elements['.claudian-selection-indicator'].addClass('claudian-hidden');
 
-  return {
-    classList: {
-      toggle: jest.fn(),
-    },
-    querySelector: jest.fn((selector: string) => elements[selector] ?? null),
-  } as any;
+  const contextRow = createMockEl();
+  const toggle = contextRow.classList.toggle;
+  contextRow.classList.toggle = jest.fn((cls: string, force?: boolean) => toggle(cls, force));
+
+  contextRow.querySelector = jest.fn((selector: string) => elements[selector] ?? null);
+  return contextRow as any;
 }
 
 function createMockCanvasNode(id: string) {
@@ -146,7 +150,8 @@ describe('CanvasSelectionController', () => {
   });
 
   it('keeps context row visible when editor selection indicator is visible', () => {
-    const editorIndicator = { style: { display: 'block' } };
+    const editorIndicator = createMockEl();
+    editorIndicator.addClass('claudian-selection-indicator');
     contextRowEl.querySelector.mockImplementation((selector: string) => {
       if (selector === '.claudian-selection-indicator') return editorIndicator;
       return null;

--- a/tests/unit/features/chat/controllers/CanvasSelectionController.test.ts
+++ b/tests/unit/features/chat/controllers/CanvasSelectionController.test.ts
@@ -44,7 +44,7 @@ describe('CanvasSelectionController', () => {
     jest.useFakeTimers();
 
     indicatorEl = createMockIndicator();
-    inputEl = {};
+    inputEl = createMockEl();
     contextRowEl = createMockContextRow();
 
     const node1 = createMockCanvasNode('abc123');

--- a/tests/unit/features/chat/controllers/ConversationController.test.ts
+++ b/tests/unit/features/chat/controllers/ConversationController.test.ts
@@ -920,6 +920,7 @@ describe('ConversationController', () => {
       expect(clickHandlers).toBeDefined();
 
       await clickHandlers![0]({ stopPropagation: jest.fn() });
+      await Promise.resolve();
 
       expect(deps.plugin.switchConversation).toHaveBeenCalledWith('conv-2');
     });

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -27,7 +27,7 @@ function createMockInputEl() {
 }
 
 function createMockWelcomeEl() {
-  return { style: { display: '' } } as any;
+  return createMockEl();
 }
 
 function createMockFileContextManager() {

--- a/tests/unit/features/chat/controllers/NavigationController.test.ts
+++ b/tests/unit/features/chat/controllers/NavigationController.test.ts
@@ -59,12 +59,14 @@ class MockElement {
   public tagName: string;
   public scrollTop = 0;
   public style: Record<string, string> = {};
+  public ownerDocument: Document;
   private attributes: Map<string, string> = new Map();
   private classes: Set<string> = new Set();
   private listeners: Map<string, { listener: Listener; options?: AddEventListenerOptions }[]> = new Map();
 
   constructor(tagName = 'DIV') {
     this.tagName = tagName;
+    this.ownerDocument = (global as any).document;
   }
 
   setAttribute(name: string, value: string): void {
@@ -165,6 +167,10 @@ describe('NavigationController', () => {
     // Mock document for event listeners
     const documentListeners: Map<string, Listener[]> = new Map();
     (global as any).document = {
+      defaultView: {
+        requestAnimationFrame: mockRaf,
+        cancelAnimationFrame: mockCancelRaf,
+      },
       addEventListener: (type: string, listener: Listener) => {
         if (!documentListeners.has(type)) {
           documentListeners.set(type, []);

--- a/tests/unit/features/chat/controllers/SelectionController.test.ts
+++ b/tests/unit/features/chat/controllers/SelectionController.test.ts
@@ -50,6 +50,7 @@ function createMockEventTarget() {
   const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
   const containedNodes = new Set<unknown>();
   const el: any = {
+    ownerDocument: createMockEl().ownerDocument,
     addEventListener: jest.fn((event: string, listener: (...args: unknown[]) => void) => {
       const handlers = listeners.get(event) ?? new Set<(...args: unknown[]) => void>();
       handlers.add(listener);

--- a/tests/unit/features/chat/controllers/SelectionController.test.ts
+++ b/tests/unit/features/chat/controllers/SelectionController.test.ts
@@ -1,3 +1,5 @@
+import { createMockEl } from '@test/helpers/mockElement';
+
 import { SelectionController } from '@/features/chat/controllers/SelectionController';
 import { hideSelectionHighlight, showSelectionHighlight } from '@/shared/components/SelectionHighlight';
 
@@ -38,10 +40,10 @@ function createMockDOMSelection(text: string, anchorNode: any, focusNode?: any, 
 }
 
 function createMockIndicator() {
-  return {
-    textContent: '',
-    style: { display: 'none' },
-  } as any;
+  const indicator = createMockEl();
+  indicator.addClass('claudian-selection-indicator');
+  indicator.addClass('claudian-hidden');
+  return indicator;
 }
 
 function createMockEventTarget() {
@@ -69,18 +71,19 @@ function createMockEventTarget() {
 
 function createMockContextRow() {
   const elements: Record<string, any> = {
-    '.claudian-selection-indicator': { style: { display: 'none' } },
-    '.claudian-canvas-indicator': { style: { display: 'none' } },
+    '.claudian-selection-indicator': createMockIndicator(),
+    '.claudian-canvas-indicator': createMockEl(),
     '.claudian-file-indicator': null,
     '.claudian-image-preview': null,
   };
+  elements['.claudian-canvas-indicator'].addClass('claudian-canvas-indicator');
+  elements['.claudian-canvas-indicator'].addClass('claudian-hidden');
+  const contextRow = createMockEl();
+  const toggle = contextRow.classList.toggle;
+  contextRow.classList.toggle = jest.fn((cls: string, force?: boolean) => toggle(cls, force));
 
-  return {
-    classList: {
-      toggle: jest.fn(),
-    },
-    querySelector: jest.fn((selector: string) => elements[selector] ?? null),
-  } as any;
+  contextRow.querySelector = jest.fn((selector: string) => elements[selector] ?? null);
+  return contextRow as any;
 }
 
 describe('SelectionController', () => {
@@ -585,7 +588,8 @@ describe('SelectionController', () => {
   });
 
   it('keeps context row visible when canvas selection indicator is visible', () => {
-    const canvasIndicator = { style: { display: 'block' } };
+    const canvasIndicator = createMockEl();
+    canvasIndicator.addClass('claudian-canvas-indicator');
     contextRowEl.querySelector.mockImplementation((selector: string) => {
       if (selector === '.claudian-canvas-indicator') return canvasIndicator;
       return null;

--- a/tests/unit/features/chat/controllers/StreamController.test.ts
+++ b/tests/unit/features/chat/controllers/StreamController.test.ts
@@ -61,6 +61,45 @@ jest.mock('@/utils/path', () => ({
   getVaultPath: jest.fn().mockReturnValue('/test/vault'),
 }));
 
+const originalWindow = (globalThis as { window?: Window }).window;
+
+function installTestWindow(): void {
+  const testWindow = {
+    requestAnimationFrame: (callback: FrameRequestCallback): number =>
+      globalThis.setTimeout(() => callback(performance.now()), 16) as unknown as number,
+    cancelAnimationFrame: (handle: number): void => {
+      globalThis.clearTimeout(handle as unknown as ReturnType<typeof setTimeout>);
+    },
+    setTimeout: (callback: () => void, timeout: number): number =>
+      globalThis.setTimeout(callback, timeout) as unknown as number,
+    clearTimeout: (handle: number): void => {
+      globalThis.clearTimeout(handle as unknown as ReturnType<typeof setTimeout>);
+    },
+    setInterval: (callback: () => void, timeout: number): number =>
+      globalThis.setInterval(callback, timeout) as unknown as number,
+    clearInterval: (handle: number): void => {
+      globalThis.clearInterval(handle as unknown as ReturnType<typeof setInterval>);
+    },
+  } as Window;
+
+  Object.defineProperty(globalThis, 'window', {
+    value: testWindow,
+    configurable: true,
+  });
+}
+
+function restoreTestWindow(): void {
+  if (originalWindow === undefined) {
+    delete (globalThis as { window?: Window }).window;
+    return;
+  }
+
+  Object.defineProperty(globalThis, 'window', {
+    value: originalWindow,
+    configurable: true,
+  });
+}
+
 function createMockDeps(): StreamControllerDeps {
   const state = new ChatState();
   const messagesEl = createMockEl();
@@ -158,6 +197,7 @@ describe('StreamController - Text Content', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
+    installTestWindow();
     deps = createMockDeps();
     controller = new StreamController(deps);
     deps.state.currentContentEl = createMockEl();
@@ -166,6 +206,7 @@ describe('StreamController - Text Content', () => {
   afterEach(() => {
     // Clean up any timers set by ChatState
     deps.state.resetStreamingState();
+    restoreTestWindow();
     jest.useRealTimers();
   });
 
@@ -2173,10 +2214,11 @@ describe('StreamController - Text Content', () => {
       // Advance fake clock so performance.now() returns non-zero
       jest.advanceTimersByTime(1);
       deps.state.responseStartTime = performance.now();
-      const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+      const activeWindow = deps.state.currentContentEl!.ownerDocument.defaultView!;
+      const clearIntervalSpy = jest.spyOn(activeWindow, 'clearInterval');
 
       // Manually set a pre-existing interval
-      deps.state.flavorTimerInterval = setInterval(() => {}, 9999) as unknown as ReturnType<typeof setInterval>;
+      deps.state.setFlavorTimerInterval(activeWindow.setInterval(() => {}, 9999), activeWindow);
 
       controller.showThinkingIndicator();
       jest.advanceTimersByTime(500);
@@ -2237,6 +2279,7 @@ describe('StreamController - Plan Mode', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
+    installTestWindow();
     deps = createMockDeps();
     controller = new StreamController(deps);
     deps.state.currentContentEl = createMockEl();
@@ -2244,6 +2287,7 @@ describe('StreamController - Plan Mode', () => {
 
   afterEach(() => {
     deps.state.resetStreamingState();
+    restoreTestWindow();
     jest.useRealTimers();
   });
 

--- a/tests/unit/features/chat/controllers/contextRowVisibility.test.ts
+++ b/tests/unit/features/chat/controllers/contextRowVisibility.test.ts
@@ -1,10 +1,16 @@
+import { createMockEl } from '@test/helpers/mockElement';
+
 import { updateContextRowHasContent } from '@/features/chat/controllers/contextRowVisibility';
 
 function createContextRow(browserIndicator: HTMLElement | null): HTMLElement {
-  const editorIndicator = { style: { display: 'none' } };
-  const canvasIndicator = { style: { display: 'none' } };
-  const fileIndicator = { style: { display: 'none' } };
-  const imagePreview = { style: { display: 'none' } };
+  const editorIndicator = createMockEl();
+  editorIndicator.addClass('claudian-selection-indicator claudian-hidden');
+  const canvasIndicator = createMockEl();
+  canvasIndicator.addClass('claudian-canvas-indicator claudian-hidden');
+  const fileIndicator = createMockEl();
+  fileIndicator.addClass('claudian-file-indicator claudian-hidden');
+  const imagePreview = createMockEl();
+  imagePreview.addClass('claudian-image-preview claudian-hidden');
   const lookup = new Map<string, unknown>([
     ['.claudian-selection-indicator', editorIndicator],
     ['.claudian-browser-selection-indicator', browserIndicator],
@@ -13,12 +19,11 @@ function createContextRow(browserIndicator: HTMLElement | null): HTMLElement {
     ['.claudian-image-preview', imagePreview],
   ]);
 
-  return {
-    classList: {
-      toggle: jest.fn(),
-    },
-    querySelector: jest.fn((selector: string) => lookup.get(selector) ?? null),
-  } as unknown as HTMLElement;
+  const contextRow = createMockEl();
+  const toggle = contextRow.classList.toggle;
+  contextRow.classList.toggle = jest.fn((cls: string, force?: boolean) => toggle(cls, force));
+  contextRow.querySelector = jest.fn((selector: string) => lookup.get(selector) ?? null);
+  return contextRow as unknown as HTMLElement;
 }
 
 describe('updateContextRowHasContent', () => {
@@ -29,8 +34,9 @@ describe('updateContextRowHasContent', () => {
     expect((contextRowEl.classList.toggle as jest.Mock)).toHaveBeenCalledWith('has-content', false);
   });
 
-  it('treats browser indicator as visible only when display is block', () => {
-    const browserIndicator = { style: { display: 'block' } } as unknown as HTMLElement;
+  it('treats browser indicator as visible only when it is not hidden', () => {
+    const browserIndicator = createMockEl();
+    browserIndicator.addClass('claudian-browser-selection-indicator');
     const contextRowEl = createContextRow(browserIndicator);
 
     updateContextRowHasContent(contextRowEl);

--- a/tests/unit/features/chat/rendering/MessageRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/MessageRenderer.test.ts
@@ -146,8 +146,9 @@ describe('MessageRenderer', () => {
     // Check the content contains interrupt styling
     const contentEl = msgEl.children[0];
     const textEl = contentEl.children[0];
-    expect(textEl.innerHTML).toContain('claudian-interrupted');
-    expect(textEl.innerHTML).toContain('Interrupted');
+    const interruptedEl = textEl.children[0];
+    expect(interruptedEl.hasClass('claudian-interrupted')).toBe(true);
+    expect(interruptedEl.textContent).toBe('Interrupted');
   });
 
   it('renders interrupted assistant message with content + interrupt indicator', () => {
@@ -173,8 +174,9 @@ describe('MessageRenderer', () => {
     // The content div should have both content rendering and an interrupt indicator
     const contentEl = msgEl.children[0];
     const lastChild = contentEl.children[contentEl.children.length - 1];
-    expect(lastChild.innerHTML).toContain('claudian-interrupted');
-    expect(lastChild.innerHTML).toContain('Interrupted');
+    const interruptedEl = lastChild.children[0];
+    expect(interruptedEl.hasClass('claudian-interrupted')).toBe(true);
+    expect(interruptedEl.textContent).toBe('Interrupted');
   });
 
   it('renders bare interrupt marker for empty interrupted assistant message', () => {
@@ -198,7 +200,7 @@ describe('MessageRenderer', () => {
     expect(msgEl.hasClass('claudian-message-assistant')).toBe(true);
     const contentEl = msgEl.children[0];
     const textEl = contentEl.children[0];
-    expect(textEl.innerHTML).toContain('claudian-interrupted');
+    expect(textEl.children[0].hasClass('claudian-interrupted')).toBe(true);
   });
 
   it('skips rebuilt context messages', () => {

--- a/tests/unit/features/chat/rendering/SubagentRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/SubagentRenderer.test.ts
@@ -78,7 +78,7 @@ describe('Sync Subagent Renderer', () => {
       // Should be expanded
       expect(state.info.isExpanded).toBe(true);
       expect((state.wrapperEl as any).hasClass('expanded')).toBe(true);
-      expect((state.contentEl as any).style.display).toBe('block');
+      expect((state.contentEl as any).hasClass('claudian-hidden')).toBe(false);
 
       // Click again to collapse
       (state.headerEl as any).click();
@@ -180,7 +180,7 @@ describe('Sync Subagent Renderer', () => {
       // Click to expand
       headerEl.click();
       expect((wrapperEl as any).hasClass('expanded')).toBe(true);
-      expect(contentEl.style.display).toBe('block');
+      expect(contentEl.hasClass('claudian-hidden')).toBe(false);
       expect(headerEl.getAttribute('aria-expanded')).toBe('true');
 
       // Click to collapse

--- a/tests/unit/features/chat/rendering/ThinkingBlockRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/ThinkingBlockRenderer.test.ts
@@ -92,7 +92,7 @@ describe('ThinkingBlockRenderer', () => {
       clickHandlers[0]();
       expect(state.isExpanded).toBe(true);
       expect((state.wrapperEl as any).hasClass('expanded')).toBe(true);
-      expect((state.contentEl as any).style.display).toBe('block');
+      expect((state.contentEl as any).hasClass('claudian-hidden')).toBe(false);
     });
 
     it('should update aria-expanded on finalize', () => {

--- a/tests/unit/features/chat/rendering/ToolCallRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/ToolCallRenderer.test.ts
@@ -205,8 +205,7 @@ describe('ToolCallRenderer', () => {
     it('should set MCP SVG for MCP tools', () => {
       const el = createMockEl();
       setToolIcon(el as unknown as HTMLElement, 'mcp__server__tool');
-      // MCP tools get innerHTML set with the SVG
-      expect(el.innerHTML).toContain('svg');
+      expect(el.children[0]?.tagName).toBe('SVG');
     });
   });
 

--- a/tests/unit/features/chat/rendering/collapsible.test.ts
+++ b/tests/unit/features/chat/rendering/collapsible.test.ts
@@ -24,7 +24,7 @@ describe('collapsible', () => {
       setupCollapsible(wrapper, header, content, state);
 
       expect(state.isExpanded).toBe(false);
-      expect(content.style.display).toBe('none');
+      expect(content.hasClass('claudian-hidden')).toBe(true);
       expect(header.getAttribute('aria-expanded')).toBe('false');
       expect(wrapper.hasClass('expanded')).toBe(false);
     });
@@ -33,7 +33,7 @@ describe('collapsible', () => {
       setupCollapsible(wrapper, header, content, state, { initiallyExpanded: true });
 
       expect(state.isExpanded).toBe(true);
-      expect(content.style.display).toBe('block');
+      expect(content.hasClass('claudian-hidden')).toBe(false);
       expect(header.getAttribute('aria-expanded')).toBe('true');
       expect(wrapper.hasClass('expanded')).toBe(true);
     });
@@ -48,14 +48,14 @@ describe('collapsible', () => {
       clickHandlers[0]();
       expect(state.isExpanded).toBe(true);
       expect(wrapper.hasClass('expanded')).toBe(true);
-      expect(content.style.display).toBe('block');
+      expect(content.hasClass('claudian-hidden')).toBe(false);
       expect(header.getAttribute('aria-expanded')).toBe('true');
 
       // Collapse
       clickHandlers[0]();
       expect(state.isExpanded).toBe(false);
       expect(wrapper.hasClass('expanded')).toBe(false);
-      expect(content.style.display).toBe('none');
+      expect(content.hasClass('claudian-hidden')).toBe(true);
       expect(header.getAttribute('aria-expanded')).toBe('false');
     });
 
@@ -144,7 +144,7 @@ describe('collapsible', () => {
 
       expect(state.isExpanded).toBe(false);
       expect(wrapper.hasClass('expanded')).toBe(false);
-      expect(content.style.display).toBe('none');
+      expect(content.hasClass('claudian-hidden')).toBe(true);
       expect(header.getAttribute('aria-expanded')).toBe('false');
     });
 
@@ -152,7 +152,7 @@ describe('collapsible', () => {
       collapseElement(wrapper, header, content, state);
 
       expect(state.isExpanded).toBe(false);
-      expect(content.style.display).toBe('none');
+      expect(content.hasClass('claudian-hidden')).toBe(true);
     });
   });
 });

--- a/tests/unit/features/chat/services/InstructionRefineService.test.ts
+++ b/tests/unit/features/chat/services/InstructionRefineService.test.ts
@@ -218,8 +218,8 @@ describe('InstructionRefineService', () => {
 
       await service.refineInstruction('test', '');
       const options = getLastOptions();
-      expect(options?.maxThinkingTokens).toBeGreaterThan(0);
-      expect(options?.thinking).toBeUndefined();
+      expect(options?.thinking).toEqual({ type: 'enabled', budgetTokens: expect.any(Number) });
+      expect(options?.maxThinkingTokens).toBeUndefined();
     });
 
     it('should ignore non-text content blocks', async () => {

--- a/tests/unit/features/chat/state/ChatState.test.ts
+++ b/tests/unit/features/chat/state/ChatState.test.ts
@@ -2,6 +2,40 @@ import { ChatState, createInitialState } from '@/features/chat/state/ChatState';
 import type { ChatStateCallbacks } from '@/features/chat/state/types';
 
 describe('ChatState', () => {
+  const originalWindow = (globalThis as { window?: Window }).window;
+
+  beforeAll(() => {
+    const testWindow = {
+      setTimeout: (callback: () => void, timeout: number): number =>
+        globalThis.setTimeout(callback, timeout) as unknown as number,
+      clearTimeout: (handle: number): void => {
+        globalThis.clearTimeout(handle as unknown as ReturnType<typeof setTimeout>);
+      },
+      setInterval: (callback: () => void, timeout: number): number =>
+        globalThis.setInterval(callback, timeout) as unknown as number,
+      clearInterval: (handle: number): void => {
+        globalThis.clearInterval(handle as unknown as ReturnType<typeof setInterval>);
+      },
+    } as Window;
+
+    Object.defineProperty(globalThis, 'window', {
+      value: testWindow,
+      configurable: true,
+    });
+  });
+
+  afterAll(() => {
+    if (originalWindow === undefined) {
+      delete (globalThis as { window?: Window }).window;
+      return;
+    }
+
+    Object.defineProperty(globalThis, 'window', {
+      value: originalWindow,
+      configurable: true,
+    });
+  });
+
   describe('createInitialState', () => {
     it('returns correct default values', () => {
       const state = createInitialState();
@@ -193,10 +227,10 @@ describe('ChatState', () => {
 
     it('stores thinkingIndicatorTimeout', () => {
       const chatState = new ChatState();
-      const timeout = setTimeout(() => {}, 100);
+      const timeout = window.setTimeout(() => {}, 100);
       chatState.thinkingIndicatorTimeout = timeout;
       expect(chatState.thinkingIndicatorTimeout).toBe(timeout);
-      clearTimeout(timeout);
+      window.clearTimeout(timeout);
     });
   });
 
@@ -328,18 +362,18 @@ describe('ChatState', () => {
 
     it('stores flavorTimerInterval', () => {
       const chatState = new ChatState();
-      const interval = setInterval(() => {}, 1000);
+      const interval = window.setInterval(() => {}, 1000);
       chatState.flavorTimerInterval = interval;
       expect(chatState.flavorTimerInterval).toBe(interval);
-      clearInterval(interval);
+      window.clearInterval(interval);
     });
   });
 
   describe('clearFlavorTimerInterval', () => {
     it('clears active interval', () => {
       const chatState = new ChatState();
-      const clearSpy = jest.spyOn(global, 'clearInterval');
-      const interval = setInterval(() => {}, 1000);
+      const clearSpy = jest.spyOn(window, 'clearInterval');
+      const interval = window.setInterval(() => {}, 1000);
       chatState.flavorTimerInterval = interval;
 
       chatState.clearFlavorTimerInterval();
@@ -351,7 +385,7 @@ describe('ChatState', () => {
 
     it('is a no-op when no interval is active', () => {
       const chatState = new ChatState();
-      const clearSpy = jest.spyOn(global, 'clearInterval');
+      const clearSpy = jest.spyOn(window, 'clearInterval');
 
       chatState.clearFlavorTimerInterval();
 
@@ -369,9 +403,9 @@ describe('ChatState', () => {
       chatState.currentThinkingState = {} as any;
       chatState.isStreaming = true;
       chatState.cancelRequested = true;
-      const timeout = setTimeout(() => {}, 1000);
+      const timeout = window.setTimeout(() => {}, 1000);
       chatState.thinkingIndicatorTimeout = timeout;
-      const interval = setInterval(() => {}, 1000);
+      const interval = window.setInterval(() => {}, 1000);
       chatState.flavorTimerInterval = interval;
       chatState.responseStartTime = 12345;
 

--- a/tests/unit/features/chat/tabs/TabManager.test.ts
+++ b/tests/unit/features/chat/tabs/TabManager.test.ts
@@ -112,6 +112,7 @@ function createMockPlugin(overrides: Record<string, any> = {}): any {
   return {
     app: {
       workspace: {
+        setActiveLeaf: jest.fn(),
         revealLeaf: jest.fn(),
       },
     },
@@ -717,7 +718,7 @@ describe('TabManager - Conversation Management', () => {
 
       await manager.openConversation('conv-123');
 
-      expect(plugin.app.workspace.revealLeaf).toHaveBeenCalled();
+      expect(plugin.app.workspace.setActiveLeaf).toHaveBeenCalledWith({ id: 'other-leaf' }, { focus: true });
     });
   });
 

--- a/tests/unit/features/chat/tabs/TabManager.test.ts
+++ b/tests/unit/features/chat/tabs/TabManager.test.ts
@@ -718,7 +718,7 @@ describe('TabManager - Conversation Management', () => {
 
       await manager.openConversation('conv-123');
 
-      expect(plugin.app.workspace.setActiveLeaf).toHaveBeenCalledWith({ id: 'other-leaf' }, { focus: true });
+      expect(plugin.app.workspace.revealLeaf).toHaveBeenCalledWith({ id: 'other-leaf' });
     });
   });
 

--- a/tests/unit/features/chat/ui/InputToolbar.test.ts
+++ b/tests/unit/features/chat/ui/InputToolbar.test.ts
@@ -713,7 +713,7 @@ describe('ServiceTierToggle', () => {
   it('shows the control when the provider exposes service tier options', () => {
     const container = parentEl.querySelector('.claudian-service-tier-toggle');
     expect(container).not.toBeNull();
-    expect(container?.style.display).toBe('');
+    expect(container?.hasClass('claudian-hidden')).toBe(false);
   });
 
   it('renders the icon button in the inactive state when fast mode is off', () => {
@@ -817,7 +817,7 @@ describe('McpServerSelector', () => {
   it('should show container when servers are configured', () => {
     selector.setMcpManager(createMockMcpManager([{ name: 'test', enabled: true }]));
     const container = parentEl.querySelector('.claudian-mcp-selector');
-    expect(container?.style.display).toBe('');
+    expect(container?.hasClass('claudian-hidden')).toBe(false);
   });
 
   it('should show empty message when all servers are disabled', () => {

--- a/tests/unit/features/chat/ui/NavigationSidebar.test.ts
+++ b/tests/unit/features/chat/ui/NavigationSidebar.test.ts
@@ -53,6 +53,7 @@ class MockElement {
   tagName: string;
   classList = new MockClassList();
   style: Record<string, string> = {};
+  ownerDocument: { defaultView: Window | null };
   children: MockElement[] = [];
   attributes: Record<string, string> = {};
   dataset: Record<string, string> = {};
@@ -68,6 +69,9 @@ class MockElement {
 
   constructor(tagName: string) {
     this.tagName = tagName.toUpperCase();
+    this.ownerDocument = {
+      defaultView: (globalThis as { window?: Window }).window ?? null,
+    };
   }
 
   set className(value: string) {
@@ -196,9 +200,26 @@ describe('NavigationSidebar', () => {
   let parentEl: MockElement;
   let messagesEl: MockElement;
   let sidebar: NavigationSidebar;
+  let originalWindow: Window | undefined;
 
   beforeEach(() => {
     jest.useFakeTimers();
+    originalWindow = (globalThis as { window?: Window }).window;
+    Object.defineProperty(globalThis, 'window', {
+      value: {
+        requestAnimationFrame: (callback: FrameRequestCallback): number =>
+          globalThis.setTimeout(() => callback(performance.now()), 16) as unknown as number,
+        cancelAnimationFrame: (handle: number): void => {
+          globalThis.clearTimeout(handle as unknown as ReturnType<typeof setTimeout>);
+        },
+        setTimeout: (callback: () => void, timeout: number): number =>
+          globalThis.setTimeout(callback, timeout) as unknown as number,
+        clearTimeout: (handle: number): void => {
+          globalThis.clearTimeout(handle as unknown as ReturnType<typeof setTimeout>);
+        },
+      } as Window,
+      configurable: true,
+    });
     parentEl = new MockElement('div');
     messagesEl = new MockElement('div');
     parentEl.appendChild(messagesEl);
@@ -206,6 +227,14 @@ describe('NavigationSidebar', () => {
 
   afterEach(() => {
     sidebar?.destroy();
+    if (originalWindow === undefined) {
+      delete (globalThis as { window?: Window }).window;
+    } else {
+      Object.defineProperty(globalThis, 'window', {
+        value: originalWindow,
+        configurable: true,
+      });
+    }
     jest.useRealTimers();
   });
 

--- a/tests/unit/features/chat/ui/StatusPanel.test.ts
+++ b/tests/unit/features/chat/ui/StatusPanel.test.ts
@@ -14,12 +14,16 @@ type Listener = (event: any) => void;
 class MockClassList {
   private classes = new Set<string>();
 
+  constructor(private onChange: () => void = () => {}) {}
+
   add(...items: string[]): void {
     items.forEach((item) => this.classes.add(item));
+    this.onChange();
   }
 
   remove(...items: string[]): void {
     items.forEach((item) => this.classes.delete(item));
+    this.onChange();
   }
 
   contains(item: string): boolean {
@@ -37,6 +41,7 @@ class MockClassList {
       } else {
         this.classes.add(item);
       }
+      this.onChange();
       return;
     }
     if (force) {
@@ -44,10 +49,12 @@ class MockClassList {
     } else {
       this.classes.delete(item);
     }
+    this.onChange();
   }
 
   clear(): void {
     this.classes.clear();
+    this.onChange();
   }
 
   toArray(): string[] {
@@ -57,7 +64,7 @@ class MockClassList {
 
 class MockElement {
   tagName: string;
-  classList = new MockClassList();
+  classList: MockClassList;
   style: Record<string, string> = {};
   children: MockElement[] = [];
   attributes: Record<string, string> = {};
@@ -69,11 +76,13 @@ class MockElement {
 
   constructor(tagName: string) {
     this.tagName = tagName.toUpperCase();
+    this.classList = new MockClassList(() => this.syncDisplay());
   }
 
   set className(value: string) {
     this.classList.clear();
     value.split(/\s+/).filter(Boolean).forEach((cls) => this.classList.add(cls));
+    this.syncDisplay();
   }
 
   get className(): string {
@@ -96,6 +105,22 @@ class MockElement {
     child.parent = this;
     this.children.push(child);
     return child;
+  }
+
+  addClass(cls: string): void {
+    cls.split(/\s+/).filter(Boolean).forEach((item) => this.classList.add(item));
+  }
+
+  removeClass(cls: string): void {
+    cls.split(/\s+/).filter(Boolean).forEach((item) => this.classList.remove(item));
+  }
+
+  toggleClass(cls: string, force: boolean): void {
+    this.classList.toggle(cls, force);
+  }
+
+  hasClass(cls: string): boolean {
+    return this.classList.has(cls);
   }
 
   remove(): void {
@@ -147,6 +172,24 @@ class MockElement {
   empty(): void {
     this.children = [];
     this.textContent = '';
+  }
+
+  private syncDisplay(): void {
+    if (this.classList.has('claudian-hidden')) {
+      this.style.display = 'none';
+      return;
+    }
+    if (
+      this.classList.has('claudian-status-panel-todos')
+      || this.classList.has('claudian-status-panel-content')
+      || this.classList.has('claudian-status-panel-bash')
+      || this.classList.has('claudian-status-panel-bash-content')
+      || this.classList.has('claudian-tool-content')
+    ) {
+      this.style.display = 'block';
+      return;
+    }
+    this.style.display = '';
   }
 
   // Obsidian-style helper methods

--- a/tests/unit/features/inline-edit/InlineEditService.test.ts
+++ b/tests/unit/features/inline-edit/InlineEditService.test.ts
@@ -435,8 +435,8 @@ describe('InlineEditService', () => {
       });
 
       const options = getLastOptions();
-      expect(options?.maxThinkingTokens).toBeGreaterThan(0);
-      expect(options?.thinking).toBeUndefined();
+      expect(options?.thinking).toEqual({ type: 'enabled', budgetTokens: expect.any(Number) });
+      expect(options?.maxThinkingTokens).toBeUndefined();
     });
 
     it('should capture session ID for conversation continuity', async () => {

--- a/tests/unit/providers/claude/runtime/ClaudianService.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudianService.test.ts
@@ -1568,14 +1568,22 @@ describe('ClaudianService', () => {
       expect(mockPersistentQuery.setModel).not.toHaveBeenCalled();
     });
 
-    it('should update thinking tokens when changed', async () => {
-      // Initial budget is 0 (not a valid ThinkingBudget value) → tokens = null
-      // Change to 'high' → tokens = 16000 (different from null → triggers update)
+    it('should restart when fixed thinking tokens change', async () => {
+      (mockPlugin as any).settings.model = 'custom-model';
+      (service as any).currentConfig = (service as any).buildPersistentQueryConfig(
+        '/mock/vault/path',
+        '/usr/local/bin/claude',
+        [],
+      );
       (mockPlugin as any).settings.thinkingBudget = 'high';
+      const ensureReadySpy = jest.spyOn(service, 'ensureReady').mockResolvedValue(true);
 
       await (service as any).applyDynamicUpdates({});
 
-      expect(mockPersistentQuery.setMaxThinkingTokens).toHaveBeenCalledWith(16000);
+      expect(mockPersistentQuery.setMaxThinkingTokens).not.toHaveBeenCalled();
+      expect(ensureReadySpy).toHaveBeenCalledWith(
+        expect.objectContaining({ force: true }),
+      );
     });
 
     it('should update effort level when changed for adaptive models', async () => {
@@ -1613,11 +1621,10 @@ describe('ClaudianService', () => {
       (mockPlugin as any).settings.model = 'sonnet';
       (mockPlugin as any).settings.effortLevel = 'max';
 
+      const previousQuery = mockPersistentQuery;
       await (service as any).applyDynamicUpdates({});
 
-      expect(mockPersistentQuery.setModel).toHaveBeenCalledWith('sonnet');
-      expect(mockPersistentQuery.setMaxThinkingTokens).toHaveBeenCalledWith(null);
-      expect(mockPersistentQuery.applyFlagSettings).toHaveBeenCalledWith({ effortLevel: 'max' });
+      expect(previousQuery.setMaxThinkingTokens).not.toHaveBeenCalled();
       expect((service as any).currentConfig.thinkingTokens).toBeNull();
       expect((service as any).currentConfig.effortLevel).toBe('max');
     });
@@ -1638,10 +1645,10 @@ describe('ClaudianService', () => {
 
       (mockPlugin as any).settings.model = 'custom-model';
 
+      const previousQuery = mockPersistentQuery;
       await (service as any).applyDynamicUpdates({});
 
-      expect(mockPersistentQuery.setModel).toHaveBeenCalledWith('custom-model');
-      expect(mockPersistentQuery.setMaxThinkingTokens).toHaveBeenCalledWith(16000);
+      expect(previousQuery.setMaxThinkingTokens).not.toHaveBeenCalled();
       expect((service as any).currentConfig.thinkingTokens).toBe(16000);
       expect((service as any).currentConfig.effortLevel).toBeNull();
     });
@@ -1782,11 +1789,21 @@ describe('ClaudianService', () => {
       await expect((service as any).applyDynamicUpdates({ model: 'claude-3-opus' })).resolves.toBeUndefined();
     });
 
-    it('should silently handle thinking tokens update error', async () => {
-      (mockPlugin as any).settings.thinkingBudget = 5000;
-      mockPersistentQuery.setMaxThinkingTokens.mockRejectedValueOnce(new Error('Thinking error'));
+    it('should not dynamically update fixed thinking tokens', async () => {
+      (mockPlugin as any).settings.model = 'custom-model';
+      (service as any).currentConfig = (service as any).buildPersistentQueryConfig(
+        '/mock/vault/path',
+        '/usr/local/bin/claude',
+        [],
+      );
+      (mockPlugin as any).settings.thinkingBudget = 'high';
+      const ensureReadySpy = jest.spyOn(service, 'ensureReady').mockResolvedValue(true);
 
       await expect((service as any).applyDynamicUpdates({})).resolves.toBeUndefined();
+      expect(mockPersistentQuery.setMaxThinkingTokens).not.toHaveBeenCalled();
+      expect(ensureReadySpy).toHaveBeenCalledWith(
+        expect.objectContaining({ force: true }),
+      );
     });
 
     it('should silently handle permission mode update error', async () => {

--- a/tests/unit/providers/claude/runtime/QueryOptionsBuilder.test.ts
+++ b/tests/unit/providers/claude/runtime/QueryOptionsBuilder.test.ts
@@ -144,6 +144,12 @@ describe('QueryOptionsBuilder', () => {
       expect(QueryOptionsBuilder.needsRestart(currentConfig, newConfig)).toBe(false);
     });
 
+    it('returns true when fixed thinking tokens change', () => {
+      const currentConfig = createMockPersistentQueryConfig({ thinkingTokens: null });
+      const newConfig = { ...currentConfig, thinkingTokens: 16000 };
+      expect(QueryOptionsBuilder.needsRestart(currentConfig, newConfig)).toBe(true);
+    });
+
     it('returns false when only model changes (dynamic update)', () => {
       const currentConfig = createMockPersistentQueryConfig();
       const newConfig = { ...currentConfig, model: 'claude-opus-4-5' };
@@ -461,8 +467,8 @@ describe('QueryOptionsBuilder', () => {
       };
       const options = QueryOptionsBuilder.buildPersistentQueryOptions(ctx);
 
-      expect(options.maxThinkingTokens).toBe(16000);
-      expect(options.thinking).toBeUndefined();
+      expect(options.thinking).toEqual({ type: 'enabled', budgetTokens: 16000 });
+      expect(options.maxThinkingTokens).toBeUndefined();
     });
 
     it('sets resume session ID when provided', () => {

--- a/tests/unit/providers/claude/ui/ClaudeSettingsTab.test.ts
+++ b/tests/unit/providers/claude/ui/ClaudeSettingsTab.test.ts
@@ -138,6 +138,7 @@ interface MockInputEl {
   style: Record<string, string>;
   dataset: Record<string, string>;
   addClass: jest.Mock;
+  toggleClass: jest.Mock;
   addEventListener: jest.Mock;
 }
 
@@ -190,6 +191,7 @@ function createInputEl(): MockInputEl & { _listeners: Map<string, Array<() => vo
     style: {},
     dataset: {},
     addClass: jest.fn(),
+    toggleClass: jest.fn(),
     addEventListener: jest.fn((event: string, handler: () => void) => {
       const handlers = listeners.get(event) ?? [];
       handlers.push(handler);
@@ -272,6 +274,7 @@ function createToggleComponent(): MockToggleComponent {
 }
 
 function createElement(): any {
+  const classes = new Set<string>();
   const element: any = {
     value: '',
     style: {},
@@ -282,6 +285,41 @@ function createElement(): any {
     createSpan: jest.fn(() => createElement()),
     setText: jest.fn(),
     empty: jest.fn(),
+    addClass: jest.fn((cls: string) => {
+      cls.split(/\s+/).filter(Boolean).forEach((item) => classes.add(item));
+    }),
+    removeClass: jest.fn((cls: string) => {
+      cls.split(/\s+/).filter(Boolean).forEach((item) => classes.delete(item));
+    }),
+    toggleClass: jest.fn((cls: string, force: boolean) => {
+      if (force) {
+        classes.add(cls);
+      } else {
+        classes.delete(cls);
+      }
+    }),
+    hasClass: jest.fn((cls: string) => classes.has(cls)),
+    classList: {
+      add: jest.fn((cls: string) => classes.add(cls)),
+      remove: jest.fn((cls: string) => classes.delete(cls)),
+      toggle: jest.fn((cls: string, force?: boolean) => {
+        if (force === undefined) {
+          if (classes.has(cls)) {
+            classes.delete(cls);
+            return false;
+          }
+          classes.add(cls);
+          return true;
+        }
+        if (force) {
+          classes.add(cls);
+        } else {
+          classes.delete(cls);
+        }
+        return force;
+      }),
+      contains: jest.fn((cls: string) => classes.has(cls)),
+    },
   };
 
   return element;

--- a/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
+++ b/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
@@ -33,7 +33,12 @@ jest.mock('obsidian', () => {
     public textAreaComponents: MockTextAreaComponent[] = [];
     public dropdownComponents: MockDropdownComponent[] = [];
     public toggleComponents: MockToggleComponent[] = [];
-    public settingEl = { style: {} };
+    public settingEl = {
+      style: {},
+      toggleClass: jest.fn(),
+      addClass: jest.fn(),
+      removeClass: jest.fn(),
+    };
 
     constructor(_container: unknown) {
       createdSettings.push(this);
@@ -163,6 +168,7 @@ interface MockInputEl {
   value: string;
   style: Record<string, string>;
   addClass: jest.Mock;
+  toggleClass: jest.Mock;
   addEventListener: jest.Mock;
 }
 
@@ -174,6 +180,7 @@ function createInputEl(): MockInputEl & { _listeners: Map<string, Array<() => vo
     value: '',
     style: {},
     addClass: jest.fn(),
+    toggleClass: jest.fn(),
     addEventListener: jest.fn((event: string, handler: () => void) => {
       const handlers = listeners.get(event) ?? [];
       handlers.push(handler);
@@ -256,6 +263,7 @@ function createToggleComponent(): MockToggleComponent {
 }
 
 function createElement(): any {
+  const classes = new Set<string>();
   const element: any = {
     value: '',
     style: {},
@@ -265,6 +273,41 @@ function createElement(): any {
     createSpan: jest.fn(() => createElement()),
     setText: jest.fn(),
     empty: jest.fn(),
+    addClass: jest.fn((cls: string) => {
+      cls.split(/\s+/).filter(Boolean).forEach((item) => classes.add(item));
+    }),
+    removeClass: jest.fn((cls: string) => {
+      cls.split(/\s+/).filter(Boolean).forEach((item) => classes.delete(item));
+    }),
+    toggleClass: jest.fn((cls: string, force: boolean) => {
+      if (force) {
+        classes.add(cls);
+      } else {
+        classes.delete(cls);
+      }
+    }),
+    hasClass: jest.fn((cls: string) => classes.has(cls)),
+    classList: {
+      add: jest.fn((cls: string) => classes.add(cls)),
+      remove: jest.fn((cls: string) => classes.delete(cls)),
+      toggle: jest.fn((cls: string, force?: boolean) => {
+        if (force === undefined) {
+          if (classes.has(cls)) {
+            classes.delete(cls);
+            return false;
+          }
+          classes.add(cls);
+          return true;
+        }
+        if (force) {
+          classes.add(cls);
+        } else {
+          classes.delete(cls);
+        }
+        return force;
+      }),
+      contains: jest.fn((cls: string) => classes.has(cls)),
+    },
   };
 
   return element;

--- a/tests/unit/providers/opencode/OpencodeSettingsTab.test.ts
+++ b/tests/unit/providers/opencode/OpencodeSettingsTab.test.ts
@@ -115,6 +115,7 @@ interface MockTextComponent {
     value: string;
     style: Record<string, string>;
     addClass: jest.Mock;
+    toggleClass: jest.Mock;
   };
 }
 
@@ -151,6 +152,7 @@ function createTextComponent(): MockTextComponent {
     value: '',
     style: {},
     addClass: jest.fn(),
+    toggleClass: jest.fn(),
   };
   component.setPlaceholder = jest.fn((value: string) => {
     component.placeholder = value;
@@ -184,6 +186,7 @@ function createToggleComponent(): MockToggleComponent {
 }
 
 function createElement(): any {
+  const classes = new Set<string>();
   const element: any = {
     value: '',
     checked: false,
@@ -192,9 +195,40 @@ function createElement(): any {
     title: '',
     style: {},
     classList: {
-      add: jest.fn(),
-      toggle: jest.fn(),
+      add: jest.fn((cls: string) => classes.add(cls)),
+      remove: jest.fn((cls: string) => classes.delete(cls)),
+      toggle: jest.fn((cls: string, force?: boolean) => {
+        if (force === undefined) {
+          if (classes.has(cls)) {
+            classes.delete(cls);
+            return false;
+          }
+          classes.add(cls);
+          return true;
+        }
+        if (force) {
+          classes.add(cls);
+        } else {
+          classes.delete(cls);
+        }
+        return force;
+      }),
+      contains: jest.fn((cls: string) => classes.has(cls)),
     },
+    addClass: jest.fn((cls: string) => {
+      cls.split(/\s+/).filter(Boolean).forEach((item) => classes.add(item));
+    }),
+    removeClass: jest.fn((cls: string) => {
+      cls.split(/\s+/).filter(Boolean).forEach((item) => classes.delete(item));
+    }),
+    toggleClass: jest.fn((cls: string, force: boolean) => {
+      if (force) {
+        classes.add(cls);
+      } else {
+        classes.delete(cls);
+      }
+    }),
+    hasClass: jest.fn((cls: string) => classes.has(cls)),
     appendText: jest.fn(),
     setText: jest.fn((value: string) => {
       element.text = value;

--- a/tests/unit/shared/icons.test.ts
+++ b/tests/unit/shared/icons.test.ts
@@ -25,7 +25,7 @@ describe('createProviderIconSvg', () => {
     expect(path?.getAttribute('fill')).toBe('currentColor');
   });
 
-  it('renders markup-based provider icons with theme variants', () => {
+  it('renders composite provider icons with theme variants', () => {
     const svg = createProviderIconSvg(OPENCODE_PROVIDER_ICON, {
       dataProvider: 'opencode',
       height: 18,

--- a/tests/unit/shared/modals/InstructionConfirmModal.test.ts
+++ b/tests/unit/shared/modals/InstructionConfirmModal.test.ts
@@ -73,13 +73,13 @@ describe('InstructionModal', () => {
 
       const loadingEl = findByClass(contentEl, 'claudian-instruction-loading');
       expect(loadingEl).not.toBeNull();
-      expect(loadingEl.style.display).not.toBe('none');
+      expect(loadingEl.hasClass('claudian-hidden')).toBe(false);
 
       const clarificationEl = findByClass(contentEl, 'claudian-instruction-clarification-section');
-      expect(clarificationEl.style.display).toBe('none');
+      expect(clarificationEl.hasClass('claudian-hidden')).toBe(true);
 
       const confirmationEl = findByClass(contentEl, 'claudian-instruction-confirmation-section');
-      expect(confirmationEl.style.display).toBe('none');
+      expect(confirmationEl.hasClass('claudian-hidden')).toBe(true);
     });
 
     it('renders Cancel button in loading state', () => {
@@ -102,10 +102,10 @@ describe('InstructionModal', () => {
       modal.showClarification('What style do you want?');
 
       const loadingEl = findByClass(contentEl, 'claudian-instruction-loading');
-      expect(loadingEl.style.display).toBe('none');
+      expect(loadingEl.hasClass('claudian-hidden')).toBe(true);
 
       const clarificationEl = findByClass(contentEl, 'claudian-instruction-clarification-section');
-      expect(clarificationEl.style.display).toBe('block');
+      expect(clarificationEl.hasClass('claudian-hidden')).toBe(false);
     });
 
     it('displays the clarification text', () => {
@@ -142,10 +142,10 @@ describe('InstructionModal', () => {
       modal.showConfirmation('Refined instruction text');
 
       const loadingEl = findByClass(contentEl, 'claudian-instruction-loading');
-      expect(loadingEl.style.display).toBe('none');
+      expect(loadingEl.hasClass('claudian-hidden')).toBe(true);
 
       const confirmationEl = findByClass(contentEl, 'claudian-instruction-confirmation-section');
-      expect(confirmationEl.style.display).toBe('block');
+      expect(confirmationEl.hasClass('claudian-hidden')).toBe(false);
     });
 
     it('displays the refined instruction', () => {
@@ -296,10 +296,10 @@ describe('InstructionModal', () => {
       modal.showClarificationLoading();
 
       const loadingEl = findByClass(contentEl, 'claudian-instruction-loading');
-      expect(loadingEl.style.display).not.toBe('none');
+      expect(loadingEl.hasClass('claudian-hidden')).toBe(false);
 
       const clarificationEl = findByClass(contentEl, 'claudian-instruction-clarification-section');
-      expect(clarificationEl.style.display).toBe('none');
+      expect(clarificationEl.hasClass('claudian-hidden')).toBe(true);
     });
   });
 });

--- a/tests/unit/utils/fileLink.dom.test.ts
+++ b/tests/unit/utils/fileLink.dom.test.ts
@@ -13,10 +13,10 @@ function createMockApp(existingFiles: string[]) {
       }),
     },
     vault: {
-      getFileByPath: jest.fn((filePath: string) => {
-        if (fileSet.has(filePath.toLowerCase())) return { path: filePath };
+      getAbstractFileByPath: jest.fn((filePath: string) => {
+        if (fileSet.has(filePath.toLowerCase())) return { path: filePath, basename: filePath.replace(/\.md$/, '') };
         if (!filePath.endsWith('.md') && fileSet.has((filePath + '.md').toLowerCase())) {
-          return { path: filePath + '.md' };
+          return { path: filePath + '.md', basename: filePath };
         }
         return null;
       }),

--- a/tests/unit/utils/imageEmbed.test.ts
+++ b/tests/unit/utils/imageEmbed.test.ts
@@ -14,7 +14,7 @@ function createMockApp(files: Map<string, string> = new Map()): App {
 
   return {
     vault: {
-      getFileByPath: (path: string) => mockFiles.get(path) || null,
+      getAbstractFileByPath: (path: string) => mockFiles.get(path) || null,
       getResourcePath: (file: TFile) => files.get(file.path) || `app://local/${file.path}`,
     },
     metadataCache: {
@@ -336,7 +336,7 @@ describe('replaceImageEmbedsWithHtml', () => {
       const mockFile = { path: 'test.png', basename: 'test' } as TFile;
       const app = {
         vault: {
-          getFileByPath: () => mockFile,
+          getAbstractFileByPath: () => mockFile,
           getResourcePath: () => {
             throw new Error('Resource path failed');
           },

--- a/tests/unit/utils/obsidianCompat.test.ts
+++ b/tests/unit/utils/obsidianCompat.test.ts
@@ -1,0 +1,31 @@
+import type { Workspace, WorkspaceLeaf } from 'obsidian';
+
+import { focusWorkspaceLeaf } from '@/utils/obsidianCompat';
+
+describe('obsidianCompat', () => {
+  describe('focusWorkspaceLeaf', () => {
+    it('uses revealLeaf when the workspace supports it', () => {
+      const leaf = {} as WorkspaceLeaf;
+      const workspace = {
+        revealLeaf: jest.fn(),
+        setActiveLeaf: jest.fn(),
+      } as unknown as Workspace;
+
+      focusWorkspaceLeaf(workspace, leaf);
+
+      expect((workspace as unknown as { revealLeaf: jest.Mock }).revealLeaf).toHaveBeenCalledWith(leaf);
+      expect(workspace.setActiveLeaf).not.toHaveBeenCalled();
+    });
+
+    it('falls back to setActiveLeaf for older Obsidian versions', () => {
+      const leaf = {} as WorkspaceLeaf;
+      const workspace = {
+        setActiveLeaf: jest.fn(),
+      } as unknown as Workspace;
+
+      focusWorkspaceLeaf(workspace, leaf);
+
+      expect(workspace.setActiveLeaf).toHaveBeenCalledWith(leaf, { focus: true });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Raise the Obsidian minimum app version and README requirement to 1.7.2 for the APIs this plugin uses.
- Replace reviewed inline style and innerHTML patterns with CSS classes and DOM-safe SVG/icon construction while preserving existing UI behavior.
- Add compatibility helpers and tests for vault file lookup, focus behavior, validation state, and provider icons.

## Validation
- npm run typecheck
- npm run lint
- npm run test
- npm run build