### PR TITLE
Improve conversation tab history controls

### DIFF
--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -13,7 +13,7 @@ import {
   scheduleAnimationFrame,
   type ScheduledAnimationFrame,
 } from '../../utils/animationFrame';
-import type { HistoryConversationOpenState } from './controllers/ConversationController';
+import type { HistoryConversationStatus } from './controllers/ConversationController';
 import {
   getTabProviderId,
   onProviderAvailabilityChanged,
@@ -187,6 +187,7 @@ export class ClaudianView extends ItemView {
       {
         onTabCreated: () => {
           this.updateTabBar();
+          this.updateHistoryDropdown();
           this.updateNavRowLocation();
           this.persistTabState();
           this.syncProviderBrandColor();
@@ -200,13 +201,18 @@ export class ClaudianView extends ItemView {
         },
         onTabClosed: () => {
           this.updateTabBar();
+          this.updateHistoryDropdown();
           this.persistTabState();
         },
-        onTabStreamingChanged: () => this.updateTabBar(),
+        onTabStreamingChanged: () => {
+          this.updateTabBar();
+          this.updateHistoryDropdown();
+        },
         onTabTitleChanged: () => this.updateTabBar(),
         onTabAttentionChanged: () => this.updateTabBar(),
         onTabConversationChanged: () => {
           this.updateTabBar();
+          this.updateHistoryDropdown();
           this.persistTabState();
           this.syncProviderBrandColor();
         },
@@ -538,7 +544,7 @@ export class ClaudianView extends ItemView {
         onSelectConversation: (id) => this.openHistoryConversation(id),
         onOpenConversationInNewTab: (id, activate) =>
           this.openHistoryConversationInNewTab(id, activate),
-        getConversationOpenState: (id) => this.getHistoryConversationOpenState(id),
+        getConversationStatus: (id) => this.getHistoryConversationStatus(id),
       });
     }
   }
@@ -559,27 +565,52 @@ export class ClaudianView extends ItemView {
     this.historyDropdown?.removeClass('visible');
   }
 
-  private getHistoryConversationOpenState(conversationId: string): HistoryConversationOpenState {
+  private getHistoryConversationStatus(conversationId: string): HistoryConversationStatus {
     const activeTab = this.tabManager?.getActiveTab();
     if (activeTab?.conversationId === conversationId) {
-      return 'current';
+      return {
+        openState: 'current',
+        isRunning: activeTab.state.isStreaming,
+        location: 'current-view',
+        tabIndex: this.getHistoryTabIndex(activeTab),
+      };
     }
 
-    if (this.findTabWithConversation(conversationId)) {
-      return 'open';
+    const localTab = this.findTabWithConversation(conversationId);
+    if (localTab) {
+      return {
+        openState: 'open',
+        isRunning: localTab.state.isStreaming,
+        location: 'current-view',
+        tabIndex: this.getHistoryTabIndex(localTab),
+      };
     }
 
     const crossViewResult = this.plugin.findConversationAcrossViews(conversationId);
     if (crossViewResult && crossViewResult.view !== this) {
-      return 'open';
+      const crossViewTab = crossViewResult.view.getTabManager()?.getTab(crossViewResult.tabId);
+      return {
+        openState: 'open',
+        isRunning: crossViewTab?.state.isStreaming ?? false,
+        location: 'other-view',
+      };
     }
 
-    return 'closed';
+    return {
+      openState: 'closed',
+      isRunning: false,
+      location: 'current-view',
+    };
   }
 
   private findTabWithConversation(conversationId: string): TabData | null {
     const tabs = this.tabManager?.getAllTabs() ?? [];
     return tabs.find(tab => tab.conversationId === conversationId) ?? null;
+  }
+
+  private getHistoryTabIndex(tab: TabData): number | undefined {
+    const index = this.tabManager?.getAllTabs().findIndex(candidate => candidate.id === tab.id) ?? -1;
+    return index >= 0 ? index + 1 : undefined;
   }
 
   // ============================================

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -58,10 +58,18 @@ type SaveOptions = {
 
 export type HistoryConversationOpenState = 'closed' | 'open' | 'current';
 
+export type HistoryConversationStatus = {
+  openState: HistoryConversationOpenState;
+  isRunning: boolean;
+  location?: 'current-view' | 'other-view';
+  tabIndex?: number;
+};
+
 type HistoryRenderOptions = {
   onSelectConversation: (id: string) => Promise<void>;
   onOpenConversationInNewTab?: (id: string, activate?: boolean) => Promise<void>;
   getConversationOpenState?: (id: string) => HistoryConversationOpenState;
+  getConversationStatus?: (id: string) => HistoryConversationStatus;
   onRerender: () => void;
 };
 
@@ -575,20 +583,36 @@ export class ConversationController {
     });
 
     for (const conv of conversations) {
-      const isCurrent = conv.id === state.currentConversationId;
+      const fallbackOpenState: HistoryConversationOpenState =
+        conv.id === state.currentConversationId ? 'current' : 'closed';
+      const conversationStatus = this.getHistoryConversationStatus(conv.id, fallbackOpenState, options);
+      const { openState, isRunning } = conversationStatus;
+      const isCurrent = openState === 'current';
+      const isOpen = openState === 'open';
       const item = list.createDiv({
-        cls: `claudian-history-item${isCurrent ? ' active' : ''}`,
+        cls: [
+          'claudian-history-item',
+          isCurrent ? 'active' : '',
+          isOpen ? 'open' : '',
+          isRunning ? 'running' : '',
+        ].filter(Boolean).join(' '),
       });
+      item.setAttribute('data-open-state', openState);
+      item.setAttribute('data-running', isRunning ? 'true' : 'false');
+      item.setAttribute('data-tab-location', conversationStatus.location ?? 'current-view');
+      if (typeof conversationStatus.tabIndex === 'number') {
+        item.setAttribute('data-tab-index', String(conversationStatus.tabIndex));
+      }
 
       const iconEl = item.createDiv({ cls: 'claudian-history-item-icon' });
-      setIcon(iconEl, isCurrent ? 'message-square-dot' : 'message-square');
+      setIcon(iconEl, this.getHistoryItemIcon(openState, isRunning));
 
       const content = item.createDiv({ cls: 'claudian-history-item-content' });
       const titleEl = content.createDiv({ cls: 'claudian-history-item-title', text: conv.title });
       titleEl.setAttribute('title', conv.title);
       content.createDiv({
         cls: 'claudian-history-item-date',
-        text: isCurrent ? 'Current session' : this.formatDate(conv.lastResponseAt ?? conv.createdAt),
+        text: this.getHistoryItemStatusText(conversationStatus, conv.lastResponseAt ?? conv.createdAt),
       });
 
       if (!isCurrent) {
@@ -657,6 +681,24 @@ export class ConversationController {
         });
       }
 
+      if (openState === 'closed' && options.onOpenConversationInNewTab) {
+        const openInNewTabBtn = actions.createEl('button', {
+          cls: 'claudian-action-btn claudian-open-new-tab-btn',
+        });
+        setIcon(openInNewTabBtn, 'square-plus');
+        openInNewTabBtn.setAttribute('aria-label', 'Open in new tab');
+        openInNewTabBtn.addEventListener('click', (e) => {
+          e.stopPropagation();
+          runConversationAction(
+            () => this.runHistoryAction(
+              () => options.onOpenConversationInNewTab?.(conv.id, true),
+              'Failed to load conversation',
+            ),
+            'Failed to load conversation',
+          );
+        });
+      }
+
       const renameBtn = actions.createEl('button', { cls: 'claudian-action-btn' });
       setIcon(renameBtn, 'pencil');
       renameBtn.setAttribute('aria-label', 'Rename');
@@ -679,6 +721,69 @@ export class ConversationController {
         );
       });
     }
+  }
+
+  private getHistoryConversationStatus(
+    conversationId: string,
+    fallbackOpenState: HistoryConversationOpenState,
+    options: HistoryRenderOptions,
+  ): HistoryConversationStatus {
+    const status = options.getConversationStatus?.(conversationId);
+    if (status) return status;
+
+    return {
+      openState: options.getConversationOpenState?.(conversationId) ?? fallbackOpenState,
+      isRunning: false,
+    };
+  }
+
+  private getHistoryItemStatusText(
+    status: HistoryConversationStatus,
+    timestamp: number,
+  ): string {
+    const { openState, isRunning } = status;
+    const location = status.location ?? 'current-view';
+
+    if (openState !== 'closed' && location === 'other-view') {
+      return isRunning ? 'Running in another pane' : 'Open in another pane';
+    }
+
+    if (isRunning) {
+      if (openState === 'closed') return 'Running';
+      return `Running in ${this.getHistoryTabLabel(status)}`;
+    }
+
+    switch (openState) {
+      case 'current':
+        return typeof status.tabIndex === 'number'
+          ? `Current tab ${status.tabIndex}`
+          : 'Current session';
+      case 'open':
+        return `Open in ${this.getHistoryTabLabel(status)}`;
+      case 'closed':
+        return this.formatDate(timestamp);
+    }
+  }
+
+  private getHistoryTabLabel(status: HistoryConversationStatus): string {
+    if (typeof status.tabIndex === 'number') {
+      return `tab ${status.tabIndex}`;
+    }
+
+    if (status.openState === 'current') {
+      return 'current tab';
+    }
+
+    return 'tab';
+  }
+
+  private getHistoryItemIcon(
+    openState: HistoryConversationOpenState,
+    isRunning: boolean,
+  ): string {
+    if (isRunning) return 'loader-2';
+    if (openState === 'current') return 'message-square-dot';
+    return 'message-square';
   }
 
   private isHistoryNewTabModifierClick(event: MouseEvent): boolean {
@@ -705,9 +810,10 @@ export class ConversationController {
     event: MouseEvent,
   ): void {
     const menu = new Menu();
-    const openState = options.getConversationOpenState?.(conversationId) ?? (isCurrent ? 'current' : 'closed');
+    const fallbackOpenState: HistoryConversationOpenState = isCurrent ? 'current' : 'closed';
+    const { openState } = this.getHistoryConversationStatus(conversationId, fallbackOpenState, options);
 
-    if (!isCurrent) {
+    if (openState !== 'current') {
       if (openState === 'closed' && options.onOpenConversationInNewTab) {
         menu.addItem((menuItem) => menuItem
           .setTitle('Open in new tab')

--- a/src/features/chat/tabs/TabBar.ts
+++ b/src/features/chat/tabs/TabBar.ts
@@ -61,8 +61,9 @@ export class TabBar {
       text: String(item.index),
     });
 
-    // Tooltip with full title (aria-label only; adding title too causes double tooltip)
+    // Native hover tooltip with the full title, while preserving an accessible label.
     badgeEl.setAttribute('aria-label', item.title);
+    badgeEl.setAttribute('title', item.title);
     badgeEl.setAttribute('data-provider', item.providerId);
 
     // Click handler to switch tab

--- a/src/providers/codex/history/CodexHistoryStore.ts
+++ b/src/providers/codex/history/CodexHistoryStore.ts
@@ -389,14 +389,66 @@ function parseSessionRecord(line: string): ParsedSessionRecord | null {
 
 const CODEX_SYSTEM_MESSAGE_PREFIXES = [
   '# AGENTS.md instructions',
-  '<environment_context>',
-  '<subagent_notification>',
-  '<skill>',
 ];
 
-function isCodexSystemMessage(text: string): boolean {
+const CODEX_CONTROL_BLOCK_TAGS = [
+  'system_instruction',
+  'environment_context',
+  'turn_aborted',
+  'user-preferences',
+  'subagent_notification',
+  'skill',
+];
+
+function stripLeadingTaggedBlock(text: string, tagName: string): string | null {
+  const openTag = `<${tagName}>`;
+  if (!text.startsWith(openTag)) {
+    return null;
+  }
+
+  const closeTag = `</${tagName}>`;
+  const closeIndex = text.indexOf(closeTag, openTag.length);
+  if (closeIndex === -1) {
+    return '';
+  }
+
+  return text.slice(closeIndex + closeTag.length);
+}
+
+function stripLeadingCodexControlBlocks(text: string): string {
+  let remaining = text.trimStart();
+  let stripped = true;
+
+  while (stripped) {
+    stripped = false;
+
+    for (const tagName of CODEX_CONTROL_BLOCK_TAGS) {
+      const next = stripLeadingTaggedBlock(remaining, tagName);
+      if (next === null) {
+        continue;
+      }
+
+      remaining = next.trimStart();
+      stripped = true;
+      break;
+    }
+  }
+
+  return remaining;
+}
+
+function extractCodexUserVisibleText(text: string): string | null {
   const trimmed = text.trimStart();
-  return CODEX_SYSTEM_MESSAGE_PREFIXES.some(prefix => trimmed.startsWith(prefix));
+  if (!trimmed) {
+    return null;
+  }
+
+  if (CODEX_SYSTEM_MESSAGE_PREFIXES.some(prefix => trimmed.startsWith(prefix))) {
+    return null;
+  }
+
+  const visible = stripLeadingCodexControlBlocks(trimmed).trim();
+  return visible ? visible : null;
 }
 
 function extractMessageText(content: PersistedMessagePart[] | undefined): string {
@@ -854,7 +906,8 @@ function processPersistedPayload(
       const text = extractMessageText(messagePayload.content);
 
       if (messagePayload.role === 'user') {
-        if (isCodexSystemMessage(text)) break;
+        const visibleText = extractCodexUserVisibleText(text);
+        if (visibleText === null) break;
 
         // Close any active bubble in the current turn before starting user content
         if (ctx.currentTurnId) {
@@ -866,9 +919,7 @@ function processPersistedPayload(
         ctx.currentTurnId = null;
         const turn = ensureTurn(ctx.turns, ctx.turnOrder, nextTurnId(ctx), null, timestamp);
         ctx.currentTurnId = turn.id;
-        if (text) {
-          appendUserChunk(turn, text, timestamp);
-        }
+        appendUserChunk(turn, visibleText, timestamp);
       } else if (messagePayload.role === 'assistant') {
         const turn = ensureTurn(ctx.turns, ctx.turnOrder, nextTurnId(ctx), ctx.currentTurnId, timestamp);
         const bubble = ensureAssistantBubble(turn, timestamp);
@@ -1006,8 +1057,11 @@ function processEventMsg(
     case 'user_message': {
       const turn = ensureTurn(ctx.turns, ctx.turnOrder, nextTurnId(ctx), ctx.currentTurnId, timestamp);
       const msg = payload.message;
-      if (typeof msg === 'string' && msg.trim()) {
-        appendUserChunk(turn, msg, timestamp);
+      if (typeof msg === 'string') {
+        const visibleText = extractCodexUserVisibleText(msg);
+        if (visibleText !== null) {
+          appendUserChunk(turn, visibleText, timestamp);
+        }
       }
       break;
     }
@@ -1064,13 +1118,13 @@ function flushBubbleTurnMessages(
 ): { messages: ChatMessage[]; nextMsgIndex: number } {
   const messages: ChatMessage[] = [];
 
-  const userText = turn.userChunks.join('\n').trim();
-  if (userText && !isCodexSystemMessage(userText)) {
-    const displayContent = extractUserDisplayContent(userText);
+  const visibleUserText = extractCodexUserVisibleText(turn.userChunks.join('\n'));
+  if (visibleUserText) {
+    const displayContent = extractUserDisplayContent(visibleUserText);
     messages.push({
       id: `codex-msg-${msgIndex}`,
       role: 'user',
-      content: userText,
+      content: visibleUserText,
       ...(displayContent !== undefined ? { displayContent } : {}),
       ...(turn.serverTurnId ? { userMessageId: turn.serverTurnId } : {}),
       timestamp: turn.userTimestamp || turn.startedAt || Date.now(),

--- a/src/style/components/history.css
+++ b/src/style/components/history.css
@@ -86,9 +86,13 @@
 }
 
 .claudian-history-item.active {
-  background: var(--background-secondary);
+  background: var(--background-modifier-hover);
   border-inline-start: 2px solid var(--interactive-accent);
   padding-inline-start: 10px;
+}
+
+.claudian-history-item.active:hover {
+  background: var(--background-modifier-active-hover, var(--background-modifier-hover));
 }
 
 .claudian-history-item.active .claudian-history-item-icon {
@@ -101,6 +105,37 @@
 
 .claudian-history-item.active .claudian-history-item-date {
   color: var(--text-faint);
+}
+
+.claudian-history-item.open {
+  background: var(--background-modifier-hover);
+  border-inline-start: 2px solid var(--interactive-accent);
+  padding-inline-start: 10px;
+}
+
+.claudian-history-item.open:hover {
+  background: var(--background-modifier-active-hover, var(--background-modifier-hover));
+}
+
+.claudian-history-item.open .claudian-history-item-icon {
+  color: var(--interactive-accent);
+}
+
+.claudian-history-item.open .claudian-history-item-date {
+  color: var(--text-muted);
+}
+
+.claudian-history-item.running .claudian-history-item-icon {
+  color: var(--interactive-accent);
+}
+
+.claudian-history-item.running .claudian-history-item-icon svg {
+  animation: spin 1s linear infinite;
+}
+
+.claudian-history-item.running .claudian-history-item-date {
+  color: var(--interactive-accent);
+  font-weight: 500;
 }
 
 .claudian-history-item-content {
@@ -136,6 +171,10 @@
   opacity: 1;
 }
 
+.claudian-history-item:focus-within .claudian-history-item-actions {
+  opacity: 1;
+}
+
 .claudian-action-btn {
   background: transparent;
   border: none;
@@ -158,6 +197,10 @@
 
 .claudian-delete-btn:hover {
   color: var(--color-red);
+}
+
+.claudian-open-new-tab-btn:hover {
+  color: var(--interactive-accent);
 }
 
 .claudian-rename-input {

--- a/tests/unit/features/chat/controllers/ConversationController.test.ts
+++ b/tests/unit/features/chat/controllers/ConversationController.test.ts
@@ -761,6 +761,222 @@ describe('ConversationController', () => {
         expect(container.children.length).toBe(2); // header + list
       });
 
+      it('should highlight conversations already open in a tab', () => {
+        const container = createMockEl();
+
+        deps.state.currentConversationId = 'conv-1';
+        (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
+          { id: 'conv-1', title: 'Current', createdAt: 1000, lastResponseAt: 2000 },
+          { id: 'conv-2', title: 'Open elsewhere', createdAt: 2000, lastResponseAt: 1000 },
+        ]);
+
+        controller.renderHistoryDropdown(container, {
+          onSelectConversation: jest.fn(),
+          getConversationOpenState: (id) => id === 'conv-2' ? 'open' : 'current',
+        });
+
+        const list = container.children[1];
+        const openItem = list.children[1];
+        const openItemDate = openItem.querySelector('.claudian-history-item-date');
+
+        expect(openItem.hasClass('open')).toBe(true);
+        expect(openItem.hasClass('active')).toBe(false);
+        expect(openItem.getAttribute('data-open-state')).toBe('open');
+        expect(openItemDate?.textContent).toBe('Open in tab');
+      });
+
+      it('should display the current tab number when available', () => {
+        const container = createMockEl();
+
+        deps.state.currentConversationId = 'conv-1';
+        (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
+          { id: 'conv-1', title: 'Current', createdAt: 1000, lastResponseAt: 2000 },
+        ]);
+
+        controller.renderHistoryDropdown(container, {
+          onSelectConversation: jest.fn(),
+          getConversationStatus: () => ({
+            openState: 'current',
+            isRunning: false,
+            location: 'current-view',
+            tabIndex: 1,
+          }),
+        });
+
+        const list = container.children[1];
+        const currentItem = list.children[0];
+        const currentItemDate = currentItem.querySelector('.claudian-history-item-date');
+
+        expect(currentItem.getAttribute('data-tab-index')).toBe('1');
+        expect(currentItem.getAttribute('data-tab-location')).toBe('current-view');
+        expect(currentItemDate?.textContent).toBe('Current tab 1');
+      });
+
+      it('should display the open tab number when available', () => {
+        const container = createMockEl();
+
+        deps.state.currentConversationId = 'conv-1';
+        (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
+          { id: 'conv-1', title: 'Current', createdAt: 1000, lastResponseAt: 2000 },
+          { id: 'conv-2', title: 'Open elsewhere', createdAt: 2000, lastResponseAt: 1000 },
+        ]);
+
+        controller.renderHistoryDropdown(container, {
+          onSelectConversation: jest.fn(),
+          getConversationStatus: (id) => id === 'conv-2'
+            ? { openState: 'open', isRunning: false, location: 'current-view', tabIndex: 2 }
+            : { openState: 'current', isRunning: false, location: 'current-view', tabIndex: 1 },
+        });
+
+        const list = container.children[1];
+        const openItem = list.children[1];
+        const openItemDate = openItem.querySelector('.claudian-history-item-date');
+
+        expect(openItem.getAttribute('data-tab-index')).toBe('2');
+        expect(openItem.getAttribute('data-tab-location')).toBe('current-view');
+        expect(openItemDate?.textContent).toBe('Open in tab 2');
+      });
+
+      it('should display running status for the current conversation', () => {
+        const container = createMockEl();
+
+        deps.state.currentConversationId = 'conv-1';
+        (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
+          { id: 'conv-1', title: 'Current', createdAt: 1000, lastResponseAt: 2000 },
+        ]);
+
+        controller.renderHistoryDropdown(container, {
+          onSelectConversation: jest.fn(),
+          getConversationStatus: () => ({
+            openState: 'current',
+            isRunning: true,
+          }),
+        });
+
+        const list = container.children[1];
+        const currentItem = list.children[0];
+        const currentItemDate = currentItem.querySelector('.claudian-history-item-date');
+
+        expect(currentItem.hasClass('active')).toBe(true);
+        expect(currentItem.hasClass('running')).toBe(true);
+        expect(currentItem.getAttribute('data-running')).toBe('true');
+        expect(currentItemDate?.textContent).toBe('Running in current tab');
+      });
+
+      it('should display running status for a conversation open in another tab', () => {
+        const container = createMockEl();
+
+        deps.state.currentConversationId = 'conv-1';
+        (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
+          { id: 'conv-1', title: 'Current', createdAt: 1000, lastResponseAt: 2000 },
+          { id: 'conv-2', title: 'Running elsewhere', createdAt: 2000, lastResponseAt: 1000 },
+        ]);
+
+        controller.renderHistoryDropdown(container, {
+          onSelectConversation: jest.fn(),
+          getConversationStatus: (id) => id === 'conv-2'
+            ? { openState: 'open', isRunning: true, location: 'current-view', tabIndex: 2 }
+            : { openState: 'current', isRunning: false },
+        });
+
+        const list = container.children[1];
+        const runningItem = list.children[1];
+        const runningItemDate = runningItem.querySelector('.claudian-history-item-date');
+
+        expect(runningItem.hasClass('open')).toBe(true);
+        expect(runningItem.hasClass('running')).toBe(true);
+        expect(runningItem.getAttribute('data-open-state')).toBe('open');
+        expect(runningItem.getAttribute('data-running')).toBe('true');
+        expect(runningItemDate?.textContent).toBe('Running in tab 2');
+      });
+
+      it('should display another-pane status without a local tab number', () => {
+        const container = createMockEl();
+
+        deps.state.currentConversationId = 'conv-1';
+        (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
+          { id: 'conv-1', title: 'Current', createdAt: 1000, lastResponseAt: 2000 },
+          { id: 'conv-2', title: 'Open elsewhere', createdAt: 2000, lastResponseAt: 1000 },
+          { id: 'conv-3', title: 'Running elsewhere', createdAt: 3000, lastResponseAt: 500 },
+        ]);
+
+        controller.renderHistoryDropdown(container, {
+          onSelectConversation: jest.fn(),
+          getConversationStatus: (id) => {
+            if (id === 'conv-2') {
+              return { openState: 'open', isRunning: false, location: 'other-view' };
+            }
+            if (id === 'conv-3') {
+              return { openState: 'open', isRunning: true, location: 'other-view' };
+            }
+            return { openState: 'current', isRunning: false, location: 'current-view', tabIndex: 1 };
+          },
+        });
+
+        const list = container.children[1];
+        const openOtherPaneItem = list.children[1];
+        const runningOtherPaneItem = list.children[2];
+        const runningOtherPaneDate = runningOtherPaneItem.querySelector('.claudian-history-item-date');
+        const openOtherPaneDate = openOtherPaneItem.querySelector('.claudian-history-item-date');
+
+        expect(runningOtherPaneItem.getAttribute('data-tab-location')).toBe('other-view');
+        expect(runningOtherPaneItem.getAttribute('data-tab-index')).toBeNull();
+        expect(runningOtherPaneDate?.textContent).toBe('Running in another pane');
+        expect(openOtherPaneDate?.textContent).toBe('Open in another pane');
+      });
+
+      it('should render a new-tab button for closed conversations', async () => {
+        const container = createMockEl();
+        const onSelectConversation = jest.fn();
+        const onOpenConversationInNewTab = jest.fn().mockResolvedValue(undefined);
+
+        deps.state.currentConversationId = 'conv-1';
+        (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
+          { id: 'conv-1', title: 'Current', createdAt: 1000, lastResponseAt: 2000 },
+          { id: 'conv-2', title: 'Closed', createdAt: 2000, lastResponseAt: 1000 },
+        ]);
+
+        controller.renderHistoryDropdown(container, {
+          onSelectConversation,
+          onOpenConversationInNewTab,
+          getConversationOpenState: (id) => id === 'conv-2' ? 'closed' : 'current',
+        });
+
+        const list = container.children[1];
+        const closedItem = list.children[1];
+        const openInNewTabBtn = closedItem.querySelector('.claudian-open-new-tab-btn');
+        const clickHandlers = openInNewTabBtn?._eventListeners?.get('click');
+
+        expect(openInNewTabBtn).toBeTruthy();
+        expect(clickHandlers).toBeDefined();
+
+        await clickHandlers![0]({ stopPropagation: jest.fn() });
+
+        expect(onOpenConversationInNewTab).toHaveBeenCalledWith('conv-2', true);
+        expect(onSelectConversation).not.toHaveBeenCalled();
+      });
+
+      it('should not render a new-tab button for already-open conversations', () => {
+        const container = createMockEl();
+
+        deps.state.currentConversationId = 'conv-1';
+        (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
+          { id: 'conv-1', title: 'Current', createdAt: 1000, lastResponseAt: 2000 },
+          { id: 'conv-2', title: 'Open elsewhere', createdAt: 2000, lastResponseAt: 1000 },
+        ]);
+
+        controller.renderHistoryDropdown(container, {
+          onSelectConversation: jest.fn(),
+          onOpenConversationInNewTab: jest.fn().mockResolvedValue(undefined),
+          getConversationOpenState: (id) => id === 'conv-2' ? 'open' : 'current',
+        });
+
+        const list = container.children[1];
+        const openItem = list.children[1];
+
+        expect(openItem.querySelector('.claudian-open-new-tab-btn')).toBeNull();
+      });
+
       it('should open a conversation in a new tab on modifier click when supported', async () => {
         const container = createMockEl();
         const onSelectConversation = jest.fn();
@@ -875,6 +1091,39 @@ describe('ConversationController', () => {
           onSelectConversation: jest.fn(),
           onOpenConversationInNewTab: jest.fn().mockResolvedValue(undefined),
           getConversationOpenState: () => 'open',
+        });
+
+        const list = container.children[1];
+        const otherItem = list.children[1];
+        otherItem.dispatchEvent({
+          type: 'contextmenu',
+          stopPropagation: jest.fn(),
+          preventDefault: jest.fn(),
+        });
+
+        const menu = (Menu as typeof Menu & { instances: Array<{ items: Array<{ title: string }> }> }).instances[0];
+        expect(menu.items.map(item => item.title)).toEqual([
+          'Switch to open session',
+          'Rename',
+          'Delete',
+        ]);
+      });
+
+      it('should derive context menu open state from conversation status', () => {
+        const container = createMockEl();
+
+        deps.state.currentConversationId = 'conv-1';
+        (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
+          { id: 'conv-1', title: 'Current', createdAt: 1000, lastResponseAt: 2000 },
+          { id: 'conv-2', title: 'Other', createdAt: 2000, lastResponseAt: 1000 },
+        ]);
+
+        controller.renderHistoryDropdown(container, {
+          onSelectConversation: jest.fn(),
+          onOpenConversationInNewTab: jest.fn().mockResolvedValue(undefined),
+          getConversationStatus: (id) => id === 'conv-2'
+            ? { openState: 'open', isRunning: false, location: 'current-view', tabIndex: 2 }
+            : { openState: 'current', isRunning: false, location: 'current-view', tabIndex: 1 },
         });
 
         const list = container.children[1];

--- a/tests/unit/features/chat/tabs/TabBar.test.ts
+++ b/tests/unit/features/chat/tabs/TabBar.test.ts
@@ -90,7 +90,7 @@ describe('TabBar', () => {
       expect(containerEl._children[0].textContent).toBe('5');
     });
 
-    it('should set aria-label tooltip from item title', () => {
+    it('should set accessible and hover labels from item title', () => {
       const containerEl = createMockEl();
       const callbacks = createMockCallbacks();
       const tabBar = new TabBar(containerEl, callbacks);
@@ -98,8 +98,7 @@ describe('TabBar', () => {
       tabBar.update([createTabBarItem({ title: 'My Conversation' })]);
 
       expect(containerEl._children[0].getAttribute('aria-label')).toBe('My Conversation');
-      // title attribute is intentionally omitted to prevent double tooltip
-      expect(containerEl._children[0].getAttribute('title')).toBeNull();
+      expect(containerEl._children[0].getAttribute('title')).toBe('My Conversation');
     });
 
     it('should set a provider attribute for per-tab streaming colors', () => {

--- a/tests/unit/providers/codex/history/CodexHistoryStore.test.ts
+++ b/tests/unit/providers/codex/history/CodexHistoryStore.test.ts
@@ -806,6 +806,102 @@ describe('CodexHistoryStore', () => {
       expect(messages[0]).toMatchObject({ role: 'assistant', content: 'Ready.' });
     });
 
+    it('should skip Conductor interrupt control envelope persisted as user message', () => {
+      const conductorControlText = [
+        '<system_instruction>',
+        'You are working inside Conductor, a Mac app that lets the user run many coding agents in parallel.',
+        '</system_instruction>',
+        '',
+        '<turn_aborted>',
+        'The user interrupted the previous turn on purpose.',
+        '</turn_aborted>',
+        '',
+        '<user-preferences>',
+        'dev notes and throwaway scripts should be placed inside .context/',
+        '</user-preferences>',
+      ].join('\n');
+
+      const content = [
+        JSON.stringify({
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'input_text', text: conductorControlText }],
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-03-27T00:00:00.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'input_text', text: 'Fix the interrupt rendering bug.' }],
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-03-27T00:00:01.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Fixed.' }],
+          },
+        }),
+      ].join('\n');
+
+      const messages = parseCodexSessionContent(content);
+
+      expect(messages).toHaveLength(2);
+      expect(messages[0]).toMatchObject({ role: 'user', content: 'Fix the interrupt rendering bug.' });
+      expect(messages[1]).toMatchObject({ role: 'assistant', content: 'Fixed.' });
+    });
+
+    it('should strip leading Conductor control blocks and keep visible user text', () => {
+      const content = [
+        JSON.stringify({
+          timestamp: '2026-03-27T00:00:00.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [{
+              type: 'input_text',
+              text: [
+                '<system_instruction>',
+                'You are working inside Conductor.',
+                '</system_instruction>',
+                '',
+                '<turn_aborted>',
+                'The user interrupted the previous turn on purpose.',
+                '</turn_aborted>',
+                '',
+                'Hide the interrupt envelope, but keep this prompt.',
+              ].join('\n'),
+            }],
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-03-27T00:00:01.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Done.' }],
+          },
+        }),
+      ].join('\n');
+
+      const messages = parseCodexSessionContent(content);
+
+      expect(messages).toHaveLength(2);
+      expect(messages[0]).toMatchObject({
+        role: 'user',
+        content: 'Hide the interrupt envelope, but keep this prompt.',
+      });
+      expect(messages[1]).toMatchObject({ role: 'assistant', content: 'Done.' });
+    });
+
     it('should set displayContent stripping bracket context from user messages', () => {
       const content = [
         JSON.stringify({


### PR DESCRIPTION
## Summary
- Highlight current/open/running conversations in the history dropdown, show same-pane tab numbers, and expose open-in-new-tab actions for closed conversations.
- Add native hover titles to numeric tab chips.
- Strip Conductor control envelopes from Codex history user messages while preserving visible prompt text.

## Tests
- npm run typecheck -- --pretty false
- npm run test -- --runTestsByPath tests/unit/features/chat/controllers/ConversationController.test.ts tests/unit/features/chat/tabs/TabBar.test.ts tests/unit/providers/codex/history/CodexHistoryStore.test.ts
- npm run lint
- npm run build