### PR TITLE
Support OpenCode ACP thinking levels

### DIFF
--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -262,6 +262,13 @@ export interface ProviderChatUIConfig {
   /** Apply model change side effects to settings (defaults, tracking). */
   applyModelDefaults(model: string, settings: unknown): void;
 
+  /** Optional provider hook to discover model-scoped metadata after a model is selected. */
+  prepareModelMetadata?(
+    model: string,
+    settings: Record<string, unknown>,
+    context: { plugin: ClaudianPlugin },
+  ): Promise<void>;
+
   /** Optional hook when the toolbar changes a reasoning selection. */
   applyReasoningSelection?(model: string, value: string, settings: unknown): void;
 

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -790,6 +790,7 @@ function initializeInputToolbar(
         if (didProviderChange) {
           await onProviderChanged?.(newProvider);
         }
+        await uiConfig.prepareModelMetadata?.(model, plugin.settings, { plugin });
         tab.ui.thinkingBudgetSelector?.updateDisplay();
         tab.ui.serviceTierToggle?.updateDisplay();
         tab.ui.modelSelector?.updateDisplay();
@@ -815,6 +816,7 @@ function initializeInputToolbar(
         settings.model = model;
         uiConfig.applyModelDefaults(model, settings);
       });
+      await uiConfig.prepareModelMetadata?.(model, plugin.settings, { plugin });
       tab.ui.thinkingBudgetSelector?.updateDisplay();
       tab.ui.serviceTierToggle?.updateDisplay();
       tab.ui.modelSelector?.updateDisplay();

--- a/src/providers/acp/AcpSessionConfig.ts
+++ b/src/providers/acp/AcpSessionConfig.ts
@@ -19,6 +19,12 @@ export interface AcpResolvedSessionModeState {
   currentModeId: string | null;
 }
 
+export interface AcpResolvedSessionThoughtLevelState {
+  availableLevels: SelectItem[];
+  configId: string | null;
+  currentLevel: string | null;
+}
+
 type SelectItem = { description?: string; id: string; name: string };
 
 export function flattenAcpSessionConfigSelectOptions(
@@ -61,16 +67,27 @@ export function extractAcpSessionModeState(params: {
   };
 }
 
+export function extractAcpSessionThoughtLevelState(params: {
+  configOptions?: AcpSessionConfigOption[] | null;
+}): AcpResolvedSessionThoughtLevelState {
+  const { configId, items, current } = resolveSelectItems(params.configOptions, 'thought_level');
+  return {
+    availableLevels: items ?? [],
+    configId,
+    currentLevel: current,
+  };
+}
+
 // `items` is null when the config option is missing or empty so callers fall back to
 // the session's own metadata. `current` is always the config option's `currentValue`
 // when one exists, so fallbacks can still seed a current id from it.
 function resolveSelectItems(
   configOptions: AcpSessionConfigOption[] | null | undefined,
-  category: 'model' | 'mode',
-): { current: string | null; items: SelectItem[] | null } {
+  category: 'model' | 'mode' | 'thought_level',
+): { configId: string | null; current: string | null; items: SelectItem[] | null } {
   const selectOption = findSessionConfigSelectOption(configOptions, category);
   if (!selectOption) {
-    return { current: null, items: null };
+    return { configId: null, current: null, items: null };
   }
 
   const items = flattenAcpSessionConfigSelectOptions(selectOption.options).map((option) => ({
@@ -80,6 +97,7 @@ function resolveSelectItems(
   }));
 
   return {
+    configId: selectOption.id,
     current: selectOption.currentValue,
     items: items.length > 0 ? items : null,
   };
@@ -87,7 +105,7 @@ function resolveSelectItems(
 
 function findSessionConfigSelectOption(
   configOptions: AcpSessionConfigOption[] | null | undefined,
-  category: 'model' | 'mode',
+  category: 'model' | 'mode' | 'thought_level',
 ): Extract<AcpSessionConfigOption, { type: 'select' }> | null {
   if (!configOptions) {
     return null;
@@ -101,9 +119,13 @@ function findSessionConfigSelectOption(
     return byCategory;
   }
   const byLegacyId = configOptions.find((option) => (
-    option.type === 'select' && normalizeComparableKey(option.id) === category
+    option.type === 'select' && normalizeComparableKey(option.id) === legacyConfigIdForCategory(category)
   ));
   return byLegacyId?.type === 'select' ? byLegacyId : null;
+}
+
+function legacyConfigIdForCategory(category: 'model' | 'mode' | 'thought_level'): string {
+  return category === 'thought_level' ? 'effort' : category;
 }
 
 function isSelectGroup(

--- a/src/providers/opencode/discoveryState.ts
+++ b/src/providers/opencode/discoveryState.ts
@@ -1,7 +1,9 @@
-import { sameDiscoveredModels, sameModes } from './internal/compareCollections';
+import { sameDiscoveredModels, sameModes, sameThinkingOptionsByModel } from './internal/compareCollections';
 import {
   normalizeOpencodeDiscoveredModels,
+  normalizeOpencodeThinkingOptionsByModel,
   type OpencodeDiscoveredModel,
+  type OpencodeThinkingOptionsByModel,
 } from './models';
 import {
   normalizeOpencodeAvailableModes,
@@ -13,6 +15,7 @@ const OPENCODE_DISCOVERY_STATE = Symbol('opencodeDiscoveryState');
 interface OpencodeDiscoveryState {
   availableModes: OpencodeMode[];
   discoveredModels: OpencodeDiscoveredModel[];
+  thinkingOptionsByModel: OpencodeThinkingOptionsByModel;
 }
 
 type SettingsBag = Record<string | symbol, unknown>;
@@ -21,12 +24,17 @@ function ensureDiscoveryState(settings: Record<string, unknown>): OpencodeDiscov
   const bag = settings as SettingsBag;
   const existing = bag[OPENCODE_DISCOVERY_STATE];
   if (existing && typeof existing === 'object' && !Array.isArray(existing)) {
-    return existing as OpencodeDiscoveryState;
+    const state = existing as Partial<OpencodeDiscoveryState>;
+    state.availableModes ??= [];
+    state.discoveredModels ??= [];
+    state.thinkingOptionsByModel ??= {};
+    return state as OpencodeDiscoveryState;
   }
 
   const next: OpencodeDiscoveryState = {
     availableModes: [],
     discoveredModels: [],
+    thinkingOptionsByModel: {},
   };
   bag[OPENCODE_DISCOVERY_STATE] = next;
   return next;
@@ -40,11 +48,23 @@ function cloneDiscoveredModels(models: OpencodeDiscoveredModel[]): OpencodeDisco
   return models.map((model) => ({ ...model }));
 }
 
+function cloneThinkingOptionsByModel(
+  optionsByModel: OpencodeThinkingOptionsByModel,
+): OpencodeThinkingOptionsByModel {
+  return Object.fromEntries(
+    Object.entries(optionsByModel).map(([rawId, options]) => [
+      rawId,
+      options.map((option) => ({ ...option })),
+    ]),
+  );
+}
+
 export function getOpencodeDiscoveryState(settings: Record<string, unknown>): OpencodeDiscoveryState {
   const state = ensureDiscoveryState(settings);
   return {
     availableModes: cloneModes(state.availableModes),
     discoveredModels: cloneDiscoveredModels(state.discoveredModels),
+    thinkingOptionsByModel: cloneThinkingOptionsByModel(state.thinkingOptionsByModel),
   };
 }
 
@@ -59,8 +79,12 @@ export function updateOpencodeDiscoveryState(
   const nextDiscoveredModels = 'discoveredModels' in updates
     ? normalizeOpencodeDiscoveredModels(updates.discoveredModels)
     : state.discoveredModels;
+  const nextThinkingOptionsByModel = 'thinkingOptionsByModel' in updates
+    ? normalizeOpencodeThinkingOptionsByModel(updates.thinkingOptionsByModel, nextDiscoveredModels)
+    : state.thinkingOptionsByModel;
   const changed = !sameModes(state.availableModes, nextAvailableModes)
-    || !sameDiscoveredModels(state.discoveredModels, nextDiscoveredModels);
+    || !sameDiscoveredModels(state.discoveredModels, nextDiscoveredModels)
+    || !sameThinkingOptionsByModel(state.thinkingOptionsByModel, nextThinkingOptionsByModel);
 
   if (!changed) {
     return false;
@@ -68,17 +92,23 @@ export function updateOpencodeDiscoveryState(
 
   state.availableModes = cloneModes(nextAvailableModes);
   state.discoveredModels = cloneDiscoveredModels(nextDiscoveredModels);
+  state.thinkingOptionsByModel = cloneThinkingOptionsByModel(nextThinkingOptionsByModel);
   return true;
 }
 
 export function clearOpencodeDiscoveryState(settings: Record<string, unknown>): boolean {
   const state = ensureDiscoveryState(settings);
-  if (state.availableModes.length === 0 && state.discoveredModels.length === 0) {
+  if (
+    state.availableModes.length === 0
+    && state.discoveredModels.length === 0
+    && Object.keys(state.thinkingOptionsByModel).length === 0
+  ) {
     return false;
   }
 
   state.availableModes = [];
   state.discoveredModels = [];
+  state.thinkingOptionsByModel = {};
   return true;
 }
 
@@ -93,9 +123,13 @@ export function seedOpencodeDiscoveryStateFromLegacyConfig(
   const nextDiscoveredModels = state.discoveredModels.length > 0
     ? state.discoveredModels
     : normalizeOpencodeDiscoveredModels(legacyConfig.discoveredModels);
+  const nextThinkingOptionsByModel = Object.keys(state.thinkingOptionsByModel).length > 0
+    ? state.thinkingOptionsByModel
+    : normalizeOpencodeThinkingOptionsByModel(legacyConfig.thinkingOptionsByModel, nextDiscoveredModels);
 
   return updateOpencodeDiscoveryState(settings, {
     availableModes: nextAvailableModes,
     discoveredModels: nextDiscoveredModels,
+    thinkingOptionsByModel: nextThinkingOptionsByModel,
   });
 }

--- a/src/providers/opencode/internal/compareCollections.ts
+++ b/src/providers/opencode/internal/compareCollections.ts
@@ -1,4 +1,4 @@
-import type { OpencodeDiscoveredModel } from '../models';
+import type { OpencodeDiscoveredModel, OpencodeThinkingOptionsByModel } from '../models';
 import type { OpencodeMode } from '../modes';
 
 export function sameStringList(left: string[], right: string[]): boolean {
@@ -46,4 +46,27 @@ export function sameDiscoveredModels(
     && model.label === right[index]?.label
     && (model.description ?? '') === (right[index]?.description ?? '')
   ));
+}
+
+export function sameThinkingOptionsByModel(
+  left: OpencodeThinkingOptionsByModel,
+  right: OpencodeThinkingOptionsByModel,
+): boolean {
+  const leftEntries = Object.entries(left);
+  if (leftEntries.length !== Object.keys(right).length) {
+    return false;
+  }
+
+  return leftEntries.every(([rawId, leftOptions]) => {
+    const rightOptions = right[rawId] ?? [];
+    if (leftOptions.length !== rightOptions.length) {
+      return false;
+    }
+
+    return leftOptions.every((option, index) => (
+      option.value === rightOptions[index]?.value
+      && option.label === rightOptions[index]?.label
+      && (option.description ?? '') === (rightOptions[index]?.description ?? '')
+    ));
+  });
 }

--- a/src/providers/opencode/models.ts
+++ b/src/providers/opencode/models.ts
@@ -10,6 +10,8 @@ export interface OpencodeModelVariant {
   value: string;
 }
 
+export type OpencodeThinkingOptionsByModel = Record<string, OpencodeModelVariant[]>;
+
 export interface OpencodeBaseModel {
   description?: string;
   label: string;
@@ -87,6 +89,65 @@ export function normalizeOpencodeDiscoveredModels(value: unknown): OpencodeDisco
       label: label || rawId,
       rawId,
     });
+  }
+
+  return normalized;
+}
+
+export function normalizeOpencodeModelVariants(value: unknown): OpencodeModelVariant[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const variants: OpencodeModelVariant[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      continue;
+    }
+
+    const record = entry as Record<string, unknown>;
+    const rawValue = typeof record.value === 'string' ? record.value.trim() : '';
+    if (!rawValue) {
+      continue;
+    }
+
+    let rawLabel = '';
+    if (typeof record.label === 'string') {
+      rawLabel = record.label.trim();
+    } else if (typeof record.name === 'string') {
+      rawLabel = record.name.trim();
+    }
+    const description = typeof record.description === 'string'
+      ? record.description.trim()
+      : '';
+
+    variants.push({
+      ...(description ? { description } : {}),
+      label: rawLabel || formatOpencodeThinkingLevelLabel(rawValue),
+      value: rawValue,
+    });
+  }
+
+  return dedupeOpencodeVariants(variants);
+}
+
+export function normalizeOpencodeThinkingOptionsByModel(
+  value: unknown,
+  discoveredModels: OpencodeDiscoveredModel[] = [],
+): OpencodeThinkingOptionsByModel {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  const normalized: OpencodeThinkingOptionsByModel = {};
+  for (const [rawId, variants] of Object.entries(value as Record<string, unknown>)) {
+    const normalizedRawId = resolveOpencodeBaseModelRawId(rawId.trim(), discoveredModels);
+    const normalizedVariants = normalizeOpencodeModelVariants(variants);
+    if (!normalizedRawId || normalizedVariants.length === 0) {
+      continue;
+    }
+
+    normalized[normalizedRawId] = normalizedVariants;
   }
 
   return normalized;

--- a/src/providers/opencode/runtime/OpencodeChatRuntime.ts
+++ b/src/providers/opencode/runtime/OpencodeChatRuntime.ts
@@ -57,6 +57,7 @@ import {
   buildAcpUsageInfo,
   extractAcpSessionModelState,
   extractAcpSessionModeState,
+  extractAcpSessionThoughtLevelState,
 } from '../../acp';
 import { OPENCODE_PROVIDER_CAPABILITIES } from '../capabilities';
 import { updateOpencodeDiscoveryState } from '../discoveryState';
@@ -65,15 +66,15 @@ import {
   sameModes,
   sameStringList,
   sameStringMap,
+  sameThinkingOptionsByModel,
 } from '../internal/compareCollections';
 import { ensureProviderProjectionMap } from '../internal/providerProjection';
 import {
-  combineOpencodeRawModelSelection,
   decodeOpencodeModelId,
   encodeOpencodeModelId,
-  extractOpencodeModelVariantValue,
   isOpencodeModelSelectionId,
   normalizeOpencodeDiscoveredModels,
+  normalizeOpencodeModelVariants,
   OPENCODE_DEFAULT_THINKING_LEVEL,
   OPENCODE_SYNTHETIC_MODEL_ID,
   resolveOpencodeBaseModelRawId,
@@ -146,6 +147,9 @@ export class OpencodeChatRuntime implements ChatRuntime {
   private contextUsage: AcpUsageUpdate | null = null;
   private currentDatabasePath: string | null = null;
   private currentLaunchKey: string | null = null;
+  private currentSessionEffortConfigId: string | null = null;
+  private currentSessionEffortValue: string | null = null;
+  private currentSessionEffortValues = new Set<string>();
   private currentSessionModelId: string | null = null;
   private currentSessionModeId: string | null = null;
   private currentTurnMetadata: ChatTurnMetadata = {};
@@ -200,6 +204,9 @@ export class OpencodeChatRuntime implements ChatRuntime {
     const previousSessionId = this.sessionId;
     const nextSessionId = conversation?.sessionId ?? null;
     if (this.sessionId !== nextSessionId) {
+      this.currentSessionEffortConfigId = null;
+      this.currentSessionEffortValue = null;
+      this.currentSessionEffortValues = new Set<string>();
       this.currentSessionModelId = null;
       this.currentSessionModeId = null;
       this.sessionInvalidated = false;
@@ -218,6 +225,43 @@ export class OpencodeChatRuntime implements ChatRuntime {
   }
 
   async reloadMcpServers(): Promise<void> {}
+
+  async warmModelMetadata(model: string): Promise<boolean> {
+    const selectedRawModelId = decodeOpencodeModelId(model);
+    if (!selectedRawModelId) {
+      return false;
+    }
+
+    if (!(await this.ensureReady({ allowSessionCreation: true }))) {
+      return false;
+    }
+    if (!this.connection || !this.sessionId) {
+      return false;
+    }
+
+    const discoveredModels = getOpencodeProviderSettings(this.plugin.settings).discoveredModels;
+    const selectedBaseRawModelId = resolveOpencodeBaseModelRawId(selectedRawModelId, discoveredModels);
+    if (!selectedBaseRawModelId) {
+      return false;
+    }
+
+    const availableModelIds = new Set(discoveredModels.map((entry) => entry.rawId));
+    if (availableModelIds.size > 0 && !availableModelIds.has(selectedBaseRawModelId)) {
+      return false;
+    }
+
+    const response = await this.connection.setConfigOption({
+      configId: 'model',
+      sessionId: this.sessionId,
+      type: 'select',
+      value: selectedBaseRawModelId,
+    });
+    this.currentSessionModelId = selectedBaseRawModelId;
+    await this.syncSessionModelState({
+      configOptions: response.configOptions,
+    });
+    return true;
+  }
 
   async ensureReady(options?: ChatRuntimeEnsureReadyOptions): Promise<boolean> {
     const settings = getOpencodeProviderSettings(this.plugin.settings);
@@ -341,6 +385,7 @@ export class OpencodeChatRuntime implements ChatRuntime {
     try {
       await this.applySelectedMode(sessionId);
       await this.applySelectedModel(sessionId, queryOptions);
+      await this.applySelectedEffort(sessionId);
     } catch (error) {
       yield {
         type: 'error',
@@ -661,25 +706,17 @@ export class OpencodeChatRuntime implements ChatRuntime {
     }
 
     const discoveredModels = getOpencodeProviderSettings(providerSettings).discoveredModels;
-    const effortLevel = typeof providerSettings.effortLevel === 'string'
-      ? providerSettings.effortLevel
-      : OPENCODE_DEFAULT_THINKING_LEVEL;
     const normalizedBaseRawModelId = resolveOpencodeBaseModelRawId(selectedBaseRawModelId, discoveredModels);
-    const resolvedRawModelId = combineOpencodeRawModelSelection(
-      normalizedBaseRawModelId,
-      effortLevel,
-      discoveredModels,
-    );
-    if (!resolvedRawModelId) {
+    if (!normalizedBaseRawModelId) {
       return null;
     }
 
     const availableModelIds = new Set(discoveredModels.map((model) => model.rawId));
-    if (availableModelIds.size > 0 && !availableModelIds.has(resolvedRawModelId)) {
+    if (availableModelIds.size > 0 && !availableModelIds.has(normalizedBaseRawModelId)) {
       return null;
     }
 
-    return resolvedRawModelId;
+    return normalizedBaseRawModelId;
   }
 
   getAuxiliaryModel(): string | null {
@@ -780,12 +817,48 @@ export class OpencodeChatRuntime implements ChatRuntime {
     });
   }
 
+  private resolveSelectedEffortValue(): string | null {
+    const providerSettings = this.getProviderSettings();
+    const selectedEffort = typeof providerSettings.effortLevel === 'string'
+      ? providerSettings.effortLevel.trim()
+      : '';
+    if (!selectedEffort || selectedEffort === OPENCODE_DEFAULT_THINKING_LEVEL) {
+      return null;
+    }
+
+    return this.currentSessionEffortValues.has(selectedEffort)
+      ? selectedEffort
+      : null;
+  }
+
+  private async applySelectedEffort(sessionId: string): Promise<void> {
+    if (!this.connection || !this.currentSessionEffortConfigId) {
+      return;
+    }
+
+    const selectedEffort = this.resolveSelectedEffortValue();
+    if (!selectedEffort || selectedEffort === this.currentSessionEffortValue) {
+      return;
+    }
+
+    const response = await this.connection.setConfigOption({
+      configId: this.currentSessionEffortConfigId,
+      sessionId,
+      type: 'select',
+      value: selectedEffort,
+    });
+    this.currentSessionEffortValue = selectedEffort;
+    await this.syncSessionModelState({
+      configOptions: response.configOptions,
+    });
+  }
+
   private async syncSessionModelState(params: {
     configOptions?: AcpSessionConfigOption[] | null;
     models?: AcpSessionModelState | null;
   }): Promise<void> {
     const acpState = extractAcpSessionModelState(params);
-    const currentRawModelId = acpState.currentModelId;
+    const currentRawModelId = acpState.currentModelId ?? this.currentSessionModelId;
     const discoveredModels = normalizeOpencodeDiscoveredModels(
       acpState.availableModels.map((model) => ({
         ...(model.description ? { description: model.description } : {}),
@@ -802,13 +875,48 @@ export class OpencodeChatRuntime implements ChatRuntime {
     const currentBaseRawModelId = currentRawModelId
       ? resolveOpencodeBaseModelRawId(currentRawModelId, discoveredModels)
       : null;
-    const currentThinkingLevel = currentRawModelId
-      ? extractOpencodeModelVariantValue(currentRawModelId, discoveredModels)
+    const thoughtLevelState = extractAcpSessionThoughtLevelState(params);
+    const currentThinkingOptions = normalizeOpencodeModelVariants(
+      thoughtLevelState.availableLevels.map((level) => ({
+        ...(level.description ? { description: level.description } : {}),
+        label: level.name,
+        value: level.id,
+      })),
+    );
+    const currentThinkingLevel = thoughtLevelState.currentLevel;
+    this.currentSessionEffortConfigId = currentThinkingOptions.length > 0
+      ? thoughtLevelState.configId
       : null;
+    this.currentSessionEffortValue = currentThinkingOptions.length > 0
+      ? currentThinkingLevel
+      : null;
+    this.currentSessionEffortValues = new Set(currentThinkingOptions.map((option) => option.value));
+
+    const nextThinkingOptionsByModel = { ...currentSettings.thinkingOptionsByModel };
+    if (currentBaseRawModelId) {
+      if (currentThinkingOptions.length > 0) {
+        nextThinkingOptionsByModel[currentBaseRawModelId] = currentThinkingOptions;
+      } else {
+        delete nextThinkingOptionsByModel[currentBaseRawModelId];
+      }
+    }
+
     const nextVisibleModels = currentSettings.visibleModels.length === 0 && currentBaseRawModelId
       ? [currentBaseRawModelId]
       : currentSettings.visibleModels;
-    const nextPreferredThinkingByModel = currentBaseRawModelId && currentThinkingLevel
+    const currentPreferredThinking = currentBaseRawModelId
+      ? currentSettings.preferredThinkingByModel[currentBaseRawModelId]
+      : '';
+    const shouldSeedCurrentThinking = currentBaseRawModelId
+      && currentThinkingLevel
+      && (
+        !currentPreferredThinking
+        || (
+          currentThinkingOptions.length > 0
+          && !this.currentSessionEffortValues.has(currentPreferredThinking)
+        )
+      );
+    const nextPreferredThinkingByModel = shouldSeedCurrentThinking && currentBaseRawModelId && currentThinkingLevel
       ? {
         ...currentSettings.preferredThinkingByModel,
         [currentBaseRawModelId]: currentThinkingLevel,
@@ -819,17 +927,15 @@ export class OpencodeChatRuntime implements ChatRuntime {
       currentSettings.preferredThinkingByModel,
       nextPreferredThinkingByModel,
     );
-    const discoveryChanged = discoveredModels.length > 0
-      && !sameDiscoveredModels(currentSettings.discoveredModels, discoveredModels)
+    const shouldUpdateDiscoveredModels = discoveredModels.length > 0
+      && !sameDiscoveredModels(currentSettings.discoveredModels, discoveredModels);
+    const shouldUpdateThinkingOptions = !sameThinkingOptionsByModel(
+      currentSettings.thinkingOptionsByModel,
+      nextThinkingOptionsByModel,
+    );
+    const discoveryChanged = shouldUpdateDiscoveredModels
       && updateOpencodeDiscoveryState(settingsBag, { discoveredModels });
     let changed = shouldSeedVisibleModels || shouldSeedPreferredThinking;
-
-    if (changed) {
-      updateOpencodeProviderSettings(settingsBag, {
-        ...(shouldSeedPreferredThinking ? { preferredThinkingByModel: nextPreferredThinkingByModel } : {}),
-        ...(shouldSeedVisibleModels ? { visibleModels: nextVisibleModels } : {}),
-      });
-    }
 
     if (currentBaseRawModelId) {
       const seeded = this.seedActiveModelSelection(
@@ -840,11 +946,19 @@ export class OpencodeChatRuntime implements ChatRuntime {
       changed = changed || seeded;
     }
 
-    if (!changed && !discoveryChanged) {
+    if (shouldUpdateThinkingOptions || shouldSeedPreferredThinking || shouldSeedVisibleModels) {
+      updateOpencodeProviderSettings(settingsBag, {
+        ...(shouldSeedPreferredThinking ? { preferredThinkingByModel: nextPreferredThinkingByModel } : {}),
+        ...(shouldUpdateThinkingOptions ? { thinkingOptionsByModel: nextThinkingOptionsByModel } : {}),
+        ...(shouldSeedVisibleModels ? { visibleModels: nextVisibleModels } : {}),
+      });
+    }
+
+    if (!changed && !discoveryChanged && !shouldUpdateThinkingOptions) {
       return;
     }
 
-    if (changed) {
+    if (changed || shouldUpdateThinkingOptions) {
       await this.plugin.saveSettings();
     }
     this.refreshModelSelectors();
@@ -867,7 +981,10 @@ export class OpencodeChatRuntime implements ChatRuntime {
 
     if (thinkingLevel) {
       const savedProviderEffort = ensureProviderProjectionMap(settingsBag, 'savedProviderEffort');
-      if (typeof savedProviderEffort.opencode !== 'string' || !savedProviderEffort.opencode) {
+      const savedEffort = typeof savedProviderEffort.opencode === 'string'
+        ? savedProviderEffort.opencode.trim()
+        : '';
+      if (!savedEffort || savedEffort === OPENCODE_DEFAULT_THINKING_LEVEL) {
         savedProviderEffort.opencode = thinkingLevel;
         changed = true;
       }
@@ -884,7 +1001,7 @@ export class OpencodeChatRuntime implements ChatRuntime {
     }
     if (thinkingLevel) {
       const activeEffort = typeof settingsBag.effortLevel === 'string' ? settingsBag.effortLevel : '';
-      if (!activeEffort) {
+      if (!activeEffort || activeEffort === OPENCODE_DEFAULT_THINKING_LEVEL) {
         settingsBag.effortLevel = thinkingLevel;
         changed = true;
       }

--- a/src/providers/opencode/settings.ts
+++ b/src/providers/opencode/settings.ts
@@ -16,8 +16,10 @@ import {
   decodeOpencodeModelId,
   encodeOpencodeModelId,
   isOpencodeModelSelectionId,
+  normalizeOpencodeThinkingOptionsByModel,
   OPENCODE_DEFAULT_THINKING_LEVEL,
   type OpencodeDiscoveredModel,
+  type OpencodeThinkingOptionsByModel,
   resolveOpencodeBaseModelRawId,
 } from './models';
 import {
@@ -34,6 +36,7 @@ export interface PersistedOpencodeProviderSettings {
   modelAliases: Record<string, string>;
   preferredThinkingByModel: Record<string, string>;
   selectedMode: string;
+  thinkingOptionsByModel: OpencodeThinkingOptionsByModel;
   visibleModels: string[];
 }
 
@@ -53,6 +56,7 @@ export const DEFAULT_OPENCODE_PROVIDER_SETTINGS: Readonly<PersistedOpencodeProvi
   modelAliases: {},
   preferredThinkingByModel: {},
   selectedMode: '',
+  thinkingOptionsByModel: {},
   visibleModels: [],
 });
 
@@ -165,6 +169,14 @@ export function getOpencodeProviderSettings(
   const discoveryState = getOpencodeDiscoveryState(settings);
   const availableModes = discoveryState.availableModes;
   const discoveredModels = discoveryState.discoveredModels;
+  const persistedThinkingOptionsByModel = normalizeOpencodeThinkingOptionsByModel(
+    config.thinkingOptionsByModel,
+    discoveredModels,
+  );
+  const thinkingOptionsByModel = normalizeOpencodeThinkingOptionsByModel({
+    ...persistedThinkingOptionsByModel,
+    ...discoveryState.thinkingOptionsByModel,
+  }, discoveredModels);
 
   return {
     availableModes,
@@ -185,6 +197,7 @@ export function getOpencodeProviderSettings(
       discoveredModels,
     ),
     selectedMode: normalizeManagedOpencodeSelectedMode(config.selectedMode, availableModes),
+    thinkingOptionsByModel,
     visibleModels: normalizeOpencodeVisibleModels(config.visibleModels, discoveredModels),
   };
 }
@@ -195,15 +208,24 @@ export function updateOpencodeProviderSettings(
 ): OpencodeProviderSettings {
   const current = getOpencodeProviderSettings(settings);
   const hostnameKey = getHostnameKey();
-  if ('availableModes' in updates || 'discoveredModels' in updates) {
+  if ('availableModes' in updates || 'discoveredModels' in updates || 'thinkingOptionsByModel' in updates) {
     updateOpencodeDiscoveryState(settings, {
       ...(updates.availableModes !== undefined ? { availableModes: updates.availableModes } : {}),
       ...(updates.discoveredModels !== undefined ? { discoveredModels: updates.discoveredModels } : {}),
+      ...(updates.thinkingOptionsByModel !== undefined
+        ? { thinkingOptionsByModel: updates.thinkingOptionsByModel }
+        : {}),
     });
   }
   const discoveryState = getOpencodeDiscoveryState(settings);
   const nextAvailableModes = discoveryState.availableModes;
   const nextDiscoveredModels = discoveryState.discoveredModels;
+  const nextThinkingOptionsByModel = updates.thinkingOptionsByModel !== undefined
+    ? discoveryState.thinkingOptionsByModel
+    : normalizeOpencodeThinkingOptionsByModel(
+      current.thinkingOptionsByModel,
+      nextDiscoveredModels,
+    );
   const nextSelectedMode = normalizeManagedOpencodeSelectedMode(
     updates.selectedMode ?? current.selectedMode,
     nextAvailableModes,
@@ -253,12 +275,18 @@ export function updateOpencodeProviderSettings(
       nextDiscoveredModels,
     ),
     selectedMode: nextSelectedMode,
+    thinkingOptionsByModel: nextThinkingOptionsByModel,
     visibleModels: nextVisibleModels,
   };
 
   if (updates.visibleModels !== undefined) {
     retargetRemovedOpencodeSelections(settings, next);
   }
+
+  const persistedThinkingOptionsByModel = pruneThinkingOptionsToPersistedSelections(
+    settings,
+    next,
+  );
 
   setProviderConfig(settings, 'opencode', {
     cliPath: next.cliPath,
@@ -269,6 +297,7 @@ export function updateOpencodeProviderSettings(
     modelAliases: next.modelAliases,
     preferredThinkingByModel: next.preferredThinkingByModel,
     selectedMode: next.selectedMode,
+    thinkingOptionsByModel: persistedThinkingOptionsByModel,
     visibleModels: next.visibleModels,
   });
 
@@ -296,6 +325,53 @@ function pruneModelAliasesToVisible(
     }
   }
   return pruned;
+}
+
+function pruneThinkingOptionsToPersistedSelections(
+  settings: Record<string, unknown>,
+  next: OpencodeProviderSettings,
+): OpencodeThinkingOptionsByModel {
+  const persistableRawIds = new Set(next.visibleModels);
+  addPersistableSelection(persistableRawIds, settings.model, next.discoveredModels);
+  addPersistableSelection(persistableRawIds, settings.titleGenerationModel, next.discoveredModels);
+
+  const savedProviderModel = settings.savedProviderModel;
+  if (savedProviderModel && typeof savedProviderModel === 'object' && !Array.isArray(savedProviderModel)) {
+    addPersistableSelection(
+      persistableRawIds,
+      (savedProviderModel as Record<string, unknown>).opencode,
+      next.discoveredModels,
+    );
+  }
+
+  const pruned: OpencodeThinkingOptionsByModel = {};
+  for (const rawId of persistableRawIds) {
+    const options = next.thinkingOptionsByModel[rawId];
+    if (options?.length) {
+      pruned[rawId] = options.map((option) => ({ ...option }));
+    }
+  }
+  return pruned;
+}
+
+function addPersistableSelection(
+  target: Set<string>,
+  value: unknown,
+  discoveredModels: OpencodeDiscoveredModel[],
+): void {
+  if (typeof value !== 'string' || !isOpencodeModelSelectionId(value)) {
+    return;
+  }
+
+  const rawModelId = decodeOpencodeModelId(value);
+  if (!rawModelId) {
+    return;
+  }
+
+  const baseRawId = resolveOpencodeBaseModelRawId(rawModelId, discoveredModels);
+  if (baseRawId) {
+    target.add(baseRawId);
+  }
 }
 
 function retargetRemovedOpencodeSelections(

--- a/src/providers/opencode/ui/OpencodeChatUIConfig.ts
+++ b/src/providers/opencode/ui/OpencodeChatUIConfig.ts
@@ -9,7 +9,6 @@ import {
   buildOpencodeBaseModels,
   decodeOpencodeModelId,
   encodeOpencodeModelId,
-  getOpencodeModelVariants,
   isOpencodeModelSelectionId,
   OPENCODE_DEFAULT_THINKING_LEVEL,
   OPENCODE_SYNTHETIC_MODEL_ID,
@@ -19,12 +18,14 @@ import {
   resolveOpencodeModeForPermissionMode,
   resolvePermissionModeForManagedOpencodeMode,
 } from '../modes';
+import { OpencodeChatRuntime } from '../runtime/OpencodeChatRuntime';
 import { getOpencodeProviderSettings, updateOpencodeProviderSettings } from '../settings';
 
 const OPENCODE_MODELS: ProviderUIOption[] = [
   { value: OPENCODE_SYNTHETIC_MODEL_ID, label: 'OpenCode', description: 'ACP runtime' },
 ];
 const DEFAULT_CONTEXT_WINDOW = 200_000;
+const OPENCODE_METADATA_WARMUP_DB = ':memory:';
 const OPENCODE_PERMISSION_MODE_TOGGLE: ProviderPermissionModeToggleConfig = {
   inactiveValue: 'normal',
   inactiveLabel: 'Safe',
@@ -114,31 +115,17 @@ export const opencodeChatUIConfig: ProviderChatUIConfig = {
     return isOpencodeModelSelectionId(model);
   },
 
-  isAdaptiveReasoningModel(_model: string, _settings: Record<string, unknown>): boolean {
-    return true;
+  isAdaptiveReasoningModel(model: string, settings: Record<string, unknown>): boolean {
+    return getOpencodeThinkingOptions(model, settings).length > 0;
   },
 
   getReasoningOptions(model: string, settings: Record<string, unknown>): ProviderReasoningOption[] {
-    const rawModelId = decodeOpencodeModelId(model);
-    if (!rawModelId) {
-      return [];
-    }
-
-    const opencodeSettings = getOpencodeProviderSettings(settings);
-    const baseRawId = resolveOpencodeBaseModelRawId(rawModelId, opencodeSettings.discoveredModels);
-    const variants = getOpencodeModelVariants(baseRawId, opencodeSettings.discoveredModels);
-    if (variants.length === 0) {
-      return [];
-    }
-
-    return [
-      { value: OPENCODE_DEFAULT_THINKING_LEVEL, label: 'Default' },
-      ...variants.map((variant) => ({
+    return getOpencodeThinkingOptions(model, settings)
+      .map((variant) => ({
         description: variant.description,
         label: variant.label,
         value: variant.value,
-      })),
-    ];
+      }));
   },
 
   getDefaultReasoningValue(model: string, settings: Record<string, unknown>): string {
@@ -178,6 +165,32 @@ export const opencodeChatUIConfig: ProviderChatUIConfig = {
     settingsBag.effortLevel = getDefaultThinkingLevelForModel(baseRawId, settingsBag);
   },
 
+  async prepareModelMetadata(model: string, _settings: Record<string, unknown>, context): Promise<void> {
+    const rawModelId = decodeOpencodeModelId(model);
+    if (!rawModelId) {
+      return;
+    }
+
+    const opencodeSettings = getOpencodeProviderSettings(context.plugin.settings);
+    const baseRawId = resolveOpencodeBaseModelRawId(rawModelId, opencodeSettings.discoveredModels);
+    if (baseRawId && opencodeSettings.thinkingOptionsByModel[baseRawId]) {
+      return;
+    }
+
+    const runtime = new OpencodeChatRuntime(context.plugin);
+    try {
+      runtime.syncConversationState({
+        providerState: { databasePath: OPENCODE_METADATA_WARMUP_DB },
+        sessionId: null,
+      });
+      await runtime.warmModelMetadata(model);
+    } catch {
+      // Metadata warmup is opportunistic; the first real turn can still discover it.
+    } finally {
+      runtime.cleanup();
+    }
+  },
+
   applyReasoningSelection(model: string, value: string, settings: unknown): void {
     if (!settings || typeof settings !== 'object' || Array.isArray(settings)) {
       return;
@@ -192,7 +205,7 @@ export const opencodeChatUIConfig: ProviderChatUIConfig = {
     const opencodeSettings = getOpencodeProviderSettings(settingsBag);
     const baseRawId = resolveOpencodeBaseModelRawId(rawModelId, opencodeSettings.discoveredModels);
     const supportedValues = new Set(
-      getOpencodeModelVariants(baseRawId, opencodeSettings.discoveredModels).map((variant) => variant.value),
+      (opencodeSettings.thinkingOptionsByModel[baseRawId] ?? []).map((variant) => variant.value),
     );
     const nextPreferredThinkingByModel = {
       ...opencodeSettings.preferredThinkingByModel,
@@ -264,13 +277,28 @@ function getDefaultThinkingLevelForModel(
   const opencodeSettings = getOpencodeProviderSettings(settings);
   const preferred = opencodeSettings.preferredThinkingByModel[baseRawId];
   const supportedValues = new Set(
-    getOpencodeModelVariants(baseRawId, opencodeSettings.discoveredModels).map((variant) => variant.value),
+    (opencodeSettings.thinkingOptionsByModel[baseRawId] ?? []).map((variant) => variant.value),
   );
   if (preferred && supportedValues.has(preferred)) {
     return preferred;
   }
 
-  return OPENCODE_DEFAULT_THINKING_LEVEL;
+  return opencodeSettings.thinkingOptionsByModel[baseRawId]?.[0]?.value
+    ?? OPENCODE_DEFAULT_THINKING_LEVEL;
+}
+
+function getOpencodeThinkingOptions(
+  model: string,
+  settings: Record<string, unknown>,
+): ProviderReasoningOption[] {
+  const rawModelId = decodeOpencodeModelId(model);
+  if (!rawModelId) {
+    return [];
+  }
+
+  const opencodeSettings = getOpencodeProviderSettings(settings);
+  const baseRawId = resolveOpencodeBaseModelRawId(rawModelId, opencodeSettings.discoveredModels);
+  return opencodeSettings.thinkingOptionsByModel[baseRawId] ?? [];
 }
 
 function pushOption(

--- a/src/providers/opencode/ui/OpencodeSettingsTab.ts
+++ b/src/providers/opencode/ui/OpencodeSettingsTab.ts
@@ -10,9 +10,11 @@ import { clearOpencodeDiscoveryState } from '../discoveryState';
 import { sameStringList } from '../internal/compareCollections';
 import {
   buildOpencodeBaseModels,
+  encodeOpencodeModelId,
   type OpencodeDiscoveredModel,
   splitOpencodeModelLabel,
 } from '../models';
+import { OpencodeChatRuntime } from '../runtime/OpencodeChatRuntime';
 import {
   getOpencodeProviderSettings,
   normalizeOpencodeVisibleModels,
@@ -22,6 +24,7 @@ import {
 import { OpencodeAgentSettings } from './OpencodeAgentSettings';
 
 const ALL_PROVIDERS_KEY = 'all';
+const OPENCODE_METADATA_WARMUP_DB = ':memory:';
 
 interface EnrichedModel {
   description: string;
@@ -206,6 +209,8 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
     });
 
     const listEl = catalogEl.createDiv({ cls: 'claudian-opencode-model-picker-list' });
+    let loadingModelCatalog = false;
+    let modelCatalogLoadFailed = false;
 
     const getEnrichedModels = (): EnrichedModel[] => {
       const current = getOpencodeProviderSettings(settingsBag);
@@ -247,6 +252,24 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
       context.refreshModelSelectors();
     };
 
+    const persistModelMetadata = async (rawId: string): Promise<void> => {
+      const runtime = new OpencodeChatRuntime(context.plugin);
+      try {
+        runtime.syncConversationState({
+          providerState: { databasePath: OPENCODE_METADATA_WARMUP_DB },
+          sessionId: null,
+        });
+        const loaded = await runtime.warmModelMetadata(encodeOpencodeModelId(rawId));
+        if (loaded) {
+          context.refreshModelSelectors();
+        }
+      } catch {
+        // Metadata warmup is opportunistic; the first chat turn can still discover it.
+      } finally {
+        runtime.cleanup();
+      }
+    };
+
     const persistModelAliases = async (modelAliases: Record<string, string>): Promise<void> => {
       updateOpencodeProviderSettings(settingsBag, { modelAliases });
       await context.plugin.saveSettings();
@@ -270,11 +293,13 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
         text: ` of ${current.discoveredModels.length} discovered • ${providerCount} ${providerWord}`,
       });
 
-      catalogSummaryCountEl.setText(
-        current.discoveredModels.length > 0
-          ? `${current.discoveredModels.length} available`
-          : 'No models discovered yet',
-      );
+      let catalogSummary = 'No models discovered yet';
+      if (loadingModelCatalog) {
+        catalogSummary = 'Loading models...';
+      } else if (current.discoveredModels.length > 0) {
+        catalogSummary = `${current.discoveredModels.length} available`;
+      }
+      catalogSummaryCountEl.setText(catalogSummary);
     };
 
     const renderSelected = (): void => {
@@ -440,9 +465,15 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
 
       if (filtered.length === 0) {
         const emptyEl = listEl.createDiv({ cls: 'claudian-opencode-model-picker-empty' });
-        emptyEl.setText(enriched.length === 0
-          ? 'Start OpenCode once to load its model catalog. Claudian will then let you pick visible models.'
-          : 'No models match your filter.');
+        let emptyText = 'No models match your filter.';
+        if (loadingModelCatalog) {
+          emptyText = 'Loading OpenCode model catalog...';
+        } else if (modelCatalogLoadFailed) {
+          emptyText = 'Could not load the OpenCode model catalog. Check the CLI path and login state, then expand this section again.';
+        } else if (enriched.length === 0) {
+          emptyText = 'Start OpenCode once to load its model catalog. Claudian will then let you pick visible models.';
+        }
+        emptyEl.setText(emptyText);
         return;
       }
 
@@ -461,7 +492,12 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
           const next = checkboxEl.checked
             ? [...currentVisibleModels, model.rawId]
             : currentVisibleModels.filter((id) => id !== model.rawId);
-          void persistVisibleModels(next);
+          void (async () => {
+            await persistVisibleModels(next);
+            if (checkboxEl.checked) {
+              await persistModelMetadata(model.rawId);
+            }
+          })();
         });
 
         const textEl = rowEl.createDiv({ cls: 'claudian-opencode-model-picker-row-text' });
@@ -504,6 +540,44 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
     };
 
     renderAll();
+
+    const loadModelCatalog = async (): Promise<void> => {
+      if (loadingModelCatalog || getOpencodeProviderSettings(settingsBag).discoveredModels.length > 0) {
+        return;
+      }
+
+      loadingModelCatalog = true;
+      modelCatalogLoadFailed = false;
+      renderAll();
+
+      const runtime = new OpencodeChatRuntime(context.plugin);
+      try {
+        runtime.syncConversationState({
+          providerState: { databasePath: OPENCODE_METADATA_WARMUP_DB },
+          sessionId: null,
+        });
+        const loaded = await runtime.ensureReady({ allowSessionCreation: true });
+        modelCatalogLoadFailed = !loaded || getOpencodeProviderSettings(settingsBag).discoveredModels.length === 0;
+        if (!modelCatalogLoadFailed) {
+          context.refreshModelSelectors();
+        }
+      } catch {
+        modelCatalogLoadFailed = true;
+      } finally {
+        loadingModelCatalog = false;
+        runtime.cleanup();
+        renderAll();
+      }
+    };
+
+    catalogEl.addEventListener('toggle', () => {
+      if (catalogEl.open) {
+        void loadModelCatalog();
+      }
+    });
+    if (catalogEl.open) {
+      void loadModelCatalog();
+    }
 
     new Setting(container).setName('Commands and skills').setHeading();
 

--- a/tests/unit/providers/acp/AcpSessionConfig.test.ts
+++ b/tests/unit/providers/acp/AcpSessionConfig.test.ts
@@ -1,6 +1,7 @@
 import {
   extractAcpSessionModelState,
   extractAcpSessionModeState,
+  extractAcpSessionThoughtLevelState,
   flattenAcpSessionConfigSelectOptions,
 } from '../../../../src/providers/acp';
 
@@ -214,6 +215,33 @@ describe('AcpSessionConfig', () => {
         { description: 'Planning-first agent', id: 'plan', name: 'Plan' },
       ],
       currentModeId: 'build',
+    });
+  });
+
+  it('extracts detached thought-level options from ACP config options', () => {
+    expect(extractAcpSessionThoughtLevelState({
+      configOptions: [
+        {
+          category: 'thought_level',
+          currentValue: 'low',
+          id: 'effort',
+          name: 'Effort',
+          options: [
+            { name: 'Low', value: 'low' },
+            { name: 'Medium', value: 'medium' },
+            { name: 'High', value: 'high' },
+          ],
+          type: 'select',
+        },
+      ],
+    })).toEqual({
+      availableLevels: [
+        { id: 'low', name: 'Low' },
+        { id: 'medium', name: 'Medium' },
+        { id: 'high', name: 'High' },
+      ],
+      configId: 'effort',
+      currentLevel: 'low',
     });
   });
 });

--- a/tests/unit/providers/opencode/OpencodeChatRuntime.test.ts
+++ b/tests/unit/providers/opencode/OpencodeChatRuntime.test.ts
@@ -546,9 +546,196 @@ describe('OpencodeChatRuntime', () => {
     expect(plugin.settings.savedProviderEffort.opencode).toBe('high');
     expect(plugin.settings.model).toBe('opencode:anthropic/claude-sonnet-4');
     expect(plugin.settings.effortLevel).toBe('high');
-    expect((runtime as any).resolveSelectedRawModelId()).toBe('anthropic/claude-sonnet-4/high');
+    expect((runtime as any).resolveSelectedRawModelId()).toBe('anthropic/claude-sonnet-4');
     expect(plugin.saveSettings).not.toHaveBeenCalled();
     expect(refreshModelSelector).not.toHaveBeenCalled();
+  });
+
+  it('syncs detached ACP thought-level options into OpenCode provider state', async () => {
+    const refreshModelSelector = jest.fn();
+    const plugin = createMockPlugin({
+      getAllViews: jest.fn().mockReturnValue([{ refreshModelSelector }]),
+      settings: {
+        model: 'opencode:deepseek/deepseek-v4-pro',
+        providerConfigs: {
+          opencode: {
+            discoveredModels: [],
+            preferredThinkingByModel: {},
+            visibleModels: ['deepseek/deepseek-v4-pro'],
+          },
+        },
+        settingsProvider: 'opencode',
+      },
+    });
+    const runtime = new OpencodeChatRuntime(plugin);
+    jest.spyOn(ProviderRegistry, 'resolveSettingsProviderId').mockReturnValue('opencode');
+
+    await (runtime as any).syncSessionModelState({
+      configOptions: [
+        {
+          category: 'model',
+          currentValue: 'deepseek/deepseek-v4-pro',
+          id: 'model',
+          name: 'Model',
+          options: [
+            { name: 'DeepSeek/DeepSeek V4 Pro', value: 'deepseek/deepseek-v4-pro' },
+          ],
+          type: 'select',
+        },
+        {
+          category: 'thought_level',
+          currentValue: 'low',
+          id: 'effort',
+          name: 'Effort',
+          options: [
+            { name: 'Low', value: 'low' },
+            { name: 'Medium', value: 'medium' },
+            { name: 'High', value: 'high' },
+            { name: 'Max', value: 'max' },
+          ],
+          type: 'select',
+        },
+      ],
+    });
+
+    expect(getOpencodeProviderSettings(plugin.settings).thinkingOptionsByModel).toEqual({
+      'deepseek/deepseek-v4-pro': [
+        { label: 'Low', value: 'low' },
+        { label: 'Medium', value: 'medium' },
+        { label: 'High', value: 'high' },
+        { label: 'Max', value: 'max' },
+      ],
+    });
+    expect(plugin.settings.providerConfigs.opencode.preferredThinkingByModel).toEqual({
+      'deepseek/deepseek-v4-pro': 'low',
+    });
+    expect(plugin.settings.providerConfigs.opencode.thinkingOptionsByModel).toEqual({
+      'deepseek/deepseek-v4-pro': [
+        { label: 'Low', value: 'low' },
+        { label: 'Medium', value: 'medium' },
+        { label: 'High', value: 'high' },
+        { label: 'Max', value: 'max' },
+      ],
+    });
+    expect(plugin.settings.effortLevel).toBe('low');
+    expect(plugin.saveSettings).toHaveBeenCalledTimes(1);
+    expect(refreshModelSelector).toHaveBeenCalledTimes(1);
+  });
+
+  it('warms selected model metadata by switching ACP model config', async () => {
+    const plugin = createMockPlugin({
+      settings: {
+        model: 'opencode:deepseek/deepseek-v4-pro',
+        providerConfigs: {
+          opencode: {
+            discoveredModels: [
+              { label: 'DeepSeek/DeepSeek V4 Pro', rawId: 'deepseek/deepseek-v4-pro' },
+            ],
+            preferredThinkingByModel: {},
+            visibleModels: ['deepseek/deepseek-v4-pro'],
+          },
+        },
+        settingsProvider: 'opencode',
+      },
+    });
+    const runtime = new OpencodeChatRuntime(plugin);
+    const setConfigOption = jest.fn().mockResolvedValue({
+      configOptions: [
+        {
+          category: 'model',
+          currentValue: 'deepseek/deepseek-v4-pro',
+          id: 'model',
+          name: 'Model',
+          options: [
+            { name: 'DeepSeek/DeepSeek V4 Pro', value: 'deepseek/deepseek-v4-pro' },
+          ],
+          type: 'select',
+        },
+        {
+          category: 'thought_level',
+          currentValue: 'low',
+          id: 'effort',
+          name: 'Effort',
+          options: [
+            { name: 'Low', value: 'low' },
+            { name: 'High', value: 'high' },
+          ],
+          type: 'select',
+        },
+      ],
+    });
+    (runtime as any).connection = { setConfigOption };
+    (runtime as any).sessionId = 'session-1';
+    jest.spyOn(runtime, 'ensureReady').mockResolvedValue(true);
+    jest.spyOn(ProviderRegistry, 'resolveSettingsProviderId').mockReturnValue('opencode');
+
+    await expect(runtime.warmModelMetadata('opencode:deepseek/deepseek-v4-pro')).resolves.toBe(true);
+
+    expect(setConfigOption).toHaveBeenCalledWith({
+      configId: 'model',
+      sessionId: 'session-1',
+      type: 'select',
+      value: 'deepseek/deepseek-v4-pro',
+    });
+    expect(plugin.settings.providerConfigs.opencode.thinkingOptionsByModel).toEqual({
+      'deepseek/deepseek-v4-pro': [
+        { label: 'Low', value: 'low' },
+        { label: 'High', value: 'high' },
+      ],
+    });
+    expect(plugin.saveSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies selected OpenCode effort through the detached ACP effort option', async () => {
+    const plugin = createMockPlugin({
+      settings: {
+        effortLevel: 'high',
+        model: 'opencode:deepseek/deepseek-v4-pro',
+        providerConfigs: {
+          opencode: {
+            discoveredModels: [
+              { label: 'DeepSeek/DeepSeek V4 Pro', rawId: 'deepseek/deepseek-v4-pro' },
+            ],
+            thinkingOptionsByModel: {
+              'deepseek/deepseek-v4-pro': [
+                { label: 'Low', value: 'low' },
+                { label: 'High', value: 'high' },
+              ],
+            },
+            visibleModels: ['deepseek/deepseek-v4-pro'],
+          },
+        },
+        settingsProvider: 'opencode',
+      },
+    });
+    const runtime = new OpencodeChatRuntime(plugin);
+    const setConfigOption = jest.fn().mockResolvedValue({
+      configOptions: [{
+        category: 'thought_level',
+        currentValue: 'high',
+        id: 'effort',
+        name: 'Effort',
+        options: [
+          { name: 'Low', value: 'low' },
+          { name: 'High', value: 'high' },
+        ],
+        type: 'select',
+      }],
+    });
+    (runtime as any).connection = { setConfigOption };
+    (runtime as any).currentSessionEffortConfigId = 'effort';
+    (runtime as any).currentSessionEffortValue = 'low';
+    (runtime as any).currentSessionEffortValues = new Set(['low', 'high']);
+    jest.spyOn(ProviderSettingsCoordinator, 'getProviderSettingsSnapshot').mockReturnValue(plugin.settings);
+
+    await (runtime as any).applySelectedEffort('session-1');
+
+    expect(setConfigOption).toHaveBeenCalledWith({
+      configId: 'effort',
+      sessionId: 'session-1',
+      type: 'select',
+      value: 'high',
+    });
   });
 
   it('exposes the active display model for auxiliary OpenCode tasks', () => {
@@ -579,6 +766,6 @@ describe('OpencodeChatRuntime', () => {
     jest.spyOn(ProviderRegistry, 'resolveSettingsProviderId').mockReturnValue('opencode');
     jest.spyOn(ProviderSettingsCoordinator, 'getProviderSettingsSnapshot').mockReturnValue(plugin.settings);
 
-    expect(runtime.getAuxiliaryModel()).toBe('opencode:anthropic/claude-sonnet-4/high');
+    expect(runtime.getAuxiliaryModel()).toBe('opencode:anthropic/claude-sonnet-4');
   });
 });

--- a/tests/unit/providers/opencode/OpencodeSettingsReconciler.test.ts
+++ b/tests/unit/providers/opencode/OpencodeSettingsReconciler.test.ts
@@ -50,6 +50,7 @@ describe('opencodeSettingsReconciler.handleEnvironmentChange', () => {
     expect(getOpencodeDiscoveryState(settings)).toEqual({
       availableModes: [],
       discoveredModels: [],
+      thinkingOptionsByModel: {},
     });
   });
 });

--- a/tests/unit/providers/opencode/OpencodeSettingsTab.test.ts
+++ b/tests/unit/providers/opencode/OpencodeSettingsTab.test.ts
@@ -11,6 +11,10 @@ const mockRefreshAgentMentions = jest.fn().mockResolvedValue(undefined);
 const mockInvalidateProviderCommandCaches = jest.fn();
 const mockRefreshModelSelector = jest.fn();
 const mockCliResolverReset = jest.fn();
+const mockRuntimeEnsureReady = jest.fn().mockResolvedValue(false);
+const mockRuntimeSyncConversationState = jest.fn();
+const mockRuntimeCleanup = jest.fn();
+const mockRuntimeWarmModelMetadata = jest.fn().mockResolvedValue(false);
 const mockAgentStorage = {};
 const mockCreatedAgentSettings: Array<{
   app: unknown;
@@ -99,6 +103,28 @@ jest.mock('@/providers/opencode/app/OpencodeWorkspaceServices', () => ({
   })),
 }));
 
+jest.mock('@/providers/opencode/runtime/OpencodeChatRuntime', () => ({
+  OpencodeChatRuntime: class MockOpencodeChatRuntime {
+    constructor(readonly plugin: any) {}
+
+    syncConversationState(...args: unknown[]) {
+      return mockRuntimeSyncConversationState(...args);
+    }
+
+    ensureReady(...args: unknown[]) {
+      return mockRuntimeEnsureReady(this.plugin, ...args);
+    }
+
+    warmModelMetadata(...args: unknown[]) {
+      return mockRuntimeWarmModelMetadata(this.plugin, ...args);
+    }
+
+    cleanup() {
+      return mockRuntimeCleanup();
+    }
+  },
+}));
+
 jest.mock('@/utils/env', () => ({
   ...jest.requireActual('@/utils/env'),
   getHostnameKey: () => mockGetHostnameKey(),
@@ -142,6 +168,7 @@ type MockElementRecord = {
 
 const createdSettings: MockSettingRecord[] = [];
 const createdElements: MockElementRecord[] = [];
+const createdDomElements: any[] = [];
 
 function createTextComponent(): MockTextComponent {
   const component = {} as MockTextComponent;
@@ -187,6 +214,7 @@ function createToggleComponent(): MockToggleComponent {
 
 function createElement(): any {
   const classes = new Set<string>();
+  const eventListeners = new Map<string, Array<(...args: unknown[]) => void>>();
   const element: any = {
     value: '',
     checked: false,
@@ -235,7 +263,16 @@ function createElement(): any {
     }),
     empty: jest.fn(),
     setAttribute: jest.fn(),
-    addEventListener: jest.fn(),
+    addEventListener: jest.fn((type: string, callback: (...args: unknown[]) => void) => {
+      const listeners = eventListeners.get(type) ?? [];
+      listeners.push(callback);
+      eventListeners.set(type, listeners);
+    }),
+    dispatchMockEvent: async (type: string, event?: unknown) => {
+      for (const listener of eventListeners.get(type) ?? []) {
+        await listener(event);
+      }
+    },
     blur: jest.fn(),
     createEl: jest.fn((_tag?: string, attrs?: Record<string, unknown>) => {
       const child = createElement();
@@ -257,6 +294,7 @@ function createElement(): any {
         tag: child.tag,
         text: child.text,
       });
+      createdDomElements.push(child);
       return child;
     }),
     createDiv: jest.fn((attrs?: Record<string, unknown>) => {
@@ -270,6 +308,7 @@ function createElement(): any {
         tag: child.tag,
         text: child.text,
       });
+      createdDomElements.push(child);
       return child;
     }),
     createSpan: jest.fn((_attrs?: Record<string, unknown>) => createElement()),
@@ -291,6 +330,7 @@ function createContainer(): any {
         tag: child.tag,
         text: child.text,
       });
+      createdDomElements.push(child);
       return child;
     }),
     createEl: jest.fn((tag?: string, attrs?: Record<string, unknown>) => {
@@ -307,6 +347,7 @@ function createContainer(): any {
         tag: child.tag,
         text: child.text,
       });
+      createdDomElements.push(child);
       return child;
     }),
   };
@@ -369,6 +410,14 @@ function findSetting(name: string): MockSettingRecord {
   return setting;
 }
 
+function findElement(tag: string, cls: string): any {
+  const element = createdDomElements.find((candidate) => candidate.tag === tag && candidate.cls === cls);
+  if (!element) {
+    throw new Error(`Element not found: ${tag}.${cls}`);
+  }
+  return element;
+}
+
 describe('OpencodeSettingsTab', () => {
   const mockedExistsSync = fs.existsSync as jest.MockedFunction<typeof fs.existsSync>;
   const mockedStatSync = fs.statSync as jest.MockedFunction<typeof fs.statSync>;
@@ -376,8 +425,11 @@ describe('OpencodeSettingsTab', () => {
   beforeEach(() => {
     createdSettings.length = 0;
     createdElements.length = 0;
+    createdDomElements.length = 0;
     mockCreatedAgentSettings.length = 0;
     jest.clearAllMocks();
+    mockRuntimeEnsureReady.mockResolvedValue(false);
+    mockRuntimeWarmModelMetadata.mockResolvedValue(false);
     mockedExistsSync.mockReturnValue(false);
     mockedStatSync.mockReturnValue({ isFile: () => true } as fs.Stats);
   });
@@ -465,5 +517,133 @@ describe('OpencodeSettingsTab', () => {
       desc: expect.stringContaining(OPENCODE_DEFAULT_ENVIRONMENT_VARIABLES),
       placeholder: `${OPENCODE_DEFAULT_ENVIRONMENT_VARIABLES}\nOPENCODE_DB=/path/to/opencode.db`,
     }));
+  });
+
+  it('loads the OpenCode model catalog when the model browser is expanded', async () => {
+    mockRuntimeEnsureReady.mockImplementation(async (plugin: any) => {
+      plugin.settings.providerConfigs.opencode.discoveredModels = [
+        { label: 'DeepSeek/DeepSeek V4 Pro', rawId: 'deepseek/deepseek-v4-pro' },
+      ];
+      return true;
+    });
+    const plugin = createPlugin({
+      providerConfigs: {
+        opencode: {
+          availableModes: [],
+          cliPath: '',
+          cliPathsByHost: {},
+          discoveredModels: [],
+          enabled: true,
+          environmentVariables: OPENCODE_DEFAULT_ENVIRONMENT_VARIABLES,
+          modelAliases: {},
+          preferredThinkingByModel: {},
+          selectedMode: '',
+          visibleModels: ['deepseek/deepseek-v4-pro'],
+        },
+      },
+    });
+    const context = createContext(plugin);
+
+    opencodeSettingsTabRenderer.render(createContainer(), context);
+
+    const catalogEl = findElement('details', 'claudian-opencode-model-picker-catalog');
+    catalogEl.open = true;
+    await catalogEl.dispatchMockEvent('toggle');
+
+    expect(mockRuntimeSyncConversationState).toHaveBeenCalledWith({
+      providerState: { databasePath: ':memory:' },
+      sessionId: null,
+    });
+    expect(mockRuntimeEnsureReady).toHaveBeenCalledWith(
+      plugin,
+      { allowSessionCreation: true },
+    );
+    expect(mockRuntimeCleanup).toHaveBeenCalledTimes(1);
+    expect(context.refreshModelSelectors).toHaveBeenCalledTimes(1);
+  });
+
+  it('loads the OpenCode model catalog immediately when a fresh picker starts expanded', async () => {
+    mockRuntimeEnsureReady.mockImplementation(async (plugin: any) => {
+      plugin.settings.providerConfigs.opencode.discoveredModels = [
+        { label: 'DeepSeek/DeepSeek V4 Pro', rawId: 'deepseek/deepseek-v4-pro' },
+      ];
+      return true;
+    });
+    const plugin = createPlugin({
+      providerConfigs: {
+        opencode: {
+          availableModes: [],
+          cliPath: '',
+          cliPathsByHost: {},
+          discoveredModels: [],
+          enabled: true,
+          environmentVariables: OPENCODE_DEFAULT_ENVIRONMENT_VARIABLES,
+          modelAliases: {},
+          preferredThinkingByModel: {},
+          selectedMode: '',
+          visibleModels: [],
+        },
+      },
+    });
+    const context = createContext(plugin);
+
+    opencodeSettingsTabRenderer.render(createContainer(), context);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockRuntimeSyncConversationState).toHaveBeenCalledWith({
+      providerState: { databasePath: ':memory:' },
+      sessionId: null,
+    });
+    expect(mockRuntimeEnsureReady).toHaveBeenCalledWith(
+      plugin,
+      { allowSessionCreation: true },
+    );
+    expect(mockRuntimeCleanup).toHaveBeenCalledTimes(1);
+    expect(context.refreshModelSelectors).toHaveBeenCalledTimes(1);
+  });
+
+  it('warms and persists thinking metadata when a model is added to the visible list', async () => {
+    mockRuntimeWarmModelMetadata.mockResolvedValue(true);
+    const plugin = createPlugin({
+      providerConfigs: {
+        opencode: {
+          availableModes: [],
+          cliPath: '',
+          cliPathsByHost: {},
+          discoveredModels: [
+            { label: 'DeepSeek/DeepSeek V4 Pro', rawId: 'deepseek/deepseek-v4-pro' },
+          ],
+          enabled: true,
+          environmentVariables: OPENCODE_DEFAULT_ENVIRONMENT_VARIABLES,
+          modelAliases: {},
+          preferredThinkingByModel: {},
+          selectedMode: '',
+          visibleModels: [],
+        },
+      },
+    });
+    const context = createContext(plugin);
+
+    opencodeSettingsTabRenderer.render(createContainer(), context);
+
+    const checkboxEl = createdDomElements.find((element) => element.type === 'checkbox');
+    if (!checkboxEl) {
+      throw new Error('Expected model checkbox');
+    }
+
+    checkboxEl.checked = true;
+    await checkboxEl.dispatchMockEvent('change');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(plugin.settings.providerConfigs.opencode.visibleModels).toEqual([
+      'deepseek/deepseek-v4-pro',
+    ]);
+    expect(mockRuntimeWarmModelMetadata).toHaveBeenCalledWith(
+      plugin,
+      'opencode:deepseek/deepseek-v4-pro',
+    );
+    expect(context.refreshModelSelectors).toHaveBeenCalled();
   });
 });

--- a/tests/unit/providers/opencode/models.test.ts
+++ b/tests/unit/providers/opencode/models.test.ts
@@ -198,18 +198,23 @@ describe('opencodeChatUIConfig', () => {
     ]);
   });
 
-  it('returns per-model thinking options from discovered variants', () => {
+  it('returns per-model thinking options from ACP thought-level discovery', () => {
     const settings = {
       model: 'opencode:anthropic/claude-sonnet-4',
       providerConfigs: {
         opencode: {
           discoveredModels: [
             { label: 'Anthropic/Claude Sonnet 4', rawId: 'anthropic/claude-sonnet-4' },
-            { label: 'Anthropic/Claude Sonnet 4 (high)', rawId: 'anthropic/claude-sonnet-4/high' },
-            { label: 'Anthropic/Claude Sonnet 4 (max)', rawId: 'anthropic/claude-sonnet-4/max' },
           ],
           preferredThinkingByModel: {
             'anthropic/claude-sonnet-4': 'max',
+          },
+          thinkingOptionsByModel: {
+            'anthropic/claude-sonnet-4': [
+              { label: 'Low', value: 'low' },
+              { label: 'High', value: 'high' },
+              { label: 'Max', value: 'max' },
+            ],
           },
         },
       },
@@ -219,7 +224,7 @@ describe('opencodeChatUIConfig', () => {
       'opencode:anthropic/claude-sonnet-4',
       settings,
     )).toEqual([
-      { label: 'Default', value: 'default' },
+      { label: 'Low', value: 'low' },
       { label: 'High', value: 'high' },
       { label: 'Max', value: 'max' },
     ]);

--- a/tests/unit/providers/opencode/settings.test.ts
+++ b/tests/unit/providers/opencode/settings.test.ts
@@ -251,6 +251,105 @@ describe('OpenCode settings normalization', () => {
     expect((settings.providerConfigs as Record<string, any>).opencode.discoveredModels).toBeUndefined();
   });
 
+  it('persists thinking options only for visible or selected OpenCode models', () => {
+    const settings: Record<string, unknown> = {
+      model: 'opencode:google/gemini-2.5-pro',
+      providerConfigs: {
+        opencode: {
+          discoveredModels,
+          visibleModels: ['anthropic/claude-sonnet-4'],
+        },
+      },
+      savedProviderModel: {
+        opencode: 'opencode:google/gemini-2.5-pro',
+      },
+    };
+
+    const next = updateOpencodeProviderSettings(settings, {
+      thinkingOptionsByModel: {
+        'anthropic/claude-sonnet-4': [
+          { label: 'High', value: 'high' },
+        ],
+        'google/gemini-2.5-pro': [
+          { label: 'Low', value: 'low' },
+        ],
+        'openai/gpt-5': [
+          { label: 'Max', value: 'max' },
+        ],
+      },
+    });
+
+    expect(next.thinkingOptionsByModel).toMatchObject({
+      'anthropic/claude-sonnet-4': [
+        { label: 'High', value: 'high' },
+      ],
+      'google/gemini-2.5-pro': [
+        { label: 'Low', value: 'low' },
+      ],
+    });
+    expect((settings.providerConfigs as Record<string, any>).opencode.thinkingOptionsByModel).toEqual({
+      'anthropic/claude-sonnet-4': [
+        { label: 'High', value: 'high' },
+      ],
+      'google/gemini-2.5-pro': [
+        { label: 'Low', value: 'low' },
+      ],
+    });
+    expect((settings.providerConfigs as Record<string, any>).opencode.discoveredModels).toBeUndefined();
+  });
+
+  it('hydrates persisted thinking options without requiring the full discovered model catalog', () => {
+    const settings = getOpencodeProviderSettings({
+      providerConfigs: {
+        opencode: {
+          thinkingOptionsByModel: {
+            'deepseek/deepseek-v4-pro': [
+              { label: 'Low', value: 'low' },
+              { label: 'Max', value: 'max' },
+            ],
+          },
+          visibleModels: ['deepseek/deepseek-v4-pro'],
+        },
+      },
+    });
+
+    expect(settings.discoveredModels).toEqual([]);
+    expect(settings.thinkingOptionsByModel).toEqual({
+      'deepseek/deepseek-v4-pro': [
+        { label: 'Low', value: 'low' },
+        { label: 'Max', value: 'max' },
+      ],
+    });
+  });
+
+  it('preserves persisted thinking options when unrelated provider settings are updated', () => {
+    const settings: Record<string, unknown> = {
+      providerConfigs: {
+        opencode: {
+          environmentHash: '',
+          thinkingOptionsByModel: {
+            'deepseek/deepseek-v4-pro': [
+              { label: 'Low', value: 'low' },
+              { label: 'Max', value: 'max' },
+            ],
+          },
+          visibleModels: ['deepseek/deepseek-v4-pro'],
+        },
+      },
+    };
+
+    updateOpencodeProviderSettings(settings, {
+      environmentHash: 'OPENCODE_DB=/tmp/opencode.db',
+    });
+
+    expect((settings.providerConfigs as Record<string, any>).opencode.thinkingOptionsByModel).toEqual({
+      'deepseek/deepseek-v4-pro': [
+        { label: 'Low', value: 'low' },
+        { label: 'Max', value: 'max' },
+      ],
+    });
+  });
+
   it('normalizes saved custom OpenCode modes back to the managed YOLO mode', () => {
     expect(getOpencodeProviderSettings({
       providerConfigs: {


### PR DESCRIPTION
Adds OpenCode ACP thought_level discovery and applies detached effort through the ACP effort config option. Persists selected-model thinking options while keeping the full OpenCode catalog in memory, including settings catalog loading and metadata warmup. Updates ACP, OpenCode runtime, settings, and UI tests.\n\nTests: npm run test; npm run typecheck && npm run lint -- --quiet; npm run build.