### PR TITLE
fix: improve fast mode icon contrast

### DIFF
--- a/src/style/toolbar/service-tier-toggle.css
+++ b/src/style/toolbar/service-tier-toggle.css
@@ -15,7 +15,7 @@
   color: var(--text-muted);
   background: transparent;
   cursor: pointer;
-  transition: color 0.15s ease, background 0.15s ease;
+  transition: color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
   flex-shrink: 0;
 }
 
@@ -36,4 +36,14 @@
 
 .claudian-service-tier-button.active {
   color: var(--claudian-brand);
+  background: rgba(var(--claudian-brand-rgb), 0.18);
+  box-shadow: inset 0 0 0 1px rgba(var(--claudian-brand-rgb), 0.28);
+}
+
+.claudian-service-tier-button.active .claudian-service-tier-icon svg {
+  fill: #ffffff;
+  stroke: #000000;
+  stroke-width: 2.5;
+  stroke-linejoin: round;
+  paint-order: stroke fill;
 }


### PR DESCRIPTION
## Summary
- Improves the active Codex fast-mode icon contrast in the toolbar.
- Keeps the existing Lucide zap icon, but renders the active state with a white fill and black outline so it stays visible on dark and light Obsidian themes.
- Adds a subtle active button background/border to make the fast-mode state easier to identify.

## Test Plan
- npm run test -- --selectProjects unit --runTestsByPath tests/unit/features/chat/ui/InputToolbar.test.ts
- npm run build
- npm run typecheck
- npm run lint