### PR TITLE
fix: focus chat input after opening Claudian

### DIFF
--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -748,6 +748,23 @@ export class ClaudianView extends ItemView {
     return this.tabManager?.getActiveTab() ?? null;
   }
 
+  /** Focuses the active tab input if the view has an active tab. */
+  focusActiveInput(): boolean {
+    const activeTab = this.getActiveTab();
+    if (!activeTab) {
+      return false;
+    }
+
+    const navigationController = activeTab.controllers.navigationController;
+    if (navigationController) {
+      navigationController.focusInput();
+      return true;
+    }
+
+    activeTab.dom.inputEl.focus();
+    return true;
+  }
+
   /** Gets the tab manager. */
   getTabManager(): TabManager | null {
     return this.tabManager;

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,10 +41,14 @@ import { buildCursorContext } from './utils/editor';
 import { revealWorkspaceLeaf } from './utils/obsidianCompat';
 import { getVaultPath } from './utils/path';
 
+const INPUT_FOCUS_RETRY_DELAY_MS = 100;
+const INPUT_FOCUS_MAX_ATTEMPTS = 3;
+
 function isClaudianView(value: unknown): value is ClaudianView {
   return !!value
     && typeof value === 'object'
-    && typeof (value as { getTabManager?: unknown }).getTabManager === 'function';
+    && typeof (value as { getTabManager?: unknown }).getTabManager === 'function'
+    && typeof (value as { focusActiveInput?: unknown }).focusActiveInput === 'function';
 }
 
 export default class ClaudianPlugin extends Plugin {
@@ -210,7 +214,30 @@ export default class ClaudianPlugin extends Plugin {
 
     if (leaf) {
       await revealWorkspaceLeaf(workspace, leaf);
+      this.focusInputAfterReveal(leaf);
     }
+  }
+
+  private focusInputAfterReveal(leaf: WorkspaceLeaf, attempt = 1): void {
+    window.setTimeout(() => {
+      const mostRecentLeaf = this.app.workspace.getMostRecentLeaf?.();
+      if (mostRecentLeaf && mostRecentLeaf !== leaf) {
+        return;
+      }
+
+      const { view } = leaf;
+      if (!isClaudianView(view)) {
+        if (attempt < INPUT_FOCUS_MAX_ATTEMPTS) {
+          this.focusInputAfterReveal(leaf, attempt + 1);
+        }
+        return;
+      }
+
+      const didFocus = view.focusActiveInput();
+      if (!didFocus && attempt < INPUT_FOCUS_MAX_ATTEMPTS) {
+        this.focusInputAfterReveal(leaf, attempt + 1);
+      }
+    }, INPUT_FOCUS_RETRY_DELAY_MS);
   }
 
   private getLeafForPlacement(placement: ChatViewPlacement): WorkspaceLeaf | null {

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -134,6 +134,60 @@ describe('ClaudianPlugin', () => {
       expect(mockApp.workspace.revealLeaf).toHaveBeenCalledWith(mockLeaf);
     });
 
+    it('should focus the active tab input after revealing a Claudian leaf', async () => {
+      const focusActiveInput = jest.fn().mockReturnValue(true);
+      const mockLeaf = {
+        id: 'existing-leaf',
+        view: {
+          getTabManager: jest.fn(),
+          focusActiveInput,
+        },
+      };
+      mockApp.workspace.getLeavesOfType.mockReturnValue([mockLeaf]);
+
+      await plugin.onload();
+
+      jest.useFakeTimers();
+      try {
+        await plugin.activateView();
+
+        expect(mockApp.workspace.revealLeaf).toHaveBeenCalledWith(mockLeaf);
+        expect(focusActiveInput).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(100);
+
+        expect(focusActiveInput).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('should not focus after reveal if another leaf becomes most recent', async () => {
+      const focusActiveInput = jest.fn().mockReturnValue(true);
+      const mockLeaf = {
+        id: 'existing-leaf',
+        view: {
+          getTabManager: jest.fn(),
+          focusActiveInput,
+        },
+      };
+      const otherLeaf = { id: 'other-leaf' };
+      mockApp.workspace.getLeavesOfType.mockReturnValue([mockLeaf]);
+      mockApp.workspace.getMostRecentLeaf = jest.fn().mockReturnValue(otherLeaf);
+
+      await plugin.onload();
+
+      jest.useFakeTimers();
+      try {
+        await plugin.activateView();
+        jest.advanceTimersByTime(100);
+
+        expect(focusActiveInput).not.toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
     it('should create new leaf in right sidebar by default if view does not exist', async () => {
       const mockRightLeaf = {
         setViewState: jest.fn().mockResolvedValue(undefined),
@@ -199,6 +253,43 @@ describe('ClaudianPlugin', () => {
         type: VIEW_TYPE_CLAUDIAN,
         active: true,
       });
+    });
+
+    it('should focus the active tab input after creating a main editor leaf', async () => {
+      const focusActiveInput = jest.fn()
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(true);
+      const mockMainLeaf = {
+        setViewState: jest.fn().mockResolvedValue(undefined),
+        view: {
+          getTabManager: jest.fn(),
+          focusActiveInput,
+        },
+      };
+      mockApp.workspace.getLeavesOfType.mockReturnValue([]);
+      mockApp.workspace.getLeaf.mockReturnValue(mockMainLeaf);
+
+      await plugin.onload();
+      plugin.settings.chatViewPlacement = 'main-tab';
+
+      jest.useFakeTimers();
+      try {
+        await plugin.activateView();
+
+        expect(mockApp.workspace.getLeaf).toHaveBeenCalledWith('tab');
+        expect(mockApp.workspace.revealLeaf).toHaveBeenCalledWith(mockMainLeaf);
+        expect(focusActiveInput).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(100);
+
+        expect(focusActiveInput).toHaveBeenCalledTimes(1);
+
+        jest.advanceTimersByTime(100);
+
+        expect(focusActiveInput).toHaveBeenCalledTimes(2);
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     it('should handle null main leaf gracefully when chatViewPlacement is main-tab', async () => {

--- a/tests/unit/features/chat/ClaudianView.test.ts
+++ b/tests/unit/features/chat/ClaudianView.test.ts
@@ -157,6 +157,56 @@ describe('ClaudianView tab controls', () => {
     expect(view.activeInputTabId).toBeNull();
   });
 
+  it('focuses active input through the navigation controller', () => {
+    const focusInput = jest.fn();
+    const inputFocus = jest.fn();
+    const view = Object.create(ClaudianView.prototype) as any;
+
+    view.tabManager = {
+      getActiveTab: jest.fn().mockReturnValue({
+        controllers: {
+          navigationController: { focusInput },
+        },
+        dom: {
+          inputEl: { focus: inputFocus },
+        },
+      }),
+    };
+
+    expect(view.focusActiveInput()).toBe(true);
+    expect(focusInput).toHaveBeenCalledTimes(1);
+    expect(inputFocus).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the active tab input element when no navigation controller exists', () => {
+    const inputFocus = jest.fn();
+    const view = Object.create(ClaudianView.prototype) as any;
+
+    view.tabManager = {
+      getActiveTab: jest.fn().mockReturnValue({
+        controllers: {
+          navigationController: null,
+        },
+        dom: {
+          inputEl: { focus: inputFocus },
+        },
+      }),
+    };
+
+    expect(view.focusActiveInput()).toBe(true);
+    expect(inputFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not focus when there is no active tab', () => {
+    const view = Object.create(ClaudianView.prototype) as any;
+
+    view.tabManager = {
+      getActiveTab: jest.fn().mockReturnValue(null),
+    };
+
+    expect(view.focusActiveInput()).toBe(false);
+  });
+
   it('toggles the history dropdown when the history button is clicked', () => {
     const historyDropdown = createMockEl();
     const view = Object.create(ClaudianView.prototype) as any;


### PR DESCRIPTION
## Summary
- focus the active Claudian chat input after `Open chat view` reveals an existing or newly-created leaf
- add `ClaudianView.focusActiveInput()` so the plugin entrypoint uses a view-level API instead of reaching into tab DOM internals
- retry focus briefly while a cold-open tab finishes restoring, and skip delayed focus if another leaf becomes most recent

## Root cause
`activateView()` revealed the Claudian leaf but never moved keyboard focus into the chat textarea, so commands/hotkeys could open the view while subsequent typing still went to the previously focused editor.

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run test` (242 suites, 5760 tests)
- `npm run build`

Fixes #739