### PR TITLE
fix: remove unsafe kill binding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,6 @@
       "version": "2.0.24",
       "hasInstallScript": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=24 <25"
-      },
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.159",
         "@codemirror/state": "^6.5.0",
@@ -37,6 +34,9 @@
         "ts-jest": "^29.4.9",
         "tsx": "^4.21.0",
         "typescript": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=24 <25"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {

--- a/src/providers/claude/runtime/customSpawn.ts
+++ b/src/providers/claude/runtime/customSpawn.ts
@@ -73,12 +73,12 @@ function installTreeAwareKill(child: ChildProcess, spawnSpec: WindowsCmdShimSpaw
     return;
   }
 
-  const originalKill: (signal?: NodeJS.Signals | number) => boolean = child.kill.bind(child);
+  const originalKill = child.kill;
   const killableChild = {
     get pid(): number | undefined {
       return child.pid;
     },
-    kill: (signal?: NodeJS.Signals | number): boolean => originalKill(signal),
+    kill: (signal?: NodeJS.Signals | number): boolean => originalKill.call(child, signal),
   };
 
   child.kill = ((signal?: NodeJS.Signals | number): boolean =>


### PR DESCRIPTION
## Summary
- replace the bound ChildProcess.kill capture in the Claude custom spawn adapter with a typed method reference and explicit receiver call
- preserve Windows process-tree termination behavior while avoiding unsafe assignment diagnostics
- include the current package-lock root metadata ordering change present on the branch

## Verification
- npm run lint -- src/providers/claude/runtime/customSpawn.ts
- npm run typecheck
- npx eslint src/providers/claude/runtime/customSpawn.ts --rule '@typescript-eslint/no-unsafe-assignment: warn' --rule '@typescript-eslint/no-unsafe-call: warn' --rule '@typescript-eslint/no-unsafe-return: warn'