### PR TITLE
fix: recover from invalid settings JSON

### DIFF
--- a/src/app/settings/ClaudianSettingsStorage.ts
+++ b/src/app/settings/ClaudianSettingsStorage.ts
@@ -210,8 +210,10 @@ export class ClaudianSettingsStorage {
       return this.getDefaults();
     }
 
-    const content = await this.adapter.read(settingsPath);
-    const stored = JSON.parse(content) as Record<string, unknown>;
+    const stored = await this.readStoredSettings(settingsPath);
+    if (!stored) {
+      return this.getDefaults();
+    }
     const hiddenProviderCommands = mergeLegacyClaudeHiddenCommands(
       normalizeHiddenProviderCommands(stored.hiddenProviderCommands),
       stored.hiddenSlashCommands,
@@ -274,6 +276,22 @@ export class ClaudianSettingsStorage {
     }
 
     return merged;
+  }
+
+  private async readStoredSettings(settingsPath: string): Promise<Record<string, unknown> | null> {
+    const content = await this.adapter.read(settingsPath);
+    try {
+      return JSON.parse(content) as Record<string, unknown>;
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) {
+        throw error;
+      }
+
+      const backupPath = `${settingsPath}.invalid-${Date.now()}`;
+      await this.adapter.rename(settingsPath, backupPath);
+      await this.save(this.getDefaults());
+      return null;
+    }
   }
 
   async save(settings: StoredClaudianSettings): Promise<void> {

--- a/tests/unit/providers/claude/storage/ClaudianSettingsStorage.test.ts
+++ b/tests/unit/providers/claude/storage/ClaudianSettingsStorage.test.ts
@@ -20,6 +20,7 @@ const mockAdapter = {
   read: jest.fn(),
   write: jest.fn(),
   delete: jest.fn(),
+  rename: jest.fn(),
 } as unknown as jest.Mocked<VaultFileAdapter>;
 
 describe('ClaudianSettingsStorage', () => {
@@ -32,6 +33,7 @@ describe('ClaudianSettingsStorage', () => {
     mockAdapter.read.mockResolvedValue('{}');
     mockAdapter.write.mockResolvedValue(undefined);
     mockAdapter.delete.mockResolvedValue(undefined);
+    mockAdapter.rename.mockResolvedValue(undefined);
     storage = new ClaudianSettingsStorage(mockAdapter);
   });
 
@@ -86,6 +88,28 @@ describe('ClaudianSettingsStorage', () => {
       expect(result.userName).toBe('TestUser');
       // Defaults should still be present for unspecified fields
       expect(result.thinkingBudget).toBe(DEFAULT_SETTINGS.thinkingBudget);
+    });
+
+    it('backs up invalid settings JSON and falls back to defaults', async () => {
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(12345);
+      mockAdapter.exists.mockResolvedValue(true);
+      mockAdapter.read.mockResolvedValue('{"systemPrompt":"line one\r\nline two"}');
+
+      try {
+        const result = await storage.load();
+
+        expect(result.model).toBe(DEFAULT_SETTINGS.model);
+        expect(mockAdapter.rename).toHaveBeenCalledWith(
+          CLAUDIAN_SETTINGS_PATH,
+          `${CLAUDIAN_SETTINGS_PATH}.invalid-12345`,
+        );
+        expect(mockAdapter.write).toHaveBeenCalledWith(
+          CLAUDIAN_SETTINGS_PATH,
+          expect.any(String),
+        );
+      } finally {
+        nowSpy.mockRestore();
+      }
     });
 
     it('migrates legacy openInMainTab true to main-tab placement', async () => {
@@ -345,11 +369,17 @@ describe('ClaudianSettingsStorage', () => {
       expect(writtenContent.envSnippets[0].scope).toBeUndefined();
     });
 
-    it('should throw on JSON parse error', async () => {
+    it('should recover from JSON parse errors', async () => {
       mockAdapter.exists.mockResolvedValue(true);
       mockAdapter.read.mockResolvedValue('invalid json');
 
-      await expect(storage.load()).rejects.toThrow();
+      const result = await storage.load();
+
+      expect(result.model).toBe(DEFAULT_SETTINGS.model);
+      expect(mockAdapter.rename).toHaveBeenCalledWith(
+        CLAUDIAN_SETTINGS_PATH,
+        expect.stringMatching(new RegExp(`^${CLAUDIAN_SETTINGS_PATH}\\.invalid-\\d+$`)),
+      );
     });
 
     it('should throw on read error', async () => {


### PR DESCRIPTION
## Summary
- back up invalid `.claudian/claudian-settings.json` files instead of crashing during settings load
- continue startup with default settings after moving the bad file to an `.invalid-<timestamp>` backup
- cover the recovery path in the Claudian settings storage tests

Fixes #616

## Tests
- `git diff --check`
- `npm run test -- tests/unit/providers/claude/storage/ClaudianSettingsStorage.test.ts`
- `npm run typecheck`
- `npm run lint -- tests/unit/providers/claude/storage/ClaudianSettingsStorage.test.ts src/app/settings/ClaudianSettingsStorage.ts`