### PR TITLE
Fix TypeScript warning cleanup

### DIFF
--- a/src/providers/claude/runtime/ClaudeApprovalHandler.ts
+++ b/src/providers/claude/runtime/ClaudeApprovalHandler.ts
@@ -86,11 +86,11 @@ export function createClaudeApprovalCallback(
         // the SDK doesn't inject isOther into the canUseTool input. Claudian
         // intercepts at canUseTool and renders its own UI, so we must inject
         // isOther here to match the Claude Code CLI's built-in behavior.
-        const questions = (input as Record<string, unknown>).questions;
+        const questions = input.questions;
         if (Array.isArray(questions)) {
           for (const q of questions) {
-            if (q && typeof q === 'object' && !('isOther' in q)) {
-              (q as Record<string, unknown>).isOther = true;
+            if (isObjectRecord(q) && !('isOther' in q)) {
+              q.isOther = true;
             }
           }
         }
@@ -146,4 +146,8 @@ export function createClaudeApprovalCallback(
       };
     }
   };
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }

--- a/src/providers/claude/runtime/customSpawn.ts
+++ b/src/providers/claude/runtime/customSpawn.ts
@@ -73,15 +73,17 @@ function installTreeAwareKill(child: ChildProcess, spawnSpec: WindowsCmdShimSpaw
     return;
   }
 
-  const originalKill = child.kill.bind(child);
+  const originalKill = child.kill;
   const killableChild = {
     get pid(): number | undefined {
       return child.pid;
     },
-    kill: originalKill,
+    kill(signal?: NodeJS.Signals | number): boolean {
+      return originalKill.call(child, signal);
+    },
   };
 
   child.kill = ((signal?: NodeJS.Signals | number): boolean =>
     terminateSpawnedProcess(killableChild, signal, spawn, spawnSpec)
-  ) as typeof child.kill;
+  );
 }

--- a/src/providers/pi/runtime/PiJsonl.ts
+++ b/src/providers/pi/runtime/PiJsonl.ts
@@ -3,8 +3,12 @@ import type { Writable } from 'node:stream';
 export type PiJsonlLineHandler = (line: string) => void;
 
 interface JsonlReadableStream {
-  off(eventName: string, listener: (...args: any[]) => void): unknown;
-  on(eventName: string, listener: (...args: any[]) => void): unknown;
+  off(eventName: 'data', listener: (chunk: Buffer | string) => void): unknown;
+  off(eventName: 'end' | 'close', listener: () => void): unknown;
+  off(eventName: 'error', listener: (error: unknown) => void): unknown;
+  on(eventName: 'data', listener: (chunk: Buffer | string) => void): unknown;
+  on(eventName: 'end' | 'close', listener: () => void): unknown;
+  on(eventName: 'error', listener: (error: unknown) => void): unknown;
 }
 
 export function subscribePiJsonlLines(

--- a/src/providers/pi/ui/ObsidianPiExtensionUiRenderer.ts
+++ b/src/providers/pi/ui/ObsidianPiExtensionUiRenderer.ts
@@ -119,7 +119,7 @@ abstract class PiExtensionModal<TResult extends Record<string, unknown>> extends
       this.close();
     };
     this.signal.addEventListener('abort', abortHandler, { once: true });
-    this.resultPromise.finally(() => {
+    void this.resultPromise.finally(() => {
       this.signal.removeEventListener('abort', abortHandler);
     });
     this.open();

--- a/src/providers/pi/ui/PiChatUIConfig.ts
+++ b/src/providers/pi/ui/PiChatUIConfig.ts
@@ -112,18 +112,7 @@ export const piChatUIConfig: ProviderChatUIConfig = {
     }));
   },
 
-  getDefaultReasoningValue(model: string, settings: Record<string, unknown>): string {
-    const piModel = getCachedModel(model, settings);
-    if (!piModel) {
-      return decodePiModelId(model) ? PI_DEFAULT_THINKING_LEVEL : 'off';
-    }
-
-    const piSettings = getPiProviderSettings(settings);
-    return clampPiThinkingLevel(
-      piSettings.preferredThinkingByModel[piModel.encodedId],
-      piModel.thinkingLevels,
-    );
-  },
+  getDefaultReasoningValue: getPiDefaultReasoningValue,
 
   getContextWindowSize(
     model: string,
@@ -152,7 +141,7 @@ export const piChatUIConfig: ProviderChatUIConfig = {
     }
 
     settingsBag.model = model;
-    settingsBag.effortLevel = this.getDefaultReasoningValue(model, settingsBag);
+    settingsBag.effortLevel = getPiDefaultReasoningValue(model, settingsBag);
   },
 
   applyReasoningSelection(model: string, value: string, settings: unknown): void {
@@ -226,6 +215,19 @@ function getCachedModel(model: string, settings: Record<string, unknown>): PiDis
   }
 
   return getPiProviderSettings(settings).discoveredModels.find(entry => entry.encodedId === model) ?? null;
+}
+
+function getPiDefaultReasoningValue(model: string, settings: Record<string, unknown>): string {
+  const piModel = getCachedModel(model, settings);
+  if (!piModel) {
+    return decodePiModelId(model) ? PI_DEFAULT_THINKING_LEVEL : 'off';
+  }
+
+  const piSettings = getPiProviderSettings(settings);
+  return clampPiThinkingLevel(
+    piSettings.preferredThinkingByModel[piModel.encodedId],
+    piModel.thinkingLevels,
+  );
 }
 
 function buildModelOption(model: PiDiscoveredModel, alias: string | undefined): ProviderUIOption {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -411,8 +411,8 @@ export function migrateLegacyHostnameKeyedMap<T extends string>(
     return entries;
   }
 
-  const hasCurrentEntry = Object.prototype.hasOwnProperty.call(entries, currentKey);
-  const hasLegacyEntry = Object.prototype.hasOwnProperty.call(entries, legacyHostnameKey);
+  const hasCurrentEntry = hasOwnEntry(entries, currentKey);
+  const hasLegacyEntry = hasOwnEntry(entries, legacyHostnameKey);
   if (!hasLegacyEntry) {
     return entries;
   }
@@ -423,6 +423,10 @@ export function migrateLegacyHostnameKeyedMap<T extends string>(
   }
   delete migrated[legacyHostnameKey];
   return migrated;
+}
+
+function hasOwnEntry<T>(entries: Record<string, T>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(entries, key) === true;
 }
 
 export const MIN_CONTEXT_LIMIT = 1_000;


### PR DESCRIPTION
## Summary
- Removes redundant type assertions in Claude approval and spawn handling.
- Tightens Pi JSONL stream listener types and marks modal cleanup as intentionally ignored.
- Avoids implicit `this` in Pi chat UI config and wraps legacy env map ownership checks.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run build`