### PR TITLE
feat(pi): add search filter to discovered models list

### DIFF
--- a/src/providers/pi/ui/PiSettingsTab.ts
+++ b/src/providers/pi/ui/PiSettingsTab.ts
@@ -97,14 +97,40 @@ export const piSettingsTabRenderer: ProviderSettingsTabRenderer = {
 
     new Setting(container).setName('Models').setHeading();
 
+    let searchQuery = '';
+    const searchContainer = container.createDiv({ cls: 'claudian-pi-model-search' });
+    new Setting(searchContainer)
+      .setName('Filter models')
+      .setDesc('Search by model name, ID, or alias.')
+      .addText((text) => {
+        text
+          .setPlaceholder('Search models...')
+          .setValue(searchQuery)
+          .onChange((value) => {
+            searchQuery = value;
+            renderModels();
+          });
+      });
+
     const modelContainer = container.createDiv({ cls: 'claudian-pi-models' });
     const renderModels = (): void => {
       modelContainer.empty();
       const current = getPiProviderSettings(settingsBag);
+      const query = searchQuery.toLowerCase();
+      const filteredModels = query
+        ? current.discoveredModels.filter(m => {
+            const label = (current.modelAliases[m.encodedId] || m.label).toLowerCase();
+            const id = m.encodedId.toLowerCase();
+            return label.includes(query) || id.includes(query);
+          })
+        : current.discoveredModels;
+
       new Setting(modelContainer)
         .setName('Discover models')
         .setDesc(current.discoveredModels.length > 0
-          ? `${current.discoveredModels.length} Pi models cached.`
+          ? (query
+            ? `${filteredModels.length} of ${current.discoveredModels.length} Pi models shown.`
+            : `${current.discoveredModels.length} Pi models cached.`)
           : 'Fetch models from `pi --mode rpc --no-session`.')
         .addButton((button) => {
           button.setButtonText('Discover').onClick(async () => {
@@ -136,7 +162,7 @@ export const piSettingsTabRenderer: ProviderSettingsTabRenderer = {
         return;
       }
 
-      for (const model of current.discoveredModels) {
+      for (const model of filteredModels) {
         new Setting(modelContainer)
           .setName(current.modelAliases[model.encodedId] || model.label)
           .setDesc(model.encodedId)


### PR DESCRIPTION
## What

Adds a filter input to the Pi discovered models list in settings.
Type to narrow by model name, encoded ID, or alias. Displays a
count when active (e.g., "3 of 12 models shown").

## Why

With many discovered models, finding and toggling a specific one
requires scrolling through the full list. A filter makes this
instant.

## Changes

- `src/providers/pi/ui/PiSettingsTab.ts`: add filter state, input,
  and filtered rendering

## Validation

- `npm run typecheck` — passes
- `npm run lint` — passes
- `npm run test` — 5677/5677 pass
- `npm run build` — succeeds
- Manual: Pi settings → Models → type in filter → list narrows
  correctly, toggle and alias still work