### PR TITLE
Fix OpenCode history hydration on Windows

### DIFF
--- a/src/providers/opencode/history/OpencodeHistoryStore.ts
+++ b/src/providers/opencode/history/OpencodeHistoryStore.ts
@@ -1,4 +1,3 @@
-import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 
 import { extractResolvedAnswersFromResultText } from '../../../core/tools/toolInput';
@@ -13,8 +12,12 @@ import {
 } from '../normalization/opencodeToolNormalization';
 import { resolveExistingOpencodeDatabasePath } from '../runtime/OpencodePaths';
 import type { OpencodeProviderState } from '../types';
+import {
+  loadOpencodeSessionRows,
+  type StoredRow,
+} from './OpencodeSqliteReader';
 
-type StoredRow = Record<string, unknown>;
+export { OPENCODE_MESSAGE_ROW_SQL } from './OpencodeSqliteReader';
 
 interface StoredMessage {
   info: StoredRow;
@@ -26,17 +29,6 @@ interface OpencodeHydrationDiagnosticContext {
   sessionId?: string;
 }
 
-interface SqliteModule {
-  DatabaseSync: new (location: string, options?: Record<string, unknown>) => {
-    close(): void;
-    prepare(sql: string): {
-      all(...params: unknown[]): StoredRow[];
-    };
-  };
-}
-
-export const OPENCODE_MESSAGE_ROW_SQL = buildOpencodeMessageRowsSql('?');
-const OPENCODE_PART_ROW_SQL = buildOpencodePartRowsSql('?');
 const OPENCODE_HYDRATION_DIAGNOSTIC_ID_PREFIX = 'opencode-hydration-error';
 
 export async function loadOpencodeSessionMessages(
@@ -477,132 +469,4 @@ function getNestedNumber(
     current = current[key];
   }
   return getNumber(current);
-}
-
-async function loadSqliteModule(): Promise<SqliteModule | null> {
-  try {
-    return await import('node:sqlite');
-  } catch {
-    return null;
-  }
-}
-
-interface StoredSessionRows {
-  messageRows: StoredRow[];
-  partRows: StoredRow[];
-}
-
-async function loadOpencodeSessionRows(
-  databasePath: string,
-  sessionId: string,
-): Promise<StoredSessionRows | null> {
-  const viaNodeSqlite = await loadSessionRowsWithNodeSqlite(databasePath, sessionId);
-  if (viaNodeSqlite) {
-    return viaNodeSqlite;
-  }
-
-  return loadSessionRowsWithSqliteCli(databasePath, sessionId);
-}
-
-async function loadSessionRowsWithNodeSqlite(
-  databasePath: string,
-  sessionId: string,
-): Promise<StoredSessionRows | null> {
-  const sqlite = await loadSqliteModule();
-  if (!sqlite) {
-    return null;
-  }
-
-  let db: InstanceType<SqliteModule['DatabaseSync']> | null = null;
-  try {
-    db = new sqlite.DatabaseSync(databasePath, { readonly: true });
-    const messageRows = db.prepare(OPENCODE_MESSAGE_ROW_SQL).all(sessionId);
-    const partRows = db.prepare(OPENCODE_PART_ROW_SQL).all(sessionId);
-    return { messageRows, partRows };
-  } catch {
-    return null;
-  } finally {
-    db?.close();
-  }
-}
-
-function loadSessionRowsWithSqliteCli(
-  databasePath: string,
-  sessionId: string,
-): StoredSessionRows | null {
-  const escapedSessionId = escapeSqlLiteral(sessionId);
-  const messageRows = runSqlite3JsonQuery(
-    databasePath,
-    buildOpencodeMessageRowsSql(`'${escapedSessionId}'`),
-  );
-  const partRows = runSqlite3JsonQuery(
-    databasePath,
-    buildOpencodePartRowsSql(`'${escapedSessionId}'`),
-  );
-
-  if (!messageRows || !partRows) {
-    return null;
-  }
-
-  return { messageRows, partRows };
-}
-
-function runSqlite3JsonQuery(
-  databasePath: string,
-  sql: string,
-): StoredRow[] | null {
-  const result = spawnSync(
-    'sqlite3',
-    ['-json', databasePath, sql],
-    {
-      encoding: 'utf8',
-    },
-  );
-
-  if (result.error || result.status !== 0) {
-    return null;
-  }
-
-  try {
-    const parsed = JSON.parse(result.stdout || '[]') as unknown;
-    return Array.isArray(parsed)
-      ? parsed.filter((row): row is StoredRow => isPlainObject(row))
-      : null;
-  } catch {
-    return null;
-  }
-}
-
-function escapeSqlLiteral(value: string): string {
-  return value.replaceAll('\'', '\'\'');
-}
-
-function buildOpencodeMessageRowsSql(sessionIdExpression: string): string {
-  return `
-with message_json as (
-  select
-    id,
-    time_created,
-    data,
-    json_valid(data) as data_valid
-  from message
-  where session_id = ${sessionIdExpression}
-)
-select
-  id,
-  time_created,
-  data_valid,
-  case when data_valid then json_extract(data, '$.role') end as role,
-  case when data_valid then json_extract(data, '$.time.created') end as data_time_created,
-  case when data_valid then json_extract(data, '$.time.completed') end as data_time_completed
-from message_json
-order by time_created asc, id asc;`.trim();
-}
-
-function buildOpencodePartRowsSql(sessionIdExpression: string): string {
-  return `
-select id, message_id, data
-from part
-where session_id = ${sessionIdExpression}
-order by message_id asc, id asc;`.trim();
 }

--- a/src/providers/opencode/history/OpencodeSqliteReader.ts
+++ b/src/providers/opencode/history/OpencodeSqliteReader.ts
@@ -1,0 +1,284 @@
+import { spawnSync as defaultSpawnSync } from 'node:child_process';
+
+import { findNodeExecutable } from '../../../utils/env';
+
+export type StoredRow = Record<string, unknown>;
+
+export interface StoredSessionRows {
+  messageRows: StoredRow[];
+  partRows: StoredRow[];
+}
+
+interface SqliteModule {
+  DatabaseSync: new (location: string, options?: Record<string, unknown>) => {
+    close(): void;
+    prepare(sql: string): {
+      all(...params: unknown[]): StoredRow[];
+    };
+  };
+}
+
+export interface OpencodeSqliteReaderDependencies {
+  findNodeExecutable?: () => string | null;
+  requireSqliteModule?: () => SqliteModule | null;
+  spawnSync?: typeof defaultSpawnSync;
+}
+
+export const OPENCODE_SQLITE_QUERY_MAX_BUFFER = 100 * 1024 * 1024;
+export const OPENCODE_MESSAGE_ROW_SQL = buildOpencodeMessageRowsSql('?');
+
+const OPENCODE_PART_ROW_SQL = buildOpencodePartRowsSql('?');
+const OPENCODE_SQLITE_CHILD_SCRIPT = `
+const { DatabaseSync } = require('node:sqlite');
+const [databasePath, sessionId, messageSql, partSql] = process.argv.slice(1);
+let db;
+try {
+  db = new DatabaseSync(databasePath, { readonly: true });
+  const messageRows = db.prepare(messageSql).all(sessionId);
+  const partRows = db.prepare(partSql).all(sessionId);
+  process.stdout.write(JSON.stringify({ messageRows, partRows }));
+} finally {
+  if (db) db.close();
+}
+`.trim();
+
+export async function loadOpencodeSessionRows(
+  databasePath: string,
+  sessionId: string,
+  dependencies: OpencodeSqliteReaderDependencies = {},
+): Promise<StoredSessionRows | null> {
+  const resolvedDependencies = resolveDependencies(dependencies);
+
+  const viaCurrentProcess = loadSessionRowsWithCurrentProcessSqlite(
+    databasePath,
+    sessionId,
+    resolvedDependencies.requireSqliteModule,
+  );
+  if (viaCurrentProcess) {
+    return viaCurrentProcess;
+  }
+
+  const viaNodeProcess = loadSessionRowsWithNodeProcess(
+    databasePath,
+    sessionId,
+    resolvedDependencies.findNodeExecutable,
+    resolvedDependencies.spawnSync,
+  );
+  if (viaNodeProcess) {
+    return viaNodeProcess;
+  }
+
+  return loadSessionRowsWithSqliteCli(
+    databasePath,
+    sessionId,
+    resolvedDependencies.spawnSync,
+  );
+}
+
+function resolveDependencies(
+  dependencies: OpencodeSqliteReaderDependencies,
+): Required<OpencodeSqliteReaderDependencies> {
+  return {
+    findNodeExecutable,
+    requireSqliteModule,
+    spawnSync: defaultSpawnSync,
+    ...dependencies,
+  };
+}
+
+function requireSqliteModule(): SqliteModule | null {
+  try {
+    if (typeof module === 'undefined' || typeof module.require !== 'function') {
+      return null;
+    }
+
+    const sqlite = module.require('node:sqlite') as unknown;
+    return isSqliteModule(sqlite) ? sqlite : null;
+  } catch {
+    return null;
+  }
+}
+
+function isSqliteModule(value: unknown): value is SqliteModule {
+  return (
+    isPlainObject(value)
+    && typeof value.DatabaseSync === 'function'
+  );
+}
+
+function loadSessionRowsWithCurrentProcessSqlite(
+  databasePath: string,
+  sessionId: string,
+  requireSqlite: () => SqliteModule | null,
+): StoredSessionRows | null {
+  const sqlite = requireSqlite();
+  if (!sqlite) {
+    return null;
+  }
+
+  let db: InstanceType<SqliteModule['DatabaseSync']> | null = null;
+  try {
+    db = new sqlite.DatabaseSync(databasePath, { readonly: true });
+    const messageRows = db.prepare(OPENCODE_MESSAGE_ROW_SQL).all(sessionId);
+    const partRows = db.prepare(OPENCODE_PART_ROW_SQL).all(sessionId);
+    return { messageRows, partRows };
+  } catch {
+    return null;
+  } finally {
+    db?.close();
+  }
+}
+
+function loadSessionRowsWithNodeProcess(
+  databasePath: string,
+  sessionId: string,
+  findNode: () => string | null,
+  spawnSync: typeof defaultSpawnSync,
+): StoredSessionRows | null {
+  const nodePath = findNode();
+  if (!nodePath) {
+    return null;
+  }
+
+  const result = spawnSync(
+    nodePath,
+    [
+      '-e',
+      OPENCODE_SQLITE_CHILD_SCRIPT,
+      databasePath,
+      sessionId,
+      OPENCODE_MESSAGE_ROW_SQL,
+      OPENCODE_PART_ROW_SQL,
+    ],
+    {
+      encoding: 'utf8',
+      maxBuffer: OPENCODE_SQLITE_QUERY_MAX_BUFFER,
+      windowsHide: true,
+    },
+  );
+
+  if (result.error || result.status !== 0) {
+    return null;
+  }
+
+  return parseStoredSessionRows(getSpawnStdout(result.stdout));
+}
+
+function loadSessionRowsWithSqliteCli(
+  databasePath: string,
+  sessionId: string,
+  spawnSync: typeof defaultSpawnSync,
+): StoredSessionRows | null {
+  const escapedSessionId = escapeSqlLiteral(sessionId);
+  const messageRows = runSqlite3JsonQuery(
+    databasePath,
+    buildOpencodeMessageRowsSql(`'${escapedSessionId}'`),
+    spawnSync,
+  );
+  const partRows = runSqlite3JsonQuery(
+    databasePath,
+    buildOpencodePartRowsSql(`'${escapedSessionId}'`),
+    spawnSync,
+  );
+
+  if (!messageRows || !partRows) {
+    return null;
+  }
+
+  return { messageRows, partRows };
+}
+
+function runSqlite3JsonQuery(
+  databasePath: string,
+  sql: string,
+  spawnSync: typeof defaultSpawnSync,
+): StoredRow[] | null {
+  const result = spawnSync(
+    'sqlite3',
+    ['-json', databasePath, sql],
+    {
+      encoding: 'utf8',
+      maxBuffer: OPENCODE_SQLITE_QUERY_MAX_BUFFER,
+      windowsHide: true,
+    },
+  );
+
+  if (result.error || result.status !== 0) {
+    return null;
+  }
+
+  return parseStoredRows(getSpawnStdout(result.stdout));
+}
+
+function parseStoredSessionRows(value: string): StoredSessionRows | null {
+  try {
+    const parsed = JSON.parse(value || '{}') as unknown;
+    if (!isPlainObject(parsed)) {
+      return null;
+    }
+
+    const messageRows = parseStoredRowsValue(parsed.messageRows);
+    const partRows = parseStoredRowsValue(parsed.partRows);
+    return messageRows && partRows ? { messageRows, partRows } : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseStoredRows(value: string): StoredRow[] | null {
+  try {
+    return parseStoredRowsValue(JSON.parse(value || '[]') as unknown);
+  } catch {
+    return null;
+  }
+}
+
+function parseStoredRowsValue(value: unknown): StoredRow[] | null {
+  return Array.isArray(value)
+    ? value.filter((row): row is StoredRow => isPlainObject(row))
+    : null;
+}
+
+function getSpawnStdout(stdout: string | Buffer | null | undefined): string {
+  return typeof stdout === 'string'
+    ? stdout
+    : stdout?.toString('utf8') ?? '';
+}
+
+function escapeSqlLiteral(value: string): string {
+  return value.replaceAll('\'', '\'\'');
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function buildOpencodeMessageRowsSql(sessionIdExpression: string): string {
+  return `
+with message_json as (
+  select
+    id,
+    time_created,
+    data,
+    json_valid(data) as data_valid
+  from message
+  where session_id = ${sessionIdExpression}
+)
+select
+  id,
+  time_created,
+  data_valid,
+  case when data_valid then json_extract(data, '$.role') end as role,
+  case when data_valid then json_extract(data, '$.time.created') end as data_time_created,
+  case when data_valid then json_extract(data, '$.time.completed') end as data_time_completed
+from message_json
+order by time_created asc, id asc;`.trim();
+}
+
+function buildOpencodePartRowsSql(sessionIdExpression: string): string {
+  return `
+select id, message_id, data
+from part
+where session_id = ${sessionIdExpression}
+order by message_id asc, id asc;`.trim();
+}

--- a/tests/unit/providers/opencode/OpencodeSqliteReader.test.ts
+++ b/tests/unit/providers/opencode/OpencodeSqliteReader.test.ts
@@ -1,0 +1,185 @@
+import type { spawnSync as nodeSpawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import {
+  loadOpencodeSessionRows,
+  OPENCODE_MESSAGE_ROW_SQL,
+  OPENCODE_SQLITE_QUERY_MAX_BUFFER,
+} from '../../../../src/providers/opencode/history/OpencodeSqliteReader';
+
+type SpawnSync = typeof nodeSpawnSync;
+
+describe('loadOpencodeSessionRows', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(path.join(os.tmpdir(), 'claudian-opencode-sqlite-reader-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { force: true, recursive: true });
+    jest.restoreAllMocks();
+  });
+
+  it('loads rows through a Node child process when in-process SQLite is unavailable', async () => {
+    const dbPath = createFixtureDatabase(tmpRoot);
+
+    await expect(loadOpencodeSessionRows(dbPath, 'ses-child', {
+      findNodeExecutable: () => process.execPath,
+      requireSqliteModule: () => null,
+    })).resolves.toEqual({
+      messageRows: [{
+        data_time_completed: null,
+        data_time_created: 1_000,
+        data_valid: 1,
+        id: 'msg-user',
+        role: 'user',
+        time_created: 1_000,
+      }],
+      partRows: [{
+        data: JSON.stringify({ text: 'Hello from child process.', type: 'text' }),
+        id: 'part-user',
+        message_id: 'msg-user',
+      }],
+    });
+  });
+
+  it('uses a discovered Node executable before the system sqlite3 fallback', async () => {
+    const spawnSync = jest.fn().mockReturnValue({
+      error: undefined,
+      status: 0,
+      stdout: JSON.stringify({
+        messageRows: [{ id: 'msg-user' }],
+        partRows: [{ id: 'part-user' }],
+      }),
+    });
+
+    await expect(loadOpencodeSessionRows('/tmp/opencode.db', 'ses-node', {
+      findNodeExecutable: () => '/usr/local/bin/node',
+      requireSqliteModule: () => null,
+      spawnSync: toSpawnSync(spawnSync),
+    })).resolves.toEqual({
+      messageRows: [{ id: 'msg-user' }],
+      partRows: [{ id: 'part-user' }],
+    });
+
+    expect(spawnSync).toHaveBeenCalledTimes(1);
+    expect(spawnSync).toHaveBeenCalledWith(
+      '/usr/local/bin/node',
+      [
+        '-e',
+        expect.stringContaining("require('node:sqlite')"),
+        '/tmp/opencode.db',
+        'ses-node',
+        OPENCODE_MESSAGE_ROW_SQL,
+        expect.stringContaining('from part'),
+      ],
+      expect.objectContaining({
+        encoding: 'utf8',
+        maxBuffer: OPENCODE_SQLITE_QUERY_MAX_BUFFER,
+        windowsHide: true,
+      }),
+    );
+  });
+
+  it('keeps sqlite3 as a buffered compatibility fallback', async () => {
+    const spawnSync = jest.fn()
+      .mockReturnValueOnce({
+        error: undefined,
+        status: 0,
+        stdout: JSON.stringify([{ id: 'msg-user' }]),
+      })
+      .mockReturnValueOnce({
+        error: undefined,
+        status: 0,
+        stdout: JSON.stringify([{ id: 'part-user' }]),
+      });
+
+    await expect(loadOpencodeSessionRows('/tmp/opencode.db', 'ses-with-quote\'s', {
+      findNodeExecutable: () => null,
+      requireSqliteModule: () => null,
+      spawnSync: toSpawnSync(spawnSync),
+    })).resolves.toEqual({
+      messageRows: [{ id: 'msg-user' }],
+      partRows: [{ id: 'part-user' }],
+    });
+
+    expect(spawnSync).toHaveBeenCalledTimes(2);
+    expect(spawnSync).toHaveBeenNthCalledWith(
+      1,
+      'sqlite3',
+      [
+        '-json',
+        '/tmp/opencode.db',
+        expect.stringContaining("where session_id = 'ses-with-quote''s'"),
+      ],
+      expect.objectContaining({
+        encoding: 'utf8',
+        maxBuffer: OPENCODE_SQLITE_QUERY_MAX_BUFFER,
+        windowsHide: true,
+      }),
+    );
+    expect(spawnSync).toHaveBeenNthCalledWith(
+      2,
+      'sqlite3',
+      [
+        '-json',
+        '/tmp/opencode.db',
+        expect.stringContaining("where session_id = 'ses-with-quote''s'"),
+      ],
+      expect.objectContaining({
+        encoding: 'utf8',
+        maxBuffer: OPENCODE_SQLITE_QUERY_MAX_BUFFER,
+        windowsHide: true,
+      }),
+    );
+  });
+});
+
+function toSpawnSync(mock: jest.Mock): SpawnSync {
+  return mock as unknown as SpawnSync;
+}
+
+function createFixtureDatabase(tmpRoot: string): string {
+  const dbPath = path.join(tmpRoot, 'opencode.db');
+  const db = new DatabaseSync(dbPath);
+  try {
+    db.exec(`
+      create table message (
+        id text primary key,
+        session_id text not null,
+        time_created integer not null,
+        data text not null
+      );
+      create table part (
+        id text primary key,
+        session_id text not null,
+        message_id text not null,
+        data text not null
+      );
+    `);
+
+    db.prepare('insert into message (id, session_id, time_created, data) values (?, ?, ?, ?)').run(
+      'msg-user',
+      'ses-child',
+      1_000,
+      JSON.stringify({
+        role: 'user',
+        time: { created: 1_000 },
+      }),
+    );
+    db.prepare('insert into part (id, session_id, message_id, data) values (?, ?, ?, ?)').run(
+      'part-user',
+      'ses-child',
+      'msg-user',
+      JSON.stringify({ text: 'Hello from child process.', type: 'text' }),
+    );
+  } finally {
+    db.close();
+  }
+
+  return dbPath;
+}


### PR DESCRIPTION
Fixes #775.

This PR moves OpenCode session row loading into a dedicated SQLite reader, avoids renderer dynamic import('node:sqlite') by using module.require plus a spawned Node fallback, and retains sqlite3 as a buffered compatibility fallback. Both spawned query paths set a 100MB maxBuffer to avoid ENOBUFS on large sessions. Added unit coverage for Node child-process hydration and buffered sqlite3 fallback.

Tests: npm run lint; npm run typecheck; npm run test; npm run build.