### PR TITLE
fix: restore scoped Escape handling for chat tabs

### DIFF
--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -1,5 +1,5 @@
 import type { EventRef, WorkspaceLeaf } from 'obsidian';
-import { ItemView, Notice, setIcon } from 'obsidian';
+import { ItemView, Notice, Scope, setIcon } from 'obsidian';
 
 import { getHiddenProviderCommandSet } from '../../core/providers/commands/hiddenCommands';
 import { ProviderRegistry } from '../../core/providers/ProviderRegistry';
@@ -236,6 +236,7 @@ export class ClaudianView extends ItemView {
 
     this.tabBar?.destroy();
     this.tabBar = null;
+    this.scope = null;
   }
 
   // ============================================
@@ -610,20 +611,19 @@ export class ClaudianView extends ItemView {
       }
     });
 
-    // Capture Escape while focus is inside the view so Obsidian does not handle
-    // it as pane navigation before Claudian can cancel streaming.
-    this.registerDomEvent(activeDocument, 'keydown', (e: KeyboardEvent) => {
-      if (e.key !== 'Escape' || e.isComposing) return;
-      const activeElement = activeDocument.activeElement;
-      if (!activeElement || !this.containerEl.contains(activeElement)) return;
-
-      e.preventDefault();
-      e.stopPropagation();
-      const activeTab = this.tabManager?.getActiveTab();
-      if (activeTab?.state.isStreaming) {
-        activeTab.controllers.inputController?.cancelStreaming();
+    // View scopes are the Obsidian-owned boundary for main-area tab hotkeys.
+    // Returning false consumes Escape before Obsidian uses it for pane navigation.
+    this.scope = new Scope(this.app.scope);
+    this.scope.register([], 'Escape', (e: KeyboardEvent) => {
+      if (e.isComposing) return;
+      if (!e.defaultPrevented) {
+        const activeTab = this.tabManager?.getActiveTab();
+        if (activeTab?.state.isStreaming) {
+          activeTab.controllers.inputController?.cancelStreaming();
+        }
       }
-    }, { capture: true });
+      return false;
+    });
 
     // Vault events - forward to active tab's file context manager
     const markCacheDirty = (includesFolders: boolean): void => {

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -63,6 +63,36 @@ export class ItemView {
 
 export class WorkspaceLeaf {}
 
+export class Scope {
+  static instances: Scope[] = [];
+
+  parent?: Scope;
+  handlers: Array<{
+    modifiers: string[] | null;
+    key: string | null;
+    func: (evt: KeyboardEvent, ctx?: unknown) => false | unknown;
+  }> = [];
+
+  constructor(parent?: Scope) {
+    this.parent = parent;
+    Scope.instances.push(this);
+  }
+
+  register = jest.fn((
+    modifiers: string[] | null,
+    key: string | null,
+    func: (evt: KeyboardEvent, ctx?: unknown) => false | unknown
+  ) => {
+    const handler = { modifiers, key, func };
+    this.handlers.push(handler);
+    return handler;
+  });
+
+  unregister = jest.fn((handler: unknown) => {
+    this.handlers = this.handlers.filter((entry) => entry !== handler);
+  });
+}
+
 export const Platform = {
   isMacOS: true,
 };

--- a/tests/unit/features/chat/ClaudianView.test.ts
+++ b/tests/unit/features/chat/ClaudianView.test.ts
@@ -1,6 +1,9 @@
 import { createMockEl } from '@test/helpers/mockElement';
+import { Scope } from 'obsidian';
 
 import { ClaudianView } from '@/features/chat/ClaudianView';
+
+const MockScope = Scope as typeof Scope & { instances: Scope[] };
 
 function createViewHarness(options: {
   canCreateTab: boolean;
@@ -52,5 +55,120 @@ describe('ClaudianView tab controls', () => {
     expect(newTabButtonEl.hasClass('claudian-hidden')).toBe(false);
     expect(newTabButtonEl.getAttribute('aria-disabled')).toBeNull();
     expect(newTabButtonEl.getAttribute('aria-hidden')).toBeNull();
+  });
+});
+
+describe('ClaudianView Escape handling', () => {
+  beforeEach(() => {
+    MockScope.instances.length = 0;
+  });
+
+  function createEscapeHarness(options: {
+    isStreaming: boolean;
+  }): {
+    cancelStreaming: jest.Mock;
+    eventRefs: unknown[];
+    view: any;
+  } {
+    const cancelStreaming = jest.fn();
+    const eventRefs: unknown[] = [];
+    const parentScope = new Scope();
+    const view = Object.create(ClaudianView.prototype) as any;
+
+    view.app = { scope: parentScope };
+    view.containerEl = createMockEl();
+    view.historyDropdown = createMockEl();
+    view.registerDomEvent = jest.fn();
+    view.registerEvent = jest.fn();
+    view.eventRefs = eventRefs;
+    view.plugin = {
+      app: {
+        vault: {
+          on: jest.fn((_event: string, handler: unknown) => {
+            const ref = { handler };
+            eventRefs.push(ref);
+            return ref;
+          }),
+        },
+        workspace: {
+          on: jest.fn((_event: string, handler: unknown) => {
+            const ref = { handler };
+            eventRefs.push(ref);
+            return ref;
+          }),
+        },
+      },
+    };
+    view.tabManager = {
+      getActiveTab: jest.fn().mockReturnValue({
+        state: { isStreaming: options.isStreaming },
+        controllers: {
+          inputController: { cancelStreaming },
+        },
+        ui: {
+          fileContextManager: {
+            markFileCacheDirty: jest.fn(),
+            markFolderCacheDirty: jest.fn(),
+            handleFileOpen: jest.fn(),
+            handleClickOutside: jest.fn(),
+          },
+        },
+      }),
+    };
+
+    return { cancelStreaming, eventRefs, view };
+  }
+
+  it('registers Escape on the Obsidian view scope instead of document keydown capture', () => {
+    const { view } = createEscapeHarness({ isStreaming: true });
+
+    view.wireEventHandlers();
+
+    expect(view.scope).toBeInstanceOf(Scope);
+    expect(view.scope.parent).toBe(view.app.scope);
+    expect(view.scope.register).toHaveBeenCalledWith([], 'Escape', expect.any(Function));
+    expect(view.registerDomEvent).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'keydown',
+      expect.any(Function),
+      { capture: true }
+    );
+  });
+
+  it('cancels streaming and consumes scoped Escape', () => {
+    const { cancelStreaming, view } = createEscapeHarness({ isStreaming: true });
+
+    view.wireEventHandlers();
+    const escapeHandler = view.scope.handlers.find((handler: any) => handler.key === 'Escape');
+    const result = escapeHandler.func({ key: 'Escape', isComposing: false } as KeyboardEvent);
+
+    expect(cancelStreaming).toHaveBeenCalledTimes(1);
+    expect(result).toBe(false);
+  });
+
+  it('consumes scoped Escape without cancelling when not streaming', () => {
+    const { cancelStreaming, view } = createEscapeHarness({ isStreaming: false });
+
+    view.wireEventHandlers();
+    const escapeHandler = view.scope.handlers.find((handler: any) => handler.key === 'Escape');
+    const result = escapeHandler.func({ key: 'Escape', isComposing: false } as KeyboardEvent);
+
+    expect(cancelStreaming).not.toHaveBeenCalled();
+    expect(result).toBe(false);
+  });
+
+  it('consumes already handled scoped Escape without cancelling again', () => {
+    const { cancelStreaming, view } = createEscapeHarness({ isStreaming: true });
+
+    view.wireEventHandlers();
+    const escapeHandler = view.scope.handlers.find((handler: any) => handler.key === 'Escape');
+    const result = escapeHandler.func({
+      key: 'Escape',
+      isComposing: false,
+      defaultPrevented: true,
+    } as KeyboardEvent);
+
+    expect(cancelStreaming).not.toHaveBeenCalled();
+    expect(result).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- restore Obsidian Scope-based Escape handling for Claudian main-editor tabs
- keep Escape consumed so Obsidian does not switch panes while stopping streaming
- add regression coverage for scoped Escape registration and cancellation behavior

## Regression
- Issue #351 was fixed by 2681e98a using Obsidian's Scope API.
- Commit 2318a6c8 (#631) replaced that path with document keydown capture, which allowed the main-editor tab navigation regression to return.

Fixes #655

## Validation
- npm run typecheck
- npm run lint
- npm run test
- npm run build