### PR TITLE
feat: add draggable input box height resize handle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ dev
 
 .claude/
 .codex/
+
+# Worktrees
+.worktrees/

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -503,12 +503,10 @@ function buildTabDOM(contentEl: HTMLElement): TabDOMElements {
 }
 
 function attachInputResizeHandle(dom: TabDOMElements): () => void {
-  const container = dom.inputContainerEl;
-  const viewport = container.closest('.claudian-container') as HTMLElement | null;
+  const viewport = dom.inputWrapper.closest('.claudian-container') as HTMLElement | null;
   if (!viewport) return () => {};
 
   return createInputResizeHandle({
-    container,
     inputWrapper: dom.inputWrapper,
     viewport,
   });

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -497,7 +497,6 @@ function buildTabDOM(contentEl: HTMLElement): TabDOMElements {
     selectionIndicatorEl: null,
     browserIndicatorEl: null,
     canvasIndicatorEl: null,
-    resizeHandleEl: null,
     eventCleanups: [],
   };
 }

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -42,6 +42,7 @@ import { ChatState } from '../state/ChatState';
 import { BangBashModeManager as BangBashModeManagerClass } from '../ui/BangBashModeManager';
 import { FileContextManager } from '../ui/FileContext';
 import { ImageContextManager } from '../ui/ImageContext';
+import { createInputResizeHandle } from '../ui/inputResizeHandle';
 import { createInputToolbar } from '../ui/InputToolbar';
 import { InstructionModeManager as InstructionModeManagerClass } from '../ui/InstructionModeManager';
 import { NavigationSidebar } from '../ui/NavigationSidebar';
@@ -397,6 +398,8 @@ export function createTab(options: TabCreateOptions): TabData {
   const subagentManager = new SubagentManager(() => {});
 
   const dom = buildTabDOM(contentEl);
+  const resizeCleanup = attachInputResizeHandle(dom);
+  dom.eventCleanups.push(resizeCleanup);
   state.queueIndicatorEl = dom.queueIndicatorEl;
 
   const isBound = !!conversation?.id;
@@ -494,8 +497,21 @@ function buildTabDOM(contentEl: HTMLElement): TabDOMElements {
     selectionIndicatorEl: null,
     browserIndicatorEl: null,
     canvasIndicatorEl: null,
+    resizeHandleEl: null,
     eventCleanups: [],
   };
+}
+
+function attachInputResizeHandle(dom: TabDOMElements): () => void {
+  const container = dom.inputContainerEl;
+  const viewport = container.closest('.claudian-container') as HTMLElement | null;
+  if (!viewport) return () => {};
+
+  return createInputResizeHandle({
+    container,
+    inputWrapper: dom.inputWrapper,
+    viewport,
+  });
 }
 
 /**

--- a/src/features/chat/tabs/types.ts
+++ b/src/features/chat/tabs/types.ts
@@ -154,6 +154,9 @@ export interface TabDOMElements {
   browserIndicatorEl: HTMLElement | null;
   canvasIndicatorEl: HTMLElement | null;
 
+  /** Resize handle for dragging input box height. */
+  resizeHandleEl: HTMLElement | null;
+
   /** Cleanup functions for event listeners (prevents memory leaks). */
   eventCleanups: Array<() => void>;
 }

--- a/src/features/chat/tabs/types.ts
+++ b/src/features/chat/tabs/types.ts
@@ -154,9 +154,6 @@ export interface TabDOMElements {
   browserIndicatorEl: HTMLElement | null;
   canvasIndicatorEl: HTMLElement | null;
 
-  /** Resize handle for dragging input box height. */
-  resizeHandleEl: HTMLElement | null;
-
   /** Cleanup functions for event listeners (prevents memory leaks). */
   eventCleanups: Array<() => void>;
 }

--- a/src/features/chat/ui/inputResizeHandle.ts
+++ b/src/features/chat/ui/inputResizeHandle.ts
@@ -60,6 +60,9 @@ export function createInputResizeHandle({ inputWrapper, viewport }: InputResizeH
   handle.addEventListener('mousedown', onMouseDown);
 
   return () => {
+    if (isDragging && doc.body) {
+      doc.body.classList.remove('claudian-dragging-ns');
+    }
     handle.removeEventListener('mousedown', onMouseDown);
     doc.removeEventListener('mousemove', onMouseMove);
     doc.removeEventListener('mouseup', onMouseUp);

--- a/src/features/chat/ui/inputResizeHandle.ts
+++ b/src/features/chat/ui/inputResizeHandle.ts
@@ -31,8 +31,7 @@ export function createInputResizeHandle({ inputWrapper, viewport }: InputResizeH
     doc.addEventListener('mousemove', onMouseMove);
     doc.addEventListener('mouseup', onMouseUp);
     if (doc.body) {
-      doc.body.style.cursor = 'ns-resize';
-      doc.body.style.userSelect = 'none';
+      doc.body.classList.add('claudian-dragging-ns');
     }
   };
 
@@ -54,8 +53,7 @@ export function createInputResizeHandle({ inputWrapper, viewport }: InputResizeH
     doc.removeEventListener('mousemove', onMouseMove);
     doc.removeEventListener('mouseup', onMouseUp);
     if (doc.body) {
-      doc.body.style.cursor = '';
-      doc.body.style.userSelect = '';
+      doc.body.classList.remove('claudian-dragging-ns');
     }
   };
 

--- a/src/features/chat/ui/inputResizeHandle.ts
+++ b/src/features/chat/ui/inputResizeHandle.ts
@@ -1,0 +1,71 @@
+/** Min/max input wrapper height in pixels. */
+export const INPUT_WRAPPER_MIN_HEIGHT = 140;
+export const INPUT_WRAPPER_MAX_HEIGHT_RATIO = 0.7;
+
+export interface InputResizeHandleOptions {
+  /** The element to insert the handle into (inputContainerEl). */
+  container: HTMLElement;
+  /** The input wrapper whose height is being controlled. */
+  inputWrapper: HTMLElement;
+  /** Viewport element for calculating max height (.claudian-container). */
+  viewport: HTMLElement;
+}
+
+/**
+ * Creates a drag handle at the top of the input container.
+ * Returns a cleanup function to remove event listeners.
+ */
+export function createInputResizeHandle({ container, inputWrapper, viewport }: InputResizeHandleOptions): () => void {
+  const handle = container.createDiv({ cls: 'claudian-input-resize-handle' });
+  handle.setAttribute('aria-label', 'Drag to resize input');
+
+  const doc = container.ownerDocument;
+  let isDragging = false;
+  let startY = 0;
+  let startHeight = 0;
+
+  const onMouseDown = (e: MouseEvent) => {
+    e.preventDefault();
+    isDragging = true;
+    startY = e.clientY;
+    startHeight = inputWrapper.offsetHeight;
+    doc.addEventListener('mousemove', onMouseMove);
+    doc.addEventListener('mouseup', onMouseUp);
+    if (doc.body) {
+      doc.body.style.cursor = 'ns-resize';
+      doc.body.style.userSelect = 'none';
+    }
+  };
+
+  const onMouseMove = (e: MouseEvent) => {
+    if (!isDragging) return;
+    const delta = startY - e.clientY;
+    const newHeight = Math.max(
+      INPUT_WRAPPER_MIN_HEIGHT,
+      Math.min(
+        viewport.clientHeight * INPUT_WRAPPER_MAX_HEIGHT_RATIO,
+        startHeight + delta,
+      ),
+    );
+    inputWrapper.style.setProperty('--claudian-input-wrapper-height', `${newHeight}px`);
+  };
+
+  const onMouseUp = () => {
+    isDragging = false;
+    doc.removeEventListener('mousemove', onMouseMove);
+    doc.removeEventListener('mouseup', onMouseUp);
+    if (doc.body) {
+      doc.body.style.cursor = '';
+      doc.body.style.userSelect = '';
+    }
+  };
+
+  handle.addEventListener('mousedown', onMouseDown);
+
+  return () => {
+    handle.removeEventListener('mousedown', onMouseDown);
+    doc.removeEventListener('mousemove', onMouseMove);
+    doc.removeEventListener('mouseup', onMouseUp);
+    handle.remove();
+  };
+}

--- a/src/features/chat/ui/inputResizeHandle.ts
+++ b/src/features/chat/ui/inputResizeHandle.ts
@@ -3,9 +3,7 @@ export const INPUT_WRAPPER_MIN_HEIGHT = 140;
 export const INPUT_WRAPPER_MAX_HEIGHT_RATIO = 0.7;
 
 export interface InputResizeHandleOptions {
-  /** The element to insert the handle into (inputContainerEl). */
-  container: HTMLElement;
-  /** The input wrapper whose height is being controlled. */
+  /** The input wrapper whose height is being controlled (handle inserts as first child). */
   inputWrapper: HTMLElement;
   /** Viewport element for calculating max height (.claudian-container). */
   viewport: HTMLElement;
@@ -15,11 +13,12 @@ export interface InputResizeHandleOptions {
  * Creates a drag handle at the top of the input container.
  * Returns a cleanup function to remove event listeners.
  */
-export function createInputResizeHandle({ container, inputWrapper, viewport }: InputResizeHandleOptions): () => void {
-  const handle = container.createDiv({ cls: 'claudian-input-resize-handle' });
+export function createInputResizeHandle({ inputWrapper, viewport }: InputResizeHandleOptions): () => void {
+  const handle = inputWrapper.createDiv({ cls: 'claudian-input-resize-handle' });
   handle.setAttribute('aria-label', 'Drag to resize input');
+  inputWrapper.insertBefore(handle, inputWrapper.firstChild);
 
-  const doc = container.ownerDocument;
+  const doc = inputWrapper.ownerDocument;
   let isDragging = false;
   let startY = 0;
   let startHeight = 0;

--- a/src/style/components/input.css
+++ b/src/style/components/input.css
@@ -33,6 +33,12 @@
   opacity: 1;
 }
 
+/* Dragging state — applied to body during resize drag */
+body.claudian-dragging-ns {
+  cursor: ns-resize;
+  user-select: none;
+}
+
 /* Input wrapper (border container) - flex column so textarea expands when no chips */
 /* Height calculation: context row (36px) + textarea min (60px) + toolbar (38px) + border (2px) = 136px */
 .claudian-input-wrapper {

--- a/src/style/components/input.css
+++ b/src/style/components/input.css
@@ -4,12 +4,41 @@
   padding: 12px 0 0 0;
 }
 
+/* Resize handle — thin bar at top of input container */
+.claudian-input-resize-handle {
+  height: 6px;
+  cursor: ns-resize;
+  position: relative;
+  flex-shrink: 0;
+  margin-bottom: 2px;
+  border-radius: 3px;
+}
+
+.claudian-input-resize-handle::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 24px;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--background-modifier-border);
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.claudian-input-resize-handle:hover::after {
+  opacity: 1;
+}
+
 /* Input wrapper (border container) - flex column so textarea expands when no chips */
 /* Height calculation: context row (36px) + textarea min (60px) + toolbar (38px) + border (2px) = 136px */
 .claudian-input-wrapper {
   position: relative;
   display: flex;
   flex-direction: column;
+  height: var(--claudian-input-wrapper-height, auto);
   min-height: 140px;
   border: 1px solid var(--background-modifier-border);
   border-radius: 6px;

--- a/src/style/components/input.css
+++ b/src/style/components/input.css
@@ -4,22 +4,23 @@
   padding: 12px 0 0 0;
 }
 
-/* Resize handle — thin bar at top of input container */
+/* Resize handle — invisible hit zone at top of input wrapper */
 .claudian-input-resize-handle {
-  height: 6px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 8px;
   cursor: ns-resize;
-  position: relative;
-  flex-shrink: 0;
-  margin-bottom: 2px;
-  border-radius: 3px;
+  z-index: 1;
 }
 
 .claudian-input-resize-handle::after {
   content: '';
   position: absolute;
-  top: 50%;
+  top: 2px;
   left: 50%;
-  transform: translate(-50%, -50%);
+  transform: translateX(-50%);
   width: 24px;
   height: 3px;
   border-radius: 2px;

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -548,11 +548,12 @@ describe('Tab - Creation', () => {
       expect(tab.dom.inputEl).toBeDefined();
     });
 
-    it('should initialize empty eventCleanups array', () => {
+    it('should initialize eventCleanups with resize handle cleanup', () => {
       const options = createMockOptions();
       const tab = createTab(options);
 
-      expect(tab.dom.eventCleanups).toEqual([]);
+      expect(tab.dom.eventCleanups.length).toBe(1);
+      expect(typeof tab.dom.eventCleanups[0]).toBe('function');
     });
 
     it('should initialize all controllers as null', () => {
@@ -1256,7 +1257,7 @@ describe('Tab - Event Wiring', () => {
 
       wireTabInputEvents(tab, options.plugin);
 
-      expect(tab.dom.eventCleanups.length).toBe(4); // keydown, input, focus, scroll
+      expect(tab.dom.eventCleanups.length).toBe(5); // resize handle + keydown, input, focus, scroll
     });
   });
 });

--- a/tests/unit/features/chat/ui/inputResizeHandle.test.ts
+++ b/tests/unit/features/chat/ui/inputResizeHandle.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  createInputResizeHandle,
+  INPUT_WRAPPER_MAX_HEIGHT_RATIO,
+  INPUT_WRAPPER_MIN_HEIGHT,
+} from '@/features/chat/ui/inputResizeHandle';
+
+function createMockDom() {
+  const container = document.createElement('div');
+  container.classList.add('claudian-input-container');
+  // Polyfill Obsidian's createDiv for jsdom
+  (container as any).createDiv = (opts?: { cls?: string }) => {
+    const div = document.createElement('div');
+    if (opts?.cls) div.className = opts.cls;
+    container.appendChild(div);
+    return div;
+  };
+
+  const viewport = document.createElement('div');
+  viewport.classList.add('claudian-container');
+  Object.defineProperty(viewport, 'clientHeight', { value: 600, configurable: true });
+  viewport.appendChild(container);
+
+  const inputWrapper = document.createElement('div');
+  inputWrapper.classList.add('claudian-input-wrapper');
+  container.appendChild(inputWrapper);
+
+  return { container, inputWrapper, viewport };
+}
+
+describe('createInputResizeHandle', () => {
+  it('should create a resize handle element inside the container', () => {
+    const { container, inputWrapper, viewport } = createMockDom();
+    const cleanup = createInputResizeHandle({ container, inputWrapper, viewport });
+
+    const handle = container.querySelector('.claudian-input-resize-handle');
+    expect(handle).toBeTruthy();
+
+    cleanup();
+  });
+
+  it('should set aria-label on the handle', () => {
+    const { container, inputWrapper, viewport } = createMockDom();
+    const cleanup = createInputResizeHandle({ container, inputWrapper, viewport });
+
+    const handle = container.querySelector('.claudian-input-resize-handle')!;
+    expect(handle.getAttribute('aria-label')).toBe('Drag to resize input');
+
+    cleanup();
+  });
+
+  it('should resize input wrapper on drag (mouse moves up)', () => {
+    const { container, inputWrapper, viewport } = createMockDom();
+    Object.defineProperty(inputWrapper, 'offsetHeight', { value: 140, configurable: true });
+    const cleanup = createInputResizeHandle({ container, inputWrapper, viewport });
+
+    const handle = container.querySelector('.claudian-input-resize-handle') as HTMLElement;
+
+    handle.dispatchEvent(new MouseEvent('mousedown', { clientY: 300, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('mousemove', { clientY: 240 }));
+
+    const setHeight = inputWrapper.style.getPropertyValue('--claudian-input-wrapper-height');
+    expect(setHeight).toBe('200px');
+
+    document.dispatchEvent(new MouseEvent('mouseup'));
+    cleanup();
+  });
+
+  it('should clamp to minimum height', () => {
+    const { container, inputWrapper, viewport } = createMockDom();
+    Object.defineProperty(inputWrapper, 'offsetHeight', { value: 140, configurable: true });
+    const cleanup = createInputResizeHandle({ container, inputWrapper, viewport });
+
+    const handle = container.querySelector('.claudian-input-resize-handle') as HTMLElement;
+
+    handle.dispatchEvent(new MouseEvent('mousedown', { clientY: 300, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('mousemove', { clientY: 500 }));
+
+    const setHeight = inputWrapper.style.getPropertyValue('--claudian-input-wrapper-height');
+    expect(parseInt(setHeight)).toBe(INPUT_WRAPPER_MIN_HEIGHT);
+
+    document.dispatchEvent(new MouseEvent('mouseup'));
+    cleanup();
+  });
+
+  it('should clamp to max height based on viewport', () => {
+    const { container, inputWrapper, viewport } = createMockDom();
+    Object.defineProperty(inputWrapper, 'offsetHeight', { value: 140, configurable: true });
+    const cleanup = createInputResizeHandle({ container, inputWrapper, viewport });
+
+    const handle = container.querySelector('.claudian-input-resize-handle') as HTMLElement;
+    const maxExpected = Math.floor(600 * INPUT_WRAPPER_MAX_HEIGHT_RATIO);
+
+    handle.dispatchEvent(new MouseEvent('mousedown', { clientY: 300, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('mousemove', { clientY: -200 }));
+
+    const setHeight = parseInt(inputWrapper.style.getPropertyValue('--claudian-input-wrapper-height'));
+    expect(setHeight).toBeLessThanOrEqual(maxExpected);
+
+    document.dispatchEvent(new MouseEvent('mouseup'));
+    cleanup();
+  });
+
+  it('should clean up event listeners on cleanup', () => {
+    const { container, inputWrapper, viewport } = createMockDom();
+    Object.defineProperty(inputWrapper, 'offsetHeight', { value: 140, configurable: true });
+    const cleanup = createInputResizeHandle({ container, inputWrapper, viewport });
+
+    const handle = container.querySelector('.claudian-input-resize-handle') as HTMLElement;
+    handle.dispatchEvent(new MouseEvent('mousedown', { clientY: 300, bubbles: true }));
+
+    cleanup();
+
+    const before = inputWrapper.style.getPropertyValue('--claudian-input-wrapper-height');
+    document.dispatchEvent(new MouseEvent('mousemove', { clientY: 240 }));
+    const after = inputWrapper.style.getPropertyValue('--claudian-input-wrapper-height');
+    expect(after).toBe(before);
+
+    document.dispatchEvent(new MouseEvent('mouseup'));
+  });
+
+  it('should remove handle element from DOM on cleanup', () => {
+    const { container, inputWrapper, viewport } = createMockDom();
+    const cleanup = createInputResizeHandle({ container, inputWrapper, viewport });
+
+    expect(container.querySelector('.claudian-input-resize-handle')).toBeTruthy();
+    cleanup();
+    expect(container.querySelector('.claudian-input-resize-handle')).toBeNull();
+  });
+
+  it('should reset body cursor and user-select on mouseup', () => {
+    const { container, inputWrapper, viewport } = createMockDom();
+    Object.defineProperty(inputWrapper, 'offsetHeight', { value: 140, configurable: true });
+    const cleanup = createInputResizeHandle({ container, inputWrapper, viewport });
+
+    const handle = container.querySelector('.claudian-input-resize-handle') as HTMLElement;
+
+    handle.dispatchEvent(new MouseEvent('mousedown', { clientY: 300, bubbles: true }));
+    expect(document.body.style.cursor).toBe('ns-resize');
+    expect(document.body.style.userSelect).toBe('none');
+
+    document.dispatchEvent(new MouseEvent('mouseup'));
+    expect(document.body.style.cursor).toBe('');
+    expect(document.body.style.userSelect).toBe('');
+
+    cleanup();
+  });
+});

--- a/tests/unit/features/chat/ui/inputResizeHandle.test.ts
+++ b/tests/unit/features/chat/ui/inputResizeHandle.test.ts
@@ -11,13 +11,6 @@ import {
 function createMockDom() {
   const container = document.createElement('div');
   container.classList.add('claudian-input-container');
-  // Polyfill Obsidian's createDiv for jsdom
-  (container as any).createDiv = (opts?: { cls?: string }) => {
-    const div = document.createElement('div');
-    if (opts?.cls) div.className = opts.cls;
-    container.appendChild(div);
-    return div;
-  };
 
   const viewport = document.createElement('div');
   viewport.classList.add('claudian-container');
@@ -26,38 +19,45 @@ function createMockDom() {
 
   const inputWrapper = document.createElement('div');
   inputWrapper.classList.add('claudian-input-wrapper');
+  // Polyfill Obsidian's createDiv + insertBefore for jsdom
+  (inputWrapper as any).createDiv = (opts?: { cls?: string }) => {
+    const div = document.createElement('div');
+    if (opts?.cls) div.className = opts.cls;
+    inputWrapper.appendChild(div);
+    return div;
+  };
   container.appendChild(inputWrapper);
 
   return { container, inputWrapper, viewport };
 }
 
 describe('createInputResizeHandle', () => {
-  it('should create a resize handle element inside the container', () => {
-    const { container, inputWrapper, viewport } = createMockDom();
-    const cleanup = createInputResizeHandle({ container, inputWrapper, viewport });
+  it('should create a resize handle element inside input wrapper', () => {
+    const { inputWrapper, viewport } = createMockDom();
+    const cleanup = createInputResizeHandle({ inputWrapper, viewport });
 
-    const handle = container.querySelector('.claudian-input-resize-handle');
+    const handle = inputWrapper.querySelector('.claudian-input-resize-handle');
     expect(handle).toBeTruthy();
 
     cleanup();
   });
 
   it('should set aria-label on the handle', () => {
-    const { container, inputWrapper, viewport } = createMockDom();
-    const cleanup = createInputResizeHandle({ container, inputWrapper, viewport });
+    const { inputWrapper, viewport } = createMockDom();
+    const cleanup = createInputResizeHandle({ inputWrapper, viewport });
 
-    const handle = container.querySelector('.claudian-input-resize-handle')!;
+    const handle = inputWrapper.querySelector('.claudian-input-resize-handle')!;
     expect(handle.getAttribute('aria-label')).toBe('Drag to resize input');
 
     cleanup();
   });
 
   it('should resize input wrapper on drag (mouse moves up)', () => {
-    const { container, inputWrapper, viewport } = createMockDom();
+    const { inputWrapper, viewport } = createMockDom();
     Object.defineProperty(inputWrapper, 'offsetHeight', { value: 140, configurable: true });
-    const cleanup = createInputResizeHandle({ container, inputWrapper, viewport });
+    const cleanup = createInputResizeHandle({ inputWrapper, viewport });
 
-    const handle = container.querySelector('.claudian-input-resize-handle') as HTMLElement;
+    const handle = inputWrapper.querySelector('.claudian-input-resize-handle') as HTMLElement;
 
     handle.dispatchEvent(new MouseEvent('mousedown', { clientY: 300, bubbles: true }));
     document.dispatchEvent(new MouseEvent('mousemove', { clientY: 240 }));
@@ -70,11 +70,11 @@ describe('createInputResizeHandle', () => {
   });
 
   it('should clamp to minimum height', () => {
-    const { container, inputWrapper, viewport } = createMockDom();
+    const { inputWrapper, viewport } = createMockDom();
     Object.defineProperty(inputWrapper, 'offsetHeight', { value: 140, configurable: true });
-    const cleanup = createInputResizeHandle({ container, inputWrapper, viewport });
+    const cleanup = createInputResizeHandle({ inputWrapper, viewport });
 
-    const handle = container.querySelector('.claudian-input-resize-handle') as HTMLElement;
+    const handle = inputWrapper.querySelector('.claudian-input-resize-handle') as HTMLElement;
 
     handle.dispatchEvent(new MouseEvent('mousedown', { clientY: 300, bubbles: true }));
     document.dispatchEvent(new MouseEvent('mousemove', { clientY: 500 }));
@@ -87,11 +87,11 @@ describe('createInputResizeHandle', () => {
   });
 
   it('should clamp to max height based on viewport', () => {
-    const { container, inputWrapper, viewport } = createMockDom();
+    const { inputWrapper, viewport } = createMockDom();
     Object.defineProperty(inputWrapper, 'offsetHeight', { value: 140, configurable: true });
-    const cleanup = createInputResizeHandle({ container, inputWrapper, viewport });
+    const cleanup = createInputResizeHandle({ inputWrapper, viewport });
 
-    const handle = container.querySelector('.claudian-input-resize-handle') as HTMLElement;
+    const handle = inputWrapper.querySelector('.claudian-input-resize-handle') as HTMLElement;
     const maxExpected = Math.floor(600 * INPUT_WRAPPER_MAX_HEIGHT_RATIO);
 
     handle.dispatchEvent(new MouseEvent('mousedown', { clientY: 300, bubbles: true }));
@@ -105,11 +105,11 @@ describe('createInputResizeHandle', () => {
   });
 
   it('should clean up event listeners on cleanup', () => {
-    const { container, inputWrapper, viewport } = createMockDom();
+    const { inputWrapper, viewport } = createMockDom();
     Object.defineProperty(inputWrapper, 'offsetHeight', { value: 140, configurable: true });
-    const cleanup = createInputResizeHandle({ container, inputWrapper, viewport });
+    const cleanup = createInputResizeHandle({ inputWrapper, viewport });
 
-    const handle = container.querySelector('.claudian-input-resize-handle') as HTMLElement;
+    const handle = inputWrapper.querySelector('.claudian-input-resize-handle') as HTMLElement;
     handle.dispatchEvent(new MouseEvent('mousedown', { clientY: 300, bubbles: true }));
 
     cleanup();
@@ -123,20 +123,20 @@ describe('createInputResizeHandle', () => {
   });
 
   it('should remove handle element from DOM on cleanup', () => {
-    const { container, inputWrapper, viewport } = createMockDom();
-    const cleanup = createInputResizeHandle({ container, inputWrapper, viewport });
+    const { inputWrapper, viewport } = createMockDom();
+    const cleanup = createInputResizeHandle({ inputWrapper, viewport });
 
-    expect(container.querySelector('.claudian-input-resize-handle')).toBeTruthy();
+    expect(inputWrapper.querySelector('.claudian-input-resize-handle')).toBeTruthy();
     cleanup();
-    expect(container.querySelector('.claudian-input-resize-handle')).toBeNull();
+    expect(inputWrapper.querySelector('.claudian-input-resize-handle')).toBeNull();
   });
 
   it('should reset body cursor and user-select on mouseup', () => {
-    const { container, inputWrapper, viewport } = createMockDom();
+    const { inputWrapper, viewport } = createMockDom();
     Object.defineProperty(inputWrapper, 'offsetHeight', { value: 140, configurable: true });
-    const cleanup = createInputResizeHandle({ container, inputWrapper, viewport });
+    const cleanup = createInputResizeHandle({ inputWrapper, viewport });
 
-    const handle = container.querySelector('.claudian-input-resize-handle') as HTMLElement;
+    const handle = inputWrapper.querySelector('.claudian-input-resize-handle') as HTMLElement;
 
     handle.dispatchEvent(new MouseEvent('mousedown', { clientY: 300, bubbles: true }));
     expect(document.body.style.cursor).toBe('ns-resize');

--- a/tests/unit/features/chat/ui/inputResizeHandle.test.ts
+++ b/tests/unit/features/chat/ui/inputResizeHandle.test.ts
@@ -139,12 +139,10 @@ describe('createInputResizeHandle', () => {
     const handle = inputWrapper.querySelector('.claudian-input-resize-handle') as HTMLElement;
 
     handle.dispatchEvent(new MouseEvent('mousedown', { clientY: 300, bubbles: true }));
-    expect(document.body.style.cursor).toBe('ns-resize');
-    expect(document.body.style.userSelect).toBe('none');
+    expect(document.body.classList.contains('claudian-dragging-ns')).toBe(true);
 
     document.dispatchEvent(new MouseEvent('mouseup'));
-    expect(document.body.style.cursor).toBe('');
-    expect(document.body.style.userSelect).toBe('');
+    expect(document.body.classList.contains('claudian-dragging-ns')).toBe(false);
 
     cleanup();
   });


### PR DESCRIPTION
## Summary
- Add a drag handle at the top edge of the chat input wrapper
- Users can drag up/down to resize the input area (min 140px, max 70% of sidebar height)
- Cursor changes to `ns-resize` and a small grip indicator appears on hover

## Changes
- New module `inputResizeHandle.ts` — self-contained drag logic with cleanup
- CSS class `claudian-dragging-ns` on body during drag (no inline styles)
- Wired into tab lifecycle via `eventCleanups`

## Test Plan
- [x] Unit tests for handle creation, drag behavior, min/max clamping, cleanup
- [x] Manual: open chat, hover over top edge of input box, drag to resize