### PR TITLE
feat: add Hermes Agent provider integration [WIP]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ Claudian is an Obsidian plugin that embeds provider-backed chat runtimes in a si
 - Provider boundary: `src/core/runtime/` and `src/core/providers/` define the chat-facing seam. `ProviderRegistry` creates runtimes and provider-owned auxiliary services. `ProviderWorkspaceRegistry` owns workspace services such as command catalogs, agent mention providers, CLI resolution, MCP managers, and provider settings tabs.
 - Claude adaptor: `src/providers/claude/` owns the Claude runtime, prompt encoding, stream transforms, history hydration, CLI resolution, plugin and agent discovery, MCP storage, and Claude-specific settings UI. `ClaudeCommandCatalog` merges vault commands, vault skills, and runtime-supported commands behind the shared command catalog contract.
 - Codex adaptor: `src/providers/codex/` owns the `codex app-server` runtime, JSON-RPC transport, prompt encoding, raw live stream projection, JSONL history reload, settings reconciliation, normalization, skill cataloging, subagent storage, and Codex settings UI. `CodexSkillCatalog` provides `$` skill discovery from `.codex/skills/` and `.agents/skills/` without relying on runtime command discovery.
+- Hermes adaptor: `src/providers/hermes/` owns the Hermes Agent runtime over ACP (Agent Client Protocol) via stdio, SQLite-backed history hydration, multi-model provider support, and Hermes-specific settings UI. Follows the shared ACP infrastructure pattern.
 - Conversations: `Conversation` carries `providerId` and opaque `providerState`. Claude state is typed behind `ClaudeProviderState`. Codex state is typed behind `CodexProviderState` and currently stores `threadId`, `sessionFilePath`, and optional fork metadata.
 
 ## Commands
@@ -34,6 +35,7 @@ npm run test:coverage
 | **core** | Provider-neutral contracts and infrastructure | See [`src/core/CLAUDE.md`](src/core/CLAUDE.md) |
 | **providers/claude** | Claude SDK adaptor | See [`src/providers/claude/CLAUDE.md`](src/providers/claude/CLAUDE.md) |
 | **providers/codex** | Codex app-server adaptor | See [`src/providers/codex/CLAUDE.md`](src/providers/codex/CLAUDE.md) |
+| **providers/hermes** | Hermes Agent ACP adaptor | See [`src/providers/hermes/CLAUDE.md`](src/providers/hermes/CLAUDE.md) |
 | **features/chat** | Main sidebar interface | See [`src/features/chat/CLAUDE.md`](src/features/chat/CLAUDE.md) |
 | **features/inline-edit** | Inline edit modal and provider-backed edit services | `InlineEditModal` plus provider-owned inline edit services |
 | **features/settings** | Shared settings shell with provider tabs | General tab plus provider-owned Claude and Codex tab renderers |
@@ -68,6 +70,8 @@ Tests mirror the `src/` layout under `tests/unit/` and `tests/integration/`.
 | `.codex/agents/*.toml` | Codex vault subagent definitions |
 | `~/.claude/projects/{vault}/*.jsonl` | Claude-native transcripts |
 | `~/.codex/sessions/**/*.jsonl` | Codex-native transcripts |
+| `~/.hermes/state.db` | Hermes SQLite sessions and messages |
+| `~/.hermes/config.yaml` | Hermes configuration (model, provider) |
 
 ## Development Notes
 

--- a/src/providers/hermes/CLAUDE.md
+++ b/src/providers/hermes/CLAUDE.md
@@ -1,0 +1,28 @@
+# Hermes Provider
+
+Hermes Agent (Nous Research) provider — uses ACP (Agent Client Protocol) over stdio via the shared `src/providers/acp/` infrastructure.
+
+## Runtime
+
+- `HermesChatRuntime` wraps `AcpClientConnection` from shared ACP layer
+- Spawns `hermes acp` as a subprocess via `AcpSubprocess`
+- Maps ACP `session/update` notifications to Claudian `StreamChunk` types
+- Session management: `session/new`, `session/load`, `session/cancel`
+- Permission handling via ACP `session/request_permission`
+
+## History
+
+- Reads directly from Hermes SQLite database at `~/.hermes/state.db`
+- Schema version 11: `sessions` and `messages` tables
+- Session IDs: `YYYYMMDD_HHMMSS_<hex_suffix>` format
+
+## Models
+
+- Hermes supports 30+ model providers (Anthropic, OpenRouter, Nous Portal, etc.)
+- Model IDs use `provider/model` format via aggregators
+- Config at `~/.hermes/config.yaml` with `model.default` and `model.provider`
+
+## Dependencies
+
+- Shared ACP infrastructure: `src/providers/acp/`
+- Follows OpenCode provider pattern (also ACP-based)

--- a/src/providers/hermes/app/HermesRuntimeCommandLoader.ts
+++ b/src/providers/hermes/app/HermesRuntimeCommandLoader.ts
@@ -1,0 +1,45 @@
+import type {
+	ProviderRuntimeCommandLoader,
+	ProviderRuntimeCommandLoaderContext,
+} from '../../../core/providers/types';
+import { HermesChatRuntime } from '../runtime/HermesChatRuntime';
+import { getHermesProviderSettings } from '../settings';
+
+export class HermesRuntimeCommandLoader implements ProviderRuntimeCommandLoader {
+	isAvailable(settings: Record<string, unknown>): boolean {
+		return getHermesProviderSettings(settings).enabled;
+	}
+
+	async loadCommands(context: ProviderRuntimeCommandLoaderContext) {
+		if (!context.runtime && !context.conversation?.sessionId) {
+			if (!context.allowSessionCreation) {
+				return [];
+			}
+		}
+
+		const canReuseRuntime = context.runtime?.providerId === 'hermes'
+			&& !context.conversation?.sessionId;
+		const runtime = canReuseRuntime
+			? context.runtime!
+			: new HermesChatRuntime(context.plugin);
+
+		try {
+			if (context.conversation) {
+				runtime.syncConversationState(context.conversation, context.externalContextPaths);
+			}
+
+			const ready = await runtime.ensureReady({
+				allowSessionCreation: context.allowSessionCreation ?? false,
+			});
+			if (!ready) {
+				return [];
+			}
+
+			return await runtime.getSupportedCommands();
+		} finally {
+			if (runtime !== context.runtime) {
+				runtime.cleanup();
+			}
+		}
+	}
+}

--- a/src/providers/hermes/app/HermesWorkspaceServices.ts
+++ b/src/providers/hermes/app/HermesWorkspaceServices.ts
@@ -1,0 +1,54 @@
+import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
+import type {
+  ProviderTabWarmupPolicy,
+  ProviderWorkspaceRegistration,
+  ProviderWorkspaceServices,
+} from '../../../core/providers/types';
+import type { VaultFileAdapter } from '../../../core/storage/VaultFileAdapter';
+import type ClaudianPlugin from '../../../main';
+import { HermesCommandCatalog } from '../commands/HermesCommandCatalog';
+import { HermesCliResolver } from '../runtime/HermesCliResolver';
+import { getHermesProviderSettings } from '../settings';
+import { HermesSkillStorage } from '../storage/HermesSkillStorage';
+import { hermesSettingsTabRenderer } from '../ui/HermesSettingsTab';
+import { HermesRuntimeCommandLoader } from './HermesRuntimeCommandLoader';
+
+export interface HermesWorkspaceServices extends ProviderWorkspaceServices {
+  cliResolver: HermesCliResolver;
+}
+
+const hermesTabWarmupPolicy: ProviderTabWarmupPolicy = {
+  resolveMode() {
+    return 'commands';
+  },
+};
+
+export async function createHermesWorkspaceServices(
+  _vaultAdapter: VaultFileAdapter,
+  plugin?: ClaudianPlugin,
+): Promise<HermesWorkspaceServices> {
+  const getProfile = () => {
+    if (!plugin) return '';
+    const settings = plugin.settings as Record<string, unknown>;
+    return getHermesProviderSettings(settings).profile;
+  };
+
+  const skillStorage = new HermesSkillStorage(getProfile);
+  const commandCatalog = new HermesCommandCatalog(skillStorage);
+
+  return {
+    cliResolver: new HermesCliResolver(),
+    commandCatalog,
+    runtimeCommandLoader: new HermesRuntimeCommandLoader(),
+    settingsTabRenderer: hermesSettingsTabRenderer,
+    tabWarmupPolicy: hermesTabWarmupPolicy,
+  };
+}
+
+export const hermesWorkspaceRegistration: ProviderWorkspaceRegistration<HermesWorkspaceServices> = {
+  initialize: async ({ vaultAdapter, plugin }) => createHermesWorkspaceServices(vaultAdapter, plugin),
+};
+
+export function maybeGetHermesWorkspaceServices(): HermesWorkspaceServices | null {
+  return ProviderWorkspaceRegistry.getServices('hermes') as HermesWorkspaceServices | null;
+}

--- a/src/providers/hermes/auxiliary/HermesInlineEditService.ts
+++ b/src/providers/hermes/auxiliary/HermesInlineEditService.ts
@@ -1,0 +1,9 @@
+import { QueryBackedInlineEditService } from '../../../core/auxiliary/QueryBackedInlineEditService';
+import type ClaudianPlugin from '../../../main';
+import { HermesAuxQueryRunner } from '../runtime/HermesAuxQueryRunner';
+
+export class HermesInlineEditService extends QueryBackedInlineEditService {
+  constructor(plugin: ClaudianPlugin) {
+    super(new HermesAuxQueryRunner(plugin));
+  }
+}

--- a/src/providers/hermes/auxiliary/HermesInstructionRefineService.ts
+++ b/src/providers/hermes/auxiliary/HermesInstructionRefineService.ts
@@ -1,0 +1,9 @@
+import { QueryBackedInstructionRefineService } from '../../../core/auxiliary/QueryBackedInstructionRefineService';
+import type ClaudianPlugin from '../../../main';
+import { HermesAuxQueryRunner } from '../runtime/HermesAuxQueryRunner';
+
+export class HermesInstructionRefineService extends QueryBackedInstructionRefineService {
+  constructor(plugin: ClaudianPlugin) {
+    super(new HermesAuxQueryRunner(plugin));
+  }
+}

--- a/src/providers/hermes/auxiliary/HermesTaskResultInterpreter.ts
+++ b/src/providers/hermes/auxiliary/HermesTaskResultInterpreter.ts
@@ -1,0 +1,29 @@
+import type {
+  ProviderTaskResultInterpreter,
+  ProviderTaskTerminalStatus,
+} from '../../../core/providers/types';
+
+export class HermesTaskResultInterpreter implements ProviderTaskResultInterpreter {
+  hasAsyncLaunchMarker(_toolUseResult: unknown): boolean {
+    return false;
+  }
+
+  extractAgentId(_toolUseResult: unknown): string | null {
+    return null;
+  }
+
+  extractStructuredResult(_toolUseResult: unknown): string | null {
+    return null;
+  }
+
+  resolveTerminalStatus(
+    _toolUseResult: unknown,
+    fallbackStatus: ProviderTaskTerminalStatus,
+  ): ProviderTaskTerminalStatus {
+    return fallbackStatus;
+  }
+
+  extractTagValue(_payload: string, _tagName: string): string | null {
+    return null;
+  }
+}

--- a/src/providers/hermes/auxiliary/HermesTitleGenerationService.ts
+++ b/src/providers/hermes/auxiliary/HermesTitleGenerationService.ts
@@ -1,0 +1,24 @@
+import { QueryBackedTitleGenerationService } from '../../../core/auxiliary/QueryBackedTitleGenerationService';
+import type ClaudianPlugin from '../../../main';
+import { decodeHermesModelId } from '../models';
+import { HermesAuxQueryRunner } from '../runtime/HermesAuxQueryRunner';
+import { hermesChatUIConfig } from '../ui/HermesChatUIConfig';
+
+export class HermesTitleGenerationService extends QueryBackedTitleGenerationService {
+  constructor(plugin: ClaudianPlugin) {
+    super({
+      createRunner: () => new HermesAuxQueryRunner(plugin),
+      resolveModel: () => {
+        const settings = plugin.settings as unknown as Record<string, unknown>;
+        const titleModel = typeof settings.titleGenerationModel === 'string'
+          ? settings.titleGenerationModel
+          : '';
+        if (!hermesChatUIConfig.ownsModel(titleModel, settings)) {
+          return undefined;
+        }
+
+        return decodeHermesModelId(titleModel) ?? undefined;
+      },
+    });
+  }
+}

--- a/src/providers/hermes/capabilities.ts
+++ b/src/providers/hermes/capabilities.ts
@@ -1,0 +1,16 @@
+import type { ProviderCapabilities } from '../../core/providers/types';
+
+export const HERMES_PROVIDER_CAPABILITIES: Readonly<ProviderCapabilities> = Object.freeze({
+  providerId: 'hermes',
+  supportsPersistentRuntime: true,
+  supportsNativeHistory: true,
+  supportsPlanMode: true,
+  supportsRewind: false,
+  supportsFork: true,
+  supportsProviderCommands: true,
+  supportsImageAttachments: true,
+  supportsInstructionMode: true,
+  supportsMcpTools: true,
+  supportsTurnSteer: true,
+  reasoningControl: 'effort',
+});

--- a/src/providers/hermes/commands/HermesCommandCatalog.ts
+++ b/src/providers/hermes/commands/HermesCommandCatalog.ts
@@ -1,0 +1,119 @@
+import type {
+	ProviderCommandCatalog,
+	ProviderCommandDropdownConfig,
+} from '../../../core/providers/commands/ProviderCommandCatalog';
+import type { ProviderCommandEntry } from '../../../core/providers/commands/ProviderCommandEntry';
+import type { SlashCommand } from '../../../core/types';
+import type { HermesSkillStorage } from '../storage/HermesSkillStorage';
+
+function slashCommandToEntry(cmd: SlashCommand): ProviderCommandEntry {
+	const isSkill = cmd.kind === 'skill';
+	return {
+		id: cmd.id,
+		providerId: 'hermes',
+		kind: isSkill ? 'skill' : 'command',
+		name: cmd.name,
+		description: cmd.description,
+		content: cmd.content,
+		argumentHint: cmd.argumentHint,
+		allowedTools: cmd.allowedTools,
+		model: cmd.model,
+		disableModelInvocation: cmd.disableModelInvocation,
+		userInvocable: cmd.userInvocable,
+		context: cmd.context,
+		agent: cmd.agent,
+		hooks: cmd.hooks,
+		scope: cmd.source === 'sdk' ? 'runtime' : 'vault',
+		source: cmd.source ?? 'user',
+		isEditable: false,
+		isDeletable: false,
+		displayPrefix: '/',
+		insertPrefix: '/',
+	};
+}
+
+export class HermesCommandCatalog implements ProviderCommandCatalog {
+	private sdkCommands: SlashCommand[] = [];
+	private cachedVaultSkills: ProviderCommandEntry[] | null = null;
+	private vaultLoadPromise: Promise<void> | null = null;
+
+	constructor(
+		private readonly skillStorage?: HermesSkillStorage,
+	) {}
+
+	setRuntimeCommands(commands: SlashCommand[]): void {
+		this.sdkCommands = commands;
+	}
+
+	async listDropdownEntries(_context: { includeBuiltIns: boolean }): Promise<ProviderCommandEntry[]> {
+		const vaultSkills = await this.getVaultEntries();
+		const runtimeCommands = this.sdkCommands.map(slashCommandToEntry);
+
+		// Deduplicate by name: vault skills win
+		const seen = new Set<string>();
+		const merged: ProviderCommandEntry[] = [];
+
+		for (const entry of vaultSkills) {
+			seen.add(entry.name);
+			merged.push(entry);
+		}
+		for (const entry of runtimeCommands) {
+			if (!seen.has(entry.name)) {
+				merged.push(entry);
+			}
+		}
+
+		return merged;
+	}
+
+	async listVaultEntries(): Promise<ProviderCommandEntry[]> {
+		return this.getVaultEntries();
+	}
+
+	async saveVaultEntry(_entry: ProviderCommandEntry): Promise<void> {
+		// Hermes skill management is owned by the Hermes CLI
+	}
+
+	async deleteVaultEntry(_entry: ProviderCommandEntry): Promise<void> {
+		// Hermes skill management is owned by the Hermes CLI
+	}
+
+	getDropdownConfig(): ProviderCommandDropdownConfig {
+		return {
+			providerId: 'hermes',
+			triggerChars: ['/'],
+			builtInPrefix: '/',
+			skillPrefix: '/',
+			commandPrefix: '/',
+		};
+	}
+
+	async refresh(): Promise<void> {
+		this.cachedVaultSkills = null;
+	}
+
+	private async getVaultEntries(): Promise<ProviderCommandEntry[]> {
+		if (this.cachedVaultSkills !== null) {
+			return this.cachedVaultSkills;
+		}
+
+		if (!this.skillStorage) {
+			return [];
+		}
+
+		// Deduplicate concurrent loads
+		if (!this.vaultLoadPromise) {
+			this.vaultLoadPromise = this.loadVaultSkills().finally(() => {
+				this.vaultLoadPromise = null;
+			});
+		}
+		await this.vaultLoadPromise;
+		return this.cachedVaultSkills ?? [];
+	}
+
+	private async loadVaultSkills(): Promise<void> {
+		if (!this.skillStorage) return;
+		const skills = await this.skillStorage.loadAll();
+		this.cachedVaultSkills = skills.map(slashCommandToEntry);
+	}
+}

--- a/src/providers/hermes/env/HermesSettingsReconciler.ts
+++ b/src/providers/hermes/env/HermesSettingsReconciler.ts
@@ -1,0 +1,77 @@
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import type { ProviderSettingsReconciler } from '../../../core/providers/types';
+import type { Conversation } from '../../../core/types';
+import { parseEnvironmentVariables } from '../../../utils/env';
+import {
+  getHermesProviderSettings,
+  updateHermesProviderSettings,
+} from '../settings';
+import { getHermesProviderState } from '../types';
+
+const HERMES_ENV_HASH_KEYS = [
+  'HERMES_CONFIG',
+  'HERMES_DB',
+  'HERMES_HOME',
+] as const;
+
+function computeHermesEnvHash(envText: string): string {
+  const envVars = parseEnvironmentVariables(envText || '');
+  return HERMES_ENV_HASH_KEYS
+    .filter((key) => envVars[key])
+    .map((key) => `${key}=${envVars[key]}`)
+    .sort()
+    .join('|');
+}
+
+export const hermesSettingsReconciler: ProviderSettingsReconciler = {
+  handleEnvironmentChange(settings: Record<string, unknown>): boolean {
+    const envText = getRuntimeEnvironmentText(settings, 'hermes');
+    const currentHash = computeHermesEnvHash(envText);
+    const savedHash = getHermesProviderSettings(settings).environmentHash;
+
+    if (currentHash === savedHash) {
+      return false;
+    }
+
+    updateHermesProviderSettings(settings, { environmentHash: currentHash });
+    return true;
+  },
+
+  reconcileModelWithEnvironment(
+    settings: Record<string, unknown>,
+    conversations: Conversation[],
+  ): { changed: boolean; invalidatedConversations: Conversation[] } {
+    const envText = getRuntimeEnvironmentText(settings, 'hermes');
+    const currentHash = computeHermesEnvHash(envText);
+    const savedHash = getHermesProviderSettings(settings).environmentHash;
+
+    if (currentHash === savedHash) {
+      return { changed: false, invalidatedConversations: [] };
+    }
+
+    const invalidatedConversations: Conversation[] = [];
+    for (const conversation of conversations) {
+      if (conversation.providerId !== 'hermes') {
+        continue;
+      }
+
+      const state = getHermesProviderState(conversation.providerState);
+      if (!conversation.sessionId && !state.sessionId) {
+        continue;
+      }
+
+      conversation.sessionId = null;
+      conversation.providerState = undefined;
+      invalidatedConversations.push(conversation);
+    }
+
+    updateHermesProviderSettings(settings, { environmentHash: currentHash });
+    return { changed: true, invalidatedConversations };
+  },
+
+  normalizeModelVariantSettings(
+    _settings: Record<string, unknown>,
+  ): boolean {
+    return false;
+  },
+};

--- a/src/providers/hermes/history/HermesConversationHistoryService.ts
+++ b/src/providers/hermes/history/HermesConversationHistoryService.ts
@@ -1,0 +1,76 @@
+import type { ProviderConversationHistoryService } from '../../../core/providers/types';
+import type { Conversation } from '../../../core/types';
+import { getHermesProviderState } from '../types';
+import {
+  isHermesSessionHydrationDiagnosticMessage,
+  loadHermesSessionMessages,
+} from './HermesHistoryStore';
+
+export class HermesConversationHistoryService implements ProviderConversationHistoryService {
+  private hydratedKeys = new Map<string, string>();
+
+  async hydrateConversationHistory(
+    conversation: Conversation,
+    _vaultPath: string | null,
+  ): Promise<void> {
+    const state = getHermesProviderState(conversation.providerState);
+    const sessionId = state.sessionId ?? conversation.sessionId;
+    if (!sessionId) {
+      this.hydratedKeys.delete(conversation.id);
+      return;
+    }
+
+    const hydrationKey = sessionId;
+    if (
+      conversation.messages.length > 0
+      && this.hydratedKeys.get(conversation.id) === hydrationKey
+    ) {
+      return;
+    }
+
+    const messages = await loadHermesSessionMessages(sessionId);
+    if (messages.length === 0) {
+      this.hydratedKeys.delete(conversation.id);
+      return;
+    }
+
+    conversation.messages = messages;
+    if (
+      messages.length === 1
+      && isHermesSessionHydrationDiagnosticMessage(messages[0])
+    ) {
+      this.hydratedKeys.delete(conversation.id);
+      return;
+    }
+
+    this.hydratedKeys.set(conversation.id, hydrationKey);
+  }
+
+  async deleteConversationSession(
+    _conversation: Conversation,
+    _vaultPath: string | null,
+  ): Promise<void> {
+    // Never mutate Hermes native history.
+  }
+
+  resolveSessionIdForConversation(conversation: Conversation | null): string | null {
+    if (!conversation) {
+      return null;
+    }
+
+    const state = getHermesProviderState(conversation.providerState);
+    return state.sessionId ?? conversation.sessionId ?? null;
+  }
+
+  isPendingForkConversation(_conversation: Conversation): boolean {
+    return false;
+  }
+
+  buildForkProviderState(
+    _sourceSessionId: string,
+    _resumeAt: string,
+    _sourceProviderState?: Record<string, unknown>,
+  ): Record<string, unknown> {
+    return {};
+  }
+}

--- a/src/providers/hermes/history/HermesHistoryStore.ts
+++ b/src/providers/hermes/history/HermesHistoryStore.ts
@@ -1,0 +1,449 @@
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import type { ChatMessage, ContentBlock, ToolCallInfo } from '../../../core/types';
+
+type StoredRow = Record<string, unknown>;
+
+const HERMES_MESSAGE_ROW_SQL = buildHermesMessageRowsSql('?');
+const HERMES_SCHEMA_VERSION_SQL = 'SELECT schema_version FROM pragma_user_version;';
+const HERMES_HYDRATION_DIAGNOSTIC_ID_PREFIX = 'hermes-hydration-error';
+const HERMES_SUPPORTED_SCHEMA_VERSION = 11;
+
+interface SqliteModule {
+  DatabaseSync: new (location: string, options?: Record<string, unknown>) => {
+    close(): void;
+    prepare(sql: string): {
+      all(...params: unknown[]): StoredRow[];
+    };
+  };
+}
+
+interface HermesHydrationDiagnosticContext {
+  databasePath?: string;
+  sessionId?: string;
+}
+
+export function resolveExistingHermesDatabasePath(): string | null {
+  const home = os.homedir();
+  const dbPath = path.join(home, '.hermes', 'state.db');
+  if (fs.existsSync(dbPath)) {
+    return dbPath;
+  }
+
+  return null;
+}
+
+export async function loadHermesSessionMessages(
+  sessionId: string,
+): Promise<ChatMessage[]> {
+  const databasePath = resolveExistingHermesDatabasePath();
+  if (!databasePath || !fs.existsSync(databasePath)) {
+    return [];
+  }
+
+  const rows = await loadHermesSessionRows(databasePath, sessionId);
+  if (!rows) {
+    return [createHermesHydrationDiagnosticMessage({
+      databasePath,
+      reason: 'Could not read Hermes session rows from SQLite.',
+      sessionId,
+    })];
+  }
+
+  return mapHermesMessages(rows, { databasePath, sessionId });
+}
+
+export function mapHermesMessages(
+  rows: StoredRow[],
+  context: HermesHydrationDiagnosticContext = {},
+): ChatMessage[] {
+  const messages: ChatMessage[] = [];
+
+  for (const row of rows) {
+    try {
+      const mapped = mapHermesMessageRow(row, context);
+      if (mapped) {
+        messages.push(mapped);
+      }
+    } catch (error) {
+      messages.push(createHermesHydrationDiagnosticMessage({
+        ...context,
+        messageId: getString(row.id) ?? undefined,
+        reason: formatUnknownError(error),
+      }));
+    }
+  }
+
+  return mergeAdjacentAssistantMessages(messages);
+}
+
+export function isHermesSessionHydrationDiagnosticMessage(message: ChatMessage): boolean {
+  return message.id.startsWith(`${HERMES_HYDRATION_DIAGNOSTIC_ID_PREFIX}-session-`);
+}
+
+// ---------------------------------------------------------------------------
+// Row-to-message mapping
+// ---------------------------------------------------------------------------
+
+function mapHermesMessageRow(
+  row: StoredRow,
+  context: HermesHydrationDiagnosticContext,
+): ChatMessage | null {
+  const id = getString(row.id);
+  if (!id) {
+    return null;
+  }
+
+  const role = getString(row.role);
+  if (role === 'tool') {
+    return null;
+  }
+  if (role !== 'user' && role !== 'assistant') {
+    return null;
+  }
+
+  const timestamp = getNumber(row.timestamp) ?? Date.now();
+  const rawContent = row.content;
+  const content = resolveContentText(rawContent);
+  const toolCalls = role === 'assistant'
+    ? parseToolCalls(row.tool_calls)
+    : undefined;
+
+  if (role === 'user') {
+    return {
+      assistantMessageId: undefined,
+      content,
+      id,
+      role: 'user',
+      timestamp,
+      userMessageId: id,
+    };
+  }
+
+  const contentBlocks = buildAssistantContentBlocks(content, toolCalls);
+
+  return {
+    assistantMessageId: id,
+    content,
+    contentBlocks: contentBlocks.length > 0 ? contentBlocks : undefined,
+    id,
+    role: 'assistant',
+    timestamp,
+    toolCalls: toolCalls?.length ? toolCalls : undefined,
+  };
+}
+
+function resolveContentText(raw: unknown): string {
+  if (typeof raw === 'string') {
+    return raw;
+  }
+
+  if (Array.isArray(raw)) {
+    return raw
+      .filter((part): part is Record<string, unknown> =>
+        isPlainObject(part) && getString(part.type) === 'text',
+      )
+      .map((part) => getString(part.text) ?? '')
+      .join('');
+  }
+
+  return '';
+}
+
+function parseToolCalls(raw: unknown): ToolCallInfo[] | undefined {
+  if (!raw || typeof raw !== 'string') {
+    return undefined;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+
+  if (!Array.isArray(parsed)) {
+    return undefined;
+  }
+
+  const calls: ToolCallInfo[] = [];
+  for (const entry of parsed) {
+    if (!isPlainObject(entry)) {
+      continue;
+    }
+
+    const id = getString(entry.id) ?? getString(entry.tool_call_id);
+    const name = getString(entry.name) ?? getString(entry.tool_name);
+    if (!id || !name) {
+      continue;
+    }
+
+    calls.push({
+      id,
+      input: isPlainObject(entry.input) ? entry.input as Record<string, unknown> : {},
+      name,
+      result: getString(entry.result) ?? undefined,
+      status: mapToolStatus(getString(entry.status)),
+    });
+  }
+
+  return calls.length > 0 ? calls : undefined;
+}
+
+function buildAssistantContentBlocks(
+  textContent: string,
+  toolCalls?: ToolCallInfo[],
+): ContentBlock[] {
+  const blocks: ContentBlock[] = [];
+
+  if (textContent) {
+    blocks.push({ content: textContent, type: 'text' });
+  }
+
+  if (toolCalls) {
+    for (const tc of toolCalls) {
+      blocks.push({ toolId: tc.id, type: 'tool_use' });
+    }
+  }
+
+  return blocks;
+}
+
+function mapToolStatus(status: string | null): ToolCallInfo['status'] {
+  switch (status) {
+    case 'completed':
+      return 'completed';
+    case 'error':
+      return 'error';
+    default:
+      return 'running';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Adjacent assistant message merging
+// ---------------------------------------------------------------------------
+
+function mergeAdjacentAssistantMessages(messages: ChatMessage[]): ChatMessage[] {
+  const merged: ChatMessage[] = [];
+
+  for (const message of messages) {
+    const previous = merged[merged.length - 1];
+    if (
+      message.role === 'assistant'
+      && previous?.role === 'assistant'
+      && !message.isInterrupt
+      && !previous.isInterrupt
+      && !isHermesHydrationDiagnosticMessage(message)
+      && !isHermesHydrationDiagnosticMessage(previous)
+    ) {
+      previous.content += message.content;
+      previous.assistantMessageId = message.assistantMessageId ?? previous.assistantMessageId;
+      previous.toolCalls = mergeOptionalArrays(previous.toolCalls, message.toolCalls);
+      previous.contentBlocks = mergeOptionalArrays(previous.contentBlocks, message.contentBlocks);
+      continue;
+    }
+
+    merged.push(message);
+  }
+
+  return merged;
+}
+
+function mergeOptionalArrays<T>(left?: T[], right?: T[]): T[] | undefined {
+  if (!left?.length && !right?.length) {
+    return undefined;
+  }
+
+  return [
+    ...(left ?? []),
+    ...(right ?? []),
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostic messages
+// ---------------------------------------------------------------------------
+
+function createHermesHydrationDiagnosticMessage(params: {
+  databasePath?: string;
+  messageId?: string;
+  reason: string;
+  sessionId?: string;
+}): ChatMessage {
+  const detailLines = [
+    'Failed to hydrate Hermes session.',
+    'provider: Hermes',
+    ...(params.sessionId ? [`sessionId: ${params.sessionId}`] : []),
+    ...(params.databasePath ? [`databasePath: ${params.databasePath}`] : []),
+    ...(params.messageId ? [`messageId: ${params.messageId}`] : []),
+    `reason: ${params.reason}`,
+  ];
+  const content = detailLines.join('\n');
+
+  return {
+    assistantMessageId: undefined,
+    content,
+    contentBlocks: [{ content, type: 'text' }],
+    id: buildHermesHydrationDiagnosticId(params),
+    role: 'assistant',
+    timestamp: Date.now(),
+  };
+}
+
+function buildHermesHydrationDiagnosticId(params: {
+  messageId?: string;
+  sessionId?: string;
+}): string {
+  const scope = params.messageId ? 'message' : 'session';
+  const rawId = params.messageId ?? params.sessionId ?? String(Date.now());
+  const safeId = rawId.replace(/[^a-zA-Z0-9._-]/g, '-').slice(0, 120) || String(Date.now());
+  return `${HERMES_HYDRATION_DIAGNOSTIC_ID_PREFIX}-${scope}-${safeId}`;
+}
+
+function isHermesHydrationDiagnosticMessage(message: ChatMessage): boolean {
+  return message.id.startsWith(HERMES_HYDRATION_DIAGNOSTIC_ID_PREFIX);
+}
+
+// ---------------------------------------------------------------------------
+// SQLite access
+// ---------------------------------------------------------------------------
+
+async function loadSqliteModule(): Promise<SqliteModule | null> {
+  try {
+    return await import('node:sqlite');
+  } catch {
+    return null;
+  }
+}
+
+async function loadHermesSessionRows(
+  databasePath: string,
+  sessionId: string,
+): Promise<StoredRow[] | null> {
+  const viaNodeSqlite = await loadSessionRowsWithNodeSqlite(databasePath, sessionId);
+  if (viaNodeSqlite !== null) {
+    return viaNodeSqlite;
+  }
+
+  return loadSessionRowsWithSqliteCli(databasePath, sessionId);
+}
+
+async function loadSessionRowsWithNodeSqlite(
+  databasePath: string,
+  sessionId: string,
+): Promise<StoredRow[] | null> {
+  const sqlite = await loadSqliteModule();
+  if (!sqlite) {
+    return null;
+  }
+
+  let db: InstanceType<SqliteModule['DatabaseSync']> | null = null;
+  try {
+    db = new sqlite.DatabaseSync(databasePath, { readonly: true });
+
+    const versionRows = db.prepare(HERMES_SCHEMA_VERSION_SQL).all();
+    const schemaVersion = versionRows.length > 0
+      ? getNumber(versionRows[0].schema_version)
+      : null;
+    if (schemaVersion !== null && schemaVersion > HERMES_SUPPORTED_SCHEMA_VERSION) {
+      return null;
+    }
+
+    return db.prepare(HERMES_MESSAGE_ROW_SQL).all(sessionId);
+  } catch {
+    return null;
+  } finally {
+    db?.close();
+  }
+}
+
+function loadSessionRowsWithSqliteCli(
+  databasePath: string,
+  sessionId: string,
+): StoredRow[] | null {
+  const escapedSessionId = escapeSqlLiteral(sessionId);
+
+  const versionResult = runSqlite3JsonQuery(
+    databasePath,
+    HERMES_SCHEMA_VERSION_SQL,
+  );
+  if (versionResult && versionResult.length > 0) {
+    const schemaVersion = getNumber(versionResult[0].schema_version);
+    if (schemaVersion !== null && schemaVersion > HERMES_SUPPORTED_SCHEMA_VERSION) {
+      return null;
+    }
+  }
+
+  return runSqlite3JsonQuery(
+    databasePath,
+    buildHermesMessageRowsSql(`'${escapedSessionId}'`),
+  );
+}
+
+function runSqlite3JsonQuery(
+  databasePath: string,
+  sql: string,
+): StoredRow[] | null {
+  const result = spawnSync(
+    'sqlite3',
+    ['-json', databasePath, sql],
+    { encoding: 'utf8' },
+  );
+
+  if (result.error || result.status !== 0) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(result.stdout || '[]') as unknown;
+    return Array.isArray(parsed)
+      ? parsed.filter((row): row is StoredRow => isPlainObject(row))
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function escapeSqlLiteral(value: string): string {
+  return value.replaceAll('\'', '\'\'');
+}
+
+function buildHermesMessageRowsSql(sessionIdExpression: string): string {
+  return `
+select
+  id,
+  role,
+  content,
+  tool_calls,
+  tool_name,
+  tool_call_id,
+  timestamp,
+  token_count
+from messages
+where session_id = ${sessionIdExpression}
+order by timestamp asc, id asc;`.trim();
+}
+
+// ---------------------------------------------------------------------------
+// Generic helpers
+// ---------------------------------------------------------------------------
+
+function formatUnknownError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function getString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function getNumber(value: unknown): number | null {
+  return typeof value === 'number' ? value : null;
+}

--- a/src/providers/hermes/models.ts
+++ b/src/providers/hermes/models.ts
@@ -1,0 +1,132 @@
+export interface HermesDiscoveredModel {
+  description?: string;
+  label: string;
+  rawId: string;
+}
+
+export interface HermesModelVariant {
+  description?: string;
+  label: string;
+  value: string;
+}
+
+export interface HermesBaseModel {
+  description?: string;
+  label: string;
+  rawId: string;
+  variants: HermesModelVariant[];
+}
+
+export const HERMES_DEFAULT_THINKING_LEVEL = 'default';
+
+const HERMES_MODEL_PREFIX = 'hermes:';
+
+export function isHermesModelSelectionId(model: string): boolean {
+  return model === 'hermes' || model.startsWith(HERMES_MODEL_PREFIX);
+}
+
+export function encodeHermesModelId(rawModelId: string): string {
+  const normalized = rawModelId.trim();
+  return normalized ? `${HERMES_MODEL_PREFIX}${normalized}` : 'hermes';
+}
+
+export function decodeHermesModelId(model: string): string | null {
+  if (!model.startsWith(HERMES_MODEL_PREFIX)) {
+    return null;
+  }
+
+  const rawModelId = model.slice(HERMES_MODEL_PREFIX.length).trim();
+  return rawModelId || null;
+}
+
+export function normalizeHermesDiscoveredModels(
+  value: unknown,
+): HermesDiscoveredModel[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const normalized: HermesDiscoveredModel[] = [];
+  const seen = new Set<string>();
+  for (const entry of value as unknown[]) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      continue;
+    }
+    const record = entry as Record<string, unknown>;
+
+    const rawId = typeof record.rawId === 'string' ? record.rawId.trim() : '';
+    const label = typeof record.label === 'string' ? record.label.trim() : rawId;
+    const description = typeof record.description === 'string'
+      ? record.description.trim()
+      : '';
+
+    if (!rawId || seen.has(rawId)) {
+      continue;
+    }
+
+    seen.add(rawId);
+    normalized.push({
+      ...(description ? { description } : {}),
+      label: label || rawId,
+      rawId,
+    });
+  }
+
+  return normalized;
+}
+
+export function resolveHermesBaseModelRawId(rawId: string): string {
+  const normalizedRawId = rawId.trim();
+  if (!normalizedRawId) {
+    return '';
+  }
+  return normalizedRawId;
+}
+
+export function splitHermesModelLabel(label: string): {
+  modelLabel: string;
+  providerLabel: string;
+} {
+  const trimmed = label.trim();
+  const slashIndex = trimmed.indexOf('/');
+  if (slashIndex <= 0 || slashIndex >= trimmed.length - 1) {
+    return {
+      modelLabel: trimmed,
+      providerLabel: 'Other',
+    };
+  }
+
+  return {
+    modelLabel: trimmed.slice(slashIndex + 1).trim(),
+    providerLabel: trimmed.slice(0, slashIndex).trim(),
+  };
+}
+
+export function groupHermesDiscoveredModels(
+  models: HermesDiscoveredModel[],
+): { models: HermesDiscoveredModel[]; providerKey: string; providerLabel: string }[] {
+  const groups = new Map<string, { models: HermesDiscoveredModel[]; providerKey: string; providerLabel: string }>();
+
+  for (const model of models) {
+    const { providerLabel } = splitHermesModelLabel(model.label || model.rawId);
+    const providerKey = providerLabel.toLowerCase();
+    const existing = groups.get(providerKey);
+    if (existing) {
+      existing.models.push(model);
+      continue;
+    }
+
+    groups.set(providerKey, {
+      models: [model],
+      providerKey,
+      providerLabel,
+    });
+  }
+
+  return Array.from(groups.values())
+    .map((group) => ({
+      ...group,
+      models: [...group.models].sort((left, right) => left.label.localeCompare(right.label)),
+    }))
+    .sort((left, right) => left.providerLabel.localeCompare(right.providerLabel));
+}

--- a/src/providers/hermes/registration.ts
+++ b/src/providers/hermes/registration.ts
@@ -1,0 +1,27 @@
+import type { ProviderRegistration } from '../../core/providers/types';
+import { HermesInlineEditService } from './auxiliary/HermesInlineEditService';
+import { HermesInstructionRefineService } from './auxiliary/HermesInstructionRefineService';
+import { HermesTaskResultInterpreter } from './auxiliary/HermesTaskResultInterpreter';
+import { HermesTitleGenerationService } from './auxiliary/HermesTitleGenerationService';
+import { HERMES_PROVIDER_CAPABILITIES } from './capabilities';
+import { hermesSettingsReconciler } from './env/HermesSettingsReconciler';
+import { HermesConversationHistoryService } from './history/HermesConversationHistoryService';
+import { HermesChatRuntime } from './runtime/HermesChatRuntime';
+import { getHermesProviderSettings } from './settings';
+import { hermesChatUIConfig } from './ui/HermesChatUIConfig';
+
+export const hermesProviderRegistration: ProviderRegistration = {
+  blankTabOrder: 12,
+  capabilities: HERMES_PROVIDER_CAPABILITIES,
+  chatUIConfig: hermesChatUIConfig,
+  createInlineEditService: (plugin) => new HermesInlineEditService(plugin),
+  createInstructionRefineService: (plugin) => new HermesInstructionRefineService(plugin),
+  createRuntime: ({ plugin }) => new HermesChatRuntime(plugin),
+  createTitleGenerationService: (plugin) => new HermesTitleGenerationService(plugin),
+  displayName: 'Hermes',
+  environmentKeyPatterns: [/^HERMES_/i],
+  historyService: new HermesConversationHistoryService(),
+  isEnabled: (settings) => getHermesProviderSettings(settings).enabled,
+  settingsReconciler: hermesSettingsReconciler,
+  taskResultInterpreter: new HermesTaskResultInterpreter(),
+};

--- a/src/providers/hermes/runtime/HermesAuxQueryRunner.ts
+++ b/src/providers/hermes/runtime/HermesAuxQueryRunner.ts
@@ -1,0 +1,285 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import type { AuxQueryConfig, AuxQueryRunner } from '../../../core/auxiliary/AuxQueryRunner';
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import type ClaudianPlugin from '../../../main';
+import { getVaultPath } from '../../../utils/path';
+import {
+	AcpClientConnection,
+	AcpJsonRpcTransport,
+	type AcpReadTextFileRequest,
+	type AcpRequestPermissionRequest,
+	type AcpRequestPermissionResponse,
+	AcpSessionUpdateNormalizer,
+	AcpSubprocess,
+} from '../../acp';
+import { decodeHermesModelId } from '../models';
+
+export class HermesAuxQueryRunner implements AuxQueryRunner {
+	private connection: AcpClientConnection | null = null;
+	private currentModelId: string | null = null;
+	private currentLaunchKey: string | null = null;
+	private process: AcpSubprocess | null = null;
+	private readonly sessionCwds = new Map<string, string>();
+	private sessionId: string | null = null;
+	private readonly sessionUpdateNormalizer = new AcpSessionUpdateNormalizer();
+	private transport: AcpJsonRpcTransport | null = null;
+
+	constructor(
+		private readonly plugin: ClaudianPlugin,
+	) {}
+
+	async query(config: AuxQueryConfig, prompt: string): Promise<string> {
+		const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
+		await this.ensureReady(cwd);
+
+		if (!this.connection) {
+			throw new Error('Hermes runtime is not ready.');
+		}
+
+		if (!this.sessionId) {
+			const sessionId = await this.createSession(cwd);
+			if (!sessionId) {
+				throw new Error('Failed to create a Hermes session.');
+			}
+		}
+
+		const sessionId = this.sessionId!;
+		const selectedModel = this.resolveSelectedRawModel(config.model);
+		if (selectedModel && selectedModel !== this.currentModelId) {
+			await this.connection.setConfigOption({
+				configId: 'model',
+				sessionId,
+				type: 'select',
+				value: selectedModel,
+			});
+			this.currentModelId = selectedModel;
+		}
+
+		this.sessionUpdateNormalizer.reset();
+		let accumulatedText = '';
+		const removeListener = this.connection.onSessionNotification((notification) => {
+			if (notification.sessionId !== sessionId) {
+				return;
+			}
+
+			const normalized = this.sessionUpdateNormalizer.normalize(notification.update);
+			if (normalized.type !== 'message_chunk' || normalized.role !== 'assistant') {
+				return;
+			}
+
+			for (const chunk of normalized.streamChunks) {
+				if (chunk.type !== 'text') {
+					continue;
+				}
+
+				accumulatedText += chunk.content;
+				config.onTextChunk?.(accumulatedText);
+			}
+		});
+
+		const abortHandler = () => {
+			if (this.connection && this.sessionId) {
+				this.connection.cancel({ sessionId: this.sessionId });
+			}
+		};
+		config.abortController?.signal.addEventListener('abort', abortHandler, { once: true });
+
+		try {
+			if (config.abortController?.signal.aborted) {
+				throw new Error('Cancelled');
+			}
+
+			await this.connection.prompt({
+				prompt: [{ type: 'text', text: prompt }],
+				sessionId,
+			});
+
+			if (config.abortController?.signal.aborted) {
+				throw new Error('Cancelled');
+			}
+
+			return accumulatedText;
+		} catch (error) {
+			const message = error instanceof Error ? error.message : 'Hermes request failed';
+			const stderr = this.process?.getStderrSnapshot();
+			throw new Error(
+				stderr ? `${message}\n\n${stderr}` : message,
+				error instanceof Error ? { cause: error } : undefined,
+			);
+		} finally {
+			config.abortController?.signal.removeEventListener('abort', abortHandler);
+			removeListener();
+		}
+	}
+
+	reset(): void {
+		this.sessionId = null;
+		this.sessionCwds.clear();
+		this.currentModelId = null;
+		this.currentLaunchKey = null;
+		this.connection?.dispose();
+		this.connection = null;
+		this.transport?.dispose();
+		this.transport = null;
+		if (this.process) {
+			void this.process.shutdown().catch(() => {});
+		}
+		this.process = null;
+		this.sessionUpdateNormalizer.reset();
+	}
+
+	private async ensureReady(cwd: string): Promise<void> {
+		const resolvedCliPath = this.plugin.getResolvedProviderCliPath('hermes') ?? 'hermes';
+
+		const settings = this.plugin.settings as unknown as Record<string, unknown>;
+		const nextLaunchKey = JSON.stringify({
+			command: resolvedCliPath,
+			envText: getRuntimeEnvironmentText(settings, 'hermes'),
+		});
+
+		const shouldRestart = !this.process
+			|| !this.transport
+			|| !this.connection
+			|| !this.process.isAlive()
+			|| this.transport.isClosed
+			|| this.currentLaunchKey !== nextLaunchKey;
+
+		if (!shouldRestart) {
+			return;
+		}
+
+		this.reset();
+		await this.startProcess(resolvedCliPath, cwd);
+		this.currentLaunchKey = nextLaunchKey;
+	}
+
+	private async createSession(cwd: string): Promise<string | null> {
+		if (!this.connection) {
+			return null;
+		}
+
+		try {
+			const response = await this.connection.newSession({
+				cwd,
+				mcpServers: [],
+			});
+			this.sessionId = response.sessionId;
+			this.sessionCwds.set(response.sessionId, cwd);
+			return response.sessionId;
+		} catch {
+			return null;
+		}
+	}
+
+	private async startProcess(command: string, cwd: string): Promise<void> {
+		const processEnv: NodeJS.ProcessEnv = { ...process.env };
+
+		this.process = new AcpSubprocess({
+			args: ['acp', `--cwd=${cwd}`],
+			command,
+			cwd,
+			env: processEnv,
+		});
+		this.process.start();
+
+		this.transport = new AcpJsonRpcTransport({
+			input: this.process.stdout,
+			onClose: (listener) => this.process!.onClose(listener),
+			output: this.process.stdin,
+		});
+
+		this.connection = new AcpClientConnection({
+			clientInfo: {
+				name: 'claudian-aux',
+				version: this.plugin.manifest?.version ?? '0.0.0',
+			},
+			delegate: {
+				requestPermission: (request) => this.handlePermissionRequest(request),
+			},
+			transport: this.transport,
+		});
+
+		this.transport.start();
+		await this.connection.initialize();
+	}
+
+	private async handlePermissionRequest(
+		request: AcpRequestPermissionRequest,
+	): Promise<AcpRequestPermissionResponse> {
+		// Aux queries run autonomously; reject any permission prompts.
+		return selectPermissionOption(request.options, ['reject_once', 'reject_always']);
+	}
+
+	private async readTextFile(
+		request: AcpReadTextFileRequest,
+	): Promise<{ content: string }> {
+		const resolvedPath = this.resolveSessionPath(request.sessionId, request.path);
+		const content = await fs.readFile(resolvedPath, 'utf-8');
+
+		if (request.line === undefined && request.limit === undefined) {
+			return { content };
+		}
+
+		const lines = content.split(/\r?\n/);
+		const startIndex = Math.max(0, (request.line ?? 1) - 1);
+		const endIndex = request.limit
+			? startIndex + Math.max(0, request.limit)
+			: lines.length;
+
+		return {
+			content: lines.slice(startIndex, endIndex).join('\n'),
+		};
+	}
+
+	private resolveSelectedRawModel(explicitModel?: string): string | null {
+		if (!explicitModel) {
+			return null;
+		}
+
+		const trimmed = explicitModel.trim();
+		if (!trimmed) {
+			return null;
+		}
+
+		return decodeHermesModelId(trimmed) ?? trimmed;
+	}
+
+	private resolveSessionPath(sessionId: string, rawPath: string): string {
+		const cwd = this.sessionCwds.get(sessionId)
+			?? getVaultPath(this.plugin.app)
+			?? process.cwd();
+		const resolvedPath = path.isAbsolute(rawPath)
+			? path.resolve(rawPath)
+			: path.resolve(cwd, rawPath);
+		const relative = path.relative(cwd, resolvedPath);
+		if (relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))) {
+			return resolvedPath;
+		}
+
+		throw new Error('Hermes aux read access is limited to the current workspace.');
+	}
+}
+
+function selectPermissionOption(
+	options: readonly {
+		kind: 'allow_once' | 'allow_always' | 'reject_once' | 'reject_always';
+		optionId: string;
+	}[],
+	preferredKinds: readonly ('allow_once' | 'allow_always' | 'reject_once' | 'reject_always')[],
+): AcpRequestPermissionResponse {
+	for (const kind of preferredKinds) {
+		const option = options.find((entry) => entry.kind === kind);
+		if (option) {
+			return {
+				outcome: {
+					optionId: option.optionId,
+					outcome: 'selected',
+				},
+			};
+		}
+	}
+
+	return { outcome: { outcome: 'cancelled' } };
+}

--- a/src/providers/hermes/runtime/HermesChatRuntime.ts
+++ b/src/providers/hermes/runtime/HermesChatRuntime.ts
@@ -1,0 +1,898 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import type { ProviderCapabilities } from '../../../core/providers/types';
+import type { ChatRuntime } from '../../../core/runtime/ChatRuntime';
+import type {
+	ApprovalCallback,
+	ApprovalDecisionOption,
+	AskUserQuestionCallback,
+	AutoTurnCallback,
+	ChatRewindMode,
+	ChatRewindResult,
+	ChatRuntimeConversationState,
+	ChatRuntimeEnsureReadyOptions,
+	ChatRuntimeQueryOptions,
+	ChatTurnMetadata,
+	ChatTurnRequest,
+	ExitPlanModeCallback,
+	PreparedChatTurn,
+	SessionUpdateResult,
+	SubagentRuntimeState,
+} from '../../../core/runtime/types';
+import type {
+	ApprovalDecision,
+	ChatMessage,
+	Conversation,
+	SlashCommand,
+	StreamChunk,
+	ToolCallInfo,
+} from '../../../core/types';
+import type ClaudianPlugin from '../../../main';
+import { getEnhancedPath } from '../../../utils/env';
+import { getVaultPath } from '../../../utils/path';
+import {
+	AcpClientConnection,
+	AcpJsonRpcTransport,
+	type AcpReadTextFileRequest,
+	type AcpRequestPermissionRequest,
+	type AcpRequestPermissionResponse,
+	type AcpSessionNotification,
+	AcpSessionUpdateNormalizer,
+	AcpSubprocess,
+	type AcpUsage,
+	type AcpUsageUpdate,
+	type AcpWriteTextFileRequest,
+	buildAcpUsageInfo,
+} from '../../acp';
+import { HERMES_PROVIDER_CAPABILITIES } from '../capabilities';
+import {
+	decodeHermesModelId,
+	isHermesModelSelectionId,
+} from '../models';
+import { getHermesProviderSettings } from '../settings';
+import { getHermesProviderState, type HermesProviderState } from '../types';
+
+interface ActiveTurn {
+	queue: StreamChunkQueue;
+	sessionId: string;
+}
+
+class StreamChunkQueue {
+	private closed = false;
+	private readonly items: StreamChunk[] = [];
+	private readonly waiters: Array<(chunk: StreamChunk | null) => void> = [];
+
+	push(chunk: StreamChunk): void {
+		const waiter = this.waiters.shift();
+		if (waiter) {
+			waiter(chunk);
+			return;
+		}
+		this.items.push(chunk);
+	}
+
+	close(): void {
+		if (this.closed) {
+			return;
+		}
+
+		this.closed = true;
+		while (this.waiters.length > 0) {
+			this.waiters.shift()?.(null);
+		}
+	}
+
+	async next(): Promise<StreamChunk | null> {
+		if (this.items.length > 0) {
+			return this.items.shift() ?? null;
+		}
+
+		if (this.closed) {
+			return null;
+		}
+
+		return new Promise<StreamChunk | null>((resolve) => {
+			this.waiters.push(resolve);
+		});
+	}
+}
+
+export class HermesChatRuntime implements ChatRuntime {
+	readonly providerId = 'hermes' as const;
+
+	private activeTurn: ActiveTurn | null = null;
+	private approvalCallback: ApprovalCallback | null = null;
+	private connection: AcpClientConnection | null = null;
+	private contextUsage: AcpUsageUpdate | null = null;
+	private currentLaunchKey: string | null = null;
+	private currentSessionModelId: string | null = null;
+	private currentTurnMetadata: ChatTurnMetadata = {};
+	private loadedSessionId: string | null = null;
+	private process: AcpSubprocess | null = null;
+	private promptUsage: AcpUsage | null = null;
+	private readonly readyListeners: Array<(ready: boolean) => void> = [];
+	private ready = false;
+	private sessionInvalidated = false;
+	private readonly supportedCommandWaiters: Array<(commands: SlashCommand[]) => void> = [];
+	private supportedCommands: SlashCommand[] = [];
+	private sessionCwds = new Map<string, string>();
+	private sessionId: string | null = null;
+	private readonly sessionUpdateNormalizer = new AcpSessionUpdateNormalizer();
+	private transport: AcpJsonRpcTransport | null = null;
+	private unregisterTransportClose: (() => void) | null = null;
+
+	constructor(
+		private readonly plugin: ClaudianPlugin,
+	) {}
+
+	getCapabilities(): Readonly<ProviderCapabilities> {
+		return HERMES_PROVIDER_CAPABILITIES;
+	}
+
+	prepareTurn(request: ChatTurnRequest): PreparedChatTurn {
+		return {
+			isCompact: false,
+			mcpMentions: request.enabledMcpServers ?? new Set(),
+			persistedContent: '',
+			prompt: request.text,
+			request,
+		};
+	}
+
+	onReadyStateChange(listener: (ready: boolean) => void): () => void {
+		this.readyListeners.push(listener);
+		return () => {
+			const index = this.readyListeners.indexOf(listener);
+			if (index >= 0) {
+				this.readyListeners.splice(index, 1);
+			}
+		};
+	}
+
+	setResumeCheckpoint(_checkpointId: string | undefined): void {}
+
+	syncConversationState(
+		conversation: ChatRuntimeConversationState | null,
+	): void {
+		const nextSessionId = conversation?.sessionId ?? null;
+		if (this.sessionId !== nextSessionId) {
+			this.currentSessionModelId = null;
+			this.sessionInvalidated = false;
+			this.setSupportedCommands([]);
+		}
+		this.sessionId = nextSessionId;
+	}
+
+	async reloadMcpServers(): Promise<void> {}
+
+	async ensureReady(options?: ChatRuntimeEnsureReadyOptions): Promise<boolean> {
+		const settings = getHermesProviderSettings(this.plugin.settings);
+		if (!settings.enabled) {
+			this.setReady(false);
+			return false;
+		}
+
+		const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
+		const targetSessionId = this.sessionId;
+		const resolvedCliPath = this.plugin.getResolvedProviderCliPath('hermes') ?? 'hermes';
+
+		const nextLaunchKey = JSON.stringify({
+			command: resolvedCliPath,
+			envText: getRuntimeEnvironmentText(this.plugin.settings, 'hermes'),
+			profile: settings.profile,
+		});
+
+		const shouldRestart = !this.process
+			|| !this.transport
+			|| !this.connection
+			|| !this.process.isAlive()
+			|| this.transport.isClosed
+			|| options?.force === true
+			|| this.currentLaunchKey !== nextLaunchKey;
+
+		if (shouldRestart) {
+			await this.shutdownProcess();
+			await this.startProcess({
+				command: resolvedCliPath,
+				cwd,
+			});
+			this.currentLaunchKey = nextLaunchKey;
+			this.loadedSessionId = null;
+		}
+
+		if (targetSessionId) {
+			if (this.loadedSessionId !== targetSessionId) {
+				const loaded = await this.loadSession(targetSessionId, cwd);
+				if (!loaded) {
+					this.sessionInvalidated = true;
+					this.clearActiveSession();
+				}
+			}
+			return true;
+		}
+
+		if (!this.sessionId && !this.sessionInvalidated) {
+			if (options?.allowSessionCreation === false) {
+				return true;
+			}
+			return Boolean(await this.createSession(cwd));
+		}
+
+		return true;
+	}
+
+	async *query(
+		turn: PreparedChatTurn,
+		conversationHistory?: ChatMessage[],
+		queryOptions?: ChatRuntimeQueryOptions,
+	): AsyncGenerator<StreamChunk> {
+
+		if (!(await this.ensureReady())) {
+			yield { type: 'error', content: 'Failed to start Hermes. Check the CLI path and login state.' };
+			yield { type: 'done' };
+			return;
+		}
+
+		if (!this.connection) {
+			yield { type: 'error', content: 'Hermes runtime is not ready.' };
+			yield { type: 'done' };
+			return;
+		}
+
+		const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
+
+		if (!this.sessionId) {
+			const sessionId = await this.createSession(cwd);
+			if (!sessionId) {
+				yield { type: 'error', content: 'Failed to create a Hermes session.' };
+				yield { type: 'done' };
+				return;
+			}
+		}
+
+		const sessionId = this.sessionId!;
+		this.activeTurn?.queue.close();
+		this.activeTurn = {
+			queue: new StreamChunkQueue(),
+			sessionId,
+		};
+		this.currentTurnMetadata = {};
+		this.contextUsage = null;
+		this.promptUsage = null;
+		this.sessionUpdateNormalizer.reset();
+
+		const activeTurn = this.activeTurn;
+		try {
+			await this.applySelectedModel(sessionId, queryOptions);
+		} catch (error) {
+			yield {
+				type: 'error',
+				content: this.formatRuntimeError(error),
+			};
+			yield { type: 'done' };
+			activeTurn.queue.close();
+			this.activeTurn = null;
+			return;
+		}
+
+		const promptPromise = this.connection.prompt({
+			prompt: [{ type: 'text', text: turn.prompt }],
+			sessionId,
+		}).then((response) => {
+			if (response.userMessageId) {
+				this.currentTurnMetadata.userMessageId = response.userMessageId;
+			}
+			this.promptUsage = response.usage ?? null;
+
+			const usage = buildAcpUsageInfo({
+				contextWindow: this.contextUsage,
+				model: this.getActiveDisplayModel(queryOptions),
+				promptUsage: this.promptUsage,
+			});
+			if (usage) {
+				activeTurn.queue.push({ sessionId, type: 'usage', usage });
+			}
+
+			activeTurn.queue.push({ type: 'done' });
+			activeTurn.queue.close();
+		}).catch((error) => {
+			activeTurn.queue.push({
+				type: 'error',
+				content: this.formatRuntimeError(error),
+			});
+			activeTurn.queue.push({ type: 'done' });
+			activeTurn.queue.close();
+		}).finally(() => {
+			if (this.activeTurn === activeTurn) {
+				this.activeTurn = null;
+			}
+		});
+
+		try {
+			while (true) {
+				const chunk = await activeTurn.queue.next();
+				if (!chunk) {
+					break;
+				}
+				yield chunk;
+			}
+			await promptPromise;
+		} finally {
+			if (this.activeTurn === activeTurn) {
+				this.activeTurn = null;
+			}
+		}
+	}
+
+	cancel(): void {
+		if (this.connection && this.sessionId) {
+			this.connection.cancel({ sessionId: this.sessionId });
+		}
+	}
+
+	resetSession(): void {
+		this.clearActiveSession();
+		this.sessionInvalidated = false;
+	}
+
+	getSessionId(): string | null {
+		return this.sessionId;
+	}
+
+	consumeSessionInvalidation(): boolean {
+		const invalidated = this.sessionInvalidated;
+		this.sessionInvalidated = false;
+		return invalidated;
+	}
+
+	isReady(): boolean {
+		return this.ready;
+	}
+
+	async getSupportedCommands(): Promise<SlashCommand[]> {
+		if (this.supportedCommands.length > 0 && this.loadedSessionId === this.sessionId) {
+			return [...this.supportedCommands];
+		}
+
+		if (this.sessionId && this.loadedSessionId !== this.sessionId) {
+			const ready = await this.ensureReady({ allowSessionCreation: false });
+			if (!ready) {
+				return [];
+			}
+		}
+
+		if (!this.sessionId) {
+			return [];
+		}
+
+		if (this.supportedCommands.length > 0) {
+			return [...this.supportedCommands];
+		}
+
+		if (!this.sessionId || this.loadedSessionId !== this.sessionId) {
+			return [];
+		}
+
+		return this.waitForSupportedCommands();
+	}
+
+	cleanup(): void {
+		this.activeTurn?.queue.close();
+		void this.shutdownProcess();
+	}
+
+	async rewind(
+		_userMessageId: string,
+		_assistantMessageId: string,
+		_mode?: ChatRewindMode,
+	): Promise<ChatRewindResult> {
+		return { canRewind: false };
+	}
+
+	setApprovalCallback(callback: ApprovalCallback | null): void {
+		this.approvalCallback = callback;
+	}
+
+	setApprovalDismisser(_dismisser: (() => void) | null): void {}
+
+	setAskUserQuestionCallback(_callback: AskUserQuestionCallback | null): void {}
+
+	setExitPlanModeCallback(_callback: ExitPlanModeCallback | null): void {}
+
+	setPermissionModeSyncCallback(_callback: ((sdkMode: string) => void) | null): void {}
+
+	setSubagentHookProvider(_getState: () => SubagentRuntimeState): void {}
+
+	setAutoTurnCallback(_callback: AutoTurnCallback | null): void {}
+
+	consumeTurnMetadata(): ChatTurnMetadata {
+		const metadata = this.currentTurnMetadata;
+		this.currentTurnMetadata = {};
+		return metadata;
+	}
+
+	buildSessionUpdates(params: {
+		conversation: Conversation | null;
+		sessionInvalidated: boolean;
+	}): SessionUpdateResult {
+		const providerState: HermesProviderState = {};
+		const updates: Partial<Conversation> = {
+			providerState: undefined,
+			sessionId: this.sessionId,
+		};
+
+		if (this.sessionId) {
+			providerState.sessionId = this.sessionId;
+		}
+
+		if (Object.keys(providerState).length > 0) {
+			updates.providerState = providerState as Record<string, unknown>;
+		}
+
+		if (params.sessionInvalidated) {
+			if (!this.sessionId) {
+				updates.providerState = undefined;
+				updates.sessionId = null;
+			}
+		}
+
+		return { updates };
+	}
+
+	resolveSessionIdForFork(conversation: Conversation | null): string | null {
+		const state = conversation?.providerState
+			? getHermesProviderState(conversation.providerState)
+			: null;
+		return this.sessionId ?? state?.sessionId ?? conversation?.sessionId ?? null;
+	}
+
+	async loadSubagentToolCalls(_agentId: string): Promise<ToolCallInfo[]> {
+		return [];
+	}
+
+	async loadSubagentFinalResult(_agentId: string): Promise<string | null> {
+		return null;
+	}
+
+	private async startProcess(params: {
+		command: string;
+		cwd: string;
+	}): Promise<void> {
+		const processEnv: NodeJS.ProcessEnv = {
+			...process.env,
+			PATH: getEnhancedPath(
+				process.env.PATH,
+				path.isAbsolute(params.command) ? params.command : undefined,
+			),
+		};
+
+		const hermesSettings = getHermesProviderSettings(this.plugin.settings);
+		const args = ['acp'];
+		if (hermesSettings.profile) {
+			args.push('--profile', hermesSettings.profile);
+		}
+
+		this.process = new AcpSubprocess({
+			args,
+			command: params.command,
+			cwd: params.cwd,
+			env: processEnv,
+		});
+		this.process.start();
+
+		this.transport = new AcpJsonRpcTransport({
+			input: this.process.stdout,
+			onClose: (listener) => this.process!.onClose(listener),
+			output: this.process.stdin,
+		});
+		const transport = this.transport;
+		this.unregisterTransportClose = transport.onClose(() => {
+			if (this.transport === transport) {
+				this.setReady(false);
+			}
+		});
+
+		this.connection = new AcpClientConnection({
+			clientInfo: {
+				name: 'claudian',
+				version: this.plugin.manifest?.version ?? '0.0.0',
+			},
+			delegate: {
+				fileSystem: {
+					readTextFile: (request) => this.readTextFile(request),
+					writeTextFile: (request) => this.writeTextFile(request),
+				},
+				onSessionNotification: (notification) => this.handleSessionNotification(notification),
+				requestPermission: (request) => this.handlePermissionRequest(request),
+			},
+			transport: this.transport,
+		});
+
+		this.transport.start();
+		await this.connection.initialize();
+		this.setReady(true);
+	}
+
+	private async shutdownProcess(): Promise<void> {
+		this.setReady(false);
+		this.activeTurn?.queue.close();
+		this.activeTurn = null;
+		this.currentSessionModelId = null;
+		this.setSupportedCommands([]);
+
+		this.unregisterTransportClose?.();
+		this.unregisterTransportClose = null;
+
+		this.connection?.dispose();
+		this.connection = null;
+
+		this.transport?.dispose();
+		this.transport = null;
+
+		if (this.process) {
+			await this.process.shutdown().catch(() => {});
+			this.process = null;
+		}
+	}
+
+	private setReady(ready: boolean): void {
+		if (this.ready === ready) {
+			return;
+		}
+
+		this.ready = ready;
+		for (const listener of this.readyListeners) {
+			listener(ready);
+		}
+	}
+
+	private async applySelectedModel(
+		sessionId: string,
+		queryOptions?: ChatRuntimeQueryOptions,
+	): Promise<void> {
+		if (!this.connection) {
+			return;
+		}
+
+		const selectedRawModelId = this.resolveSelectedRawModelId(queryOptions);
+		if (!selectedRawModelId || selectedRawModelId === this.currentSessionModelId) {
+			return;
+		}
+
+		await this.connection.setConfigOption({
+			configId: 'model',
+			sessionId,
+			type: 'select',
+			value: selectedRawModelId,
+		});
+		this.currentSessionModelId = selectedRawModelId;
+	}
+
+	private resolveSelectedRawModelId(queryOptions?: ChatRuntimeQueryOptions): string | null {
+		const providerSettings = this.plugin.settings as unknown as Record<string, unknown>;
+		const hermesSettings = getHermesProviderSettings(providerSettings);
+		const selectedModel = typeof queryOptions?.model === 'string'
+			? queryOptions.model
+			: typeof (providerSettings as Record<string, unknown>).model === 'string'
+				? (providerSettings as Record<string, unknown>).model as string
+				: '';
+
+		if (!selectedModel || !isHermesModelSelectionId(selectedModel)) {
+			return null;
+		}
+
+		const decoded = decodeHermesModelId(selectedModel);
+		if (!decoded) {
+			return null;
+		}
+
+		const availableModelIds = new Set(hermesSettings.discoveredModels.map((model) => model.rawId));
+		if (availableModelIds.size > 0 && !availableModelIds.has(decoded)) {
+			return null;
+		}
+
+		return decoded;
+	}
+
+	private getActiveDisplayModel(queryOptions?: ChatRuntimeQueryOptions): string | undefined {
+		const selectedRawModelId = this.resolveSelectedRawModelId(queryOptions);
+		if (selectedRawModelId) {
+			return `hermes:${selectedRawModelId}`;
+		}
+
+		return this.currentSessionModelId
+			? `hermes:${this.currentSessionModelId}`
+			: undefined;
+	}
+
+	private async createSession(cwd: string): Promise<string | null> {
+		if (!this.connection) {
+			return null;
+		}
+
+		try {
+			this.setSupportedCommands([]);
+			const response = await this.connection.newSession({
+				cwd,
+				mcpServers: [],
+			});
+			this.loadedSessionId = response.sessionId;
+			this.sessionId = response.sessionId;
+			this.sessionCwds.set(response.sessionId, cwd);
+			return response.sessionId;
+		} catch {
+			return null;
+		}
+	}
+
+	private async loadSession(sessionId: string, cwd: string): Promise<boolean> {
+		if (!this.connection) {
+			return false;
+		}
+
+		try {
+			this.setSupportedCommands([]);
+			const response = await this.connection.loadSession({
+				cwd,
+				mcpServers: [],
+				sessionId,
+			});
+			this.sessionInvalidated = false;
+			this.loadedSessionId = response.sessionId;
+			this.sessionId = response.sessionId;
+			this.sessionCwds.set(response.sessionId, cwd);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	private async handleSessionNotification(
+		notification: AcpSessionNotification,
+	): Promise<void> {
+		if (notification.sessionId !== this.sessionId) {
+			return;
+		}
+
+		const normalized = this.sessionUpdateNormalizer.normalize(notification.update);
+
+		if (normalized.type === 'commands') {
+			this.setSupportedCommands(normalized.commands);
+			return;
+		}
+
+		if (!this.activeTurn || this.activeTurn.sessionId !== notification.sessionId) {
+			return;
+		}
+
+		switch (normalized.type) {
+			case 'message_chunk': {
+				if (normalized.role === 'assistant' && normalized.messageId) {
+					this.currentTurnMetadata.assistantMessageId = normalized.messageId;
+				}
+				if (normalized.role === 'user' && normalized.messageId) {
+					this.currentTurnMetadata.userMessageId = normalized.messageId;
+				}
+				for (const chunk of normalized.streamChunks) {
+					this.activeTurn.queue.push(chunk);
+				}
+				return;
+			}
+			case 'tool_call':
+			case 'tool_call_update': {
+				for (const chunk of normalized.streamChunks) {
+					this.activeTurn.queue.push(chunk);
+				}
+				return;
+			}
+			case 'usage': {
+				this.contextUsage = normalized.usage;
+				const usage = buildAcpUsageInfo({
+					contextWindow: normalized.usage,
+					model: this.getActiveDisplayModel(),
+					promptUsage: this.promptUsage,
+				});
+				if (usage) {
+					this.activeTurn.queue.push({
+						sessionId: notification.sessionId,
+						type: 'usage',
+						usage,
+					});
+				}
+				return;
+			}
+			default:
+				return;
+		}
+	}
+
+	private async handlePermissionRequest(
+		request: AcpRequestPermissionRequest,
+	): Promise<AcpRequestPermissionResponse> {
+		if (!this.approvalCallback) {
+			return { outcome: { outcome: 'cancelled' } };
+		}
+
+		const input = normalizeApprovalInput(request.toolCall.rawInput);
+		const toolName = request.toolCall.title || 'tool';
+		const description = `Hermes wants permission to use ${toolName}.`;
+		const decision = await this.approvalCallback(
+			toolName,
+			input,
+			description,
+			{
+				decisionOptions: buildAcpApprovalDecisionOptions(request.options),
+			},
+		);
+
+		return mapApprovalDecision(decision, request.options);
+	}
+
+	private async readTextFile(
+		request: AcpReadTextFileRequest,
+	): Promise<{ content: string }> {
+		const resolvedPath = this.resolveSessionPath(request.sessionId, request.path);
+		const content = await fs.readFile(resolvedPath, 'utf-8');
+
+		if (request.line === undefined && request.limit === undefined) {
+			return { content };
+		}
+
+		const lines = content.split(/\r?\n/);
+		const startIndex = Math.max(0, (request.line ?? 1) - 1);
+		const endIndex = request.limit
+			? startIndex + Math.max(0, request.limit)
+			: lines.length;
+
+		return {
+			content: lines.slice(startIndex, endIndex).join('\n'),
+		};
+	}
+
+	private async writeTextFile(
+		request: AcpWriteTextFileRequest,
+	): Promise<Record<string, never>> {
+		const resolvedPath = this.resolveSessionPath(request.sessionId, request.path);
+		await fs.mkdir(path.dirname(resolvedPath), { recursive: true });
+		await fs.writeFile(resolvedPath, request.content, 'utf-8');
+		return {};
+	}
+
+	private resolveSessionPath(sessionId: string, rawPath: string): string {
+		if (path.isAbsolute(rawPath)) {
+			return rawPath;
+		}
+
+		const cwd = this.sessionCwds.get(sessionId)
+			?? getVaultPath(this.plugin.app)
+			?? process.cwd();
+		return path.resolve(cwd, rawPath);
+	}
+
+	private formatRuntimeError(error: unknown): string {
+		const baseMessage = error instanceof Error ? error.message : 'Hermes request failed';
+		const stderr = this.process?.getStderrSnapshot();
+		return stderr ? `${baseMessage}\n\n${stderr}` : baseMessage;
+	}
+
+	private clearActiveSession(): void {
+		this.sessionId = null;
+		this.loadedSessionId = null;
+		this.currentSessionModelId = null;
+		this.setSupportedCommands([]);
+	}
+
+	private setSupportedCommands(commands: SlashCommand[]): void {
+		this.supportedCommands = commands.map((command) => ({ ...command }));
+
+		const waiters = this.supportedCommandWaiters.splice(0);
+		for (const waiter of waiters) {
+			waiter(this.supportedCommands);
+		}
+	}
+
+	private waitForSupportedCommands(timeoutMs = 250): Promise<SlashCommand[]> {
+		if (this.supportedCommands.length > 0) {
+			return Promise.resolve([...this.supportedCommands]);
+		}
+
+		return new Promise<SlashCommand[]>((resolve) => {
+			const waiter = (commands: SlashCommand[]) => {
+				window.clearTimeout(timeoutId);
+				resolve([...commands]);
+			};
+			const timeoutId = window.setTimeout(() => {
+				const index = this.supportedCommandWaiters.indexOf(waiter);
+				if (index >= 0) {
+					this.supportedCommandWaiters.splice(index, 1);
+				}
+				resolve([...this.supportedCommands]);
+			}, timeoutMs);
+
+			this.supportedCommandWaiters.push(waiter);
+		});
+	}
+}
+
+function normalizeApprovalInput(rawInput: unknown): Record<string, unknown> {
+	if (rawInput && typeof rawInput === 'object' && !Array.isArray(rawInput)) {
+		return rawInput as Record<string, unknown>;
+	}
+	if (rawInput === undefined) {
+		return {};
+	}
+	return { value: rawInput };
+}
+
+function mapApprovalDecision(
+	decision: ApprovalDecision,
+	options: readonly {
+		kind: 'allow_once' | 'allow_always' | 'reject_once' | 'reject_always';
+		optionId: string;
+	}[],
+): AcpRequestPermissionResponse {
+	if (decision === 'allow') {
+		return selectPermissionOption(options, ['allow_once', 'allow_always']);
+	}
+
+	if (decision === 'allow-always') {
+		return selectPermissionOption(options, ['allow_always', 'allow_once']);
+	}
+
+	if (decision === 'deny') {
+		return selectPermissionOption(options, ['reject_once', 'reject_always']);
+	}
+
+	if (typeof decision === 'object' && decision.type === 'select-option') {
+		return {
+			outcome: {
+				optionId: decision.value,
+				outcome: 'selected',
+			},
+		};
+	}
+
+	return { outcome: { outcome: 'cancelled' } };
+}
+
+function buildAcpApprovalDecisionOptions(
+	options: readonly {
+		kind: 'allow_once' | 'allow_always' | 'reject_once' | 'reject_always';
+		name: string;
+		optionId: string;
+	}[],
+): ApprovalDecisionOption[] {
+	return options.map((option) => ({
+		...(option.kind === 'allow_once'
+			? { decision: 'allow' as const }
+			: option.kind === 'allow_always'
+				? { decision: 'allow-always' as const }
+				: {}),
+		label: option.name,
+		value: option.optionId,
+	}));
+}
+
+function selectPermissionOption(
+	options: readonly {
+		kind: 'allow_once' | 'allow_always' | 'reject_once' | 'reject_always';
+		optionId: string;
+	}[],
+	preferredKinds: readonly ('allow_once' | 'allow_always' | 'reject_once' | 'reject_always')[],
+): AcpRequestPermissionResponse {
+	for (const kind of preferredKinds) {
+		const option = options.find((entry) => entry.kind === kind);
+		if (option) {
+			return {
+				outcome: {
+					optionId: option.optionId,
+					outcome: 'selected',
+				},
+			};
+		}
+	}
+
+	return { outcome: { outcome: 'cancelled' } };
+}

--- a/src/providers/hermes/runtime/HermesCliResolver.ts
+++ b/src/providers/hermes/runtime/HermesCliResolver.ts
@@ -1,0 +1,80 @@
+import * as os from 'os';
+import * as path from 'path';
+
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import { findCliBinaryPath, isExistingFile, resolveConfiguredCliPath } from '../../../utils/cliBinaryLocator';
+import { getHostnameKey, parseEnvironmentVariables } from '../../../utils/env';
+import { expandHomePath } from '../../../utils/path';
+import { getHermesProviderSettings } from '../settings';
+
+const HERMES_COMMON_INSTALL_PATHS = [
+	'~/.local/bin/hermes',
+	'~/.hermes/hermes-agent/.venv/bin/hermes',
+];
+
+export class HermesCliResolver {
+	private readonly cachedHostname = getHostnameKey();
+	private lastCliPath = '';
+	private lastHostnamePath = '';
+	private lastEnvText = '';
+	private resolvedPath: string | null = null;
+
+	resolveFromSettings(settings: Record<string, unknown>): string | null {
+		const hermesSettings = getHermesProviderSettings(settings);
+		const cliPath = hermesSettings.cliPath.trim();
+		const hostnamePath = (hermesSettings.cliPathsByHost[this.cachedHostname] ?? '').trim();
+		const envText = getRuntimeEnvironmentText(settings, 'hermes');
+
+		if (
+			this.resolvedPath !== null
+			&& cliPath === this.lastCliPath
+			&& hostnamePath === this.lastHostnamePath
+			&& envText === this.lastEnvText
+		) {
+			return this.resolvedPath;
+		}
+
+		this.lastCliPath = cliPath;
+		this.lastHostnamePath = hostnamePath;
+		this.lastEnvText = envText;
+		this.resolvedPath = this.resolve(
+			hermesSettings.cliPathsByHost,
+			cliPath,
+			envText,
+		);
+		return this.resolvedPath;
+	}
+
+	resolve(
+		hostnamePaths: Record<string, string> | undefined,
+		legacyPath: string,
+		envText: string,
+	): string | null {
+		const hostnamePath = (hostnamePaths?.[this.cachedHostname] ?? '').trim();
+		const customEnv = parseEnvironmentVariables(envText || '');
+		return resolveConfiguredCliPath(hostnamePath)
+			?? resolveConfiguredCliPath(legacyPath.trim())
+			?? resolveCommonInstallPath()
+			?? findCliBinaryPath('hermes', customEnv.PATH);
+	}
+
+	reset(): void {
+		this.lastCliPath = '';
+		this.lastHostnamePath = '';
+		this.lastEnvText = '';
+		this.resolvedPath = null;
+	}
+}
+
+function resolveCommonInstallPath(): string | null {
+	const home = os.homedir();
+	for (const candidate of HERMES_COMMON_INSTALL_PATHS) {
+		const expanded = candidate.startsWith('~')
+			? path.join(home, candidate.slice(1))
+			: expandHomePath(candidate);
+		if (isExistingFile(expanded)) {
+			return expanded;
+		}
+	}
+	return null;
+}

--- a/src/providers/hermes/settings.ts
+++ b/src/providers/hermes/settings.ts
@@ -1,0 +1,261 @@
+import { getProviderConfig, setProviderConfig } from '../../core/providers/providerConfig';
+import { getProviderEnvironmentVariables } from '../../core/providers/providerEnvironment';
+import type { HostnameCliPaths } from '../../core/types/settings';
+import {
+  getHostnameKey,
+  getLegacyHostnameKey,
+  migrateLegacyHostnameKeyedMap,
+} from '../../utils/env';
+import {
+  type HermesDiscoveredModel,
+  normalizeHermesDiscoveredModels,
+  resolveHermesBaseModelRawId,
+} from './models';
+
+export interface PersistedHermesProviderSettings {
+  cliPath: string;
+  cliPathsByHost: HostnameCliPaths;
+  discoveredModels: HermesDiscoveredModel[];
+  enabled: boolean;
+  environmentHash: string;
+  environmentVariables: string;
+  modelAliases: Record<string, string>;
+  preferredThinkingByModel: Record<string, string>;
+  profile: string;
+  visibleModels: string[];
+}
+
+export const HERMES_DEFAULT_ENVIRONMENT_VARIABLES = '';
+
+export const DEFAULT_HERMES_PROVIDER_SETTINGS: Readonly<PersistedHermesProviderSettings> = Object.freeze({
+  cliPath: '',
+  cliPathsByHost: {},
+  discoveredModels: [],
+  enabled: false,
+  environmentHash: '',
+  environmentVariables: HERMES_DEFAULT_ENVIRONMENT_VARIABLES,
+  modelAliases: {},
+  preferredThinkingByModel: {},
+  profile: '',
+  visibleModels: [],
+});
+
+function normalizeHostnameCliPaths(value: unknown): HostnameCliPaths {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  const result: HostnameCliPaths = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry === 'string' && entry.trim()) {
+      result[key] = entry.trim();
+    }
+  }
+  return result;
+}
+
+export function normalizeHermesVisibleModels(
+  value: unknown,
+  discoveredModels: HermesDiscoveredModel[] = [],
+): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (typeof entry !== 'string') {
+      continue;
+    }
+
+    const trimmed = resolveHermesBaseModelRawId(entry.trim());
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+
+  return normalized;
+}
+
+export function normalizeHermesModelAliases(
+  value: unknown,
+  discoveredModels: HermesDiscoveredModel[] = [],
+): Record<string, string> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  const normalized: Record<string, string> = {};
+  for (const [rawId, alias] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof alias !== 'string') {
+      continue;
+    }
+
+    const normalizedRawId = resolveHermesBaseModelRawId(rawId.trim());
+    const normalizedAlias = alias.trim();
+    if (!normalizedRawId || !normalizedAlias) {
+      continue;
+    }
+
+    normalized[normalizedRawId] = normalizedAlias;
+  }
+
+  return normalized;
+}
+
+export function normalizeHermesPreferredThinkingByModel(
+  value: unknown,
+): Record<string, string> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  const normalized: Record<string, string> = {};
+  for (const [rawId, thinkingLevel] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof thinkingLevel !== 'string') {
+      continue;
+    }
+
+    const normalizedRawId = resolveHermesBaseModelRawId(rawId.trim());
+    const normalizedThinkingLevel = thinkingLevel.trim();
+    if (!normalizedRawId || !normalizedThinkingLevel) {
+      continue;
+    }
+
+    normalized[normalizedRawId] = normalizedThinkingLevel;
+  }
+
+  return normalized;
+}
+
+export function getHermesProviderSettings(
+  settings: Record<string, unknown>,
+): PersistedHermesProviderSettings {
+  const config = getProviderConfig(settings, 'hermes');
+  const normalizedCliPathsByHost = normalizeHostnameCliPaths(config.cliPathsByHost);
+  const cliPathsByHost = Object.keys(normalizedCliPathsByHost).length > 0
+    ? migrateLegacyHostnameKeyedMap(
+      normalizedCliPathsByHost,
+      getHostnameKey(),
+      getLegacyHostnameKey(),
+    )
+    : normalizedCliPathsByHost;
+  const discoveredModels = normalizeHermesDiscoveredModels(config.discoveredModels);
+
+  return {
+    cliPath: (config.cliPath as string | undefined)
+      ?? DEFAULT_HERMES_PROVIDER_SETTINGS.cliPath,
+    cliPathsByHost,
+    discoveredModels,
+    enabled: (config.enabled as boolean | undefined)
+      ?? DEFAULT_HERMES_PROVIDER_SETTINGS.enabled,
+    environmentHash: (config.environmentHash as string | undefined)
+      ?? DEFAULT_HERMES_PROVIDER_SETTINGS.environmentHash,
+    environmentVariables: (config.environmentVariables as string | undefined)
+      ?? getProviderEnvironmentVariables(settings, 'hermes')
+      ?? DEFAULT_HERMES_PROVIDER_SETTINGS.environmentVariables,
+    modelAliases: normalizeHermesModelAliases(config.modelAliases, discoveredModels),
+    preferredThinkingByModel: normalizeHermesPreferredThinkingByModel(
+      config.preferredThinkingByModel,
+    ),
+    profile: typeof config.profile === 'string' ? config.profile.trim() : DEFAULT_HERMES_PROVIDER_SETTINGS.profile,
+    visibleModels: normalizeHermesVisibleModels(config.visibleModels, discoveredModels),
+  };
+}
+
+export function updateHermesProviderSettings(
+  settings: Record<string, unknown>,
+  updates: Partial<PersistedHermesProviderSettings>,
+): PersistedHermesProviderSettings {
+  const current = getHermesProviderSettings(settings);
+  const hostnameKey = getHostnameKey();
+
+  const nextDiscoveredModels = updates.discoveredModels !== undefined
+    ? normalizeHermesDiscoveredModels(updates.discoveredModels)
+    : current.discoveredModels;
+
+  const nextVisibleModels = normalizeHermesVisibleModels(
+    updates.visibleModels ?? current.visibleModels,
+    nextDiscoveredModels,
+  );
+
+  const nextModelAliases = pruneModelAliasesToVisible(
+    normalizeHermesModelAliases(
+      updates.modelAliases ?? current.modelAliases,
+      nextDiscoveredModels,
+    ),
+    nextVisibleModels,
+  );
+
+  const nextCliPathsByHost = 'cliPathsByHost' in updates
+    ? normalizeHostnameCliPaths(updates.cliPathsByHost)
+    : { ...current.cliPathsByHost };
+  let nextCliPath = 'cliPathsByHost' in updates
+    ? (
+      typeof updates.cliPath === 'string'
+        ? updates.cliPath.trim()
+        : DEFAULT_HERMES_PROVIDER_SETTINGS.cliPath
+    )
+    : current.cliPath.trim();
+
+  if ('cliPath' in updates && !('cliPathsByHost' in updates)) {
+    const trimmedCliPath = typeof updates.cliPath === 'string' ? updates.cliPath.trim() : '';
+    if (trimmedCliPath) {
+      nextCliPathsByHost[hostnameKey] = trimmedCliPath;
+    } else {
+      delete nextCliPathsByHost[hostnameKey];
+    }
+    nextCliPath = DEFAULT_HERMES_PROVIDER_SETTINGS.cliPath;
+  }
+
+  const next: PersistedHermesProviderSettings = {
+    ...current,
+    ...updates,
+    cliPath: nextCliPath,
+    cliPathsByHost: nextCliPathsByHost,
+    discoveredModels: nextDiscoveredModels,
+    modelAliases: nextModelAliases,
+    preferredThinkingByModel: normalizeHermesPreferredThinkingByModel(
+      updates.preferredThinkingByModel ?? current.preferredThinkingByModel,
+    ),
+    profile: typeof updates.profile === 'string' ? updates.profile.trim() : current.profile,
+    visibleModels: nextVisibleModels,
+  };
+
+  setProviderConfig(settings, 'hermes', {
+    cliPath: next.cliPath,
+    cliPathsByHost: next.cliPathsByHost,
+    discoveredModels: next.discoveredModels,
+    enabled: next.enabled,
+    environmentHash: next.environmentHash,
+    environmentVariables: next.environmentVariables,
+    modelAliases: next.modelAliases,
+    preferredThinkingByModel: next.preferredThinkingByModel,
+    profile: next.profile,
+    visibleModels: next.visibleModels,
+  });
+
+  return next;
+}
+
+function pruneModelAliasesToVisible(
+  aliases: Record<string, string>,
+  visibleModels: string[],
+): Record<string, string> {
+  if (visibleModels.length === 0 || Object.keys(aliases).length === 0) {
+    return {};
+  }
+
+  const visibleSet = new Set(visibleModels);
+  const pruned: Record<string, string> = {};
+  for (const [rawId, alias] of Object.entries(aliases)) {
+    if (visibleSet.has(rawId)) {
+      pruned[rawId] = alias;
+    }
+  }
+  return pruned;
+}

--- a/src/providers/hermes/storage/HermesSkillStorage.ts
+++ b/src/providers/hermes/storage/HermesSkillStorage.ts
@@ -1,0 +1,115 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import type { SlashCommand } from '../../../core/types';
+import { parseFrontmatter } from '../../../utils/frontmatter';
+
+const HERMES_SKILLS_ROOT = '.hermes/skills';
+const SKILL_FILENAME = 'SKILL.md';
+
+function extractSkillName(filePath: string, root: string): string {
+	// Derive name from the parent directory: <root>/.../category/<name>/SKILL.md → <name>
+	const dir = path.dirname(filePath);
+	const relative = path.relative(root, dir);
+	const segments = relative.split(path.sep);
+	return segments.length > 0 ? segments[segments.length - 1] : '';
+}
+
+async function globSkillFiles(rootDir: string): Promise<string[]> {
+	const results: string[] = [];
+
+	async function walk(dir: string): Promise<void> {
+		let entries: fs.Dirent[];
+		try {
+			entries = await fs.promises.readdir(dir, { withFileTypes: true });
+		} catch {
+			return;
+		}
+
+		for (const entry of entries) {
+			const fullPath = path.join(dir, entry.name);
+			if (entry.isDirectory()) {
+				await walk(fullPath);
+			} else if (entry.isFile() && entry.name === SKILL_FILENAME) {
+				results.push(fullPath);
+			}
+		}
+	}
+
+	await walk(rootDir);
+	return results;
+}
+
+function parseSkillFile(filePath: string, rootDir: string): SlashCommand | null {
+	let content: string;
+	try {
+		content = fs.readFileSync(filePath, 'utf-8');
+	} catch {
+		return null;
+	}
+
+	const parsed = parseFrontmatter(content);
+	if (!parsed) return null;
+
+	const fm = parsed.frontmatter;
+
+	// Name from frontmatter, fallback to parent directory
+	const dirName = extractSkillName(filePath, rootDir);
+	const name = typeof fm.name === 'string' && fm.name.trim()
+		? fm.name.trim()
+		: dirName;
+
+	if (!name) return null;
+
+	const description = typeof fm.description === 'string' ? fm.description : undefined;
+
+	return {
+		argumentHint: undefined,
+		content: parsed.body,
+		description,
+		id: `hermes-skill:${name}`,
+		kind: 'skill',
+		name,
+		source: 'user',
+	};
+}
+
+export class HermesSkillStorage {
+	private readonly homeDir: string;
+
+	constructor(
+		private readonly getProfile: () => string,
+		homeDir?: string,
+	) {
+		this.homeDir = homeDir ?? os.homedir();
+	}
+
+	async loadAll(): Promise<SlashCommand[]> {
+		const skillsByName = new Map<string, SlashCommand>();
+
+		// Scan global skills
+		const globalRoot = path.join(this.homeDir, HERMES_SKILLS_ROOT);
+		await this.scanRoot(globalRoot, skillsByName);
+
+		// Scan profile skills (profile wins on conflict)
+		const profile = this.getProfile();
+		if (profile) {
+			const profileRoot = path.join(this.homeDir, '.hermes', 'profiles', profile, 'skills');
+			await this.scanRoot(profileRoot, skillsByName);
+		}
+
+		return Array.from(skillsByName.values());
+	}
+
+	private async scanRoot(rootDir: string, skillsByName: Map<string, SlashCommand>): Promise<void> {
+		const files = await globSkillFiles(rootDir);
+
+		for (const filePath of files) {
+			const skill = parseSkillFile(filePath, rootDir);
+			if (skill) {
+				skillsByName.set(skill.name, skill);
+			}
+		}
+	}
+}

--- a/src/providers/hermes/types.ts
+++ b/src/providers/hermes/types.ts
@@ -1,0 +1,67 @@
+export interface HermesProviderState {
+  sessionId?: string;
+  sessionFile?: string;
+  forkSource?: {
+    resumeAt: string;
+    sessionId: string;
+  };
+}
+
+export function getHermesProviderState(
+  providerState?: Record<string, unknown>,
+): HermesProviderState {
+  if (!providerState || typeof providerState !== 'object') {
+    return {};
+  }
+
+  const sessionId = typeof providerState.sessionId === 'string'
+    ? providerState.sessionId
+    : undefined;
+  const sessionFile = typeof providerState.sessionFile === 'string'
+    ? providerState.sessionFile
+    : undefined;
+  const forkSource = extractForkSource(providerState.forkSource);
+
+  const result: HermesProviderState = {};
+  if (sessionId) {
+    result.sessionId = sessionId;
+  }
+  if (sessionFile) {
+    result.sessionFile = sessionFile;
+  }
+  if (forkSource) {
+    result.forkSource = forkSource;
+  }
+
+  return result;
+}
+
+export function setHermesProviderState(
+  state: HermesProviderState,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  if (state.sessionId !== undefined) {
+    result.sessionId = state.sessionId;
+  }
+  if (state.sessionFile !== undefined) {
+    result.sessionFile = state.sessionFile;
+  }
+  if (state.forkSource !== undefined) {
+    result.forkSource = state.forkSource;
+  }
+  return result;
+}
+
+function extractForkSource(
+  value: unknown,
+): HermesProviderState['forkSource'] {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  const sessionId = typeof record.sessionId === 'string' ? record.sessionId : '';
+  const resumeAt = typeof record.resumeAt === 'string' ? record.resumeAt : '';
+
+  return sessionId && resumeAt ? { resumeAt, sessionId } : undefined;
+}

--- a/src/providers/hermes/ui/HermesChatUIConfig.ts
+++ b/src/providers/hermes/ui/HermesChatUIConfig.ts
@@ -1,0 +1,134 @@
+import type {
+  ProviderChatUIConfig,
+  ProviderReasoningOption,
+  ProviderUIOption,
+} from '../../../core/providers/types';
+import {
+  decodeHermesModelId,
+  encodeHermesModelId,
+  HERMES_DEFAULT_THINKING_LEVEL,
+  isHermesModelSelectionId,
+  resolveHermesBaseModelRawId,
+} from '../models';
+import { getHermesProviderSettings } from '../settings';
+
+const HERMES_MODELS: ProviderUIOption[] = [
+  { value: 'hermes', label: 'Hermes', description: 'ACP runtime' },
+];
+const DEFAULT_CONTEXT_WINDOW = 128_000;
+
+export const hermesChatUIConfig: ProviderChatUIConfig = {
+  getModelOptions(settings): ProviderUIOption[] {
+    const hermesSettings = getHermesProviderSettings(settings);
+    const applyAlias = (rawId: string, option: ProviderUIOption): ProviderUIOption => {
+      const alias = hermesSettings.modelAliases[rawId];
+      return alias ? { ...option, label: alias } : option;
+    };
+
+    const seenValues = new Set<string>();
+    const options: ProviderUIOption[] = [];
+
+    for (const rawModelId of hermesSettings.visibleModels) {
+      const encodedModelId = encodeHermesModelId(rawModelId);
+      pushOption(
+        options,
+        seenValues,
+        encodedModelId,
+        applyAlias(rawModelId, {
+          description: 'Hermes model',
+          label: rawModelId,
+          value: encodedModelId,
+        }),
+      );
+    }
+
+    // Ensure currently selected model appears even if not in visible list
+    const selectedModel = typeof settings.model === 'string' ? settings.model : '';
+    const rawModelId = decodeHermesModelId(selectedModel);
+    if (rawModelId && isHermesModelSelectionId(selectedModel)) {
+      const baseRawId = resolveHermesBaseModelRawId(rawModelId);
+      const baseModelId = encodeHermesModelId(baseRawId);
+      pushOption(
+        options,
+        seenValues,
+        baseModelId,
+        applyAlias(baseRawId, {
+          description: 'Selected model',
+          label: baseRawId,
+          value: baseModelId,
+        }),
+      );
+    }
+
+    return options.length > 0 ? options : [...HERMES_MODELS];
+  },
+
+  ownsModel(model: string): boolean {
+    return isHermesModelSelectionId(model);
+  },
+
+  isAdaptiveReasoningModel(): boolean {
+    return false;
+  },
+
+  getReasoningOptions(): ProviderReasoningOption[] {
+    return [];
+  },
+
+  getDefaultReasoningValue(): string {
+    return HERMES_DEFAULT_THINKING_LEVEL;
+  },
+
+  getContextWindowSize(model: string, customLimits?: Record<string, number>): number {
+    return customLimits?.[model] ?? DEFAULT_CONTEXT_WINDOW;
+  },
+
+  isDefaultModel(model: string): boolean {
+    return isHermesModelSelectionId(model);
+  },
+
+  applyModelDefaults(model: string, settings: unknown): void {
+    if (!settings || typeof settings !== 'object' || Array.isArray(settings)) {
+      return;
+    }
+
+    const settingsBag = settings as Record<string, unknown>;
+    const rawModelId = decodeHermesModelId(model);
+    if (!rawModelId) {
+      settingsBag.effortLevel = HERMES_DEFAULT_THINKING_LEVEL;
+      return;
+    }
+
+    const baseRawId = resolveHermesBaseModelRawId(rawModelId);
+    settingsBag.model = encodeHermesModelId(baseRawId);
+    settingsBag.effortLevel = HERMES_DEFAULT_THINKING_LEVEL;
+  },
+
+  normalizeModelVariant(model: string, settings: Record<string, unknown>): string {
+    const rawModelId = decodeHermesModelId(model);
+    if (!rawModelId) {
+      return model;
+    }
+
+    const baseRawId = resolveHermesBaseModelRawId(rawModelId);
+    return encodeHermesModelId(baseRawId);
+  },
+
+  getCustomModelIds(): Set<string> {
+    return new Set<string>();
+  },
+};
+
+function pushOption(
+  target: ProviderUIOption[],
+  seenValues: Set<string>,
+  value: string,
+  option: ProviderUIOption,
+): void {
+  if (seenValues.has(value)) {
+    return;
+  }
+
+  seenValues.add(value);
+  target.push(option);
+}

--- a/src/providers/hermes/ui/HermesSettingsTab.ts
+++ b/src/providers/hermes/ui/HermesSettingsTab.ts
@@ -1,0 +1,153 @@
+import * as fs from 'fs';
+import { Setting } from 'obsidian';
+
+import type { ProviderSettingsTabRenderer } from '../../../core/providers/types';
+import { renderEnvironmentSettingsSection } from '../../../features/settings/ui/EnvironmentSettingsSection';
+import { getHostnameKey } from '../../../utils/env';
+import { expandHomePath } from '../../../utils/path';
+import {
+  getHermesProviderSettings,
+  HERMES_DEFAULT_ENVIRONMENT_VARIABLES,
+  updateHermesProviderSettings,
+} from '../settings';
+
+export const hermesSettingsTabRenderer: ProviderSettingsTabRenderer = {
+  render(container, context) {
+    const settingsBag = context.plugin.settings as unknown as Record<string, unknown>;
+    const hermesSettings = getHermesProviderSettings(settingsBag);
+    const hostnameKey = getHostnameKey();
+
+    new Setting(container).setName('Setup').setHeading();
+
+    new Setting(container)
+      .setName('Enable Hermes')
+      .setDesc('Launch `hermes acp` as a provider. Requires Hermes Agent installed with ACP extra.')
+      .addToggle((toggle) =>
+        toggle
+          .setValue(hermesSettings.enabled)
+          .onChange(async (value) => {
+            updateHermesProviderSettings(settingsBag, { enabled: value });
+            await context.plugin.saveSettings();
+            context.refreshModelSelectors();
+          })
+      );
+
+    const cliPathSetting = new Setting(container)
+      .setName('CLI path')
+      .setDesc('Optional absolute path to the Hermes CLI for this computer. Leave empty to use `hermes` from PATH.');
+
+    const validationEl = container.createDiv({
+      cls: 'claudian-cli-path-validation claudian-setting-validation claudian-setting-validation-error claudian-hidden',
+    });
+
+    const validatePath = (value: string): string | null => {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return null;
+      }
+
+      const expandedPath = expandHomePath(trimmed);
+      if (!fs.existsSync(expandedPath)) {
+        return 'Path does not exist';
+      }
+
+      const stat = fs.statSync(expandedPath);
+      if (!stat.isFile()) {
+        return 'Path is not a file';
+      }
+
+      return null;
+    };
+
+    const currentHostCliPath = hermesSettings.cliPathsByHost[hostnameKey]
+      || hermesSettings.cliPath;
+
+    cliPathSetting.addText((text) =>
+      text
+        .setValue(currentHostCliPath)
+        .setPlaceholder('hermes')
+        .onChange(async (value) => {
+          const error = validatePath(value);
+          if (error) {
+            validationEl.setText(error);
+            validationEl.removeClass('claudian-hidden');
+          } else {
+            validationEl.addClass('claudian-hidden');
+          }
+
+          updateHermesProviderSettings(settingsBag, { cliPath: value.trim() });
+          await context.plugin.saveSettings();
+        })
+    );
+
+    new Setting(container)
+      .setName('Agent profile')
+      .setDesc('Optional Hermes agent profile name. Passed as `--profile` when starting `hermes acp`.')
+      .addText((text) =>
+        text
+          .setValue(hermesSettings.profile)
+          .setPlaceholder('default')
+          .onChange(async (value) => {
+            updateHermesProviderSettings(settingsBag, { profile: value.trim() });
+            await context.plugin.saveSettings();
+          })
+      );
+
+    new Setting(container).setName('Configuration').setHeading();
+
+    renderEnvironmentSettingsSection({
+      container,
+      plugin: context.plugin,
+      scope: 'provider:hermes',
+      name: 'Hermes environment',
+      desc: 'Hermes-specific environment variables applied to all sessions.',
+      placeholder: HERMES_DEFAULT_ENVIRONMENT_VARIABLES,
+    });
+
+    new Setting(container).setName('Models').setHeading();
+
+    const visibleModels = hermesSettings.visibleModels;
+    if (visibleModels.length === 0) {
+      container.createEl('p', {
+        text: 'No models configured. Start a Hermes session to discover models, or configure them in ~/.hermes/config.yaml.',
+        cls: 'claudian-setting-description',
+      });
+    } else {
+      const modelList = container.createEl('div', { cls: 'claudian-model-list' });
+      for (const rawId of visibleModels) {
+        const alias = hermesSettings.modelAliases[rawId];
+        modelList.createEl('div', {
+          text: alias ? `${rawId} → ${alias}` : rawId,
+          cls: 'claudian-model-list-item',
+        });
+      }
+    }
+
+    new Setting(container).setName('Installation').setHeading();
+
+    container.createEl('p', {
+      text: 'Hermes Agent requires Python 3.11+. Install with:',
+      cls: 'claudian-setting-description',
+    });
+
+    container.createEl('code', {
+      text: 'pip install hermes-agent[acp]',
+      cls: 'claudian-setting-code',
+    });
+
+    container.createEl('p', {
+      text: 'Or use the one-line installer (Linux/macOS/WSL2):',
+      cls: 'claudian-setting-description',
+    });
+
+    container.createEl('code', {
+      text: 'curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash',
+      cls: 'claudian-setting-code',
+    });
+
+    container.createEl('p', {
+      text: 'After installation, configure a model provider with: hermes model',
+      cls: 'claudian-setting-description',
+    });
+  },
+};

--- a/tests/unit/providers/hermes/commands/HermesCommandCatalog.test.ts
+++ b/tests/unit/providers/hermes/commands/HermesCommandCatalog.test.ts
@@ -1,0 +1,233 @@
+import type { SlashCommand } from '@/core/types';
+import { HermesCommandCatalog } from '@/providers/hermes/commands/HermesCommandCatalog';
+import type { HermesSkillStorage } from '@/providers/hermes/storage/HermesSkillStorage';
+
+function createMockSkillStorage(skills: SlashCommand[]): HermesSkillStorage {
+	return {
+		loadAll: jest.fn().mockResolvedValue(skills),
+	} as unknown as HermesSkillStorage;
+}
+
+describe('HermesCommandCatalog', () => {
+	describe('listDropdownEntries', () => {
+		it('returns SDK runtime commands as ProviderCommandEntry', async () => {
+			const catalog = new HermesCommandCatalog();
+
+			const sdkCommands: SlashCommand[] = [
+				{ id: 'acp:search', name: 'search', description: 'Search files', content: '', source: 'sdk' },
+				{ id: 'acp:analyze', name: 'analyze', description: 'Analyze code', content: '', source: 'sdk' },
+			];
+			catalog.setRuntimeCommands(sdkCommands);
+
+			const entries = await catalog.listDropdownEntries({ includeBuiltIns: false });
+
+			expect(entries).toHaveLength(2);
+
+			const searchEntry = entries.find(e => e.name === 'search');
+			expect(searchEntry).toBeDefined();
+			expect(searchEntry!.providerId).toBe('hermes');
+			expect(searchEntry!.kind).toBe('command');
+			expect(searchEntry!.scope).toBe('runtime');
+			expect(searchEntry!.source).toBe('sdk');
+			expect(searchEntry!.isEditable).toBe(false);
+			expect(searchEntry!.isDeletable).toBe(false);
+			expect(searchEntry!.displayPrefix).toBe('/');
+			expect(searchEntry!.insertPrefix).toBe('/');
+		});
+
+		it('returns empty when no runtime commands', async () => {
+			const catalog = new HermesCommandCatalog();
+
+			const entries = await catalog.listDropdownEntries({ includeBuiltIns: true });
+
+			expect(entries).toHaveLength(0);
+		});
+
+		it('includes all commands without filtering', async () => {
+			const catalog = new HermesCommandCatalog();
+
+			const sdkCommands: SlashCommand[] = [
+				{ id: 'acp:search', name: 'search', description: 'Search', content: '', source: 'sdk' },
+				{ id: 'acp:analyze', name: 'analyze', description: 'Analyze', content: '', source: 'sdk' },
+				{ id: 'acp:debug', name: 'debug', description: 'Debug', content: '', source: 'sdk' },
+			];
+			catalog.setRuntimeCommands(sdkCommands);
+
+			const withBuiltins = await catalog.listDropdownEntries({ includeBuiltIns: true });
+			const withoutBuiltins = await catalog.listDropdownEntries({ includeBuiltIns: false });
+
+			expect(withBuiltins).toHaveLength(3);
+			expect(withoutBuiltins).toHaveLength(3);
+		});
+
+		it('replaces commands on subsequent setRuntimeCommands calls', async () => {
+			const catalog = new HermesCommandCatalog();
+
+			catalog.setRuntimeCommands([
+				{ id: 'acp:old', name: 'old', description: 'Old', content: '', source: 'sdk' },
+			]);
+			expect(await catalog.listDropdownEntries({ includeBuiltIns: true })).toHaveLength(1);
+
+			catalog.setRuntimeCommands([
+				{ id: 'acp:new1', name: 'new1', description: 'New 1', content: '', source: 'sdk' },
+				{ id: 'acp:new2', name: 'new2', description: 'New 2', content: '', source: 'sdk' },
+			]);
+
+			const entries = await catalog.listDropdownEntries({ includeBuiltIns: true });
+			expect(entries).toHaveLength(2);
+			expect(entries.find(e => e.name === 'old')).toBeUndefined();
+		});
+	});
+
+	describe('getDropdownConfig', () => {
+		it('returns correct config for Hermes', () => {
+			const catalog = new HermesCommandCatalog();
+
+			const config = catalog.getDropdownConfig();
+
+			expect(config.providerId).toBe('hermes');
+			expect(config.triggerChars).toEqual(['/']);
+			expect(config.builtInPrefix).toBe('/');
+			expect(config.skillPrefix).toBe('/');
+			expect(config.commandPrefix).toBe('/');
+		});
+	});
+
+	describe('vault operations', () => {
+		it('listVaultEntries returns empty array', async () => {
+			const catalog = new HermesCommandCatalog();
+
+			const entries = await catalog.listVaultEntries();
+
+			expect(entries).toEqual([]);
+		});
+
+		it('saveVaultEntry does not throw', async () => {
+			const catalog = new HermesCommandCatalog();
+
+			await expect(catalog.saveVaultEntry({
+				id: 'test',
+				providerId: 'hermes',
+				kind: 'command',
+				name: 'test',
+				content: '',
+				scope: 'vault',
+				source: 'user',
+				isEditable: true,
+				isDeletable: true,
+				displayPrefix: '/',
+				insertPrefix: '/',
+			})).resolves.toBeUndefined();
+		});
+
+		it('deleteVaultEntry does not throw', async () => {
+			const catalog = new HermesCommandCatalog();
+
+			await expect(catalog.deleteVaultEntry({
+				id: 'test',
+				providerId: 'hermes',
+				kind: 'command',
+				name: 'test',
+				content: '',
+				scope: 'vault',
+				source: 'user',
+				isEditable: true,
+				isDeletable: true,
+				displayPrefix: '/',
+				insertPrefix: '/',
+			})).resolves.toBeUndefined();
+		});
+	});
+
+	describe('refresh', () => {
+		it('does not throw', async () => {
+			const catalog = new HermesCommandCatalog();
+
+			await expect(catalog.refresh()).resolves.toBeUndefined();
+		});
+	});
+
+	describe('vault skill integration', () => {
+		const vaultSkills: SlashCommand[] = [
+			{ id: 'hermes-skill:llm-wiki', name: 'llm-wiki', description: 'Wiki builder', content: 'wiki prompt', kind: 'skill', source: 'user' },
+			{ id: 'hermes-skill:yuanbao', name: 'yuanbao', description: 'Yuanbao skill', content: 'yuanbao prompt', kind: 'skill', source: 'user' },
+		];
+
+		it('includes vault skills in dropdown entries', async () => {
+			const storage = createMockSkillStorage(vaultSkills);
+			const catalog = new HermesCommandCatalog(storage);
+
+			const entries = await catalog.listDropdownEntries({ includeBuiltIns: false });
+
+			expect(entries).toHaveLength(2);
+			const wiki = entries.find(e => e.name === 'llm-wiki');
+			expect(wiki).toBeDefined();
+			expect(wiki!.kind).toBe('skill');
+			expect(wiki!.scope).toBe('vault');
+			expect(wiki!.isEditable).toBe(false);
+			expect(wiki!.isDeletable).toBe(false);
+		});
+
+		it('merges vault skills and runtime commands', async () => {
+			const storage = createMockSkillStorage(vaultSkills);
+			const catalog = new HermesCommandCatalog(storage);
+
+			catalog.setRuntimeCommands([
+				{ id: 'acp:search', name: 'search', description: 'Search', content: '', source: 'sdk' },
+			]);
+
+			const entries = await catalog.listDropdownEntries({ includeBuiltIns: false });
+			expect(entries).toHaveLength(3);
+		});
+
+		it('vault skills win on name conflict with runtime commands', async () => {
+			const storage = createMockSkillStorage([
+				{ id: 'hermes-skill:search', name: 'search', description: 'Vault search', content: '', kind: 'skill', source: 'user' },
+			]);
+			const catalog = new HermesCommandCatalog(storage);
+
+			catalog.setRuntimeCommands([
+				{ id: 'acp:search', name: 'search', description: 'ACP search', content: '', source: 'sdk' },
+			]);
+
+			const entries = await catalog.listDropdownEntries({ includeBuiltIns: false });
+			expect(entries).toHaveLength(1);
+			expect(entries[0].description).toBe('Vault search');
+			expect(entries[0].kind).toBe('skill');
+		});
+
+		it('returns runtime commands when vault is empty', async () => {
+			const storage = createMockSkillStorage([]);
+			const catalog = new HermesCommandCatalog(storage);
+
+			catalog.setRuntimeCommands([
+				{ id: 'acp:search', name: 'search', description: 'Search', content: '', source: 'sdk' },
+			]);
+
+			const entries = await catalog.listDropdownEntries({ includeBuiltIns: false });
+			expect(entries).toHaveLength(1);
+			expect(entries[0].kind).toBe('command');
+		});
+
+		it('listVaultEntries returns skill entries', async () => {
+			const storage = createMockSkillStorage(vaultSkills);
+			const catalog = new HermesCommandCatalog(storage);
+
+			const entries = await catalog.listVaultEntries();
+			expect(entries).toHaveLength(2);
+			expect(entries.every(e => e.kind === 'skill')).toBe(true);
+		});
+
+		it('refresh clears vault cache', async () => {
+			const storage = createMockSkillStorage(vaultSkills);
+			const catalog = new HermesCommandCatalog(storage);
+
+			await catalog.listDropdownEntries({ includeBuiltIns: false });
+			expect(storage.loadAll).toHaveBeenCalledTimes(1);
+
+			await catalog.refresh();
+			await catalog.listDropdownEntries({ includeBuiltIns: false });
+			expect(storage.loadAll).toHaveBeenCalledTimes(2);
+		});
+	});
+});

--- a/tests/unit/providers/hermes/runtime/HermesChatRuntime.test.ts
+++ b/tests/unit/providers/hermes/runtime/HermesChatRuntime.test.ts
@@ -1,0 +1,126 @@
+const mockSubprocessInstances: Array<{ args: string[] }> = [];
+
+class MockAcpSubprocess {
+	readonly stdin = {};
+	readonly stdout = {};
+	readonly args: string[];
+
+	constructor(spec: { args: string[] }) {
+		this.args = [...spec.args];
+		mockSubprocessInstances.push(this);
+	}
+
+	start = jest.fn();
+	isAlive = jest.fn(() => true);
+	getStderrSnapshot = jest.fn(() => '');
+	onClose = jest.fn(() => jest.fn());
+	shutdown = jest.fn(async () => {});
+}
+
+jest.mock('@/providers/acp/AcpSubprocess', () => ({
+	AcpSubprocess: MockAcpSubprocess,
+}));
+
+const mockTransportInstances: Array<{ initialize: jest.Mock }> = [];
+
+class MockAcpJsonRpcTransport {
+	initialize = jest.fn(async () => {});
+	start = jest.fn();
+	dispose = jest.fn();
+	onClose = jest.fn(() => jest.fn());
+
+	constructor() {
+		mockTransportInstances.push(this);
+	}
+}
+
+jest.mock('@/providers/acp/AcpJsonRpcTransport', () => ({
+	AcpJsonRpcTransport: MockAcpJsonRpcTransport,
+}));
+
+jest.mock('@/providers/acp/AcpClientConnection', () => ({
+	AcpClientConnection: jest.fn().mockImplementation(() => ({
+		dispose: jest.fn(),
+		initialize: jest.fn(async () => {}),
+	})),
+}));
+
+jest.mock('@/providers/acp/AcpSessionUpdateNormalizer', () => ({
+	AcpSessionUpdateNormalizer: jest.fn().mockImplementation(() => ({
+		normalize: jest.fn(),
+	})),
+}));
+
+jest.mock('@/utils/env', () => ({
+	...jest.requireActual('@/utils/env'),
+	getEnhancedPath: (base: string) => base,
+}));
+
+jest.mock('@/utils/path', () => ({
+	getVaultPath: () => '/tmp/hermes-vault',
+}));
+
+import '@/providers';
+
+import { HermesChatRuntime } from '@/providers/hermes/runtime/HermesChatRuntime';
+
+function createPlugin(profile?: string): any {
+	return {
+		app: {
+			vault: {
+				adapter: {
+					basePath: '/tmp/hermes-vault',
+				},
+			},
+		},
+		getResolvedProviderCliPath: jest.fn(() => 'hermes'),
+		manifest: { version: '1.0.0' },
+		settings: {
+			providerConfigs: {
+				hermes: {
+					enabled: true,
+					...(profile ? { profile } : {}),
+				},
+			},
+		},
+	};
+}
+
+describe('HermesChatRuntime — profile arg', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockSubprocessInstances.length = 0;
+		mockTransportInstances.length = 0;
+	});
+
+	it('spawns with bare acp args when no profile is set', async () => {
+		const runtime = new HermesChatRuntime(createPlugin());
+		await runtime.ensureReady();
+
+		expect(mockSubprocessInstances).toHaveLength(1);
+		expect(mockSubprocessInstances[0].args).toEqual(['acp']);
+	});
+
+	it('spawns with --profile when profile is configured', async () => {
+		const runtime = new HermesChatRuntime(createPlugin('my-agent'));
+		await runtime.ensureReady();
+
+		expect(mockSubprocessInstances).toHaveLength(1);
+		expect(mockSubprocessInstances[0].args).toEqual(['acp', '--profile', 'my-agent']);
+	});
+
+	it('restarts when profile changes between ensureReady calls', async () => {
+		const plugin = createPlugin();
+		const runtime = new HermesChatRuntime(plugin);
+		await runtime.ensureReady();
+
+		expect(mockSubprocessInstances).toHaveLength(1);
+		expect(mockSubprocessInstances[0].args).toEqual(['acp']);
+
+		plugin.settings.providerConfigs.hermes.profile = 'new-profile';
+		await runtime.ensureReady({ force: true });
+
+		expect(mockSubprocessInstances).toHaveLength(2);
+		expect(mockSubprocessInstances[1].args).toEqual(['acp', '--profile', 'new-profile']);
+	});
+});

--- a/tests/unit/providers/hermes/settings/hermesSettings.test.ts
+++ b/tests/unit/providers/hermes/settings/hermesSettings.test.ts
@@ -1,0 +1,78 @@
+import {
+	DEFAULT_HERMES_PROVIDER_SETTINGS,
+	getHermesProviderSettings,
+	updateHermesProviderSettings,
+} from '@/providers/hermes/settings';
+
+function hermesConfig(config: Record<string, unknown>): Record<string, unknown> {
+	return { providerConfigs: { hermes: config } };
+}
+
+describe('Hermes provider settings — profile', () => {
+	it('defaults to empty string', () => {
+		expect(DEFAULT_HERMES_PROVIDER_SETTINGS.profile).toBe('');
+	});
+
+	it('returns empty profile when not set in config', () => {
+		const settings = hermesConfig({});
+		const result = getHermesProviderSettings(settings);
+		expect(result.profile).toBe('');
+	});
+
+	it('returns empty profile when config has no hermes key', () => {
+		const settings = {};
+		const result = getHermesProviderSettings(settings);
+		expect(result.profile).toBe('');
+	});
+
+	it('returns profile from config', () => {
+		const settings = hermesConfig({ profile: 'my-agent' });
+		const result = getHermesProviderSettings(settings);
+		expect(result.profile).toBe('my-agent');
+	});
+
+	it('trims whitespace from profile', () => {
+		const settings = hermesConfig({ profile: '  spaced-agent  ' });
+		const result = getHermesProviderSettings(settings);
+		expect(result.profile).toBe('spaced-agent');
+	});
+
+	it('returns empty string when profile is not a string', () => {
+		const settings = hermesConfig({ profile: 123 });
+		const result = getHermesProviderSettings(settings);
+		expect(result.profile).toBe('');
+	});
+
+	it('updates profile via updateHermesProviderSettings', () => {
+		const settings: Record<string, unknown> = hermesConfig({});
+
+		const updated = updateHermesProviderSettings(settings, { profile: 'new-profile' });
+
+		expect(updated.profile).toBe('new-profile');
+		expect(getHermesProviderSettings(settings).profile).toBe('new-profile');
+	});
+
+	it('trims profile on update', () => {
+		const settings: Record<string, unknown> = hermesConfig({});
+
+		const updated = updateHermesProviderSettings(settings, { profile: '  trimmed  ' });
+
+		expect(updated.profile).toBe('trimmed');
+	});
+
+	it('clears profile when set to empty string', () => {
+		const settings: Record<string, unknown> = hermesConfig({ profile: 'existing' });
+
+		const updated = updateHermesProviderSettings(settings, { profile: '' });
+
+		expect(updated.profile).toBe('');
+	});
+
+	it('preserves existing profile when not included in updates', () => {
+		const settings: Record<string, unknown> = hermesConfig({ profile: 'keep-me' });
+
+		const updated = updateHermesProviderSettings(settings, { enabled: true });
+
+		expect(updated.profile).toBe('keep-me');
+	});
+});

--- a/tests/unit/providers/hermes/storage/HermesSkillStorage.test.ts
+++ b/tests/unit/providers/hermes/storage/HermesSkillStorage.test.ts
@@ -1,0 +1,224 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { HermesSkillStorage } from '@/providers/hermes/storage/HermesSkillStorage';
+
+function createTempDir(): string {
+	return fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-skill-test-'));
+}
+
+const SKILLS_DIR = ['.hermes', 'skills'];
+
+function writeSkill(homeDir: string, ...categoryAndName: string[]): void {
+	const segments = [...SKILLS_DIR, ...categoryAndName];
+	const skillPath = path.join(homeDir, ...segments, 'SKILL.md');
+	fs.mkdirSync(path.dirname(skillPath), { recursive: true });
+	fs.writeFileSync(skillPath, `---
+name: ${categoryAndName[categoryAndName.length - 1]}
+description: "A test skill"
+---
+
+Skill content here.
+`);
+}
+
+function writeSkillWithCustomName(homeDir: string, categoryAndName: string[], name: string, description?: string): void {
+	const segments = [...SKILLS_DIR, ...categoryAndName];
+	const skillPath = path.join(homeDir, ...segments, 'SKILL.md');
+	fs.mkdirSync(path.dirname(skillPath), { recursive: true });
+	const desc = description ?? 'Custom skill';
+	fs.writeFileSync(skillPath, `---
+name: ${name}
+description: "${desc}"
+---
+
+Custom content.
+`);
+}
+
+function writeNonSkillFile(homeDir: string, ...segments: string[]): void {
+	const filePath = path.join(homeDir, ...SKILLS_DIR, ...segments, 'README.md');
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, 'Not a skill file');
+}
+
+describe('HermesSkillStorage', () => {
+	let homeDir: string;
+
+	beforeEach(() => {
+		homeDir = createTempDir();
+	});
+
+	afterEach(() => {
+		fs.rmSync(homeDir, { recursive: true, force: true });
+	});
+
+	it('discovers nested skills', async () => {
+		writeSkill(homeDir, 'research', 'llm-wiki');
+		const storage = new HermesSkillStorage(() => '', homeDir);
+
+		const skills = await storage.loadAll();
+
+		expect(skills).toHaveLength(1);
+		expect(skills[0].name).toBe('llm-wiki');
+		expect(skills[0].description).toBe('A test skill');
+		expect(skills[0].kind).toBe('skill');
+		expect(skills[0].source).toBe('user');
+		expect(skills[0].id).toBe('hermes-skill:llm-wiki');
+	});
+
+	it('discovers flat skills without category', async () => {
+		writeSkill(homeDir, 'yuanbao');
+		const storage = new HermesSkillStorage(() => '', homeDir);
+
+		const skills = await storage.loadAll();
+
+		expect(skills).toHaveLength(1);
+		expect(skills[0].name).toBe('yuanbao');
+	});
+
+	it('discovers deeply nested skills', async () => {
+		writeSkill(homeDir, 'mlops', 'training', 'peft');
+		const storage = new HermesSkillStorage(() => '', homeDir);
+
+		const skills = await storage.loadAll();
+
+		expect(skills).toHaveLength(1);
+		expect(skills[0].name).toBe('peft');
+	});
+
+	it('discovers multiple skills across categories', async () => {
+		writeSkill(homeDir, 'research', 'llm-wiki');
+		writeSkill(homeDir, 'creative', 'story-gen');
+		writeSkill(homeDir, 'devops', 'deploy');
+		const storage = new HermesSkillStorage(() => '', homeDir);
+
+		const skills = await storage.loadAll();
+
+		expect(skills).toHaveLength(3);
+		const names = skills.map(s => s.name).sort();
+		expect(names).toEqual(['deploy', 'llm-wiki', 'story-gen']);
+	});
+
+	it('returns empty when directory does not exist', async () => {
+		const missingDir = path.join(homeDir, 'nonexistent');
+		const storage = new HermesSkillStorage(() => '', missingDir);
+
+		const skills = await storage.loadAll();
+
+		expect(skills).toEqual([]);
+	});
+
+	it('ignores non-SKILL.md files', async () => {
+		writeSkill(homeDir, 'research', 'llm-wiki');
+		writeNonSkillFile(homeDir, 'research');
+		const storage = new HermesSkillStorage(() => '', homeDir);
+
+		const skills = await storage.loadAll();
+
+		expect(skills).toHaveLength(1);
+		expect(skills[0].name).toBe('llm-wiki');
+	});
+
+	it('uses frontmatter name over directory name', async () => {
+		writeSkillWithCustomName(homeDir, ['tools', 'my-dir'], 'custom-name', 'Custom description');
+		const storage = new HermesSkillStorage(() => '', homeDir);
+
+		const skills = await storage.loadAll();
+
+		expect(skills).toHaveLength(1);
+		expect(skills[0].name).toBe('custom-name');
+		expect(skills[0].description).toBe('Custom description');
+	});
+
+	it('falls back to directory name when frontmatter has no name', async () => {
+		const skillPath = path.join(homeDir, '.hermes', 'skills', 'tools', 'fallback-name', 'SKILL.md');
+		fs.mkdirSync(path.dirname(skillPath), { recursive: true });
+		fs.writeFileSync(skillPath, `---
+description: "No name field"
+---
+
+Content.
+`);
+		const storage = new HermesSkillStorage(() => '', homeDir);
+
+		const skills = await storage.loadAll();
+
+		expect(skills).toHaveLength(1);
+		expect(skills[0].name).toBe('fallback-name');
+	});
+
+	it('skips files without frontmatter', async () => {
+		const skillPath = path.join(homeDir, '.hermes', 'skills', 'broken', 'SKILL.md');
+		fs.mkdirSync(path.dirname(skillPath), { recursive: true });
+		fs.writeFileSync(skillPath, 'No frontmatter here');
+		const storage = new HermesSkillStorage(() => '', homeDir);
+
+		const skills = await storage.loadAll();
+
+		expect(skills).toEqual([]);
+	});
+
+	it('scans profile skills when profile is set', async () => {
+		writeSkill(homeDir, 'research', 'llm-wiki');
+
+		// Profile skill
+		const profileSkillPath = path.join(homeDir, '.hermes', 'profiles', 'coding', 'skills', 'code-gen', 'SKILL.md');
+		fs.mkdirSync(path.dirname(profileSkillPath), { recursive: true });
+		fs.writeFileSync(profileSkillPath, `---
+name: code-gen
+description: "Code gen skill"
+---
+
+Content
+`);
+
+		const storage = new HermesSkillStorage(() => 'coding', homeDir);
+		const skills = await storage.loadAll();
+
+		expect(skills).toHaveLength(2);
+		const names = skills.map(s => s.name).sort();
+		expect(names).toEqual(['code-gen', 'llm-wiki']);
+	});
+
+	it('profile skills override global skills on name conflict', async () => {
+		// Global skill
+		writeSkill(homeDir, 'my-skill');
+
+		// Profile skill with same name
+		const profileSkillPath = path.join(homeDir, '.hermes', 'profiles', 'coding', 'skills', 'my-skill', 'SKILL.md');
+		fs.mkdirSync(path.dirname(profileSkillPath), { recursive: true });
+		fs.writeFileSync(profileSkillPath, `---
+name: my-skill
+description: "Profile version"
+---
+
+Profile
+`);
+
+		const storage = new HermesSkillStorage(() => 'coding', homeDir);
+		const skills = await storage.loadAll();
+
+		expect(skills).toHaveLength(1);
+		expect(skills[0].description).toBe('Profile version');
+	});
+
+	it('returns global skills only when profile is empty', async () => {
+		writeSkill(homeDir, 'global-skill');
+		const storage = new HermesSkillStorage(() => '', homeDir);
+		const skills = await storage.loadAll();
+
+		expect(skills).toHaveLength(1);
+		expect(skills[0].name).toBe('global-skill');
+	});
+
+	it('does not error when profile directory is missing', async () => {
+		writeSkill(homeDir, 'my-skill');
+		const storage = new HermesSkillStorage(() => 'nonexistent-profile', homeDir);
+		const skills = await storage.loadAll();
+
+		expect(skills).toHaveLength(1);
+		expect(skills[0].name).toBe('my-skill');
+	});
+});

--- a/tests/unit/providers/hermes/ui/HermesSettingsTab.test.ts
+++ b/tests/unit/providers/hermes/ui/HermesSettingsTab.test.ts
@@ -1,0 +1,197 @@
+import * as fs from 'node:fs';
+
+const mockRenderEnvironmentSettingsSection = jest.fn();
+
+interface MockToggleComponent {
+	onChangeCallback: ((value: boolean) => Promise<void> | void) | null;
+	setValue: jest.Mock;
+	value: boolean;
+	onChange(callback: (value: boolean) => Promise<void> | void): MockToggleComponent;
+}
+
+interface MockTextComponent {
+	inputEl: {
+		toggleClass: jest.Mock;
+	};
+	onChangeCallback: ((value: string) => Promise<void> | void) | null;
+	setPlaceholder: jest.Mock;
+	setValue: jest.Mock;
+	value: string;
+	onChange(callback: (value: string) => Promise<void> | void): MockTextComponent;
+}
+
+class MockSetting {
+	heading = false;
+	name = '';
+	desc = '';
+	textComponents: MockTextComponent[] = [];
+	toggleComponents: MockToggleComponent[] = [];
+
+	constructor(_container: unknown) {
+		createdSettings.push(this);
+	}
+
+	setName(name: string): this {
+		this.name = name;
+		return this;
+	}
+
+	setDesc(desc: string): this {
+		this.desc = desc;
+		return this;
+	}
+
+	setHeading(): this {
+		this.heading = true;
+		return this;
+	}
+
+	addToggle(callback: (toggle: MockToggleComponent) => void): this {
+		const component = createToggleComponent();
+		this.toggleComponents.push(component);
+		callback(component);
+		return this;
+	}
+
+	addText(callback: (text: MockTextComponent) => void): this {
+		const component = createTextComponent();
+		this.textComponents.push(component);
+		callback(component);
+		return this;
+	}
+}
+
+jest.mock('node:fs');
+jest.mock('obsidian', () => ({
+	Setting: MockSetting,
+}));
+jest.mock('@/features/settings/ui/EnvironmentSettingsSection', () => ({
+	renderEnvironmentSettingsSection: (...args: unknown[]) => mockRenderEnvironmentSettingsSection(...args),
+}));
+jest.mock('@/utils/env', () => ({
+	...jest.requireActual('@/utils/env'),
+	getHostnameKey: () => 'current-host',
+}));
+
+import { getHermesProviderSettings } from '@/providers/hermes/settings';
+import { hermesSettingsTabRenderer } from '@/providers/hermes/ui/HermesSettingsTab';
+
+const createdSettings: MockSetting[] = [];
+const mockedExists = fs.existsSync as jest.Mock;
+const mockedStat = fs.statSync as jest.Mock;
+
+function createToggleComponent(): MockToggleComponent {
+	const component = {} as MockToggleComponent;
+	component.onChangeCallback = null;
+	component.value = false;
+	component.setValue = jest.fn((value: boolean) => {
+		component.value = value;
+		return component;
+	});
+	component.onChange = (callback: (value: boolean) => Promise<void> | void): MockToggleComponent => {
+		component.onChangeCallback = callback;
+		return component;
+	};
+	return component;
+}
+
+function createTextComponent(): MockTextComponent {
+	const component = {} as MockTextComponent;
+	component.inputEl = { toggleClass: jest.fn() };
+	component.onChangeCallback = null;
+	component.value = '';
+	component.setPlaceholder = jest.fn(() => component);
+	component.setValue = jest.fn((value: string) => {
+		component.value = value;
+		return component;
+	});
+	component.onChange = (callback: (value: string) => Promise<void> | void): MockTextComponent => {
+		component.onChangeCallback = callback;
+		return component;
+	};
+	return component;
+}
+
+function createElement(): any {
+	return {
+		createDiv: jest.fn(() => createElement()),
+		createEl: jest.fn(() => ({ addClass: jest.fn() })),
+		empty: jest.fn(),
+		setText: jest.fn(),
+		toggleClass: jest.fn(),
+	};
+}
+
+function createContext(settings: Record<string, unknown>) {
+	return {
+		plugin: {
+			manifest: { version: '1.0.0' },
+			saveSettings: jest.fn().mockResolvedValue(undefined),
+			settings,
+		},
+		refreshModelSelectors: jest.fn(),
+		renderHiddenProviderCommandSetting: jest.fn(),
+	};
+}
+
+function render(settings: Record<string, unknown>) {
+	const context = createContext(settings);
+	hermesSettingsTabRenderer.render(createElement(), context as any);
+	return context;
+}
+
+function findSetting(name: string): MockSetting {
+	const setting = [...createdSettings].reverse().find(entry => entry.name === name);
+	if (!setting) {
+		throw new Error(`Setting not found: ${name}`);
+	}
+	return setting;
+}
+
+describe('HermesSettingsTab — profile', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		createdSettings.length = 0;
+		mockedExists.mockReturnValue(true);
+		mockedStat.mockReturnValue({ isFile: () => true });
+	});
+
+	it('renders the agent profile setting', () => {
+		render({ providerConfigs: { hermes: {} } });
+
+		expect(() => findSetting('Agent profile')).not.toThrow();
+	});
+
+	it('shows current profile value', () => {
+		render({ providerConfigs: { hermes: { profile: 'my-agent' } } });
+
+		const profileSetting = findSetting('Agent profile');
+		expect(profileSetting.textComponents[0].setValue).toHaveBeenCalledWith('my-agent');
+	});
+
+	it('shows empty value when no profile is set', () => {
+		render({ providerConfigs: { hermes: {} } });
+
+		const profileSetting = findSetting('Agent profile');
+		expect(profileSetting.textComponents[0].setValue).toHaveBeenCalledWith('');
+	});
+
+	it('persists profile on change', async () => {
+		const settings: Record<string, unknown> = { providerConfigs: { hermes: {} } };
+		const context = render(settings);
+
+		await findSetting('Agent profile').textComponents[0].onChangeCallback?.('new-profile');
+
+		expect(getHermesProviderSettings(settings).profile).toBe('new-profile');
+		expect(context.plugin.saveSettings).toHaveBeenCalled();
+	});
+
+	it('trims profile value before persisting', async () => {
+		const settings: Record<string, unknown> = { providerConfigs: { hermes: {} } };
+		render(settings);
+
+		await findSetting('Agent profile').textComponents[0].onChangeCallback?.('  spaced  ');
+
+		expect(getHermesProviderSettings(settings).profile).toBe('spaced');
+	});
+});


### PR DESCRIPTION
## Summary

Adds [Hermes Agent](https://github.com/nousresearch/hermes) (Nous Research) as a new Claudian chat provider, using ACP (Agent Client Protocol) over stdio. Follows the same pattern as the Pi provider (#712).

Closes #732

## What's Included

| Component | Status |
|-----------|--------|
| Runtime (`HermesChatRuntime`) | ✅ Working |
| History (SQLite `~/.hermes/state.db`) | ✅ Working |
| Session management (new / load / cancel) | ✅ Working |
| Settings UI (provider tab, model config) | ✅ Working |
| CLI resolution (`hermes acp`) | ✅ Working |
| Command catalog + profile selector | ✅ Working |
| Auxiliary services (inline edit, title gen) | ✅ Working |
| Unit tests (runtime, settings, UI, commands) | ✅ Working |
| Slash commands | 🚧 In progress |
| Full tool stream support | 🚧 In progress |
| Runtime command discovery | 🚧 In progress |

## Architecture

```
src/providers/hermes/
├── runtime/              # HermesChatRuntime (ACP), HermesCliResolver, HermesAuxQueryRunner
├── history/              # HermesConversationHistoryService, HermesHistoryStore (SQLite)
├── commands/             # HermesCommandCatalog with profile selector
├── app/                  # HermesWorkspaceServices, HermesRuntimeCommandLoader
├── storage/              # HermesSkillStorage
├── auxiliary/            # Inline edit, title gen, instruction refine, task result interpreter
├── ui/                   # HermesSettingsTab, HermesChatUIConfig
├── env/                  # HermesSettingsReconciler
├── capabilities.ts       # Provider capability flags
├── models.ts             # Model definitions (30+ providers)
├── settings.ts           # Provider settings schema
├── types.ts              # Hermes-specific types
└── registration.ts       # ProviderRegistration
```

## How It Works

1. **Runtime**: Spawns `hermes acp` via `AcpSubprocess`, communicates over JSON-RPC
2. **History**: Reads directly from Hermes SQLite database (`~/.hermes/state.db`, schema v11)
3. **Models**: Supports 30+ model providers via aggregators, configured at `~/.hermes/config.yaml`
4. **Settings**: Reconciles Claudian settings with native Hermes config

## Testing

Unit tests cover:
- Runtime transport and launch behavior
- Settings parsing and reconciliation
- UI config rendering
- Command catalog and profile selection

## Dependencies

- Uses shared ACP infrastructure from `src/providers/acp/` (already in main)
- No new npm dependencies

---

⚠️ **This is a Draft PR.** Looking for early architecture review before completing the remaining features. Feedback on the overall approach is very welcome.