### PR TITLE
Fix Obsidian review warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Open the chat sidebar from the ribbon icon or command palette. Select text and u
 
 - **Claude provider**: [Claude Code CLI](https://code.claude.com/docs/en/overview) installed (native install recommended). Claude subscription/API or compatible provider ([Openrouter](https://openrouter.ai/docs/guides/guides/claude-code-integration), [Kimi](https://platform.moonshot.ai/docs/guide/agent-support), etc.).
 - **Optional providers**: [Codex CLI](https://github.com/openai/codex), [Opencode](https://opencode.ai/).
-- Obsidian v1.4.5+
+- Obsidian v1.7.2+
 - Desktop only (macOS, Linux, Windows)
 
 ## Installation

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "realclaudian",
   "name": "Claudian",
   "version": "2.0.13",
-  "minAppVersion": "1.4.5",
+  "minAppVersion": "1.7.2",
   "description": "Embeds Claude Code/Codex as an AI collaborator in your vault. Your vault becomes agent's working directory, giving it full agentic capabilities: file read/write, search, bash commands, and multi-step workflows.",
   "author": "Yishen Tu",
   "authorUrl": "https://github.com/YishenTu",

--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -13,7 +13,7 @@ import type { Conversation, SlashCommand } from '../../../core/types';
 import { t } from '../../../i18n/i18n';
 import type ClaudianPlugin from '../../../main';
 import { chooseForkTarget } from '../../../shared/modals/ForkTargetModal';
-import { focusWorkspaceLeaf } from '../../../utils/obsidianCompat';
+import { revealWorkspaceLeaf } from '../../../utils/obsidianCompat';
 import { getTabProviderId } from './providerResolution';
 import {
   activateTab,
@@ -447,7 +447,7 @@ export class TabManager implements TabManagerInterface {
     const isSameView = crossViewResult?.view === this.view;
     if (crossViewResult && !isSameView) {
       // Focus the other view and switch to its tab instead of opening duplicate
-      focusWorkspaceLeaf(this.plugin.app.workspace, crossViewResult.view.leaf);
+      await revealWorkspaceLeaf(this.plugin.app.workspace, crossViewResult.view.leaf);
       await crossViewResult.view.getTabManager()?.switchToTab(crossViewResult.tabId);
       return;
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,7 +37,7 @@ import { setLocale } from './i18n/i18n';
 import type { Locale } from './i18n/types';
 import { OPENCODE_PLAN_MODE_ID, OPENCODE_SAFE_MODE_ID } from './providers/opencode/modes';
 import { buildCursorContext } from './utils/editor';
-import { focusWorkspaceLeaf } from './utils/obsidianCompat';
+import { revealWorkspaceLeaf } from './utils/obsidianCompat';
 import { getVaultPath } from './utils/path';
 
 function isClaudianView(value: unknown): value is ClaudianView {
@@ -204,7 +204,7 @@ export default class ClaudianPlugin extends Plugin {
     }
 
     if (leaf) {
-      focusWorkspaceLeaf(workspace, leaf);
+      await revealWorkspaceLeaf(workspace, leaf);
     }
   }
 

--- a/src/utils/obsidianCompat.ts
+++ b/src/utils/obsidianCompat.ts
@@ -8,14 +8,8 @@ export function getVaultFileByPath(app: App, filePath: string): TFile | null {
   return null;
 }
 
-export function focusWorkspaceLeaf(workspace: Workspace, leaf: WorkspaceLeaf): void {
-  const revealLeaf = (workspace as unknown as Record<string, unknown>)['revealLeaf'];
-  if (typeof revealLeaf === 'function') {
-    (revealLeaf as (leaf: WorkspaceLeaf) => void).call(workspace, leaf);
-    return;
-  }
-
-  workspace.setActiveLeaf(leaf, { focus: true });
+export async function revealWorkspaceLeaf(workspace: Workspace, leaf: WorkspaceLeaf): Promise<void> {
+  await workspace.revealLeaf(leaf);
 }
 
 function isVaultFile(value: unknown): value is TFile {

--- a/tests/unit/utils/obsidianCompat.test.ts
+++ b/tests/unit/utils/obsidianCompat.test.ts
@@ -1,31 +1,18 @@
 import type { Workspace, WorkspaceLeaf } from 'obsidian';
 
-import { focusWorkspaceLeaf } from '@/utils/obsidianCompat';
+import { revealWorkspaceLeaf } from '@/utils/obsidianCompat';
 
 describe('obsidianCompat', () => {
-  describe('focusWorkspaceLeaf', () => {
-    it('uses revealLeaf when the workspace supports it', () => {
+  describe('revealWorkspaceLeaf', () => {
+    it('reveals the workspace leaf', async () => {
       const leaf = {} as WorkspaceLeaf;
       const workspace = {
-        revealLeaf: jest.fn(),
-        setActiveLeaf: jest.fn(),
+        revealLeaf: jest.fn().mockResolvedValue(undefined),
       } as unknown as Workspace;
 
-      focusWorkspaceLeaf(workspace, leaf);
+      await revealWorkspaceLeaf(workspace, leaf);
 
       expect((workspace as unknown as { revealLeaf: jest.Mock }).revealLeaf).toHaveBeenCalledWith(leaf);
-      expect(workspace.setActiveLeaf).not.toHaveBeenCalled();
-    });
-
-    it('falls back to setActiveLeaf for older Obsidian versions', () => {
-      const leaf = {} as WorkspaceLeaf;
-      const workspace = {
-        setActiveLeaf: jest.fn(),
-      } as unknown as Workspace;
-
-      focusWorkspaceLeaf(workspace, leaf);
-
-      expect(workspace.setActiveLeaf).toHaveBeenCalledWith(leaf, { focus: true });
     });
   });
 });


### PR DESCRIPTION
## Summary

- Resolve the follow-up review warnings from the Obsidian/Claude runtime warning pass.
- Require Obsidian 1.7.2 and use `Workspace.revealLeaf()` directly for sidebar reveal behavior.
- Replace deprecated Claude thinking-token source usage with provider-owned `thinking` options and restart-required handling for fixed budgets.
- Add explicit CodeMirror dependencies, wrap targeted async UI handlers, improve popout-window timer/RAF usage, and safely stringify provider/tool payload values.

## Verification

- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run test`
- `npm run build`
