### PR TITLE
Support editing queued messages

### DIFF
--- a/src/core/runtime/QueuedTurn.ts
+++ b/src/core/runtime/QueuedTurn.ts
@@ -1,0 +1,97 @@
+import type { ImageAttachment } from '../types';
+import type { ChatTurnRequest } from './types';
+
+export interface QueuedChatTurn {
+  displayContent: string;
+  request: ChatTurnRequest;
+}
+
+export function cloneChatTurnRequest(request: ChatTurnRequest): ChatTurnRequest {
+  return {
+    ...request,
+    images: cloneImages(request.images),
+    externalContextPaths: request.externalContextPaths
+      ? [...request.externalContextPaths]
+      : undefined,
+    enabledMcpServers: request.enabledMcpServers
+      ? new Set(request.enabledMcpServers)
+      : undefined,
+  };
+}
+
+export function cloneQueuedChatTurn(turn: QueuedChatTurn): QueuedChatTurn {
+  return {
+    displayContent: turn.displayContent,
+    request: cloneChatTurnRequest(turn.request),
+  };
+}
+
+export function mergeQueuedChatTurns(
+  existing: QueuedChatTurn,
+  incoming: QueuedChatTurn,
+): QueuedChatTurn {
+  const existingRequest = existing.request;
+  const incomingRequest = incoming.request;
+
+  return {
+    displayContent: mergeText(existing.displayContent, incoming.displayContent),
+    request: {
+      ...cloneChatTurnRequest(incomingRequest),
+      text: mergeText(existingRequest.text, incomingRequest.text),
+      images: mergeImages(existingRequest.images, incomingRequest.images),
+      currentNotePath: incomingRequest.currentNotePath ?? existingRequest.currentNotePath,
+      externalContextPaths: mergeStringLists(
+        existingRequest.externalContextPaths,
+        incomingRequest.externalContextPaths,
+      ),
+      enabledMcpServers: mergeSets(
+        existingRequest.enabledMcpServers,
+        incomingRequest.enabledMcpServers,
+      ),
+    },
+  };
+}
+
+function mergeText(first: string, second: string): string {
+  return [first, second]
+    .map(part => part.trim())
+    .filter(part => part.length > 0)
+    .join('\n\n');
+}
+
+function cloneImages(images: ImageAttachment[] | undefined): ImageAttachment[] | undefined {
+  return images && images.length > 0 ? [...images] : undefined;
+}
+
+function mergeImages(
+  first: ImageAttachment[] | undefined,
+  second: ImageAttachment[] | undefined,
+): ImageAttachment[] | undefined {
+  const merged = [...(first ?? []), ...(second ?? [])];
+  return merged.length > 0 ? merged : undefined;
+}
+
+function mergeStringLists(
+  first: string[] | undefined,
+  second: string[] | undefined,
+): string[] | undefined {
+  const merged = [...(first ?? []), ...(second ?? [])];
+  if (merged.length === 0) {
+    return undefined;
+  }
+  return Array.from(new Set(merged));
+}
+
+function mergeSets<T>(
+  first: Set<T> | undefined,
+  second: Set<T> | undefined,
+): Set<T> | undefined {
+  const merged = new Set<T>();
+  for (const value of first ?? []) {
+    merged.add(value);
+  }
+  for (const value of second ?? []) {
+    merged.add(value);
+  }
+  return merged.size > 0 ? merged : undefined;
+}

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -1,4 +1,4 @@
-import { Notice } from 'obsidian';
+import { Notice, setIcon } from 'obsidian';
 
 import {
   type BuiltInCommand,
@@ -14,6 +14,11 @@ import {
   type TitleGenerationService,
 } from '../../../core/providers/types';
 import type { ChatRuntime } from '../../../core/runtime/ChatRuntime';
+import {
+  cloneChatTurnRequest,
+  mergeQueuedChatTurns,
+  type QueuedChatTurn,
+} from '../../../core/runtime/QueuedTurn';
 import type {
   ApprovalCallbackOptions,
   ApprovalDecisionOption,
@@ -188,6 +193,8 @@ export class InputController {
     browserContextOverride?: BrowserSelectionContext | null;
     canvasContextOverride?: CanvasSelectionContext | null;
     content?: string;
+    images?: ChatMessage['images'];
+    turnRequestOverride?: ChatTurnRequest;
   }): Promise<void> {
     const {
       plugin,
@@ -210,7 +217,10 @@ export class InputController {
     const contentOverride = options?.content;
     const shouldUseInput = contentOverride === undefined;
     const content = (contentOverride ?? inputEl.value).trim();
-    const hasImages = imageContextManager?.hasImages() ?? false;
+    const imageOverride = options?.images;
+    const hasImages = imageOverride !== undefined
+      ? imageOverride.length > 0
+      : (imageContextManager?.hasImages() ?? false);
     if (!content && !hasImages) return;
 
     // Check for built-in commands first (e.g., /clear, /new, /add-dir)
@@ -226,23 +236,31 @@ export class InputController {
 
     // If agent is working, queue the message instead of dropping it
     if (state.isStreaming) {
-      const images = hasImages ? [...(imageContextManager?.getAttachedImages() || [])] : undefined;
+      const images = hasImages
+        ? [...(imageOverride ?? imageContextManager?.getAttachedImages() ?? [])]
+        : undefined;
       const editorContext = selectionController.getContext();
       const browserContext = browserSelectionController?.getContext() ?? null;
       const canvasContext = canvasSelectionController.getContext();
-      state.queuedMessage = this.mergeQueuedMessages(state.queuedMessage, {
+      const { displayContent, turnRequest } = this.buildTurnSubmission({
         content,
         images,
-        editorContext,
-        browserContext,
-        canvasContext,
+        editorContextOverride: editorContext,
+        browserContextOverride: browserContext,
+        canvasContextOverride: canvasContext,
       });
+      state.queuedMessage = this.mergeQueuedMessages(
+        state.queuedMessage,
+        this.createQueuedMessage(displayContent, turnRequest),
+      );
 
       if (shouldUseInput) {
         inputEl.value = '';
         this.deps.resetInputHeight();
       }
-      imageContextManager?.clearImages();
+      if (shouldUseInput) {
+        imageContextManager?.clearImages();
+      }
       this.updateQueueIndicator();
       return;
     }
@@ -268,7 +286,7 @@ export class InputController {
 
     // Slash commands are passed directly to SDK for handling
     // SDK handles expansion, $ARGUMENTS, @file references, and frontmatter options
-    const images = imageContextManager?.getAttachedImages() || [];
+    const images = imageOverride ?? imageContextManager?.getAttachedImages() ?? [];
     const imagesForMessage = images.length > 0 ? [...images] : undefined;
     const isCompact = /^\/compact(\s|$)/i.test(content);
 
@@ -277,13 +295,19 @@ export class InputController {
       imageContextManager?.clearImages();
     }
 
-    const { displayContent, turnRequest } = this.buildTurnSubmission({
-      content,
-      images: imagesForMessage,
-      editorContextOverride: options?.editorContextOverride,
-      browserContextOverride: options?.browserContextOverride,
-      canvasContextOverride: options?.canvasContextOverride,
-    });
+    const turnSubmission = options?.turnRequestOverride
+      ? {
+        displayContent: content,
+        turnRequest: cloneChatTurnRequest(options.turnRequestOverride),
+      }
+      : this.buildTurnSubmission({
+        content,
+        images: imagesForMessage,
+        editorContextOverride: options?.editorContextOverride,
+        browserContextOverride: options?.browserContextOverride,
+        canvasContextOverride: options?.canvasContextOverride,
+      });
+    const { displayContent, turnRequest } = turnSubmission;
 
     fileContextManager?.markCurrentNoteSent();
 
@@ -554,20 +578,44 @@ export class InputController {
         text: `${isPendingSteerOnly ? '⌙ Steering: ' : '⌙ Queued: '}${this.getQueuedMessageDisplay(visibleQueuedMessage)}`,
       });
 
-      if (state.queuedMessage && this.canSteerQueuedMessage()) {
-        const steerButton = indicatorEl.createEl('button', {
-          cls: 'claudian-queue-indicator-action',
-          text: this.steerInFlight ? 'Steering...' : 'Steer Now',
-        });
-        steerButton.setAttribute('type', 'button');
-        if (this.steerInFlight) {
-          steerButton.setAttribute('disabled', 'true');
-        } else {
-          steerButton.addEventListener('click', (event) => {
-            event.stopPropagation();
-            void this.steerQueuedMessage();
+      if (state.queuedMessage) {
+        const actionsEl = indicatorEl.createDiv({ cls: 'claudian-queue-indicator-actions' });
+
+        if (this.canSteerQueuedMessage()) {
+          const steerButton = actionsEl.createEl('button', {
+            cls: 'claudian-queue-indicator-action',
+            text: this.steerInFlight ? 'Steering...' : 'Steer Now',
           });
+          steerButton.setAttribute('type', 'button');
+          if (this.steerInFlight) {
+            steerButton.setAttribute('disabled', 'true');
+          } else {
+            steerButton.addEventListener('click', (event) => {
+              event.stopPropagation();
+              void this.steerQueuedMessage();
+            });
+          }
         }
+
+        const editButton = this.createQueueIconButton(
+          actionsEl,
+          'pencil',
+          'Edit queued message',
+        );
+        editButton.addEventListener('click', (event) => {
+          event.stopPropagation();
+          this.withdrawQueuedMessageToComposer();
+        });
+
+        const discardButton = this.createQueueIconButton(
+          actionsEl,
+          'trash-2',
+          'Discard queued message',
+        );
+        discardButton.addEventListener('click', (event) => {
+          event.stopPropagation();
+          this.clearQueuedMessage();
+        });
       }
 
       indicatorEl.addClass('claudian-visible-flex');
@@ -585,15 +633,39 @@ export class InputController {
     this.updateQueueIndicator();
   }
 
-  private restoreMessageToInput(message: QueuedMessage | null): void {
+  withdrawQueuedMessageToComposer(): void {
+    const { state } = this.deps;
+    if (!state.queuedMessage) return;
+
+    const queuedMessage = this.cloneQueuedMessage(state.queuedMessage);
+    state.queuedMessage = null;
+    this.restoreMessageToInput(queuedMessage, { mergeWithComposer: true });
+    this.updateQueueIndicator();
+  }
+
+  private restoreMessageToInput(
+    message: QueuedMessage | null,
+    options: { mergeWithComposer?: boolean } = {},
+  ): void {
     if (!message) return;
 
     const { content, images } = message;
     const inputEl = this.deps.getInputEl();
-    inputEl.value = content;
-    if (images && images.length > 0) {
-      this.deps.getImageContextManager()?.setImages(images);
+    const currentContent = options.mergeWithComposer ? inputEl.value.trim() : '';
+    inputEl.value = currentContent
+      ? appendMarkdownSnippet(content, currentContent)
+      : content;
+
+    const imageContextManager = this.deps.getImageContextManager();
+    const currentImages = options.mergeWithComposer
+      ? (imageContextManager?.getAttachedImages() ?? [])
+      : [];
+    const restoredImages = [...(images ?? []), ...currentImages];
+    if (restoredImages.length > 0) {
+      imageContextManager?.setImages(restoredImages);
     }
+    this.deps.resetInputHeight();
+    inputEl.focus();
   }
 
   private restorePendingMessagesToInput(): void {
@@ -602,7 +674,7 @@ export class InputController {
       this.pendingSteerMessage,
       state.queuedMessage,
     );
-    this.restoreMessageToInput(combinedMessage);
+    this.restoreMessageToInput(combinedMessage, { mergeWithComposer: true });
     state.queuedMessage = null;
     this.clearPendingSteerState();
     this.updateQueueIndicator();
@@ -612,22 +684,16 @@ export class InputController {
     const { state } = this.deps;
     if (!state.queuedMessage) return;
 
-    const { content, images, editorContext, browserContext, canvasContext } = state.queuedMessage;
+    const queuedMessage = this.cloneQueuedMessage(state.queuedMessage);
     state.queuedMessage = null;
     this.updateQueueIndicator();
-
-    const inputEl = this.deps.getInputEl();
-    inputEl.value = content;
-    if (images && images.length > 0) {
-      this.deps.getImageContextManager()?.setImages(images);
-    }
 
     window.setTimeout(
       () => {
         void this.sendMessage({
-          editorContextOverride: editorContext,
-          browserContextOverride: browserContext ?? null,
-          canvasContextOverride: canvasContext,
+          content: queuedMessage.content,
+          images: queuedMessage.images,
+          turnRequestOverride: this.toQueuedChatTurn(queuedMessage).request,
         });
       },
       0
@@ -711,6 +777,23 @@ export class InputController {
     return preview;
   }
 
+  private createQueueIconButton(
+    parentEl: HTMLElement,
+    icon: string,
+    label: string,
+  ): HTMLElement {
+    const button = parentEl.createEl('button', {
+      cls: 'claudian-queue-indicator-icon-action',
+      attr: {
+        'aria-label': label,
+        title: label,
+        type: 'button',
+      },
+    });
+    setIcon(button, icon);
+    return button;
+  }
+
   private canSteerQueuedMessage(): boolean {
     const agentService = this.getAgentService();
     return this.deps.state.isStreaming
@@ -722,6 +805,41 @@ export class InputController {
     return {
       ...message,
       images: message.images ? [...message.images] : undefined,
+      turnRequest: message.turnRequest
+        ? cloneChatTurnRequest(message.turnRequest)
+        : undefined,
+    };
+  }
+
+  private createQueuedMessage(displayContent: string, turnRequest: ChatTurnRequest): QueuedMessage {
+    const request = cloneChatTurnRequest(turnRequest);
+    return {
+      content: displayContent,
+      images: request.images,
+      editorContext: request.editorSelection ?? null,
+      browserContext: request.browserSelection ?? null,
+      canvasContext: request.canvasSelection ?? null,
+      turnRequest: request,
+    };
+  }
+
+  private toQueuedChatTurn(message: QueuedMessage): QueuedChatTurn {
+    if (message.turnRequest) {
+      return {
+        displayContent: message.content,
+        request: cloneChatTurnRequest(message.turnRequest),
+      };
+    }
+
+    return {
+      displayContent: message.content,
+      request: {
+        text: message.content,
+        images: message.images ? [...message.images] : undefined,
+        editorSelection: message.editorContext,
+        browserSelection: message.browserContext ?? null,
+        canvasSelection: message.canvasContext,
+      },
     };
   }
 
@@ -768,23 +886,14 @@ export class InputController {
     incoming: QueuedMessage,
   ): QueuedMessage {
     if (!existing) {
-      return {
-        ...incoming,
-        images: incoming.images ? [...incoming.images] : undefined,
-      };
+      return this.cloneQueuedMessage(incoming);
     }
 
-    const contentParts = [existing.content, incoming.content].filter(part => part.length > 0);
-
-    return {
-      content: contentParts.join('\n\n'),
-      images: [...(existing.images || []), ...(incoming.images || [])].filter(Boolean).length > 0
-        ? [...(existing.images || []), ...(incoming.images || [])]
-        : undefined,
-      editorContext: incoming.editorContext,
-      browserContext: incoming.browserContext,
-      canvasContext: incoming.canvasContext,
-    };
+    const mergedTurn = mergeQueuedChatTurns(
+      this.toQueuedChatTurn(existing),
+      this.toQueuedChatTurn(incoming),
+    );
+    return this.createQueuedMessage(mergedTurn.displayContent, mergedTurn.request);
   }
 
   private async steerQueuedMessage(): Promise<void> {
@@ -805,15 +914,9 @@ export class InputController {
     this.updateQueueIndicator();
 
     try {
-      const { displayContent, turnRequest } = this.buildTurnSubmission({
-        content: queuedMessage.content,
-        images: queuedMessage.images,
-        editorContextOverride: queuedMessage.editorContext,
-        browserContextOverride: queuedMessage.browserContext ?? null,
-        canvasContextOverride: queuedMessage.canvasContext,
-      });
+      const { displayContent, request } = this.toQueuedChatTurn(queuedMessage);
 
-      const preparedTurn = agentService.prepareTurn(turnRequest);
+      const preparedTurn = agentService.prepareTurn(request);
       const accepted = await agentService.steer(preparedTurn);
       if (state.cancelRequested || !this.pendingSteerMessage) {
         return;
@@ -831,7 +934,7 @@ export class InputController {
         currentNote: preparedTurn.isCompact
           ? undefined
           : preparedTurn.request.currentNotePath,
-        images: queuedMessage.images,
+        images: request.images,
       });
     } catch {
       this.restoreQueuedMessageAfterSteerFailure(queuedMessage);
@@ -857,7 +960,7 @@ export class InputController {
       return;
     }
 
-    this.restoreMessageToInput(message);
+    this.restoreMessageToInput(message, { mergeWithComposer: true });
     this.updateQueueIndicator();
   }
 

--- a/src/features/chat/state/types.ts
+++ b/src/features/chat/state/types.ts
@@ -1,6 +1,6 @@
 import type { EditorView } from '@codemirror/view';
 
-import type { ChatRuntimeQueryOptions } from '../../../core/runtime/types';
+import type { ChatRuntimeQueryOptions, ChatTurnRequest } from '../../../core/runtime/types';
 import type { TodoItem } from '../../../core/tools/todo';
 import type {
   ChatMessage,
@@ -22,6 +22,8 @@ export interface QueuedMessage {
   editorContext: EditorSelectionContext | null;
   browserContext?: BrowserSelectionContext | null;
   canvasContext: CanvasSelectionContext | null;
+  /** Provider-neutral turn snapshot captured at enqueue time. */
+  turnRequest?: ChatTurnRequest;
 }
 
 /** Pending tool call waiting to be rendered (buffered until input is complete). */

--- a/src/style/components/input.css
+++ b/src/style/components/input.css
@@ -199,6 +199,13 @@
   text-overflow: ellipsis;
 }
 
+.claudian-queue-indicator-actions {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .claudian-queue-indicator-action {
   flex: 0 0 auto;
   padding: 1px 8px;
@@ -217,6 +224,31 @@
   color: var(--text-faint);
   cursor: default;
   text-decoration: none;
+}
+
+.claudian-queue-indicator-icon-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.claudian-queue-indicator-icon-action:hover {
+  background: var(--background-modifier-hover);
+  color: var(--text-normal);
+}
+
+.claudian-queue-indicator-icon-action svg {
+  width: 14px;
+  height: 14px;
 }
 
 /* Light blue border when instruction mode is active */

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -233,12 +233,18 @@ describe('InputController - Message Queue', () => {
 
       await controller.sendMessage();
 
-      expect(deps.state.queuedMessage).toEqual({
+      expect(deps.state.queuedMessage).toMatchObject({
         content: 'queued message',
         images: undefined,
         editorContext: null,
         browserContext: null,
         canvasContext: null,
+      });
+      expect(deps.state.queuedMessage?.turnRequest).toMatchObject({
+        text: 'queued message',
+        editorSelection: null,
+        browserSelection: null,
+        canvasSelection: null,
       });
       expect(inputEl.value).toBe('');
     });
@@ -253,12 +259,16 @@ describe('InputController - Message Queue', () => {
 
       await controller.sendMessage();
 
-      expect(deps.state.queuedMessage).toEqual({
+      expect(deps.state.queuedMessage).toMatchObject({
         content: 'queued with images',
         images: mockImages,
         editorContext: null,
         browserContext: null,
         canvasContext: null,
+      });
+      expect(deps.state.queuedMessage?.turnRequest).toMatchObject({
+        text: 'queued with images',
+        images: mockImages,
       });
       expect(imageContextManager.clearImages).toHaveBeenCalled();
     });
@@ -322,7 +332,14 @@ describe('InputController - Message Queue', () => {
         jest.runAllTimers();
         await Promise.resolve();
 
-        expect(sendSpy).toHaveBeenCalledWith(expect.objectContaining({ editorContextOverride: null }));
+        expect(sendSpy).toHaveBeenCalledWith(expect.objectContaining({
+          content: 'queued plan',
+          turnRequestOverride: expect.objectContaining({
+            text: 'queued plan',
+            editorSelection: null,
+            canvasSelection: null,
+          }),
+        }));
         sendSpy.mockRestore();
       } finally {
         jest.useRealTimers();
@@ -347,6 +364,57 @@ describe('InputController - Message Queue', () => {
       controller.updateQueueIndicator();
 
       const queueIndicatorEl = deps.state.queueIndicatorEl as any;
+      expect(queueIndicatorEl.style.display).toBe('none');
+    });
+
+    it('should withdraw queued message to the composer for editing', () => {
+      const mockImages = [{ id: 'img1', name: 'queued.png' }];
+      const draftImages = [{ id: 'img2', name: 'draft.png' }];
+      deps.state.queuedMessage = {
+        content: 'queued content',
+        images: mockImages as any,
+        editorContext: null,
+        canvasContext: null,
+      };
+      inputEl.value = 'draft content';
+      const imageContextManager = deps.getImageContextManager()!;
+      (imageContextManager.getAttachedImages as jest.Mock).mockReturnValue(draftImages);
+
+      controller.updateQueueIndicator();
+
+      const queueIndicatorEl = deps.state.queueIndicatorEl as any;
+      const editButton = queueIndicatorEl
+        .querySelectorAll('.claudian-queue-indicator-icon-action')
+        .find((button: any) => button.getAttribute('aria-label') === 'Edit queued message');
+      editButton?.click();
+
+      expect(deps.state.queuedMessage).toBeNull();
+      expect(inputEl.value).toBe('queued content\n\ndraft content');
+      expect(imageContextManager.setImages).toHaveBeenCalledWith([...mockImages, ...draftImages]);
+      expect(deps.resetInputHeight).toHaveBeenCalled();
+      expect(inputEl.focus).toHaveBeenCalled();
+      expect(queueIndicatorEl.style.display).toBe('none');
+    });
+
+    it('should discard queued message without changing the composer', () => {
+      deps.state.queuedMessage = {
+        content: 'queued content',
+        images: undefined,
+        editorContext: null,
+        canvasContext: null,
+      };
+      inputEl.value = 'draft content';
+
+      controller.updateQueueIndicator();
+
+      const queueIndicatorEl = deps.state.queueIndicatorEl as any;
+      const discardButton = queueIndicatorEl
+        .querySelectorAll('.claudian-queue-indicator-icon-action')
+        .find((button: any) => button.getAttribute('aria-label') === 'Discard queued message');
+      discardButton?.click();
+
+      expect(deps.state.queuedMessage).toBeNull();
+      expect(inputEl.value).toBe('draft content');
       expect(queueIndicatorEl.style.display).toBe('none');
     });
 
@@ -2525,8 +2593,8 @@ describe('InputController - Message Queue', () => {
     });
   });
 
-  describe('processQueuedMessage restores images', () => {
-    it('should restore images from queued message', () => {
+  describe('processQueuedMessage sends the queued snapshot', () => {
+    it('should send images from the queued message without rebuilding composer state', () => {
       jest.useFakeTimers();
       try {
         const mockImages = [{ id: 'img1', name: 'test.png' }];
@@ -2536,13 +2604,19 @@ describe('InputController - Message Queue', () => {
           editorContext: null,
           canvasContext: null,
         };
-        const imageContextManager = deps.getImageContextManager()!;
         const sendSpy = jest.spyOn(controller, 'sendMessage').mockResolvedValue(undefined);
 
         (controller as any).processQueuedMessage();
         jest.runAllTimers();
 
-        expect(imageContextManager.setImages).toHaveBeenCalledWith(mockImages);
+        expect(sendSpy).toHaveBeenCalledWith(expect.objectContaining({
+          content: 'queued content',
+          images: mockImages,
+          turnRequestOverride: expect.objectContaining({
+            text: 'queued content',
+            images: mockImages,
+          }),
+        }));
         sendSpy.mockRestore();
       } finally {
         jest.useRealTimers();


### PR DESCRIPTION
Adds provider-neutral queued turn snapshots so queued prompts drain and steer using captured runtime request data across providers. Adds edit and discard actions to the shared composer queue row while keeping Codex steer behavior capability-gated. Covers queued snapshots, edit/discard, and queued image sends with unit tests. Fixes #647.