### PR TITLE
feat: add model discovery via Anthropic /v1/models API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,10 @@
 # CLAUDE.md
 
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 ## Project Overview
 
-Claudian is an Obsidian plugin that embeds provider-backed chat runtimes in a sidebar and inline-edit flow. Claude is the default provider. Codex is optional and joins the same conversation model through `Conversation.providerId` plus provider-owned `providerState`.
+Claudian is an Obsidian plugin that embeds provider-backed chat runtimes in a sidebar and inline-edit flow. Claude is the default provider. Codex, Opencode, and Pi are optional providers that join the same conversation model through `Conversation.providerId` plus provider-owned `providerState`. Build output is `main.js` + `styles.css` + `manifest.json` — standard Obsidian plugin artifacts.
 
 ## Architecture Status
 
@@ -16,14 +18,20 @@ Claudian is an Obsidian plugin that embeds provider-backed chat runtimes in a si
 ## Commands
 
 ```bash
-npm run dev
-npm run build
-npm run typecheck
-npm run lint
-npm run lint:fix
-npm run test
-npm run test:watch
-npm run test:coverage
+npm run dev              # watch mode (CSS build + esbuild)
+npm run build            # production build
+npm run typecheck        # tsc --noEmit
+npm run lint             # eslint
+npm run lint:fix         # eslint --fix
+npm run test             # all tests (unit + integration)
+npm run test:watch       # jest watch mode
+npm run test:coverage    # coverage report
+
+# Run a single test file
+npm run test -- --testPathPattern="tests/unit/cruntime"
+
+# Run a single test by name
+npm run test -- -t "should handle stream chunks"
 ```
 
 ## Architecture
@@ -51,6 +59,15 @@ npm run test:coverage -- --selectProjects unit
 ```
 
 Tests mirror the `src/` layout under `tests/unit/` and `tests/integration/`.
+
+## Path Aliases
+
+| Alias | Maps to |
+|-------|---------|
+| `@/*` | `./src/*` |
+| `@test/*` | `./tests/*` |
+
+These are configured in `tsconfig.json` and mirrored in `jest.config.js` via `moduleNameMapper`.
 
 ## Storage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -135,7 +135,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -635,7 +634,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
       "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -645,7 +643,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
       "integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
@@ -741,7 +738,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -765,7 +761,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2770,7 +2765,6 @@
       "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.59.3",
@@ -2800,7 +2794,6 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -3294,7 +3287,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3802,7 +3794,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4769,7 +4760,6 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5332,7 +5322,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5877,7 +5866,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6540,7 +6528,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
       "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7316,7 +7303,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -7949,7 +7935,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -8884,7 +8869,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10998,7 +10982,6 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11687,7 +11670,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/providers/claude/modelOptions.ts
+++ b/src/providers/claude/modelOptions.ts
@@ -53,6 +53,15 @@ export function getClaudeModelOptions(settings: Record<string, unknown>): Provid
   }
 
   const claudeSettings = getClaudeProviderSettings(settings);
+
+  if (claudeSettings.discoveredModels.length > 0) {
+    return claudeSettings.discoveredModels.map(model => ({
+      value: model.id,
+      label: customModelAliases[model.id] ?? model.displayName,
+      description: model.createdAt ? `Created ${model.createdAt.slice(0, 10)}` : undefined,
+    }));
+  }
+
   const models = filterVisibleModelOptions(
     [...DEFAULT_CLAUDE_MODELS],
     claudeSettings.enableOpus1M,

--- a/src/providers/claude/runtime/ClaudeChatRuntime.ts
+++ b/src/providers/claude/runtime/ClaudeChatRuntime.ts
@@ -1203,7 +1203,9 @@ export class ClaudianService implements ChatRuntime {
                 effectiveQueryOptions
               );
             } catch (retryError) {
-              const msg = retryError instanceof Error ? retryError.message : 'Unknown error';
+              const msg = retryError instanceof Error
+                ? retryError.message
+                : `Non-Error thrown: ${JSON.stringify(retryError) ?? String(retryError)}`;
               yield { type: 'error', content: msg };
             } finally {
               this.coldStartInProgress = false;
@@ -1245,7 +1247,9 @@ export class ClaudianService implements ChatRuntime {
         return;
       }
 
-      const msg = error instanceof Error ? error.message : 'Unknown error';
+      const msg = error instanceof Error
+        ? error.message
+        : `Non-Error thrown: ${JSON.stringify(error) ?? String(error)}`;
       yield { type: 'error', content: msg };
     } finally {
       this.coldStartInProgress = false;
@@ -1594,7 +1598,9 @@ export class ClaudianService implements ChatRuntime {
       if (isSessionExpiredError(error)) {
         throw error;
       }
-      const msg = error instanceof Error ? error.message : 'Unknown error';
+      const msg = error instanceof Error
+        ? error.message
+        : `Non-Error thrown: ${JSON.stringify(error) ?? String(error)}`;
       yield { type: 'error', content: msg };
     } finally {
       this.sessionManager.clearPendingModel();

--- a/src/providers/claude/runtime/ClaudeModelDiscoveryService.ts
+++ b/src/providers/claude/runtime/ClaudeModelDiscoveryService.ts
@@ -1,0 +1,129 @@
+import * as http from 'http';
+import * as https from 'https';
+
+import { getRuntimeEnvironmentVariables } from '../../../core/providers/providerEnvironment';
+import type ClaudianPlugin from '../../../main';
+import type { ClaudeDiscoveredModel } from '../types/models';
+
+export interface ClaudeModelDiscoveryResult {
+  diagnostics?: string;
+  models: ClaudeDiscoveredModel[];
+}
+
+interface ApiModelEntry {
+  id?: string;
+  display_name?: string;
+  created_at?: string;
+  type?: string;
+}
+
+export class ClaudeModelDiscoveryService {
+  constructor(private readonly plugin: ClaudianPlugin) {}
+
+  async discoverModels(): Promise<ClaudeModelDiscoveryResult> {
+    const envVars = getRuntimeEnvironmentVariables(
+      this.plugin.settings as unknown as Record<string, unknown>,
+      'claude',
+    );
+
+    const apiKey = envVars.ANTHROPIC_API_KEY || process.env.ANTHROPIC_API_KEY || '';
+    if (!apiKey) {
+      return {
+        diagnostics: 'No ANTHROPIC_API_KEY found. Set it in Claudian environment variables or system environment.',
+        models: [],
+      };
+    }
+
+    const baseUrl = envVars.ANTHROPIC_BASE_URL || process.env.ANTHROPIC_BASE_URL || 'https://api.anthropic.com';
+
+    try {
+      const data = await this.fetchModels(baseUrl, apiKey);
+      const models = normalizeApiResponse(data);
+      return { models };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Model discovery failed';
+      return { diagnostics: message, models: [] };
+    }
+  }
+
+  private fetchModels(baseUrl: string, apiKey: string): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const url = new URL('/v1/models', baseUrl);
+      const transport = url.protocol === 'https:' ? https : http;
+
+      const req = transport.request(
+        url,
+        {
+          method: 'GET',
+          headers: {
+            'x-api-key': apiKey,
+            'anthropic-version': '2023-06-01',
+            'content-type': 'application/json',
+          },
+        },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on('data', (chunk: Buffer) => chunks.push(chunk));
+          res.on('end', () => {
+            const body = Buffer.concat(chunks).toString('utf-8');
+            if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+              try {
+                resolve(JSON.parse(body));
+              } catch {
+                reject(new Error(`Invalid JSON response from /v1/models`));
+              }
+            } else {
+              reject(new Error(`API returned ${res.statusCode}: ${body.slice(0, 200)}`));
+            }
+          });
+          res.on('error', reject);
+        },
+      );
+
+      req.on('error', reject);
+      req.setTimeout(15_000, () => {
+        req.destroy(new Error('Request timed out'));
+      });
+      req.end();
+    });
+  }
+}
+
+function normalizeApiResponse(data: unknown): ClaudeDiscoveredModel[] {
+  const entries = extractModelEntries(data);
+  const models: ClaudeDiscoveredModel[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of entries) {
+    const id = typeof entry.id === 'string' ? entry.id.trim() : '';
+    if (!id || seen.has(id)) {
+      continue;
+    }
+
+    seen.add(id);
+    const displayName = typeof entry.display_name === 'string' && entry.display_name.trim()
+      ? entry.display_name.trim()
+      : id;
+    const createdAt = typeof entry.created_at === 'string' ? entry.created_at : undefined;
+
+    models.push({ id, displayName, createdAt });
+  }
+
+  return models;
+}
+
+function extractModelEntries(data: unknown): ApiModelEntry[] {
+  if (!data || typeof data !== 'object') {
+    return [];
+  }
+
+  const record = data as Record<string, unknown>;
+  const candidates = record.data ?? record.models ?? record.results;
+  if (Array.isArray(candidates)) {
+    return candidates.filter(
+      (entry): entry is ApiModelEntry => entry !== null && typeof entry === 'object',
+    );
+  }
+
+  return [];
+}

--- a/src/providers/claude/settings.ts
+++ b/src/providers/claude/settings.ts
@@ -6,6 +6,7 @@ import {
   getLegacyHostnameKey,
   migrateLegacyHostnameKeyedMap,
 } from '../../utils/env';
+import type { ClaudeDiscoveredModel } from './types/models';
 
 export const CLAUDE_SAFE_MODES = ['acceptEdits', 'auto', 'default'] as const;
 export type ClaudeSafeMode = typeof CLAUDE_SAFE_MODES[number];
@@ -24,6 +25,7 @@ export interface ClaudeProviderSettings {
   lastModel: string;
   environmentVariables: string;
   environmentHash: string;
+  discoveredModels: ClaudeDiscoveredModel[];
 }
 
 export const DEFAULT_CLAUDE_PROVIDER_SETTINGS: Readonly<ClaudeProviderSettings> = Object.freeze({
@@ -39,6 +41,7 @@ export const DEFAULT_CLAUDE_PROVIDER_SETTINGS: Readonly<ClaudeProviderSettings> 
   lastModel: 'haiku',
   environmentVariables: '',
   environmentHash: '',
+  discoveredModels: [],
 });
 
 function normalizeHostnameCliPaths(value: unknown): HostnameCliPaths {
@@ -59,6 +62,20 @@ function normalizeClaudeSafeMode(value: unknown): ClaudeSafeMode | undefined {
   return (CLAUDE_SAFE_MODES as readonly unknown[]).includes(value)
     ? value as ClaudeSafeMode
     : undefined;
+}
+
+function normalizeDiscoveredModels(value: unknown): ClaudeDiscoveredModel[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter(
+    (entry): entry is ClaudeDiscoveredModel =>
+      entry !== null &&
+      typeof entry === 'object' &&
+      typeof entry.id === 'string' &&
+      typeof entry.displayName === 'string',
+  );
 }
 
 export function getClaudeProviderSettings(
@@ -110,6 +127,7 @@ export function getClaudeProviderSettings(
     environmentHash: (config.environmentHash as string | undefined)
       ?? (settings.lastEnvHash as string | undefined)
       ?? DEFAULT_CLAUDE_PROVIDER_SETTINGS.environmentHash,
+    discoveredModels: normalizeDiscoveredModels(config.discoveredModels),
   };
 }
 

--- a/src/providers/claude/types/models.ts
+++ b/src/providers/claude/types/models.ts
@@ -5,6 +5,13 @@
 /** Model identifier (string to support custom models via environment variables). */
 export type ClaudeModel = string;
 
+/** A model discovered from the Anthropic /v1/models API. */
+export interface ClaudeDiscoveredModel {
+  id: string;
+  displayName: string;
+  createdAt?: string;
+}
+
 export const DEFAULT_CLAUDE_MODELS: { value: ClaudeModel; label: string; description: string }[] = [
   { value: 'haiku', label: 'Haiku', description: 'Fast and efficient' },
   { value: 'sonnet', label: 'Sonnet', description: 'Balanced performance' },

--- a/src/providers/claude/ui/ClaudeSettingsTab.ts
+++ b/src/providers/claude/ui/ClaudeSettingsTab.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { Setting } from 'obsidian';
+import { Notice, Setting } from 'obsidian';
 
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type { ProviderSettingsTabRenderer } from '../../../core/providers/types';
@@ -10,6 +10,7 @@ import { getHostnameKey } from '../../../utils/env';
 import { expandHomePath } from '../../../utils/path';
 import { getClaudeWorkspaceServices } from '../app/ClaudeWorkspaceServices';
 import { resolveClaudeModelSelection } from '../modelOptions';
+import { ClaudeModelDiscoveryService } from '../runtime/ClaudeModelDiscoveryService';
 import {
   CLAUDE_SAFE_MODES,
   type ClaudeSafeMode,
@@ -176,6 +177,41 @@ export const claudeSettingsTabRenderer: ProviderSettingsTabRenderer = {
     // --- Models ---
 
     new Setting(container).setName(t('settings.models')).setHeading();
+
+    new Setting(container)
+      .setName('Discover models')
+      .setDesc(claudeSettings.discoveredModels.length > 0
+        ? `${claudeSettings.discoveredModels.length} models cached from Anthropic API.`
+        : 'Fetch available models from the Anthropic API.')
+      .addButton((button) => {
+        button.setButtonText('Discover').onClick(async () => {
+          button.setDisabled(true);
+          const result = await new ClaudeModelDiscoveryService(context.plugin).discoverModels();
+          if (result.diagnostics) {
+            new Notice(`Model discovery failed: ${result.diagnostics}`);
+            button.setDisabled(false);
+            return;
+          }
+          updateClaudeProviderSettings(settingsBag, { discoveredModels: result.models });
+          reconcileActiveClaudeModelSelection();
+          await context.plugin.saveSettings();
+          context.refreshModelSelectors();
+          new Notice(`Discovered ${result.models.length} models.`);
+          button.setDisabled(false);
+        });
+      })
+      .addButton((button) => {
+        if (claudeSettings.discoveredModels.length === 0) {
+          return;
+        }
+        button.setButtonText('Clear').onClick(async () => {
+          updateClaudeProviderSettings(settingsBag, { discoveredModels: [] });
+          reconcileActiveClaudeModelSelection();
+          await context.plugin.saveSettings();
+          context.refreshModelSelectors();
+          new Notice('Cleared discovered models. Using default model list.');
+        });
+      });
 
     new Setting(container)
       .setName(t('settings.enableOpus1M.name'))

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -135,6 +135,7 @@ export class Setting {
   setDesc = jest.fn().mockReturnThis();
   addToggle = jest.fn().mockReturnThis();
   addTextArea = jest.fn().mockReturnThis();
+  addButton = jest.fn().mockReturnThis();
 }
 
 export class TextAreaComponent {

--- a/tests/unit/providers/claude/ui/ClaudeSettingsTab.test.ts
+++ b/tests/unit/providers/claude/ui/ClaudeSettingsTab.test.ts
@@ -79,6 +79,15 @@ jest.mock('obsidian', () => {
       callback(component);
       return this;
     }
+
+    addButton(callback: (button: { setButtonText: (t: string) => any; onClick: (cb: () => void) => any; setDisabled: (v: boolean) => any }) => void) {
+      callback({
+        setButtonText: () => ({ onClick: () => ({}) }),
+        onClick: () => ({}),
+        setDisabled: () => ({}),
+      });
+      return this;
+    }
   }
 
   return {


### PR DESCRIPTION
- Add ClaudeModelDiscoveryService to fetch available models

- Add discoveredModels to ClaudeProviderSettings with persistence

- Add Discover/Clear buttons in settings UI

- Prefer discovered models over hardcoded defaults when available

- Improve non-Error throw messages in ClaudeChatRuntime

- Update CLAUDE.md with path aliases and command docs