### PR TITLE
Add configurable chat send shortcut

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -135,6 +135,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -634,6 +635,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
       "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -643,6 +645,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
       "integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
@@ -738,6 +741,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -761,6 +765,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2765,6 +2770,7 @@
       "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.59.3",
@@ -2794,6 +2800,7 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -3287,6 +3294,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3794,6 +3802,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4760,6 +4769,7 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5322,6 +5332,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5866,6 +5877,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6528,6 +6540,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
       "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7303,6 +7316,7 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -7935,6 +7949,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -8869,6 +8884,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10982,6 +10998,7 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11670,6 +11687,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/settings/defaultSettings.ts
+++ b/src/app/settings/defaultSettings.ts
@@ -28,6 +28,7 @@ export const DEFAULT_CLAUDIAN_SETTINGS: ClaudianSettings = {
     scrollDownKey: 's',
     focusInputKey: 'i',
   },
+  requireCommandOrControlEnterToSend: false,
 
   locale: 'en',
 

--- a/src/core/types/settings.ts
+++ b/src/core/types/settings.ts
@@ -119,6 +119,7 @@ export interface ClaudianSettings {
 
   // UI settings
   keyboardNavigation: KeyboardNavigationSettings;
+  requireCommandOrControlEnterToSend: boolean;
 
   // Internationalization
   locale: string;

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -1,5 +1,5 @@
 import type { Component } from 'obsidian';
-import { Notice } from 'obsidian';
+import { Notice, Platform } from 'obsidian';
 
 import { getHiddenProviderCommandSet } from '../../../core/providers/commands/hiddenCommands';
 import type { ProviderCommandDropdownConfig } from '../../../core/providers/commands/ProviderCommandCatalog';
@@ -20,7 +20,7 @@ import {
 import type { ChatRuntime } from '../../../core/runtime/ChatRuntime';
 import type { AutoTurnResult } from '../../../core/runtime/types';
 import { TOOL_AGENT_OUTPUT } from '../../../core/tools/toolNames';
-import type { ChatMessage, Conversation, StreamChunk } from '../../../core/types';
+import type { ChatMessage, ClaudianSettings, Conversation, StreamChunk } from '../../../core/types';
 import { t } from '../../../i18n/i18n';
 import type ClaudianPlugin from '../../../main';
 import { SlashCommandDropdown } from '../../../shared/components/SlashCommandDropdown';
@@ -167,6 +167,25 @@ function getTabHiddenCommands(
     plugin.settings,
     getTabProviderId(tab, plugin, conversation),
   );
+}
+
+function shouldSendMessageFromEnterKey(
+  e: KeyboardEvent,
+  settings: Pick<ClaudianSettings, 'requireCommandOrControlEnterToSend'>,
+): boolean {
+  if (e.key !== 'Enter' || e.shiftKey || e.isComposing) {
+    return false;
+  }
+
+  if (settings.requireCommandOrControlEnterToSend !== true) {
+    return true;
+  }
+
+  if (Platform.isMacOS) {
+    return e.metaKey === true && !e.ctrlKey && !e.altKey;
+  }
+
+  return e.ctrlKey === true && !e.metaKey && !e.altKey;
 }
 
 type ProviderCatalogInfo = {
@@ -1462,7 +1481,7 @@ export function wireTabInputEvents(tab: TabData, plugin: ClaudianPlugin): void {
       return;
     }
 
-    if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
+    if (shouldSendMessageFromEnterKey(e, plugin.settings)) {
       e.preventDefault();
       void controllers.inputController?.sendMessage();
     }

--- a/src/features/settings/ClaudianSettings.ts
+++ b/src/features/settings/ClaudianSettings.ts
@@ -413,6 +413,18 @@ export class ClaudianSettingTab extends PluginSettingTab {
     new Setting(container).setName(t('settings.input')).setHeading();
 
     new Setting(container)
+      .setName(t('settings.requireCommandOrControlEnterToSend.name'))
+      .setDesc(t('settings.requireCommandOrControlEnterToSend.desc'))
+      .addToggle((toggle) => {
+        toggle
+          .setValue(this.plugin.settings.requireCommandOrControlEnterToSend ?? false)
+          .onChange(async (value) => {
+            this.plugin.settings.requireCommandOrControlEnterToSend = value;
+            await this.plugin.saveSettings();
+          });
+      });
+
+    new Setting(container)
       .setName(t('settings.navMappings.name'))
       .setDesc(t('settings.navMappings.desc'))
       .addTextArea((text) => {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -107,6 +107,10 @@
       "name": "Vim-Style Navigationszuordnungen",
       "desc": "Eine Zuordnung pro Zeile. Format: \"map <Taste> <Aktion>\" (Aktionen: scrollUp, scrollDown, focusInput)."
     },
+    "requireCommandOrControlEnterToSend": {
+      "name": "Command/Ctrl+Enter zum Senden erfordern",
+      "desc": "Wenn aktiviert, fügt Enter einen Zeilenumbruch ein. Command+Enter sendet unter macOS; Ctrl+Enter sendet unter Windows und Linux."
+    },
     "hotkeys": "Tastenkürzel",
     "inlineEditHotkey": {
       "name": "Inline-Bearbeitung",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -107,6 +107,10 @@
       "name": "Vim-style navigation mappings",
       "desc": "One mapping per line. Format: \"map <key> <action>\" (actions: scrollUp, scrollDown, focusInput)."
     },
+    "requireCommandOrControlEnterToSend": {
+      "name": "Require Command/Ctrl+Enter to send",
+      "desc": "When enabled, Enter inserts a newline. Command+Enter sends on macOS; Ctrl+Enter sends on Windows and Linux."
+    },
     "hotkeys": "Hotkeys",
     "inlineEditHotkey": {
       "name": "Inline Edit",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -107,6 +107,10 @@
       "name": "Mapeos de navegación estilo Vim",
       "desc": "Un mapeo por línea. Formato: \"map <tecla> <acción>\" (acciones: scrollUp, scrollDown, focusInput)."
     },
+    "requireCommandOrControlEnterToSend": {
+      "name": "Requerir Command/Ctrl+Enter para enviar",
+      "desc": "Cuando está activado, Enter inserta un salto de línea. Command+Enter envía en macOS; Ctrl+Enter envía en Windows y Linux."
+    },
     "hotkeys": "Atajos de teclado",
     "inlineEditHotkey": {
       "name": "Edición en línea",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -107,6 +107,10 @@
       "name": "Mappages de navigation style Vim",
       "desc": "Un mappage par ligne. Format : \"map <touche> <action>\" (actions : scrollUp, scrollDown, focusInput)."
     },
+    "requireCommandOrControlEnterToSend": {
+      "name": "Exiger Command/Ctrl+Entrée pour envoyer",
+      "desc": "Lorsque cette option est activée, Entrée insère une nouvelle ligne. Command+Entrée envoie sur macOS ; Ctrl+Entrée envoie sur Windows et Linux."
+    },
     "hotkeys": "Raccourcis clavier",
     "inlineEditHotkey": {
       "name": "Édition en ligne",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -107,6 +107,10 @@
       "name": "Vimスタイルナビゲーションマッピング",
       "desc": "1行に1つのマッピング。形式：\"map <キー> <アクション>\"（アクション：scrollUp, scrollDown, focusInput）。"
     },
+    "requireCommandOrControlEnterToSend": {
+      "name": "送信に Command/Ctrl+Enter を必須にする",
+      "desc": "有効にすると、Enter は改行を挿入します。macOS では Command+Enter、Windows と Linux では Ctrl+Enter で送信します。"
+    },
     "hotkeys": "ホットキー",
     "inlineEditHotkey": {
       "name": "インライン編集",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -107,6 +107,10 @@
       "name": "Vim 스타일 네비게이션 매핑",
       "desc": "한 줄에 하나의 매핑. 형식: \"map <키> <동작>\" (동작: scrollUp, scrollDown, focusInput)."
     },
+    "requireCommandOrControlEnterToSend": {
+      "name": "Command/Ctrl+Enter로 보내기 필수",
+      "desc": "활성화하면 Enter는 줄바꿈을 삽입합니다. macOS에서는 Command+Enter, Windows와 Linux에서는 Ctrl+Enter로 보냅니다."
+    },
     "hotkeys": "단축키",
     "inlineEditHotkey": {
       "name": "인라인 편집",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -107,6 +107,10 @@
       "name": "Mapeamentos de navegação estilo Vim",
       "desc": "Um mapeamento por linha. Formato: \"map <tecla> <ação>\" (ações: scrollUp, scrollDown, focusInput)."
     },
+    "requireCommandOrControlEnterToSend": {
+      "name": "Exigir Command/Ctrl+Enter para enviar",
+      "desc": "Quando ativado, Enter insere uma quebra de linha. Command+Enter envia no macOS; Ctrl+Enter envia no Windows e Linux."
+    },
     "hotkeys": "Atalhos",
     "inlineEditHotkey": {
       "name": "Edição em linha",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -107,6 +107,10 @@
       "name": "Сопоставления навигации в стиле Vim",
       "desc": "По одному сопоставлению в строке. Формат: \"map <ключ> <действие>\" (действия: scrollUp, scrollDown, focusInput)."
     },
+    "requireCommandOrControlEnterToSend": {
+      "name": "Требовать Command/Ctrl+Enter для отправки",
+      "desc": "Если включено, Enter вставляет новую строку. Command+Enter отправляет на macOS; Ctrl+Enter отправляет на Windows и Linux."
+    },
     "hotkeys": "Горячие клавиши",
     "inlineEditHotkey": {
       "name": "Инлайн-редактирование",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -107,6 +107,10 @@
       "name": "Vim 风格导航映射",
       "desc": "每行一个映射。格式：\"map <键> <动作>\"（动作：scrollUp, scrollDown, focusInput）。"
     },
+    "requireCommandOrControlEnterToSend": {
+      "name": "需要 Command/Ctrl+Enter 发送",
+      "desc": "启用后，Enter 会插入换行。macOS 使用 Command+Enter 发送；Windows 和 Linux 使用 Ctrl+Enter 发送。"
+    },
     "hotkeys": "快捷键",
     "inlineEditHotkey": {
       "name": "内联编辑",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -107,6 +107,10 @@
       "name": "Vim 風格導航映射",
       "desc": "每行一個映射。格式：\"map <鍵> <動作>\"（動作：scrollUp, scrollDown, focusInput）。"
     },
+    "requireCommandOrControlEnterToSend": {
+      "name": "需要 Command/Ctrl+Enter 才能傳送",
+      "desc": "啟用後，Enter 會插入換行。macOS 使用 Command+Enter 傳送；Windows 和 Linux 使用 Ctrl+Enter 傳送。"
+    },
     "hotkeys": "快捷鍵",
     "inlineEditHotkey": {
       "name": "內嵌編輯",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -86,6 +86,8 @@ export type TranslationKey =
   | 'settings.titleModel.auto'
   | 'settings.navMappings.name'
   | 'settings.navMappings.desc'
+  | 'settings.requireCommandOrControlEnterToSend.name'
+  | 'settings.requireCommandOrControlEnterToSend.desc'
 
   // Settings - Hotkeys
   | 'settings.hotkeys'

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -1,7 +1,7 @@
 import '@/providers';
 
 import { createMockEl } from '@test/helpers/mockElement';
-import { Notice } from 'obsidian';
+import { Notice, Platform } from 'obsidian';
 
 import { ProviderRegistry } from '@/core/providers/ProviderRegistry';
 import { ProviderWorkspaceRegistry } from '@/core/providers/ProviderWorkspaceRegistry';
@@ -1891,6 +1891,7 @@ describe('Tab - Controller Initialization', () => {
 describe('Tab - Event Handler Behavior', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    Platform.isMacOS = true;
     mockFileContextManager = createMockFileContextManager();
     mockSlashCommandDropdown = createMockSlashCommandDropdown();
     mockInstructionModeManager = createMockInstructionModeManager();
@@ -2107,6 +2108,56 @@ describe('Tab - Event Handler Behavior', () => {
 
       expect(event.preventDefault).not.toHaveBeenCalled();
       expect(mockInputController.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('should require Command+Enter on macOS when the send shortcut setting is enabled', () => {
+      mockInstructionModeManager.handleTriggerKey.mockReturnValue(false);
+      mockInstructionModeManager.handleKeydown.mockReturnValue(false);
+      mockSlashCommandDropdown.handleKeydown.mockReturnValue(false);
+      mockFileContextManager.handleMentionKeydown.mockReturnValue(false);
+      const { options, fireKeydown } = setupKeydownTab();
+      Platform.isMacOS = true;
+      options.plugin.settings.requireCommandOrControlEnterToSend = true;
+
+      const enterEvent = { key: 'Enter', shiftKey: false, ctrlKey: false, metaKey: false, isComposing: false, preventDefault: jest.fn() };
+      fireKeydown(enterEvent);
+
+      expect(enterEvent.preventDefault).not.toHaveBeenCalled();
+      expect(mockInputController.sendMessage).not.toHaveBeenCalled();
+
+      const controlEnterEvent = { key: 'Enter', shiftKey: false, ctrlKey: true, metaKey: false, isComposing: false, preventDefault: jest.fn() };
+      fireKeydown(controlEnterEvent);
+
+      expect(controlEnterEvent.preventDefault).not.toHaveBeenCalled();
+      expect(mockInputController.sendMessage).not.toHaveBeenCalled();
+
+      const commandEnterEvent = { key: 'Enter', shiftKey: false, ctrlKey: false, metaKey: true, isComposing: false, preventDefault: jest.fn() };
+      fireKeydown(commandEnterEvent);
+
+      expect(commandEnterEvent.preventDefault).toHaveBeenCalled();
+      expect(mockInputController.sendMessage).toHaveBeenCalled();
+    });
+
+    it('should require Ctrl+Enter off macOS when the send shortcut setting is enabled', () => {
+      mockInstructionModeManager.handleTriggerKey.mockReturnValue(false);
+      mockInstructionModeManager.handleKeydown.mockReturnValue(false);
+      mockSlashCommandDropdown.handleKeydown.mockReturnValue(false);
+      mockFileContextManager.handleMentionKeydown.mockReturnValue(false);
+      const { options, fireKeydown } = setupKeydownTab();
+      Platform.isMacOS = false;
+      options.plugin.settings.requireCommandOrControlEnterToSend = true;
+
+      const commandEnterEvent = { key: 'Enter', shiftKey: false, ctrlKey: false, metaKey: true, isComposing: false, preventDefault: jest.fn() };
+      fireKeydown(commandEnterEvent);
+
+      expect(commandEnterEvent.preventDefault).not.toHaveBeenCalled();
+      expect(mockInputController.sendMessage).not.toHaveBeenCalled();
+
+      const controlEnterEvent = { key: 'Enter', shiftKey: false, ctrlKey: true, metaKey: false, isComposing: false, preventDefault: jest.fn() };
+      fireKeydown(controlEnterEvent);
+
+      expect(controlEnterEvent.preventDefault).toHaveBeenCalled();
+      expect(mockInputController.sendMessage).toHaveBeenCalled();
     });
 
     it('should not send message on Enter when isComposing (IME)', () => {

--- a/tests/unit/i18n/locales.test.ts
+++ b/tests/unit/i18n/locales.test.ts
@@ -69,6 +69,8 @@ const localizedKeys = [
   'settings.enableBangBash.name',
   'settings.enableBangBash.desc',
   'settings.enableBangBash.validation.noNode',
+  'settings.requireCommandOrControlEnterToSend.name',
+  'settings.requireCommandOrControlEnterToSend.desc',
 ] as const;
 
 const staleBangBashDesc =

--- a/tests/unit/providers/claude/storage/ClaudianSettingsStorage.test.ts
+++ b/tests/unit/providers/claude/storage/ClaudianSettingsStorage.test.ts
@@ -44,6 +44,7 @@ describe('ClaudianSettingsStorage', () => {
       expect(result.model).toBe(DEFAULT_SETTINGS.model);
       expect(result.thinkingBudget).toBe(DEFAULT_SETTINGS.thinkingBudget);
       expect(result.permissionMode).toBe(DEFAULT_SETTINGS.permissionMode);
+      expect(result.requireCommandOrControlEnterToSend).toBe(false);
       expect(mockAdapter.read).not.toHaveBeenCalled();
     });
 

--- a/tests/unit/providers/claude/types/types.test.ts
+++ b/tests/unit/providers/claude/types/types.test.ts
@@ -82,6 +82,7 @@ describe('types.ts', () => {
 
         persistentExternalContextPaths: [],
         keyboardNavigation: { scrollUpKey: 'w', scrollDownKey: 's', focusInputKey: 'i' },
+        requireCommandOrControlEnterToSend: false,
         locale: 'en',
         providerConfigs: {},
         claudeCliPath: '',
@@ -134,6 +135,7 @@ describe('types.ts', () => {
 
         persistentExternalContextPaths: [],
         keyboardNavigation: { scrollUpKey: 'w', scrollDownKey: 's', focusInputKey: 'i' },
+        requireCommandOrControlEnterToSend: false,
         locale: 'zh-CN',
         providerConfigs: {},
         claudeCliPath: '',
@@ -187,6 +189,7 @@ describe('types.ts', () => {
 
         persistentExternalContextPaths: [],
         keyboardNavigation: { scrollUpKey: 'w', scrollDownKey: 's', focusInputKey: 'i' },
+        requireCommandOrControlEnterToSend: true,
         locale: 'en',
         providerConfigs: {},
         claudeCliPath: '',


### PR DESCRIPTION
## Summary
- add an opt-in setting that makes Enter insert a newline in chat input
- send with Command+Enter on macOS and Ctrl+Enter on Windows/Linux when enabled
- localize the new setting and cover shortcut behavior across platforms

## Tests
- npm run test -- tests/unit/features/chat/tabs/Tab.test.ts --runInBand
- npm run test -- tests/unit/i18n/locales.test.ts --runInBand
- npm run test -- tests/unit/providers/claude/storage/ClaudianSettingsStorage.test.ts --runInBand
- npm run test -- tests/unit/providers/claude/types/types.test.ts --runInBand
- npm run typecheck
- npm run lint
- npm run test
- npm run build

Related: #640, #361