### PR TITLE
fix: harden OpenCode ACP transport restarts

### DIFF
--- a/src/providers/acp/AcpJsonRpcTransport.ts
+++ b/src/providers/acp/AcpJsonRpcTransport.ts
@@ -82,6 +82,7 @@ export class AcpJsonRpcTransport {
   private readonly pending = new Map<number, PendingRequest>();
   private readline: Interface | null = null;
   private readonly requestHandlers = new Map<string, JsonRpcRequestHandler>();
+  private readonly streamUnsubscribers: Array<() => void> = [];
   private unregisterClose?: () => void;
 
   constructor(
@@ -112,6 +113,28 @@ export class AcpJsonRpcTransport {
         this.dispose(new JsonRpcTransportClosedError('JSON-RPC input closed'));
       }
     });
+
+    this.streamUnsubscribers.push(
+      subscribeStreamEvent(this.streams.input, 'error', (error?: unknown) => {
+        if (!this.disposed) {
+          this.dispose(error instanceof Error
+            ? error
+            : new JsonRpcTransportClosedError('JSON-RPC input error'));
+        }
+      }),
+      subscribeStreamEvent(this.streams.output, 'close', () => {
+        if (!this.disposed) {
+          this.dispose(new JsonRpcTransportClosedError('JSON-RPC output closed'));
+        }
+      }),
+      subscribeStreamEvent(this.streams.output, 'error', (error?: unknown) => {
+        if (!this.disposed) {
+          this.dispose(error instanceof Error
+            ? error
+            : new JsonRpcTransportClosedError('JSON-RPC output error'));
+        }
+      }),
+    );
 
     this.unregisterClose = this.streams.onClose?.((error) => {
       if (!this.disposed) {
@@ -218,7 +241,9 @@ export class AcpJsonRpcTransport {
       } catch (error) {
         this.pending.delete(id);
         cleanup();
-        reject(error instanceof Error ? error : new Error(String(error)));
+        const transportError = error instanceof Error ? error : new Error(String(error));
+        this.dispose(transportError);
+        reject(transportError);
       }
     });
   }
@@ -228,7 +253,7 @@ export class AcpJsonRpcTransport {
     if (this.disposed) {
       return;
     }
-    this.sendRaw({ jsonrpc: '2.0', method, params });
+    this.trySendRaw({ jsonrpc: '2.0', method, params });
   }
 
   dispose(error: Error = new JsonRpcTransportClosedError('JSON-RPC transport disposed')): void {
@@ -241,6 +266,10 @@ export class AcpJsonRpcTransport {
 
     this.unregisterClose?.();
     this.unregisterClose = undefined;
+
+    while (this.streamUnsubscribers.length > 0) {
+      this.streamUnsubscribers.pop()?.();
+    }
 
     if (this.readline) {
       this.readline.removeAllListeners();
@@ -330,7 +359,7 @@ export class AcpJsonRpcTransport {
   private handleRequest(message: JsonRpcRequestMessage): void {
     const handler = this.requestHandlers.get(message.method);
     if (!handler) {
-      this.sendRaw({
+      this.trySendRaw({
         error: {
           code: -32601,
           message: `Unhandled server request: ${message.method}`,
@@ -343,10 +372,10 @@ export class AcpJsonRpcTransport {
 
     void Promise.resolve(handler(message.params)).then(
       (result) => {
-        this.sendRaw({ id: message.id, jsonrpc: '2.0', result });
+        this.trySendRaw({ id: message.id, jsonrpc: '2.0', result });
       },
       (error) => {
-        this.sendRaw({
+        this.trySendRaw({
           error: {
             code: -32603,
             message: error instanceof Error ? error.message : 'Internal error',
@@ -364,4 +393,35 @@ export class AcpJsonRpcTransport {
     }
     this.streams.output.write(`${JSON.stringify(message)}\n`);
   }
+
+  private trySendRaw(message: JsonRpcMessage): void {
+    try {
+      this.sendRaw(message);
+    } catch (error) {
+      const transportError = error instanceof Error ? error : new Error(String(error));
+      this.dispose(transportError);
+    }
+  }
+}
+
+type StreamWithEvents = {
+  off?: (eventName: string, listener: (...args: unknown[]) => void) => void;
+  on?: (eventName: string, listener: (...args: unknown[]) => void) => void;
+  removeListener?: (eventName: string, listener: (...args: unknown[]) => void) => void;
+};
+
+function subscribeStreamEvent(
+  stream: NodeJS.ReadableStream | NodeJS.WritableStream,
+  eventName: string,
+  listener: (...args: unknown[]) => void,
+): () => void {
+  const evented = stream as StreamWithEvents;
+  evented.on?.(eventName, listener);
+  return () => {
+    if (typeof evented.off === 'function') {
+      evented.off(eventName, listener);
+      return;
+    }
+    evented.removeListener?.(eventName, listener);
+  };
 }

--- a/src/providers/opencode/runtime/OpencodeAuxQueryRunner.ts
+++ b/src/providers/opencode/runtime/OpencodeAuxQueryRunner.ts
@@ -192,6 +192,7 @@ export class OpencodeAuxQueryRunner implements AuxQueryRunner {
       || !this.transport
       || !this.connection
       || !this.process.isAlive()
+      || this.transport.isClosed
       || this.currentLaunchKey !== nextLaunchKey;
 
     if (!shouldRestart) {

--- a/src/providers/opencode/runtime/OpencodeChatRuntime.ts
+++ b/src/providers/opencode/runtime/OpencodeChatRuntime.ts
@@ -167,6 +167,7 @@ export class OpencodeChatRuntime implements ChatRuntime {
   private readonly sessionUpdateNormalizer = new AcpSessionUpdateNormalizer();
   private readonly toolStreamAdapter = createOpencodeToolStreamAdapter();
   private transport: AcpJsonRpcTransport | null = null;
+  private unregisterTransportClose: (() => void) | null = null;
 
   constructor(
     private readonly plugin: ClaudianPlugin,
@@ -297,6 +298,7 @@ export class OpencodeChatRuntime implements ChatRuntime {
       || !this.transport
       || !this.connection
       || !this.process.isAlive()
+      || this.transport.isClosed
       || options?.force === true
       || this.currentLaunchKey !== nextLaunchKey;
 
@@ -608,6 +610,12 @@ export class OpencodeChatRuntime implements ChatRuntime {
       onClose: (listener) => this.process!.onClose(listener),
       output: this.process.stdin,
     });
+    const transport = this.transport;
+    this.unregisterTransportClose = transport.onClose(() => {
+      if (this.transport === transport) {
+        this.setReady(false);
+      }
+    });
 
     this.connection = new AcpClientConnection({
       clientInfo: {
@@ -637,6 +645,9 @@ export class OpencodeChatRuntime implements ChatRuntime {
     this.currentSessionModelId = null;
     this.currentSessionModeId = null;
     this.setSupportedCommands([]);
+
+    this.unregisterTransportClose?.();
+    this.unregisterTransportClose = null;
 
     this.connection?.dispose();
     this.connection = null;

--- a/src/providers/opencode/runtime/OpencodeLaunchArtifacts.ts
+++ b/src/providers/opencode/runtime/OpencodeLaunchArtifacts.ts
@@ -114,7 +114,6 @@ export async function prepareOpencodeLaunchArtifacts(
       promptKey,
       configContent,
       databasePath ?? '',
-      params.runtimeEnv.OPENCODE_DB ?? '',
       params.runtimeEnv.XDG_DATA_HOME ?? '',
     ].join('::'),
     systemPromptPath,

--- a/tests/unit/providers/acp/AcpJsonRpcTransport.test.ts
+++ b/tests/unit/providers/acp/AcpJsonRpcTransport.test.ts
@@ -8,6 +8,8 @@ import {
 
 interface TransportHarness {
   close: () => void;
+  closeInput: () => void;
+  closeOutput: () => void;
   nextOutbound: () => Promise<Record<string, unknown>>;
   sendInbound: (message: Record<string, unknown>) => void;
   transport: AcpJsonRpcTransport;
@@ -35,6 +37,12 @@ function createTransportHarness(): TransportHarness {
       reader.close();
       input.end();
       output.end();
+    },
+    closeInput: () => {
+      input.end();
+    },
+    closeOutput: () => {
+      output.destroy();
     },
     nextOutbound: () => {
       if (queued.length > 0) {
@@ -144,5 +152,35 @@ describe('AcpJsonRpcTransport', () => {
     harness.transport.dispose(new Error('transport stopped'));
 
     await expect(requestPromise).rejects.toThrow('transport stopped');
+  });
+
+  it('rejects pending requests when input closes', async () => {
+    const requestPromise = harness.transport.request('session/prompt', {
+      prompt: [{ text: 'hi', type: 'text' }],
+      sessionId: 'session-1',
+    }, {
+      timeoutMs: 0,
+    });
+
+    await harness.nextOutbound();
+    harness.closeInput();
+
+    await expect(requestPromise).rejects.toThrow('JSON-RPC input closed');
+    expect(harness.transport.isClosed).toBe(true);
+  });
+
+  it('rejects pending requests when output closes', async () => {
+    const requestPromise = harness.transport.request('session/prompt', {
+      prompt: [{ text: 'hi', type: 'text' }],
+      sessionId: 'session-1',
+    }, {
+      timeoutMs: 0,
+    });
+
+    await harness.nextOutbound();
+    harness.closeOutput();
+
+    await expect(requestPromise).rejects.toThrow('JSON-RPC output closed');
+    expect(harness.transport.isClosed).toBe(true);
   });
 });

--- a/tests/unit/providers/opencode/OpencodeAuxQueryRunner.test.ts
+++ b/tests/unit/providers/opencode/OpencodeAuxQueryRunner.test.ts
@@ -72,6 +72,7 @@ describe('OpencodeAuxQueryRunner', () => {
   };
   let mockTransport: {
     dispose: jest.Mock;
+    isClosed: boolean;
     start: jest.Mock;
   };
   let sessionNotificationListener: ((notification: any) => void | Promise<void>) | null;
@@ -121,6 +122,7 @@ describe('OpencodeAuxQueryRunner', () => {
     };
     mockTransport = {
       dispose: jest.fn(),
+      isClosed: false,
       start: jest.fn(),
     };
 
@@ -190,6 +192,40 @@ describe('OpencodeAuxQueryRunner', () => {
     expect(MockAcpSubprocess).toHaveBeenCalledWith(expect.objectContaining({
       command: 'opencode',
     }));
+  });
+
+  it('restarts the auxiliary ACP subprocess when the cached transport closed', async () => {
+    const firstTransport = {
+      dispose: jest.fn(),
+      isClosed: false,
+      start: jest.fn(),
+    };
+    const secondTransport = {
+      dispose: jest.fn(),
+      isClosed: false,
+      start: jest.fn(),
+    };
+    MockAcpJsonRpcTransport
+      .mockImplementationOnce(() => firstTransport as any)
+      .mockImplementationOnce(() => secondTransport as any);
+    const runner = new OpencodeAuxQueryRunner(createMockPlugin(), {
+      agentProfile: 'passive',
+      artifactPurpose: 'title-gen',
+    });
+
+    await expect(runner.query({
+      systemPrompt: 'Use this custom system prompt.',
+    }, 'Generate a title')).resolves.toBe('Fix title now');
+
+    firstTransport.isClosed = true;
+
+    await expect(runner.query({
+      systemPrompt: 'Use this custom system prompt.',
+    }, 'Generate another title')).resolves.toBe('Fix title now');
+
+    expect(firstTransport.dispose).toHaveBeenCalledTimes(1);
+    expect(MockAcpSubprocess).toHaveBeenCalledTimes(2);
+    expect(MockAcpJsonRpcTransport).toHaveBeenCalledTimes(2);
   });
 
   it('uses an explicit encoded OpenCode model override from the active chat tab', async () => {

--- a/tests/unit/providers/opencode/OpencodeChatRuntime.test.ts
+++ b/tests/unit/providers/opencode/OpencodeChatRuntime.test.ts
@@ -190,6 +190,43 @@ describe('OpencodeChatRuntime', () => {
     await expect(runtime.ensureReady({ allowSessionCreation: false })).resolves.toBe(true);
   });
 
+  it('restarts when the ACP transport closed even if the subprocess still looks alive', async () => {
+    const plugin = createMockPlugin({
+      settings: {
+        providerConfigs: {
+          opencode: {
+            enabled: true,
+          },
+        },
+      },
+    });
+    const runtime = new OpencodeChatRuntime(plugin);
+    const mockTransport = { dispose: jest.fn(), isClosed: false };
+    const mockProcess = { isAlive: jest.fn().mockReturnValue(true), shutdown: jest.fn() };
+    const mockConnection = { dispose: jest.fn() };
+
+    jest.spyOn(launchArtifacts, 'prepareOpencodeLaunchArtifacts').mockResolvedValue({
+      configPath: '/tmp/claudian-opencode-config.json',
+      configContent: '{}\n',
+      databasePath: '/default/opencode.db',
+      launchKey: 'launch-key',
+      systemPromptPath: '/tmp/claudian-opencode-system.md',
+    });
+    const shutdownProcess = jest.spyOn(runtime as any, 'shutdownProcess').mockResolvedValue(undefined);
+    const startProcess = jest.spyOn(runtime as any, 'startProcess').mockImplementation(async () => {
+      (runtime as any).connection = mockConnection;
+      (runtime as any).process = mockProcess;
+      (runtime as any).transport = mockTransport;
+    });
+
+    await expect(runtime.ensureReady({ allowSessionCreation: false })).resolves.toBe(true);
+    mockTransport.isClosed = true;
+    await expect(runtime.ensureReady({ allowSessionCreation: false })).resolves.toBe(true);
+
+    expect(shutdownProcess).toHaveBeenCalledTimes(2);
+    expect(startProcess).toHaveBeenCalledTimes(2);
+  });
+
   it('maps ACP permission options through the shared approval UI', async () => {
     const runtime = new OpencodeChatRuntime(createMockPlugin());
     const approvalCallback = jest.fn().mockResolvedValue('allow');

--- a/tests/unit/providers/opencode/OpencodeLaunchArtifacts.test.ts
+++ b/tests/unit/providers/opencode/OpencodeLaunchArtifacts.test.ts
@@ -212,4 +212,34 @@ describe('prepareOpencodeLaunchArtifacts', () => {
       },
     });
   });
+
+  it('keeps the launch key stable when the resolved default database is later passed as OPENCODE_DB', async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'claudian-opencode-artifacts-'));
+    const baseParams = {
+      settings: {
+        customPrompt: '',
+        mediaFolder: '',
+        userName: '',
+        vaultPath: tmpRoot,
+      },
+      workspaceRoot: tmpRoot,
+    };
+    const first = await prepareOpencodeLaunchArtifacts({
+      ...baseParams,
+      runtimeEnv: {
+        HOME: tmpRoot,
+      } as NodeJS.ProcessEnv,
+    });
+
+    const second = await prepareOpencodeLaunchArtifacts({
+      ...baseParams,
+      runtimeEnv: {
+        HOME: tmpRoot,
+        OPENCODE_DB: first.databasePath ?? undefined,
+      } as NodeJS.ProcessEnv,
+    });
+
+    expect(first.databasePath).toBe(second.databasePath);
+    expect(first.launchKey).toBe(second.launchKey);
+  });
 });


### PR DESCRIPTION
## Summary
- Detect ACP input/output stream close and error events so pending JSON-RPC calls fail immediately instead of leaving stale transports alive.
- Restart OpenCode chat and auxiliary runtimes when the cached transport is closed, even if the subprocess still appears alive.
- Keep the OpenCode launch key stable when the resolved database path is later passed through OPENCODE_DB.

## Tests
- npm run typecheck
- npm run lint
- npm run test -- --selectProjects unit
- npm run build