### PR TITLE
feat: add Pi provider integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 ![Preview](Preview.png)
 
-An Obsidian plugin that embeds AI coding agents (Claude Code, Codex, Opencode and more to come) in your vault. Your vault becomes the agent's working directory — file read/write, search, bash, and multi-step workflows all work out of the box.
+An Obsidian plugin that embeds AI coding agents (Claude Code, Codex, Opencode, Pi, and more to come) in your vault. Your vault becomes the agent's working directory — file read/write, search, bash, and multi-step workflows all work out of the box.
 
 ## Features & Usage
 
-Open the chat sidebar from the ribbon icon or command palette. Select text and use the hotkey for inline edit. Everything works like your familiar coding agent, Claude Code, Codex and Opencode — talk to the agent, and it reads, writes, edits, and searches files in your vault.
+Open the chat sidebar from the ribbon icon or command palette. Select text and use the hotkey for inline edit. Everything works like your familiar coding agent, Claude Code, Codex, Opencode, and Pi — talk to the agent, and it reads, writes, edits, and searches files in your vault.
 
 **Inline Edit** — Select text or start at the cursor position + hotkey to edit directly in notes with word-level diff preview.
 
@@ -29,7 +29,7 @@ Open the chat sidebar from the ribbon icon or command palette. Select text and u
 ## Requirements
 
 - **Claude provider**: [Claude Code CLI](https://code.claude.com/docs/en/overview) installed (native install recommended). Claude subscription/API or compatible provider ([Openrouter](https://openrouter.ai/docs/guides/guides/claude-code-integration), [Kimi](https://platform.moonshot.ai/docs/guide/agent-support), etc.).
-- **Optional providers**: [Codex CLI](https://github.com/openai/codex), [Opencode](https://opencode.ai/).
+- **Optional providers**: [Codex CLI](https://github.com/openai/codex), [Opencode](https://opencode.ai/), [Pi](https://github.com/earendil-works/pi).
 - Obsidian v1.7.2+
 - Desktop only (macOS, Linux, Windows)
 
@@ -84,8 +84,8 @@ npm run build
 
 ## Privacy & Data Use
 
-- **Sent to API**: Your input, attached files, images, and tool call outputs. Default: Anthropic (Claude) or OpenAI (Codex); configurable via provider settings and environment variables.
-- **Local storage**: Claudian settings and session metadata in `vault/.claudian/`; Claude provider files in `vault/.claude/`; transcripts in `~/.claude/projects/` (Claude) and `~/.codex/sessions/` (Codex).
+- **Sent to API**: Your input, attached files, images, and tool call outputs. Default: Anthropic (Claude), OpenAI (Codex), or the provider configured in Opencode/Pi; configurable via provider settings and environment variables.
+- **Local storage**: Claudian settings and session metadata in `vault/.claudian/`; Claude provider files in `vault/.claude/`; transcripts in `~/.claude/projects/` (Claude), `~/.codex/sessions/` (Codex), and `.pi/agent/sessions/` or `~/.pi/agent/sessions/` (Pi).
 - **Environment variables**: Provider subprocesses inherit the Obsidian process environment plus any variables you configure in Claudian. This is needed for CLI authentication, proxies, certificates, and PATH resolution.
 - **Device-specific paths**: Per-device CLI paths use an opaque local key stored in browser local storage, not your system hostname.
 - **Background activity**: Claudian does not run telemetry beacons. UI polling timers read local Obsidian/editor selection state only. Network activity is limited to explicit provider runtime work, configured MCP endpoints, and provider SDK/CLI calls needed to answer your requests.
@@ -124,7 +124,7 @@ If different, GUI apps like Obsidian may not find Node.js.
 
 ### Other providers
 
-Codex and Opencode support are live but features might be incomplete, and still need more testing across platforms and installation methods. If you have feature request or run into any bugs, please [submit a GitHub issue](https://github.com/YishenTu/claudian/issues).
+Codex, Opencode, and Pi support are live but features might be incomplete, and still need more testing across platforms and installation methods. If you have feature request or run into any bugs, please [submit a GitHub issue](https://github.com/YishenTu/claudian/issues).
 
 ## Architecture
 
@@ -143,6 +143,7 @@ src/
 │   ├── claude/                  # Claude SDK adaptor, prompt encoding, storage, MCP, plugins
 │   ├── codex/                   # Codex app-server adaptor, JSON-RPC transport, JSONL history
 │   ├── opencode/                # Opencode adaptor
+│   ├── pi/                      # Pi RPC adaptor, model discovery, JSONL history
 │   └── acp/                     # Agent Client Protocol shared transport
 ├── features/
 │   ├── chat/                    # Sidebar chat: tabs, controllers, renderers
@@ -160,6 +161,7 @@ src/
 - [x] 1M Opus and Sonnet models
 - [x] Codex provider integration
 - [x] Opencode support
+- [x] Pi provider support
 - [ ] More to come!
 
 ## License
@@ -182,3 +184,4 @@ Licensed under the [MIT License](LICENSE).
 - [Anthropic](https://anthropic.com) for Claude and the [Claude Agent SDK](https://platform.claude.com/docs/en/agent-sdk/overview)
 - [OpenAI](https://openai.com) for [Codex](https://github.com/openai/codex)
 - [Opencode](https://opencode.ai/) 
+- [Pi](https://github.com/earendil-works/pi)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,8 +45,8 @@ const stagedObsidianRules = {
   'obsidianmd/ui/sentence-case': [
     obsidianRuleSeverity,
     {
-      ignoreWords: ['Claudian', 'Codex', 'OpenCode', 'WSL'],
-      brands: [...DEFAULT_BRANDS, 'Claudian', 'Codex', 'OpenCode'],
+      ignoreWords: ['Claudian', 'Codex', 'OpenCode', 'Pi', 'WSL'],
+      brands: [...DEFAULT_BRANDS, 'Claudian', 'Codex', 'OpenCode', 'Pi'],
       acronyms: [...DEFAULT_ACRONYMS, 'TOML', 'WSL'],
       ignoreRegex: ['\\.(?:claude|codex|opencode)/'],
       enforceCamelCaseLower: true,

--- a/src/app/settings/ClaudianSettingsStorage.ts
+++ b/src/app/settings/ClaudianSettingsStorage.ts
@@ -33,6 +33,10 @@ import {
   getOpencodeProviderSettings,
   updateOpencodeProviderSettings,
 } from '../../providers/opencode/settings';
+import {
+  getPiProviderSettings,
+  updatePiProviderSettings,
+} from '../../providers/pi/settings';
 import { DEFAULT_CLAUDIAN_SETTINGS } from './defaultSettings';
 
 export {
@@ -132,6 +136,7 @@ const HOST_SCOPED_PROVIDER_CONFIG_FIELDS: Record<string, string[]> = {
   claude: ['cliPathsByHost'],
   codex: ['cliPathsByHost', 'installationMethodsByHost', 'wslDistroOverridesByHost'],
   opencode: ['cliPathsByHost'],
+  pi: ['cliPathsByHost'],
 };
 
 function hasHostScopedProviderConfigNormalization(
@@ -323,6 +328,10 @@ export class ClaudianSettingsStorage {
     updateOpencodeProviderSettings(
       merged,
       getOpencodeProviderSettings(legacyProviderSettings),
+    );
+    updatePiProviderSettings(
+      merged,
+      getPiProviderSettings(legacyProviderSettings),
     );
     const didNormalizeHostScopedProviderConfigs = hasHostScopedProviderConfigNormalization(
       providerConfigs,

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -254,7 +254,11 @@ export interface ProviderChatUIConfig {
   getDefaultReasoningValue(model: string, settings: Record<string, unknown>): string;
 
   /** Context window size in tokens. */
-  getContextWindowSize(model: string, customLimits?: Record<string, number>): number;
+  getContextWindowSize(
+    model: string,
+    customLimits?: Record<string, number>,
+    settings?: Record<string, unknown>,
+  ): number;
 
   /** Whether this is a built-in (default) model vs custom/env model. */
   isDefaultModel(model: string): boolean;

--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -111,6 +111,7 @@ export class ClaudianView extends ItemView {
       const contextWindow = uiConfig.getContextWindowSize(
         model,
         providerSettings.customContextLimits,
+        providerSettings,
       );
 
       if (tab.state.usage) {

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -828,6 +828,7 @@ function initializeInputToolbar(
         const newContextWindow = uiConfig.getContextWindowSize(
           model,
           providerSettings.customContextLimits,
+          providerSettings,
         );
         tab.state.usage = recalculateUsageForModel(currentUsage, model, newContextWindow);
       }

--- a/src/providers/acp/AcpSubprocess.ts
+++ b/src/providers/acp/AcpSubprocess.ts
@@ -1,6 +1,12 @@
 import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
 import type { Readable, Writable } from 'node:stream';
 
+import {
+  resolveWindowsCmdShimSpawnSpec,
+  terminateSpawnedProcess,
+  type WindowsCmdShimSpawnSpec,
+} from '../../utils/windowsCmdShim';
+
 const SIGKILL_TIMEOUT_MS = 3_000;
 const STDERR_BUFFER_LIMIT = 8_000;
 
@@ -18,6 +24,7 @@ export class AcpSubprocess {
   private readonly closeListeners = new Set<CloseListener>();
   private notifiedClose = false;
   private proc: ChildProcessWithoutNullStreams | null = null;
+  private resolvedSpawnSpec: WindowsCmdShimSpawnSpec | null = null;
   private stderrBuffer = '';
 
   constructor(private readonly launchSpec: AcpSubprocessLaunchSpec) {}
@@ -46,11 +53,14 @@ export class AcpSubprocess {
       return;
     }
 
-    const proc = spawn(this.launchSpec.command, this.launchSpec.args, {
+    const resolvedSpawnSpec = resolveWindowsCmdShimSpawnSpec(this.launchSpec);
+    this.resolvedSpawnSpec = resolvedSpawnSpec;
+    const proc = spawn(resolvedSpawnSpec.command, resolvedSpawnSpec.args, {
       cwd: this.launchSpec.cwd,
       env: this.launchSpec.env,
       stdio: 'pipe',
       windowsHide: true,
+      ...(resolvedSpawnSpec.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
     });
 
     proc.stderr.on('data', (chunk: Buffer | string) => {
@@ -102,7 +112,7 @@ export class AcpSubprocess {
         resolve();
       };
       const killTimer = window.setTimeout(() => {
-        proc.kill('SIGKILL');
+        this.killProc(proc, 'SIGKILL');
       }, SIGKILL_TIMEOUT_MS);
       const cleanup = () => {
         window.clearTimeout(killTimer);
@@ -110,8 +120,12 @@ export class AcpSubprocess {
       };
 
       proc.once('exit', onClose);
-      proc.kill('SIGTERM');
+      this.killProc(proc, 'SIGTERM');
     });
+  }
+
+  private killProc(proc: ChildProcessWithoutNullStreams, signal: NodeJS.Signals): boolean {
+    return terminateSpawnedProcess(proc, signal, spawn, this.resolvedSpawnSpec);
   }
 
   private notifyClose(error?: Error): void {

--- a/src/providers/claude/runtime/customSpawn.ts
+++ b/src/providers/claude/runtime/customSpawn.ts
@@ -1,7 +1,12 @@
 import type { SpawnedProcess, SpawnOptions } from '@anthropic-ai/claude-agent-sdk';
-import { spawn } from 'child_process';
+import { type ChildProcess, spawn } from 'child_process';
 
 import { cliPathRequiresNode, findNodeExecutable } from '../../../utils/env';
+import {
+  resolveWindowsCmdShimSpawnSpec,
+  terminateSpawnedProcess,
+  type WindowsCmdShimSpawnSpec,
+} from '../../../utils/windowsCmdShim';
 
 export function createCustomSpawnFunction(
   enhancedPath: string
@@ -26,21 +31,28 @@ export function createCustomSpawnFunction(
       }
     }
 
+    const resolvedSpawnSpec = resolveWindowsCmdShimSpawnSpec({ args, command });
+
     // Do not pass `signal` directly to spawn() — Obsidian's Electron runtime
     // uses a different realm for AbortSignal, causing `instanceof EventTarget`
     // checks inside Node's internals to fail. Handle abort manually instead.
-    const child = spawn(command, args, {
+    const child = spawn(resolvedSpawnSpec.command, resolvedSpawnSpec.args, {
       cwd,
       env: env,
       stdio: ['pipe', 'pipe', shouldPipeStderr ? 'pipe' : 'ignore'],
       windowsHide: true,
+      ...(resolvedSpawnSpec.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
     });
+    installTreeAwareKill(child, resolvedSpawnSpec);
 
     if (signal) {
+      const killChild = (): void => {
+        child.kill('SIGTERM');
+      };
       if (signal.aborted) {
-        child.kill();
+        killChild();
       } else {
-        signal.addEventListener('abort', () => child.kill(), { once: true });
+        signal.addEventListener('abort', killChild, { once: true });
       }
     }
 
@@ -54,4 +66,22 @@ export function createCustomSpawnFunction(
 
     return child as unknown as SpawnedProcess;
   };
+}
+
+function installTreeAwareKill(child: ChildProcess, spawnSpec: WindowsCmdShimSpawnSpec): void {
+  if (!spawnSpec.killProcessTree) {
+    return;
+  }
+
+  const originalKill = child.kill.bind(child);
+  const killableChild = {
+    get pid(): number | undefined {
+      return child.pid;
+    },
+    kill: originalKill,
+  };
+
+  child.kill = ((signal?: NodeJS.Signals | number): boolean =>
+    terminateSpawnedProcess(killableChild, signal, spawn, spawnSpec)
+  ) as typeof child.kill;
 }

--- a/src/providers/codex/runtime/CodexAppServerProcess.ts
+++ b/src/providers/codex/runtime/CodexAppServerProcess.ts
@@ -1,7 +1,11 @@
 import { type ChildProcess, spawn } from 'child_process';
 import type { Readable, Writable } from 'stream';
 
-import { resolveWindowsCmdShimSpawnSpec } from '../../../utils/windowsCmdShim';
+import {
+  resolveWindowsCmdShimSpawnSpec,
+  terminateSpawnedProcess,
+  type WindowsCmdShimSpawnSpec,
+} from '../../../utils/windowsCmdShim';
 import type { CodexLaunchSpec } from './codexLaunchTypes';
 
 const SIGKILL_TIMEOUT_MS = 3_000;
@@ -12,6 +16,7 @@ export class CodexAppServerProcess {
   private proc: ChildProcess | null = null;
   private alive = false;
   private exitCallbacks: ExitCallback[] = [];
+  private resolvedSpawnSpec: WindowsCmdShimSpawnSpec | null = null;
 
   constructor(
     private readonly launchSpec: Pick<CodexLaunchSpec, 'command' | 'args' | 'spawnCwd' | 'env'>,
@@ -19,6 +24,7 @@ export class CodexAppServerProcess {
 
   start(): void {
     const resolvedSpawnSpec = resolveWindowsCmdShimSpawnSpec(this.launchSpec);
+    this.resolvedSpawnSpec = resolvedSpawnSpec;
 
     this.proc = spawn(resolvedSpawnSpec.command, resolvedSpawnSpec.args, {
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -80,13 +86,20 @@ export class CodexAppServerProcess {
       };
 
       this.proc!.once('exit', onExit);
-      this.proc!.kill('SIGTERM');
+      this.killProc('SIGTERM');
 
       const killTimer = window.setTimeout(() => {
         if (this.alive) {
-          this.proc!.kill('SIGKILL');
+          this.killProc('SIGKILL');
         }
       }, SIGKILL_TIMEOUT_MS);
     });
+  }
+
+  private killProc(signal: NodeJS.Signals): boolean {
+    if (!this.proc) {
+      return false;
+    }
+    return terminateSpawnedProcess(this.proc, signal, spawn, this.resolvedSpawnSpec);
   }
 }

--- a/src/providers/codex/runtime/CodexAppServerProcess.ts
+++ b/src/providers/codex/runtime/CodexAppServerProcess.ts
@@ -1,60 +1,10 @@
-import { type ChildProcess,spawn } from 'child_process';
+import { type ChildProcess, spawn } from 'child_process';
 import type { Readable, Writable } from 'stream';
 
+import { resolveWindowsCmdShimSpawnSpec } from '../../../utils/windowsCmdShim';
 import type { CodexLaunchSpec } from './codexLaunchTypes';
 
 const SIGKILL_TIMEOUT_MS = 3_000;
-const WINDOWS_CMD_ARGUMENT_CHARS = /[\s"&<>|{}^=;!'+,`~()%@]/u;
-
-function requiresWindowsShellQuoting(value: string): boolean {
-  return WINDOWS_CMD_ARGUMENT_CHARS.test(value)
-    || value.includes('[')
-    || value.includes(']');
-}
-
-function quoteWindowsShellArgument(value: string): string {
-  if (!value.length) {
-    return '""';
-  }
-
-  if (!requiresWindowsShellQuoting(value)) {
-    return value;
-  }
-
-  return `"${value.replace(/"/g, '""')}"`;
-}
-
-function resolveWindowsSpawnSpec(launchSpec: Pick<CodexLaunchSpec, 'command' | 'args' | 'spawnCwd' | 'env'>) {
-  const command = launchSpec.command.trim();
-  const lowerCommand = command.toLowerCase();
-
-  if (!command || process.platform !== 'win32') {
-    return {
-      command: launchSpec.command,
-      args: launchSpec.args,
-      env: launchSpec.env,
-    };
-  }
-
-  if (lowerCommand.endsWith('.cmd')) {
-    const shellCommand = [command, ...launchSpec.args]
-      .map(value => quoteWindowsShellArgument(value))
-      .join(' ');
-
-    return {
-      command: process.env.ComSpec || process.env.comspec || 'cmd.exe',
-      args: ['/d', '/s', '/c', `"${shellCommand}"`],
-      env: launchSpec.env,
-      windowsVerbatimArguments: true,
-    };
-  }
-
-  return {
-    command: launchSpec.command,
-    args: launchSpec.args,
-    env: launchSpec.env,
-  };
-}
 
 type ExitCallback = (code: number | null, signal: string | null) => void;
 
@@ -68,12 +18,12 @@ export class CodexAppServerProcess {
   ) {}
 
   start(): void {
-    const resolvedSpawnSpec = resolveWindowsSpawnSpec(this.launchSpec);
+    const resolvedSpawnSpec = resolveWindowsCmdShimSpawnSpec(this.launchSpec);
 
     this.proc = spawn(resolvedSpawnSpec.command, resolvedSpawnSpec.args, {
       stdio: ['pipe', 'pipe', 'pipe'],
       cwd: this.launchSpec.spawnCwd,
-      env: resolvedSpawnSpec.env,
+      env: this.launchSpec.env,
       windowsHide: true,
       ...(resolvedSpawnSpec.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
     });

--- a/src/providers/codex/runtime/CodexBinaryLocator.ts
+++ b/src/providers/codex/runtime/CodexBinaryLocator.ts
@@ -1,31 +1,6 @@
-import * as fs from 'fs';
-import * as path from 'path';
-
-import { getEnhancedPath, parseEnvironmentVariables } from '../../../utils/env';
-import { expandHomePath, parsePathEntries } from '../../../utils/path';
+import { findCliBinaryPath, resolveConfiguredCliPath } from '../../../utils/cliBinaryLocator';
+import { parseEnvironmentVariables } from '../../../utils/env';
 import type { CodexInstallationMethod } from '../settings';
-
-function isExistingFile(filePath: string): boolean {
-  try {
-    return fs.statSync(filePath).isFile();
-  } catch {
-    return false;
-  }
-}
-
-function resolveConfiguredPath(configuredPath: string | undefined): string | null {
-  const trimmed = (configuredPath ?? '').trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  try {
-    const expandedPath = expandHomePath(trimmed);
-    return isExistingFile(expandedPath) ? expandedPath : null;
-  } catch {
-    return null;
-  }
-}
 
 export function isWindowsStyleCliReference(value: string | null | undefined): boolean {
   const trimmed = (value ?? '').trim();
@@ -42,23 +17,7 @@ export function findCodexBinaryPath(
   additionalPath?: string,
   platform: NodeJS.Platform = process.platform,
 ): string | null {
-  const binaryNames = platform === 'win32'
-    ? ['codex.exe', 'codex.cmd', 'codex']
-    : ['codex'];
-  const searchEntries = parsePathEntries(getEnhancedPath(additionalPath));
-
-  for (const dir of searchEntries) {
-    if (!dir) continue;
-
-    for (const binaryName of binaryNames) {
-      const candidate = path.join(dir, binaryName);
-      if (isExistingFile(candidate)) {
-        return candidate;
-      }
-    }
-  }
-
-  return null;
+  return findCliBinaryPath('codex', additionalPath, platform);
 }
 
 export function resolveCodexCliPath(
@@ -75,12 +34,12 @@ export function resolveCodexCliPath(
     return configuredCommand || 'codex';
   }
 
-  const configuredHostnamePath = resolveConfiguredPath(hostnamePath);
+  const configuredHostnamePath = resolveConfiguredCliPath(hostnamePath);
   if (configuredHostnamePath) {
     return configuredHostnamePath;
   }
 
-  const configuredLegacyPath = resolveConfiguredPath(legacyPath);
+  const configuredLegacyPath = resolveConfiguredCliPath(legacyPath);
   if (configuredLegacyPath) {
     return configuredLegacyPath;
   }

--- a/src/providers/defaultProviderConfigs.ts
+++ b/src/providers/defaultProviderConfigs.ts
@@ -2,11 +2,13 @@ import type { ProviderConfigMap } from '../core/types/settings';
 import { DEFAULT_CLAUDE_PROVIDER_SETTINGS } from './claude/settings';
 import { DEFAULT_CODEX_PROVIDER_SETTINGS } from './codex/settings';
 import { DEFAULT_OPENCODE_PROVIDER_SETTINGS } from './opencode/settings';
+import { DEFAULT_PI_PROVIDER_SETTINGS } from './pi/settings';
 
 export function getBuiltInProviderDefaultConfigs(): ProviderConfigMap {
   return {
     claude: { ...DEFAULT_CLAUDE_PROVIDER_SETTINGS },
     codex: { ...DEFAULT_CODEX_PROVIDER_SETTINGS },
     opencode: { ...DEFAULT_OPENCODE_PROVIDER_SETTINGS },
+    pi: { ...DEFAULT_PI_PROVIDER_SETTINGS },
   };
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -6,6 +6,8 @@ import { codexWorkspaceRegistration } from './codex/app/CodexWorkspaceServices';
 import { codexProviderRegistration } from './codex/registration';
 import { opencodeWorkspaceRegistration } from './opencode/app/OpencodeWorkspaceServices';
 import { opencodeProviderRegistration } from './opencode/registration';
+import { piWorkspaceRegistration } from './pi/app/PiWorkspaceServices';
+import { piProviderRegistration } from './pi/registration';
 
 let builtInProvidersRegistered = false;
 
@@ -17,9 +19,11 @@ export function registerBuiltInProviders(): void {
   ProviderRegistry.register('claude', claudeProviderRegistration);
   ProviderRegistry.register('codex', codexProviderRegistration);
   ProviderRegistry.register('opencode', opencodeProviderRegistration);
+  ProviderRegistry.register('pi', piProviderRegistration);
   ProviderWorkspaceRegistry.register('claude', claudeWorkspaceRegistration);
   ProviderWorkspaceRegistry.register('codex', codexWorkspaceRegistration);
   ProviderWorkspaceRegistry.register('opencode', opencodeWorkspaceRegistration);
+  ProviderWorkspaceRegistry.register('pi', piWorkspaceRegistration);
   builtInProvidersRegistered = true;
 }
 

--- a/src/providers/opencode/runtime/OpencodeCliResolver.ts
+++ b/src/providers/opencode/runtime/OpencodeCliResolver.ts
@@ -1,8 +1,6 @@
-import * as fs from 'node:fs';
-
 import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
-import { getHostnameKey } from '../../../utils/env';
-import { expandHomePath } from '../../../utils/path';
+import { findCliBinaryPath, resolveConfiguredCliPath } from '../../../utils/cliBinaryLocator';
+import { getHostnameKey, parseEnvironmentVariables } from '../../../utils/env';
 import { getOpencodeProviderSettings } from '../settings';
 
 export class OpencodeCliResolver {
@@ -41,10 +39,13 @@ export class OpencodeCliResolver {
   resolve(
     hostnamePaths: Record<string, string> | undefined,
     legacyPath: string,
-    _envText: string,
+    envText: string,
   ): string | null {
     const hostnamePath = (hostnamePaths?.[this.cachedHostname] ?? '').trim();
-    return resolveConfiguredCliPath(hostnamePath) ?? resolveConfiguredCliPath(legacyPath.trim());
+    const customEnv = parseEnvironmentVariables(envText || '');
+    return resolveConfiguredCliPath(hostnamePath)
+      ?? resolveConfiguredCliPath(legacyPath.trim())
+      ?? findCliBinaryPath('opencode', customEnv.PATH);
   }
 
   reset(): void {
@@ -53,21 +54,4 @@ export class OpencodeCliResolver {
     this.lastEnvText = '';
     this.resolvedPath = null;
   }
-}
-
-function resolveConfiguredCliPath(cliPath: string): string | null {
-  if (!cliPath) {
-    return null;
-  }
-
-  try {
-    const expanded = expandHomePath(cliPath);
-    if (fs.existsSync(expanded) && fs.statSync(expanded).isFile()) {
-      return expanded;
-    }
-  } catch {
-    return null;
-  }
-
-  return null;
 }

--- a/src/providers/pi/app/PiRuntimeCommandLoader.ts
+++ b/src/providers/pi/app/PiRuntimeCommandLoader.ts
@@ -1,0 +1,57 @@
+import type {
+  ProviderRuntimeCommandLoader,
+  ProviderRuntimeCommandLoaderContext,
+} from '../../../core/providers/types';
+import { PiChatRuntime } from '../runtime/PiChatRuntime';
+import { getPiProviderSettings } from '../settings';
+import { getPiState } from '../types';
+
+export class PiRuntimeCommandLoader implements ProviderRuntimeCommandLoader {
+  isAvailable(settings: Record<string, unknown>): boolean {
+    return getPiProviderSettings(settings).enabled;
+  }
+
+  async loadCommands(context: ProviderRuntimeCommandLoaderContext) {
+    const persistedState = getPiState(context.conversation?.providerState);
+    const hasPersistedSession = Boolean(
+      context.conversation?.sessionId
+      || persistedState.sessionId
+      || persistedState.sessionFile,
+    );
+    const shouldWarmBlankSession = context.allowSessionCreation === true
+      && !context.conversation;
+    const shouldWarmPreSessionConversation = context.allowSessionCreation === true
+      && !!context.conversation
+      && !hasPersistedSession
+      && context.conversation.messages.length > 0;
+
+    if (!hasPersistedSession && !shouldWarmBlankSession && !shouldWarmPreSessionConversation) {
+      return [];
+    }
+
+    const canReuseRuntime = context.runtime?.providerId === 'pi'
+      && context.runtime.isReady();
+    const runtime = canReuseRuntime
+      ? context.runtime!
+      : new PiChatRuntime(context.plugin);
+
+    try {
+      if (canReuseRuntime && context.conversation) {
+        runtime.syncConversationState(context.conversation, context.externalContextPaths);
+      }
+
+      const ready = await runtime.ensureReady({
+        allowSessionCreation: false,
+      });
+      if (!ready) {
+        return [];
+      }
+
+      return await runtime.getSupportedCommands();
+    } finally {
+      if (runtime !== context.runtime) {
+        runtime.cleanup();
+      }
+    }
+  }
+}

--- a/src/providers/pi/app/PiWorkspaceServices.ts
+++ b/src/providers/pi/app/PiWorkspaceServices.ts
@@ -1,0 +1,39 @@
+import type { ProviderCommandCatalog } from '../../../core/providers/commands/ProviderCommandCatalog';
+import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
+import type {
+  ProviderTabWarmupPolicy,
+  ProviderWorkspaceRegistration,
+  ProviderWorkspaceServices,
+} from '../../../core/providers/types';
+import { PiCommandCatalog } from '../commands/PiCommandCatalog';
+import { PiCliResolver } from '../runtime/PiCliResolver';
+import { piSettingsTabRenderer } from '../ui/PiSettingsTab';
+import { PiRuntimeCommandLoader } from './PiRuntimeCommandLoader';
+
+export interface PiWorkspaceServices extends ProviderWorkspaceServices {
+  commandCatalog: ProviderCommandCatalog;
+}
+
+const piTabWarmupPolicy: ProviderTabWarmupPolicy = {
+  resolveMode() {
+    return 'commands';
+  },
+};
+
+export async function createPiWorkspaceServices(): Promise<PiWorkspaceServices> {
+  return {
+    cliResolver: new PiCliResolver(),
+    commandCatalog: new PiCommandCatalog(),
+    runtimeCommandLoader: new PiRuntimeCommandLoader(),
+    settingsTabRenderer: piSettingsTabRenderer,
+    tabWarmupPolicy: piTabWarmupPolicy,
+  };
+}
+
+export const piWorkspaceRegistration: ProviderWorkspaceRegistration<PiWorkspaceServices> = {
+  initialize: async () => createPiWorkspaceServices(),
+};
+
+export function maybeGetPiWorkspaceServices(): PiWorkspaceServices | null {
+  return ProviderWorkspaceRegistry.getServices('pi') as PiWorkspaceServices | null;
+}

--- a/src/providers/pi/auxiliary/PiInlineEditService.ts
+++ b/src/providers/pi/auxiliary/PiInlineEditService.ts
@@ -1,0 +1,9 @@
+import { QueryBackedInlineEditService } from '../../../core/auxiliary/QueryBackedInlineEditService';
+import type ClaudianPlugin from '../../../main';
+import { PiAuxQueryRunner } from '../runtime/PiAuxQueryRunner';
+
+export class PiInlineEditService extends QueryBackedInlineEditService {
+  constructor(plugin: ClaudianPlugin) {
+    super(new PiAuxQueryRunner(plugin, { profile: 'readonly' }));
+  }
+}

--- a/src/providers/pi/auxiliary/PiInstructionRefineService.ts
+++ b/src/providers/pi/auxiliary/PiInstructionRefineService.ts
@@ -1,0 +1,9 @@
+import { QueryBackedInstructionRefineService } from '../../../core/auxiliary/QueryBackedInstructionRefineService';
+import type ClaudianPlugin from '../../../main';
+import { PiAuxQueryRunner } from '../runtime/PiAuxQueryRunner';
+
+export class PiInstructionRefineService extends QueryBackedInstructionRefineService {
+  constructor(plugin: ClaudianPlugin) {
+    super(new PiAuxQueryRunner(plugin, { profile: 'passive' }));
+  }
+}

--- a/src/providers/pi/auxiliary/PiTaskResultInterpreter.ts
+++ b/src/providers/pi/auxiliary/PiTaskResultInterpreter.ts
@@ -1,0 +1,29 @@
+import type {
+  ProviderTaskResultInterpreter,
+  ProviderTaskTerminalStatus,
+} from '../../../core/providers/types';
+
+export class PiTaskResultInterpreter implements ProviderTaskResultInterpreter {
+  hasAsyncLaunchMarker(_toolUseResult: unknown): boolean {
+    return false;
+  }
+
+  extractAgentId(_toolUseResult: unknown): string | null {
+    return null;
+  }
+
+  extractStructuredResult(_toolUseResult: unknown): string | null {
+    return null;
+  }
+
+  resolveTerminalStatus(
+    _toolUseResult: unknown,
+    fallbackStatus: ProviderTaskTerminalStatus,
+  ): ProviderTaskTerminalStatus {
+    return fallbackStatus;
+  }
+
+  extractTagValue(_payload: string, _tagName: string): string | null {
+    return null;
+  }
+}

--- a/src/providers/pi/auxiliary/PiTitleGenerationService.ts
+++ b/src/providers/pi/auxiliary/PiTitleGenerationService.ts
@@ -1,0 +1,19 @@
+import { QueryBackedTitleGenerationService } from '../../../core/auxiliary/QueryBackedTitleGenerationService';
+import type ClaudianPlugin from '../../../main';
+import { PiAuxQueryRunner } from '../runtime/PiAuxQueryRunner';
+import { piChatUIConfig } from '../ui/PiChatUIConfig';
+
+export class PiTitleGenerationService extends QueryBackedTitleGenerationService {
+  constructor(plugin: ClaudianPlugin) {
+    super({
+      createRunner: () => new PiAuxQueryRunner(plugin, { profile: 'passive' }),
+      resolveModel: () => {
+        const settings = plugin.settings as unknown as Record<string, unknown>;
+        const titleModel = typeof settings.titleGenerationModel === 'string'
+          ? settings.titleGenerationModel
+          : '';
+        return piChatUIConfig.ownsModel(titleModel, settings) ? titleModel : undefined;
+      },
+    });
+  }
+}

--- a/src/providers/pi/capabilities.ts
+++ b/src/providers/pi/capabilities.ts
@@ -6,7 +6,7 @@ export const PI_PROVIDER_CAPABILITIES: Readonly<ProviderCapabilities> = Object.f
   supportsNativeHistory: true,
   supportsPlanMode: false,
   supportsRewind: false,
-  supportsFork: false,
+  supportsFork: true,
   supportsProviderCommands: true,
   supportsImageAttachments: true,
   supportsInstructionMode: true,

--- a/src/providers/pi/capabilities.ts
+++ b/src/providers/pi/capabilities.ts
@@ -1,0 +1,16 @@
+import type { ProviderCapabilities } from '../../core/providers/types';
+
+export const PI_PROVIDER_CAPABILITIES: Readonly<ProviderCapabilities> = Object.freeze({
+  providerId: 'pi',
+  supportsPersistentRuntime: true,
+  supportsNativeHistory: true,
+  supportsPlanMode: false,
+  supportsRewind: false,
+  supportsFork: false,
+  supportsProviderCommands: true,
+  supportsImageAttachments: true,
+  supportsInstructionMode: true,
+  supportsMcpTools: false,
+  supportsTurnSteer: true,
+  reasoningControl: 'effort',
+});

--- a/src/providers/pi/commands/PiCommandCatalog.ts
+++ b/src/providers/pi/commands/PiCommandCatalog.ts
@@ -1,0 +1,92 @@
+import type {
+  ProviderCommandCatalog,
+  ProviderCommandDropdownConfig,
+} from '../../../core/providers/commands/ProviderCommandCatalog';
+import type { ProviderCommandEntry } from '../../../core/providers/commands/ProviderCommandEntry';
+import type { SlashCommand } from '../../../core/types';
+
+function slashCommandToEntry(command: SlashCommand): ProviderCommandEntry {
+  return {
+    agent: command.agent,
+    allowedTools: command.allowedTools,
+    argumentHint: command.argumentHint,
+    content: command.content,
+    context: command.context,
+    description: command.description,
+    disableModelInvocation: command.disableModelInvocation,
+    displayPrefix: '/',
+    hooks: command.hooks,
+    id: command.id,
+    insertPrefix: '/',
+    isDeletable: false,
+    isEditable: false,
+    kind: command.kind ?? 'command',
+    model: command.model,
+    name: command.name,
+    providerId: 'pi',
+    scope: 'runtime',
+    source: command.source ?? 'sdk',
+    userInvocable: command.userInvocable,
+  };
+}
+
+function dedupeRuntimeCommands(commands: SlashCommand[]): SlashCommand[] {
+  const deduped: SlashCommand[] = [];
+  const seen = new Set<string>();
+
+  for (const command of commands) {
+    const normalizedName = command.name.trim().replace(/^\/+/, '');
+    if (!normalizedName) {
+      continue;
+    }
+
+    const key = normalizedName.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    deduped.push({
+      ...command,
+      name: normalizedName,
+    });
+  }
+
+  return deduped;
+}
+
+export class PiCommandCatalog implements ProviderCommandCatalog {
+  private runtimeCommands: SlashCommand[] = [];
+
+  setRuntimeCommands(commands: SlashCommand[]): void {
+    this.runtimeCommands = dedupeRuntimeCommands(commands);
+  }
+
+  async listDropdownEntries(_context: { includeBuiltIns: boolean }): Promise<ProviderCommandEntry[]> {
+    return this.runtimeCommands.map(slashCommandToEntry);
+  }
+
+  async listVaultEntries(): Promise<ProviderCommandEntry[]> {
+    return [];
+  }
+
+  async saveVaultEntry(_entry: ProviderCommandEntry): Promise<void> {
+    throw new Error('Pi runtime commands are not editable from Claudian.');
+  }
+
+  async deleteVaultEntry(_entry: ProviderCommandEntry): Promise<void> {
+    throw new Error('Pi runtime commands are not deletable from Claudian.');
+  }
+
+  getDropdownConfig(): ProviderCommandDropdownConfig {
+    return {
+      builtInPrefix: '/',
+      commandPrefix: '/',
+      providerId: 'pi',
+      skillPrefix: '/',
+      triggerChars: ['/'],
+    };
+  }
+
+  async refresh(): Promise<void> {}
+}

--- a/src/providers/pi/env/PiSettingsReconciler.ts
+++ b/src/providers/pi/env/PiSettingsReconciler.ts
@@ -85,25 +85,36 @@ export const piSettingsReconciler: ProviderSettingsReconciler = {
     const piSettings = getPiProviderSettings(settings);
     let changed = false;
 
-    const normalizeSelection = (value: unknown): string | null => {
+    const normalizeSelection = (
+      value: unknown,
+      fallback: 'clear' | 'synthetic',
+    ): string | null => {
       if (typeof value !== 'string' || !isPiModelSelectionId(value)) {
         return null;
       }
 
+      if (value === 'pi') {
+        return value;
+      }
+
       const decoded = decodePiModelId(value);
-      return decoded ? encodePiModelId(decoded.provider, decoded.modelId) : value;
+      if (decoded) {
+        return encodePiModelId(decoded.provider, decoded.modelId);
+      }
+
+      return fallback === 'synthetic' ? 'pi' : '';
     };
 
-    const modelSelection = normalizeSelection(settings.model);
+    const modelSelection = normalizeSelection(settings.model, 'synthetic');
     if (typeof settings.model === 'string' && modelSelection && settings.model !== modelSelection) {
       settings.model = modelSelection;
       changed = true;
     }
 
-    const titleModelSelection = normalizeSelection(settings.titleGenerationModel);
+    const titleModelSelection = normalizeSelection(settings.titleGenerationModel, 'clear');
     if (
       typeof settings.titleGenerationModel === 'string'
-      && titleModelSelection
+      && titleModelSelection !== null
       && settings.titleGenerationModel !== titleModelSelection
     ) {
       settings.titleGenerationModel = titleModelSelection;
@@ -113,13 +124,17 @@ export const piSettingsReconciler: ProviderSettingsReconciler = {
     const savedProviderModelRaw = settings.savedProviderModel;
     if (savedProviderModelRaw && typeof savedProviderModelRaw === 'object' && !Array.isArray(savedProviderModelRaw)) {
       const savedProviderModel = savedProviderModelRaw as Record<string, unknown>;
-      const savedSelection = normalizeSelection(savedProviderModel.pi);
+      const savedSelection = normalizeSelection(savedProviderModel.pi, 'clear');
       if (
         typeof savedProviderModel.pi === 'string'
-        && savedSelection
+        && savedSelection !== null
         && savedProviderModel.pi !== savedSelection
       ) {
-        savedProviderModel.pi = savedSelection;
+        if (savedSelection) {
+          savedProviderModel.pi = savedSelection;
+        } else {
+          delete savedProviderModel.pi;
+        }
         changed = true;
       }
     }

--- a/src/providers/pi/env/PiSettingsReconciler.ts
+++ b/src/providers/pi/env/PiSettingsReconciler.ts
@@ -1,0 +1,165 @@
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import type { ProviderSettingsReconciler } from '../../../core/providers/types';
+import type { Conversation } from '../../../core/types';
+import { parseEnvironmentVariables } from '../../../utils/env';
+import { sameStringList } from '../internal/compareCollections';
+import {
+  clampPiThinkingLevel,
+  decodePiModelId,
+  encodePiModelId,
+  findPiModel,
+  isPiModelSelectionId,
+  PI_DEFAULT_THINKING_LEVEL,
+} from '../models';
+import {
+  getPiProviderSettings,
+  normalizePiVisibleModels,
+  updatePiProviderSettings,
+} from '../settings';
+import { getPiState } from '../types';
+
+const PI_ENV_HASH_KEYS = [
+  'PI_CODING_AGENT_DIR',
+  'PI_CODING_AGENT_SESSION_DIR',
+  'PI_PACKAGE_DIR',
+  'PI_OFFLINE',
+  'PI_SKIP_VERSION_CHECK',
+  'PI_TELEMETRY',
+  'PI_CACHE_RETENTION',
+] as const;
+
+function computePiEnvHash(envText: string): string {
+  const envVars = parseEnvironmentVariables(envText || '');
+  return PI_ENV_HASH_KEYS
+    .filter((key) => envVars[key])
+    .map((key) => `${key}=${envVars[key]}`)
+    .sort()
+    .join('|');
+}
+
+export const piSettingsReconciler: ProviderSettingsReconciler = {
+  handleEnvironmentChange(settings: Record<string, unknown>): boolean {
+    const current = getPiProviderSettings(settings);
+    if (current.discoveredModels.length === 0) {
+      return false;
+    }
+    updatePiProviderSettings(settings, {
+      discoveredModels: [],
+    });
+    return true;
+  },
+
+  reconcileModelWithEnvironment(
+    settings: Record<string, unknown>,
+    conversations: Conversation[],
+  ): { changed: boolean; invalidatedConversations: Conversation[] } {
+    const envText = getRuntimeEnvironmentText(settings, 'pi');
+    const currentHash = computePiEnvHash(envText);
+    const savedHash = getPiProviderSettings(settings).environmentHash;
+
+    if (currentHash === savedHash) {
+      return { changed: false, invalidatedConversations: [] };
+    }
+
+    const invalidatedConversations: Conversation[] = [];
+    for (const conversation of conversations) {
+      if (conversation.providerId !== 'pi') {
+        continue;
+      }
+
+      const state = getPiState(conversation.providerState);
+      if (!conversation.sessionId && !state.sessionId && !state.sessionFile) {
+        continue;
+      }
+
+      conversation.sessionId = null;
+      conversation.providerState = undefined;
+      invalidatedConversations.push(conversation);
+    }
+
+    updatePiProviderSettings(settings, { environmentHash: currentHash });
+    return { changed: true, invalidatedConversations };
+  },
+
+  normalizeModelVariantSettings(settings: Record<string, unknown>): boolean {
+    const piSettings = getPiProviderSettings(settings);
+    let changed = false;
+
+    const normalizeSelection = (value: unknown): string | null => {
+      if (typeof value !== 'string' || !isPiModelSelectionId(value)) {
+        return null;
+      }
+
+      const decoded = decodePiModelId(value);
+      return decoded ? encodePiModelId(decoded.provider, decoded.modelId) : value;
+    };
+
+    const modelSelection = normalizeSelection(settings.model);
+    if (typeof settings.model === 'string' && modelSelection && settings.model !== modelSelection) {
+      settings.model = modelSelection;
+      changed = true;
+    }
+
+    const titleModelSelection = normalizeSelection(settings.titleGenerationModel);
+    if (
+      typeof settings.titleGenerationModel === 'string'
+      && titleModelSelection
+      && settings.titleGenerationModel !== titleModelSelection
+    ) {
+      settings.titleGenerationModel = titleModelSelection;
+      changed = true;
+    }
+
+    const savedProviderModelRaw = settings.savedProviderModel;
+    if (savedProviderModelRaw && typeof savedProviderModelRaw === 'object' && !Array.isArray(savedProviderModelRaw)) {
+      const savedProviderModel = savedProviderModelRaw as Record<string, unknown>;
+      const savedSelection = normalizeSelection(savedProviderModel.pi);
+      if (
+        typeof savedProviderModel.pi === 'string'
+        && savedSelection
+        && savedProviderModel.pi !== savedSelection
+      ) {
+        savedProviderModel.pi = savedSelection;
+        changed = true;
+      }
+    }
+
+    const normalizedVisibleModels = normalizePiVisibleModels(
+      piSettings.visibleModels,
+      piSettings.discoveredModels,
+    );
+    const shouldUpdateProviderSettings = !sameStringList(normalizedVisibleModels, piSettings.visibleModels);
+    if (shouldUpdateProviderSettings) {
+      updatePiProviderSettings(settings, {
+        visibleModels: normalizedVisibleModels,
+      });
+      changed = true;
+    }
+
+    if (typeof settings.effortLevel === 'string' && !settings.effortLevel.trim()) {
+      settings.effortLevel = getDefaultPiEffortForSelection(settings.model, piSettings);
+      changed = true;
+    }
+
+    return changed;
+  },
+};
+
+function getDefaultPiEffortForSelection(
+  selection: unknown,
+  piSettings: ReturnType<typeof getPiProviderSettings>,
+): string {
+  if (typeof selection !== 'string') {
+    return 'off';
+  }
+
+  const decoded = decodePiModelId(selection);
+  if (!decoded) {
+    return 'off';
+  }
+
+  const model = findPiModel(piSettings, encodePiModelId(decoded.provider, decoded.modelId));
+  return model
+    ? clampPiThinkingLevel(PI_DEFAULT_THINKING_LEVEL, model.thinkingLevels)
+    : PI_DEFAULT_THINKING_LEVEL;
+}

--- a/src/providers/pi/history/PiConversationHistoryService.ts
+++ b/src/providers/pi/history/PiConversationHistoryService.ts
@@ -13,6 +13,37 @@ export class PiConversationHistoryService implements ProviderConversationHistory
     vaultPath: string | null,
   ): Promise<void> {
     const state = getPiState(conversation.providerState);
+    if (this.isPendingForkConversation(conversation)) {
+      if (conversation.messages.length > 0) {
+        return;
+      }
+
+      const sourceSessionFile = state.forkSourceSessionFile
+        ?? findPiSessionFile(state.forkSource!.sessionId, vaultPath);
+      if (!sourceSessionFile) {
+        this.hydratedKeys.delete(conversation.id);
+        return;
+      }
+
+      try {
+        const content = await fs.readFile(sourceSessionFile, 'utf-8');
+        const messages = parsePiSessionContent(content, {
+          leafEntryId: state.forkSource!.resumeAt,
+          requireLeafEntryId: true,
+        });
+        if (messages.length === 0) {
+          this.hydratedKeys.delete(conversation.id);
+          return;
+        }
+
+        conversation.messages = messages;
+        this.hydratedKeys.set(conversation.id, `fork::${sourceSessionFile}::${state.forkSource!.resumeAt}`);
+      } catch {
+        this.hydratedKeys.delete(conversation.id);
+      }
+      return;
+    }
+
     const sessionTarget = state.sessionFile ?? state.sessionId ?? conversation.sessionId;
     if (!sessionTarget) {
       this.hydratedKeys.delete(conversation.id);
@@ -59,19 +90,29 @@ export class PiConversationHistoryService implements ProviderConversationHistory
 
   resolveSessionIdForConversation(conversation: Conversation | null): string | null {
     const state = getPiState(conversation?.providerState);
-    return state.sessionId ?? conversation?.sessionId ?? null;
+    return state.sessionFile
+      ?? state.sessionId
+      ?? conversation?.sessionId
+      ?? state.forkSource?.sessionId
+      ?? null;
   }
 
   isPendingForkConversation(_conversation: Conversation): boolean {
-    return false;
+    const state = getPiState(_conversation.providerState);
+    return !!state.forkSource && !state.sessionId && !state.sessionFile && !_conversation.sessionId;
   }
 
   buildForkProviderState(
-    _sourceSessionId: string,
-    _resumeAt: string,
-    _sourceProviderState?: Record<string, unknown>,
+    sourceSessionId: string,
+    resumeAt: string,
+    sourceProviderState?: Record<string, unknown>,
   ): Record<string, unknown> {
-    return {};
+    const sourceState = getPiState(sourceProviderState);
+    const sourceSessionFile = sourceState.sessionFile ?? sourceState.forkSourceSessionFile;
+    return buildPersistedPiState({
+      forkSource: { sessionId: sourceSessionId, resumeAt },
+      ...(sourceSessionFile ? { forkSourceSessionFile: sourceSessionFile } : {}),
+    }) as Record<string, unknown>;
   }
 
   buildPersistedProviderState(

--- a/src/providers/pi/history/PiConversationHistoryService.ts
+++ b/src/providers/pi/history/PiConversationHistoryService.ts
@@ -1,0 +1,82 @@
+import * as fs from 'node:fs/promises';
+
+import type { ProviderConversationHistoryService } from '../../../core/providers/types';
+import type { Conversation } from '../../../core/types';
+import { buildPersistedPiState, getPiState } from '../types';
+import { findPiSessionFile, parsePiSessionContent } from './PiHistoryStore';
+
+export class PiConversationHistoryService implements ProviderConversationHistoryService {
+  private hydratedKeys = new Map<string, string>();
+
+  async hydrateConversationHistory(
+    conversation: Conversation,
+    vaultPath: string | null,
+  ): Promise<void> {
+    const state = getPiState(conversation.providerState);
+    const sessionTarget = state.sessionFile ?? state.sessionId ?? conversation.sessionId;
+    if (!sessionTarget) {
+      this.hydratedKeys.delete(conversation.id);
+      return;
+    }
+
+    const sessionFile = state.sessionFile ?? findPiSessionFile(sessionTarget, vaultPath);
+    if (!sessionFile) {
+      this.hydratedKeys.delete(conversation.id);
+      return;
+    }
+
+    const hydrationKey = `${sessionFile}::${state.leafEntryId ?? ''}`;
+    if (
+      conversation.messages.length > 0
+      && this.hydratedKeys.get(conversation.id) === hydrationKey
+    ) {
+      return;
+    }
+
+    try {
+      const content = await fs.readFile(sessionFile, 'utf-8');
+      const messages = parsePiSessionContent(content, {
+        leafEntryId: state.leafEntryId,
+      });
+      if (messages.length === 0) {
+        this.hydratedKeys.delete(conversation.id);
+        return;
+      }
+
+      conversation.messages = messages;
+      this.hydratedKeys.set(conversation.id, hydrationKey);
+    } catch {
+      this.hydratedKeys.delete(conversation.id);
+    }
+  }
+
+  async deleteConversationSession(
+    _conversation: Conversation,
+    _vaultPath: string | null,
+  ): Promise<void> {
+    // Never mutate Pi native history.
+  }
+
+  resolveSessionIdForConversation(conversation: Conversation | null): string | null {
+    const state = getPiState(conversation?.providerState);
+    return state.sessionId ?? conversation?.sessionId ?? null;
+  }
+
+  isPendingForkConversation(_conversation: Conversation): boolean {
+    return false;
+  }
+
+  buildForkProviderState(
+    _sourceSessionId: string,
+    _resumeAt: string,
+    _sourceProviderState?: Record<string, unknown>,
+  ): Record<string, unknown> {
+    return {};
+  }
+
+  buildPersistedProviderState(
+    conversation: Conversation,
+  ): Record<string, unknown> | undefined {
+    return buildPersistedPiState(getPiState(conversation.providerState)) as Record<string, unknown> | undefined;
+  }
+}

--- a/src/providers/pi/history/PiHistoryStore.ts
+++ b/src/providers/pi/history/PiHistoryStore.ts
@@ -1,4 +1,6 @@
+import { randomUUID } from 'node:crypto';
 import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
@@ -26,15 +28,39 @@ export interface ParsedPiSessionEntries {
 
 export interface ParsePiSessionContentOptions {
   leafEntryId?: string;
+  requireLeafEntryId?: boolean;
+}
+
+export interface CreatePiForkSessionFileOptions {
+  now?: Date;
+  sessionDir?: string;
+  sessionId?: string;
+  targetCwd?: string;
+}
+
+export interface CreatedPiForkSessionFile {
+  leafEntryId: string;
+  parentSession: string;
+  sessionFile: string;
+  sessionId: string;
 }
 
 export function parsePiSessionContent(
   content: string,
   options: ParsePiSessionContentOptions = {},
 ): ChatMessage[] {
+  const parsed = parsePiSessionEntries(content);
+  const leafEntryId = options.leafEntryId?.trim();
+  if (
+    options.requireLeafEntryId
+    && (!leafEntryId || !parsed.entries.some(entry => entry.id === leafEntryId))
+  ) {
+    return [];
+  }
+
   return mapPiSessionEntries(resolvePiActivePath(
-    parsePiSessionEntries(content).entries,
-    options.leafEntryId,
+    parsed.entries,
+    leafEntryId,
   ));
 }
 
@@ -80,15 +106,17 @@ export function parsePiSessionEntries(content: string): ParsedPiSessionEntries {
 }
 
 export function resolvePiActivePath(entries: PiSessionEntry[], leafId?: string): PiSessionEntry[] {
-  const entriesWithIds = entries.filter(entry => entry.id);
+  const entriesWithIds = entries.filter((entry): entry is PiSessionEntry & { id: string } => !!entry.id);
   if (entriesWithIds.length === 0) {
     return entries;
   }
-  if (!entriesWithIds.some(entry => entry.parentId)) {
+
+  const hasBranchGraph = hasPiBranchGraph(entriesWithIds);
+  if (!leafId && !hasBranchGraph) {
     return entries;
   }
 
-  const byId = new Map(entriesWithIds.map(entry => [entry.id!, entry] as const));
+  const byId = new Map(entriesWithIds.map(entry => [entry.id, entry] as const));
   const targetLeafId = leafId && byId.has(leafId)
     ? leafId
     : entriesWithIds[entriesWithIds.length - 1]?.id;
@@ -96,6 +124,46 @@ export function resolvePiActivePath(entries: PiSessionEntry[], leafId?: string):
     return entries;
   }
 
+  const activePath = hasBranchGraph
+    ? resolvePiGraphEntryPath(byId, targetLeafId)
+    : resolvePiLinearEntryPath(entries, targetLeafId);
+  if (activePath.length === 0) {
+    return entries;
+  }
+
+  return hasBranchGraph
+    ? includePiGraphPathEntries(entries, activePath)
+    : includePiLinearPathEntries(entries, activePath);
+}
+
+export function resolvePiEntryPath(entries: PiSessionEntry[], leafId: string): PiSessionEntry[] {
+  const entriesWithIds = entries.filter((entry): entry is PiSessionEntry & { id: string } => !!entry.id);
+  const byId = new Map(entriesWithIds.map(entry => [entry.id, entry] as const));
+  if (!byId.has(leafId)) {
+    return [];
+  }
+
+  const hasBranchGraph = hasPiBranchGraph(entriesWithIds);
+  const activePath = hasBranchGraph
+    ? resolvePiGraphEntryPath(byId, leafId)
+    : resolvePiLinearEntryPath(entries, leafId);
+  if (activePath.length === 0) {
+    return [];
+  }
+
+  return hasBranchGraph
+    ? includePiGraphPathEntries(entries, activePath)
+    : includePiLinearPathEntries(entries, activePath);
+}
+
+function hasPiBranchGraph(entriesWithIds: PiSessionEntry[]): boolean {
+  return entriesWithIds.some(entry => !!entry.parentId && !isToolResultEntry(entry));
+}
+
+function resolvePiGraphEntryPath(
+  byId: Map<string, PiSessionEntry>,
+  targetLeafId: string,
+): PiSessionEntry[] {
   const activePath: PiSessionEntry[] = [];
   const seen = new Set<string>();
   let current: PiSessionEntry | undefined = byId.get(targetLeafId);
@@ -108,6 +176,21 @@ export function resolvePiActivePath(entries: PiSessionEntry[], leafId?: string):
     current = current.parentId ? byId.get(current.parentId) : undefined;
   }
 
+  return activePath;
+}
+
+function resolvePiLinearEntryPath(entries: PiSessionEntry[], targetLeafId: string): PiSessionEntry[] {
+  const leafIndex = entries.findIndex(entry => entry.id === targetLeafId);
+  if (leafIndex < 0) {
+    return [];
+  }
+  return entries.slice(0, leafIndex + 1);
+}
+
+function includePiGraphPathEntries(
+  entries: PiSessionEntry[],
+  activePath: PiSessionEntry[],
+): PiSessionEntry[] {
   const activeIds = new Set(activePath.map(entry => entry.id).filter((id): id is string => !!id));
   const activeToolCallIds = collectToolCallIds(activePath);
   return entries.filter((entry) => {
@@ -125,6 +208,71 @@ export function resolvePiActivePath(entries: PiSessionEntry[], leafId?: string):
     }
     return false;
   });
+}
+
+function includePiLinearPathEntries(
+  entries: PiSessionEntry[],
+  activePath: PiSessionEntry[],
+): PiSessionEntry[] {
+  const activeEntries = new Set(activePath);
+  const activeToolCallIds = collectToolCallIds(activePath);
+  return entries.filter((entry) => {
+    if (activeEntries.has(entry)) {
+      return true;
+    }
+    if (!isToolResultEntry(entry)) {
+      return false;
+    }
+    const toolCallId = getToolResultCallId(entry);
+    return !!toolCallId && activeToolCallIds.has(toolCallId);
+  });
+}
+
+export async function createPiForkSessionFile(
+  sourceSessionFile: string,
+  resumeAt: string,
+  options: CreatePiForkSessionFileOptions = {},
+): Promise<CreatedPiForkSessionFile> {
+  const sourceContent = await fsp.readFile(sourceSessionFile, 'utf-8');
+  const parsed = parsePiSessionEntries(sourceContent);
+  const branchEntries = resolvePiEntryPath(parsed.entries, resumeAt);
+  if (branchEntries.length === 0) {
+    throw new Error(`Pi fork checkpoint not found: ${resumeAt}`);
+  }
+
+  const timestamp = options.now ?? new Date();
+  const timestampText = timestamp.toISOString();
+  const sessionId = options.sessionId ?? randomUUID();
+  const sessionDir = options.sessionDir ?? path.dirname(sourceSessionFile);
+  const sessionFile = path.join(
+    sessionDir,
+    `${timestampText.replace(/[:.]/g, '-')}_${sessionId}.jsonl`,
+  );
+  const sourceCwd = typeof parsed.header?.cwd === 'string' && parsed.header.cwd.trim()
+    ? parsed.header.cwd.trim()
+    : process.cwd();
+  const header = {
+    type: 'session',
+    version: 3,
+    id: sessionId,
+    timestamp: timestampText,
+    cwd: options.targetCwd ?? sourceCwd,
+    parentSession: sourceSessionFile,
+  };
+  const lines = [
+    JSON.stringify(header),
+    ...branchEntries.map(entry => JSON.stringify(entry.raw)),
+  ];
+
+  await fsp.mkdir(sessionDir, { recursive: true });
+  await fsp.writeFile(sessionFile, `${lines.join('\n')}\n`, { flag: 'wx' });
+
+  return {
+    leafEntryId: resumeAt,
+    parentSession: sourceSessionFile,
+    sessionFile,
+    sessionId,
+  };
 }
 
 export function findPiSessionFile(

--- a/src/providers/pi/history/PiHistoryStore.ts
+++ b/src/providers/pi/history/PiHistoryStore.ts
@@ -1,0 +1,516 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { isWriteEditTool } from '../../../core/tools/toolNames';
+import type { ChatMessage, ContentBlock, ToolCallInfo } from '../../../core/types';
+import { extractDiffData } from '../../../utils/diff';
+import {
+  extractPiToolTextContent,
+  normalizePiToolInput,
+  normalizePiToolName,
+} from '../normalizations/piToolNormalization';
+
+export interface PiSessionEntry {
+  id?: string;
+  message?: Record<string, unknown>;
+  parentId?: string;
+  raw: Record<string, unknown>;
+  type: string;
+}
+
+export interface ParsedPiSessionEntries {
+  entries: PiSessionEntry[];
+  header: Record<string, unknown> | null;
+}
+
+export interface ParsePiSessionContentOptions {
+  leafEntryId?: string;
+}
+
+export function parsePiSessionContent(
+  content: string,
+  options: ParsePiSessionContentOptions = {},
+): ChatMessage[] {
+  return mapPiSessionEntries(resolvePiActivePath(
+    parsePiSessionEntries(content).entries,
+    options.leafEntryId,
+  ));
+}
+
+export function parsePiSessionEntries(content: string): ParsedPiSessionEntries {
+  const entries: PiSessionEntry[] = [];
+  let header: Record<string, unknown> | null = null;
+
+  for (const line of content.split(/\r?\n/)) {
+    if (!line.trim()) {
+      continue;
+    }
+
+    let record: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(line) as unknown;
+      if (!isPlainObject(parsed)) {
+        continue;
+      }
+      record = parsed;
+    } catch {
+      continue;
+    }
+
+    const type = getString(record.type) ?? getString(record.kind) ?? '';
+    if (type === 'session') {
+      header = record;
+      continue;
+    }
+
+    const message = getRecord(record.message) ?? getRecord(record.data) ?? inferMessageRecord(record);
+    entries.push({
+      ...(getString(record.id) ? { id: getString(record.id)! } : {}),
+      ...(message ? { message } : {}),
+      ...(getString(record.parentId) ?? getString(record.parent_id)
+        ? { parentId: (getString(record.parentId) ?? getString(record.parent_id))! }
+        : {}),
+      raw: record,
+      type,
+    });
+  }
+
+  return { entries, header };
+}
+
+export function resolvePiActivePath(entries: PiSessionEntry[], leafId?: string): PiSessionEntry[] {
+  const entriesWithIds = entries.filter(entry => entry.id);
+  if (entriesWithIds.length === 0) {
+    return entries;
+  }
+  if (!entriesWithIds.some(entry => entry.parentId)) {
+    return entries;
+  }
+
+  const byId = new Map(entriesWithIds.map(entry => [entry.id!, entry] as const));
+  const targetLeafId = leafId && byId.has(leafId)
+    ? leafId
+    : entriesWithIds[entriesWithIds.length - 1]?.id;
+  if (!targetLeafId) {
+    return entries;
+  }
+
+  const activePath: PiSessionEntry[] = [];
+  const seen = new Set<string>();
+  let current: PiSessionEntry | undefined = byId.get(targetLeafId);
+  while (current) {
+    if (!current.id || seen.has(current.id)) {
+      break;
+    }
+    seen.add(current.id);
+    activePath.push(current);
+    current = current.parentId ? byId.get(current.parentId) : undefined;
+  }
+
+  const activeIds = new Set(activePath.map(entry => entry.id).filter((id): id is string => !!id));
+  const activeToolCallIds = collectToolCallIds(activePath);
+  return entries.filter((entry) => {
+    if (isToolResultEntry(entry)) {
+      const toolCallId = getToolResultCallId(entry);
+      return (!!toolCallId && activeToolCallIds.has(toolCallId))
+        || (!!entry.id && activeIds.has(entry.id))
+        || (!!entry.parentId && activeIds.has(entry.parentId));
+    }
+    if (entry.id) {
+      return activeIds.has(entry.id);
+    }
+    if (entry.parentId && activeIds.has(entry.parentId)) {
+      return true;
+    }
+    return false;
+  });
+}
+
+export function findPiSessionFile(
+  sessionIdOrFile: string,
+  cwd?: string | null,
+  sessionDir?: string | null,
+): string | null {
+  const trimmed = sessionIdOrFile.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (path.isAbsolute(trimmed) && fileExists(trimmed)) {
+    return trimmed;
+  }
+
+  const roots = [
+    sessionDir,
+    cwd ? path.join(cwd, '.pi', 'agent', 'sessions') : null,
+    path.join(os.homedir(), '.pi', 'agent', 'sessions'),
+  ].filter((root): root is string => !!root);
+
+  for (const root of roots) {
+    const direct = path.join(root, trimmed.endsWith('.jsonl') ? trimmed : `${trimmed}.jsonl`);
+    if (fileExists(direct)) {
+      return direct;
+    }
+
+    const found = findSessionFileInRoot(root, trimmed);
+    if (found) {
+      return found;
+    }
+  }
+
+  return null;
+}
+
+export function derivePiSessionsRootFromSessionPath(sessionPath: string): string | null {
+  const normalized = sessionPath.trim();
+  if (!normalized) {
+    return null;
+  }
+
+  return path.dirname(normalized);
+}
+
+function mapPiSessionEntries(entries: PiSessionEntry[]): ChatMessage[] {
+  const messages: ChatMessage[] = [];
+
+  for (const entry of entries) {
+    const mapped = mapPiSessionEntry(entry, messages);
+    if (mapped) {
+      const previous = messages[messages.length - 1];
+      if (isAssistantMessageEntry(entry) && canMergeAssistantContinuation(previous, mapped)) {
+        mergeAssistantContinuation(previous, mapped);
+      } else {
+        messages.push(mapped);
+      }
+    }
+  }
+
+  return messages;
+}
+
+function isAssistantMessageEntry(entry: PiSessionEntry): boolean {
+  const message = entry.message ?? entry.raw;
+  return (getString(message.role) ?? inferRole(entry.type)) === 'assistant';
+}
+
+function isBoundaryMessage(message: ChatMessage): boolean {
+  return message.contentBlocks?.some(block => block.type === 'context_compacted') === true;
+}
+
+function canMergeAssistantContinuation(
+  previous: ChatMessage | undefined,
+  next: ChatMessage,
+): previous is ChatMessage {
+  return previous?.role === 'assistant'
+    && next.role === 'assistant'
+    && !isBoundaryMessage(previous)
+    && !isBoundaryMessage(next);
+}
+
+function mergeAssistantContinuation(target: ChatMessage, source: ChatMessage): void {
+  target.content += source.content;
+  target.assistantMessageId = source.assistantMessageId ?? target.assistantMessageId;
+
+  if (source.contentBlocks && source.contentBlocks.length > 0) {
+    target.contentBlocks = [
+      ...(target.contentBlocks ?? []),
+      ...source.contentBlocks,
+    ];
+  }
+
+  if (source.toolCalls && source.toolCalls.length > 0) {
+    const existingToolIds = new Set(target.toolCalls?.map(toolCall => toolCall.id) ?? []);
+    const newToolCalls = source.toolCalls.filter(toolCall => !existingToolIds.has(toolCall.id));
+    if (newToolCalls.length > 0) {
+      target.toolCalls = [
+        ...(target.toolCalls ?? []),
+        ...newToolCalls,
+      ];
+    }
+  }
+}
+
+function mapPiSessionEntry(
+  entry: PiSessionEntry,
+  messages: ChatMessage[],
+): ChatMessage | null {
+  const message = entry.message ?? entry.raw;
+  const role = getString(message.role) ?? inferRole(entry.type);
+  const timestamp = getTimestamp(message.timestamp ?? entry.raw.timestamp);
+
+  if (role === 'user') {
+    return {
+      content: extractTextContent(message.content ?? message.text ?? message.message),
+      id: entry.id ?? `pi-user-${messages.length}`,
+      role: 'user',
+      timestamp,
+      userMessageId: entry.id,
+    };
+  }
+
+  if (role === 'assistant') {
+    const contentBlocks = extractAssistantContentBlocks(message.content ?? message.parts ?? message.blocks);
+    const toolCalls = extractAssistantToolCalls(message.content ?? message.parts ?? message.blocks);
+    const text = contentBlocks
+      .filter((block): block is Extract<ContentBlock, { type: 'text' }> => block.type === 'text')
+      .map(block => block.content)
+      .join('');
+
+    return {
+      assistantMessageId: entry.id,
+      content: text,
+      ...(contentBlocks.length > 0 ? { contentBlocks } : {}),
+      id: entry.id ?? `pi-assistant-${messages.length}`,
+      role: 'assistant',
+      timestamp,
+      ...(toolCalls.length > 0 ? { toolCalls } : {}),
+    };
+  }
+
+  if (isToolResultEntry(entry)) {
+    applyToolResult(messages, entry);
+    return null;
+  }
+
+  if (entry.type === 'compaction') {
+    return {
+      content: '',
+      contentBlocks: [{ type: 'context_compacted' }],
+      id: entry.id ?? `pi-compaction-${messages.length}`,
+      role: 'assistant',
+      timestamp,
+    };
+  }
+
+  if (
+    (entry.type === 'branch_summary' || entry.type === 'compactionSummary' || entry.type === 'custom_message')
+    && entry.raw.display !== false
+  ) {
+    const content = extractTextContent(entry.raw.content ?? entry.raw.summary ?? entry.raw.message);
+    if (!content) {
+      return null;
+    }
+    return {
+      content,
+      contentBlocks: [{ type: 'text', content }],
+      id: entry.id ?? `pi-notice-${messages.length}`,
+      role: 'assistant',
+      timestamp,
+    };
+  }
+
+  return null;
+}
+
+function extractAssistantContentBlocks(value: unknown): ContentBlock[] {
+  const blocks: ContentBlock[] = [];
+  const parts = Array.isArray(value) ? value : [{ type: 'text', text: extractTextContent(value) }];
+
+  for (const part of parts) {
+    if (!isPlainObject(part)) {
+      continue;
+    }
+
+    const type = getString(part.type);
+    if (type === 'thinking' || type === 'reasoning') {
+      const content = extractTextContent(part.thinking ?? part.text ?? part.content);
+      if (content) {
+        blocks.push({ type: 'thinking', content });
+      }
+      continue;
+    }
+
+    if (type === 'toolCall' || type === 'tool_call' || type === 'toolUse' || type === 'tool_use') {
+      const toolId = getString(part.id) ?? getString(part.toolCallId) ?? getString(part.callId);
+      if (toolId) {
+        blocks.push({ type: 'tool_use', toolId });
+      }
+      continue;
+    }
+
+    const content = extractTextContent(part.text ?? part.content);
+    if (content) {
+      blocks.push({ type: 'text', content });
+    }
+  }
+
+  return blocks;
+}
+
+function extractAssistantToolCalls(value: unknown): ToolCallInfo[] {
+  const parts = Array.isArray(value) ? value : [];
+  return parts.flatMap((part): ToolCallInfo[] => {
+    if (!isPlainObject(part)) {
+      return [];
+    }
+
+    const type = getString(part.type);
+    if (type !== 'toolCall' && type !== 'tool_call' && type !== 'toolUse' && type !== 'tool_use') {
+      return [];
+    }
+
+    const id = getString(part.id) ?? getString(part.toolCallId) ?? getString(part.callId);
+    const rawName = getString(part.name) ?? getString(part.tool) ?? getString(part.toolName);
+    if (!id || !rawName) {
+      return [];
+    }
+    const name = normalizePiToolName(rawName);
+
+    return [{
+      id,
+      input: normalizePiToolInput(part.input ?? part.arguments ?? part.args, name),
+      name,
+      status: 'running',
+    }];
+  });
+}
+
+function collectToolCallIds(entries: PiSessionEntry[]): Set<string> {
+  const ids = new Set<string>();
+  for (const entry of entries) {
+    const message = entry.message ?? entry.raw;
+    const parts = message.content ?? message.parts ?? message.blocks;
+    for (const toolCall of extractAssistantToolCalls(parts)) {
+      ids.add(toolCall.id);
+    }
+  }
+  return ids;
+}
+
+function isToolResultEntry(entry: PiSessionEntry): boolean {
+  const message = entry.message ?? entry.raw;
+  return entry.type === 'toolResult'
+    || entry.type === 'tool_result'
+    || getString(message.role) === 'toolResult'
+    || getString(message.role) === 'tool_result';
+}
+
+function getToolResultCallId(entry: PiSessionEntry): string | null {
+  const message = entry.message ?? entry.raw;
+  return getString(message.toolCallId)
+    ?? getString(message.tool_call_id)
+    ?? getString(message.id)
+    ?? getString(entry.raw.toolCallId)
+    ?? getString(entry.raw.tool_call_id)
+    ?? getString(entry.raw.id);
+}
+
+function applyToolResult(messages: ChatMessage[], entry: PiSessionEntry): void {
+  const toolCallId = getToolResultCallId(entry);
+  if (!toolCallId) {
+    return;
+  }
+
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const chatMessage = messages[index];
+    const toolCall = chatMessage.toolCalls?.find(call => call.id === toolCallId);
+    if (!toolCall) {
+      continue;
+    }
+
+    const resultMessage = entry.message ?? entry.raw;
+    toolCall.status = resultMessage.error === true || resultMessage.isError === true ? 'error' : 'completed';
+    toolCall.result = extractPiToolTextContent(resultMessage.result ?? resultMessage.content ?? resultMessage.output);
+    if (toolCall.status === 'completed' && isWriteEditTool(toolCall.name)) {
+      const diffData = extractDiffData(resultMessage, toolCall);
+      if (diffData) {
+        toolCall.diffData = diffData;
+      }
+    }
+    return;
+  }
+}
+
+function inferMessageRecord(record: Record<string, unknown>): Record<string, unknown> | undefined {
+  return getString(record.role) ? record : undefined;
+}
+
+function inferRole(type: string): string | null {
+  if (type === 'user' || type === 'assistant') {
+    return type;
+  }
+  return null;
+}
+
+function extractTextContent(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(extractTextContent).filter(Boolean).join('');
+  }
+
+  if (!isPlainObject(value)) {
+    return '';
+  }
+
+  if (typeof value.text === 'string') {
+    return value.text;
+  }
+
+  if (typeof value.content === 'string') {
+    return value.content;
+  }
+
+  return '';
+}
+
+function findSessionFileInRoot(root: string, sessionId: string): string | null {
+  try {
+    const entries = fs.readdirSync(root, { withFileTypes: true });
+    for (const entry of entries) {
+      const candidate = path.join(root, entry.name);
+      if (entry.isDirectory()) {
+        const nested = findSessionFileInRoot(candidate, sessionId);
+        if (nested) {
+          return nested;
+        }
+      } else if (
+        entry.isFile()
+        && entry.name.endsWith('.jsonl')
+        && entry.name.includes(sessionId)
+      ) {
+        return candidate;
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+function fileExists(filePath: string): boolean {
+  try {
+    return fs.existsSync(filePath) && fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function getTimestamp(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return Date.now();
+}
+
+function getRecord(value: unknown): Record<string, unknown> | null {
+  return isPlainObject(value) ? value : null;
+}
+
+function getString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/providers/pi/internal/compareCollections.ts
+++ b/src/providers/pi/internal/compareCollections.ts
@@ -1,0 +1,4 @@
+export function sameStringList(left: string[], right: string[]): boolean {
+  return left.length === right.length
+    && left.every((value, index) => value === right[index]);
+}

--- a/src/providers/pi/internal/providerProjection.ts
+++ b/src/providers/pi/internal/providerProjection.ts
@@ -1,0 +1,18 @@
+export function ensureProviderProjectionMap(
+  settings: Record<string, unknown>,
+  key:
+  | 'savedProviderEffort'
+  | 'savedProviderModel'
+  | 'savedProviderPermissionMode'
+  | 'savedProviderServiceTier'
+  | 'savedProviderThinkingBudget',
+): Partial<Record<string, string>> {
+  const current = settings[key];
+  if (current && typeof current === 'object' && !Array.isArray(current)) {
+    return current as Partial<Record<string, string>>;
+  }
+
+  const next: Partial<Record<string, string>> = {};
+  settings[key] = next;
+  return next;
+}

--- a/src/providers/pi/models.ts
+++ b/src/providers/pi/models.ts
@@ -1,0 +1,302 @@
+export type PiThinkingLevel = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+
+export interface PiDiscoveredModel {
+  api?: string;
+  contextWindow?: number;
+  encodedId: string;
+  id: string;
+  input: Array<'text' | 'image'>;
+  label: string;
+  maxTokens?: number;
+  provider: string;
+  reasoning: boolean;
+  thinkingLevels: PiThinkingLevel[];
+}
+
+export interface DecodedPiModelId {
+  modelId: string;
+  provider: string;
+}
+
+export const PI_SYNTHETIC_MODEL_ID = 'pi';
+export const PI_MODEL_PREFIX = 'pi:';
+export const PI_DEFAULT_THINKING_LEVEL: PiThinkingLevel = 'medium';
+
+const VALID_THINKING_LEVELS = new Set<PiThinkingLevel>([
+  'off',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+]);
+
+const DEFAULT_REASONING_LEVELS: PiThinkingLevel[] = [
+  'off',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+];
+
+export function isPiModelSelectionId(model: string): boolean {
+  return model === PI_SYNTHETIC_MODEL_ID || model.startsWith(PI_MODEL_PREFIX);
+}
+
+export function encodePiModelId(provider: string, modelId: string): string {
+  const normalizedProvider = provider.trim();
+  const normalizedModelId = modelId.trim();
+  if (!normalizedProvider || !normalizedModelId) {
+    return PI_SYNTHETIC_MODEL_ID;
+  }
+
+  return `${PI_MODEL_PREFIX}${normalizedProvider}/${normalizedModelId}`;
+}
+
+export function decodePiModelId(model: string): DecodedPiModelId | null {
+  if (!model.startsWith(PI_MODEL_PREFIX)) {
+    return null;
+  }
+
+  const raw = model.slice(PI_MODEL_PREFIX.length).trim();
+  const slashIndex = raw.indexOf('/');
+  if (slashIndex <= 0 || slashIndex >= raw.length - 1) {
+    return null;
+  }
+
+  const provider = raw.slice(0, slashIndex).trim();
+  const modelId = raw.slice(slashIndex + 1).trim();
+  return provider && modelId ? { provider, modelId } : null;
+}
+
+export function normalizePiThinkingLevel(value: unknown): PiThinkingLevel | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return VALID_THINKING_LEVELS.has(normalized as PiThinkingLevel)
+    ? normalized as PiThinkingLevel
+    : null;
+}
+
+export function getPiSupportedThinkingLevels(value: unknown): PiThinkingLevel[] {
+  const record = isPlainObject(value) ? value : {};
+  const explicitLevels = collectExplicitThinkingLevels(record);
+  const mappedLevels = collectThinkingLevelMapLevels(record);
+  const reasoning = record.reasoning === true
+    || record.supportsReasoning === true
+    || record.thinking === true
+    || record.canReason === true
+    || explicitLevels.length > 0
+    || mappedLevels.levels.length > 0;
+  if (!reasoning) {
+    return ['off'];
+  }
+
+  if (explicitLevels.length === 0 && mappedLevels.levels.length === 0) {
+    return [...DEFAULT_REASONING_LEVELS];
+  }
+
+  const result: PiThinkingLevel[] = [];
+  const seen = new Set<PiThinkingLevel>();
+  for (const level of [...explicitLevels, ...mappedLevels.levels]) {
+    if (level === null || mappedLevels.disabledLevels.has(level)) {
+      continue;
+    }
+
+    if (!seen.has(level)) {
+      seen.add(level);
+      result.push(level);
+    }
+  }
+
+  return result.length > 0 ? sortThinkingLevels(result) : [...DEFAULT_REASONING_LEVELS];
+}
+
+export function normalizePiDiscoveredModels(value: unknown): PiDiscoveredModel[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const normalized: PiDiscoveredModel[] = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (!isPlainObject(entry)) {
+      continue;
+    }
+
+    const provider = firstString(entry.provider, entry.providerId, entry.api)?.trim() ?? '';
+    const id = firstString(entry.id, entry.modelId, entry.model, entry.name)?.trim() ?? '';
+    if (!provider || !id) {
+      continue;
+    }
+
+    const key = `${provider}\0${id}`;
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    const label = firstString(entry.label, entry.displayName, entry.name)?.trim()
+      || `${provider}/${id}`;
+    const api = firstString(entry.api)?.trim();
+    const contextWindow = firstFinitePositiveNumber(
+      entry.contextWindow,
+      entry.context_window,
+      entry.context,
+      entry.maxContextTokens,
+      entry.max_context_tokens,
+    );
+    const maxTokens = firstFinitePositiveNumber(
+      entry.maxTokens,
+      entry.max_tokens,
+      entry.outputTokens,
+      entry.output_tokens,
+    );
+    const input = normalizeModelInputs(
+      entry.input ?? entry.inputs ?? entry.modalities ?? entry.supportedInputs,
+    );
+    const thinkingLevels = getPiSupportedThinkingLevels(entry);
+    const reasoning = thinkingLevels.some(level => level !== 'off');
+
+    normalized.push({
+      ...(api ? { api } : {}),
+      ...(contextWindow !== undefined ? { contextWindow } : {}),
+      encodedId: encodePiModelId(provider, id),
+      id,
+      input,
+      label,
+      ...(maxTokens !== undefined ? { maxTokens } : {}),
+      provider,
+      reasoning,
+      thinkingLevels,
+    });
+  }
+
+  return normalized;
+}
+
+export function findPiModel(
+  settings: { discoveredModels: PiDiscoveredModel[] },
+  encodedId: string,
+): PiDiscoveredModel | null {
+  return settings.discoveredModels.find(model => model.encodedId === encodedId) ?? null;
+}
+
+export function clampPiThinkingLevel(
+  level: string | undefined,
+  supportedLevels: PiThinkingLevel[],
+): PiThinkingLevel {
+  const normalized = normalizePiThinkingLevel(level);
+  if (normalized && supportedLevels.includes(normalized)) {
+    return normalized;
+  }
+
+  if (supportedLevels.includes(PI_DEFAULT_THINKING_LEVEL)) {
+    return PI_DEFAULT_THINKING_LEVEL;
+  }
+
+  return supportedLevels[0] ?? 'off';
+}
+
+function collectExplicitThinkingLevels(record: Record<string, unknown>): Array<PiThinkingLevel | null> {
+  const rawLevels = [
+    record.thinkingLevels,
+    record.thinking_levels,
+    record.reasoningLevels,
+    record.reasoning_levels,
+    isPlainObject(record.thinking) ? record.thinking.levels : undefined,
+    isPlainObject(record.reasoning) ? record.reasoning.levels : undefined,
+  ].find(Array.isArray);
+
+  if (!Array.isArray(rawLevels)) {
+    return [];
+  }
+
+  return rawLevels
+    .map((level): PiThinkingLevel | null | undefined => {
+      if (level === null) {
+        return null;
+      }
+      return normalizePiThinkingLevel(level) ?? undefined;
+    })
+    .filter((level): level is PiThinkingLevel | null => level !== undefined);
+}
+
+function collectThinkingLevelMapLevels(record: Record<string, unknown>): {
+  disabledLevels: Set<PiThinkingLevel>;
+  levels: PiThinkingLevel[];
+} {
+  const rawMap = isPlainObject(record.thinkingLevelMap)
+    ? record.thinkingLevelMap
+    : isPlainObject(record.thinking_level_map)
+    ? record.thinking_level_map
+    : null;
+  if (!rawMap) {
+    return { disabledLevels: new Set<PiThinkingLevel>(), levels: [] };
+  }
+
+  const disabledLevels = new Set<PiThinkingLevel>();
+  const levels: PiThinkingLevel[] = [...DEFAULT_REASONING_LEVELS];
+  for (const [rawLevel, mappedLevel] of Object.entries(rawMap)) {
+    const level = normalizePiThinkingLevel(rawLevel);
+    if (!level) {
+      continue;
+    }
+    if (mappedLevel === null) {
+      disabledLevels.add(level);
+    } else {
+      levels.push(level);
+    }
+  }
+  return { disabledLevels, levels };
+}
+
+function sortThinkingLevels(levels: PiThinkingLevel[]): PiThinkingLevel[] {
+  const rank = new Map(DEFAULT_REASONING_LEVELS.concat('xhigh').map((level, index) => [level, index] as const));
+  return [...levels].sort((left, right) => (rank.get(left) ?? 99) - (rank.get(right) ?? 99));
+}
+
+function normalizeModelInputs(value: unknown): Array<'text' | 'image'> {
+  const rawInputs = Array.isArray(value) ? value : ['text'];
+  const inputs: Array<'text' | 'image'> = [];
+  const seen = new Set<'text' | 'image'>();
+
+  for (const entry of rawInputs) {
+    const normalized = typeof entry === 'string' ? entry.trim().toLowerCase() : '';
+    const input = normalized === 'image' || normalized === 'images'
+      ? 'image'
+      : normalized === 'text'
+      ? 'text'
+      : null;
+    if (input && !seen.has(input)) {
+      seen.add(input);
+      inputs.push(input);
+    }
+  }
+
+  return inputs.length > 0 ? inputs : ['text'];
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string') {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function firstFinitePositiveNumber(...values: unknown[]): number | undefined {
+  for (const value of values) {
+    if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/providers/pi/normalizations/piEventNormalization.ts
+++ b/src/providers/pi/normalizations/piEventNormalization.ts
@@ -35,6 +35,9 @@ export function normalizePiRpcEvent(
       return normalizeToolOutput(event, state);
     case 'tool_execution_end':
       return normalizeToolResult(event, state);
+    case 'message_end':
+    case 'turn_end':
+      return normalizeTerminalError(event);
     case 'compaction_end':
       return [{ type: 'context_compacted' }];
     case 'auto_retry_start':
@@ -46,6 +49,25 @@ export function normalizePiRpcEvent(
     default:
       return [];
   }
+}
+
+export function getPiTerminalErrorMessage(event: Record<string, unknown>): string | null {
+  if (event.type !== 'message_end' && event.type !== 'turn_end') {
+    return null;
+  }
+
+  const terminalEvent = getNestedRecord(event, 'assistantMessageEvent')
+    ?? getNestedRecord(event, 'assistant_message_event')
+    ?? event;
+  const records = terminalEvent === event ? [event] : [terminalEvent, event];
+  const stopReason = getStringField(records, ['stopReason', 'stop_reason']);
+  if (stopReason?.toLowerCase() !== 'error') {
+    return null;
+  }
+
+  return getStringField(records, ['errorMessage', 'error_message', 'error', 'message'])
+    ?? getNestedStringField(records, 'error', ['message'])
+    ?? 'Pi turn failed.';
 }
 
 function normalizeMessageUpdate(event: Record<string, unknown>): StreamChunk[] {
@@ -75,6 +97,11 @@ function normalizeMessageUpdate(event: Record<string, unknown>): StreamChunk[] {
   }
 
   return [];
+}
+
+function normalizeTerminalError(event: Record<string, unknown>): StreamChunk[] {
+  const message = getPiTerminalErrorMessage(event);
+  return message ? [{ type: 'error', content: message }] : [];
 }
 
 function normalizeToolUse(
@@ -148,4 +175,37 @@ function getNestedRecord(
 
 function getString(value: unknown): string | null {
   return typeof value === 'string' ? value : null;
+}
+
+function getStringField(
+  records: Array<Record<string, unknown>>,
+  keys: string[],
+): string | null {
+  for (const record of records) {
+    for (const key of keys) {
+      const value = getString(record[key]);
+      if (value) {
+        return value;
+      }
+    }
+  }
+  return null;
+}
+
+function getNestedStringField(
+  records: Array<Record<string, unknown>>,
+  parentKey: string,
+  keys: string[],
+): string | null {
+  for (const record of records) {
+    const nested = getNestedRecord(record, parentKey);
+    if (!nested) {
+      continue;
+    }
+    const value = getStringField([nested], keys);
+    if (value) {
+      return value;
+    }
+  }
+  return null;
 }

--- a/src/providers/pi/normalizations/piEventNormalization.ts
+++ b/src/providers/pi/normalizations/piEventNormalization.ts
@@ -1,0 +1,151 @@
+import type { StreamChunk } from '../../../core/types';
+import {
+  extractPiToolTextContent,
+  getPiToolId,
+  getPiToolName,
+  normalizePiToolInput,
+} from './piToolNormalization';
+
+export interface PiEventNormalizationState {
+  emittedToolIds: Set<string>;
+  toolOutputs: Map<string, string>;
+}
+
+export function createPiEventNormalizationState(): PiEventNormalizationState {
+  return {
+    emittedToolIds: new Set<string>(),
+    toolOutputs: new Map<string, string>(),
+  };
+}
+
+export function normalizePiRpcEvent(
+  event: Record<string, unknown>,
+  state: PiEventNormalizationState,
+): StreamChunk[] {
+  switch (event.type) {
+    case 'agent_start':
+      return [];
+    case 'message_update':
+      return normalizeMessageUpdate(event);
+    case 'toolcall_end':
+      return normalizeToolUse(getNestedRecord(event, 'toolCall') ?? event, state);
+    case 'tool_execution_start':
+      return normalizeToolUse(getNestedRecord(event, 'toolCall') ?? event, state);
+    case 'tool_execution_update':
+      return normalizeToolOutput(event, state);
+    case 'tool_execution_end':
+      return normalizeToolResult(event, state);
+    case 'compaction_end':
+      return [{ type: 'context_compacted' }];
+    case 'auto_retry_start':
+      return [{ type: 'notice', content: 'Pi is retrying the turn.', level: 'warning' }];
+    case 'auto_retry_end':
+      return [{ type: 'notice', content: 'Pi retry finished.', level: 'info' }];
+    case 'extension_error':
+      return [{ type: 'notice', content: getString(event.error) ?? 'Pi extension error.', level: 'warning' }];
+    default:
+      return [];
+  }
+}
+
+function normalizeMessageUpdate(event: Record<string, unknown>): StreamChunk[] {
+  const assistantEvent = getNestedRecord(event, 'assistantMessageEvent')
+    ?? getNestedRecord(event, 'assistant_message_event')
+    ?? event;
+  const textDelta = getString(assistantEvent.text_delta)
+    ?? getString(assistantEvent.textDelta)
+    ?? (
+      assistantEvent.type === 'text_delta'
+        ? getString(assistantEvent.delta)
+        : null
+    );
+  if (textDelta) {
+    return [{ type: 'text', content: textDelta }];
+  }
+
+  const thinkingDelta = getString(assistantEvent.thinking_delta)
+    ?? getString(assistantEvent.thinkingDelta)
+    ?? (
+      assistantEvent.type === 'thinking_delta'
+        ? getString(assistantEvent.delta)
+        : null
+    );
+  if (thinkingDelta) {
+    return [{ type: 'thinking', content: thinkingDelta }];
+  }
+
+  return [];
+}
+
+function normalizeToolUse(
+  event: Record<string, unknown>,
+  state: PiEventNormalizationState,
+): StreamChunk[] {
+  const id = getPiToolId(event);
+  if (!id || state.emittedToolIds.has(id)) {
+    return [];
+  }
+
+  state.emittedToolIds.add(id);
+  const name = getPiToolName(event);
+  return [{
+    type: 'tool_use',
+    id,
+    input: normalizePiToolInput(event.input ?? event.arguments ?? event.args, name),
+    name,
+  }];
+}
+
+function normalizeToolOutput(
+  event: Record<string, unknown>,
+  state: PiEventNormalizationState,
+): StreamChunk[] {
+  const id = getPiToolId(event);
+  if (!id) {
+    return [];
+  }
+
+  const content = extractPiToolTextContent(event.partialResult ?? event.output ?? event.result ?? event.content);
+  if (!content) {
+    return [];
+  }
+
+  state.toolOutputs.set(id, content);
+  return [{ type: 'tool_output', id, content }];
+}
+
+function normalizeToolResult(
+  event: Record<string, unknown>,
+  state: PiEventNormalizationState,
+): StreamChunk[] {
+  const id = getPiToolId(event);
+  if (!id) {
+    return [];
+  }
+
+  const content = extractPiToolTextContent(event.result ?? event.output ?? event.content)
+    || state.toolOutputs.get(id)
+    || '';
+  const toolUseResult = getNestedRecord(event, 'result');
+  return [{
+    type: 'tool_result',
+    content,
+    id,
+    isError: event.isError === true || event.error === true || event.success === false,
+    ...(toolUseResult ? { toolUseResult } : {}),
+  }];
+}
+
+function getNestedRecord(
+  event: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | null {
+  const value = event[key];
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function getString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}

--- a/src/providers/pi/normalizations/piToolNormalization.ts
+++ b/src/providers/pi/normalizations/piToolNormalization.ts
@@ -1,0 +1,97 @@
+import {
+  TOOL_BASH,
+  TOOL_EDIT,
+  TOOL_GLOB,
+  TOOL_GREP,
+  TOOL_LS,
+  TOOL_READ,
+  TOOL_WRITE,
+} from '../../../core/tools/toolNames';
+
+const PI_BUILT_IN_TOOL_NAMES: Record<string, string> = {
+  bash: TOOL_BASH,
+  edit: TOOL_EDIT,
+  find: TOOL_GLOB,
+  grep: TOOL_GREP,
+  ls: TOOL_LS,
+  read: TOOL_READ,
+  write: TOOL_WRITE,
+};
+
+export function extractPiToolTextContent(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .map(extractPiToolTextContent)
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  if (!isPlainObject(value)) {
+    return '';
+  }
+
+  if (typeof value.text === 'string') {
+    return value.text;
+  }
+  if (typeof value.content === 'string') {
+    return value.content;
+  }
+  if (Array.isArray(value.content)) {
+    return extractPiToolTextContent(value.content);
+  }
+  if (isPlainObject(value.partialResult)) {
+    return extractPiToolTextContent(value.partialResult.content);
+  }
+  if (isPlainObject(value.result)) {
+    return extractPiToolTextContent(value.result.content ?? value.result);
+  }
+
+  return '';
+}
+
+export function normalizePiToolInput(value: unknown, toolName?: string): Record<string, unknown> {
+  const input = isPlainObject(value) ? { ...value } : {};
+  const normalizedToolName = toolName ? normalizePiToolName(toolName) : '';
+
+  if (
+    (normalizedToolName === TOOL_READ || normalizedToolName === TOOL_WRITE || normalizedToolName === TOOL_EDIT)
+    && typeof input.path === 'string'
+    && typeof input.file_path !== 'string'
+  ) {
+    input.file_path = input.path;
+  }
+
+  return input;
+}
+
+export function getPiToolId(value: Record<string, unknown>): string {
+  return firstString(value.id, value.toolCallId, value.callId, value.call_id) ?? '';
+}
+
+export function getPiToolName(value: Record<string, unknown>): string {
+  return normalizePiToolName(firstString(value.name, value.tool, value.toolName, value.tool_name) ?? 'tool');
+}
+
+export function normalizePiToolName(name: string): string {
+  return PI_BUILT_IN_TOOL_NAMES[name.trim().toLowerCase()] ?? name;
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+  }
+  return undefined;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/providers/pi/registration.ts
+++ b/src/providers/pi/registration.ts
@@ -1,0 +1,30 @@
+import type { ProviderRegistration } from '../../core/providers/types';
+import { PiInlineEditService } from './auxiliary/PiInlineEditService';
+import { PiInstructionRefineService } from './auxiliary/PiInstructionRefineService';
+import { PiTaskResultInterpreter } from './auxiliary/PiTaskResultInterpreter';
+import { PiTitleGenerationService } from './auxiliary/PiTitleGenerationService';
+import { PI_PROVIDER_CAPABILITIES } from './capabilities';
+import { piSettingsReconciler } from './env/PiSettingsReconciler';
+import { PiConversationHistoryService } from './history/PiConversationHistoryService';
+import { PiChatRuntime } from './runtime/PiChatRuntime';
+import { getPiProviderSettings } from './settings';
+import { ObsidianPiExtensionUiRenderer } from './ui/ObsidianPiExtensionUiRenderer';
+import { piChatUIConfig } from './ui/PiChatUIConfig';
+
+export const piProviderRegistration: ProviderRegistration = {
+  blankTabOrder: 11,
+  capabilities: PI_PROVIDER_CAPABILITIES,
+  chatUIConfig: piChatUIConfig,
+  createInlineEditService: (plugin) => new PiInlineEditService(plugin),
+  createInstructionRefineService: (plugin) => new PiInstructionRefineService(plugin),
+  createRuntime: ({ plugin }) => new PiChatRuntime(plugin, {
+    extensionUiRenderer: new ObsidianPiExtensionUiRenderer(plugin.app),
+  }),
+  createTitleGenerationService: (plugin) => new PiTitleGenerationService(plugin),
+  displayName: 'Pi',
+  environmentKeyPatterns: [/^PI_/i],
+  historyService: new PiConversationHistoryService(),
+  isEnabled: (settings) => getPiProviderSettings(settings).enabled,
+  settingsReconciler: piSettingsReconciler,
+  taskResultInterpreter: new PiTaskResultInterpreter(),
+};

--- a/src/providers/pi/runtime/PiAuxQueryRunner.ts
+++ b/src/providers/pi/runtime/PiAuxQueryRunner.ts
@@ -92,6 +92,10 @@ export class PiAuxQueryRunner implements AuxQueryRunner {
         return;
       }
       for (const chunk of normalizePiRpcEvent(event, normalizationState)) {
+        if (chunk.type === 'error') {
+          rejectTerminal(new Error(chunk.content));
+          continue;
+        }
         if (chunk.type !== 'text') {
           continue;
         }

--- a/src/providers/pi/runtime/PiAuxQueryRunner.ts
+++ b/src/providers/pi/runtime/PiAuxQueryRunner.ts
@@ -1,0 +1,212 @@
+import type { AuxQueryConfig, AuxQueryRunner } from '../../../core/auxiliary/AuxQueryRunner';
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
+import type ClaudianPlugin from '../../../main';
+import { parseEnvironmentVariables } from '../../../utils/env';
+import { getVaultPath } from '../../../utils/path';
+import { decodePiModelId } from '../models';
+import {
+  createPiEventNormalizationState,
+  normalizePiRpcEvent,
+} from '../normalizations/piEventNormalization';
+import { getPiProviderSettings } from '../settings';
+import { buildPiLaunchSpec } from './PiLaunchSpec';
+import { buildPiSetModelPayload } from './PiRpcPayloads';
+import { PiRpcTransport } from './PiRpcTransport';
+import { PiSubprocess } from './PiSubprocess';
+
+type PiAuxProfile = 'passive' | 'readonly';
+
+export interface PiAuxQueryRunnerOptions {
+  profile: PiAuxProfile;
+}
+
+export class PiAuxQueryRunner implements AuxQueryRunner {
+  private currentLaunchKey: string | null = null;
+  private process: PiSubprocess | null = null;
+  private transport: PiRpcTransport | null = null;
+
+  constructor(
+    private readonly plugin: ClaudianPlugin,
+    private readonly options: PiAuxQueryRunnerOptions,
+  ) {}
+
+  async query(config: AuxQueryConfig, prompt: string): Promise<string> {
+    await this.ensureReady(config.systemPrompt);
+    const transport = this.transport;
+    if (!transport) {
+      throw new Error('Pi auxiliary runtime is not ready.');
+    }
+
+    const model = this.resolveSelectedModel(config.model);
+    if (model) {
+      const payload = buildPiSetModelPayload(model);
+      if (payload) {
+        await transport.request('set_model', payload);
+      }
+    }
+
+    let accumulatedText = '';
+    const normalizationState = createPiEventNormalizationState();
+    let terminalSettled = false;
+    let resolveTerminal!: () => void;
+    let rejectTerminal!: (error: Error) => void;
+    const terminalPromise = new Promise<void>((resolve, reject) => {
+      resolveTerminal = () => {
+        if (terminalSettled) {
+          return;
+        }
+        terminalSettled = true;
+        resolve();
+      };
+      rejectTerminal = (error) => {
+        if (terminalSettled) {
+          return;
+        }
+        terminalSettled = true;
+        reject(error);
+      };
+    });
+    terminalPromise.catch(() => {});
+    const removeListener = transport.onEvent((event) => {
+      if (event.type === 'extension_ui_request') {
+        const id = typeof event.id === 'string' && event.id.trim() ? event.id.trim() : '';
+        if (id) {
+          transport.send({
+            cancelled: true,
+            id,
+            type: 'extension_ui_response',
+          });
+        }
+        return;
+      }
+
+      if (event.type === 'agent_end') {
+        resolveTerminal();
+        return;
+      }
+      if (event.type === 'error') {
+        rejectTerminal(new Error(
+          typeof event.error === 'string' ? event.error : 'Pi auxiliary request failed',
+        ));
+        return;
+      }
+      for (const chunk of normalizePiRpcEvent(event, normalizationState)) {
+        if (chunk.type !== 'text') {
+          continue;
+        }
+        accumulatedText += chunk.content;
+        config.onTextChunk?.(accumulatedText);
+      }
+    });
+    const removeCloseListener = transport.onClose((error) => {
+      rejectTerminal(error ?? new Error('Pi auxiliary runtime closed before completion.'));
+    });
+    const abortHandler = () => {
+      transport.send({ type: 'abort' });
+      rejectTerminal(new Error('Cancelled'));
+    };
+    config.abortController?.signal.addEventListener('abort', abortHandler, { once: true });
+
+    try {
+      if (config.abortController?.signal.aborted) {
+        throw new Error('Cancelled');
+      }
+
+      const promptRequest = transport.request('prompt', { message: prompt });
+      promptRequest.catch(() => {});
+      await Promise.race([promptRequest, terminalPromise]);
+      await terminalPromise;
+      if (config.abortController?.signal.aborted) {
+        throw new Error('Cancelled');
+      }
+
+      return accumulatedText;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Pi request failed';
+      const stderr = this.process?.getStderrSnapshot();
+      if (config.abortController?.signal.aborted) {
+        this.reset();
+      }
+      throw new Error(
+        stderr ? `${message}\n\n${stderr}` : message,
+        error instanceof Error ? { cause: error } : undefined,
+      );
+    } finally {
+      config.abortController?.signal.removeEventListener('abort', abortHandler);
+      removeCloseListener();
+      removeListener();
+    }
+  }
+
+  reset(): void {
+    this.currentLaunchKey = null;
+    this.transport?.dispose();
+    this.transport = null;
+    if (this.process) {
+      void this.process.shutdown().catch(() => {});
+      this.process = null;
+    }
+  }
+
+  private async ensureReady(systemPrompt: string): Promise<void> {
+    const settingsBag = this.plugin.settings as unknown as Record<string, unknown>;
+    const settings = getPiProviderSettings(settingsBag);
+    const command = this.plugin.getResolvedProviderCliPath('pi') ?? 'pi';
+    const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
+    const envText = getRuntimeEnvironmentText(settingsBag, 'pi');
+    const env = {
+      ...process.env,
+      ...parseEnvironmentVariables(envText),
+    };
+    const launchSpec = buildPiLaunchSpec({
+      command,
+      cwd,
+      env,
+      envText,
+      noSession: true,
+      noTools: this.options.profile === 'passive',
+      settings: {
+        ...settings,
+        toolMode: this.options.profile === 'readonly' ? 'readonly' : settings.toolMode,
+      },
+      systemPrompt,
+    });
+
+    if (
+      this.process
+      && this.transport
+      && this.process.isAlive()
+      && !this.transport.isClosed
+      && this.currentLaunchKey === launchSpec.launchKey
+    ) {
+      return;
+    }
+
+    this.reset();
+    this.process = new PiSubprocess(launchSpec);
+    this.process.start();
+    this.transport = new PiRpcTransport({
+      input: this.process.stdout,
+      onClose: (listener) => this.process!.onClose(listener),
+      output: this.process.stdin,
+    });
+    this.transport.start();
+    this.currentLaunchKey = launchSpec.launchKey;
+  }
+
+  private resolveSelectedModel(explicitModel?: string): string | undefined {
+    if (explicitModel && decodePiModelId(explicitModel)) {
+      return explicitModel;
+    }
+
+    const projectedSettings = ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+      this.plugin.settings as unknown as Record<string, unknown>,
+      'pi',
+    );
+    const selectedModel = typeof projectedSettings.model === 'string'
+      ? projectedSettings.model
+      : '';
+    return decodePiModelId(selectedModel) ? selectedModel : undefined;
+  }
+}

--- a/src/providers/pi/runtime/PiChatRuntime.ts
+++ b/src/providers/pi/runtime/PiChatRuntime.ts
@@ -1,3 +1,5 @@
+import * as path from 'node:path';
+
 import {
   buildSystemPrompt,
   computeSystemPromptKey,
@@ -119,6 +121,7 @@ export class PiChatRuntime implements ChatRuntime {
   private activeTurn: ActiveTurn | null = null;
   private currentLaunchKey: string | null = null;
   private currentModel: string | null = null;
+  private currentSessionTarget: string | null = null;
   private currentThinkingLevel: string | null = null;
   private currentTurnMetadata: ChatTurnMetadata = {};
   private extensionBridge: PiExtensionUiBridge | null = null;
@@ -194,37 +197,51 @@ export class PiChatRuntime implements ChatRuntime {
     const resolvedCliPath = this.plugin.getResolvedProviderCliPath('pi') ?? 'pi';
     const runtimeEnvText = getRuntimeEnvironmentText(this.plugin.settings as unknown as Record<string, unknown>, 'pi');
     const promptSettings = this.getSystemPromptSettings(cwd);
+    const systemPrompt = buildSystemPrompt(promptSettings);
+    const noSession = !allowSessionCreation && !hasSessionTarget;
     const launchSpec = buildPiLaunchSpec({
       command: resolvedCliPath,
       cwd,
       env: this.buildRuntimeEnv(runtimeEnvText),
       envText: runtimeEnvText,
-      noSession: !allowSessionCreation && !hasSessionTarget,
+      noSession,
       providerState: this.getCurrentProviderState(),
       settings,
-      systemPrompt: buildSystemPrompt(promptSettings),
+      systemPrompt,
     });
+    const sessionTarget = this.sessionFile ?? this.sessionId ?? null;
     const nextLaunchKey = JSON.stringify({
-      launchKey: launchSpec.launchKey,
+      command: resolvedCliPath,
+      cwd,
+      envText: runtimeEnvText,
+      noSession,
       promptKey: computeSystemPromptKey(promptSettings),
+      systemPrompt,
       toolMode: settings.toolMode,
     });
+    const sessionTargetChanged = sessionTarget !== this.currentSessionTarget;
+    const canSwitchSessionTarget = sessionTargetChanged && this.isSwitchableSessionFile(this.sessionFile);
+    const unSwitchableSessionTargetChanged = sessionTargetChanged && !canSwitchSessionTarget;
 
     const shouldRestart = !this.process
       || !this.transport
       || !this.process.isAlive()
       || this.transport.isClosed
       || options?.force === true
-      || this.currentLaunchKey !== nextLaunchKey;
+      || this.currentLaunchKey !== nextLaunchKey
+      || unSwitchableSessionTargetChanged;
 
     if (shouldRestart) {
       await this.shutdownProcess();
       await this.startProcess(launchSpec);
       this.currentLaunchKey = nextLaunchKey;
+      this.currentSessionTarget = sessionTarget;
+    } else if (canSwitchSessionTarget && this.sessionFile) {
+      await this.switchSession(this.sessionFile, launchSpec, nextLaunchKey);
     }
 
     if (allowSessionCreation || hasSessionTarget) {
-      await this.refreshState().catch(() => {});
+      await this.refreshStateAndSessionTarget();
     }
     this.setReady(true);
     return true;
@@ -294,8 +311,9 @@ export class PiChatRuntime implements ChatRuntime {
     }
 
     try {
+      const images = buildPiPromptImages(turn.request.images);
       await this.transport.request('steer', {
-        images: buildPiPromptImages(turn.request.images),
+        ...(images.length > 0 ? { images } : {}),
         message: buildPiPromptText(turn.request),
       });
       this.activeTurn?.queue.push({
@@ -317,9 +335,13 @@ export class PiChatRuntime implements ChatRuntime {
     this.sessionId = null;
     this.sessionFile = null;
     this.leafEntryId = null;
+    this.currentSessionTarget = null;
     if (this.transport && !this.transport.isClosed) {
       void this.transport.request('new_session')
-        .then((response) => this.applyStateResponse(response))
+        .then((response) => {
+          this.applyStateResponse(response);
+          this.currentSessionTarget = this.sessionFile ?? this.sessionId ?? null;
+        })
         .catch(() => {});
     }
   }
@@ -486,7 +508,7 @@ export class PiChatRuntime implements ChatRuntime {
         await activeTurn.terminalPromise;
       }
 
-      await this.refreshState().catch(() => {});
+      await this.refreshStateAndSessionTarget();
       const usage = await this.fetchUsage(queryOptions).catch(() => null);
       if (usage) {
         activeTurn.queue.push({ sessionId: this.sessionId, type: 'usage', usage });
@@ -554,6 +576,7 @@ export class PiChatRuntime implements ChatRuntime {
     const process = this.process;
     this.process = null;
     this.currentModel = null;
+    this.currentSessionTarget = null;
     this.currentThinkingLevel = null;
     if (process) {
       await process.shutdown().catch(() => {});
@@ -638,6 +661,15 @@ export class PiChatRuntime implements ChatRuntime {
     this.applyStateResponse(response);
   }
 
+  private async refreshStateAndSessionTarget(): Promise<void> {
+    try {
+      await this.refreshState();
+      this.currentSessionTarget = this.sessionFile ?? this.sessionId ?? null;
+    } catch {
+      // State refresh is opportunistic; the next turn can still proceed.
+    }
+  }
+
   private applyStateResponse(response: unknown): void {
     const state = extractStateRecord(response);
     this.sessionId = getString(state.sessionId)
@@ -660,8 +692,13 @@ export class PiChatRuntime implements ChatRuntime {
       return null;
     }
 
+    const providerSettings = this.getProviderSettings();
+    const selectedModel = this.resolveSelectedModel(providerSettings, queryOptions);
+    const fallbackContextWindow = selectedModel
+      ? findPiModel(getPiProviderSettings(providerSettings), selectedModel)?.contextWindow
+      : undefined;
     const response = await this.transport.request('get_session_stats', {}, 10_000);
-    return buildPiUsageInfo(response, this.resolveSelectedModel(this.getProviderSettings(), queryOptions));
+    return buildPiUsageInfo(response, selectedModel, fallbackContextWindow);
   }
 
   private getSystemPromptSettings(vaultPath: string): SystemPromptSettings {
@@ -748,6 +785,30 @@ export class PiChatRuntime implements ChatRuntime {
     const message = error instanceof Error ? error.message : 'Pi request failed';
     const stderr = this.process?.getStderrSnapshot();
     return stderr ? `${message}\n\n${stderr}` : message;
+  }
+
+  private isSwitchableSessionFile(sessionFile: string | null): sessionFile is string {
+    return typeof sessionFile === 'string'
+      && sessionFile.trim().length > 0
+      && path.isAbsolute(sessionFile);
+  }
+
+  private async switchSession(
+    sessionFile: string,
+    launchSpec: PiLaunchSpec,
+    nextLaunchKey: string,
+  ): Promise<void> {
+    try {
+      await this.transport!.request('switch_session', { sessionPath: sessionFile });
+      this.currentLaunchKey = nextLaunchKey;
+      this.currentSessionTarget = sessionFile;
+      this.sessionInvalidated = false;
+    } catch {
+      await this.shutdownProcess();
+      await this.startProcess(launchSpec);
+      this.currentLaunchKey = nextLaunchKey;
+      this.currentSessionTarget = this.sessionFile ?? this.sessionId ?? null;
+    }
   }
 }
 

--- a/src/providers/pi/runtime/PiChatRuntime.ts
+++ b/src/providers/pi/runtime/PiChatRuntime.ts
@@ -52,6 +52,7 @@ import {
 } from '../models';
 import {
   createPiEventNormalizationState,
+  getPiTerminalErrorMessage,
   normalizePiRpcEvent,
   type PiEventNormalizationState,
 } from '../normalizations/piEventNormalization';
@@ -661,8 +662,12 @@ export class PiChatRuntime implements ChatRuntime {
     }
 
     const state = this.getNormalizationState();
-    for (const chunk of normalizePiRpcEvent(event, state)) {
+    const chunks = normalizePiRpcEvent(event, state);
+    for (const chunk of chunks) {
       this.activeTurn?.queue.push(chunk);
+    }
+    if (getPiTerminalErrorMessage(event)) {
+      this.activeTurn?.resolveTerminal();
     }
   }
 

--- a/src/providers/pi/runtime/PiChatRuntime.ts
+++ b/src/providers/pi/runtime/PiChatRuntime.ts
@@ -1,3 +1,4 @@
+import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 
 import {
@@ -38,6 +39,12 @@ import { parseEnvironmentVariables } from '../../../utils/env';
 import { getVaultPath } from '../../../utils/path';
 import { PI_PROVIDER_CAPABILITIES } from '../capabilities';
 import {
+  createPiForkSessionFile,
+  findPiSessionFile,
+  parsePiSessionEntries,
+  resolvePiActivePath,
+} from '../history/PiHistoryStore';
+import {
   clampPiThinkingLevel,
   decodePiModelId,
   findPiModel,
@@ -49,7 +56,12 @@ import {
   type PiEventNormalizationState,
 } from '../normalizations/piEventNormalization';
 import { getPiProviderSettings } from '../settings';
-import { buildPersistedPiState, getPiState, type PiProviderState } from '../types';
+import {
+  buildPersistedPiState,
+  getPiState,
+  type PiForkSource,
+  type PiProviderState,
+} from '../types';
 import { buildPiPromptImages, buildPiPromptText } from './buildPiPrompt';
 import { buildPiUsageInfo } from './buildPiUsageInfo';
 import { PiExtensionUiBridge, type PiExtensionUiRenderer } from './PiExtensionUiBridge';
@@ -126,6 +138,9 @@ export class PiChatRuntime implements ChatRuntime {
   private currentTurnMetadata: ChatTurnMetadata = {};
   private extensionBridge: PiExtensionUiBridge | null = null;
   private leafEntryId: string | null = null;
+  private parentSession: string | null = null;
+  private pendingFork: PiForkSource | null = null;
+  private pendingForkSourceSessionFile: string | null = null;
   private process: PiSubprocess | null = null;
   private ready = false;
   private readonly readyListeners = new Set<(ready: boolean) => void>();
@@ -171,14 +186,31 @@ export class PiChatRuntime implements ChatRuntime {
       this.sessionId = null;
       this.sessionFile = null;
       this.leafEntryId = null;
+      this.parentSession = null;
+      this.pendingFork = null;
+      this.pendingForkSourceSessionFile = null;
       this.sessionInvalidated = false;
       return;
     }
 
     const state = getPiState(conversation.providerState);
+    if (state.forkSource && !state.sessionId && !state.sessionFile && !conversation.sessionId) {
+      this.sessionId = null;
+      this.sessionFile = null;
+      this.leafEntryId = null;
+      this.parentSession = null;
+      this.pendingFork = state.forkSource;
+      this.pendingForkSourceSessionFile = state.forkSourceSessionFile ?? null;
+      this.sessionInvalidated = false;
+      return;
+    }
+
     this.sessionId = state.sessionId ?? conversation.sessionId ?? null;
     this.sessionFile = state.sessionFile ?? null;
     this.leafEntryId = state.leafEntryId ?? null;
+    this.parentSession = state.parentSession ?? null;
+    this.pendingFork = null;
+    this.pendingForkSourceSessionFile = null;
     this.sessionInvalidated = false;
   }
 
@@ -191,11 +223,15 @@ export class PiChatRuntime implements ChatRuntime {
       return false;
     }
 
-    const hasSessionTarget = Boolean(this.sessionId || this.sessionFile);
     const allowSessionCreation = options?.allowSessionCreation !== false;
     const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
     const resolvedCliPath = this.plugin.getResolvedProviderCliPath('pi') ?? 'pi';
     const runtimeEnvText = getRuntimeEnvironmentText(this.plugin.settings as unknown as Record<string, unknown>, 'pi');
+    if (allowSessionCreation) {
+      await this.materializePendingFork(cwd, runtimeEnvText);
+    }
+
+    const hasSessionTarget = Boolean(this.sessionId || this.sessionFile);
     const promptSettings = this.getSystemPromptSettings(cwd);
     const systemPrompt = buildSystemPrompt(promptSettings);
     const noSession = !allowSessionCreation && !hasSessionTarget;
@@ -253,7 +289,16 @@ export class PiChatRuntime implements ChatRuntime {
     queryOptions?: ChatRuntimeQueryOptions,
   ): AsyncGenerator<StreamChunk> {
     this.currentTurnMetadata = {};
-    if (!(await this.ensureReady())) {
+    let isReady: boolean;
+    try {
+      isReady = await this.ensureReady();
+    } catch (error) {
+      yield { type: 'error', content: this.formatRuntimeError(error) };
+      yield { type: 'done' };
+      return;
+    }
+
+    if (!isReady) {
       yield { type: 'error', content: 'Failed to start Pi. Check the CLI path and login state.' };
       yield { type: 'done' };
       return;
@@ -335,6 +380,9 @@ export class PiChatRuntime implements ChatRuntime {
     this.sessionId = null;
     this.sessionFile = null;
     this.leafEntryId = null;
+    this.parentSession = null;
+    this.pendingFork = null;
+    this.pendingForkSourceSessionFile = null;
     this.currentSessionTarget = null;
     if (this.transport && !this.transport.isClosed) {
       void this.transport.request('new_session')
@@ -428,7 +476,14 @@ export class PiChatRuntime implements ChatRuntime {
   }
 
   resolveSessionIdForFork(conversation: Conversation | null): string | null {
-    return this.sessionId ?? conversation?.sessionId ?? null;
+    const state = getPiState(conversation?.providerState);
+    return this.sessionFile
+      ?? this.sessionId
+      ?? state.sessionFile
+      ?? state.sessionId
+      ?? conversation?.sessionId
+      ?? state.forkSource?.sessionId
+      ?? null;
   }
 
   async loadSubagentToolCalls(_agentId: string): Promise<ToolCallInfo[]> {
@@ -483,6 +538,7 @@ export class PiChatRuntime implements ChatRuntime {
     queryOptions?: ChatRuntimeQueryOptions,
   ): Promise<void> {
     try {
+      const turnStartLeafId = await this.resolveCurrentLeafEntryId();
       await this.applySelectedModel(queryOptions);
       await this.applySelectedThinkingLevel(queryOptions);
       if (activeTurn.cancelled) {
@@ -509,6 +565,7 @@ export class PiChatRuntime implements ChatRuntime {
       }
 
       await this.refreshStateAndSessionTarget();
+      await this.updateTurnMetadataFromSessionFile(turnStartLeafId);
       const usage = await this.fetchUsage(queryOptions).catch(() => null);
       if (usage) {
         activeTurn.queue.push({ sessionId: this.sessionId, type: 'usage', usage });
@@ -685,6 +742,9 @@ export class PiChatRuntime implements ChatRuntime {
     this.leafEntryId = getString(state.leafEntryId)
       ?? getString(state.leaf_entry_id)
       ?? this.leafEntryId;
+    this.parentSession = getString(state.parentSession)
+      ?? getString(state.parent_session)
+      ?? this.parentSession;
   }
 
   private async fetchUsage(queryOptions?: ChatRuntimeQueryOptions): Promise<UsageInfo | null> {
@@ -699,6 +759,93 @@ export class PiChatRuntime implements ChatRuntime {
       : undefined;
     const response = await this.transport.request('get_session_stats', {}, 10_000);
     return buildPiUsageInfo(response, selectedModel, fallbackContextWindow);
+  }
+
+  private async materializePendingFork(cwd: string, runtimeEnvText: string): Promise<void> {
+    if (!this.pendingFork) {
+      return;
+    }
+
+    const env = parseEnvironmentVariables(runtimeEnvText);
+    const sourceSessionFile = this.pendingForkSourceSessionFile
+      ?? findPiSessionFile(
+        this.pendingFork.sessionId,
+        cwd,
+        typeof env.PI_CODING_AGENT_SESSION_DIR === 'string' ? env.PI_CODING_AGENT_SESSION_DIR : null,
+      );
+    if (!sourceSessionFile) {
+      throw new Error(`Pi fork source session not found: ${this.pendingFork.sessionId}`);
+    }
+
+    const forkedSession = await createPiForkSessionFile(
+      sourceSessionFile,
+      this.pendingFork.resumeAt,
+      { targetCwd: cwd },
+    );
+    this.sessionId = forkedSession.sessionId;
+    this.sessionFile = forkedSession.sessionFile;
+    this.leafEntryId = forkedSession.leafEntryId;
+    this.parentSession = forkedSession.parentSession;
+    this.pendingFork = null;
+    this.pendingForkSourceSessionFile = null;
+    this.sessionInvalidated = false;
+    this.currentSessionTarget = null;
+  }
+
+  private async resolveCurrentLeafEntryId(): Promise<string | null> {
+    if (this.leafEntryId) {
+      return this.leafEntryId;
+    }
+    if (!this.sessionFile) {
+      return null;
+    }
+
+    try {
+      const content = await fsp.readFile(this.sessionFile, 'utf-8');
+      const entries = parsePiSessionEntries(content).entries;
+      const activePath = resolvePiActivePath(entries);
+      const leafEntryId = getLastPiEntryId(activePath);
+      this.leafEntryId = leafEntryId;
+      return leafEntryId;
+    } catch {
+      return null;
+    }
+  }
+
+  private async updateTurnMetadataFromSessionFile(previousLeafEntryId: string | null): Promise<void> {
+    if (!this.sessionFile) {
+      return;
+    }
+
+    try {
+      const content = await fsp.readFile(this.sessionFile, 'utf-8');
+      const entries = parsePiSessionEntries(content).entries;
+      const activePath = resolvePiActivePath(entries);
+      if (activePath.length === 0) {
+        return;
+      }
+
+      this.leafEntryId = getLastPiEntryId(activePath) ?? this.leafEntryId;
+      const previousLeafIndex = previousLeafEntryId
+        ? activePath.findIndex(entry => entry.id === previousLeafEntryId)
+        : -1;
+      const newEntries = previousLeafIndex >= 0
+        ? activePath.slice(previousLeafIndex + 1)
+        : activePath;
+      const userEntry = previousLeafIndex >= 0
+        ? newEntries.find(entry => getPiEntryRole(entry) === 'user')
+        : findLastPiEntryByRole(newEntries, 'user');
+      const assistantEntry = findLastPiEntryByRole(newEntries, 'assistant');
+
+      if (userEntry?.id) {
+        this.currentTurnMetadata.userMessageId = userEntry.id;
+      }
+      if (assistantEntry?.id) {
+        this.currentTurnMetadata.assistantMessageId = assistantEntry.id;
+      }
+    } catch {
+      // Live checkpoint metadata is best-effort; hydration can still recover IDs later.
+    }
   }
 
   private getSystemPromptSettings(vaultPath: string): SystemPromptSettings {
@@ -763,8 +910,18 @@ export class PiChatRuntime implements ChatRuntime {
   }
 
   private getCurrentProviderState(): PiProviderState {
+    if (this.pendingFork) {
+      return {
+        forkSource: this.pendingFork,
+        ...(this.pendingForkSourceSessionFile
+          ? { forkSourceSessionFile: this.pendingForkSourceSessionFile }
+          : {}),
+      };
+    }
+
     return {
       ...(this.leafEntryId ? { leafEntryId: this.leafEntryId } : {}),
+      ...(this.parentSession ? { parentSession: this.parentSession } : {}),
       ...(this.sessionFile ? { sessionFile: this.sessionFile } : {}),
       ...(this.sessionId ? { sessionId: this.sessionId } : {}),
     };
@@ -854,6 +1011,41 @@ function normalizePiRuntimeCommands(response: unknown): SlashCommand[] {
 function extractStateRecord(response: unknown): Record<string, unknown> {
   const record = getRecord(response);
   return getRecord(record.state ?? record.session ?? response);
+}
+
+function getPiEntryRole(entry: { message?: Record<string, unknown>; type: string }): string | null {
+  const message = entry.message ?? {};
+  const role = getString(message.role);
+  if (role) {
+    return role;
+  }
+
+  if (entry.type === 'toolResult') {
+    return 'toolResult';
+  }
+  return null;
+}
+
+function getLastPiEntryId(entries: Array<{ id?: string }>): string | null {
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const id = entries[i].id;
+    if (id) {
+      return id;
+    }
+  }
+  return null;
+}
+
+function findLastPiEntryByRole<T extends { message?: Record<string, unknown>; type: string }>(
+  entries: T[],
+  role: string,
+): T | undefined {
+  for (let i = entries.length - 1; i >= 0; i--) {
+    if (getPiEntryRole(entries[i]) === role) {
+      return entries[i];
+    }
+  }
+  return undefined;
 }
 
 function getRecord(value: unknown): Record<string, unknown> {

--- a/src/providers/pi/runtime/PiChatRuntime.ts
+++ b/src/providers/pi/runtime/PiChatRuntime.ts
@@ -1,0 +1,806 @@
+import {
+  buildSystemPrompt,
+  computeSystemPromptKey,
+  type SystemPromptSettings,
+} from '../../../core/prompt/mainAgent';
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
+import type { ProviderCapabilities } from '../../../core/providers/types';
+import type { ChatRuntime } from '../../../core/runtime/ChatRuntime';
+import type {
+  ApprovalCallback,
+  AskUserQuestionCallback,
+  AutoTurnCallback,
+  ChatRewindMode,
+  ChatRewindResult,
+  ChatRuntimeConversationState,
+  ChatRuntimeEnsureReadyOptions,
+  ChatRuntimeQueryOptions,
+  ChatTurnMetadata,
+  ChatTurnRequest,
+  ExitPlanModeCallback,
+  PreparedChatTurn,
+  SessionUpdateResult,
+  SubagentRuntimeState,
+} from '../../../core/runtime/types';
+import type {
+  ChatMessage,
+  Conversation,
+  SlashCommand,
+  StreamChunk,
+  ToolCallInfo,
+  UsageInfo,
+} from '../../../core/types';
+import type ClaudianPlugin from '../../../main';
+import { parseEnvironmentVariables } from '../../../utils/env';
+import { getVaultPath } from '../../../utils/path';
+import { PI_PROVIDER_CAPABILITIES } from '../capabilities';
+import {
+  clampPiThinkingLevel,
+  decodePiModelId,
+  findPiModel,
+  PI_SYNTHETIC_MODEL_ID,
+} from '../models';
+import {
+  createPiEventNormalizationState,
+  normalizePiRpcEvent,
+  type PiEventNormalizationState,
+} from '../normalizations/piEventNormalization';
+import { getPiProviderSettings } from '../settings';
+import { buildPersistedPiState, getPiState, type PiProviderState } from '../types';
+import { buildPiPromptImages, buildPiPromptText } from './buildPiPrompt';
+import { buildPiUsageInfo } from './buildPiUsageInfo';
+import { PiExtensionUiBridge, type PiExtensionUiRenderer } from './PiExtensionUiBridge';
+import { buildPiLaunchSpec, type PiLaunchSpec } from './PiLaunchSpec';
+import { buildPiSetModelPayload } from './PiRpcPayloads';
+import { type PiRpcRecord, PiRpcTransport } from './PiRpcTransport';
+import { PiSubprocess } from './PiSubprocess';
+
+interface ActiveTurn {
+  cancel: (error: Error) => void;
+  cancelled: boolean;
+  queue: StreamChunkQueue;
+  rejectTerminal: (error: Error) => void;
+  resolveTerminal: () => void;
+  terminalPromise: Promise<void>;
+}
+
+class StreamChunkQueue {
+  private closed = false;
+  private readonly items: StreamChunk[] = [];
+  private readonly waiters: Array<(chunk: StreamChunk | null) => void> = [];
+
+  push(chunk: StreamChunk): void {
+    if (this.closed) {
+      return;
+    }
+
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter(chunk);
+      return;
+    }
+    this.items.push(chunk);
+  }
+
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+
+    this.closed = true;
+    while (this.waiters.length > 0) {
+      this.waiters.shift()?.(null);
+    }
+  }
+
+  async next(): Promise<StreamChunk | null> {
+    if (this.items.length > 0) {
+      return this.items.shift() ?? null;
+    }
+
+    if (this.closed) {
+      return null;
+    }
+
+    return new Promise<StreamChunk | null>((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+}
+
+export interface PiChatRuntimeOptions {
+  extensionUiRenderer?: PiExtensionUiRenderer | null;
+}
+
+export class PiChatRuntime implements ChatRuntime {
+  readonly providerId = 'pi' as const;
+
+  private activeTurn: ActiveTurn | null = null;
+  private currentLaunchKey: string | null = null;
+  private currentModel: string | null = null;
+  private currentThinkingLevel: string | null = null;
+  private currentTurnMetadata: ChatTurnMetadata = {};
+  private extensionBridge: PiExtensionUiBridge | null = null;
+  private leafEntryId: string | null = null;
+  private process: PiSubprocess | null = null;
+  private ready = false;
+  private readonly readyListeners = new Set<(ready: boolean) => void>();
+  private sessionFile: string | null = null;
+  private sessionId: string | null = null;
+  private sessionInvalidated = false;
+  private supportedCommands: SlashCommand[] = [];
+  private shutdownPromise: Promise<void> | null = null;
+  private transport: PiRpcTransport | null = null;
+  private unregisterTransportClose: (() => void) | null = null;
+
+  constructor(
+    private readonly plugin: ClaudianPlugin,
+    private readonly options: PiChatRuntimeOptions = {},
+  ) {}
+
+  getCapabilities(): Readonly<ProviderCapabilities> {
+    return PI_PROVIDER_CAPABILITIES;
+  }
+
+  prepareTurn(request: ChatTurnRequest): PreparedChatTurn {
+    const isCompact = isCompactCommand(request.text);
+    return {
+      isCompact,
+      mcpMentions: request.enabledMcpServers ?? new Set(),
+      persistedContent: '',
+      prompt: buildPiPromptText(request),
+      request,
+    };
+  }
+
+  onReadyStateChange(listener: (ready: boolean) => void): () => void {
+    this.readyListeners.add(listener);
+    return () => {
+      this.readyListeners.delete(listener);
+    };
+  }
+
+  setResumeCheckpoint(_checkpointId: string | undefined): void {}
+
+  syncConversationState(conversation: ChatRuntimeConversationState | null): void {
+    if (!conversation) {
+      this.sessionId = null;
+      this.sessionFile = null;
+      this.leafEntryId = null;
+      this.sessionInvalidated = false;
+      return;
+    }
+
+    const state = getPiState(conversation.providerState);
+    this.sessionId = state.sessionId ?? conversation.sessionId ?? null;
+    this.sessionFile = state.sessionFile ?? null;
+    this.leafEntryId = state.leafEntryId ?? null;
+    this.sessionInvalidated = false;
+  }
+
+  async reloadMcpServers(): Promise<void> {}
+
+  async ensureReady(options?: ChatRuntimeEnsureReadyOptions): Promise<boolean> {
+    const settings = getPiProviderSettings(this.plugin.settings as unknown as Record<string, unknown>);
+    if (!settings.enabled) {
+      this.setReady(false);
+      return false;
+    }
+
+    const hasSessionTarget = Boolean(this.sessionId || this.sessionFile);
+    const allowSessionCreation = options?.allowSessionCreation !== false;
+    const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
+    const resolvedCliPath = this.plugin.getResolvedProviderCliPath('pi') ?? 'pi';
+    const runtimeEnvText = getRuntimeEnvironmentText(this.plugin.settings as unknown as Record<string, unknown>, 'pi');
+    const promptSettings = this.getSystemPromptSettings(cwd);
+    const launchSpec = buildPiLaunchSpec({
+      command: resolvedCliPath,
+      cwd,
+      env: this.buildRuntimeEnv(runtimeEnvText),
+      envText: runtimeEnvText,
+      noSession: !allowSessionCreation && !hasSessionTarget,
+      providerState: this.getCurrentProviderState(),
+      settings,
+      systemPrompt: buildSystemPrompt(promptSettings),
+    });
+    const nextLaunchKey = JSON.stringify({
+      launchKey: launchSpec.launchKey,
+      promptKey: computeSystemPromptKey(promptSettings),
+      toolMode: settings.toolMode,
+    });
+
+    const shouldRestart = !this.process
+      || !this.transport
+      || !this.process.isAlive()
+      || this.transport.isClosed
+      || options?.force === true
+      || this.currentLaunchKey !== nextLaunchKey;
+
+    if (shouldRestart) {
+      await this.shutdownProcess();
+      await this.startProcess(launchSpec);
+      this.currentLaunchKey = nextLaunchKey;
+    }
+
+    if (allowSessionCreation || hasSessionTarget) {
+      await this.refreshState().catch(() => {});
+    }
+    this.setReady(true);
+    return true;
+  }
+
+  async *query(
+    turn: PreparedChatTurn,
+    conversationHistory?: ChatMessage[],
+    queryOptions?: ChatRuntimeQueryOptions,
+  ): AsyncGenerator<StreamChunk> {
+    this.currentTurnMetadata = {};
+    if (!(await this.ensureReady())) {
+      yield { type: 'error', content: 'Failed to start Pi. Check the CLI path and login state.' };
+      yield { type: 'done' };
+      return;
+    }
+
+    if (!this.transport) {
+      yield { type: 'error', content: 'Pi runtime is not ready.' };
+      yield { type: 'done' };
+      return;
+    }
+
+    const activeTurn = this.createActiveTurn();
+    this.activeTurn = activeTurn;
+    this.normalizationState = createPiEventNormalizationState();
+    const shouldBootstrapHistory = (conversationHistory?.length ?? 0) > 0
+      && !this.sessionId
+      && !this.sessionFile;
+    const promptText = buildPiPromptText(
+      turn.request,
+      shouldBootstrapHistory ? conversationHistory : [],
+    );
+    const images = buildPiPromptImages(turn.request.images);
+
+    const runTurn = this.runTurn(
+      activeTurn,
+      turn,
+      promptText,
+      images,
+      queryOptions,
+    );
+
+    try {
+      while (true) {
+        const chunk = await activeTurn.queue.next();
+        if (!chunk) {
+          break;
+        }
+        yield chunk;
+      }
+      await runTurn;
+    } finally {
+      if (this.activeTurn === activeTurn) {
+        this.transport?.send({ type: 'abort' });
+        activeTurn.cancel(new Error('Pi turn cancelled'));
+        activeTurn.queue.close();
+        this.activeTurn = null;
+        void this.shutdownProcess();
+      }
+    }
+  }
+
+  async steer(turn: PreparedChatTurn): Promise<boolean> {
+    if (!this.transport || this.transport.isClosed) {
+      return false;
+    }
+
+    try {
+      await this.transport.request('steer', {
+        images: buildPiPromptImages(turn.request.images),
+        message: buildPiPromptText(turn.request),
+      });
+      this.activeTurn?.queue.push({
+        type: 'user_message_start',
+        content: turn.request.text,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  cancel(): void {
+    this.transport?.send({ type: 'abort' });
+  }
+
+  resetSession(): void {
+    this.sessionInvalidated = true;
+    this.sessionId = null;
+    this.sessionFile = null;
+    this.leafEntryId = null;
+    if (this.transport && !this.transport.isClosed) {
+      void this.transport.request('new_session')
+        .then((response) => this.applyStateResponse(response))
+        .catch(() => {});
+    }
+  }
+
+  getSessionId(): string | null {
+    return this.sessionId;
+  }
+
+  consumeSessionInvalidation(): boolean {
+    const invalidated = this.sessionInvalidated;
+    this.sessionInvalidated = false;
+    return invalidated;
+  }
+
+  isReady(): boolean {
+    return this.ready;
+  }
+
+  async getSupportedCommands(): Promise<SlashCommand[]> {
+    if (this.supportedCommands.length > 0) {
+      return [...this.supportedCommands];
+    }
+    if (!this.transport || this.transport.isClosed) {
+      return [];
+    }
+
+    try {
+      const response = await this.transport.request('get_commands', {}, 10_000);
+      this.supportedCommands = normalizePiRuntimeCommands(response);
+      return [...this.supportedCommands];
+    } catch {
+      return [];
+    }
+  }
+
+  getAuxiliaryModel(): string | null {
+    return this.currentModel;
+  }
+
+  cleanup(): void {
+    this.activeTurn?.queue.close();
+    this.extensionBridge?.cleanup();
+    void this.shutdownProcess();
+  }
+
+  async rewind(
+    _userMessageId: string,
+    _assistantMessageId: string,
+    _mode?: ChatRewindMode,
+  ): Promise<ChatRewindResult> {
+    return { canRewind: false };
+  }
+
+  setApprovalCallback(_callback: ApprovalCallback | null): void {}
+  setApprovalDismisser(_dismisser: (() => void) | null): void {}
+  setAskUserQuestionCallback(_callback: AskUserQuestionCallback | null): void {}
+  setExitPlanModeCallback(_callback: ExitPlanModeCallback | null): void {}
+  setPermissionModeSyncCallback(_callback: ((sdkMode: string) => void) | null): void {}
+  setSubagentHookProvider(_getState: () => SubagentRuntimeState): void {}
+  setAutoTurnCallback(_callback: AutoTurnCallback | null): void {}
+
+  consumeTurnMetadata(): ChatTurnMetadata {
+    const metadata = this.currentTurnMetadata;
+    this.currentTurnMetadata = {};
+    return metadata;
+  }
+
+  buildSessionUpdates(params: {
+    conversation: Conversation | null;
+    sessionInvalidated: boolean;
+  }): SessionUpdateResult {
+    const providerState = buildPersistedPiState(this.getCurrentProviderState());
+    const updates: Partial<Conversation> = {
+      providerState: providerState as Record<string, unknown> | undefined,
+      sessionId: this.sessionId,
+    };
+
+    if (params.sessionInvalidated && !this.sessionId) {
+      updates.providerState = undefined;
+      updates.sessionId = null;
+    }
+
+    return { updates };
+  }
+
+  resolveSessionIdForFork(conversation: Conversation | null): string | null {
+    return this.sessionId ?? conversation?.sessionId ?? null;
+  }
+
+  async loadSubagentToolCalls(_agentId: string): Promise<ToolCallInfo[]> {
+    return [];
+  }
+
+  async loadSubagentFinalResult(_agentId: string): Promise<string | null> {
+    return null;
+  }
+
+  private createActiveTurn(): ActiveTurn {
+    let terminalSettled = false;
+    let resolveTerminal!: () => void;
+    let rejectTerminal!: (error: Error) => void;
+    const terminalPromise = new Promise<void>((resolve, reject) => {
+      resolveTerminal = () => {
+        if (terminalSettled) {
+          return;
+        }
+        terminalSettled = true;
+        resolve();
+      };
+      rejectTerminal = (error) => {
+        if (terminalSettled) {
+          return;
+        }
+        terminalSettled = true;
+        reject(error);
+      };
+    });
+    terminalPromise.catch(() => {});
+
+    const activeTurn: ActiveTurn = {
+      cancel: (error) => {
+        activeTurn.cancelled = true;
+        rejectTerminal(error);
+      },
+      cancelled: false,
+      queue: new StreamChunkQueue(),
+      rejectTerminal,
+      resolveTerminal,
+      terminalPromise,
+    };
+    return activeTurn;
+  }
+
+  private async runTurn(
+    activeTurn: ActiveTurn,
+    turn: PreparedChatTurn,
+    promptText: string,
+    images: ReturnType<typeof buildPiPromptImages>,
+    queryOptions?: ChatRuntimeQueryOptions,
+  ): Promise<void> {
+    try {
+      await this.applySelectedModel(queryOptions);
+      await this.applySelectedThinkingLevel(queryOptions);
+      if (activeTurn.cancelled) {
+        throw new Error('Pi turn cancelled');
+      }
+
+      if (turn.isCompact) {
+        await this.transport!.request('compact', {
+          customInstructions: stripCompactCommand(turn.request.text),
+        });
+        this.currentTurnMetadata.wasSent = true;
+        activeTurn.queue.push({ type: 'context_compacted' });
+      } else {
+        activeTurn.queue.push({
+          type: 'user_message_start',
+          content: turn.request.text,
+        });
+        await this.transport!.request('prompt', {
+          ...(images.length > 0 ? { images } : {}),
+          message: promptText,
+        });
+        this.currentTurnMetadata.wasSent = true;
+        await activeTurn.terminalPromise;
+      }
+
+      await this.refreshState().catch(() => {});
+      const usage = await this.fetchUsage(queryOptions).catch(() => null);
+      if (usage) {
+        activeTurn.queue.push({ sessionId: this.sessionId, type: 'usage', usage });
+      }
+      activeTurn.queue.push({ type: 'done' });
+    } catch (error) {
+      activeTurn.queue.push({
+        type: 'error',
+        content: this.formatRuntimeError(error),
+      });
+      activeTurn.queue.push({ type: 'done' });
+    } finally {
+      activeTurn.queue.close();
+      if (this.activeTurn === activeTurn) {
+        this.activeTurn = null;
+      }
+    }
+  }
+
+  private async startProcess(launchSpec: PiLaunchSpec): Promise<void> {
+    this.process = new PiSubprocess(launchSpec);
+    this.process.start();
+    this.transport = new PiRpcTransport({
+      input: this.process.stdout,
+      onClose: (listener) => this.process!.onClose(listener),
+      output: this.process.stdin,
+    });
+    this.transport.start();
+    this.extensionBridge = new PiExtensionUiBridge(
+      this.transport,
+      this.options.extensionUiRenderer ?? null,
+      (chunk) => this.activeTurn?.queue.push(chunk),
+    );
+    this.transport.onEvent((event) => this.handleRpcEvent(event));
+    this.unregisterTransportClose = this.transport.onClose((error) => {
+      this.setReady(false);
+      this.extensionBridge?.cleanup();
+      this.activeTurn?.rejectTerminal(error ?? new Error('Pi runtime closed'));
+    });
+    this.setReady(true);
+  }
+
+  private async shutdownProcess(): Promise<void> {
+    if (this.shutdownPromise) {
+      return this.shutdownPromise;
+    }
+
+    this.shutdownPromise = this.doShutdownProcess().finally(() => {
+      this.shutdownPromise = null;
+    });
+    return this.shutdownPromise;
+  }
+
+  private async doShutdownProcess(): Promise<void> {
+    this.setReady(false);
+    this.activeTurn?.cancel(new Error('Pi runtime stopped'));
+    this.activeTurn?.queue.close();
+    this.activeTurn = null;
+    this.extensionBridge?.cleanup();
+    this.extensionBridge = null;
+    this.unregisterTransportClose?.();
+    this.unregisterTransportClose = null;
+    this.transport?.dispose();
+    this.transport = null;
+    const process = this.process;
+    this.process = null;
+    this.currentModel = null;
+    this.currentThinkingLevel = null;
+    if (process) {
+      await process.shutdown().catch(() => {});
+    }
+    this.supportedCommands = [];
+  }
+
+  private handleRpcEvent(event: PiRpcRecord): void {
+    if (this.extensionBridge?.handleRequest(event)) {
+      return;
+    }
+
+    if (event.type === 'agent_end') {
+      this.activeTurn?.resolveTerminal();
+      return;
+    }
+
+    if (event.type === 'error') {
+      this.activeTurn?.queue.push({
+        type: 'error',
+        content: typeof event.error === 'string' ? event.error : 'Pi runtime error.',
+      });
+      this.activeTurn?.resolveTerminal();
+      return;
+    }
+
+    const state = this.getNormalizationState();
+    for (const chunk of normalizePiRpcEvent(event, state)) {
+      this.activeTurn?.queue.push(chunk);
+    }
+  }
+
+  private normalizationState: PiEventNormalizationState = createPiEventNormalizationState();
+
+  private getNormalizationState(): PiEventNormalizationState {
+    if (!this.activeTurn) {
+      this.normalizationState = createPiEventNormalizationState();
+      return this.normalizationState;
+    }
+    return this.normalizationState;
+  }
+
+  private async applySelectedModel(queryOptions?: ChatRuntimeQueryOptions): Promise<void> {
+    if (!this.transport) {
+      return;
+    }
+
+    const selectedModel = this.resolveSelectedModel(this.getProviderSettings(), queryOptions);
+    const payload = selectedModel ? buildPiSetModelPayload(selectedModel) : null;
+    if (!payload || this.currentModel === selectedModel) {
+      return;
+    }
+
+    await this.transport.request('set_model', payload);
+    this.currentModel = selectedModel;
+    this.currentThinkingLevel = null;
+  }
+
+  private async applySelectedThinkingLevel(queryOptions?: ChatRuntimeQueryOptions): Promise<void> {
+    if (!this.transport) {
+      return;
+    }
+
+    const providerSettings = this.getProviderSettings();
+    const selectedThinkingLevel = this.resolveSelectedThinkingLevel(providerSettings, queryOptions);
+    if (!selectedThinkingLevel || this.currentThinkingLevel === selectedThinkingLevel) {
+      return;
+    }
+
+    await this.transport.request('set_thinking_level', {
+      level: selectedThinkingLevel,
+    });
+    this.currentThinkingLevel = selectedThinkingLevel;
+  }
+
+  private async refreshState(): Promise<void> {
+    if (!this.transport || this.transport.isClosed) {
+      return;
+    }
+
+    const response = await this.transport.request('get_state', {}, 10_000);
+    this.applyStateResponse(response);
+  }
+
+  private applyStateResponse(response: unknown): void {
+    const state = extractStateRecord(response);
+    this.sessionId = getString(state.sessionId)
+      ?? getString(state.session_id)
+      ?? getString(getRecord(state.session)?.id)
+      ?? this.sessionId;
+    this.sessionFile = getString(state.sessionFile)
+      ?? getString(state.session_file)
+      ?? getString(state.sessionPath)
+      ?? getString(state.session_path)
+      ?? getString(state.path)
+      ?? this.sessionFile;
+    this.leafEntryId = getString(state.leafEntryId)
+      ?? getString(state.leaf_entry_id)
+      ?? this.leafEntryId;
+  }
+
+  private async fetchUsage(queryOptions?: ChatRuntimeQueryOptions): Promise<UsageInfo | null> {
+    if (!this.transport || this.transport.isClosed) {
+      return null;
+    }
+
+    const response = await this.transport.request('get_session_stats', {}, 10_000);
+    return buildPiUsageInfo(response, this.resolveSelectedModel(this.getProviderSettings(), queryOptions));
+  }
+
+  private getSystemPromptSettings(vaultPath: string): SystemPromptSettings {
+    return {
+      customPrompt: this.plugin.settings.systemPrompt,
+      mediaFolder: this.plugin.settings.mediaFolder,
+      userName: this.plugin.settings.userName,
+      vaultPath,
+    };
+  }
+
+  private getProviderSettings(): Record<string, unknown> {
+    return ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+      this.plugin.settings as unknown as Record<string, unknown>,
+      this.providerId,
+    );
+  }
+
+  private resolveSelectedModel(
+    providerSettings: Record<string, unknown>,
+    queryOptions?: ChatRuntimeQueryOptions,
+  ): string | null {
+    const selectedModel = typeof queryOptions?.model === 'string'
+      ? queryOptions.model
+      : typeof providerSettings.model === 'string'
+      ? providerSettings.model
+      : '';
+
+    if (!selectedModel || selectedModel === PI_SYNTHETIC_MODEL_ID || !decodePiModelId(selectedModel)) {
+      return null;
+    }
+
+    return selectedModel;
+  }
+
+  private resolveSelectedThinkingLevel(
+    providerSettings: Record<string, unknown>,
+    queryOptions?: ChatRuntimeQueryOptions,
+  ): string | null {
+    const selectedModel = this.resolveSelectedModel(providerSettings, queryOptions);
+    if (!selectedModel) {
+      return null;
+    }
+
+    const piSettings = getPiProviderSettings(providerSettings);
+    const selectedThinkingLevel = typeof providerSettings.effortLevel === 'string' && providerSettings.effortLevel.trim()
+      ? providerSettings.effortLevel.trim()
+      : piSettings.preferredThinkingByModel[selectedModel];
+    const selectedPiModel = findPiModel(piSettings, selectedModel);
+    if (selectedPiModel) {
+      return clampPiThinkingLevel(selectedThinkingLevel, selectedPiModel.thinkingLevels);
+    }
+
+    return selectedThinkingLevel ?? null;
+  }
+
+  private buildRuntimeEnv(runtimeEnvText: string): NodeJS.ProcessEnv {
+    return {
+      ...process.env,
+      ...parseEnvironmentVariables(runtimeEnvText),
+    };
+  }
+
+  private getCurrentProviderState(): PiProviderState {
+    return {
+      ...(this.leafEntryId ? { leafEntryId: this.leafEntryId } : {}),
+      ...(this.sessionFile ? { sessionFile: this.sessionFile } : {}),
+      ...(this.sessionId ? { sessionId: this.sessionId } : {}),
+    };
+  }
+
+  private setReady(ready: boolean): void {
+    if (this.ready === ready) {
+      return;
+    }
+
+    this.ready = ready;
+    for (const listener of this.readyListeners) {
+      listener(ready);
+    }
+  }
+
+  private formatRuntimeError(error: unknown): string {
+    const message = error instanceof Error ? error.message : 'Pi request failed';
+    const stderr = this.process?.getStderrSnapshot();
+    return stderr ? `${message}\n\n${stderr}` : message;
+  }
+}
+
+function stripCompactCommand(text: string): string {
+  return text.trim().replace(/^\/compact(?:\s|$)/i, '').trim();
+}
+
+function isCompactCommand(text: string): boolean {
+  return /^\/compact(\s|$)/i.test(text);
+}
+
+function normalizePiRuntimeCommands(response: unknown): SlashCommand[] {
+  const records = Array.isArray(response)
+    ? response
+    : Array.isArray(getRecord(response).commands)
+    ? getRecord(response).commands as unknown[]
+    : [];
+  const commands: SlashCommand[] = [];
+  const seen = new Set<string>();
+
+  for (const record of records) {
+    const entry = getRecord(record);
+    const name = getString(entry.name)?.replace(/^\/+/, '');
+    if (!name || seen.has(name.toLowerCase())) {
+      continue;
+    }
+
+    seen.add(name.toLowerCase());
+    const source = getString(entry.source);
+    commands.push({
+      content: '',
+      description: getString(entry.description) ?? undefined,
+      id: `pi:${source ?? 'runtime'}:${name}`,
+      kind: source === 'skill' ? 'skill' : 'command',
+      name,
+      source: 'sdk',
+    });
+  }
+
+  return commands;
+}
+
+function extractStateRecord(response: unknown): Record<string, unknown> {
+  const record = getRecord(response);
+  return getRecord(record.state ?? record.session ?? response);
+}
+
+function getRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function getString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}

--- a/src/providers/pi/runtime/PiCliResolver.ts
+++ b/src/providers/pi/runtime/PiCliResolver.ts
@@ -1,8 +1,6 @@
-import * as fs from 'node:fs';
-
 import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
-import { getHostnameKey } from '../../../utils/env';
-import { expandHomePath } from '../../../utils/path';
+import { findCliBinaryPath, resolveConfiguredCliPath } from '../../../utils/cliBinaryLocator';
+import { getHostnameKey, parseEnvironmentVariables } from '../../../utils/env';
 import { getPiProviderSettings } from '../settings';
 
 export class PiCliResolver {
@@ -30,13 +28,20 @@ export class PiCliResolver {
     this.lastCliPath = cliPath;
     this.lastHostnamePath = hostnamePath;
     this.lastEnvText = envText;
-    this.resolvedPath = this.resolve(piSettings.cliPathsByHost, cliPath);
+    this.resolvedPath = this.resolve(piSettings.cliPathsByHost, cliPath, envText);
     return this.resolvedPath;
   }
 
-  resolve(hostnamePaths: Record<string, string> | undefined, legacyPath: string): string | null {
+  resolve(
+    hostnamePaths: Record<string, string> | undefined,
+    legacyPath: string,
+    envText = '',
+  ): string | null {
     const hostnamePath = (hostnamePaths?.[this.cachedHostname] ?? '').trim();
-    return resolveConfiguredCliPath(hostnamePath) ?? resolveConfiguredCliPath(legacyPath.trim());
+    const customEnv = parseEnvironmentVariables(envText || '');
+    return resolveConfiguredCliPath(hostnamePath)
+      ?? resolveConfiguredCliPath(legacyPath.trim())
+      ?? findCliBinaryPath('pi', customEnv.PATH);
   }
 
   reset(): void {
@@ -45,21 +50,4 @@ export class PiCliResolver {
     this.lastEnvText = '';
     this.resolvedPath = null;
   }
-}
-
-function resolveConfiguredCliPath(cliPath: string): string | null {
-  if (!cliPath) {
-    return null;
-  }
-
-  try {
-    const expanded = expandHomePath(cliPath);
-    if (fs.existsSync(expanded) && fs.statSync(expanded).isFile()) {
-      return expanded;
-    }
-  } catch {
-    return null;
-  }
-
-  return null;
 }

--- a/src/providers/pi/runtime/PiCliResolver.ts
+++ b/src/providers/pi/runtime/PiCliResolver.ts
@@ -1,0 +1,65 @@
+import * as fs from 'node:fs';
+
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import { getHostnameKey } from '../../../utils/env';
+import { expandHomePath } from '../../../utils/path';
+import { getPiProviderSettings } from '../settings';
+
+export class PiCliResolver {
+  private readonly cachedHostname = getHostnameKey();
+  private lastCliPath = '';
+  private lastEnvText = '';
+  private lastHostnamePath = '';
+  private resolvedPath: string | null = null;
+
+  resolveFromSettings(settings: Record<string, unknown>): string | null {
+    const piSettings = getPiProviderSettings(settings);
+    const cliPath = piSettings.cliPath.trim();
+    const hostnamePath = (piSettings.cliPathsByHost[this.cachedHostname] ?? '').trim();
+    const envText = getRuntimeEnvironmentText(settings, 'pi');
+
+    if (
+      this.resolvedPath !== null
+      && cliPath === this.lastCliPath
+      && hostnamePath === this.lastHostnamePath
+      && envText === this.lastEnvText
+    ) {
+      return this.resolvedPath;
+    }
+
+    this.lastCliPath = cliPath;
+    this.lastHostnamePath = hostnamePath;
+    this.lastEnvText = envText;
+    this.resolvedPath = this.resolve(piSettings.cliPathsByHost, cliPath);
+    return this.resolvedPath;
+  }
+
+  resolve(hostnamePaths: Record<string, string> | undefined, legacyPath: string): string | null {
+    const hostnamePath = (hostnamePaths?.[this.cachedHostname] ?? '').trim();
+    return resolveConfiguredCliPath(hostnamePath) ?? resolveConfiguredCliPath(legacyPath.trim());
+  }
+
+  reset(): void {
+    this.lastCliPath = '';
+    this.lastHostnamePath = '';
+    this.lastEnvText = '';
+    this.resolvedPath = null;
+  }
+}
+
+function resolveConfiguredCliPath(cliPath: string): string | null {
+  if (!cliPath) {
+    return null;
+  }
+
+  try {
+    const expanded = expandHomePath(cliPath);
+    if (fs.existsSync(expanded) && fs.statSync(expanded).isFile()) {
+      return expanded;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}

--- a/src/providers/pi/runtime/PiExtensionUiBridge.ts
+++ b/src/providers/pi/runtime/PiExtensionUiBridge.ts
@@ -1,0 +1,161 @@
+import type { StreamChunk } from '../../../core/types';
+import type { PiRpcRecord, PiRpcTransport } from './PiRpcTransport';
+
+export interface PiExtensionUiSelectRequest extends PiRpcRecord {
+  id: string;
+}
+
+export interface PiExtensionUiConfirmRequest extends PiRpcRecord {
+  id: string;
+}
+
+export interface PiExtensionUiInputRequest extends PiRpcRecord {
+  id: string;
+}
+
+export interface PiExtensionUiEditorRequest extends PiRpcRecord {
+  id: string;
+}
+
+export type PiExtensionUiNotifyRequest = PiRpcRecord;
+export type PiExtensionUiSetEditorTextRequest = PiRpcRecord;
+export type PiExtensionUiSetStatusRequest = PiRpcRecord;
+export type PiExtensionUiSetTitleRequest = PiRpcRecord;
+export type PiExtensionUiSetWidgetRequest = PiRpcRecord;
+
+export interface PiExtensionUiRenderer {
+  confirm(request: PiExtensionUiConfirmRequest, signal: AbortSignal): Promise<{ cancelled?: boolean; confirmed?: boolean }>;
+  editor(request: PiExtensionUiEditorRequest, signal: AbortSignal): Promise<{ cancelled?: boolean; value?: string }>;
+  input(request: PiExtensionUiInputRequest, signal: AbortSignal): Promise<{ cancelled?: boolean; value?: string }>;
+  notify(request: PiExtensionUiNotifyRequest): void;
+  select(request: PiExtensionUiSelectRequest, signal: AbortSignal): Promise<{ cancelled?: boolean; value?: string }>;
+  setEditorText(request: PiExtensionUiSetEditorTextRequest): void;
+  setStatus(request: PiExtensionUiSetStatusRequest): void;
+  setTitle(request: PiExtensionUiSetTitleRequest): void;
+  setWidget(request: PiExtensionUiSetWidgetRequest): void;
+}
+
+export class PiExtensionUiBridge {
+  private readonly pending = new Map<string, AbortController>();
+
+  constructor(
+    private readonly transport: PiRpcTransport,
+    private readonly renderer: PiExtensionUiRenderer | null,
+    private readonly emit?: (chunk: StreamChunk) => void,
+  ) {}
+
+  handleRequest(request: PiRpcRecord): boolean {
+    if (request.type !== 'extension_ui_request') {
+      return false;
+    }
+
+    const method = getString(request.method) ?? getString(request.action) ?? getString(request.uiType);
+    switch (method) {
+      case 'select':
+        this.handleDialog(request, (renderer, signal) =>
+          renderer.select(requireDialogRequest(request), signal));
+        return true;
+      case 'confirm':
+        this.handleDialog(request, (renderer, signal) =>
+          renderer.confirm(requireDialogRequest(request), signal));
+        return true;
+      case 'input':
+        this.handleDialog(request, (renderer, signal) =>
+          renderer.input(requireDialogRequest(request), signal));
+        return true;
+      case 'editor':
+        this.handleDialog(request, (renderer, signal) =>
+          renderer.editor(requireDialogRequest(request), signal));
+        return true;
+      case 'notify':
+        this.renderer?.notify(request);
+        this.emit?.({
+          type: 'notice',
+          content: getString(request.message) ?? getString(request.title) ?? 'Pi extension notification.',
+          level: 'info',
+        });
+        return true;
+      case 'setStatus':
+      case 'set_status':
+        this.renderer?.setStatus(request);
+        return true;
+      case 'setWidget':
+      case 'set_widget':
+        this.renderer?.setWidget(request);
+        return true;
+      case 'setTitle':
+      case 'set_title':
+        this.renderer?.setTitle(request);
+        return true;
+      case 'setEditorText':
+      case 'set_editor_text':
+        this.renderer?.setEditorText(request);
+        return true;
+      default:
+        this.sendCancellation(request);
+        return true;
+    }
+  }
+
+  cleanup(): void {
+    for (const [id, controller] of this.pending) {
+      controller.abort();
+      this.sendResponse(id, { cancelled: true });
+    }
+    this.pending.clear();
+  }
+
+  private handleDialog(
+    request: PiRpcRecord,
+    render: (
+      renderer: PiExtensionUiRenderer,
+      signal: AbortSignal,
+    ) => Promise<Record<string, unknown>>,
+  ): void {
+    const id = getString(request.id);
+    if (!id || !this.renderer) {
+      this.sendCancellation(request);
+      return;
+    }
+
+    const controller = new AbortController();
+    this.pending.set(id, controller);
+    render(this.renderer, controller.signal)
+      .then((response) => {
+        if (!controller.signal.aborted) {
+          this.sendResponse(id, response.cancelled ? { cancelled: true } : response);
+        }
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) {
+          this.sendResponse(id, { cancelled: true });
+        }
+      })
+      .finally(() => {
+        this.pending.delete(id);
+      });
+  }
+
+  private sendCancellation(request: PiRpcRecord): void {
+    const id = getString(request.id);
+    if (id) {
+      this.sendResponse(id, { cancelled: true });
+    }
+  }
+
+  private sendResponse(id: string, response: Record<string, unknown>): void {
+    this.transport.send({
+      id,
+      type: 'extension_ui_response',
+      ...response,
+    });
+  }
+}
+
+function requireDialogRequest<T extends PiRpcRecord & { id: string }>(request: PiRpcRecord): T {
+  return request as T;
+}
+
+function getString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}

--- a/src/providers/pi/runtime/PiJsonl.ts
+++ b/src/providers/pi/runtime/PiJsonl.ts
@@ -1,0 +1,67 @@
+import type { Writable } from 'node:stream';
+
+export type PiJsonlLineHandler = (line: string) => void;
+
+interface JsonlReadableStream {
+  off(eventName: string, listener: (...args: any[]) => void): unknown;
+  on(eventName: string, listener: (...args: any[]) => void): unknown;
+}
+
+export function subscribePiJsonlLines(
+  input: JsonlReadableStream,
+  onLine: PiJsonlLineHandler,
+  onEnd?: () => void,
+  onError?: (error: Error) => void,
+): () => void {
+  let buffer = '';
+
+  const handleData = (chunk: Buffer | string): void => {
+    buffer += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+
+    while (true) {
+      const newlineIndex = buffer.indexOf('\n');
+      if (newlineIndex < 0) {
+        break;
+      }
+
+      const line = stripTrailingCarriageReturn(buffer.slice(0, newlineIndex));
+      buffer = buffer.slice(newlineIndex + 1);
+      onLine(line);
+    }
+  };
+
+  const handleEnd = (): void => {
+    if (buffer.length > 0) {
+      onLine(stripTrailingCarriageReturn(buffer));
+      buffer = '';
+    }
+    onEnd?.();
+  };
+
+  const handleError = (error: unknown): void => {
+    onError?.(error instanceof Error ? error : new Error(String(error)));
+  };
+
+  input.on('data', handleData);
+  input.on('end', handleEnd);
+  input.on('close', handleEnd);
+  input.on('error', handleError);
+
+  return () => {
+    input.off('data', handleData);
+    input.off('end', handleEnd);
+    input.off('close', handleEnd);
+    input.off('error', handleError);
+  };
+}
+
+export function writePiJsonl(
+  output: Writable | NodeJS.WritableStream,
+  record: unknown,
+): void {
+  output.write(`${JSON.stringify(record)}\n`);
+}
+
+function stripTrailingCarriageReturn(value: string): string {
+  return value.endsWith('\r') ? value.slice(0, -1) : value;
+}

--- a/src/providers/pi/runtime/PiLaunchSpec.ts
+++ b/src/providers/pi/runtime/PiLaunchSpec.ts
@@ -1,0 +1,70 @@
+import { decodePiModelId, normalizePiThinkingLevel } from '../models';
+import type { PiProviderSettings } from '../settings';
+import type { PiProviderState } from '../types';
+
+export interface BuildPiLaunchSpecParams {
+  command: string;
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+  envText?: string;
+  model?: string | null;
+  noSession?: boolean;
+  noTools?: boolean;
+  providerState?: PiProviderState | null;
+  settings: PiProviderSettings;
+  systemPrompt?: string;
+  thinkingLevel?: string | null;
+}
+
+export interface PiLaunchSpec {
+  args: string[];
+  command: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  launchKey: string;
+}
+
+const READONLY_TOOLS = 'read,grep,find,ls';
+
+export function buildPiLaunchSpec(params: BuildPiLaunchSpecParams): PiLaunchSpec {
+  const args = ['--mode', 'rpc'];
+  const systemPrompt = params.systemPrompt?.trim();
+  if (systemPrompt) {
+    args.push('--system-prompt', systemPrompt);
+  }
+
+  if (params.noSession) {
+    args.push('--no-session');
+  } else if (params.providerState?.sessionFile || params.providerState?.sessionId) {
+    args.push('--session', params.providerState.sessionFile ?? params.providerState.sessionId!);
+  }
+
+  if (params.noTools) {
+    args.push('--no-tools');
+  } else if (params.settings.toolMode === 'readonly') {
+    args.push('--tools', READONLY_TOOLS);
+  }
+
+  const decodedModel = typeof params.model === 'string' ? decodePiModelId(params.model) : null;
+  if (decodedModel) {
+    args.push('--provider', decodedModel.provider, '--model', decodedModel.modelId);
+  }
+
+  const thinkingLevel = normalizePiThinkingLevel(params.thinkingLevel);
+  if (thinkingLevel && thinkingLevel !== 'off') {
+    args.push('--thinking', thinkingLevel);
+  }
+
+  return {
+    args,
+    command: params.command,
+    cwd: params.cwd,
+    env: params.env ?? process.env,
+    launchKey: JSON.stringify({
+      args,
+      command: params.command,
+      cwd: params.cwd,
+      envText: params.envText ?? params.settings.environmentVariables,
+    }),
+  };
+}

--- a/src/providers/pi/runtime/PiModelDiscoveryService.ts
+++ b/src/providers/pi/runtime/PiModelDiscoveryService.ts
@@ -1,0 +1,92 @@
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import type ClaudianPlugin from '../../../main';
+import { parseEnvironmentVariables } from '../../../utils/env';
+import { getVaultPath } from '../../../utils/path';
+import {
+  normalizePiDiscoveredModels,
+  type PiDiscoveredModel,
+} from '../models';
+import { getPiProviderSettings } from '../settings';
+import { buildPiLaunchSpec } from './PiLaunchSpec';
+import { PiRpcTransport } from './PiRpcTransport';
+import { PiSubprocess } from './PiSubprocess';
+
+export interface PiModelDiscoveryResult {
+  diagnostics?: string;
+  models: PiDiscoveredModel[];
+}
+
+export class PiModelDiscoveryService {
+  constructor(private readonly plugin: ClaudianPlugin) {}
+
+  async discoverModels(): Promise<PiModelDiscoveryResult> {
+    const settings = getPiProviderSettings(this.plugin.settings as unknown as Record<string, unknown>);
+    const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
+    const command = this.plugin.getResolvedProviderCliPath('pi') ?? 'pi';
+    const envText = getRuntimeEnvironmentText(this.plugin.settings as unknown as Record<string, unknown>, 'pi');
+    const env = {
+      ...process.env,
+      ...parseEnvironmentVariables(envText),
+    };
+    const launchSpec = buildPiLaunchSpec({
+      command,
+      cwd,
+      env,
+      envText,
+      noSession: true,
+      settings,
+    });
+    const subprocess = new PiSubprocess(launchSpec);
+    let transport: PiRpcTransport | null = null;
+    let removeEventListener: (() => void) | null = null;
+
+    try {
+      subprocess.start();
+      transport = new PiRpcTransport({
+        input: subprocess.stdout,
+        onClose: (listener) => subprocess.onClose(listener),
+        output: subprocess.stdin,
+      });
+      transport.start();
+      removeEventListener = transport.onEvent((event) => {
+        if (event.type !== 'extension_ui_request') {
+          return;
+        }
+
+        const id = typeof event.id === 'string' && event.id.trim() ? event.id.trim() : '';
+        if (id) {
+          transport?.send({
+            cancelled: true,
+            id,
+            type: 'extension_ui_response',
+          });
+        }
+      });
+      const response = await transport.request('get_available_models', {}, 20_000);
+      const models = normalizePiDiscoveredModels(extractModels(response));
+      return { models };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Pi model discovery failed';
+      const stderr = subprocess.getStderrSnapshot();
+      return {
+        diagnostics: stderr ? `${message}\n\n${stderr}` : message,
+        models: [],
+      };
+    } finally {
+      removeEventListener?.();
+      transport?.dispose();
+      await subprocess.shutdown().catch(() => {});
+    }
+  }
+}
+
+function extractModels(response: unknown): unknown {
+  if (Array.isArray(response)) {
+    return response;
+  }
+  if (response && typeof response === 'object' && !Array.isArray(response)) {
+    const record = response as Record<string, unknown>;
+    return record.models ?? record.availableModels ?? record.available_models ?? [];
+  }
+  return [];
+}

--- a/src/providers/pi/runtime/PiRpcPayloads.ts
+++ b/src/providers/pi/runtime/PiRpcPayloads.ts
@@ -1,0 +1,18 @@
+import { decodePiModelId } from '../models';
+
+export interface PiSetModelPayload extends Record<string, unknown> {
+  modelId: string;
+  provider: string;
+}
+
+export function buildPiSetModelPayload(model: string): PiSetModelPayload | null {
+  const decoded = decodePiModelId(model);
+  if (!decoded) {
+    return null;
+  }
+
+  return {
+    modelId: decoded.modelId,
+    provider: decoded.provider,
+  };
+}

--- a/src/providers/pi/runtime/PiRpcTransport.ts
+++ b/src/providers/pi/runtime/PiRpcTransport.ts
@@ -1,0 +1,243 @@
+import type { Readable, Writable } from 'node:stream';
+
+import { subscribePiJsonlLines, writePiJsonl } from './PiJsonl';
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export type PiRpcRecord = Record<string, unknown>;
+export type PiRpcEventHandler = (event: PiRpcRecord) => void;
+
+export interface PiRpcStreams {
+  input: Readable | NodeJS.ReadableStream;
+  onClose?: (listener: (error?: Error) => void) => () => void;
+  output: Writable | NodeJS.WritableStream;
+}
+
+interface PendingRequest {
+  cleanup: () => void;
+  reject: (error: Error) => void;
+  resolve: (response: unknown) => void;
+  type: string;
+}
+
+export class PiRpcTransportClosedError extends Error {
+  constructor(message = 'Pi RPC transport closed') {
+    super(message);
+    this.name = 'PiRpcTransportClosedError';
+  }
+}
+
+export class PiRpcResponseError extends Error {
+  constructor(
+    readonly commandType: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'PiRpcResponseError';
+  }
+}
+
+export class PiRpcTransport {
+  private readonly closeListeners = new Set<(error?: Error) => void>();
+  private disposed = false;
+  private readonly eventHandlers = new Set<PiRpcEventHandler>();
+  private nextId = 1;
+  private readonly pending = new Map<string, PendingRequest>();
+  private unregisterClose?: () => void;
+  private unsubscribeLines?: () => void;
+
+  constructor(
+    private readonly streams: PiRpcStreams,
+    private readonly defaultTimeoutMs = DEFAULT_TIMEOUT_MS,
+  ) {}
+
+  get isClosed(): boolean {
+    return this.disposed;
+  }
+
+  start(): void {
+    if (this.unsubscribeLines || this.disposed) {
+      return;
+    }
+
+    this.unsubscribeLines = subscribePiJsonlLines(
+      this.streams.input,
+      (line) => this.handleLine(line),
+      () => {
+        if (!this.disposed) {
+          this.dispose(new PiRpcTransportClosedError('Pi RPC input closed'));
+        }
+      },
+      (error) => {
+        if (!this.disposed) {
+          this.dispose(error);
+        }
+      },
+    );
+
+    this.unregisterClose = this.streams.onClose?.((error) => {
+      if (!this.disposed) {
+        this.dispose(error ?? new PiRpcTransportClosedError());
+      }
+    });
+  }
+
+  onEvent(handler: PiRpcEventHandler): () => void {
+    this.eventHandlers.add(handler);
+    return () => {
+      this.eventHandlers.delete(handler);
+    };
+  }
+
+  onClose(listener: (error?: Error) => void): () => void {
+    this.closeListeners.add(listener);
+    return () => {
+      this.closeListeners.delete(listener);
+    };
+  }
+
+  request<T = unknown>(
+    commandType: string,
+    payload: Record<string, unknown> = {},
+    timeoutMs = this.defaultTimeoutMs,
+  ): Promise<T> {
+    this.start();
+    if (this.disposed) {
+      return Promise.reject(new PiRpcTransportClosedError());
+    }
+
+    const id = `req_${this.nextId++}`;
+    return new Promise<T>((resolve, reject) => {
+      let timer: number | undefined;
+      const cleanup = (): void => {
+        if (timer !== undefined) {
+          window.clearTimeout(timer);
+        }
+      };
+
+      if (timeoutMs > 0) {
+        timer = window.setTimeout(() => {
+          this.pending.delete(id);
+          cleanup();
+          reject(new Error(`Request timeout: ${commandType} (${timeoutMs}ms)`));
+        }, timeoutMs);
+      }
+
+      this.pending.set(id, {
+        cleanup,
+        reject,
+        resolve: (response: unknown) => resolve(response as T),
+        type: commandType,
+      });
+
+      try {
+        this.sendRaw({ id, type: commandType, ...payload });
+      } catch (error) {
+        this.pending.delete(id);
+        cleanup();
+        const transportError = error instanceof Error ? error : new Error(String(error));
+        this.dispose(transportError);
+        reject(transportError);
+      }
+    });
+  }
+
+  send(record: PiRpcRecord): void {
+    this.start();
+    if (this.disposed) {
+      return;
+    }
+    this.sendRaw(record);
+  }
+
+  dispose(error: Error = new PiRpcTransportClosedError('Pi RPC transport disposed')): void {
+    if (this.disposed) {
+      return;
+    }
+
+    this.disposed = true;
+    this.unsubscribeLines?.();
+    this.unsubscribeLines = undefined;
+    this.unregisterClose?.();
+    this.unregisterClose = undefined;
+    this.rejectAllPending(error);
+    for (const listener of this.closeListeners) {
+      try {
+        listener(error);
+      } catch {
+        // Best-effort close notification.
+      }
+    }
+    this.closeListeners.clear();
+    this.eventHandlers.clear();
+  }
+
+  private sendRaw(record: PiRpcRecord): void {
+    writePiJsonl(this.streams.output, record);
+  }
+
+  private handleLine(line: string): void {
+    if (!line.trim()) {
+      return;
+    }
+
+    let record: PiRpcRecord;
+    try {
+      const parsed = JSON.parse(line) as unknown;
+      if (!isPlainObject(parsed)) {
+        return;
+      }
+      record = parsed;
+    } catch {
+      return;
+    }
+
+    if (record.type === 'response' && typeof record.id === 'string') {
+      this.handleResponse(record.id, record);
+      return;
+    }
+
+    for (const handler of this.eventHandlers) {
+      handler(record);
+    }
+  }
+
+  private handleResponse(id: string, record: PiRpcRecord): void {
+    const pending = this.pending.get(id);
+    if (!pending) {
+      return;
+    }
+
+    this.pending.delete(id);
+    pending.cleanup();
+    if (record.success === false) {
+      const errorText = typeof record.error === 'string'
+        ? record.error
+        : `Pi RPC command failed: ${pending.type}`;
+      pending.reject(new PiRpcResponseError(pending.type, errorText));
+      return;
+    }
+
+    if ('result' in record) {
+      pending.resolve(record.result);
+      return;
+    }
+    if ('data' in record) {
+      pending.resolve(record.data);
+      return;
+    }
+    pending.resolve(record);
+  }
+
+  private rejectAllPending(error: Error): void {
+    for (const pending of this.pending.values()) {
+      pending.cleanup();
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+}
+
+function isPlainObject(value: unknown): value is PiRpcRecord {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/providers/pi/runtime/PiSubprocess.ts
+++ b/src/providers/pi/runtime/PiSubprocess.ts
@@ -1,0 +1,146 @@
+import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
+import * as path from 'node:path';
+import type { Readable, Writable } from 'node:stream';
+
+import { getEnhancedPath } from '../../../utils/env';
+
+const SIGKILL_TIMEOUT_MS = 3_000;
+const STDERR_BUFFER_LIMIT = 8_000;
+
+export interface PiSubprocessLaunchSpec {
+  args: string[];
+  command: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+}
+
+type CloseListener = (error?: Error) => void;
+
+export class PiSubprocess {
+  private closeError: Error | null = null;
+  private readonly closeListeners = new Set<CloseListener>();
+  private notifiedClose = false;
+  private proc: ChildProcessWithoutNullStreams | null = null;
+  private stderrBuffer = '';
+
+  constructor(private readonly launchSpec: PiSubprocessLaunchSpec) {}
+
+  get stdin(): Writable {
+    return this.requireProc().stdin;
+  }
+
+  get stdout(): Readable {
+    return this.requireProc().stdout;
+  }
+
+  private requireProc(): ChildProcessWithoutNullStreams {
+    if (!this.proc) {
+      throw new Error('Pi subprocess is not started');
+    }
+    return this.proc;
+  }
+
+  start(): void {
+    if (this.proc) {
+      return;
+    }
+
+    const proc = spawn(this.launchSpec.command, this.launchSpec.args, {
+      cwd: this.launchSpec.cwd,
+      env: {
+        ...this.launchSpec.env,
+        PATH: getEnhancedPath(
+          this.launchSpec.env.PATH,
+          path.isAbsolute(this.launchSpec.command) ? this.launchSpec.command : undefined,
+        ),
+      },
+      stdio: 'pipe',
+      windowsHide: true,
+    });
+
+    proc.stderr.on('data', (chunk: Buffer | string) => {
+      const text = typeof chunk === 'string' ? chunk : chunk.toString('utf-8');
+      this.stderrBuffer = `${this.stderrBuffer}${text}`.slice(-STDERR_BUFFER_LIMIT);
+    });
+
+    proc.on('error', (error) => {
+      this.closeError = error;
+      this.notifyClose(error);
+    });
+
+    proc.on('exit', (code, signal) => {
+      const exitError = this.closeError ?? (
+        code === 0 && signal === null
+          ? undefined
+          : new Error(`Pi subprocess exited (${formatExit(code, signal)})`)
+      );
+      this.notifyClose(exitError);
+    });
+
+    this.proc = proc;
+  }
+
+  isAlive(): boolean {
+    return this.proc !== null && this.proc.exitCode === null && !this.proc.killed;
+  }
+
+  getStderrSnapshot(): string {
+    return this.stderrBuffer.trim();
+  }
+
+  onClose(listener: CloseListener): () => void {
+    this.closeListeners.add(listener);
+    return () => {
+      this.closeListeners.delete(listener);
+    };
+  }
+
+  async shutdown(): Promise<void> {
+    if (!this.proc || this.proc.exitCode !== null) {
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      const proc = this.proc!;
+      const onClose = () => {
+        cleanup();
+        resolve();
+      };
+      const killTimer = window.setTimeout(() => {
+        proc.kill('SIGKILL');
+      }, SIGKILL_TIMEOUT_MS);
+      const cleanup = () => {
+        window.clearTimeout(killTimer);
+        proc.off('exit', onClose);
+      };
+
+      proc.once('exit', onClose);
+      proc.kill('SIGTERM');
+    });
+  }
+
+  private notifyClose(error?: Error): void {
+    if (this.notifiedClose) {
+      return;
+    }
+
+    this.notifiedClose = true;
+    for (const listener of this.closeListeners) {
+      try {
+        listener(error);
+      } catch {
+        // Best-effort cleanup notification.
+      }
+    }
+  }
+}
+
+function formatExit(code: number | null, signal: string | null): string {
+  if (signal) {
+    return `signal ${signal}`;
+  }
+  if (code === null) {
+    return 'unknown';
+  }
+  return `code ${code}`;
+}

--- a/src/providers/pi/runtime/PiSubprocess.ts
+++ b/src/providers/pi/runtime/PiSubprocess.ts
@@ -3,7 +3,11 @@ import * as path from 'node:path';
 import type { Readable, Writable } from 'node:stream';
 
 import { getEnhancedPath } from '../../../utils/env';
-import { resolveWindowsCmdShimSpawnSpec } from '../../../utils/windowsCmdShim';
+import {
+  resolveWindowsCmdShimSpawnSpec,
+  terminateSpawnedProcess,
+  type WindowsCmdShimSpawnSpec,
+} from '../../../utils/windowsCmdShim';
 
 const SIGKILL_TIMEOUT_MS = 3_000;
 const STDERR_BUFFER_LIMIT = 8_000;
@@ -22,6 +26,7 @@ export class PiSubprocess {
   private readonly closeListeners = new Set<CloseListener>();
   private notifiedClose = false;
   private proc: ChildProcessWithoutNullStreams | null = null;
+  private resolvedSpawnSpec: WindowsCmdShimSpawnSpec | null = null;
   private stderrBuffer = '';
 
   constructor(private readonly launchSpec: PiSubprocessLaunchSpec) {}
@@ -47,6 +52,7 @@ export class PiSubprocess {
     }
 
     const resolvedSpawnSpec = resolveWindowsCmdShimSpawnSpec(this.launchSpec);
+    this.resolvedSpawnSpec = resolvedSpawnSpec;
     const proc = spawn(resolvedSpawnSpec.command, resolvedSpawnSpec.args, {
       cwd: this.launchSpec.cwd,
       env: {
@@ -110,7 +116,7 @@ export class PiSubprocess {
         resolve();
       };
       const killTimer = window.setTimeout(() => {
-        proc.kill('SIGKILL');
+        this.killProc(proc, 'SIGKILL');
       }, SIGKILL_TIMEOUT_MS);
       const cleanup = () => {
         window.clearTimeout(killTimer);
@@ -118,8 +124,12 @@ export class PiSubprocess {
       };
 
       proc.once('exit', onClose);
-      proc.kill('SIGTERM');
+      this.killProc(proc, 'SIGTERM');
     });
+  }
+
+  private killProc(proc: ChildProcessWithoutNullStreams, signal: NodeJS.Signals): boolean {
+    return terminateSpawnedProcess(proc, signal, spawn, this.resolvedSpawnSpec);
   }
 
   private notifyClose(error?: Error): void {

--- a/src/providers/pi/runtime/PiSubprocess.ts
+++ b/src/providers/pi/runtime/PiSubprocess.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import type { Readable, Writable } from 'node:stream';
 
 import { getEnhancedPath } from '../../../utils/env';
+import { resolveWindowsCmdShimSpawnSpec } from '../../../utils/windowsCmdShim';
 
 const SIGKILL_TIMEOUT_MS = 3_000;
 const STDERR_BUFFER_LIMIT = 8_000;
@@ -45,7 +46,8 @@ export class PiSubprocess {
       return;
     }
 
-    const proc = spawn(this.launchSpec.command, this.launchSpec.args, {
+    const resolvedSpawnSpec = resolveWindowsCmdShimSpawnSpec(this.launchSpec);
+    const proc = spawn(resolvedSpawnSpec.command, resolvedSpawnSpec.args, {
       cwd: this.launchSpec.cwd,
       env: {
         ...this.launchSpec.env,
@@ -56,6 +58,7 @@ export class PiSubprocess {
       },
       stdio: 'pipe',
       windowsHide: true,
+      ...(resolvedSpawnSpec.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
     });
 
     proc.stderr.on('data', (chunk: Buffer | string) => {

--- a/src/providers/pi/runtime/buildPiPrompt.ts
+++ b/src/providers/pi/runtime/buildPiPrompt.ts
@@ -1,0 +1,62 @@
+import type { ChatTurnRequest } from '../../../core/runtime/types';
+import type { ChatMessage, ImageAttachment } from '../../../core/types';
+import { appendBrowserContext } from '../../../utils/browser';
+import { appendCanvasContext } from '../../../utils/canvas';
+import { appendCurrentNote } from '../../../utils/context';
+import { appendEditorContext } from '../../../utils/editor';
+import { buildContextFromHistory, buildPromptWithHistoryContext } from '../../../utils/session';
+
+export interface PiPromptImage {
+  data: string;
+  mimeType: string;
+  type: 'image';
+}
+
+export function buildPiPromptText(
+  request: ChatTurnRequest,
+  conversationHistory: ChatMessage[] = [],
+): string {
+  let prompt = request.text;
+
+  if (request.currentNotePath) {
+    prompt = appendCurrentNote(prompt, request.currentNotePath);
+  }
+
+  if (request.editorSelection && request.editorSelection.mode !== 'none') {
+    prompt = appendEditorContext(prompt, request.editorSelection);
+  }
+
+  if (request.browserSelection) {
+    prompt = appendBrowserContext(prompt, request.browserSelection);
+  }
+
+  if (request.canvasSelection) {
+    prompt = appendCanvasContext(prompt, request.canvasSelection);
+  }
+
+  if (conversationHistory.length > 0) {
+    const historyContext = buildContextFromHistory(conversationHistory);
+    prompt = buildPromptWithHistoryContext(
+      historyContext,
+      prompt,
+      prompt,
+      conversationHistory,
+    );
+  }
+
+  return prompt;
+}
+
+export function buildPiPromptImages(images: ImageAttachment[] | undefined): PiPromptImage[] {
+  return (images ?? []).flatMap((image) => {
+    if (!image.data) {
+      return [];
+    }
+
+    return [{
+      data: image.data,
+      mimeType: image.mediaType,
+      type: 'image' as const,
+    }];
+  });
+}

--- a/src/providers/pi/runtime/buildPiUsageInfo.ts
+++ b/src/providers/pi/runtime/buildPiUsageInfo.ts
@@ -1,0 +1,65 @@
+import type { UsageInfo } from '../../../core/types';
+
+export function buildPiUsageInfo(response: unknown, model: string | null): UsageInfo | null {
+  const stats = getRecord(response);
+  const contextUsage = getRecord(stats.contextUsage ?? stats.context_usage ?? stats);
+  const contextWindow = getNumber(contextUsage.contextWindow)
+    ?? getNumber(contextUsage.context_window)
+    ?? getNumber(contextUsage.window)
+    ?? 200_000;
+  const contextTokens = getNumber(contextUsage.contextTokens)
+    ?? getNumber(contextUsage.context_tokens)
+    ?? getNumber(contextUsage.tokens)
+    ?? getNumber(contextUsage.used)
+    ?? 0;
+  const inputTokens = getNumber(contextUsage.inputTokens)
+    ?? getNumber(contextUsage.input_tokens)
+    ?? contextTokens;
+
+  if (contextTokens === 0 && inputTokens === 0) {
+    return null;
+  }
+
+  return {
+    cacheCreationInputTokens: getNumber(contextUsage.cacheCreationInputTokens)
+      ?? getNumber(contextUsage.cache_creation_input_tokens)
+      ?? 0,
+    cacheReadInputTokens: getNumber(contextUsage.cacheReadInputTokens)
+      ?? getNumber(contextUsage.cache_read_input_tokens)
+      ?? 0,
+    contextTokens,
+    contextWindow,
+    contextWindowIsAuthoritative: true,
+    inputTokens,
+    ...(model ? { model } : {}),
+    percentage: normalizePiUsagePercentage(
+      getNumber(contextUsage.percentage),
+      contextTokens,
+      contextWindow,
+    ),
+  };
+}
+
+function normalizePiUsagePercentage(
+  providerPercentage: number | null,
+  contextTokens: number,
+  contextWindow: number,
+): number {
+  const rawPercentage = providerPercentage
+    ?? (contextWindow > 0 ? (contextTokens / contextWindow) * 100 : 0);
+  const wholePercentage = providerPercentage !== null && rawPercentage >= 0 && rawPercentage <= 1
+    ? rawPercentage * 100
+    : rawPercentage;
+
+  return Math.min(100, Math.max(0, Math.round(wholePercentage)));
+}
+
+function getRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function getNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}

--- a/src/providers/pi/runtime/buildPiUsageInfo.ts
+++ b/src/providers/pi/runtime/buildPiUsageInfo.ts
@@ -1,12 +1,16 @@
 import type { UsageInfo } from '../../../core/types';
 
-export function buildPiUsageInfo(response: unknown, model: string | null): UsageInfo | null {
+export function buildPiUsageInfo(
+  response: unknown,
+  model: string | null,
+  fallbackContextWindow = 200_000,
+): UsageInfo | null {
   const stats = getRecord(response);
   const contextUsage = getRecord(stats.contextUsage ?? stats.context_usage ?? stats);
-  const contextWindow = getNumber(contextUsage.contextWindow)
+  const providerContextWindow = getNumber(contextUsage.contextWindow)
     ?? getNumber(contextUsage.context_window)
-    ?? getNumber(contextUsage.window)
-    ?? 200_000;
+    ?? getNumber(contextUsage.window);
+  const contextWindow = providerContextWindow ?? fallbackContextWindow;
   const contextTokens = getNumber(contextUsage.contextTokens)
     ?? getNumber(contextUsage.context_tokens)
     ?? getNumber(contextUsage.tokens)
@@ -29,7 +33,7 @@ export function buildPiUsageInfo(response: unknown, model: string | null): Usage
       ?? 0,
     contextTokens,
     contextWindow,
-    contextWindowIsAuthoritative: true,
+    contextWindowIsAuthoritative: providerContextWindow !== null,
     inputTokens,
     ...(model ? { model } : {}),
     percentage: normalizePiUsagePercentage(

--- a/src/providers/pi/settings.ts
+++ b/src/providers/pi/settings.ts
@@ -1,0 +1,468 @@
+import { getProviderConfig, setProviderConfig } from '../../core/providers/providerConfig';
+import { getProviderEnvironmentVariables } from '../../core/providers/providerEnvironment';
+import type { HostnameCliPaths } from '../../core/types/settings';
+import {
+  getHostnameKey,
+  getLegacyHostnameKey,
+  migrateLegacyHostnameKeyedMap,
+} from '../../utils/env';
+import { ensureProviderProjectionMap } from './internal/providerProjection';
+import {
+  decodePiModelId,
+  findPiModel,
+  isPiModelSelectionId,
+  normalizePiDiscoveredModels,
+  normalizePiThinkingLevel,
+  PI_DEFAULT_THINKING_LEVEL,
+  type PiDiscoveredModel,
+  type PiThinkingLevel,
+} from './models';
+
+export type PiToolMode = 'all' | 'readonly';
+
+export interface PersistedPiProviderSettings {
+  cliPath: string;
+  cliPathsByHost: HostnameCliPaths;
+  discoveredModels: PiDiscoveredModel[];
+  enabled: boolean;
+  environmentHash: string;
+  environmentVariables: string;
+  modelAliases: Record<string, string>;
+  preferredThinkingByModel: Record<string, PiThinkingLevel>;
+  toolMode: PiToolMode;
+  visibleModels: string[];
+}
+
+export type PiProviderSettings = PersistedPiProviderSettings;
+
+export const DEFAULT_PI_PROVIDER_SETTINGS: Readonly<PersistedPiProviderSettings> = Object.freeze({
+  cliPath: '',
+  cliPathsByHost: {},
+  discoveredModels: [],
+  enabled: false,
+  environmentHash: '',
+  environmentVariables: '',
+  modelAliases: {},
+  preferredThinkingByModel: {},
+  toolMode: 'all',
+  visibleModels: [],
+});
+
+function normalizeHostnameCliPaths(value: unknown): HostnameCliPaths {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  const result: HostnameCliPaths = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry === 'string' && entry.trim()) {
+      result[key] = entry.trim();
+    }
+  }
+  return result;
+}
+
+export function normalizePiVisibleModels(
+  value: unknown,
+  discoveredModels: PiDiscoveredModel[] = [],
+): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const knownIds = new Set(discoveredModels.map(model => model.encodedId));
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (typeof entry !== 'string') {
+      continue;
+    }
+
+    const trimmed = entry.trim();
+    if (!trimmed || !decodePiModelId(trimmed)) {
+      continue;
+    }
+    if (knownIds.size > 0 && !knownIds.has(trimmed)) {
+      continue;
+    }
+    if (seen.has(trimmed)) {
+      continue;
+    }
+
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+
+  return normalized;
+}
+
+export function normalizePiModelAliases(
+  value: unknown,
+  discoveredModels: PiDiscoveredModel[] = [],
+): Record<string, string> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  const normalized: Record<string, string> = {};
+  for (const [encodedId, alias] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof alias !== 'string') {
+      continue;
+    }
+
+    const normalizedEncodedId = normalizePiEncodedId(encodedId, discoveredModels);
+    const normalizedAlias = alias.trim();
+    if (!normalizedEncodedId || !normalizedAlias) {
+      continue;
+    }
+
+    normalized[normalizedEncodedId] = normalizedAlias;
+  }
+
+  return normalized;
+}
+
+export function normalizePiPreferredThinkingByModel(
+  value: unknown,
+  discoveredModels: PiDiscoveredModel[] = [],
+): Record<string, PiThinkingLevel> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  const normalized: Record<string, PiThinkingLevel> = {};
+  for (const [encodedId, thinkingLevel] of Object.entries(value as Record<string, unknown>)) {
+    const normalizedEncodedId = normalizePiEncodedId(encodedId, discoveredModels);
+    const normalizedThinkingLevel = normalizePiThinkingLevel(thinkingLevel);
+    if (!normalizedEncodedId || !normalizedThinkingLevel) {
+      continue;
+    }
+
+    const discoveredModel = discoveredModels.find(model => model.encodedId === normalizedEncodedId);
+    if (discoveredModel && !discoveredModel.thinkingLevels.includes(normalizedThinkingLevel)) {
+      continue;
+    }
+
+    normalized[normalizedEncodedId] = normalizedThinkingLevel;
+  }
+
+  return normalized;
+}
+
+export function getPiProviderSettings(settings: Record<string, unknown>): PiProviderSettings {
+  const config = getProviderConfig(settings, 'pi');
+  const normalizedCliPathsByHost = normalizeHostnameCliPaths(config.cliPathsByHost);
+  const cliPathsByHost = Object.keys(normalizedCliPathsByHost).length > 0
+    ? migrateLegacyHostnameKeyedMap(
+      normalizedCliPathsByHost,
+      getHostnameKey(),
+      getLegacyHostnameKey(),
+    )
+    : normalizedCliPathsByHost;
+  const discoveredModels = normalizePiDiscoveredModels(config.discoveredModels);
+  const visibleModels = normalizePiVisibleModels(config.visibleModels, discoveredModels);
+  const persistableIds = getPersistablePiModelIds(settings, visibleModels);
+
+  return {
+    cliPath: (config.cliPath as string | undefined)
+      ?? DEFAULT_PI_PROVIDER_SETTINGS.cliPath,
+    cliPathsByHost,
+    discoveredModels,
+    enabled: (config.enabled as boolean | undefined)
+      ?? DEFAULT_PI_PROVIDER_SETTINGS.enabled,
+    environmentHash: (config.environmentHash as string | undefined)
+      ?? DEFAULT_PI_PROVIDER_SETTINGS.environmentHash,
+    environmentVariables: (config.environmentVariables as string | undefined)
+      ?? getProviderEnvironmentVariables(settings, 'pi')
+      ?? DEFAULT_PI_PROVIDER_SETTINGS.environmentVariables,
+    modelAliases: normalizePiModelAliasesForPersistableIds(
+      config.modelAliases,
+      discoveredModels,
+      persistableIds,
+    ),
+    preferredThinkingByModel: normalizePiPreferredThinkingForPersistableIds(
+      config.preferredThinkingByModel,
+      discoveredModels,
+      persistableIds,
+    ),
+    toolMode: normalizePiToolMode(config.toolMode),
+    visibleModels,
+  };
+}
+
+export function updatePiProviderSettings(
+  settings: Record<string, unknown>,
+  updates: Partial<PiProviderSettings>,
+): PiProviderSettings {
+  const current = getPiProviderSettings(settings);
+  const hostnameKey = getHostnameKey();
+  const nextDiscoveredModels = normalizePiDiscoveredModels(
+    updates.discoveredModels ?? current.discoveredModels,
+  );
+  const nextVisibleModels = normalizePiVisibleModels(
+    updates.visibleModels ?? current.visibleModels,
+    nextDiscoveredModels,
+  );
+  const persistableIds = getPersistablePiModelIds(settings, nextVisibleModels);
+  const nextModelAliases = pruneMapToPersistableIds(
+    normalizePiModelAliasesForPersistableIds(
+      updates.modelAliases ?? current.modelAliases,
+      nextDiscoveredModels,
+      persistableIds,
+    ),
+    persistableIds,
+  );
+  const nextPreferredThinkingByModel = pruneMapToPersistableIds(
+    normalizePiPreferredThinkingForPersistableIds(
+      updates.preferredThinkingByModel ?? current.preferredThinkingByModel,
+      nextDiscoveredModels,
+      persistableIds,
+    ),
+    persistableIds,
+  );
+  const nextCliPathsByHost = 'cliPathsByHost' in updates
+    ? normalizeHostnameCliPaths(updates.cliPathsByHost)
+    : { ...current.cliPathsByHost };
+  let nextCliPath = 'cliPathsByHost' in updates
+    ? (
+      typeof updates.cliPath === 'string'
+        ? updates.cliPath.trim()
+        : DEFAULT_PI_PROVIDER_SETTINGS.cliPath
+    )
+    : current.cliPath.trim();
+
+  if ('cliPath' in updates && !('cliPathsByHost' in updates)) {
+    const trimmedCliPath = typeof updates.cliPath === 'string' ? updates.cliPath.trim() : '';
+    if (trimmedCliPath) {
+      nextCliPathsByHost[hostnameKey] = trimmedCliPath;
+    } else {
+      delete nextCliPathsByHost[hostnameKey];
+    }
+    nextCliPath = DEFAULT_PI_PROVIDER_SETTINGS.cliPath;
+  }
+
+  const next: PiProviderSettings = {
+    ...current,
+    ...updates,
+    cliPath: nextCliPath,
+    cliPathsByHost: nextCliPathsByHost,
+    discoveredModels: nextDiscoveredModels,
+    modelAliases: nextModelAliases,
+    preferredThinkingByModel: nextPreferredThinkingByModel,
+    toolMode: normalizePiToolMode(updates.toolMode ?? current.toolMode),
+    visibleModels: nextVisibleModels,
+  };
+
+  if (updates.visibleModels !== undefined) {
+    retargetRemovedPiSelections(settings, next);
+    const retargetedPersistableIds = getPersistablePiModelIds(settings, next.visibleModels);
+    next.modelAliases = pruneMapToPersistableIds(next.modelAliases, retargetedPersistableIds);
+    next.preferredThinkingByModel = pruneMapToPersistableIds(
+      next.preferredThinkingByModel,
+      retargetedPersistableIds,
+    );
+  }
+
+  setProviderConfig(settings, 'pi', {
+    cliPath: next.cliPath,
+    cliPathsByHost: next.cliPathsByHost,
+    discoveredModels: next.discoveredModels,
+    enabled: next.enabled,
+    environmentHash: next.environmentHash,
+    environmentVariables: next.environmentVariables,
+    modelAliases: next.modelAliases,
+    preferredThinkingByModel: next.preferredThinkingByModel,
+    toolMode: next.toolMode,
+    visibleModels: next.visibleModels,
+  });
+
+  return next;
+}
+
+function normalizePiModelAliasesForPersistableIds(
+  value: unknown,
+  discoveredModels: PiDiscoveredModel[],
+  persistableIds: Set<string>,
+): Record<string, string> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  const normalized: Record<string, string> = {};
+  for (const [encodedId, alias] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof alias !== 'string') {
+      continue;
+    }
+
+    const normalizedEncodedId = normalizePiPersistableEncodedId(
+      encodedId,
+      discoveredModels,
+      persistableIds,
+    );
+    const normalizedAlias = alias.trim();
+    if (!normalizedEncodedId || !normalizedAlias) {
+      continue;
+    }
+
+    normalized[normalizedEncodedId] = normalizedAlias;
+  }
+
+  return normalized;
+}
+
+function normalizePiPreferredThinkingForPersistableIds(
+  value: unknown,
+  discoveredModels: PiDiscoveredModel[],
+  persistableIds: Set<string>,
+): Record<string, PiThinkingLevel> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  const normalized: Record<string, PiThinkingLevel> = {};
+  for (const [encodedId, thinkingLevel] of Object.entries(value as Record<string, unknown>)) {
+    const normalizedEncodedId = normalizePiPersistableEncodedId(
+      encodedId,
+      discoveredModels,
+      persistableIds,
+    );
+    const normalizedThinkingLevel = normalizePiThinkingLevel(thinkingLevel);
+    if (!normalizedEncodedId || !normalizedThinkingLevel) {
+      continue;
+    }
+
+    const discoveredModel = discoveredModels.find(model => model.encodedId === normalizedEncodedId);
+    if (discoveredModel && !discoveredModel.thinkingLevels.includes(normalizedThinkingLevel)) {
+      continue;
+    }
+
+    normalized[normalizedEncodedId] = normalizedThinkingLevel;
+  }
+
+  return normalized;
+}
+
+export function resolvePiModelAlias(
+  settings: PiProviderSettings,
+  encodedId: string,
+): string | null {
+  return settings.modelAliases[encodedId] ?? null;
+}
+
+function normalizePiToolMode(value: unknown): PiToolMode {
+  return value === 'readonly' ? 'readonly' : 'all';
+}
+
+function normalizePiEncodedId(
+  value: string,
+  discoveredModels: PiDiscoveredModel[],
+): string {
+  const trimmed = value.trim();
+  const decoded = decodePiModelId(trimmed);
+  if (!decoded) {
+    return '';
+  }
+
+  if (discoveredModels.length === 0) {
+    return trimmed;
+  }
+
+  const discoveredModel = findPiModel({ discoveredModels }, trimmed);
+  return discoveredModel ? discoveredModel.encodedId : '';
+}
+
+function normalizePiPersistableEncodedId(
+  value: string,
+  discoveredModels: PiDiscoveredModel[],
+  persistableIds: Set<string>,
+): string {
+  const trimmed = value.trim();
+  const decoded = decodePiModelId(trimmed);
+  if (!decoded) {
+    return '';
+  }
+
+  const discoveredModel = findPiModel({ discoveredModels }, trimmed);
+  if (discoveredModel) {
+    return discoveredModel.encodedId;
+  }
+
+  return persistableIds.has(trimmed) ? trimmed : '';
+}
+
+function getPersistablePiModelIds(
+  settings: Record<string, unknown>,
+  visibleModels: string[],
+): Set<string> {
+  const persistableIds = new Set(visibleModels);
+  addPersistableSelection(persistableIds, settings.model);
+  addPersistableSelection(persistableIds, settings.titleGenerationModel);
+
+  const savedProviderModel = settings.savedProviderModel;
+  if (savedProviderModel && typeof savedProviderModel === 'object' && !Array.isArray(savedProviderModel)) {
+    addPersistableSelection(persistableIds, (savedProviderModel as Record<string, unknown>).pi);
+  }
+
+  return persistableIds;
+}
+
+function addPersistableSelection(target: Set<string>, value: unknown): void {
+  if (typeof value === 'string' && decodePiModelId(value)) {
+    target.add(value);
+  }
+}
+
+function pruneMapToPersistableIds<T extends string>(
+  value: Record<string, T>,
+  persistableIds: Set<string>,
+): Record<string, T> {
+  const pruned: Record<string, T> = {};
+  for (const [encodedId, entry] of Object.entries(value)) {
+    if (persistableIds.has(encodedId)) {
+      pruned[encodedId] = entry;
+    }
+  }
+  return pruned;
+}
+
+function retargetRemovedPiSelections(
+  settings: Record<string, unknown>,
+  next: PiProviderSettings,
+): void {
+  if (next.visibleModels.length === 0) {
+    if (typeof settings.titleGenerationModel === 'string' && isPiModelSelectionId(settings.titleGenerationModel)) {
+      settings.titleGenerationModel = '';
+    }
+    return;
+  }
+
+  const visibleSet = new Set(next.visibleModels);
+  const fallbackModelId = next.visibleModels[0];
+  const fallbackEffort = next.preferredThinkingByModel[fallbackModelId] ?? PI_DEFAULT_THINKING_LEVEL;
+
+  const maybeRetargetModel = (value: unknown): string | null => {
+    if (typeof value !== 'string' || !isPiModelSelectionId(value) || value === 'pi') {
+      return null;
+    }
+
+    return visibleSet.has(value) ? null : fallbackModelId;
+  };
+
+  const savedProviderModel = ensureProviderProjectionMap(settings, 'savedProviderModel');
+  const nextSavedModel = maybeRetargetModel(savedProviderModel.pi);
+  if (nextSavedModel) {
+    savedProviderModel.pi = nextSavedModel;
+    ensureProviderProjectionMap(settings, 'savedProviderEffort').pi = fallbackEffort;
+  }
+
+  const nextTopLevelModel = maybeRetargetModel(settings.model);
+  if (nextTopLevelModel) {
+    settings.model = nextTopLevelModel;
+    settings.effortLevel = fallbackEffort;
+  }
+
+  const nextTitleGenerationModel = maybeRetargetModel(settings.titleGenerationModel);
+  if (nextTitleGenerationModel) {
+    settings.titleGenerationModel = nextTitleGenerationModel;
+  }
+}

--- a/src/providers/pi/types.ts
+++ b/src/providers/pi/types.ts
@@ -1,0 +1,39 @@
+export interface PiProviderState {
+  leafEntryId?: string;
+  parentSession?: string;
+  sessionFile?: string;
+  sessionId?: string;
+}
+
+export function getPiState(value: unknown): PiProviderState {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  const record = value as Record<string, unknown>;
+  return {
+    ...(typeof record.leafEntryId === 'string' && record.leafEntryId.trim()
+      ? { leafEntryId: record.leafEntryId.trim() }
+      : {}),
+    ...(typeof record.parentSession === 'string' && record.parentSession.trim()
+      ? { parentSession: record.parentSession.trim() }
+      : {}),
+    ...(typeof record.sessionFile === 'string' && record.sessionFile.trim()
+      ? { sessionFile: record.sessionFile.trim() }
+      : {}),
+    ...(typeof record.sessionId === 'string' && record.sessionId.trim()
+      ? { sessionId: record.sessionId.trim() }
+      : {}),
+  };
+}
+
+export function buildPersistedPiState(state: PiProviderState): PiProviderState | undefined {
+  const persisted: PiProviderState = {
+    ...(state.leafEntryId ? { leafEntryId: state.leafEntryId } : {}),
+    ...(state.parentSession ? { parentSession: state.parentSession } : {}),
+    ...(state.sessionFile ? { sessionFile: state.sessionFile } : {}),
+    ...(state.sessionId ? { sessionId: state.sessionId } : {}),
+  };
+
+  return Object.keys(persisted).length > 0 ? persisted : undefined;
+}

--- a/src/providers/pi/types.ts
+++ b/src/providers/pi/types.ts
@@ -1,4 +1,11 @@
+export interface PiForkSource {
+  resumeAt: string;
+  sessionId: string;
+}
+
 export interface PiProviderState {
+  forkSource?: PiForkSource;
+  forkSourceSessionFile?: string;
   leafEntryId?: string;
   parentSession?: string;
   sessionFile?: string;
@@ -11,7 +18,12 @@ export function getPiState(value: unknown): PiProviderState {
   }
 
   const record = value as Record<string, unknown>;
+  const forkSource = getPiForkSource(record.forkSource);
   return {
+    ...(forkSource ? { forkSource } : {}),
+    ...(typeof record.forkSourceSessionFile === 'string' && record.forkSourceSessionFile.trim()
+      ? { forkSourceSessionFile: record.forkSourceSessionFile.trim() }
+      : {}),
     ...(typeof record.leafEntryId === 'string' && record.leafEntryId.trim()
       ? { leafEntryId: record.leafEntryId.trim() }
       : {}),
@@ -29,6 +41,8 @@ export function getPiState(value: unknown): PiProviderState {
 
 export function buildPersistedPiState(state: PiProviderState): PiProviderState | undefined {
   const persisted: PiProviderState = {
+    ...(state.forkSource ? { forkSource: state.forkSource } : {}),
+    ...(state.forkSourceSessionFile ? { forkSourceSessionFile: state.forkSourceSessionFile } : {}),
     ...(state.leafEntryId ? { leafEntryId: state.leafEntryId } : {}),
     ...(state.parentSession ? { parentSession: state.parentSession } : {}),
     ...(state.sessionFile ? { sessionFile: state.sessionFile } : {}),
@@ -36,4 +50,15 @@ export function buildPersistedPiState(state: PiProviderState): PiProviderState |
   };
 
   return Object.keys(persisted).length > 0 ? persisted : undefined;
+}
+
+function getPiForkSource(value: unknown): PiForkSource | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  const sessionId = typeof record.sessionId === 'string' ? record.sessionId.trim() : '';
+  const resumeAt = typeof record.resumeAt === 'string' ? record.resumeAt.trim() : '';
+  return sessionId && resumeAt ? { resumeAt, sessionId } : undefined;
 }

--- a/src/providers/pi/ui/ObsidianPiExtensionUiRenderer.ts
+++ b/src/providers/pi/ui/ObsidianPiExtensionUiRenderer.ts
@@ -1,0 +1,251 @@
+import { type App, Modal, Notice } from 'obsidian';
+
+import type {
+  PiExtensionUiConfirmRequest,
+  PiExtensionUiEditorRequest,
+  PiExtensionUiInputRequest,
+  PiExtensionUiNotifyRequest,
+  PiExtensionUiRenderer,
+  PiExtensionUiSelectRequest,
+  PiExtensionUiSetEditorTextRequest,
+  PiExtensionUiSetStatusRequest,
+  PiExtensionUiSetTitleRequest,
+  PiExtensionUiSetWidgetRequest,
+} from './PiExtensionUiRenderer';
+
+export class ObsidianPiExtensionUiRenderer implements PiExtensionUiRenderer {
+  constructor(private readonly app: App) {}
+
+  async select(
+    request: PiExtensionUiSelectRequest,
+    signal: AbortSignal,
+  ): Promise<{ cancelled?: boolean; value?: string }> {
+    return new PiSelectModal(this.app, request, signal).openAndWait();
+  }
+
+  async confirm(
+    request: PiExtensionUiConfirmRequest,
+    signal: AbortSignal,
+  ): Promise<{ cancelled?: boolean; confirmed?: boolean }> {
+    return new PiConfirmModal(this.app, request, signal).openAndWait();
+  }
+
+  async input(
+    request: PiExtensionUiInputRequest,
+    signal: AbortSignal,
+  ): Promise<{ cancelled?: boolean; value?: string }> {
+    return new PiTextModal(this.app, request, signal, false).openAndWait();
+  }
+
+  async editor(
+    request: PiExtensionUiEditorRequest,
+    signal: AbortSignal,
+  ): Promise<{ cancelled?: boolean; value?: string }> {
+    return new PiTextModal(this.app, request, signal, true).openAndWait();
+  }
+
+  notify(request: PiExtensionUiNotifyRequest): void {
+    new Notice(getDisplayText(request));
+  }
+
+  setStatus(_request: PiExtensionUiSetStatusRequest): void {}
+  setWidget(_request: PiExtensionUiSetWidgetRequest): void {}
+  setTitle(_request: PiExtensionUiSetTitleRequest): void {}
+  setEditorText(_request: PiExtensionUiSetEditorTextRequest): void {}
+}
+
+function getDisplayText(request: Record<string, unknown>): string {
+  const message = typeof request.message === 'string' ? request.message.trim() : '';
+  const title = typeof request.title === 'string' ? request.title.trim() : '';
+  return message || title || 'Pi extension notification.';
+}
+
+function getTitle(request: Record<string, unknown>, fallback: string): string {
+  return typeof request.title === 'string' && request.title.trim()
+    ? request.title.trim()
+    : fallback;
+}
+
+function getMessage(request: Record<string, unknown>): string {
+  return typeof request.message === 'string' ? request.message.trim() : '';
+}
+
+interface PiSelectOption {
+  label: string;
+  value: string;
+}
+
+function getSelectOptions(request: Record<string, unknown>): PiSelectOption[] {
+  const rawOptions = Array.isArray(request.options) ? request.options : [];
+  return rawOptions.flatMap((option): PiSelectOption[] => {
+    if (typeof option === 'string' && option.trim()) {
+      return [{ label: option.trim(), value: option.trim() }];
+    }
+    if (!option || typeof option !== 'object' || Array.isArray(option)) {
+      return [];
+    }
+
+    const record = option as Record<string, unknown>;
+    const value = typeof record.value === 'string' ? record.value.trim() : '';
+    const label = typeof record.label === 'string' && record.label.trim()
+      ? record.label.trim()
+      : value;
+    return value ? [{ label, value }] : [];
+  });
+}
+
+abstract class PiExtensionModal<TResult extends Record<string, unknown>> extends Modal {
+  private done = false;
+  private resolve!: (result: TResult) => void;
+  private readonly resultPromise = new Promise<TResult>((resolve) => {
+    this.resolve = resolve;
+  });
+
+  constructor(
+    app: App,
+    protected readonly request: Record<string, unknown>,
+    private readonly signal: AbortSignal,
+  ) {
+    super(app);
+  }
+
+  openAndWait(): Promise<TResult> {
+    if (this.signal.aborted) {
+      return Promise.resolve(this.cancelledResult());
+    }
+
+    const abortHandler = (): void => {
+      this.finish(this.cancelledResult());
+      this.close();
+    };
+    this.signal.addEventListener('abort', abortHandler, { once: true });
+    this.resultPromise.finally(() => {
+      this.signal.removeEventListener('abort', abortHandler);
+    });
+    this.open();
+    return this.resultPromise;
+  }
+
+  override onOpen(): void {
+    this.contentEl.empty();
+    this.contentEl.addClass('claudian-pi-extension-modal');
+    this.render();
+  }
+
+  override onClose(): void {
+    this.finish(this.cancelledResult());
+  }
+
+  protected abstract cancelledResult(): TResult;
+  protected abstract render(): void;
+
+  protected finish(result: TResult): void {
+    if (this.done) {
+      return;
+    }
+
+    this.done = true;
+    this.resolve(result);
+  }
+
+  protected renderHeader(fallbackTitle: string): void {
+    this.contentEl.createEl('h2', { text: getTitle(this.request, fallbackTitle) });
+    const message = getMessage(this.request);
+    if (message) {
+      this.contentEl.createEl('p', { text: message });
+    }
+  }
+}
+
+class PiSelectModal extends PiExtensionModal<{ cancelled?: boolean; value?: string }> {
+  protected cancelledResult(): { cancelled: true } {
+    return { cancelled: true };
+  }
+
+  protected render(): void {
+    this.renderHeader('Pi extension');
+    const options = getSelectOptions(this.request);
+    const listEl = this.contentEl.createDiv({ cls: 'claudian-pi-extension-options' });
+    for (const option of options) {
+      const button = listEl.createEl('button', { text: option.label });
+      button.addEventListener('click', () => {
+        this.finish({ value: option.value });
+        this.close();
+      });
+    }
+    this.renderCancelButton();
+  }
+
+  private renderCancelButton(): void {
+    const cancelButton = this.contentEl.createEl('button', { text: 'Cancel' });
+    cancelButton.addEventListener('click', () => {
+      this.finish({ cancelled: true });
+      this.close();
+    });
+  }
+}
+
+class PiConfirmModal extends PiExtensionModal<{ cancelled?: boolean; confirmed?: boolean }> {
+  protected cancelledResult(): { cancelled: true } {
+    return { cancelled: true };
+  }
+
+  protected render(): void {
+    this.renderHeader('Pi extension');
+    const actionsEl = this.contentEl.createDiv({ cls: 'claudian-pi-extension-actions' });
+    const confirmButton = actionsEl.createEl('button', { text: 'Confirm' });
+    confirmButton.addEventListener('click', () => {
+      this.finish({ confirmed: true });
+      this.close();
+    });
+    const cancelButton = actionsEl.createEl('button', { text: 'Cancel' });
+    cancelButton.addEventListener('click', () => {
+      this.finish({ confirmed: false });
+      this.close();
+    });
+  }
+}
+
+class PiTextModal extends PiExtensionModal<{ cancelled?: boolean; value?: string }> {
+  constructor(
+    app: App,
+    request: Record<string, unknown>,
+    signal: AbortSignal,
+    private readonly multiline: boolean,
+  ) {
+    super(app, request, signal);
+  }
+
+  protected cancelledResult(): { cancelled: true } {
+    return { cancelled: true };
+  }
+
+  protected render(): void {
+    this.renderHeader('Pi extension');
+    const initialValue = typeof this.request.value === 'string'
+      ? this.request.value
+      : typeof this.request.defaultValue === 'string'
+      ? this.request.defaultValue
+      : '';
+    const input = this.multiline
+      ? this.contentEl.createEl('textarea')
+      : this.contentEl.createEl('input', { type: 'text' });
+    input.value = initialValue;
+    if (this.multiline) {
+      (input as HTMLTextAreaElement).rows = 8;
+    }
+
+    const actionsEl = this.contentEl.createDiv({ cls: 'claudian-pi-extension-actions' });
+    const submitButton = actionsEl.createEl('button', { text: 'Submit' });
+    submitButton.addEventListener('click', () => {
+      this.finish({ value: input.value });
+      this.close();
+    });
+    const cancelButton = actionsEl.createEl('button', { text: 'Cancel' });
+    cancelButton.addEventListener('click', () => {
+      this.finish({ cancelled: true });
+      this.close();
+    });
+    window.setTimeout(() => input.focus(), 0);
+  }
+}

--- a/src/providers/pi/ui/PiChatUIConfig.ts
+++ b/src/providers/pi/ui/PiChatUIConfig.ts
@@ -90,7 +90,7 @@ export const piChatUIConfig: ProviderChatUIConfig = {
   },
 
   ownsModel(model: string): boolean {
-    return isPiModelSelectionId(model);
+    return model === PI_SYNTHETIC_MODEL_ID || decodePiModelId(model) !== null;
   },
 
   isAdaptiveReasoningModel(model: string, settings: Record<string, unknown>): boolean {
@@ -125,8 +125,15 @@ export const piChatUIConfig: ProviderChatUIConfig = {
     );
   },
 
-  getContextWindowSize(model: string, customLimits?: Record<string, number>): number {
-    return customLimits?.[model] ?? DEFAULT_CONTEXT_WINDOW;
+  getContextWindowSize(
+    model: string,
+    customLimits?: Record<string, number>,
+    settings?: Record<string, unknown>,
+  ): number {
+    const metadataContextWindow = settings
+      ? getCachedModel(model, settings)?.contextWindow
+      : undefined;
+    return metadataContextWindow ?? customLimits?.[model] ?? DEFAULT_CONTEXT_WINDOW;
   },
 
   isDefaultModel(model: string): boolean {

--- a/src/providers/pi/ui/PiChatUIConfig.ts
+++ b/src/providers/pi/ui/PiChatUIConfig.ts
@@ -1,0 +1,256 @@
+import type {
+  ProviderChatUIConfig,
+  ProviderPermissionModeToggleConfig,
+  ProviderReasoningOption,
+  ProviderUIOption,
+} from '../../../core/providers/types';
+import { PI_PROVIDER_ICON } from '../../../shared/icons';
+import {
+  clampPiThinkingLevel,
+  decodePiModelId,
+  getPiSupportedThinkingLevels,
+  isPiModelSelectionId,
+  PI_DEFAULT_THINKING_LEVEL,
+  PI_SYNTHETIC_MODEL_ID,
+  type PiDiscoveredModel,
+  type PiThinkingLevel,
+} from '../models';
+import {
+  getPiProviderSettings,
+  updatePiProviderSettings,
+} from '../settings';
+
+const PI_MODELS: ProviderUIOption[] = [
+  { value: PI_SYNTHETIC_MODEL_ID, label: 'Pi', description: 'Configure models in settings' },
+];
+const DEFAULT_PI_REASONING_LEVELS = getPiSupportedThinkingLevels({ reasoning: true });
+const DEFAULT_CONTEXT_WINDOW = 200_000;
+const PI_PERMISSION_MODE_TOGGLE: ProviderPermissionModeToggleConfig = {
+  inactiveValue: 'normal',
+  inactiveLabel: 'Read-only',
+  activeValue: 'yolo',
+  activeLabel: 'All tools',
+};
+
+export const piChatUIConfig: ProviderChatUIConfig = {
+  getModelOptions(settings): ProviderUIOption[] {
+    const piSettings = getPiProviderSettings(settings);
+    const discoveredModels = new Map(piSettings.discoveredModels.map((model) => [
+      model.encodedId,
+      buildModelOption(model, piSettings.modelAliases[model.encodedId]),
+    ]));
+    const savedProviderModel = (
+      settings.savedProviderModel
+      && typeof settings.savedProviderModel === 'object'
+      && !Array.isArray(settings.savedProviderModel)
+    )
+      ? settings.savedProviderModel as Record<string, unknown>
+      : null;
+
+    const options: ProviderUIOption[] = [];
+    const seen = new Set<string>();
+    for (const encodedId of piSettings.visibleModels) {
+      pushOption(
+        options,
+        seen,
+        encodedId,
+        discoveredModels.get(encodedId)
+          ?? {
+            description: 'Configured model',
+            label: piSettings.modelAliases[encodedId] ?? formatFallbackLabel(encodedId),
+            value: encodedId,
+          },
+      );
+    }
+
+    const selectedModelValues = [
+      typeof settings.model === 'string' ? settings.model : '',
+      typeof savedProviderModel?.pi === 'string' ? savedProviderModel.pi : '',
+    ];
+
+    for (const model of selectedModelValues) {
+      if (!model || model === PI_SYNTHETIC_MODEL_ID || !decodePiModelId(model)) {
+        continue;
+      }
+
+      pushOption(
+        options,
+        seen,
+        model,
+        discoveredModels.get(model)
+          ?? {
+            description: 'Selected in an existing session',
+            label: piSettings.modelAliases[model] ?? formatFallbackLabel(model),
+            value: model,
+          },
+      );
+    }
+
+    return options.length > 0 ? options : [...PI_MODELS];
+  },
+
+  ownsModel(model: string): boolean {
+    return isPiModelSelectionId(model);
+  },
+
+  isAdaptiveReasoningModel(model: string, settings: Record<string, unknown>): boolean {
+    const piModel = getCachedModel(model, settings);
+    if (piModel) {
+      return piModel.thinkingLevels.some(level => level !== 'off');
+    }
+
+    return !!decodePiModelId(model);
+  },
+
+  getReasoningOptions(model: string, settings: Record<string, unknown>): ProviderReasoningOption[] {
+    const piModel = getCachedModel(model, settings);
+    const levels = piModel?.thinkingLevels
+      ?? (decodePiModelId(model) ? DEFAULT_PI_REASONING_LEVELS : ['off']);
+    return levels.map((level) => ({
+      label: formatThinkingLevelLabel(level),
+      value: level,
+    }));
+  },
+
+  getDefaultReasoningValue(model: string, settings: Record<string, unknown>): string {
+    const piModel = getCachedModel(model, settings);
+    if (!piModel) {
+      return decodePiModelId(model) ? PI_DEFAULT_THINKING_LEVEL : 'off';
+    }
+
+    const piSettings = getPiProviderSettings(settings);
+    return clampPiThinkingLevel(
+      piSettings.preferredThinkingByModel[piModel.encodedId],
+      piModel.thinkingLevels,
+    );
+  },
+
+  getContextWindowSize(model: string, customLimits?: Record<string, number>): number {
+    return customLimits?.[model] ?? DEFAULT_CONTEXT_WINDOW;
+  },
+
+  isDefaultModel(model: string): boolean {
+    return isPiModelSelectionId(model);
+  },
+
+  applyModelDefaults(model: string, settings: unknown): void {
+    if (!settings || typeof settings !== 'object' || Array.isArray(settings)) {
+      return;
+    }
+
+    const settingsBag = settings as Record<string, unknown>;
+    if (!decodePiModelId(model)) {
+      settingsBag.effortLevel = 'off';
+      return;
+    }
+
+    settingsBag.model = model;
+    settingsBag.effortLevel = this.getDefaultReasoningValue(model, settingsBag);
+  },
+
+  applyReasoningSelection(model: string, value: string, settings: unknown): void {
+    if (!settings || typeof settings !== 'object' || Array.isArray(settings)) {
+      return;
+    }
+
+    const settingsBag = settings as Record<string, unknown>;
+    const piModel = getCachedModel(model, settingsBag);
+    const encodedId = piModel?.encodedId ?? (decodePiModelId(model) ? model : '');
+    if (!encodedId) {
+      return;
+    }
+    const supportedLevels = piModel?.thinkingLevels ?? DEFAULT_PI_REASONING_LEVELS;
+
+    const nextPreferredThinkingByModel = {
+      ...getPiProviderSettings(settingsBag).preferredThinkingByModel,
+    };
+    const normalizedValue = value as PiThinkingLevel;
+    if (!supportedLevels.includes(normalizedValue)) {
+      delete nextPreferredThinkingByModel[encodedId];
+    } else {
+      nextPreferredThinkingByModel[encodedId] = normalizedValue;
+    }
+
+    updatePiProviderSettings(settingsBag, {
+      preferredThinkingByModel: nextPreferredThinkingByModel,
+    });
+  },
+
+  normalizeModelVariant(model: string): string {
+    return decodePiModelId(model) ? model : model;
+  },
+
+  getCustomModelIds(): Set<string> {
+    return new Set<string>();
+  },
+
+  getModeSelector(): null {
+    return null;
+  },
+
+  getPermissionModeToggle(): ProviderPermissionModeToggleConfig {
+    return PI_PERMISSION_MODE_TOGGLE;
+  },
+
+  resolvePermissionMode(settings: Record<string, unknown>): string | null {
+    return getPiProviderSettings(settings).toolMode === 'readonly' ? 'normal' : 'yolo';
+  },
+
+  applyPermissionMode(value: string, settings: unknown): void {
+    if (!settings || typeof settings !== 'object' || Array.isArray(settings)) {
+      return;
+    }
+
+    const settingsBag = settings as Record<string, unknown>;
+    settingsBag.permissionMode = value;
+    updatePiProviderSettings(settingsBag, {
+      toolMode: value === 'normal' ? 'readonly' : 'all',
+    });
+  },
+
+  getProviderIcon() {
+    return PI_PROVIDER_ICON;
+  },
+};
+
+function getCachedModel(model: string, settings: Record<string, unknown>): PiDiscoveredModel | null {
+  if (!decodePiModelId(model)) {
+    return null;
+  }
+
+  return getPiProviderSettings(settings).discoveredModels.find(entry => entry.encodedId === model) ?? null;
+}
+
+function buildModelOption(model: PiDiscoveredModel, alias: string | undefined): ProviderUIOption {
+  return {
+    description: `${model.provider} runtime`,
+    group: model.provider,
+    label: alias ?? model.label,
+    value: model.encodedId,
+  };
+}
+
+function formatFallbackLabel(encodedId: string): string {
+  const decoded = decodePiModelId(encodedId);
+  return decoded ? `${decoded.provider}/${decoded.modelId}` : 'Pi';
+}
+
+function formatThinkingLevelLabel(value: PiThinkingLevel): string {
+  return value === 'xhigh'
+    ? 'XHigh'
+    : value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function pushOption(
+  target: ProviderUIOption[],
+  seenValues: Set<string>,
+  value: string,
+  option: ProviderUIOption,
+): void {
+  if (seenValues.has(value)) {
+    return;
+  }
+
+  seenValues.add(value);
+  target.push(option);
+}

--- a/src/providers/pi/ui/PiExtensionUiRenderer.ts
+++ b/src/providers/pi/ui/PiExtensionUiRenderer.ts
@@ -1,0 +1,12 @@
+export type {
+  PiExtensionUiConfirmRequest,
+  PiExtensionUiEditorRequest,
+  PiExtensionUiInputRequest,
+  PiExtensionUiNotifyRequest,
+  PiExtensionUiRenderer,
+  PiExtensionUiSelectRequest,
+  PiExtensionUiSetEditorTextRequest,
+  PiExtensionUiSetStatusRequest,
+  PiExtensionUiSetTitleRequest,
+  PiExtensionUiSetWidgetRequest,
+} from '../runtime/PiExtensionUiBridge';

--- a/src/providers/pi/ui/PiSettingsTab.ts
+++ b/src/providers/pi/ui/PiSettingsTab.ts
@@ -1,0 +1,228 @@
+import * as fs from 'node:fs';
+
+import { Notice, Setting } from 'obsidian';
+
+import type { ProviderSettingsTabRenderer } from '../../../core/providers/types';
+import { renderEnvironmentSettingsSection } from '../../../features/settings/ui/EnvironmentSettingsSection';
+import { getHostnameKey } from '../../../utils/env';
+import { expandHomePath } from '../../../utils/path';
+import { maybeGetPiWorkspaceServices } from '../app/PiWorkspaceServices';
+import { sameStringList } from '../internal/compareCollections';
+import { PiModelDiscoveryService } from '../runtime/PiModelDiscoveryService';
+import {
+  getPiProviderSettings,
+  normalizePiVisibleModels,
+  updatePiProviderSettings,
+} from '../settings';
+
+export const piSettingsTabRenderer: ProviderSettingsTabRenderer = {
+  render(container, context) {
+    const settingsBag = context.plugin.settings as unknown as Record<string, unknown>;
+    const piSettings = getPiProviderSettings(settingsBag);
+    const hostnameKey = getHostnameKey();
+    const workspace = maybeGetPiWorkspaceServices();
+
+    new Setting(container).setName('Setup').setHeading();
+
+    new Setting(container)
+      .setName('Enable Pi')
+      .setDesc('Launch `pi --mode rpc` as a provider.')
+      .addToggle((toggle) =>
+        toggle
+          .setValue(piSettings.enabled)
+          .onChange(async (value) => {
+            updatePiProviderSettings(settingsBag, { enabled: value });
+            await context.plugin.saveSettings();
+            context.refreshModelSelectors();
+          })
+      );
+
+    const validationEl = container.createDiv({
+      cls: 'claudian-cli-path-validation claudian-setting-validation claudian-setting-validation-error claudian-hidden',
+    });
+    const cliPathsByHost = { ...piSettings.cliPathsByHost };
+    let cliPathInputEl: HTMLInputElement | null = null;
+
+    const updateCliPathValidation = (value: string, inputEl?: HTMLInputElement): boolean => {
+      const error = validateCliPath(value);
+      if (error) {
+        validationEl.setText(error);
+        validationEl.toggleClass('claudian-hidden', false);
+        inputEl?.toggleClass('claudian-input-error', true);
+        return false;
+      }
+
+      validationEl.toggleClass('claudian-hidden', true);
+      inputEl?.toggleClass('claudian-input-error', false);
+      return true;
+    };
+
+    const persistCliPath = async (value: string): Promise<void> => {
+      if (!updateCliPathValidation(value, cliPathInputEl ?? undefined)) {
+        return;
+      }
+
+      const trimmed = value.trim();
+      if (trimmed) {
+        cliPathsByHost[hostnameKey] = trimmed;
+      } else {
+        delete cliPathsByHost[hostnameKey];
+      }
+
+      updatePiProviderSettings(settingsBag, {
+        cliPathsByHost: { ...cliPathsByHost },
+        discoveredModels: [],
+      });
+      workspace?.cliResolver?.reset();
+      await context.plugin.saveSettings();
+      context.refreshModelSelectors();
+    };
+
+    new Setting(container)
+      .setName('CLI path')
+      .setDesc('Optional absolute path to the Pi CLI for this computer. Leave empty to use `pi` from PATH.')
+      .addText((text) => {
+        const currentValue = piSettings.cliPathsByHost[hostnameKey] || '';
+        text
+          .setPlaceholder(process.platform === 'win32'
+            ? 'C:\\Users\\you\\AppData\\Roaming\\npm\\pi.cmd'
+            : '/usr/local/bin/pi')
+          .setValue(currentValue)
+          .onChange((value) => {
+            void persistCliPath(value);
+          });
+        cliPathInputEl = text.inputEl;
+        updateCliPathValidation(currentValue, text.inputEl);
+      });
+
+    new Setting(container).setName('Models').setHeading();
+
+    const modelContainer = container.createDiv({ cls: 'claudian-pi-models' });
+    const renderModels = (): void => {
+      modelContainer.empty();
+      const current = getPiProviderSettings(settingsBag);
+      new Setting(modelContainer)
+        .setName('Discover models')
+        .setDesc(current.discoveredModels.length > 0
+          ? `${current.discoveredModels.length} Pi models cached.`
+          : 'Fetch models from `pi --mode rpc --no-session`.')
+        .addButton((button) => {
+          button.setButtonText('Discover').onClick(async () => {
+            button.setDisabled(true);
+            const result = await new PiModelDiscoveryService(context.plugin).discoverModels();
+            if (result.diagnostics) {
+              new Notice(`Pi discovery failed: ${result.diagnostics}`);
+              button.setDisabled(false);
+              return;
+            }
+            updatePiProviderSettings(settingsBag, {
+              discoveredModels: result.models,
+              visibleModels: normalizePiVisibleModels(
+                current.visibleModels,
+                result.models,
+              ),
+            });
+            await context.plugin.saveSettings();
+            renderModels();
+            context.refreshModelSelectors();
+          });
+        });
+
+      if (current.discoveredModels.length === 0) {
+        modelContainer.createDiv({
+          cls: 'setting-item-description',
+          text: 'No Pi models discovered yet.',
+        });
+        return;
+      }
+
+      for (const model of current.discoveredModels) {
+        new Setting(modelContainer)
+          .setName(current.modelAliases[model.encodedId] || model.label)
+          .setDesc(model.encodedId)
+          .addToggle((toggle) => {
+            toggle
+              .setValue(current.visibleModels.includes(model.encodedId))
+              .onChange(async (value) => {
+                const visibleModels = value
+                  ? [...current.visibleModels, model.encodedId]
+                  : current.visibleModels.filter(id => id !== model.encodedId);
+                const normalized = normalizePiVisibleModels(visibleModels, current.discoveredModels);
+                if (!sameStringList(current.visibleModels, normalized)) {
+                  updatePiProviderSettings(settingsBag, { visibleModels: normalized });
+                  await context.plugin.saveSettings();
+                  renderModels();
+                  context.refreshModelSelectors();
+                }
+              });
+          })
+          .addText((text) => {
+            text
+              .setPlaceholder('Alias')
+              .setValue(current.modelAliases[model.encodedId] ?? '')
+              .onChange(async (value) => {
+                updatePiProviderSettings(settingsBag, {
+                  modelAliases: {
+                    ...getPiProviderSettings(settingsBag).modelAliases,
+                    [model.encodedId]: value,
+                  },
+                });
+                await context.plugin.saveSettings();
+                context.refreshModelSelectors();
+              });
+          });
+      }
+    };
+    renderModels();
+
+    new Setting(container)
+      .setName('Tool mode')
+      .setDesc('Controls whether Pi gets all configured tools or read-only tools.')
+      .addDropdown((dropdown) => {
+        dropdown
+          .addOption('all', 'All tools')
+          .addOption('readonly', 'Read-only')
+          .setValue(piSettings.toolMode)
+          .onChange(async (value) => {
+            updatePiProviderSettings(settingsBag, {
+              toolMode: value === 'readonly' ? 'readonly' : 'all',
+            });
+            await context.plugin.saveSettings();
+          });
+      });
+
+    context.renderHiddenProviderCommandSetting(container, 'pi', {
+      desc: 'Hide Pi runtime commands by name.',
+      name: 'Hidden Pi commands',
+      placeholder: 'review, tests',
+    });
+
+    renderEnvironmentSettingsSection({
+      container,
+      desc: 'Environment variables passed only to Pi.',
+      heading: 'Environment',
+      name: 'Pi environment variables',
+      placeholder: 'PI_CODING_AGENT_SESSION_DIR=/path/to/sessions',
+      plugin: context.plugin,
+      scope: 'provider:pi',
+    });
+  },
+};
+
+function validateCliPath(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const expandedPath = expandHomePath(trimmed);
+  if (!fs.existsSync(expandedPath)) {
+    return 'Path does not exist';
+  }
+
+  if (!fs.statSync(expandedPath).isFile()) {
+    return 'Path must point to a file';
+  }
+
+  return null;
+}

--- a/src/providers/pi/ui/PiSettingsTab.ts
+++ b/src/providers/pi/ui/PiSettingsTab.ts
@@ -175,28 +175,6 @@ export const piSettingsTabRenderer: ProviderSettingsTabRenderer = {
     };
     renderModels();
 
-    new Setting(container)
-      .setName('Tool mode')
-      .setDesc('Controls whether Pi gets all configured tools or read-only tools.')
-      .addDropdown((dropdown) => {
-        dropdown
-          .addOption('all', 'All tools')
-          .addOption('readonly', 'Read-only')
-          .setValue(piSettings.toolMode)
-          .onChange(async (value) => {
-            updatePiProviderSettings(settingsBag, {
-              toolMode: value === 'readonly' ? 'readonly' : 'all',
-            });
-            await context.plugin.saveSettings();
-          });
-      });
-
-    context.renderHiddenProviderCommandSetting(container, 'pi', {
-      desc: 'Hide Pi runtime commands by name.',
-      name: 'Hidden Pi commands',
-      placeholder: 'review, tests',
-    });
-
     renderEnvironmentSettingsSection({
       container,
       desc: 'Environment variables passed only to Pi.',

--- a/src/shared/icons.ts
+++ b/src/shared/icons.ts
@@ -96,6 +96,28 @@ export const OPENCODE_PROVIDER_ICON: ProviderIconSvg = {
   ],
 };
 
+export const PI_PROVIDER_ICON: ProviderIconSvg = {
+  kind: 'composite',
+  viewBox: '0 0 800 800',
+  children: [
+    {
+      tag: 'path',
+      attributes: {
+        d: 'M165.29 165.29H517.36V400H400V517.36H282.65V634.72H165.29ZM282.65 282.65V400H400V282.65Z',
+        fill: 'currentColor',
+        'fill-rule': 'evenodd',
+      },
+    },
+    {
+      tag: 'path',
+      attributes: {
+        d: 'M517.36 400H634.72V634.72H517.36Z',
+        fill: 'currentColor',
+      },
+    },
+  ],
+};
+
 export interface CreateProviderIconSvgOptions {
   className?: string;
   dataProvider?: string;

--- a/src/style/base/variables.css
+++ b/src/style/base/variables.css
@@ -8,6 +8,8 @@
   --claudian-brand-codex-rgb: 208, 208, 208;
   --claudian-brand-opencode: #B8B8B8;
   --claudian-brand-opencode-rgb: 184, 184, 184;
+  --claudian-brand-pi: #ffffff;
+  --claudian-brand-pi-rgb: 255, 255, 255;
   --claudian-error: #dc3545;
   --claudian-error-rgb: 220, 53, 69;
   --claudian-compact: #5bc0de;
@@ -18,6 +20,8 @@ body.theme-light .claudian-container {
   --claudian-brand-codex-rgb: 0, 0, 0;
   --claudian-brand-opencode: #707070;
   --claudian-brand-opencode-rgb: 112, 112, 112;
+  --claudian-brand-pi: #000000;
+  --claudian-brand-pi-rgb: 0, 0, 0;
 }
 
 /* Active-provider alias for single-provider surfaces. */
@@ -34,4 +38,9 @@ body.theme-light .claudian-container {
 .claudian-container[data-provider="opencode"] {
   --claudian-brand: var(--claudian-brand-opencode);
   --claudian-brand-rgb: var(--claudian-brand-opencode-rgb);
+}
+
+.claudian-container[data-provider="pi"] {
+  --claudian-brand: var(--claudian-brand-pi);
+  --claudian-brand-rgb: var(--claudian-brand-pi-rgb);
 }

--- a/src/style/components/tabs.css
+++ b/src/style/components/tabs.css
@@ -52,6 +52,10 @@
   border-color: var(--claudian-brand-opencode, #C8C8C8);
 }
 
+.claudian-tab-badge-streaming[data-provider="pi"] {
+  border-color: var(--claudian-brand-pi, #ffffff);
+}
+
 .claudian-tab-badge-attention {
   border-color: var(--text-error);
 }

--- a/src/utils/cliBinaryLocator.ts
+++ b/src/utils/cliBinaryLocator.ts
@@ -1,0 +1,97 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { getEnhancedPath } from './env';
+import { expandHomePath, parsePathEntries } from './path';
+
+export function isExistingFile(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+export function resolveConfiguredCliPath(configuredPath: string | undefined): string | null {
+  const trimmed = (configuredPath ?? '').trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const expandedPath = expandHomePath(trimmed);
+    return isExistingFile(expandedPath) ? expandedPath : null;
+  } catch {
+    return null;
+  }
+}
+
+export function findCliBinaryPath(
+  binaryName: string,
+  additionalPath?: string,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  const binaryNames = platform === 'win32'
+    ? [`${binaryName}.exe`, `${binaryName}.cmd`, binaryName]
+    : [binaryName];
+  const searchEntries = platform === process.platform
+    ? parsePathEntries(getEnhancedPath(additionalPath))
+    : parsePathEntriesForPlatform(additionalPath, platform);
+
+  for (const dir of searchEntries) {
+    if (!dir) continue;
+
+    for (const candidateName of binaryNames) {
+      const candidate = path.join(dir, candidateName);
+      if (isExistingFile(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  return null;
+}
+
+function parsePathEntriesForPlatform(pathValue: string | undefined, platform: NodeJS.Platform): string[] {
+  if (!pathValue) {
+    return [];
+  }
+
+  const delimiter = platform === 'win32' ? ';' : ':';
+  return pathValue
+    .split(delimiter)
+    .map(segment => stripSurroundingQuotes(segment.trim()))
+    .filter(segment => {
+      if (!segment) return false;
+      const upper = segment.toUpperCase();
+      return upper !== '$PATH' && upper !== '${PATH}' && upper !== '%PATH%';
+    })
+    .map(segment => translateMsysPathForPlatform(expandHomePath(segment), platform));
+}
+
+function stripSurroundingQuotes(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function translateMsysPathForPlatform(value: string, platform: NodeJS.Platform): string {
+  if (platform !== 'win32') {
+    return value;
+  }
+
+  const msysMatch = value.match(/^\/([a-zA-Z])(?:\/(.*))?$/);
+  if (!msysMatch) {
+    return value;
+  }
+
+  const driveLetter = msysMatch[1].toUpperCase();
+  const restOfPath = msysMatch[2] ?? '';
+  return restOfPath
+    ? `${driveLetter}:\\${restOfPath.replace(/\//g, '\\')}`
+    : `${driveLetter}:`;
+}

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -128,7 +128,9 @@ export function parseFileUpdateChangeDiffs(changes: unknown): ApplyPatchFileDiff
 }
 
 export function extractDiffData(toolUseResult: unknown, toolCall: ToolCallInfo): ToolDiffData | undefined {
-  const filePath = (toolCall.input.file_path as string) || 'file';
+  const filePath = getNonEmptyStringValue(toolCall.input.file_path)
+    ?? getNonEmptyStringValue(toolCall.input.path)
+    ?? 'file';
 
   if (toolUseResult && typeof toolUseResult === 'object') {
     const result = toolUseResult as Record<string, unknown>;
@@ -138,6 +140,17 @@ export function extractDiffData(toolUseResult: unknown, toolCall: ToolCallInfo):
       const diffLines = structuredPatchToDiffLines(hunks);
       const stats = countLineChanges(diffLines);
       return { filePath: resultFilePath, diffLines, stats };
+    }
+
+    const unifiedDiff = getUnifiedDiffText(result);
+    if (unifiedDiff) {
+      const diffLines = parseUnifiedDiffLines(unifiedDiff);
+      if (diffLines.length > 0) {
+        const resultFilePath = (typeof result.filePath === 'string' ? result.filePath : null)
+          || (typeof result.path === 'string' ? result.path : null)
+          || filePath;
+        return { filePath: resultFilePath, diffLines, stats: countLineChanges(diffLines) };
+      }
     }
   }
 
@@ -149,17 +162,13 @@ export function diffFromToolInput(toolCall: ToolCallInfo, filePath: string): Too
     const oldStr = toolCall.input.old_string;
     const newStr = toolCall.input.new_string;
     if (typeof oldStr === 'string' && typeof newStr === 'string') {
-      const diffLines: DiffLine[] = [];
-      const oldLines = oldStr.split('\n');
-      const newLines = newStr.split('\n');
-      let oldLineNum = 1;
-      for (const line of oldLines) {
-        diffLines.push({ type: 'delete', text: line, oldLineNum: oldLineNum++ });
-      }
-      let newLineNum = 1;
-      for (const line of newLines) {
-        diffLines.push({ type: 'insert', text: line, newLineNum: newLineNum++ });
-      }
+      const diffLines = buildReplacementDiffLines([{ oldText: oldStr, newText: newStr }]);
+      return { filePath, diffLines, stats: countLineChanges(diffLines) };
+    }
+
+    const editPairs = getEditPairs(toolCall.input);
+    if (editPairs.length > 0) {
+      const diffLines = buildReplacementDiffLines(editPairs);
       return { filePath, diffLines, stats: countLineChanges(diffLines) };
     }
   }
@@ -178,6 +187,79 @@ export function diffFromToolInput(toolCall: ToolCallInfo, filePath: string): Too
   }
 
   return undefined;
+}
+
+function getUnifiedDiffText(result: Record<string, unknown>): string | null {
+  if (typeof result.diff === 'string' && result.diff.trim()) {
+    return result.diff;
+  }
+
+  const details = result.details;
+  if (details && typeof details === 'object' && !Array.isArray(details)) {
+    const diff = (details as Record<string, unknown>).diff;
+    if (typeof diff === 'string' && diff.trim()) {
+      return diff;
+    }
+  }
+
+  return null;
+}
+
+interface ReplacementPair {
+  oldText: string;
+  newText: string;
+}
+
+function getEditPairs(input: Record<string, unknown>): ReplacementPair[] {
+  const topLevelPair = getReplacementPair(input);
+  if (topLevelPair) {
+    return [topLevelPair];
+  }
+
+  const edits = input.edits;
+  if (!Array.isArray(edits)) {
+    return [];
+  }
+
+  return edits
+    .map(getReplacementPair)
+    .filter((pair): pair is ReplacementPair => pair !== null);
+}
+
+function getReplacementPair(value: unknown): ReplacementPair | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  const oldText = getStringValue(record.oldText ?? record.old_text ?? record.old_string);
+  const newText = getStringValue(record.newText ?? record.new_text ?? record.new_string);
+  return oldText !== null && newText !== null ? { oldText, newText } : null;
+}
+
+function getStringValue(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function getNonEmptyStringValue(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function buildReplacementDiffLines(pairs: ReplacementPair[]): DiffLine[] {
+  const diffLines: DiffLine[] = [];
+  let oldLineNum = 1;
+  let newLineNum = 1;
+
+  for (const pair of pairs) {
+    for (const line of pair.oldText.split('\n')) {
+      diffLines.push({ type: 'delete', text: line, oldLineNum: oldLineNum++ });
+    }
+    for (const line of pair.newText.split('\n')) {
+      diffLines.push({ type: 'insert', text: line, newLineNum: newLineNum++ });
+    }
+  }
+
+  return diffLines;
 }
 
 function buildApplyPatchFileDiff(current: {

--- a/src/utils/windowsCmdShim.ts
+++ b/src/utils/windowsCmdShim.ts
@@ -1,0 +1,47 @@
+const WINDOWS_CMD_ARGUMENT_CHARS = /[\s"&<>|{}^=;!'+,`~()%@]/u;
+
+export interface WindowsCmdShimSpawnSpec {
+  args: string[];
+  command: string;
+  windowsVerbatimArguments?: boolean;
+}
+
+export function resolveWindowsCmdShimSpawnSpec(
+  spec: Pick<WindowsCmdShimSpawnSpec, 'args' | 'command'>,
+): WindowsCmdShimSpawnSpec {
+  const command = spec.command.trim();
+  if (!command || process.platform !== 'win32' || !command.toLowerCase().endsWith('.cmd')) {
+    return {
+      args: spec.args,
+      command: spec.command,
+    };
+  }
+
+  const shellCommand = [command, ...spec.args]
+    .map(value => quoteWindowsShellArgument(value))
+    .join(' ');
+
+  return {
+    args: ['/d', '/s', '/c', `"${shellCommand}"`],
+    command: process.env.ComSpec || process.env.comspec || 'cmd.exe',
+    windowsVerbatimArguments: true,
+  };
+}
+
+function requiresWindowsShellQuoting(value: string): boolean {
+  return WINDOWS_CMD_ARGUMENT_CHARS.test(value)
+    || value.includes('[')
+    || value.includes(']');
+}
+
+function quoteWindowsShellArgument(value: string): string {
+  if (!value.length) {
+    return '""';
+  }
+
+  if (!requiresWindowsShellQuoting(value)) {
+    return value;
+  }
+
+  return `"${value.replace(/"/g, '""')}"`;
+}

--- a/src/utils/windowsCmdShim.ts
+++ b/src/utils/windowsCmdShim.ts
@@ -3,8 +3,24 @@ const WINDOWS_CMD_ARGUMENT_CHARS = /[\s"&<>|{}^=;!'+,`~()%@]/u;
 export interface WindowsCmdShimSpawnSpec {
   args: string[];
   command: string;
+  killProcessTree?: boolean;
   windowsVerbatimArguments?: boolean;
 }
+
+interface KillableProcess {
+  kill(signal?: NodeJS.Signals | number): boolean;
+  pid?: number;
+}
+
+interface ErrorEmitterLike {
+  on(event: 'error', listener: (error: Error) => void): unknown;
+}
+
+type SpawnProcess = (
+  command: string,
+  args: string[],
+  options: { stdio: 'ignore'; windowsHide: true },
+) => unknown;
 
 export function resolveWindowsCmdShimSpawnSpec(
   spec: Pick<WindowsCmdShimSpawnSpec, 'args' | 'command'>,
@@ -24,8 +40,43 @@ export function resolveWindowsCmdShimSpawnSpec(
   return {
     args: ['/d', '/s', '/c', `"${shellCommand}"`],
     command: process.env.ComSpec || process.env.comspec || 'cmd.exe',
+    killProcessTree: true,
     windowsVerbatimArguments: true,
   };
+}
+
+export function terminateSpawnedProcess(
+  proc: KillableProcess,
+  signal: NodeJS.Signals | number | undefined,
+  spawnProcess: SpawnProcess,
+  spawnSpec?: WindowsCmdShimSpawnSpec | null,
+): boolean {
+  if (
+    process.platform !== 'win32'
+    || !spawnSpec?.killProcessTree
+    || typeof proc.pid !== 'number'
+  ) {
+    return proc.kill(signal);
+  }
+
+  try {
+    const taskkill = spawnProcess('taskkill.exe', ['/pid', String(proc.pid), '/t', '/f'], {
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    if (isErrorEmitterLike(taskkill)) {
+      taskkill.on('error', () => {});
+    }
+    return true;
+  } catch {
+    return proc.kill(signal);
+  }
+}
+
+function isErrorEmitterLike(value: unknown): value is ErrorEmitterLike {
+  return value !== null
+    && typeof value === 'object'
+    && typeof (value as { on?: unknown }).on === 'function';
 }
 
 function requiresWindowsShellQuoting(value: string): boolean {

--- a/tests/unit/core/providers/ProviderRegistry.test.ts
+++ b/tests/unit/core/providers/ProviderRegistry.test.ts
@@ -90,10 +90,20 @@ describe('ProviderRegistry', () => {
     expect(caps.supportsFork).toBe(false);
   });
 
+  it('returns Pi capabilities', () => {
+    const caps = ProviderRegistry.getCapabilities('pi');
+    expect(caps.providerId).toBe('pi');
+    expect(caps.supportsProviderCommands).toBe(true);
+    expect(caps.supportsImageAttachments).toBe(true);
+    expect(caps.supportsTurnSteer).toBe(true);
+    expect(caps.supportsFork).toBe(false);
+  });
+
   it('lists registered provider ids', () => {
     const ids = ProviderRegistry.getRegisteredProviderIds();
     expect(ids).toContain('claude');
     expect(ids).toContain('codex');
+    expect(ids).toContain('pi');
   });
 
   it('filters enabled provider ids using registration metadata', () => {
@@ -113,6 +123,13 @@ describe('ProviderRegistry', () => {
         opencode: { enabled: true },
       },
     })).toEqual(['opencode', 'codex', 'claude']);
+    expect(ProviderRegistry.getEnabledProviderIds({
+      providerConfigs: {
+        codex: { enabled: true },
+        opencode: { enabled: true },
+        pi: { enabled: true },
+      },
+    })).toEqual(['opencode', 'pi', 'codex', 'claude']);
   });
 
   it('returns the display name from provider registration metadata', () => {

--- a/tests/unit/core/providers/ProviderRegistry.test.ts
+++ b/tests/unit/core/providers/ProviderRegistry.test.ts
@@ -96,7 +96,7 @@ describe('ProviderRegistry', () => {
     expect(caps.supportsProviderCommands).toBe(true);
     expect(caps.supportsImageAttachments).toBe(true);
     expect(caps.supportsTurnSteer).toBe(true);
-    expect(caps.supportsFork).toBe(false);
+    expect(caps.supportsFork).toBe(true);
   });
 
   it('lists registered provider ids', () => {

--- a/tests/unit/providers/acp/AcpSubprocess.test.ts
+++ b/tests/unit/providers/acp/AcpSubprocess.test.ts
@@ -7,7 +7,7 @@ jest.mock('node:child_process', () => ({
 
 import { spawn } from 'node:child_process';
 
-import { PiSubprocess } from '@/providers/pi/runtime/PiSubprocess';
+import { AcpSubprocess } from '@/providers/acp/AcpSubprocess';
 
 const mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
 
@@ -19,14 +19,11 @@ function createMockProcess(): any {
   proc.exitCode = null;
   proc.killed = false;
   proc.pid = 12345;
-  proc.kill = jest.fn((signal?: string) => {
-    proc.killed = signal === 'SIGKILL';
-    return true;
-  });
+  proc.kill = jest.fn(() => true);
   return proc;
 }
 
-describe('PiSubprocess', () => {
+describe('AcpSubprocess', () => {
   const originalPlatform = process.platform;
   let proc: any;
 
@@ -38,34 +35,30 @@ describe('PiSubprocess', () => {
 
   afterEach(() => {
     Object.defineProperty(process, 'platform', { value: originalPlatform });
-    jest.useRealTimers();
   });
 
-  it('spawns Pi RPC with the launch spec args, cwd, stdio, and enhanced PATH', () => {
-    const subprocess = new PiSubprocess({
-      args: ['--mode', 'rpc'],
-      command: '/opt/pi/bin/pi',
+  it('spawns ACP runtimes directly on non-Windows commands', () => {
+    const subprocess = new AcpSubprocess({
+      args: ['acp', '--cwd=/vault'],
+      command: '/opt/opencode/bin/opencode',
       cwd: '/vault',
       env: { PATH: '/usr/bin' },
     });
 
     subprocess.start();
 
-    expect(mockSpawn).toHaveBeenCalledWith('/opt/pi/bin/pi', ['--mode', 'rpc'], expect.objectContaining({
+    expect(mockSpawn).toHaveBeenCalledWith('/opt/opencode/bin/opencode', ['acp', '--cwd=/vault'], expect.objectContaining({
       cwd: '/vault',
       stdio: 'pipe',
       windowsHide: true,
-      env: expect.objectContaining({
-        PATH: expect.stringContaining('/usr/bin'),
-      }),
     }));
   });
 
   it('wraps Windows .cmd shims through cmd.exe', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
-    const subprocess = new PiSubprocess({
-      args: ['--mode', 'rpc', '--system-prompt', 'Use R&D policy'],
-      command: 'C:\\Users\\R&D\\AppData\\Roaming\\npm\\pi.cmd',
+    const subprocess = new AcpSubprocess({
+      args: ['acp', '--cwd=C:\\Vault'],
+      command: 'C:\\Users\\R&D\\AppData\\Roaming\\npm\\opencode.cmd',
       cwd: 'C:\\Vault',
       env: { PATH: 'C:\\Windows\\System32' },
     });
@@ -74,7 +67,7 @@ describe('PiSubprocess', () => {
 
     expect(mockSpawn).toHaveBeenCalledWith(
       process.env.ComSpec || process.env.comspec || 'cmd.exe',
-      ['/d', '/s', '/c', '""C:\\Users\\R&D\\AppData\\Roaming\\npm\\pi.cmd" --mode rpc --system-prompt "Use R&D policy""'],
+      ['/d', '/s', '/c', '""C:\\Users\\R&D\\AppData\\Roaming\\npm\\opencode.cmd" acp "--cwd=C:\\Vault""'],
       expect.objectContaining({
         cwd: 'C:\\Vault',
         windowsHide: true,
@@ -85,9 +78,9 @@ describe('PiSubprocess', () => {
 
   it('kills the process tree when shutting down Windows .cmd shims', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
-    const subprocess = new PiSubprocess({
-      args: ['--mode', 'rpc'],
-      command: 'C:\\Users\\R&D\\AppData\\Roaming\\npm\\pi.cmd',
+    const subprocess = new AcpSubprocess({
+      args: ['acp', '--cwd=C:\\Vault'],
+      command: 'C:\\Users\\R&D\\AppData\\Roaming\\npm\\opencode.cmd',
       cwd: 'C:\\Vault',
       env: { PATH: 'C:\\Windows\\System32' },
     });
@@ -108,44 +101,5 @@ describe('PiSubprocess', () => {
     proc.exitCode = 0;
     proc.emit('exit', 0, null);
     await shutdown;
-  });
-
-  it('keeps a bounded stderr snapshot for runtime errors', () => {
-    const subprocess = new PiSubprocess({
-      args: ['--mode', 'rpc'],
-      command: 'pi',
-      cwd: '/vault',
-      env: {},
-    });
-    subprocess.start();
-
-    proc.stderr.emit('data', 'a'.repeat(9_000));
-
-    expect(subprocess.getStderrSnapshot()).toHaveLength(8_000);
-  });
-
-  it('notifies close listeners and escalates shutdown after timeout', async () => {
-    jest.useFakeTimers();
-    const subprocess = new PiSubprocess({
-      args: ['--mode', 'rpc'],
-      command: 'pi',
-      cwd: '/vault',
-      env: {},
-    });
-    const onClose = jest.fn();
-    subprocess.onClose(onClose);
-    subprocess.start();
-
-    const shutdown = subprocess.shutdown();
-    expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
-
-    jest.advanceTimersByTime(3_000);
-    expect(proc.kill).toHaveBeenCalledWith('SIGKILL');
-
-    proc.exitCode = 1;
-    proc.emit('exit', 1, 'SIGKILL');
-    await shutdown;
-
-    expect(onClose).toHaveBeenCalledWith(expect.any(Error));
   });
 });

--- a/tests/unit/providers/claude/runtime/customSpawn.test.ts
+++ b/tests/unit/providers/claude/runtime/customSpawn.test.ts
@@ -9,9 +9,11 @@ jest.mock('child_process', () => ({
 }));
 
 describe('createCustomSpawnFunction', () => {
+  const originalPlatform = process.platform;
   const spawnMock = spawn as jest.MockedFunction<typeof spawn>;
 
   afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
     jest.restoreAllMocks();
     spawnMock.mockReset();
   });
@@ -22,6 +24,7 @@ describe('createCustomSpawnFunction', () => {
       stdin: {} as NodeJS.WritableStream,
       stdout: {} as NodeJS.ReadableStream,
       stderr,
+      pid: 12345,
       killed: false,
       exitCode: null,
       kill: jest.fn(),
@@ -207,6 +210,92 @@ describe('createCustomSpawnFunction', () => {
 
     expect(findNodeExecutable).not.toHaveBeenCalled();
     expect(spawnMock).toHaveBeenCalledWith('python', ['script.py'], expect.any(Object));
+  });
+
+  it('wraps manually configured Windows .cmd commands through cmd.exe', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const mockProcess = createMockProcess();
+    spawnMock.mockReturnValue(mockProcess as unknown as ReturnType<typeof spawn>);
+
+    const findNodeExecutable = jest.spyOn(env, 'findNodeExecutable');
+
+    const spawnFn = createCustomSpawnFunction('/enhanced/path');
+    spawnFn({
+      command: 'C:\\Users\\R&D\\AppData\\Roaming\\npm\\claude.cmd',
+      args: ['--output-format', 'stream-json'],
+      cwd: 'C:\\Vault',
+      env: {},
+    } as SpawnOptions);
+
+    expect(findNodeExecutable).not.toHaveBeenCalled();
+    expect(spawnMock).toHaveBeenCalledWith(
+      process.env.ComSpec || process.env.comspec || 'cmd.exe',
+      ['/d', '/s', '/c', '""C:\\Users\\R&D\\AppData\\Roaming\\npm\\claude.cmd" --output-format stream-json"'],
+      expect.objectContaining({
+        cwd: 'C:\\Vault',
+        windowsHide: true,
+        windowsVerbatimArguments: true,
+      }),
+    );
+  });
+
+  it('kills the process tree when aborting manually configured Windows .cmd commands', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const mockProcess = createMockProcess();
+    const originalKill = mockProcess.kill;
+    spawnMock.mockReturnValue(mockProcess as unknown as ReturnType<typeof spawn>);
+
+    const controller = new AbortController();
+    const spawnFn = createCustomSpawnFunction('/enhanced/path');
+    spawnFn({
+      command: 'C:\\Users\\R&D\\AppData\\Roaming\\npm\\claude.cmd',
+      args: ['--output-format', 'stream-json'],
+      cwd: 'C:\\Vault',
+      env: {},
+      signal: controller.signal,
+    } as SpawnOptions);
+
+    controller.abort();
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'taskkill.exe',
+      ['/pid', '12345', '/t', '/f'],
+      expect.objectContaining({
+        stdio: 'ignore',
+        windowsHide: true,
+      }),
+    );
+    expect(originalKill).not.toHaveBeenCalled();
+  });
+
+  it('delegates returned Windows .cmd process kill to process-tree termination', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const mockProcess = createMockProcess();
+    const originalKill = mockProcess.kill;
+    spawnMock.mockReturnValue(mockProcess as unknown as ReturnType<typeof spawn>);
+
+    const spawnFn = createCustomSpawnFunction('/enhanced/path');
+    const result = spawnFn({
+      command: 'C:\\Users\\R&D\\AppData\\Roaming\\npm\\claude.cmd',
+      args: ['--output-format', 'stream-json'],
+      cwd: 'C:\\Vault',
+      env: {},
+    } as SpawnOptions);
+
+    expect(result).toBe(mockProcess);
+    expect(result.kill).not.toBe(originalKill);
+
+    result.kill('SIGKILL');
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'taskkill.exe',
+      ['/pid', '12345', '/t', '/f'],
+      expect.objectContaining({
+        stdio: 'ignore',
+        windowsHide: true,
+      }),
+    );
+    expect(originalKill).not.toHaveBeenCalled();
   });
 
   it('does not pass signal to spawn options', () => {

--- a/tests/unit/providers/claude/storage/ClaudianSettingsStorage.test.ts
+++ b/tests/unit/providers/claude/storage/ClaudianSettingsStorage.test.ts
@@ -10,6 +10,7 @@ import {
 import { DEFAULT_SETTINGS } from '@/providers/claude/types/settings';
 import { getCodexProviderSettings } from '@/providers/codex/settings';
 import { getOpencodeProviderSettings } from '@/providers/opencode/settings';
+import { getPiProviderSettings } from '@/providers/pi/settings';
 
 const mockGetHostnameKey = jest.fn(() => 'host-a');
 const mockGetLegacyHostnameKey = jest.fn(() => 'legacy-host');
@@ -228,6 +229,12 @@ describe('ClaudianSettingsStorage', () => {
               'host-b': '/custom/opencode-b',
             },
           },
+          pi: {
+            cliPathsByHost: {
+              'host-a': '/custom/pi-a',
+              'host-b': '/custom/pi-b',
+            },
+          },
         },
       }));
 
@@ -235,7 +242,9 @@ describe('ClaudianSettingsStorage', () => {
       const claudeSettings = getClaudeProviderSettings(result);
       const codexSettings = getCodexProviderSettings(result);
       const opencodeSettings = getOpencodeProviderSettings(result);
+      const piSettings = getPiProviderSettings(result);
       const persistedOpencodeConfig = result.providerConfigs.opencode as Record<string, unknown>;
+      const persistedPiConfig = result.providerConfigs.pi as Record<string, unknown>;
       const writtenContent = JSON.parse(mockAdapter.write.mock.calls[0][1]);
 
       expect(claudeSettings.cliPathsByHost).toEqual({
@@ -260,9 +269,17 @@ describe('ClaudianSettingsStorage', () => {
         'device:current': '/custom/opencode-a',
         'host-b': '/custom/opencode-b',
       });
+      expect(piSettings.cliPathsByHost).toEqual({
+        'device:current': '/custom/pi-a',
+        'host-b': '/custom/pi-b',
+      });
       expect(persistedOpencodeConfig.cliPathsByHost).toEqual({
         'device:current': '/custom/opencode-a',
         'host-b': '/custom/opencode-b',
+      });
+      expect(persistedPiConfig.cliPathsByHost).toEqual({
+        'device:current': '/custom/pi-a',
+        'host-b': '/custom/pi-b',
       });
       expect(writtenContent.providerConfigs.claude.cliPathsByHost).toEqual({
         'device:current': '/custom/claude-a',
@@ -275,6 +292,10 @@ describe('ClaudianSettingsStorage', () => {
       expect(writtenContent.providerConfigs.opencode.cliPathsByHost).toEqual({
         'device:current': '/custom/opencode-a',
         'host-b': '/custom/opencode-b',
+      });
+      expect(writtenContent.providerConfigs.pi.cliPathsByHost).toEqual({
+        'device:current': '/custom/pi-a',
+        'host-b': '/custom/pi-b',
       });
     });
 

--- a/tests/unit/providers/codex/runtime/CodexAppServerProcess.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexAppServerProcess.test.ts
@@ -192,6 +192,29 @@ describe('CodexAppServerProcess', () => {
       expect(mockProc.kill).toHaveBeenCalledWith('SIGTERM');
     });
 
+    it('kills the process tree when shutting down Windows .cmd shims', async () => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      const server = new CodexAppServerProcess(createLaunchSpec({
+        command: 'C:\\Users\\R&D\\AppData\\Roaming\\npm\\codex.cmd',
+      }));
+      server.start();
+
+      const shutdownPromise = server.shutdown();
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'taskkill.exe',
+        ['/pid', '12345', '/t', '/f'],
+        expect.objectContaining({
+          stdio: 'ignore',
+          windowsHide: true,
+        }),
+      );
+      expect(mockProc.kill).not.toHaveBeenCalled();
+
+      mockProc.emit('exit', 0, null);
+      await shutdownPromise;
+    });
+
     it('sends SIGKILL if process does not exit within timeout', async () => {
       jest.useFakeTimers();
       const server = new CodexAppServerProcess(createLaunchSpec());

--- a/tests/unit/providers/defaultProviderConfigs.test.ts
+++ b/tests/unit/providers/defaultProviderConfigs.test.ts
@@ -8,9 +8,11 @@ describe('getBuiltInProviderDefaultConfigs', () => {
     expect(first).toHaveProperty('claude');
     expect(first).toHaveProperty('codex');
     expect(first).toHaveProperty('opencode');
+    expect(first).toHaveProperty('pi');
     expect(first).not.toBe(second);
     expect(first.claude).not.toBe(second.claude);
     expect(first.codex).not.toBe(second.codex);
     expect(first.opencode).not.toBe(second.opencode);
+    expect(first.pi).not.toBe(second.pi);
   });
 });

--- a/tests/unit/providers/opencode/OpencodeCliResolver.test.ts
+++ b/tests/unit/providers/opencode/OpencodeCliResolver.test.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as path from 'path';
 
 import { OpencodeCliResolver } from '@/providers/opencode/runtime/OpencodeCliResolver';
 
@@ -8,17 +9,21 @@ jest.mock('@/utils/env', () => ({
   getHostnameKey: () => 'current-host',
 }));
 
-const mockedExists = fs.existsSync as jest.Mock;
 const mockedStat = fs.statSync as jest.Mock;
 
 describe('OpencodeCliResolver', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (fs.existsSync as jest.Mock).mockReturnValue(false);
   });
 
   it('uses the current host path instead of another synced host path', () => {
-    mockedExists.mockImplementation((filePath: string) => filePath === '/current/opencode');
-    mockedStat.mockReturnValue({ isFile: () => true });
+    mockedStat.mockImplementation((filePath: string) => {
+      if (filePath === '/current/opencode') {
+        return { isFile: () => true };
+      }
+      throw new Error(`ENOENT: ${filePath}`);
+    });
 
     const resolver = new OpencodeCliResolver();
     const resolved = resolver.resolve(
@@ -34,8 +39,12 @@ describe('OpencodeCliResolver', () => {
   });
 
   it('falls back to the legacy path when the current host has no custom path', () => {
-    mockedExists.mockImplementation((filePath: string) => filePath === '/legacy/opencode');
-    mockedStat.mockReturnValue({ isFile: () => true });
+    mockedStat.mockImplementation((filePath: string) => {
+      if (filePath === '/legacy/opencode') {
+        return { isFile: () => true };
+      }
+      throw new Error(`ENOENT: ${filePath}`);
+    });
 
     const resolver = new OpencodeCliResolver();
     const resolved = resolver.resolve(
@@ -50,7 +59,9 @@ describe('OpencodeCliResolver', () => {
   });
 
   it('returns null when neither the current host nor the legacy path resolve to a file', () => {
-    mockedExists.mockReturnValue(false);
+    mockedStat.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
 
     const resolver = new OpencodeCliResolver();
     const resolved = resolver.resolve(
@@ -62,5 +73,21 @@ describe('OpencodeCliResolver', () => {
     );
 
     expect(resolved).toBeNull();
+  });
+
+  it('falls back to PATH lookup when no OpenCode CLI path is configured', () => {
+    const pathDir = '/custom/bin';
+    const pathBinary = path.join(pathDir, 'opencode');
+    mockedStat.mockImplementation((filePath: string) => {
+      if (filePath === pathBinary) {
+        return { isFile: () => true };
+      }
+      throw new Error(`ENOENT: ${filePath}`);
+    });
+
+    const resolver = new OpencodeCliResolver();
+    const resolved = resolver.resolve({}, '', `PATH=${pathDir}`);
+
+    expect(resolved).toBe(pathBinary);
   });
 });

--- a/tests/unit/providers/pi/PiRuntimeCommandLoader.test.ts
+++ b/tests/unit/providers/pi/PiRuntimeCommandLoader.test.ts
@@ -1,0 +1,149 @@
+const mockCreatedRuntimes: Array<{
+  cleanup: jest.Mock;
+  ensureReady: jest.Mock;
+  getSupportedCommands: jest.Mock;
+  providerId: string;
+  syncConversationState: jest.Mock;
+}> = [];
+
+jest.mock('@/providers/pi/runtime/PiChatRuntime', () => ({
+  PiChatRuntime: jest.fn().mockImplementation(() => {
+    const runtime = {
+      cleanup: jest.fn(),
+      ensureReady: jest.fn().mockResolvedValue(true),
+      getSupportedCommands: jest.fn().mockResolvedValue([
+        { content: '', id: 'pi:runtime:test', name: 'test', source: 'sdk' },
+      ]),
+      providerId: 'pi',
+      syncConversationState: jest.fn(),
+    };
+    mockCreatedRuntimes.push(runtime);
+    return runtime;
+  }),
+}));
+
+import type { Conversation } from '@/core/types';
+import { PiRuntimeCommandLoader } from '@/providers/pi/app/PiRuntimeCommandLoader';
+import { PiChatRuntime } from '@/providers/pi/runtime/PiChatRuntime';
+
+function createConversation(overrides: Partial<Conversation> = {}): Conversation {
+  return {
+    createdAt: 1,
+    id: 'conversation-1',
+    messages: [],
+    providerId: 'pi',
+    sessionId: null,
+    title: 'Conversation',
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+describe('PiRuntimeCommandLoader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreatedRuntimes.length = 0;
+  });
+
+  it('does not reuse a live runtime for a pre-session conversation when session creation is disallowed', async () => {
+    const runtime = {
+      cleanup: jest.fn(),
+      ensureReady: jest.fn(),
+      getSupportedCommands: jest.fn(),
+      isReady: jest.fn().mockReturnValue(true),
+      providerId: 'pi',
+      syncConversationState: jest.fn(),
+    };
+    const conversation = createConversation({
+      messages: [{ content: 'Existing imported prompt', id: 'm1', role: 'user', timestamp: 1 }],
+      sessionId: null,
+    });
+
+    const commands = await new PiRuntimeCommandLoader().loadCommands({
+      allowSessionCreation: false,
+      conversation,
+      externalContextPaths: [],
+      plugin: {} as any,
+      runtime: runtime as any,
+    });
+
+    expect(commands).toEqual([]);
+    expect(runtime.ensureReady).not.toHaveBeenCalled();
+    expect(runtime.syncConversationState).not.toHaveBeenCalled();
+    expect(PiChatRuntime).not.toHaveBeenCalled();
+  });
+
+  it('loads commands for conversations with persisted Pi session state', async () => {
+    const conversation = createConversation({
+      providerState: { sessionFile: '/tmp/pi-session.jsonl' },
+      sessionId: null,
+    });
+
+    const commands = await new PiRuntimeCommandLoader().loadCommands({
+      allowSessionCreation: false,
+      conversation,
+      externalContextPaths: ['docs'],
+      plugin: {} as any,
+      runtime: null,
+    });
+
+    expect(commands).toEqual([
+      { content: '', id: 'pi:runtime:test', name: 'test', source: 'sdk' },
+    ]);
+    expect(PiChatRuntime).toHaveBeenCalledTimes(1);
+    expect(mockCreatedRuntimes[0].syncConversationState).not.toHaveBeenCalled();
+    expect(mockCreatedRuntimes[0].ensureReady).toHaveBeenCalledWith({ allowSessionCreation: false });
+    expect(mockCreatedRuntimes[0].cleanup).toHaveBeenCalled();
+  });
+
+  it('uses a no-session runtime for blank-tab command warmup', async () => {
+    const commands = await new PiRuntimeCommandLoader().loadCommands({
+      allowSessionCreation: true,
+      conversation: null,
+      externalContextPaths: [],
+      plugin: {} as any,
+      runtime: null,
+    });
+
+    expect(commands).toEqual([
+      { content: '', id: 'pi:runtime:test', name: 'test', source: 'sdk' },
+    ]);
+    expect(PiChatRuntime).toHaveBeenCalledTimes(1);
+    expect(mockCreatedRuntimes[0].syncConversationState).not.toHaveBeenCalled();
+    expect(mockCreatedRuntimes[0].ensureReady).toHaveBeenCalledWith({ allowSessionCreation: false });
+    expect(mockCreatedRuntimes[0].cleanup).toHaveBeenCalled();
+  });
+
+  it('reuses a ready Pi runtime without creating a command-only process', async () => {
+    const runtime = {
+      cleanup: jest.fn(),
+      ensureReady: jest.fn().mockResolvedValue(true),
+      getSupportedCommands: jest.fn().mockResolvedValue([
+        { content: '', id: 'pi:runtime:live', name: 'live', source: 'sdk' },
+      ]),
+      isReady: jest.fn().mockReturnValue(true),
+      providerId: 'pi',
+      syncConversationState: jest.fn(),
+    };
+    const conversation = createConversation({
+      providerState: { sessionFile: '/tmp/pi-session.jsonl' },
+      sessionId: null,
+    });
+
+    const commands = await new PiRuntimeCommandLoader().loadCommands({
+      allowSessionCreation: false,
+      conversation,
+      externalContextPaths: ['docs'],
+      plugin: {} as any,
+      runtime: runtime as any,
+    });
+
+    expect(commands).toEqual([
+      { content: '', id: 'pi:runtime:live', name: 'live', source: 'sdk' },
+    ]);
+    expect(PiChatRuntime).not.toHaveBeenCalled();
+    expect(runtime.syncConversationState).toHaveBeenCalledWith(conversation, ['docs']);
+    expect(runtime.ensureReady).toHaveBeenCalledWith({ allowSessionCreation: false });
+    expect(runtime.cleanup).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/providers/pi/capabilities.test.ts
+++ b/tests/unit/providers/pi/capabilities.test.ts
@@ -1,14 +1,14 @@
 import { PI_PROVIDER_CAPABILITIES } from '@/providers/pi/capabilities';
 
 describe('PI_PROVIDER_CAPABILITIES', () => {
-  it('exposes the Phase 1-3 Pi capability contract', () => {
+  it('exposes the Pi capability contract', () => {
     expect(PI_PROVIDER_CAPABILITIES).toMatchObject({
       providerId: 'pi',
       supportsPersistentRuntime: true,
       supportsNativeHistory: true,
       supportsPlanMode: false,
       supportsRewind: false,
-      supportsFork: false,
+      supportsFork: true,
       supportsProviderCommands: true,
       supportsImageAttachments: true,
       supportsInstructionMode: true,

--- a/tests/unit/providers/pi/capabilities.test.ts
+++ b/tests/unit/providers/pi/capabilities.test.ts
@@ -1,0 +1,20 @@
+import { PI_PROVIDER_CAPABILITIES } from '@/providers/pi/capabilities';
+
+describe('PI_PROVIDER_CAPABILITIES', () => {
+  it('exposes the Phase 1-3 Pi capability contract', () => {
+    expect(PI_PROVIDER_CAPABILITIES).toMatchObject({
+      providerId: 'pi',
+      supportsPersistentRuntime: true,
+      supportsNativeHistory: true,
+      supportsPlanMode: false,
+      supportsRewind: false,
+      supportsFork: false,
+      supportsProviderCommands: true,
+      supportsImageAttachments: true,
+      supportsInstructionMode: true,
+      supportsMcpTools: false,
+      supportsTurnSteer: true,
+      reasoningControl: 'effort',
+    });
+  });
+});

--- a/tests/unit/providers/pi/commands/PiCommandCatalog.test.ts
+++ b/tests/unit/providers/pi/commands/PiCommandCatalog.test.ts
@@ -1,0 +1,69 @@
+import { PiCommandCatalog } from '@/providers/pi/commands/PiCommandCatalog';
+
+describe('PiCommandCatalog', () => {
+  it('maps deduped runtime commands into slash dropdown entries', async () => {
+    const catalog = new PiCommandCatalog();
+    catalog.setRuntimeCommands([
+      {
+        argumentHint: '<topic>',
+        content: '',
+        description: 'Review changes',
+        id: 'pi:prompt:review',
+        name: '/review',
+        source: 'sdk',
+      },
+      {
+        content: '',
+        description: 'Duplicate review',
+        id: 'pi:prompt:review-duplicate',
+        name: 'review',
+        source: 'sdk',
+      },
+      {
+        content: '',
+        description: 'Skill command',
+        id: 'pi:skill:test',
+        kind: 'skill',
+        name: 'test',
+        source: 'sdk',
+      },
+    ]);
+
+    await expect(catalog.listDropdownEntries({ includeBuiltIns: false })).resolves.toEqual([
+      expect.objectContaining({
+        argumentHint: '<topic>',
+        description: 'Review changes',
+        displayPrefix: '/',
+        id: 'pi:prompt:review',
+        insertPrefix: '/',
+        isDeletable: false,
+        isEditable: false,
+        kind: 'command',
+        name: 'review',
+        providerId: 'pi',
+        scope: 'runtime',
+      }),
+      expect.objectContaining({
+        id: 'pi:skill:test',
+        kind: 'skill',
+        name: 'test',
+        providerId: 'pi',
+      }),
+    ]);
+  });
+
+  it('uses slash triggers and rejects vault edits', async () => {
+    const catalog = new PiCommandCatalog();
+
+    expect(catalog.getDropdownConfig()).toEqual({
+      builtInPrefix: '/',
+      commandPrefix: '/',
+      providerId: 'pi',
+      skillPrefix: '/',
+      triggerChars: ['/'],
+    });
+    await expect(catalog.listVaultEntries()).resolves.toEqual([]);
+    await expect(catalog.saveVaultEntry({} as any)).rejects.toThrow('not editable');
+    await expect(catalog.deleteVaultEntry({} as any)).rejects.toThrow('not deletable');
+  });
+});

--- a/tests/unit/providers/pi/env/PiSettingsReconciler.test.ts
+++ b/tests/unit/providers/pi/env/PiSettingsReconciler.test.ts
@@ -1,0 +1,61 @@
+import type { Conversation } from '@/core/types';
+import { piSettingsReconciler } from '@/providers/pi/env/PiSettingsReconciler';
+
+describe('piSettingsReconciler', () => {
+  it('invalidates Pi conversations when Pi session/config environment changes', () => {
+    const settings: Record<string, unknown> = {
+      providerConfigs: {
+        pi: {
+          environmentHash: 'PI_CODING_AGENT_SESSION_DIR=/old',
+          environmentVariables: 'PI_CODING_AGENT_SESSION_DIR=/new\nPI_OFFLINE=1',
+        },
+      },
+    };
+    const piConversation = {
+      id: 'pi-conversation',
+      messages: [],
+      providerId: 'pi',
+      providerState: { sessionFile: '/old/session.jsonl' },
+      sessionId: 'session-1',
+    } as unknown as Conversation;
+    const claudeConversation = {
+      id: 'claude-conversation',
+      messages: [],
+      providerId: 'claude',
+      providerState: { providerSessionId: 'claude-session' },
+      sessionId: 'claude-session',
+    } as unknown as Conversation;
+
+    const result = piSettingsReconciler.reconcileModelWithEnvironment(
+      settings,
+      [piConversation, claudeConversation],
+    );
+
+    expect(result.changed).toBe(true);
+    expect(result.invalidatedConversations).toEqual([piConversation]);
+    expect(piConversation.sessionId).toBeNull();
+    expect(piConversation.providerState).toBeUndefined();
+    expect(claudeConversation.sessionId).toBe('claude-session');
+    expect((settings.providerConfigs as any).pi.environmentHash).toBe(
+      'PI_CODING_AGENT_SESSION_DIR=/new|PI_OFFLINE=1',
+    );
+  });
+
+  it('normalizes malformed Pi model selections instead of preserving invalid ids', () => {
+    const settings: Record<string, unknown> = {
+      model: 'pi:missing-slash',
+      providerConfigs: {
+        pi: {},
+      },
+      savedProviderModel: {
+        pi: 'pi:also-invalid',
+      },
+      titleGenerationModel: 'pi:invalid-title',
+    };
+
+    expect(piSettingsReconciler.normalizeModelVariantSettings(settings)).toBe(true);
+    expect(settings.model).toBe('pi');
+    expect(settings.titleGenerationModel).toBe('');
+    expect(settings.savedProviderModel).toEqual({});
+  });
+});

--- a/tests/unit/providers/pi/history/PiConversationHistoryService.test.ts
+++ b/tests/unit/providers/pi/history/PiConversationHistoryService.test.ts
@@ -39,20 +39,107 @@ describe('PiConversationHistoryService', () => {
     });
   });
 
-  it('sanitizes persisted provider state and keeps fork disabled', () => {
+  it('builds pending fork state from source session metadata', () => {
+    const service = new PiConversationHistoryService();
+    const conversation = createConversation('/tmp/session.jsonl');
+    conversation.providerState = {
+      forkSource: { sessionId: 'source-session', resumeAt: 'assistant-1' },
+      forkSourceSessionFile: '/tmp/source.jsonl',
+    };
+    conversation.sessionId = null;
+
+    expect(service.isPendingForkConversation(conversation)).toBe(true);
+    expect(service.resolveSessionIdForConversation(conversation)).toBe('source-session');
+    expect(service.buildForkProviderState('s1', 'checkpoint', {
+      sessionFile: '/tmp/session.jsonl',
+    })).toEqual({
+      forkSource: { sessionId: 's1', resumeAt: 'checkpoint' },
+      forkSourceSessionFile: '/tmp/session.jsonl',
+    });
+    expect(service.buildForkProviderState('source-session', 'checkpoint', {
+      forkSource: { sessionId: 'source-session', resumeAt: 'assistant-1' },
+      forkSourceSessionFile: '/tmp/source.jsonl',
+    })).toEqual({
+      forkSource: { sessionId: 'source-session', resumeAt: 'checkpoint' },
+      forkSourceSessionFile: '/tmp/source.jsonl',
+    });
+  });
+
+  it('resolves file-only Pi sessions as fork sources', () => {
+    const service = new PiConversationHistoryService();
+    const conversation = createConversation('/tmp/session.jsonl');
+    conversation.providerState = { sessionFile: '/tmp/session.jsonl' };
+    conversation.sessionId = null;
+
+    expect(service.resolveSessionIdForConversation(conversation)).toBe('/tmp/session.jsonl');
+    expect(service.buildForkProviderState('/tmp/session.jsonl', 'checkpoint', {
+      sessionFile: '/tmp/session.jsonl',
+    })).toEqual({
+      forkSource: { sessionId: '/tmp/session.jsonl', resumeAt: 'checkpoint' },
+      forkSourceSessionFile: '/tmp/session.jsonl',
+    });
+  });
+
+  it('hydrates pending forks from the source session truncated at the checkpoint', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-history-fork-'));
+    const sessionFile = path.join(dir, 'source.jsonl');
+    await fs.writeFile(sessionFile, [
+      JSON.stringify({ type: 'session', id: 'source-session' }),
+      JSON.stringify({ id: 'u1', type: 'message', message: { role: 'user', content: 'First' } }),
+      JSON.stringify({ id: 'a1', type: 'message', message: { role: 'assistant', content: 'Done' } }),
+      JSON.stringify({ id: 'u2', type: 'message', message: { role: 'user', content: 'Later' } }),
+    ].join('\n'));
+    const conversation = createConversation(sessionFile);
+    conversation.messages = [];
+    conversation.providerState = {
+      forkSource: { sessionId: 'source-session', resumeAt: 'a1' },
+      forkSourceSessionFile: sessionFile,
+    };
+    conversation.sessionId = null;
+    const service = new PiConversationHistoryService();
+
+    await service.hydrateConversationHistory(conversation, null);
+
+    expect(conversation.messages.map(message => message.content)).toEqual(['First', 'Done']);
+  });
+
+  it('does not hydrate pending forks when the checkpoint is missing', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-history-fork-missing-'));
+    const sessionFile = path.join(dir, 'source.jsonl');
+    await fs.writeFile(sessionFile, [
+      JSON.stringify({ type: 'session', id: 'source-session' }),
+      JSON.stringify({ id: 'u1', type: 'message', message: { role: 'user', content: 'First' } }),
+      JSON.stringify({ id: 'a1', type: 'message', message: { role: 'assistant', content: 'Done' } }),
+      JSON.stringify({ id: 'u2', type: 'message', message: { role: 'user', content: 'Later' } }),
+    ].join('\n'));
+    const conversation = createConversation(sessionFile);
+    conversation.messages = [];
+    conversation.providerState = {
+      forkSource: { sessionId: 'source-session', resumeAt: 'missing-checkpoint' },
+      forkSourceSessionFile: sessionFile,
+    };
+    conversation.sessionId = null;
+    const service = new PiConversationHistoryService();
+
+    await service.hydrateConversationHistory(conversation, null);
+
+    expect(conversation.messages).toEqual([]);
+  });
+
+  it('sanitizes persisted provider state', () => {
     const service = new PiConversationHistoryService();
     const conversation = createConversation('/tmp/session.jsonl');
     conversation.providerState = {
       empty: '',
       leafEntryId: 'leaf-1',
+      parentSession: '/tmp/source.jsonl',
       sessionFile: '/tmp/session.jsonl',
       sessionId: 's1',
     };
 
-    expect(service.isPendingForkConversation(conversation)).toBe(false);
-    expect(service.buildForkProviderState('s1', 'checkpoint')).toEqual({});
     expect(service.buildPersistedProviderState?.(conversation)).toEqual({
       leafEntryId: 'leaf-1',
+      parentSession: '/tmp/source.jsonl',
       sessionFile: '/tmp/session.jsonl',
       sessionId: 's1',
     });

--- a/tests/unit/providers/pi/history/PiConversationHistoryService.test.ts
+++ b/tests/unit/providers/pi/history/PiConversationHistoryService.test.ts
@@ -1,0 +1,60 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import type { Conversation } from '@/core/types';
+import { PiConversationHistoryService } from '@/providers/pi/history/PiConversationHistoryService';
+
+function createConversation(sessionFile: string): Conversation {
+  return {
+    createdAt: 1,
+    id: 'conv-1',
+    messages: [],
+    providerId: 'pi',
+    providerState: { sessionFile, sessionId: 's1' },
+    sessionId: 's1',
+    title: 'Pi',
+    updatedAt: 1,
+  };
+}
+
+describe('PiConversationHistoryService', () => {
+  it('hydrates from providerState sessionFile', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-history-'));
+    const sessionFile = path.join(dir, 'session.jsonl');
+    await fs.writeFile(sessionFile, JSON.stringify({
+      id: 'u1',
+      message: { content: 'Hello', role: 'user' },
+      type: 'entry',
+    }));
+    const conversation = createConversation(sessionFile);
+    const service = new PiConversationHistoryService();
+
+    await service.hydrateConversationHistory(conversation, null);
+
+    expect(conversation.messages).toHaveLength(1);
+    expect(conversation.messages[0]).toMatchObject({
+      content: 'Hello',
+      role: 'user',
+    });
+  });
+
+  it('sanitizes persisted provider state and keeps fork disabled', () => {
+    const service = new PiConversationHistoryService();
+    const conversation = createConversation('/tmp/session.jsonl');
+    conversation.providerState = {
+      empty: '',
+      leafEntryId: 'leaf-1',
+      sessionFile: '/tmp/session.jsonl',
+      sessionId: 's1',
+    };
+
+    expect(service.isPendingForkConversation(conversation)).toBe(false);
+    expect(service.buildForkProviderState('s1', 'checkpoint')).toEqual({});
+    expect(service.buildPersistedProviderState?.(conversation)).toEqual({
+      leafEntryId: 'leaf-1',
+      sessionFile: '/tmp/session.jsonl',
+      sessionId: 's1',
+    });
+  });
+});

--- a/tests/unit/providers/pi/history/PiHistoryStore.test.ts
+++ b/tests/unit/providers/pi/history/PiHistoryStore.test.ts
@@ -1,0 +1,367 @@
+import {
+  parsePiSessionContent,
+  type PiSessionEntry,
+  resolvePiActivePath,
+} from '@/providers/pi/history/PiHistoryStore';
+
+describe('PiHistoryStore', () => {
+  it('parses linear user and assistant messages', () => {
+    const content = [
+      JSON.stringify({ type: 'session', id: 's1' }),
+      JSON.stringify({ id: 'u1', type: 'entry', message: { role: 'user', content: 'Hello' } }),
+      JSON.stringify({
+        id: 'a1',
+        type: 'entry',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', text: 'Thinking' },
+            { type: 'text', text: 'Hi' },
+          ],
+        },
+      }),
+    ].join('\n');
+
+    const messages = parsePiSessionContent(content);
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toMatchObject({
+      content: 'Hello',
+      role: 'user',
+      userMessageId: 'u1',
+    });
+    expect(messages[1]).toMatchObject({
+      assistantMessageId: 'a1',
+      content: 'Hi',
+      contentBlocks: [
+        { type: 'thinking', content: 'Thinking' },
+        { type: 'text', content: 'Hi' },
+      ],
+      role: 'assistant',
+    });
+  });
+
+  it('attaches tool results to the previous assistant tool call', () => {
+    const content = [
+      JSON.stringify({
+        id: 'a1',
+        type: 'entry',
+        message: {
+          role: 'assistant',
+          content: [
+            { id: 'tool-1', input: { path: 'a.md' }, name: 'read', type: 'toolCall' },
+          ],
+        },
+      }),
+      JSON.stringify({
+        result: { content: [{ text: 'file contents', type: 'text' }] },
+        toolCallId: 'tool-1',
+        type: 'toolResult',
+      }),
+    ].join('\n');
+
+    const messages = parsePiSessionContent(content);
+
+    expect(messages[0].toolCalls).toEqual([{
+      id: 'tool-1',
+      input: { file_path: 'a.md', path: 'a.md' },
+      name: 'Read',
+      result: 'file contents',
+      status: 'completed',
+    }]);
+  });
+
+  it('attaches real Pi message-role tool results to shared renderer tool calls', () => {
+    const content = [
+      JSON.stringify({
+        id: 'a1',
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [
+            { arguments: { path: 'a.md' }, id: 'tool-1', name: 'read', type: 'toolCall' },
+          ],
+        },
+      }),
+      JSON.stringify({
+        id: 'tr1',
+        parentId: 'a1',
+        type: 'message',
+        message: {
+          content: [{ text: 'file contents', type: 'text' }],
+          isError: false,
+          role: 'toolResult',
+          toolCallId: 'tool-1',
+          toolName: 'read',
+        },
+      }),
+    ].join('\n');
+
+    const messages = parsePiSessionContent(content);
+
+    expect(messages[0].toolCalls).toEqual([{
+      id: 'tool-1',
+      input: { file_path: 'a.md', path: 'a.md' },
+      name: 'Read',
+      result: 'file contents',
+      status: 'completed',
+    }]);
+    expect(messages[0].contentBlocks).toEqual([{ toolId: 'tool-1', type: 'tool_use' }]);
+  });
+
+  it('merges Pi assistant continuations split by tool results into one chat message', () => {
+    const content = [
+      JSON.stringify({ id: 'u1', type: 'message', message: { role: 'user', content: 'Hide scrollbars' } }),
+      JSON.stringify({
+        id: 'a1',
+        parentId: 'u1',
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'Inspecting snippets' },
+            { arguments: { path: '.obsidian' }, id: 'ls-1', name: 'ls', type: 'toolCall' },
+            { arguments: { path: '.obsidian/snippets' }, id: 'ls-2', name: 'ls', type: 'toolCall' },
+          ],
+        },
+      }),
+      JSON.stringify({
+        id: 'tr1',
+        parentId: 'a1',
+        type: 'message',
+        message: {
+          content: [{ text: 'appearance.json\nsnippets/', type: 'text' }],
+          isError: false,
+          role: 'toolResult',
+          toolCallId: 'ls-1',
+          toolName: 'ls',
+        },
+      }),
+      JSON.stringify({
+        id: 'tr2',
+        parentId: 'tr1',
+        type: 'message',
+        message: {
+          content: [{ text: 'existing.css', type: 'text' }],
+          isError: false,
+          role: 'toolResult',
+          toolCallId: 'ls-2',
+          toolName: 'ls',
+        },
+      }),
+      JSON.stringify({
+        id: 'a2',
+        parentId: 'tr2',
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [
+            { arguments: { path: '.obsidian/appearance.json' }, id: 'read-1', name: 'read', type: 'toolCall' },
+          ],
+        },
+      }),
+      JSON.stringify({
+        id: 'tr3',
+        parentId: 'a2',
+        type: 'message',
+        message: {
+          content: [{ text: '{"enabledCssSnippets":[]}', type: 'text' }],
+          isError: false,
+          role: 'toolResult',
+          toolCallId: 'read-1',
+          toolName: 'read',
+        },
+      }),
+      JSON.stringify({
+        id: 'a3',
+        parentId: 'tr3',
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'Creating snippet' },
+            { arguments: { path: '.obsidian/snippets/hide-scrollbars.css', content: 'css' }, id: 'write-1', name: 'write', type: 'toolCall' },
+          ],
+        },
+      }),
+      JSON.stringify({
+        id: 'tr4',
+        parentId: 'a3',
+        type: 'message',
+        message: {
+          content: [{ text: 'Successfully wrote file', type: 'text' }],
+          isError: false,
+          role: 'toolResult',
+          toolCallId: 'write-1',
+          toolName: 'write',
+        },
+      }),
+      JSON.stringify({
+        id: 'a4',
+        parentId: 'tr4',
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Done.' }],
+        },
+      }),
+    ].join('\n');
+
+    const messages = parsePiSessionContent(content);
+
+    expect(messages).toHaveLength(2);
+    expect(messages[1]).toMatchObject({
+      assistantMessageId: 'a4',
+      content: 'Done.',
+      role: 'assistant',
+    });
+    expect(messages[1].contentBlocks).toEqual([
+      { type: 'thinking', content: 'Inspecting snippets' },
+      { type: 'tool_use', toolId: 'ls-1' },
+      { type: 'tool_use', toolId: 'ls-2' },
+      { type: 'tool_use', toolId: 'read-1' },
+      { type: 'thinking', content: 'Creating snippet' },
+      { type: 'tool_use', toolId: 'write-1' },
+      { type: 'text', content: 'Done.' },
+    ]);
+    expect(messages[1].toolCalls?.map(toolCall => ({
+      id: toolCall.id,
+      result: toolCall.result,
+      status: toolCall.status,
+    }))).toEqual([
+      { id: 'ls-1', result: 'appearance.json\nsnippets/', status: 'completed' },
+      { id: 'ls-2', result: 'existing.css', status: 'completed' },
+      { id: 'read-1', result: '{"enabledCssSnippets":[]}', status: 'completed' },
+      { id: 'write-1', result: 'Successfully wrote file', status: 'completed' },
+    ]);
+  });
+
+  it('hydrates Pi write/edit tool calls with diff data for stored rendering', () => {
+    const content = [
+      JSON.stringify({
+        id: 'a1',
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              arguments: {
+                edits: [{ oldText: 'old', newText: 'new' }],
+                path: 'notes/a.md',
+              },
+              id: 'edit-1',
+              name: 'edit',
+              type: 'toolCall',
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        id: 'tr1',
+        parentId: 'a1',
+        type: 'message',
+        message: {
+          content: [{ text: 'Edited notes/a.md', type: 'text' }],
+          details: {
+            diff: '--- a/notes/a.md\n+++ b/notes/a.md\n@@ -1 +1 @@\n-old\n+new',
+          },
+          isError: false,
+          role: 'toolResult',
+          toolCallId: 'edit-1',
+          toolName: 'edit',
+        },
+      }),
+    ].join('\n');
+
+    const messages = parsePiSessionContent(content);
+
+    expect(messages[0].toolCalls?.[0]).toMatchObject({
+      id: 'edit-1',
+      input: {
+        edits: [{ oldText: 'old', newText: 'new' }],
+        file_path: 'notes/a.md',
+        path: 'notes/a.md',
+      },
+      name: 'Edit',
+      result: 'Edited notes/a.md',
+      status: 'completed',
+    });
+    expect(messages[0].toolCalls?.[0].diffData).toMatchObject({
+      filePath: 'notes/a.md',
+      stats: { added: 1, removed: 1 },
+    });
+    expect(messages[0].toolCalls?.[0].diffData?.diffLines.map(line => line.text)).toEqual(['old', 'new']);
+  });
+
+  it('resolves only the active branch path', () => {
+    const entries: PiSessionEntry[] = [
+      { id: 'root', raw: {}, type: 'entry' },
+      { id: 'left', parentId: 'root', raw: {}, type: 'entry' },
+      { id: 'right', parentId: 'root', raw: {}, type: 'entry' },
+    ];
+
+    expect(resolvePiActivePath(entries, 'left').map(entry => entry.id)).toEqual(['root', 'left']);
+    expect(resolvePiActivePath(entries).map(entry => entry.id)).toEqual(['root', 'right']);
+  });
+
+  it('keeps id-less tool results attached to the active branch', () => {
+    const content = [
+      JSON.stringify({
+        id: 'root',
+        type: 'entry',
+        message: { role: 'user', content: 'Read the active file' },
+      }),
+      JSON.stringify({
+        id: 'left',
+        parentId: 'root',
+        type: 'entry',
+        message: {
+          role: 'assistant',
+          content: [
+            { id: 'tool-left', input: { path: 'left.md' }, name: 'read', type: 'toolCall' },
+          ],
+        },
+      }),
+      JSON.stringify({
+        result: { content: [{ text: 'left contents', type: 'text' }] },
+        toolCallId: 'tool-left',
+        type: 'toolResult',
+      }),
+      JSON.stringify({
+        id: 'right',
+        parentId: 'root',
+        type: 'entry',
+        message: {
+          role: 'assistant',
+          content: [
+            { id: 'tool-right', input: { path: 'right.md' }, name: 'read', type: 'toolCall' },
+          ],
+        },
+      }),
+      JSON.stringify({
+        result: { content: [{ text: 'right contents', type: 'text' }] },
+        toolCallId: 'tool-right',
+        type: 'toolResult',
+      }),
+    ].join('\n');
+
+    const messages = parsePiSessionContent(content, { leafEntryId: 'left' });
+
+    expect(messages[1].toolCalls).toEqual([{
+      id: 'tool-left',
+      input: { file_path: 'left.md', path: 'left.md' },
+      name: 'Read',
+      result: 'left contents',
+      status: 'completed',
+    }]);
+  });
+
+  it('ignores malformed lines and maps compaction boundaries', () => {
+    const content = [
+      'not-json',
+      JSON.stringify({ id: 'c1', type: 'compaction' }),
+    ].join('\n');
+
+    expect(parsePiSessionContent(content)[0].contentBlocks).toEqual([{ type: 'context_compacted' }]);
+  });
+});

--- a/tests/unit/providers/pi/history/PiHistoryStore.test.ts
+++ b/tests/unit/providers/pi/history/PiHistoryStore.test.ts
@@ -1,7 +1,14 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
 import {
+  createPiForkSessionFile,
   parsePiSessionContent,
+  parsePiSessionEntries,
   type PiSessionEntry,
   resolvePiActivePath,
+  resolvePiEntryPath,
 } from '@/providers/pi/history/PiHistoryStore';
 
 describe('PiHistoryStore', () => {
@@ -352,6 +359,134 @@ describe('PiHistoryStore', () => {
       input: { file_path: 'left.md', path: 'left.md' },
       name: 'Read',
       result: 'left contents',
+      status: 'completed',
+    }]);
+  });
+
+  it('resolves a strict entry path for fork checkpoints without sibling branches', () => {
+    const entries = parsePiSessionEntries([
+      JSON.stringify({ id: 'u1', type: 'message', message: { role: 'user', content: 'First' } }),
+      JSON.stringify({ id: 'a1', parentId: 'u1', type: 'message', message: { role: 'assistant', content: 'Done' } }),
+      JSON.stringify({ id: 'u2', parentId: 'a1', type: 'message', message: { role: 'user', content: 'Next branch' } }),
+      JSON.stringify({ id: 'a2', parentId: 'u2', type: 'message', message: { role: 'assistant', content: 'Later' } }),
+    ].join('\n')).entries;
+
+    expect(resolvePiEntryPath(entries, 'a1').map(entry => entry.id)).toEqual(['u1', 'a1']);
+  });
+
+  it('truncates linear Pi sessions through the requested checkpoint', () => {
+    const content = [
+      JSON.stringify({ id: 'u1', type: 'message', message: { role: 'user', content: 'First' } }),
+      JSON.stringify({ id: 'a1', type: 'message', message: { role: 'assistant', content: 'Done' } }),
+      JSON.stringify({ id: 'u2', type: 'message', message: { role: 'user', content: 'Later' } }),
+      JSON.stringify({ id: 'a2', type: 'message', message: { role: 'assistant', content: 'Do not include' } }),
+    ].join('\n');
+    const entries = parsePiSessionEntries(content).entries;
+
+    expect(resolvePiEntryPath(entries, 'a1').map(entry => entry.id)).toEqual(['u1', 'a1']);
+    expect(parsePiSessionContent(content, { leafEntryId: 'a1' }).map(message => message.content)).toEqual([
+      'First',
+      'Done',
+    ]);
+  });
+
+  it('keeps id-less trailing entries during normal linear hydration', () => {
+    const content = [
+      JSON.stringify({ id: 'u1', type: 'message', message: { role: 'user', content: 'First' } }),
+      JSON.stringify({ id: 'a1', type: 'message', message: { role: 'assistant', content: 'Done' } }),
+      JSON.stringify({ type: 'custom_message', content: 'Trailing notice' }),
+    ].join('\n');
+
+    expect(parsePiSessionContent(content).map(message => message.content)).toEqual([
+      'First',
+      'Done',
+      'Trailing notice',
+    ]);
+    expect(parsePiSessionContent(content, { leafEntryId: 'a1' }).map(message => message.content)).toEqual([
+      'First',
+      'Done',
+    ]);
+  });
+
+  it('creates a self-contained Pi fork session file at the assistant checkpoint', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-fork-'));
+    const sourceFile = path.join(dir, 'source.jsonl');
+    await fs.writeFile(sourceFile, [
+      JSON.stringify({ type: 'session', version: 3, id: 'source-session', timestamp: '2026-01-01T00:00:00.000Z', cwd: '/source-cwd' }),
+      JSON.stringify({ id: 'u1', parentId: null, type: 'message', message: { role: 'user', content: 'First' } }),
+      JSON.stringify({ id: 'a1', parentId: 'u1', type: 'message', message: { role: 'assistant', content: 'Done' } }),
+      JSON.stringify({ id: 'u2', parentId: 'a1', type: 'message', message: { role: 'user', content: 'Do not copy' } }),
+    ].join('\n'));
+
+    const forked = await createPiForkSessionFile(sourceFile, 'a1', {
+      now: new Date('2026-02-03T04:05:06.789Z'),
+      sessionId: 'fork-session',
+      targetCwd: '/target-cwd',
+    });
+    const forkedContent = await fs.readFile(forked.sessionFile, 'utf-8');
+    const forkedLines = forkedContent.trim().split('\n').map(line => JSON.parse(line));
+
+    expect(forked).toEqual({
+      leafEntryId: 'a1',
+      parentSession: sourceFile,
+      sessionFile: path.join(dir, '2026-02-03T04-05-06-789Z_fork-session.jsonl'),
+      sessionId: 'fork-session',
+    });
+    expect(forkedLines).toEqual([
+      {
+        cwd: '/target-cwd',
+        id: 'fork-session',
+        parentSession: sourceFile,
+        timestamp: '2026-02-03T04:05:06.789Z',
+        type: 'session',
+        version: 3,
+      },
+      { id: 'u1', parentId: null, type: 'message', message: { role: 'user', content: 'First' } },
+      { id: 'a1', parentId: 'u1', type: 'message', message: { role: 'assistant', content: 'Done' } },
+    ]);
+  });
+
+  it('includes active id-less tool results when creating linear Pi fork files', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-fork-linear-'));
+    const sourceFile = path.join(dir, 'source.jsonl');
+    await fs.writeFile(sourceFile, [
+      JSON.stringify({ type: 'session', version: 3, id: 'source-session', timestamp: '2026-01-01T00:00:00.000Z', cwd: '/source-cwd' }),
+      JSON.stringify({ id: 'u1', type: 'message', message: { role: 'user', content: 'Read a file' } }),
+      JSON.stringify({
+        id: 'a1',
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [
+            { id: 'tool-1', input: { path: 'a.md' }, name: 'read', type: 'toolCall' },
+          ],
+        },
+      }),
+      JSON.stringify({
+        result: { content: [{ text: 'file contents', type: 'text' }] },
+        toolCallId: 'tool-1',
+        type: 'toolResult',
+      }),
+      JSON.stringify({ id: 'u2', type: 'message', message: { role: 'user', content: 'Do not copy' } }),
+    ].join('\n'));
+
+    const forked = await createPiForkSessionFile(sourceFile, 'a1', {
+      now: new Date('2026-02-03T04:05:06.789Z'),
+      sessionId: 'fork-session',
+    });
+    const forkedContent = await fs.readFile(forked.sessionFile, 'utf-8');
+    const forkedLines = forkedContent.trim().split('\n').map(line => JSON.parse(line));
+
+    expect(forkedLines.map(line => line.id)).toEqual(['fork-session', 'u1', 'a1', undefined]);
+    expect(forkedLines[3]).toMatchObject({
+      toolCallId: 'tool-1',
+      type: 'toolResult',
+    });
+    expect(parsePiSessionContent(forkedContent)[1].toolCalls).toEqual([{
+      id: 'tool-1',
+      input: { file_path: 'a.md', path: 'a.md' },
+      name: 'Read',
+      result: 'file contents',
       status: 'completed',
     }]);
   });

--- a/tests/unit/providers/pi/models.test.ts
+++ b/tests/unit/providers/pi/models.test.ts
@@ -1,0 +1,96 @@
+import {
+  decodePiModelId,
+  encodePiModelId,
+  getPiSupportedThinkingLevels,
+  normalizePiDiscoveredModels,
+} from '@/providers/pi/models';
+
+describe('Pi model helpers', () => {
+  it('encodes and decodes provider/model ids', () => {
+    expect(encodePiModelId('anthropic', 'claude/sonnet')).toBe('pi:anthropic/claude/sonnet');
+    expect(decodePiModelId('pi:anthropic/claude/sonnet')).toEqual({
+      modelId: 'claude/sonnet',
+      provider: 'anthropic',
+    });
+  });
+
+  it('rejects invalid Pi model ids', () => {
+    expect(decodePiModelId('')).toBeNull();
+    expect(decodePiModelId('pi:')).toBeNull();
+    expect(decodePiModelId('pi:anthropic')).toBeNull();
+    expect(decodePiModelId('claude')).toBeNull();
+  });
+
+  it('normalizes thinking levels with Pi reasoning rules', () => {
+    expect(getPiSupportedThinkingLevels({ reasoning: false })).toEqual(['off']);
+    expect(getPiSupportedThinkingLevels({ reasoning: true })).toEqual([
+      'off',
+      'minimal',
+      'low',
+      'medium',
+      'high',
+    ]);
+    expect(getPiSupportedThinkingLevels({
+      reasoning: true,
+      thinkingLevels: ['low', null, 'xhigh', 'invalid', 'low'],
+    })).toEqual(['low', 'xhigh']);
+    expect(getPiSupportedThinkingLevels({
+      reasoning: {
+        levels: ['minimal', 'high'],
+      },
+    })).toEqual(['minimal', 'high']);
+    expect(getPiSupportedThinkingLevels({
+      reasoning: true,
+      thinkingLevelMap: {
+        high: null,
+        minimal: 'low',
+        xhigh: 'xhigh',
+      },
+    })).toEqual(['off', 'minimal', 'low', 'medium', 'xhigh']);
+  });
+
+  it('normalizes discovered model records', () => {
+    expect(normalizePiDiscoveredModels([
+      {
+        contextWindow: 100_000,
+        id: 'claude/sonnet',
+        input: ['text', 'image', 'audio'],
+        label: '  Sonnet  ',
+        provider: 'anthropic',
+        reasoning: true,
+        thinkingLevels: ['off', 'medium'],
+      },
+      {
+        id: 'claude/sonnet',
+        label: 'Duplicate',
+        provider: 'anthropic',
+      },
+      {
+        id: 'gpt-5',
+        name: 'GPT-5',
+        provider: 'openai',
+        reasoning: false,
+      },
+    ])).toEqual([
+      {
+        contextWindow: 100_000,
+        encodedId: 'pi:anthropic/claude/sonnet',
+        id: 'claude/sonnet',
+        input: ['text', 'image'],
+        label: 'Sonnet',
+        provider: 'anthropic',
+        reasoning: true,
+        thinkingLevels: ['off', 'medium'],
+      },
+      {
+        encodedId: 'pi:openai/gpt-5',
+        id: 'gpt-5',
+        input: ['text'],
+        label: 'GPT-5',
+        provider: 'openai',
+        reasoning: false,
+        thinkingLevels: ['off'],
+      },
+    ]);
+  });
+});

--- a/tests/unit/providers/pi/registration.test.ts
+++ b/tests/unit/providers/pi/registration.test.ts
@@ -1,0 +1,54 @@
+import '@/providers';
+
+import { ProviderRegistry } from '@/core/providers/ProviderRegistry';
+import { opencodeProviderRegistration } from '@/providers/opencode/registration';
+import { piProviderRegistration } from '@/providers/pi/registration';
+
+function createPlugin(): any {
+  return {
+    app: {
+      vault: {
+        adapter: {
+          basePath: '/tmp/pi-vault',
+        },
+      },
+    },
+    getResolvedProviderCliPath: jest.fn(() => 'pi'),
+    settings: {
+      mediaFolder: 'media',
+      providerConfigs: {
+        pi: {
+          enabled: true,
+        },
+      },
+      systemPrompt: '',
+      userName: '',
+    },
+  };
+}
+
+describe('Pi provider registration', () => {
+  it('registers Pi metadata and runtime factories', () => {
+    expect(piProviderRegistration.displayName).toBe('Pi');
+    expect(piProviderRegistration.blankTabOrder).toBeGreaterThan(opencodeProviderRegistration.blankTabOrder);
+    expect(piProviderRegistration.isEnabled({ providerConfigs: { pi: { enabled: true } } })).toBe(true);
+    expect(piProviderRegistration.isEnabled({ providerConfigs: { pi: { enabled: false } } })).toBe(false);
+    expect(piProviderRegistration.environmentKeyPatterns?.some(pattern => pattern.test('PI_CODING_AGENT_DIR'))).toBe(true);
+
+    const runtime = piProviderRegistration.createRuntime({ plugin: createPlugin() });
+    expect(runtime.providerId).toBe('pi');
+    runtime.cleanup();
+  });
+
+  it('routes Pi model ids through the provider registry', () => {
+    const settings = {
+      providerConfigs: {
+        pi: { enabled: true },
+      },
+    };
+
+    expect(ProviderRegistry.resolveProviderForModel('pi:anthropic/claude-sonnet-4', settings)).toBe('pi');
+    expect(ProviderRegistry.getEnabledProviderIds(settings)).toContain('pi');
+    expect(ProviderRegistry.getEnabledProviderIds({ providerConfigs: { pi: { enabled: false } } })).not.toContain('pi');
+  });
+});

--- a/tests/unit/providers/pi/runtime/PiAuxQueryRunner.test.ts
+++ b/tests/unit/providers/pi/runtime/PiAuxQueryRunner.test.ts
@@ -1,0 +1,157 @@
+import '@/providers';
+
+const mockTransportRequest = jest.fn();
+const mockTransportSend = jest.fn();
+const mockTransportStart = jest.fn();
+const mockTransportDispose = jest.fn();
+const mockTransportOnEvent = jest.fn();
+const mockTransportOnClose = jest.fn();
+const mockRemoveEventListener = jest.fn();
+const mockRemoveCloseListener = jest.fn();
+let mockCloseHandler: ((error?: Error) => void) | null = null;
+let mockEventHandler: ((event: Record<string, unknown>) => void) | null = null;
+
+const mockProcessStart = jest.fn();
+const mockProcessShutdown = jest.fn().mockResolvedValue(undefined);
+const mockProcessOnClose = jest.fn();
+
+jest.mock('@/providers/pi/runtime/PiRpcTransport', () => ({
+  PiRpcTransport: jest.fn().mockImplementation(() => ({
+    dispose: mockTransportDispose,
+    isClosed: false,
+    onClose: mockTransportOnClose,
+    onEvent: mockTransportOnEvent,
+    request: mockTransportRequest,
+    send: mockTransportSend,
+    start: mockTransportStart,
+  })),
+}));
+
+jest.mock('@/providers/pi/runtime/PiSubprocess', () => ({
+  PiSubprocess: jest.fn().mockImplementation(() => ({
+    getStderrSnapshot: jest.fn().mockReturnValue(''),
+    isAlive: jest.fn().mockReturnValue(true),
+    onClose: mockProcessOnClose,
+    shutdown: mockProcessShutdown,
+    start: mockProcessStart,
+    stderr: {},
+    stdin: {},
+    stdout: {},
+  })),
+}));
+
+import { PiAuxQueryRunner } from '@/providers/pi/runtime/PiAuxQueryRunner';
+
+function createPlugin() {
+  return {
+    app: {
+      vault: {
+        adapter: {
+          basePath: '/tmp/vault',
+        },
+      },
+    },
+    getResolvedProviderCliPath: jest.fn().mockReturnValue('/usr/local/bin/pi'),
+    settings: {},
+  } as any;
+}
+
+function rejectAfter(ms: number): { cancel: () => void; promise: Promise<never> } {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const promise = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error('timed out waiting for Pi auxiliary query')), ms);
+  });
+  return {
+    cancel: () => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    },
+    promise,
+  };
+}
+
+async function flushPromises(): Promise<void> {
+  await new Promise(resolve => setImmediate(resolve));
+}
+
+describe('PiAuxQueryRunner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCloseHandler = null;
+    mockEventHandler = null;
+    mockTransportOnEvent.mockImplementation((handler: (event: Record<string, unknown>) => void) => {
+      mockEventHandler = handler;
+      return mockRemoveEventListener;
+    });
+    mockTransportOnClose.mockImplementation((handler: (error?: Error) => void) => {
+      mockCloseHandler = handler;
+      return mockRemoveCloseListener;
+    });
+    mockTransportRequest.mockImplementation(async (type: string) => {
+      if (type === 'prompt') {
+        queueMicrotask(() => {
+          mockCloseHandler?.(new Error('Pi auxiliary runtime closed'));
+        });
+      }
+      return {};
+    });
+  });
+
+  it('rejects when the transport closes after accepting the prompt', async () => {
+    const runner = new PiAuxQueryRunner(createPlugin(), { profile: 'passive' });
+    const timeout = rejectAfter(100);
+
+    try {
+      await expect(Promise.race([
+        runner.query({ systemPrompt: 'Summarize briefly.' }, 'Hello'),
+        timeout.promise,
+      ])).rejects.toThrow('Pi auxiliary runtime closed');
+    } finally {
+      timeout.cancel();
+    }
+
+    expect(mockTransportOnClose).toHaveBeenCalled();
+    expect(mockRemoveCloseListener).toHaveBeenCalled();
+    expect(mockRemoveEventListener).toHaveBeenCalled();
+  });
+
+  it('rejects promptly when cancelled while prompt acceptance is pending', async () => {
+    mockTransportRequest.mockImplementation((type: string) => (
+      type === 'prompt'
+        ? new Promise(() => {})
+        : Promise.resolve({})
+    ));
+    const abortController = new AbortController();
+    const runner = new PiAuxQueryRunner(createPlugin(), { profile: 'passive' });
+    const query = runner.query({
+      abortController,
+      systemPrompt: 'Summarize briefly.',
+    }, 'Hello');
+
+    await flushPromises();
+    abortController.abort();
+
+    await expect(query).rejects.toThrow('Cancelled');
+    expect(mockTransportSend).toHaveBeenCalledWith({ type: 'abort' });
+    expect(mockTransportDispose).toHaveBeenCalled();
+    expect(mockProcessShutdown).toHaveBeenCalled();
+  });
+
+  it('cancels extension UI requests in auxiliary sessions', async () => {
+    mockTransportRequest.mockResolvedValue({});
+    const runner = new PiAuxQueryRunner(createPlugin(), { profile: 'passive' });
+    const query = runner.query({ systemPrompt: 'Summarize briefly.' }, 'Hello');
+
+    await flushPromises();
+    mockEventHandler?.({ id: 'ui-1', type: 'extension_ui_request' });
+    mockEventHandler?.({ type: 'agent_end' });
+
+    await expect(query).resolves.toBe('');
+    expect(mockTransportSend).toHaveBeenCalledWith({
+      cancelled: true,
+      id: 'ui-1',
+      type: 'extension_ui_response',
+    });
+  });
+});

--- a/tests/unit/providers/pi/runtime/PiAuxQueryRunner.test.ts
+++ b/tests/unit/providers/pi/runtime/PiAuxQueryRunner.test.ts
@@ -154,4 +154,19 @@ describe('PiAuxQueryRunner', () => {
       type: 'extension_ui_response',
     });
   });
+
+  it('rejects terminal Pi stop-reason errors', async () => {
+    mockTransportRequest.mockResolvedValue({});
+    const runner = new PiAuxQueryRunner(createPlugin(), { profile: 'passive' });
+    const query = runner.query({ systemPrompt: 'Summarize briefly.' }, 'Hello');
+
+    await flushPromises();
+    mockEventHandler?.({
+      errorMessage: 'Authentication failed',
+      stopReason: 'error',
+      type: 'turn_end',
+    });
+
+    await expect(query).rejects.toThrow('Authentication failed');
+  });
 });

--- a/tests/unit/providers/pi/runtime/PiChatRuntime.test.ts
+++ b/tests/unit/providers/pi/runtime/PiChatRuntime.test.ts
@@ -307,6 +307,31 @@ describe('PiChatRuntime', () => {
     });
   });
 
+  it('emits terminal Pi stop-reason errors before completing the turn', async () => {
+    const runtime = new PiChatRuntime(createPlugin());
+    const iterator = runtime.query(createTurn(runtime));
+
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: 'user_message_start', content: 'Hello Pi' },
+    });
+
+    mockTransportInstances[0].eventHandlers[0]({
+      errorMessage: 'Invalid image',
+      stopReason: 'error',
+      type: 'message_end',
+    });
+
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: 'error', content: 'Invalid image' },
+    });
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: 'done' },
+    });
+  });
+
   it('maps steer images and filters empty image data', async () => {
     const runtime = new PiChatRuntime(createPlugin());
     const iterator = runtime.query(createTurn(runtime));

--- a/tests/unit/providers/pi/runtime/PiChatRuntime.test.ts
+++ b/tests/unit/providers/pi/runtime/PiChatRuntime.test.ts
@@ -126,6 +126,42 @@ describe('PiChatRuntime', () => {
     expect(runtime.prepareTurn({ text: ' /compact' }).isCompact).toBe(false);
   });
 
+  it('yields error and done without spawning when Pi is disabled', async () => {
+    const plugin = createPlugin();
+    plugin.settings.providerConfigs.pi.enabled = false;
+    const runtime = new PiChatRuntime(plugin);
+
+    const chunks: unknown[] = [];
+    for await (const chunk of runtime.query(createTurn(runtime))) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual([
+      { type: 'error', content: 'Failed to start Pi. Check the CLI path and login state.' },
+      { type: 'done' },
+    ]);
+    expect(mockSubprocessInstances).toHaveLength(0);
+  });
+
+  it('sends native compact requests and yields a context boundary', async () => {
+    const runtime = new PiChatRuntime(createPlugin());
+    const chunks: unknown[] = [];
+
+    for await (const chunk of runtime.query(runtime.prepareTurn({
+      text: '/compact keep decisions',
+    }))) {
+      chunks.push(chunk);
+    }
+
+    expect(mockTransportInstances[0].request).toHaveBeenCalledWith('compact', {
+      customInstructions: 'keep decisions',
+    });
+    expect(chunks).toEqual([
+      { type: 'context_compacted' },
+      { type: 'done' },
+    ]);
+  });
+
   it('yields a terminal error and done when the Pi process closes mid-turn', async () => {
     const runtime = new PiChatRuntime(createPlugin());
     const iterator = runtime.query(createTurn(runtime));
@@ -253,12 +289,58 @@ describe('PiChatRuntime', () => {
 
     expect(steerAccepted).toBe(true);
     expect(mockTransportInstances[0].request).toHaveBeenCalledWith('steer', {
-      images: [],
       message: 'Follow up',
     });
     await expect(iterator.next()).resolves.toEqual({
       done: false,
       value: { type: 'user_message_start', content: 'Follow up' },
+    });
+
+    mockTransportInstances[0].eventHandlers[0]({ type: 'agent_end' });
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: 'done' },
+    });
+  });
+
+  it('maps steer images and filters empty image data', async () => {
+    const runtime = new PiChatRuntime(createPlugin());
+    const iterator = runtime.query(createTurn(runtime));
+
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: 'user_message_start', content: 'Hello Pi' },
+    });
+
+    await expect(runtime.steer(runtime.prepareTurn({
+      images: [
+        {
+          data: 'base64-image',
+          id: 'image-1',
+          mediaType: 'image/png',
+          name: 'image.png',
+          size: 12,
+          source: 'paste',
+        },
+        {
+          data: '',
+          id: 'image-2',
+          mediaType: 'image/jpeg',
+          name: 'empty.jpg',
+          size: 0,
+          source: 'paste',
+        },
+      ],
+      text: 'Follow up with image',
+    } as any))).resolves.toBe(true);
+
+    expect(mockTransportInstances[0].request).toHaveBeenCalledWith('steer', {
+      images: [{ data: 'base64-image', mimeType: 'image/png', type: 'image' }],
+      message: 'Follow up with image',
+    });
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: 'user_message_start', content: 'Follow up with image' },
     });
 
     mockTransportInstances[0].eventHandlers[0]({ type: 'agent_end' });
@@ -315,6 +397,37 @@ describe('PiChatRuntime', () => {
     mockTransportInstances[0].eventHandlers[0]({ type: 'agent_end' });
     await promise;
     expect(chunks[chunks.length - 1]).toEqual({ type: 'done' });
+  });
+
+  it('does not restart after a live Pi runtime reports a newly created session id', async () => {
+    const runtime = new PiChatRuntime(createPlugin());
+
+    const runQuery = async (): Promise<void> => {
+      const chunks: unknown[] = [];
+      const promise = (async () => {
+        for await (const chunk of runtime.query(createTurn(runtime))) {
+          chunks.push(chunk);
+        }
+      })();
+      await flushPromises();
+      (mockTransportInstances[0].request as jest.Mock).mockImplementation(async (type: string) => {
+        if (type === 'get_state') {
+          return { sessionId: 'live-session' };
+        }
+        if (type === 'get_session_stats') {
+          return {};
+        }
+        return {};
+      });
+      mockTransportInstances[0].eventHandlers[0]({ type: 'agent_end' });
+      await promise;
+      expect(chunks[chunks.length - 1]).toEqual({ type: 'done' });
+    };
+
+    await runQuery();
+    await runQuery();
+
+    expect(mockSubprocessInstances).toHaveLength(1);
   });
 
   it('clamps stale effort selections to the selected Pi model thinking levels', async () => {
@@ -424,6 +537,64 @@ describe('PiChatRuntime', () => {
       ['set_thinking_level', { level: 'medium' }],
       ['set_thinking_level', { level: 'medium' }],
     ]);
+  });
+
+  it('switches warm runtimes by absolute session file without restarting Pi', async () => {
+    const runtime = new PiChatRuntime(createPlugin());
+
+    runtime.syncConversationState({
+      providerState: { sessionFile: '/tmp/pi-session-a.jsonl' },
+      sessionId: null,
+    });
+    await runtime.ensureReady();
+
+    runtime.syncConversationState({
+      providerState: { sessionFile: '/tmp/pi-session-b.jsonl' },
+      sessionId: null,
+    });
+    await runtime.ensureReady();
+
+    expect(mockSubprocessInstances).toHaveLength(1);
+    expect(mockTransportInstances[0].request).toHaveBeenCalledWith('switch_session', {
+      sessionPath: '/tmp/pi-session-b.jsonl',
+    });
+  });
+
+  it('restarts instead of calling switch_session for bare saved session ids', async () => {
+    const runtime = new PiChatRuntime(createPlugin());
+
+    runtime.syncConversationState({
+      providerState: {},
+      sessionId: 'session-a',
+    });
+    await runtime.ensureReady();
+
+    runtime.syncConversationState({
+      providerState: {},
+      sessionId: 'session-b',
+    });
+    await runtime.ensureReady();
+
+    expect(mockSubprocessInstances).toHaveLength(2);
+    expect(mockTransportInstances[0].request).not.toHaveBeenCalledWith(
+      'switch_session',
+      expect.anything(),
+    );
+  });
+
+  it('restarts when a previously bound Pi session target is cleared', async () => {
+    const runtime = new PiChatRuntime(createPlugin());
+
+    runtime.syncConversationState({
+      providerState: { sessionFile: '/tmp/pi-session-a.jsonl' },
+      sessionId: null,
+    });
+    await runtime.ensureReady();
+
+    runtime.syncConversationState(null);
+    await runtime.ensureReady();
+
+    expect(mockSubprocessInstances).toHaveLength(2);
   });
 
   it('does not persist stale session file state after a reset starts a new Pi session', () => {

--- a/tests/unit/providers/pi/runtime/PiChatRuntime.test.ts
+++ b/tests/unit/providers/pi/runtime/PiChatRuntime.test.ts
@@ -1,0 +1,458 @@
+const mockTransportInstances: MockPiRpcTransport[] = [];
+const mockSubprocessInstances: MockPiSubprocess[] = [];
+
+class MockPiSubprocess {
+  readonly stdin = {};
+  readonly stdout = {};
+  private alive = true;
+
+  constructor(readonly launchSpec: unknown) {
+    mockSubprocessInstances.push(this);
+  }
+
+  start = jest.fn();
+  isAlive = jest.fn(() => this.alive);
+  getStderrSnapshot = jest.fn(() => '');
+  onClose = jest.fn(() => jest.fn());
+  shutdown = jest.fn(async () => {
+    this.alive = false;
+  });
+}
+
+class MockPiRpcTransport {
+  isClosed = false;
+  readonly eventHandlers: Array<(event: Record<string, unknown>) => void> = [];
+  readonly closeHandlers: Array<(error?: Error) => void> = [];
+  readonly request = jest.fn(async (type: string) => {
+    if (type === 'prompt') {
+      return { accepted: true };
+    }
+    if (type === 'get_state') {
+      return {};
+    }
+    if (type === 'get_session_stats') {
+      return {};
+    }
+    return {};
+  });
+  readonly send = jest.fn();
+  readonly dispose = jest.fn(() => {
+    this.isClosed = true;
+  });
+
+  constructor(_streams: unknown) {
+    mockTransportInstances.push(this);
+  }
+
+  start = jest.fn();
+
+  onEvent(handler: (event: Record<string, unknown>) => void): () => void {
+    this.eventHandlers.push(handler);
+    return jest.fn();
+  }
+
+  onClose(handler: (error?: Error) => void): () => void {
+    this.closeHandlers.push(handler);
+    return jest.fn();
+  }
+
+  triggerClose(error?: Error): void {
+    this.isClosed = true;
+    for (const handler of this.closeHandlers) {
+      handler(error);
+    }
+  }
+}
+
+jest.mock('@/providers/pi/runtime/PiSubprocess', () => ({
+  PiSubprocess: MockPiSubprocess,
+}));
+
+jest.mock('@/providers/pi/runtime/PiRpcTransport', () => ({
+  PiRpcTransport: MockPiRpcTransport,
+}));
+
+import '@/providers';
+
+import type { ChatMessage, Conversation } from '@/core/types';
+import { PiChatRuntime } from '@/providers/pi/runtime/PiChatRuntime';
+
+function createPlugin(): any {
+  return {
+    app: {
+      vault: {
+        adapter: {
+          basePath: '/tmp/pi-vault',
+        },
+      },
+    },
+    getResolvedProviderCliPath: jest.fn(() => 'pi'),
+    settings: {
+      mediaFolder: 'media',
+      providerConfigs: {
+        pi: {
+          enabled: true,
+        },
+      },
+      systemPrompt: '',
+      userName: '',
+    },
+  };
+}
+
+function createTurn(runtime: PiChatRuntime) {
+  return runtime.prepareTurn({
+    enabledMcpServers: new Set(),
+    text: 'Hello Pi',
+  } as any);
+}
+
+async function flushPromises(): Promise<void> {
+  await new Promise(resolve => setImmediate(resolve));
+}
+
+describe('PiChatRuntime', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTransportInstances.length = 0;
+    mockSubprocessInstances.length = 0;
+  });
+
+  it('uses command-boundary, case-insensitive compact detection', () => {
+    const runtime = new PiChatRuntime(createPlugin());
+
+    expect(runtime.prepareTurn({ text: '/Compact extra instructions' }).isCompact).toBe(true);
+    expect(runtime.prepareTurn({ text: '/compactfoo' }).isCompact).toBe(false);
+    expect(runtime.prepareTurn({ text: ' /compact' }).isCompact).toBe(false);
+  });
+
+  it('yields a terminal error and done when the Pi process closes mid-turn', async () => {
+    const runtime = new PiChatRuntime(createPlugin());
+    const iterator = runtime.query(createTurn(runtime));
+
+    const firstChunk = iterator.next();
+    await flushPromises();
+
+    expect(mockTransportInstances).toHaveLength(1);
+    expect(mockTransportInstances[0].request).toHaveBeenCalledWith('prompt', {
+      message: 'Hello Pi',
+    });
+
+    await expect(firstChunk).resolves.toEqual({
+      done: false,
+      value: { type: 'user_message_start', content: 'Hello Pi' },
+    });
+
+    mockTransportInstances[0].triggerClose(new Error('Pi exited'));
+
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: 'error', content: 'Pi exited' },
+    });
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: 'done' },
+    });
+    await expect(iterator.next()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+  });
+
+  it('aborts and tears down Pi when the stream consumer closes before agent_end', async () => {
+    const runtime = new PiChatRuntime(createPlugin());
+    const iterator = runtime.query(createTurn(runtime));
+
+    const firstChunk = iterator.next();
+    await flushPromises();
+
+    await expect(firstChunk).resolves.toEqual({
+      done: false,
+      value: { type: 'user_message_start', content: 'Hello Pi' },
+    });
+
+    const textChunk = iterator.next();
+    mockTransportInstances[0].eventHandlers[0]({
+      assistantMessageEvent: { text_delta: 'partial' },
+      type: 'message_update',
+    });
+
+    await expect(textChunk).resolves.toEqual({
+      done: false,
+      value: { type: 'text', content: 'partial' },
+    });
+
+    await iterator.return(undefined);
+    await flushPromises();
+
+    expect(mockTransportInstances[0].send).toHaveBeenCalledWith({ type: 'abort' });
+    expect(mockTransportInstances[0].dispose).toHaveBeenCalled();
+    expect(mockSubprocessInstances[0].shutdown).toHaveBeenCalled();
+  });
+
+  it('cancels pending extension UI dialogs when the Pi process closes', async () => {
+    const dialogState: { signal?: AbortSignal } = {};
+    const renderer = {
+      input: jest.fn((_request: unknown, signal: AbortSignal) => {
+        dialogState.signal = signal;
+        return new Promise<{ cancelled?: boolean }>((resolve) => {
+          signal.addEventListener('abort', () => resolve({ cancelled: true }));
+        });
+      }),
+    };
+    const runtime = new PiChatRuntime(createPlugin(), {
+      extensionUiRenderer: renderer as any,
+    });
+    const iterator = runtime.query(createTurn(runtime));
+
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: 'user_message_start', content: 'Hello Pi' },
+    });
+
+    mockTransportInstances[0].eventHandlers[0]({
+      id: 'ui-1',
+      method: 'input',
+      type: 'extension_ui_request',
+    });
+    expect(renderer.input).toHaveBeenCalled();
+
+    mockTransportInstances[0].triggerClose(new Error('Pi exited'));
+    await flushPromises();
+
+    expect(dialogState.signal?.aborted).toBe(true);
+    expect(mockTransportInstances[0].send).toHaveBeenCalledWith({
+      cancelled: true,
+      id: 'ui-1',
+      type: 'extension_ui_response',
+    });
+
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: 'error', content: 'Pi exited' },
+    });
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: 'done' },
+    });
+  });
+
+  it('emits provider user-message boundaries for accepted prompts and steering turns', async () => {
+    const runtime = new PiChatRuntime(createPlugin());
+    const iterator = runtime.query(createTurn(runtime));
+
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: 'user_message_start', content: 'Hello Pi' },
+    });
+
+    const steerAccepted = await runtime.steer(runtime.prepareTurn({
+      enabledMcpServers: new Set(),
+      text: 'Follow up',
+    } as any));
+
+    expect(steerAccepted).toBe(true);
+    expect(mockTransportInstances[0].request).toHaveBeenCalledWith('steer', {
+      images: [],
+      message: 'Follow up',
+    });
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: 'user_message_start', content: 'Follow up' },
+    });
+
+    mockTransportInstances[0].eventHandlers[0]({ type: 'agent_end' });
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: 'done' },
+    });
+  });
+
+  it('does not apply thinking level when only the synthetic Pi fallback model is selected', async () => {
+    const runtime = new PiChatRuntime(createPlugin());
+    const chunks: unknown[] = [];
+    const promise = (async () => {
+      for await (const chunk of runtime.query(createTurn(runtime))) {
+        chunks.push(chunk);
+      }
+    })();
+
+    await flushPromises();
+    mockTransportInstances[0].eventHandlers[0]({ type: 'agent_end' });
+    await promise;
+
+    expect(chunks[chunks.length - 1]).toEqual({ type: 'done' });
+    expect(mockTransportInstances[0].request).not.toHaveBeenCalledWith(
+      'set_thinking_level',
+      expect.anything(),
+    );
+  });
+
+  it('does not bootstrap local history after readiness refresh finds an existing Pi session', async () => {
+    const runtime = new PiChatRuntime(createPlugin());
+    (runtime as any).refreshState = jest.fn(async () => {
+      (runtime as any).sessionId = 'existing-session';
+    });
+    const history: ChatMessage[] = [{
+      content: 'Older message',
+      id: 'm1',
+      role: 'user',
+      timestamp: 1,
+    }];
+    const chunks: unknown[] = [];
+    const promise = (async () => {
+      for await (const chunk of runtime.query(createTurn(runtime), history)) {
+        chunks.push(chunk);
+      }
+    })();
+
+    await flushPromises();
+
+    expect(mockTransportInstances[0].request).toHaveBeenCalledWith('prompt', {
+      message: 'Hello Pi',
+    });
+
+    mockTransportInstances[0].eventHandlers[0]({ type: 'agent_end' });
+    await promise;
+    expect(chunks[chunks.length - 1]).toEqual({ type: 'done' });
+  });
+
+  it('clamps stale effort selections to the selected Pi model thinking levels', async () => {
+    const plugin = createPlugin();
+    plugin.settings.providerConfigs.pi = {
+      discoveredModels: [
+        {
+          encodedId: 'pi:openai/gpt-5',
+          id: 'gpt-5',
+          input: ['text'],
+          label: 'GPT-5',
+          provider: 'openai',
+          reasoning: false,
+          thinkingLevels: ['off'],
+        },
+      ],
+      enabled: true,
+      visibleModels: ['pi:openai/gpt-5'],
+    };
+    plugin.settings.savedProviderModel = {
+      pi: 'pi:openai/gpt-5',
+    };
+    plugin.settings.savedProviderEffort = {
+      pi: 'high',
+    };
+    const runtime = new PiChatRuntime(plugin);
+    const chunks: unknown[] = [];
+    const promise = (async () => {
+      for await (const chunk of runtime.query(createTurn(runtime))) {
+        chunks.push(chunk);
+      }
+    })();
+
+    await flushPromises();
+    mockTransportInstances[0].eventHandlers[0]({ type: 'agent_end' });
+    await promise;
+
+    expect(chunks[chunks.length - 1]).toEqual({ type: 'done' });
+    expect(mockTransportInstances[0].request).toHaveBeenCalledWith('set_thinking_level', {
+      level: 'off',
+    });
+  });
+
+  it('applies changed models over RPC without restarting the Pi process', async () => {
+    const plugin = createPlugin();
+    plugin.settings.providerConfigs.pi = {
+      discoveredModels: [
+        {
+          encodedId: 'pi:anthropic/claude-sonnet-4',
+          id: 'claude-sonnet-4',
+          input: ['text'],
+          label: 'Claude Sonnet 4',
+          provider: 'anthropic',
+          reasoning: true,
+          thinkingLevels: ['off', 'medium', 'high'],
+        },
+        {
+          encodedId: 'pi:openai/gpt-5',
+          id: 'gpt-5',
+          input: ['text'],
+          label: 'GPT-5',
+          provider: 'openai',
+          reasoning: true,
+          thinkingLevels: ['off', 'medium', 'high'],
+        },
+      ],
+      enabled: true,
+      visibleModels: ['pi:anthropic/claude-sonnet-4', 'pi:openai/gpt-5'],
+    };
+    plugin.settings.savedProviderModel = {
+      pi: 'pi:anthropic/claude-sonnet-4',
+    };
+    plugin.settings.savedProviderEffort = {
+      pi: 'medium',
+    };
+    const runtime = new PiChatRuntime(plugin);
+
+    const runQuery = async (): Promise<void> => {
+      const chunks: unknown[] = [];
+      const promise = (async () => {
+        for await (const chunk of runtime.query(createTurn(runtime))) {
+          chunks.push(chunk);
+        }
+      })();
+      await flushPromises();
+      mockTransportInstances[0].eventHandlers[0]({ type: 'agent_end' });
+      await promise;
+      expect(chunks[chunks.length - 1]).toEqual({ type: 'done' });
+    };
+
+    await runQuery();
+    plugin.settings.savedProviderModel.pi = 'pi:openai/gpt-5';
+    await runQuery();
+
+    expect(mockSubprocessInstances).toHaveLength(1);
+    expect(mockTransportInstances[0].request).toHaveBeenCalledWith('set_model', {
+      modelId: 'claude-sonnet-4',
+      provider: 'anthropic',
+    });
+    expect(mockTransportInstances[0].request).toHaveBeenCalledWith('set_model', {
+      modelId: 'gpt-5',
+      provider: 'openai',
+    });
+    expect(mockTransportInstances[0].request.mock.calls.filter(([type]) =>
+      type === 'set_thinking_level'
+    )).toEqual([
+      ['set_thinking_level', { level: 'medium' }],
+      ['set_thinking_level', { level: 'medium' }],
+    ]);
+  });
+
+  it('does not persist stale session file state after a reset starts a new Pi session', () => {
+    const runtime = new PiChatRuntime(createPlugin());
+    const conversation = {
+      createdAt: 1,
+      id: 'conversation-1',
+      messages: [],
+      providerId: 'pi',
+      providerState: {
+        leafEntryId: 'old-leaf',
+        sessionFile: '/tmp/old-pi-session.jsonl',
+        sessionId: 'old-session',
+      },
+      sessionId: 'old-session',
+      title: 'Pi',
+      updatedAt: 1,
+    } satisfies Conversation;
+
+    runtime.syncConversationState(conversation);
+    runtime.resetSession();
+    (runtime as any).sessionId = 'new-session';
+
+    expect(runtime.buildSessionUpdates({
+      conversation,
+      sessionInvalidated: false,
+    }).updates).toEqual({
+      providerState: { sessionId: 'new-session' },
+      sessionId: 'new-session',
+    });
+  });
+});

--- a/tests/unit/providers/pi/runtime/PiChatRuntime.test.ts
+++ b/tests/unit/providers/pi/runtime/PiChatRuntime.test.ts
@@ -115,16 +115,6 @@ async function flushPromises(): Promise<void> {
   await new Promise(resolve => setImmediate(resolve));
 }
 
-async function waitForCondition(condition: () => boolean): Promise<void> {
-  for (let i = 0; i < 20; i++) {
-    if (condition()) {
-      return;
-    }
-    await flushPromises();
-  }
-  throw new Error('Condition was not met');
-}
-
 describe('PiChatRuntime', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -749,13 +739,15 @@ describe('PiChatRuntime', () => {
       sessionId: 'session-1',
     });
 
-    const chunks: unknown[] = [];
-    const promise = (async () => {
-      for await (const chunk of runtime.query(createTurn(runtime))) {
-        chunks.push(chunk);
-      }
-    })();
-    await waitForCondition(() => mockTransportInstances[0]?.request.mock.calls.some(([type]) => type === 'prompt'));
+    const iterator = runtime.query(createTurn(runtime));
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: 'user_message_start', content: 'Hello Pi' },
+    });
+    expect(mockTransportInstances[0].request).toHaveBeenCalledWith('prompt', {
+      message: 'Hello Pi',
+    });
+
     await fs.writeFile(sessionFile, [
       JSON.stringify({ type: 'session', id: 'session-1' }),
       JSON.stringify({ id: 'u0', parentId: null, type: 'message', message: { role: 'user', content: 'Before' } }),
@@ -764,8 +756,15 @@ describe('PiChatRuntime', () => {
       JSON.stringify({ id: 'a1', parentId: 'u1', type: 'message', message: { role: 'assistant', content: 'Hello' } }),
     ].join('\n'));
     mockTransportInstances[0].eventHandlers[0]({ type: 'agent_end' });
-    await promise;
 
+    const chunks: unknown[] = [];
+    while (true) {
+      const next = await iterator.next();
+      if (next.done) {
+        break;
+      }
+      chunks.push(next.value);
+    }
     expect(chunks[chunks.length - 1]).toEqual({ type: 'done' });
     expect(runtime.consumeTurnMetadata()).toMatchObject({
       assistantMessageId: 'a1',

--- a/tests/unit/providers/pi/runtime/PiChatRuntime.test.ts
+++ b/tests/unit/providers/pi/runtime/PiChatRuntime.test.ts
@@ -1,3 +1,7 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
 const mockTransportInstances: MockPiRpcTransport[] = [];
 const mockSubprocessInstances: MockPiSubprocess[] = [];
 
@@ -109,6 +113,16 @@ function createTurn(runtime: PiChatRuntime) {
 
 async function flushPromises(): Promise<void> {
   await new Promise(resolve => setImmediate(resolve));
+}
+
+async function waitForCondition(condition: () => boolean): Promise<void> {
+  for (let i = 0; i < 20; i++) {
+    if (condition()) {
+      return;
+    }
+    await flushPromises();
+  }
+  throw new Error('Condition was not met');
 }
 
 describe('PiChatRuntime', () => {
@@ -595,6 +609,169 @@ describe('PiChatRuntime', () => {
     await runtime.ensureReady();
 
     expect(mockSubprocessInstances).toHaveLength(2);
+  });
+
+  it('materializes pending Pi forks into a new one-to-one session file before startup', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-runtime-fork-'));
+    const sourceFile = path.join(dir, 'source.jsonl');
+    await fs.writeFile(sourceFile, [
+      JSON.stringify({ type: 'session', version: 3, id: 'source-session', timestamp: '2026-01-01T00:00:00.000Z', cwd: '/tmp/pi-vault' }),
+      JSON.stringify({ id: 'u1', parentId: null, type: 'message', message: { role: 'user', content: 'First' } }),
+      JSON.stringify({ id: 'a1', parentId: 'u1', type: 'message', message: { role: 'assistant', content: 'Done' } }),
+      JSON.stringify({ id: 'u2', parentId: 'a1', type: 'message', message: { role: 'user', content: 'Do not copy' } }),
+    ].join('\n'));
+    const runtime = new PiChatRuntime(createPlugin());
+
+    runtime.syncConversationState({
+      providerState: {
+        forkSource: { sessionId: 'source-session', resumeAt: 'a1' },
+        forkSourceSessionFile: sourceFile,
+      },
+      sessionId: null,
+    });
+    await runtime.ensureReady();
+
+    const launchSpec = mockSubprocessInstances[0].launchSpec as { args: string[] };
+    const sessionArgIndex = launchSpec.args.indexOf('--session');
+    expect(sessionArgIndex).toBeGreaterThanOrEqual(0);
+    const forkedSessionFile = launchSpec.args[sessionArgIndex + 1];
+    expect(forkedSessionFile).toMatch(new RegExp(`${dir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/.*\\.jsonl$`));
+    const forkedLines = (await fs.readFile(forkedSessionFile, 'utf-8'))
+      .trim()
+      .split('\n')
+      .map(line => JSON.parse(line));
+    expect(forkedLines.map(line => line.id)).toEqual([
+      expect.any(String),
+      'u1',
+      'a1',
+    ]);
+    expect(forkedLines[0]).toMatchObject({
+      cwd: '/tmp/pi-vault',
+      parentSession: sourceFile,
+      type: 'session',
+      version: 3,
+    });
+    expect(runtime.buildSessionUpdates({
+      conversation: null,
+      sessionInvalidated: false,
+    }).updates.providerState).toMatchObject({
+      leafEntryId: 'a1',
+      parentSession: sourceFile,
+      sessionFile: forkedSessionFile,
+      sessionId: forkedLines[0].id,
+    });
+  });
+
+  it('does not materialize pending Pi forks when session creation is disallowed', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-runtime-fork-warmup-'));
+    const sourceFile = path.join(dir, 'source.jsonl');
+    await fs.writeFile(sourceFile, [
+      JSON.stringify({ type: 'session', version: 3, id: 'source-session', timestamp: '2026-01-01T00:00:00.000Z', cwd: '/tmp/pi-vault' }),
+      JSON.stringify({ id: 'u1', type: 'message', message: { role: 'user', content: 'First' } }),
+      JSON.stringify({ id: 'a1', type: 'message', message: { role: 'assistant', content: 'Done' } }),
+    ].join('\n'));
+    const runtime = new PiChatRuntime(createPlugin());
+    const forkSource = { sessionId: 'source-session', resumeAt: 'a1' };
+
+    runtime.syncConversationState({
+      providerState: {
+        forkSource,
+        forkSourceSessionFile: sourceFile,
+      },
+      sessionId: null,
+    });
+    await runtime.ensureReady({ allowSessionCreation: false });
+
+    const launchSpec = mockSubprocessInstances[0].launchSpec as { args: string[] };
+    expect(launchSpec.args).toContain('--no-session');
+    expect(launchSpec.args).not.toContain('--session');
+    expect((await fs.readdir(dir)).sort()).toEqual(['source.jsonl']);
+    expect(runtime.buildSessionUpdates({
+      conversation: null,
+      sessionInvalidated: false,
+    }).updates.providerState).toEqual({
+      forkSource,
+      forkSourceSessionFile: sourceFile,
+    });
+  });
+
+  it('resolves fork source sessions from pending Pi fork metadata', () => {
+    const runtime = new PiChatRuntime(createPlugin());
+    const conversation = {
+      createdAt: 1,
+      id: 'conversation-1',
+      messages: [],
+      providerId: 'pi',
+      providerState: {
+        forkSource: { sessionId: 'source-session', resumeAt: 'a1' },
+      },
+      sessionId: null,
+      title: 'Pi',
+      updatedAt: 1,
+    } satisfies Conversation;
+
+    expect(runtime.resolveSessionIdForFork(conversation)).toBe('source-session');
+  });
+
+  it('resolves file-only Pi sessions as fork sources', () => {
+    const runtime = new PiChatRuntime(createPlugin());
+    const conversation = {
+      createdAt: 1,
+      id: 'conversation-1',
+      messages: [],
+      providerId: 'pi',
+      providerState: {
+        sessionFile: '/tmp/pi-session.jsonl',
+      },
+      sessionId: null,
+      title: 'Pi',
+      updatedAt: 1,
+    } satisfies Conversation;
+
+    expect(runtime.resolveSessionIdForFork(conversation)).toBe('/tmp/pi-session.jsonl');
+
+    runtime.syncConversationState(conversation);
+
+    expect(runtime.resolveSessionIdForFork(null)).toBe('/tmp/pi-session.jsonl');
+  });
+
+  it('records live Pi message ids from the appended session path after a turn', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-runtime-metadata-'));
+    const sessionFile = path.join(dir, 'session.jsonl');
+    await fs.writeFile(sessionFile, [
+      JSON.stringify({ type: 'session', id: 'session-1' }),
+      JSON.stringify({ id: 'u0', parentId: null, type: 'message', message: { role: 'user', content: 'Before' } }),
+      JSON.stringify({ id: 'a0', parentId: 'u0', type: 'message', message: { role: 'assistant', content: 'Ready' } }),
+    ].join('\n'));
+    const runtime = new PiChatRuntime(createPlugin());
+    runtime.syncConversationState({
+      providerState: { sessionFile, sessionId: 'session-1' },
+      sessionId: 'session-1',
+    });
+
+    const chunks: unknown[] = [];
+    const promise = (async () => {
+      for await (const chunk of runtime.query(createTurn(runtime))) {
+        chunks.push(chunk);
+      }
+    })();
+    await waitForCondition(() => mockTransportInstances[0]?.request.mock.calls.some(([type]) => type === 'prompt'));
+    await fs.writeFile(sessionFile, [
+      JSON.stringify({ type: 'session', id: 'session-1' }),
+      JSON.stringify({ id: 'u0', parentId: null, type: 'message', message: { role: 'user', content: 'Before' } }),
+      JSON.stringify({ id: 'a0', parentId: 'u0', type: 'message', message: { role: 'assistant', content: 'Ready' } }),
+      JSON.stringify({ id: 'u1', parentId: 'a0', type: 'message', message: { role: 'user', content: 'Hello Pi' } }),
+      JSON.stringify({ id: 'a1', parentId: 'u1', type: 'message', message: { role: 'assistant', content: 'Hello' } }),
+    ].join('\n'));
+    mockTransportInstances[0].eventHandlers[0]({ type: 'agent_end' });
+    await promise;
+
+    expect(chunks[chunks.length - 1]).toEqual({ type: 'done' });
+    expect(runtime.consumeTurnMetadata()).toMatchObject({
+      assistantMessageId: 'a1',
+      userMessageId: 'u1',
+      wasSent: true,
+    });
   });
 
   it('does not persist stale session file state after a reset starts a new Pi session', () => {

--- a/tests/unit/providers/pi/runtime/PiCliResolver.test.ts
+++ b/tests/unit/providers/pi/runtime/PiCliResolver.test.ts
@@ -1,0 +1,75 @@
+import * as fs from 'node:fs';
+
+import { PiCliResolver } from '@/providers/pi/runtime/PiCliResolver';
+
+jest.mock('node:fs');
+jest.mock('@/utils/env', () => ({
+  ...jest.requireActual('@/utils/env'),
+  getHostnameKey: () => 'current-host',
+}));
+
+const mockedExists = fs.existsSync as jest.Mock;
+const mockedStat = fs.statSync as jest.Mock;
+
+describe('PiCliResolver', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolves the current host path before the legacy Pi CLI path', () => {
+    mockedExists.mockImplementation((filePath: string) => filePath === '/current/pi');
+    mockedStat.mockReturnValue({ isFile: () => true });
+
+    const resolver = new PiCliResolver();
+
+    expect(resolver.resolve({
+      'current-host': '/current/pi',
+      'other-host': '/other/pi',
+    }, '/legacy/pi')).toBe('/current/pi');
+  });
+
+  it('falls back to cliPath and returns null for invalid paths', () => {
+    mockedExists.mockImplementation((filePath: string) => filePath === '/legacy/pi');
+    mockedStat.mockReturnValue({ isFile: () => true });
+
+    const resolver = new PiCliResolver();
+    expect(resolver.resolve({ 'other-host': '/other/pi' }, '/legacy/pi')).toBe('/legacy/pi');
+
+    mockedExists.mockReturnValue(false);
+    expect(resolver.resolve({ 'other-host': '/other/pi' }, '/legacy/pi')).toBeNull();
+  });
+
+  it('invalidates cached resolutions when provider environment changes', () => {
+    mockedExists.mockReturnValue(true);
+    mockedStat.mockReturnValue({ isFile: () => true });
+
+    const resolver = new PiCliResolver();
+    const firstSettings = {
+      providerConfigs: {
+        pi: {
+          cliPathsByHost: {
+            'current-host': '/current/pi',
+          },
+          environmentVariables: 'PI_OFFLINE=0',
+        },
+      },
+    };
+    const secondSettings = {
+      providerConfigs: {
+        pi: {
+          cliPathsByHost: {
+            'current-host': '/current/pi',
+          },
+          environmentVariables: 'PI_OFFLINE=1',
+        },
+      },
+    };
+
+    expect(resolver.resolveFromSettings(firstSettings)).toBe('/current/pi');
+    expect(resolver.resolveFromSettings(firstSettings)).toBe('/current/pi');
+    expect(mockedStat).toHaveBeenCalledTimes(1);
+
+    expect(resolver.resolveFromSettings(secondSettings)).toBe('/current/pi');
+    expect(mockedStat).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/providers/pi/runtime/PiCliResolver.test.ts
+++ b/tests/unit/providers/pi/runtime/PiCliResolver.test.ts
@@ -1,24 +1,29 @@
-import * as fs from 'node:fs';
+import * as fs from 'fs';
+import * as path from 'path';
 
 import { PiCliResolver } from '@/providers/pi/runtime/PiCliResolver';
 
-jest.mock('node:fs');
+jest.mock('fs');
 jest.mock('@/utils/env', () => ({
   ...jest.requireActual('@/utils/env'),
   getHostnameKey: () => 'current-host',
 }));
 
-const mockedExists = fs.existsSync as jest.Mock;
 const mockedStat = fs.statSync as jest.Mock;
 
 describe('PiCliResolver', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (fs.existsSync as jest.Mock).mockReturnValue(false);
   });
 
   it('resolves the current host path before the legacy Pi CLI path', () => {
-    mockedExists.mockImplementation((filePath: string) => filePath === '/current/pi');
-    mockedStat.mockReturnValue({ isFile: () => true });
+    mockedStat.mockImplementation((filePath: string) => {
+      if (filePath === '/current/pi') {
+        return { isFile: () => true };
+      }
+      throw new Error(`ENOENT: ${filePath}`);
+    });
 
     const resolver = new PiCliResolver();
 
@@ -29,19 +34,44 @@ describe('PiCliResolver', () => {
   });
 
   it('falls back to cliPath and returns null for invalid paths', () => {
-    mockedExists.mockImplementation((filePath: string) => filePath === '/legacy/pi');
-    mockedStat.mockReturnValue({ isFile: () => true });
+    mockedStat.mockImplementation((filePath: string) => {
+      if (filePath === '/legacy/pi') {
+        return { isFile: () => true };
+      }
+      throw new Error(`ENOENT: ${filePath}`);
+    });
 
     const resolver = new PiCliResolver();
     expect(resolver.resolve({ 'other-host': '/other/pi' }, '/legacy/pi')).toBe('/legacy/pi');
 
-    mockedExists.mockReturnValue(false);
+    mockedStat.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
     expect(resolver.resolve({ 'other-host': '/other/pi' }, '/legacy/pi')).toBeNull();
   });
 
+  it('falls back to PATH lookup when no Pi CLI path is configured', () => {
+    const pathDir = '/custom/bin';
+    const pathBinary = path.join(pathDir, 'pi');
+    mockedStat.mockImplementation((filePath: string) => {
+      if (filePath === pathBinary) {
+        return { isFile: () => true };
+      }
+      throw new Error(`ENOENT: ${filePath}`);
+    });
+
+    const resolver = new PiCliResolver();
+
+    expect(resolver.resolve({}, '', `PATH=${pathDir}`)).toBe(pathBinary);
+  });
+
   it('invalidates cached resolutions when provider environment changes', () => {
-    mockedExists.mockReturnValue(true);
-    mockedStat.mockReturnValue({ isFile: () => true });
+    mockedStat.mockImplementation((filePath: string) => {
+      if (filePath === '/current/pi') {
+        return { isFile: () => true };
+      }
+      throw new Error(`ENOENT: ${filePath}`);
+    });
 
     const resolver = new PiCliResolver();
     const firstSettings = {

--- a/tests/unit/providers/pi/runtime/PiEventNormalization.test.ts
+++ b/tests/unit/providers/pi/runtime/PiEventNormalization.test.ts
@@ -1,0 +1,129 @@
+import {
+  createPiEventNormalizationState,
+  normalizePiRpcEvent,
+} from '@/providers/pi/normalizations/piEventNormalization';
+
+describe('Pi event normalization', () => {
+  it('normalizes text and thinking deltas', () => {
+    const state = createPiEventNormalizationState();
+    expect(normalizePiRpcEvent({
+      assistantMessageEvent: { text_delta: 'hello' },
+      type: 'message_update',
+    }, state)).toEqual([{ type: 'text', content: 'hello' }]);
+    expect(normalizePiRpcEvent({
+      assistantMessageEvent: { thinking_delta: 'hmm' },
+      type: 'message_update',
+    }, state)).toEqual([{ type: 'thinking', content: 'hmm' }]);
+  });
+
+  it('dedupes tool use and maps output/result chunks', () => {
+    const state = createPiEventNormalizationState();
+    expect(normalizePiRpcEvent({
+      id: 'tool-1',
+      input: { path: 'a.md' },
+      name: 'read',
+      type: 'toolcall_end',
+    }, state)).toEqual([{
+      id: 'tool-1',
+      input: { file_path: 'a.md', path: 'a.md' },
+      name: 'Read',
+      type: 'tool_use',
+    }]);
+    expect(normalizePiRpcEvent({
+      id: 'tool-1',
+      input: { path: 'a.md' },
+      name: 'read',
+      type: 'tool_execution_start',
+    }, state)).toEqual([]);
+    expect(normalizePiRpcEvent({
+      id: 'tool-1',
+      partialResult: { content: [{ text: 'partial', type: 'text' }] },
+      type: 'tool_execution_update',
+    }, state)).toEqual([{ id: 'tool-1', content: 'partial', type: 'tool_output' }]);
+    expect(normalizePiRpcEvent({
+      id: 'tool-1',
+      result: { content: [{ text: 'done', type: 'text' }] },
+      type: 'tool_execution_end',
+    }, state)).toEqual([{
+      id: 'tool-1',
+      content: 'done',
+      isError: false,
+      toolUseResult: { content: [{ text: 'done', type: 'text' }] },
+      type: 'tool_result',
+    }]);
+  });
+
+  it('normalizes Pi RPC toolName and args to shared renderer tool shapes', () => {
+    const state = createPiEventNormalizationState();
+
+    expect(normalizePiRpcEvent({
+      args: { command: 'pwd' },
+      toolCallId: 'bash-1',
+      toolName: 'bash',
+      type: 'tool_execution_start',
+    }, state)).toEqual([{
+      id: 'bash-1',
+      input: { command: 'pwd' },
+      name: 'Bash',
+      type: 'tool_use',
+    }]);
+
+    expect(normalizePiRpcEvent({
+      args: { pattern: 'src/**/*.ts' },
+      toolCallId: 'find-1',
+      toolName: 'find',
+      type: 'tool_execution_start',
+    }, state)).toEqual([{
+      id: 'find-1',
+      input: { pattern: 'src/**/*.ts' },
+      name: 'Glob',
+      type: 'tool_use',
+    }]);
+  });
+
+  it('preserves Pi write/edit result payloads for diff extraction', () => {
+    const state = createPiEventNormalizationState();
+
+    expect(normalizePiRpcEvent({
+      args: { content: 'new text', path: 'notes/a.md' },
+      toolCallId: 'write-1',
+      toolName: 'write',
+      type: 'tool_execution_start',
+    }, state)).toEqual([{
+      id: 'write-1',
+      input: { content: 'new text', file_path: 'notes/a.md', path: 'notes/a.md' },
+      name: 'Write',
+      type: 'tool_use',
+    }]);
+
+    expect(normalizePiRpcEvent({
+      isError: false,
+      result: {
+        content: [{ text: 'Edited notes/a.md', type: 'text' }],
+        details: { diff: '--- a/notes/a.md\n+++ b/notes/a.md\n@@ -1 +1 @@\n-old\n+new' },
+      },
+      toolCallId: 'write-1',
+      toolName: 'write',
+      type: 'tool_execution_end',
+    }, state)).toEqual([{
+      id: 'write-1',
+      content: 'Edited notes/a.md',
+      isError: false,
+      toolUseResult: {
+        content: [{ text: 'Edited notes/a.md', type: 'text' }],
+        details: { diff: '--- a/notes/a.md\n+++ b/notes/a.md\n@@ -1 +1 @@\n-old\n+new' },
+      },
+      type: 'tool_result',
+    }]);
+  });
+
+  it('maps compaction and extension errors', () => {
+    const state = createPiEventNormalizationState();
+    expect(normalizePiRpcEvent({ type: 'compaction_end' }, state)).toEqual([{ type: 'context_compacted' }]);
+    expect(normalizePiRpcEvent({ error: 'extension failed', type: 'extension_error' }, state)).toEqual([{
+      content: 'extension failed',
+      level: 'warning',
+      type: 'notice',
+    }]);
+  });
+});

--- a/tests/unit/providers/pi/runtime/PiEventNormalization.test.ts
+++ b/tests/unit/providers/pi/runtime/PiEventNormalization.test.ts
@@ -126,4 +126,22 @@ describe('Pi event normalization', () => {
       type: 'notice',
     }]);
   });
+
+  it('surfaces terminal Pi stop-reason errors', () => {
+    const state = createPiEventNormalizationState();
+
+    expect(normalizePiRpcEvent({
+      errorMessage: 'Invalid image',
+      stopReason: 'error',
+      type: 'message_end',
+    }, state)).toEqual([{ type: 'error', content: 'Invalid image' }]);
+
+    expect(normalizePiRpcEvent({
+      assistant_message_event: {
+        error_message: 'Authentication failed',
+        stop_reason: 'error',
+      },
+      type: 'turn_end',
+    }, state)).toEqual([{ type: 'error', content: 'Authentication failed' }]);
+  });
 });

--- a/tests/unit/providers/pi/runtime/PiExtensionUiBridge.test.ts
+++ b/tests/unit/providers/pi/runtime/PiExtensionUiBridge.test.ts
@@ -1,0 +1,98 @@
+import { PiExtensionUiBridge, type PiExtensionUiRenderer } from '@/providers/pi/runtime/PiExtensionUiBridge';
+import type { PiRpcTransport } from '@/providers/pi/runtime/PiRpcTransport';
+
+function createBridge(renderer: Partial<PiExtensionUiRenderer>) {
+  const transport = {
+    send: jest.fn(),
+  } as unknown as PiRpcTransport;
+  const bridge = new PiExtensionUiBridge(transport, renderer as PiExtensionUiRenderer);
+  return { bridge, transport };
+}
+
+describe('PiExtensionUiBridge', () => {
+  it('sends dialog responses through the transport', async () => {
+    const renderer = {
+      select: jest.fn().mockResolvedValue({ value: 'choice-a' }),
+    };
+    const { bridge, transport } = createBridge(renderer);
+
+    expect(bridge.handleRequest({ id: 'ui-1', method: 'select', type: 'extension_ui_request' })).toBe(true);
+    await Promise.resolve();
+
+    expect(renderer.select).toHaveBeenCalled();
+    expect(transport.send).toHaveBeenCalledWith({
+      id: 'ui-1',
+      type: 'extension_ui_response',
+      value: 'choice-a',
+    });
+  });
+
+  it('cancels dialog requests when no renderer is available', () => {
+    const transport = {
+      send: jest.fn(),
+    } as unknown as PiRpcTransport;
+    const bridge = new PiExtensionUiBridge(transport, null);
+
+    bridge.handleRequest({ id: 'ui-1', method: 'confirm', type: 'extension_ui_request' });
+
+    expect(transport.send).toHaveBeenCalledWith({
+      cancelled: true,
+      id: 'ui-1',
+      type: 'extension_ui_response',
+    });
+  });
+
+  it('handles notify without sending a response', () => {
+    const renderer = {
+      notify: jest.fn(),
+    };
+    const { bridge, transport } = createBridge(renderer);
+
+    bridge.handleRequest({ message: 'hello', method: 'notify', type: 'extension_ui_request' });
+
+    expect(renderer.notify).toHaveBeenCalledWith({
+      message: 'hello',
+      method: 'notify',
+      type: 'extension_ui_request',
+    });
+    expect(transport.send).not.toHaveBeenCalled();
+  });
+
+  it('cancels pending dialogs on cleanup', () => {
+    const renderer = {
+      input: jest.fn((_request: unknown, signal: AbortSignal) => new Promise<{ cancelled?: boolean }>((resolve) => {
+        signal.addEventListener('abort', () => resolve({ cancelled: true }));
+      })),
+    };
+    const { bridge, transport } = createBridge(renderer);
+
+    bridge.handleRequest({ id: 'ui-1', method: 'input', type: 'extension_ui_request' });
+    bridge.cleanup();
+
+    expect(transport.send).toHaveBeenCalledWith({
+      cancelled: true,
+      id: 'ui-1',
+      type: 'extension_ui_response',
+    });
+  });
+
+  it('does not send duplicate cancellation responses when cleanup aborts a rejecting renderer', async () => {
+    const renderer = {
+      input: jest.fn((_request: unknown, signal: AbortSignal) => new Promise<never>((_resolve, reject) => {
+        signal.addEventListener('abort', () => reject(new Error('aborted')));
+      })),
+    };
+    const { bridge, transport } = createBridge(renderer);
+
+    bridge.handleRequest({ id: 'ui-1', method: 'input', type: 'extension_ui_request' });
+    bridge.cleanup();
+    await Promise.resolve();
+
+    expect(transport.send).toHaveBeenCalledTimes(1);
+    expect(transport.send).toHaveBeenCalledWith({
+      cancelled: true,
+      id: 'ui-1',
+      type: 'extension_ui_response',
+    });
+  });
+});

--- a/tests/unit/providers/pi/runtime/PiJsonl.test.ts
+++ b/tests/unit/providers/pi/runtime/PiJsonl.test.ts
@@ -8,12 +8,13 @@ describe('PiJsonl', () => {
     const lines: string[] = [];
     subscribePiJsonlLines(stream, line => lines.push(line));
     const separator = String.fromCharCode(0x2028);
+    const paragraphSeparator = String.fromCharCode(0x2029);
 
-    stream.write(`{"a":1}\r\n{"b":"line${separator}separator"}\n`);
+    stream.write(`{"a":1}\r\n{"b":"line${separator}separator${paragraphSeparator}still same record"}\n`);
 
     expect(lines).toEqual([
       '{"a":1}',
-      `{"b":"line${separator}separator"}`,
+      `{"b":"line${separator}separator${paragraphSeparator}still same record"}`,
     ]);
   });
 

--- a/tests/unit/providers/pi/runtime/PiJsonl.test.ts
+++ b/tests/unit/providers/pi/runtime/PiJsonl.test.ts
@@ -1,0 +1,41 @@
+import { PassThrough } from 'node:stream';
+
+import { subscribePiJsonlLines, writePiJsonl } from '@/providers/pi/runtime/PiJsonl';
+
+describe('PiJsonl', () => {
+  it('splits only on LF and strips CR', () => {
+    const stream = new PassThrough();
+    const lines: string[] = [];
+    subscribePiJsonlLines(stream, line => lines.push(line));
+    const separator = String.fromCharCode(0x2028);
+
+    stream.write(`{"a":1}\r\n{"b":"line${separator}separator"}\n`);
+
+    expect(lines).toEqual([
+      '{"a":1}',
+      `{"b":"line${separator}separator"}`,
+    ]);
+  });
+
+  it('emits trailing buffered records on end', async () => {
+    const stream = new PassThrough();
+    const lines: string[] = [];
+    subscribePiJsonlLines(stream, line => lines.push(line));
+
+    stream.write('{"a":1}');
+    stream.end();
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(lines).toEqual(['{"a":1}']);
+  });
+
+  it('writes JSONL records', () => {
+    const output = new PassThrough();
+    const chunks: string[] = [];
+    output.on('data', chunk => chunks.push(chunk.toString('utf8')));
+
+    writePiJsonl(output, { type: 'ping' });
+
+    expect(chunks.join('')).toBe('{"type":"ping"}\n');
+  });
+});

--- a/tests/unit/providers/pi/runtime/PiLaunchSpec.test.ts
+++ b/tests/unit/providers/pi/runtime/PiLaunchSpec.test.ts
@@ -1,0 +1,92 @@
+import { buildPiLaunchSpec } from '@/providers/pi/runtime/PiLaunchSpec';
+import type { PiProviderSettings } from '@/providers/pi/settings';
+
+const baseSettings: PiProviderSettings = {
+  cliPath: '',
+  cliPathsByHost: {},
+  discoveredModels: [],
+  enabled: true,
+  environmentHash: '',
+  environmentVariables: '',
+  modelAliases: {},
+  preferredThinkingByModel: {},
+  toolMode: 'all',
+  visibleModels: [],
+};
+
+describe('PiLaunchSpec', () => {
+  it('builds main launch args with replacement system prompt and model flags', () => {
+    expect(buildPiLaunchSpec({
+      command: '/bin/pi',
+      cwd: '/vault',
+      model: 'pi:anthropic/claude/sonnet',
+      providerState: { sessionFile: '/tmp/session.jsonl' },
+      settings: baseSettings,
+      systemPrompt: 'System prompt',
+      thinkingLevel: 'high',
+    }).args).toEqual([
+      '--mode',
+      'rpc',
+      '--system-prompt',
+      'System prompt',
+      '--session',
+      '/tmp/session.jsonl',
+      '--provider',
+      'anthropic',
+      '--model',
+      'claude/sonnet',
+      '--thinking',
+      'high',
+    ]);
+  });
+
+  it('adds no-session and read-only tools when requested', () => {
+    expect(buildPiLaunchSpec({
+      command: 'pi',
+      cwd: '/vault',
+      noSession: true,
+      settings: {
+        ...baseSettings,
+        toolMode: 'readonly',
+      },
+    }).args).toEqual([
+      '--mode',
+      'rpc',
+      '--no-session',
+      '--tools',
+      'read,grep,find,ls',
+    ]);
+  });
+
+  it('uses no-tools for passive auxiliary launches', () => {
+    expect(buildPiLaunchSpec({
+      command: 'pi',
+      cwd: '/vault',
+      noSession: true,
+      noTools: true,
+      settings: baseSettings,
+    }).args).toEqual([
+      '--mode',
+      'rpc',
+      '--no-session',
+      '--no-tools',
+    ]);
+  });
+
+  it('includes full runtime environment text in the launch key', () => {
+    const first = buildPiLaunchSpec({
+      command: 'pi',
+      cwd: '/vault',
+      envText: 'PATH=/first',
+      settings: baseSettings,
+    });
+    const second = buildPiLaunchSpec({
+      command: 'pi',
+      cwd: '/vault',
+      envText: 'PATH=/second',
+      settings: baseSettings,
+    });
+
+    expect(first.launchKey).not.toBe(second.launchKey);
+  });
+});

--- a/tests/unit/providers/pi/runtime/PiModelDiscoveryService.test.ts
+++ b/tests/unit/providers/pi/runtime/PiModelDiscoveryService.test.ts
@@ -1,0 +1,135 @@
+import '@/providers';
+
+const mockTransportRequest = jest.fn();
+const mockTransportSend = jest.fn();
+const mockTransportStart = jest.fn();
+const mockTransportDispose = jest.fn();
+const mockTransportOnEvent = jest.fn();
+const mockRemoveEventListener = jest.fn();
+const mockProcessStart = jest.fn();
+const mockProcessShutdown = jest.fn().mockResolvedValue(undefined);
+const mockProcessOnClose = jest.fn();
+const mockGetStderrSnapshot = jest.fn(() => '');
+let mockEventHandler: ((event: Record<string, unknown>) => void) | null = null;
+
+jest.mock('@/providers/pi/runtime/PiRpcTransport', () => ({
+  PiRpcTransport: jest.fn().mockImplementation(() => ({
+    dispose: mockTransportDispose,
+    onEvent: mockTransportOnEvent,
+    request: mockTransportRequest,
+    send: mockTransportSend,
+    start: mockTransportStart,
+  })),
+}));
+
+jest.mock('@/providers/pi/runtime/PiSubprocess', () => ({
+  PiSubprocess: jest.fn().mockImplementation(() => ({
+    getStderrSnapshot: mockGetStderrSnapshot,
+    onClose: mockProcessOnClose,
+    shutdown: mockProcessShutdown,
+    start: mockProcessStart,
+    stdin: {},
+    stdout: {},
+  })),
+}));
+
+import { PiModelDiscoveryService } from '@/providers/pi/runtime/PiModelDiscoveryService';
+
+function createPlugin() {
+  return {
+    app: {
+      vault: {
+        adapter: {
+          basePath: '/tmp/vault',
+        },
+      },
+    },
+    getResolvedProviderCliPath: jest.fn(() => '/usr/local/bin/pi'),
+    settings: {
+      providerConfigs: {
+        pi: {
+          enabled: true,
+        },
+      },
+    },
+  } as any;
+}
+
+describe('PiModelDiscoveryService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEventHandler = null;
+    mockGetStderrSnapshot.mockReturnValue('');
+    mockTransportOnEvent.mockImplementation((handler: (event: Record<string, unknown>) => void) => {
+      mockEventHandler = handler;
+      return mockRemoveEventListener;
+    });
+  });
+
+  it('discovers and normalizes Pi models through a short-lived no-session runtime', async () => {
+    mockTransportRequest.mockResolvedValue({
+      models: [{
+        contextWindow: 200000,
+        id: 'gpt-5',
+        input: ['text', 'image'],
+        maxTokens: 8192,
+        name: 'GPT-5',
+        provider: 'openai',
+        reasoning: true,
+      }],
+    });
+
+    const result = await new PiModelDiscoveryService(createPlugin()).discoverModels();
+
+    expect(result.diagnostics).toBeUndefined();
+    expect(result.models).toEqual([{
+      contextWindow: 200000,
+      encodedId: 'pi:openai/gpt-5',
+      id: 'gpt-5',
+      input: ['text', 'image'],
+      label: 'GPT-5',
+      maxTokens: 8192,
+      provider: 'openai',
+      reasoning: true,
+      thinkingLevels: ['off', 'minimal', 'low', 'medium', 'high'],
+    }]);
+    expect(mockProcessStart).toHaveBeenCalled();
+    expect(mockTransportStart).toHaveBeenCalled();
+    expect(mockTransportRequest).toHaveBeenCalledWith('get_available_models', {}, 20_000);
+    expect(mockRemoveEventListener).toHaveBeenCalled();
+    expect(mockTransportDispose).toHaveBeenCalled();
+    expect(mockProcessShutdown).toHaveBeenCalled();
+  });
+
+  it('cancels extension UI requests during discovery', async () => {
+    mockTransportRequest.mockImplementation(async () => {
+      mockEventHandler?.({
+        id: 'ui-1',
+        type: 'extension_ui_request',
+      });
+      return { models: [] };
+    });
+
+    await new PiModelDiscoveryService(createPlugin()).discoverModels();
+
+    expect(mockTransportSend).toHaveBeenCalledWith({
+      cancelled: true,
+      id: 'ui-1',
+      type: 'extension_ui_response',
+    });
+  });
+
+  it('returns diagnostics and still shuts down when discovery fails', async () => {
+    mockTransportRequest.mockRejectedValue(new Error('not logged in'));
+    mockGetStderrSnapshot.mockReturnValue('Pi stderr');
+
+    const result = await new PiModelDiscoveryService(createPlugin()).discoverModels();
+
+    expect(result).toEqual({
+      diagnostics: 'not logged in\n\nPi stderr',
+      models: [],
+    });
+    expect(mockTransportDispose).toHaveBeenCalled();
+    expect(mockProcessShutdown).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/providers/pi/runtime/PiRpcPayloads.test.ts
+++ b/tests/unit/providers/pi/runtime/PiRpcPayloads.test.ts
@@ -1,0 +1,15 @@
+import { buildPiSetModelPayload } from '@/providers/pi/runtime/PiRpcPayloads';
+
+describe('Pi RPC payload builders', () => {
+  it('uses Pi RPC modelId field for set_model payloads', () => {
+    expect(buildPiSetModelPayload('pi:openai-codex/gpt-5.2')).toEqual({
+      modelId: 'gpt-5.2',
+      provider: 'openai-codex',
+    });
+  });
+
+  it('rejects invalid Pi model ids', () => {
+    expect(buildPiSetModelPayload('openai-codex/gpt-5.2')).toBeNull();
+    expect(buildPiSetModelPayload('pi:openai-codex')).toBeNull();
+  });
+});

--- a/tests/unit/providers/pi/runtime/PiRpcTransport.test.ts
+++ b/tests/unit/providers/pi/runtime/PiRpcTransport.test.ts
@@ -17,6 +17,10 @@ function createTransport() {
 }
 
 describe('PiRpcTransport', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('writes command requests with string ids', async () => {
     const { input, transport, writes } = createTransport();
     const promise = transport.request('get_state', { foo: 'bar' });
@@ -74,6 +78,16 @@ describe('PiRpcTransport', () => {
     expect(events).toEqual([{ type: 'message_update', delta: 'hi' }]);
   });
 
+  it('ignores malformed JSON records without failing pending requests', async () => {
+    const { input, transport } = createTransport();
+    const promise = transport.request('prompt');
+
+    input.write('not-json\n');
+    input.write('{"type":"response","id":"req_1","success":true,"result":{"accepted":true}}\n');
+
+    await expect(promise).resolves.toEqual({ accepted: true });
+  });
+
   it('rejects failed responses and pending requests on dispose', async () => {
     const { input, transport } = createTransport();
     const failed = transport.request('prompt');
@@ -84,5 +98,19 @@ describe('PiRpcTransport', () => {
     const pending = transport.request('prompt');
     transport.dispose();
     await expect(pending).rejects.toBeInstanceOf(PiRpcTransportClosedError);
+  });
+
+  it('rejects timed-out requests and removes them from the pending set', async () => {
+    jest.useFakeTimers();
+    const { input, transport } = createTransport();
+    const timedOut = transport.request('prompt', {}, 100);
+
+    jest.advanceTimersByTime(100);
+    await expect(timedOut).rejects.toThrow('Request timeout: prompt');
+
+    input.write('{"type":"response","id":"req_1","success":true,"result":"late"}\n');
+    const next = transport.request('get_state', {}, 100);
+    input.write('{"type":"response","id":"req_2","success":true,"result":{"ok":true}}\n');
+    await expect(next).resolves.toEqual({ ok: true });
   });
 });

--- a/tests/unit/providers/pi/runtime/PiRpcTransport.test.ts
+++ b/tests/unit/providers/pi/runtime/PiRpcTransport.test.ts
@@ -1,0 +1,88 @@
+import { PassThrough } from 'node:stream';
+
+import {
+  PiRpcResponseError,
+  PiRpcTransport,
+  PiRpcTransportClosedError,
+} from '@/providers/pi/runtime/PiRpcTransport';
+
+function createTransport() {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const writes: string[] = [];
+  output.on('data', chunk => writes.push(chunk.toString('utf8')));
+  const transport = new PiRpcTransport({ input, output }, 100);
+  transport.start();
+  return { input, output, transport, writes };
+}
+
+describe('PiRpcTransport', () => {
+  it('writes command requests with string ids', async () => {
+    const { input, transport, writes } = createTransport();
+    const promise = transport.request('get_state', { foo: 'bar' });
+
+    expect(JSON.parse(writes[0]) as unknown).toEqual({
+      foo: 'bar',
+      id: 'req_1',
+      type: 'get_state',
+    });
+
+    input.write('{"type":"response","id":"req_1","success":true,"result":{"ok":true}}\n');
+    await expect(promise).resolves.toEqual({ ok: true });
+  });
+
+  it('sends fire-and-forget records without pending request tracking', () => {
+    const { transport, writes } = createTransport();
+
+    transport.send({ id: 'ui-1', type: 'extension_ui_response', value: 'ok' });
+
+    expect(JSON.parse(writes[0]) as unknown).toEqual({
+      id: 'ui-1',
+      type: 'extension_ui_response',
+      value: 'ok',
+    });
+  });
+
+  it('resolves concurrent requests by id out of order', async () => {
+    const { input, transport } = createTransport();
+    const first = transport.request('first');
+    const second = transport.request('second');
+
+    input.write('{"type":"response","id":"req_2","success":true,"result":2}\n');
+    input.write('{"type":"response","id":"req_1","success":true,"result":1}\n');
+
+    await expect(second).resolves.toBe(2);
+    await expect(first).resolves.toBe(1);
+  });
+
+  it('unwraps Pi response data when result is absent', async () => {
+    const { input, transport } = createTransport();
+    const promise = transport.request('get_available_models');
+
+    input.write('{"type":"response","id":"req_1","success":true,"data":{"models":[{"id":"gpt-5"}]}}\n');
+
+    await expect(promise).resolves.toEqual({ models: [{ id: 'gpt-5' }] });
+  });
+
+  it('routes non-response events to listeners', () => {
+    const { input, transport } = createTransport();
+    const events: unknown[] = [];
+    transport.onEvent(event => events.push(event));
+
+    input.write('{"type":"message_update","delta":"hi"}\n');
+
+    expect(events).toEqual([{ type: 'message_update', delta: 'hi' }]);
+  });
+
+  it('rejects failed responses and pending requests on dispose', async () => {
+    const { input, transport } = createTransport();
+    const failed = transport.request('prompt');
+    input.write('{"type":"response","id":"req_1","success":false,"error":"boom"}\n');
+
+    await expect(failed).rejects.toBeInstanceOf(PiRpcResponseError);
+
+    const pending = transport.request('prompt');
+    transport.dispose();
+    await expect(pending).rejects.toBeInstanceOf(PiRpcTransportClosedError);
+  });
+});

--- a/tests/unit/providers/pi/runtime/PiSubprocess.test.ts
+++ b/tests/unit/providers/pi/runtime/PiSubprocess.test.ts
@@ -26,6 +26,7 @@ function createMockProcess(): any {
 }
 
 describe('PiSubprocess', () => {
+  const originalPlatform = process.platform;
   let proc: any;
 
   beforeEach(() => {
@@ -35,6 +36,7 @@ describe('PiSubprocess', () => {
   });
 
   afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
     jest.useRealTimers();
   });
 
@@ -56,6 +58,28 @@ describe('PiSubprocess', () => {
         PATH: expect.stringContaining('/usr/bin'),
       }),
     }));
+  });
+
+  it('wraps Windows .cmd shims through cmd.exe', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const subprocess = new PiSubprocess({
+      args: ['--mode', 'rpc', '--system-prompt', 'Use R&D policy'],
+      command: 'C:\\Users\\R&D\\AppData\\Roaming\\npm\\pi.cmd',
+      cwd: 'C:\\Vault',
+      env: { PATH: 'C:\\Windows\\System32' },
+    });
+
+    subprocess.start();
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      process.env.ComSpec || process.env.comspec || 'cmd.exe',
+      ['/d', '/s', '/c', '""C:\\Users\\R&D\\AppData\\Roaming\\npm\\pi.cmd" --mode rpc --system-prompt "Use R&D policy""'],
+      expect.objectContaining({
+        cwd: 'C:\\Vault',
+        windowsHide: true,
+        windowsVerbatimArguments: true,
+      }),
+    );
   });
 
   it('keeps a bounded stderr snapshot for runtime errors', () => {

--- a/tests/unit/providers/pi/runtime/PiSubprocess.test.ts
+++ b/tests/unit/providers/pi/runtime/PiSubprocess.test.ts
@@ -1,0 +1,99 @@
+import { EventEmitter } from 'node:events';
+import { Readable, Writable } from 'node:stream';
+
+jest.mock('node:child_process', () => ({
+  spawn: jest.fn(),
+}));
+
+import { spawn } from 'node:child_process';
+
+import { PiSubprocess } from '@/providers/pi/runtime/PiSubprocess';
+
+const mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
+
+function createMockProcess(): any {
+  const proc = new EventEmitter() as any;
+  proc.stdin = new Writable({ write: (_chunk, _encoding, callback) => callback() });
+  proc.stdout = new Readable({ read() {} });
+  proc.stderr = new Readable({ read() {} });
+  proc.exitCode = null;
+  proc.killed = false;
+  proc.kill = jest.fn((signal?: string) => {
+    proc.killed = signal === 'SIGKILL';
+    return true;
+  });
+  return proc;
+}
+
+describe('PiSubprocess', () => {
+  let proc: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('spawns Pi RPC with the launch spec args, cwd, stdio, and enhanced PATH', () => {
+    const subprocess = new PiSubprocess({
+      args: ['--mode', 'rpc'],
+      command: '/opt/pi/bin/pi',
+      cwd: '/vault',
+      env: { PATH: '/usr/bin' },
+    });
+
+    subprocess.start();
+
+    expect(mockSpawn).toHaveBeenCalledWith('/opt/pi/bin/pi', ['--mode', 'rpc'], expect.objectContaining({
+      cwd: '/vault',
+      stdio: 'pipe',
+      windowsHide: true,
+      env: expect.objectContaining({
+        PATH: expect.stringContaining('/usr/bin'),
+      }),
+    }));
+  });
+
+  it('keeps a bounded stderr snapshot for runtime errors', () => {
+    const subprocess = new PiSubprocess({
+      args: ['--mode', 'rpc'],
+      command: 'pi',
+      cwd: '/vault',
+      env: {},
+    });
+    subprocess.start();
+
+    proc.stderr.emit('data', 'a'.repeat(9_000));
+
+    expect(subprocess.getStderrSnapshot()).toHaveLength(8_000);
+  });
+
+  it('notifies close listeners and escalates shutdown after timeout', async () => {
+    jest.useFakeTimers();
+    const subprocess = new PiSubprocess({
+      args: ['--mode', 'rpc'],
+      command: 'pi',
+      cwd: '/vault',
+      env: {},
+    });
+    const onClose = jest.fn();
+    subprocess.onClose(onClose);
+    subprocess.start();
+
+    const shutdown = subprocess.shutdown();
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+
+    jest.advanceTimersByTime(3_000);
+    expect(proc.kill).toHaveBeenCalledWith('SIGKILL');
+
+    proc.exitCode = 1;
+    proc.emit('exit', 1, 'SIGKILL');
+    await shutdown;
+
+    expect(onClose).toHaveBeenCalledWith(expect.any(Error));
+  });
+});

--- a/tests/unit/providers/pi/runtime/buildPiPrompt.test.ts
+++ b/tests/unit/providers/pi/runtime/buildPiPrompt.test.ts
@@ -1,0 +1,84 @@
+import {
+  buildPiPromptImages,
+  buildPiPromptText,
+} from '@/providers/pi/runtime/buildPiPrompt';
+
+describe('buildPiPrompt', () => {
+  it('appends provider-neutral note and selection context without embedding images', () => {
+    const prompt = buildPiPromptText({
+      browserSelection: {
+        selectedText: 'Browser text',
+        source: 'browser',
+        title: 'Docs',
+        url: 'https://example.com',
+      },
+      canvasSelection: {
+        canvasPath: 'Board.canvas',
+        nodeIds: ['node-a', 'node-b'],
+      },
+      currentNotePath: 'Notes/today.md',
+      editorSelection: {
+        lineCount: 2,
+        mode: 'selection',
+        notePath: 'Notes/today.md',
+        selectedText: 'Selected text',
+        startLine: 4,
+      },
+      images: [{
+        data: 'base64-image',
+        id: 'image-1',
+        mediaType: 'image/png',
+        name: 'image.png',
+        size: 12,
+        source: 'paste',
+      }],
+      text: 'Summarize this',
+    });
+
+    expect(prompt).toContain('Summarize this');
+    expect(prompt).toContain('<current_note>\nNotes/today.md\n</current_note>');
+    expect(prompt).toContain('<editor_selection path="Notes/today.md" lines="4-5">\nSelected text\n</editor_selection>');
+    expect(prompt).toContain('<browser_selection source="browser" title="Docs" url="https://example.com">\nBrowser text\n</browser_selection>');
+    expect(prompt).toContain('<canvas_selection path="Board.canvas">\nnode-a, node-b\n</canvas_selection>');
+    expect(prompt).not.toContain('base64-image');
+  });
+
+  it('uses history context only when conversation history is supplied', () => {
+    const withoutHistory = buildPiPromptText({ text: 'Continue' });
+    const withHistory = buildPiPromptText({ text: 'Continue' }, [
+      {
+        content: 'Earlier request',
+        id: 'm1',
+        role: 'user',
+        timestamp: 1,
+      },
+    ]);
+
+    expect(withoutHistory).toBe('Continue');
+    expect(withHistory).toContain('Earlier request');
+    expect(withHistory).toContain('Continue');
+  });
+
+  it('maps image attachments separately for Pi RPC payloads', () => {
+    expect(buildPiPromptImages([
+      {
+        data: 'image-a',
+        id: 'image-a',
+        mediaType: 'image/png',
+        name: 'a.png',
+        size: 12,
+        source: 'paste',
+      },
+      {
+        data: '',
+        id: 'image-b',
+        mediaType: 'image/jpeg',
+        name: 'b.jpg',
+        size: 12,
+        source: 'paste',
+      },
+    ])).toEqual([
+      { data: 'image-a', mimeType: 'image/png', type: 'image' },
+    ]);
+  });
+});

--- a/tests/unit/providers/pi/runtime/buildPiUsageInfo.test.ts
+++ b/tests/unit/providers/pi/runtime/buildPiUsageInfo.test.ts
@@ -1,0 +1,54 @@
+import { buildPiUsageInfo } from '@/providers/pi/runtime/buildPiUsageInfo';
+
+describe('buildPiUsageInfo', () => {
+  it('normalizes fractional provider percentages to whole context-meter percentages', () => {
+    const usage = buildPiUsageInfo({
+      contextUsage: {
+        contextTokens: 24_691,
+        contextWindow: 200_000,
+        inputTokens: 1200,
+        percentage: 0.123456789,
+      },
+    }, 'pi:openai/gpt-5');
+
+    expect(usage?.percentage).toBe(12);
+  });
+
+  it('preserves provider percentages that are already whole percent values', () => {
+    const usage = buildPiUsageInfo({
+      context_usage: {
+        context_tokens: 50_000,
+        context_window: 200_000,
+        input_tokens: 1200,
+        percentage: 25,
+      },
+    }, null);
+
+    expect(usage?.percentage).toBe(25);
+  });
+
+  it('rounds provider percentage decimals when they are already percent values', () => {
+    const usage = buildPiUsageInfo({
+      contextUsage: {
+        contextTokens: 24_691,
+        contextWindow: 200_000,
+        inputTokens: 1200,
+        percentage: 12.3456789,
+      },
+    }, null);
+
+    expect(usage?.percentage).toBe(12);
+  });
+
+  it('rounds derived percentages to match the shared context meter contract', () => {
+    const usage = buildPiUsageInfo({
+      contextUsage: {
+        contextTokens: 11_830,
+        contextWindow: 200_000,
+        inputTokens: 38,
+      },
+    }, null);
+
+    expect(usage?.percentage).toBe(6);
+  });
+});

--- a/tests/unit/providers/pi/runtime/buildPiUsageInfo.test.ts
+++ b/tests/unit/providers/pi/runtime/buildPiUsageInfo.test.ts
@@ -51,4 +51,19 @@ describe('buildPiUsageInfo', () => {
 
     expect(usage?.percentage).toBe(6);
   });
+
+  it('uses a fallback context window without marking it provider-authoritative', () => {
+    const usage = buildPiUsageInfo({
+      contextUsage: {
+        contextTokens: 50_000,
+        inputTokens: 1200,
+      },
+    }, 'pi:anthropic/claude-sonnet-4', 1_000_000);
+
+    expect(usage).toMatchObject({
+      contextWindow: 1_000_000,
+      contextWindowIsAuthoritative: false,
+      percentage: 5,
+    });
+  });
 });

--- a/tests/unit/providers/pi/settings.test.ts
+++ b/tests/unit/providers/pi/settings.test.ts
@@ -1,0 +1,253 @@
+const mockGetHostnameKey = jest.fn(() => 'host-a');
+const mockGetLegacyHostnameKey = jest.fn(() => 'legacy-host');
+
+jest.mock('../../../../src/utils/env', () => ({
+  ...jest.requireActual('../../../../src/utils/env'),
+  getHostnameKey: () => mockGetHostnameKey(),
+  getLegacyHostnameKey: () => mockGetLegacyHostnameKey(),
+}));
+
+import { piSettingsReconciler } from '@/providers/pi/env/PiSettingsReconciler';
+import {
+  DEFAULT_PI_PROVIDER_SETTINGS,
+  getPiProviderSettings,
+  normalizePiModelAliases,
+  normalizePiPreferredThinkingByModel,
+  normalizePiVisibleModels,
+  updatePiProviderSettings,
+} from '@/providers/pi/settings';
+
+describe('Pi settings normalization', () => {
+  const discoveredModels = [
+    {
+      encodedId: 'pi:anthropic/claude-sonnet-4',
+      id: 'claude-sonnet-4',
+      input: ['text' as const],
+      label: 'Claude Sonnet 4',
+      provider: 'anthropic',
+      reasoning: true,
+      thinkingLevels: ['off' as const, 'medium' as const, 'high' as const],
+    },
+    {
+      encodedId: 'pi:openai/gpt-5',
+      id: 'gpt-5',
+      input: ['text' as const, 'image' as const],
+      label: 'GPT-5',
+      provider: 'openai',
+      reasoning: true,
+      thinkingLevels: ['off' as const, 'low' as const, 'medium' as const],
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetHostnameKey.mockReturnValue('host-a');
+    mockGetLegacyHostnameKey.mockReturnValue('legacy-host');
+  });
+
+  it('defaults Pi to disabled all-tools mode', () => {
+    expect(DEFAULT_PI_PROVIDER_SETTINGS).toMatchObject({
+      enabled: false,
+      toolMode: 'all',
+      visibleModels: [],
+    });
+  });
+
+  it('migrates current legacy hostname-scoped CLI paths', () => {
+    mockGetHostnameKey.mockReturnValue('device:current');
+    mockGetLegacyHostnameKey.mockReturnValue('host-a');
+
+    expect(getPiProviderSettings({
+      providerConfigs: {
+        pi: {
+          cliPathsByHost: {
+            'host-a': '/host-a/pi',
+            'host-b': '/host-b/pi',
+          },
+        },
+      },
+    }).cliPathsByHost).toEqual({
+      'device:current': '/host-a/pi',
+      'host-b': '/host-b/pi',
+    });
+  });
+
+  it('normalizes visible models to valid encoded ids', () => {
+    expect(normalizePiVisibleModels([
+      'pi:anthropic/claude-sonnet-4',
+      'pi:anthropic/claude-sonnet-4',
+      'pi:missing/model',
+      'openai/gpt-5',
+    ], discoveredModels)).toEqual(['pi:anthropic/claude-sonnet-4']);
+  });
+
+  it('normalizes aliases and preferred thinking', () => {
+    expect(normalizePiModelAliases({
+      'pi:anthropic/claude-sonnet-4': '  Sonnet  ',
+      'pi:missing/model': 'Missing',
+    }, discoveredModels)).toEqual({
+      'pi:anthropic/claude-sonnet-4': 'Sonnet',
+    });
+    expect(normalizePiPreferredThinkingByModel({
+      'pi:anthropic/claude-sonnet-4': 'high',
+      'pi:openai/gpt-5': 'xhigh',
+    }, discoveredModels)).toEqual({
+      'pi:anthropic/claude-sonnet-4': 'high',
+    });
+  });
+
+  it('keeps selected model metadata even when the selected model is no longer discovered', () => {
+    const settings: Record<string, unknown> = {
+      model: 'pi:old-provider/old-model',
+      providerConfigs: {
+        pi: {
+          discoveredModels,
+          modelAliases: {
+            'pi:old-provider/old-model': 'Legacy model',
+            'pi:missing/model': 'Missing',
+          },
+          preferredThinkingByModel: {
+            'pi:old-provider/old-model': 'high',
+            'pi:missing/model': 'low',
+          },
+          visibleModels: ['pi:anthropic/claude-sonnet-4'],
+        },
+      },
+      savedProviderModel: {},
+      titleGenerationModel: '',
+    };
+
+    expect(getPiProviderSettings(settings).modelAliases).toEqual({
+      'pi:old-provider/old-model': 'Legacy model',
+    });
+    expect(getPiProviderSettings(settings).preferredThinkingByModel).toEqual({
+      'pi:old-provider/old-model': 'high',
+    });
+  });
+
+  it('preserves selected model metadata during model variant reconciliation when discovery is stale', () => {
+    const settings: Record<string, unknown> = {
+      model: 'pi:old-provider/old-model',
+      providerConfigs: {
+        pi: {
+          discoveredModels,
+          modelAliases: {
+            'pi:old-provider/old-model': 'Legacy model',
+          },
+          preferredThinkingByModel: {
+            'pi:old-provider/old-model': 'high',
+          },
+          visibleModels: ['pi:anthropic/claude-sonnet-4'],
+        },
+      },
+      savedProviderModel: {},
+      titleGenerationModel: '',
+    };
+
+    expect(piSettingsReconciler.normalizeModelVariantSettings(settings)).toBe(false);
+    expect(getPiProviderSettings(settings).modelAliases).toEqual({
+      'pi:old-provider/old-model': 'Legacy model',
+    });
+    expect(getPiProviderSettings(settings).preferredThinkingByModel).toEqual({
+      'pi:old-provider/old-model': 'high',
+    });
+  });
+
+  it('retargets active and saved Pi selections when visible models change', () => {
+    const settings: Record<string, unknown> = {
+      effortLevel: 'high',
+      model: 'pi:openai/gpt-5',
+      providerConfigs: {
+        pi: {
+          discoveredModels,
+          preferredThinkingByModel: {
+            'pi:anthropic/claude-sonnet-4': 'high',
+          },
+          visibleModels: ['pi:openai/gpt-5', 'pi:anthropic/claude-sonnet-4'],
+        },
+      },
+      savedProviderEffort: {
+        pi: 'medium',
+      },
+      savedProviderModel: {
+        pi: 'pi:openai/gpt-5',
+      },
+      titleGenerationModel: 'pi:openai/gpt-5',
+    };
+
+    updatePiProviderSettings(settings, {
+      visibleModels: ['pi:anthropic/claude-sonnet-4'],
+    });
+
+    expect(settings.model).toBe('pi:anthropic/claude-sonnet-4');
+    expect(settings.effortLevel).toBe('high');
+    expect((settings.savedProviderModel as Record<string, string>).pi).toBe('pi:anthropic/claude-sonnet-4');
+    expect((settings.savedProviderEffort as Record<string, string>).pi).toBe('high');
+    expect(settings.titleGenerationModel).toBe('pi:anthropic/claude-sonnet-4');
+  });
+
+  it('clears the Pi title model when all visible models are removed', () => {
+    const settings: Record<string, unknown> = {
+      providerConfigs: {
+        pi: {
+          discoveredModels,
+          visibleModels: ['pi:openai/gpt-5'],
+        },
+      },
+      titleGenerationModel: 'pi:openai/gpt-5',
+    };
+
+    updatePiProviderSettings(settings, { visibleModels: [] });
+
+    expect(settings.titleGenerationModel).toBe('');
+  });
+
+  it('clears stale discovery metadata on environment change without dropping visible model choices', () => {
+    const settings: Record<string, unknown> = {
+      providerConfigs: {
+        pi: {
+          discoveredModels,
+          visibleModels: ['pi:anthropic/claude-sonnet-4'],
+        },
+      },
+    };
+
+    expect(piSettingsReconciler.handleEnvironmentChange?.(settings)).toBe(true);
+
+    expect(getPiProviderSettings(settings).discoveredModels).toEqual([]);
+    expect(getPiProviderSettings(settings).visibleModels).toEqual(['pi:anthropic/claude-sonnet-4']);
+  });
+
+  it('normalizes blank Pi effort to a value supported by the selected model', () => {
+    const nonReasoningSettings: Record<string, unknown> = {
+      effortLevel: '',
+      model: 'pi:openai/gpt-5',
+      providerConfigs: {
+        pi: {
+          discoveredModels: [{
+            encodedId: 'pi:openai/gpt-5',
+            id: 'gpt-5',
+            input: ['text'],
+            label: 'GPT-5',
+            provider: 'openai',
+            reasoning: false,
+            thinkingLevels: ['off'],
+          }],
+          visibleModels: ['pi:openai/gpt-5'],
+        },
+      },
+    };
+
+    expect(piSettingsReconciler.normalizeModelVariantSettings(nonReasoningSettings)).toBe(true);
+    expect(nonReasoningSettings.effortLevel).toBe('off');
+
+    const fallbackSettings: Record<string, unknown> = {
+      effortLevel: '',
+      model: 'pi',
+      providerConfigs: { pi: {} },
+    };
+
+    expect(piSettingsReconciler.normalizeModelVariantSettings(fallbackSettings)).toBe(true);
+    expect(fallbackSettings.effortLevel).toBe('off');
+  });
+});

--- a/tests/unit/providers/pi/ui/PiChatUIConfig.test.ts
+++ b/tests/unit/providers/pi/ui/PiChatUIConfig.test.ts
@@ -60,6 +60,9 @@ describe('PiChatUIConfig', () => {
     expect(piChatUIConfig.getModelOptions({ providerConfigs: { pi: {} } })).toEqual([
       { value: 'pi', label: 'Pi', description: 'Configure models in settings' },
     ]);
+    expect(piChatUIConfig.ownsModel('pi', { providerConfigs: { pi: {} } })).toBe(true);
+    expect(piChatUIConfig.ownsModel('pi:anthropic/claude-sonnet-4', { providerConfigs: { pi: {} } })).toBe(true);
+    expect(piChatUIConfig.ownsModel('pi:invalid', { providerConfigs: { pi: {} } })).toBe(false);
     expect(piChatUIConfig.getReasoningOptions('pi', { providerConfigs: { pi: {} } })).toEqual([
       { label: 'Off', value: 'off' },
     ]);
@@ -74,6 +77,38 @@ describe('PiChatUIConfig', () => {
       { label: 'High', value: 'high' },
     ]);
     expect(piChatUIConfig.getDefaultReasoningValue('pi:anthropic/claude-sonnet-4', settings)).toBe('high');
+  });
+
+  it('resolves context windows from cached Pi model metadata before falling back', () => {
+    const contextSettings: Record<string, unknown> = {
+      providerConfigs: {
+        pi: {
+          discoveredModels: [{
+            contextWindow: 1_000_000,
+            encodedId: 'pi:anthropic/claude-sonnet-4',
+            id: 'claude-sonnet-4',
+            input: ['text'],
+            label: 'Claude Sonnet 4',
+            provider: 'anthropic',
+            reasoning: true,
+            thinkingLevels: ['off', 'medium', 'high'],
+          }],
+          visibleModels: ['pi:anthropic/claude-sonnet-4'],
+        },
+      },
+    };
+
+    expect(piChatUIConfig.getContextWindowSize(
+      'pi:anthropic/claude-sonnet-4',
+      { 'pi:anthropic/claude-sonnet-4': 123_000 },
+      contextSettings,
+    )).toBe(1_000_000);
+    expect(piChatUIConfig.getContextWindowSize(
+      'pi:missing/model',
+      { 'pi:missing/model': 123_000 },
+      contextSettings,
+    )).toBe(123_000);
+    expect(piChatUIConfig.getContextWindowSize('pi:missing/model', undefined, contextSettings)).toBe(200_000);
   });
 
   it('keeps decoded models on Pi effort controls when discovery metadata is stale', () => {

--- a/tests/unit/providers/pi/ui/PiChatUIConfig.test.ts
+++ b/tests/unit/providers/pi/ui/PiChatUIConfig.test.ts
@@ -1,0 +1,126 @@
+import { getPiProviderSettings } from '@/providers/pi/settings';
+import { piChatUIConfig } from '@/providers/pi/ui/PiChatUIConfig';
+
+const settings: Record<string, unknown> = {
+  providerConfigs: {
+    pi: {
+      discoveredModels: [
+        {
+          encodedId: 'pi:anthropic/claude-sonnet-4',
+          id: 'claude-sonnet-4',
+          input: ['text'],
+          label: 'Claude Sonnet 4',
+          provider: 'anthropic',
+          reasoning: true,
+          thinkingLevels: ['off', 'medium', 'high'],
+        },
+        {
+          encodedId: 'pi:openai/gpt-5',
+          id: 'gpt-5',
+          input: ['text'],
+          label: 'GPT-5',
+          provider: 'openai',
+          reasoning: false,
+          thinkingLevels: ['off'],
+        },
+      ],
+      modelAliases: {
+        'pi:anthropic/claude-sonnet-4': 'Sonnet',
+      },
+      preferredThinkingByModel: {
+        'pi:anthropic/claude-sonnet-4': 'high',
+      },
+      visibleModels: ['pi:anthropic/claude-sonnet-4'],
+    },
+  },
+};
+
+describe('PiChatUIConfig', () => {
+  it('returns visible model options with aliases and pins saved selections', () => {
+    const options = piChatUIConfig.getModelOptions({
+      ...settings,
+      savedProviderModel: {
+        pi: 'pi:openai/gpt-5',
+      },
+    });
+
+    expect(options).toEqual([
+      expect.objectContaining({
+        label: 'Sonnet',
+        value: 'pi:anthropic/claude-sonnet-4',
+      }),
+      expect.objectContaining({
+        label: 'GPT-5',
+        value: 'pi:openai/gpt-5',
+      }),
+    ]);
+  });
+
+  it('returns a synthetic fallback before discovery', () => {
+    expect(piChatUIConfig.getModelOptions({ providerConfigs: { pi: {} } })).toEqual([
+      { value: 'pi', label: 'Pi', description: 'Configure models in settings' },
+    ]);
+    expect(piChatUIConfig.getReasoningOptions('pi', { providerConfigs: { pi: {} } })).toEqual([
+      { label: 'Off', value: 'off' },
+    ]);
+    expect(piChatUIConfig.getDefaultReasoningValue('pi', { providerConfigs: { pi: {} } })).toBe('off');
+  });
+
+  it('maps reasoning options and defaults from cached model metadata', () => {
+    expect(piChatUIConfig.isAdaptiveReasoningModel('pi:anthropic/claude-sonnet-4', settings)).toBe(true);
+    expect(piChatUIConfig.getReasoningOptions('pi:anthropic/claude-sonnet-4', settings)).toEqual([
+      { label: 'Off', value: 'off' },
+      { label: 'Medium', value: 'medium' },
+      { label: 'High', value: 'high' },
+    ]);
+    expect(piChatUIConfig.getDefaultReasoningValue('pi:anthropic/claude-sonnet-4', settings)).toBe('high');
+  });
+
+  it('keeps decoded models on Pi effort controls when discovery metadata is stale', () => {
+    const staleSettings: Record<string, unknown> = {
+      providerConfigs: {
+        pi: {
+          visibleModels: ['pi:custom/model'],
+        },
+      },
+      savedProviderModel: {
+        pi: 'pi:custom/model',
+      },
+    };
+
+    expect(piChatUIConfig.getModelOptions(staleSettings)).toEqual([
+      expect.objectContaining({
+        label: 'custom/model',
+        value: 'pi:custom/model',
+      }),
+    ]);
+    expect(piChatUIConfig.isAdaptiveReasoningModel('pi:custom/model', staleSettings)).toBe(true);
+    expect(piChatUIConfig.getReasoningOptions('pi:custom/model', staleSettings)).toEqual([
+      { label: 'Off', value: 'off' },
+      { label: 'Minimal', value: 'minimal' },
+      { label: 'Low', value: 'low' },
+      { label: 'Medium', value: 'medium' },
+      { label: 'High', value: 'high' },
+    ]);
+    expect(piChatUIConfig.getDefaultReasoningValue('pi:custom/model', staleSettings)).toBe('medium');
+
+    piChatUIConfig.applyReasoningSelection?.('pi:custom/model', 'high', staleSettings);
+    expect(getPiProviderSettings(staleSettings).preferredThinkingByModel).toEqual({
+      'pi:custom/model': 'high',
+    });
+  });
+
+  it('maps toolbar permission mode to Pi tool mode', () => {
+    const mutableSettings: Record<string, unknown> = {
+      providerConfigs: {
+        pi: {
+          toolMode: 'readonly',
+        },
+      },
+    };
+
+    expect(piChatUIConfig.resolvePermissionMode?.(mutableSettings)).toBe('normal');
+    piChatUIConfig.applyPermissionMode?.('yolo', mutableSettings);
+    expect(piChatUIConfig.resolvePermissionMode?.(mutableSettings)).toBe('yolo');
+  });
+});

--- a/tests/unit/providers/pi/ui/PiSettingsTab.test.ts
+++ b/tests/unit/providers/pi/ui/PiSettingsTab.test.ts
@@ -273,6 +273,19 @@ describe('PiSettingsTab', () => {
     expect(context.refreshModelSelectors).toHaveBeenCalled();
   });
 
+  it('does not render hidden command settings for Pi', () => {
+    const settings: Record<string, unknown> = { providerConfigs: { pi: {} } };
+    const context = render(settings);
+
+    expect(context.renderHiddenProviderCommandSetting).not.toHaveBeenCalled();
+  });
+
+  it('does not render the chat input tool mode setting for Pi', () => {
+    render({ providerConfigs: { pi: { toolMode: 'readonly' } } });
+
+    expect(() => findSetting('Tool mode')).toThrow('Setting not found: Tool mode');
+  });
+
   it('validates host-scoped CLI paths and resets the resolver after valid changes', async () => {
     const settings: Record<string, unknown> = { providerConfigs: { pi: {} } };
     const context = render(settings);

--- a/tests/unit/providers/pi/ui/PiSettingsTab.test.ts
+++ b/tests/unit/providers/pi/ui/PiSettingsTab.test.ts
@@ -1,0 +1,341 @@
+import * as fs from 'node:fs';
+
+const mockRenderEnvironmentSettingsSection = jest.fn();
+const mockCliResolverReset = jest.fn();
+const mockDiscoverModels = jest.fn();
+const mockNotices: string[] = [];
+
+interface MockToggleComponent {
+  onChangeCallback: ((value: boolean) => Promise<void> | void) | null;
+  setValue: jest.Mock;
+  value: boolean;
+  onChange(callback: (value: boolean) => Promise<void> | void): MockToggleComponent;
+}
+
+interface MockTextComponent {
+  inputEl: {
+    toggleClass: jest.Mock;
+  };
+  onChangeCallback: ((value: string) => Promise<void> | void) | null;
+  setPlaceholder: jest.Mock;
+  setValue: jest.Mock;
+  value: string;
+  onChange(callback: (value: string) => Promise<void> | void): MockTextComponent;
+}
+
+interface MockButtonComponent {
+  disabled: boolean;
+  onClickCallback: (() => Promise<void> | void) | null;
+  setButtonText: jest.Mock;
+  setDisabled: jest.Mock;
+  text: string;
+  onClick(callback: () => Promise<void> | void): MockButtonComponent;
+}
+
+interface MockDropdownComponent {
+  onChangeCallback: ((value: string) => Promise<void> | void) | null;
+  options: Record<string, string>;
+  setValue: jest.Mock;
+  value: string;
+  addOption(value: string, label: string): MockDropdownComponent;
+  onChange(callback: (value: string) => Promise<void> | void): MockDropdownComponent;
+}
+
+class MockSetting {
+  buttonComponents: MockButtonComponent[] = [];
+  desc = '';
+  dropdownComponents: MockDropdownComponent[] = [];
+  heading = false;
+  name = '';
+  textComponents: MockTextComponent[] = [];
+  toggleComponents: MockToggleComponent[] = [];
+
+  constructor(_container: unknown) {
+    createdSettings.push(this);
+  }
+
+  setName(name: string): this {
+    this.name = name;
+    return this;
+  }
+
+  setDesc(desc: string): this {
+    this.desc = desc;
+    return this;
+  }
+
+  setHeading(): this {
+    this.heading = true;
+    return this;
+  }
+
+  addToggle(callback: (toggle: MockToggleComponent) => void): this {
+    const component = createToggleComponent();
+    this.toggleComponents.push(component);
+    callback(component);
+    return this;
+  }
+
+  addText(callback: (text: MockTextComponent) => void): this {
+    const component = createTextComponent();
+    this.textComponents.push(component);
+    callback(component);
+    return this;
+  }
+
+  addButton(callback: (button: MockButtonComponent) => void): this {
+    const component = createButtonComponent();
+    this.buttonComponents.push(component);
+    callback(component);
+    return this;
+  }
+
+  addDropdown(callback: (dropdown: MockDropdownComponent) => void): this {
+    const component = createDropdownComponent();
+    this.dropdownComponents.push(component);
+    callback(component);
+    return this;
+  }
+}
+
+jest.mock('node:fs');
+jest.mock('obsidian', () => ({
+  Notice: class MockNotice {
+    constructor(message: string) {
+      mockNotices.push(message);
+    }
+  },
+  Setting: MockSetting,
+}));
+jest.mock('@/features/settings/ui/EnvironmentSettingsSection', () => ({
+  renderEnvironmentSettingsSection: (...args: unknown[]) => mockRenderEnvironmentSettingsSection(...args),
+}));
+jest.mock('@/providers/pi/app/PiWorkspaceServices', () => ({
+  maybeGetPiWorkspaceServices: jest.fn(() => ({
+    cliResolver: {
+      reset: mockCliResolverReset,
+    },
+  })),
+}));
+jest.mock('@/providers/pi/runtime/PiModelDiscoveryService', () => ({
+  PiModelDiscoveryService: jest.fn().mockImplementation(() => ({
+    discoverModels: mockDiscoverModels,
+  })),
+}));
+jest.mock('@/utils/env', () => ({
+  ...jest.requireActual('@/utils/env'),
+  getHostnameKey: () => 'current-host',
+}));
+
+import { getPiProviderSettings } from '@/providers/pi/settings';
+import { piSettingsTabRenderer } from '@/providers/pi/ui/PiSettingsTab';
+
+const createdSettings: MockSetting[] = [];
+const mockedExists = fs.existsSync as jest.Mock;
+const mockedStat = fs.statSync as jest.Mock;
+
+function createToggleComponent(): MockToggleComponent {
+  const component = {} as MockToggleComponent;
+  component.onChangeCallback = null;
+  component.value = false;
+  component.setValue = jest.fn((value: boolean) => {
+    component.value = value;
+    return component;
+  });
+  component.onChange = (callback: (value: boolean) => Promise<void> | void): MockToggleComponent => {
+    component.onChangeCallback = callback;
+    return component;
+  };
+  return component;
+}
+
+function createTextComponent(): MockTextComponent {
+  const component = {} as MockTextComponent;
+  component.inputEl = {
+    toggleClass: jest.fn(),
+  };
+  component.onChangeCallback = null;
+  component.value = '';
+  component.setPlaceholder = jest.fn(() => component);
+  component.setValue = jest.fn((value: string) => {
+    component.value = value;
+    return component;
+  });
+  component.onChange = (callback: (value: string) => Promise<void> | void): MockTextComponent => {
+    component.onChangeCallback = callback;
+    return component;
+  };
+  return component;
+}
+
+function createButtonComponent(): MockButtonComponent {
+  const component = {} as MockButtonComponent;
+  component.disabled = false;
+  component.onClickCallback = null;
+  component.text = '';
+  component.setButtonText = jest.fn((value: string) => {
+    component.text = value;
+    return component;
+  });
+  component.setDisabled = jest.fn((value: boolean) => {
+    component.disabled = value;
+    return component;
+  });
+  component.onClick = (callback: () => Promise<void> | void): MockButtonComponent => {
+    component.onClickCallback = callback;
+    return component;
+  };
+  return component;
+}
+
+function createDropdownComponent(): MockDropdownComponent {
+  const component = {} as MockDropdownComponent;
+  component.onChangeCallback = null;
+  component.options = {};
+  component.value = '';
+  component.addOption = (value: string, label: string): MockDropdownComponent => {
+    component.options[value] = label;
+    return component;
+  };
+  component.setValue = jest.fn((value: string) => {
+    component.value = value;
+    return component;
+  });
+  component.onChange = (callback: (value: string) => Promise<void> | void): MockDropdownComponent => {
+    component.onChangeCallback = callback;
+    return component;
+  };
+  return component;
+}
+
+function createElement(): any {
+  return {
+    createDiv: jest.fn(() => createElement()),
+    empty: jest.fn(),
+    setText: jest.fn(),
+    toggleClass: jest.fn(),
+  };
+}
+
+function createContext(settings: Record<string, unknown>) {
+  return {
+    plugin: {
+      saveSettings: jest.fn().mockResolvedValue(undefined),
+      settings,
+    },
+    refreshModelSelectors: jest.fn(),
+    renderHiddenProviderCommandSetting: jest.fn(),
+  };
+}
+
+function render(settings: Record<string, unknown>) {
+  const context = createContext(settings);
+  piSettingsTabRenderer.render(createElement(), context as any);
+  return context;
+}
+
+function findSetting(name: string): MockSetting {
+  const setting = [...createdSettings].reverse().find(entry => entry.name === name);
+  if (!setting) {
+    throw new Error(`Setting not found: ${name}`);
+  }
+  return setting;
+}
+
+describe('PiSettingsTab', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    createdSettings.length = 0;
+    mockNotices.length = 0;
+    mockedExists.mockReturnValue(true);
+    mockedStat.mockReturnValue({ isFile: () => true });
+    mockDiscoverModels.mockResolvedValue({
+      models: [{
+        encodedId: 'pi:anthropic/claude-sonnet-4',
+        id: 'claude-sonnet-4',
+        input: ['text'],
+        label: 'Claude Sonnet 4',
+        provider: 'anthropic',
+        reasoning: true,
+        thinkingLevels: ['off', 'medium'],
+      }],
+    });
+  });
+
+  it('updates provider config when Pi is enabled', async () => {
+    const settings: Record<string, unknown> = { providerConfigs: { pi: { enabled: false } } };
+    const context = render(settings);
+
+    await findSetting('Enable Pi').toggleComponents[0].onChangeCallback?.(true);
+
+    expect(getPiProviderSettings(settings).enabled).toBe(true);
+    expect(context.plugin.saveSettings).toHaveBeenCalled();
+    expect(context.refreshModelSelectors).toHaveBeenCalled();
+  });
+
+  it('validates host-scoped CLI paths and resets the resolver after valid changes', async () => {
+    const settings: Record<string, unknown> = { providerConfigs: { pi: {} } };
+    const context = render(settings);
+    const cliInput = findSetting('CLI path').textComponents[0];
+
+    mockedExists.mockReturnValue(false);
+    await cliInput.onChangeCallback?.('/missing/pi');
+    expect(context.plugin.saveSettings).not.toHaveBeenCalled();
+    expect(mockCliResolverReset).not.toHaveBeenCalled();
+
+    mockedExists.mockReturnValue(true);
+    mockedStat.mockReturnValue({ isFile: () => true });
+    await cliInput.onChangeCallback?.('/valid/pi');
+    expect(getPiProviderSettings(settings).cliPathsByHost).toEqual({
+      'current-host': '/valid/pi',
+    });
+    expect(mockCliResolverReset).toHaveBeenCalled();
+    expect(context.plugin.saveSettings).toHaveBeenCalled();
+  });
+
+  it('discovers models through PiModelDiscoveryService and reports failures', async () => {
+    const settings: Record<string, unknown> = { providerConfigs: { pi: {} } };
+    const context = render(settings);
+
+    await findSetting('Discover models').buttonComponents[0].onClickCallback?.();
+
+    expect(mockDiscoverModels).toHaveBeenCalledTimes(1);
+    expect(getPiProviderSettings(settings).discoveredModels).toHaveLength(1);
+    expect(getPiProviderSettings(settings).visibleModels).toEqual([]);
+    expect(context.refreshModelSelectors).toHaveBeenCalled();
+
+    mockDiscoverModels.mockResolvedValueOnce({ diagnostics: 'not logged in', models: [] });
+    await findSetting('Discover models').buttonComponents[0].onClickCallback?.();
+    expect(mockNotices[0]).toContain('not logged in');
+  });
+
+  it('persists visible model choices and aliases', async () => {
+    const settings: Record<string, unknown> = {
+      providerConfigs: {
+        pi: {
+          discoveredModels: [{
+            encodedId: 'pi:anthropic/claude-sonnet-4',
+            id: 'claude-sonnet-4',
+            input: ['text'],
+            label: 'Claude Sonnet 4',
+            provider: 'anthropic',
+            reasoning: true,
+            thinkingLevels: ['off', 'medium'],
+          }],
+          visibleModels: [],
+        },
+      },
+    };
+    const context = render(settings);
+    const modelSetting = findSetting('Claude Sonnet 4');
+
+    await modelSetting.toggleComponents[0].onChangeCallback?.(true);
+    expect(getPiProviderSettings(settings).visibleModels).toEqual(['pi:anthropic/claude-sonnet-4']);
+
+    await findSetting('Claude Sonnet 4').textComponents[0].onChangeCallback?.('Sonnet');
+    expect(getPiProviderSettings(settings).modelAliases).toEqual({
+      'pi:anthropic/claude-sonnet-4': 'Sonnet',
+    });
+    expect(context.refreshModelSelectors).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/shared/icons.test.ts
+++ b/tests/unit/shared/icons.test.ts
@@ -4,6 +4,7 @@ import {
   createProviderIconSvg,
   OPENAI_PROVIDER_ICON,
   OPENCODE_PROVIDER_ICON,
+  PI_PROVIDER_ICON,
 } from '@/shared/icons';
 
 describe('createProviderIconSvg', () => {
@@ -38,5 +39,18 @@ describe('createProviderIconSvg', () => {
     expect(svg.getAttribute('viewBox')).toBe(OPENCODE_PROVIDER_ICON.viewBox);
     expect(svg.querySelector('.claudian-provider-icon-variant--light')).not.toBeNull();
     expect(svg.querySelector('.claudian-provider-icon-variant--dark')).not.toBeNull();
+  });
+
+  it('renders the Pi provider icon as currentColor composite paths', () => {
+    const svg = createProviderIconSvg(PI_PROVIDER_ICON, {
+      dataProvider: 'pi',
+      ownerDocument: document,
+    });
+
+    expect(svg.getAttribute('viewBox')).toBe('0 0 800 800');
+    const paths = Array.from(svg.querySelectorAll('path'));
+    expect(paths).toHaveLength(2);
+    expect(paths[0].getAttribute('fill-rule')).toBe('evenodd');
+    expect(paths.every(path => path.getAttribute('fill') === 'currentColor')).toBe(true);
   });
 });

--- a/tests/unit/utils/cliBinaryLocator.test.ts
+++ b/tests/unit/utils/cliBinaryLocator.test.ts
@@ -1,0 +1,33 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { findCliBinaryPath, resolveConfiguredCliPath } from '@/utils/cliBinaryLocator';
+
+describe('cliBinaryLocator', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-binary-locator-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('resolves configured CLI files', () => {
+    const cliPath = path.join(tempDir, 'pi');
+    fs.writeFileSync(cliPath, '');
+
+    expect(resolveConfiguredCliPath(cliPath)).toBe(cliPath);
+  });
+
+  it('finds Windows npm .cmd shims on a PATH entry', () => {
+    const binDir = path.join(tempDir, 'bin');
+    const shimPath = path.join(binDir, 'pi.cmd');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(shimPath, '');
+
+    expect(findCliBinaryPath('pi', binDir, 'win32')).toBe(shimPath);
+  });
+});

--- a/tests/unit/utils/diff.test.ts
+++ b/tests/unit/utils/diff.test.ts
@@ -25,6 +25,34 @@ describe('extractDiffData', () => {
     expect(result!.stats).toEqual({ added: 1, removed: 1 });
   });
 
+  it('returns ToolDiffData from Pi result details.diff', () => {
+    const toolCall = makeToolCall('Edit', { file_path: 'src/pi.ts' });
+    const toolUseResult = {
+      content: [{ text: 'Edited src/pi.ts', type: 'text' }],
+      details: {
+        diff: [
+          '--- a/src/pi.ts',
+          '+++ b/src/pi.ts',
+          '@@ -2,2 +2,2 @@',
+          ' keep',
+          '-old',
+          '+new',
+        ].join('\n'),
+      },
+    };
+
+    const result = extractDiffData(toolUseResult, toolCall);
+
+    expect(result).toBeDefined();
+    expect(result!.filePath).toBe('src/pi.ts');
+    expect(result!.diffLines).toEqual([
+      { type: 'equal', text: 'keep', oldLineNum: 2, newLineNum: 2 },
+      { type: 'delete', text: 'old', oldLineNum: 3 },
+      { type: 'insert', text: 'new', newLineNum: 3 },
+    ]);
+    expect(result!.stats).toEqual({ added: 1, removed: 1 });
+  });
+
   it('uses SDK filePath when present in toolUseResult', () => {
     const toolCall = makeToolCall('Write', { file_path: 'input/path.ts' });
     const toolUseResult = {
@@ -121,6 +149,49 @@ describe('diffFromToolInput', () => {
     expect(result!.diffLines.filter(l => l.type === 'delete')).toHaveLength(2);
     expect(result!.diffLines.filter(l => l.type === 'insert')).toHaveLength(3);
     expect(result!.stats).toEqual({ added: 3, removed: 2 });
+  });
+
+  it('returns delete + insert lines for Pi Edit edits array', () => {
+    const toolCall = makeToolCall('Edit', {
+      file_path: 'src/pi.ts',
+      edits: [
+        { oldText: 'one\ntwo', newText: 'uno\ndos' },
+        { oldText: 'three', newText: 'tres' },
+      ],
+    });
+
+    const result = diffFromToolInput(toolCall, 'src/pi.ts');
+
+    expect(result).toBeDefined();
+    expect(result!.filePath).toBe('src/pi.ts');
+    expect(result!.diffLines.filter(l => l.type === 'delete').map(l => l.text)).toEqual(['one', 'two', 'three']);
+    expect(result!.diffLines.filter(l => l.type === 'insert').map(l => l.text)).toEqual(['uno', 'dos', 'tres']);
+    expect(result!.stats).toEqual({ added: 3, removed: 3 });
+  });
+
+  it('uses path as the fallback file path for Pi Write input', () => {
+    const toolCall = makeToolCall('Write', {
+      path: 'src/pi-new.ts',
+      content: 'created',
+    });
+
+    const result = extractDiffData(undefined, toolCall);
+
+    expect(result).toBeDefined();
+    expect(result!.filePath).toBe('src/pi-new.ts');
+  });
+
+  it('ignores non-string file_path values when a Pi path fallback is available', () => {
+    const toolCall = makeToolCall('Write', {
+      file_path: 123,
+      path: 'src/pi-new.ts',
+      content: 'created',
+    });
+
+    const result = extractDiffData(undefined, toolCall);
+
+    expect(result).toBeDefined();
+    expect(result!.filePath).toBe('src/pi-new.ts');
   });
 
   it('returns all insert lines for Write with valid content', () => {


### PR DESCRIPTION
Adds the Pi provider integration across registration, settings, runtime launch/RPC, command discovery, model discovery, history hydration, UI config, and auxiliary services.

Includes Pi JSONL parsing, tool/event normalization, fork session materialization, file-backed session handling, and runtime command warmup.

Adds unit coverage for provider registration/settings, runtime transport and launch behavior, history parsing/hydration, fork edge cases, UI config, and shared utility changes.

Validation: npm run typecheck, npm run lint -- --quiet, npm run test -- --selectProjects unit, npm run build.