### PR TITLE
Unify Pi model picker style

### DIFF
--- a/src/providers/pi/ui/PiSettingsTab.ts
+++ b/src/providers/pi/ui/PiSettingsTab.ts
@@ -8,12 +8,27 @@ import { getHostnameKey } from '../../../utils/env';
 import { expandHomePath } from '../../../utils/path';
 import { maybeGetPiWorkspaceServices } from '../app/PiWorkspaceServices';
 import { sameStringList } from '../internal/compareCollections';
+import {
+  decodePiModelId,
+  type PiDiscoveredModel,
+} from '../models';
 import { PiModelDiscoveryService } from '../runtime/PiModelDiscoveryService';
 import {
   getPiProviderSettings,
   normalizePiVisibleModels,
   updatePiProviderSettings,
 } from '../settings';
+
+const ALL_PROVIDERS_KEY = 'all';
+
+interface EnrichedPiModel {
+  description: string;
+  encodedId: string;
+  isAvailable: boolean;
+  modelLabel: string;
+  providerKey: string;
+  providerLabel: string;
+}
 
 export const piSettingsTabRenderer: ProviderSettingsTabRenderer = {
   render(container, context) {
@@ -97,83 +112,417 @@ export const piSettingsTabRenderer: ProviderSettingsTabRenderer = {
 
     new Setting(container).setName('Models').setHeading();
 
-    const modelContainer = container.createDiv({ cls: 'claudian-pi-models' });
-    const renderModels = (): void => {
-      modelContainer.empty();
-      const current = getPiProviderSettings(settingsBag);
-      new Setting(modelContainer)
-        .setName('Discover models')
-        .setDesc(current.discoveredModels.length > 0
-          ? `${current.discoveredModels.length} Pi models cached.`
-          : 'Fetch models from `pi --mode rpc --no-session`.')
-        .addButton((button) => {
-          button.setButtonText('Discover').onClick(async () => {
-            button.setDisabled(true);
-            const result = await new PiModelDiscoveryService(context.plugin).discoverModels();
-            if (result.diagnostics) {
-              new Notice(`Pi discovery failed: ${result.diagnostics}`);
-              button.setDisabled(false);
-              return;
-            }
-            updatePiProviderSettings(settingsBag, {
-              discoveredModels: result.models,
-              visibleModels: normalizePiVisibleModels(
-                current.visibleModels,
-                result.models,
-              ),
-            });
-            await context.plugin.saveSettings();
-            renderModels();
-            context.refreshModelSelectors();
-          });
-        });
+    new Setting(container)
+      .setName('Visible models')
+      .setDesc('Choose which Pi models appear in the chat selector. Filter by provider or type to search. The current session model stays pinned even if it is not selected here.');
 
-      if (current.discoveredModels.length === 0) {
-        modelContainer.createDiv({
-          cls: 'setting-item-description',
-          text: 'No Pi models discovered yet.',
-        });
+    const pickerEl = container.createDiv({ cls: 'claudian-provider-model-picker claudian-provider-model-picker--pi' });
+
+    let searchQuery = '';
+    let providerFilter = ALL_PROVIDERS_KEY;
+    let loadingModelCatalog = false;
+    let modelCatalogLoadFailed = false;
+
+    const summaryEl = pickerEl.createDiv({ cls: 'claudian-provider-model-picker-summary' });
+    const selectedEl = pickerEl.createDiv({ cls: 'claudian-provider-model-picker-selected' });
+    const catalogEl = pickerEl.createEl('details', { cls: 'claudian-provider-model-picker-catalog' });
+    catalogEl.open = getPiProviderSettings(settingsBag).visibleModels.length === 0;
+
+    const catalogSummaryEl = catalogEl.createEl('summary', {
+      cls: 'claudian-provider-model-picker-catalog-summary',
+    });
+    catalogSummaryEl.createSpan({
+      cls: 'claudian-provider-model-picker-catalog-caret',
+      text: '▸',
+    });
+    catalogSummaryEl.createSpan({
+      cls: 'claudian-provider-model-picker-catalog-title',
+      text: 'Browse models',
+    });
+    const catalogSummaryCountEl = catalogSummaryEl.createSpan({
+      cls: 'claudian-provider-model-picker-catalog-count',
+    });
+
+    const controlsEl = catalogEl.createDiv({ cls: 'claudian-provider-model-picker-controls' });
+
+    const searchInput = controlsEl.createEl('input', {
+      cls: 'claudian-provider-model-picker-search',
+      type: 'search',
+    });
+    searchInput.placeholder = 'Filter by model, provider, or ID...';
+    searchInput.addEventListener('input', () => {
+      searchQuery = searchInput.value.trim().toLowerCase();
+      renderList();
+    });
+
+    const providerSelectEl = controlsEl.createEl('select', {
+      cls: 'claudian-provider-model-picker-provider',
+    });
+    providerSelectEl.addEventListener('change', () => {
+      providerFilter = providerSelectEl.value;
+      renderList();
+    });
+
+    const discoverButtonEl = controlsEl.createEl('button', {
+      cls: 'claudian-provider-model-picker-action',
+      text: 'Discover',
+    });
+    discoverButtonEl.setAttribute('type', 'button');
+    discoverButtonEl.addEventListener('click', () => {
+      void loadModelCatalog({ force: true });
+    });
+
+    const listEl = catalogEl.createDiv({ cls: 'claudian-provider-model-picker-list' });
+
+    const getEnrichedModels = (): EnrichedPiModel[] => {
+      const current = getPiProviderSettings(settingsBag);
+      return buildEnrichedPiModels(current.discoveredModels, current.visibleModels);
+    };
+
+    const filterModels = (models: EnrichedPiModel[]): EnrichedPiModel[] => {
+      return models.filter((model) => {
+        if (providerFilter !== ALL_PROVIDERS_KEY && model.providerKey !== providerFilter) {
+          return false;
+        }
+
+        if (!searchQuery) {
+          return true;
+        }
+
+        return (
+          model.encodedId.toLowerCase().includes(searchQuery)
+          || model.modelLabel.toLowerCase().includes(searchQuery)
+          || model.providerLabel.toLowerCase().includes(searchQuery)
+          || model.description.toLowerCase().includes(searchQuery)
+        );
+      });
+    };
+
+    const persistVisibleModels = async (visibleModels: string[]): Promise<void> => {
+      const current = getPiProviderSettings(settingsBag);
+      const normalized = normalizePiVisibleModels(visibleModels, current.discoveredModels);
+      if (sameStringList(current.visibleModels, normalized)) {
         return;
       }
 
-      for (const model of current.discoveredModels) {
-        new Setting(modelContainer)
-          .setName(current.modelAliases[model.encodedId] || model.label)
-          .setDesc(model.encodedId)
-          .addToggle((toggle) => {
-            toggle
-              .setValue(current.visibleModels.includes(model.encodedId))
-              .onChange(async (value) => {
-                const visibleModels = value
-                  ? [...current.visibleModels, model.encodedId]
-                  : current.visibleModels.filter(id => id !== model.encodedId);
-                const normalized = normalizePiVisibleModels(visibleModels, current.discoveredModels);
-                if (!sameStringList(current.visibleModels, normalized)) {
-                  updatePiProviderSettings(settingsBag, { visibleModels: normalized });
-                  await context.plugin.saveSettings();
-                  renderModels();
-                  context.refreshModelSelectors();
-                }
-              });
-          })
-          .addText((text) => {
-            text
-              .setPlaceholder('Alias')
-              .setValue(current.modelAliases[model.encodedId] ?? '')
-              .onChange(async (value) => {
-                updatePiProviderSettings(settingsBag, {
-                  modelAliases: {
-                    ...getPiProviderSettings(settingsBag).modelAliases,
-                    [model.encodedId]: value,
-                  },
-                });
-                await context.plugin.saveSettings();
-                context.refreshModelSelectors();
-              });
+      updatePiProviderSettings(settingsBag, { visibleModels: normalized });
+      await context.plugin.saveSettings();
+      renderAll();
+      context.refreshModelSelectors();
+    };
+
+    const persistModelAliases = async (modelAliases: Record<string, string>): Promise<void> => {
+      updatePiProviderSettings(settingsBag, { modelAliases });
+      await context.plugin.saveSettings();
+      renderSelected();
+      context.refreshModelSelectors();
+    };
+
+    const renderSummary = (): void => {
+      summaryEl.empty();
+      const current = getPiProviderSettings(settingsBag);
+      const enriched = getEnrichedModels();
+      const providerCount = new Set(enriched.map((model) => model.providerKey)).size;
+      const providerWord = providerCount === 1 ? 'provider' : 'providers';
+
+      summaryEl.createSpan({ text: 'Visible: ' });
+      summaryEl.createSpan({
+        cls: 'claudian-provider-model-picker-summary-value',
+        text: String(current.visibleModels.length),
+      });
+      summaryEl.createSpan({
+        text: ` of ${current.discoveredModels.length} discovered | ${providerCount} ${providerWord}`,
+      });
+
+      let catalogSummary = 'No models discovered yet';
+      if (loadingModelCatalog) {
+        catalogSummary = 'Loading models...';
+      } else if (current.discoveredModels.length > 0) {
+        catalogSummary = `${current.discoveredModels.length} available`;
+      }
+      catalogSummaryCountEl.setText(catalogSummary);
+      discoverButtonEl.disabled = loadingModelCatalog;
+      discoverButtonEl.setText(loadingModelCatalog
+        ? 'Loading...'
+        : current.discoveredModels.length > 0
+        ? 'Refresh'
+        : 'Discover');
+    };
+
+    const renderSelected = (): void => {
+      selectedEl.empty();
+      const current = getPiProviderSettings(settingsBag);
+      if (current.visibleModels.length === 0) {
+        selectedEl.toggleClass('claudian-hidden', true);
+        return;
+      }
+
+      selectedEl.toggleClass('claudian-hidden', false);
+      const enrichedById = new Map(
+        getEnrichedModels().map((model) => [model.encodedId, model] as const),
+      );
+
+      const headerEl = selectedEl.createDiv({ cls: 'claudian-provider-model-picker-selected-header' });
+      headerEl.createEl('span', {
+        cls: 'claudian-provider-model-picker-selected-label',
+        text: `Selected (${current.visibleModels.length})`,
+      });
+      const clearAllBtn = headerEl.createEl('button', {
+        cls: 'claudian-provider-model-picker-selected-clear',
+        text: 'Clear all',
+      });
+      clearAllBtn.setAttribute('aria-label', 'Clear all selected Pi models');
+      clearAllBtn.addEventListener('click', () => {
+        void persistVisibleModels([]);
+      });
+
+      const rowsEl = selectedEl.createDiv({ cls: 'claudian-provider-model-picker-selected-rows' });
+
+      for (const encodedId of current.visibleModels) {
+        const enriched = enrichedById.get(encodedId);
+        const defaultLabel = enriched
+          ? `${enriched.providerLabel}/${enriched.modelLabel}`
+          : encodedId;
+
+        const rowEl = rowsEl.createDiv({ cls: 'claudian-provider-model-picker-selected-row' });
+        if (enriched && !enriched.isAvailable) {
+          rowEl.classList.add('claudian-provider-model-picker-selected-row--unavailable');
+        }
+
+        const infoEl = rowEl.createDiv({ cls: 'claudian-provider-model-picker-selected-info' });
+        const titleEl = infoEl.createDiv({ cls: 'claudian-provider-model-picker-selected-title' });
+        if (enriched) {
+          titleEl.createEl('span', {
+            cls: 'claudian-provider-model-picker-selected-badge',
+            text: enriched.providerLabel,
           });
+          titleEl.createEl('span', {
+            cls: 'claudian-provider-model-picker-selected-name',
+            text: enriched.modelLabel,
+          });
+        } else {
+          titleEl.createEl('span', {
+            cls: 'claudian-provider-model-picker-selected-name',
+            text: encodedId,
+          });
+        }
+
+        if (enriched && !enriched.isAvailable) {
+          infoEl.createEl('div', {
+            cls: 'claudian-provider-model-picker-selected-unavailable',
+            text: 'Not currently reported by Pi',
+          });
+        }
+
+        infoEl.createEl('div', {
+          cls: 'claudian-provider-model-picker-selected-id',
+          text: encodedId,
+        });
+
+        const rowControlsEl = rowEl.createDiv({ cls: 'claudian-provider-model-picker-selected-controls' });
+        const aliasInput = rowControlsEl.createEl('input', {
+          cls: 'claudian-provider-model-picker-selected-alias',
+          type: 'text',
+        });
+        aliasInput.placeholder = defaultLabel;
+        aliasInput.value = current.modelAliases[encodedId] ?? '';
+        aliasInput.setAttribute('aria-label', `Alias for ${defaultLabel}`);
+        aliasInput.title = 'Custom label shown in the model selector. Leave empty to use the default.';
+
+        const commitAlias = (): void => {
+          const latest = getPiProviderSettings(settingsBag);
+          const existing = latest.modelAliases[encodedId] ?? '';
+          const next = aliasInput.value.trim();
+          if (next === existing) {
+            aliasInput.value = existing;
+            return;
+          }
+
+          const nextAliases = { ...latest.modelAliases };
+          if (next) {
+            nextAliases[encodedId] = next;
+          } else {
+            delete nextAliases[encodedId];
+          }
+          void persistModelAliases(nextAliases);
+        };
+
+        aliasInput.addEventListener('blur', commitAlias);
+        aliasInput.addEventListener('keydown', (event) => {
+          if (event.key === 'Enter') {
+            event.preventDefault();
+            aliasInput.blur();
+          } else if (event.key === 'Escape') {
+            event.preventDefault();
+            aliasInput.value = getPiProviderSettings(settingsBag).modelAliases[encodedId] ?? '';
+            aliasInput.blur();
+          }
+        });
+
+        const removeBtn = rowControlsEl.createEl('button', {
+          cls: 'claudian-provider-model-picker-selected-remove',
+          text: '×',
+        });
+        removeBtn.setAttribute('aria-label', `Remove ${defaultLabel}`);
+        removeBtn.addEventListener('click', () => {
+          void persistVisibleModels(getPiProviderSettings(settingsBag).visibleModels.filter((entry) => entry !== encodedId));
+        });
       }
     };
-    renderModels();
+
+    const renderProviderSelect = (): void => {
+      const enriched = getEnrichedModels();
+      const providers = new Map<string, { count: number; label: string }>();
+      for (const model of enriched) {
+        const existing = providers.get(model.providerKey);
+        if (existing) {
+          existing.count += 1;
+        } else {
+          providers.set(model.providerKey, { count: 1, label: model.providerLabel });
+        }
+      }
+
+      providerSelectEl.empty();
+      providerSelectEl.createEl('option', {
+        text: `All providers (${enriched.length})`,
+        value: ALL_PROVIDERS_KEY,
+      });
+
+      const sortedProviders = Array.from(providers.entries())
+        .sort(([, left], [, right]) => left.label.localeCompare(right.label));
+      for (const [key, { count, label }] of sortedProviders) {
+        providerSelectEl.createEl('option', {
+          text: `${label} (${count})`,
+          value: key,
+        });
+      }
+
+      if (providerFilter !== ALL_PROVIDERS_KEY && !providers.has(providerFilter)) {
+        providerFilter = ALL_PROVIDERS_KEY;
+      }
+      providerSelectEl.value = providerFilter;
+    };
+
+    const renderList = (): void => {
+      listEl.empty();
+      const current = getPiProviderSettings(settingsBag);
+      const selectedIds = new Set(current.visibleModels);
+      const enriched = getEnrichedModels();
+      const filtered = filterModels(enriched);
+
+      if (filtered.length === 0) {
+        const emptyEl = listEl.createDiv({ cls: 'claudian-provider-model-picker-empty' });
+        let emptyText = 'No models match your filter.';
+        if (loadingModelCatalog) {
+          emptyText = 'Loading Pi model catalog...';
+        } else if (modelCatalogLoadFailed) {
+          emptyText = 'Could not load the Pi model catalog. Check the CLI path and login state, then try again.';
+        } else if (enriched.length === 0) {
+          emptyText = 'No Pi models discovered yet. Click Discover to load models from Pi.';
+        }
+        emptyEl.setText(emptyText);
+        return;
+      }
+
+      for (const model of filtered) {
+        const rowEl = listEl.createEl('label', { cls: 'claudian-provider-model-picker-row' });
+        const isSelected = selectedIds.has(model.encodedId);
+        if (isSelected) {
+          rowEl.classList.add('claudian-provider-model-picker-row--selected');
+        }
+        rowEl.title = model.encodedId;
+
+        const checkboxEl = rowEl.createEl('input', { type: 'checkbox' });
+        checkboxEl.checked = isSelected;
+        checkboxEl.addEventListener('change', () => {
+          const currentVisibleModels = getPiProviderSettings(settingsBag).visibleModels;
+          const next = checkboxEl.checked
+            ? [...currentVisibleModels, model.encodedId]
+            : currentVisibleModels.filter((id) => id !== model.encodedId);
+          void persistVisibleModels(next);
+        });
+
+        const textEl = rowEl.createDiv({ cls: 'claudian-provider-model-picker-row-text' });
+
+        const headerEl = textEl.createDiv({ cls: 'claudian-provider-model-picker-row-header' });
+        headerEl.createEl('span', {
+          cls: 'claudian-provider-model-picker-row-name',
+          text: model.modelLabel,
+        });
+        const badgeEl = headerEl.createEl('span', {
+          cls: 'claudian-provider-model-picker-row-badge',
+          text: model.providerLabel,
+        });
+        if (!model.isAvailable) {
+          badgeEl.classList.add('claudian-provider-model-picker-row-badge--unavailable');
+          badgeEl.setText('Unavailable');
+          badgeEl.title = 'Configured model not currently reported by Pi';
+        }
+
+        textEl.createDiv({
+          cls: 'claudian-provider-model-picker-row-meta',
+          text: model.encodedId,
+        });
+
+        if (model.description) {
+          textEl.createDiv({
+            cls: 'claudian-provider-model-picker-row-desc',
+            text: model.description,
+          });
+        }
+      }
+    };
+
+    const renderAll = (): void => {
+      renderSummary();
+      renderSelected();
+      renderProviderSelect();
+      renderList();
+    };
+
+    const loadModelCatalog = async ({ force = false }: { force?: boolean } = {}): Promise<void> => {
+      if (loadingModelCatalog || (!force && getPiProviderSettings(settingsBag).discoveredModels.length > 0)) {
+        return;
+      }
+
+      loadingModelCatalog = true;
+      modelCatalogLoadFailed = false;
+      renderAll();
+
+      try {
+        const result = await new PiModelDiscoveryService(context.plugin).discoverModels();
+        if (result.diagnostics) {
+          modelCatalogLoadFailed = true;
+          new Notice(`Pi discovery failed: ${result.diagnostics}`);
+          return;
+        }
+
+        const current = getPiProviderSettings(settingsBag);
+        const normalizedVisibleModels = normalizePiVisibleModels(current.visibleModels, result.models);
+        const shouldPersist = result.models.length > 0
+          || current.discoveredModels.length > 0
+          || !sameStringList(current.visibleModels, normalizedVisibleModels);
+        if (shouldPersist) {
+          updatePiProviderSettings(settingsBag, {
+            discoveredModels: result.models,
+            visibleModels: normalizedVisibleModels,
+          });
+          await context.plugin.saveSettings();
+          context.refreshModelSelectors();
+        }
+      } finally {
+        loadingModelCatalog = false;
+        renderAll();
+      }
+    };
+
+    renderAll();
+
+    catalogEl.addEventListener('toggle', () => {
+      if (catalogEl.open) {
+        void loadModelCatalog();
+      }
+    });
 
     renderEnvironmentSettingsSection({
       container,
@@ -203,4 +552,91 @@ function validateCliPath(value: string): string | null {
   }
 
   return null;
+}
+
+function buildEnrichedPiModels(
+  discoveredModels: PiDiscoveredModel[],
+  visibleModels: string[],
+): EnrichedPiModel[] {
+  const enriched: EnrichedPiModel[] = [];
+  const discoveredIds = new Set<string>();
+
+  for (const model of discoveredModels) {
+    discoveredIds.add(model.encodedId);
+    enriched.push({
+      description: buildPiModelDescription(model),
+      encodedId: model.encodedId,
+      isAvailable: true,
+      modelLabel: model.label || model.id,
+      providerKey: model.provider.toLowerCase(),
+      providerLabel: formatProviderLabel(model.provider),
+    });
+  }
+
+  for (const encodedId of visibleModels) {
+    if (discoveredIds.has(encodedId)) {
+      continue;
+    }
+
+    const decoded = decodePiModelId(encodedId);
+    const provider = decoded?.provider ?? 'pi';
+    enriched.push({
+      description: 'Configured model',
+      encodedId,
+      isAvailable: false,
+      modelLabel: decoded?.modelId ?? encodedId,
+      providerKey: provider.toLowerCase(),
+      providerLabel: formatProviderLabel(provider),
+    });
+  }
+
+  return enriched.sort((left, right) => {
+    const providerCmp = left.providerLabel.localeCompare(right.providerLabel);
+    if (providerCmp !== 0) {
+      return providerCmp;
+    }
+    return left.modelLabel.localeCompare(right.modelLabel);
+  });
+}
+
+function buildPiModelDescription(model: PiDiscoveredModel): string {
+  const details: string[] = [];
+  if (model.api) {
+    details.push(`API: ${model.api}`);
+  }
+  if (model.contextWindow) {
+    details.push(`${model.contextWindow.toLocaleString()} context`);
+  }
+  if (model.maxTokens) {
+    details.push(`${model.maxTokens.toLocaleString()} output`);
+  }
+  if (model.input.includes('image')) {
+    details.push('image input');
+  }
+  details.push(model.reasoning
+    ? `thinking: ${model.thinkingLevels.join(', ')}`
+    : 'thinking: off');
+
+  return details.join(' | ');
+}
+
+function formatProviderLabel(provider: string): string {
+  const normalized = provider.trim();
+  const knownProviders: Record<string, string> = {
+    anthropic: 'Anthropic',
+    deepseek: 'DeepSeek',
+    google: 'Google',
+    openai: 'OpenAI',
+    xai: 'xAI',
+  };
+  const known = knownProviders[normalized.toLowerCase()];
+  if (known) {
+    return known;
+  }
+
+  return normalized
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ') || 'Pi';
 }

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -54,7 +54,7 @@
 @import "./settings/mcp-settings.css";
 @import "./settings/plugin-settings.css";
 @import "./settings/agent-settings.css";
-@import "./settings/opencode-model-picker.css";
+@import "./settings/provider-model-picker.css";
 
 /* Accessibility */
 @import "./accessibility.css";

--- a/src/style/settings/provider-model-picker.css
+++ b/src/style/settings/provider-model-picker.css
@@ -1,13 +1,13 @@
-/* OpenCode model picker */
+/* Provider model picker */
 
-.claudian-opencode-model-picker {
+:is(.claudian-provider-model-picker, .claudian-opencode-model-picker) {
   display: flex;
   flex-direction: column;
   gap: 12px;
   margin-top: 8px;
 }
 
-.claudian-opencode-model-picker-summary {
+:is(.claudian-provider-model-picker-summary, .claudian-opencode-model-picker-summary) {
   display: flex;
   flex-wrap: wrap;
   gap: 6px 12px;
@@ -15,12 +15,12 @@
   color: var(--text-muted);
 }
 
-.claudian-opencode-model-picker-summary-value {
+:is(.claudian-provider-model-picker-summary-value, .claudian-opencode-model-picker-summary-value) {
   color: var(--text-normal);
   font-weight: var(--font-medium);
 }
 
-.claudian-opencode-model-picker-selected {
+:is(.claudian-provider-model-picker-selected, .claudian-opencode-model-picker-selected) {
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -29,21 +29,21 @@
   border-radius: 6px;
 }
 
-.claudian-opencode-model-picker-selected-header {
+:is(.claudian-provider-model-picker-selected-header, .claudian-opencode-model-picker-selected-header) {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
 }
 
-.claudian-opencode-model-picker-selected-label {
+:is(.claudian-provider-model-picker-selected-label, .claudian-opencode-model-picker-selected-label) {
   font-size: var(--font-ui-smaller);
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
 
-.claudian-opencode-model-picker-selected-clear {
+:is(.claudian-provider-model-picker-selected-clear, .claudian-opencode-model-picker-selected-clear) {
   padding: 2px 8px;
   font-size: var(--font-ui-smaller);
   color: var(--text-muted);
@@ -53,18 +53,38 @@
   cursor: pointer;
 }
 
-.claudian-opencode-model-picker-selected-clear:hover {
+:is(.claudian-provider-model-picker-selected-clear, .claudian-opencode-model-picker-selected-clear):hover {
   background: var(--background-modifier-hover);
   color: var(--text-normal);
 }
 
-.claudian-opencode-model-picker-selected-rows {
+:is(.claudian-provider-model-picker-action, .claudian-opencode-model-picker-action) {
+  padding: 5px 10px;
+  font-size: var(--font-ui-small);
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+:is(.claudian-provider-model-picker-action, .claudian-opencode-model-picker-action):hover:not(:disabled) {
+  background: var(--background-modifier-hover);
+  color: var(--text-normal);
+}
+
+:is(.claudian-provider-model-picker-action, .claudian-opencode-model-picker-action):disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+:is(.claudian-provider-model-picker-selected-rows, .claudian-opencode-model-picker-selected-rows) {
   display: flex;
   flex-direction: column;
   gap: 6px;
 }
 
-.claudian-opencode-model-picker-selected-row {
+:is(.claudian-provider-model-picker-selected-row, .claudian-opencode-model-picker-selected-row) {
   display: flex;
   align-items: center;
   gap: 12px;
@@ -74,11 +94,11 @@
   border-radius: 6px;
 }
 
-.claudian-opencode-model-picker-selected-row--unavailable {
+:is(.claudian-provider-model-picker-selected-row--unavailable, .claudian-opencode-model-picker-selected-row--unavailable) {
   border-style: dashed;
 }
 
-.claudian-opencode-model-picker-selected-info {
+:is(.claudian-provider-model-picker-selected-info, .claudian-opencode-model-picker-selected-info) {
   flex: 1;
   min-width: 0;
   display: flex;
@@ -86,7 +106,7 @@
   gap: 2px;
 }
 
-.claudian-opencode-model-picker-selected-title {
+:is(.claudian-provider-model-picker-selected-title, .claudian-opencode-model-picker-selected-title) {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
@@ -94,7 +114,7 @@
   min-width: 0;
 }
 
-.claudian-opencode-model-picker-selected-badge {
+:is(.claudian-provider-model-picker-selected-badge, .claudian-opencode-model-picker-selected-badge) {
   font-size: var(--font-ui-smaller);
   padding: 1px 6px;
   border-radius: 999px;
@@ -104,7 +124,7 @@
   letter-spacing: 0.04em;
 }
 
-.claudian-opencode-model-picker-selected-name {
+:is(.claudian-provider-model-picker-selected-name, .claudian-opencode-model-picker-selected-name) {
   color: var(--text-normal);
   font-weight: var(--font-medium);
   overflow: hidden;
@@ -112,7 +132,7 @@
   white-space: nowrap;
 }
 
-.claudian-opencode-model-picker-selected-id {
+:is(.claudian-provider-model-picker-selected-id, .claudian-opencode-model-picker-selected-id) {
   font-size: var(--font-ui-smaller);
   color: var(--text-muted);
   font-family: var(--font-monospace);
@@ -121,20 +141,20 @@
   white-space: nowrap;
 }
 
-.claudian-opencode-model-picker-selected-unavailable {
+:is(.claudian-provider-model-picker-selected-unavailable, .claudian-opencode-model-picker-selected-unavailable) {
   font-size: var(--font-ui-smaller);
   color: var(--text-muted);
   font-style: italic;
 }
 
-.claudian-opencode-model-picker-selected-controls {
+:is(.claudian-provider-model-picker-selected-controls, .claudian-opencode-model-picker-selected-controls) {
   display: flex;
   align-items: center;
   gap: 6px;
   flex-shrink: 0;
 }
 
-.claudian-opencode-model-picker-selected-alias {
+:is(.claudian-provider-model-picker-selected-alias, .claudian-opencode-model-picker-selected-alias) {
   width: 180px;
   padding: 4px 8px;
   border: 1px solid var(--background-modifier-border);
@@ -144,12 +164,12 @@
   font-size: var(--font-ui-small);
 }
 
-.claudian-opencode-model-picker-selected-alias:focus {
+:is(.claudian-provider-model-picker-selected-alias, .claudian-opencode-model-picker-selected-alias):focus {
   outline: none;
   border-color: var(--interactive-accent);
 }
 
-.claudian-opencode-model-picker-selected-remove {
+:is(.claudian-provider-model-picker-selected-remove, .claudian-opencode-model-picker-selected-remove) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -165,12 +185,12 @@
   font-size: 16px;
 }
 
-.claudian-opencode-model-picker-selected-remove:hover {
+:is(.claudian-provider-model-picker-selected-remove, .claudian-opencode-model-picker-selected-remove):hover {
   background: var(--background-modifier-hover);
   color: var(--text-normal);
 }
 
-.claudian-opencode-model-picker-catalog {
+:is(.claudian-provider-model-picker-catalog, .claudian-opencode-model-picker-catalog) {
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -179,7 +199,7 @@
   border-radius: 6px;
 }
 
-.claudian-opencode-model-picker-catalog-summary {
+:is(.claudian-provider-model-picker-catalog-summary, .claudian-opencode-model-picker-catalog-summary) {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -188,11 +208,11 @@
   list-style: none;
 }
 
-.claudian-opencode-model-picker-catalog-summary::-webkit-details-marker {
+:is(.claudian-provider-model-picker-catalog-summary, .claudian-opencode-model-picker-catalog-summary)::-webkit-details-marker {
   display: none;
 }
 
-.claudian-opencode-model-picker-catalog-caret {
+:is(.claudian-provider-model-picker-catalog-caret, .claudian-opencode-model-picker-catalog-caret) {
   font-size: 16px;
   color: var(--text-muted);
   transition: transform 0.12s ease;
@@ -202,30 +222,30 @@
   line-height: 1;
 }
 
-.claudian-opencode-model-picker-catalog[open] .claudian-opencode-model-picker-catalog-caret {
+:is(.claudian-provider-model-picker-catalog, .claudian-opencode-model-picker-catalog)[open] :is(.claudian-provider-model-picker-catalog-caret, .claudian-opencode-model-picker-catalog-caret) {
   transform: rotate(90deg);
 }
 
-.claudian-opencode-model-picker-catalog-title {
+:is(.claudian-provider-model-picker-catalog-title, .claudian-opencode-model-picker-catalog-title) {
   color: var(--text-normal);
   font-weight: var(--font-medium);
   font-size: var(--font-ui-small);
 }
 
-.claudian-opencode-model-picker-catalog-count {
+:is(.claudian-provider-model-picker-catalog-count, .claudian-opencode-model-picker-catalog-count) {
   font-size: var(--font-ui-smaller);
   color: var(--text-muted);
   margin-left: auto;
 }
 
-.claudian-opencode-model-picker-controls {
+:is(.claudian-provider-model-picker-controls, .claudian-opencode-model-picker-controls) {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
   align-items: center;
 }
 
-.claudian-opencode-model-picker-search {
+:is(.claudian-provider-model-picker-search, .claudian-opencode-model-picker-search) {
   flex: 1 1 220px;
   min-width: 180px;
   padding: 6px 10px;
@@ -236,12 +256,12 @@
   font-size: var(--font-ui-small);
 }
 
-.claudian-opencode-model-picker-search:focus {
+:is(.claudian-provider-model-picker-search, .claudian-opencode-model-picker-search):focus {
   outline: none;
   border-color: var(--interactive-accent);
 }
 
-.claudian-opencode-model-picker-provider {
+:is(.claudian-provider-model-picker-provider, .claudian-opencode-model-picker-provider) {
   padding: 6px 10px;
   border: 1px solid var(--background-modifier-border);
   border-radius: 6px;
@@ -250,7 +270,7 @@
   font-size: var(--font-ui-small);
 }
 
-.claudian-opencode-model-picker-list {
+:is(.claudian-provider-model-picker-list, .claudian-opencode-model-picker-list) {
   display: flex;
   flex-direction: column;
   margin-top: 8px;
@@ -261,7 +281,7 @@
   overflow-y: auto;
 }
 
-.claudian-opencode-model-picker-row {
+:is(.claudian-provider-model-picker-row, .claudian-opencode-model-picker-row) {
   display: flex;
   align-items: flex-start;
   gap: 10px;
@@ -270,23 +290,23 @@
   cursor: pointer;
 }
 
-.claudian-opencode-model-picker-row:last-child {
+:is(.claudian-provider-model-picker-row, .claudian-opencode-model-picker-row):last-child {
   border-bottom: none;
 }
 
-.claudian-opencode-model-picker-row:hover {
+:is(.claudian-provider-model-picker-row, .claudian-opencode-model-picker-row):hover {
   background: var(--background-modifier-hover);
 }
 
-.claudian-opencode-model-picker-row--selected {
+:is(.claudian-provider-model-picker-row--selected, .claudian-opencode-model-picker-row--selected) {
   background: var(--background-modifier-hover);
 }
 
-.claudian-opencode-model-picker-row input[type="checkbox"] {
+:is(.claudian-provider-model-picker-row, .claudian-opencode-model-picker-row) input[type="checkbox"] {
   margin-top: 3px;
 }
 
-.claudian-opencode-model-picker-row-text {
+:is(.claudian-provider-model-picker-row-text, .claudian-opencode-model-picker-row-text) {
   flex: 1;
   min-width: 0;
   display: flex;
@@ -294,7 +314,7 @@
   gap: 2px;
 }
 
-.claudian-opencode-model-picker-row-header {
+:is(.claudian-provider-model-picker-row-header, .claudian-opencode-model-picker-row-header) {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -302,7 +322,7 @@
   min-width: 0;
 }
 
-.claudian-opencode-model-picker-row-name {
+:is(.claudian-provider-model-picker-row-name, .claudian-opencode-model-picker-row-name) {
   color: var(--text-normal);
   font-weight: var(--font-medium);
   overflow: hidden;
@@ -310,7 +330,7 @@
   white-space: nowrap;
 }
 
-.claudian-opencode-model-picker-row-badge {
+:is(.claudian-provider-model-picker-row-badge, .claudian-opencode-model-picker-row-badge) {
   font-size: var(--font-ui-smaller);
   padding: 1px 6px;
   border-radius: 999px;
@@ -320,12 +340,12 @@
   letter-spacing: 0.04em;
 }
 
-.claudian-opencode-model-picker-row-badge--unavailable {
+:is(.claudian-provider-model-picker-row-badge--unavailable, .claudian-opencode-model-picker-row-badge--unavailable) {
   background: var(--background-modifier-error);
   color: var(--text-on-accent);
 }
 
-.claudian-opencode-model-picker-row-meta {
+:is(.claudian-provider-model-picker-row-meta, .claudian-opencode-model-picker-row-meta) {
   font-size: var(--font-ui-smaller);
   color: var(--text-muted);
   font-family: var(--font-monospace);
@@ -334,12 +354,12 @@
   white-space: nowrap;
 }
 
-.claudian-opencode-model-picker-row-desc {
+:is(.claudian-provider-model-picker-row-desc, .claudian-opencode-model-picker-row-desc) {
   font-size: var(--font-ui-smaller);
   color: var(--text-muted);
 }
 
-.claudian-opencode-model-picker-empty {
+:is(.claudian-provider-model-picker-empty, .claudian-opencode-model-picker-empty) {
   padding: 24px 16px;
   text-align: center;
   color: var(--text-muted);

--- a/tests/unit/providers/pi/ui/PiSettingsTab.test.ts
+++ b/tests/unit/providers/pi/ui/PiSettingsTab.test.ts
@@ -14,7 +14,10 @@ interface MockToggleComponent {
 
 interface MockTextComponent {
   inputEl: {
+    addClass: jest.Mock;
+    style: Record<string, string>;
     toggleClass: jest.Mock;
+    value: string;
   };
   onChangeCallback: ((value: string) => Promise<void> | void) | null;
   setPlaceholder: jest.Mock;
@@ -131,6 +134,7 @@ import { getPiProviderSettings } from '@/providers/pi/settings';
 import { piSettingsTabRenderer } from '@/providers/pi/ui/PiSettingsTab';
 
 const createdSettings: MockSetting[] = [];
+const createdDomElements: any[] = [];
 const mockedExists = fs.existsSync as jest.Mock;
 const mockedStat = fs.statSync as jest.Mock;
 
@@ -152,13 +156,17 @@ function createToggleComponent(): MockToggleComponent {
 function createTextComponent(): MockTextComponent {
   const component = {} as MockTextComponent;
   component.inputEl = {
+    addClass: jest.fn(),
+    style: {},
     toggleClass: jest.fn(),
+    value: '',
   };
   component.onChangeCallback = null;
   component.value = '';
   component.setPlaceholder = jest.fn(() => component);
   component.setValue = jest.fn((value: string) => {
     component.value = value;
+    component.inputEl.value = value;
     return component;
   });
   component.onChange = (callback: (value: string) => Promise<void> | void): MockTextComponent => {
@@ -209,12 +217,108 @@ function createDropdownComponent(): MockDropdownComponent {
 }
 
 function createElement(): any {
-  return {
-    createDiv: jest.fn(() => createElement()),
+  const classes = new Set<string>();
+  const eventListeners = new Map<string, Array<(...args: unknown[]) => void>>();
+  const element: any = {
+    checked: false,
+    open: false,
+    placeholder: '',
+    style: {},
+    title: '',
+    value: '',
+    classList: {
+      add: jest.fn((cls: string) => classes.add(cls)),
+      remove: jest.fn((cls: string) => classes.delete(cls)),
+      toggle: jest.fn((cls: string, force?: boolean) => {
+        if (force === undefined) {
+          if (classes.has(cls)) {
+            classes.delete(cls);
+            return false;
+          }
+          classes.add(cls);
+          return true;
+        }
+        if (force) {
+          classes.add(cls);
+        } else {
+          classes.delete(cls);
+        }
+        return force;
+      }),
+      contains: jest.fn((cls: string) => classes.has(cls)),
+    },
+    addClass: jest.fn((cls: string) => {
+      cls.split(/\s+/).filter(Boolean).forEach((item) => classes.add(item));
+    }),
+    removeClass: jest.fn((cls: string) => {
+      cls.split(/\s+/).filter(Boolean).forEach((item) => classes.delete(item));
+    }),
+    toggleClass: jest.fn((cls: string, force: boolean) => {
+      if (force) {
+        classes.add(cls);
+      } else {
+        classes.delete(cls);
+      }
+    }),
+    hasClass: jest.fn((cls: string) => classes.has(cls)),
+    setText: jest.fn((value: string) => {
+      element.text = value;
+    }),
     empty: jest.fn(),
-    setText: jest.fn(),
-    toggleClass: jest.fn(),
+    setAttribute: jest.fn(),
+    addEventListener: jest.fn((type: string, callback: (...args: unknown[]) => void) => {
+      const listeners = eventListeners.get(type) ?? [];
+      listeners.push(callback);
+      eventListeners.set(type, listeners);
+    }),
+    dispatchMockEvent: async (type: string, event?: unknown) => {
+      for (const listener of eventListeners.get(type) ?? []) {
+        await listener(event);
+      }
+    },
+    blur: jest.fn(),
+    createEl: jest.fn((tag?: string, attrs?: Record<string, unknown>) => {
+      const child = createElement();
+      child.tag = tag;
+      applyElementAttrs(child, attrs);
+      createdDomElements.push(child);
+      return child;
+    }),
+    createDiv: jest.fn((attrs?: Record<string, unknown>) => {
+      const child = createElement();
+      child.tag = 'div';
+      applyElementAttrs(child, attrs);
+      createdDomElements.push(child);
+      return child;
+    }),
+    createSpan: jest.fn((attrs?: Record<string, unknown>) => {
+      const child = createElement();
+      child.tag = 'span';
+      applyElementAttrs(child, attrs);
+      createdDomElements.push(child);
+      return child;
+    }),
   };
+
+  return element;
+}
+
+function applyElementAttrs(element: any, attrs?: Record<string, unknown>): void {
+  if (!attrs) {
+    return;
+  }
+  if (typeof attrs.cls === 'string') {
+    element.cls = attrs.cls;
+  }
+  if (typeof attrs.text === 'string') {
+    element.text = attrs.text;
+  }
+  if (typeof attrs.value === 'string') {
+    element.value = attrs.value;
+  }
+  if (typeof attrs.type === 'string') {
+    element.type = attrs.type;
+  }
 }
 
 function createContext(settings: Record<string, unknown>) {
@@ -242,23 +346,36 @@ function findSetting(name: string): MockSetting {
   return setting;
 }
 
+function findElement(tag: string, cls: string): any {
+  const element = [...createdDomElements].reverse().find(
+    candidate => candidate.tag === tag && candidate.cls === cls,
+  );
+  if (!element) {
+    throw new Error(`Element not found: ${tag}.${cls}`);
+  }
+  return element;
+}
+
+function findInputByType(type: string): any {
+  const element = [...createdDomElements].reverse().find(
+    candidate => candidate.tag === 'input' && candidate.type === type,
+  );
+  if (!element) {
+    throw new Error(`Input not found: ${type}`);
+  }
+  return element;
+}
+
 describe('PiSettingsTab', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     createdSettings.length = 0;
+    createdDomElements.length = 0;
     mockNotices.length = 0;
     mockedExists.mockReturnValue(true);
     mockedStat.mockReturnValue({ isFile: () => true });
     mockDiscoverModels.mockResolvedValue({
-      models: [{
-        encodedId: 'pi:anthropic/claude-sonnet-4',
-        id: 'claude-sonnet-4',
-        input: ['text'],
-        label: 'Claude Sonnet 4',
-        provider: 'anthropic',
-        reasoning: true,
-        thinkingLevels: ['off', 'medium'],
-      }],
+      models: [],
     });
   });
 
@@ -307,18 +424,35 @@ describe('PiSettingsTab', () => {
   });
 
   it('discovers models through PiModelDiscoveryService and reports failures', async () => {
-    const settings: Record<string, unknown> = { providerConfigs: { pi: {} } };
+    mockDiscoverModels.mockResolvedValueOnce({
+      models: [{
+        encodedId: 'pi:anthropic/claude-sonnet-4',
+        id: 'claude-sonnet-4',
+        input: ['text'],
+        label: 'Claude Sonnet 4',
+        provider: 'anthropic',
+        reasoning: true,
+        thinkingLevels: ['off', 'medium'],
+      }],
+    });
+    const settings: Record<string, unknown> = {
+      providerConfigs: {
+        pi: {
+          visibleModels: ['pi:anthropic/claude-sonnet-4'],
+        },
+      },
+    };
     const context = render(settings);
 
-    await findSetting('Discover models').buttonComponents[0].onClickCallback?.();
+    await findElement('button', 'claudian-provider-model-picker-action').dispatchMockEvent('click');
 
     expect(mockDiscoverModels).toHaveBeenCalledTimes(1);
     expect(getPiProviderSettings(settings).discoveredModels).toHaveLength(1);
-    expect(getPiProviderSettings(settings).visibleModels).toEqual([]);
+    expect(getPiProviderSettings(settings).visibleModels).toEqual(['pi:anthropic/claude-sonnet-4']);
     expect(context.refreshModelSelectors).toHaveBeenCalled();
 
     mockDiscoverModels.mockResolvedValueOnce({ diagnostics: 'not logged in', models: [] });
-    await findSetting('Discover models').buttonComponents[0].onClickCallback?.();
+    await findElement('button', 'claudian-provider-model-picker-action').dispatchMockEvent('click');
     expect(mockNotices[0]).toContain('not logged in');
   });
 
@@ -340,12 +474,16 @@ describe('PiSettingsTab', () => {
       },
     };
     const context = render(settings);
-    const modelSetting = findSetting('Claude Sonnet 4');
+    const checkboxEl = findInputByType('checkbox');
 
-    await modelSetting.toggleComponents[0].onChangeCallback?.(true);
+    checkboxEl.checked = true;
+    await checkboxEl.dispatchMockEvent('change');
     expect(getPiProviderSettings(settings).visibleModels).toEqual(['pi:anthropic/claude-sonnet-4']);
 
-    await findSetting('Claude Sonnet 4').textComponents[0].onChangeCallback?.('Sonnet');
+    const aliasInput = findElement('input', 'claudian-provider-model-picker-selected-alias');
+    aliasInput.value = 'Sonnet';
+    await aliasInput.dispatchMockEvent('blur');
+
     expect(getPiProviderSettings(settings).modelAliases).toEqual({
       'pi:anthropic/claude-sonnet-4': 'Sonnet',
     });


### PR DESCRIPTION
## Summary
- Reworks Pi visible-model settings to use the same selected-list and catalog picker pattern as OpenCode.
- Generalizes the OpenCode model-picker stylesheet into a shared provider picker while preserving OpenCode class compatibility.
- Updates Pi settings tests for discovery, selection, and alias editing.

## Verification
- npm run typecheck
- npm run lint
- npm run test
- npm run build