### PR TITLE
fix: rank exact slash command matches first

### DIFF
--- a/src/shared/components/SlashCommandDropdown.ts
+++ b/src/shared/components/SlashCommandDropdown.ts
@@ -219,7 +219,7 @@ export class SlashCommandDropdown {
         item.name.toLowerCase().includes(searchLower) ||
         item.description?.toLowerCase().includes(searchLower)
       )
-      .sort((a, b) => a.name.localeCompare(b.name));
+      .sort((a, b) => this.compareSearchResults(a, b, searchLower));
 
     if (currentRequest !== this.requestId) return;
 
@@ -306,6 +306,23 @@ export class SlashCommandDropdown {
     }
 
     return items;
+  }
+
+  private compareSearchResults(a: DropdownItem, b: DropdownItem, searchLower: string): number {
+    const rankDiff = this.getSearchRank(a, searchLower) - this.getSearchRank(b, searchLower);
+    if (rankDiff !== 0) return rankDiff;
+    return a.name.localeCompare(b.name);
+  }
+
+  private getSearchRank(item: DropdownItem, searchLower: string): number {
+    if (searchLower.length === 0) return 0;
+
+    const nameLower = item.name.toLowerCase();
+    if (nameLower === searchLower) return 0;
+    if (nameLower.startsWith(searchLower)) return 1;
+    if (nameLower.includes(searchLower)) return 2;
+    if (item.description?.toLowerCase().includes(searchLower)) return 3;
+    return 4;
   }
 
   private render(): void {

--- a/tests/unit/shared/components/SlashCommandDropdown.provider.test.ts
+++ b/tests/unit/shared/components/SlashCommandDropdown.provider.test.ts
@@ -169,6 +169,48 @@ describe('SlashCommandDropdown - provider catalog', () => {
       dropdown.destroy();
     });
 
+    it('ranks exact Codex skill matches first on $ trigger', async () => {
+      const getProviderEntries = jest.fn().mockResolvedValue([
+        {
+          id: 'codex-skill-aa-analyze-helper', providerId: 'codex', kind: 'skill', name: 'aa-analyze-helper',
+          description: 'Substring match', content: '', scope: 'vault', source: 'user',
+          isEditable: true, isDeletable: true, displayPrefix: '$', insertPrefix: '$',
+        },
+        {
+          id: 'codex-skill-alpha-helper', providerId: 'codex', kind: 'skill', name: 'alpha-helper',
+          description: 'Description mentions analyze', content: '', scope: 'vault', source: 'user',
+          isEditable: true, isDeletable: true, displayPrefix: '$', insertPrefix: '$',
+        },
+        {
+          id: 'codex-skill-analyze-more', providerId: 'codex', kind: 'skill', name: 'analyze-more',
+          description: 'Prefix match', content: '', scope: 'vault', source: 'user',
+          isEditable: true, isDeletable: true, displayPrefix: '$', insertPrefix: '$',
+        },
+        {
+          id: 'codex-skill-analyze', providerId: 'codex', kind: 'skill', name: 'analyze',
+          description: 'Exact match', content: '', scope: 'vault', source: 'user',
+          isEditable: true, isDeletable: true, displayPrefix: '$', insertPrefix: '$',
+        },
+      ]);
+      const dropdown = new SlashCommandDropdown(
+        containerEl, inputEl, callbacks, { providerConfig: CODEX_CONFIG, getProviderEntries }
+      );
+
+      inputEl.value = '$analyze';
+      inputEl.selectionStart = 8;
+      dropdown.handleInputChange();
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(getRenderedCommandNames(containerEl)).toEqual([
+        '$analyze',
+        '$analyze-more',
+        '$aa-analyze-helper',
+        '$alpha-helper',
+      ]);
+
+      dropdown.destroy();
+    });
+
     it('shows built-ins + skills on / trigger at position 0', async () => {
       const getProviderEntries = jest.fn().mockResolvedValue(CODEX_ENTRIES);
       const dropdown = new SlashCommandDropdown(

--- a/tests/unit/shared/components/SlashCommandDropdown.test.ts
+++ b/tests/unit/shared/components/SlashCommandDropdown.test.ts
@@ -213,6 +213,63 @@ describe('SlashCommandDropdown', () => {
     });
   });
 
+  describe('search result ranking', () => {
+    it('should rank exact command name matches before prefix, substring, and description matches', async () => {
+      const entries: ProviderCommandEntry[] = [
+        makeEntry('my-paper-writer', 'Substring match'),
+        makeEntry('paper-writer-long', 'Prefix match'),
+        makeEntry('alpha-helper', 'Description mentions paper-writer'),
+        makeEntry('paper-writer', 'Exact match'),
+      ];
+      const getProviderEntries = jest.fn().mockResolvedValue(entries);
+
+      const dropdownWithEntries = new SlashCommandDropdown(
+        containerEl, inputEl, callbacks,
+        { providerConfig: CLAUDE_CONFIG, getProviderEntries }
+      );
+
+      inputEl.value = '/paper-writer';
+      inputEl.selectionStart = 13;
+      dropdownWithEntries.handleInputChange();
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(getRenderedCommandNames(containerEl)).toEqual([
+        'paper-writer',
+        'paper-writer-long',
+        'my-paper-writer',
+        'alpha-helper',
+      ]);
+
+      dropdownWithEntries.destroy();
+    });
+
+    it('should keep empty search results alphabetically sorted', async () => {
+      const getProviderEntries = jest.fn().mockResolvedValue([
+        makeEntry('zebra'),
+        makeEntry('alpha'),
+      ]);
+
+      const dropdownWithEntries = new SlashCommandDropdown(
+        containerEl, inputEl, callbacks,
+        { providerConfig: CLAUDE_CONFIG, getProviderEntries }
+      );
+
+      inputEl.value = '/';
+      inputEl.selectionStart = 1;
+      dropdownWithEntries.handleInputChange();
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(getRenderedCommandNames(containerEl)).toEqual([
+        'add-dir',
+        'alpha',
+        'clear',
+        'zebra',
+      ]);
+
+      dropdownWithEntries.destroy();
+    });
+  });
+
   describe('provider entry caching', () => {
     it('should cache entries after first successful fetch', async () => {
       const getProviderEntries = jest.fn().mockResolvedValue(PROVIDER_ENTRIES);


### PR DESCRIPTION
## Summary
- Fixes #741.
- Ranks slash command and skill search results by match quality before alphabetical order.
- Keeps empty searches alphabetically sorted and preserves existing hidden-command, built-in, and provider trigger behavior.

## Test Plan
- npm run test -- --selectProjects unit --runTestsByPath tests/unit/shared/components/SlashCommandDropdown.test.ts tests/unit/shared/components/SlashCommandDropdown.provider.test.ts
- npm run typecheck
- npm run lint
- npm run test
- npm run build