### PR TITLE
feat: add Remote Control support for the Claude provider

### DIFF
--- a/src/core/runtime/ChatRuntime.ts
+++ b/src/core/runtime/ChatRuntime.ts
@@ -43,6 +43,14 @@ export interface ChatRuntime {
   isReady(): boolean;
   getSupportedCommands(): Promise<SlashCommand[]>;
   getAuxiliaryModel?(): string | null;
+
+  /**
+   * Registers (or unregisters) this session for remote control via the
+   * underlying agent SDK, so it can be driven from a paired Claude client.
+   * Only providers backed by an SDK that supports the `remote_control`
+   * control request implement this.
+   */
+  enableRemoteControl?(enabled: boolean, name?: string): Promise<unknown>;
   cleanup(): void;
   rewind(userMessageId: string, assistantMessageId: string, mode?: ChatRewindMode): Promise<ChatRewindResult>;
   setApprovalCallback(callback: ApprovalCallback | null): void;

--- a/src/core/runtime/types.ts
+++ b/src/core/runtime/types.ts
@@ -3,6 +3,7 @@ import type { CanvasSelectionContext } from '../../utils/canvas';
 import type { EditorSelectionContext } from '../../utils/editor';
 import type {
   ApprovalDecision,
+  ChatMessage,
   Conversation,
   ExitPlanModeCallback,
   ImageAttachment,
@@ -108,6 +109,14 @@ export interface ChatTurnMetadata {
 export interface AutoTurnResult {
   chunks: StreamChunk[];
   metadata: ChatTurnMetadata;
+  /**
+   * User message that triggered this auto-turn, when it originated outside the
+   * local UI (e.g. a remote-control turn sent from claude.ai). The SDK stream
+   * does not echo such prompts, so the runtime sources it from the transcript
+   * for the renderer to show before the assistant reply. Undefined for local
+   * background turns (e.g. subagent notifications).
+   */
+  precedingUserMessage?: ChatMessage;
 }
 
 export type AutoTurnCallback = (result: AutoTurnResult) => void | Promise<void>;

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -1877,6 +1877,18 @@ async function renderAutoTriggeredTurn(tab: TabData, result: AutoTurnResult): Pr
       tab.renderer?.scrollToBottom();
     }
   }
+
+  // Route the rendered auto-turn through the normal conversation save boundary
+  // so metadata stays consistent (lastResponseAt, title/preview, provider state)
+  // and a later tab switch/reload does not restore stale messages. For native
+  // (SDK) sessions save() writes metadata and lazily creates + binds the
+  // conversation with the SDK session id when the tab has none yet — which is
+  // what makes a remote-first turn recoverable from history on reload.
+  if ((hasVisibleContent || !!precedingUserMessage) && !tab.state.isStreaming) {
+    void tab.controllers.conversationController?.save(true).catch(() => {
+      // Best-effort persistence; avoid surfacing background-save failures here.
+    });
+  }
 }
 
 export function updatePlanModeUI(tab: TabData, plugin: ClaudianPlugin, mode: string): void {

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -1794,8 +1794,23 @@ async function renderAutoTriggeredTurn(tab: TabData, result: AutoTurnResult): Pr
     return;
   }
 
-  const { chunks, metadata } = result;
+  const { chunks, metadata, precedingUserMessage } = result;
   if (chunks.length === 0) return;
+
+  // Remote-control turns carry the originating user prompt (the SDK stream omits
+  // it). Render it as a user bubble before the assistant reply, de-duplicating
+  // against messages already shown (e.g. rebuilt on reload).
+  if (precedingUserMessage) {
+    const alreadyShown = tab.state.messages?.some(
+      msg => msg.id === precedingUserMessage.id
+        || (precedingUserMessage.userMessageId
+          && msg.userMessageId === precedingUserMessage.userMessageId)
+    );
+    if (!alreadyShown) {
+      tab.state.addMessage(precedingUserMessage);
+      tab.renderer?.addMessage?.(precedingUserMessage);
+    }
+  }
 
   const hiddenToolIds = new Set(
     chunks

--- a/src/main.ts
+++ b/src/main.ts
@@ -192,7 +192,6 @@ export default class ClaudianPlugin extends Plugin {
           void (async () => {
             try {
               const result = await runtime.enableRemoteControl!(true);
-              console.log('[Claudian] remote_control response:', result);
               new Notice(`Remote control enabled.\n${JSON.stringify(result)}`, 15000);
             } catch (err) {
               const message = err instanceof Error ? err.message : String(err);

--- a/src/main.ts
+++ b/src/main.ts
@@ -174,6 +174,36 @@ export default class ClaudianPlugin extends Plugin {
       },
     });
 
+    this.addCommand({
+      id: 'enable-remote-control',
+      name: 'Enable remote control (current session)',
+      checkCallback: (checking: boolean) => {
+        const view = this.getView();
+        if (!view) return false;
+
+        const tabManager = view.getTabManager();
+        if (!tabManager) return false;
+
+        const runtime = tabManager.getActiveTab()?.service ?? null;
+        if (!runtime || typeof runtime.enableRemoteControl !== 'function') return false;
+        if (!runtime.isReady()) return false;
+
+        if (!checking) {
+          void (async () => {
+            try {
+              const result = await runtime.enableRemoteControl!(true);
+              console.log('[Claudian] remote_control response:', result);
+              new Notice(`Remote control enabled.\n${JSON.stringify(result)}`, 15000);
+            } catch (err) {
+              const message = err instanceof Error ? err.message : String(err);
+              new Notice(`Remote control failed: ${message}`, 8000);
+            }
+          })();
+        }
+        return true;
+      },
+    });
+
     this.addSettingTab(new ClaudianSettingTab(this.app, this));
   }
 

--- a/src/providers/claude/runtime/ClaudeChatRuntime.ts
+++ b/src/providers/claude/runtime/ClaudeChatRuntime.ts
@@ -68,6 +68,8 @@ import {
 } from '../../../utils/session';
 import { CLAUDE_PROVIDER_CAPABILITIES } from '../capabilities';
 import { loadSubagentFinalResult, loadSubagentToolCalls } from '../history/ClaudeHistoryStore';
+import { parseSDKMessageToChat } from '../history/sdkMessageParsing';
+import { readSDKSession } from '../history/sdkSessionPaths';
 import { createStopSubagentHook, type SubagentHookState } from '../hooks/SubagentHooks';
 import { encodeClaudeTurn } from '../prompt/ClaudeTurnEncoder';
 import { isContextWindowEvent, isSessionInitEvent, isStreamChunk } from '../sdk/typeGuards';
@@ -148,6 +150,10 @@ export class ClaudianService implements ChatRuntime {
   private mcpManager: McpServerManager;
 
   private persistentQuery: Query | null = null;
+
+  // Tracks the query for which "remote control by default" was already applied,
+  // so it fires once per query lifecycle (re-applies after a restart).
+  private remoteControlAppliedForQuery: Query | null = null;
   private messageChannel: MessageChannel | null = null;
   private queryAbortController: AbortController | null = null;
   private responseHandlers: ResponseHandler[] = [];
@@ -829,6 +835,7 @@ export class ClaudianService implements ChatRuntime {
     const handler = this.responseHandlers[this.responseHandlers.length - 1];
     const autoTurnBufferStartLength = this._autoTurnBuffer.length;
 
+
     // Transform SDK message to StreamChunks
     for (const event of transformSDKMessage(message, this.getTransformOptions())) {
       this.noteVisibleStreamContent(message, event, {
@@ -867,6 +874,8 @@ export class ClaudianService implements ChatRuntime {
         // Pass the current query instance so late completions from a dead query
         // cannot overwrite the active cache after a restart or shutdown.
         void this.fetchAndCacheCommands(this.persistentQuery);
+        // Auto-enable remote control for this session when the user opted in.
+        void this.maybeEnableRemoteControlByDefault();
       } else if (isContextWindowEvent(event)) {
         const usageChunk = this.updateBufferedUsageContextWindow(event.contextWindow);
         if (!usageChunk) {
@@ -957,11 +966,63 @@ export class ClaudianService implements ChatRuntime {
     const chunks = [...this._autoTurnBuffer];
     const metadata = this.consumeTurnMetadata();
     this._autoTurnBuffer = [];
+
+    // Remote-control turns (sent from claude.ai) are not echoed as `user` messages
+    // on the SDK stream, so the prompt is missing from the rendered transcript.
+    // Recover it from the on-disk session transcript so the renderer can show it.
+    const precedingUserMessage = await this.resolvePrecedingRemoteUserMessage(
+      metadata.assistantMessageId,
+    );
+
     try {
-      await this._autoTurnCallback?.({ chunks, metadata });
+      await this._autoTurnCallback?.({ chunks, metadata, precedingUserMessage });
     } catch {
       new Notice('Background task completed, but the result could not be rendered.');
     }
+  }
+
+  /**
+   * Finds the user prompt that triggered an auto-turn by reading the session
+   * transcript and walking back from the assistant message to the nearest real
+   * user message. Returns undefined when there is no session, no transcript
+   * entry, or the preceding user turn is a tool result / interrupt / rebuilt
+   * context. The renderer is responsible for de-duplicating against messages it
+   * has already shown.
+   */
+  private async resolvePrecedingRemoteUserMessage(
+    assistantUuid?: string,
+  ): Promise<ChatMessage | undefined> {
+    if (!assistantUuid) return undefined;
+    const sessionId = this.getSessionId();
+    if (!sessionId) return undefined;
+    const vaultPath = getVaultPath(this.plugin.app);
+    if (!vaultPath) return undefined;
+
+    try {
+      const { messages } = await readSDKSession(vaultPath, sessionId);
+      // Primary: anchor on the assistant uuid for precision. The assistant write
+      // can lag the stream though, so when it is not on disk yet, fall back to the
+      // last real user message — the user turn is written before the assistant
+      // generates, so it is reliably present. The renderer de-duplicates.
+      const assistantIdx = messages.findIndex(entry => entry.uuid === assistantUuid);
+      const startBefore = assistantIdx >= 0 ? assistantIdx : messages.length;
+
+      for (let i = startBefore - 1; i >= 0; i--) {
+        const entry = messages[i];
+        if (entry.type !== 'user') continue;
+        const chat = parseSDKMessageToChat(entry);
+        // tool_result-only user turns parse to null; skip them to reach the prompt
+        if (!chat || chat.role !== 'user') continue;
+        if (chat.isInterrupt || chat.isRebuiltContext) return undefined;
+        const hasText = !!chat.content?.trim();
+        const hasImages = !!chat.images?.length;
+        if (!hasText && !hasImages) continue;
+        return chat;
+      }
+    } catch {
+      return undefined;
+    }
+    return undefined;
   }
 
   private registerResponseHandler(handler: ResponseHandler): void {
@@ -1738,6 +1799,48 @@ export class ClaudianService implements ChatRuntime {
     if (!this.persistentQuery) throw new Error('No active query');
     if (this.shuttingDown) throw new Error('Service is shutting down');
     return this.persistentQuery.rewindFiles(userMessageId, { dryRun });
+  }
+
+  /**
+   * Registers this session for remote control via the agent SDK's
+   * `remote_control` control request. Returns the SDK response (e.g. pairing
+   * info). Throws if no live query, while shutting down, or if the installed
+   * SDK build does not expose the method.
+   */
+  async enableRemoteControl(enabled: boolean, name?: string): Promise<unknown> {
+    if (!this.persistentQuery) throw new Error('No active query');
+    if (this.shuttingDown) throw new Error('Service is shutting down');
+    const query = this.persistentQuery as Query & {
+      enableRemoteControl?: (enabled: boolean, name?: string) => Promise<unknown>;
+    };
+    if (typeof query.enableRemoteControl !== 'function') {
+      throw new Error('Installed claude-agent-sdk does not support remote control');
+    }
+    return query.enableRemoteControl(enabled, name);
+  }
+
+  /**
+   * Enables remote control once per query when the user turned on the
+   * "remote control by default" setting. Best-effort: failures (e.g. an SDK
+   * build without the control request) are swallowed and retried on the next
+   * session init. Note: headless/SDK mode cannot reuse the CLI's persistent
+   * bridge, so this registers a fresh claude.ai session each time.
+   */
+  private async maybeEnableRemoteControlByDefault(): Promise<void> {
+    const query = this.persistentQuery;
+    if (!query) return;
+    if (this.remoteControlAppliedForQuery === query) return;
+    if (!getClaudeProviderSettings(this.plugin.settings).remoteControlByDefault) return;
+
+    this.remoteControlAppliedForQuery = query;
+    try {
+      await this.enableRemoteControl(true);
+    } catch {
+      // Allow a retry on the next init if this attempt failed.
+      if (this.remoteControlAppliedForQuery === query) {
+        this.remoteControlAppliedForQuery = null;
+      }
+    }
   }
 
   async rewind(

--- a/src/providers/claude/settings.ts
+++ b/src/providers/claude/settings.ts
@@ -20,6 +20,12 @@ export interface ClaudeProviderSettings {
   enableBangBash: boolean;
   enableOpus1M: boolean;
   enableSonnet1M: boolean;
+  /**
+   * Auto-enable Remote Control for every session via the SDK control request.
+   * Headless/SDK mode cannot use the CLI's persistent bridge, so each session
+   * (including after an Obsidian reload) registers a fresh claude.ai session.
+   */
+  remoteControlByDefault: boolean;
   customModels: string;
   lastModel: string;
   environmentVariables: string;
@@ -35,6 +41,7 @@ export const DEFAULT_CLAUDE_PROVIDER_SETTINGS: Readonly<ClaudeProviderSettings> 
   enableBangBash: false,
   enableOpus1M: false,
   enableSonnet1M: false,
+  remoteControlByDefault: false,
   customModels: '',
   lastModel: 'haiku',
   environmentVariables: '',
@@ -99,6 +106,8 @@ export function getClaudeProviderSettings(
     enableSonnet1M: (config.enableSonnet1M as boolean | undefined)
       ?? (settings.enableSonnet1M as boolean | undefined)
       ?? DEFAULT_CLAUDE_PROVIDER_SETTINGS.enableSonnet1M,
+    remoteControlByDefault: (config.remoteControlByDefault as boolean | undefined)
+      ?? DEFAULT_CLAUDE_PROVIDER_SETTINGS.remoteControlByDefault,
     customModels: (config.customModels as string | undefined)
       ?? DEFAULT_CLAUDE_PROVIDER_SETTINGS.customModels,
     lastModel: (config.lastModel as string | undefined)

--- a/src/providers/claude/ui/ClaudeSettingsTab.ts
+++ b/src/providers/claude/ui/ClaudeSettingsTab.ts
@@ -378,6 +378,22 @@ export const claudeSettingsTabRenderer: ProviderSettingsTabRenderer = {
       );
 
     new Setting(container)
+      .setName('Remote control by default')
+      .setDesc(
+        'Auto-enable Remote Control for every Claude session so it can be driven '
+        + 'from claude.ai/code. Headless mode cannot reuse the persistent bridge, '
+        + 'so reloading Obsidian registers a new claude.ai session each time.',
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(claudeSettings.remoteControlByDefault)
+          .onChange(async (value) => {
+            updateClaudeProviderSettings(settingsBag, { remoteControlByDefault: value });
+            await context.plugin.saveSettings();
+          })
+      );
+
+    new Setting(container)
       .setName(t('settings.enableBangBash.name'))
       .setDesc(t('settings.enableBangBash.desc'))
       .addToggle((toggle) =>


### PR DESCRIPTION
## Summary

Adds **Remote Control** support to the Claude provider, so a Claudian-hosted session can be driven from [claude.ai/code](https://claude.ai/code) and the Claude mobile app, plus the fixes needed to make remotely sent prompts render in Obsidian.

## What's included

1. **Manual command** — "Enable remote control (current session)" calls the agent SDK's `enableRemoteControl` control request on the active session's runtime and surfaces the returned session URL via a `Notice`.

2. **"Remote control by default" toggle** — Claude provider settings → Experimental (default **off**). Auto-enables Remote Control on every session at init. Headless/SDK mode cannot reuse the CLI's persistent bridge, so each session (including after an Obsidian reload) registers a fresh claude.ai session; this is noted in the toggle description.

3. **Render remotely sent user prompts** — Remote Control turns arrive without a handler and the SDK stream does not echo the originating user message, so previously only the assistant reply appeared. The runtime now recovers the prompt from the on-disk session transcript (anchored on the assistant uuid, with a fallback to the last real user message to tolerate the transcript-write race) and passes it via `AutoTurnResult.precedingUserMessage`; the renderer shows it before the assistant reply, de-duplicating against messages already displayed.

## Implementation notes

- `enableRemoteControl` is added as an **optional** method on the `ChatRuntime` interface; only the Claude provider implements it (the underlying `@anthropic-ai/claude-agent-sdk` exposes it on `Query` but does not declare it in its `.d.ts`, so the implementation casts).
- Persistent/resumable Remote Control across a process restart is not available in headless/SDK mode today — see anthropics/claude-code#30447. The default-off toggle reflects the resulting "new session per reload" behavior.

## Testing

- `npm run typecheck` ✓
- `npm run lint` ✓
- `npm run build` ✓
- `npm run test` — 240 suites / 5677 tests ✓
- Manually verified in Obsidian: manual command registers a session that appears on claude.ai/code; messages sent from the web render in Obsidian (both user prompt and assistant reply), including the transcript-write-race path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
