### PR TITLE
Fix first-turn Claude rewind button

### DIFF
--- a/src/core/runtime/ChatRuntime.ts
+++ b/src/core/runtime/ChatRuntime.ts
@@ -44,7 +44,7 @@ export interface ChatRuntime {
   getSupportedCommands(): Promise<SlashCommand[]>;
   getAuxiliaryModel?(): string | null;
   cleanup(): void;
-  rewind(userMessageId: string, assistantMessageId: string, mode?: ChatRewindMode): Promise<ChatRewindResult>;
+  rewind(userMessageId: string, assistantMessageId: string | undefined, mode?: ChatRewindMode): Promise<ChatRewindResult>;
   setApprovalCallback(callback: ApprovalCallback | null): void;
   setApprovalDismisser(dismisser: (() => void) | null): void;
   setAskUserQuestionCallback(callback: AskUserQuestionCallback | null): void;

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -54,6 +54,7 @@ export interface ConversationControllerDeps {
 
 type SaveOptions = {
   resumeAtMessageId?: string;
+  resetProviderSession?: boolean;
 };
 
 export type HistoryConversationOpenState = 'closed' | 'open' | 'current';
@@ -310,7 +311,7 @@ export class ConversationController {
     }
 
     const rewindCtx = findRewindContext(msgs, userIdx);
-    if (!rewindCtx.hasResponse || !rewindCtx.prevAssistantUuid) {
+    if (!rewindCtx.hasResponse) {
       new Notice(t('chat.rewind.unavailableNoUuid'));
       return;
     }
@@ -361,7 +362,10 @@ export class ConversationController {
     const filesChanged = result.filesChanged?.length ?? 0;
     let saveError: string | null = null;
     try {
-      await this.save(false, { resumeAtMessageId: prevAssistantUuid });
+      await this.save(false, {
+        resumeAtMessageId: prevAssistantUuid,
+        resetProviderSession: !prevAssistantUuid,
+      });
     } catch (e) {
       saveError = e instanceof Error ? e.message : 'Failed to save';
     }
@@ -422,7 +426,7 @@ export class ConversationController {
 
     const conversation = plugin.getConversationSync(state.currentConversationId!);
 
-    const { updates: sessionUpdates } = agentService
+    const { updates: sessionUpdates } = agentService && !options?.resetProviderSession
       ? agentService.buildSessionUpdates({ conversation, sessionInvalidated })
       : { updates: {} };
 
@@ -441,6 +445,10 @@ export class ConversationController {
 
     if (options) {
       updates.resumeAtMessageId = options.resumeAtMessageId;
+      if (options.resetProviderSession) {
+        updates.sessionId = null;
+        updates.providerState = undefined;
+      }
     }
 
     await plugin.updateConversation(state.currentConversationId!, updates);

--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -277,11 +277,11 @@ export class MessageRenderer {
         void this.renderContent(textEl, textToShow);
         this.addUserCopyButton(msgEl, textToShow);
       }
-      if (msg.userMessageId && this.isRewindEligible(allMessages, index)) {
-        if (this.rewindCallback) {
+      if (msg.userMessageId) {
+        if (this.rewindCallback && this.isRewindEligible(allMessages, index)) {
           this.addRewindButton(msgEl, msg.id);
         }
-        if (this.forkCallback) {
+        if (this.forkCallback && this.isForkEligible(allMessages, index)) {
           this.addForkButton(msgEl, msg.id);
         }
       }
@@ -312,6 +312,12 @@ export class MessageRenderer {
   }
 
   private isRewindEligible(allMessages?: ChatMessage[], index?: number): boolean {
+    if (!allMessages || index === undefined) return false;
+    const ctx = findRewindContext(allMessages, index);
+    return ctx.hasResponse;
+  }
+
+  private isForkEligible(allMessages?: ChatMessage[], index?: number): boolean {
     if (!allMessages || index === undefined) return false;
     const ctx = findRewindContext(allMessages, index);
     return !!ctx.prevAssistantUuid && ctx.hasResponse;
@@ -767,22 +773,32 @@ export class MessageRenderer {
 
   refreshActionButtons(msg: ChatMessage, allMessages?: ChatMessage[], index?: number): void {
     if (!msg.userMessageId) return;
-    if (!this.isRewindEligible(allMessages, index)) return;
+    const canRewind = this.isRewindEligible(allMessages, index);
+    const canFork = this.isForkEligible(allMessages, index);
+    if (!canRewind && !canFork) return;
     const msgEl = this.liveMessageEls.get(msg.id);
     if (!msgEl) return;
 
-    if (this.rewindCallback && !msgEl.querySelector('.claudian-message-rewind-btn')) {
+    if (canRewind && this.rewindCallback && !msgEl.querySelector('.claudian-message-rewind-btn')) {
       this.addRewindButton(msgEl, msg.id);
     }
-    if (this.forkCallback && !msgEl.querySelector('.claudian-message-fork-btn')) {
+    if (canFork && this.forkCallback && !msgEl.querySelector('.claudian-message-fork-btn')) {
       this.addForkButton(msgEl, msg.id);
     }
-    this.cleanupLiveMessageEl(msg.id, msgEl);
+    this.cleanupLiveMessageEl(msg.id, msgEl, { canRewind, canFork });
   }
 
-  private cleanupLiveMessageEl(msgId: string, msgEl: HTMLElement): void {
-    const needsRewind = this.rewindCallback && !msgEl.querySelector('.claudian-message-rewind-btn');
-    const needsFork = this.forkCallback && !msgEl.querySelector('.claudian-message-fork-btn');
+  private cleanupLiveMessageEl(
+    msgId: string,
+    msgEl: HTMLElement,
+    expectedActions: { canRewind: boolean; canFork: boolean },
+  ): void {
+    const needsRewind = expectedActions.canRewind
+      && this.rewindCallback
+      && !msgEl.querySelector('.claudian-message-rewind-btn');
+    const needsFork = expectedActions.canFork
+      && this.forkCallback
+      && !msgEl.querySelector('.claudian-message-fork-btn');
     if (!needsRewind && !needsFork) {
       this.liveMessageEls.delete(msgId);
     }

--- a/src/providers/claude/runtime/ClaudeChatRuntime.ts
+++ b/src/providers/claude/runtime/ClaudeChatRuntime.ts
@@ -1743,7 +1743,7 @@ export class ClaudianService implements ChatRuntime {
 
   async rewind(
     userMessageId: string,
-    assistantMessageId: string,
+    assistantMessageId: string | undefined,
     mode: ChatRewindMode = 'code-and-conversation',
   ): Promise<ChatRewindResult> {
     return executeClaudeRewind(userMessageId, {
@@ -1754,6 +1754,7 @@ export class ClaudianService implements ChatRuntime {
       setPendingResumeAt: (resumeAt) => {
         this.pendingResumeAt = resumeAt;
       },
+      resetSession: () => this.resetSession(),
       vaultPath: this.vaultPath,
     });
   }

--- a/src/providers/claude/runtime/ClaudeRewindService.ts
+++ b/src/providers/claude/runtime/ClaudeRewindService.ts
@@ -32,11 +32,12 @@ export interface ClaudeRewindBackup {
 }
 
 export interface ExecuteClaudeRewindDeps {
-  assistantMessageId: string;
+  assistantMessageId: string | undefined;
   mode: ChatRewindMode;
   rewindFiles: (userMessageId: string, dryRun?: boolean) => Promise<RewindFilesResult>;
   closePersistentQuery: (reason: string) => void;
   setPendingResumeAt: (assistantMessageId: string) => void;
+  resetSession: () => void;
   vaultPath: string | null;
 }
 
@@ -170,8 +171,12 @@ export async function executeClaudeRewind(
   deps: ExecuteClaudeRewindDeps,
 ): Promise<ChatRewindResult> {
   if (deps.mode === 'conversation') {
-    deps.setPendingResumeAt(deps.assistantMessageId);
-    deps.closePersistentQuery('conversation rewind');
+    if (deps.assistantMessageId) {
+      deps.setPendingResumeAt(deps.assistantMessageId);
+      deps.closePersistentQuery('conversation rewind');
+    } else {
+      deps.resetSession();
+    }
     return { canRewind: true, filesChanged: [] };
   }
 
@@ -190,8 +195,12 @@ export async function executeClaudeRewind(
       return result;
     }
 
-    deps.setPendingResumeAt(deps.assistantMessageId);
-    deps.closePersistentQuery('rewind');
+    if (deps.assistantMessageId) {
+      deps.setPendingResumeAt(deps.assistantMessageId);
+      deps.closePersistentQuery('rewind');
+    } else {
+      deps.resetSession();
+    }
     return {
       ...result,
       filesChanged: preview.filesChanged,

--- a/src/providers/codex/runtime/CodexChatRuntime.ts
+++ b/src/providers/codex/runtime/CodexChatRuntime.ts
@@ -626,7 +626,7 @@ export class CodexChatRuntime implements ChatRuntime {
 
   async rewind(
     _userMessageId: string,
-    _assistantMessageId: string,
+    _assistantMessageId: string | undefined,
     _mode?: ChatRewindMode,
   ): Promise<ChatRewindResult> {
     return { canRewind: false, error: 'Codex does not support rewind' };

--- a/src/providers/opencode/runtime/OpencodeChatRuntime.ts
+++ b/src/providers/opencode/runtime/OpencodeChatRuntime.ts
@@ -510,7 +510,7 @@ export class OpencodeChatRuntime implements ChatRuntime {
 
   async rewind(
     _userMessageId: string,
-    _assistantMessageId: string,
+    _assistantMessageId: string | undefined,
     _mode?: ChatRewindMode,
   ): Promise<ChatRewindResult> {
     return { canRewind: false };

--- a/src/providers/pi/runtime/PiChatRuntime.ts
+++ b/src/providers/pi/runtime/PiChatRuntime.ts
@@ -438,7 +438,7 @@ export class PiChatRuntime implements ChatRuntime {
 
   async rewind(
     _userMessageId: string,
-    _assistantMessageId: string,
+    _assistantMessageId: string | undefined,
     _mode?: ChatRewindMode,
   ): Promise<ChatRewindResult> {
     return { canRewind: false };

--- a/tests/unit/features/chat/controllers/ConversationController.test.ts
+++ b/tests/unit/features/chat/controllers/ConversationController.test.ts
@@ -2574,7 +2574,7 @@ describe('ConversationController - Rewind', () => {
     expect(mockAgentService.rewind).not.toHaveBeenCalled();
   });
 
-  it('should show Notice when no previous assistant with uuid exists', async () => {
+  it('should allow rewind when no previous assistant with uuid exists', async () => {
     deps.state.messages = [
       { id: 'm1', role: 'user', content: 'test', timestamp: 1, userMessageId: 'u1' },
       { id: 'm2', role: 'assistant', content: '', timestamp: 2, assistantMessageId: 'a1' },
@@ -2582,8 +2582,7 @@ describe('ConversationController - Rewind', () => {
 
     await controller.rewind('m1');
 
-    expect(mockNotice).toHaveBeenCalled();
-    expect(mockAgentService.rewind).not.toHaveBeenCalled();
+    expect(mockAgentService.rewind).toHaveBeenCalledWith('u1', undefined, 'code-and-conversation');
   });
 
   it('should show Notice when no response assistant with uuid exists', async () => {
@@ -2663,6 +2662,37 @@ describe('ConversationController - Rewind', () => {
     expect(noticeMsg).toContain('1');
 
     truncateSpy.mockRestore();
+  });
+
+  it('should rewind to before the first user message and clear provider session state', async () => {
+    deps.state.currentConversationId = 'conv-1';
+    deps.state.messages = [
+      { id: 'm1', role: 'user', content: 'first prompt', timestamp: 1, userMessageId: 'user-uuid' },
+      { id: 'm2', role: 'assistant', content: 'resp', timestamp: 2, assistantMessageId: 'resp-a' },
+    ];
+    (deps.plugin.getConversationSync as jest.Mock).mockReturnValue({
+      id: 'conv-1',
+      providerId: 'claude',
+      sessionId: 'old-session',
+      providerState: { providerSessionId: 'old-session' },
+      messages: deps.state.messages,
+    });
+
+    await controller.rewind('m1');
+
+    expect(mockAgentService.rewind).toHaveBeenCalledWith('user-uuid', undefined, 'code-and-conversation');
+    expect(mockAgentService.buildSessionUpdates).not.toHaveBeenCalled();
+    expect(deps.state.messages).toEqual([]);
+    expect(deps.plugin.updateConversation).toHaveBeenCalledWith(
+      'conv-1',
+      expect.objectContaining({
+        messages: [],
+        sessionId: null,
+        providerState: undefined,
+        resumeAtMessageId: undefined,
+      })
+    );
+    expect(deps.getInputEl().value).toBe('first prompt');
   });
 
   it('should pass conversation-only mode and keep file changes', async () => {

--- a/tests/unit/features/chat/rendering/MessageRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/MessageRenderer.test.ts
@@ -346,6 +346,32 @@ describe('MessageRenderer', () => {
     expect(messagesEl.querySelector('.claudian-message-rewind-btn')).not.toBeNull();
   });
 
+  it('adds rewind but not fork for a completed first user message', () => {
+    const messagesEl = createMockEl();
+    const rewindCallback = jest.fn().mockResolvedValue(undefined);
+    const forkCallback = jest.fn().mockResolvedValue(undefined);
+    const renderer = new MessageRenderer(
+      { app: {}, settings: { mediaFolder: '' } } as any,
+      createMockComponent() as any,
+      messagesEl,
+      rewindCallback,
+      forkCallback,
+      mockCapabilities(),
+    );
+    jest.spyOn(renderer, 'renderContent').mockResolvedValue(undefined);
+
+    const allMessages: ChatMessage[] = [
+      { id: 'u1', role: 'user', content: 'hello', timestamp: 1, userMessageId: 'user-u' },
+      { id: 'a1', role: 'assistant', content: 'response', timestamp: 2, assistantMessageId: 'resp-a' },
+    ];
+
+    renderer.renderStoredMessage(allMessages[0], allMessages, 0);
+
+    expect(messagesEl.querySelector('.claudian-message-rewind-btn')).not.toBeNull();
+    expect(messagesEl.querySelector('.claudian-message-fork-btn')).toBeNull();
+    expect((renderer as any).liveMessageEls.has('u1')).toBe(false);
+  });
+
   it('does not add a rewind button when stored render is called without context', () => {
     const messagesEl = createMockEl();
     const rewindCallback = jest.fn().mockResolvedValue(undefined);
@@ -402,6 +428,38 @@ describe('MessageRenderer', () => {
     await Promise.resolve();
 
     expect(rewindCallback).toHaveBeenCalledWith('u1', 'conversation');
+  });
+
+  it('refreshes rewind but not fork for a streamed first user message', () => {
+    const messagesEl = createMockEl();
+    const rewindCallback = jest.fn().mockResolvedValue(undefined);
+    const forkCallback = jest.fn().mockResolvedValue(undefined);
+    const renderer = new MessageRenderer(
+      { app: {}, settings: { mediaFolder: '' } } as any,
+      createMockComponent() as any,
+      messagesEl,
+      rewindCallback,
+      forkCallback,
+      mockCapabilities(),
+    );
+    jest.spyOn(renderer, 'renderContent').mockResolvedValue(undefined);
+
+    const userMsg: ChatMessage = {
+      id: 'u1',
+      role: 'user',
+      content: 'hello',
+      timestamp: 1,
+      userMessageId: 'user-u',
+    };
+    renderer.addMessage(userMsg);
+
+    renderer.refreshActionButtons(userMsg, [
+      userMsg,
+      { id: 'a1', role: 'assistant', content: 'response', timestamp: 2, assistantMessageId: 'resp-a' },
+    ], 0);
+
+    expect(messagesEl.querySelector('.claudian-message-rewind-btn')).not.toBeNull();
+    expect(messagesEl.querySelector('.claudian-message-fork-btn')).toBeNull();
   });
 
   // ============================================

--- a/tests/unit/providers/claude/runtime/ClaudianService.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudianService.test.ts
@@ -3541,6 +3541,24 @@ describe('ClaudianService', () => {
       expect((service as any).persistentQuery).toBeNull();
     });
 
+    it('conversation-only mode resets the session when rewinding before the first assistant checkpoint', async () => {
+      const mockRewindFiles = jest.fn();
+      const mockInterrupt = jest.fn().mockResolvedValue(undefined);
+      service.setSessionId('old-session');
+      (service as any).persistentQuery = { rewindFiles: mockRewindFiles, interrupt: mockInterrupt };
+      (service as any).messageChannel = { close: jest.fn() };
+      (service as any).queryAbortController = { abort: jest.fn() };
+      (service as any).shuttingDown = false;
+
+      const result = await service.rewind('user-uuid', undefined, 'conversation');
+
+      expect(mockRewindFiles).not.toHaveBeenCalled();
+      expect(result).toEqual({ canRewind: true, filesChanged: [] });
+      expect((service as any).pendingResumeAt).toBeUndefined();
+      expect(service.getSessionId()).toBeNull();
+      expect((service as any).persistentQuery).toBeNull();
+    });
+
     it('dry-runs first to capture filesChanged, then performs actual rewind', async () => {
       // SDK only returns filesChanged on dry run, not on actual rewind
       const mockRewindFiles = jest.fn()
@@ -3562,6 +3580,26 @@ describe('ClaudianService', () => {
       expect(result.insertions).toBe(5);
       expect(result.deletions).toBe(3);
       expect((service as any).pendingResumeAt).toBe('assistant-uuid');
+      expect((service as any).persistentQuery).toBeNull();
+    });
+
+    it('resets the session after code rewind without a previous assistant checkpoint', async () => {
+      const mockRewindFiles = jest.fn()
+        .mockResolvedValueOnce({ canRewind: true, filesChanged: ['a.txt'] })
+        .mockResolvedValueOnce({ canRewind: true });
+      const mockInterrupt = jest.fn().mockResolvedValue(undefined);
+      service.setSessionId('old-session');
+      (service as any).persistentQuery = { rewindFiles: mockRewindFiles, interrupt: mockInterrupt };
+      (service as any).messageChannel = { close: jest.fn() };
+      (service as any).queryAbortController = { abort: jest.fn() };
+      (service as any).shuttingDown = false;
+
+      const result = await service.rewind('user-uuid', undefined);
+
+      expect(result.canRewind).toBe(true);
+      expect(result.filesChanged).toEqual(['a.txt']);
+      expect((service as any).pendingResumeAt).toBeUndefined();
+      expect(service.getSessionId()).toBeNull();
       expect((service as any).persistentQuery).toBeNull();
     });
 


### PR DESCRIPTION
Restores the Claude rewind action for the first completed user message in a session, where there is no previous assistant checkpoint to resume from. Rewind now accepts a missing assistant checkpoint for that start-of-session case and clears Claude provider session metadata so the next send starts from the reverted state. Fork remains gated on a previous assistant checkpoint. Tests cover stored and streamed first-message buttons plus Claude runtime/session reset behavior.