### PR TITLE
Fix inline edit markdown diff preview

### DIFF
--- a/src/features/inline-edit/ui/InlineEditModal.ts
+++ b/src/features/inline-edit/ui/InlineEditModal.ts
@@ -44,58 +44,16 @@ const showDiff = StateEffect.define<{
   to: number;
   diffOps: DiffOp[];
   previewPos: number;
-  previewText: string;
   widget: InlineEditController;
 }>();
 const showInsertion = StateEffect.define<{
-  pos: number;
   diffOps: DiffOp[];
   previewPos: number;
-  previewText: string;
   widget: InlineEditController;
 }>();
 const hideInlineEdit = StateEffect.define<null>();
 
 let activeController: InlineEditController | null = null;
-
-class DiffWidget extends WidgetType {
-  constructor(private diffOps: DiffOp[], private controller: InlineEditController) {
-    super();
-  }
-  toDOM(): HTMLElement {
-    const ownerDocument = this.controller.getOwnerDocument();
-    const span = ownerDocument.createElement('span');
-    span.className = 'claudian-inline-diff-replace';
-    appendDiffOps(span, this.diffOps);
-
-    const btns = ownerDocument.createElement('span');
-    btns.className = 'claudian-inline-diff-buttons';
-
-    const rejectBtn = ownerDocument.createElement('button');
-    rejectBtn.className = 'claudian-inline-diff-btn reject';
-    rejectBtn.textContent = '✕';
-    rejectBtn.title = 'Reject (esc)';
-    rejectBtn.onclick = () => this.controller.reject();
-
-    const acceptBtn = ownerDocument.createElement('button');
-    acceptBtn.className = 'claudian-inline-diff-btn accept';
-    acceptBtn.textContent = '✓';
-    acceptBtn.title = 'Accept (enter)';
-    acceptBtn.onclick = () => this.controller.accept();
-
-    btns.appendChild(rejectBtn);
-    btns.appendChild(acceptBtn);
-    span.appendChild(btns);
-
-    return span;
-  }
-  eq(other: DiffWidget): boolean {
-    return diffOpsEqual(this.diffOps, other.diffOps);
-  }
-  ignoreEvent(): boolean {
-    return true;
-  }
-}
 
 class InputWidget extends WidgetType {
   constructor(private controller: InlineEditController) {
@@ -112,15 +70,15 @@ class InputWidget extends WidgetType {
   }
 }
 
-class PreviewWidget extends WidgetType {
-  constructor(private markdown: string, private controller: InlineEditController) {
+class MarkdownDiffWidget extends WidgetType {
+  constructor(private diffOps: DiffOp[], private controller: InlineEditController) {
     super();
   }
   toDOM(): HTMLElement {
-    return this.controller.createPreviewDOM(this.markdown);
+    return this.controller.createDiffPreviewDOM(this.diffOps);
   }
-  eq(other: PreviewWidget): boolean {
-    return this.markdown === other.markdown;
+  eq(other: MarkdownDiffWidget): boolean {
+    return diffOpsEqual(this.diffOps, other.diffOps);
   }
   ignoreEvent(): boolean {
     return true;
@@ -165,25 +123,19 @@ const inlineEditField = StateField.define<DecorationSet>({
       } else if (e.is(showDiff)) {
         deco = Decoration.set([
           Decoration.widget({
-            widget: new PreviewWidget(e.value.previewText, e.value.widget),
+            widget: new MarkdownDiffWidget(e.value.diffOps, e.value.widget),
             block: true,
             side: -1,
           }).range(e.value.previewPos),
-          Decoration.replace({
-            widget: new DiffWidget(e.value.diffOps, e.value.widget),
-          }).range(e.value.from, e.value.to),
+          Decoration.replace({}).range(e.value.from, e.value.to),
         ], true);
       } else if (e.is(showInsertion)) {
         deco = Decoration.set([
           Decoration.widget({
-            widget: new PreviewWidget(e.value.previewText, e.value.widget),
+            widget: new MarkdownDiffWidget(e.value.diffOps, e.value.widget),
             block: true,
             side: -1,
           }).range(e.value.previewPos),
-          Decoration.widget({
-            widget: new DiffWidget(e.value.diffOps, e.value.widget),
-            side: 1, // After the position
-          }).range(e.value.pos),
         ], true);
       } else if (e.is(hideInlineEdit)) {
         deco = Decoration.none;
@@ -198,61 +150,94 @@ const installedEditors = new WeakSet<EditorView>();
 
 interface DiffOp { type: 'equal' | 'insert' | 'delete'; text: string; }
 
-function computeDiff(oldText: string, newText: string): DiffOp[] {
-  const oldWords = oldText.split(/(\s+)/);
-  const newWords = newText.split(/(\s+)/);
-  const m = oldWords.length, n = newWords.length;
+function splitLinesPreservingEndings(text: string): string[] {
+  if (!text) return [];
+  return text.match(/[^\n]*(?:\n|$)/g)?.filter(line => line.length > 0) ?? [];
+}
+
+function computeMarkdownDiff(oldText: string, newText: string): DiffOp[] {
+  const oldLines = splitLinesPreservingEndings(oldText);
+  const newLines = splitLinesPreservingEndings(newText);
+  const m = oldLines.length, n = newLines.length;
   const dp: number[][] = Array.from({ length: m + 1 }, () => Array<number>(n + 1).fill(0));
 
   for (let i = 1; i <= m; i++) {
     for (let j = 1; j <= n; j++) {
-      dp[i][j] = oldWords[i-1] === newWords[j-1]
+      dp[i][j] = oldLines[i-1] === newLines[j-1]
         ? dp[i-1][j-1] + 1
         : Math.max(dp[i-1][j], dp[i][j-1]);
     }
   }
 
-  const ops: DiffOp[] = [];
-  let i = m, j = n;
   const temp: DiffOp[] = [];
+  let i = m, j = n;
 
   while (i > 0 || j > 0) {
-    if (i > 0 && j > 0 && oldWords[i-1] === newWords[j-1]) {
-      temp.push({ type: 'equal', text: oldWords[i-1] });
+    if (i > 0 && j > 0 && oldLines[i-1] === newLines[j-1]) {
+      temp.push({ type: 'equal', text: oldLines[i-1] });
       i--; j--;
     } else if (j > 0 && (i === 0 || dp[i][j-1] >= dp[i-1][j])) {
-      temp.push({ type: 'insert', text: newWords[j-1] });
+      temp.push({ type: 'insert', text: newLines[j-1] });
       j--;
     } else {
-      temp.push({ type: 'delete', text: oldWords[i-1] });
+      temp.push({ type: 'delete', text: oldLines[i-1] });
       i--;
     }
   }
 
-  temp.reverse();
-  for (const op of temp) {
-    if (ops.length > 0 && ops[ops.length-1].type === op.type) {
-      ops[ops.length-1].text += op.text;
-    } else {
-      ops.push({ ...op });
-    }
-  }
-  return ops;
+  return mergeAdjacentDiffOps(temp.reverse());
 }
 
-function appendDiffOps(container: HTMLElement, ops: DiffOp[]): void {
+function mergeAdjacentDiffOps(ops: DiffOp[]): DiffOp[] {
+  const merged: DiffOp[] = [];
   for (const op of ops) {
-    switch (op.type) {
-      case 'delete':
-        container.createSpan({ cls: 'claudian-diff-del', text: op.text });
-        break;
-      case 'insert':
-        container.createSpan({ cls: 'claudian-diff-ins', text: op.text });
-        break;
-      default:
-        container.appendText(op.text);
+    if (merged.length > 0 && merged[merged.length-1].type === op.type) {
+      merged[merged.length-1].text += op.text;
+    } else {
+      merged.push({ ...op });
     }
   }
+  return merged;
+}
+
+function getDiffBlockClass(type: DiffOp['type']): string {
+  switch (type) {
+    case 'delete':
+      return 'claudian-diff-del';
+    case 'insert':
+      return 'claudian-diff-ins';
+    default:
+      return 'claudian-diff-equal';
+  }
+}
+
+function buildMarkdownDiffDocuments(diffOps: DiffOp[]): Array<{ type: DiffOp['type']; markdown: string }> {
+  const oldMarkdown = diffOps
+    .filter(op => op.type !== 'insert')
+    .map(op => op.text)
+    .join('');
+  const newMarkdown = diffOps
+    .filter(op => op.type !== 'delete')
+    .map(op => op.text)
+    .join('');
+  const hasDeletion = diffOps.some(op => op.type === 'delete');
+  const hasInsertion = diffOps.some(op => op.type === 'insert');
+
+  const documents: Array<{ type: DiffOp['type']; markdown: string }> = [];
+
+  if (hasDeletion && oldMarkdown) {
+    documents.push({ type: 'delete', markdown: oldMarkdown });
+  }
+
+  if (hasInsertion && newMarkdown) {
+    documents.push({ type: 'insert', markdown: newMarkdown });
+  }
+
+  if (documents.length === 0 && newMarkdown) {
+    documents.push({ type: 'equal', markdown: newMarkdown });
+  }
+
+  return documents;
 }
 
 function diffOpsEqual(left: DiffOp[], right: DiffOp[]): boolean {
@@ -547,17 +532,42 @@ class InlineEditController {
     return container;
   }
 
-  createPreviewDOM(markdown: string): HTMLElement {
+  createDiffPreviewDOM(diffOps: DiffOp[]): HTMLElement {
     const ownerDocument = this.getOwnerDocument();
     const previewEl = ownerDocument.createElement('div');
-    previewEl.className = 'claudian-inline-markdown-preview';
+    previewEl.className = 'claudian-inline-diff-preview';
 
     const bodyEl = ownerDocument.createElement('div');
-    bodyEl.className = 'claudian-inline-markdown-preview-body markdown-rendered';
+    bodyEl.className = 'claudian-inline-diff-preview-body markdown-rendered';
     previewEl.appendChild(bodyEl);
 
-    void this.renderMarkdownPreview(bodyEl, markdown);
+    const actionsEl = ownerDocument.createElement('div');
+    actionsEl.className = 'claudian-inline-preview-actions';
+    actionsEl.appendChild(this.createPreviewActionButton('Reject', 'reject', () => this.reject()));
+    actionsEl.appendChild(this.createPreviewActionButton('Accept', 'accept', () => this.accept()));
+    previewEl.appendChild(actionsEl);
+
+    void this.renderMarkdownDiffPreview(bodyEl, diffOps);
     return previewEl;
+  }
+
+  private createPreviewActionButton(
+    label: string,
+    variant: 'accept' | 'reject',
+    onClick: () => void
+  ): HTMLButtonElement {
+    const ownerDocument = this.getOwnerDocument();
+    const button = ownerDocument.createElement('button');
+    button.type = 'button';
+    button.className = `claudian-inline-preview-action ${variant}`;
+    button.textContent = label;
+    button.title = variant === 'accept' ? 'Accept (enter)' : 'Reject (esc)';
+    button.addEventListener('click', (event) => {
+      event.preventDefault?.();
+      event.stopPropagation?.();
+      onClick();
+    });
+    return button;
   }
 
   private async renderMarkdownPreview(container: HTMLElement, markdown: string): Promise<void> {
@@ -569,6 +579,18 @@ class InlineEditController {
       sourcePath: this.notePath,
       mediaFolder: this.plugin.settings?.mediaFolder ?? '',
     });
+  }
+
+  private async renderMarkdownDiffPreview(container: HTMLElement, diffOps: DiffOp[]): Promise<void> {
+    container.empty();
+    for (const document of buildMarkdownDiffDocuments(diffOps)) {
+      if (!document.markdown) continue;
+
+      const opEl = this.getOwnerDocument().createElement('div');
+      opEl.className = `claudian-diff-block ${getDiffBlockClass(document.type)}`;
+      container.appendChild(opEl);
+      await this.renderMarkdownPreview(opEl, document.markdown);
+    }
   }
 
   private replaceRenderedPreview(target: HTMLElement, rendered: HTMLElement): void {
@@ -682,7 +704,7 @@ class InlineEditController {
 
     hideSelectionHighlight(this.editorView);
 
-    const diffOps = computeDiff(this.selectedText, this.editedText);
+    const diffOps = computeMarkdownDiff(this.selectedText, this.editedText);
     const previewPos = this.editorView.state.doc.lineAt(this.selFrom).from;
 
     this.editorView.dispatch({
@@ -691,7 +713,6 @@ class InlineEditController {
         to: this.selTo,
         diffOps,
         previewPos,
-        previewText: this.editedText,
         widget: this,
       }),
     });
@@ -712,10 +733,8 @@ class InlineEditController {
 
     this.editorView.dispatch({
       effects: showInsertion.of({
-        pos: this.selFrom,
         diffOps,
         previewPos,
-        previewText: trimmedText,
         widget: this,
       }),
     });

--- a/src/style/features/inline-edit.css
+++ b/src/style/features/inline-edit.css
@@ -99,34 +99,100 @@
 }
 
 .claudian-inline-agent-reply > :first-child,
-.claudian-inline-markdown-preview-body > :first-child {
+.claudian-inline-diff-preview-body > :first-child {
   margin-top: 0;
 }
 
 .claudian-inline-agent-reply > :last-child,
-.claudian-inline-markdown-preview-body > :last-child {
+.claudian-inline-diff-preview-body > :last-child {
   margin-bottom: 0;
 }
 
-.claudian-inline-markdown-preview {
+.claudian-inline-diff-preview {
   margin: 4px 0 6px;
   padding: 8px 10px;
   border: 1px solid var(--background-modifier-border);
   border-radius: 8px;
   background: var(--background-primary);
   color: var(--text-normal);
-  overflow-x: auto;
+  overflow: hidden;
 }
 
-.claudian-inline-markdown-preview-body {
+.claudian-inline-diff-preview-body {
   font-family: var(--font-text);
   font-size: var(--font-text-size);
   line-height: var(--line-height-normal);
+  overflow-x: auto;
+  --p-spacing: 0.4rem;
+  --heading-spacing: 0.5rem;
 }
 
-.claudian-inline-markdown-preview img {
+.claudian-inline-diff-preview img {
   max-width: 100%;
   height: auto;
+}
+
+.claudian-inline-diff-preview p {
+  margin: 0 0 6px !important;
+}
+
+.claudian-inline-diff-preview p:last-child {
+  margin-bottom: 0;
+}
+
+.claudian-inline-diff-preview h1,
+.claudian-inline-diff-preview h2,
+.claudian-inline-diff-preview h3,
+.claudian-inline-diff-preview h4,
+.claudian-inline-diff-preview h5,
+.claudian-inline-diff-preview h6 {
+  margin: 0 0 6px !important;
+  line-height: 1.25;
+}
+
+.claudian-inline-diff-preview h1:first-child,
+.claudian-inline-diff-preview h2:first-child,
+.claudian-inline-diff-preview h3:first-child,
+.claudian-inline-diff-preview h4:first-child,
+.claudian-inline-diff-preview h5:first-child,
+.claudian-inline-diff-preview h6:first-child {
+  margin-top: 0;
+}
+
+.claudian-inline-diff-preview ul,
+.claudian-inline-diff-preview ol {
+  margin: 2px 0 8px !important;
+  padding-inline-start: 1.5em !important;
+}
+
+.claudian-inline-diff-preview li {
+  margin: 2px 0 !important;
+}
+
+.claudian-inline-diff-preview li > p {
+  margin: 0 !important;
+}
+
+.claudian-inline-diff-preview pre,
+.claudian-inline-diff-preview table,
+.claudian-inline-diff-preview blockquote {
+  margin: 2px 0 8px !important;
+}
+
+.claudian-inline-diff-preview .el-h1,
+.claudian-inline-diff-preview .el-h2,
+.claudian-inline-diff-preview .el-h3,
+.claudian-inline-diff-preview .el-h4,
+.claudian-inline-diff-preview .el-h5,
+.claudian-inline-diff-preview .el-h6,
+.claudian-inline-diff-preview .el-p,
+.claudian-inline-diff-preview .el-ul,
+.claudian-inline-diff-preview .el-ol,
+.claudian-inline-diff-preview .el-pre,
+.claudian-inline-diff-preview .el-table,
+.claudian-inline-diff-preview .el-blockquote {
+  margin-block-start: 0 !important;
+  margin-block-end: 6px !important;
 }
 
 .claudian-inline-markdown-fallback {
@@ -134,49 +200,79 @@
   word-wrap: break-word;
 }
 
-/* Inline Diff - replaces selection in place */
-.claudian-inline-diff-replace {
-  /* Inherit all font properties from document */
-  font-size: inherit;
-  font-family: inherit;
-  line-height: inherit;
-  font-weight: inherit;
+.claudian-diff-block {
+  border-radius: 4px;
+  padding: 2px 4px;
 }
 
-/* Deleted text - red strikethrough */
-.claudian-diff-del {
+.claudian-diff-block + .claudian-diff-block {
+  margin-top: 2px;
+}
+
+.claudian-diff-block > :first-child {
+  margin-top: 0;
+}
+
+.claudian-diff-block > :last-child {
+  margin-bottom: 0;
+}
+
+.claudian-diff-del:not(.claudian-diff-block) {
   background: rgba(255, 80, 80, 0.2);
   text-decoration: line-through;
   color: var(--text-muted);
 }
 
-/* Inserted text - green background */
-.claudian-diff-ins {
+.claudian-diff-ins:not(.claudian-diff-block) {
   background: rgba(80, 200, 80, 0.2);
 }
 
-/* Accept/Reject buttons inline with diff */
-.claudian-inline-diff-buttons {
-  display: inline-flex;
-  gap: 8px;
-  margin-inline-start: 6px;
-  background: none !important;
+.claudian-diff-block.claudian-diff-del {
+  background: rgba(255, 80, 80, 0.14);
+  color: var(--text-muted);
 }
 
-.claudian-inline-diff-btn {
-  padding: 4px 6px;
-  border: none !important;
-  background: none !important;
+.claudian-diff-block.claudian-diff-ins {
+  background: rgba(80, 200, 80, 0.14);
+}
+
+.claudian-inline-preview-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--background-modifier-border);
+}
+
+.claudian-inline-preview-action {
+  min-height: 28px;
+  padding: 4px 10px;
+  border: 1px solid var(--background-modifier-border) !important;
+  border-radius: 6px !important;
+  background: var(--background-secondary) !important;
   box-shadow: none !important;
-  outline: none !important;
-  font-size: 16px;
+  color: var(--text-normal);
+  font-family: var(--font-interface, -apple-system, BlinkMacSystemFont, sans-serif) !important;
+  font-size: var(--font-ui-small, 13px) !important;
+  line-height: 1.2;
   cursor: pointer;
 }
 
-.claudian-inline-diff-btn.reject {
+.claudian-inline-preview-action:hover {
+  background: var(--background-modifier-hover) !important;
+}
+
+.claudian-inline-preview-action.reject {
   color: var(--color-red);
 }
 
-.claudian-inline-diff-btn.accept {
-  color: var(--color-green);
+.claudian-inline-preview-action.accept {
+  border-color: var(--interactive-accent) !important;
+  background: var(--interactive-accent) !important;
+  color: var(--text-on-accent);
+}
+
+.claudian-inline-preview-action.accept:hover {
+  background: var(--interactive-accent-hover) !important;
 }

--- a/tests/unit/features/inline-edit/ui/InlineEditModal.openAndWait.test.ts
+++ b/tests/unit/features/inline-edit/ui/InlineEditModal.openAndWait.test.ts
@@ -1226,7 +1226,7 @@ describe('InlineEditModal - openAndWait', () => {
     }
   });
 
-  it('adds rendered preview text to inline edit diff effects', async () => {
+  it('renders accept and reject controls in the block preview', async () => {
     const originalDocument = (global as any).document;
     (global as any).document = {
       body: createMockEl('body'),
@@ -1255,16 +1255,10 @@ describe('InlineEditModal - openAndWait', () => {
         },
         getSdkCommands: jest.fn().mockReturnValue([]),
       } as any;
-      const editor = {
-        getCursor: jest.fn((which: string) => which === 'from'
-          ? { line: 0, ch: 0 }
-          : { line: 0, ch: 3 }),
-        getSelection: jest.fn().mockReturnValue('old'),
-      } as any;
+      const editor = {} as any;
       const view = { editor } as any;
 
       let widgetRef: any = null;
-      let previewText: string | undefined;
       const dispatch = jest.fn((transaction: any) => {
         const effects = Array.isArray(transaction?.effects)
           ? transaction.effects
@@ -1272,8 +1266,130 @@ describe('InlineEditModal - openAndWait', () => {
             ? [transaction.effects]
             : [];
         for (const effect of effects) {
+          const widget = effect?.value?.widget;
+          if (widget && typeof widget.createInputDOM === 'function') {
+            widgetRef = widget;
+            widget.createInputDOM();
+          }
+        }
+      });
+      const editorView = {
+        state: {
+          doc: {
+            line: jest.fn(() => ({ from: 0 })),
+            lineAt: jest.fn(() => ({ from: 0, number: 1 })),
+          },
+        },
+        dispatch,
+        dom: {
+          ownerDocument: (global as any).document,
+          addEventListener: jest.fn(),
+          removeEventListener: jest.fn(),
+        },
+      } as any;
+
+      const getEditorViewSpy = jest
+        .spyOn(editorUtils, 'getEditorView')
+        .mockReturnValue(editorView);
+
+      const editContext: InlineEditContext = {
+        mode: 'cursor',
+        cursorContext: {
+          beforeCursor: '',
+          afterCursor: '',
+          isInbetween: true,
+          line: 0,
+          column: 0,
+        },
+      };
+
+      const modal = new InlineEditModal(app, plugin, editor, view, editContext, 'math/note.md');
+      const resultPromise = modal.openAndWait();
+
+      const rejectSpy = jest.spyOn(widgetRef, 'reject').mockImplementation(() => {});
+      const acceptSpy = jest.spyOn(widgetRef, 'accept').mockImplementation(() => {});
+
+      const previewEl = widgetRef.createDiffPreviewDOM([
+        { type: 'insert', text: 'Updated text' },
+      ]);
+      const actionBar = previewEl.querySelector('.claudian-inline-preview-actions');
+      const actionButtons = previewEl.querySelectorAll('.claudian-inline-preview-action');
+
+      expect(actionBar).not.toBeNull();
+      expect(actionButtons).toHaveLength(2);
+      expect(actionButtons[0].textContent).toBe('Reject');
+      expect(actionButtons[1].textContent).toBe('Accept');
+
+      actionButtons[0].click();
+      actionButtons[1].click();
+
+      expect(rejectSpy).toHaveBeenCalledTimes(1);
+      expect(acceptSpy).toHaveBeenCalledTimes(1);
+
+      rejectSpy.mockRestore();
+      acceptSpy.mockRestore();
+      widgetRef.reject();
+      await expect(resultPromise).resolves.toEqual({ decision: 'reject' });
+      getEditorViewSpy.mockRestore();
+    } finally {
+      (global as any).document = originalDocument;
+    }
+  });
+
+  it('renders markdown diff documents with block context', async () => {
+    const originalDocument = (global as any).document;
+    (global as any).document = {
+      body: createMockEl('body'),
+      createElement: (tagName: string) => createMockEl(tagName),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+
+    try {
+      const app = {
+        vault: {
+          getFiles: jest.fn().mockReturnValue([]),
+          getAllLoadedFiles: jest.fn().mockReturnValue([]),
+        },
+        workspace: {
+          getActiveViewOfType: jest.fn(),
+        },
+      } as any;
+      const plugin = {
+        settings: {
+          hiddenProviderCommands: {
+            claude: [],
+            codex: [],
+          },
+          mediaFolder: '',
+        },
+        getSdkCommands: jest.fn().mockReturnValue([]),
+      } as any;
+      const oldMarkdown = '```ts\nconst value = 1;\n```';
+      const newMarkdown = '```ts\nconst value = 2;\n```';
+      const editor = {
+        getCursor: jest.fn((which: string) => which === 'from'
+          ? { line: 0, ch: 0 }
+          : { line: 0, ch: 3 }),
+        getSelection: jest.fn().mockReturnValue(oldMarkdown),
+      } as any;
+      const view = { editor } as any;
+
+      let widgetRef: any = null;
+      let diffOps: Array<{ type: string; text: string }> | undefined;
+      let hasPreviewText = false;
+      const dispatch = jest.fn((transaction: any) => {
+        const effects = Array.isArray(transaction?.effects)
+          ? transaction.effects
+          : transaction?.effects
+            ? [transaction.effects]
+            : [];
+        for (const effect of effects) {
+          if (effect?.value?.diffOps) {
+            diffOps = effect.value.diffOps;
+          }
           if (effect?.value?.previewText) {
-            previewText = effect.value.previewText;
+            hasPreviewText = true;
           }
 
           const widget = effect?.value?.widget;
@@ -1304,7 +1420,7 @@ describe('InlineEditModal - openAndWait', () => {
 
       const editContext: InlineEditContext = {
         mode: 'selection',
-        selectedText: 'old',
+        selectedText: oldMarkdown,
       };
 
       const modal = new InlineEditModal(app, plugin, editor, view, editContext, 'math/note.md');
@@ -1312,7 +1428,7 @@ describe('InlineEditModal - openAndWait', () => {
       widgetRef.inlineEditService = {
         editText: jest.fn().mockResolvedValue({
           success: true,
-          editedText: '**new** $x^2$',
+          editedText: newMarkdown,
         }),
         continueConversation: jest.fn(),
         cancel: jest.fn(),
@@ -1322,7 +1438,39 @@ describe('InlineEditModal - openAndWait', () => {
       widgetRef.inputEl.value = 'Improve the statement';
       await widgetRef.generate();
 
-      expect(previewText).toBe('**new** $x^2$');
+      expect(diffOps).toEqual([
+        { type: 'equal', text: '```ts\n' },
+        { type: 'delete', text: 'const value = 1;\n' },
+        { type: 'insert', text: 'const value = 2;\n' },
+        { type: 'equal', text: '```' },
+      ]);
+      expect(hasPreviewText).toBe(false);
+
+      (MarkdownRenderer.renderMarkdown as jest.Mock).mockClear();
+      const previewEl = widgetRef.createDiffPreviewDOM(diffOps);
+      for (let i = 0; i < 5 && (MarkdownRenderer.renderMarkdown as jest.Mock).mock.calls.length < 2; i++) {
+        await Promise.resolve();
+      }
+
+      expect(MarkdownRenderer.renderMarkdown).toHaveBeenNthCalledWith(
+        1,
+        oldMarkdown,
+        expect.anything(),
+        'math/note.md',
+        plugin
+      );
+      expect(MarkdownRenderer.renderMarkdown).toHaveBeenNthCalledWith(
+        2,
+        newMarkdown,
+        expect.anything(),
+        'math/note.md',
+        plugin
+      );
+
+      const diffBlocks = previewEl.querySelectorAll('.claudian-diff-block');
+      expect(diffBlocks).toHaveLength(2);
+      expect(diffBlocks[0].hasClass('claudian-diff-del')).toBe(true);
+      expect(diffBlocks[1].hasClass('claudian-diff-ins')).toBe(true);
 
       widgetRef.reject();
       await expect(resultPromise).resolves.toEqual({ decision: 'reject' });


### PR DESCRIPTION
Renders inline edit diff previews as markdown blocks instead of raw inline text, so markdown structures keep context and Accept/Reject controls stay visible in the preview. Replaces the inline glyph button widget with explicit preview action buttons and hides the original selected range while the preview is active. Adds focused tests for preview action buttons and fenced-code markdown diff rendering. Verification: npm run test -- tests/unit/features/inline-edit/ui/InlineEditModal.openAndWait.test.ts --runInBand; npm run lint -- src/features/inline-edit/ui/InlineEditModal.ts tests/unit/features/inline-edit/ui/InlineEditModal.openAndWait.test.ts; npm run test -- tests/unit/features/inline-edit --runInBand; npm run typecheck; npm run build; git diff --check.