### PR TITLE
feat: support drag-and-drop files and folders in chat view input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -237,7 +237,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -673,6 +672,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -737,7 +737,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
       "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -747,7 +746,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
       "integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
@@ -843,7 +841,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -867,7 +864,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2250,7 +2246,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -2569,7 +2564,6 @@
       "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.59.3",
@@ -2599,7 +2593,6 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -3093,7 +3086,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3601,7 +3593,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4568,7 +4559,6 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5131,7 +5121,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5676,7 +5665,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6339,7 +6327,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
       "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7115,7 +7102,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -7748,7 +7734,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -7825,6 +7810,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "ts-algebra": "^2.0.0"
@@ -8683,7 +8669,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10023,7 +10008,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -10797,7 +10783,6 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11486,7 +11471,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/features/chat/ui/FileContext.ts
+++ b/src/features/chat/ui/FileContext.ts
@@ -1,5 +1,5 @@
 import type { App, EventRef } from 'obsidian';
-import { Notice, TFile } from 'obsidian';
+import { Notice, TFile, TFolder } from 'obsidian';
 
 import type { McpServerManager } from '../../../core/mcp/McpServerManager';
 import type { AgentMentionProvider } from '../../../shared/mention/MentionDropdownController';
@@ -36,6 +36,7 @@ export class FileContextManager {
   private mentionDropdown: MentionDropdownController;
   private deleteEventRef: EventRef | null = null;
   private renameEventRef: EventRef | null = null;
+  private dropOverlay: HTMLElement | null = null;
 
   // Current note (shown as chip)
   private currentNotePath: string | null = null;
@@ -108,6 +109,8 @@ export class FileContextManager {
     this.renameEventRef = this.app.vault.on('rename', (file, oldPath) => {
       if (file instanceof TFile) this.handleFileRenamed(oldPath, file.path);
     });
+
+    this.setupDragAndDrop();
   }
 
   /** Returns the current note path (shown as chip). */
@@ -259,6 +262,183 @@ export class FileContextManager {
     if (this.renameEventRef) this.app.vault.offref(this.renameEventRef);
     this.mentionDropdown.destroy();
     this.chipsView.destroy();
+  }
+
+  private setupDragAndDrop() {
+    const inputWrapper = this.inputEl.closest('.claudian-input-wrapper') as HTMLElement;
+    if (!inputWrapper) return;
+
+    const ownerDocument = inputWrapper.ownerDocument ?? window.document;
+    this.dropOverlay = inputWrapper.createDiv({ cls: 'claudian-file-drop-overlay' });
+    const dropContent = this.dropOverlay.createDiv({ cls: 'claudian-file-drop-content' });
+
+    const svg = ownerDocument.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 24 24');
+    svg.setAttribute('width', '32');
+    svg.setAttribute('height', '32');
+    svg.setAttribute('fill', 'none');
+    svg.setAttribute('stroke', 'currentColor');
+    svg.setAttribute('stroke-width', '2');
+    const pathEl = ownerDocument.createElementNS('http://www.w3.org/2000/svg', 'path');
+    pathEl.setAttribute('d', 'M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z');
+    svg.appendChild(pathEl);
+    dropContent.appendChild(svg);
+    dropContent.createSpan({ text: 'Drop file or folder here' });
+
+    const dropZone = inputWrapper;
+
+    dropZone.addEventListener('dragenter', (e) => this.handleDragEnter(e));
+    dropZone.addEventListener('dragover', (e) => this.handleDragOver(e));
+    dropZone.addEventListener('dragleave', (e) => this.handleDragLeave(e));
+    dropZone.addEventListener('drop', (e) => {
+      void this.handleDrop(e);
+    });
+  }
+
+  private handleDragEnter(e: DragEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const draggedItems = (this.app as any).dragManager?.draggedItems;
+    const hasDraggedFiles = draggedItems && draggedItems.length > 0 && draggedItems.some((item: any) => item.file);
+    const hasExternalFiles = e.dataTransfer?.types.includes('Files');
+    const hasInternalUri = e.dataTransfer?.types.includes('text/uri-list');
+
+    if (hasDraggedFiles || hasExternalFiles || hasInternalUri) {
+      this.dropOverlay?.addClass('visible');
+    }
+  }
+
+  private handleDragOver(e: DragEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
+  private handleDragLeave(e: DragEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const inputWrapper = this.inputEl.closest('.claudian-input-wrapper');
+    if (!inputWrapper) {
+      this.dropOverlay?.removeClass('visible');
+      return;
+    }
+
+    const rect = inputWrapper.getBoundingClientRect();
+    if (
+      e.clientX <= rect.left ||
+      e.clientX >= rect.right ||
+      e.clientY <= rect.top ||
+      e.clientY >= rect.bottom
+    ) {
+      this.dropOverlay?.removeClass('visible');
+    }
+  }
+
+  private async handleDrop(e: DragEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    this.dropOverlay?.removeClass('visible');
+
+    const addedPaths: string[] = [];
+    let hasResolvedInternal = false;
+
+    // 1. Resolve internal Obsidian file/folder drags via dataTransfer URIs
+    const plainText = typeof e.dataTransfer?.getData === 'function'
+      ? e.dataTransfer.getData('text/plain') || ''
+      : '';
+    if (plainText.includes('obsidian://open')) {
+      const lines = plainText.split(/\r?\n/);
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed.startsWith('obsidian://open')) {
+          try {
+            const url = new URL(trimmed);
+            const fileParam = url.searchParams.get('file');
+            if (fileParam) {
+              const decodedPath = decodeURIComponent(fileParam);
+              const normalizedPath = this.normalizePathForVault(decodedPath);
+              if (normalizedPath) {
+                this.state.attachFile(normalizedPath);
+                const abstractFile = this.app.vault.getAbstractFileByPath(normalizedPath);
+                const isFolder = abstractFile instanceof TFolder;
+                const formatted = isFolder ? `${normalizedPath}/` : normalizedPath;
+                addedPaths.push(formatted);
+                hasResolvedInternal = true;
+              }
+            }
+          } catch (err) {
+            // Ignore invalid URIs
+          }
+        }
+      }
+    }
+
+    // 2. Fallback to app.dragManager (just in case)
+    if (!hasResolvedInternal) {
+      const draggedItems = (this.app as any).dragManager?.draggedItems;
+      if (draggedItems && draggedItems.length > 0) {
+        for (const item of draggedItems) {
+          if (item.file) {
+            const rawPath = item.file.path;
+            const normalizedPath = this.normalizePathForVault(rawPath);
+            if (normalizedPath) {
+              this.state.attachFile(normalizedPath);
+              const isFolder = item.file instanceof TFolder;
+              const formatted = isFolder ? `${normalizedPath}/` : normalizedPath;
+              addedPaths.push(formatted);
+              hasResolvedInternal = true;
+            }
+          }
+        }
+      }
+    }
+
+    // 3. Resolve external OS drags
+    if (!hasResolvedInternal) {
+      const files = e.dataTransfer?.files;
+      if (files && files.length > 0) {
+        for (let i = 0; i < files.length; i++) {
+          const file = files[i];
+          let rawPath = (file as any).path || '';
+          if (!rawPath && (window as any).electron?.webUtils) {
+            rawPath = (window as any).electron.webUtils.getPathForFile(file);
+          }
+          if (rawPath) {
+            const normalizedPath = this.normalizePathForVault(rawPath);
+            if (normalizedPath) {
+              this.state.attachFile(normalizedPath);
+              addedPaths.push(normalizedPath);
+            }
+          }
+        }
+      }
+    }
+
+    if (addedPaths.length > 0) {
+      const textToInsert = addedPaths.map(p => `@${p}`).join(' ') + ' ';
+      this.insertTextAtCursor(textToInsert);
+      this.callbacks.onChipsChanged?.();
+    }
+  }
+
+  private insertTextAtCursor(textToInsert: string) {
+    const input = this.inputEl;
+    const start = input.selectionStart || 0;
+    const end = input.selectionEnd || 0;
+    const value = input.value;
+
+    let prefix = '';
+    if (start > 0 && !/\s/.test(value[start - 1])) {
+      prefix = ' ';
+    }
+
+    input.value = value.substring(0, start) + prefix + textToInsert + value.substring(end);
+    const newCursorPos = start + prefix.length + textToInsert.length;
+    input.selectionStart = input.selectionEnd = newCursorPos;
+
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.focus();
   }
 
   /** Normalizes a file path to be vault-relative with forward slashes. */

--- a/src/style/features/file-context.css
+++ b/src/style/features/file-context.css
@@ -186,3 +186,42 @@
   white-space: nowrap;
   min-width: 0;
 }
+
+/* Drag and drop for files/folders overlay */
+.claudian-file-drop-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(var(--claudian-brand-rgb), 0.08);
+  border: 2px dashed var(--claudian-brand);
+  border-radius: 6px;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  pointer-events: none;
+}
+
+.claudian-file-drop-overlay.visible {
+  display: flex;
+}
+
+.claudian-file-drop-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  color: var(--claudian-brand);
+}
+
+.claudian-file-drop-content svg {
+  opacity: 0.7;
+}
+
+.claudian-file-drop-content span {
+  font-size: 12px;
+  font-weight: 500;
+}
+

--- a/tests/unit/features/chat/ui/FileContextManager.test.ts
+++ b/tests/unit/features/chat/ui/FileContextManager.test.ts
@@ -112,6 +112,7 @@ function createMockCallbacks(options: {
 describe('FileContextManager', () => {
   let containerEl: MockElement;
   let inputEl: HTMLTextAreaElement;
+  let mockInputWrapper: MockElement;
 
   beforeEach(() => {
     jest.useFakeTimers();
@@ -119,12 +120,20 @@ describe('FileContextManager', () => {
     mockVaultPath = '/vault';
     mockScanPaths.mockReturnValue([]);
     containerEl = createMockEl();
-    inputEl = {
-      value: '',
-      selectionStart: 0,
-      selectionEnd: 0,
-      focus: jest.fn(),
-    } as unknown as HTMLTextAreaElement;
+    mockInputWrapper = createMockEl();
+    mockInputWrapper.className = 'claudian-input-wrapper';
+
+    const mockInput = createMockEl('textarea');
+    mockInput.value = '';
+    mockInput.selectionStart = 0;
+    mockInput.selectionEnd = 0;
+    mockInput.focus = jest.fn();
+    mockInput.closest = jest.fn((selector) => {
+      if (selector === '.claudian-input-wrapper') return mockInputWrapper;
+      return null;
+    });
+
+    inputEl = mockInput;
   });
 
   afterEach(() => {
@@ -870,6 +879,182 @@ describe('FileContextManager', () => {
 
       await openCallback('notes/missing.md');
       expect(NoticeMock).toHaveBeenCalledWith(expect.stringContaining('Could not open file'));
+      manager.destroy();
+    });
+  });
+
+  describe('drag and drop', () => {
+    it('should show drop overlay on dragenter with valid files', () => {
+      const app = createMockApp();
+      const manager = new FileContextManager(
+        app, containerEl as any, inputEl, createMockCallbacks()
+      );
+
+      const dragEnterHandler = mockInputWrapper._eventListeners.get('dragenter')?.[0];
+      expect(dragEnterHandler).toBeDefined();
+
+      // Mock internal Obsidian draggedItems
+      (app as any).dragManager = {
+        draggedItems: [{ file: createMockTFile('notes/drop.md') }],
+      };
+
+      const event = {
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+        dataTransfer: {
+          types: [],
+        },
+      } as any;
+
+      dragEnterHandler!(event);
+
+      const overlay = mockInputWrapper.querySelector('.claudian-file-drop-overlay');
+      expect(overlay).toBeDefined();
+      expect(overlay?.hasClass('visible')).toBe(true);
+
+      manager.destroy();
+    });
+
+    it('should hide drop overlay on dragleave', () => {
+      const app = createMockApp();
+      const manager = new FileContextManager(
+        app, containerEl as any, inputEl, createMockCallbacks()
+      );
+
+      const dragLeaveHandler = mockInputWrapper._eventListeners.get('dragleave')?.[0];
+      const overlay = mockInputWrapper.querySelector('.claudian-file-drop-overlay');
+      overlay?.addClass('visible');
+
+      // Mock bounding box so dragleave client position is outside the wrapper
+      mockInputWrapper.getBoundingClientRect = () => ({
+        top: 10,
+        left: 10,
+        width: 100,
+        height: 100,
+        right: 110,
+        bottom: 110,
+        x: 10,
+        y: 10,
+        toJSON: () => {},
+      });
+
+      const event = {
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+        clientX: 5,
+        clientY: 5,
+      } as any;
+
+      dragLeaveHandler!(event);
+      expect(overlay?.hasClass('visible')).toBe(false);
+
+      manager.destroy();
+    });
+
+    it('should attach file and insert text on drop from internal explorer', async () => {
+      const app = createMockApp();
+      const manager = new FileContextManager(
+        app, containerEl as any, inputEl, createMockCallbacks()
+      );
+
+      const dropHandler = mockInputWrapper._eventListeners.get('drop')?.[0];
+      expect(dropHandler).toBeDefined();
+
+      // Mock internal Obsidian draggedItems (including folder and file)
+      const mockFile = createMockTFile('notes/alpha.md');
+      const mockFolder = new (jest.requireMock('obsidian').TFolder)('notes/sub');
+
+      (app as any).dragManager = {
+        draggedItems: [
+          { file: mockFile },
+          { file: mockFolder },
+        ],
+      };
+
+      const event = {
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+        dataTransfer: {
+          types: [],
+          files: [],
+        },
+      } as any;
+
+      await dropHandler!(event);
+
+      expect(inputEl.value).toBe('@notes/alpha.md @notes/sub/ ');
+      expect(manager.getAttachedFiles().has('notes/alpha.md')).toBe(true);
+      expect(manager.getAttachedFiles().has('notes/sub')).toBe(true);
+
+      manager.destroy();
+    });
+
+    it('should attach file and insert text on drop from internal explorer using dataTransfer URIs', async () => {
+      const app = createMockApp();
+      const manager = new FileContextManager(
+        app, containerEl as any, inputEl, createMockCallbacks()
+      );
+
+      const dropHandler = mockInputWrapper._eventListeners.get('drop')?.[0];
+      expect(dropHandler).toBeDefined();
+
+      const event = {
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+        dataTransfer: {
+          types: ['text/plain', 'text/uri-list'],
+          getData: jest.fn((type) => {
+            if (type === 'text/plain') {
+              return 'obsidian://open?vault=DragonXing&file=notes%2Falpha.md\nobsidian://open?vault=DragonXing&file=notes%2Fsub';
+            }
+            return '';
+          }),
+        },
+      } as any;
+
+      // Mock TFolder for folder check
+      const TFolderMock = jest.requireMock('obsidian').TFolder;
+      const folderMock = new TFolderMock('notes/sub');
+      app.vault.getAbstractFileByPath = jest.fn((p) => {
+        if (p === 'notes/alpha.md') return createMockTFile('notes/alpha.md');
+        if (p === 'notes/sub') return folderMock;
+        return null;
+      });
+
+      await dropHandler!(event);
+
+      expect(inputEl.value).toBe('@notes/alpha.md @notes/sub/ ');
+      expect(manager.getAttachedFiles().has('notes/alpha.md')).toBe(true);
+      expect(manager.getAttachedFiles().has('notes/sub')).toBe(true);
+
+      manager.destroy();
+    });
+
+    it('should attach file and insert text on drop from external OS drag', async () => {
+      const app = createMockApp();
+      const manager = new FileContextManager(
+        app, containerEl as any, inputEl, createMockCallbacks()
+      );
+
+      const dropHandler = mockInputWrapper._eventListeners.get('drop')?.[0];
+
+      // Mock external file
+      const event = {
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+        dataTransfer: {
+          types: ['Files'],
+          files: [
+            { path: '/vault/notes/external.md', name: 'external.md' },
+          ],
+        },
+      } as any;
+
+      await dropHandler!(event);
+
+      expect(inputEl.value).toBe('@notes/external.md ');
+      expect(manager.getAttachedFiles().has('notes/external.md')).toBe(true);
+
       manager.destroy();
     });
   });


### PR DESCRIPTION
Supports dragging files and folders from Obsidian's internal File Explorer (as well as external files from the OS) and dropping them directly into the Claudian chat view input area to automatically add them as @ mentions. Normalizes relative paths and handles folders (appends trailing slash). Includes full unit test coverage.