### PR TITLE
Fix OpenCode database directory creation

### DIFF
--- a/src/providers/opencode/runtime/OpencodeLaunchArtifacts.ts
+++ b/src/providers/opencode/runtime/OpencodeLaunchArtifacts.ts
@@ -103,6 +103,7 @@ export async function prepareOpencodeLaunchArtifacts(
   const databasePath = resolveOpencodeDatabasePath(params.runtimeEnv);
 
   await fs.mkdir(artifactsDir, { recursive: true });
+  await ensureOpencodeDatabaseDirectory(databasePath);
   await writeIfChanged(systemPromptPath, systemPrompt);
   await writeIfChanged(configPath, configContent);
 
@@ -119,6 +120,14 @@ export async function prepareOpencodeLaunchArtifacts(
     ].join('::'),
     systemPromptPath,
   };
+}
+
+async function ensureOpencodeDatabaseDirectory(databasePath: string | null): Promise<void> {
+  if (!databasePath || databasePath === ':memory:') {
+    return;
+  }
+
+  await fs.mkdir(path.dirname(databasePath), { recursive: true });
 }
 
 export function buildOpencodeManagedConfig(

--- a/tests/unit/providers/opencode/OpencodeLaunchArtifacts.test.ts
+++ b/tests/unit/providers/opencode/OpencodeLaunchArtifacts.test.ts
@@ -212,4 +212,27 @@ describe('prepareOpencodeLaunchArtifacts', () => {
       },
     });
   });
+
+  it('creates the resolved OpenCode database directory before launch', async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'claudian-opencode-artifacts-'));
+    const xdgDataHome = path.join(tmpRoot, 'xdg-data');
+    const databaseDir = path.join(xdgDataHome, 'opencode');
+
+    const result = await prepareOpencodeLaunchArtifacts({
+      runtimeEnv: {
+        HOME: path.join(tmpRoot, 'home'),
+        XDG_DATA_HOME: xdgDataHome,
+      } as NodeJS.ProcessEnv,
+      settings: {
+        customPrompt: '',
+        mediaFolder: '',
+        userName: '',
+        vaultPath: tmpRoot,
+      },
+      workspaceRoot: tmpRoot,
+    });
+
+    expect(result.databasePath).toBe(path.join(databaseDir, 'opencode.db'));
+    await expect(fs.access(databaseDir)).resolves.toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- Create the resolved OpenCode database parent directory during launch artifact preparation.
- Skip directory creation for null and `:memory:` database paths.
- Add regression coverage for fresh OpenCode data directories.

Fixes #668.

## Tests
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run build`