### PR TITLE
fix: allow spaces in @mentioned filenames (#736)

### DIFF
--- a/src/shared/mention/MentionDropdownController.ts
+++ b/src/shared/mention/MentionDropdownController.ts
@@ -278,6 +278,10 @@ export class MentionDropdownController {
       const firstVaultItemIndex = this.filteredMentionItems.length;
       const vaultItemCount = this.appendVaultItems(searchLower);
 
+      if (this.hideIfNoResults()) {
+        return;
+      }
+
       if (this.filteredContextFiles.length === 0 && vaultItemCount > 0) {
         this.selectedMentionIndex = firstVaultItemIndex;
       } else {
@@ -332,8 +336,7 @@ export class MentionDropdownController {
     const firstVaultItemIndex = this.filteredMentionItems.length;
     const vaultItemCount = this.appendVaultItems(searchLower);
 
-    if (this.filteredMentionItems.length === 0 && this.filteredContextFiles.length === 0) {
-      this.hide();
+    if (this.hideIfNoResults()) {
       return;
     }
 
@@ -414,6 +417,13 @@ export class MentionDropdownController {
     }
 
     return merged.length;
+  }
+
+  private hideIfNoResults(): boolean {
+    if (this.filteredMentionItems.length > 0) return false;
+
+    this.hide();
+    return true;
   }
 
   private renderMentionDropdown(): void {

--- a/src/shared/mention/MentionDropdownController.ts
+++ b/src/shared/mention/MentionDropdownController.ts
@@ -156,11 +156,6 @@ export class MentionDropdownController {
 
       const searchText = textBeforeCursor.substring(lastAtIndex + 1);
 
-      if (/\s/.test(searchText)) {
-        this.hide();
-        return;
-      }
-
       this.mentionStartIndex = lastAtIndex;
       this.showMentionDropdown(searchText);
     }, 200);
@@ -336,6 +331,11 @@ export class MentionDropdownController {
 
     const firstVaultItemIndex = this.filteredMentionItems.length;
     const vaultItemCount = this.appendVaultItems(searchLower);
+
+    if (this.filteredMentionItems.length === 0 && this.filteredContextFiles.length === 0) {
+      this.hide();
+      return;
+    }
 
     this.selectedMentionIndex = vaultItemCount > 0 ? firstVaultItemIndex : 0;
 

--- a/tests/unit/shared/mention/MentionDropdownController.test.ts
+++ b/tests/unit/shared/mention/MentionDropdownController.test.ts
@@ -110,6 +110,9 @@ describe('MentionDropdownController', () => {
     mockDropdownVisible = false;
     const { SelectableDropdown } = jest.requireMock('@/shared/components/SelectableDropdown');
     (SelectableDropdown as jest.Mock).mockClear();
+    const { externalContextScanner } = jest.requireMock('@/utils/externalContextScanner');
+    (externalContextScanner.scanPaths as jest.Mock).mockReset();
+    (externalContextScanner.scanPaths as jest.Mock).mockReturnValue([]);
     containerEl = createMockEl();
     inputEl = createMockInput();
     callbacks = createMockCallbacks();
@@ -349,6 +352,63 @@ describe('MentionDropdownController', () => {
       inputEl.selectionStart = 6;
       controller.handleInputChange();
       expect(() => jest.advanceTimersByTime(200)).not.toThrow();
+    });
+
+    it('keeps matching vault filenames with spaces', () => {
+      callbacks = createMockCallbacks({
+        getCachedVaultFiles: jest.fn().mockReturnValue([
+          {
+            path: 'folder/test file 2.md',
+            name: 'test file 2.md',
+            stat: { mtime: Date.now() },
+          } as any,
+        ]),
+      });
+      controller.destroy();
+      controller = new MentionDropdownController(containerEl, inputEl, callbacks);
+
+      inputEl.value = '@test file';
+      inputEl.selectionStart = inputEl.value.length;
+      controller.handleInputChange();
+      jest.advanceTimersByTime(200);
+
+      const renderOptions = getLatestDropdownRenderOptions();
+      expect(renderOptions.items.map((item: any) => item.path)).toContain('folder/test file 2.md');
+      expect(controller.isVisible()).toBe(true);
+    });
+
+    it('hides external context dropdown after completed spaced mention stops matching', () => {
+      const { externalContextScanner } = jest.requireMock('@/utils/externalContextScanner');
+      (externalContextScanner.scanPaths as jest.Mock).mockReturnValue([
+        {
+          path: '/tmp/external/test file.md',
+          name: 'test file.md',
+          relativePath: 'test file.md',
+          contextRoot: '/tmp/external',
+          mtime: 1000,
+        },
+      ]);
+      callbacks = createMockCallbacks({
+        getExternalContexts: jest.fn().mockReturnValue(['/tmp/external']),
+      });
+      controller.destroy();
+      controller = new MentionDropdownController(containerEl, inputEl, callbacks);
+
+      inputEl.value = '@external/test file';
+      inputEl.selectionStart = inputEl.value.length;
+      controller.handleInputChange();
+      jest.advanceTimersByTime(200);
+      expect(controller.isVisible()).toBe(true);
+
+      const dropdownInstance = getLatestDropdownInstance();
+
+      inputEl.value = '@external/test file.md next';
+      inputEl.selectionStart = inputEl.value.length;
+      controller.handleInputChange();
+      jest.advanceTimersByTime(200);
+
+      expect(dropdownInstance.hide).toHaveBeenCalled();
+      expect(controller.isVisible()).toBe(false);
     });
 
     it('handles @ at start of line', () => {


### PR DESCRIPTION
Closes #736.

**What:** Fix the `@` mention dropdown to support filenames with spaces (e.g. `@test file 2.md`).

**Why:** The dropdown previously called `this.hide()` whenever `searchText` matched `/\s/`, which blocked users from `@mention`ing any file whose name contains a space.

**Changes (`MentionDropdownController.ts`):**
- Remove the `/\s/.test(searchText)` early-return gate.
- Add a zero-results guard after `appendVaultItems` so the dropdown auto-closes when nothing matches instead of showing "No matches".

**Validation:**
- `@test file 2.md` — dropdown stays open, file matches.
- Tab-select, then continue typing — dropdown stays closed.
- `@randomtext` in normal messages — auto-closes (no matches).