### PR TITLE
Fix Mod+Enter composer send

### DIFF
--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -14,7 +14,12 @@ import {
   type ScheduledAnimationFrame,
 } from '../../utils/animationFrame';
 import type { HistoryConversationOpenState } from './controllers/ConversationController';
-import { getTabProviderId, onProviderAvailabilityChanged, updatePlanModeUI } from './tabs/Tab';
+import {
+  getTabProviderId,
+  onProviderAvailabilityChanged,
+  sendTabInputMessageFromExplicitEnterShortcut,
+  updatePlanModeUI,
+} from './tabs/Tab';
 import { TabBar } from './tabs/TabBar';
 import { TabManager } from './tabs/TabManager';
 import type { TabData, TabId } from './tabs/types';
@@ -623,6 +628,14 @@ export class ClaudianView extends ItemView {
         }
       }
       return false;
+    });
+    this.scope.register(['Mod'], 'Enter', (e: KeyboardEvent) => {
+      if (e.isComposing || e.defaultPrevented) return;
+      const activeTab = this.tabManager?.getActiveTab();
+      if (!activeTab) return;
+      if (sendTabInputMessageFromExplicitEnterShortcut(activeTab, e, { requireInputFocus: true })) {
+        return false;
+      }
     });
 
     // Vault events - forward to active tab's file context manager

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -170,23 +170,86 @@ function getTabHiddenCommands(
   );
 }
 
-function shouldSendMessageFromEnterKey(
-  e: KeyboardEvent,
-  settings: Pick<ClaudianSettings, 'requireCommandOrControlEnterToSend'>,
-): boolean {
+function isEnterWithoutShiftOrComposition(e: KeyboardEvent): boolean {
   if (e.key !== 'Enter' || e.shiftKey || e.isComposing) {
     return false;
   }
 
-  if (settings.requireCommandOrControlEnterToSend !== true) {
-    return true;
-  }
+  return true;
+}
 
+function hasPlatformSendModifier(e: KeyboardEvent): boolean {
   if (Platform.isMacOS) {
     return e.metaKey === true && !e.ctrlKey && !e.altKey;
   }
 
   return e.ctrlKey === true && !e.metaKey && !e.altKey;
+}
+
+function shouldSendMessageFromExplicitEnterShortcut(e: KeyboardEvent): boolean {
+  return isEnterWithoutShiftOrComposition(e) && hasPlatformSendModifier(e);
+}
+
+function shouldSendMessageFromEnterKey(
+  e: KeyboardEvent,
+  settings: Pick<ClaudianSettings, 'requireCommandOrControlEnterToSend'>,
+): boolean {
+  if (!isEnterWithoutShiftOrComposition(e)) {
+    return false;
+  }
+
+  if (settings.requireCommandOrControlEnterToSend === true) {
+    return hasPlatformSendModifier(e);
+  }
+
+  return true;
+}
+
+function isTabInputFocused(tab: TabData): boolean {
+  return tab.dom.inputEl.ownerDocument.activeElement === tab.dom.inputEl;
+}
+
+function sendTabInputMessage(
+  tab: TabData,
+  e: KeyboardEvent,
+  options?: { requireInputFocus?: boolean },
+): boolean {
+  if (options?.requireInputFocus && !isTabInputFocused(tab)) {
+    return false;
+  }
+
+  const inputController = tab.controllers.inputController;
+  if (!inputController) {
+    return false;
+  }
+
+  e.preventDefault();
+  void inputController.sendMessage();
+  return true;
+}
+
+export function sendTabInputMessageFromExplicitEnterShortcut(
+  tab: TabData,
+  e: KeyboardEvent,
+  options?: { requireInputFocus?: boolean },
+): boolean {
+  if (!shouldSendMessageFromExplicitEnterShortcut(e)) {
+    return false;
+  }
+
+  return sendTabInputMessage(tab, e, options);
+}
+
+function sendTabInputMessageFromEnterKey(
+  tab: TabData,
+  settings: Pick<ClaudianSettings, 'requireCommandOrControlEnterToSend'>,
+  e: KeyboardEvent,
+): boolean {
+  if (!shouldSendMessageFromEnterKey(e, settings)) {
+    return false;
+  }
+
+  return sendTabInputMessage(tab, e);
 }
 
 type ProviderCatalogInfo = {
@@ -1441,6 +1504,10 @@ export function wireTabInputEvents(tab: TabData, plugin: ClaudianPlugin): void {
       return;
     }
 
+    if (sendTabInputMessageFromExplicitEnterShortcut(tab, e)) {
+      return;
+    }
+
     if (controllers.inputController?.handleResumeKeydown(e)) {
       return;
     }
@@ -1460,9 +1527,8 @@ export function wireTabInputEvents(tab: TabData, plugin: ClaudianPlugin): void {
       return;
     }
 
-    if (shouldSendMessageFromEnterKey(e, plugin.settings)) {
-      e.preventDefault();
-      void controllers.inputController?.sendMessage();
+    if (sendTabInputMessageFromEnterKey(tab, plugin.settings, e)) {
+      return;
     }
   };
   dom.inputEl.addEventListener('keydown', keydownHandler);

--- a/tests/unit/features/chat/ClaudianView.test.ts
+++ b/tests/unit/features/chat/ClaudianView.test.ts
@@ -1,5 +1,5 @@
 import { createMockEl } from '@test/helpers/mockElement';
-import { Scope } from 'obsidian';
+import { Platform, Scope } from 'obsidian';
 
 import { ClaudianView } from '@/features/chat/ClaudianView';
 
@@ -119,6 +119,68 @@ describe('ClaudianView Escape handling', () => {
     return { cancelStreaming, eventRefs, view };
   }
 
+  function createScopedSendHarness(options: {
+    inputFocused: boolean;
+  }): {
+    inputEl: HTMLTextAreaElement;
+    sendMessage: jest.Mock;
+    view: any;
+  } {
+    const sendMessage = jest.fn();
+    const inputEl = createMockEl('textarea') as unknown as HTMLTextAreaElement;
+    Object.defineProperty(inputEl.ownerDocument, 'activeElement', {
+      configurable: true,
+      get: () => options.inputFocused ? inputEl : null,
+    });
+    const eventRefs: unknown[] = [];
+    const parentScope = new Scope();
+    const view = Object.create(ClaudianView.prototype) as any;
+
+    view.app = { scope: parentScope };
+    view.containerEl = createMockEl();
+    view.historyDropdown = createMockEl();
+    view.registerDomEvent = jest.fn();
+    view.registerEvent = jest.fn();
+    view.eventRefs = eventRefs;
+    view.plugin = {
+      app: {
+        vault: {
+          on: jest.fn((_event: string, handler: unknown) => {
+            const ref = { handler };
+            eventRefs.push(ref);
+            return ref;
+          }),
+        },
+        workspace: {
+          on: jest.fn((_event: string, handler: unknown) => {
+            const ref = { handler };
+            eventRefs.push(ref);
+            return ref;
+          }),
+        },
+      },
+    };
+    view.tabManager = {
+      getActiveTab: jest.fn().mockReturnValue({
+        state: { isStreaming: false },
+        dom: { inputEl },
+        controllers: {
+          inputController: { sendMessage },
+        },
+        ui: {
+          fileContextManager: {
+            markFileCacheDirty: jest.fn(),
+            markFolderCacheDirty: jest.fn(),
+            handleFileOpen: jest.fn(),
+            handleClickOutside: jest.fn(),
+          },
+        },
+      }),
+    };
+
+    return { inputEl, sendMessage, view };
+  }
+
   it('registers Escape on the Obsidian view scope instead of document keydown capture', () => {
     const { view } = createEscapeHarness({ isStreaming: true });
 
@@ -170,5 +232,55 @@ describe('ClaudianView Escape handling', () => {
 
     expect(cancelStreaming).not.toHaveBeenCalled();
     expect(result).toBe(false);
+  });
+
+  it('sends from focused composer through scoped Mod+Enter', () => {
+    Platform.isMacOS = true;
+    const { sendMessage, view } = createScopedSendHarness({ inputFocused: true });
+
+    view.wireEventHandlers();
+    const sendHandler = view.scope.handlers.find(
+      (handler: any) => handler.key === 'Enter' && handler.modifiers?.includes('Mod')
+    );
+    const event = {
+      key: 'Enter',
+      shiftKey: false,
+      ctrlKey: false,
+      metaKey: true,
+      altKey: false,
+      isComposing: false,
+      defaultPrevented: false,
+      preventDefault: jest.fn(),
+    } as unknown as KeyboardEvent;
+    const result = sendHandler.func(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(result).toBe(false);
+  });
+
+  it('ignores scoped Mod+Enter when composer is not focused', () => {
+    Platform.isMacOS = true;
+    const { sendMessage, view } = createScopedSendHarness({ inputFocused: false });
+
+    view.wireEventHandlers();
+    const sendHandler = view.scope.handlers.find(
+      (handler: any) => handler.key === 'Enter' && handler.modifiers?.includes('Mod')
+    );
+    const event = {
+      key: 'Enter',
+      shiftKey: false,
+      ctrlKey: false,
+      metaKey: true,
+      altKey: false,
+      isComposing: false,
+      defaultPrevented: false,
+      preventDefault: jest.fn(),
+    } as unknown as KeyboardEvent;
+    const result = sendHandler.func(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
   });
 });

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -2047,6 +2047,52 @@ describe('Tab - Event Handler Behavior', () => {
       expect(mockSlashCommandDropdown.handleKeydown).toHaveBeenCalled();
     });
 
+    it('should let explicit Command+Enter send before slash dropdown handles Enter', () => {
+      mockInstructionModeManager.handleTriggerKey.mockReturnValue(false);
+      mockInstructionModeManager.handleKeydown.mockReturnValue(false);
+      mockSlashCommandDropdown.handleKeydown.mockReturnValue(true);
+      mockFileContextManager.handleMentionKeydown.mockReturnValue(false);
+      const { fireKeydown } = setupKeydownTab();
+      Platform.isMacOS = true;
+
+      const event = {
+        key: 'Enter',
+        shiftKey: false,
+        ctrlKey: false,
+        metaKey: true,
+        altKey: false,
+        isComposing: false,
+        preventDefault: jest.fn(),
+      };
+      fireKeydown(event);
+
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(mockInputController.sendMessage).toHaveBeenCalled();
+      expect(mockSlashCommandDropdown.handleKeydown).not.toHaveBeenCalled();
+    });
+
+    it('should keep plain Enter routed to visible slash dropdown before sending', () => {
+      mockInstructionModeManager.handleTriggerKey.mockReturnValue(false);
+      mockInstructionModeManager.handleKeydown.mockReturnValue(false);
+      mockSlashCommandDropdown.handleKeydown.mockReturnValue(true);
+      mockFileContextManager.handleMentionKeydown.mockReturnValue(false);
+      const { fireKeydown } = setupKeydownTab();
+
+      const event = {
+        key: 'Enter',
+        shiftKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        altKey: false,
+        isComposing: false,
+        preventDefault: jest.fn(),
+      };
+      fireKeydown(event);
+
+      expect(mockSlashCommandDropdown.handleKeydown).toHaveBeenCalled();
+      expect(mockInputController.sendMessage).not.toHaveBeenCalled();
+    });
+
     it('should handle resume dropdown keydown', () => {
       mockInstructionModeManager.handleTriggerKey.mockReturnValue(false);
       mockInstructionModeManager.handleKeydown.mockReturnValue(false);


### PR DESCRIPTION
## Summary
- Restores the explicit Mod+Enter composer send shortcut before dropdown Enter handlers can consume it.
- Adds an Obsidian scope fallback for focused composer sends when the textarea keydown path is bypassed.
- Covers the dropdown priority and scoped shortcut behavior with unit tests.

## Verification
- npm run typecheck
- npm run lint
- npm test -- --runInBand
- npm run build
- npm test -- --runTestsByPath tests/unit/features/chat/tabs/Tab.test.ts tests/unit/features/chat/ClaudianView.test.ts --runInBand