### PR TITLE
[codex] Remove history menu backdrop filter

### DIFF
--- a/src/style/components/history.css
+++ b/src/style/components/history.css
@@ -9,8 +9,6 @@
   bottom: 100%;
   margin-bottom: 4px;
   background: var(--background-secondary);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
   border: 1px solid var(--background-modifier-border);
   border-radius: 6px;
   box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.25);


### PR DESCRIPTION
## What changed

Removed the `backdrop-filter` and `-webkit-backdrop-filter` declarations from the chat history menu surface.

## Why

On translucent Obsidian windows, the history dropdown's backdrop filter can cause Chromium/Electron to render an extra white compositing layer behind the menu. The menu itself should keep the normal Obsidian background, but it should not alter the panel background behind it.

## Impact

The history dropdown still uses the existing theme background, border, radius, and shadow. Opening the history list no longer creates the extra white block behind the menu in translucent Obsidian themes.

## Validation

- Ran `npm run build`
- Applied the generated `styles.css` to a local Obsidian plugin install and verified the white block no longer appears