### PR TITLE
fix: include attached file chips in chat context

### DIFF
--- a/src/core/runtime/QueuedTurn.ts
+++ b/src/core/runtime/QueuedTurn.ts
@@ -10,6 +10,9 @@ export function cloneChatTurnRequest(request: ChatTurnRequest): ChatTurnRequest 
   return {
     ...request,
     images: cloneImages(request.images),
+    contextFiles: request.contextFiles
+      ? [...request.contextFiles]
+      : undefined,
     externalContextPaths: request.externalContextPaths
       ? [...request.externalContextPaths]
       : undefined,
@@ -40,6 +43,10 @@ export function mergeQueuedChatTurns(
       text: mergeText(existingRequest.text, incomingRequest.text),
       images: mergeImages(existingRequest.images, incomingRequest.images),
       currentNotePath: incomingRequest.currentNotePath ?? existingRequest.currentNotePath,
+      contextFiles: mergeStringLists(
+        existingRequest.contextFiles,
+        incomingRequest.contextFiles,
+      ),
       externalContextPaths: mergeStringLists(
         existingRequest.externalContextPaths,
         incomingRequest.externalContextPaths,

--- a/src/core/runtime/types.ts
+++ b/src/core/runtime/types.ts
@@ -46,6 +46,7 @@ export interface ChatTurnRequest {
   text: string;
   images?: ImageAttachment[];
   currentNotePath?: string;
+  contextFiles?: string[];
   editorSelection?: EditorSelectionContext | null;
   browserSelection?: BrowserSelectionContext | null;
   canvasSelection?: CanvasSelectionContext | null;

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -723,6 +723,7 @@ export class InputController {
 
     const currentNotePath = fileContextManager?.getCurrentNotePath() || null;
     const shouldSendCurrentNote = fileContextManager?.shouldSendCurrentNote(currentNotePath) ?? false;
+    const currentNoteContextPath = shouldSendCurrentNote && currentNotePath ? currentNotePath : null;
 
     const editorContext = options.editorContextOverride !== undefined
       ? options.editorContextOverride
@@ -739,6 +740,15 @@ export class InputController {
     const transformedText = !isCompact && fileContextManager
       ? fileContextManager.transformContextMentions(options.content)
       : options.content;
+    const attachedFiles = !isCompact && fileContextManager
+      ? Array.from(fileContextManager.getAttachedFiles())
+      : [];
+    const contextFiles = attachedFiles
+      .map(filePath => filePath.trim())
+      .filter(filePath => filePath.length > 0 && filePath !== currentNoteContextPath);
+    const dedupedContextFiles = contextFiles.length > 0
+      ? Array.from(new Set(contextFiles))
+      : undefined;
     const enabledMcpServers = mcpServerSelector?.getEnabledServers();
 
     return {
@@ -746,7 +756,8 @@ export class InputController {
       turnRequest: {
         text: transformedText,
         images: options.images,
-        currentNotePath: shouldSendCurrentNote && currentNotePath ? currentNotePath : undefined,
+        currentNotePath: currentNoteContextPath ?? undefined,
+        contextFiles: dedupedContextFiles,
         editorSelection: editorContext,
         browserSelection: browserContext,
         canvasSelection: canvasContext,

--- a/src/providers/claude/prompt/ClaudeTurnEncoder.ts
+++ b/src/providers/claude/prompt/ClaudeTurnEncoder.ts
@@ -2,7 +2,7 @@ import type { McpServerManager } from '../../../core/mcp/McpServerManager';
 import type { ChatTurnRequest, PreparedChatTurn } from '../../../core/runtime/types';
 import { appendBrowserContext } from '../../../utils/browser';
 import { appendCanvasContext } from '../../../utils/canvas';
-import { appendCurrentNote } from '../../../utils/context';
+import { appendContextFiles, appendCurrentNote } from '../../../utils/context';
 import { appendEditorContext } from '../../../utils/editor';
 
 function isCompactCommand(text: string): boolean {
@@ -19,6 +19,10 @@ export function encodeClaudeTurn(
   if (!isCompact) {
     if (request.currentNotePath) {
       persistedContent = appendCurrentNote(persistedContent, request.currentNotePath);
+    }
+
+    if (request.contextFiles && request.contextFiles.length > 0) {
+      persistedContent = appendContextFiles(persistedContent, request.contextFiles);
     }
 
     if (request.editorSelection) {

--- a/src/providers/codex/prompt/encodeCodexTurn.ts
+++ b/src/providers/codex/prompt/encodeCodexTurn.ts
@@ -1,4 +1,5 @@
 import type { ChatTurnRequest, PreparedChatTurn } from '../../../core/runtime/types';
+import { appendContextFiles } from '../../../utils/context';
 
 function isCompactCommand(text: string): boolean {
   return /^\/compact(\s|$)/i.test(text);
@@ -45,7 +46,10 @@ export function encodeCodexTurn(request: ChatTurnRequest): PreparedChatTurn {
     }
   }
 
-  const prompt = sections.join('');
+  let prompt = sections.join('');
+  if (request.contextFiles && request.contextFiles.length > 0) {
+    prompt = appendContextFiles(prompt, request.contextFiles);
+  }
 
   return {
     request,

--- a/src/providers/opencode/runtime/buildOpencodePrompt.ts
+++ b/src/providers/opencode/runtime/buildOpencodePrompt.ts
@@ -2,7 +2,7 @@ import type { ChatTurnRequest } from '../../../core/runtime/types';
 import type { ChatMessage } from '../../../core/types';
 import { appendBrowserContext } from '../../../utils/browser';
 import { appendCanvasContext } from '../../../utils/canvas';
-import { appendCurrentNote } from '../../../utils/context';
+import { appendContextFiles, appendCurrentNote } from '../../../utils/context';
 import { appendEditorContext } from '../../../utils/editor';
 import { buildContextFromHistory, buildPromptWithHistoryContext } from '../../../utils/session';
 import type { AcpContentBlock } from '../../acp';
@@ -15,6 +15,10 @@ export function buildOpencodePromptText(
 
   if (request.currentNotePath) {
     prompt = appendCurrentNote(prompt, request.currentNotePath);
+  }
+
+  if (request.contextFiles && request.contextFiles.length > 0) {
+    prompt = appendContextFiles(prompt, request.contextFiles);
   }
 
   if (request.editorSelection && request.editorSelection.mode !== 'none') {

--- a/src/providers/pi/runtime/buildPiPrompt.ts
+++ b/src/providers/pi/runtime/buildPiPrompt.ts
@@ -2,7 +2,7 @@ import type { ChatTurnRequest } from '../../../core/runtime/types';
 import type { ChatMessage, ImageAttachment } from '../../../core/types';
 import { appendBrowserContext } from '../../../utils/browser';
 import { appendCanvasContext } from '../../../utils/canvas';
-import { appendCurrentNote } from '../../../utils/context';
+import { appendContextFiles, appendCurrentNote } from '../../../utils/context';
 import { appendEditorContext } from '../../../utils/editor';
 import { buildContextFromHistory, buildPromptWithHistoryContext } from '../../../utils/session';
 
@@ -20,6 +20,10 @@ export function buildPiPromptText(
 
   if (request.currentNotePath) {
     prompt = appendCurrentNote(prompt, request.currentNotePath);
+  }
+
+  if (request.contextFiles && request.contextFiles.length > 0) {
+    prompt = appendContextFiles(prompt, request.contextFiles);
   }
 
   if (request.editorSelection && request.editorSelection.mode !== 'none') {

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -34,6 +34,7 @@ function createMockFileContextManager() {
   return {
     startSession: jest.fn(),
     getCurrentNotePath: jest.fn().mockReturnValue(null),
+    getAttachedFiles: jest.fn().mockReturnValue(new Set<string>()),
     shouldSendCurrentNote: jest.fn().mockReturnValue(false),
     markCurrentNoteSent: jest.fn(),
     transformContextMentions: jest.fn().mockImplementation((text: string) => text),
@@ -172,6 +173,7 @@ function createMockDeps(overrides: Partial<InputControllerDeps> = {}): InputCont
     getFileContextManager: () => ({
       startSession: jest.fn(),
       getCurrentNotePath: jest.fn().mockReturnValue(null),
+      getAttachedFiles: jest.fn().mockReturnValue(new Set<string>()),
       shouldSendCurrentNote: jest.fn().mockReturnValue(false),
       markCurrentNoteSent: jest.fn(),
       transformContextMentions: jest.fn().mockImplementation((text: string) => text),
@@ -977,12 +979,79 @@ describe('InputController - Message Queue', () => {
       expect(deps.state.messages[0].content).not.toBe('@server-a MCP hello');
     });
 
+    it('should pass an already-sent current note chip as focused context files', async () => {
+      const fileContextManager = createMockFileContextManager();
+      (fileContextManager.getCurrentNotePath as jest.Mock).mockReturnValue('notes/session.md');
+      (fileContextManager.shouldSendCurrentNote as jest.Mock).mockReturnValue(false);
+      (fileContextManager.getAttachedFiles as jest.Mock).mockReturnValue(new Set([
+        'notes/session.md',
+      ]));
+
+      deps = createSendableDeps({
+        getFileContextManager: () => fileContextManager as any,
+      });
+      (deps as any).mockAgentService.query = jest.fn().mockImplementation(() => createMockStream([{ type: 'done' }]));
+
+      inputEl = deps.getInputEl() as ReturnType<typeof createMockInputEl>;
+      inputEl.value = 'Use the attached note';
+      controller = new InputController(deps);
+
+      await controller.sendMessage();
+
+      const prepareTurnCall = ((deps as any).mockAgentService.prepareTurn as jest.Mock).mock.calls[0];
+      expect(prepareTurnCall[0]).toMatchObject({
+        text: 'Use the attached note',
+        currentNotePath: undefined,
+        contextFiles: ['notes/session.md'],
+      });
+
+      const queryCall = ((deps as any).mockAgentService.query as jest.Mock).mock.calls[0];
+      expect(queryCall[0].prompt).toContain('<context_files>\nnotes/session.md\n</context_files>');
+      expect(queryCall[0].prompt).not.toContain('<current_note>');
+    });
+
+    it('should pass attached file chips as deduped focused context files', async () => {
+      const fileContextManager = createMockFileContextManager();
+      (fileContextManager.getCurrentNotePath as jest.Mock).mockReturnValue('notes/current.md');
+      (fileContextManager.shouldSendCurrentNote as jest.Mock).mockReturnValue(true);
+      (fileContextManager.getAttachedFiles as jest.Mock).mockReturnValue(new Set([
+        'notes/current.md',
+        'notes/attached.md',
+        'notes/spaced.md',
+        ' notes/spaced.md ',
+        '',
+      ]));
+
+      deps = createSendableDeps({
+        getFileContextManager: () => fileContextManager as any,
+      });
+      (deps as any).mockAgentService.query = jest.fn().mockImplementation(() => createMockStream([{ type: 'done' }]));
+
+      inputEl = deps.getInputEl() as ReturnType<typeof createMockInputEl>;
+      inputEl.value = 'Review the attached notes';
+      controller = new InputController(deps);
+
+      await controller.sendMessage();
+
+      const prepareTurnCall = ((deps as any).mockAgentService.prepareTurn as jest.Mock).mock.calls[0];
+      expect(prepareTurnCall[0]).toMatchObject({
+        text: 'Review the attached notes',
+        currentNotePath: 'notes/current.md',
+        contextFiles: ['notes/attached.md', 'notes/spaced.md'],
+      });
+
+      const queryCall = ((deps as any).mockAgentService.query as jest.Mock).mock.calls[0];
+      expect(queryCall[0].prompt).toContain('<current_note>\nnotes/current.md\n</current_note>');
+      expect(queryCall[0].prompt).toContain('<context_files>\nnotes/attached.md, notes/spaced.md\n</context_files>');
+    });
+
     it('should prepend current note only once per session', async () => {
       const prompts: string[] = [];
       let currentNoteSent = false;
       const fileContextManager = {
         startSession: jest.fn(),
         getCurrentNotePath: jest.fn().mockReturnValue('notes/session.md'),
+        getAttachedFiles: jest.fn().mockReturnValue(new Set<string>()),
         shouldSendCurrentNote: jest.fn().mockImplementation(() => !currentNoteSent),
         markCurrentNoteSent: jest.fn().mockImplementation(() => { currentNoteSent = true; }),
         transformContextMentions: jest.fn().mockImplementation((text: string) => text),
@@ -1008,6 +1077,7 @@ describe('InputController - Message Queue', () => {
       const fileContextManager = {
         startSession: jest.fn(),
         getCurrentNotePath: jest.fn().mockReturnValue('notes/session.md'),
+        getAttachedFiles: jest.fn().mockReturnValue(new Set(['notes/session.md'])),
         shouldSendCurrentNote: jest.fn().mockReturnValue(true),
         markCurrentNoteSent: jest.fn(),
         transformContextMentions: jest.fn().mockImplementation((text: string) => text),
@@ -1026,6 +1096,8 @@ describe('InputController - Message Queue', () => {
 
       expect(deps.state.messages[0].content).toBe('/compact');
       expect(deps.state.messages[0].currentNote).toBeUndefined();
+      const prepareTurnCall = ((deps as any).mockAgentService.prepareTurn as jest.Mock).mock.calls[0];
+      expect(prepareTurnCall[0].contextFiles).toBeUndefined();
     });
 
     it('should include MCP options in query when mentions are present', async () => {

--- a/tests/unit/providers/claude/prompt/ClaudeTurnEncoder.test.ts
+++ b/tests/unit/providers/claude/prompt/ClaudeTurnEncoder.test.ts
@@ -47,6 +47,7 @@ describe('encodeClaudeTurn', () => {
     const request: ChatTurnRequest = {
       text: '/compact',
       currentNotePath: 'notes/test.md',
+      contextFiles: ['notes/a.md'],
       editorSelection: { notePath: 'test.md', mode: 'selection', selectedText: 'selected' } as any,
       browserSelection: { source: 'surfing-view', selectedText: 'browser text' } as any,
     };
@@ -54,6 +55,7 @@ describe('encodeClaudeTurn', () => {
 
     expect(result.persistedContent).toBe('/compact');
     expect(result.prompt).toBe('/compact');
+    expect(result.prompt).not.toContain('<context_files>');
   });
 
   it('should append current note context', () => {
@@ -65,6 +67,17 @@ describe('encodeClaudeTurn', () => {
 
     expect(result.persistedContent).toContain('<current_note>');
     expect(result.persistedContent).toContain('notes/test.md');
+  });
+
+  it('should append focused context files', () => {
+    const request: ChatTurnRequest = {
+      text: 'review these',
+      contextFiles: ['notes/a.md', 'notes/b.md'],
+    };
+    const result = encodeClaudeTurn(request, mcpManager);
+
+    expect(result.persistedContent).toContain('<context_files>\nnotes/a.md, notes/b.md\n</context_files>');
+    expect(result.prompt).toContain('<context_files>\nnotes/a.md, notes/b.md\n</context_files>');
   });
 
   it('should append editor selection context', () => {

--- a/tests/unit/providers/codex/prompt/encodeCodexTurn.test.ts
+++ b/tests/unit/providers/codex/prompt/encodeCodexTurn.test.ts
@@ -24,6 +24,17 @@ describe('encodeCodexTurn', () => {
     expect(result.persistedContent).toBe('Fix this');
   });
 
+  it('should include focused context files', () => {
+    const request: ChatTurnRequest = {
+      text: 'Review these',
+      contextFiles: ['notes/a.md', 'notes/b.md'],
+    };
+    const result = encodeCodexTurn(request);
+
+    expect(result.prompt).toContain('<context_files>\nnotes/a.md, notes/b.md\n</context_files>');
+    expect(result.persistedContent).toBe('Review these');
+  });
+
   it('should include editor selection context', () => {
     const request: ChatTurnRequest = {
       text: 'Explain this',
@@ -151,6 +162,7 @@ describe('encodeCodexTurn', () => {
       const request: ChatTurnRequest = {
         text: '/compact',
         currentNotePath: 'note.md',
+        contextFiles: ['notes/a.md'],
         editorSelection: { notePath: 'src/main.ts', mode: 'selection', selectedText: 'code' },
         browserSelection: { source: 'chrome', selectedText: 'web text', url: 'https://example.com' },
         canvasSelection: { canvasPath: 'c.canvas', nodeIds: ['n1'] },
@@ -160,6 +172,7 @@ describe('encodeCodexTurn', () => {
       expect(result.isCompact).toBe(true);
       expect(result.prompt).toBe('/compact');
       expect(result.prompt).not.toContain('[Current note');
+      expect(result.prompt).not.toContain('<context_files>');
       expect(result.prompt).not.toContain('[Editor selection');
       expect(result.prompt).not.toContain('[Browser selection');
       expect(result.prompt).not.toContain('[Canvas selection');

--- a/tests/unit/providers/opencode/buildOpencodePrompt.test.ts
+++ b/tests/unit/providers/opencode/buildOpencodePrompt.test.ts
@@ -10,6 +10,7 @@ describe('buildOpencodePromptText', () => {
         url: 'https://example.com',
       },
       currentNotePath: 'notes/today.md',
+      contextFiles: ['notes/a.md', 'notes/b.md'],
       editorSelection: {
         mode: 'selection',
         notePath: 'notes/today.md',
@@ -23,6 +24,7 @@ describe('buildOpencodePromptText', () => {
     expect(prompt).toContain('Summarize this');
     expect(prompt).toContain('<current_note>');
     expect(prompt).toContain('notes/today.md');
+    expect(prompt).toContain('<context_files>\nnotes/a.md, notes/b.md\n</context_files>');
     expect(prompt).toContain('<editor_selection path="notes/today.md" lines="4-5">');
     expect(prompt).toContain('<browser_selection source="browser:https://example.com" title="Example" url="https://example.com">');
   });

--- a/tests/unit/providers/pi/runtime/buildPiPrompt.test.ts
+++ b/tests/unit/providers/pi/runtime/buildPiPrompt.test.ts
@@ -17,6 +17,7 @@ describe('buildPiPrompt', () => {
         nodeIds: ['node-a', 'node-b'],
       },
       currentNotePath: 'Notes/today.md',
+      contextFiles: ['Notes/a.md', 'Notes/b.md'],
       editorSelection: {
         lineCount: 2,
         mode: 'selection',
@@ -37,6 +38,7 @@ describe('buildPiPrompt', () => {
 
     expect(prompt).toContain('Summarize this');
     expect(prompt).toContain('<current_note>\nNotes/today.md\n</current_note>');
+    expect(prompt).toContain('<context_files>\nNotes/a.md, Notes/b.md\n</context_files>');
     expect(prompt).toContain('<editor_selection path="Notes/today.md" lines="4-5">\nSelected text\n</editor_selection>');
     expect(prompt).toContain('<browser_selection source="browser" title="Docs" url="https://example.com">\nBrowser text\n</browser_selection>');
     expect(prompt).toContain('<canvas_selection path="Board.canvas">\nnode-a, node-b\n</canvas_selection>');


### PR DESCRIPTION
## Summary

Fixes #786.

This fixes the issue where files already attached as UI chips were not included in the actual chat turn request.

The change adds `contextFiles?: string[]` to `ChatTurnRequest`, collects attached files from `FileContextManager.getAttachedFiles()`, preserves them across queued/steer turns, and emits them into provider prompts as `<context_files>`.

## Root cause

The chat UI tracked attached file chips locally, but the send path only forwarded `currentNotePath` and transformed text into the provider turn request. As a result, providers such as Codex could receive only the typed message even when the UI showed an attached file chip.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run test -- --selectProjects unit`