### PR TITLE
Fix security review followups

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      artifact-metadata: write
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout code
@@ -28,6 +30,14 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Generate artifact attestations
+        uses: actions/attest@v4
+        with:
+          subject-path: |
+            main.js
+            manifest.json
+            styles.css
 
       - name: Get previous tag
         id: prev_tag

--- a/README.md
+++ b/README.md
@@ -84,9 +84,11 @@ npm run build
 
 ## Privacy & Data Use
 
-- **Sent to API**: Your input, attached files, images, and tool call outputs. Default: Anthropic (Claude) or OpenAI (Codex); configurable via environment variables.
+- **Sent to API**: Your input, attached files, images, and tool call outputs. Default: Anthropic (Claude) or OpenAI (Codex); configurable via provider settings and environment variables.
 - **Local storage**: Claudian settings and session metadata in `vault/.claudian/`; Claude provider files in `vault/.claude/`; transcripts in `~/.claude/projects/` (Claude) and `~/.codex/sessions/` (Codex).
-- **No telemetry**: No tracking beyond your configured API provider.
+- **Environment variables**: Provider subprocesses inherit the Obsidian process environment plus any variables you configure in Claudian. This is needed for CLI authentication, proxies, certificates, and PATH resolution.
+- **Device-specific paths**: Per-device CLI paths use an opaque local key stored in browser local storage, not your system hostname.
+- **Background activity**: Claudian does not run telemetry beacons. UI polling timers read local Obsidian/editor selection state only. Network activity is limited to explicit provider runtime work, configured MCP endpoints, and provider SDK/CLI calls needed to answer your requests.
 
 ## Troubleshooting
 

--- a/src/app/settings/ClaudianSettingsStorage.ts
+++ b/src/app/settings/ClaudianSettingsStorage.ts
@@ -29,6 +29,10 @@ import {
   getCodexProviderSettings,
   updateCodexProviderSettings,
 } from '../../providers/codex/settings';
+import {
+  getOpencodeProviderSettings,
+  updateOpencodeProviderSettings,
+} from '../../providers/opencode/settings';
 import { DEFAULT_CLAUDIAN_SETTINGS } from './defaultSettings';
 
 export {
@@ -252,6 +256,10 @@ export class ClaudianSettingsStorage {
     updateCodexProviderSettings(
       merged,
       getCodexProviderSettings(legacyProviderSettings),
+    );
+    updateOpencodeProviderSettings(
+      merged,
+      getOpencodeProviderSettings(legacyProviderSettings),
     );
 
     if (

--- a/src/app/settings/ClaudianSettingsStorage.ts
+++ b/src/app/settings/ClaudianSettingsStorage.ts
@@ -128,6 +128,41 @@ function normalizeProviderConfigs(value: unknown): ProviderConfigMap {
   return result;
 }
 
+const HOST_SCOPED_PROVIDER_CONFIG_FIELDS: Record<string, string[]> = {
+  claude: ['cliPathsByHost'],
+  codex: ['cliPathsByHost', 'installationMethodsByHost', 'wslDistroOverridesByHost'],
+  opencode: ['cliPathsByHost'],
+};
+
+function hasHostScopedProviderConfigNormalization(
+  original: ProviderConfigMap,
+  normalized: unknown,
+): boolean {
+  if (!normalized || typeof normalized !== 'object' || Array.isArray(normalized)) {
+    return false;
+  }
+
+  const normalizedConfigs = normalized as ProviderConfigMap;
+  for (const [providerId, fields] of Object.entries(HOST_SCOPED_PROVIDER_CONFIG_FIELDS)) {
+    const originalConfig = original[providerId];
+    const normalizedConfig = normalizedConfigs[providerId];
+    if (!originalConfig || !normalizedConfig) {
+      continue;
+    }
+
+    for (const field of fields) {
+      if (
+        field in originalConfig
+        && JSON.stringify(originalConfig[field]) !== JSON.stringify(normalizedConfig[field])
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
 function isEnvironmentScope(value: unknown): value is EnvironmentScope {
   return value === 'shared' || (typeof value === 'string' && value.startsWith('provider:'));
 }
@@ -261,6 +296,10 @@ export class ClaudianSettingsStorage {
       merged,
       getOpencodeProviderSettings(legacyProviderSettings),
     );
+    const didNormalizeHostScopedProviderConfigs = hasHostScopedProviderConfigNormalization(
+      providerConfigs,
+      merged.providerConfigs,
+    );
 
     if (
       settingsPath !== CLAUDIAN_SETTINGS_PATH
@@ -276,6 +315,7 @@ export class ClaudianSettingsStorage {
       || 'blockedCommands' in stored
       || shouldPersistChatViewPlacementMigration(stored, chatViewPlacement)
       || JSON.stringify(envSnippets) !== JSON.stringify(stored.envSnippets ?? [])
+      || didNormalizeHostScopedProviderConfigs
       )
     ) {
       await this.save(merged);

--- a/src/core/types/settings.ts
+++ b/src/core/types/settings.ts
@@ -78,7 +78,7 @@ export type PermissionMode = 'yolo' | 'plan' | 'normal';
 /** Scope for environment variable storage and snippets. */
 export type EnvironmentScope = 'shared' | `provider:${string}`;
 
-/** Hostname-keyed CLI paths for per-device configuration. */
+/** Opaque device-keyed CLI paths for per-device configuration. */
 export type HostnameCliPaths = Record<string, string>;
 
 /** Opaque provider-owned settings bags keyed by provider id. */

--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -43,6 +43,7 @@ export class ClaudianView extends ItemView {
   private titleTextEl: HTMLElement | null = null;
   private headerActionsEl: HTMLElement | null = null;
   private headerActionsContent: HTMLElement | null = null;
+  private newTabButtonEl: HTMLElement | null = null;
 
   // Header elements
   private historyDropdown: HTMLElement | null = null;
@@ -287,10 +288,10 @@ export class ClaudianView extends ItemView {
     this.headerActionsContent.className = 'claudian-header-actions';
 
     // New tab button (plus icon)
-    const newTabBtn = this.headerActionsContent.createDiv({ cls: 'claudian-header-btn claudian-new-tab-btn' });
-    setIcon(newTabBtn, 'square-plus');
-    newTabBtn.setAttribute('aria-label', 'New tab');
-    newTabBtn.addEventListener('click', () => {
+    this.newTabButtonEl = this.headerActionsContent.createDiv({ cls: 'claudian-header-btn claudian-new-tab-btn' });
+    setIcon(this.newTabButtonEl, 'square-plus');
+    this.newTabButtonEl.setAttribute('aria-label', 'New tab');
+    this.newTabButtonEl.addEventListener('click', () => {
       void this.createNewTab().catch(() => new Notice('Failed to create tab'));
     });
 
@@ -322,7 +323,7 @@ export class ClaudianView extends ItemView {
 
     // Create a wrapper div to hold the fragment (for input mode nav row)
     const wrapper = activeDocument.createElement('div');
-    wrapper.className = 'claudian-visible-contents';
+    wrapper.className = 'claudian-input-nav-content';
     wrapper.appendChild(fragment);
     return wrapper;
   }
@@ -381,6 +382,11 @@ export class ClaudianView extends ItemView {
     this.updateTabBarVisibility();
   }
 
+  /** Refreshes tab controls after settings that affect tab availability change. */
+  refreshTabControls(): void {
+    this.updateTabBarVisibility();
+  }
+
   // ============================================
   // Tab Management
   // ============================================
@@ -409,6 +415,7 @@ export class ClaudianView extends ItemView {
     if (!tab) {
       const maxTabs = this.plugin.settings.maxTabs ?? 3;
       new Notice(`Maximum ${maxTabs} tabs allowed`);
+      this.updateTabBarVisibility();
       return;
     }
     this.updateTabBarVisibility();
@@ -451,6 +458,23 @@ export class ClaudianView extends ItemView {
     if (this.titleTextEl) {
       this.titleTextEl.toggleClass('claudian-hidden', hideBranding);
     }
+
+    this.updateNewTabButtonVisibility();
+  }
+
+  private updateNewTabButtonVisibility(): void {
+    if (!this.newTabButtonEl || !this.tabManager) return;
+
+    const canCreateTab = this.tabManager.canCreateTab();
+    this.newTabButtonEl.toggleClass('claudian-hidden', !canCreateTab);
+    if (canCreateTab) {
+      this.newTabButtonEl.removeAttribute('aria-disabled');
+      this.newTabButtonEl.removeAttribute('aria-hidden');
+      return;
+    }
+
+    this.newTabButtonEl.setAttribute('aria-disabled', 'true');
+    this.newTabButtonEl.setAttribute('aria-hidden', 'true');
   }
 
   /** Sets `data-provider` on the root container so CSS brand color follows the active provider. */

--- a/src/features/inline-edit/ui/InlineEditModal.ts
+++ b/src/features/inline-edit/ui/InlineEditModal.ts
@@ -1,4 +1,4 @@
-import { RangeSetBuilder, StateEffect, StateField } from '@codemirror/state';
+import { RangeSetBuilder, StateEffect, StateField, type Text } from '@codemirror/state';
 import type { DecorationSet } from '@codemirror/view';
 import { Decoration, EditorView, WidgetType } from '@codemirror/view';
 import type { App, Editor, MarkdownView } from 'obsidian';
@@ -107,25 +107,41 @@ class InputWidget extends WidgetType {
   }
 }
 
+export function buildInlineEditInputDecorations(options: {
+  doc: Text;
+  inputPos: number;
+  isInbetween?: boolean;
+  widget: WidgetType;
+}): DecorationSet {
+  // Decoration.set(..., true) sorts line and widget decorations by CodeMirror's
+  // internal range ordering, including equal-position block widgets at line start.
+  const isInbetween = options.isInbetween ?? false;
+  const lineStart = options.doc.lineAt(options.inputPos).from;
+  return Decoration.set([
+    Decoration.line({
+      class: 'claudian-inline-input-line',
+    }).range(lineStart),
+    Decoration.widget({
+      widget: options.widget,
+      block: !isInbetween,
+      side: isInbetween ? 1 : -1,
+    }).range(options.inputPos),
+  ], true);
+}
+
 const inlineEditField = StateField.define<DecorationSet>({
   create: () => Decoration.none,
   update: (deco, tr) => {
     deco = deco.map(tr.changes);
     for (const e of tr.effects) {
       if (e.is(showInlineEdit)) {
-        const builder = new RangeSetBuilder<Decoration>();
         // Block above line for selection/inline mode, inline widget for inbetween mode
-        const isInbetween = e.value.isInbetween ?? false;
-        const lineStart = tr.state.doc.lineAt(e.value.inputPos).from;
-        builder.add(lineStart, lineStart, Decoration.line({
-          class: 'claudian-inline-input-line',
-        }));
-        builder.add(e.value.inputPos, e.value.inputPos, Decoration.widget({
+        deco = buildInlineEditInputDecorations({
+          doc: tr.state.doc,
+          inputPos: e.value.inputPos,
+          isInbetween: e.value.isInbetween,
           widget: new InputWidget(e.value.widget),
-          block: !isInbetween,
-          side: isInbetween ? 1 : -1,
-        }));
-        deco = builder.finish();
+        });
       } else if (e.is(showDiff)) {
         const builder = new RangeSetBuilder<Decoration>();
         builder.add(e.value.from, e.value.to, Decoration.replace({

--- a/src/features/inline-edit/ui/InlineEditModal.ts
+++ b/src/features/inline-edit/ui/InlineEditModal.ts
@@ -116,6 +116,10 @@ const inlineEditField = StateField.define<DecorationSet>({
         const builder = new RangeSetBuilder<Decoration>();
         // Block above line for selection/inline mode, inline widget for inbetween mode
         const isInbetween = e.value.isInbetween ?? false;
+        const lineStart = tr.state.doc.lineAt(e.value.inputPos).from;
+        builder.add(lineStart, lineStart, Decoration.line({
+          class: 'claudian-inline-input-line',
+        }));
         builder.add(e.value.inputPos, e.value.inputPos, Decoration.widget({
           widget: new InputWidget(e.value.widget),
           block: !isInbetween,

--- a/src/features/settings/ClaudianSettings.ts
+++ b/src/features/settings/ClaudianSettings.ts
@@ -247,6 +247,9 @@ export class ClaudianSettingTab extends PluginSettingTab {
           this.plugin.settings.maxTabs = value;
           await this.plugin.saveSettings();
           updateMaxTabsWarning(value);
+          for (const view of this.plugin.getAllViews()) {
+            view.refreshTabControls();
+          }
         });
       updateMaxTabsWarning(this.plugin.settings.maxTabs ?? 3);
     });

--- a/src/providers/claude/runtime/ClaudeCliResolver.ts
+++ b/src/providers/claude/runtime/ClaudeCliResolver.ts
@@ -15,7 +15,7 @@ export class ClaudeCliResolver {
   private readonly cachedHostname = getHostnameKey();
 
   /**
-   * Resolves CLI path with priority: hostname-specific -> legacy -> auto-detect.
+   * Resolves CLI path with priority: device-specific -> legacy -> auto-detect.
    * @param settings Full app settings bag
    */
   resolveFromSettings(settings: Record<string, unknown>): string | null {

--- a/src/providers/claude/settings.ts
+++ b/src/providers/claude/settings.ts
@@ -1,6 +1,11 @@
 import { getProviderConfig, setProviderConfig } from '../../core/providers/providerConfig';
 import { getProviderEnvironmentVariables } from '../../core/providers/providerEnvironment';
 import type { HostnameCliPaths } from '../../core/types/settings';
+import {
+  getHostnameKey,
+  getLegacyHostnameKey,
+  migrateLegacyHostnameKeyedMap,
+} from '../../utils/env';
 
 export const CLAUDE_SAFE_MODES = ['acceptEdits', 'auto', 'default'] as const;
 export type ClaudeSafeMode = typeof CLAUDE_SAFE_MODES[number];
@@ -60,6 +65,16 @@ export function getClaudeProviderSettings(
   settings: Record<string, unknown>,
 ): ClaudeProviderSettings {
   const config = getProviderConfig(settings, 'claude');
+  const normalizedCliPathsByHost = normalizeHostnameCliPaths(
+    config.cliPathsByHost ?? settings.claudeCliPathsByHost,
+  );
+  const cliPathsByHost = Object.keys(normalizedCliPathsByHost).length > 0
+    ? migrateLegacyHostnameKeyedMap(
+      normalizedCliPathsByHost,
+      getHostnameKey(),
+      getLegacyHostnameKey(),
+    )
+    : normalizedCliPathsByHost;
 
   return {
     safeMode: normalizeClaudeSafeMode(config.safeMode)
@@ -68,7 +83,7 @@ export function getClaudeProviderSettings(
     cliPath: (config.cliPath as string | undefined)
       ?? (settings.claudeCliPath as string | undefined)
       ?? DEFAULT_CLAUDE_PROVIDER_SETTINGS.cliPath,
-    cliPathsByHost: normalizeHostnameCliPaths(config.cliPathsByHost ?? settings.claudeCliPathsByHost),
+    cliPathsByHost,
     loadUserSettings: (config.loadUserSettings as boolean | undefined)
       ?? (settings.loadUserClaudeSettings as boolean | undefined)
       ?? DEFAULT_CLAUDE_PROVIDER_SETTINGS.loadUserSettings,

--- a/src/providers/claude/ui/ClaudeSettingsTab.ts
+++ b/src/providers/claude/ui/ClaudeSettingsTab.ts
@@ -54,7 +54,7 @@ export const claudeSettingsTabRenderer: ProviderSettingsTabRenderer = {
     const cliPathDescription = `${t('settings.cliPath.desc')} ${platformDesc}`;
 
     const cliPathSetting = new Setting(container)
-      .setName(`${t('settings.cliPath.name')} (${hostnameKey})`)
+      .setName(t('settings.cliPath.name'))
       .setDesc(cliPathDescription);
 
     const validationEl = container.createDiv({

--- a/src/providers/codex/settings.ts
+++ b/src/providers/codex/settings.ts
@@ -1,7 +1,11 @@
 import { getProviderConfig, setProviderConfig } from '../../core/providers/providerConfig';
 import { getProviderEnvironmentVariables } from '../../core/providers/providerEnvironment';
 import type { HostnameCliPaths } from '../../core/types/settings';
-import { getHostnameKey } from '../../utils/env';
+import {
+  getHostnameKey,
+  getLegacyHostnameKey,
+  migrateLegacyHostnameKeyedMap,
+} from '../../utils/env';
 import { CODEX_SPARK_MODEL } from './types/models';
 
 export type CodexSafeMode = 'workspace-write' | 'read-only';
@@ -104,8 +108,22 @@ export function getCodexProviderSettings(
 ): CodexProviderSettings {
   const config = getProviderConfig(settings, 'codex');
   const hostnameKey = getHostnameKey();
-  const installationMethodsByHost = normalizeInstallationMethodsByHost(config.installationMethodsByHost);
-  const wslDistroOverridesByHost = normalizeHostnameCliPaths(config.wslDistroOverridesByHost);
+  const normalizedCliPathsByHost = normalizeHostnameCliPaths(config.cliPathsByHost ?? settings.codexCliPathsByHost);
+  const normalizedInstallationMethodsByHost = normalizeInstallationMethodsByHost(config.installationMethodsByHost);
+  const normalizedWslDistroOverridesByHost = normalizeHostnameCliPaths(config.wslDistroOverridesByHost);
+  const hasLegacyHostnameKeyedSettings = Object.keys(normalizedCliPathsByHost).length > 0
+    || Object.keys(normalizedInstallationMethodsByHost).length > 0
+    || Object.keys(normalizedWslDistroOverridesByHost).length > 0;
+  const legacyHostnameKey = hasLegacyHostnameKeyedSettings ? getLegacyHostnameKey() : '';
+  const cliPathsByHost = hasLegacyHostnameKeyedSettings
+    ? migrateLegacyHostnameKeyedMap(normalizedCliPathsByHost, hostnameKey, legacyHostnameKey)
+    : normalizedCliPathsByHost;
+  const installationMethodsByHost = hasLegacyHostnameKeyedSettings
+    ? migrateLegacyHostnameKeyedMap(normalizedInstallationMethodsByHost, hostnameKey, legacyHostnameKey)
+    : normalizedInstallationMethodsByHost;
+  const wslDistroOverridesByHost = hasLegacyHostnameKeyedSettings
+    ? migrateLegacyHostnameKeyedMap(normalizedWslDistroOverridesByHost, hostnameKey, legacyHostnameKey)
+    : normalizedWslDistroOverridesByHost;
   const hasHostScopedInstallationMethods = Object.keys(installationMethodsByHost).length > 0;
   const hasHostScopedWslDistroOverrides = Object.keys(wslDistroOverridesByHost).length > 0;
   const legacyInstallationMethod = normalizeCodexInstallationMethod(config.installationMethod);
@@ -121,7 +139,7 @@ export function getCodexProviderSettings(
     cliPath: (config.cliPath as string | undefined)
       ?? (settings.codexCliPath as string | undefined)
       ?? DEFAULT_CODEX_PROVIDER_SETTINGS.cliPath,
-    cliPathsByHost: normalizeHostnameCliPaths(config.cliPathsByHost ?? settings.codexCliPathsByHost),
+    cliPathsByHost,
     customModels: (config.customModels as string | undefined)
       ?? DEFAULT_CODEX_PROVIDER_SETTINGS.customModels,
     reasoningSummary: (config.reasoningSummary as CodexReasoningSummary | undefined)

--- a/src/providers/codex/ui/CodexSettingsTab.ts
+++ b/src/providers/codex/ui/CodexSettingsTab.ts
@@ -98,7 +98,7 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
     const shouldValidateCliPathAsFile = (): boolean => !isWindowsHost || installationMethod !== 'wsl';
 
     const cliPathSetting = new Setting(container)
-      .setName(`Codex CLI path (${hostnameKey})`)
+      .setName('Codex CLI path')
       .setDesc(getCliPathCopy().desc);
 
     const validationEl = container.createDiv({

--- a/src/providers/opencode/settings.ts
+++ b/src/providers/opencode/settings.ts
@@ -1,7 +1,11 @@
 import { getProviderConfig, setProviderConfig } from '../../core/providers/providerConfig';
 import { getProviderEnvironmentVariables } from '../../core/providers/providerEnvironment';
 import type { HostnameCliPaths } from '../../core/types/settings';
-import { getHostnameKey } from '../../utils/env';
+import {
+  getHostnameKey,
+  getLegacyHostnameKey,
+  migrateLegacyHostnameKeyedMap,
+} from '../../utils/env';
 import {
   getOpencodeDiscoveryState,
   seedOpencodeDiscoveryStateFromLegacyConfig,
@@ -149,6 +153,14 @@ export function getOpencodeProviderSettings(
   settings: Record<string, unknown>,
 ): OpencodeProviderSettings {
   const config = getProviderConfig(settings, 'opencode');
+  const normalizedCliPathsByHost = normalizeHostnameCliPaths(config.cliPathsByHost);
+  const cliPathsByHost = Object.keys(normalizedCliPathsByHost).length > 0
+    ? migrateLegacyHostnameKeyedMap(
+      normalizedCliPathsByHost,
+      getHostnameKey(),
+      getLegacyHostnameKey(),
+    )
+    : normalizedCliPathsByHost;
   seedOpencodeDiscoveryStateFromLegacyConfig(settings, config);
   const discoveryState = getOpencodeDiscoveryState(settings);
   const availableModes = discoveryState.availableModes;
@@ -158,7 +170,7 @@ export function getOpencodeProviderSettings(
     availableModes,
     cliPath: (config.cliPath as string | undefined)
       ?? DEFAULT_OPENCODE_PROVIDER_SETTINGS.cliPath,
-    cliPathsByHost: normalizeHostnameCliPaths(config.cliPathsByHost),
+    cliPathsByHost,
     discoveredModels,
     enabled: (config.enabled as boolean | undefined)
       ?? DEFAULT_OPENCODE_PROVIDER_SETTINGS.enabled,
@@ -214,7 +226,7 @@ export function updateOpencodeProviderSettings(
     ? DEFAULT_OPENCODE_PROVIDER_SETTINGS.cliPath
     : current.cliPath.trim();
 
-  if ('cliPath' in updates) {
+  if ('cliPath' in updates && !('cliPathsByHost' in updates)) {
     const trimmedCliPath = typeof updates.cliPath === 'string' ? updates.cliPath.trim() : '';
     if (trimmedCliPath) {
       nextCliPathsByHost[hostnameKey] = trimmedCliPath;

--- a/src/providers/opencode/settings.ts
+++ b/src/providers/opencode/settings.ts
@@ -223,7 +223,11 @@ export function updateOpencodeProviderSettings(
     ? normalizeHostnameCliPaths(updates.cliPathsByHost)
     : { ...current.cliPathsByHost };
   let nextCliPath = 'cliPathsByHost' in updates
-    ? DEFAULT_OPENCODE_PROVIDER_SETTINGS.cliPath
+    ? (
+      typeof updates.cliPath === 'string'
+        ? updates.cliPath.trim()
+        : DEFAULT_OPENCODE_PROVIDER_SETTINGS.cliPath
+    )
     : current.cliPath.trim();
 
   if ('cliPath' in updates && !('cliPathsByHost' in updates)) {

--- a/src/providers/opencode/ui/OpencodeSettingsTab.ts
+++ b/src/providers/opencode/ui/OpencodeSettingsTab.ts
@@ -55,7 +55,7 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
       );
 
     const cliPathSetting = new Setting(container)
-      .setName(`CLI Path (${hostnameKey})`)
+      .setName('CLI path')
       .setDesc('Optional absolute path to the OpenCode CLI for this computer. Leave empty to use `opencode` from PATH.');
 
     const validationEl = container.createDiv({

--- a/src/style/base/container.css
+++ b/src/style/base/container.css
@@ -19,10 +19,6 @@
   display: flex !important;
 }
 
-.claudian-visible-contents {
-  display: contents !important;
-}
-
 .claudian-provider-icon-variant--dark {
   display: none;
 }

--- a/src/style/components/input.css
+++ b/src/style/components/input.css
@@ -41,6 +41,14 @@
   min-height: 0;
 }
 
+.claudian-input-nav-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  min-width: 0;
+}
+
 /* Header mode: hide nav row above input (content moved to header) */
 .claudian-container--header-mode .claudian-input-nav-row {
   display: none;

--- a/src/style/components/status-panel.css
+++ b/src/style/components/status-panel.css
@@ -174,7 +174,6 @@
 
 .claudian-status-panel-bash-content {
   padding-top: 2px;
-  max-height: 320px;
   max-height: min(40vh, 320px);
   overflow-y: auto;
   overscroll-behavior: contain;

--- a/src/style/features/inline-edit.css
+++ b/src/style/features/inline-edit.css
@@ -16,7 +16,7 @@
 
 /* CM6 widget container - ensure transparent background */
 .cm-widgetBuffer,
-.cm-line:has(.claudian-inline-input-container) {
+.cm-line.claudian-inline-input-line {
   background: transparent !important;
 }
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -7,6 +7,8 @@ import { parsePathEntries, resolveNvmDefaultBin } from './path';
 const isWindows = process.platform === 'win32';
 const PATH_SEPARATOR = isWindows ? ';' : ':';
 const NODE_EXECUTABLE = isWindows ? 'node.exe' : 'node';
+const DEVICE_SETTINGS_STORAGE_KEY = 'claudian.deviceSettingsKey';
+let cachedDeviceSettingsKey: string | null = null;
 
 function getHomeDir(): string {
   return process.env.HOME || process.env.USERPROFILE || '';
@@ -342,8 +344,85 @@ export function parseEnvironmentVariables(input: string): Record<string, string>
   return result;
 }
 
+function getDeviceSettingsStorage(): Storage | null {
+  try {
+    return typeof window === 'undefined' ? null : window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function createOpaqueDeviceSettingsKey(): string {
+  const cryptoApi = typeof window === 'undefined' ? null : window.crypto;
+  const randomUUID = cryptoApi?.randomUUID?.();
+  if (randomUUID) {
+    return `device:${randomUUID}`;
+  }
+
+  if (cryptoApi?.getRandomValues) {
+    const randomBytes = new Uint8Array(16);
+    cryptoApi.getRandomValues(randomBytes);
+    const entropy = Array.from(randomBytes, byte => byte.toString(16).padStart(2, '0')).join('');
+    return `device:${Date.now().toString(36)}:${entropy}`;
+  }
+
+  const entropy = Math.random().toString(36).slice(2);
+  return `device:${Date.now().toString(36)}:${entropy}`;
+}
+
+// Backward-compatible name: provider settings still store legacy `cliPathsByHost`
+// maps, but new keys are opaque per-install identifiers rather than hostnames.
 export function getHostnameKey(): string {
-  return os.hostname();
+  if (cachedDeviceSettingsKey) {
+    return cachedDeviceSettingsKey;
+  }
+
+  const storage = getDeviceSettingsStorage();
+  const stored = storage?.getItem(DEVICE_SETTINGS_STORAGE_KEY)?.trim();
+  if (stored) {
+    cachedDeviceSettingsKey = stored;
+    return cachedDeviceSettingsKey;
+  }
+
+  cachedDeviceSettingsKey = createOpaqueDeviceSettingsKey();
+  try {
+    storage?.setItem(DEVICE_SETTINGS_STORAGE_KEY, cachedDeviceSettingsKey);
+  } catch {
+    // Local storage can be unavailable in restricted renderer contexts.
+  }
+
+  return cachedDeviceSettingsKey;
+}
+
+export function getLegacyHostnameKey(): string {
+  try {
+    return os.hostname();
+  } catch {
+    return '';
+  }
+}
+
+export function migrateLegacyHostnameKeyedMap<T extends string>(
+  entries: Record<string, T>,
+  currentKey: string,
+  legacyHostnameKey: string,
+): Record<string, T> {
+  if (!currentKey || !legacyHostnameKey || currentKey === legacyHostnameKey) {
+    return entries;
+  }
+
+  const hasCurrentEntry = Object.prototype.hasOwnProperty.call(entries, currentKey);
+  const hasLegacyEntry = Object.prototype.hasOwnProperty.call(entries, legacyHostnameKey);
+  if (!hasLegacyEntry) {
+    return entries;
+  }
+
+  const migrated = { ...entries };
+  if (!hasCurrentEntry) {
+    migrated[currentKey] = entries[legacyHostnameKey];
+  }
+  delete migrated[legacyHostnameKey];
+  return migrated;
 }
 
 export const MIN_CONTEXT_LIMIT = 1_000;

--- a/tests/helpers/mockElement.ts
+++ b/tests/helpers/mockElement.ts
@@ -91,7 +91,6 @@ const CLASS_DISPLAY: Record<string, string> = {
 const DISPLAY_CLASSES = new Set([
   'claudian-hidden',
   'claudian-visible-block',
-  'claudian-visible-contents',
   'claudian-visible-flex',
   ...Object.keys(CLASS_DISPLAY),
 ]);
@@ -109,7 +108,6 @@ export function createMockEl(tag = 'div'): any {
     if (classes.has('claudian-hidden')) return 'none';
     if (classes.has('claudian-visible-flex')) return 'flex';
     if (classes.has('claudian-visible-block')) return 'block';
-    if (classes.has('claudian-visible-contents')) return 'contents';
 
     for (const [cls, display] of Object.entries(CLASS_DISPLAY)) {
       if (classes.has(cls)) return display;

--- a/tests/unit/features/chat/ClaudianView.test.ts
+++ b/tests/unit/features/chat/ClaudianView.test.ts
@@ -1,0 +1,56 @@
+import { createMockEl } from '@test/helpers/mockElement';
+
+import { ClaudianView } from '@/features/chat/ClaudianView';
+
+function createViewHarness(options: {
+  canCreateTab: boolean;
+  tabBarPosition?: 'input' | 'header';
+  tabCount?: number;
+}): {
+  newTabButtonEl: ReturnType<typeof createMockEl>;
+  view: any;
+} {
+  const newTabButtonEl = createMockEl();
+  const view = Object.create(ClaudianView.prototype) as any;
+
+  view.plugin = {
+    settings: {
+      tabBarPosition: options.tabBarPosition ?? 'input',
+    },
+  };
+  view.tabManager = {
+    canCreateTab: jest.fn().mockReturnValue(options.canCreateTab),
+    getTabCount: jest.fn().mockReturnValue(options.tabCount ?? 1),
+  };
+  view.tabBarContainerEl = createMockEl();
+  view.logoEl = createMockEl();
+  view.titleTextEl = createMockEl();
+  view.newTabButtonEl = newTabButtonEl;
+
+  return { newTabButtonEl, view };
+}
+
+describe('ClaudianView tab controls', () => {
+  it('hides the new-tab button when the tab manager is at capacity', () => {
+    const { newTabButtonEl, view } = createViewHarness({ canCreateTab: false });
+
+    view.refreshTabControls();
+
+    expect(newTabButtonEl.hasClass('claudian-hidden')).toBe(true);
+    expect(newTabButtonEl.getAttribute('aria-disabled')).toBe('true');
+    expect(newTabButtonEl.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('shows the new-tab button when another tab can be created', () => {
+    const { newTabButtonEl, view } = createViewHarness({ canCreateTab: true });
+    newTabButtonEl.addClass('claudian-hidden');
+    newTabButtonEl.setAttribute('aria-disabled', 'true');
+    newTabButtonEl.setAttribute('aria-hidden', 'true');
+
+    view.refreshTabControls();
+
+    expect(newTabButtonEl.hasClass('claudian-hidden')).toBe(false);
+    expect(newTabButtonEl.getAttribute('aria-disabled')).toBeNull();
+    expect(newTabButtonEl.getAttribute('aria-hidden')).toBeNull();
+  });
+});

--- a/tests/unit/features/inline-edit/ui/InlineEditModal.test.ts
+++ b/tests/unit/features/inline-edit/ui/InlineEditModal.test.ts
@@ -1,7 +1,17 @@
 import '@/providers';
 
+import { Text } from '@codemirror/state';
+import { WidgetType } from '@codemirror/view';
+
+import { buildInlineEditInputDecorations } from '@/features/inline-edit/ui/InlineEditModal';
 import { escapeHtml, normalizeInsertionText } from '@/utils/inlineEdit';
 import { normalizePathForVault } from '@/utils/path';
+
+class TestWidget extends WidgetType {
+  toDOM(): HTMLElement {
+    return {} as HTMLElement;
+  }
+}
 
 // Copy of the diff algorithm from InlineEditModal for testing
 interface DiffOp {
@@ -74,6 +84,15 @@ function diffToHtml(ops: DiffOp[]): string {
 }
 
 describe('InlineEditModal - Insertion Newline Trimming', () => {
+  it('builds line-start block widget decorations without range ordering errors', () => {
+    expect(() => buildInlineEditInputDecorations({
+      doc: Text.of(['First line', 'Second line']),
+      inputPos: 0,
+      widget: new TestWidget(),
+      isInbetween: false,
+    })).not.toThrow();
+  });
+
   describe('normalizeInsertionText', () => {
     it('should remove leading newlines', () => {
       const input = '\n\nContent here';

--- a/tests/unit/providers/claude/storage/ClaudianSettingsStorage.test.ts
+++ b/tests/unit/providers/claude/storage/ClaudianSettingsStorage.test.ts
@@ -9,10 +9,15 @@ import {
 } from '@/providers/claude/storage/ClaudianSettingsStorage';
 import { DEFAULT_SETTINGS } from '@/providers/claude/types/settings';
 import { getCodexProviderSettings } from '@/providers/codex/settings';
+import { getOpencodeProviderSettings } from '@/providers/opencode/settings';
+
+const mockGetHostnameKey = jest.fn(() => 'host-a');
+const mockGetLegacyHostnameKey = jest.fn(() => 'legacy-host');
 
 jest.mock('@/utils/env', () => ({
   ...jest.requireActual('@/utils/env'),
-  getHostnameKey: () => 'host-a',
+  getHostnameKey: () => mockGetHostnameKey(),
+  getLegacyHostnameKey: () => mockGetLegacyHostnameKey(),
 }));
 
 const mockAdapter = {
@@ -32,6 +37,8 @@ describe('ClaudianSettingsStorage', () => {
     mockAdapter.read.mockResolvedValue('{}');
     mockAdapter.write.mockResolvedValue(undefined);
     mockAdapter.delete.mockResolvedValue(undefined);
+    mockGetHostnameKey.mockReturnValue('host-a');
+    mockGetLegacyHostnameKey.mockReturnValue('legacy-host');
     storage = new ClaudianSettingsStorage(mockAdapter);
   });
 
@@ -187,6 +194,75 @@ describe('ClaudianSettingsStorage', () => {
 
       expect(getCodexProviderSettings(result).cliPathsByHost['host-a']).toBe('/custom/codex-a');
       expect(getCodexProviderSettings(result).cliPathsByHost['host-b']).toBe('/custom/codex-b');
+    });
+
+    it('migrates current legacy hostname-scoped provider settings to the opaque device key', async () => {
+      mockGetHostnameKey.mockReturnValue('device:current');
+      mockGetLegacyHostnameKey.mockReturnValue('host-a');
+      mockAdapter.exists.mockResolvedValue(true);
+      mockAdapter.read.mockResolvedValue(JSON.stringify({
+        providerConfigs: {
+          claude: {
+            cliPathsByHost: {
+              'host-a': '/custom/claude-a',
+              'host-b': '/custom/claude-b',
+            },
+          },
+          codex: {
+            cliPathsByHost: {
+              'host-a': '/custom/codex-a',
+              'host-b': '/custom/codex-b',
+            },
+            installationMethodsByHost: {
+              'host-a': 'wsl',
+              'host-b': 'native-windows',
+            },
+            wslDistroOverridesByHost: {
+              'host-a': 'Ubuntu',
+              'host-b': 'Debian',
+            },
+          },
+          opencode: {
+            cliPathsByHost: {
+              'host-a': '/custom/opencode-a',
+              'host-b': '/custom/opencode-b',
+            },
+          },
+        },
+      }));
+
+      const result = await storage.load();
+      const claudeSettings = getClaudeProviderSettings(result);
+      const codexSettings = getCodexProviderSettings(result);
+      const opencodeSettings = getOpencodeProviderSettings(result);
+      const persistedOpencodeConfig = result.providerConfigs.opencode as Record<string, unknown>;
+
+      expect(claudeSettings.cliPathsByHost).toEqual({
+        'device:current': '/custom/claude-a',
+        'host-b': '/custom/claude-b',
+      });
+      expect(codexSettings.cliPathsByHost).toEqual({
+        'device:current': '/custom/codex-a',
+        'host-b': '/custom/codex-b',
+      });
+      expect(codexSettings.installationMethod).toBe('wsl');
+      expect(codexSettings.installationMethodsByHost).toEqual({
+        'device:current': 'wsl',
+        'host-b': 'native-windows',
+      });
+      expect(codexSettings.wslDistroOverride).toBe('Ubuntu');
+      expect(codexSettings.wslDistroOverridesByHost).toEqual({
+        'device:current': 'Ubuntu',
+        'host-b': 'Debian',
+      });
+      expect(opencodeSettings.cliPathsByHost).toEqual({
+        'device:current': '/custom/opencode-a',
+        'host-b': '/custom/opencode-b',
+      });
+      expect(persistedOpencodeConfig.cliPathsByHost).toEqual({
+        'device:current': '/custom/opencode-a',
+        'host-b': '/custom/opencode-b',
+      });
     });
 
     it('should preserve legacy codexCliPath field', async () => {

--- a/tests/unit/providers/claude/storage/ClaudianSettingsStorage.test.ts
+++ b/tests/unit/providers/claude/storage/ClaudianSettingsStorage.test.ts
@@ -236,6 +236,7 @@ describe('ClaudianSettingsStorage', () => {
       const codexSettings = getCodexProviderSettings(result);
       const opencodeSettings = getOpencodeProviderSettings(result);
       const persistedOpencodeConfig = result.providerConfigs.opencode as Record<string, unknown>;
+      const writtenContent = JSON.parse(mockAdapter.write.mock.calls[0][1]);
 
       expect(claudeSettings.cliPathsByHost).toEqual({
         'device:current': '/custom/claude-a',
@@ -260,6 +261,18 @@ describe('ClaudianSettingsStorage', () => {
         'host-b': '/custom/opencode-b',
       });
       expect(persistedOpencodeConfig.cliPathsByHost).toEqual({
+        'device:current': '/custom/opencode-a',
+        'host-b': '/custom/opencode-b',
+      });
+      expect(writtenContent.providerConfigs.claude.cliPathsByHost).toEqual({
+        'device:current': '/custom/claude-a',
+        'host-b': '/custom/claude-b',
+      });
+      expect(writtenContent.providerConfigs.codex.cliPathsByHost).toEqual({
+        'device:current': '/custom/codex-a',
+        'host-b': '/custom/codex-b',
+      });
+      expect(writtenContent.providerConfigs.opencode.cliPathsByHost).toEqual({
         'device:current': '/custom/opencode-a',
         'host-b': '/custom/opencode-b',
       });

--- a/tests/unit/providers/claude/ui/ClaudeSettingsTab.test.ts
+++ b/tests/unit/providers/claude/ui/ClaudeSettingsTab.test.ts
@@ -398,7 +398,7 @@ describe('ClaudeSettingsTab', () => {
 
     claudeSettingsTabRenderer.render(createContainer(), context);
 
-    const cliPathSetting = findSetting('settings.cliPath.name (host-a)');
+    const cliPathSetting = findSetting('settings.cliPath.name');
     const cliPathInput = cliPathSetting.textComponents[0];
 
     expect(cliPathInput.placeholder).toContain('cli-wrapper.cjs');

--- a/tests/unit/providers/codex/runtime/CodexCliResolver.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexCliResolver.test.ts
@@ -1,19 +1,25 @@
 import * as fs from 'fs';
-import * as os from 'os';
 
 import { CodexCliResolver } from '@/providers/codex/runtime/CodexCliResolver';
+import { getHostnameKey } from '@/utils/env';
 
 jest.mock('fs');
-jest.mock('os');
+jest.mock('@/utils/env', () => {
+  const actual = jest.requireActual('@/utils/env');
+  return {
+    ...actual,
+    getHostnameKey: jest.fn(() => 'current-host'),
+  };
+});
 
 const mockedExists = fs.existsSync as jest.Mock;
 const mockedStat = fs.statSync as jest.Mock;
-const mockedHostname = os.hostname as jest.Mock;
+const mockedDeviceKey = getHostnameKey as jest.Mock;
 
 describe('CodexCliResolver', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedHostname.mockReturnValue('current-host');
+    mockedDeviceKey.mockReturnValue('current-host');
   });
 
   it('uses the current host path instead of another synced host path', () => {

--- a/tests/unit/providers/codex/settings.test.ts
+++ b/tests/unit/providers/codex/settings.test.ts
@@ -8,14 +8,19 @@ import {
 import { CODEX_SPARK_MODEL } from '@/providers/codex/types/models';
 
 const mockGetHostnameKey = jest.fn(() => 'host-a');
+const mockGetLegacyHostnameKey = jest.fn(() => 'legacy-host');
 
 jest.mock('@/utils/env', () => ({
+  ...jest.requireActual('@/utils/env'),
   getHostnameKey: () => mockGetHostnameKey(),
+  getLegacyHostnameKey: () => mockGetLegacyHostnameKey(),
 }));
 
 describe('codex settings', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetHostnameKey.mockReturnValue('host-a');
+    mockGetLegacyHostnameKey.mockReturnValue('legacy-host');
   });
 
   it('defaults installationMethod to native-windows and leaves wslDistroOverride empty', () => {
@@ -60,6 +65,45 @@ describe('codex settings', () => {
 
     expect(settings.installationMethod).toBe('native-windows');
     expect(settings.wslDistroOverride).toBe('');
+  });
+
+  it('migrates current legacy hostname-scoped settings to the opaque device key', () => {
+    mockGetHostnameKey.mockReturnValue('device:current');
+    mockGetLegacyHostnameKey.mockReturnValue('host-a');
+
+    const settings = getCodexProviderSettings({
+      providerConfigs: {
+        codex: {
+          cliPathsByHost: {
+            'host-a': '/host-a/codex',
+            'host-b': '/host-b/codex',
+          },
+          installationMethodsByHost: {
+            'host-a': 'wsl',
+            'host-b': 'native-windows',
+          },
+          wslDistroOverridesByHost: {
+            'host-a': 'Ubuntu',
+            'host-b': 'Debian',
+          },
+        },
+      },
+    });
+
+    expect(settings.cliPathsByHost).toEqual({
+      'device:current': '/host-a/codex',
+      'host-b': '/host-b/codex',
+    });
+    expect(settings.installationMethod).toBe('wsl');
+    expect(settings.installationMethodsByHost).toEqual({
+      'device:current': 'wsl',
+      'host-b': 'native-windows',
+    });
+    expect(settings.wslDistroOverride).toBe('Ubuntu');
+    expect(settings.wslDistroOverridesByHost).toEqual({
+      'device:current': 'Ubuntu',
+      'host-b': 'Debian',
+    });
   });
 
   it('round-trips installationMethod and trims wslDistroOverride on update for the current host', () => {

--- a/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
+++ b/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
@@ -434,7 +434,7 @@ describe('CodexSettingsTab', () => {
 
     codexSettingsTabRenderer.render(createContainer(), createContext(plugin));
 
-    const cliPathSetting = findSetting('Codex CLI path (host-a)');
+    const cliPathSetting = findSetting('Codex CLI path');
     expect(cliPathSetting.desc).toBe('Custom path to the local Codex CLI. Leave empty for auto-detection from PATH.');
     expect(cliPathSetting.textComponents[0].placeholder).toBe('/usr/local/bin/codex');
 
@@ -454,7 +454,7 @@ describe('CodexSettingsTab', () => {
     const installationMethodSetting = findSetting('Installation method');
     await installationMethodSetting.dropdownComponents[0].onChangeCallback?.('wsl');
 
-    const cliPathSetting = findSetting('Codex CLI path (host-a)');
+    const cliPathSetting = findSetting('Codex CLI path');
     await cliPathSetting.textComponents[0].onChangeCallback?.('codex');
 
     expect(plugin.settings.providerConfigs.codex.installationMethodsByHost).toEqual({
@@ -484,7 +484,7 @@ describe('CodexSettingsTab', () => {
     const installationMethodSetting = findSetting('Installation method');
     await installationMethodSetting.dropdownComponents[0].onChangeCallback?.('wsl');
 
-    const cliPathSetting = findSetting('Codex CLI path (host-a)');
+    const cliPathSetting = findSetting('Codex CLI path');
     await cliPathSetting.textComponents[0].onChangeCallback?.('C:\\Users\\me\\AppData\\Roaming\\npm\\codex.exe');
 
     expect(plugin.settings.providerConfigs.codex.installationMethodsByHost).toEqual({

--- a/tests/unit/providers/opencode/OpencodeSettingsTab.test.ts
+++ b/tests/unit/providers/opencode/OpencodeSettingsTab.test.ts
@@ -388,7 +388,7 @@ describe('OpencodeSettingsTab', () => {
 
     opencodeSettingsTabRenderer.render(createContainer(), createContext(plugin));
 
-    const cliPathSetting = findSetting('CLI Path (host-a)');
+    const cliPathSetting = findSetting('CLI path');
     await cliPathSetting.textComponents[0].onChangeCallback?.('/custom/opencode');
 
     expect(plugin.settings.providerConfigs.opencode.cliPathsByHost).toEqual({

--- a/tests/unit/providers/opencode/settings.test.ts
+++ b/tests/unit/providers/opencode/settings.test.ts
@@ -314,6 +314,30 @@ describe('OpenCode settings normalization', () => {
     });
   });
 
+  it('preserves legacy cliPath when applying a full settings snapshot', () => {
+    const settings: Record<string, unknown> = {
+      providerConfigs: {
+        opencode: {
+          cliPath: '/legacy/opencode',
+          cliPathsByHost: {
+            'host-b': '/other-host/opencode',
+          },
+        },
+      },
+    };
+
+    const snapshot = getOpencodeProviderSettings(settings);
+    const next = updateOpencodeProviderSettings(settings, snapshot);
+
+    expect(next.cliPath).toBe('/legacy/opencode');
+    expect((settings.providerConfigs as Record<string, any>).opencode).toMatchObject({
+      cliPath: '/legacy/opencode',
+      cliPathsByHost: {
+        'host-b': '/other-host/opencode',
+      },
+    });
+  });
+
   it('drops the legacy cliPath once host-scoped paths are explicitly edited', () => {
     const settings: Record<string, unknown> = {
       providerConfigs: {

--- a/tests/unit/providers/opencode/settings.test.ts
+++ b/tests/unit/providers/opencode/settings.test.ts
@@ -1,6 +1,10 @@
+const mockGetHostnameKey = jest.fn(() => 'host-a');
+const mockGetLegacyHostnameKey = jest.fn(() => 'legacy-host');
+
 jest.mock('../../../../src/utils/env', () => ({
   ...jest.requireActual('../../../../src/utils/env'),
-  getHostnameKey: () => 'host-a',
+  getHostnameKey: () => mockGetHostnameKey(),
+  getLegacyHostnameKey: () => mockGetLegacyHostnameKey(),
 }));
 
 import {
@@ -18,6 +22,12 @@ describe('OpenCode settings normalization', () => {
     { label: 'Anthropic/Claude Sonnet 4 (high)', rawId: 'anthropic/claude-sonnet-4/high' },
     { label: 'Google/Gemini 2.5 Pro', rawId: 'google/gemini-2.5-pro' },
   ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetHostnameKey.mockReturnValue('host-a');
+    mockGetLegacyHostnameKey.mockReturnValue('legacy-host');
+  });
 
   it('enables Exa-backed web search in the default provider env', () => {
     expect(DEFAULT_OPENCODE_PROVIDER_SETTINGS.environmentVariables).toBe('OPENCODE_ENABLE_EXA=1');
@@ -76,6 +86,27 @@ describe('OpenCode settings normalization', () => {
         'anthropic/claude-sonnet-4',
         'google/gemini-2.5-pro',
       ],
+    });
+  });
+
+  it('migrates current legacy hostname-scoped CLI paths to the opaque device key', () => {
+    mockGetHostnameKey.mockReturnValue('device:current');
+    mockGetLegacyHostnameKey.mockReturnValue('host-a');
+
+    const settings = getOpencodeProviderSettings({
+      providerConfigs: {
+        opencode: {
+          cliPathsByHost: {
+            'host-a': '/host-a/opencode',
+            'host-b': '/host-b/opencode',
+          },
+        },
+      },
+    });
+
+    expect(settings.cliPathsByHost).toEqual({
+      'device:current': '/host-a/opencode',
+      'host-b': '/host-b/opencode',
     });
   });
 

--- a/tests/unit/utils/claudeCli.test.ts
+++ b/tests/unit/utils/claudeCli.test.ts
@@ -1,11 +1,17 @@
 import * as fs from 'fs';
-import * as os from 'os';
 
 import { findClaudeCLIPath } from '@/providers/claude/cli/findClaudeCLIPath';
 import { ClaudeCliResolver, resolveClaudeCliPath } from '@/providers/claude/runtime/ClaudeCliResolver';
+import { getHostnameKey } from '@/utils/env';
 
 jest.mock('fs');
-jest.mock('os');
+jest.mock('@/utils/env', () => {
+  const actual = jest.requireActual('@/utils/env');
+  return {
+    ...actual,
+    getHostnameKey: jest.fn(() => 'test-host'),
+  };
+});
 jest.mock('@/providers/claude/cli/findClaudeCLIPath', () => {
   const actual = jest.requireActual('@/providers/claude/cli/findClaudeCLIPath');
   return {
@@ -17,12 +23,12 @@ jest.mock('@/providers/claude/cli/findClaudeCLIPath', () => {
 const mockedExists = fs.existsSync as jest.Mock;
 const mockedStat = fs.statSync as jest.Mock;
 const mockedFind = findClaudeCLIPath as jest.Mock;
-const mockedHostname = os.hostname as jest.Mock;
+const mockedDeviceKey = getHostnameKey as jest.Mock;
 
 describe('ClaudeCliResolver', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedHostname.mockReturnValue('test-host');
+    mockedDeviceKey.mockReturnValue('test-host');
   });
 
   describe('hostname-based resolution', () => {

--- a/tests/unit/utils/env.test.ts
+++ b/tests/unit/utils/env.test.ts
@@ -1,9 +1,7 @@
 import type * as fsType from 'fs';
-import type * as osType from 'os';
 import type * as pathType from 'path';
 
 const fs = jest.requireActual<typeof fsType>('fs');
-const os = jest.requireActual<typeof osType>('os');
 const path = jest.requireActual<typeof pathType>('path');
 
 import * as env from '../../../src/utils/env';
@@ -16,6 +14,7 @@ const {
   getEnhancedPath,
   getMissingNodeError,
   getHostnameKey,
+  migrateLegacyHostnameKeyedMap,
   parseContextLimit,
   parseEnvironmentVariables,
 } = env;
@@ -858,20 +857,36 @@ describe('findNodeDirectory', () => {
 
 describe('getHostnameKey', () => {
   it('returns a non-empty string', () => {
-    const hostname = getHostnameKey();
-    expect(typeof hostname).toBe('string');
-    expect(hostname.length).toBeGreaterThan(0);
+    const key = getHostnameKey();
+    expect(typeof key).toBe('string');
+    expect(key.length).toBeGreaterThan(0);
   });
 
-  it('returns the system hostname', () => {
-    const hostname = getHostnameKey();
-    expect(hostname).toBe(os.hostname());
+  it('returns an opaque device key instead of the system hostname', () => {
+    const key = getHostnameKey();
+    expect(key).toMatch(/^device:/);
   });
 
   it('returns consistent value on repeated calls', () => {
     const first = getHostnameKey();
     const second = getHostnameKey();
     expect(first).toBe(second);
+  });
+
+  it('migrates the current legacy hostname entry to the opaque device key', () => {
+    const migrated = migrateLegacyHostnameKeyedMap(
+      {
+        'legacy-host': '/legacy/cli',
+        'other-host': '/other/cli',
+      },
+      'device:new',
+      'legacy-host',
+    );
+
+    expect(migrated).toEqual({
+      'device:new': '/legacy/cli',
+      'other-host': '/other/cli',
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- replace hostname-scoped CLI settings with opaque per-device keys and migrate legacy maps for Claude, Codex, and OpenCode
- hide unavailable new-tab controls when max tab capacity is reached
- add release artifact attestations and privacy documentation updates
- adjust inline-edit/input styling to avoid fragile selectors and layout issues

## Verification
- npm run typecheck
- npm run lint
- npm run test -- --selectProjects unit