### PR TITLE
fix: pin obsidian devDependency to ^1.12.3 instead of latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "jest": "^30.3.0",
     "jest-environment-jsdom": "^30.3.0",
-    "obsidian": "latest",
+    "obsidian": "^1.12.3",
     "ts-jest": "^29.4.9",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2"


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: `"obsidian": "latest"` in `devDependencies` resolves to the current npm dist-tag at install time; a future major obsidian release could silently introduce breaking API changes without any commit in this repo.

**Evidence**: `package-lock.json` shows `node_modules/obsidian` already resolved to `1.12.3` — `latest` is floating freely above the locked version on every fresh install.

**Fix**: Replace `"latest"` with `"^1.12.3"` to match the currently-resolved version; update deliberately when upgrading obsidian.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"SEC-unpinned-semver","fingerprint":"sha256:74ec9eea07014b8ff71de966d41ee83dbaa7d8b601a7c3cea698177d57e60dc5"}]}
nlpm-metadata-end -->