### PR TITLE
Fix OpenCode hydration with large metadata

### DIFF
--- a/src/providers/opencode/history/OpencodeConversationHistoryService.ts
+++ b/src/providers/opencode/history/OpencodeConversationHistoryService.ts
@@ -1,7 +1,10 @@
 import type { ProviderConversationHistoryService } from '../../../core/providers/types';
 import type { Conversation } from '../../../core/types';
 import { getOpencodeState, type OpencodeProviderState } from '../types';
-import { loadOpencodeSessionMessages } from './OpencodeHistoryStore';
+import {
+  isOpencodeSessionHydrationDiagnosticMessage,
+  loadOpencodeSessionMessages,
+} from './OpencodeHistoryStore';
 
 export class OpencodeConversationHistoryService implements ProviderConversationHistoryService {
   private hydratedKeys = new Map<string, string>();
@@ -32,6 +35,14 @@ export class OpencodeConversationHistoryService implements ProviderConversationH
     }
 
     conversation.messages = messages;
+    if (
+      messages.length === 1
+      && isOpencodeSessionHydrationDiagnosticMessage(messages[0])
+    ) {
+      this.hydratedKeys.delete(conversation.id);
+      return;
+    }
+
     this.hydratedKeys.set(conversation.id, hydrationKey);
   }
 

--- a/src/providers/opencode/history/OpencodeHistoryStore.ts
+++ b/src/providers/opencode/history/OpencodeHistoryStore.ts
@@ -21,6 +21,11 @@ interface StoredMessage {
   parts: StoredRow[];
 }
 
+interface OpencodeHydrationDiagnosticContext {
+  databasePath?: string;
+  sessionId?: string;
+}
+
 interface SqliteModule {
   DatabaseSync: new (location: string, options?: Record<string, unknown>) => {
     close(): void;
@@ -29,6 +34,10 @@ interface SqliteModule {
     };
   };
 }
+
+export const OPENCODE_MESSAGE_ROW_SQL = buildOpencodeMessageRowsSql('?');
+const OPENCODE_PART_ROW_SQL = buildOpencodePartRowsSql('?');
+const OPENCODE_HYDRATION_DIAGNOSTIC_ID_PREFIX = 'opencode-hydration-error';
 
 export async function loadOpencodeSessionMessages(
   sessionId: string,
@@ -41,18 +50,41 @@ export async function loadOpencodeSessionMessages(
 
   const rows = await loadOpencodeSessionRows(databasePath, sessionId);
   if (!rows) {
-    return [];
+    return [createOpencodeHydrationDiagnosticMessage({
+      databasePath,
+      reason: 'Could not read OpenCode session rows from SQLite.',
+      sessionId,
+    })];
   }
 
   return mapOpencodeMessages(
     hydrateStoredMessages(rows.messageRows, rows.partRows),
+    { databasePath, sessionId },
   );
 }
 
-export function mapOpencodeMessages(messages: StoredMessage[]): ChatMessage[] {
-  return mergeAdjacentAssistantMessages(messages
-    .map((message) => mapStoredMessage(message))
-    .filter((message): message is ChatMessage => message !== null));
+export function mapOpencodeMessages(
+  messages: StoredMessage[],
+  context: OpencodeHydrationDiagnosticContext = {},
+): ChatMessage[] {
+  const mappedMessages: ChatMessage[] = [];
+
+  for (const message of messages) {
+    try {
+      const mappedMessage = mapStoredMessage(message, context);
+      if (mappedMessage) {
+        mappedMessages.push(mappedMessage);
+      }
+    } catch (error) {
+      mappedMessages.push(createOpencodeHydrationDiagnosticMessage({
+        ...context,
+        messageId: getString(message.info.id) ?? undefined,
+        reason: formatUnknownError(error),
+      }));
+    }
+  }
+
+  return mergeAdjacentAssistantMessages(mappedMessages);
 }
 
 function hydrateStoredMessages(
@@ -76,27 +108,48 @@ function hydrateStoredMessages(
 
   return messageRows.flatMap((row) => {
     const id = getString(row.id);
-    const data = parseJsonObject(row.data);
-    if (!id || !data) {
+    if (!id) {
       return [];
     }
 
+    const data = parseJsonObject(row.data);
     return [{
-      info: { ...data, id, time_created: row.time_created },
+      info: data
+        ? { ...data, id, time_created: row.time_created }
+        : {
+            data_time_completed: row.data_time_completed,
+            data_time_created: row.data_time_created,
+            data_valid: row.data_valid,
+            id,
+            role: row.role,
+            time_created: row.time_created,
+          },
       parts: partsByMessage.get(id) ?? [],
     }];
   });
 }
 
-function mapStoredMessage(message: StoredMessage): ChatMessage | null {
+function mapStoredMessage(
+  message: StoredMessage,
+  context: OpencodeHydrationDiagnosticContext,
+): ChatMessage | null {
   const role = getString(message.info.role);
   const id = getString(message.info.id);
-  if (!id || (role !== 'user' && role !== 'assistant')) {
+  if (!id) {
+    return null;
+  }
+  if (isInvalidStoredMessageData(message.info)) {
+    return createOpencodeHydrationDiagnosticMessage({
+      ...context,
+      messageId: id,
+      reason: 'OpenCode message metadata is not valid JSON.',
+    });
+  }
+  if (role !== 'user' && role !== 'assistant') {
     return null;
   }
 
-  const createdAt = getNestedNumber(message.info, ['time', 'created'])
-    ?? getNumber(message.info.time_created)
+  const createdAt = getMessageCreatedAt(message.info)
     ?? Date.now();
 
   if (role === 'user') {
@@ -113,7 +166,7 @@ function mapStoredMessage(message: StoredMessage): ChatMessage | null {
 
   const contentBlocks = buildAssistantContentBlocks(message.parts);
   const toolCalls = buildAssistantToolCalls(message.parts);
-  const completedAt = getNestedNumber(message.info, ['time', 'completed']);
+  const completedAt = getMessageCompletedAt(message.info);
   const durationSeconds = completedAt && completedAt >= createdAt
     ? Math.max(0, (completedAt - createdAt) / 1_000)
     : undefined;
@@ -143,6 +196,8 @@ function mergeAdjacentAssistantMessages(messages: ChatMessage[]): ChatMessage[] 
       && previous?.role === 'assistant'
       && !message.isInterrupt
       && !previous.isInterrupt
+      && !isOpencodeHydrationDiagnosticMessage(message)
+      && !isOpencodeHydrationDiagnosticMessage(previous)
     ) {
       previous.content += message.content;
       previous.assistantMessageId = message.assistantMessageId ?? previous.assistantMessageId;
@@ -190,6 +245,69 @@ function getMessageCompletionTime(message: ChatMessage): number | null {
   }
 
   return message.timestamp + (message.durationSeconds * 1_000);
+}
+
+function getMessageCreatedAt(info: StoredRow): number | null {
+  return getNestedNumber(info, ['time', 'created'])
+    ?? getNumber(info.data_time_created)
+    ?? getNumber(info.time_created);
+}
+
+function getMessageCompletedAt(info: StoredRow): number | null {
+  return getNestedNumber(info, ['time', 'completed'])
+    ?? getNumber(info.data_time_completed);
+}
+
+function isInvalidStoredMessageData(info: StoredRow): boolean {
+  return getNumber(info.data_valid) === 0;
+}
+
+function createOpencodeHydrationDiagnosticMessage(params: {
+  databasePath?: string;
+  messageId?: string;
+  reason: string;
+  sessionId?: string;
+}): ChatMessage {
+  const detailLines = [
+    'Failed to hydrate OpenCode session.',
+    'provider: OpenCode',
+    ...(params.sessionId ? [`sessionId: ${params.sessionId}`] : []),
+    ...(params.databasePath ? [`databasePath: ${params.databasePath}`] : []),
+    ...(params.messageId ? [`messageId: ${params.messageId}`] : []),
+    `reason: ${params.reason}`,
+  ];
+  const content = detailLines.join('\n');
+
+  return {
+    assistantMessageId: undefined,
+    content,
+    contentBlocks: [{ content, type: 'text' }],
+    id: buildOpencodeHydrationDiagnosticId(params),
+    role: 'assistant',
+    timestamp: Date.now(),
+  };
+}
+
+function buildOpencodeHydrationDiagnosticId(params: {
+  messageId?: string;
+  sessionId?: string;
+}): string {
+  const scope = params.messageId ? 'message' : 'session';
+  const rawId = params.messageId ?? params.sessionId ?? String(Date.now());
+  const safeId = rawId.replace(/[^a-zA-Z0-9._-]/g, '-').slice(0, 120) || String(Date.now());
+  return `${OPENCODE_HYDRATION_DIAGNOSTIC_ID_PREFIX}-${scope}-${safeId}`;
+}
+
+export function isOpencodeSessionHydrationDiagnosticMessage(message: ChatMessage): boolean {
+  return message.id.startsWith(`${OPENCODE_HYDRATION_DIAGNOSTIC_ID_PREFIX}-session-`);
+}
+
+function isOpencodeHydrationDiagnosticMessage(message: ChatMessage): boolean {
+  return message.id.startsWith(OPENCODE_HYDRATION_DIAGNOSTIC_ID_PREFIX);
+}
+
+function formatUnknownError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function buildAssistantContentBlocks(parts: StoredRow[]): ContentBlock[] {
@@ -398,12 +516,8 @@ async function loadSessionRowsWithNodeSqlite(
   let db: InstanceType<SqliteModule['DatabaseSync']> | null = null;
   try {
     db = new sqlite.DatabaseSync(databasePath, { readonly: true });
-    const messageRows = db.prepare(
-      'select id, time_created, data from message where session_id = ? order by time_created asc, id asc',
-    ).all(sessionId);
-    const partRows = db.prepare(
-      'select id, message_id, data from part where session_id = ? order by message_id asc, id asc',
-    ).all(sessionId);
+    const messageRows = db.prepare(OPENCODE_MESSAGE_ROW_SQL).all(sessionId);
+    const partRows = db.prepare(OPENCODE_PART_ROW_SQL).all(sessionId);
     return { messageRows, partRows };
   } catch {
     return null;
@@ -419,11 +533,11 @@ function loadSessionRowsWithSqliteCli(
   const escapedSessionId = escapeSqlLiteral(sessionId);
   const messageRows = runSqlite3JsonQuery(
     databasePath,
-    `select id, time_created, data from message where session_id = '${escapedSessionId}' order by time_created asc, id asc;`,
+    buildOpencodeMessageRowsSql(`'${escapedSessionId}'`),
   );
   const partRows = runSqlite3JsonQuery(
     databasePath,
-    `select id, message_id, data from part where session_id = '${escapedSessionId}' order by message_id asc, id asc;`,
+    buildOpencodePartRowsSql(`'${escapedSessionId}'`),
   );
 
   if (!messageRows || !partRows) {
@@ -461,4 +575,34 @@ function runSqlite3JsonQuery(
 
 function escapeSqlLiteral(value: string): string {
   return value.replaceAll('\'', '\'\'');
+}
+
+function buildOpencodeMessageRowsSql(sessionIdExpression: string): string {
+  return `
+with message_json as (
+  select
+    id,
+    time_created,
+    data,
+    json_valid(data) as data_valid
+  from message
+  where session_id = ${sessionIdExpression}
+)
+select
+  id,
+  time_created,
+  data_valid,
+  case when data_valid then json_extract(data, '$.role') end as role,
+  case when data_valid then json_extract(data, '$.time.created') end as data_time_created,
+  case when data_valid then json_extract(data, '$.time.completed') end as data_time_completed
+from message_json
+order by time_created asc, id asc;`.trim();
+}
+
+function buildOpencodePartRowsSql(sessionIdExpression: string): string {
+  return `
+select id, message_id, data
+from part
+where session_id = ${sessionIdExpression}
+order by message_id asc, id asc;`.trim();
 }

--- a/tests/unit/providers/opencode/OpencodeConversationHistoryService.test.ts
+++ b/tests/unit/providers/opencode/OpencodeConversationHistoryService.test.ts
@@ -1,0 +1,103 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import type { Conversation } from '../../../../src/core/types';
+import { OpencodeConversationHistoryService } from '../../../../src/providers/opencode/history/OpencodeConversationHistoryService';
+
+describe('OpencodeConversationHistoryService', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(path.join(os.tmpdir(), 'claudian-opencode-conversation-history-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { force: true, recursive: true });
+  });
+
+  it('retries after a session-level hydration diagnostic', async () => {
+    const dbPath = path.join(tmpRoot, 'opencode.db');
+    const sessionId = 'session-retry';
+    const conversation = createConversation(sessionId, dbPath);
+    const service = new OpencodeConversationHistoryService();
+
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        create table message (
+          id text primary key,
+          session_id text not null,
+          time_created integer not null,
+          data text not null
+        );
+      `);
+      db.prepare('insert into message (id, session_id, time_created, data) values (?, ?, ?, ?)').run(
+        'msg-user',
+        sessionId,
+        1_000,
+        JSON.stringify({
+          role: 'user',
+          time: { created: 1_000 },
+        }),
+      );
+    } finally {
+      db.close();
+    }
+
+    await service.hydrateConversationHistory(conversation, null);
+
+    expect(conversation.messages).toHaveLength(1);
+    expect(conversation.messages[0]).toMatchObject({
+      id: 'opencode-hydration-error-session-session-retry',
+      role: 'assistant',
+    });
+
+    const repairedDb = new DatabaseSync(dbPath);
+    try {
+      repairedDb.exec(`
+        create table part (
+          id text primary key,
+          session_id text not null,
+          message_id text not null,
+          data text not null
+        );
+      `);
+      repairedDb.prepare('insert into part (id, session_id, message_id, data) values (?, ?, ?, ?)').run(
+        'part-user',
+        sessionId,
+        'msg-user',
+        JSON.stringify({ text: 'Recovered prompt', type: 'text' }),
+      );
+    } finally {
+      repairedDb.close();
+    }
+
+    await service.hydrateConversationHistory(conversation, null);
+
+    expect(conversation.messages).toEqual([
+      {
+        assistantMessageId: undefined,
+        content: 'Recovered prompt',
+        id: 'msg-user',
+        role: 'user',
+        timestamp: 1_000,
+        userMessageId: 'msg-user',
+      },
+    ]);
+  });
+});
+
+function createConversation(sessionId: string, databasePath: string): Conversation {
+  return {
+    createdAt: 1,
+    id: 'conv-opencode',
+    messages: [],
+    providerId: 'opencode',
+    providerState: { databasePath },
+    sessionId,
+    title: 'OpenCode conversation',
+    updatedAt: 1,
+  };
+}

--- a/tests/unit/providers/opencode/OpencodeHistoryStore.test.ts
+++ b/tests/unit/providers/opencode/OpencodeHistoryStore.test.ts
@@ -1,4 +1,13 @@
-import { mapOpencodeMessages } from '../../../../src/providers/opencode/history/OpencodeHistoryStore';
+import { mkdtempSync, rmSync } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import {
+  loadOpencodeSessionMessages,
+  mapOpencodeMessages,
+  OPENCODE_MESSAGE_ROW_SQL,
+} from '../../../../src/providers/opencode/history/OpencodeHistoryStore';
 
 describe('mapOpencodeMessages', () => {
   it('maps stored OpenCode messages into Claudian chat messages', () => {
@@ -258,5 +267,152 @@ describe('mapOpencodeMessages', () => {
         }],
       },
     ]);
+  });
+
+  it('keeps rendering surrounding messages when one message has invalid metadata', () => {
+    const messages = mapOpencodeMessages([
+      {
+        info: {
+          data_valid: 0,
+          id: 'msg-bad',
+        },
+        parts: [],
+      },
+      {
+        info: {
+          id: 'msg-assistant',
+          role: 'assistant',
+          time: { created: 2_000, completed: 3_000 },
+        },
+        parts: [
+          {
+            id: 'part-text',
+            text: 'Still visible.',
+            type: 'text',
+          },
+        ],
+      },
+    ]);
+
+    expect(messages).toEqual([
+      expect.objectContaining({
+        content: [
+          'Failed to hydrate OpenCode session.',
+          'provider: OpenCode',
+          'messageId: msg-bad',
+          'reason: OpenCode message metadata is not valid JSON.',
+        ].join('\n'),
+        id: 'opencode-hydration-error-message-msg-bad',
+        role: 'assistant',
+      }),
+      {
+        assistantMessageId: 'msg-assistant',
+        content: 'Still visible.',
+        contentBlocks: [{ content: 'Still visible.', type: 'text' }],
+        durationSeconds: 1,
+        id: 'msg-assistant',
+        role: 'assistant',
+        timestamp: 2_000,
+      },
+    ]);
+  });
+});
+
+describe('loadOpencodeSessionMessages', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(path.join(os.tmpdir(), 'claudian-opencode-history-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { force: true, recursive: true });
+  });
+
+  it('loads conversation content without selecting raw message metadata', async () => {
+    expect(OPENCODE_MESSAGE_ROW_SQL).toContain("json_extract(data, '$.role')");
+    expect(OPENCODE_MESSAGE_ROW_SQL).not.toMatch(/\btime_created,\s*data\s+from\s+message\b/i);
+
+    const dbPath = path.join(tmpRoot, 'opencode.db');
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        create table message (
+          id text primary key,
+          session_id text not null,
+          time_created integer not null,
+          data text not null
+        );
+        create table part (
+          id text primary key,
+          session_id text not null,
+          message_id text not null,
+          data text not null
+        );
+      `);
+
+      const sessionId = 'session-with-summary-diffs';
+      const largeMetadata = {
+        diffs: Array.from({ length: 64 }, (_, index) => ({
+          path: `src/file-${index}.ts`,
+          patch: `@@ -1 +1 @@\n-${'old'.repeat(1000)}\n+${'new'.repeat(1000)}`,
+        })),
+      };
+
+      db.prepare('insert into message (id, session_id, time_created, data) values (?, ?, ?, ?)').run(
+        'msg-user',
+        sessionId,
+        1_000,
+        JSON.stringify({
+          role: 'user',
+          summary: largeMetadata,
+          time: { created: 1_000 },
+        }),
+      );
+      db.prepare('insert into message (id, session_id, time_created, data) values (?, ?, ?, ?)').run(
+        'msg-assistant',
+        sessionId,
+        2_000,
+        JSON.stringify({
+          role: 'assistant',
+          summary: largeMetadata,
+          time: { completed: 4_000, created: 2_000 },
+        }),
+      );
+      db.prepare('insert into part (id, session_id, message_id, data) values (?, ?, ?, ?)').run(
+        'part-user',
+        sessionId,
+        'msg-user',
+        JSON.stringify({ text: 'Restore this session', type: 'text' }),
+      );
+      db.prepare('insert into part (id, session_id, message_id, data) values (?, ?, ?, ?)').run(
+        'part-assistant',
+        sessionId,
+        'msg-assistant',
+        JSON.stringify({ text: 'Session restored.', type: 'text' }),
+      );
+
+      await expect(loadOpencodeSessionMessages(sessionId, { databasePath: dbPath })).resolves.toEqual([
+        {
+          assistantMessageId: undefined,
+          content: 'Restore this session',
+          id: 'msg-user',
+          role: 'user',
+          timestamp: 1_000,
+          userMessageId: 'msg-user',
+        },
+        {
+          assistantMessageId: 'msg-assistant',
+          content: 'Session restored.',
+          contentBlocks: [{ content: 'Session restored.', type: 'text' }],
+          durationSeconds: 2,
+          id: 'msg-assistant',
+          role: 'assistant',
+          timestamp: 2_000,
+        },
+      ]);
+    } finally {
+      db.close();
+    }
   });
 });


### PR DESCRIPTION
OpenCode history hydration now avoids selecting/parsing full message.data and extracts only role/timestamps in SQLite, preventing large summary.diffs metadata from blocking restored session rendering. It emits visible diagnostic chat messages with provider/session/database/message context when session rows or individual messages cannot hydrate, while preserving surrounding transcript content. Session-level hydration diagnostics are not cached as successful loads, so a repaired OpenCode database can hydrate on retry. Tests cover large summary diff metadata, malformed message metadata, and retry behavior after session diagnostics.