### PR TITLE
fix: stop composer textarea resize bounce

### DIFF
--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -46,10 +46,11 @@ import { createInputToolbar } from '../ui/InputToolbar';
 import { InstructionModeManager as InstructionModeManagerClass } from '../ui/InstructionModeManager';
 import { NavigationSidebar } from '../ui/NavigationSidebar';
 import { StatusPanel } from '../ui/StatusPanel';
+import { autoResizeTextarea } from '../ui/textareaResize';
 import { recalculateUsageForModel } from '../utils/usageInfo';
 import { getTabProviderId } from './providerResolution';
 import type { TabData, TabDOMElements, TabId, TabProviderContext } from './types';
-import { generateTabId, TEXTAREA_MAX_HEIGHT_PERCENT, TEXTAREA_MIN_MAX_HEIGHT } from './types';
+import { generateTabId } from './types';
 
 type TabProviderSettings = Record<string, unknown> & {
   model: string;
@@ -455,35 +456,6 @@ export function createTab(options: TabCreateOptions): TabData {
   };
 
   return tab;
-}
-
-/**
- * Auto-resizes a textarea based on its content.
- *
- * Logic:
- * - At minimum wrapper height: let flexbox allocate space (textarea fills available)
- * - When content exceeds flex allocation: set min-height to force wrapper growth
- * - When content shrinks: remove min-height override to let wrapper shrink
- * - Max height is capped at 55% of view height (minimum 150px)
- */
-function autoResizeTextarea(textarea: HTMLTextAreaElement): void {
-  // Calculate max height: 55% of view height, minimum 150px
-  const viewHeight = textarea.closest('.claudian-container')?.clientHeight ?? window.innerHeight;
-  const maxHeight = Math.max(TEXTAREA_MIN_MAX_HEIGHT, viewHeight * TEXTAREA_MAX_HEIGHT_PERCENT);
-
-  // Get flex-allocated height (what flexbox gives the textarea)
-  const flexAllocatedHeight = textarea.offsetHeight;
-
-  // Get content height (what the content actually needs), capped at max
-  const contentHeight = Math.min(textarea.scrollHeight, maxHeight);
-
-  // Only set min-height if content exceeds flex allocation
-  // This forces the wrapper to grow while letting it shrink when content reduces
-  const minHeight = contentHeight > flexAllocatedHeight ? contentHeight : 60;
-  textarea.setCssProps({
-    '--claudian-textarea-min-height': `${minHeight}px`,
-    '--claudian-textarea-max-height': `${maxHeight}px`,
-  });
 }
 
 /**

--- a/src/features/chat/tabs/types.ts
+++ b/src/features/chat/tabs/types.ts
@@ -52,18 +52,6 @@ export const MIN_TABS = 3;
 export const MAX_TABS = 10;
 
 /**
- * Minimum max-height for textarea in pixels.
- * Used by autoResizeTextarea to ensure minimum usable space.
- */
-export const TEXTAREA_MIN_MAX_HEIGHT = 150;
-
-/**
- * Percentage of view height for max textarea height.
- * Textarea can grow up to this portion of the view.
- */
-export const TEXTAREA_MAX_HEIGHT_PERCENT = 0.55;
-
-/**
  * Minimal interface for the ClaudianView methods used by TabManager and Tab.
  * Extends Component for Obsidian integration (event handling, cleanup).
  * Avoids circular dependency by not importing ClaudianView directly.

--- a/src/features/chat/ui/textareaResize.ts
+++ b/src/features/chat/ui/textareaResize.ts
@@ -1,0 +1,47 @@
+export const TEXTAREA_BASE_MIN_HEIGHT = 60;
+export const TEXTAREA_MIN_MAX_HEIGHT = 150;
+export const TEXTAREA_MAX_HEIGHT_PERCENT = 0.55;
+
+interface TextareaMinHeightInput {
+  contentHeight: number;
+  flexAllocatedHeight: number;
+}
+
+export function calculateTextareaMaxHeight(viewHeight: number): number {
+  return Math.max(TEXTAREA_MIN_MAX_HEIGHT, viewHeight * TEXTAREA_MAX_HEIGHT_PERCENT);
+}
+
+export function calculateTextareaMinHeight({
+  contentHeight,
+  flexAllocatedHeight,
+}: TextareaMinHeightInput): number {
+  return contentHeight > flexAllocatedHeight ? contentHeight : TEXTAREA_BASE_MIN_HEIGHT;
+}
+
+/**
+ * Auto-resizes a textarea based on its content.
+ *
+ * Logic:
+ * - At minimum wrapper height: let flexbox allocate space (textarea fills available)
+ * - When content exceeds flex allocation: set min-height to force wrapper growth
+ * - When content shrinks: remove min-height override to let wrapper shrink
+ * - Max height is capped at 55% of view height (minimum 150px)
+ */
+export function autoResizeTextarea(textarea: HTMLTextAreaElement): void {
+  const viewHeight = textarea.closest('.claudian-container')?.clientHeight ?? window.innerHeight;
+  const maxHeight = calculateTextareaMaxHeight(viewHeight);
+
+  textarea.setCssProps({
+    '--claudian-textarea-min-height': `${TEXTAREA_BASE_MIN_HEIGHT}px`,
+    '--claudian-textarea-max-height': `${maxHeight}px`,
+  });
+
+  const flexAllocatedHeight = textarea.offsetHeight;
+  const contentHeight = Math.min(textarea.scrollHeight, maxHeight);
+  const minHeight = calculateTextareaMinHeight({ contentHeight, flexAllocatedHeight });
+
+  textarea.setCssProps({
+    '--claudian-textarea-min-height': `${minHeight}px`,
+    '--claudian-textarea-max-height': `${maxHeight}px`,
+  });
+}

--- a/tests/unit/features/chat/ui/textareaResize.test.ts
+++ b/tests/unit/features/chat/ui/textareaResize.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  autoResizeTextarea,
+  calculateTextareaMaxHeight,
+  calculateTextareaMinHeight,
+  TEXTAREA_BASE_MIN_HEIGHT,
+  TEXTAREA_MAX_HEIGHT_PERCENT,
+  TEXTAREA_MIN_MAX_HEIGHT,
+} from '@/features/chat/ui/textareaResize';
+
+describe('textareaResize', () => {
+  it('returns the base height when content exactly matches base flex allocation', () => {
+    expect(calculateTextareaMinHeight({
+      contentHeight: 102,
+      flexAllocatedHeight: 102,
+    })).toBe(TEXTAREA_BASE_MIN_HEIGHT);
+  });
+
+  it('uses the content height when content exceeds flex allocation', () => {
+    expect(calculateTextareaMinHeight({
+      contentHeight: 128,
+      flexAllocatedHeight: 102,
+    })).toBe(128);
+  });
+
+  it('returns the base height when content fits inside flex allocation', () => {
+    expect(calculateTextareaMinHeight({
+      contentHeight: 80,
+      flexAllocatedHeight: 102,
+    })).toBe(TEXTAREA_BASE_MIN_HEIGHT);
+  });
+
+  it('measures from base height so previously grown content can shrink', () => {
+    const textarea = createResizeTextarea({
+      baseOffsetHeight: 102,
+      grownOffsetHeight: 116,
+      baseScrollHeight: 102,
+      grownScrollHeight: 116,
+    });
+
+    textarea.style.setProperty('--claudian-textarea-min-height', '116px');
+
+    autoResizeTextarea(textarea);
+
+    expect(textarea.style.getPropertyValue('--claudian-textarea-min-height')).toBe('60px');
+  });
+
+  it('measures from base height so long content does not bounce', () => {
+    const textarea = createResizeTextarea({
+      baseOffsetHeight: 102,
+      grownOffsetHeight: 116,
+      baseScrollHeight: 116,
+      grownScrollHeight: 116,
+    });
+
+    textarea.style.setProperty('--claudian-textarea-min-height', '116px');
+
+    autoResizeTextarea(textarea);
+
+    expect(textarea.style.getPropertyValue('--claudian-textarea-min-height')).toBe('116px');
+  });
+
+  it('caps max height by viewport percentage with a minimum usable cap', () => {
+    expect(calculateTextareaMaxHeight(100)).toBe(TEXTAREA_MIN_MAX_HEIGHT);
+    expect(calculateTextareaMaxHeight(1000)).toBe(1000 * TEXTAREA_MAX_HEIGHT_PERCENT);
+  });
+});
+
+function createResizeTextarea({
+  baseOffsetHeight,
+  grownOffsetHeight,
+  baseScrollHeight,
+  grownScrollHeight,
+}: {
+  baseOffsetHeight: number;
+  grownOffsetHeight: number;
+  baseScrollHeight: number;
+  grownScrollHeight: number;
+}): HTMLTextAreaElement {
+  const textarea = document.createElement('textarea');
+
+  textarea.setCssProps = (props: Record<string, string>) => {
+    Object.entries(props).forEach(([key, value]) => {
+      textarea.style.setProperty(key, value);
+    });
+  };
+
+  const isBaseHeight = () =>
+    textarea.style.getPropertyValue('--claudian-textarea-min-height') === `${TEXTAREA_BASE_MIN_HEIGHT}px`;
+
+  Object.defineProperty(textarea, 'offsetHeight', {
+    get: () => (isBaseHeight() ? baseOffsetHeight : grownOffsetHeight),
+  });
+  Object.defineProperty(textarea, 'scrollHeight', {
+    get: () => (isBaseHeight() ? baseScrollHeight : grownScrollHeight),
+  });
+
+  return textarea;
+}


### PR DESCRIPTION
## Summary

- Fix the composer textarea resize oscillation reported in #659.
- Extract textarea resize calculation into a focused helper owned by chat UI.
- Measure from the base textarea height before growing so shortened or cleared content can shrink back to normal.
- Add regression tests for both long-content stability and shrink-after-delete behavior.

## Testing

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run test -- --selectProjects unit`

Fixes #659
