### PR TITLE
Render Markdown in inline edit previews

### DIFF
--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -637,7 +637,7 @@ export class MessageRenderer {
       const processedMarkdown = replaceImageEmbedsWithHtml(
         renderMarkdown,
         this.app,
-        this.plugin.settings.mediaFolder
+        { mediaFolder: this.plugin.settings.mediaFolder }
       );
       await MarkdownRenderer.render(
         this.app,

--- a/src/features/inline-edit/ui/InlineEditModal.ts
+++ b/src/features/inline-edit/ui/InlineEditModal.ts
@@ -1,4 +1,4 @@
-import { RangeSetBuilder, StateEffect, StateField, type Text } from '@codemirror/state';
+import { StateEffect, StateField, type Text } from '@codemirror/state';
 import type { DecorationSet } from '@codemirror/view';
 import { Decoration, EditorView, WidgetType } from '@codemirror/view';
 import type { App, Editor, MarkdownView } from 'obsidian';
@@ -26,6 +26,7 @@ import { buildExternalContextDisplayEntries } from '../../../utils/externalConte
 import { externalContextScanner } from '../../../utils/externalContextScanner';
 import { normalizeInsertionText } from '../../../utils/inlineEdit';
 import { getVaultPath, normalizePathForVault as normalizePathForVaultUtil } from '../../../utils/path';
+import { renderInlineEditMarkdownPreview } from './inlineEditMarkdownPreview';
 
 export type InlineEditContext =
   | { mode: 'selection'; selectedText: string }
@@ -42,11 +43,15 @@ const showDiff = StateEffect.define<{
   from: number;
   to: number;
   diffOps: DiffOp[];
+  previewPos: number;
+  previewText: string;
   widget: InlineEditController;
 }>();
 const showInsertion = StateEffect.define<{
   pos: number;
   diffOps: DiffOp[];
+  previewPos: number;
+  previewText: string;
   widget: InlineEditController;
 }>();
 const hideInlineEdit = StateEffect.define<null>();
@@ -107,6 +112,21 @@ class InputWidget extends WidgetType {
   }
 }
 
+class PreviewWidget extends WidgetType {
+  constructor(private markdown: string, private controller: InlineEditController) {
+    super();
+  }
+  toDOM(): HTMLElement {
+    return this.controller.createPreviewDOM(this.markdown);
+  }
+  eq(other: PreviewWidget): boolean {
+    return this.markdown === other.markdown;
+  }
+  ignoreEvent(): boolean {
+    return true;
+  }
+}
+
 export function buildInlineEditInputDecorations(options: {
   doc: Text;
   inputPos: number;
@@ -143,18 +163,28 @@ const inlineEditField = StateField.define<DecorationSet>({
           widget: new InputWidget(e.value.widget),
         });
       } else if (e.is(showDiff)) {
-        const builder = new RangeSetBuilder<Decoration>();
-        builder.add(e.value.from, e.value.to, Decoration.replace({
-          widget: new DiffWidget(e.value.diffOps, e.value.widget),
-        }));
-        deco = builder.finish();
+        deco = Decoration.set([
+          Decoration.widget({
+            widget: new PreviewWidget(e.value.previewText, e.value.widget),
+            block: true,
+            side: -1,
+          }).range(e.value.previewPos),
+          Decoration.replace({
+            widget: new DiffWidget(e.value.diffOps, e.value.widget),
+          }).range(e.value.from, e.value.to),
+        ], true);
       } else if (e.is(showInsertion)) {
-        const builder = new RangeSetBuilder<Decoration>();
-        builder.add(e.value.pos, e.value.pos, Decoration.widget({
-          widget: new DiffWidget(e.value.diffOps, e.value.widget),
-          side: 1, // After the position
-        }));
-        deco = builder.finish();
+        deco = Decoration.set([
+          Decoration.widget({
+            widget: new PreviewWidget(e.value.previewText, e.value.widget),
+            block: true,
+            side: -1,
+          }).range(e.value.previewPos),
+          Decoration.widget({
+            widget: new DiffWidget(e.value.diffOps, e.value.widget),
+            side: 1, // After the position
+          }).range(e.value.pos),
+        ], true);
       } else if (e.is(hideInlineEdit)) {
         deco = Decoration.none;
       }
@@ -308,6 +338,7 @@ class InlineEditController {
   private slashCommandDropdown: SlashCommandDropdown | null = null;
   private mentionDropdown: MentionDropdownController | null = null;
   private mentionDataProvider: VaultMentionDataProvider;
+  private agentReplyRenderVersion = 0;
 
   constructor(
     private app: App,
@@ -516,6 +547,45 @@ class InlineEditController {
     return container;
   }
 
+  createPreviewDOM(markdown: string): HTMLElement {
+    const ownerDocument = this.getOwnerDocument();
+    const previewEl = ownerDocument.createElement('div');
+    previewEl.className = 'claudian-inline-markdown-preview';
+
+    const bodyEl = ownerDocument.createElement('div');
+    bodyEl.className = 'claudian-inline-markdown-preview-body markdown-rendered';
+    previewEl.appendChild(bodyEl);
+
+    void this.renderMarkdownPreview(bodyEl, markdown);
+    return previewEl;
+  }
+
+  private async renderMarkdownPreview(container: HTMLElement, markdown: string): Promise<void> {
+    await renderInlineEditMarkdownPreview({
+      app: this.app,
+      component: this.plugin,
+      container,
+      markdown,
+      sourcePath: this.notePath,
+      mediaFolder: this.plugin.settings?.mediaFolder ?? '',
+    });
+  }
+
+  private replaceRenderedPreview(target: HTMLElement, rendered: HTMLElement): void {
+    target.empty();
+
+    if (rendered.childNodes) {
+      for (const child of Array.from(rendered.childNodes)) {
+        target.appendChild(child);
+      }
+      return;
+    }
+
+    for (const child of Array.from(rendered.children)) {
+      target.appendChild(child);
+    }
+  }
+
   private async generate() {
     if (!this.inputEl || !this.spinnerEl) return;
     const userMessage = this.inputEl.value.trim();
@@ -582,8 +652,18 @@ class InlineEditController {
 
   private showAgentReply(message: string) {
     if (!this.agentReplyEl || !this.containerEl) return;
-    this.agentReplyEl.removeClass('claudian-hidden');
-    this.agentReplyEl.textContent = message;
+    const replyEl = this.agentReplyEl;
+    const renderVersion = ++this.agentReplyRenderVersion;
+    const renderedEl = this.getOwnerDocument().createElement('div');
+
+    replyEl.removeClass('claudian-hidden');
+    replyEl.empty();
+    void this.renderMarkdownPreview(renderedEl, message).then(() => {
+      if (renderVersion !== this.agentReplyRenderVersion || replyEl !== this.agentReplyEl) {
+        return;
+      }
+      this.replaceRenderedPreview(replyEl, renderedEl);
+    });
     this.containerEl.classList.add('has-agent-reply');
   }
 
@@ -603,12 +683,15 @@ class InlineEditController {
     hideSelectionHighlight(this.editorView);
 
     const diffOps = computeDiff(this.selectedText, this.editedText);
+    const previewPos = this.editorView.state.doc.lineAt(this.selFrom).from;
 
     this.editorView.dispatch({
       effects: showDiff.of({
         from: this.selFrom,
         to: this.selTo,
         diffOps,
+        previewPos,
+        previewText: this.editedText,
         widget: this,
       }),
     });
@@ -625,11 +708,14 @@ class InlineEditController {
     this.insertedText = trimmedText;
 
     const diffOps: DiffOp[] = [{ type: 'insert', text: trimmedText }];
+    const previewPos = this.editorView.state.doc.lineAt(this.selFrom).from;
 
     this.editorView.dispatch({
       effects: showInsertion.of({
         pos: this.selFrom,
         diffOps,
+        previewPos,
+        previewText: trimmedText,
         widget: this,
       }),
     });

--- a/src/features/inline-edit/ui/inlineEditMarkdownPreview.ts
+++ b/src/features/inline-edit/ui/inlineEditMarkdownPreview.ts
@@ -1,0 +1,55 @@
+import type { App, Component } from 'obsidian';
+import { MarkdownRenderer } from 'obsidian';
+
+import { processFileLinks } from '../../../utils/fileLink';
+import { replaceImageEmbedsWithHtml } from '../../../utils/imageEmbed';
+
+interface RenderInlineEditMarkdownPreviewOptions {
+  app: App;
+  component: Component;
+  container: HTMLElement;
+  markdown: string;
+  sourcePath: string;
+  mediaFolder?: string;
+}
+
+function emptyElement(container: HTMLElement): void {
+  if (typeof container.empty === 'function') {
+    container.empty();
+    return;
+  }
+  container.replaceChildren();
+}
+
+function appendFallback(container: HTMLElement, markdown: string): void {
+  const fallback = container.ownerDocument.createElement('div');
+  fallback.className = 'claudian-inline-markdown-fallback';
+  fallback.textContent = markdown;
+  container.appendChild(fallback);
+}
+
+export async function renderInlineEditMarkdownPreview({
+  app,
+  component,
+  container,
+  markdown,
+  sourcePath,
+  mediaFolder = '',
+}: RenderInlineEditMarkdownPreviewOptions): Promise<void> {
+  emptyElement(container);
+
+  try {
+    const processedMarkdown = replaceImageEmbedsWithHtml(markdown, app, {
+      mediaFolder,
+      sourcePath,
+    });
+    await MarkdownRenderer.render(app, processedMarkdown, container, sourcePath, component);
+
+    if (processedMarkdown.includes('[[') && app.metadataCache) {
+      processFileLinks(app, container);
+    }
+  } catch {
+    emptyElement(container);
+    appendFallback(container, markdown);
+  }
+}

--- a/src/style/features/inline-edit.css
+++ b/src/style/features/inline-edit.css
@@ -94,6 +94,42 @@
   font-size: var(--font-ui-small, 13px);
   line-height: 1.4;
   color: var(--text-muted);
+  overflow-x: auto;
+  word-wrap: break-word;
+}
+
+.claudian-inline-agent-reply > :first-child,
+.claudian-inline-markdown-preview-body > :first-child {
+  margin-top: 0;
+}
+
+.claudian-inline-agent-reply > :last-child,
+.claudian-inline-markdown-preview-body > :last-child {
+  margin-bottom: 0;
+}
+
+.claudian-inline-markdown-preview {
+  margin: 4px 0 6px;
+  padding: 8px 10px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 8px;
+  background: var(--background-primary);
+  color: var(--text-normal);
+  overflow-x: auto;
+}
+
+.claudian-inline-markdown-preview-body {
+  font-family: var(--font-text);
+  font-size: var(--font-text-size);
+  line-height: var(--line-height-normal);
+}
+
+.claudian-inline-markdown-preview img {
+  max-width: 100%;
+  height: auto;
+}
+
+.claudian-inline-markdown-fallback {
   white-space: pre-wrap;
   word-wrap: break-word;
 }

--- a/src/utils/imageEmbed.ts
+++ b/src/utils/imageEmbed.ts
@@ -25,6 +25,11 @@ const IMAGE_EXTENSIONS = new Set([
 
 const IMAGE_EMBED_PATTERN = /!\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g;
 
+interface ReplaceImageEmbedsOptions {
+  mediaFolder?: string;
+  sourcePath?: string;
+}
+
 function isImagePath(path: string): boolean {
   const ext = path.split('.').pop()?.toLowerCase();
   return ext ? IMAGE_EXTENSIONS.has(ext) : false;
@@ -33,18 +38,18 @@ function isImagePath(path: string): boolean {
 function resolveImageFile(
   app: App,
   imagePath: string,
-  mediaFolder: string
+  options: Required<ReplaceImageEmbedsOptions>
 ): TFile | null {
   let file = getVaultFileByPath(app, imagePath);
   if (file) return file;
 
-  if (mediaFolder) {
-    const withFolder = `${mediaFolder}/${imagePath}`;
+  if (options.mediaFolder) {
+    const withFolder = `${options.mediaFolder}/${imagePath}`;
     file = getVaultFileByPath(app, withFolder);
     if (file) return file;
   }
 
-  const resolved = app.metadataCache.getFirstLinkpathDest(imagePath, '');
+  const resolved = app.metadataCache.getFirstLinkpathDest(imagePath, options.sourcePath);
   if (resolved) return resolved;
 
   return null;
@@ -83,18 +88,31 @@ function createFallbackHtml(wikilink: string): string {
   return `<span class="claudian-embedded-image-fallback">${escapeHtml(wikilink)}</span>`;
 }
 
+function normalizeOptions(options?: string | ReplaceImageEmbedsOptions): Required<ReplaceImageEmbedsOptions> {
+  if (typeof options === 'string') {
+    return { mediaFolder: options, sourcePath: '' };
+  }
+
+  return {
+    mediaFolder: options?.mediaFolder ?? '',
+    sourcePath: options?.sourcePath ?? '',
+  };
+}
+
 /**
- * Call before MarkdownRenderer.renderMarkdown().
+ * Call before MarkdownRenderer.render().
  * Non-image embeds (e.g., ![[note.md]]) pass through unchanged.
  */
 export function replaceImageEmbedsWithHtml(
   markdown: string,
   app: App,
-  mediaFolder: string = ''
+  options?: string | ReplaceImageEmbedsOptions
 ): string {
   if (!app?.vault || !app?.metadataCache) {
     return markdown;
   }
+
+  const normalizedOptions = normalizeOptions(options);
 
   // Reset lastIndex to avoid issues with global regex
   IMAGE_EMBED_PATTERN.lastIndex = 0;
@@ -107,7 +125,7 @@ export function replaceImageEmbedsWithHtml(
           return match;
         }
 
-        const file = resolveImageFile(app, imagePath, mediaFolder);
+        const file = resolveImageFile(app, imagePath, normalizedOptions);
         if (!file) {
           return createFallbackHtml(match);
         }

--- a/tests/unit/features/chat/rendering/MessageRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/MessageRenderer.test.ts
@@ -1681,7 +1681,7 @@ describe('MessageRenderer', () => {
       expect(replaceImageEmbedsWithHtml).toHaveBeenCalledWith(
         'before-images ![[image.png]] [[note.md]]',
         expect.anything(),
-        ''
+        { mediaFolder: '' }
       );
       expect(MarkdownRenderer.renderMarkdown).toHaveBeenCalledWith(
         '<span title="[[note.md]]">raw html</span>\n    [[note.md]]',

--- a/tests/unit/features/inline-edit/ui/InlineEditModal.openAndWait.test.ts
+++ b/tests/unit/features/inline-edit/ui/InlineEditModal.openAndWait.test.ts
@@ -1,7 +1,7 @@
 import '@/providers';
 
 import { createMockEl } from '@test/helpers/mockElement';
-import { Notice } from 'obsidian';
+import { MarkdownRenderer, Notice } from 'obsidian';
 
 import { ProviderRegistry } from '@/core/providers/ProviderRegistry';
 import { type InlineEditContext, InlineEditModal } from '@/features/inline-edit/ui/InlineEditModal';
@@ -32,6 +32,14 @@ jest.mock('@/utils/externalContextScanner', () => ({
     scanPaths: jest.fn().mockReturnValue([]),
   },
 }));
+
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
 
 describe('InlineEditModal - openAndWait', () => {
   beforeEach(() => {
@@ -990,6 +998,331 @@ describe('InlineEditModal - openAndWait', () => {
 
       expect(editTextMock).toHaveBeenCalledTimes(1);
       expect(editTextMock.mock.calls[0][0].contextFiles).toEqual(['/external/src/my file.md']);
+
+      widgetRef.reject();
+      await expect(resultPromise).resolves.toEqual({ decision: 'reject' });
+      getEditorViewSpy.mockRestore();
+    } finally {
+      (global as any).document = originalDocument;
+    }
+  });
+
+  it('renders clarification replies as markdown with the active note path', async () => {
+    const originalDocument = (global as any).document;
+    (global as any).document = {
+      body: createMockEl('body'),
+      createElement: (tagName: string) => createMockEl(tagName),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+
+    try {
+      const app = {
+        vault: {
+          getFiles: jest.fn().mockReturnValue([]),
+          getAllLoadedFiles: jest.fn().mockReturnValue([]),
+        },
+        workspace: {
+          getActiveViewOfType: jest.fn(),
+        },
+      } as any;
+      const plugin = {
+        settings: {
+          hiddenProviderCommands: {
+            claude: [],
+            codex: [],
+          },
+          mediaFolder: '',
+        },
+        getSdkCommands: jest.fn().mockReturnValue([]),
+      } as any;
+      const editor = {} as any;
+      const view = { editor } as any;
+
+      let widgetRef: any = null;
+      const dispatch = jest.fn((transaction: any) => {
+        const effects = Array.isArray(transaction?.effects)
+          ? transaction.effects
+          : transaction?.effects
+            ? [transaction.effects]
+            : [];
+        for (const effect of effects) {
+          const widget = effect?.value?.widget;
+          if (widget && typeof widget.createInputDOM === 'function') {
+            widgetRef = widget;
+            widget.createInputDOM();
+          }
+        }
+      });
+      const editorView = {
+        state: {
+          doc: {
+            line: jest.fn(() => ({ from: 0 })),
+            lineAt: jest.fn(() => ({ from: 0, number: 1 })),
+          },
+        },
+        dispatch,
+        dom: {
+          ownerDocument: (global as any).document,
+          addEventListener: jest.fn(),
+          removeEventListener: jest.fn(),
+        },
+      } as any;
+
+      const getEditorViewSpy = jest
+        .spyOn(editorUtils, 'getEditorView')
+        .mockReturnValue(editorView);
+
+      const editContext: InlineEditContext = {
+        mode: 'cursor',
+        cursorContext: {
+          beforeCursor: '',
+          afterCursor: '',
+          isInbetween: true,
+          line: 0,
+          column: 0,
+        },
+      };
+
+      const modal = new InlineEditModal(app, plugin, editor, view, editContext, 'math/note.md');
+      const resultPromise = modal.openAndWait();
+
+      (MarkdownRenderer.renderMarkdown as jest.Mock).mockClear();
+      widgetRef.showAgentReply('Should this use $Z(f)$?');
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(MarkdownRenderer.renderMarkdown).toHaveBeenCalledWith(
+        'Should this use $Z(f)$?',
+        expect.anything(),
+        'math/note.md',
+        plugin
+      );
+
+      widgetRef.reject();
+      await expect(resultPromise).resolves.toEqual({ decision: 'reject' });
+      getEditorViewSpy.mockRestore();
+    } finally {
+      (global as any).document = originalDocument;
+    }
+  });
+
+  it('does not let stale clarification markdown renders overwrite newer replies', async () => {
+    const originalDocument = (global as any).document;
+    (global as any).document = {
+      body: createMockEl('body'),
+      createElement: (tagName: string) => createMockEl(tagName),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+
+    try {
+      const app = {
+        vault: {
+          getFiles: jest.fn().mockReturnValue([]),
+          getAllLoadedFiles: jest.fn().mockReturnValue([]),
+        },
+        workspace: {
+          getActiveViewOfType: jest.fn(),
+        },
+      } as any;
+      const plugin = {
+        settings: {
+          hiddenProviderCommands: {
+            claude: [],
+            codex: [],
+          },
+          mediaFolder: '',
+        },
+        getSdkCommands: jest.fn().mockReturnValue([]),
+      } as any;
+      const editor = {} as any;
+      const view = { editor } as any;
+
+      let widgetRef: any = null;
+      const dispatch = jest.fn((transaction: any) => {
+        const effects = Array.isArray(transaction?.effects)
+          ? transaction.effects
+          : transaction?.effects
+            ? [transaction.effects]
+            : [];
+        for (const effect of effects) {
+          const widget = effect?.value?.widget;
+          if (widget && typeof widget.createInputDOM === 'function') {
+            widgetRef = widget;
+            widget.createInputDOM();
+          }
+        }
+      });
+      const editorView = {
+        state: {
+          doc: {
+            line: jest.fn(() => ({ from: 0 })),
+            lineAt: jest.fn(() => ({ from: 0, number: 1 })),
+          },
+        },
+        dispatch,
+        dom: {
+          ownerDocument: (global as any).document,
+          addEventListener: jest.fn(),
+          removeEventListener: jest.fn(),
+        },
+      } as any;
+
+      const getEditorViewSpy = jest
+        .spyOn(editorUtils, 'getEditorView')
+        .mockReturnValue(editorView);
+
+      const firstRender = createDeferred();
+      const secondRender = createDeferred();
+      (MarkdownRenderer.renderMarkdown as jest.Mock)
+        .mockImplementationOnce((markdown: string, container: any) => {
+          container.createDiv({ text: markdown });
+          return firstRender.promise;
+        })
+        .mockImplementationOnce((markdown: string, container: any) => {
+          container.createDiv({ text: markdown });
+          return secondRender.promise;
+        });
+
+      const editContext: InlineEditContext = {
+        mode: 'cursor',
+        cursorContext: {
+          beforeCursor: '',
+          afterCursor: '',
+          isInbetween: true,
+          line: 0,
+          column: 0,
+        },
+      };
+
+      const modal = new InlineEditModal(app, plugin, editor, view, editContext, 'math/note.md');
+      const resultPromise = modal.openAndWait();
+
+      widgetRef.showAgentReply('First clarification');
+      widgetRef.showAgentReply('Second clarification');
+
+      secondRender.resolve();
+      await secondRender.promise;
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(widgetRef.agentReplyEl.children).toHaveLength(1);
+      expect(widgetRef.agentReplyEl.children[0].textContent).toBe('Second clarification');
+
+      firstRender.resolve();
+      await firstRender.promise;
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(widgetRef.agentReplyEl.children).toHaveLength(1);
+      expect(widgetRef.agentReplyEl.children[0].textContent).toBe('Second clarification');
+
+      widgetRef.reject();
+      await expect(resultPromise).resolves.toEqual({ decision: 'reject' });
+      getEditorViewSpy.mockRestore();
+    } finally {
+      (global as any).document = originalDocument;
+    }
+  });
+
+  it('adds rendered preview text to inline edit diff effects', async () => {
+    const originalDocument = (global as any).document;
+    (global as any).document = {
+      body: createMockEl('body'),
+      createElement: (tagName: string) => createMockEl(tagName),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+
+    try {
+      const app = {
+        vault: {
+          getFiles: jest.fn().mockReturnValue([]),
+          getAllLoadedFiles: jest.fn().mockReturnValue([]),
+        },
+        workspace: {
+          getActiveViewOfType: jest.fn(),
+        },
+      } as any;
+      const plugin = {
+        settings: {
+          hiddenProviderCommands: {
+            claude: [],
+            codex: [],
+          },
+          mediaFolder: '',
+        },
+        getSdkCommands: jest.fn().mockReturnValue([]),
+      } as any;
+      const editor = {
+        getCursor: jest.fn((which: string) => which === 'from'
+          ? { line: 0, ch: 0 }
+          : { line: 0, ch: 3 }),
+        getSelection: jest.fn().mockReturnValue('old'),
+      } as any;
+      const view = { editor } as any;
+
+      let widgetRef: any = null;
+      let previewText: string | undefined;
+      const dispatch = jest.fn((transaction: any) => {
+        const effects = Array.isArray(transaction?.effects)
+          ? transaction.effects
+          : transaction?.effects
+            ? [transaction.effects]
+            : [];
+        for (const effect of effects) {
+          if (effect?.value?.previewText) {
+            previewText = effect.value.previewText;
+          }
+
+          const widget = effect?.value?.widget;
+          if (widget && typeof widget.createInputDOM === 'function' && !widgetRef) {
+            widgetRef = widget;
+            widget.createInputDOM();
+          }
+        }
+      });
+      const editorView = {
+        state: {
+          doc: {
+            line: jest.fn(() => ({ from: 0 })),
+            lineAt: jest.fn(() => ({ from: 0, number: 1 })),
+          },
+        },
+        dispatch,
+        dom: {
+          ownerDocument: (global as any).document,
+          addEventListener: jest.fn(),
+          removeEventListener: jest.fn(),
+        },
+      } as any;
+
+      const getEditorViewSpy = jest
+        .spyOn(editorUtils, 'getEditorView')
+        .mockReturnValue(editorView);
+
+      const editContext: InlineEditContext = {
+        mode: 'selection',
+        selectedText: 'old',
+      };
+
+      const modal = new InlineEditModal(app, plugin, editor, view, editContext, 'math/note.md');
+      const resultPromise = modal.openAndWait();
+      widgetRef.inlineEditService = {
+        editText: jest.fn().mockResolvedValue({
+          success: true,
+          editedText: '**new** $x^2$',
+        }),
+        continueConversation: jest.fn(),
+        cancel: jest.fn(),
+        resetConversation: jest.fn(),
+      };
+
+      widgetRef.inputEl.value = 'Improve the statement';
+      await widgetRef.generate();
+
+      expect(previewText).toBe('**new** $x^2$');
 
       widgetRef.reject();
       await expect(resultPromise).resolves.toEqual({ decision: 'reject' });

--- a/tests/unit/features/inline-edit/ui/inlineEditMarkdownPreview.test.ts
+++ b/tests/unit/features/inline-edit/ui/inlineEditMarkdownPreview.test.ts
@@ -1,0 +1,92 @@
+import { createMockEl } from '@test/helpers/mockElement';
+import { MarkdownRenderer } from 'obsidian';
+
+import { renderInlineEditMarkdownPreview } from '@/features/inline-edit/ui/inlineEditMarkdownPreview';
+
+describe('renderInlineEditMarkdownPreview', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders markdown and math through Obsidian with the note source path', async () => {
+    const app = { vault: {}, metadataCache: {} } as any;
+    const component = {} as any;
+    const container = createMockEl();
+
+    await renderInlineEditMarkdownPreview({
+      app,
+      component,
+      container,
+      markdown: '**Claim.** $Z(f)$ and $V(f)$ have the same parity.',
+      sourcePath: 'math/note.md',
+    });
+
+    expect(MarkdownRenderer.renderMarkdown).toHaveBeenCalledWith(
+      '**Claim.** $Z(f)$ and $V(f)$ have the same parity.',
+      container,
+      'math/note.md',
+      component
+    );
+  });
+
+  it('resolves image embeds using the note source path before rendering', async () => {
+    const imageFile = {
+      path: 'math/assets/image.png',
+      basename: 'image',
+    };
+    const getFirstLinkpathDest = jest
+      .fn()
+      .mockImplementation((linkPath: string, sourcePath: string) => {
+        return linkPath === 'image.png' && sourcePath === 'math/note.md'
+          ? imageFile
+          : null;
+      });
+    const app = {
+      vault: {
+        getAbstractFileByPath: jest.fn().mockReturnValue(null),
+        getResourcePath: jest.fn().mockReturnValue('app://local/math/assets/image.png'),
+      },
+      metadataCache: {
+        getFirstLinkpathDest,
+      },
+    } as any;
+    const component = {} as any;
+    const container = createMockEl();
+
+    await renderInlineEditMarkdownPreview({
+      app,
+      component,
+      container,
+      markdown: '![[image.png]]',
+      sourcePath: 'math/note.md',
+    });
+
+    expect(getFirstLinkpathDest).toHaveBeenCalledWith('image.png', 'math/note.md');
+    expect(MarkdownRenderer.renderMarkdown).toHaveBeenCalledWith(
+      expect.stringContaining('src="app://local/math/assets/image.png"'),
+      container,
+      'math/note.md',
+      component
+    );
+  });
+
+  it('falls back to raw markdown when Obsidian rendering fails', async () => {
+    (MarkdownRenderer.renderMarkdown as jest.Mock).mockRejectedValueOnce(new Error('render failed'));
+
+    const app = { vault: {}, metadataCache: {} } as any;
+    const component = {} as any;
+    const container = createMockEl();
+
+    await renderInlineEditMarkdownPreview({
+      app,
+      component,
+      container,
+      markdown: 'Use $x^2$ here.',
+      sourcePath: 'note.md',
+    });
+
+    expect(container.children).toHaveLength(1);
+    expect(container.children[0].hasClass('claudian-inline-markdown-fallback')).toBe(true);
+    expect(container.children[0].textContent).toBe('Use $x^2$ here.');
+  });
+});

--- a/tests/unit/utils/imageEmbed.test.ts
+++ b/tests/unit/utils/imageEmbed.test.ts
@@ -2,8 +2,14 @@ import type { App, TFile } from 'obsidian';
 
 import { replaceImageEmbedsWithHtml } from '@/utils/imageEmbed';
 
+type LinkResolver = (
+  linkPath: string,
+  sourcePath: string,
+  files: Map<string, TFile>
+) => TFile | null | undefined;
+
 // Mock App and vault for testing
-function createMockApp(files: Map<string, string> = new Map()): App {
+function createMockApp(files: Map<string, string> = new Map(), resolveLink?: LinkResolver): App {
   const mockFiles = new Map<string, TFile>();
   files.forEach((resourcePath, filePath) => {
     mockFiles.set(filePath, {
@@ -18,7 +24,12 @@ function createMockApp(files: Map<string, string> = new Map()): App {
       getResourcePath: (file: TFile) => files.get(file.path) || `app://local/${file.path}`,
     },
     metadataCache: {
-      getFirstLinkpathDest: (linkPath: string) => {
+      getFirstLinkpathDest: (linkPath: string, sourcePath: string) => {
+        const resolved = resolveLink?.(linkPath, sourcePath, mockFiles);
+        if (resolved !== undefined) {
+          return resolved;
+        }
+
         // Try to find by basename
         for (const [path, file] of mockFiles) {
           if (path.endsWith(linkPath) || path === linkPath) {
@@ -184,6 +195,30 @@ describe('replaceImageEmbedsWithHtml', () => {
       const result = replaceImageEmbedsWithHtml('![[image.png]]', app, 'attachments');
 
       expect(result).toContain('src="app://local/image.png"');
+    });
+  });
+
+  describe('source path resolution', () => {
+    it('passes source path into Obsidian link resolution for ambiguous image embeds', () => {
+      const app = createMockApp(
+        new Map([
+          ['section-a/image.png', 'app://local/section-a/image.png'],
+          ['section-b/image.png', 'app://local/section-b/image.png'],
+        ]),
+        (linkPath, sourcePath, files) => {
+          if (linkPath === 'image.png' && sourcePath === 'section-b/note.md') {
+            return files.get('section-b/image.png');
+          }
+          return files.get('section-a/image.png');
+        }
+      );
+
+      const result = replaceImageEmbedsWithHtml('![[image.png]]', app, {
+        sourcePath: 'section-b/note.md',
+      });
+
+      expect(result).toContain('src="app://local/section-b/image.png"');
+      expect(result).not.toContain('section-a/image.png');
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds rendered Markdown/LaTeX previews for inline edit replacements, insertions, and clarification replies while preserving the raw diff controls.
- Routes inline preview rendering through Obsidian MarkdownRenderer, including source-path-aware image embed resolution.
- Extends image embed and inline edit tests for math rendering, stale reply handling, and ambiguous embeds.

## Validation
- npm run typecheck
- npm run lint
- npm run test
- npm run build