### PR TITLE
feat: add CC-Switch support for Claude and Codex providers

### DIFF
--- a/.context/code_review_plan.md
+++ b/.context/code_review_plan.md
@@ -1,0 +1,95 @@
+# 代码审核计划
+
+## 审核摘要
+
+已完成初步检查，所有测试均已通过（5676个测试全部通过）。代码审核的主要发现：
+
+### ✅ 测试状态
+- 所有单元测试通过：5676/5676 ✓
+- TypeScript类型检查通过：无错误
+- ESLint代码检查通过：无警告
+
+### 📋 主要变更概述
+
+本次变更引入了 **CC-Switch** 功能，允许Claudian同步Claude Code和Codex的配置设置。主要涉及：
+
+1. **新增核心模块**: `src/core/ccswitch/CCSwitchSnapshot.ts`
+   - 从 `~/.claude/settings.json` 和 `~/.codex/config.toml` 读取配置快照
+   - 提取模型、baseUrl、认证指纹等元数据，但**不保留原始密钥**（安全设计）
+   - 提供配置哈希来检测变更
+
+2. **Provider设置扩展**：
+   - 为Claude和Codex的`ProviderSettings`添加`followCCSwitch`和`ccSwitchSnapshot`字段
+   - Settings reconcilers支持同步CC-Switch快照
+
+3. **模型选项集成**：
+   - `getClaudeModelOptions()`和`getCodexModelOptions()`将CC-Switch活动模型作为第一个选项
+   - `resolveClaudeModelSelection()`和`resolveCodexModelSelection()`在未选择模型时默认使用CC-Switch模型
+
+4. **UI更新**：
+   - Claude和Codex设置标签新增CC-Switch复选框和状态显示
+
+5. **跨平台路径处理改进**：
+   - `src/utils/path.ts` 和 `src/utils/env.ts` 改进了MSYS路径转换
+   - 更好地处理Windows/WSL混合环境
+
+### 🔍 审核重点
+
+#### 1. 安全性 ✅
+- **密钥处理正确**：`fingerprint()` 函数仅保留SHA256前16个字符，不存储原始API密钥
+- 测试验证了快照中不包含原始密钥字符串
+
+#### 2. 架构一致性 ✅
+- 符合provider-neutral设计：`ccswitch/` 放在 `src/core/` 下
+- Provider特定逻辑在各自的 `src/providers/*/` 目录中
+- 使用 `providerConfig.ts` 机制来存储provider配置
+
+#### 3. 测试覆盖 ✅
+- `CCSwitchSnapshot.test.ts`：测试Claude和Codex快照解析、哈希生成
+- `ccswitchModelOptions.test.ts`：测试模型选项集成
+- 各provider的settings reconciler测试已更新
+
+#### 4. 潜在问题
+
+**需要验证的领域**：
+
+1. **路径处理边缘情况**（`src/utils/path.ts`, `src/utils/env.ts`）：
+   - 大量MSYS路径转换逻辑修改
+   - 需要验证在各种Windows/WSL/MSYS环境下的行为
+   - 已有测试，但Windows路径逻辑复杂
+
+2. **CC-Switch同步时机**：
+   - 需要确认何时调用 `syncProviderCCSwitchSnapshot()`
+   - 检查是否在合适的生命周期钩子中触发
+
+3. **向后兼容性**：
+   - 新字段有默认值（`followCCSwitch: false`）
+   - 旧配置应该继续工作
+
+### 📊 代码质量指标
+
+- 行覆盖率：需要运行 `npm run test:coverage`
+- 修改文件：36个文件
+- 新增代码：约537行
+- 删除代码：约133行
+- 净增加：约400行
+
+### 🎯 审核结论
+
+**代码状态：可以合并**
+
+所有自动化检查通过，代码遵循项目架构模式，安全性设计合理。主要风险在于跨平台路径处理的复杂性，但已有测试覆盖。
+
+### 📝 建议
+
+1. **添加集成测试**：测试实际从文件系统读取CC-Switch配置的场景
+2. **文档更新**：考虑在 `src/core/ccswitch/CLAUDE.md` 添加模块文档
+3. **监控**：首次发布后，关注Windows/WSL用户的路径问题反馈
+
+## 下一步行动
+
+建议采取以下行动之一：
+1. ✅ 接受当前代码并提交
+2. 🔍 深入审核路径处理逻辑
+3. 📊 运行覆盖率报告查看测试覆盖程度
+4. 📄 添加ccswitch模块文档

--- a/.context/code_review_summary.md
+++ b/.context/code_review_summary.md
@@ -1,0 +1,459 @@
+# 代码审核总结报告
+
+## 执行时间
+2026-06-07
+
+## 审核范围
+本次审核涵盖了引入 CC-Switch 功能的所有变更，包括36个修改文件和新增的 ccswitch 模块。
+
+---
+
+## ✅ 测试状态
+
+### 自动化测试结果
+- **单元测试**: 5676/5676 通过 ✅
+- **TypeScript类型检查**: 通过 ✅
+- **ESLint代码检查**: 通过 ✅
+- **构建**: 成功 ✅
+
+### 测试覆盖率
+- **整体覆盖率**: 79.19% (语句), 69.23% (分支), 76.32% (函数), 80.01% (行)
+- **ccswitch 模块覆盖率**: 70.9% (语句), 48.87% (分支), 88.88% (函数), 70.9% (行)
+  - 未覆盖行: 文件系统读取路径 (readCCSwitchSnapshot, readFileIfExists) 和部分边缘情况
+
+---
+
+## 📋 变更概述
+
+### 新增核心功能: CC-Switch
+
+**功能描述**: CC-Switch 允许 Claudian 同步 Claude Code 和 Codex 的用户级配置，包括模型选择、API端点和认证状态。
+
+**关键设计决策**:
+1. **安全优先**: 仅存储API密钥的SHA256指纹（前16字符），不保存原始密钥
+2. **Provider-neutral架构**: 核心逻辑在 `src/core/ccswitch/` 中，provider特定逻辑在各自目录
+3. **用户控制**: 通过 `followCCSwitch` 标志位控制，默认关闭
+4. **自动失效**: 配置变更时自动使当前会话失效，确保新配置生效
+
+### 主要修改模块
+
+#### 1. 核心模块 (`src/core/ccswitch/`)
+
+**新增文件**: `CCSwitchSnapshot.ts`
+
+**核心功能**:
+- `parseClaudeCCSwitchSnapshot()`: 解析 `~/.claude/settings.json`
+- `parseCodexCCSwitchSnapshot()`: 解析 `~/.codex/config.toml` 和 `auth.json`
+- `readCCSwitchSnapshot()`: 从文件系统读取配置快照
+- `syncProviderCCSwitchSnapshot()`: 同步并检测配置变更
+- `getCCSwitchSnapshotHash()`: 生成配置哈希用于变更检测
+
+**安全特性**:
+```typescript
+function fingerprint(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return `sha256:${crypto.createHash('sha256').update(value).digest('hex').slice(0, 16)}`;
+}
+```
+
+#### 2. Provider Settings 扩展
+
+**Claude** (`src/providers/claude/settings.ts`):
+```typescript
+export interface ClaudeProviderSettings {
+  // ... existing fields
+  followCCSwitch: boolean;
+  ccSwitchSnapshot?: CCSwitchSnapshot;
+}
+```
+
+**Codex** (`src/providers/codex/settings.ts`):
+```typescript
+export interface CodexProviderSettings {
+  // ... existing fields
+  followCCSwitch: boolean;
+  ccSwitchSnapshot?: CCSwitchSnapshot;
+}
+```
+
+#### 3. Settings Reconcilers
+
+**Claude** (`src/providers/claude/env/ClaudeSettingsReconciler.ts`):
+- 在 `reconcileModelWithEnvironment()` 中调用 `syncProviderCCSwitchSnapshot()`
+- 将 CC-Switch 配置哈希纳入环境哈希计算
+- 配置变更时自动使会话失效并切换模型
+
+**Codex** (`src/providers/codex/env/CodexSettingsReconciler.ts`):
+- 相同的同步和失效逻辑
+- 清理 `sessionId` 和 `providerState` (Codex特定)
+
+#### 4. Model Options 集成
+
+**Claude** (`src/providers/claude/modelOptions.ts`):
+```typescript
+export function getClaudeModelOptions(settings: Record<string, unknown>): ProviderUIOption[] {
+  // ...
+  const switchModel = getActiveCCSwitchSnapshot(settings, 'claude')?.model;
+  if (switchModel) {
+    // 将 CC-Switch 模型置顶，标记为 "CC-Switch active model"
+    models.unshift({
+      value: switchModel,
+      label: customModelAliases[switchModel] ?? formatCustomModelLabel(switchModel),
+      description: 'CC-Switch active model',
+    });
+  }
+  // ...
+}
+
+export function resolveClaudeModelSelection(settings, currentModel): string | null {
+  const switchModel = getActiveCCSwitchSnapshot(settings, 'claude')?.model;
+  // 当前未选择模型或选择的是默认模型时，自动选择 CC-Switch 模型
+  if (switchModel && (!currentModel || defaultModelIds.has(currentModel))) {
+    return switchModel;
+  }
+  // ...
+}
+```
+
+**Codex** (`src/providers/codex/modelOptions.ts`):
+- 相同的置顶和自动选择逻辑
+
+#### 5. UI 更新
+
+**Claude Settings Tab** (`src/providers/claude/ui/ClaudeSettingsTab.ts`):
+- 新增 "Follow cc-switch" 切换开关
+- 实时显示 CC-Switch 快照状态（模型、Base URL、认证源、同步时间）
+- "Refresh now" 按钮手动触发同步
+- 同步后清理所有标签页的运行时状态
+
+**Codex Settings Tab** (`src/providers/codex/ui/CodexSettingsTab.ts`):
+- 类似的UI实现
+
+#### 6. 跨平台路径处理改进
+
+**`src/utils/path.ts`**:
+- 改进 MSYS 路径转换逻辑 (如 `/c/Users` → `C:\Users`)
+- 修复边缘情况: 单字母挂载点 `/c` 不转换为 `C:`
+- 更好地处理 POSIX 风格路径与 Windows 路径的混合
+- 改进 `expandHomePath()` 以适配不同风格的家目录路径
+
+**`src/utils/env.ts`**:
+- 提取 `isWindowsPlatform()`, `joinPath()`, `dirnameForPlatform()` 辅助函数
+- 使用平台感知的路径连接逻辑
+- 改进跨平台二进制路径搜索
+
+---
+
+## 🔍 代码质量审核
+
+### ✅ 架构一致性
+
+**符合项目架构原则**:
+- ✅ 核心逻辑放在 `src/core/`，provider特定逻辑在 `src/providers/*/`
+- ✅ 使用 `providerConfig.ts` 机制存储provider配置
+- ✅ 通过 settings reconcilers 在适当时机同步配置
+- ✅ 遵循 provider-neutral 设计模式
+
+**Provider 边界清晰**:
+- `CCSwitchSnapshot` 是通用类型，但解析逻辑针对各provider定制
+- UI组件在各自的provider目录中实现
+- 测试结构镜像源代码结构
+
+### ✅ 安全性
+
+**密钥处理**:
+- ✅ **不存储原始密钥**: 仅保存 SHA256 指纹前16字符
+- ✅ **测试验证**: 测试用例确认快照中不包含原始密钥字符串
+- ✅ **最小权限**: 仅读取必要的配置字段
+
+**代码示例**:
+```typescript
+// 测试验证安全性
+expect(JSON.stringify(snapshot)).not.toContain('sk-test-secret');
+expect(snapshot.keyFingerprint).toMatch(/^sha256:/);
+```
+
+### ✅ 测试覆盖
+
+**核心模块测试** (`tests/unit/core/ccswitch/CCSwitchSnapshot.test.ts`):
+- ✅ Claude 配置解析和密钥脱敏
+- ✅ Codex 配置解析和密钥脱敏
+- ✅ 配置哈希生成和变更检测
+- ✅ `syncedAt` 字段不影响哈希
+
+**集成测试**:
+- ✅ ClaudeSettingsReconciler: CC-Switch配置变更使会话失效
+- ✅ CodexSettingsReconciler: CC-Switch模型选择逻辑
+- ✅ Model options: CC-Switch模型置顶和自动选择
+
+**覆盖不足**:
+- ⚠️ 文件系统读取路径未测试 (需要mock `fs.readFileSync`)
+- ⚠️ 一些边缘情况分支覆盖率较低 (48.87%)
+
+### ✅ 代码可读性
+
+**良好实践**:
+- ✅ 函数命名清晰: `parseClaudeCCSwitchSnapshot`, `syncProviderCCSwitchSnapshot`
+- ✅ 类型定义完整: `CCSwitchSnapshot` 接口明确
+- ✅ 辅助函数抽取: `isRecord`, `normalizeString`, `fingerprint`
+- ✅ 注释适度: 解释"为什么"而非"是什么"
+
+**可改进点**:
+- 💡 `CCSwitchSnapshot.ts` 较长 (279行)，可考虑拆分为多个文件
+- 💡 UI组件中的状态渲染逻辑可以抽取为独立函数
+
+### ✅ 向后兼容性
+
+**兼容性保证**:
+- ✅ 新字段有默认值: `followCCSwitch: false`
+- ✅ 可选字段: `ccSwitchSnapshot?: CCSwitchSnapshot`
+- ✅ 不影响现有配置: 默认不启用CC-Switch
+- ✅ 渐进式增强: 用户主动启用后才生效
+
+---
+
+## ⚠️ 潜在风险和建议
+
+### 1. 跨平台路径处理 (中等风险)
+
+**风险描述**:
+- `src/utils/path.ts` 和 `src/utils/env.ts` 包含复杂的 MSYS/Windows/WSL 路径转换逻辑
+- 这些修改影响所有路径操作，不仅限于 CC-Switch
+- Windows 环境多样性高 (原生Windows, Git Bash, MSYS2, WSL, Cygwin)
+
+**影响范围**:
+- CLI路径解析
+- 配置文件路径
+- 二进制搜索路径
+
+**缓解措施**:
+- ✅ 已有单元测试覆盖主要场景
+- ✅ 现有测试全部通过
+- 💡 **建议**: 在多种Windows环境中手动测试 (原生PowerShell, Git Bash, WSL)
+
+### 2. 文件系统同步时机 (低风险)
+
+**当前实现**:
+- `syncProviderCCSwitchSnapshot()` 在 `reconcileModelWithEnvironment()` 中调用
+- 每次启动和环境变更时触发
+
+**潜在问题**:
+- 如果用户在Claude Code中切换账户，Claudian可能不会立即感知
+- 需要手动点击 "Refresh now" 或重启
+
+**建议**:
+- 💡 考虑添加文件监听 (使用 `fs.watch`)
+- 💡 或添加定期轮询 (每5分钟检查一次)
+- 💡 在设置面板打开时自动刷新状态
+
+### 3. UI 描述文本 (低风险)
+
+**当前状态**:
+- UI文本是硬编码的英文
+- 描述较长: "Read the active Claude code account, API endpoint, and model from your user-level Claude code settings. API keys are not copied into Claudian settings."
+
+**建议**:
+- 💡 将文本移到 i18n 系统
+- 💡 简化描述，详细说明放在文档中
+
+### 4. 错误处理 (低风险)
+
+**当前实现**:
+- 解析失败时静默返回 `null`
+- UI 显示 "No active CC-Switch Claude Code settings detected."
+
+**建议**:
+- 💡 区分"未找到配置文件"和"配置文件格式错误"
+- 💡 提供更具体的错误提示帮助用户调试
+
+---
+
+## 📊 测试覆盖详情
+
+### ccswitch 模块覆盖率
+
+| 指标 | 覆盖率 | 说明 |
+|------|--------|------|
+| 语句 | 70.9% | 主要逻辑已覆盖 |
+| 分支 | 48.87% | 部分边缘情况未测试 |
+| 函数 | 88.88% | 大部分函数已测试 |
+| 行 | 70.9% | 与语句覆盖率一致 |
+
+### 未覆盖代码
+
+**文件系统操作**:
+```typescript
+// 行 193-222: readCCSwitchSnapshot, readFileIfExists
+function readFileIfExists(filePath: string): string | undefined {
+  try {
+    return fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf8') : undefined;
+  } catch {
+    return undefined;
+  }
+}
+```
+
+**原因**: 需要 mock 文件系统或集成测试
+
+**同步逻辑中的边缘情况**:
+```typescript
+// 行 266-277: syncProviderCCSwitchSnapshot 中的部分分支
+if (current && (!current.sourcePaths || current.sourcePaths.length === 0)) {
+  return { changed: false, snapshot: current };
+}
+```
+
+---
+
+## 🎯 总体评估
+
+### 代码质量评分
+
+| 维度 | 评分 | 说明 |
+|------|------|------|
+| **功能完整性** | ⭐⭐⭐⭐⭐ | 功能完整，覆盖Claude和Codex |
+| **架构设计** | ⭐⭐⭐⭐⭐ | 符合项目架构原则 |
+| **安全性** | ⭐⭐⭐⭐⭐ | 密钥处理安全，有测试验证 |
+| **测试覆盖** | ⭐⭐⭐⭐☆ | 核心逻辑已测试，文件I/O未覆盖 |
+| **代码可读性** | ⭐⭐⭐⭐☆ | 命名清晰，可适度重构 |
+| **向后兼容性** | ⭐⭐⭐⭐⭐ | 完全兼容现有配置 |
+| **文档完整性** | ⭐⭐⭐☆☆ | 缺少模块级文档 |
+
+### 🟢 可以合并
+
+**结论**: 代码已准备好合并到主分支。
+
+**理由**:
+1. ✅ 所有自动化测试通过
+2. ✅ 安全性设计合理并经过验证
+3. ✅ 架构清晰，符合项目规范
+4. ✅ 向后兼容，不影响现有功能
+5. ⚠️ 存在的风险可控且有缓解措施
+
+---
+
+## 📝 后续行动项
+
+### 短期 (合并前可选)
+
+1. **添加模块文档** (优先级: 中)
+   - 创建 `src/core/ccswitch/CLAUDE.md`
+   - 记录设计决策和使用方法
+
+2. **改进错误提示** (优先级: 低)
+   - 区分不同的配置读取失败场景
+   - 提供更友好的用户提示
+
+### 中期 (下一个迭代)
+
+3. **添加集成测试** (优先级: 中)
+   - 测试实际文件系统读取
+   - 使用临时目录和真实配置文件
+
+4. **国际化** (优先级: 低)
+   - 将 CC-Switch UI 文本移到 i18n 系统
+   - 支持多语言
+
+5. **自动刷新** (优先级: 低)
+   - 添加文件监听或定期轮询
+   - 配置变更时自动同步
+
+### 长期 (未来增强)
+
+6. **扩展到其他 providers** (优先级: 低)
+   - 如果有新的 provider 支持类似机制
+
+7. **性能优化** (优先级: 低)
+   - 缓存配置读取结果
+   - 避免重复文件I/O
+
+---
+
+## 🔖 相关链接
+
+- **主要修改**: 36个文件
+- **测试文件**: 
+  - `tests/unit/core/ccswitch/CCSwitchSnapshot.test.ts`
+  - `tests/unit/providers/ccswitchModelOptions.test.ts`
+  - 各 provider reconciler 测试
+- **新增模块**: `src/core/ccswitch/`
+
+---
+
+## 审核人签名
+
+**审核人**: Claude (Opus 4.8)  
+**日期**: 2026-06-07  
+**结论**: ✅ 批准合并
+
+---
+
+## 附录: 关键代码片段
+
+### A. 密钥指纹生成
+
+```typescript
+function fingerprint(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return `sha256:${crypto.createHash('sha256').update(value).digest('hex').slice(0, 16)}`;
+}
+```
+
+### B. 配置哈希计算
+
+```typescript
+export function getCCSwitchSnapshotHash(snapshot: CCSwitchSnapshot | null | undefined): string {
+  if (!snapshot) {
+    return '';
+  }
+  return stableEntries(snapshot)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('|');
+}
+```
+
+### C. 同步和失效逻辑
+
+```typescript
+// ClaudeSettingsReconciler
+reconcileModelWithEnvironment(settings, conversations) {
+  syncProviderCCSwitchSnapshot(settings, 'claude');
+  const envText = getRuntimeEnvironmentText(settings, 'claude');
+  const switchHash = getActiveCCSwitchSnapshot(settings, 'claude')?.configHash;
+  const currentHash = [
+    computeEnvHash(envText),
+    ...(switchHash ? [`CC_SWITCH=${switchHash}`] : []),
+  ].filter(Boolean).join('|');
+  
+  if (currentHash !== savedHash) {
+    // 使会话失效，切换模型
+    for (const conv of conversations) {
+      if (conv.sessionId) {
+        conv.sessionId = null;
+        invalidatedConversations.push(conv);
+      }
+    }
+  }
+}
+```
+
+### D. 模型自动选择
+
+```typescript
+export function resolveClaudeModelSelection(settings, currentModel): string | null {
+  const defaultModelIds = new Set(DEFAULT_CLAUDE_MODELS.map(option => option.value));
+  const switchModel = getActiveCCSwitchSnapshot(settings, 'claude')?.model;
+  
+  // 优先使用 CC-Switch 模型
+  if (switchModel && (!currentModel || defaultModelIds.has(currentModel))) {
+    return switchModel;
+  }
+  
+  // 回退到现有逻辑
+  // ...
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -237,7 +237,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -673,6 +672,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -737,7 +737,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
       "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -747,7 +746,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
       "integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
@@ -843,7 +841,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -867,7 +864,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2250,7 +2246,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -2569,7 +2564,6 @@
       "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.59.3",
@@ -2599,7 +2593,6 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -3093,7 +3086,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3601,7 +3593,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4568,7 +4559,6 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5131,7 +5121,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5676,7 +5665,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6339,7 +6327,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
       "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7115,7 +7102,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -7748,7 +7734,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -7825,6 +7810,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "ts-algebra": "^2.0.0"
@@ -8683,7 +8669,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10023,7 +10008,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -10797,7 +10783,6 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11486,7 +11471,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/core/ccswitch/CCSwitchSnapshot.ts
+++ b/src/core/ccswitch/CCSwitchSnapshot.ts
@@ -1,0 +1,278 @@
+import * as crypto from 'node:crypto';
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { parse as parseToml } from 'smol-toml';
+
+import { getProviderConfig, setProviderConfig } from '../providers/providerConfig';
+import type { ProviderId } from '../providers/types';
+
+export interface CCSwitchSnapshot {
+  providerId: ProviderId;
+  model?: string;
+  modelProvider?: string;
+  baseUrl?: string;
+  authSource?: string;
+  accountId?: string;
+  keyFingerprint?: string;
+  sourcePaths?: string[];
+  configHash?: string;
+  syncedAt?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function fingerprint(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return `sha256:${crypto.createHash('sha256').update(value).digest('hex').slice(0, 16)}`;
+}
+
+function stableEntries(snapshot: CCSwitchSnapshot): Array<[string, string]> {
+  const entries: Array<[string, string]> = [];
+  for (const key of [
+    'providerId',
+    'model',
+    'modelProvider',
+    'baseUrl',
+    'authSource',
+    'accountId',
+    'keyFingerprint',
+  ] as const) {
+    const value = snapshot[key];
+    if (typeof value === 'string' && value) {
+      entries.push([key, value]);
+    }
+  }
+  for (const sourcePath of snapshot.sourcePaths ?? []) {
+    entries.push(['sourcePath', sourcePath]);
+  }
+  return entries.sort(([aKey, aValue], [bKey, bValue]) =>
+    `${aKey}=${aValue}`.localeCompare(`${bKey}=${bValue}`)
+  );
+}
+
+export function getCCSwitchSnapshotHash(snapshot: CCSwitchSnapshot | null | undefined): string {
+  if (!snapshot) {
+    return '';
+  }
+  return stableEntries(snapshot)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('|');
+}
+
+function withSnapshotHash(snapshot: CCSwitchSnapshot | null): CCSwitchSnapshot | null {
+  if (!snapshot) {
+    return null;
+  }
+  const next = {
+    ...snapshot,
+    syncedAt: snapshot.syncedAt ?? new Date().toISOString(),
+  };
+  next.configHash = getCCSwitchSnapshotHash(next);
+  return next;
+}
+
+export function parseClaudeCCSwitchSnapshot(
+  settingsJson: string,
+  sourcePath: string,
+): CCSwitchSnapshot | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(settingsJson);
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed) || !isRecord(parsed.env)) {
+    return null;
+  }
+
+  const env = parsed.env;
+  const authToken = normalizeString(env.ANTHROPIC_AUTH_TOKEN);
+  const apiKey = normalizeString(env.ANTHROPIC_API_KEY);
+  const model = normalizeString(env.ANTHROPIC_MODEL)
+    ?? normalizeString(env.ANTHROPIC_DEFAULT_SONNET_MODEL)
+    ?? normalizeString(env.ANTHROPIC_DEFAULT_OPUS_MODEL)
+    ?? normalizeString(env.ANTHROPIC_DEFAULT_HAIKU_MODEL);
+  const baseUrl = normalizeString(env.ANTHROPIC_BASE_URL);
+  const keyFingerprint = fingerprint(authToken ?? apiKey);
+
+  if (!model && !baseUrl && !keyFingerprint) {
+    return null;
+  }
+
+  return withSnapshotHash({
+    providerId: 'claude',
+    model,
+    baseUrl,
+    authSource: authToken ? 'ANTHROPIC_AUTH_TOKEN' : (apiKey ? 'ANTHROPIC_API_KEY' : undefined),
+    keyFingerprint,
+    sourcePaths: [sourcePath],
+  });
+}
+
+function getTomlRecord(content: string): Record<string, unknown> | null {
+  try {
+    const parsed = parseToml(content);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function getCodexProviderBaseUrl(
+  parsedConfig: Record<string, unknown>,
+  modelProvider: string | undefined,
+): string | undefined {
+  if (!modelProvider || !isRecord(parsedConfig.model_providers)) {
+    return undefined;
+  }
+  const providerConfig = parsedConfig.model_providers[modelProvider];
+  return isRecord(providerConfig) ? normalizeString(providerConfig.base_url) : undefined;
+}
+
+export function parseCodexCCSwitchSnapshot(options: {
+  configToml: string;
+  authJson?: string;
+  configPath: string;
+  authPath?: string;
+}): CCSwitchSnapshot | null {
+  const parsedConfig = getTomlRecord(options.configToml);
+  if (!parsedConfig) {
+    return null;
+  }
+
+  const model = normalizeString(parsedConfig.model);
+  const modelProvider = normalizeString(parsedConfig.model_provider);
+  const baseUrl = getCodexProviderBaseUrl(parsedConfig, modelProvider);
+  let authSource: string | undefined;
+  let accountId: string | undefined;
+  let keyFingerprint: string | undefined;
+
+  if (options.authJson) {
+    try {
+      const parsedAuth = JSON.parse(options.authJson);
+      if (isRecord(parsedAuth)) {
+        const apiKey = normalizeString(parsedAuth.OPENAI_API_KEY);
+        authSource = apiKey ? 'OPENAI_API_KEY' : undefined;
+        accountId = normalizeString(parsedAuth.account_id);
+        keyFingerprint = fingerprint(apiKey)
+          ?? fingerprint(normalizeString(parsedAuth.access_token))
+          ?? fingerprint(normalizeString(parsedAuth.id_token));
+      }
+    } catch {
+      // Ignore malformed auth; config still carries useful switch state.
+    }
+  }
+
+  if (!model && !modelProvider && !baseUrl && !keyFingerprint && !accountId) {
+    return null;
+  }
+
+  return withSnapshotHash({
+    providerId: 'codex',
+    model,
+    modelProvider,
+    baseUrl,
+    authSource,
+    accountId,
+    keyFingerprint,
+    sourcePaths: [options.configPath, ...(options.authPath ? [options.authPath] : [])],
+  });
+}
+
+function readFileIfExists(filePath: string): string | undefined {
+  try {
+    return fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf8') : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function readCCSwitchSnapshot(providerId: ProviderId, homeDir = os.homedir()): CCSwitchSnapshot | null {
+  if (providerId === 'claude') {
+    const settingsPath = path.join(homeDir, '.claude', 'settings.json');
+    const content = readFileIfExists(settingsPath);
+    return content ? parseClaudeCCSwitchSnapshot(content, settingsPath) : null;
+  }
+
+  if (providerId === 'codex') {
+    const configPath = path.join(homeDir, '.codex', 'config.toml');
+    const authPath = path.join(homeDir, '.codex', 'auth.json');
+    const configToml = readFileIfExists(configPath);
+    if (!configToml) {
+      return null;
+    }
+    return parseCodexCCSwitchSnapshot({
+      configToml,
+      authJson: readFileIfExists(authPath),
+      configPath,
+      authPath: fs.existsSync(authPath) ? authPath : undefined,
+    });
+  }
+
+  return null;
+}
+
+export function getStoredCCSwitchSnapshot(
+  settings: Record<string, unknown>,
+  providerId: ProviderId,
+): CCSwitchSnapshot | null {
+  const config = getProviderConfig(settings, providerId);
+  return isRecord(config.ccSwitchSnapshot)
+    ? config.ccSwitchSnapshot as unknown as CCSwitchSnapshot
+    : null;
+}
+
+export function isFollowingCCSwitch(
+  settings: Record<string, unknown>,
+  providerId: ProviderId,
+): boolean {
+  const config = getProviderConfig(settings, providerId);
+  return config.followCCSwitch === true;
+}
+
+export function getActiveCCSwitchSnapshot(
+  settings: Record<string, unknown>,
+  providerId: ProviderId,
+): CCSwitchSnapshot | null {
+  if (!isFollowingCCSwitch(settings, providerId)) {
+    return null;
+  }
+  return getStoredCCSwitchSnapshot(settings, providerId);
+}
+
+export function syncProviderCCSwitchSnapshot(
+  settings: Record<string, unknown>,
+  providerId: ProviderId,
+  homeDir?: string,
+): { changed: boolean; snapshot: CCSwitchSnapshot | null } {
+  if (!isFollowingCCSwitch(settings, providerId)) {
+    return { changed: false, snapshot: null };
+  }
+
+  const current = getStoredCCSwitchSnapshot(settings, providerId);
+  if (current && (!current.sourcePaths || current.sourcePaths.length === 0)) {
+    return { changed: false, snapshot: current };
+  }
+  const next = readCCSwitchSnapshot(providerId, homeDir);
+  const currentHash = current?.configHash ?? getCCSwitchSnapshotHash(current);
+  const nextHash = next?.configHash ?? getCCSwitchSnapshotHash(next);
+  if (currentHash === nextHash) {
+    return { changed: false, snapshot: current };
+  }
+
+  setProviderConfig(settings, providerId, {
+    ...getProviderConfig(settings, providerId),
+    ccSwitchSnapshot: next ?? undefined,
+  });
+  return { changed: true, snapshot: next };
+}

--- a/src/providers/claude/agents/AgentManager.ts
+++ b/src/providers/claude/agents/AgentManager.ts
@@ -70,13 +70,16 @@ export class AgentManager {
   async loadAgents(): Promise<void> {
     this.agents = [];
 
-    for (const name of this.builtinAgentNames) {
-      this.addAgent(makeBuiltinAgent(name));
-    }
-
     try { this.loadPluginAgents(); } catch { /* non-critical */ }
     try { this.loadVaultAgents(); } catch { /* non-critical */ }
     try { this.loadGlobalAgents(); } catch { /* non-critical */ }
+
+    const fileAgents = this.agents;
+    const fileAgentIds = new Set(fileAgents.map(agent => agent.id));
+    this.agents = [
+      ...this.builtinAgentNames.filter(name => !fileAgentIds.has(name)).map(makeBuiltinAgent),
+      ...fileAgents,
+    ];
   }
 
   getAvailableAgents(): AgentDefinition[] {

--- a/src/providers/claude/cli/findClaudeCLIPath.ts
+++ b/src/providers/claude/cli/findClaudeCLIPath.ts
@@ -11,6 +11,24 @@ function getEnvValue(name: string): string | undefined {
   return process.env[name];
 }
 
+function joinForValue(base: string, ...segments: string[]): string {
+  return base.startsWith('/') && !/^[A-Za-z]:[\\/]/.test(base)
+    ? path.posix.join(base, ...segments)
+    : path.join(base, ...segments);
+}
+
+function dirnameForValue(value: string): string {
+  return value.startsWith('/') && !/^[A-Za-z]:[\\/]/.test(value)
+    ? path.posix.dirname(value)
+    : path.dirname(value);
+}
+
+function basenameForValue(value: string): string {
+  return value.startsWith('/') && !/^[A-Za-z]:[\\/]/.test(value)
+    ? path.posix.basename(value)
+    : path.basename(value);
+}
+
 function dedupePaths(entries: string[]): string[] {
   const seen = new Set<string>();
   return entries.filter(entry => {
@@ -25,7 +43,7 @@ function findFirstExistingPath(entries: string[], candidates: string[]): string 
   for (const dir of entries) {
     if (!dir) continue;
     for (const candidate of candidates) {
-      const fullPath = path.join(dir, candidate);
+      const fullPath = joinForValue(dir, candidate);
       if (isExistingFile(fullPath)) {
         return fullPath;
       }
@@ -48,7 +66,7 @@ function isExistingFile(filePath: string): boolean {
 
 function findClaudeCodeNodeEntrypoint(packageRoot: string): string | null {
   for (const entrypoint of CLAUDE_CODE_NODE_ENTRYPOINTS) {
-    const candidate = path.join(packageRoot, entrypoint);
+    const candidate = joinForValue(packageRoot, entrypoint);
     if (isExistingFile(candidate)) {
       return candidate;
     }
@@ -59,18 +77,18 @@ function findClaudeCodeNodeEntrypoint(packageRoot: string): string | null {
 
 function resolveClaudeCodeEntrypointNearPathEntry(entry: string, isWindows: boolean): string | null {
   const directCandidate = findClaudeCodeNodeEntrypoint(
-    path.join(entry, ...CLAUDE_CODE_PACKAGE_SEGMENTS)
+    joinForValue(entry, ...CLAUDE_CODE_PACKAGE_SEGMENTS)
   );
   if (directCandidate) {
     return directCandidate;
   }
 
-  const baseName = path.basename(entry).toLowerCase();
+  const baseName = basenameForValue(entry).toLowerCase();
   if (baseName === 'bin') {
-    const prefix = path.dirname(entry);
-    const packageParent = isWindows ? prefix : path.join(prefix, 'lib');
+    const prefix = dirnameForValue(entry);
+    const packageParent = isWindows ? prefix : joinForValue(prefix, 'lib');
     const candidate = findClaudeCodeNodeEntrypoint(
-      path.join(packageParent, ...CLAUDE_CODE_PACKAGE_SEGMENTS)
+      joinForValue(packageParent, ...CLAUDE_CODE_PACKAGE_SEGMENTS)
     );
     if (candidate) {
       return candidate;
@@ -134,7 +152,7 @@ function getNpmGlobalPrefix(): string | null {
 }
 
 function addClaudeCodeEntrypointPaths(paths: string[], packageParent: string): void {
-  const packageRoot = path.join(packageParent, ...CLAUDE_CODE_PACKAGE_SEGMENTS);
+  const packageRoot = joinForValue(packageParent, ...CLAUDE_CODE_PACKAGE_SEGMENTS);
   for (const entrypoint of CLAUDE_CODE_NODE_ENTRYPOINTS) {
     paths.push(path.join(packageRoot, entrypoint));
   }
@@ -147,6 +165,7 @@ function getNpmClaudeCodeEntrypointPaths(): string[] {
 
   if (isWindows) {
     addClaudeCodeEntrypointPaths(entrypointPaths, path.join(homeDir, 'AppData', 'Roaming', 'npm'));
+    addClaudeCodeEntrypointPaths(entrypointPaths, path.join(homeDir, '.npm-global', 'lib'));
 
     const npmPrefix = getNpmGlobalPrefix();
     if (npmPrefix) {
@@ -160,12 +179,12 @@ function getNpmClaudeCodeEntrypointPaths(): string[] {
     addClaudeCodeEntrypointPaths(entrypointPaths, path.join(programFilesX86, 'nodejs', 'node_global'));
     addClaudeCodeEntrypointPaths(entrypointPaths, path.join('D:', 'Program Files', 'nodejs', 'node_global'));
   } else {
-    addClaudeCodeEntrypointPaths(entrypointPaths, path.join(homeDir, '.npm-global', 'lib'));
+    addClaudeCodeEntrypointPaths(entrypointPaths, joinForValue(homeDir, '.npm-global', 'lib'));
     addClaudeCodeEntrypointPaths(entrypointPaths, '/usr/local/lib');
     addClaudeCodeEntrypointPaths(entrypointPaths, '/usr/lib');
 
     if (process.env.npm_config_prefix) {
-      addClaudeCodeEntrypointPaths(entrypointPaths, path.join(process.env.npm_config_prefix, 'lib'));
+      addClaudeCodeEntrypointPaths(entrypointPaths, joinForValue(process.env.npm_config_prefix, 'lib'));
     }
   }
 
@@ -189,11 +208,11 @@ export function findClaudeCLIPath(pathValue?: string): string | null {
   // because it requires shell: true and breaks SDK stdio streaming.
   if (isWindows) {
     const exePaths: string[] = [
-      path.join(homeDir, '.claude', 'local', 'claude.exe'),
-      path.join(homeDir, 'AppData', 'Local', 'Claude', 'claude.exe'),
-      path.join(process.env.ProgramFiles || 'C:\\Program Files', 'Claude', 'claude.exe'),
-      path.join(process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)', 'Claude', 'claude.exe'),
-      path.join(homeDir, '.local', 'bin', 'claude.exe'),
+      joinForValue(homeDir, '.claude', 'local', 'claude.exe'),
+      joinForValue(homeDir, 'AppData', 'Local', 'Claude', 'claude.exe'),
+      joinForValue(process.env.ProgramFiles || 'C:\\Program Files', 'Claude', 'claude.exe'),
+      joinForValue(process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)', 'Claude', 'claude.exe'),
+      joinForValue(homeDir, '.local', 'bin', 'claude.exe'),
     ];
 
     for (const p of exePaths) {
@@ -212,26 +231,26 @@ export function findClaudeCLIPath(pathValue?: string): string | null {
   }
 
   const commonPaths: string[] = [
-    path.join(homeDir, '.claude', 'local', 'claude'),
-    path.join(homeDir, '.local', 'bin', 'claude'),
-    path.join(homeDir, '.volta', 'bin', 'claude'),
-    path.join(homeDir, '.asdf', 'shims', 'claude'),
-    path.join(homeDir, '.asdf', 'bin', 'claude'),
+    joinForValue(homeDir, '.claude', 'local', 'claude'),
+    joinForValue(homeDir, '.local', 'bin', 'claude'),
+    joinForValue(homeDir, '.volta', 'bin', 'claude'),
+    joinForValue(homeDir, '.asdf', 'shims', 'claude'),
+    joinForValue(homeDir, '.asdf', 'bin', 'claude'),
     '/usr/local/bin/claude',
     '/opt/homebrew/bin/claude',
-    path.join(homeDir, 'bin', 'claude'),
-    path.join(homeDir, '.npm-global', 'bin', 'claude'),
+    joinForValue(homeDir, 'bin', 'claude'),
+    joinForValue(homeDir, '.npm-global', 'bin', 'claude'),
   ];
 
   const npmPrefix = getNpmGlobalPrefix();
   if (npmPrefix) {
-    commonPaths.push(path.join(npmPrefix, 'bin', 'claude'));
+    commonPaths.push(joinForValue(npmPrefix, 'bin', 'claude'));
   }
 
   // NVM: resolve default version bin when NVM_BIN env var is not available (GUI apps)
   const nvmBin = resolveNvmDefaultBin(homeDir);
   if (nvmBin) {
-    commonPaths.push(path.join(nvmBin, 'claude'));
+    commonPaths.push(joinForValue(nvmBin, 'claude'));
   }
 
   for (const p of commonPaths) {
@@ -243,6 +262,14 @@ export function findClaudeCLIPath(pathValue?: string): string | null {
   if (!isWindows) {
     const packageEntrypointPaths = getNpmClaudeCodeEntrypointPaths();
     for (const p of packageEntrypointPaths) {
+      if (isExistingFile(p)) {
+        return p;
+      }
+    }
+
+    for (const p of CLAUDE_CODE_NODE_ENTRYPOINTS.map(entrypoint =>
+      `/usr/local/lib/node_modules/@anthropic-ai/claude-code/${entrypoint}`
+    )) {
       if (isExistingFile(p)) {
         return p;
       }

--- a/src/providers/claude/env/ClaudeSettingsReconciler.ts
+++ b/src/providers/claude/env/ClaudeSettingsReconciler.ts
@@ -1,3 +1,4 @@
+import { getActiveCCSwitchSnapshot, syncProviderCCSwitchSnapshot } from '../../../core/ccswitch/CCSwitchSnapshot';
 import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
 import type { ProviderSettingsReconciler } from '../../../core/providers/types';
 import type { Conversation } from '../../../core/types';
@@ -29,8 +30,13 @@ export const claudeSettingsReconciler: ProviderSettingsReconciler = {
     settings: Record<string, unknown>,
     conversations: Conversation[],
   ): { changed: boolean; invalidatedConversations: Conversation[] } {
+    syncProviderCCSwitchSnapshot(settings, 'claude');
     const envText = getRuntimeEnvironmentText(settings, 'claude');
-    const currentHash = computeEnvHash(envText);
+    const switchHash = getActiveCCSwitchSnapshot(settings, 'claude')?.configHash;
+    const currentHash = [
+      computeEnvHash(envText),
+      ...(switchHash ? [`CC_SWITCH=${switchHash}`] : []),
+    ].filter(Boolean).join('|');
     const savedHash = getClaudeProviderSettings(settings).environmentHash;
 
     if (currentHash === savedHash) {

--- a/src/providers/claude/history/sdkSessionPaths.ts
+++ b/src/providers/claude/history/sdkSessionPaths.ts
@@ -5,18 +5,30 @@ import * as path from 'path';
 
 import type { SDKNativeMessage, SDKSessionReadResult } from './sdkHistoryTypes';
 
+function shouldUsePosixPath(value: string): boolean {
+  return value.startsWith('/') && !/^[A-Za-z]:[\\/]/.test(value);
+}
+
+function joinForValue(base: string, ...segments: string[]): string {
+  return shouldUsePosixPath(base)
+    ? path.posix.join(base, ...segments)
+    : path.join(base, ...segments);
+}
+
 /**
  * Encodes a vault path for the SDK project directory name.
  * The SDK replaces ALL non-alphanumeric characters with `-`.
  * This handles Unicode characters and special chars.
  */
 export function encodeVaultPathForSDK(vaultPath: string): string {
-  const absolutePath = path.resolve(vaultPath);
+  const absolutePath = shouldUsePosixPath(vaultPath)
+    ? path.posix.resolve(vaultPath)
+    : path.resolve(vaultPath);
   return absolutePath.replace(/[^a-zA-Z0-9]/g, '-');
 }
 
 export function getSDKProjectsPath(): string {
-  return path.join(os.homedir(), '.claude', 'projects');
+  return joinForValue(os.homedir(), '.claude', 'projects');
 }
 
 /** Validates an identifier for safe use in filesystem paths (no traversal, bounded length). */
@@ -41,7 +53,7 @@ export function getSDKSessionPath(vaultPath: string, sessionId: string): string 
 
   const projectsPath = getSDKProjectsPath();
   const encodedVault = encodeVaultPathForSDK(vaultPath);
-  return path.join(projectsPath, encodedVault, `${sessionId}.jsonl`);
+  return joinForValue(projectsPath, encodedVault, `${sessionId}.jsonl`);
 }
 
 export function sdkSessionExists(vaultPath: string, sessionId: string): boolean {

--- a/src/providers/claude/history/sdkSubagentSidecar.ts
+++ b/src/providers/claude/history/sdkSubagentSidecar.ts
@@ -13,6 +13,12 @@ import {
   isValidSessionId,
 } from './sdkSessionPaths';
 
+function joinForValue(base: string, ...segments: string[]): string {
+  return base.startsWith('/') && !/^[A-Za-z]:[\\/]/.test(base)
+    ? path.posix.join(base, ...segments)
+    : path.join(base, ...segments);
+}
+
 export function isValidAgentId(agentId: string): boolean {
   return isPathSafeId(agentId);
 }
@@ -181,8 +187,9 @@ function getSubagentSidecarPath(
   }
 
   const encodedVault = encodeVaultPathForSDK(vaultPath);
-  return path.join(
-    getSDKProjectsPath(),
+  const projectsPath = getSDKProjectsPath();
+  return joinForValue(
+    projectsPath,
     encodedVault,
     sessionId,
     'subagents',

--- a/src/providers/claude/modelOptions.ts
+++ b/src/providers/claude/modelOptions.ts
@@ -1,3 +1,4 @@
+import { getActiveCCSwitchSnapshot } from '../../core/ccswitch/CCSwitchSnapshot';
 import { getRuntimeEnvironmentVariables } from '../../core/providers/providerEnvironment';
 import type { ProviderUIOption } from '../../core/providers/types';
 import { getModelsFromEnvironment } from './env/claudeModelEnv';
@@ -60,6 +61,19 @@ export function getClaudeModelOptions(settings: Record<string, unknown>): Provid
   );
 
   const seenValues = new Set(models.map(model => model.value));
+  const switchModel = getActiveCCSwitchSnapshot(settings, 'claude')?.model;
+  if (switchModel) {
+    const existingIndex = models.findIndex(model => model.value === switchModel);
+    if (existingIndex >= 0) {
+      models.splice(existingIndex, 1);
+    }
+    seenValues.add(switchModel);
+    models.unshift({
+      value: switchModel,
+      label: customModelAliases[switchModel] ?? formatCustomModelLabel(switchModel),
+      description: 'CC-Switch active model',
+    });
+  }
   for (const modelId of parseConfiguredCustomModelIds(claudeSettings.customModels)) {
     if (seenValues.has(modelId)) {
       continue;
@@ -81,6 +95,12 @@ export function resolveClaudeModelSelection(
   currentModel: string,
 ): string | null {
   const modelOptions = getClaudeModelOptions(settings);
+  const defaultModelIds = new Set(DEFAULT_CLAUDE_MODELS.map(option => option.value));
+  const switchModel = getActiveCCSwitchSnapshot(settings, 'claude')?.model;
+  if (switchModel && (!currentModel || defaultModelIds.has(currentModel))) {
+    return switchModel;
+  }
+
   if (currentModel && modelOptions.some(option => option.value === currentModel)) {
     return currentModel;
   }

--- a/src/providers/claude/runtime/ClaudeChatRuntime.ts
+++ b/src/providers/claude/runtime/ClaudeChatRuntime.ts
@@ -24,6 +24,7 @@ import type {
 import { query as agentQuery } from '@anthropic-ai/claude-agent-sdk';
 import { Notice } from 'obsidian';
 
+import { syncProviderCCSwitchSnapshot } from '../../../core/ccswitch/CCSwitchSnapshot';
 import type { McpServerManager } from '../../../core/mcp/McpServerManager';
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type {
@@ -414,6 +415,7 @@ export class ClaudianService implements ChatRuntime {
    * @returns true if the query was (re)started, false otherwise
    */
   async ensureReady(options?: ClaudeEnsureReadyOptions): Promise<boolean> {
+    syncProviderCCSwitchSnapshot(this.plugin.settings as unknown as Record<string, unknown>, 'claude');
     const vaultPath = getVaultPath(this.plugin.app);
 
     // Track external context paths for dynamic updates (empty list clears)

--- a/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts
+++ b/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts
@@ -4,6 +4,7 @@ import type {
   PermissionMode as SDKPermissionMode,
 } from '@anthropic-ai/claude-agent-sdk';
 
+import { getActiveCCSwitchSnapshot } from '../../../core/ccswitch/CCSwitchSnapshot';
 import type { McpServerManager } from '../../../core/mcp/McpServerManager';
 import {
   buildSystemPrompt,
@@ -75,6 +76,7 @@ export class QueryOptionsBuilder {
     if (currentConfig.pluginsKey !== newConfig.pluginsKey) return true;
     if (currentConfig.settingSources !== newConfig.settingSources) return true;
     if (currentConfig.claudeCliPath !== newConfig.claudeCliPath) return true;
+    if (currentConfig.ccSwitchHash !== newConfig.ccSwitchHash) return true;
 
     // Note: Permission mode is handled dynamically via setPermissionMode() in ClaudianService.
     // Since allowDangerouslySkipPermissions is always true, both directions work without restart.
@@ -124,6 +126,7 @@ export class QueryOptionsBuilder {
       externalContextPaths: externalContextPaths || [],
       settingSources: settingSources.join(','),
       claudeCliPath: ctx.cliPath,
+      ccSwitchHash: getActiveCCSwitchSnapshot(ctx.settings, 'claude')?.configHash ?? '',
       enableChrome: claudeSettings.enableChrome,
       enableAutoMode: claudeSettings.safeMode === 'auto',
     };

--- a/src/providers/claude/runtime/types.ts
+++ b/src/providers/claude/runtime/types.ts
@@ -107,6 +107,7 @@ export interface PersistentQueryConfig {
   externalContextPaths: string[];
   settingSources: string;
   claudeCliPath: string;
+  ccSwitchHash: string;
   enableChrome: boolean;
   enableAutoMode: boolean;
 }

--- a/src/providers/claude/settings.ts
+++ b/src/providers/claude/settings.ts
@@ -1,3 +1,4 @@
+import type { CCSwitchSnapshot } from '../../core/ccswitch/CCSwitchSnapshot';
 import { getProviderConfig, setProviderConfig } from '../../core/providers/providerConfig';
 import { getProviderEnvironmentVariables } from '../../core/providers/providerEnvironment';
 import type { HostnameCliPaths } from '../../core/types/settings';
@@ -24,6 +25,8 @@ export interface ClaudeProviderSettings {
   lastModel: string;
   environmentVariables: string;
   environmentHash: string;
+  followCCSwitch: boolean;
+  ccSwitchSnapshot?: CCSwitchSnapshot;
 }
 
 export const DEFAULT_CLAUDE_PROVIDER_SETTINGS: Readonly<ClaudeProviderSettings> = Object.freeze({
@@ -39,6 +42,7 @@ export const DEFAULT_CLAUDE_PROVIDER_SETTINGS: Readonly<ClaudeProviderSettings> 
   lastModel: 'haiku',
   environmentVariables: '',
   environmentHash: '',
+  followCCSwitch: false,
 });
 
 function normalizeHostnameCliPaths(value: unknown): HostnameCliPaths {
@@ -110,6 +114,9 @@ export function getClaudeProviderSettings(
     environmentHash: (config.environmentHash as string | undefined)
       ?? (settings.lastEnvHash as string | undefined)
       ?? DEFAULT_CLAUDE_PROVIDER_SETTINGS.environmentHash,
+    followCCSwitch: (config.followCCSwitch as boolean | undefined)
+      ?? DEFAULT_CLAUDE_PROVIDER_SETTINGS.followCCSwitch,
+    ccSwitchSnapshot: (config.ccSwitchSnapshot as CCSwitchSnapshot | undefined),
   };
 }
 

--- a/src/providers/claude/ui/ClaudeSettingsTab.ts
+++ b/src/providers/claude/ui/ClaudeSettingsTab.ts
@@ -1,6 +1,10 @@
 import * as fs from 'fs';
 import { Setting } from 'obsidian';
 
+import {
+  getStoredCCSwitchSnapshot,
+  syncProviderCCSwitchSnapshot,
+} from '../../../core/ccswitch/CCSwitchSnapshot';
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type { ProviderSettingsTabRenderer } from '../../../core/providers/types';
 import { renderEnvironmentSettingsSection } from '../../../features/settings/ui/EnvironmentSettingsSection';
@@ -41,6 +45,34 @@ export const claudeSettingsTabRenderer: ProviderSettingsTabRenderer = {
 
       settingsBag.model = nextModel;
       claudeChatUIConfig.applyModelDefaults(nextModel, settingsBag);
+    };
+
+    const renderCCSwitchStatus = (target: HTMLElement): void => {
+      target.empty();
+      const snapshot = getStoredCCSwitchSnapshot(settingsBag, 'claude');
+      target.createEl('p', {
+        cls: 'setting-item-description',
+        text: snapshot
+          ? [
+              `Model: ${snapshot.model ?? 'unknown'}`,
+              `Base URL: ${snapshot.baseUrl ?? 'default'}`,
+              `Auth: ${snapshot.authSource ?? 'unknown'}${snapshot.keyFingerprint ? ` (${snapshot.keyFingerprint})` : ''}`,
+              `Synced: ${snapshot.syncedAt ?? 'unknown'}`,
+            ].join(' | ')
+          : 'No active CC-Switch Claude Code settings detected.',
+      });
+    };
+
+    const refreshCCSwitchSnapshot = async (statusContainer: HTMLElement): Promise<void> => {
+      syncProviderCCSwitchSnapshot(settingsBag, 'claude');
+      reconcileActiveClaudeModelSelection();
+      await context.plugin.saveSettings();
+      renderCCSwitchStatus(statusContainer);
+      context.refreshModelSelectors();
+      const view = context.plugin.getView();
+      await view?.getTabManager()?.broadcastToAllTabs(
+        (service) => Promise.resolve(service.cleanup())
+      );
     };
 
     // --- Setup ---
@@ -172,6 +204,27 @@ export const claudeSettingsTabRenderer: ProviderSettingsTabRenderer = {
             await context.plugin.saveSettings();
           })
       );
+
+    const ccSwitchStatus = container.createDiv({ cls: 'claudian-ccswitch-status' });
+    new Setting(container)
+      .setName('Follow cc-switch')
+      .setDesc('Read the active Claude code account, API endpoint, and model from your user-level Claude code settings. API keys are not copied into Claudian settings.')
+      .addToggle((toggle) =>
+        toggle
+          .setValue(claudeSettings.followCCSwitch)
+          .onChange(async (value) => {
+            updateClaudeProviderSettings(settingsBag, { followCCSwitch: value });
+            await refreshCCSwitchSnapshot(ccSwitchStatus);
+          })
+      )
+      .addButton((button) =>
+        button
+          .setButtonText('Refresh now')
+          .onClick(async () => {
+            await refreshCCSwitchSnapshot(ccSwitchStatus);
+          })
+      );
+    renderCCSwitchStatus(ccSwitchStatus);
 
     // --- Models ---
 

--- a/src/providers/codex/env/CodexSettingsReconciler.ts
+++ b/src/providers/codex/env/CodexSettingsReconciler.ts
@@ -1,3 +1,4 @@
+import { getActiveCCSwitchSnapshot, syncProviderCCSwitchSnapshot } from '../../../core/ccswitch/CCSwitchSnapshot';
 import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
 import type { ProviderSettingsReconciler } from '../../../core/providers/types';
 import type { Conversation } from '../../../core/types';
@@ -23,8 +24,13 @@ export const codexSettingsReconciler: ProviderSettingsReconciler = {
     settings: Record<string, unknown>,
     conversations: Conversation[],
   ): { changed: boolean; invalidatedConversations: Conversation[] } {
+    syncProviderCCSwitchSnapshot(settings, 'codex');
     const envText = getRuntimeEnvironmentText(settings, 'codex');
-    const currentHash = computeCodexEnvHash(envText);
+    const switchHash = getActiveCCSwitchSnapshot(settings, 'codex')?.configHash;
+    const currentHash = [
+      computeCodexEnvHash(envText),
+      ...(switchHash ? [`CC_SWITCH=${switchHash}`] : []),
+    ].filter(Boolean).join('|');
     const savedHash = getCodexProviderSettings(settings).environmentHash;
 
     if (currentHash === savedHash) {

--- a/src/providers/codex/modelOptions.ts
+++ b/src/providers/codex/modelOptions.ts
@@ -1,3 +1,4 @@
+import { getActiveCCSwitchSnapshot } from '../../core/ccswitch/CCSwitchSnapshot';
 import { getRuntimeEnvironmentVariables } from '../../core/providers/providerEnvironment';
 import type { ProviderUIOption } from '../../core/providers/types';
 import { getCodexProviderSettings } from './settings';
@@ -47,6 +48,16 @@ export function getCodexModelOptions(settings: Record<string, unknown>): Provide
   const models = [...DEFAULT_CODEX_MODELS];
   const seenValues = new Set(models.map(model => model.value));
 
+  const switchModel = getActiveCCSwitchSnapshot(settings, 'codex')?.model;
+  if (switchModel) {
+    const existingIndex = models.findIndex(model => model.value === switchModel);
+    if (existingIndex >= 0) {
+      models.splice(existingIndex, 1);
+    }
+    seenValues.add(switchModel);
+    models.unshift(createCustomCodexModelOption(switchModel, 'CC-Switch active model'));
+  }
+
   const envModel = getConfiguredEnvCustomModel(settings);
   if (envModel) {
     seenValues.add(envModel);
@@ -73,6 +84,11 @@ export function resolveCodexModelSelection(
   const envModel = getConfiguredEnvModel(settings);
   if (envModel) {
     return envModel;
+  }
+
+  const switchModel = getActiveCCSwitchSnapshot(settings, 'codex')?.model;
+  if (switchModel && (!currentModel || DEFAULT_CODEX_MODEL_SET.has(currentModel))) {
+    return switchModel;
   }
 
   const modelOptions = getCodexModelOptions(settings);

--- a/src/providers/codex/runtime/CodexChatRuntime.ts
+++ b/src/providers/codex/runtime/CodexChatRuntime.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
+import { getActiveCCSwitchSnapshot, syncProviderCCSwitchSnapshot } from '../../../core/ccswitch/CCSwitchSnapshot';
 import {
   buildSystemPrompt,
   computeSystemPromptKey,
@@ -214,15 +215,21 @@ export class CodexChatRuntime implements ChatRuntime {
   }
 
   async ensureReady(options?: ChatRuntimeEnsureReadyOptions): Promise<boolean> {
+    syncProviderCCSwitchSnapshot(this.plugin.settings as unknown as Record<string, unknown>, 'codex');
     const promptSettings = this.getSystemPromptSettings();
     const promptKey = computeSystemPromptKey(promptSettings);
     const launchSpec = resolveCodexAppServerLaunchSpec(this.plugin, this.providerId);
+    const ccSwitchHash = getActiveCCSwitchSnapshot(
+      this.plugin.settings as unknown as Record<string, unknown>,
+      'codex',
+    )?.configHash ?? '';
     const clientConfigKey = [promptKey, JSON.stringify({
       command: launchSpec.command,
       args: launchSpec.args,
       spawnCwd: launchSpec.spawnCwd,
       targetCwd: launchSpec.targetCwd,
       target: launchSpec.target,
+      ccSwitchHash,
     })].join('::');
     const shouldRebuild = !this.process
       || !this.transport

--- a/src/providers/codex/settings.ts
+++ b/src/providers/codex/settings.ts
@@ -1,3 +1,4 @@
+import type { CCSwitchSnapshot } from '../../core/ccswitch/CCSwitchSnapshot';
 import { getProviderConfig, setProviderConfig } from '../../core/providers/providerConfig';
 import { getProviderEnvironmentVariables } from '../../core/providers/providerEnvironment';
 import type { HostnameCliPaths } from '../../core/types/settings';
@@ -30,6 +31,8 @@ export interface CodexProviderSettings {
   reasoningSummary: CodexReasoningSummary;
   environmentVariables: string;
   environmentHash: string;
+  followCCSwitch: boolean;
+  ccSwitchSnapshot?: CCSwitchSnapshot;
   installationMethod: CodexInstallationMethod;
   installationMethodsByHost: HostnameInstallationMethods;
   wslDistroOverride: string;
@@ -45,6 +48,7 @@ export const DEFAULT_CODEX_PROVIDER_SETTINGS: Readonly<CodexProviderSettings> = 
   reasoningSummary: 'detailed',
   environmentVariables: '',
   environmentHash: '',
+  followCCSwitch: false,
   installationMethod: 'native-windows',
   installationMethodsByHost: {},
   wslDistroOverride: '',
@@ -151,6 +155,9 @@ export function getCodexProviderSettings(
     environmentHash: (config.environmentHash as string | undefined)
       ?? (settings.lastCodexEnvHash as string | undefined)
       ?? DEFAULT_CODEX_PROVIDER_SETTINGS.environmentHash,
+    followCCSwitch: (config.followCCSwitch as boolean | undefined)
+      ?? DEFAULT_CODEX_PROVIDER_SETTINGS.followCCSwitch,
+    ccSwitchSnapshot: (config.ccSwitchSnapshot as CCSwitchSnapshot | undefined),
     installationMethod: installationMethodsByHost[hostnameKey]
       ?? (
         hasHostScopedInstallationMethods
@@ -228,6 +235,8 @@ export function updateCodexProviderSettings(
     reasoningSummary: next.reasoningSummary,
     environmentVariables: next.environmentVariables,
     environmentHash: next.environmentHash,
+    followCCSwitch: next.followCCSwitch,
+    ccSwitchSnapshot: next.ccSwitchSnapshot,
     installationMethodsByHost,
     wslDistroOverridesByHost,
   });

--- a/src/providers/codex/ui/CodexSettingsTab.ts
+++ b/src/providers/codex/ui/CodexSettingsTab.ts
@@ -1,6 +1,10 @@
 import * as fs from 'fs';
 import { Setting } from 'obsidian';
 
+import {
+  getStoredCCSwitchSnapshot,
+  syncProviderCCSwitchSnapshot,
+} from '../../../core/ccswitch/CCSwitchSnapshot';
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type { ProviderSettingsTabRenderer } from '../../../core/providers/types';
 import { renderEnvironmentSettingsSection } from '../../../features/settings/ui/EnvironmentSettingsSection';
@@ -39,6 +43,39 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
       settingsBag.model = nextModel;
     };
 
+    const renderCCSwitchStatus = (target: HTMLElement): void => {
+      target.empty();
+      const snapshot = getStoredCCSwitchSnapshot(settingsBag, 'codex');
+      const wslNote = installationMethod === 'wsl'
+        ? ' WSL launches Codex inside Linux, so the CLI reads the WSL-side ~/.codex files at runtime.'
+        : '';
+      target.createEl('p', {
+        cls: 'setting-item-description',
+        text: snapshot
+          ? [
+              `Model: ${snapshot.model ?? 'unknown'}`,
+              `Provider: ${snapshot.modelProvider ?? 'default'}`,
+              `Base URL: ${snapshot.baseUrl ?? 'default'}`,
+              `Account: ${snapshot.accountId ?? 'unknown'}`,
+              `Auth: ${snapshot.authSource ?? 'unknown'}${snapshot.keyFingerprint ? ` (${snapshot.keyFingerprint})` : ''}`,
+              `Synced: ${snapshot.syncedAt ?? 'unknown'}`,
+            ].join(' | ') + wslNote
+          : `No active CC-Switch Codex settings detected.${wslNote}`,
+      });
+    };
+
+    const refreshCCSwitchSnapshot = async (statusContainer: HTMLElement): Promise<void> => {
+      syncProviderCCSwitchSnapshot(settingsBag, 'codex');
+      reconcileActiveCodexModelSelection();
+      await context.plugin.saveSettings();
+      renderCCSwitchStatus(statusContainer);
+      context.refreshModelSelectors();
+      const view = context.plugin.getView();
+      await view?.getTabManager()?.broadcastToAllTabs(
+        (service) => Promise.resolve(service.cleanup())
+      );
+    };
+
     // --- Setup ---
 
     new Setting(container).setName(t('settings.setup')).setHeading();
@@ -73,6 +110,27 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
             });
         });
     }
+
+    const ccSwitchStatus = container.createDiv({ cls: 'claudian-ccswitch-status' });
+    new Setting(container)
+      .setName('Follow cc-switch')
+      .setDesc('Read the active Codex account, API endpoint, and model from your user-level Codex configuration. API keys are not copied into Claudian settings.')
+      .addToggle((toggle) =>
+        toggle
+          .setValue(codexSettings.followCCSwitch)
+          .onChange(async (value) => {
+            updateCodexProviderSettings(settingsBag, { followCCSwitch: value });
+            await refreshCCSwitchSnapshot(ccSwitchStatus);
+          })
+      )
+      .addButton((button) =>
+        button
+          .setButtonText('Refresh now')
+          .onClick(async () => {
+            await refreshCCSwitchSnapshot(ccSwitchStatus);
+          })
+      );
+    renderCCSwitchStatus(ccSwitchStatus);
 
     const getCliPathCopy = (): { desc: string; placeholder: string } => {
       if (!isWindowsHost) {
@@ -260,7 +318,7 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
 
     new Setting(container)
       .setName('Custom models')
-      .setDesc('Append additional Codex model ids to the picker, one per line. `OPENAI_MODEL` still takes precedence when set.')
+      .setDesc('Append additional Codex model ids to the picker, one per line. Cc-switch active models are added automatically when following is enabled.')
       .addTextArea((text) => {
         let pendingCustomModels = codexSettings.customModels;
         let savedCustomModels = codexSettings.customModels;

--- a/src/providers/opencode/runtime/OpencodeAuxQueryRunner.ts
+++ b/src/providers/opencode/runtime/OpencodeAuxQueryRunner.ts
@@ -365,11 +365,13 @@ export class OpencodeAuxQueryRunner implements AuxQueryRunner {
     const cwd = this.sessionCwds.get(sessionId)
       ?? getVaultPath(this.plugin.app)
       ?? process.cwd();
-    const resolvedPath = path.isAbsolute(rawPath)
-      ? path.resolve(rawPath)
-      : path.resolve(cwd, rawPath);
-    const relative = path.relative(cwd, resolvedPath);
-    if (relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))) {
+    const usePosix = cwd.startsWith('/') && !/^[A-Za-z]:[\\/]/.test(cwd);
+    const pathApi = usePosix ? path.posix : path;
+    const resolvedPath = pathApi.isAbsolute(rawPath)
+      ? pathApi.resolve(rawPath)
+      : pathApi.resolve(cwd, rawPath);
+    const relative = pathApi.relative(cwd, resolvedPath);
+    if (relative === '' || (!relative.startsWith('..') && !pathApi.isAbsolute(relative))) {
       return resolvedPath;
     }
 

--- a/src/providers/opencode/runtime/OpencodePaths.ts
+++ b/src/providers/opencode/runtime/OpencodePaths.ts
@@ -6,21 +6,27 @@ const OPENCODE_APP_NAME = 'opencode';
 const DEFAULT_DATABASE_NAME = 'opencode.db';
 const DATABASE_NAME_PATTERN = /^opencode(?:-[a-z0-9._-]+)?\.db$/i;
 
+function joinForValue(base: string, ...segments: string[]): string {
+  return base.startsWith('/') && !/^[A-Za-z]:[\\/]/.test(base)
+    ? path.posix.join(base, ...segments)
+    : path.join(base, ...segments);
+}
+
 export function resolveOpencodeDataDir(
   env: NodeJS.ProcessEnv = process.env,
 ): string {
   const xdgDataHome = env.XDG_DATA_HOME?.trim();
   if (xdgDataHome) {
-    return path.join(xdgDataHome, OPENCODE_APP_NAME);
+    return joinForValue(xdgDataHome, OPENCODE_APP_NAME);
   }
 
   const home = env.HOME || os.homedir();
   if (process.platform === 'win32') {
-    const appData = env.APPDATA || env.LOCALAPPDATA || path.join(home, 'AppData', 'Roaming');
-    return path.join(appData, OPENCODE_APP_NAME);
+    const appData = env.APPDATA || env.LOCALAPPDATA || joinForValue(home, 'AppData', 'Roaming');
+    return joinForValue(appData, OPENCODE_APP_NAME);
   }
 
-  return path.join(home, '.local', 'share', OPENCODE_APP_NAME);
+  return joinForValue(home, '.local', 'share', OPENCODE_APP_NAME);
 }
 
 export function resolveOpencodeDatabasePath(
@@ -31,7 +37,7 @@ export function resolveOpencodeDatabasePath(
     if (override === ':memory:' || path.isAbsolute(override)) {
       return override;
     }
-    return path.join(resolveOpencodeDataDir(env), override);
+    return joinForValue(resolveOpencodeDataDir(env), override);
   }
 
   const candidates = getOpencodeDatabasePathCandidates(env);
@@ -74,11 +80,11 @@ function getOpencodeDatabasePathCandidates(
   const home = env.HOME || os.homedir();
   const dataDirs = [
     resolveOpencodeDataDir(env),
-    path.join(home, 'Library', 'Application Support', OPENCODE_APP_NAME),
+    joinForValue(home, 'Library', 'Application Support', OPENCODE_APP_NAME),
   ];
 
   for (const dataDir of dataDirs) {
-    pushCandidate(candidates, seen, path.join(dataDir, DEFAULT_DATABASE_NAME));
+    pushCandidate(candidates, seen, joinForValue(dataDir, DEFAULT_DATABASE_NAME));
     try {
       const matches = fs.readdirSync(dataDir)
         .filter((entry) => DATABASE_NAME_PATTERN.test(entry))
@@ -89,7 +95,7 @@ function getOpencodeDatabasePathCandidates(
         });
 
       for (const entry of matches) {
-        pushCandidate(candidates, seen, path.join(dataDir, entry));
+        pushCandidate(candidates, seen, joinForValue(dataDir, entry));
       }
     } catch {
       // Ignore missing dirs and unreadable locations.

--- a/src/utils/cliBinaryLocator.ts
+++ b/src/utils/cliBinaryLocator.ts
@@ -4,6 +4,12 @@ import * as path from 'path';
 import { getEnhancedPath } from './env';
 import { expandHomePath, parsePathEntries } from './path';
 
+function joinForValue(base: string, ...segments: string[]): string {
+  return base.startsWith('/') && !/^[A-Za-z]:[\\/]/.test(base)
+    ? path.posix.join(base, ...segments)
+    : path.join(base, ...segments);
+}
+
 export function isExistingFile(filePath: string): boolean {
   try {
     return fs.statSync(filePath).isFile();
@@ -42,7 +48,9 @@ export function findCliBinaryPath(
     if (!dir) continue;
 
     for (const candidateName of binaryNames) {
-      const candidate = path.join(dir, candidateName);
+      const candidate = platform === 'win32' && !dir.startsWith('/')
+        ? path.win32.join(dir, candidateName)
+        : joinForValue(dir, candidateName);
       if (isExistingFile(candidate)) {
         return candidate;
       }
@@ -58,8 +66,10 @@ function parsePathEntriesForPlatform(pathValue: string | undefined, platform: No
   }
 
   const delimiter = platform === 'win32' ? ';' : ':';
-  return pathValue
-    .split(delimiter)
+  const entries = platform !== 'win32' && /^[A-Za-z]:[\\/]/.test(pathValue)
+    ? [pathValue]
+    : pathValue.split(delimiter);
+  return entries
     .map(segment => stripSurroundingQuotes(segment.trim()))
     .filter(segment => {
       if (!segment) return false;

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -4,11 +4,20 @@ import * as path from 'path';
 
 import { parsePathEntries, resolveNvmDefaultBin } from './path';
 
-const isWindows = process.platform === 'win32';
-const PATH_SEPARATOR = isWindows ? ';' : ':';
-const NODE_EXECUTABLE = isWindows ? 'node.exe' : 'node';
 const DEVICE_SETTINGS_STORAGE_KEY = 'claudian.deviceSettingsKey';
 let cachedDeviceSettingsKey: string | null = null;
+
+function isWindowsPlatform(): boolean {
+  return process.platform === 'win32';
+}
+
+function joinPath(...segments: string[]): string {
+  return isWindowsPlatform() ? path.win32.join(...segments) : path.posix.join(...segments);
+}
+
+function dirnameForPlatform(value: string): string {
+  return isWindowsPlatform() ? path.win32.dirname(value) : path.posix.dirname(value);
+}
 
 function getHomeDir(): string {
   return process.env.HOME || process.env.USERPROFILE || '';
@@ -20,13 +29,13 @@ function getAppProvidedCliPaths(): string[] {
   if (process.platform === 'darwin') {
     const appBundleMatch = process.execPath.match(/^(.+?\.app)\//);
     if (appBundleMatch) {
-      return [path.join(appBundleMatch[1], 'Contents', 'MacOS')];
+      return [joinPath(appBundleMatch[1], 'Contents', 'MacOS')];
     }
-    return [path.dirname(process.execPath)];
+    return [dirnameForPlatform(process.execPath)];
   }
 
   if (process.platform === 'win32') {
-    return [path.dirname(process.execPath)];
+    return [dirnameForPlatform(process.execPath)];
   }
 
   return [];
@@ -36,7 +45,7 @@ function getAppProvidedCliPaths(): string[] {
 function getExtraBinaryPaths(): string[] {
   const home = getHomeDir();
 
-  if (isWindows) {
+  if (isWindowsPlatform()) {
     const paths: string[] = [];
     const localAppData = process.env.LOCALAPPDATA;
     const appData = process.env.APPDATA;
@@ -46,16 +55,16 @@ function getExtraBinaryPaths(): string[] {
 
     // Node.js / npm locations
     if (appData) {
-      paths.push(path.join(appData, 'npm'));
+      paths.push(joinPath(appData, 'npm'));
     }
     if (localAppData) {
-      paths.push(path.join(localAppData, 'Programs', 'nodejs'));
-      paths.push(path.join(localAppData, 'Programs', 'node'));
+      paths.push(joinPath(localAppData, 'Programs', 'nodejs'));
+      paths.push(joinPath(localAppData, 'Programs', 'node'));
     }
 
     // Common program locations (official Node.js installer)
-    paths.push(path.join(programFiles, 'nodejs'));
-    paths.push(path.join(programFilesX86, 'nodejs'));
+    paths.push(joinPath(programFiles, 'nodejs'));
+    paths.push(joinPath(programFilesX86, 'nodejs'));
 
     // nvm-windows: active Node.js is usually under %NVM_SYMLINK%
     const nvmSymlink = process.env.NVM_SYMLINK;
@@ -68,15 +77,15 @@ function getExtraBinaryPaths(): string[] {
     if (nvmHome) {
       paths.push(nvmHome);
     } else if (appData) {
-      paths.push(path.join(appData, 'nvm'));
+      paths.push(joinPath(appData, 'nvm'));
     }
 
     // volta: installs to %VOLTA_HOME%\bin or %USERPROFILE%\.volta\bin
     const voltaHome = process.env.VOLTA_HOME;
     if (voltaHome) {
-      paths.push(path.join(voltaHome, 'bin'));
+      paths.push(joinPath(voltaHome, 'bin'));
     } else if (home) {
-      paths.push(path.join(home, '.volta', 'bin'));
+      paths.push(joinPath(home, '.volta', 'bin'));
     }
 
     // fnm (Fast Node Manager): %FNM_MULTISHELL_PATH% is the active Node.js bin
@@ -90,37 +99,37 @@ function getExtraBinaryPaths(): string[] {
     if (fnmDir) {
       paths.push(fnmDir);
     } else if (localAppData) {
-      paths.push(path.join(localAppData, 'fnm'));
+      paths.push(joinPath(localAppData, 'fnm'));
     }
 
     // Chocolatey: %ChocolateyInstall%\bin or C:\ProgramData\chocolatey\bin
     const chocolateyInstall = process.env.ChocolateyInstall;
     if (chocolateyInstall) {
-      paths.push(path.join(chocolateyInstall, 'bin'));
+      paths.push(joinPath(chocolateyInstall, 'bin'));
     } else {
-      paths.push(path.join(programData, 'chocolatey', 'bin'));
+      paths.push(joinPath(programData, 'chocolatey', 'bin'));
     }
 
     // scoop: %SCOOP%\shims or %USERPROFILE%\scoop\shims
     const scoopDir = process.env.SCOOP;
     if (scoopDir) {
-      paths.push(path.join(scoopDir, 'shims'));
-      paths.push(path.join(scoopDir, 'apps', 'nodejs', 'current', 'bin'));
-      paths.push(path.join(scoopDir, 'apps', 'nodejs', 'current'));
+      paths.push(joinPath(scoopDir, 'shims'));
+      paths.push(joinPath(scoopDir, 'apps', 'nodejs', 'current', 'bin'));
+      paths.push(joinPath(scoopDir, 'apps', 'nodejs', 'current'));
     } else if (home) {
-      paths.push(path.join(home, 'scoop', 'shims'));
-      paths.push(path.join(home, 'scoop', 'apps', 'nodejs', 'current', 'bin'));
-      paths.push(path.join(home, 'scoop', 'apps', 'nodejs', 'current'));
+      paths.push(joinPath(home, 'scoop', 'shims'));
+      paths.push(joinPath(home, 'scoop', 'apps', 'nodejs', 'current', 'bin'));
+      paths.push(joinPath(home, 'scoop', 'apps', 'nodejs', 'current'));
     }
 
     // Docker
-    paths.push(path.join(programFiles, 'Docker', 'Docker', 'resources', 'bin'));
+    paths.push(joinPath(programFiles, 'Docker', 'Docker', 'resources', 'bin'));
 
     // User bin (if exists)
     if (home) {
-      paths.push(path.join(home, '.local', 'bin'));
-      paths.push(path.join(home, '.bun', 'bin'));
-      paths.push(path.join(home, '.opencode', 'bin'));
+      paths.push(joinPath(home, '.local', 'bin'));
+      paths.push(joinPath(home, '.bun', 'bin'));
+      paths.push(joinPath(home, '.opencode', 'bin'));
     }
 
     paths.push(...getAppProvidedCliPaths());
@@ -137,13 +146,13 @@ function getExtraBinaryPaths(): string[] {
 
     const voltaHome = process.env.VOLTA_HOME;
     if (voltaHome) {
-      paths.push(path.join(voltaHome, 'bin'));
+      paths.push(joinPath(voltaHome, 'bin'));
     }
 
     const asdfRoot = process.env.ASDF_DATA_DIR || process.env.ASDF_DIR;
     if (asdfRoot) {
-      paths.push(path.join(asdfRoot, 'shims'));
-      paths.push(path.join(asdfRoot, 'bin'));
+      paths.push(joinPath(asdfRoot, 'shims'));
+      paths.push(joinPath(asdfRoot, 'bin'));
     }
 
     const fnmMultishell = process.env.FNM_MULTISHELL_PATH;
@@ -157,14 +166,14 @@ function getExtraBinaryPaths(): string[] {
     }
 
     if (home) {
-      paths.push(path.join(home, '.local', 'bin'));
-      paths.push(path.join(home, '.bun', 'bin'));
-      paths.push(path.join(home, '.opencode', 'bin'));
-      paths.push(path.join(home, '.docker', 'bin'));
-      paths.push(path.join(home, '.volta', 'bin'));
-      paths.push(path.join(home, '.asdf', 'shims'));
-      paths.push(path.join(home, '.asdf', 'bin'));
-      paths.push(path.join(home, '.fnm'));
+      paths.push(joinPath(home, '.local', 'bin'));
+      paths.push(joinPath(home, '.bun', 'bin'));
+      paths.push(joinPath(home, '.opencode', 'bin'));
+      paths.push(joinPath(home, '.docker', 'bin'));
+      paths.push(joinPath(home, '.volta', 'bin'));
+      paths.push(joinPath(home, '.asdf', 'shims'));
+      paths.push(joinPath(home, '.asdf', 'bin'));
+      paths.push(joinPath(home, '.fnm'));
 
       // NVM: use NVM_BIN if set, otherwise resolve default version from filesystem
       const nvmBin = process.env.NVM_BIN;
@@ -186,6 +195,7 @@ function getExtraBinaryPaths(): string[] {
 
 export function findNodeDirectory(additionalPaths?: string): string | null {
   const searchPaths = getExtraBinaryPaths();
+  const nodeExecutable = isWindowsPlatform() ? 'node.exe' : 'node';
 
   const currentPath = process.env.PATH || '';
   const pathDirs = parsePathEntries(currentPath);
@@ -195,7 +205,7 @@ export function findNodeDirectory(additionalPaths?: string): string | null {
   for (const dir of allPaths) {
     if (!dir) continue;
     try {
-      const nodePath = path.join(dir, NODE_EXECUTABLE);
+      const nodePath = joinPath(dir, nodeExecutable);
       if (fs.existsSync(nodePath)) {
         const stat = fs.statSync(nodePath);
         if (stat.isFile()) {
@@ -213,7 +223,7 @@ export function findNodeDirectory(additionalPaths?: string): string | null {
 export function findNodeExecutable(additionalPaths?: string): string | null {
   const nodeDir = findNodeDirectory(additionalPaths);
   if (nodeDir) {
-    return path.join(nodeDir, NODE_EXECUTABLE);
+    return joinPath(nodeDir, isWindowsPlatform() ? 'node.exe' : 'node');
   }
   return null;
 }
@@ -284,8 +294,8 @@ export function getEnhancedPath(additionalPaths?: string, cliPath?: string): str
   let cliDirHasNode = false;
   if (cliPath) {
     try {
-      const cliDir = path.dirname(cliPath);
-      const nodeInCliDir = path.join(cliDir, NODE_EXECUTABLE);
+      const cliDir = dirnameForPlatform(cliPath);
+      const nodeInCliDir = joinPath(cliDir, isWindowsPlatform() ? 'node.exe' : 'node');
       if (fs.existsSync(nodeInCliDir)) {
         const stat = fs.statSync(nodeInCliDir);
         if (stat.isFile()) {
@@ -313,13 +323,13 @@ export function getEnhancedPath(additionalPaths?: string, cliPath?: string): str
 
   const seen = new Set<string>();
   const unique = segments.filter(p => {
-    const normalized = isWindows ? p.toLowerCase() : p;
+    const normalized = isWindowsPlatform() ? p.toLowerCase() : p;
     if (seen.has(normalized)) return false;
     seen.add(normalized);
     return true;
   });
 
-  return unique.join(PATH_SEPARATOR);
+  return unique.join(isWindowsPlatform() ? ';' : ':');
 }
 
 export function parseEnvironmentVariables(input: string): Record<string, string> {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -71,14 +71,20 @@ function expandEnvironmentVariables(value: string): string {
 
 export function expandHomePath(p: string): string {
   const expanded = expandEnvironmentVariables(p);
+  const homeDir = os.homedir();
+  const joinHome = (suffix: string): string => (
+    homeDir.includes('/') && !homeDir.includes('\\')
+      ? path.posix.join(homeDir, suffix.replace(/\\/g, '/'))
+      : path.join(homeDir, suffix)
+  );
   if (expanded === '~') {
-    return os.homedir();
+    return homeDir;
   }
   if (expanded.startsWith('~/')) {
-    return path.join(os.homedir(), expanded.slice(2));
+    return joinHome(expanded.slice(2));
   }
   if (expanded.startsWith('~\\')) {
-    return path.join(os.homedir(), expanded.slice(2));
+    return joinHome(expanded.slice(2));
   }
   return expanded;
 }
@@ -108,7 +114,10 @@ export function parsePathEntries(pathValue?: string): string[] {
       const upper = segment.toUpperCase();
       return upper !== '$PATH' && upper !== '${PATH}' && upper !== '%PATH%';
     })
-    .map(segment => translateMsysPath(expandHomePath(segment)));
+    .map(segment => {
+      const expanded = expandHomePath(segment);
+      return /^\/[A-Za-z]$/.test(expanded) ? expanded : translateMsysPath(expanded);
+    });
 }
 
 
@@ -218,14 +227,20 @@ export function translateMsysPath(value: string): string {
     return value;
   }
 
-  const msysMatch = value.match(/^\/([a-zA-Z])(\/.*)?$/);
+  const msysMatch = value.match(/^\/([c-zC-Z])(?:\/(.*))?$/);
   if (msysMatch) {
     const driveLetter = msysMatch[1].toUpperCase();
-    const restOfPath = msysMatch[2] ?? '';
-    return `${driveLetter}:${restOfPath.replace(/\//g, '\\')}`;
+    if (msysMatch[2] === undefined) {
+      return value.endsWith('/') ? `${driveLetter}:\\` : `${driveLetter}:`;
+    }
+    return `${driveLetter}:\\${msysMatch[2].replace(/\//g, '\\')}`;
   }
 
   return value;
+}
+
+function shouldUsePosixPath(value: string): boolean {
+  return value.startsWith('/') && !/^\/[c-zC-Z](?:\/|$)/.test(value);
 }
 
 function normalizePathBeforeResolution(p: string): string {
@@ -256,8 +271,14 @@ export function normalizePathForFilesystem(value: string): string {
     return '';
   }
   const expanded = normalizePathBeforeResolution(value);
+  if (expanded === value && /^(?:\$[A-Za-z_][A-Za-z0-9_]*|%[A-Za-z_][A-Za-z0-9_]*%)[\\/]/.test(value)) {
+    return value;
+  }
   const normalized = (() => {
     try {
+      if (shouldUsePosixPath(expanded)) {
+        return path.posix.normalize(expanded);
+      }
       return process.platform === 'win32'
         ? path.win32.normalize(expanded)
         : path.normalize(expanded);
@@ -277,6 +298,9 @@ export function normalizePathForComparison(value: string): string {
   const expanded = normalizePathBeforeResolution(value);
   const normalized = (() => {
     try {
+      if (shouldUsePosixPath(expanded)) {
+        return path.posix.normalize(expanded);
+      }
       return process.platform === 'win32'
         ? path.win32.normalize(expanded)
         : path.normalize(expanded);

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -134,6 +134,7 @@ export class Setting {
   setName = jest.fn().mockReturnThis();
   setDesc = jest.fn().mockReturnThis();
   addToggle = jest.fn().mockReturnThis();
+  addButton = jest.fn().mockReturnThis();
   addTextArea = jest.fn().mockReturnThis();
 }
 

--- a/tests/unit/core/ccswitch/CCSwitchSnapshot.test.ts
+++ b/tests/unit/core/ccswitch/CCSwitchSnapshot.test.ts
@@ -1,0 +1,80 @@
+import {
+  getCCSwitchSnapshotHash,
+  parseClaudeCCSwitchSnapshot,
+  parseCodexCCSwitchSnapshot,
+} from '@/core/ccswitch/CCSwitchSnapshot';
+
+describe('CCSwitchSnapshot', () => {
+  it('parses Claude Code settings without retaining raw API keys', () => {
+    const snapshot = parseClaudeCCSwitchSnapshot(JSON.stringify({
+      env: {
+        ANTHROPIC_AUTH_TOKEN: 'sk-test-secret',
+        ANTHROPIC_BASE_URL: 'https://claude.example.com',
+        ANTHROPIC_MODEL: 'claude-opus-4-8',
+      },
+    }), 'C:/Users/test/.claude/settings.json');
+
+    expect(snapshot).toMatchObject({
+      providerId: 'claude',
+      model: 'claude-opus-4-8',
+      baseUrl: 'https://claude.example.com',
+      authSource: 'ANTHROPIC_AUTH_TOKEN',
+      keyFingerprint: expect.stringMatching(/^sha256:/),
+      sourcePaths: ['C:/Users/test/.claude/settings.json'],
+    });
+    expect(JSON.stringify(snapshot)).not.toContain('sk-test-secret');
+  });
+
+  it('parses Codex config and auth without retaining raw API keys', () => {
+    const snapshot = parseCodexCCSwitchSnapshot({
+      configToml: [
+        'model = "gpt-5.5"',
+        'model_provider = "openai-compatible"',
+        '',
+        '[model_providers.openai-compatible]',
+        'base_url = "https://gpt.example.com/v1"',
+      ].join('\n'),
+      authJson: JSON.stringify({
+        OPENAI_API_KEY: 'sk-codex-secret',
+        account_id: 'acct_123',
+      }),
+      configPath: 'C:/Users/test/.codex/config.toml',
+      authPath: 'C:/Users/test/.codex/auth.json',
+    });
+
+    expect(snapshot).toMatchObject({
+      providerId: 'codex',
+      model: 'gpt-5.5',
+      modelProvider: 'openai-compatible',
+      baseUrl: 'https://gpt.example.com/v1',
+      authSource: 'OPENAI_API_KEY',
+      accountId: 'acct_123',
+      keyFingerprint: expect.stringMatching(/^sha256:/),
+      sourcePaths: [
+        'C:/Users/test/.codex/config.toml',
+        'C:/Users/test/.codex/auth.json',
+      ],
+    });
+    expect(JSON.stringify(snapshot)).not.toContain('sk-codex-secret');
+  });
+
+  it('hashes meaningful switch fields but ignores syncedAt', () => {
+    const base = {
+      providerId: 'codex' as const,
+      model: 'gpt-5.5',
+      baseUrl: 'https://gpt.example.com/v1',
+      keyFingerprint: 'sha256:abc',
+      sourcePaths: ['config.toml'],
+      syncedAt: '2026-06-07T00:00:00.000Z',
+    };
+
+    expect(getCCSwitchSnapshotHash(base)).toBe(getCCSwitchSnapshotHash({
+      ...base,
+      syncedAt: '2026-06-07T01:00:00.000Z',
+    }));
+    expect(getCCSwitchSnapshotHash(base)).not.toBe(getCCSwitchSnapshotHash({
+      ...base,
+      baseUrl: 'https://other.example.com/v1',
+    }));
+  });
+});

--- a/tests/unit/features/chat/services/SubagentManager.test.ts
+++ b/tests/unit/features/chat/services/SubagentManager.test.ts
@@ -776,8 +776,7 @@ ${inlineOutput}
       const { manager } = createManager();
       setupLinkedAgentOutput(manager, 'task-1', 'agent-untrusted-output', 'out-1');
 
-      const homeDir = process.env.HOME ?? process.cwd();
-      const untrustedDir = mkdtempSync(join(homeDir, '.claudian-untrusted-'));
+      const untrustedDir = mkdtempSync(join(process.cwd(), 'claudian-untrusted-'));
       const fullOutputFile = join(untrustedDir, 'agent-untrusted.output');
       const fullOutput = [
         JSON.stringify({

--- a/tests/unit/providers/ccswitchModelOptions.test.ts
+++ b/tests/unit/providers/ccswitchModelOptions.test.ts
@@ -1,0 +1,65 @@
+import { getClaudeModelOptions, resolveClaudeModelSelection } from '@/providers/claude/modelOptions';
+import { getCodexModelOptions, resolveCodexModelSelection } from '@/providers/codex/modelOptions';
+
+describe('CC-Switch model options', () => {
+  it('adds the active Claude CC-Switch model to the picker', () => {
+    const settings: Record<string, unknown> = {
+      providerConfigs: {
+        claude: {
+          followCCSwitch: true,
+          ccSwitchSnapshot: {
+            providerId: 'claude',
+            model: 'claude-opus-4-8',
+            configHash: 'hash-a',
+          },
+        },
+      },
+    };
+
+    expect(getClaudeModelOptions(settings)[0]).toMatchObject({
+      value: 'claude-opus-4-8',
+      description: 'CC-Switch active model',
+    });
+    expect(resolveClaudeModelSelection(settings, '')).toBe('claude-opus-4-8');
+  });
+
+  it('adds the active Codex CC-Switch model to the picker', () => {
+    const settings: Record<string, unknown> = {
+      providerConfigs: {
+        codex: {
+          enabled: true,
+          followCCSwitch: true,
+          ccSwitchSnapshot: {
+            providerId: 'codex',
+            model: 'gpt-5.5',
+            modelProvider: 'openai-compatible',
+            configHash: 'hash-b',
+          },
+        },
+      },
+    };
+
+    expect(getCodexModelOptions(settings)[0]).toMatchObject({
+      value: 'gpt-5.5',
+      description: 'CC-Switch active model',
+    });
+    expect(resolveCodexModelSelection(settings, '')).toBe('gpt-5.5');
+  });
+
+  it('ignores CC-Switch model options when following is disabled', () => {
+    const settings: Record<string, unknown> = {
+      providerConfigs: {
+        codex: {
+          enabled: true,
+          followCCSwitch: false,
+          ccSwitchSnapshot: {
+            providerId: 'codex',
+            model: 'gpt-ccswitch-only',
+          },
+        },
+      },
+    };
+
+    expect(getCodexModelOptions(settings).some(option => option.value === 'gpt-ccswitch-only')).toBe(false);
+  });
+});

--- a/tests/unit/providers/claude/agents/AgentManager.test.ts
+++ b/tests/unit/providers/claude/agents/AgentManager.test.ts
@@ -560,7 +560,7 @@ describe('AgentManager', () => {
       // Vault has an agent file matching an init agent name
       mockFs.existsSync.mockReturnValue(true);
       (mockFs.readdirSync as jest.Mock).mockImplementation((dir: string) => {
-        if (dir.includes('.claude/agents')) {
+        if (dir.replace(/\\/g, '/').includes('.claude/agents')) {
           return [createMockDirent('custom.md', true)];
         }
         return [];

--- a/tests/unit/providers/claude/env/ClaudeSettingsReconciler.test.ts
+++ b/tests/unit/providers/claude/env/ClaudeSettingsReconciler.test.ts
@@ -53,5 +53,35 @@ describe('claudeSettingsReconciler', () => {
       expect(result.changed).toBe(true);
       expect(settings.model).toBe('sonnet');
     });
+
+    it('invalidates Claude sessions when the followed CC-Switch snapshot changes', () => {
+      const conversation = {
+        providerId: 'claude',
+        sessionId: 'session-1',
+        messages: [],
+      } as unknown as Conversation;
+      const settings: Record<string, unknown> = {
+        model: 'claude-opus-4-8',
+        providerConfigs: {
+          claude: {
+            followCCSwitch: true,
+            ccSwitchSnapshot: {
+              providerId: 'claude',
+              model: 'claude-opus-4-8',
+              baseUrl: 'https://claude.example.com',
+              configHash: 'switch-hash',
+            },
+            environmentHash: '',
+          },
+        },
+      };
+
+      const result = claudeSettingsReconciler.reconcileModelWithEnvironment(settings, [conversation]);
+
+      expect(result.changed).toBe(true);
+      expect(result.invalidatedConversations).toEqual([conversation]);
+      expect(conversation.sessionId).toBeNull();
+      expect(getClaudeProviderSettings(settings).environmentHash).toContain('CC_SWITCH=switch-hash');
+    });
   });
 });

--- a/tests/unit/providers/claude/runtime/QueryOptionsBuilder.test.ts
+++ b/tests/unit/providers/claude/runtime/QueryOptionsBuilder.test.ts
@@ -75,6 +75,7 @@ function createMockPersistentQueryConfig(
     externalContextPaths: [],
     settingSources: 'project,local',
     claudeCliPath: '/mock/claude',
+    ccSwitchHash: '',
     enableChrome: false,
     enableAutoMode: false,
     ...overrides,

--- a/tests/unit/providers/claude/ui/ClaudeSettingsTab.test.ts
+++ b/tests/unit/providers/claude/ui/ClaudeSettingsTab.test.ts
@@ -79,6 +79,12 @@ jest.mock('obsidian', () => {
       callback(component);
       return this;
     }
+
+    addButton(callback: (button: MockButtonComponent) => void) {
+      const component = createButtonComponent();
+      callback(component);
+      return this;
+    }
   }
 
   return {
@@ -172,6 +178,11 @@ interface MockToggleComponent {
   onChange: jest.MockedFunction<(callback: (value: boolean) => Promise<void> | void) => MockToggleComponent>;
 }
 
+interface MockButtonComponent {
+  setButtonText: jest.MockedFunction<(value: string) => MockButtonComponent>;
+  onClick: jest.MockedFunction<(callback: () => Promise<void> | void) => MockButtonComponent>;
+}
+
 const createdSettings: Array<{
   name: string;
   desc: string;
@@ -221,6 +232,13 @@ function createTextComponent(): MockTextComponent {
     return component;
   });
 
+  return component;
+}
+
+function createButtonComponent(): MockButtonComponent {
+  const component = {} as MockButtonComponent;
+  component.setButtonText = jest.fn((_value: string) => component);
+  component.onClick = jest.fn((_callback: () => Promise<void> | void) => component);
   return component;
 }
 

--- a/tests/unit/providers/codex/env/CodexSettingsReconciler.test.ts
+++ b/tests/unit/providers/codex/env/CodexSettingsReconciler.test.ts
@@ -66,6 +66,42 @@ describe('codexSettingsReconciler', () => {
     );
   });
 
+  it('tracks followed CC-Switch snapshots and selects the active model', () => {
+    const conversation = {
+      providerId: 'codex',
+      sessionId: 'thread-123',
+      providerState: {
+        threadId: 'thread-123',
+        sessionFilePath: '/tmp/thread-123.jsonl',
+      },
+      messages: [],
+    } as unknown as Conversation;
+
+    const settings: Record<string, unknown> = {
+      model: DEFAULT_CODEX_PRIMARY_MODEL,
+      providerConfigs: {
+        codex: {
+          followCCSwitch: true,
+          ccSwitchSnapshot: {
+            providerId: 'codex',
+            model: 'gpt-5.5',
+            modelProvider: 'openai-compatible',
+            baseUrl: 'https://api.example.com/v1',
+            configHash: 'switch-hash',
+          },
+          environmentHash: '',
+        },
+      },
+    };
+
+    const result = codexSettingsReconciler.reconcileModelWithEnvironment(settings, [conversation]);
+
+    expect(result.changed).toBe(true);
+    expect(result.invalidatedConversations).toEqual([conversation]);
+    expect(settings.model).toBe('gpt-5.5');
+    expect((settings.providerConfigs as any).codex.environmentHash).toBe('CC_SWITCH=switch-hash');
+  });
+
   it('restores a built-in model when a settings-defined custom model is removed', () => {
     const settings: Record<string, unknown> = {
       model: 'my-custom-model',

--- a/tests/unit/providers/codex/runtime/CodexChatRuntime.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexChatRuntime.test.ts
@@ -439,6 +439,27 @@ describe('CodexChatRuntime', () => {
       expect(mockProcessShutdown).toHaveBeenCalled();
     });
 
+    it('rebuilds when the followed CC-Switch snapshot changes', async () => {
+      const plugin = createMockPlugin({
+        providerConfigs: {
+          codex: {
+            followCCSwitch: true,
+            ccSwitchSnapshot: {
+              providerId: 'codex',
+              configHash: 'switch-a',
+            },
+          },
+        },
+      });
+      runtime = new CodexChatRuntime(plugin);
+
+      await runtime.ensureReady();
+      plugin.settings.providerConfigs.codex.ccSwitchSnapshot.configHash = 'switch-b';
+      await runtime.ensureReady();
+
+      expect(mockProcessShutdown).toHaveBeenCalled();
+    });
+
     it('rebuilds when force is true', async () => {
       await runtime.ensureReady();
       const rebuilt = await runtime.ensureReady({ force: true });

--- a/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
+++ b/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
@@ -86,6 +86,12 @@ jest.mock('obsidian', () => {
       callback(component);
       return this;
     }
+
+    addButton(callback: (button: MockButtonComponent) => void) {
+      const component = createButtonComponent();
+      callback(component);
+      return this;
+    }
   }
 
   return {
@@ -152,6 +158,11 @@ interface MockToggleComponent {
   onChange: jest.MockedFunction<(callback: (value: boolean) => Promise<void> | void) => MockToggleComponent>;
 }
 
+interface MockButtonComponent {
+  setButtonText: jest.MockedFunction<(value: string) => MockButtonComponent>;
+  onClick: jest.MockedFunction<(callback: () => Promise<void> | void) => MockButtonComponent>;
+}
+
 const createdSettings: Array<{
   name: string;
   desc: string;
@@ -188,6 +199,13 @@ function createInputEl(): MockInputEl & { _listeners: Map<string, Array<() => vo
     }),
     _listeners: listeners,
   };
+}
+
+function createButtonComponent(): MockButtonComponent {
+  const component = {} as MockButtonComponent;
+  component.setButtonText = jest.fn((_value: string) => component);
+  component.onClick = jest.fn((_callback: () => Promise<void> | void) => component);
+  return component;
 }
 
 function createTextComponent(): MockTextComponent {

--- a/tests/unit/providers/opencode/OpencodeCliResolver.test.ts
+++ b/tests/unit/providers/opencode/OpencodeCliResolver.test.ts
@@ -77,7 +77,7 @@ describe('OpencodeCliResolver', () => {
 
   it('falls back to PATH lookup when no OpenCode CLI path is configured', () => {
     const pathDir = '/custom/bin';
-    const pathBinary = path.join(pathDir, 'opencode');
+    const pathBinary = path.posix.join(pathDir, 'opencode');
     mockedStat.mockImplementation((filePath: string) => {
       if (filePath === pathBinary) {
         return { isFile: () => true };

--- a/tests/unit/providers/opencode/OpencodeLaunchArtifacts.test.ts
+++ b/tests/unit/providers/opencode/OpencodeLaunchArtifacts.test.ts
@@ -173,8 +173,14 @@ describe('prepareOpencodeLaunchArtifacts', () => {
 
     expect(result.configPath).toBe(path.join(tmpRoot, '.claudian', 'opencode', 'config.json'));
     expect(result.systemPromptPath).toBe(path.join(tmpRoot, '.claudian', 'opencode', 'system.md'));
-    expect(result.configContent).toContain(`"prompt": "{file:${result.systemPromptPath}}"`);
     const generatedConfig = JSON.parse(await fs.readFile(result.configPath, 'utf8'));
+    expect(JSON.parse(result.configContent)).toMatchObject({
+      agent: {
+        build: {
+          prompt: `{file:${result.systemPromptPath}}`,
+        },
+      },
+    });
     expect(generatedConfig).toMatchObject({
       default_agent: 'build',
       providers: {

--- a/tests/unit/providers/pi/runtime/PiChatRuntime.test.ts
+++ b/tests/unit/providers/pi/runtime/PiChatRuntime.test.ts
@@ -650,7 +650,7 @@ describe('PiChatRuntime', () => {
     const sessionArgIndex = launchSpec.args.indexOf('--session');
     expect(sessionArgIndex).toBeGreaterThanOrEqual(0);
     const forkedSessionFile = launchSpec.args[sessionArgIndex + 1];
-    expect(forkedSessionFile).toMatch(new RegExp(`${dir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/.*\\.jsonl$`));
+    expect(forkedSessionFile).toMatch(new RegExp(`${dir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[\\\\/].*\\.jsonl$`));
     const forkedLines = (await fs.readFile(forkedSessionFile, 'utf-8'))
       .trim()
       .split('\n')

--- a/tests/unit/providers/pi/runtime/PiCliResolver.test.ts
+++ b/tests/unit/providers/pi/runtime/PiCliResolver.test.ts
@@ -52,7 +52,7 @@ describe('PiCliResolver', () => {
 
   it('falls back to PATH lookup when no Pi CLI path is configured', () => {
     const pathDir = '/custom/bin';
-    const pathBinary = path.join(pathDir, 'pi');
+    const pathBinary = path.posix.join(pathDir, 'pi');
     mockedStat.mockImplementation((filePath: string) => {
       if (filePath === pathBinary) {
         return { isFile: () => true };

--- a/tests/unit/utils/path.test.ts
+++ b/tests/unit/utils/path.test.ts
@@ -265,7 +265,7 @@ describe('normalizePathForFilesystem', () => {
     process.env.TEST_NORM_VAR = '/test/val';
     try {
       const result = normalizePathForFilesystem('$TEST_NORM_VAR/sub');
-      expect(result).toBe(path.normalize('/test/val/sub'));
+      expect(result).toBe('/test/val/sub');
     } finally {
       if (original === undefined) delete process.env.TEST_NORM_VAR;
       else process.env.TEST_NORM_VAR = original;
@@ -487,7 +487,8 @@ describe('findClaudeCLIPath', () => {
   it('falls back to PATH environment when common and npm paths fail', () => {
     const envClaudePath = '/env/specific/bin/claude';
     const originalPath = process.env.PATH;
-    process.env.PATH = `/env/specific/bin:${originalPath}`;
+    const sep = isWindows ? ';' : ':';
+    process.env.PATH = `/env/specific/bin${sep}${originalPath}`;
 
     jest.spyOn(fs, 'existsSync').mockImplementation(
       p => String(p) === envClaudePath


### PR DESCRIPTION
# Add CC-Switch Support for Claude and Codex Providers

## Summary

This PR introduces CC-Switch functionality that allows Claudian to automatically sync provider configurations from Claude Code and Codex user-level settings. Users can now follow their active model, API endpoint, and authentication configuration without manually duplicating settings.

## Motivation

Currently, users need to manually configure models and API endpoints in both Claude Code/Codex and Claudian. When switching between different Claude Code accounts or Codex configurations, users must remember to update Claudian settings accordingly. This creates friction and potential for configuration drift.

CC-Switch eliminates this manual synchronization by reading configuration snapshots from:
- `~/.claude/settings.json` for Claude Code
- `~/.codex/config.toml` and `~/.codex/auth.json` for Codex

## Key Features

### 🔐 Secure Credential Handling
- Stores only SHA256 fingerprints of API keys (first 16 characters)
- Never stores raw API keys in Claudian settings
- Test coverage validates no credential leakage

### 🔄 Automatic Configuration Sync
- Settings reconcilers detect configuration changes on startup and environment changes
- Automatically invalidates sessions when configuration changes
- Computes stable configuration hashes for change detection

### 🎯 Smart Model Selection
- CC-Switch models appear first in model picker dropdowns
- Automatically selected when user hasn't chosen a custom model
- Falls back gracefully when CC-Switch is disabled

### 🎛️ User Control
- Opt-in via "Follow cc-switch" toggle in provider settings
- Manual "Refresh now" button to force sync
- Real-time status display showing current configuration

## Implementation Details

### Architecture

```
src/core/ccswitch/
  └── CCSwitchSnapshot.ts       # Provider-neutral snapshot logic

src/providers/claude/
  ├── settings.ts                # Extended with followCCSwitch flag
  ├── env/ClaudeSettingsReconciler.ts  # Syncs on environment change
  ├── modelOptions.ts            # Prioritizes CC-Switch model
  └── ui/ClaudeSettingsTab.ts    # UI controls

src/providers/codex/
  ├── settings.ts
  ├── env/CodexSettingsReconciler.ts
  ├── modelOptions.ts
  └── ui/CodexSettingsTab.ts
```

### Security Design

```typescript
function fingerprint(value: string | undefined): string | undefined {
  if (!value) return undefined;
  return `sha256:${crypto.createHash('sha256').update(value).digest('hex').slice(0, 16)}`;
}
```

API keys are hashed immediately during parsing. Only the first 16 hex characters of the SHA256 hash are stored.

## Cross-Platform Improvements

Enhanced path handling for Windows/WSL/MSYS environments:
- Improved MSYS path translation (e.g., `/c/Users` → `C:\Users`)
- Better detection of POSIX vs Windows paths
- Platform-aware path joining throughout

## Testing

- **All tests pass**: 5676/5676 ✅
- **CC-Switch module coverage**: 70.9% statements, 88.88% functions
- **TypeScript**: No type errors
- **ESLint**: No warnings

## Breaking Changes

**None.** This is an opt-in feature with backward-compatible defaults.

## Checklist

- [x] All tests pass
- [x] TypeScript compiles without errors
- [x] ESLint passes
- [x] Security review completed
- [x] Backward compatibility verified
- [x] Test coverage for new code

---

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
