### PR TITLE
Fix custom model routing collisions

### DIFF
--- a/src/core/providers/ProviderRegistry.ts
+++ b/src/core/providers/ProviderRegistry.ts
@@ -1,5 +1,6 @@
 import type ClaudianPlugin from '../../main';
 import type { ChatRuntime } from '../runtime/ChatRuntime';
+import { decodeProviderModelSelectionId } from './modelSelection';
 import {
   type CreateChatRuntimeOptions,
   DEFAULT_CHAT_PROVIDER_ID,
@@ -168,6 +169,15 @@ export class ProviderRegistry {
       : (options.onlyEnabledProviders
         ? this.resolveSettingsProviderId(settings)
         : DEFAULT_CHAT_PROVIDER_ID);
+    const decodedSelection = decodeProviderModelSelectionId(model);
+
+    if (
+      decodedSelection
+      && providerIds.includes(decodedSelection.providerId)
+      && (!options.onlyEnabledProviders || this.isEnabled(decodedSelection.providerId, settings))
+    ) {
+      return decodedSelection.providerId;
+    }
 
     for (const providerId of providerIds) {
       if (providerId === fallbackProviderId) {

--- a/src/core/providers/ProviderSettingsCoordinator.ts
+++ b/src/core/providers/ProviderSettingsCoordinator.ts
@@ -1,4 +1,5 @@
 import type { Conversation } from '../types';
+import { toProviderRuntimeModelId } from './modelSelection';
 import { ProviderRegistry } from './ProviderRegistry';
 import type { ProviderChatUIConfig, ProviderId } from './types';
 
@@ -121,12 +122,27 @@ export class ProviderSettingsCoordinator {
       return false;
     }
 
-    const isValid = ProviderRegistry.getRegisteredProviderIds().some((providerId) =>
-      ProviderRegistry.getChatUIConfig(providerId)
-        .getModelOptions(settings)
-        .some((option) => option.value === currentModel)
-    );
-    if (isValid) {
+    for (const providerId of ProviderRegistry.getRegisteredProviderIds()) {
+      const uiConfig = ProviderRegistry.getChatUIConfig(providerId);
+      if (!uiConfig.ownsModel(currentModel, settings)) {
+        continue;
+      }
+
+      const normalizedModel = normalizeProviderModel(uiConfig, settings, currentModel);
+      const currentRuntimeModel = toProviderRuntimeModelId(providerId, currentModel);
+      const isValid = normalizedModel !== undefined
+        && uiConfig.getModelOptions(settings).some((option) =>
+          option.value === normalizedModel
+          && toProviderRuntimeModelId(providerId, option.value) === currentRuntimeModel
+        );
+      if (!isValid) {
+        continue;
+      }
+
+      if (normalizedModel !== currentModel) {
+        settings.titleGenerationModel = normalizedModel;
+        return true;
+      }
       return false;
     }
 

--- a/src/core/providers/modelSelection.ts
+++ b/src/core/providers/modelSelection.ts
@@ -1,0 +1,72 @@
+import type { ProviderId } from './types';
+
+const PROVIDER_MODEL_SELECTION_PREFIXES: Partial<Record<ProviderId, string>> = {
+  claude: 'claude-code/',
+  codex: 'openai-codex/',
+  opencode: 'opencode/',
+  pi: 'pi/',
+};
+
+export interface ProviderModelSelection {
+  modelId: string;
+  providerId: ProviderId;
+}
+
+export function getProviderModelSelectionPrefix(providerId: ProviderId): string | null {
+  return PROVIDER_MODEL_SELECTION_PREFIXES[providerId] ?? null;
+}
+
+export function encodeProviderModelSelectionId(
+  providerId: ProviderId,
+  modelId: string,
+): string {
+  const normalized = modelId.trim();
+  const prefix = getProviderModelSelectionPrefix(providerId);
+  if (!prefix || !normalized || normalized.startsWith(prefix)) {
+    return normalized;
+  }
+
+  return `${prefix}${normalized}`;
+}
+
+export function decodeProviderModelSelectionId(
+  value: string,
+): ProviderModelSelection | null {
+  const normalized = value.trim();
+  if (!normalized) {
+    return null;
+  }
+
+  for (const [providerId, prefix] of Object.entries(PROVIDER_MODEL_SELECTION_PREFIXES)) {
+    if (!prefix || !normalized.startsWith(prefix)) {
+      continue;
+    }
+
+    const modelId = normalized.slice(prefix.length).trim();
+    if (!modelId) {
+      return null;
+    }
+
+    return {
+      providerId: providerId as ProviderId,
+      modelId,
+    };
+  }
+
+  return null;
+}
+
+export function isProviderModelSelectionId(
+  providerId: ProviderId,
+  value: string,
+): boolean {
+  return decodeProviderModelSelectionId(value)?.providerId === providerId;
+}
+
+export function toProviderRuntimeModelId(
+  providerId: ProviderId,
+  value: string,
+): string {
+  const decoded = decodeProviderModelSelectionId(value);
+  return decoded?.providerId === providerId ? decoded.modelId : value;
+}

--- a/src/providers/claude/auxiliary/ClaudeTitleGenerationService.ts
+++ b/src/providers/claude/auxiliary/ClaudeTitleGenerationService.ts
@@ -5,6 +5,7 @@ import type {
 } from '../../../core/providers/types';
 import type ClaudianPlugin from '../../../main';
 import { parseEnvironmentVariables } from '../../../utils/env';
+import { toClaudeRuntimeModelId } from '../modelSelection';
 import { runColdStartQuery } from '../runtime/claudeColdStartQuery';
 import { claudeChatUIConfig } from '../ui/ClaudeChatUIConfig';
 
@@ -79,7 +80,7 @@ export class TitleGenerationService {
       titleModel,
       this.plugin.settings as unknown as Record<string, unknown>,
     )) {
-      return titleModel;
+      return toClaudeRuntimeModelId(titleModel);
     }
 
     return (

--- a/src/providers/claude/env/ClaudeSettingsReconciler.ts
+++ b/src/providers/claude/env/ClaudeSettingsReconciler.ts
@@ -4,7 +4,7 @@ import type { Conversation } from '../../../core/types';
 import { parseEnvironmentVariables } from '../../../utils/env';
 import { resolveClaudeModelSelection } from '../modelOptions';
 import { getClaudeProviderSettings, updateClaudeProviderSettings } from '../settings';
-import { normalizeVisibleModelVariant } from '../types/models';
+import { claudeChatUIConfig } from '../ui/ClaudeChatUIConfig';
 
 const ENV_HASH_MODEL_KEYS = [
   'ANTHROPIC_MODEL',
@@ -56,15 +56,9 @@ export const claudeSettingsReconciler: ProviderSettingsReconciler = {
   },
 
   normalizeModelVariantSettings(settings: Record<string, unknown>): boolean {
-    const claudeSettings = getClaudeProviderSettings(settings);
     let changed = false;
 
-    const normalize = (model: string): string =>
-      normalizeVisibleModelVariant(
-        model,
-        claudeSettings.enableOpus1M,
-        claudeSettings.enableSonnet1M,
-      );
+    const normalize = (model: string): string => claudeChatUIConfig.normalizeModelVariant(model, settings);
 
     const model = settings.model as string;
     const normalizedModel = normalize(model);
@@ -82,7 +76,7 @@ export const claudeSettingsReconciler: ProviderSettingsReconciler = {
       }
     }
 
-    const lastClaudeModel = claudeSettings.lastModel;
+    const lastClaudeModel = getClaudeProviderSettings(settings).lastModel;
     if (lastClaudeModel) {
       const normalizedLastClaudeModel = normalize(lastClaudeModel);
       if (lastClaudeModel !== normalizedLastClaudeModel) {

--- a/src/providers/claude/modelOptions.ts
+++ b/src/providers/claude/modelOptions.ts
@@ -2,6 +2,7 @@ import { getRuntimeEnvironmentVariables } from '../../core/providers/providerEnv
 import type { ProviderUIOption } from '../../core/providers/types';
 import { getModelsFromEnvironment } from './env/claudeModelEnv';
 import { formatCustomModelLabel } from './modelLabels';
+import { encodeClaudeModelSelectionId, toClaudeRuntimeModelId } from './modelSelection';
 import { getClaudeProviderSettings } from './settings';
 import { DEFAULT_CLAUDE_MODELS, filterVisibleModelOptions } from './types/models';
 
@@ -49,7 +50,10 @@ export function getClaudeModelOptions(settings: Record<string, unknown>): Provid
     customModelAliases,
   );
   if (customModels.length > 0) {
-    return customModels;
+    return customModels.map((model) => ({
+      ...model,
+      value: encodeClaudeModelSelectionId(model.value),
+    }));
   }
 
   const claudeSettings = getClaudeProviderSettings(settings);
@@ -59,15 +63,16 @@ export function getClaudeModelOptions(settings: Record<string, unknown>): Provid
     claudeSettings.enableSonnet1M,
   );
 
-  const seenValues = new Set(models.map(model => model.value));
-  for (const modelId of parseConfiguredCustomModelIds(claudeSettings.customModels)) {
-    if (seenValues.has(modelId)) {
+  const seenModelIds = new Set(models.map(model => toClaudeRuntimeModelId(model.value)));
+  for (const configuredModelId of parseConfiguredCustomModelIds(claudeSettings.customModels)) {
+    const modelId = toClaudeRuntimeModelId(configuredModelId);
+    if (seenModelIds.has(modelId)) {
       continue;
     }
 
-    seenValues.add(modelId);
+    seenModelIds.add(modelId);
     models.push({
-      value: modelId,
+      value: encodeClaudeModelSelectionId(modelId),
       label: customModelAliases[modelId] ?? formatCustomModelLabel(modelId),
       description: 'Custom model',
     });
@@ -81,13 +86,27 @@ export function resolveClaudeModelSelection(
   currentModel: string,
 ): string | null {
   const modelOptions = getClaudeModelOptions(settings);
-  if (currentModel && modelOptions.some(option => option.value === currentModel)) {
-    return currentModel;
+  if (currentModel) {
+    const currentRuntimeModel = toClaudeRuntimeModelId(currentModel);
+    const currentOption = modelOptions.find(option =>
+      option.value === currentModel
+      || toClaudeRuntimeModelId(option.value) === currentRuntimeModel
+    );
+    if (currentOption) {
+      return currentOption.value;
+    }
   }
 
   const lastModel = getClaudeProviderSettings(settings).lastModel;
-  if (lastModel && modelOptions.some(option => option.value === lastModel)) {
-    return lastModel;
+  if (lastModel) {
+    const lastRuntimeModel = toClaudeRuntimeModelId(lastModel);
+    const lastOption = modelOptions.find(option =>
+      option.value === lastModel
+      || toClaudeRuntimeModelId(option.value) === lastRuntimeModel
+    );
+    if (lastOption) {
+      return lastOption.value;
+    }
   }
 
   return modelOptions[0]?.value ?? null;

--- a/src/providers/claude/modelSelection.ts
+++ b/src/providers/claude/modelSelection.ts
@@ -1,0 +1,17 @@
+import {
+  encodeProviderModelSelectionId,
+  isProviderModelSelectionId,
+  toProviderRuntimeModelId,
+} from '../../core/providers/modelSelection';
+
+export function encodeClaudeModelSelectionId(modelId: string): string {
+  return encodeProviderModelSelectionId('claude', modelId);
+}
+
+export function isClaudeModelSelectionId(modelId: string): boolean {
+  return isProviderModelSelectionId('claude', modelId);
+}
+
+export function toClaudeRuntimeModelId(modelId: string): string {
+  return toProviderRuntimeModelId('claude', modelId);
+}

--- a/src/providers/claude/runtime/ClaudeChatRuntime.ts
+++ b/src/providers/claude/runtime/ClaudeChatRuntime.ts
@@ -69,6 +69,7 @@ import {
 import { CLAUDE_PROVIDER_CAPABILITIES } from '../capabilities';
 import { loadSubagentFinalResult, loadSubagentToolCalls } from '../history/ClaudeHistoryStore';
 import { createStopSubagentHook, type SubagentHookState } from '../hooks/SubagentHooks';
+import { toClaudeRuntimeModelId } from '../modelSelection';
 import { encodeClaudeTurn } from '../prompt/ClaudeTurnEncoder';
 import { isContextWindowEvent, isSessionInitEvent, isStreamChunk } from '../sdk/typeGuards';
 import type { TransformEvent } from '../sdk/types';
@@ -806,7 +807,7 @@ export class ClaudianService implements ChatRuntime {
   ) {
     const settings = this.getScopedSettings();
     return {
-      intendedModel: modelOverride ?? settings.model,
+      intendedModel: toClaudeRuntimeModelId(modelOverride ?? settings.model),
       customContextLimits: settings.customContextLimits,
       streamState,
       usageState,
@@ -1499,7 +1500,7 @@ export class ClaudianService implements ChatRuntime {
     queryOptions?: QueryOptions
   ): AsyncGenerator<StreamChunk> {
     this.resetTurnMetadata();
-    const selectedModel = queryOptions?.model || this.getScopedSettings().model;
+    const selectedModel = toClaudeRuntimeModelId(queryOptions?.model || this.getScopedSettings().model);
 
     this.sessionManager.setPendingModel(selectedModel);
     this.vaultPath = cwd;

--- a/src/providers/claude/runtime/ClaudeDynamicUpdates.ts
+++ b/src/providers/claude/runtime/ClaudeDynamicUpdates.ts
@@ -9,6 +9,7 @@ import type {
   ChatRuntimeQueryOptions,
 } from '../../../core/runtime/types';
 import type { ClaudianSettings, PermissionMode } from '../../../core/types/settings';
+import { toClaudeRuntimeModelId } from '../modelSelection';
 import {
   resolveEffortLevel,
 } from '../types/models';
@@ -61,7 +62,7 @@ export async function applyClaudeDynamicUpdates(
   }
 
   const settings = deps.getScopedSettings();
-  const selectedModel = queryOptions?.model || settings.model;
+  const selectedModel = toClaudeRuntimeModelId(queryOptions?.model || settings.model);
   const permissionMode = deps.getPermissionMode();
 
   const currentConfig = deps.getCurrentConfig();

--- a/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts
+++ b/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../core/prompt/mainAgent';
 import type { AppPluginManager } from '../../../core/providers/types';
 import type { ClaudianSettings, PermissionMode } from '../../../core/types/settings';
+import { toClaudeRuntimeModelId } from '../modelSelection';
 import {
   type ClaudeSafeMode,
   getClaudeProviderSettings,
@@ -111,10 +112,11 @@ export class QueryOptionsBuilder {
     const pluginsKey = ctx.pluginManager.getPluginsKey();
 
     const settingSources = resolveClaudeSettingSources(claudeSettings.loadUserSettings);
+    const runtimeModel = toClaudeRuntimeModelId(ctx.settings.model);
 
     return {
-      model: ctx.settings.model,
-      effortLevel: resolveEffortLevel(ctx.settings.model, ctx.settings.effortLevel),
+      model: runtimeModel,
+      effortLevel: resolveEffortLevel(runtimeModel, ctx.settings.effortLevel),
       permissionMode: ctx.settings.permissionMode,
       sdkPermissionMode,
       systemPromptKey: computeSystemPromptKey(systemPromptSettings),
@@ -130,9 +132,10 @@ export class QueryOptionsBuilder {
   }
 
   static buildPersistentQueryOptions(ctx: PersistentQueryContext): Options {
+    const runtimeModel = toClaudeRuntimeModelId(ctx.settings.model);
     const { options, claudeSettings } = QueryOptionsBuilder.buildBaseOptions(
       ctx,
-      ctx.settings.model,
+      runtimeModel,
       ctx.abortController,
     );
 
@@ -148,7 +151,7 @@ export class QueryOptionsBuilder {
       claudeSettings.safeMode,
       ctx.canUseTool,
     );
-    QueryOptionsBuilder.applyThinking(options, ctx.settings, ctx.settings.model);
+    QueryOptionsBuilder.applyThinking(options, ctx.settings, runtimeModel);
     options.hooks = ctx.hooks;
 
     options.enableFileCheckpointing = true;
@@ -171,7 +174,7 @@ export class QueryOptionsBuilder {
   }
 
   static buildColdStartQueryOptions(ctx: ColdStartQueryContext): Options {
-    const selectedModel = ctx.modelOverride ?? ctx.settings.model;
+    const selectedModel = toClaudeRuntimeModelId(ctx.modelOverride ?? ctx.settings.model);
     const { options, claudeSettings } = QueryOptionsBuilder.buildBaseOptions(
       ctx,
       selectedModel,
@@ -201,7 +204,7 @@ export class QueryOptionsBuilder {
       ctx.canUseTool,
     );
     options.hooks = ctx.hooks;
-    QueryOptionsBuilder.applyThinking(options, ctx.settings, ctx.modelOverride ?? ctx.settings.model);
+    QueryOptionsBuilder.applyThinking(options, ctx.settings, selectedModel);
 
     if (ctx.allowedTools !== undefined && ctx.allowedTools.length > 0) {
       options.tools = ctx.allowedTools;

--- a/src/providers/claude/runtime/claudeColdStartQuery.ts
+++ b/src/providers/claude/runtime/claudeColdStartQuery.ts
@@ -6,6 +6,7 @@ import type ClaudianPlugin from '../../../main';
 import { getEnhancedPath, getMissingNodeError, parseEnvironmentVariables } from '../../../utils/env';
 import { getVaultPath } from '../../../utils/path';
 import { extractAssistantText } from '../auxiliary/extractAssistantText';
+import { toClaudeRuntimeModelId } from '../modelSelection';
 import {
   getClaudeProviderSettings,
   resolveClaudeSettingSources,
@@ -75,7 +76,7 @@ export async function runColdStartQuery(
     );
   const claudeSettings = getClaudeProviderSettings(settings);
 
-  const selectedModel = config.model ?? (settings.model as string);
+  const selectedModel = toClaudeRuntimeModelId(config.model ?? (settings.model as string));
 
   const options: Options = {
     cwd: vaultPath,

--- a/src/providers/claude/types/models.ts
+++ b/src/providers/claude/types/models.ts
@@ -2,6 +2,8 @@
  * Model type definitions and constants.
  */
 
+import { toClaudeRuntimeModelId } from '../modelSelection';
+
 /** Model identifier (string to support custom models via environment variables). */
 export type ClaudeModel = string;
 
@@ -37,7 +39,7 @@ const ONE_M_SUFFIX = '[1m]';
 const DEFAULT_MODEL_VALUES = new Set(DEFAULT_CLAUDE_MODELS.map(m => m.value.toLowerCase()));
 
 function normalizeModelId(model: string): string {
-  return model.trim().toLowerCase();
+  return toClaudeRuntimeModelId(model).trim().toLowerCase();
 }
 
 function has1MContextSuffix(model: string): boolean {

--- a/src/providers/claude/ui/ClaudeChatUIConfig.ts
+++ b/src/providers/claude/ui/ClaudeChatUIConfig.ts
@@ -7,6 +7,7 @@ import type {
 import { CLAUDE_PROVIDER_ICON } from '../../../shared/icons';
 import { getCustomModelIds } from '../env/claudeModelEnv';
 import { getClaudeModelOptions } from '../modelOptions';
+import { toClaudeRuntimeModelId } from '../modelSelection';
 import { getClaudeProviderSettings, updateClaudeProviderSettings } from '../settings';
 import {
   DEFAULT_CLAUDE_MODELS,
@@ -33,7 +34,10 @@ export const claudeChatUIConfig: ProviderChatUIConfig = {
   },
 
   ownsModel(model: string, settings: Record<string, unknown>): boolean {
-    return getClaudeModelOptions(settings).some((option: ProviderUIOption) => option.value === model);
+    const runtimeModel = toClaudeRuntimeModelId(model);
+    return getClaudeModelOptions(settings).some((option: ProviderUIOption) =>
+      option.value === model || toClaudeRuntimeModelId(option.value) === runtimeModel
+    );
   },
 
   isAdaptiveReasoningModel(_model: string, _settings: Record<string, unknown>): boolean {
@@ -41,43 +45,51 @@ export const claudeChatUIConfig: ProviderChatUIConfig = {
   },
 
   getReasoningOptions(model: string, _settings: Record<string, unknown>): ProviderReasoningOption[] {
-    const levels = supportsXHighEffort(model)
+    const runtimeModel = toClaudeRuntimeModelId(model);
+    const levels = supportsXHighEffort(runtimeModel)
       ? EFFORT_LEVELS
       : EFFORT_LEVELS.filter(e => e.value !== 'xhigh');
     return levels.map(e => ({ value: e.value, label: e.label }));
   },
 
   getDefaultReasoningValue(model: string, _settings: Record<string, unknown>): string {
-    return DEFAULT_EFFORT_LEVEL[model] ?? 'high';
+    return DEFAULT_EFFORT_LEVEL[toClaudeRuntimeModelId(model)] ?? 'high';
   },
 
   getContextWindowSize(model: string, customLimits?: Record<string, number>): number {
-    return getContextWindowSize(model, customLimits);
+    return getContextWindowSize(toClaudeRuntimeModelId(model), customLimits);
   },
 
   isDefaultModel(model: string): boolean {
-    return DEFAULT_CLAUDE_MODELS.some(m => m.value === model);
+    const runtimeModel = toClaudeRuntimeModelId(model);
+    return DEFAULT_CLAUDE_MODELS.some(m => m.value === runtimeModel);
   },
 
   applyModelDefaults(model: string, settings: unknown): void {
     const target = settings as Record<string, unknown>;
 
-    if (DEFAULT_CLAUDE_MODELS.some(m => m.value === model)) {
-      target.effortLevel = DEFAULT_EFFORT_LEVEL[model] ?? 'high';
-      updateClaudeProviderSettings(target, { lastModel: model });
+    const runtimeModel = toClaudeRuntimeModelId(model);
+    if (DEFAULT_CLAUDE_MODELS.some(m => m.value === runtimeModel)) {
+      target.effortLevel = DEFAULT_EFFORT_LEVEL[runtimeModel] ?? 'high';
+      updateClaudeProviderSettings(target, { lastModel: runtimeModel });
     } else {
       target.lastCustomModel = model;
-      target.effortLevel = normalizeEffortLevel(model, target.effortLevel);
+      target.effortLevel = normalizeEffortLevel(runtimeModel, target.effortLevel);
     }
   },
 
   normalizeModelVariant(model: string, settings) {
     const claudeSettings = getClaudeProviderSettings(settings);
-    return normalizeVisibleModelVariant(
-      model,
+    const normalizedRuntimeModel = normalizeVisibleModelVariant(
+      toClaudeRuntimeModelId(model),
       claudeSettings.enableOpus1M,
       claudeSettings.enableSonnet1M,
     );
+    const option = getClaudeModelOptions(settings).find(candidate =>
+      candidate.value === normalizedRuntimeModel
+      || toClaudeRuntimeModelId(candidate.value) === normalizedRuntimeModel
+    );
+    return option?.value ?? normalizedRuntimeModel;
   },
 
   getCustomModelIds(envVars: Record<string, string>): Set<string> {

--- a/src/providers/codex/auxiliary/CodexTitleGenerationService.ts
+++ b/src/providers/codex/auxiliary/CodexTitleGenerationService.ts
@@ -1,5 +1,6 @@
 import { QueryBackedTitleGenerationService } from '../../../core/auxiliary/QueryBackedTitleGenerationService';
 import type ClaudianPlugin from '../../../main';
+import { toCodexRuntimeModelId } from '../modelSelection';
 import { CodexAuxQueryRunner } from '../runtime/CodexAuxQueryRunner';
 import { codexChatUIConfig } from '../ui/CodexChatUIConfig';
 
@@ -13,7 +14,7 @@ export class CodexTitleGenerationService extends QueryBackedTitleGenerationServi
           ? settings.titleGenerationModel
           : '';
         return codexChatUIConfig.ownsModel(titleModel, settings)
-          ? titleModel
+          ? toCodexRuntimeModelId(titleModel)
           : undefined;
       },
     });

--- a/src/providers/codex/modelOptions.ts
+++ b/src/providers/codex/modelOptions.ts
@@ -1,5 +1,6 @@
 import { getRuntimeEnvironmentVariables } from '../../core/providers/providerEnvironment';
 import type { ProviderUIOption } from '../../core/providers/types';
+import { encodeCodexModelSelectionId, toCodexRuntimeModelId } from './modelSelection';
 import { getCodexProviderSettings } from './settings';
 import {
   DEFAULT_CODEX_MODEL_SET,
@@ -9,9 +10,10 @@ import {
 } from './types/models';
 
 function createCustomCodexModelOption(modelId: string, description: string): ProviderUIOption {
+  const runtimeModelId = toCodexRuntimeModelId(modelId);
   return {
-    value: modelId,
-    label: formatCodexModelLabel(modelId),
+    value: encodeCodexModelSelectionId(runtimeModelId),
+    label: formatCodexModelLabel(runtimeModelId),
     description,
   };
 }
@@ -45,21 +47,22 @@ export function parseConfiguredCustomModelIds(value: string): string[] {
 
 export function getCodexModelOptions(settings: Record<string, unknown>): ProviderUIOption[] {
   const models = [...DEFAULT_CODEX_MODELS];
-  const seenValues = new Set(models.map(model => model.value));
+  const seenModelIds = new Set(models.map(model => toCodexRuntimeModelId(model.value)));
 
   const envModel = getConfiguredEnvCustomModel(settings);
   if (envModel) {
-    seenValues.add(envModel);
+    seenModelIds.add(envModel);
     models.unshift(createCustomCodexModelOption(envModel, 'Custom (env)'));
   }
 
   const codexSettings = getCodexProviderSettings(settings);
-  for (const modelId of parseConfiguredCustomModelIds(codexSettings.customModels)) {
-    if (seenValues.has(modelId)) {
+  for (const configuredModelId of parseConfiguredCustomModelIds(codexSettings.customModels)) {
+    const modelId = toCodexRuntimeModelId(configuredModelId);
+    if (seenModelIds.has(modelId)) {
       continue;
     }
 
-    seenValues.add(modelId);
+    seenModelIds.add(modelId);
     models.push(createCustomCodexModelOption(modelId, 'Custom model'));
   }
 
@@ -70,14 +73,26 @@ export function resolveCodexModelSelection(
   settings: Record<string, unknown>,
   currentModel: string,
 ): string | null {
+  const modelOptions = getCodexModelOptions(settings);
   const envModel = getConfiguredEnvModel(settings);
   if (envModel) {
-    return envModel;
+    const envRuntimeModel = toCodexRuntimeModelId(envModel);
+    const envOption = modelOptions.find(option =>
+      option.value === envModel
+      || toCodexRuntimeModelId(option.value) === envRuntimeModel
+    );
+    return envOption?.value ?? envModel;
   }
 
-  const modelOptions = getCodexModelOptions(settings);
-  if (currentModel && modelOptions.some(option => option.value === currentModel)) {
-    return currentModel;
+  if (currentModel) {
+    const currentRuntimeModel = toCodexRuntimeModelId(currentModel);
+    const currentOption = modelOptions.find(option =>
+      option.value === currentModel
+      || toCodexRuntimeModelId(option.value) === currentRuntimeModel
+    );
+    if (currentOption) {
+      return currentOption.value;
+    }
   }
 
   return modelOptions[0]?.value ?? DEFAULT_CODEX_PRIMARY_MODEL;

--- a/src/providers/codex/modelSelection.ts
+++ b/src/providers/codex/modelSelection.ts
@@ -1,0 +1,17 @@
+import {
+  encodeProviderModelSelectionId,
+  isProviderModelSelectionId,
+  toProviderRuntimeModelId,
+} from '../../core/providers/modelSelection';
+
+export function encodeCodexModelSelectionId(modelId: string): string {
+  return encodeProviderModelSelectionId('codex', modelId);
+}
+
+export function isCodexModelSelectionId(modelId: string): boolean {
+  return isProviderModelSelectionId('codex', modelId);
+}
+
+export function toCodexRuntimeModelId(modelId: string): string {
+  return toProviderRuntimeModelId('codex', modelId);
+}

--- a/src/providers/codex/runtime/CodexAuxQueryRunner.ts
+++ b/src/providers/codex/runtime/CodexAuxQueryRunner.ts
@@ -1,5 +1,6 @@
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type ClaudianPlugin from '../../../main';
+import { toCodexRuntimeModelId } from '../modelSelection';
 import { DEFAULT_CODEX_PRIMARY_MODEL } from '../types/models';
 import { CodexAppServerProcess } from './CodexAppServerProcess';
 import { resolveCodexAppServerLaunchSpec } from './codexAppServerSupport';
@@ -42,7 +43,7 @@ export class CodexAuxQueryRunner {
     }
 
     if (!this.threadId) {
-      const model = config.model ?? this.resolveProviderModel();
+      const model = toCodexRuntimeModelId(config.model ?? this.resolveProviderModel());
       const result = await this.transport!.request<ThreadStartResult>('thread/start', {
         model,
         cwd: this.launchSpec?.targetCwd ?? process.cwd(),
@@ -116,7 +117,7 @@ export class CodexAuxQueryRunner {
     const turnResult = await this.transport!.request<TurnStartResult>('turn/start', {
       threadId: this.threadId,
       input: [{ type: 'text', text: prompt }],
-      model: config.model,
+      model: config.model ? toCodexRuntimeModelId(config.model) : undefined,
     });
     turnId = turnResult.turn.id;
 
@@ -156,7 +157,8 @@ export class CodexAuxQueryRunner {
       this.plugin.settings,
       'codex',
     );
-    return (providerSettings.model) ?? DEFAULT_CODEX_PRIMARY_MODEL;
+    const model = providerSettings.model;
+    return typeof model === 'string' ? toCodexRuntimeModelId(model) : DEFAULT_CODEX_PRIMARY_MODEL;
   }
 
   private async startProcess(): Promise<void> {

--- a/src/providers/codex/runtime/CodexChatRuntime.ts
+++ b/src/providers/codex/runtime/CodexChatRuntime.ts
@@ -36,6 +36,7 @@ import {
   deriveCodexSessionsRootFromSessionPath,
   findCodexSessionFile,
 } from '../history/CodexHistoryStore';
+import { toCodexRuntimeModelId } from '../modelSelection';
 import { encodeCodexTurn } from '../prompt/encodeCodexTurn';
 import {
   type CodexSafeMode,
@@ -798,7 +799,8 @@ export class CodexChatRuntime implements ChatRuntime {
 
   private resolveModel(queryOptions?: ChatRuntimeQueryOptions): string | undefined {
     const providerSettings = this.getProviderSettings();
-    return queryOptions?.model ?? providerSettings.model as string | undefined;
+    const model = queryOptions?.model ?? providerSettings.model as string | undefined;
+    return model ? toCodexRuntimeModelId(model) : undefined;
   }
 
   private resolveSandboxConfig(): { approvalPolicy: string; sandbox: string } {

--- a/src/providers/codex/settings.ts
+++ b/src/providers/codex/settings.ts
@@ -6,6 +6,7 @@ import {
   getLegacyHostnameKey,
   migrateLegacyHostnameKeyedMap,
 } from '../../utils/env';
+import { toCodexRuntimeModelId } from './modelSelection';
 import { CODEX_SPARK_MODEL } from './types/models';
 
 export type CodexSafeMode = 'workspace-write' | 'read-only';
@@ -52,7 +53,7 @@ export const DEFAULT_CODEX_PROVIDER_SETTINGS: Readonly<CodexProviderSettings> = 
 });
 
 export function shouldDisableCodexReasoningSummary(model: string | undefined): boolean {
-  return model === CODEX_SPARK_MODEL;
+  return model ? toCodexRuntimeModelId(model) === CODEX_SPARK_MODEL : false;
 }
 
 export function getEffectiveCodexReasoningSummary(

--- a/src/providers/codex/ui/CodexChatUIConfig.ts
+++ b/src/providers/codex/ui/CodexChatUIConfig.ts
@@ -7,6 +7,7 @@ import type {
 } from '../../../core/providers/types';
 import { OPENAI_PROVIDER_ICON } from '../../../shared/icons';
 import { getCodexModelOptions } from '../modelOptions';
+import { isCodexModelSelectionId, toCodexRuntimeModelId } from '../modelSelection';
 import { applyCodexModelDefaults } from '../settings';
 import {
   DEFAULT_CODEX_MODEL_SET,
@@ -51,11 +52,18 @@ export const codexChatUIConfig: ProviderChatUIConfig = {
   },
 
   ownsModel(model: string, settings: Record<string, unknown>): boolean {
-    if (getCodexModelOptions(settings).some((option: ProviderUIOption) => option.value === model)) {
+    if (isCodexModelSelectionId(model)) {
       return true;
     }
 
-    return looksLikeCodexModel(model);
+    const runtimeModel = toCodexRuntimeModelId(model);
+    if (getCodexModelOptions(settings).some((option: ProviderUIOption) =>
+      option.value === model || toCodexRuntimeModelId(option.value) === runtimeModel
+    )) {
+      return true;
+    }
+
+    return looksLikeCodexModel(runtimeModel);
   },
 
   isAdaptiveReasoningModel(_model: string, _settings: Record<string, unknown>): boolean {
@@ -83,12 +91,16 @@ export const codexChatUIConfig: ProviderChatUIConfig = {
       return;
     }
 
-    applyCodexModelDefaults(model, settings as Record<string, unknown>);
+    applyCodexModelDefaults(toCodexRuntimeModelId(model), settings as Record<string, unknown>);
   },
 
   normalizeModelVariant(model: string, settings: Record<string, unknown>): string {
-    if (getCodexModelOptions(settings).some((option) => option.value === model)) {
-      return model;
+    const runtimeModel = toCodexRuntimeModelId(model);
+    const option = getCodexModelOptions(settings).find((candidate) =>
+      candidate.value === model || toCodexRuntimeModelId(candidate.value) === runtimeModel
+    );
+    if (option) {
+      return option.value;
     }
 
     return DEFAULT_CODEX_PRIMARY_MODEL;

--- a/src/providers/codex/ui/CodexSettingsTab.ts
+++ b/src/providers/codex/ui/CodexSettingsTab.ts
@@ -9,6 +9,7 @@ import { getHostnameKey } from '../../../utils/env';
 import { expandHomePath } from '../../../utils/path';
 import { getCodexWorkspaceServices } from '../app/CodexWorkspaceServices';
 import { parseConfiguredCustomModelIds, resolveCodexModelSelection } from '../modelOptions';
+import { toCodexRuntimeModelId } from '../modelSelection';
 import { isWindowsStyleCliReference } from '../runtime/CodexBinaryLocator';
 import { getCodexProviderSettings, updateCodexProviderSettings } from '../settings';
 import { DEFAULT_CODEX_PRIMARY_MODEL } from '../types/models';
@@ -286,7 +287,7 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
           }
 
           const previousCustomModelIds = new Set(parseConfiguredCustomModelIds(previousCustomModels));
-          if (!previousCustomModelIds.has(currentSavedModel)) {
+          if (!previousCustomModelIds.has(toCodexRuntimeModelId(currentSavedModel))) {
             return false;
           }
 

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -325,7 +325,7 @@ describe('ClaudianPlugin', () => {
       const saveSpy = jest.spyOn(plugin, 'saveSettings');
       await plugin.loadSettings();
 
-      expect(plugin.settings.model).toBe('custom-model');
+      expect(plugin.settings.model).toBe('claude-code/custom-model');
       expect(saveSpy).toHaveBeenCalled();
     });
   });

--- a/tests/unit/core/providers/ProviderSettingsCoordinator.test.ts
+++ b/tests/unit/core/providers/ProviderSettingsCoordinator.test.ts
@@ -106,7 +106,7 @@ describe('ProviderSettingsCoordinator', () => {
   });
 
   describe('reconcileTitleGenerationModelSelection', () => {
-    it('keeps custom title models while they are still available', () => {
+    it('migrates available Claude custom title models to provider-qualified ids', () => {
       const settings: Record<string, unknown> = {
         titleGenerationModel: 'claude-opus-4-6',
         providerConfigs: {
@@ -119,8 +119,8 @@ describe('ProviderSettingsCoordinator', () => {
 
       expect(
         ProviderSettingsCoordinator.reconcileTitleGenerationModelSelection(settings),
-      ).toBe(false);
-      expect(settings.titleGenerationModel).toBe('claude-opus-4-6');
+      ).toBe(true);
+      expect(settings.titleGenerationModel).toBe('claude-code/claude-opus-4-6');
     });
 
     it('clears titleGenerationModel when no provider exposes the saved model', () => {
@@ -140,7 +140,24 @@ describe('ProviderSettingsCoordinator', () => {
       expect(settings.titleGenerationModel).toBe('');
     });
 
-    it('keeps Codex custom title models while they are still available', () => {
+    it('clears stale provider-qualified custom title models instead of retargeting to a fallback', () => {
+      const settings: Record<string, unknown> = {
+        titleGenerationModel: 'openai-codex/my-custom-model',
+        providerConfigs: {
+          codex: {
+            enabled: true,
+            customModels: '',
+          },
+        },
+      };
+
+      expect(
+        ProviderSettingsCoordinator.reconcileTitleGenerationModelSelection(settings),
+      ).toBe(true);
+      expect(settings.titleGenerationModel).toBe('');
+    });
+
+    it('migrates available Codex custom title models to provider-qualified ids', () => {
       const settings: Record<string, unknown> = {
         titleGenerationModel: 'my-custom-model',
         providerConfigs: {
@@ -153,8 +170,8 @@ describe('ProviderSettingsCoordinator', () => {
 
       expect(
         ProviderSettingsCoordinator.reconcileTitleGenerationModelSelection(settings),
-      ).toBe(false);
-      expect(settings.titleGenerationModel).toBe('my-custom-model');
+      ).toBe(true);
+      expect(settings.titleGenerationModel).toBe('openai-codex/my-custom-model');
     });
   });
 

--- a/tests/unit/core/providers/modelRouting.test.ts
+++ b/tests/unit/core/providers/modelRouting.test.ts
@@ -38,6 +38,23 @@ describe('getProviderForModel', () => {
     expect(getProviderForModel('my-custom-model', settings)).toBe('codex');
   });
 
+  it('routes provider-qualified custom model ids without raw name collisions', () => {
+    const settings = {
+      providerConfigs: {
+        claude: {
+          customModels: 'deepseek-v4-pro',
+        },
+        codex: {
+          enabled: true,
+          customModels: 'deepseek-v4-pro',
+        },
+      },
+    };
+
+    expect(getProviderForModel('claude-code/deepseek-v4-pro', settings)).toBe('claude');
+    expect(getProviderForModel('openai-codex/deepseek-v4-pro', settings)).toBe('codex');
+  });
+
   it('routes settings-defined custom Codex models to codex when settings are provided', () => {
     const settings = {
       providerConfigs: {

--- a/tests/unit/providers/claude/env/ClaudeSettingsReconciler.test.ts
+++ b/tests/unit/providers/claude/env/ClaudeSettingsReconciler.test.ts
@@ -28,7 +28,7 @@ describe('claudeSettingsReconciler', () => {
       expect(result.changed).toBe(true);
       expect(result.invalidatedConversations).toEqual([conversation]);
       expect(conversation.sessionId).toBeNull();
-      expect(settings.model).toBe('claude-opus-4-6');
+      expect(settings.model).toBe('claude-code/claude-opus-4-6');
       expect(getClaudeProviderSettings(settings).environmentHash).toBe(
         'ANTHROPIC_BASE_URL=https://api.example.com',
       );

--- a/tests/unit/providers/claude/ui/ClaudeChatUIConfig.test.ts
+++ b/tests/unit/providers/claude/ui/ClaudeChatUIConfig.test.ts
@@ -15,17 +15,17 @@ describe('claudeChatUIConfig', () => {
         'haiku',
         'sonnet',
         'opus',
-        'claude-opus-4-6',
-        'claude-opus-4-6[1m]',
+        'claude-code/claude-opus-4-6',
+        'claude-code/claude-opus-4-6[1m]',
       ]);
       expect(options.slice(-2)).toEqual([
         {
-          value: 'claude-opus-4-6',
+          value: 'claude-code/claude-opus-4-6',
           label: 'Opus 4.6',
           description: 'Custom model',
         },
         {
-          value: 'claude-opus-4-6[1m]',
+          value: 'claude-code/claude-opus-4-6[1m]',
           label: 'Opus 4.6 (1M)',
           description: 'Custom model',
         },
@@ -45,7 +45,7 @@ describe('claudeChatUIConfig', () => {
         'haiku',
         'sonnet',
         'opus',
-        'claude-opus-4-6',
+        'claude-code/claude-opus-4-6',
       ]);
     });
 
@@ -59,7 +59,7 @@ describe('claudeChatUIConfig', () => {
       });
 
       expect(options.at(-1)).toEqual({
-        value: 'claude-opus-4-5-20251101',
+        value: 'claude-code/claude-opus-4-5-20251101',
         label: 'Opus 4.5 (2511)',
         description: 'Custom model',
       });
@@ -78,7 +78,7 @@ describe('claudeChatUIConfig', () => {
       });
 
       expect(options.at(-1)).toEqual({
-        value: 'claude-opus-4-6',
+        value: 'claude-code/claude-opus-4-6',
         label: 'Work Opus',
         description: 'Custom model',
       });
@@ -96,7 +96,7 @@ describe('claudeChatUIConfig', () => {
 
       expect(options).toEqual([
         {
-          value: 'claude-sonnet-4-5',
+          value: 'claude-code/claude-sonnet-4-5',
           label: 'Sonnet 4.5',
           description: 'Custom model (model)',
         },
@@ -117,7 +117,7 @@ describe('claudeChatUIConfig', () => {
 
       expect(options).toEqual([
         {
-          value: 'claude-sonnet-4-5',
+          value: 'claude-code/claude-sonnet-4-5',
           label: 'Gateway Sonnet',
           description: 'Custom model (model)',
         },

--- a/tests/unit/providers/codex/env/CodexSettingsReconciler.test.ts
+++ b/tests/unit/providers/codex/env/CodexSettingsReconciler.test.ts
@@ -32,6 +32,23 @@ describe('codexSettingsReconciler', () => {
     expect(settings.model).toBe(DEFAULT_CODEX_PRIMARY_MODEL);
   });
 
+  it('persists a provider-qualified selection for custom OPENAI_MODEL values', () => {
+    const settings: Record<string, unknown> = {
+      model: DEFAULT_CODEX_PRIMARY_MODEL,
+      providerConfigs: {
+        codex: {
+          environmentVariables: 'OPENAI_MODEL=deepseek-v4-pro',
+          environmentHash: '',
+        },
+      },
+    };
+
+    const result = codexSettingsReconciler.reconcileModelWithEnvironment(settings, []);
+
+    expect(result.changed).toBe(true);
+    expect(settings.model).toBe('openai-codex/deepseek-v4-pro');
+  });
+
   it('preserves an active settings-defined custom model across non-model env changes', () => {
     const conversation = {
       providerId: 'codex',
@@ -60,7 +77,7 @@ describe('codexSettingsReconciler', () => {
     expect(result.invalidatedConversations).toEqual([conversation]);
     expect(conversation.sessionId).toBeNull();
     expect(conversation.providerState).toBeUndefined();
-    expect(settings.model).toBe('my-custom-model');
+    expect(settings.model).toBe('openai-codex/my-custom-model');
     expect((settings.providerConfigs as any).codex.environmentHash).toBe(
       'OPENAI_BASE_URL=https://api.example.com/v1',
     );

--- a/tests/unit/providers/codex/runtime/CodexChatRuntime.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexChatRuntime.test.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 
 import type { PreparedChatTurn } from '@/core/runtime/types';
 import type { StreamChunk } from '@/core/types/chat';
+import { encodeCodexModelSelectionId } from '@/providers/codex/modelSelection';
 import { CODEX_SPARK_MODEL, DEFAULT_CODEX_PRIMARY_MODEL } from '@/providers/codex/types/models';
 
 // ---------------------------------------------------------------------------
@@ -519,7 +520,7 @@ describe('CodexChatRuntime', () => {
     it('sends reasoning summary off for GPT-5.3 Codex Spark turns', async () => {
       runtime.cleanup();
       runtime = new CodexChatRuntime(createMockPlugin({
-        model: CODEX_SPARK_MODEL,
+        model: encodeCodexModelSelectionId(CODEX_SPARK_MODEL),
         providerConfigs: {
           codex: {
             customModels: CODEX_SPARK_MODEL,

--- a/tests/unit/providers/codex/ui/CodexChatUIConfig.test.ts
+++ b/tests/unit/providers/codex/ui/CodexChatUIConfig.test.ts
@@ -31,12 +31,12 @@ describe('CodexChatUIConfig', () => {
           description: 'Latest',
         },
         {
-          value: 'gpt-5.6-preview',
+          value: 'openai-codex/gpt-5.6-preview',
           label: 'GPT-5.6 Preview',
           description: 'Custom model',
         },
         {
-          value: 'my-custom-model',
+          value: 'openai-codex/my-custom-model',
           label: 'my-custom-model',
           description: 'Custom model',
         },
@@ -47,7 +47,7 @@ describe('CodexChatUIConfig', () => {
       const options = codexChatUIConfig.getModelOptions({
         environmentVariables: 'OPENAI_MODEL=my-custom-model',
       });
-      expect(options[0].value).toBe('my-custom-model');
+      expect(options[0].value).toBe('openai-codex/my-custom-model');
       expect(options[0].description).toBe('Custom (env)');
       expect(options.length).toBe(3);
     });
@@ -63,10 +63,10 @@ describe('CodexChatUIConfig', () => {
       });
 
       expect(options.map(option => option.value)).toEqual([
-        'my-custom-model',
+        'openai-codex/my-custom-model',
         'gpt-5.4-mini',
         DEFAULT_CODEX_PRIMARY_MODEL,
-        'second-custom-model',
+        'openai-codex/second-custom-model',
       ]);
     });
 
@@ -167,14 +167,14 @@ describe('CodexChatUIConfig', () => {
       expect(codexChatUIConfig.normalizeModelVariant(DEFAULT_CODEX_PRIMARY_MODEL, {})).toBe(DEFAULT_CODEX_PRIMARY_MODEL);
       expect(codexChatUIConfig.normalizeModelVariant('custom', {
         environmentVariables: 'OPENAI_MODEL=custom',
-      })).toBe('custom');
+      })).toBe('openai-codex/custom');
       expect(codexChatUIConfig.normalizeModelVariant('settings-custom', {
         providerConfigs: {
           codex: {
             customModels: 'settings-custom',
           },
         },
-      })).toBe('settings-custom');
+      })).toBe('openai-codex/settings-custom');
     });
   });
 


### PR DESCRIPTION
Adds provider-qualified selection IDs for custom Claude and Codex models so identical raw model names no longer collide in routing or selector state. Decodes those IDs before provider runtime calls and reconciles persisted model, title generation, and env-derived OPENAI_MODEL selections to the qualified app-state form. Adds regression coverage for routing, settings reconciliation, model selector options, and Codex runtime decode behavior. Validated with npm run typecheck, npm run lint, and npm run test.