### PR TITLE
Fix title generation model routing

### DIFF
--- a/src/core/CLAUDE.md
+++ b/src/core/CLAUDE.md
@@ -50,10 +50,13 @@ for await (const chunk of runtime.query(preparedTurn, history)) {
 ### Provider Factories
 
 ```typescript
-const titleService = ProviderRegistry.createTitleGenerationService(plugin, providerId);
+const titleService = ProviderRegistry.createTitleGenerationService(plugin);
 const refineService = ProviderRegistry.createInstructionRefineService(plugin, providerId);
 const inlineEditService = ProviderRegistry.createInlineEditService(plugin, providerId);
 ```
+
+Title generation is provider-routed by the global `titleGenerationModel` setting.
+It is intentionally independent from the active chat tab provider.
 
 ### Workspace Services
 

--- a/src/core/providers/ProviderRegistry.ts
+++ b/src/core/providers/ProviderRegistry.ts
@@ -13,6 +13,7 @@ import {
   type ProviderSettingsReconciler,
   type ProviderSubagentLifecycleAdapter,
   type ProviderTaskResultInterpreter,
+  type TitleGenerationCallback,
   type TitleGenerationService,
 } from './types';
 
@@ -46,8 +47,25 @@ export class ProviderRegistry {
     return this.getProviderRegistration(providerId).createRuntime(options);
   }
 
-  static createTitleGenerationService(plugin: ClaudianPlugin, providerId: ProviderId = DEFAULT_CHAT_PROVIDER_ID): TitleGenerationService {
+  static createTitleGenerationService(plugin: ClaudianPlugin, providerId?: ProviderId): TitleGenerationService {
+    if (!providerId) {
+      return new RoutedTitleGenerationService(plugin);
+    }
     return this.getProviderRegistration(providerId).createTitleGenerationService(plugin);
+  }
+
+  static resolveTitleGenerationProviderId(settings: Record<string, unknown>): ProviderId {
+    const titleModel = typeof settings.titleGenerationModel === 'string'
+      ? settings.titleGenerationModel.trim()
+      : '';
+
+    if (!titleModel) {
+      return DEFAULT_CHAT_PROVIDER_ID;
+    }
+
+    return this.resolveProviderForModel(titleModel, settings, {
+      fallbackProviderId: DEFAULT_CHAT_PROVIDER_ID,
+    });
   }
 
   static createInstructionRefineService(plugin: ClaudianPlugin, providerId: ProviderId = DEFAULT_CHAT_PROVIDER_ID): InstructionRefineService {
@@ -172,5 +190,54 @@ export class ProviderRegistry {
       }
     }
     return ids;
+  }
+}
+
+interface ActiveTitleGeneration {
+  service: TitleGenerationService;
+}
+
+class RoutedTitleGenerationService implements TitleGenerationService {
+  private readonly activeGenerations = new Map<string, ActiveTitleGeneration>();
+
+  constructor(private readonly plugin: ClaudianPlugin) {}
+
+  async generateTitle(
+    conversationId: string,
+    userMessage: string,
+    callback: TitleGenerationCallback,
+  ): Promise<void> {
+    const providerId = ProviderRegistry.resolveTitleGenerationProviderId(
+      this.plugin.settings as unknown as Record<string, unknown>,
+    );
+    const service = ProviderRegistry.createTitleGenerationService(this.plugin, providerId);
+    const generation = { service };
+    const previous = this.activeGenerations.get(conversationId);
+
+    this.activeGenerations.set(conversationId, generation);
+    previous?.service.cancel();
+
+    try {
+      await service.generateTitle(conversationId, userMessage, async (convId, result) => {
+        if (this.activeGenerations.get(conversationId) !== generation) {
+          return;
+        }
+        await callback(convId, result);
+      });
+    } finally {
+      if (this.activeGenerations.get(conversationId) === generation) {
+        this.activeGenerations.delete(conversationId);
+      }
+    }
+  }
+
+  cancel(): void {
+    const services = new Set<TitleGenerationService>(
+      [...this.activeGenerations.values()].map(generation => generation.service),
+    );
+    this.activeGenerations.clear();
+    for (const service of services) {
+      service.cancel();
+    }
   }
 }

--- a/src/features/chat/CLAUDE.md
+++ b/src/features/chat/CLAUDE.md
@@ -122,7 +122,7 @@ for await (const chunk of runtime.query(preparedTurn, history)) {
 
 - `ClaudianView.onClose()` must abort active tabs and dispose runtimes
 - `ChatState` is per-tab; `TabManager` coordinates tab-level operations such as fork targets and provider-aware command catalogs
-- Title generation runs concurrently per conversation
+- Title generation runs concurrently per conversation and routes by the global title-generation model selection, not by the active chat tab provider
 - `/compact`
   - Claude skips context injection so the provider recognizes the built-in command and persists the compaction boundary
   - Codex routes compact turns to `thread/compact/start` and persists the durable `context_compacted` boundary from JSONL history

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -298,12 +298,16 @@ function syncTabProviderServices(
 ): void {
   tab.services.instructionRefineService?.cancel();
   tab.services.instructionRefineService?.resetConversation();
-  tab.services.titleGenerationService?.cancel();
   tab.services.instructionRefineService = ProviderRegistry.createInstructionRefineService(plugin, tab.providerId);
-  tab.services.titleGenerationService = ProviderRegistry.createTitleGenerationService(plugin, tab.providerId);
   tab.services.subagentManager.setTaskResultInterpreter?.(
     ProviderRegistry.getTaskResultInterpreter(tab.providerId)
   );
+}
+
+function ensureTitleGenerationService(tab: TabData, plugin: ClaudianPlugin): void {
+  if (!tab.services.titleGenerationService) {
+    tab.services.titleGenerationService = ProviderRegistry.createTitleGenerationService(plugin);
+  }
 }
 
 function cleanupTabRuntime(tab: TabData): void {
@@ -701,6 +705,7 @@ function initializeInstructionAndTodo(tab: TabData, plugin: ClaudianPlugin): voi
   const { dom } = tab;
 
   syncTabProviderServices(tab, plugin);
+  ensureTitleGenerationService(tab, plugin);
   tab.ui.instructionModeManager = new InstructionModeManagerClass(
     dom.inputEl,
     {

--- a/src/providers/claude/auxiliary/ClaudeTitleGenerationService.ts
+++ b/src/providers/claude/auxiliary/ClaudeTitleGenerationService.ts
@@ -6,6 +6,7 @@ import type {
 import type ClaudianPlugin from '../../../main';
 import { parseEnvironmentVariables } from '../../../utils/env';
 import { runColdStartQuery } from '../runtime/claudeColdStartQuery';
+import { claudeChatUIConfig } from '../ui/ClaudeChatUIConfig';
 
 export type { TitleGenerationResult };
 
@@ -73,8 +74,15 @@ export class TitleGenerationService {
     const envVars = parseEnvironmentVariables(
       this.plugin.getActiveEnvironmentVariables('claude')
     );
+    const titleModel = this.plugin.settings.titleGenerationModel;
+    if (titleModel && claudeChatUIConfig.ownsModel(
+      titleModel,
+      this.plugin.settings as unknown as Record<string, unknown>,
+    )) {
+      return titleModel;
+    }
+
     return (
-      this.plugin.settings.titleGenerationModel ||
       envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL ||
       'claude-haiku-4-5'
     );

--- a/tests/unit/core/providers/ProviderRegistry.test.ts
+++ b/tests/unit/core/providers/ProviderRegistry.test.ts
@@ -2,6 +2,13 @@ import '@/providers';
 
 import { ProviderRegistry } from '@/core/providers/ProviderRegistry';
 import { ProviderWorkspaceRegistry } from '@/core/providers/ProviderWorkspaceRegistry';
+import type {
+  ProviderId,
+  TitleGenerationCallback,
+  TitleGenerationResult,
+  TitleGenerationService,
+} from '@/core/providers/types';
+import { DEFAULT_CODEX_PRIMARY_MODEL } from '@/providers/codex/types/models';
 
 describe('ProviderRegistry', () => {
   beforeEach(() => {
@@ -10,6 +17,10 @@ describe('ProviderRegistry', () => {
       mcpManager: {} as any,
       mcpServerManager: {} as any,
     } as any);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('creates a runtime with the default provider id', () => {
@@ -108,4 +119,140 @@ describe('ProviderRegistry', () => {
     expect(ProviderRegistry.getProviderDisplayName('claude')).toBe('Claude');
     expect(ProviderRegistry.getProviderDisplayName('codex')).toBe('Codex');
   });
+
+  it('routes auto title generation to Claude independently of chat provider state', async () => {
+    const providerCalls: ProviderId[] = [];
+    const originalCreate = ProviderRegistry.createTitleGenerationService.bind(ProviderRegistry);
+    jest.spyOn(ProviderRegistry, 'createTitleGenerationService')
+      .mockImplementation((plugin: any, providerId?: ProviderId) => {
+        if (!providerId) {
+          return originalCreate(plugin);
+        }
+        providerCalls.push(providerId);
+        return createMockTitleService(providerId);
+      });
+
+    const service = ProviderRegistry.createTitleGenerationService({
+      settings: {
+        titleGenerationModel: '',
+        providerConfigs: {
+          codex: { enabled: true },
+        },
+      },
+    } as any);
+    const callback = jest.fn();
+
+    await service.generateTitle('conv-1', 'hello', callback);
+
+    expect(providerCalls).toEqual(['claude']);
+    expect(callback).toHaveBeenCalledWith('conv-1', {
+      success: true,
+      title: 'claude title',
+    });
+  });
+
+  it('routes explicit title model selections to the owning provider', async () => {
+    const providerCalls: ProviderId[] = [];
+    const originalCreate = ProviderRegistry.createTitleGenerationService.bind(ProviderRegistry);
+    jest.spyOn(ProviderRegistry, 'createTitleGenerationService')
+      .mockImplementation((plugin: any, providerId?: ProviderId) => {
+        if (!providerId) {
+          return originalCreate(plugin);
+        }
+        providerCalls.push(providerId);
+        return createMockTitleService(providerId);
+      });
+
+    const service = ProviderRegistry.createTitleGenerationService({
+      settings: {
+        titleGenerationModel: DEFAULT_CODEX_PRIMARY_MODEL,
+        providerConfigs: {
+          codex: { enabled: true },
+        },
+      },
+    } as any);
+    const callback = jest.fn();
+
+    await service.generateTitle('conv-1', 'hello', callback);
+
+    expect(providerCalls).toEqual(['codex']);
+    expect(callback).toHaveBeenCalledWith('conv-1', {
+      success: true,
+      title: 'codex title',
+    });
+  });
+
+  it('suppresses stale callbacks when a newer title generation replaces the old one', async () => {
+    const originalCreate = ProviderRegistry.createTitleGenerationService.bind(ProviderRegistry);
+    const claudeService = createDeferredTitleService();
+    const codexService = createMockTitleService('codex');
+
+    jest.spyOn(ProviderRegistry, 'createTitleGenerationService')
+      .mockImplementation((plugin: any, providerId?: ProviderId) => {
+        if (!providerId) {
+          return originalCreate(plugin);
+        }
+        return providerId === 'claude' ? claudeService : codexService;
+      });
+
+    const plugin = {
+      settings: {
+        titleGenerationModel: 'sonnet',
+        providerConfigs: {
+          codex: { enabled: true },
+        },
+      },
+    } as any;
+    const service = ProviderRegistry.createTitleGenerationService(plugin);
+    const callback = jest.fn();
+
+    const first = service.generateTitle('conv-1', 'first', callback);
+    plugin.settings.titleGenerationModel = DEFAULT_CODEX_PRIMARY_MODEL;
+    await service.generateTitle('conv-1', 'second', callback);
+    await claudeService.resolve({ success: true, title: 'stale title' });
+    await first;
+
+    expect(claudeService.cancel).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith('conv-1', {
+      success: true,
+      title: 'codex title',
+    });
+  });
 });
+
+function createMockTitleService(providerId: ProviderId): TitleGenerationService {
+  return {
+    cancel: jest.fn(),
+    generateTitle: jest.fn(async (conversationId, _userMessage, callback) => {
+      await callback(conversationId, {
+        success: true,
+        title: `${providerId} title`,
+      });
+    }),
+  };
+}
+
+function createDeferredTitleService(): TitleGenerationService & {
+  resolve: (result: TitleGenerationResult) => Promise<void>;
+} {
+  let callback: TitleGenerationCallback | null = null;
+  let conversationId = '';
+  let resolvePromise: (() => void) | null = null;
+  const done = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  return {
+    cancel: jest.fn(),
+    generateTitle: jest.fn(async (nextConversationId, _userMessage, nextCallback) => {
+      conversationId = nextConversationId;
+      callback = nextCallback;
+      await done;
+    }),
+    resolve: async (result) => {
+      await callback?.(conversationId, result);
+      resolvePromise?.();
+    },
+  };
+}

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -923,7 +923,7 @@ describe('Tab - Service Initialization', () => {
       expect(mockSlashCommandDropdown.resetSdkSkillsCache).toHaveBeenCalled();
     });
 
-    it('rebinds blank-tab helper services when a newly enabled provider takes over the draft model', () => {
+    it('rebinds provider-scoped helper services when a newly enabled provider takes over the draft model', () => {
       const createInstructionRefineServiceSpy = jest.spyOn(ProviderRegistry, 'createInstructionRefineService')
         .mockReturnValue({ cancel: jest.fn(), resetConversation: jest.fn() } as any);
       const createTitleGenerationServiceSpy = jest.spyOn(ProviderRegistry, 'createTitleGenerationService')
@@ -959,7 +959,7 @@ describe('Tab - Service Initialization', () => {
 
       expect(tab.providerId).toBe('codex');
       expect(createInstructionRefineServiceSpy).toHaveBeenLastCalledWith(plugin, 'codex');
-      expect(createTitleGenerationServiceSpy).toHaveBeenLastCalledWith(plugin, 'codex');
+      expect(createTitleGenerationServiceSpy).not.toHaveBeenCalledWith(plugin, 'codex');
     });
 
     it('surfaces provider-scoped model settings for inactive-provider tabs and saves back to that provider snapshot', async () => {
@@ -3960,7 +3960,7 @@ describe('Tab - Blank Tab Draft Model Change', () => {
     expect(tab.serviceInitialized).toBe(false);
     expect(tab.providerId).toBe('claude');
     expect(createInstructionRefineServiceSpy.mock.calls.length).toBeGreaterThan(initialInstructionCalls);
-    expect(createTitleGenerationServiceSpy.mock.calls.length).toBeGreaterThan(initialTitleCalls);
+    expect(createTitleGenerationServiceSpy.mock.calls.length).toBe(initialTitleCalls);
   });
 });
 


### PR DESCRIPTION
## Summary
- Route title generation through a registry-owned service based on the selected title model, independent of the active chat tab provider.
- Keep title generation stable across provider switches and suppress stale callbacks from replaced generations.
- Guard Claude title generation from using non-Claude title model ids and update coverage/docs.

## Tests
- npm run typecheck
- npm run lint
- npm run test -- --selectProjects unit
- npm run build