### PR TITLE
fix: use em dash consistently in @mention feature bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Open the chat sidebar from the ribbon icon or command palette. Select text and u
 
 **Slash Commands & Skills** — Type `/` or `$` for reusable prompt templates or Skills from user- and vault-level scopes.
 
-**`@mention`** - Type `@` to mention anything you want the agent to work with, vault files, subagents, MCP servers, or files in external directories.
+**`@mention`** — Type `@` to mention anything you want the agent to work with, vault files, subagents, MCP servers, or files in external directories.
 
 **Plan Mode** — Toggle via `Shift+Tab`. The agent explores and designs before implementing, then presents a plan for approval.
 


### PR DESCRIPTION
## Summary

- All feature bullets in the **Features & Usage** section use an em dash (`—`) as the separator between the bold label and its description
- The `` `@mention` `` bullet was the odd one out, using a plain hyphen (` - `) instead
- This PR makes it consistent with the rest of the section

## Change

```diff
- **`@mention`** - Type `@` to mention anything...
+ **`@mention`** — Type `@` to mention anything...
```

## Test plan

- [x] Visual check: README renders consistently in GitHub and Obsidian preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)