### PR TITLE
Fix Codex history after compaction

### DIFF
--- a/src/providers/codex/CLAUDE.md
+++ b/src/providers/codex/CLAUDE.md
@@ -46,7 +46,7 @@ For normal turns, the turn ID comes from the `turn/start` RPC response. For comp
 
 ### JSONL Format Duality
 
-A single session file may contain both legacy (`type: 'event'`) and modern (`type: 'event_msg'`, `type: 'response_item'`) records. The parser scans all records and uses the modern path if any modern records are present. A `type: 'compacted'` record completely resets the turn context and replays from `replacement_history`.
+A single session file may contain both legacy (`type: 'event'`) and modern (`type: 'event_msg'`, `type: 'response_item'`) records. The parser scans all records and uses the modern path if any modern records are present. For visible history, do not replay `type: 'compacted'` `replacement_history`. Codex uses that field as compacted provider context, and real auto-compaction records may contain only user messages plus an encrypted compaction blob. Replaying it erases assistant responses and tool progress from the UI. The durable visible compaction marker is `event_msg:context_compacted`.
 
 ### Image Lifecycle
 

--- a/src/providers/codex/history/CodexHistoryStore.ts
+++ b/src/providers/codex/history/CodexHistoryStore.ts
@@ -107,11 +107,6 @@ interface PersistedCompactionPayload {
   encrypted_content?: string;
 }
 
-interface PersistedCompactedPayload {
-  message?: string;
-  replacement_history?: PersistedPayload[];
-}
-
 interface ParsedSessionRecord {
   timestamp: number;
   type?: string;
@@ -967,37 +962,6 @@ function processPersistedPayload(
   }
 }
 
-function applyCompactedReplacementHistory(
-  payload: PersistedCompactedPayload | undefined,
-  timestamp: number,
-  ctx: PersistedParseContext,
-): void {
-  ctx.turns.clear();
-  ctx.turnOrder.length = 0;
-  ctx.currentTurnId = null;
-  ctx.toolCallToTurn.clear();
-  ctx.suppressedToolOutputIds.clear();
-  ctx.terminalSessionToCommandId.clear();
-  ctx.stdinCallToCommandId.clear();
-  ctx.turnCounter = 0;
-
-  const replacementHistory = Array.isArray(payload?.replacement_history)
-    ? payload.replacement_history
-    : [];
-
-  for (const [index, item] of replacementHistory.entries()) {
-    processPersistedPayload(item, timestamp + index, index, ctx);
-  }
-
-  if (ctx.currentTurnId) {
-    const turn = ctx.turns.get(ctx.currentTurnId);
-    if (turn) {
-      closeAssistantBubble(turn);
-    }
-    ctx.currentTurnId = null;
-  }
-}
-
 // ---------------------------------------------------------------------------
 // event_msg processing
 // ---------------------------------------------------------------------------
@@ -1411,7 +1375,8 @@ function parseModernSessionTurns(records: ParsedSessionRecord[]): CodexParsedTur
     }
 
     if (parsed.type === 'compacted') {
-      applyCompactedReplacementHistory(parsed.payload as PersistedCompactedPayload | undefined, timestamp, ctx);
+      // Codex replacement_history is compacted provider context, not a role-complete
+      // UI transcript. The durable visible marker is event_msg:context_compacted.
       continue;
     }
 

--- a/tests/unit/providers/codex/history/CodexHistoryStore.test.ts
+++ b/tests/unit/providers/codex/history/CodexHistoryStore.test.ts
@@ -2090,13 +2090,16 @@ describe('CodexHistoryStore', () => {
   });
 
   describe('parseCodexSessionContent - context_compacted boundary', () => {
-    it('applies compacted replacement_history before rendering the compact boundary', () => {
+    it('preserves visible transcript records instead of replaying compacted replacement_history', () => {
       const content = [
         JSON.stringify({ timestamp: '2026-03-03T16:00:00.000Z', type: 'event_msg', payload: { type: 'task_started' } }),
         JSON.stringify({ timestamp: '2026-03-03T16:00:01.000Z', type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello' }] } }),
+        JSON.stringify({ timestamp: '2026-03-03T16:00:01.500Z', type: 'response_item', payload: { type: 'function_call', name: 'exec_command', call_id: 'call-1', arguments: '{"cmd":"npm test"}' } }),
+        JSON.stringify({ timestamp: '2026-03-03T16:00:01.700Z', type: 'response_item', payload: { type: 'function_call_output', call_id: 'call-1', output: 'Process exited with code 0\nOutput:\npassed' } }),
         JSON.stringify({ timestamp: '2026-03-03T16:00:02.000Z', type: 'response_item', payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'Hi there!' }] } }),
         JSON.stringify({ timestamp: '2026-03-03T16:00:03.000Z', type: 'event_msg', payload: { type: 'task_complete' } }),
-        // Compaction happens here
+        JSON.stringify({ timestamp: '2026-03-03T16:00:03.500Z', type: 'event_msg', payload: { type: 'task_started' } }),
+        // Compaction replacement_history is provider context, not visible UI history.
         JSON.stringify({
           timestamp: '2026-03-03T16:00:04.000Z',
           type: 'compacted',
@@ -2107,6 +2110,11 @@ describe('CodexHistoryStore', () => {
                 type: 'message',
                 role: 'user',
                 content: [{ type: 'input_text', text: '<COMPACTION_SUMMARY>\nSummary after compact' }],
+              },
+              {
+                type: 'message',
+                role: 'user',
+                content: [{ type: 'input_text', text: 'replacement-only user message' }],
               },
               {
                 type: 'compaction',
@@ -2125,11 +2133,23 @@ describe('CodexHistoryStore', () => {
 
       const messages = parseCodexSessionContent(content);
 
-      expect(messages.map(m => m.content)).not.toContain('hello');
-      expect(messages.map(m => m.content)).not.toContain('Hi there!');
+      expect(messages.map(m => m.content)).toContain('hello');
+      expect(messages.map(m => m.content)).toContain('Hi there!');
+      expect(messages.map(m => m.content)).not.toContain('<COMPACTION_SUMMARY>\nSummary after compact');
+      expect(messages.map(m => m.content)).not.toContain('replacement-only user message');
+
+      const firstAssistant = messages.find(m => m.role === 'assistant' && m.content === 'Hi there!');
+      expect(firstAssistant).toBeDefined();
+      expect(firstAssistant!.toolCalls).toHaveLength(1);
+      expect(firstAssistant!.toolCalls![0]).toMatchObject({
+        id: 'call-1',
+        name: 'Bash',
+        status: 'completed',
+      });
+
       expect(messages[0]).toMatchObject({
         role: 'user',
-        content: '<COMPACTION_SUMMARY>\nSummary after compact',
+        content: 'hello',
       });
 
       const compactMsg = messages.find(m =>
@@ -2139,20 +2159,20 @@ describe('CodexHistoryStore', () => {
       expect(compactMsg!.role).toBe('assistant');
       expect(compactMsg!.content).toBe('');
 
-      // context_compacted should appear after the compacted replacement history
+      // context_compacted should appear after the preserved pre-compaction transcript.
       const compactIdx = messages.indexOf(compactMsg!);
       expect(compactIdx).toBeGreaterThan(0);
 
       const beforeCompact = messages[compactIdx - 1];
-      expect(beforeCompact.role).toBe('user');
-      expect(beforeCompact.content).toBe('<COMPACTION_SUMMARY>\nSummary after compact');
+      expect(beforeCompact.role).toBe('assistant');
+      expect(beforeCompact.content).toBe('Hi there!');
 
       const afterCompact = messages[compactIdx + 1];
       expect(afterCompact.role).toBe('user');
       expect(afterCompact.content).toContain('continue');
     });
 
-    it('uses the latest compacted replacement_history when multiple compactions occur', () => {
+    it('renders compact boundaries without surfacing replacement_history summaries', () => {
       const content = [
         JSON.stringify({
           timestamp: '2026-03-03T16:00:00.000Z',
@@ -2189,14 +2209,12 @@ describe('CodexHistoryStore', () => {
       const messages = parseCodexSessionContent(content);
 
       expect(messages).toHaveLength(2);
-      expect(messages[0]).toMatchObject({
-        role: 'user',
-        content: 'Second summary',
-      });
+      expect(messages.map(m => m.content)).not.toContain('First summary');
+      expect(messages.map(m => m.content)).not.toContain('Second summary');
       const compactMessages = messages.filter(m =>
         m.contentBlocks?.some(b => b.type === 'context_compacted'),
       );
-      expect(compactMessages).toHaveLength(1);
+      expect(compactMessages).toHaveLength(2);
     });
   });
 });


### PR DESCRIPTION
Fixes Codex session rehydration after auto-compaction by treating compacted replacement_history as provider context instead of visible chat history. Keeps the durable context_compacted boundary while preserving assistant responses and tool progress from the original transcript records. Updates Codex history tests and provider notes to lock in the contract.