### PR TITLE
Import native Codex history sessions

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -18,13 +18,13 @@ import {
 import { ProviderRegistry } from './core/providers/ProviderRegistry';
 import { ProviderSettingsCoordinator } from './core/providers/ProviderSettingsCoordinator';
 import { ProviderWorkspaceRegistry } from './core/providers/ProviderWorkspaceRegistry';
-import type { ProviderId } from './core/providers/types';
-import type { AppTabManagerState } from './core/providers/types';
+import type { AppTabManagerState, ProviderId } from './core/providers/types';
 import { DEFAULT_CHAT_PROVIDER_ID } from './core/providers/types';
 import type {
   ClaudianSettings,
   Conversation,
   ConversationMeta,
+  SessionMetadata,
 } from './core/types';
 import {
   VIEW_TYPE_CLAUDIAN,
@@ -35,6 +35,7 @@ import { type InlineEditContext, InlineEditModal } from './features/inline-edit/
 import { ClaudianSettingTab } from './features/settings/ClaudianSettings';
 import { setLocale } from './i18n/i18n';
 import type { Locale } from './i18n/types';
+import { type CodexNativeSessionImportResult, importCodexNativeSessionsForVault } from './providers/codex/history/CodexNativeSessionImport';
 import { OPENCODE_PLAN_MODE_ID, OPENCODE_SAFE_MODE_ID } from './providers/opencode/modes';
 import { buildCursorContext } from './utils/editor';
 import { revealWorkspaceLeaf } from './utils/obsidianCompat';
@@ -314,27 +315,7 @@ export default class ClaudianPlugin extends Plugin {
     const didNormalizeModelVariants = this.normalizeModelVariantSettings();
 
     const allMetadata = await this.storage.sessions.listMetadata();
-    this.conversations = allMetadata.map(meta => {
-      const resumeSessionId = meta.sessionId !== undefined ? meta.sessionId : meta.id;
-
-      return {
-        id: meta.id,
-        providerId: meta.providerId ?? DEFAULT_CHAT_PROVIDER_ID,
-        title: meta.title,
-        createdAt: meta.createdAt,
-        updatedAt: meta.updatedAt,
-        lastResponseAt: meta.lastResponseAt,
-        sessionId: resumeSessionId,
-        providerState: meta.providerState,
-        messages: [],
-        currentNote: meta.currentNote,
-        externalContextPaths: meta.externalContextPaths,
-        enabledMcpServers: meta.enabledMcpServers,
-        usage: meta.usage,
-        titleGenerationStatus: meta.titleGenerationStatus,
-        resumeAtMessageId: meta.resumeAtMessageId,
-      };
-    }).sort(
+    this.conversations = allMetadata.map(meta => this.metadataToConversation(meta)).sort(
       (a, b) => (b.lastResponseAt ?? b.updatedAt) - (a.lastResponseAt ?? a.updatedAt)
     );
     setLocale(this.settings.locale as Locale);
@@ -588,6 +569,58 @@ export default class ClaudianPlugin extends Plugin {
       return 'New conversation';
     }
     return firstUserMsg.content.substring(0, 50) + (firstUserMsg.content.length > 50 ? '...' : '');
+  }
+
+  private metadataToConversation(meta: SessionMetadata): Conversation {
+    const resumeSessionId = meta.sessionId !== undefined ? meta.sessionId : meta.id;
+
+    return {
+      id: meta.id,
+      providerId: meta.providerId ?? DEFAULT_CHAT_PROVIDER_ID,
+      title: meta.title,
+      createdAt: meta.createdAt,
+      updatedAt: meta.updatedAt,
+      lastResponseAt: meta.lastResponseAt,
+      sessionId: resumeSessionId,
+      providerState: meta.providerState,
+      messages: [],
+      currentNote: meta.currentNote,
+      externalContextPaths: meta.externalContextPaths,
+      enabledMcpServers: meta.enabledMcpServers,
+      usage: meta.usage,
+      titleGenerationStatus: meta.titleGenerationStatus,
+      resumeAtMessageId: meta.resumeAtMessageId,
+    };
+  }
+
+  async importCodexNativeSessionsForCurrentVault(): Promise<CodexNativeSessionImportResult> {
+    const vaultPath = getVaultPath(this.app);
+    const emptyResult: CodexNativeSessionImportResult = {
+      imported: [],
+      skippedDuplicate: 0,
+      skippedOtherWorkspace: 0,
+      scanned: 0,
+    };
+    if (!vaultPath) {
+      return emptyResult;
+    }
+
+    const existingMetadata = await this.storage.sessions.listMetadata();
+    const result = importCodexNativeSessionsForVault({
+      existingMetadata,
+      vaultPath,
+    });
+
+    for (const meta of result.imported) {
+      await this.storage.sessions.saveMetadata(meta);
+      this.conversations.push(this.metadataToConversation(meta));
+    }
+
+    this.conversations.sort(
+      (a, b) => (b.lastResponseAt ?? b.updatedAt) - (a.lastResponseAt ?? a.updatedAt)
+    );
+
+    return result;
   }
 
   private async loadSdkMessagesForConversation(conversation: Conversation): Promise<void> {

--- a/src/providers/codex/history/CodexNativeSessionImport.ts
+++ b/src/providers/codex/history/CodexNativeSessionImport.ts
@@ -1,0 +1,313 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import type { SessionMetadata } from '../../../core/types';
+import { deriveCodexSessionsRootFromSessionPath } from './CodexHistoryStore';
+
+interface CodexSessionScanRecord {
+  timestamp?: string;
+  type?: string;
+  payload?: Record<string, unknown>;
+}
+
+interface CodexNativeSessionCandidate {
+  cwd: string;
+  createdAt: number;
+  lastResponseAt?: number;
+  sessionFilePath: string;
+  threadId: string;
+  title: string;
+  updatedAt: number;
+}
+
+export interface CodexNativeSessionImportResult {
+  imported: SessionMetadata[];
+  skippedDuplicate: number;
+  skippedOtherWorkspace: number;
+  scanned: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseRecord(line: string): CodexSessionScanRecord | null {
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    if (!isRecord(parsed)) return null;
+    return {
+      timestamp: typeof parsed.timestamp === 'string' ? parsed.timestamp : undefined,
+      type: typeof parsed.type === 'string' ? parsed.type : undefined,
+      payload: isRecord(parsed.payload) ? parsed.payload : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function toMillis(value: unknown): number | null {
+  if (typeof value !== 'string') return null;
+  const millis = Date.parse(value);
+  return Number.isFinite(millis) ? millis : null;
+}
+
+function normalizeComparablePath(value: string): string {
+  const normalized = path.resolve(value);
+  return process.platform === 'win32' || process.platform === 'darwin'
+    ? normalized.toLowerCase()
+    : normalized;
+}
+
+function isWithinOrEqualPath(candidatePath: string, parentPath: string): boolean {
+  const candidate = normalizeComparablePath(candidatePath);
+  const parent = normalizeComparablePath(parentPath);
+  return candidate === parent || candidate.startsWith(`${parent}${path.sep}`);
+}
+
+function extractTextContent(content: unknown): string | null {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return null;
+
+  const parts: string[] = [];
+  for (const item of content) {
+    if (!isRecord(item)) continue;
+    if (typeof item.text === 'string') {
+      parts.push(item.text);
+    }
+  }
+
+  return parts.length > 0 ? parts.join('\n') : null;
+}
+
+function cleanTitle(text: string): string | null {
+  const trimmedText = text.trim();
+  if (
+    trimmedText.startsWith('<environment_context>')
+    || trimmedText.startsWith('# AGENTS.md instructions')
+    || trimmedText.startsWith('<INSTRUCTIONS>')
+    || trimmedText.startsWith('<system-reminder>')
+  ) {
+    return null;
+  }
+
+  const normalized = text
+    .replace(/\r/g, '')
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean);
+
+  const requestIndex = normalized.findIndex(line => /my request for codex/i.test(line));
+  const titleSource = requestIndex >= 0
+    ? normalized.slice(requestIndex + 1).find(Boolean)
+    : normalized.find(line => (
+      !line.startsWith('<')
+      && !line.startsWith('# AGENTS.md')
+      && !line.startsWith('## Open tabs:')
+      && !line.startsWith('## Active file:')
+    ));
+
+  const title = titleSource ?? text.trim();
+  return title.length > 80 ? `${title.slice(0, 77)}...` : title;
+}
+
+function extractUserTitle(record: CodexSessionScanRecord): string | null {
+  const payload = record.payload;
+  if (!payload) return null;
+
+  if (record.type === 'event_msg' && payload.type === 'user_message') {
+    const message = typeof payload.message === 'string' ? payload.message : null;
+    return message ? cleanTitle(message) : null;
+  }
+
+  if (record.type === 'response_item' && payload.type === 'message' && payload.role === 'user') {
+    const text = extractTextContent(payload.content);
+    return text ? cleanTitle(text) : null;
+  }
+
+  return null;
+}
+
+function extractThreadIdFromFilePath(filePath: string): string {
+  const base = path.basename(filePath, '.jsonl');
+  const match = base.match(/([A-Za-z0-9][A-Za-z0-9_-]*)$/);
+  return match?.[1] ?? base.replace(/[^A-Za-z0-9_-]/g, '_');
+}
+
+function scanSessionFile(filePath: string): CodexNativeSessionCandidate | null {
+  let content: string;
+  let stat: fs.Stats;
+  try {
+    content = fs.readFileSync(filePath, 'utf-8');
+    stat = fs.statSync(filePath);
+  } catch {
+    return null;
+  }
+
+  let cwd: string | null = null;
+  let title: string | null = null;
+  let threadId: string | null = null;
+  let createdAt: number | null = null;
+  let updatedAt = Number.isFinite(stat.mtimeMs) ? stat.mtimeMs : Date.now();
+
+  for (const line of content.split('\n')) {
+    if (!line.trim()) continue;
+    const record = parseRecord(line);
+    if (!record) continue;
+
+    const timestamp = toMillis(record.timestamp);
+    if (timestamp != null) {
+      createdAt = createdAt == null ? timestamp : Math.min(createdAt, timestamp);
+      updatedAt = Math.max(updatedAt, timestamp);
+    }
+
+    const payload = record.payload;
+    if (!payload) continue;
+
+    if (record.type === 'session_meta') {
+      if (!cwd && typeof payload.cwd === 'string') cwd = payload.cwd;
+      if (!threadId && typeof payload.id === 'string') threadId = payload.id;
+      const payloadTimestamp = toMillis(payload.timestamp);
+      if (payloadTimestamp != null) {
+        createdAt = createdAt == null ? payloadTimestamp : Math.min(createdAt, payloadTimestamp);
+      }
+    }
+
+    if (record.type === 'turn_context' && !cwd && typeof payload.cwd === 'string') {
+      cwd = payload.cwd;
+    }
+
+    if (!title) {
+      title = extractUserTitle(record);
+    }
+  }
+
+  if (!cwd) return null;
+
+  const resolvedThreadId = threadId ?? extractThreadIdFromFilePath(filePath);
+  const resolvedCreatedAt = createdAt ?? stat.birthtimeMs ?? stat.mtimeMs ?? Date.now();
+  return {
+    cwd,
+    createdAt: resolvedCreatedAt,
+    updatedAt,
+    lastResponseAt: updatedAt,
+    sessionFilePath: filePath,
+    threadId: resolvedThreadId,
+    title: title || 'Codex session',
+  };
+}
+
+function collectJsonlFiles(root: string): string[] {
+  const files: string[] = [];
+  const stack = [root];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) continue;
+
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const fullPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(fullPath);
+      } else if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  return files;
+}
+
+function buildDuplicateSets(existing: SessionMetadata[]): {
+  ids: Set<string>;
+  paths: Set<string>;
+  threadIds: Set<string>;
+} {
+  const ids = new Set<string>();
+  const paths = new Set<string>();
+  const threadIds = new Set<string>();
+
+  for (const meta of existing) {
+    ids.add(meta.id);
+    if (meta.sessionId) threadIds.add(meta.sessionId);
+    const state = isRecord(meta.providerState) ? meta.providerState : {};
+    if (typeof state.threadId === 'string') threadIds.add(state.threadId);
+    if (typeof state.sessionFilePath === 'string') {
+      paths.add(normalizeComparablePath(state.sessionFilePath));
+    }
+  }
+
+  return { ids, paths, threadIds };
+}
+
+function toSessionMetadata(candidate: CodexNativeSessionCandidate): SessionMetadata {
+  const transcriptRootPath = deriveCodexSessionsRootFromSessionPath(candidate.sessionFilePath) ?? undefined;
+  return {
+    id: `codex-${candidate.threadId}`,
+    providerId: 'codex',
+    title: candidate.title,
+    createdAt: candidate.createdAt,
+    updatedAt: candidate.updatedAt,
+    lastResponseAt: candidate.lastResponseAt,
+    sessionId: candidate.threadId,
+    providerState: {
+      threadId: candidate.threadId,
+      sessionFilePath: candidate.sessionFilePath,
+      ...(transcriptRootPath ? { transcriptRootPath } : {}),
+    },
+  };
+}
+
+export function importCodexNativeSessionsForVault(params: {
+  existingMetadata: SessionMetadata[];
+  sessionsRoot?: string;
+  vaultPath: string;
+}): CodexNativeSessionImportResult {
+  const sessionsRoot = params.sessionsRoot ?? path.join(os.homedir(), '.codex', 'sessions');
+  const result: CodexNativeSessionImportResult = {
+    imported: [],
+    skippedDuplicate: 0,
+    skippedOtherWorkspace: 0,
+    scanned: 0,
+  };
+
+  if (!fs.existsSync(sessionsRoot)) {
+    return result;
+  }
+
+  const duplicates = buildDuplicateSets(params.existingMetadata);
+
+  for (const filePath of collectJsonlFiles(sessionsRoot)) {
+    result.scanned += 1;
+    const candidate = scanSessionFile(filePath);
+    if (!candidate || !isWithinOrEqualPath(candidate.cwd, params.vaultPath)) {
+      result.skippedOtherWorkspace += 1;
+      continue;
+    }
+
+    const meta = toSessionMetadata(candidate);
+    const normalizedSessionPath = normalizeComparablePath(candidate.sessionFilePath);
+    if (
+      duplicates.ids.has(meta.id)
+      || duplicates.threadIds.has(candidate.threadId)
+      || duplicates.paths.has(normalizedSessionPath)
+    ) {
+      result.skippedDuplicate += 1;
+      continue;
+    }
+
+    duplicates.ids.add(meta.id);
+    duplicates.threadIds.add(candidate.threadId);
+    duplicates.paths.add(normalizedSessionPath);
+    result.imported.push(meta);
+  }
+
+  return result;
+}

--- a/src/providers/codex/ui/CodexSettingsTab.ts
+++ b/src/providers/codex/ui/CodexSettingsTab.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { Setting } from 'obsidian';
+import { Notice, Setting } from 'obsidian';
 
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type { ProviderSettingsTabRenderer } from '../../../core/providers/types';
@@ -225,6 +225,34 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
     }
 
     refreshInstallationMethodUI();
+
+    // --- History ---
+
+    new Setting(container).setName('History').setHeading();
+
+    new Setting(container)
+      .setName('Import Codex history')
+      .setDesc('Scan native Codex sessions for this vault and its subfolders, then add missing sessions to Claudian history.')
+      .addButton((button) => {
+        button
+          .setButtonText('Import')
+          .onClick(async () => {
+            button.setDisabled(true);
+            button.setButtonText('Importing...');
+            try {
+              const result = await context.plugin.importCodexNativeSessionsForCurrentVault();
+              new Notice(
+                `Imported ${result.imported.length} Codex session${result.imported.length === 1 ? '' : 's'}. `
+                + `Skipped ${result.skippedDuplicate} duplicate${result.skippedDuplicate === 1 ? '' : 's'}.`
+              );
+            } catch {
+              new Notice('Failed to import Codex history');
+            } finally {
+              button.setButtonText('Import');
+              button.setDisabled(false);
+            }
+          });
+      });
 
     // --- Safety ---
 

--- a/tests/unit/providers/codex/history/CodexNativeSessionImport.test.ts
+++ b/tests/unit/providers/codex/history/CodexNativeSessionImport.test.ts
@@ -1,0 +1,179 @@
+import type * as fsType from 'fs';
+import type * as osType from 'os';
+import type * as pathType from 'path';
+
+const fs = jest.requireActual<typeof fsType>('fs');
+const os = jest.requireActual<typeof osType>('os');
+const path = jest.requireActual<typeof pathType>('path');
+
+import type { SessionMetadata } from '@/core/types';
+import { importCodexNativeSessionsForVault } from '@/providers/codex/history/CodexNativeSessionImport';
+
+function writeSession(filePath: string, params: {
+  cwd: string;
+  threadId: string;
+  extraUserMessage?: string;
+  userMessage?: string;
+  timestamp?: string;
+}): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const timestamp = params.timestamp ?? '2026-06-01T00:00:00.000Z';
+  fs.writeFileSync(
+    filePath,
+    [
+      JSON.stringify({
+        type: 'session_meta',
+        timestamp,
+        payload: {
+          id: params.threadId,
+          cwd: params.cwd,
+          timestamp,
+        },
+      }),
+      JSON.stringify({
+        type: 'event_msg',
+        timestamp: '2026-06-01T00:00:01.000Z',
+        payload: {
+          type: 'user_message',
+          message: params.userMessage ?? 'Summarize this vault',
+        },
+      }),
+      ...(params.extraUserMessage ? [JSON.stringify({
+        type: 'event_msg',
+        timestamp: '2026-06-01T00:00:01.500Z',
+        payload: {
+          type: 'user_message',
+          message: params.extraUserMessage,
+        },
+      })] : []),
+      JSON.stringify({
+        type: 'turn_context',
+        timestamp: '2026-06-01T00:00:02.000Z',
+        payload: {
+          cwd: params.cwd,
+        },
+      }),
+    ].join('\n'),
+    'utf-8',
+  );
+}
+
+describe('importCodexNativeSessionsForVault', () => {
+  let tempDir: string;
+  let sessionsRoot: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claudian-codex-import-'));
+    sessionsRoot = path.join(tempDir, '.codex', 'sessions');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('imports native Codex sessions whose cwd is the current vault', () => {
+    const vaultPath = path.join(tempDir, 'vault');
+    const sessionFile = path.join(sessionsRoot, '2026', '06', '01', 'rollout-thread-1.jsonl');
+    writeSession(sessionFile, {
+      cwd: vaultPath,
+      threadId: 'thread-1',
+      userMessage: 'Count todos',
+    });
+
+    const result = importCodexNativeSessionsForVault({
+      existingMetadata: [],
+      sessionsRoot,
+      vaultPath,
+    });
+
+    expect(result.imported).toHaveLength(1);
+    expect(result.imported[0]).toMatchObject({
+      id: 'codex-thread-1',
+      providerId: 'codex',
+      title: 'Count todos',
+      sessionId: 'thread-1',
+      providerState: {
+        threadId: 'thread-1',
+        sessionFilePath: sessionFile,
+      },
+    });
+  });
+
+  it('allows sessions from current vault subdirectories', () => {
+    const vaultPath = path.join(tempDir, 'vault');
+    writeSession(path.join(sessionsRoot, 'rollout-thread-child.jsonl'), {
+      cwd: path.join(vaultPath, 'notes', 'project-a'),
+      threadId: 'thread-child',
+    });
+
+    const result = importCodexNativeSessionsForVault({
+      existingMetadata: [],
+      sessionsRoot,
+      vaultPath,
+    });
+
+    expect(result.imported.map(meta => meta.sessionId)).toEqual(['thread-child']);
+  });
+
+  it('skips sessions outside the current vault', () => {
+    const vaultPath = path.join(tempDir, 'vault');
+    writeSession(path.join(sessionsRoot, 'rollout-thread-other.jsonl'), {
+      cwd: path.join(tempDir, 'other-vault'),
+      threadId: 'thread-other',
+    });
+
+    const result = importCodexNativeSessionsForVault({
+      existingMetadata: [],
+      sessionsRoot,
+      vaultPath,
+    });
+
+    expect(result.imported).toHaveLength(0);
+    expect(result.skippedOtherWorkspace).toBe(1);
+  });
+
+  it('skips sessions already represented by existing metadata', () => {
+    const vaultPath = path.join(tempDir, 'vault');
+    const sessionFile = path.join(sessionsRoot, 'rollout-thread-duplicate.jsonl');
+    writeSession(sessionFile, {
+      cwd: vaultPath,
+      threadId: 'thread-duplicate',
+    });
+
+    const existingMetadata: SessionMetadata[] = [{
+      id: 'existing',
+      providerId: 'codex',
+      title: 'Existing',
+      createdAt: 1,
+      updatedAt: 1,
+      sessionId: 'thread-duplicate',
+    }];
+
+    const result = importCodexNativeSessionsForVault({
+      existingMetadata,
+      sessionsRoot,
+      vaultPath,
+    });
+
+    expect(result.imported).toHaveLength(0);
+    expect(result.skippedDuplicate).toBe(1);
+  });
+
+  it('skips setup context messages when deriving the imported title', () => {
+    const vaultPath = path.join(tempDir, 'vault');
+    writeSession(path.join(sessionsRoot, 'rollout-thread-context.jsonl'), {
+      cwd: vaultPath,
+      threadId: 'thread-context',
+      userMessage: '# AGENTS.md instructions for /vault\n\n<INSTRUCTIONS>\n硬约束\n</INSTRUCTIONS>',
+      extraUserMessage: 'Real user request',
+    });
+
+    const result = importCodexNativeSessionsForVault({
+      existingMetadata: [],
+      sessionsRoot,
+      vaultPath,
+    });
+
+    expect(result.imported[0]?.title).toBe('Real user request');
+  });
+});


### PR DESCRIPTION
Adds a Codex settings action to import native Codex sessions for the current Obsidian vault.\n\nChanges:\n- Scan ~/.codex/sessions for JSONL transcripts whose cwd is inside the current vault.\n- Create Claudian session metadata pointing at the native Codex transcript, with duplicate prevention by id, thread id, and session path.\n- Preserve support for vault subdirectories.\n\nVerification:\n- npm run typecheck\n- npm run lint\n- npm run test -- --selectProjects unit --runTestsByPath tests/unit/providers/codex/history/CodexNativeSessionImport.test.ts\n- npm run build