### PR TITLE
feat: right-sidebar session switcher

### DIFF
--- a/src/core/types/chat.ts
+++ b/src/core/types/chat.ts
@@ -11,6 +11,9 @@ export interface ForkSource {
 /** View type identifier for Obsidian. */
 export const VIEW_TYPE_CLAUDIAN = 'claudian-view';
 
+/** View type identifier for the companion right-sidebar session switcher. */
+export const VIEW_TYPE_CLAUDIAN_SESSIONS = 'claudian-sessions-view';
+
 /** Supported image media types for attachments. */
 export type ImageMediaType = 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp';
 

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -11,6 +11,7 @@ export {
   type StreamChunk,
   type UsageInfo,
   VIEW_TYPE_CLAUDIAN,
+  VIEW_TYPE_CLAUDIAN_SESSIONS,
 } from './chat';
 export { type ProviderId } from './provider';
 

--- a/src/core/types/settings.ts
+++ b/src/core/types/settings.ts
@@ -53,8 +53,8 @@ export interface KeyboardNavigationSettings {
   focusInputKey: string;       // Key to focus input (default: 'i', like vim insert mode)
 }
 
-/** Tab bar position setting. */
-export type TabBarPosition = 'input' | 'header';
+/** Tab bar position setting. `right-sidebar` moves tab switching into the companion sessions panel. */
+export type TabBarPosition = 'input' | 'header' | 'right-sidebar';
 
 export const CHAT_VIEW_PLACEMENTS = [
   'right-sidebar',

--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -190,6 +190,7 @@ export class ClaudianView extends ItemView {
           this.updateNavRowLocation();
           this.persistTabState();
           this.syncProviderBrandColor();
+          this.plugin.notifySessionsChanged();
         },
         onTabSwitched: () => {
           this.updateTabBar();
@@ -197,22 +198,35 @@ export class ClaudianView extends ItemView {
           this.updateNavRowLocation();
           this.persistTabState();
           this.syncProviderBrandColor();
+          this.plugin.notifySessionsChanged();
         },
         onTabClosed: () => {
           this.updateTabBar();
           this.persistTabState();
+          this.plugin.notifySessionsChanged();
         },
-        onTabStreamingChanged: () => this.updateTabBar(),
-        onTabTitleChanged: () => this.updateTabBar(),
-        onTabAttentionChanged: () => this.updateTabBar(),
+        onTabStreamingChanged: () => {
+          this.updateTabBar();
+          this.plugin.notifySessionsChanged();
+        },
+        onTabTitleChanged: () => {
+          this.updateTabBar();
+          this.plugin.notifySessionsChanged();
+        },
+        onTabAttentionChanged: () => {
+          this.updateTabBar();
+          this.plugin.notifySessionsChanged();
+        },
         onTabConversationChanged: () => {
           this.updateTabBar();
           this.persistTabState();
           this.syncProviderBrandColor();
+          this.plugin.notifySessionsChanged();
         },
         onTabProviderChanged: () => {
           this.updateTabBar();
           this.syncProviderBrandColor();
+          this.plugin.notifySessionsChanged();
         },
       }
     );
@@ -450,7 +464,10 @@ export class ClaudianView extends ItemView {
     if (!this.tabBarContainerEl || !this.tabManager) return;
 
     const tabCount = this.tabManager.getTabCount();
-    const showTabBar = tabCount >= 2;
+    // In right-sidebar mode the companion sessions panel owns tab switching, so
+    // the in-chat badges are hidden entirely regardless of tab count.
+    const isRightSidebarMode = this.plugin.settings.tabBarPosition === 'right-sidebar';
+    const showTabBar = tabCount >= 2 && !isRightSidebarMode;
     const isHeaderMode = this.plugin.settings.tabBarPosition === 'header';
 
     // Hide tab badges when only 1 tab, show when 2+

--- a/src/features/chat/SessionsView.ts
+++ b/src/features/chat/SessionsView.ts
@@ -1,0 +1,55 @@
+import type { WorkspaceLeaf } from 'obsidian';
+import { ItemView } from 'obsidian';
+
+import { VIEW_TYPE_CLAUDIAN_SESSIONS } from '../../core/types';
+import type ClaudianPlugin from '../../main';
+import { SessionsPanel } from './ui/SessionsPanel';
+
+/**
+ * Companion right-sidebar view that hosts the session switcher panel.
+ *
+ * Thin shell: lifecycle only. It mounts a `SessionsPanel` (which drives the
+ * active main-window chat view's TabManager) and subscribes to the plugin's
+ * sessions-change emitter so the panel re-renders as tabs and conversations change.
+ */
+export class SessionsView extends ItemView {
+  private plugin: ClaudianPlugin;
+  private panel: SessionsPanel | null = null;
+  private unsubscribe: (() => void) | null = null;
+
+  constructor(leaf: WorkspaceLeaf, plugin: ClaudianPlugin) {
+    super(leaf);
+    this.plugin = plugin;
+  }
+
+  getViewType(): string {
+    return VIEW_TYPE_CLAUDIAN_SESSIONS;
+  }
+
+  getDisplayText(): string {
+    return 'Claudian sessions';
+  }
+
+  getIcon(): string {
+    return 'list';
+  }
+
+  async onOpen(): Promise<void> {
+    const container = this.contentEl;
+    container.empty();
+    container.addClass('claudian-sessions-view');
+
+    this.panel = new SessionsPanel(this.plugin, container);
+    this.panel.render();
+
+    this.unsubscribe = this.plugin.onSessionsChanged(() => this.panel?.render());
+  }
+
+  async onClose(): Promise<void> {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+
+    this.panel?.destroy();
+    this.panel = null;
+  }
+}

--- a/src/features/chat/SessionsView.ts
+++ b/src/features/chat/SessionsView.ts
@@ -31,7 +31,8 @@ export class SessionsView extends ItemView {
   }
 
   getIcon(): string {
-    return 'list';
+    // Match the main chat view's icon so the sidebar tab reads as Claudian.
+    return 'bot';
   }
 
   async onOpen(): Promise<void> {

--- a/src/features/chat/ui/SessionsPanel.ts
+++ b/src/features/chat/ui/SessionsPanel.ts
@@ -1,0 +1,261 @@
+import { Menu, Notice, setIcon } from 'obsidian';
+
+import { ProviderRegistry } from '../../../core/providers/ProviderRegistry';
+import type { ProviderId } from '../../../core/providers/types';
+import type { ConversationMeta } from '../../../core/types';
+import type ClaudianPlugin from '../../../main';
+import { createProviderIconSvg } from '../../../shared/icons';
+import type { TabManager } from '../tabs/TabManager';
+import type { TabBarItem } from '../tabs/types';
+
+/**
+ * Plain-DOM renderer for the right-sidebar session switcher.
+ *
+ * Reads from and drives the active main-window chat view's TabManager. Open tabs
+ * and recent (non-open) conversations are rendered as two sections; the panel
+ * stays fresh via the plugin's sessions-change emitter (re-render on each notify).
+ */
+export class SessionsPanel {
+  private plugin: ClaudianPlugin;
+  private containerEl: HTMLElement;
+
+  constructor(plugin: ClaudianPlugin, containerEl: HTMLElement) {
+    this.plugin = plugin;
+    this.containerEl = containerEl;
+  }
+
+  render(): void {
+    this.containerEl.empty();
+
+    this.renderNewSessionButton();
+
+    const tabManager = this.plugin.getActiveChatView()?.getTabManager() ?? null;
+    const openItems = tabManager?.getTabBarItems() ?? [];
+    const openConversationIds = new Set(
+      (tabManager?.getAllTabs() ?? [])
+        .map((tab) => tab.conversationId)
+        .filter((id): id is string => !!id),
+    );
+
+    this.renderOpenTabs(openItems, tabManager);
+    this.renderRecentSessions(openConversationIds);
+  }
+
+  destroy(): void {
+    this.containerEl.empty();
+  }
+
+  // ============================================
+  // Sections
+  // ============================================
+
+  private renderNewSessionButton(): void {
+    const btn = this.containerEl.createDiv({ cls: 'claudian-sessions-new-btn' });
+    const iconEl = btn.createSpan({ cls: 'claudian-sessions-new-btn-icon' });
+    setIcon(iconEl, 'square-plus');
+    btn.createSpan({ cls: 'claudian-sessions-new-btn-label', text: 'New session' });
+    btn.setAttribute('aria-label', 'Create a new session');
+    btn.addEventListener('click', () => {
+      void this.withTabManager(async (tabManager) => {
+        const tab = await tabManager.createTab();
+        if (!tab) {
+          const maxTabs = this.plugin.settings.maxTabs ?? 3;
+          new Notice(`Maximum ${maxTabs} tabs allowed`);
+        }
+      }, 'Failed to create session');
+    });
+  }
+
+  private renderOpenTabs(items: TabBarItem[], tabManager: TabManager | null): void {
+    if (!tabManager || items.length === 0) {
+      return;
+    }
+
+    this.containerEl.createDiv({ cls: 'claudian-sessions-section-header', text: 'Open' });
+    const list = this.containerEl.createDiv({ cls: 'claudian-sessions-list' });
+
+    for (const item of items) {
+      const row = list.createDiv({
+        cls: `claudian-sessions-item${item.isActive ? ' claudian-sessions-item--active' : ''}`,
+      });
+      if (item.needsAttention) {
+        row.addClass('claudian-sessions-item--attention');
+      } else if (item.isStreaming) {
+        row.addClass('claudian-sessions-item--streaming');
+      }
+
+      this.appendProviderDot(row, item.providerId);
+
+      const content = row.createDiv({ cls: 'claudian-sessions-item-content' });
+      const titleEl = content.createDiv({ cls: 'claudian-sessions-item-title', text: item.title });
+      titleEl.setAttribute('title', item.title);
+
+      const statusText = item.isActive
+        ? 'Active'
+        : item.needsAttention
+          ? 'Needs attention'
+          : item.isStreaming
+            ? 'Working…'
+            : 'Open';
+      content.createDiv({ cls: 'claudian-sessions-item-meta', text: statusText });
+
+      content.addEventListener('click', () => {
+        void this.runAction(
+          () => tabManager.switchToTab(item.id),
+          'Failed to switch session',
+        );
+      });
+
+      if (item.canClose) {
+        const closeBtn = row.createEl('button', {
+          cls: 'claudian-sessions-item-close',
+        });
+        setIcon(closeBtn, 'x');
+        closeBtn.setAttribute('aria-label', 'Close session');
+        closeBtn.addEventListener('click', (e) => {
+          e.stopPropagation();
+          void this.runAction(
+            () => tabManager.closeTab(item.id, item.isStreaming),
+            'Failed to close session',
+          );
+        });
+      }
+    }
+  }
+
+  private renderRecentSessions(openConversationIds: Set<string>): void {
+    const conversations = [...this.plugin.getConversationList()]
+      .sort((a, b) => (b.lastResponseAt ?? b.createdAt) - (a.lastResponseAt ?? a.createdAt))
+      .filter((conv) => !openConversationIds.has(conv.id));
+
+    this.containerEl.createDiv({ cls: 'claudian-sessions-section-header', text: 'Recent' });
+
+    if (conversations.length === 0) {
+      this.containerEl.createDiv({
+        cls: 'claudian-sessions-empty',
+        text: openConversationIds.size > 0 ? 'No other sessions' : 'No sessions yet',
+      });
+      return;
+    }
+
+    const list = this.containerEl.createDiv({ cls: 'claudian-sessions-list' });
+
+    for (const conv of conversations) {
+      const row = list.createDiv({ cls: 'claudian-sessions-item' });
+
+      this.appendProviderDot(row, conv.providerId);
+
+      const content = row.createDiv({ cls: 'claudian-sessions-item-content' });
+      const titleEl = content.createDiv({ cls: 'claudian-sessions-item-title', text: conv.title });
+      titleEl.setAttribute('title', conv.title);
+      content.createDiv({
+        cls: 'claudian-sessions-item-meta',
+        text: conv.titleGenerationStatus === 'pending'
+          ? 'Generating title…'
+          : this.formatDate(conv.lastResponseAt ?? conv.createdAt),
+      });
+
+      content.addEventListener('click', () => {
+        void this.withTabManager(
+          (tabManager) => tabManager.openConversation(conv.id, { preferNewTab: true, activate: true }),
+          'Failed to open session',
+        );
+      });
+
+      row.addEventListener('contextmenu', (e) => {
+        e.preventDefault();
+        this.showRecentContextMenu(conv, e);
+      });
+    }
+  }
+
+  // ============================================
+  // Context menu
+  // ============================================
+
+  private showRecentContextMenu(conv: ConversationMeta, event: MouseEvent): void {
+    const menu = new Menu();
+
+    menu.addItem((item) => item
+      .setTitle('Open in new tab')
+      .setIcon('square-plus')
+      .onClick(() => {
+        void this.withTabManager(
+          (tabManager) => tabManager.openConversation(conv.id, { preferNewTab: true, activate: true }),
+          'Failed to open session',
+        );
+      }));
+
+    menu.addItem((item) => item
+      .setTitle('Delete')
+      .setIcon('trash-2')
+      .onClick(() => {
+        void this.runAction(
+          () => this.plugin.deleteConversation(conv.id),
+          'Failed to delete session',
+        );
+      }));
+
+    menu.showAtMouseEvent(event);
+  }
+
+  // ============================================
+  // Helpers
+  // ============================================
+
+  /**
+   * Resolves the active chat view's TabManager, opening the chat view first when
+   * none exists, then runs the action against it.
+   */
+  private async withTabManager(
+    action: (tabManager: TabManager) => Promise<void>,
+    errorMessage: string,
+  ): Promise<void> {
+    try {
+      let view = this.plugin.getActiveChatView();
+      if (!view) {
+        await this.plugin.activateView();
+        view = this.plugin.getActiveChatView();
+      }
+      const tabManager = view?.getTabManager();
+      if (!tabManager) {
+        new Notice('Open the Claudian chat view first.');
+        return;
+      }
+      await action(tabManager);
+    } catch {
+      new Notice(errorMessage);
+    }
+  }
+
+  private async runAction(action: () => Promise<unknown>, errorMessage: string): Promise<void> {
+    try {
+      await action();
+    } catch {
+      new Notice(errorMessage);
+    }
+  }
+
+  private appendProviderDot(parent: HTMLElement, providerId: ProviderId): void {
+    const dot = parent.createSpan({ cls: 'claudian-sessions-provider-dot' });
+    dot.setAttribute('data-provider', providerId);
+    const icon = ProviderRegistry.getChatUIConfig(providerId).getProviderIcon?.();
+    if (icon) {
+      dot.appendChild(createProviderIconSvg(icon, {
+        dataProvider: providerId,
+        height: 12,
+        ownerDocument: dot.ownerDocument,
+        width: 12,
+      }));
+    }
+  }
+
+  private formatDate(timestamp: number): string {
+    const date = new Date(timestamp);
+    const now = new Date();
+    if (date.toDateString() === now.toDateString()) {
+      return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', hour12: false });
+    }
+    return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  }
+}

--- a/src/features/settings/ClaudianSettings.ts
+++ b/src/features/settings/ClaudianSettings.ts
@@ -8,7 +8,7 @@ import {
 import { ProviderRegistry } from '../../core/providers/ProviderRegistry';
 import { ProviderWorkspaceRegistry } from '../../core/providers/ProviderWorkspaceRegistry';
 import type { ProviderId } from '../../core/providers/types';
-import type { ChatViewPlacement } from '../../core/types/settings';
+import type { ChatViewPlacement, TabBarPosition } from '../../core/types/settings';
 import { getAvailableLocales, getLocaleDisplayName, setLocale, t } from '../../i18n/i18n';
 import type { Locale, TranslationKey } from '../../i18n/types';
 import type ClaudianPlugin from '../../main';
@@ -214,13 +214,18 @@ export class ClaudianSettingTab extends PluginSettingTab {
         dropdown
           .addOption('input', t('settings.tabBarPosition.input'))
           .addOption('header', t('settings.tabBarPosition.header'))
+          .addOption('right-sidebar', 'Right sidebar')
           .setValue(this.plugin.settings.tabBarPosition ?? 'input')
           .onChange(async (value) => {
-            this.plugin.settings.tabBarPosition = value as 'input' | 'header';
+            this.plugin.settings.tabBarPosition = value as TabBarPosition;
             await this.plugin.saveSettings();
 
             for (const view of this.plugin.getAllViews()) {
               view.updateLayoutForPosition();
+            }
+
+            if (value === 'right-sidebar') {
+              await this.plugin.activateSessionsView();
             }
           });
       });

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,6 +55,8 @@ export default class ClaudianPlugin extends Plugin {
   private lastKnownTabManagerState: AppTabManagerState | null = null;
   private sessionsListeners = new Set<() => void>();
   private sessionsViewOpening: Promise<WorkspaceLeaf | null> | null = null;
+  /** Last non-sessions right-sidebar tab (e.g. Outline) to restore off the chat view. */
+  private lastRightSidebarLeaf: WorkspaceLeaf | null = null;
 
   async onload() {
     await this.loadSettings();
@@ -94,14 +96,12 @@ export default class ClaudianPlugin extends Plugin {
       },
     });
 
-    // In right-sidebar mode, focus the session switcher whenever the chat view
-    // becomes active, so the sidebar follows the chat tab (and frees up for the
-    // document Outline etc. when a non-chat tab is active).
+    // In right-sidebar mode, make the right sidebar follow the active main-area
+    // tab: show the session switcher on the chat view, and restore the user's
+    // previous sidebar tab (e.g. the document Outline) on any other file.
     this.registerEvent(
       this.app.workspace.on('active-leaf-change', (leaf) => {
-        if (this.settings.tabBarPosition !== 'right-sidebar') return;
-        if (!isClaudianView(leaf?.view)) return;
-        void this.activateSessionsView({ focus: true });
+        this.syncSessionsSidebarToActiveLeaf(leaf);
       }),
     );
 
@@ -288,6 +288,47 @@ export default class ClaudianPlugin extends Plugin {
     const leaf = await this.sessionsViewOpening;
     if (focus && leaf) {
       await revealWorkspaceLeaf(workspace, leaf);
+    }
+  }
+
+  /**
+   * Keeps the right sidebar in step with the active main-area tab in
+   * right-sidebar mode: focus the session switcher on the chat view, and
+   * restore the user's previous sidebar tab (e.g. Outline) on any other file.
+   * Only acts on main-area leaves; sidebar activations are recorded so the
+   * preferred tab can be restored later.
+   */
+  private syncSessionsSidebarToActiveLeaf(leaf: WorkspaceLeaf | null): void {
+    if (this.settings.tabBarPosition !== 'right-sidebar') return;
+    if (!leaf) return;
+
+    const { workspace } = this.app;
+    const root = leaf.getRoot();
+
+    if (root === workspace.rightSplit) {
+      // Remember the user's chosen sidebar tab so we can bring it back; never
+      // record our own panel as the thing to restore.
+      if (leaf.view?.getViewType() !== VIEW_TYPE_CLAUDIAN_SESSIONS) {
+        this.lastRightSidebarLeaf = leaf;
+      }
+      return;
+    }
+
+    // Only react to the main editor area; ignore left-sidebar activations.
+    if (root !== workspace.rootSplit) return;
+
+    if (isClaudianView(leaf.view)) {
+      void this.activateSessionsView({ focus: true });
+      return;
+    }
+
+    const target = this.lastRightSidebarLeaf
+      ?? workspace.getLeavesOfType('outline')[0]
+      ?? null;
+    if (target) {
+      void revealWorkspaceLeaf(workspace, target).catch(() => {
+        this.lastRightSidebarLeaf = null;
+      });
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,9 +28,11 @@ import type {
 } from './core/types';
 import {
   VIEW_TYPE_CLAUDIAN,
+  VIEW_TYPE_CLAUDIAN_SESSIONS,
 } from './core/types';
 import type { ChatViewPlacement, EnvironmentScope } from './core/types/settings';
 import { ClaudianView } from './features/chat/ClaudianView';
+import { SessionsView } from './features/chat/SessionsView';
 import { type InlineEditContext, InlineEditModal } from './features/inline-edit/ui/InlineEditModal';
 import { ClaudianSettingTab } from './features/settings/ClaudianSettings';
 import { setLocale } from './i18n/i18n';
@@ -51,6 +53,8 @@ export default class ClaudianPlugin extends Plugin {
   storage!: SharedAppStorage;
   private conversations: Conversation[] = [];
   private lastKnownTabManagerState: AppTabManagerState | null = null;
+  private sessionsListeners = new Set<() => void>();
+  private sessionsViewOpening: Promise<WorkspaceLeaf | null> | null = null;
 
   async onload() {
     await this.loadSettings();
@@ -61,8 +65,17 @@ export default class ClaudianPlugin extends Plugin {
       (leaf) => new ClaudianView(leaf, this)
     );
 
+    this.registerView(
+      VIEW_TYPE_CLAUDIAN_SESSIONS,
+      (leaf) => new SessionsView(leaf, this)
+    );
+
     this.addRibbonIcon('bot', 'Open Claudian', () => {
       void this.activateView();
+    });
+
+    this.addRibbonIcon('panel-right', 'Open Claudian sessions', () => {
+      void this.activateSessionsView();
     });
 
     this.addCommand({
@@ -72,6 +85,25 @@ export default class ClaudianPlugin extends Plugin {
         void this.activateView();
       },
     });
+
+    this.addCommand({
+      id: 'open-sessions-panel',
+      name: 'Open sessions panel',
+      callback: () => {
+        void this.activateSessionsView();
+      },
+    });
+
+    // In right-sidebar mode, focus the session switcher whenever the chat view
+    // becomes active, so the sidebar follows the chat tab (and frees up for the
+    // document Outline etc. when a non-chat tab is active).
+    this.registerEvent(
+      this.app.workspace.on('active-leaf-change', (leaf) => {
+        if (this.settings.tabBarPosition !== 'right-sidebar') return;
+        if (!isClaudianView(leaf?.view)) return;
+        void this.activateSessionsView({ focus: true });
+      }),
+    );
 
     this.addCommand({
       id: 'inline-edit',
@@ -208,6 +240,53 @@ export default class ClaudianPlugin extends Plugin {
     }
 
     if (leaf) {
+      await revealWorkspaceLeaf(workspace, leaf);
+    }
+
+    if (this.settings.tabBarPosition === 'right-sidebar') {
+      // Opening the app is an explicit action: focus the switcher (creating it
+      // if a fresh reload left no panel). Switching to a non-chat tab never
+      // calls this, so the sidebar stays free for the document Outline etc.
+      await this.activateSessionsView({ focus: true });
+    }
+  }
+
+  /**
+   * Opens the companion session switcher in the right sidebar.
+   * @param focus When true, reveals and focuses the panel. When false, creates
+   *   it only if missing without stealing focus from another active
+   *   right-sidebar tab such as the Outline.
+   */
+  async activateSessionsView({ focus = true }: { focus?: boolean } = {}): Promise<void> {
+    const { workspace } = this.app;
+
+    const existing = workspace.getLeavesOfType(VIEW_TYPE_CLAUDIAN_SESSIONS)[0];
+    if (existing) {
+      if (focus) {
+        await revealWorkspaceLeaf(workspace, existing);
+      }
+      return;
+    }
+
+    // Serialize concurrent opens (activateView and the active-leaf-change
+    // listener can both fire on a fresh load) so only one panel is created.
+    if (!this.sessionsViewOpening) {
+      this.sessionsViewOpening = (async () => {
+        const newLeaf = workspace.getRightLeaf(false);
+        if (newLeaf) {
+          await newLeaf.setViewState({
+            type: VIEW_TYPE_CLAUDIAN_SESSIONS,
+            active: focus,
+          });
+        }
+        return newLeaf;
+      })().finally(() => {
+        this.sessionsViewOpening = null;
+      });
+    }
+
+    const leaf = await this.sessionsViewOpening;
+    if (focus && leaf) {
       await revealWorkspaceLeaf(workspace, leaf);
     }
   }
@@ -618,6 +697,8 @@ export default class ClaudianPlugin extends Plugin {
       this.storage.sessions.toSessionMetadata(conversation)
     );
 
+    this.notifySessionsChanged();
+
     return conversation;
   }
 
@@ -654,6 +735,8 @@ export default class ClaudianPlugin extends Plugin {
         }
       }
     }
+
+    this.notifySessionsChanged();
   }
 
   async renameConversation(id: string, title: string): Promise<void> {
@@ -666,6 +749,8 @@ export default class ClaudianPlugin extends Plugin {
     await this.storage.sessions.saveMetadata(
       this.storage.sessions.toSessionMetadata(conversation)
     );
+
+    this.notifySessionsChanged();
   }
 
   async updateConversation(id: string, updates: Partial<Conversation>): Promise<void> {
@@ -692,6 +777,8 @@ export default class ClaudianPlugin extends Plugin {
         }
       }
     }
+
+    this.notifySessionsChanged();
   }
 
   async getConversationById(id: string): Promise<Conversation | null> {
@@ -739,6 +826,31 @@ export default class ClaudianPlugin extends Plugin {
   getAllViews(): ClaudianView[] {
     const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_CLAUDIAN);
     return leaves.map(leaf => leaf.view).filter(isClaudianView);
+  }
+
+  /** Resolves the chat view the session switcher should drive (active, else first open). */
+  getActiveChatView(): ClaudianView | null {
+    const active = this.app.workspace.getActiveViewOfType(ClaudianView);
+    return active ?? this.getView();
+  }
+
+  /** Subscribes to session/tab changes. Returns an unsubscribe function. */
+  onSessionsChanged(listener: () => void): () => void {
+    this.sessionsListeners.add(listener);
+    return () => {
+      this.sessionsListeners.delete(listener);
+    };
+  }
+
+  /** Notifies subscribers (the session switcher) that sessions or tabs changed. */
+  notifySessionsChanged(): void {
+    for (const listener of this.sessionsListeners) {
+      try {
+        listener();
+      } catch {
+        // A failing listener must not break others or the caller.
+      }
+    }
   }
 
   findConversationAcrossViews(conversationId: string): { view: ClaudianView; tabId: string } | null {

--- a/src/style/components/sessions-panel.css
+++ b/src/style/components/sessions-panel.css
@@ -1,0 +1,158 @@
+.claudian-sessions-view {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px;
+  overflow-y: auto;
+}
+
+.claudian-sessions-new-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  margin-bottom: 4px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--text-normal);
+  background: var(--background-primary);
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.claudian-sessions-new-btn:hover {
+  background: var(--background-modifier-hover);
+  border-color: var(--interactive-accent);
+}
+
+.claudian-sessions-new-btn-icon {
+  display: flex;
+  align-items: center;
+  color: var(--text-muted);
+}
+
+.claudian-sessions-new-btn-icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.claudian-sessions-new-btn-label {
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.claudian-sessions-section-header {
+  padding: 8px 6px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.claudian-sessions-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.claudian-sessions-empty {
+  padding: 8px 6px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.claudian-sessions-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  transition: background 0.15s ease;
+}
+
+.claudian-sessions-item:hover {
+  background: var(--background-modifier-hover);
+}
+
+.claudian-sessions-item--active {
+  background: var(--background-secondary);
+  border-inline-start: 2px solid var(--interactive-accent);
+  padding-inline-start: 6px;
+}
+
+.claudian-sessions-provider-dot {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  color: var(--text-muted);
+}
+
+.claudian-sessions-provider-dot svg {
+  width: 12px;
+  height: 12px;
+}
+
+.claudian-sessions-item--streaming .claudian-sessions-provider-dot {
+  color: var(--claudian-brand, #da7756);
+}
+
+.claudian-sessions-item--attention .claudian-sessions-provider-dot {
+  color: var(--text-error);
+}
+
+.claudian-sessions-item-content {
+  flex: 1;
+  min-width: 0;
+  cursor: pointer;
+}
+
+.claudian-sessions-item--active .claudian-sessions-item-content {
+  cursor: default;
+}
+
+.claudian-sessions-item-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-normal);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.claudian-sessions-item-meta {
+  font-size: 11px;
+  color: var(--text-faint);
+  margin-top: 2px;
+}
+
+.claudian-sessions-item-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 4px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--text-muted);
+  background: transparent;
+  opacity: 0;
+  transition: opacity 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+
+.claudian-sessions-item:hover .claudian-sessions-item-close {
+  opacity: 1;
+}
+
+.claudian-sessions-item-close:hover {
+  background: var(--background-modifier-hover);
+  color: var(--text-normal);
+}
+
+.claudian-sessions-item-close svg {
+  width: 14px;
+  height: 14px;
+}

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -10,6 +10,7 @@
 @import "./components/header.css";
 @import "./components/tabs.css";
 @import "./components/history.css";
+@import "./components/sessions-panel.css";
 @import "./components/messages.css";
 @import "./components/nav-sidebar.css";
 @import "./components/code.css";

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -13,6 +13,7 @@ export class Plugin {
   addCommand = jest.fn();
   addSettingTab = jest.fn();
   registerView = jest.fn();
+  registerEvent = jest.fn();
   loadData = jest.fn().mockResolvedValue({});
   saveData = jest.fn().mockResolvedValue(undefined);
 }
@@ -116,6 +117,7 @@ export class App {
     }),
     setActiveLeaf: jest.fn(),
     revealLeaf: jest.fn(),
+    on: jest.fn().mockReturnValue({}),
   };
 }
 

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -58,6 +58,7 @@ describe('ClaudianPlugin', () => {
         }),
         setActiveLeaf: jest.fn(),
         revealLeaf: jest.fn(),
+        on: jest.fn().mockReturnValue({}),
       },
     };
 

--- a/tests/unit/features/chat/ui/SessionsPanel.test.ts
+++ b/tests/unit/features/chat/ui/SessionsPanel.test.ts
@@ -1,0 +1,196 @@
+import { createMockEl } from '@test/helpers/mockElement';
+
+import type { ConversationMeta } from '@/core/types';
+import type { TabBarItem } from '@/features/chat/tabs/types';
+import { SessionsPanel } from '@/features/chat/ui/SessionsPanel';
+
+jest.mock('@/core/providers/ProviderRegistry', () => ({
+  ProviderRegistry: {
+    getChatUIConfig: jest.fn(() => ({ getProviderIcon: () => null })),
+  },
+}));
+
+jest.mock('@/shared/icons', () => ({
+  createProviderIconSvg: jest.fn(() => ({ tagName: 'svg' })),
+}));
+
+type FakeTabManager = {
+  getTabBarItems: jest.Mock<TabBarItem[], []>;
+  getAllTabs: jest.Mock<Array<{ conversationId: string | null }>, []>;
+  switchToTab: jest.Mock;
+  closeTab: jest.Mock;
+  createTab: jest.Mock;
+  openConversation: jest.Mock;
+};
+
+function makeTabItem(overrides: Partial<TabBarItem> = {}): TabBarItem {
+  return {
+    id: 'tab-1',
+    index: 1,
+    title: 'Tab one',
+    providerId: 'claude',
+    isActive: false,
+    isStreaming: false,
+    needsAttention: false,
+    canClose: true,
+    ...overrides,
+  };
+}
+
+function makeConversation(overrides: Partial<ConversationMeta> = {}): ConversationMeta {
+  return {
+    id: 'conv-1',
+    providerId: 'claude',
+    title: 'Conversation one',
+    createdAt: 1000,
+    updatedAt: 1000,
+    lastResponseAt: 1000,
+    messageCount: 1,
+    preview: '',
+    ...overrides,
+  };
+}
+
+describe('SessionsPanel', () => {
+  let container: ReturnType<typeof createMockEl>;
+  let tabManager: FakeTabManager;
+  let plugin: any;
+
+  function buildPlugin(options: {
+    tabItems?: TabBarItem[];
+    openConversationIds?: Array<string | null>;
+    conversations?: ConversationMeta[];
+    hasChatView?: boolean;
+  }) {
+    tabManager = {
+      getTabBarItems: jest.fn(() => options.tabItems ?? []),
+      getAllTabs: jest.fn(() => (options.openConversationIds ?? []).map((id) => ({ conversationId: id }))),
+      switchToTab: jest.fn().mockResolvedValue(undefined),
+      closeTab: jest.fn().mockResolvedValue(true),
+      createTab: jest.fn().mockResolvedValue({ id: 'tab-new' }),
+      openConversation: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const chatView = { getTabManager: () => tabManager };
+
+    plugin = {
+      settings: { maxTabs: 3 },
+      getActiveChatView: jest.fn(() => (options.hasChatView === false ? null : chatView)),
+      getConversationList: jest.fn(() => options.conversations ?? []),
+      activateView: jest.fn().mockResolvedValue(undefined),
+      deleteConversation: jest.fn().mockResolvedValue(undefined),
+      renameConversation: jest.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  beforeEach(() => {
+    container = createMockEl('div');
+  });
+
+  it('renders open tabs with active highlight and excludes open conversations from recent', () => {
+    buildPlugin({
+      tabItems: [
+        makeTabItem({ id: 'tab-1', title: 'Active tab', isActive: true }),
+        makeTabItem({ id: 'tab-2', title: 'Other tab' }),
+      ],
+      openConversationIds: ['conv-open'],
+      conversations: [
+        makeConversation({ id: 'conv-open', title: 'Already open' }),
+        makeConversation({ id: 'conv-recent', title: 'Recent only' }),
+      ],
+    });
+
+    const panel = new SessionsPanel(plugin, container as unknown as HTMLElement);
+    panel.render();
+
+    const lists = container.querySelectorAll('.claudian-sessions-list');
+    expect(lists.length).toBe(2);
+
+    const openItems = lists[0].querySelectorAll('.claudian-sessions-item');
+    expect(openItems.length).toBe(2);
+    expect(openItems[0].hasClass('claudian-sessions-item--active')).toBe(true);
+
+    const recentItems = lists[1].querySelectorAll('.claudian-sessions-item');
+    // conv-open is excluded because it is already an open tab
+    expect(recentItems.length).toBe(1);
+    const recentTitle = recentItems[0].querySelector('.claudian-sessions-item-title');
+    expect(recentTitle?.textContent).toBe('Recent only');
+  });
+
+  it('switches to a tab when an open row is clicked', () => {
+    buildPlugin({
+      tabItems: [makeTabItem({ id: 'tab-42', title: 'Clickable' })],
+    });
+
+    const panel = new SessionsPanel(plugin, container as unknown as HTMLElement);
+    panel.render();
+
+    const lists = container.querySelectorAll('.claudian-sessions-list');
+    const content = lists[0].querySelectorAll('.claudian-sessions-item')[0]
+      .querySelector('.claudian-sessions-item-content');
+    content!.dispatchEvent({ type: 'click', stopPropagation: () => {} });
+
+    expect(tabManager.switchToTab).toHaveBeenCalledWith('tab-42');
+  });
+
+  it('force-closes a streaming tab when its close button is clicked', () => {
+    buildPlugin({
+      tabItems: [makeTabItem({ id: 'tab-7', isStreaming: true, canClose: true })],
+    });
+
+    const panel = new SessionsPanel(plugin, container as unknown as HTMLElement);
+    panel.render();
+
+    const closeBtn = container.querySelector('.claudian-sessions-item-close');
+    closeBtn!.dispatchEvent({ type: 'click', stopPropagation: () => {} });
+
+    expect(tabManager.closeTab).toHaveBeenCalledWith('tab-7', true);
+  });
+
+  it('opens a recent conversation in a new tab when clicked', async () => {
+    buildPlugin({
+      conversations: [makeConversation({ id: 'conv-x', title: 'Resume me' })],
+    });
+
+    const panel = new SessionsPanel(plugin, container as unknown as HTMLElement);
+    panel.render();
+
+    const lists = container.querySelectorAll('.claudian-sessions-list');
+    const content = lists[0].querySelectorAll('.claudian-sessions-item')[0]
+      .querySelector('.claudian-sessions-item-content');
+    content!.dispatchEvent({ type: 'click', stopPropagation: () => {} });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(tabManager.openConversation).toHaveBeenCalledWith('conv-x', {
+      preferNewTab: true,
+      activate: true,
+    });
+  });
+
+  it('creates a new tab when the New session button is clicked', async () => {
+    buildPlugin({ tabItems: [makeTabItem()] });
+
+    const panel = new SessionsPanel(plugin, container as unknown as HTMLElement);
+    panel.render();
+
+    const newBtn = container.querySelector('.claudian-sessions-new-btn');
+    newBtn!.dispatchEvent({ type: 'click', stopPropagation: () => {} });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(tabManager.createTab).toHaveBeenCalled();
+  });
+
+  it('shows an empty hint when there are no recent sessions', () => {
+    buildPlugin({ tabItems: [], conversations: [] });
+
+    const panel = new SessionsPanel(plugin, container as unknown as HTMLElement);
+    panel.render();
+
+    const empty = container.querySelector('.claudian-sessions-empty');
+    expect(empty).not.toBeNull();
+  });
+});

--- a/tests/unit/main.sessionsEmitter.test.ts
+++ b/tests/unit/main.sessionsEmitter.test.ts
@@ -1,0 +1,45 @@
+import ClaudianPlugin from '@/main';
+
+describe('ClaudianPlugin sessions-change emitter', () => {
+  function createPlugin(): ClaudianPlugin {
+    // The emitter methods operate only on the in-memory listener set, so a bare
+    // instance (no onload) is sufficient to exercise the subscribe/notify contract.
+    return new ClaudianPlugin({} as never, {} as never);
+  }
+
+  it('delivers notifications to subscribers', () => {
+    const plugin = createPlugin();
+    const listener = jest.fn();
+
+    plugin.onSessionsChanged(listener);
+    plugin.notifySessionsChanged();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops delivery after unsubscribe', () => {
+    const plugin = createPlugin();
+    const listener = jest.fn();
+
+    const unsubscribe = plugin.onSessionsChanged(listener);
+    plugin.notifySessionsChanged();
+    unsubscribe();
+    plugin.notifySessionsChanged();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('isolates a failing listener from the others', () => {
+    const plugin = createPlugin();
+    const failing = jest.fn(() => {
+      throw new Error('listener boom');
+    });
+    const healthy = jest.fn();
+
+    plugin.onSessionsChanged(failing);
+    plugin.onSessionsChanged(healthy);
+
+    expect(() => plugin.notifySessionsChanged()).not.toThrow();
+    expect(healthy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a companion **right-sidebar session switcher** — an Obsidian view that lists open tabs and recent conversations and drives the active chat view's `TabManager`. It's offered as a new **tab bar position** so switching can live in the sidebar instead of the in-chat badges.

This is primarily intended for the use case where the Claudian chat panel is opened in the **main editor window** (rather than in a sidebar). With chat in the main window, the right sidebar hosts the switcher and follows the active chat tab, while still freeing up for the document Outline on non-chat tabs.

No changes to runtimes, providers, or the conversation model — this is a UI/coordination layer over the existing `TabManager` and conversation list.

## What's included

- **New view + entry points**: `claudian-sessions-view` (`SessionsView`) hosting a plain-DOM `SessionsPanel`; a ribbon icon and an `open-sessions-panel` command.
- **SessionsPanel**: two sections — *Open* (from `getTabBarItems()`, with active/streaming/attention state and a provider dot; row → `switchToTab`, close → `closeTab(id, force)`) and *Recent* (`getConversationList()` minus already-open conversations; row → `openConversation(id, { preferNewTab, activate })`), plus a *New session* button. Resolves the target chat view via a new `getActiveChatView()`, opening the chat first if none exists.
- **Sync seam**: a lightweight plugin emitter (`onSessionsChanged` / `notifySessionsChanged`) fired from the existing `TabManager` callbacks and conversation CRUD, so the panel stays current.
- **New tab bar position `right-sidebar`**: hides the in-chat tab badges, auto-opens the panel, and makes the sidebar follow the active chat tab (via `active-leaf-change`) while leaving the sidebar free for the document Outline on non-chat tabs.

## Tests

- `SessionsPanel` renderer: open-tabs section with active highlight, recent section that excludes already-open conversations, and the right calls on click/close/new.
- Plugin emitter: subscribe receives notifications; unsubscribe stops delivery; a failing listener is isolated.

`npm run typecheck`, `npm run lint`, and the new unit suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)