### PR TITLE
Fix unsafe process kill assignment

### DIFF
--- a/src/providers/claude/runtime/customSpawn.ts
+++ b/src/providers/claude/runtime/customSpawn.ts
@@ -73,12 +73,14 @@ function installTreeAwareKill(child: ChildProcess, spawnSpec: WindowsCmdShimSpaw
     return;
   }
 
-  const originalKill: (signal?: NodeJS.Signals | number) => boolean = child.kill.bind(child);
+  const originalKill = child.kill;
+  const callOriginalKill = (signal?: NodeJS.Signals | number): boolean =>
+    originalKill.call(child, signal);
   const killableChild = {
     get pid(): number | undefined {
       return child.pid;
     },
-    kill: (signal?: NodeJS.Signals | number): boolean => originalKill(signal),
+    kill: callOriginalKill,
   };
 
   child.kill = ((signal?: NodeJS.Signals | number): boolean =>


### PR DESCRIPTION
Summary:
- Replaces the unsafe bound ChildProcess.kill assignment with an explicitly typed wrapper.
- Preserves Windows .cmd process-tree termination behavior while satisfying @typescript-eslint/no-unsafe-assignment.

Verification:
- Ran lint, focused custom spawn tests, typecheck, and build under Node 24.16.0.