### PR TITLE
fix: AskUserQuestion "Other" custom input unreachable for Claude provider

### DIFF
--- a/src/features/chat/rendering/InlineAskUserQuestion.ts
+++ b/src/features/chat/rendering/InlineAskUserQuestion.ts
@@ -512,10 +512,6 @@ export class InlineAskUserQuestion {
   }
 
   private handleNavigationKey(e: KeyboardEvent, maxFocusIndex: number): boolean {
-    if (this.isInputFocused && e.key !== 'Escape') {
-      (this.rootEl.ownerDocument.activeElement as HTMLElement | null)?.blur();
-      this.isInputFocused = false;
-    }
     switch (e.key) {
       case 'ArrowDown':
         e.preventDefault();
@@ -575,6 +571,22 @@ export class InlineAskUserQuestion {
         } else {
           this.switchTab(this.activeTabIndex + 1);
         }
+        return;
+      }
+      if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        e.stopPropagation();
+        (this.rootEl.ownerDocument.activeElement as HTMLElement | null)?.blur();
+        this.isInputFocused = false;
+        const q = this.questions[this.activeTabIndex];
+        const maxIdx = this.canShowCustomInputForQuestion(q) ? q.options.length : q.options.length - 1;
+        if (e.key === 'ArrowUp') {
+          this.focusedItemIndex = Math.max(this.focusedItemIndex - 1, 0);
+        } else {
+          this.focusedItemIndex = Math.min(this.focusedItemIndex + 1, maxIdx);
+        }
+        this.updateFocusIndicator();
+        this.rootEl.focus();
         return;
       }
       return;

--- a/src/features/chat/rendering/InlineAskUserQuestion.ts
+++ b/src/features/chat/rendering/InlineAskUserQuestion.ts
@@ -324,6 +324,12 @@ export class InlineAskUserQuestion {
         this.isInputFocused = false;
       });
 
+      customRow.addEventListener('click', () => {
+        this.focusedItemIndex = customIdx;
+        this.updateFocusIndicator();
+        inputEl.focus();
+      });
+
       this.currentItems.push(customRow);
     }
 
@@ -482,25 +488,9 @@ export class InlineAskUserQuestion {
         item.addClass('is-focused');
         if (cursor) cursor.textContent = '\u203A';
         item.scrollIntoView({ block: 'nearest' });
-
-        if (item.hasClass('claudian-ask-custom-item')) {
-          const input = item.querySelector('.claudian-ask-custom-text') as HTMLInputElement;
-          if (input) {
-            input.focus();
-            this.isInputFocused = true;
-          }
-        }
       } else {
         item.removeClass('is-focused');
         if (cursor) cursor.textContent = '\u00A0';
-
-        if (item.hasClass('claudian-ask-custom-item')) {
-          const input = item.querySelector('.claudian-ask-custom-text') as HTMLInputElement;
-          if (input && this.rootEl.ownerDocument.activeElement === input) {
-            input.blur();
-            this.isInputFocused = false;
-          }
-        }
       }
     }
   }
@@ -522,6 +512,10 @@ export class InlineAskUserQuestion {
   }
 
   private handleNavigationKey(e: KeyboardEvent, maxFocusIndex: number): boolean {
+    if (this.isInputFocused && e.key !== 'Escape') {
+      (this.rootEl.ownerDocument.activeElement as HTMLElement | null)?.blur();
+      this.isInputFocused = false;
+    }
     switch (e.key) {
       case 'ArrowDown':
         e.preventDefault();
@@ -632,9 +626,8 @@ export class InlineAskUserQuestion {
           this.selectOption(this.activeTabIndex, q.options[this.focusedItemIndex]);
         } else if (this.canShowCustomInputForQuestion(q)) {
           this.isInputFocused = true;
-          const input = this.contentArea.querySelector(
-            '.claudian-ask-custom-text',
-          ) as HTMLInputElement;
+          const customRow = this.currentItems[this.focusedItemIndex];
+          const input = customRow?.querySelector('.claudian-ask-custom-text') as HTMLInputElement;
           input?.focus();
         }
         break;

--- a/src/providers/claude/runtime/ClaudeApprovalHandler.ts
+++ b/src/providers/claude/runtime/ClaudeApprovalHandler.ts
@@ -82,6 +82,18 @@ export function createClaudeApprovalCallback(
     const askUserQuestionCallback = deps.getAskUserQuestionCallback();
     if (toolName === TOOL_ASK_USER_QUESTION && askUserQuestionCallback) {
       try {
+        // The SDK's JSDoc says "Other will be provided automatically" but
+        // the SDK doesn't inject isOther into the canUseTool input. Claudian
+        // intercepts at canUseTool and renders its own UI, so we must inject
+        // isOther here to match the Claude Code CLI's built-in behavior.
+        const questions = (input as Record<string, unknown>).questions;
+        if (Array.isArray(questions)) {
+          for (const q of questions) {
+            if (q && typeof q === 'object' && !('isOther' in q)) {
+              (q as Record<string, unknown>).isOther = true;
+            }
+          }
+        }
         const answers = await askUserQuestionCallback(input, options.signal);
         if (answers === null) {
           return { behavior: 'deny', message: 'User declined to answer.', interrupt: true };

--- a/tests/helpers/mockElement.ts
+++ b/tests/helpers/mockElement.ts
@@ -286,8 +286,14 @@ export function createMockEl(tag = 'div'): any {
       return children.some(child => (child as any).contains?.(node));
     },
     scrollIntoView() {},
-    focus() {},
-    blur() {},
+    focus() {
+      const handlers = eventListeners.get('focus') || [];
+      handlers.forEach(h => h({ type: 'focus', target: element }));
+    },
+    blur() {
+      const handlers = eventListeners.get('blur') || [];
+      handlers.forEach(h => h({ type: 'blur', target: element }));
+    },
     select() {},
 
     setAttribute(name: string, value: string) {

--- a/tests/unit/features/chat/rendering/InlineAskUserQuestion.test.ts
+++ b/tests/unit/features/chat/rendering/InlineAskUserQuestion.test.ts
@@ -17,6 +17,7 @@ function makeInput(
     options: unknown[];
     multiSelect?: boolean;
     header?: string;
+    isOther?: boolean;
   }>,
 ): Record<string, unknown> {
   return { questions };
@@ -705,6 +706,80 @@ describe('InlineAskUserQuestion', () => {
       expect(submitTab?.hasClass('is-active')).toBe(true);
 
       jest.useRealTimers();
+    });
+
+    it('click on custom row focuses it', () => {
+      const input = makeInput([{ question: 'Q', options: ['A', 'B'], isOther: true }]);
+      const { container } = renderWidget(input);
+
+      const items = findItems(container);
+      const customItem = items.find((i: any) => i.hasClass('claudian-ask-custom-item'));
+      customItem?.click();
+
+      expect(customItem?.hasClass('is-focused')).toBe(true);
+    });
+
+    it('ArrowUp from custom row blurs input focus and moves to option above', () => {
+      const input = makeInput([{ question: 'Q', options: ['A', 'B'], isOther: true }]);
+      const { container } = renderWidget(input);
+      const root = findRoot(container);
+
+      const items = findItems(container);
+      const customItem = items.find((i: any) => i.hasClass('claudian-ask-custom-item'));
+      // Simulate click on custom row (focusedItemIndex = options.length, isInputFocused = true)
+      customItem?.click();
+
+      fireKeyDown(root, 'ArrowUp');
+
+      // Focus should move to the last regular option (index = options.length - 1)
+      const updatedItems = findItems(container);
+      const lastOption = updatedItems.filter(
+        (i: any) => !i.hasClass('claudian-ask-custom-item'),
+      );
+      expect(lastOption[lastOption.length - 1]?.hasClass('is-focused')).toBe(true);
+      expect(customItem?.hasClass('is-focused')).toBe(false);
+    });
+
+    it('Enter on custom item activates input without advancing tab', () => {
+      const input = makeInput([
+        { question: 'Q1', options: ['A'], isOther: true },
+        { question: 'Q2', options: ['B'] },
+      ]);
+      const { container } = renderWidget(input);
+      const root = findRoot(container);
+
+      // Arrow down to custom item
+      fireKeyDown(root, 'ArrowDown'); // Focus on option A (index 0)
+      fireKeyDown(root, 'ArrowDown'); // Focus on custom item (index 1)
+
+      // Press Enter — should activate input, NOT advance tab
+      fireKeyDown(root, 'Enter');
+
+      // Should still be on Q1 tab
+      const tabs = container.querySelectorAll('claudian-ask-tab');
+      expect(tabs[0]?.hasClass('is-active')).toBe(true);
+    });
+
+    it('Enter on custom item then Enter again advances to next tab', () => {
+      const input = makeInput([
+        { question: 'Q1', options: ['A'], isOther: true },
+        { question: 'Q2', options: ['B'] },
+      ]);
+      const { container } = renderWidget(input);
+      const root = findRoot(container);
+
+      // Arrow down to custom item
+      fireKeyDown(root, 'ArrowDown');
+      fireKeyDown(root, 'ArrowDown');
+
+      // First Enter activates input
+      fireKeyDown(root, 'Enter');
+      // Second Enter advances
+      fireKeyDown(root, 'Enter');
+
+      // Should be on Q2 tab now
+      const tabs = container.querySelectorAll('claudian-ask-tab');
+      expect(tabs[1]?.hasClass('is-active')).toBe(true);
     });
   });
 });

--- a/tests/unit/features/chat/rendering/InlineAskUserQuestion.test.ts
+++ b/tests/unit/features/chat/rendering/InlineAskUserQuestion.test.ts
@@ -781,6 +781,77 @@ describe('InlineAskUserQuestion', () => {
       const tabs = container.querySelectorAll('claudian-ask-tab');
       expect(tabs[1]?.hasClass('is-active')).toBe(true);
     });
+
+    it('ArrowDown from custom input blurs and clamps at max', () => {
+      const input = makeInput([{ question: 'Q', options: ['A', 'B'], isOther: true }]);
+      const { container } = renderWidget(input);
+      const root = findRoot(container);
+
+      const items = findItems(container);
+      const customItem = items.find((i: any) => i.hasClass('claudian-ask-custom-item'));
+      customItem?.click();
+
+      fireKeyDown(root, 'ArrowDown');
+
+      // Custom row is last item, ArrowDown clamps — focus stays on custom row (navigation mode)
+      expect(customItem?.hasClass('is-focused')).toBe(true);
+    });
+
+    it('Escape from custom input returns to navigation without cancelling dialog', () => {
+      const input = makeInput([
+        { question: 'Q1', options: ['A'], isOther: true },
+        { question: 'Q2', options: ['B'] },
+      ]);
+      const { container, resolve } = renderWidget(input);
+      const root = findRoot(container);
+
+      // Navigate to custom input and activate
+      fireKeyDown(root, 'ArrowDown'); // focus on custom row (index 1)
+      fireKeyDown(root, 'Enter');     // activate input
+
+      // Escape should exit input mode, not cancel
+      fireKeyDown(root, 'Escape');
+
+      // Dialog should NOT be resolved
+      expect(resolve).not.toHaveBeenCalled();
+
+      // Should still be on Q1 tab
+      const tabs = container.querySelectorAll('claudian-ask-tab');
+      expect(tabs[0]?.hasClass('is-active')).toBe(true);
+
+      // Custom row should still be focused in navigation mode
+      const items = findItems(container);
+      const customItem = items.find((i: any) => i.hasClass('claudian-ask-custom-item'));
+      expect(customItem?.hasClass('is-focused')).toBe(true);
+    });
+
+    it('Enter from custom input commits text and advances tab', () => {
+      const input = makeInput([
+        { question: 'Q1', options: ['A'], isOther: true },
+        { question: 'Q2', options: ['B'] },
+      ]);
+      const { container } = renderWidget(input);
+      const root = findRoot(container);
+
+      // Navigate to custom input and activate
+      fireKeyDown(root, 'ArrowDown'); // focus on custom row (index 1)
+      fireKeyDown(root, 'Enter');     // activate input
+
+      // Simulate typing text
+      const customItem = findItems(container).find((i: any) =>
+        i.hasClass('claudian-ask-custom-item'),
+      );
+      const inputEl = customItem?.querySelector('.claudian-ask-custom-text');
+      inputEl.value = 'my custom text';
+      inputEl.dispatchEvent({ type: 'input' });
+
+      // Enter should commit and advance
+      fireKeyDown(root, 'Enter');
+
+      // Should be on Q2 tab
+      const tabs = container.querySelectorAll('claudian-ask-tab');
+      expect(tabs[1]?.hasClass('is-active')).toBe(true);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

修复了Plan Mode下 AskUserQuestion 对话框中 "Other"（其他/请具体说明）选项的两个问题：

1. **键盘导航Bug**：箭头选中 "Other" 后按Enter直接跳转到下一个tab，用户无法输入文字
2. **isOther Gap**：Claude 提供者的 "Other" 选项从不渲染 —— SDK 承诺"会自动提供"但不把 `isOther` 注入到 `canUseTool` 回调

## Root Cause

### 键盘导航：`updateFocusIndicator` 的副作用

`InlineAskUserQuestion.updateFocusIndicator()` 本该只处理视觉指示器（高亮、光标），却通过 `.focus()` 调用将 `isInputFocused` 从 `false` 切换为 `true`，改变了键盘处理分派（从导航模式切换为输入模式）。由于此模式切换发生在 ArrowDown 到 Enter 之间，Enter 就被误认为是 "确认并前进" 而非 "激活输入框"（Enter行为根据不同模式不同）。

### isOther Gap：Chaudian 的 `canUseTool` 拦截跳过了 SDK 的内置UI

SDK 文档说明 "Other will be provided automatically"，但这仅适用于 SDK 自己的 Inquirer UI。Chaudian 在 `canUseTool` 阶段直接拦截并用 `InlineAskUserQuestion` 渲染自定义 UI，导致 SDK 的内置 "Other" 注入逻辑永远不会执行。且 `AskUserQuestionInput` 类型中根本没有 `isOther` 字段。

## Changes

### Commit 1: `fix: prevent custom input from advancing tab before user can type`

**`InlineAskUserQuestion.ts`**:
- **Fix 1**: 移除 `updateFocusIndicator()` 内的自动 `.focus()`/`.blur()` 副作用（原Line 486-492, 497-503）—— 该方法现在仅处理视觉指示器
- **Fix 2**: 在 `handleNavigationKey()` 开头增加 guard，当 `isInputFocused =true` 时先 blur 再处理导航（Enter 两次操作流：首次激活输入、二次前进tab）
- **Fix 3**: 为 `customRow` 增加 click handler，点击行即可直接激活输入框
- **Fix 4**: 将 `contentArea.querySelector()` 改为 `currentItems[focusedItemIndex].querySelector()` —— 多 question 场景下正确获取对应输入框

**`InlineAskUserQuestion.test.ts`**:
- 新增 4 个单元测试：click focus, ArrowUp blur, Enter 激活, Enter 再 Enter 前进

### Commit 2: `fix: inject isOther into Claude AskUserQuestion input`

**`ClaudeApprovalHandler.ts`** (Line 85-93):
- 在调用 `askUserQuestionCallback` 前，遍历 `input.questions` 并注入 `isOther: true`
- `!('isOther' in q)` guard 保证 SDK 未来如果开始注入 `isOther` 时自动跳过，避免 double-set
- 仅影响 Claude 提供者（Codex 已有独立的 `isOther` 支持，不经过此回调）

## Verification

- [x] `npm run typecheck` — 通过
- [x] `npm run lint` — 通过
- [x] `npm run test -- --selectProjects unit` — 198 test suite 通过
- [x] `npm run build` — 成功
- [x] 手动测试 Obsidian v1.10.3 — Plan Mode 触发 AskUserQuestion，每个 tab 页底部渲染 "Other" 输入框，可正常输入并提交

## Test Plan

1. 启动 Obsidian，进入 Plan Mode (`/plan`)
2. 让 AI 调用 AskUserQuestion（例如提问带有选项的问题）
3. 在每个 question tab 中，使用箭头键导航到底部的 "Other" 行
4. 按 Enter 激活输入框，输入自定义文字
5. 按 Enter 前进到下一 tab
6. 在最终 Review tab 中确认自定义文本正确显示
7. 用鼠标点击 "Other" 行，验证直接激活输入
8. 在输入框激活状态按 ArrowUp，验证输入框失焦并回到导航状态