### PR TITLE
feat: replace tab right-click close with hover × close button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ dev
 
 .claude/
 .codex/
+
+# Worktrees
+.worktrees/

--- a/src/features/chat/tabs/TabBar.ts
+++ b/src/features/chat/tabs/TabBar.ts
@@ -71,8 +71,10 @@ export class TabBar {
         cls: 'claudian-tab-badge-close',
         text: '×',
       });
-      closeEl.addEventListener('click', (e) => {
+      closeEl.addEventListener('click', (e: Event) => {
         e.stopPropagation();
+        e.stopImmediatePropagation();
+        e.preventDefault();
         this.callbacks.onTabClose(item.id);
       });
     }

--- a/src/features/chat/tabs/TabBar.ts
+++ b/src/features/chat/tabs/TabBar.ts
@@ -65,18 +65,22 @@ export class TabBar {
     badgeEl.setAttribute('aria-label', item.title);
     badgeEl.setAttribute('data-provider', item.providerId);
 
+    // Close button (visible on hover)
+    if (item.canClose) {
+      const closeEl = badgeEl.createDiv({
+        cls: 'claudian-tab-badge-close',
+        text: '×',
+      });
+      closeEl.addEventListener('click', (e) => {
+        e.stopPropagation();
+        this.callbacks.onTabClose(item.id);
+      });
+    }
+
     // Click handler to switch tab
     badgeEl.addEventListener('click', () => {
       this.callbacks.onTabClick(item.id);
     });
-
-    // Right-click to close (if allowed)
-    if (item.canClose) {
-      badgeEl.addEventListener('contextmenu', (e) => {
-        e.preventDefault();
-        this.callbacks.onTabClose(item.id);
-      });
-    }
   }
 
   /** Destroys the tab bar. */

--- a/src/features/chat/tabs/TabBar.ts
+++ b/src/features/chat/tabs/TabBar.ts
@@ -71,6 +71,7 @@ export class TabBar {
         cls: 'claudian-tab-badge-close',
         text: '×',
       });
+      closeEl.setAttribute('aria-label', 'Close tab');
       closeEl.addEventListener('click', (e: Event) => {
         e.stopPropagation();
         e.stopImmediatePropagation();

--- a/src/style/components/tabs.css
+++ b/src/style/components/tabs.css
@@ -11,6 +11,7 @@
 }
 
 .claudian-tab-badge {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -75,4 +76,33 @@
   flex: 1;
   min-height: 0;
   overflow: hidden;
+}
+
+/* Close button — hidden by default, shown on badge hover */
+.claudian-tab-badge-close {
+  display: none;
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--background-modifier-border);
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 1;
+}
+
+.claudian-tab-badge-close:hover {
+  background: var(--text-error);
+  color: var(--text-on-accent);
+}
+
+/* Show close button on badge hover */
+.claudian-tab-badge:hover .claudian-tab-badge-close {
+  display: flex;
 }

--- a/tests/unit/features/chat/tabs/TabBar.test.ts
+++ b/tests/unit/features/chat/tabs/TabBar.test.ts
@@ -202,30 +202,45 @@ describe('TabBar', () => {
       expect(callbacks.onTabClick).toHaveBeenCalledWith('clicked-tab');
     });
 
-    it('should call onTabClose on right-click when canClose is true', () => {
+    it('should render close button when canClose is true', () => {
       const containerEl = createMockEl();
       const callbacks = createMockCallbacks();
       const tabBar = new TabBar(containerEl, callbacks);
 
       tabBar.update([createTabBarItem({ id: 'closeable-tab', canClose: true })]);
 
-      // Simulate right-click (contextmenu)
-      const mockEvent = { preventDefault: jest.fn() };
-      containerEl._children[0].dispatchEvent('contextmenu', mockEvent);
-
-      expect(mockEvent.preventDefault).toHaveBeenCalled();
-      expect(callbacks.onTabClose).toHaveBeenCalledWith('closeable-tab');
+      const badge = containerEl._children[0];
+      const closeBtn = badge._children.find((c: any) => c._classList.has('claudian-tab-badge-close'));
+      expect(closeBtn).toBeDefined();
+      expect(closeBtn.textContent).toBe('×');
     });
 
-    it('should not register contextmenu handler when canClose is false', () => {
+    it('should not render close button when canClose is false', () => {
       const containerEl = createMockEl();
       const callbacks = createMockCallbacks();
       const tabBar = new TabBar(containerEl, callbacks);
 
       tabBar.update([createTabBarItem({ id: 'uncloseable-tab', canClose: false })]);
 
-      // Check that contextmenu handler was not registered
-      expect(containerEl._children[0]._eventListeners.has('contextmenu')).toBe(false);
+      const badge = containerEl._children[0];
+      const closeBtn = badge._children.find((c: any) => c._classList.has('claudian-tab-badge-close'));
+      expect(closeBtn).toBeUndefined();
+    });
+
+    it('should call onTabClose when close button is clicked', () => {
+      const containerEl = createMockEl();
+      const callbacks = createMockCallbacks();
+      const tabBar = new TabBar(containerEl, callbacks);
+
+      tabBar.update([createTabBarItem({ id: 'closeable-tab', canClose: true })]);
+
+      const badge = containerEl._children[0];
+      const closeBtn = badge._children.find((c: any) => c._classList.has('claudian-tab-badge-close'));
+      const mockEvent = { stopPropagation: jest.fn() };
+      closeBtn.dispatchEvent('click', mockEvent);
+
+      expect(mockEvent.stopPropagation).toHaveBeenCalled();
+      expect(callbacks.onTabClose).toHaveBeenCalledWith('closeable-tab');
     });
   });
 

--- a/tests/unit/features/chat/tabs/TabBar.test.ts
+++ b/tests/unit/features/chat/tabs/TabBar.test.ts
@@ -236,7 +236,7 @@ describe('TabBar', () => {
 
       const badge = containerEl._children[0];
       const closeBtn = badge._children.find((c: any) => c._classList.has('claudian-tab-badge-close'));
-      const mockEvent = { stopPropagation: jest.fn() };
+      const mockEvent = { stopPropagation: jest.fn(), stopImmediatePropagation: jest.fn(), preventDefault: jest.fn() };
       closeBtn.dispatchEvent('click', mockEvent);
 
       expect(mockEvent.stopPropagation).toHaveBeenCalled();

--- a/tests/unit/features/chat/tabs/TabBar.test.ts
+++ b/tests/unit/features/chat/tabs/TabBar.test.ts
@@ -213,6 +213,7 @@ describe('TabBar', () => {
       const closeBtn = badge._children.find((c: any) => c._classList.has('claudian-tab-badge-close'));
       expect(closeBtn).toBeDefined();
       expect(closeBtn.textContent).toBe('×');
+      expect(closeBtn.getAttribute('aria-label')).toBe('Close tab');
     });
 
     it('should not render close button when canClose is false', () => {


### PR DESCRIPTION
## Summary
- Replace right-click (contextmenu) tab close with a visible × button on badge hover
- Close button appears on hover, clicks are isolated with `stopPropagation`/`stopImmediatePropagation`
- Adds `aria-label="Close tab"` for accessibility

## Changes
- `TabBar.renderBadge()` now renders a `×` div instead of listening for contextmenu
- CSS: close button hidden by default, absolutely positioned, shown on badge hover

## Test Plan
- [x] Unit tests for close button rendering, canClose gating, click callback
- [x] Manual: open 2+ tabs, hover over a tab badge, click × to close