### PR TITLE
[codex] Fix Command/Ctrl+Enter send shortcut

### DIFF
--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -614,6 +614,26 @@ export class ClaudianView extends ItemView {
     // View scopes are the Obsidian-owned boundary for main-area tab hotkeys.
     // Returning false consumes Escape before Obsidian uses it for pane navigation.
     this.scope = new Scope(this.app.scope);
+    this.scope.register(['Meta'], 'Enter', (e: KeyboardEvent) => {
+      if (
+        e.isComposing
+        || e.defaultPrevented
+        || e.shiftKey
+        || e.altKey
+        || this.plugin.settings.requireCommandOrControlEnterToSend !== true
+      ) {
+        return;
+      }
+
+      const activeTab = this.tabManager?.getActiveTab();
+      if (!activeTab || activeDocument.activeElement !== activeTab.dom.inputEl) {
+        return;
+      }
+
+      e.preventDefault();
+      void activeTab.controllers.inputController?.sendMessage();
+      return false;
+    });
     this.scope.register([], 'Escape', (e: KeyboardEvent) => {
       if (e.isComposing) return;
       if (!e.defaultPrevented) {

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -1,5 +1,5 @@
 import type { Component } from 'obsidian';
-import { Notice, Platform } from 'obsidian';
+import { Notice } from 'obsidian';
 
 import { getHiddenProviderCommandSet } from '../../../core/providers/commands/hiddenCommands';
 import type { ProviderCommandDropdownConfig } from '../../../core/providers/commands/ProviderCommandCatalog';
@@ -182,11 +182,7 @@ function shouldSendMessageFromEnterKey(
     return true;
   }
 
-  if (Platform.isMacOS) {
-    return e.metaKey === true && !e.ctrlKey && !e.altKey;
-  }
-
-  return e.ctrlKey === true && !e.metaKey && !e.altKey;
+  return (e.metaKey === true || e.ctrlKey === true) && !e.altKey;
 }
 
 type ProviderCatalogInfo = {

--- a/tests/unit/features/chat/ClaudianView.test.ts
+++ b/tests/unit/features/chat/ClaudianView.test.ts
@@ -82,6 +82,9 @@ describe('ClaudianView Escape handling', () => {
     view.registerEvent = jest.fn();
     view.eventRefs = eventRefs;
     view.plugin = {
+      settings: {
+        requireCommandOrControlEnterToSend: false,
+      },
       app: {
         vault: {
           on: jest.fn((_event: string, handler: unknown) => {
@@ -126,6 +129,7 @@ describe('ClaudianView Escape handling', () => {
 
     expect(view.scope).toBeInstanceOf(Scope);
     expect(view.scope.parent).toBe(view.app.scope);
+    expect(view.scope.register).toHaveBeenCalledWith(['Meta'], 'Enter', expect.any(Function));
     expect(view.scope.register).toHaveBeenCalledWith([], 'Escape', expect.any(Function));
     expect(view.registerDomEvent).not.toHaveBeenCalledWith(
       expect.anything(),
@@ -170,5 +174,87 @@ describe('ClaudianView Escape handling', () => {
 
     expect(cancelStreaming).not.toHaveBeenCalled();
     expect(result).toBe(false);
+  });
+
+  it('sends from scoped Meta+Enter when the send shortcut setting is enabled and input is focused', () => {
+    const { view } = createEscapeHarness({ isStreaming: false });
+    const inputEl = createMockEl('textarea');
+    const sendMessage = jest.fn();
+    view.plugin.settings.requireCommandOrControlEnterToSend = true;
+    view.tabManager.getActiveTab.mockReturnValue({
+      state: { isStreaming: false },
+      dom: { inputEl },
+      controllers: {
+        inputController: { sendMessage },
+      },
+      ui: {
+        fileContextManager: {
+          markFileCacheDirty: jest.fn(),
+          markFolderCacheDirty: jest.fn(),
+          handleFileOpen: jest.fn(),
+          handleClickOutside: jest.fn(),
+        },
+      },
+    });
+    Object.defineProperty(view.containerEl.ownerDocument, 'activeElement', {
+      configurable: true,
+      value: inputEl,
+    });
+
+    view.wireEventHandlers();
+    const metaEnterHandler = view.scope.handlers.find((handler: any) => handler.key === 'Enter');
+    const event = {
+      isComposing: false,
+      defaultPrevented: false,
+      shiftKey: false,
+      altKey: false,
+      preventDefault: jest.fn(),
+    } as unknown as KeyboardEvent;
+    const result = metaEnterHandler.func(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(result).toBe(false);
+  });
+
+  it('does not send scoped Meta+Enter when the input is not focused', () => {
+    const { view } = createEscapeHarness({ isStreaming: false });
+    const inputEl = createMockEl('textarea');
+    const sendMessage = jest.fn();
+    view.plugin.settings.requireCommandOrControlEnterToSend = true;
+    view.tabManager.getActiveTab.mockReturnValue({
+      state: { isStreaming: false },
+      dom: { inputEl },
+      controllers: {
+        inputController: { sendMessage },
+      },
+      ui: {
+        fileContextManager: {
+          markFileCacheDirty: jest.fn(),
+          markFolderCacheDirty: jest.fn(),
+          handleFileOpen: jest.fn(),
+          handleClickOutside: jest.fn(),
+        },
+      },
+    });
+    Object.defineProperty(view.containerEl.ownerDocument, 'activeElement', {
+      configurable: true,
+      value: createMockEl('button'),
+    });
+
+    view.wireEventHandlers();
+    const metaEnterHandler = view.scope.handlers.find((handler: any) => handler.key === 'Enter');
+    const event = {
+      isComposing: false,
+      defaultPrevented: false,
+      shiftKey: false,
+      altKey: false,
+      preventDefault: jest.fn(),
+    } as unknown as KeyboardEvent;
+    const result = metaEnterHandler.func(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
   });
 });

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -1,7 +1,7 @@
 import '@/providers';
 
 import { createMockEl } from '@test/helpers/mockElement';
-import { Notice, Platform } from 'obsidian';
+import { Notice } from 'obsidian';
 
 import { ProviderRegistry } from '@/core/providers/ProviderRegistry';
 import { ProviderWorkspaceRegistry } from '@/core/providers/ProviderWorkspaceRegistry';
@@ -1911,7 +1911,6 @@ describe('Tab - Controller Initialization', () => {
 describe('Tab - Event Handler Behavior', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    Platform.isMacOS = true;
     mockFileContextManager = createMockFileContextManager();
     mockSlashCommandDropdown = createMockSlashCommandDropdown();
     mockInstructionModeManager = createMockInstructionModeManager();
@@ -2130,13 +2129,12 @@ describe('Tab - Event Handler Behavior', () => {
       expect(mockInputController.sendMessage).not.toHaveBeenCalled();
     });
 
-    it('should require Command+Enter on macOS when the send shortcut setting is enabled', () => {
+    it('should require Command or Ctrl+Enter when the send shortcut setting is enabled', () => {
       mockInstructionModeManager.handleTriggerKey.mockReturnValue(false);
       mockInstructionModeManager.handleKeydown.mockReturnValue(false);
       mockSlashCommandDropdown.handleKeydown.mockReturnValue(false);
       mockFileContextManager.handleMentionKeydown.mockReturnValue(false);
       const { options, fireKeydown } = setupKeydownTab();
-      Platform.isMacOS = true;
       options.plugin.settings.requireCommandOrControlEnterToSend = true;
 
       const enterEvent = { key: 'Enter', shiftKey: false, ctrlKey: false, metaKey: false, isComposing: false, preventDefault: jest.fn() };
@@ -2148,36 +2146,35 @@ describe('Tab - Event Handler Behavior', () => {
       const controlEnterEvent = { key: 'Enter', shiftKey: false, ctrlKey: true, metaKey: false, isComposing: false, preventDefault: jest.fn() };
       fireKeydown(controlEnterEvent);
 
-      expect(controlEnterEvent.preventDefault).not.toHaveBeenCalled();
-      expect(mockInputController.sendMessage).not.toHaveBeenCalled();
+      expect(controlEnterEvent.preventDefault).toHaveBeenCalled();
+      expect(mockInputController.sendMessage).toHaveBeenCalledTimes(1);
 
       const commandEnterEvent = { key: 'Enter', shiftKey: false, ctrlKey: false, metaKey: true, isComposing: false, preventDefault: jest.fn() };
       fireKeydown(commandEnterEvent);
 
       expect(commandEnterEvent.preventDefault).toHaveBeenCalled();
-      expect(mockInputController.sendMessage).toHaveBeenCalled();
+      expect(mockInputController.sendMessage).toHaveBeenCalledTimes(2);
     });
 
-    it('should require Ctrl+Enter off macOS when the send shortcut setting is enabled', () => {
+    it('should ignore Alt and Shift when the send shortcut setting is enabled', () => {
       mockInstructionModeManager.handleTriggerKey.mockReturnValue(false);
       mockInstructionModeManager.handleKeydown.mockReturnValue(false);
       mockSlashCommandDropdown.handleKeydown.mockReturnValue(false);
       mockFileContextManager.handleMentionKeydown.mockReturnValue(false);
       const { options, fireKeydown } = setupKeydownTab();
-      Platform.isMacOS = false;
       options.plugin.settings.requireCommandOrControlEnterToSend = true;
 
-      const commandEnterEvent = { key: 'Enter', shiftKey: false, ctrlKey: false, metaKey: true, isComposing: false, preventDefault: jest.fn() };
-      fireKeydown(commandEnterEvent);
+      const altCommandEnterEvent = { key: 'Enter', shiftKey: false, altKey: true, ctrlKey: false, metaKey: true, isComposing: false, preventDefault: jest.fn() };
+      fireKeydown(altCommandEnterEvent);
 
-      expect(commandEnterEvent.preventDefault).not.toHaveBeenCalled();
+      expect(altCommandEnterEvent.preventDefault).not.toHaveBeenCalled();
       expect(mockInputController.sendMessage).not.toHaveBeenCalled();
 
-      const controlEnterEvent = { key: 'Enter', shiftKey: false, ctrlKey: true, metaKey: false, isComposing: false, preventDefault: jest.fn() };
-      fireKeydown(controlEnterEvent);
+      const shiftControlEnterEvent = { key: 'Enter', shiftKey: true, altKey: false, ctrlKey: true, metaKey: false, isComposing: false, preventDefault: jest.fn() };
+      fireKeydown(shiftControlEnterEvent);
 
-      expect(controlEnterEvent.preventDefault).toHaveBeenCalled();
-      expect(mockInputController.sendMessage).toHaveBeenCalled();
+      expect(shiftControlEnterEvent.preventDefault).not.toHaveBeenCalled();
+      expect(mockInputController.sendMessage).not.toHaveBeenCalled();
     });
 
     it('should not send message on Enter when isComposing (IME)', () => {


### PR DESCRIPTION
## Summary

Fix the optional Command/Ctrl+Enter send shortcut so macOS Command+Enter works reliably in the Obsidian chat view.

## Why

The existing textarea keydown handler checked `metaKey` on macOS, but Command+Enter can be intercepted before it reaches that handler in Obsidian/Electron. Ctrl+Enter could still work because it reached the textarea handler, which made the bug appear macOS-specific.

## Changes

- Keep the input keydown path accepting either Command or Ctrl when the send-shortcut setting is enabled.
- Add an Obsidian view `Scope` handler for `Meta+Enter`, limited to the active chat textarea and the existing setting.
- Add unit coverage for both the tab input handler and scoped Meta+Enter behavior.

## Validation

- `npm run test -- tests/unit/features/chat/ClaudianView.test.ts tests/unit/features/chat/tabs/Tab.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`