### PR TITLE
[codex] Add current chat directory navigation

### DIFF
--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -45,6 +45,8 @@ function runRendererAction(action: () => Promise<void>): void {
   });
 }
 
+const TOC_TITLE_MAX_LENGTH = 80;
+
 export class MessageRenderer {
   private app: App;
   private plugin: ClaudianPlugin;
@@ -105,6 +107,25 @@ export class MessageRenderer {
     return msg.displayContent ?? extractUserDisplayContent(msg.content) ?? msg.content;
   }
 
+  private getMessageTocTitle(text: string): string {
+    const firstLine = text
+      .split(/\r?\n/)
+      .map(line => line.trim())
+      .find(Boolean);
+    if (!firstLine) return '';
+    if (firstLine.length <= TOC_TITLE_MAX_LENGTH) return firstLine;
+    return `${firstLine.slice(0, TOC_TITLE_MAX_LENGTH - 3)}...`;
+  }
+
+  private applyTocTitle(msgEl: HTMLElement, text: string): void {
+    const tocTitle = this.getMessageTocTitle(text);
+    if (tocTitle) {
+      msgEl.setAttribute('data-toc-title', tocTitle);
+    } else {
+      msgEl.removeAttribute('data-toc-title');
+    }
+  }
+
   // ============================================
   // Streaming Message Rendering
   // ============================================
@@ -145,6 +166,7 @@ export class MessageRenderer {
         const textEl = contentEl.createDiv({ cls: 'claudian-text-block' });
         void this.renderContent(textEl, textToShow);
         this.addUserCopyButton(msgEl, textToShow);
+        this.applyTocTitle(msgEl, textToShow);
       }
       if (this.rewindCallback || this.forkCallback) {
         this.liveMessageEls.set(msg.id, msgEl);
@@ -177,6 +199,9 @@ export class MessageRenderer {
     if (textToShow) {
       const textEl = contentEl.createDiv({ cls: 'claudian-text-block' });
       void this.renderContent(textEl, textToShow);
+      this.applyTocTitle(msgEl, textToShow);
+    } else {
+      msgEl.removeAttribute('data-toc-title');
     }
 
     const toolbar = msgEl.querySelector<HTMLElement>('.claudian-user-msg-actions');
@@ -276,6 +301,7 @@ export class MessageRenderer {
         const textEl = contentEl.createDiv({ cls: 'claudian-text-block' });
         void this.renderContent(textEl, textToShow);
         this.addUserCopyButton(msgEl, textToShow);
+        this.applyTocTitle(msgEl, textToShow);
       }
       if (msg.userMessageId) {
         if (this.rewindCallback && this.isRewindEligible(allMessages, index)) {

--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -20,6 +20,7 @@ import { processFileLinks, registerFileLinkHandler } from '../../../utils/fileLi
 import { replaceImageEmbedsWithHtml } from '../../../utils/imageEmbed';
 import { escapeMathDelimitersForStreaming } from '../../../utils/markdownMath';
 import { findRewindContext } from '../rewind';
+import { formatConversationDirectoryTitle } from '../utils/conversationDirectoryTitle';
 import { resolveSubagentLifecycleAdapter } from './subagentLifecycleResolution';
 import {
   renderStoredAsyncSubagent,
@@ -44,8 +45,6 @@ function runRendererAction(action: () => Promise<void>): void {
     // UI actions already surface expected failures locally.
   });
 }
-
-const TOC_TITLE_MAX_LENGTH = 80;
 
 export class MessageRenderer {
   private app: App;
@@ -107,18 +106,8 @@ export class MessageRenderer {
     return msg.displayContent ?? extractUserDisplayContent(msg.content) ?? msg.content;
   }
 
-  private getMessageTocTitle(text: string): string {
-    const firstLine = text
-      .split(/\r?\n/)
-      .map(line => line.trim())
-      .find(Boolean);
-    if (!firstLine) return '';
-    if (firstLine.length <= TOC_TITLE_MAX_LENGTH) return firstLine;
-    return `${firstLine.slice(0, TOC_TITLE_MAX_LENGTH - 3)}...`;
-  }
-
   private applyTocTitle(msgEl: HTMLElement, text: string): void {
-    const tocTitle = this.getMessageTocTitle(text);
+    const tocTitle = formatConversationDirectoryTitle(text);
     if (tocTitle) {
       msgEl.setAttribute('data-toc-title', tocTitle);
     } else {

--- a/src/features/chat/ui/NavigationSidebar.ts
+++ b/src/features/chat/ui/NavigationSidebar.ts
@@ -6,6 +6,8 @@ import {
   type ScheduledAnimationFrame,
 } from '../../../utils/animationFrame';
 
+const TOC_TITLE_MAX_LENGTH = 80;
+
 /**
  * Floating sidebar for navigating chat history.
  * Provides quick access to top/bottom and previous/next user messages.
@@ -14,9 +16,13 @@ export class NavigationSidebar {
   private container: HTMLElement;
   private topBtn: HTMLElement;
   private prevBtn: HTMLElement;
+  private tocBtn: HTMLElement;
   private nextBtn: HTMLElement;
   private bottomBtn: HTMLElement;
+  private tocPopover: HTMLElement | null = null;
   private scrollHandler: () => void = () => {};
+  private outsideClickHandler: ((event: MouseEvent) => void) | null = null;
+  private mutationObserver: MutationObserver | null = null;
   private pendingVisibilityFrame: ScheduledAnimationFrame | null = null;
   private isVisible: boolean | null = null;
 
@@ -29,6 +35,7 @@ export class NavigationSidebar {
     // Create buttons
     this.topBtn = this.createButton('claudian-nav-btn-top', 'chevrons-up', 'Scroll to top');
     this.prevBtn = this.createButton('claudian-nav-btn-prev', 'chevron-up', 'Previous message');
+    this.tocBtn = this.createButton('claudian-nav-btn-toc', 'list-tree', 'Conversation directory');
     this.nextBtn = this.createButton('claudian-nav-btn-next', 'chevron-down', 'Next message');
     this.bottomBtn = this.createButton('claudian-nav-btn-bottom', 'chevrons-down', 'Scroll to bottom');
 
@@ -59,6 +66,36 @@ export class NavigationSidebar {
 
     this.prevBtn.addEventListener('click', () => this.scrollToMessage('prev'));
     this.nextBtn.addEventListener('click', () => this.scrollToMessage('next'));
+    this.tocBtn.addEventListener('click', (event) => {
+      event.stopPropagation();
+      this.toggleDirectory();
+    });
+
+    this.outsideClickHandler = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (!target) return;
+      const containerContainsTarget = typeof this.container.contains === 'function'
+        && this.container.contains(target);
+      const popoverContainsTarget = typeof this.tocPopover?.contains === 'function'
+        && this.tocPopover.contains(target);
+      if (!containerContainsTarget && !popoverContainsTarget) {
+        this.closeDirectory();
+      }
+    };
+    this.parentEl.ownerDocument?.addEventListener?.('click', this.outsideClickHandler);
+
+    if (typeof MutationObserver !== 'undefined') {
+      this.mutationObserver = new MutationObserver(() => {
+        this.updateVisibility();
+        this.refreshOpenDirectory();
+      });
+      this.mutationObserver.observe(this.messagesEl, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['data-toc-title'],
+      });
+    }
   }
 
   /**
@@ -76,9 +113,99 @@ export class NavigationSidebar {
   private applyVisibility(): void {
     const { scrollHeight, clientHeight } = this.messagesEl;
     const isScrollable = scrollHeight > clientHeight + 50; // Small buffer
+    this.tocBtn.classList.remove('claudian-hidden');
     if (this.isVisible === isScrollable) return;
     this.isVisible = isScrollable;
     this.container.classList.toggle('visible', isScrollable);
+  }
+
+  private getDirectoryEntries(): Array<{ el: HTMLElement; title: string }> {
+    return Array.from(this.messagesEl.querySelectorAll<HTMLElement>('.claudian-message-user, [data-role="user"]'))
+      .map(el => ({
+        el,
+        title: this.getDirectoryTitle(el),
+      }))
+      .filter((entry): entry is { el: HTMLElement; title: string } => entry.title.length > 0);
+  }
+
+  private getDirectoryTitle(el: HTMLElement): string {
+    const explicitTitle = (el.getAttribute('data-toc-title') ?? '').trim();
+    if (explicitTitle) return explicitTitle;
+
+    const contentEl = el.querySelector<HTMLElement>('.claudian-message-content');
+    return this.formatDirectoryTitle(contentEl?.textContent ?? el.textContent ?? '');
+  }
+
+  private formatDirectoryTitle(text: string): string {
+    const firstLine = text
+      .split(/\r?\n/)
+      .map(line => line.trim())
+      .find(Boolean);
+    if (!firstLine) return '';
+    if (firstLine.length <= TOC_TITLE_MAX_LENGTH) return firstLine;
+    return `${firstLine.slice(0, TOC_TITLE_MAX_LENGTH - 3)}...`;
+  }
+
+  private toggleDirectory(): void {
+    if (this.tocPopover) {
+      this.closeDirectory();
+      return;
+    }
+    this.openDirectory();
+  }
+
+  private openDirectory(): void {
+    const entries = this.getDirectoryEntries();
+    this.closeDirectory();
+    this.tocPopover = this.parentEl.createDiv({ cls: 'claudian-nav-toc-popover' });
+    this.tocPopover.createDiv({ cls: 'claudian-nav-toc-title', text: 'Conversation directory' });
+    const listEl = this.tocPopover.createDiv({ cls: 'claudian-nav-toc-list' });
+
+    if (entries.length === 0) {
+      listEl.createDiv({
+        cls: 'claudian-nav-toc-empty',
+        text: 'No user prompts in this conversation',
+      });
+      return;
+    }
+
+    entries.forEach((entry, index) => {
+      const itemEl = listEl.createDiv({
+        cls: 'claudian-nav-toc-item',
+        text: `${index + 1}. ${entry.title}`,
+      });
+      itemEl.setAttribute('role', 'button');
+      itemEl.setAttribute('tabindex', '0');
+      itemEl.setAttribute('title', entry.title);
+
+      const selectEntry = () => {
+        this.scrollToElement(entry.el);
+        this.closeDirectory();
+      };
+      itemEl.addEventListener('click', selectEntry);
+      itemEl.addEventListener('keydown', (event: KeyboardEvent) => {
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        event.preventDefault();
+        selectEntry();
+      });
+    });
+  }
+
+  private refreshOpenDirectory(): void {
+    if (!this.tocPopover) return;
+    this.openDirectory();
+  }
+
+  private closeDirectory(): void {
+    this.tocPopover?.remove();
+    this.tocPopover = null;
+  }
+
+  private scrollToElement(el: HTMLElement): void {
+    this.messagesEl.scrollTo({
+      top: Math.max(el.offsetTop - 10, 0),
+      behavior: 'smooth',
+    });
   }
 
   /**
@@ -96,7 +223,7 @@ export class NavigationSidebar {
       // Find the last message strictly above the current scroll position
       for (let i = messages.length - 1; i >= 0; i--) {
         if (messages[i].offsetTop < scrollTop - threshold) {
-          this.messagesEl.scrollTo({ top: messages[i].offsetTop - 10, behavior: 'smooth' });
+          this.scrollToElement(messages[i]);
           return;
         }
       }
@@ -106,7 +233,7 @@ export class NavigationSidebar {
       // Find the first message strictly below the current scroll position
       for (let i = 0; i < messages.length; i++) {
         if (messages[i].offsetTop > scrollTop + threshold) {
-          this.messagesEl.scrollTo({ top: messages[i].offsetTop - 10, behavior: 'smooth' });
+          this.scrollToElement(messages[i]);
           return;
         }
       }
@@ -120,6 +247,13 @@ export class NavigationSidebar {
       cancelScheduledAnimationFrame(this.pendingVisibilityFrame);
       this.pendingVisibilityFrame = null;
     }
+    this.closeDirectory();
+    if (this.outsideClickHandler) {
+      this.parentEl.ownerDocument?.removeEventListener?.('click', this.outsideClickHandler);
+      this.outsideClickHandler = null;
+    }
+    this.mutationObserver?.disconnect();
+    this.mutationObserver = null;
     this.messagesEl.removeEventListener('scroll', this.scrollHandler);
     this.container.remove();
   }

--- a/src/features/chat/ui/NavigationSidebar.ts
+++ b/src/features/chat/ui/NavigationSidebar.ts
@@ -5,8 +5,7 @@ import {
   scheduleAnimationFrame,
   type ScheduledAnimationFrame,
 } from '../../../utils/animationFrame';
-
-const TOC_TITLE_MAX_LENGTH = 80;
+import { formatConversationDirectoryTitle } from '../utils/conversationDirectoryTitle';
 
 /**
  * Floating sidebar for navigating chat history.
@@ -85,9 +84,11 @@ export class NavigationSidebar {
     this.parentEl.ownerDocument?.addEventListener?.('click', this.outsideClickHandler);
 
     if (typeof MutationObserver !== 'undefined') {
-      this.mutationObserver = new MutationObserver(() => {
+      this.mutationObserver = new MutationObserver((mutations) => {
         this.updateVisibility();
-        this.refreshOpenDirectory();
+        if (this.shouldRefreshDirectory(mutations)) {
+          this.refreshOpenDirectory();
+        }
       });
       this.mutationObserver.observe(this.messagesEl, {
         childList: true,
@@ -133,17 +134,40 @@ export class NavigationSidebar {
     if (explicitTitle) return explicitTitle;
 
     const contentEl = el.querySelector<HTMLElement>('.claudian-message-content');
-    return this.formatDirectoryTitle(contentEl?.textContent ?? el.textContent ?? '');
+    return formatConversationDirectoryTitle(contentEl?.textContent ?? el.textContent ?? '');
   }
 
-  private formatDirectoryTitle(text: string): string {
-    const firstLine = text
-      .split(/\r?\n/)
-      .map(line => line.trim())
-      .find(Boolean);
-    if (!firstLine) return '';
-    if (firstLine.length <= TOC_TITLE_MAX_LENGTH) return firstLine;
-    return `${firstLine.slice(0, TOC_TITLE_MAX_LENGTH - 3)}...`;
+  private shouldRefreshDirectory(mutations: MutationRecord[]): boolean {
+    if (!this.tocPopover) return false;
+    return mutations.some((mutation) => {
+      if (mutation.type === 'attributes') {
+        return mutation.attributeName === 'data-toc-title'
+          && this.isDirectoryMessageElement(mutation.target);
+      }
+      if (mutation.type !== 'childList') return false;
+      return Array.from(mutation.addedNodes).some(node => this.nodeContainsDirectoryMessage(node))
+        || Array.from(mutation.removedNodes).some(node => this.nodeContainsDirectoryMessage(node));
+    });
+  }
+
+  private nodeContainsDirectoryMessage(node: Node): boolean {
+    if (this.isDirectoryMessageElement(node)) return true;
+    const candidate = node as { querySelector?: (selector: string) => Element | null };
+    return typeof candidate.querySelector === 'function'
+      && candidate.querySelector('.claudian-message-user, [data-role="user"]') !== null;
+  }
+
+  private isDirectoryMessageElement(node: Node): boolean {
+    const candidate = node as {
+      matches?: (selector: string) => boolean;
+      classList?: { contains?: (className: string) => boolean };
+      getAttribute?: (name: string) => string | null;
+    };
+    if (typeof candidate.matches === 'function') {
+      return candidate.matches('.claudian-message-user, [data-role="user"]');
+    }
+    return candidate.classList?.contains?.('claudian-message-user') === true
+      || candidate.getAttribute?.('data-role') === 'user';
   }
 
   private toggleDirectory(): void {

--- a/src/features/chat/utils/conversationDirectoryTitle.ts
+++ b/src/features/chat/utils/conversationDirectoryTitle.ts
@@ -1,0 +1,11 @@
+const CONVERSATION_DIRECTORY_TITLE_MAX_LENGTH = 80;
+
+export function formatConversationDirectoryTitle(text: string): string {
+  const firstLine = text
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .find(Boolean);
+  if (!firstLine) return '';
+  if (firstLine.length <= CONVERSATION_DIRECTORY_TITLE_MAX_LENGTH) return firstLine;
+  return `${firstLine.slice(0, CONVERSATION_DIRECTORY_TITLE_MAX_LENGTH - 3)}...`;
+}

--- a/src/style/components/nav-sidebar.css
+++ b/src/style/components/nav-sidebar.css
@@ -48,6 +48,62 @@
     height: 18px;
 }
 
+.claudian-nav-toc-popover {
+    position: absolute;
+    right: 42px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: min(260px, calc(100% - 56px));
+    max-height: min(420px, calc(100% - 32px));
+    z-index: 101;
+    display: flex;
+    flex-direction: column;
+    padding: 8px;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 8px;
+    background: var(--background-primary);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+}
+
+.claudian-nav-toc-title {
+    padding: 4px 6px 8px;
+    color: var(--text-muted);
+    font-size: var(--font-ui-smaller);
+    font-weight: 600;
+}
+
+.claudian-nav-toc-list {
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.claudian-nav-toc-item {
+    padding: 6px 8px;
+    border-radius: 6px;
+    color: var(--text-normal);
+    font-size: var(--font-ui-small);
+    line-height: 1.35;
+    cursor: pointer;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.claudian-nav-toc-item:hover,
+.claudian-nav-toc-item:focus {
+    background: var(--background-secondary);
+    outline: none;
+}
+
+.claudian-nav-toc-empty {
+    padding: 8px;
+    color: var(--text-muted);
+    font-size: var(--font-ui-small);
+    line-height: 1.35;
+}
+
 /* Specific button spacing/grouping if needed */
 .claudian-nav-btn-top {
     margin-bottom: 4px;

--- a/src/style/components/nav-sidebar.css
+++ b/src/style/components/nav-sidebar.css
@@ -61,8 +61,14 @@
     padding: 8px;
     border: 1px solid var(--background-modifier-border);
     border-radius: 8px;
-    background: var(--background-primary);
+    overflow: hidden;
+    background-color: #ffffff;
+    background-image: linear-gradient(var(--background-primary), var(--background-primary));
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+}
+
+body.theme-dark .claudian-nav-toc-popover {
+    background-color: #1e1e1e;
 }
 
 .claudian-nav-toc-title {
@@ -77,9 +83,13 @@
     display: flex;
     flex-direction: column;
     gap: 2px;
+    min-height: 0;
 }
 
 .claudian-nav-toc-item {
+    box-sizing: border-box;
+    min-height: calc(1.35em + 12px);
+    max-width: 100%;
     padding: 6px 8px;
     border-radius: 6px;
     color: var(--text-normal);

--- a/tests/unit/features/chat/rendering/MessageRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/MessageRenderer.test.ts
@@ -1081,6 +1081,23 @@ describe('MessageRenderer', () => {
     expect(msgEl.hasClass('claudian-message-user')).toBe(true);
   });
 
+  it('addMessage stores a truncated first-line table-of-contents title for user messages', () => {
+    const messagesEl = createMockEl();
+    const { renderer } = createRenderer(messagesEl);
+    jest.spyOn(renderer, 'renderContent').mockResolvedValue(undefined);
+
+    const msg: ChatMessage = {
+      id: 'u1',
+      role: 'user',
+      content: `${'x'.repeat(90)}\nsecond line`,
+      timestamp: Date.now(),
+    };
+
+    const msgEl = renderer.addMessage(msg);
+
+    expect(msgEl.getAttribute('data-toc-title')).toBe(`${'x'.repeat(77)}...`);
+  });
+
   it('addMessage renders images for user messages', () => {
     const messagesEl = createMockEl();
     const { renderer } = createRenderer(messagesEl);
@@ -1431,6 +1448,27 @@ describe('MessageRenderer', () => {
 
     expect(welcomeEl).toBeDefined();
     expect(welcomeEl!.hasClass('claudian-welcome')).toBe(true);
+  });
+
+  it('renderMessages should store table-of-contents title from displayContent before content', () => {
+    const messagesEl = createMockEl();
+    const { renderer } = createRenderer(messagesEl);
+    jest.spyOn(renderer, 'renderContent').mockResolvedValue(undefined);
+
+    const messages: ChatMessage[] = [
+      {
+        id: 'u1',
+        role: 'user',
+        content: 'Expanded prompt that should not appear',
+        displayContent: 'Visible slash command\nwith details',
+        timestamp: Date.now(),
+      },
+    ];
+
+    renderer.renderMessages(messages, () => 'Hello');
+
+    const msgEl = messagesEl.querySelector('.claudian-message-user');
+    expect(msgEl?.getAttribute('data-toc-title')).toBe('Visible slash command');
   });
 
   it('renderMessages should hide welcome when messages exist', () => {

--- a/tests/unit/features/chat/ui/NavigationSidebar.test.ts
+++ b/tests/unit/features/chat/ui/NavigationSidebar.test.ts
@@ -761,7 +761,7 @@ describe('NavigationSidebar', () => {
     it('should refresh an open directory to an empty state when user messages are removed', () => {
       messagesEl.scrollHeight = 2000;
       messagesEl.clientHeight = 500;
-      addMessage(messagesEl, 'user', 0, 'First prompt');
+      const userMsg = addMessage(messagesEl, 'user', 0, 'First prompt');
 
       sidebar = new NavigationSidebar(
         parentEl as unknown as HTMLElement,
@@ -773,13 +773,82 @@ describe('NavigationSidebar', () => {
       expect(parentEl.querySelector('.claudian-nav-toc-popover')).not.toBeNull();
 
       messagesEl.empty();
-      mutationCallback?.([], {} as MutationObserver);
+      mutationCallback?.([
+        {
+          type: 'childList',
+          target: messagesEl,
+          addedNodes: [],
+          removedNodes: [userMsg],
+        } as unknown as MutationRecord,
+      ], {} as MutationObserver);
       jest.advanceTimersByTime(16);
 
       const emptyState = parentEl.querySelector('.claudian-nav-toc-empty');
       expect(directoryBtn.classList.contains('claudian-hidden')).toBe(false);
       expect(parentEl.querySelector('.claudian-nav-toc-popover')).not.toBeNull();
       expect(emptyState?.textContent).toBe('No user prompts in this conversation');
+    });
+
+    it('should not rebuild an open directory for assistant content mutations', () => {
+      messagesEl.scrollHeight = 2000;
+      messagesEl.clientHeight = 500;
+      addMessage(messagesEl, 'user', 0, 'First prompt');
+      const assistantMsg = addMessage(messagesEl, 'assistant', 120);
+      const assistantContent = assistantMsg.createDiv({ cls: 'claudian-message-content' });
+
+      sidebar = new NavigationSidebar(
+        parentEl as unknown as HTMLElement,
+        messagesEl as unknown as HTMLElement
+      );
+
+      const directoryBtn = getDirectoryButton(parentEl);
+      directoryBtn.click();
+      const originalPopover = parentEl.querySelector('.claudian-nav-toc-popover');
+      expect(originalPopover).not.toBeNull();
+
+      const assistantChunk = assistantContent.createDiv({ text: 'Streaming response chunk' });
+      mutationCallback?.([
+        {
+          type: 'childList',
+          target: assistantContent,
+          addedNodes: [assistantChunk],
+          removedNodes: [],
+        } as unknown as MutationRecord,
+      ], {} as MutationObserver);
+      jest.advanceTimersByTime(16);
+
+      expect(parentEl.querySelector('.claudian-nav-toc-popover')).toBe(originalPopover);
+    });
+
+    it('should refresh an open directory when a user message toc title changes', () => {
+      messagesEl.scrollHeight = 2000;
+      messagesEl.clientHeight = 500;
+      const userMsg = addMessage(messagesEl, 'user', 0, 'First prompt');
+
+      sidebar = new NavigationSidebar(
+        parentEl as unknown as HTMLElement,
+        messagesEl as unknown as HTMLElement
+      );
+
+      getDirectoryButton(parentEl).click();
+      const originalPopover = parentEl.querySelector('.claudian-nav-toc-popover');
+      expect(originalPopover).not.toBeNull();
+
+      userMsg.setAttribute('data-toc-title', 'Updated prompt');
+      mutationCallback?.([
+        {
+          type: 'attributes',
+          target: userMsg,
+          attributeName: 'data-toc-title',
+        } as unknown as MutationRecord,
+      ], {} as MutationObserver);
+      jest.advanceTimersByTime(16);
+
+      const updatedPopover = parentEl.querySelector('.claudian-nav-toc-popover');
+      const items = parentEl.querySelectorAll('.claudian-nav-toc-item');
+      expect(updatedPopover).not.toBe(originalPopover);
+      expect(items).toHaveLength(1);
+      expect(items[0].textContent).toBe('1. Updated prompt');
     });
   });
 

--- a/tests/unit/features/chat/ui/NavigationSidebar.test.ts
+++ b/tests/unit/features/chat/ui/NavigationSidebar.test.ts
@@ -179,13 +179,21 @@ class MockElement {
 
   querySelectorAll(selector: string): MockElement[] {
     const matches: MockElement[] = [];
+    const selectors = selector.split(',').map((part) => part.trim()).filter(Boolean);
+    const matchesSelector = (el: MockElement, singleSelector: string): boolean => {
+      if (singleSelector.startsWith('.')) {
+        const className = singleSelector.slice(1);
+        return el.classList.contains(className);
+      }
+      const attributeMatch = singleSelector.match(/^\[([^=\]]+)="([^"]+)"\]$/);
+      if (attributeMatch) {
+        return el.getAttribute(attributeMatch[1]) === attributeMatch[2];
+      }
+      return false;
+    };
     const traverse = (el: MockElement): void => {
-      // Handle class selectors
-      if (selector.startsWith('.')) {
-        const className = selector.slice(1);
-        if (el.classList.contains(className)) {
-          matches.push(el);
-        }
+      if (selectors.some((singleSelector) => matchesSelector(el, singleSelector))) {
+        matches.push(el);
       }
       for (const child of el.children) {
         traverse(child);
@@ -201,10 +209,14 @@ describe('NavigationSidebar', () => {
   let messagesEl: MockElement;
   let sidebar: NavigationSidebar;
   let originalWindow: Window | undefined;
+  let originalMutationObserver: typeof MutationObserver | undefined;
+  let mutationCallback: MutationCallback | null;
 
   beforeEach(() => {
     jest.useFakeTimers();
     originalWindow = (globalThis as { window?: Window }).window;
+    originalMutationObserver = (globalThis as { MutationObserver?: typeof MutationObserver }).MutationObserver;
+    mutationCallback = null;
     Object.defineProperty(globalThis, 'window', {
       value: {
         requestAnimationFrame: (callback: FrameRequestCallback): number =>
@@ -218,6 +230,20 @@ describe('NavigationSidebar', () => {
           globalThis.clearTimeout(handle as unknown as ReturnType<typeof setTimeout>);
         },
       } as Window,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'MutationObserver', {
+      value: class MockMutationObserver {
+        constructor(callback: MutationCallback) {
+          mutationCallback = callback;
+        }
+
+        observe(): void {}
+        disconnect(): void {}
+        takeRecords(): MutationRecord[] {
+          return [];
+        }
+      } as unknown as typeof MutationObserver,
       configurable: true,
     });
     parentEl = new MockElement('div');
@@ -235,6 +261,14 @@ describe('NavigationSidebar', () => {
         configurable: true,
       });
     }
+    if (originalMutationObserver === undefined) {
+      delete (globalThis as { MutationObserver?: typeof MutationObserver }).MutationObserver;
+    } else {
+      Object.defineProperty(globalThis, 'MutationObserver', {
+        value: originalMutationObserver,
+        configurable: true,
+      });
+    }
     jest.useRealTimers();
   });
 
@@ -249,7 +283,7 @@ describe('NavigationSidebar', () => {
       expect(container).not.toBeNull();
     });
 
-    it('should create four navigation buttons', () => {
+    it('should create five navigation buttons', () => {
       sidebar = new NavigationSidebar(
         parentEl as unknown as HTMLElement,
         messagesEl as unknown as HTMLElement
@@ -257,7 +291,7 @@ describe('NavigationSidebar', () => {
 
       const container = parentEl.querySelector('.claudian-nav-sidebar');
       expect(container).not.toBeNull();
-      expect(container!.children.length).toBe(4);
+      expect(container!.children.length).toBe(5);
     });
 
     it('should set correct aria-labels on buttons', () => {
@@ -271,8 +305,9 @@ describe('NavigationSidebar', () => {
 
       expect(buttons[0].getAttribute('aria-label')).toBe('Scroll to top');
       expect(buttons[1].getAttribute('aria-label')).toBe('Previous message');
-      expect(buttons[2].getAttribute('aria-label')).toBe('Next message');
-      expect(buttons[3].getAttribute('aria-label')).toBe('Scroll to bottom');
+      expect(buttons[2].getAttribute('aria-label')).toBe('Conversation directory');
+      expect(buttons[3].getAttribute('aria-label')).toBe('Next message');
+      expect(buttons[4].getAttribute('aria-label')).toBe('Scroll to bottom');
     });
 
     it('should set correct icons on buttons', () => {
@@ -286,8 +321,9 @@ describe('NavigationSidebar', () => {
 
       expect(buttons[0].getAttribute('data-icon')).toBe('chevrons-up');
       expect(buttons[1].getAttribute('data-icon')).toBe('chevron-up');
-      expect(buttons[2].getAttribute('data-icon')).toBe('chevron-down');
-      expect(buttons[3].getAttribute('data-icon')).toBe('chevrons-down');
+      expect(buttons[2].getAttribute('data-icon')).toBe('list-tree');
+      expect(buttons[3].getAttribute('data-icon')).toBe('chevron-down');
+      expect(buttons[4].getAttribute('data-icon')).toBe('chevrons-down');
     });
   });
 
@@ -393,7 +429,7 @@ describe('NavigationSidebar', () => {
       );
 
       const container = parentEl.querySelector('.claudian-nav-sidebar');
-      const bottomBtn = container!.children[3];
+      const bottomBtn = container!.children[4];
       bottomBtn.click();
 
       expect(messagesEl.scrollToCalls.length).toBe(1);
@@ -431,7 +467,7 @@ describe('NavigationSidebar', () => {
       const container = parent.querySelector('.claudian-nav-sidebar')!;
       return {
         prev: container.children[1],
-        next: container.children[2],
+        next: container.children[3],
       };
     }
 
@@ -550,6 +586,200 @@ describe('NavigationSidebar', () => {
 
       const lastCall = messagesEl.scrollToCalls[messagesEl.scrollToCalls.length - 1];
       expect(lastCall.top).toBe(0);
+    });
+  });
+
+  describe('conversation directory', () => {
+    function addMessage(
+      el: MockElement,
+      role: 'user' | 'assistant',
+      offset: number,
+      tocTitle?: string
+    ): MockElement {
+      const msg = el.createDiv({ cls: `claudian-message claudian-message-${role}` });
+      msg.offsetTop = offset;
+      if (tocTitle) {
+        msg.setAttribute('data-toc-title', tocTitle);
+      }
+      return msg;
+    }
+
+    function getDirectoryButton(parent: MockElement): MockElement {
+      const container = parent.querySelector('.claudian-nav-sidebar')!;
+      return container.children[2];
+    }
+
+    it('should show an empty directory state when there are no user messages', () => {
+      messagesEl.scrollHeight = 1000;
+      messagesEl.clientHeight = 500;
+
+      sidebar = new NavigationSidebar(
+        parentEl as unknown as HTMLElement,
+        messagesEl as unknown as HTMLElement
+      );
+
+      const directoryBtn = getDirectoryButton(parentEl);
+      expect(directoryBtn.classList.contains('claudian-hidden')).toBe(false);
+
+      directoryBtn.click();
+
+      const popover = parentEl.querySelector('.claudian-nav-toc-popover');
+      const emptyState = parentEl.querySelector('.claudian-nav-toc-empty');
+      expect(popover).not.toBeNull();
+      expect(emptyState?.textContent).toBe('No user prompts in this conversation');
+    });
+
+    it('should render directory entries for user messages only', () => {
+      messagesEl.scrollHeight = 2000;
+      messagesEl.clientHeight = 500;
+      addMessage(messagesEl, 'user', 0, 'First prompt');
+      addMessage(messagesEl, 'assistant', 120, 'Assistant should not appear');
+      addMessage(messagesEl, 'user', 400, 'Second prompt');
+
+      sidebar = new NavigationSidebar(
+        parentEl as unknown as HTMLElement,
+        messagesEl as unknown as HTMLElement
+      );
+
+      getDirectoryButton(parentEl).click();
+
+      const popover = parentEl.querySelector('.claudian-nav-toc-popover');
+      const items = parentEl.querySelectorAll('.claudian-nav-toc-item');
+      expect(popover).not.toBeNull();
+      expect(items).toHaveLength(2);
+      expect(items[0].textContent).toBe('1. First prompt');
+      expect(items[1].textContent).toBe('2. Second prompt');
+    });
+
+    it('should fall back to visible user message text when toc metadata is missing', () => {
+      messagesEl.scrollHeight = 2000;
+      messagesEl.clientHeight = 500;
+      const userMsg = addMessage(messagesEl, 'user', 0);
+      userMsg.createDiv({
+        cls: 'claudian-message-content',
+        text: 'Legacy prompt title\nsecond line',
+      });
+
+      sidebar = new NavigationSidebar(
+        parentEl as unknown as HTMLElement,
+        messagesEl as unknown as HTMLElement
+      );
+
+      const directoryBtn = getDirectoryButton(parentEl);
+      expect(directoryBtn.classList.contains('claudian-hidden')).toBe(false);
+
+      directoryBtn.click();
+
+      const items = parentEl.querySelectorAll('.claudian-nav-toc-item');
+      expect(items).toHaveLength(1);
+      expect(items[0].textContent).toBe('1. Legacy prompt title');
+    });
+
+    it('should include user messages marked by data-role when class lookup misses', () => {
+      messagesEl.scrollHeight = 2000;
+      messagesEl.clientHeight = 500;
+      const userMsg = messagesEl.createDiv({
+        cls: 'claudian-message',
+        attr: { 'data-role': 'user' },
+      });
+      userMsg.offsetTop = 120;
+      userMsg.createDiv({
+        cls: 'claudian-message-content',
+        text: 'Role based prompt',
+      });
+
+      sidebar = new NavigationSidebar(
+        parentEl as unknown as HTMLElement,
+        messagesEl as unknown as HTMLElement
+      );
+
+      getDirectoryButton(parentEl).click();
+
+      const items = parentEl.querySelectorAll('.claudian-nav-toc-item');
+      expect(items).toHaveLength(1);
+      expect(items[0].textContent).toBe('1. Role based prompt');
+    });
+
+    it('should scroll to a selected directory entry and close the directory', () => {
+      messagesEl.scrollHeight = 2000;
+      messagesEl.clientHeight = 500;
+      addMessage(messagesEl, 'user', 0, 'First prompt');
+      addMessage(messagesEl, 'user', 400, 'Second prompt');
+
+      sidebar = new NavigationSidebar(
+        parentEl as unknown as HTMLElement,
+        messagesEl as unknown as HTMLElement
+      );
+
+      getDirectoryButton(parentEl).click();
+      const items = parentEl.querySelectorAll('.claudian-nav-toc-item');
+      items[1].click();
+
+      const lastCall = messagesEl.scrollToCalls[messagesEl.scrollToCalls.length - 1];
+      expect(lastCall.top).toBe(390);
+      expect(lastCall.behavior).toBe('smooth');
+      expect(parentEl.querySelector('.claudian-nav-toc-popover')).toBeNull();
+    });
+
+    it('should close the directory when the directory button is clicked again', () => {
+      messagesEl.scrollHeight = 2000;
+      messagesEl.clientHeight = 500;
+      addMessage(messagesEl, 'user', 0, 'First prompt');
+
+      sidebar = new NavigationSidebar(
+        parentEl as unknown as HTMLElement,
+        messagesEl as unknown as HTMLElement
+      );
+
+      const directoryBtn = getDirectoryButton(parentEl);
+      directoryBtn.click();
+      expect(parentEl.querySelector('.claudian-nav-toc-popover')).not.toBeNull();
+
+      directoryBtn.click();
+      expect(parentEl.querySelector('.claudian-nav-toc-popover')).toBeNull();
+    });
+
+    it('should keep the directory button visible when message DOM changes', () => {
+      messagesEl.scrollHeight = 1000;
+      messagesEl.clientHeight = 500;
+
+      sidebar = new NavigationSidebar(
+        parentEl as unknown as HTMLElement,
+        messagesEl as unknown as HTMLElement
+      );
+
+      const directoryBtn = getDirectoryButton(parentEl);
+      expect(directoryBtn.classList.contains('claudian-hidden')).toBe(false);
+
+      addMessage(messagesEl, 'user', 0, 'New prompt');
+      mutationCallback?.([], {} as MutationObserver);
+      jest.advanceTimersByTime(16);
+
+      expect(directoryBtn.classList.contains('claudian-hidden')).toBe(false);
+    });
+
+    it('should refresh an open directory to an empty state when user messages are removed', () => {
+      messagesEl.scrollHeight = 2000;
+      messagesEl.clientHeight = 500;
+      addMessage(messagesEl, 'user', 0, 'First prompt');
+
+      sidebar = new NavigationSidebar(
+        parentEl as unknown as HTMLElement,
+        messagesEl as unknown as HTMLElement
+      );
+
+      const directoryBtn = getDirectoryButton(parentEl);
+      directoryBtn.click();
+      expect(parentEl.querySelector('.claudian-nav-toc-popover')).not.toBeNull();
+
+      messagesEl.empty();
+      mutationCallback?.([], {} as MutationObserver);
+      jest.advanceTimersByTime(16);
+
+      const emptyState = parentEl.querySelector('.claudian-nav-toc-empty');
+      expect(directoryBtn.classList.contains('claudian-hidden')).toBe(false);
+      expect(parentEl.querySelector('.claudian-nav-toc-popover')).not.toBeNull();
+      expect(emptyState?.textContent).toBe('No user prompts in this conversation');
     });
   });
 


### PR DESCRIPTION
## Summary
- Add a conversation directory button to the existing floating navigation sidebar.
- Populate the directory from visible user prompts in the active chat and jump to the selected prompt with smooth scrolling.
- Add TOC metadata to rendered user messages, with fallbacks for existing DOM and role-based message lookup.

## Why
Long conversations can be hard to navigate with only previous/next controls. This gives users a compact directory of their own turns without changing conversation storage or provider APIs.

## Validation
- npm run typecheck
- npm run lint
- npm run test
- npm run build
- git diff --check