### PR TITLE
Rename note context tag to linked_note

### DIFF
--- a/src/core/prompt/mainAgent.ts
+++ b/src/core/prompt/mainAgent.ts
@@ -62,9 +62,9 @@ User messages have the query first, followed by optional XML context tags:
 \`\`\`
 User's question or request here
 
-<current_note>
+<linked_note>
 path/to/note.md
-</current_note>
+</linked_note>
 
 <editor_selection path="path/to/note.md" lines="10-15">
 selected text content
@@ -76,7 +76,7 @@ selected content from an Obsidian browser view
 \`\`\`
 
 - The user's query/instruction always comes first in the message.
-- \`<current_note>\`: The note the user is currently viewing/focused on. Read this to understand context.
+- \`<linked_note>\`: The note this session is linked to. Read this to understand session context. Legacy messages may use \`<current_note>\` for the same context.
 - \`<editor_selection>\`: Text currently selected in the editor, with file path and line numbers.
 - \`<browser_selection>\`: Text selected in an Obsidian browser/web view (for example Surfing), including optional source/title/url metadata.
 - \`@filename.md\`: Files mentioned with @ in the query. Read these files when referenced.

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -1,25 +1,28 @@
 /**
  * Claudian - Context Utilities
  *
- * Current note and context file formatting for prompts.
+ * Note and context file formatting for prompts.
  */
 
-// Matches <current_note> at the START of prompt (legacy format)
-const CURRENT_NOTE_PREFIX_REGEX = /^<current_note>\n[\s\S]*?<\/current_note>\n\n/;
-// Matches <current_note> at the END of prompt (current format)
-const CURRENT_NOTE_SUFFIX_REGEX = /\n\n<current_note>\n[\s\S]*?<\/current_note>$/;
+const LINKED_NOTE_TAG = 'linked_note';
+const NOTE_CONTEXT_TAG_PATTERN = '(linked_note|current_note)';
+
+// Matches note context at the START of prompt (legacy placement)
+const NOTE_CONTEXT_PREFIX_REGEX = new RegExp(`^<${NOTE_CONTEXT_TAG_PATTERN}>\\n[\\s\\S]*?<\\/\\1>\\n\\n`);
+// Matches note context at the END of prompt (current placement)
+const NOTE_CONTEXT_SUFFIX_REGEX = new RegExp(`\\n\\n<${NOTE_CONTEXT_TAG_PATTERN}>\\n[\\s\\S]*?<\\/\\1>$`);
 
 /**
  * Pattern to match XML context tags appended to prompts.
  * These tags are always preceded by \n\n separator.
- * Matches: current_note, editor_selection (with attributes), editor_cursor (with attributes),
+ * Matches: linked_note/current_note, editor_selection (with attributes), editor_cursor (with attributes),
  * context_files, canvas_selection, browser_selection
  */
-export const XML_CONTEXT_PATTERN = /\n\n<(?:current_note|editor_selection|editor_cursor|context_files|canvas_selection|browser_selection)[\s>]/;
+export const XML_CONTEXT_PATTERN = /\n\n<(?:linked_note|current_note|editor_selection|editor_cursor|context_files|canvas_selection|browser_selection)[\s>]/;
 const BRACKET_CONTEXT_PATTERN = /\n\[(?:Current note|Editor selection from|Browser selection from|Canvas selection from)\b/;
 
 export function formatCurrentNote(notePath: string): string {
-  return `<current_note>\n${notePath}\n</current_note>`;
+  return `<${LINKED_NOTE_TAG}>\n${notePath}\n</${LINKED_NOTE_TAG}>`;
 }
 
 export function appendCurrentNote(prompt: string, notePath: string): string {
@@ -27,17 +30,15 @@ export function appendCurrentNote(prompt: string, notePath: string): string {
 }
 
 /**
- * Strips current note context from a prompt (both prefix and suffix formats).
- * Handles legacy (prefix) and current (suffix) formats.
+ * Strips note context from a prompt.
+ * Handles legacy <current_note> tags and canonical <linked_note> tags.
  */
 export function stripCurrentNoteContext(prompt: string): string {
-  // Try prefix format first (legacy)
-  const strippedPrefix = prompt.replace(CURRENT_NOTE_PREFIX_REGEX, '');
+  const strippedPrefix = prompt.replace(NOTE_CONTEXT_PREFIX_REGEX, '');
   if (strippedPrefix !== prompt) {
     return strippedPrefix;
   }
-  // Try suffix format (current)
-  return prompt.replace(CURRENT_NOTE_SUFFIX_REGEX, '');
+  return prompt.replace(NOTE_CONTEXT_SUFFIX_REGEX, '');
 }
 
 /**
@@ -99,7 +100,7 @@ export function extractUserQuery(prompt: string): string {
 
   // No XML context - return the whole prompt stripped of any remaining tags
   return prompt
-    .replace(/<current_note>[\s\S]*?<\/current_note>\s*/g, '')
+    .replace(/<(linked_note|current_note)>[\s\S]*?<\/\1>\s*/g, '')
     .replace(/<editor_selection[\s\S]*?<\/editor_selection>\s*/g, '')
     .replace(/<editor_cursor[\s\S]*?<\/editor_cursor>\s*/g, '')
     .replace(/<context_files>[\s\S]*?<\/context_files>\s*/g, '')

--- a/tests/integration/core/agent/ClaudianService.test.ts
+++ b/tests/integration/core/agent/ClaudianService.test.ts
@@ -1139,7 +1139,7 @@ describe('ClaudianService', () => {
       // Now test the standalone function directly
       const context = buildContextFromHistory(messages);
 
-      expect(context).toContain('<current_note>');
+      expect(context).toContain('<linked_note>');
       expect(context).toContain('notes/file.md');
     });
 
@@ -1201,7 +1201,7 @@ describe('ClaudianService', () => {
       expect(prompts[0]).toBe('Follow up');
       expect(prompts[1]).toContain('User: First question');
       expect(prompts[1]).toContain('Assistant: Answer');
-      expect(prompts[1]).toContain('<current_note>');
+      expect(prompts[1]).toContain('<linked_note>');
       expect(prompts[1]).toContain('note.md');
       expect(chunks.some((c) => c.type === 'text' && c.content === 'Recovered')).toBe(true);
       expect(service.getSessionId()).toBeNull();

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -1000,8 +1000,8 @@ describe('InputController - Message Queue', () => {
       inputEl.value = 'Second message';
       await controller.sendMessage();
 
-      expect(prompts[0]).toContain('<current_note>');
-      expect(prompts[1]).not.toContain('<current_note>');
+      expect(prompts[0]).toContain('<linked_note>');
+      expect(prompts[1]).not.toContain('<linked_note>');
     });
 
     it('should not persist currentNote metadata for /compact turns', async () => {

--- a/tests/unit/providers/claude/prompt/ClaudeTurnEncoder.test.ts
+++ b/tests/unit/providers/claude/prompt/ClaudeTurnEncoder.test.ts
@@ -63,7 +63,7 @@ describe('encodeClaudeTurn', () => {
     };
     const result = encodeClaudeTurn(request, mcpManager);
 
-    expect(result.persistedContent).toContain('<current_note>');
+    expect(result.persistedContent).toContain('<linked_note>');
     expect(result.persistedContent).toContain('notes/test.md');
   });
 

--- a/tests/unit/providers/claude/runtime/ClaudianService.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudianService.test.ts
@@ -93,7 +93,7 @@ describe('ClaudianService', () => {
         text: 'explain this',
         currentNotePath: 'notes/test.md',
       });
-      expect(result.persistedContent).toContain('<current_note>');
+      expect(result.persistedContent).toContain('<linked_note>');
       expect(result.persistedContent).toContain('notes/test.md');
     });
 

--- a/tests/unit/providers/opencode/buildOpencodePrompt.test.ts
+++ b/tests/unit/providers/opencode/buildOpencodePrompt.test.ts
@@ -21,7 +21,7 @@ describe('buildOpencodePromptText', () => {
     });
 
     expect(prompt).toContain('Summarize this');
-    expect(prompt).toContain('<current_note>');
+    expect(prompt).toContain('<linked_note>');
     expect(prompt).toContain('notes/today.md');
     expect(prompt).toContain('<editor_selection path="notes/today.md" lines="4-5">');
     expect(prompt).toContain('<browser_selection source="browser:https://example.com" title="Example" url="https://example.com">');

--- a/tests/unit/providers/pi/runtime/buildPiPrompt.test.ts
+++ b/tests/unit/providers/pi/runtime/buildPiPrompt.test.ts
@@ -36,7 +36,7 @@ describe('buildPiPrompt', () => {
     });
 
     expect(prompt).toContain('Summarize this');
-    expect(prompt).toContain('<current_note>\nNotes/today.md\n</current_note>');
+    expect(prompt).toContain('<linked_note>\nNotes/today.md\n</linked_note>');
     expect(prompt).toContain('<editor_selection path="Notes/today.md" lines="4-5">\nSelected text\n</editor_selection>');
     expect(prompt).toContain('<browser_selection source="browser" title="Docs" url="https://example.com">\nBrowser text\n</browser_selection>');
     expect(prompt).toContain('<canvas_selection path="Board.canvas">\nnode-a, node-b\n</canvas_selection>');

--- a/tests/unit/utils/context.test.ts
+++ b/tests/unit/utils/context.test.ts
@@ -12,13 +12,13 @@ import {
 describe('formatCurrentNote', () => {
   it('formats note path in XML tags', () => {
     expect(formatCurrentNote('notes/test.md')).toBe(
-      '<current_note>\nnotes/test.md\n</current_note>'
+      '<linked_note>\nnotes/test.md\n</linked_note>'
     );
   });
 
   it('handles paths with special characters', () => {
     expect(formatCurrentNote('notes/my file (1).md')).toBe(
-      '<current_note>\nnotes/my file (1).md\n</current_note>'
+      '<linked_note>\nnotes/my file (1).md\n</linked_note>'
     );
   });
 });
@@ -27,7 +27,7 @@ describe('appendCurrentNote', () => {
   it('appends current note to prompt with double newline separator', () => {
     const result = appendCurrentNote('Hello', 'notes/test.md');
     expect(result).toBe(
-      'Hello\n\n<current_note>\nnotes/test.md\n</current_note>'
+      'Hello\n\n<linked_note>\nnotes/test.md\n</linked_note>'
     );
   });
 
@@ -38,44 +38,61 @@ describe('appendCurrentNote', () => {
 });
 
 describe('stripCurrentNoteContext', () => {
-  describe('legacy prefix format', () => {
+  describe('prefix format', () => {
+    it('strips linked_note from start of prompt', () => {
+      const prompt = '<linked_note>\nnotes/test.md\n</linked_note>\n\nUser query here';
+      expect(stripCurrentNoteContext(prompt)).toBe('User query here');
+    });
+
+    it('handles multiline note content in prefix', () => {
+      const prompt = '<linked_note>\npath/to/note.md\nwith extra info\n</linked_note>\n\nQuery';
+      expect(stripCurrentNoteContext(prompt)).toBe('Query');
+    });
+  });
+
+  describe('suffix format', () => {
+    it('strips linked_note from end of prompt', () => {
+      const prompt = 'User query here\n\n<linked_note>\nnotes/test.md\n</linked_note>';
+      expect(stripCurrentNoteContext(prompt)).toBe('User query here');
+    });
+
+    it('handles multiline note content in suffix', () => {
+      const prompt = 'Query\n\n<linked_note>\npath/to/note.md\n</linked_note>';
+      expect(stripCurrentNoteContext(prompt)).toBe('Query');
+    });
+  });
+
+  describe('legacy current_note compatibility', () => {
     it('strips current_note from start of prompt', () => {
       const prompt = '<current_note>\nnotes/test.md\n</current_note>\n\nUser query here';
       expect(stripCurrentNoteContext(prompt)).toBe('User query here');
     });
 
-    it('handles multiline note content in prefix', () => {
-      const prompt = '<current_note>\npath/to/note.md\nwith extra info\n</current_note>\n\nQuery';
-      expect(stripCurrentNoteContext(prompt)).toBe('Query');
-    });
-  });
-
-  describe('current suffix format', () => {
     it('strips current_note from end of prompt', () => {
       const prompt = 'User query here\n\n<current_note>\nnotes/test.md\n</current_note>';
       expect(stripCurrentNoteContext(prompt)).toBe('User query here');
     });
-
-    it('handles multiline note content in suffix', () => {
-      const prompt = 'Query\n\n<current_note>\npath/to/note.md\n</current_note>';
-      expect(stripCurrentNoteContext(prompt)).toBe('Query');
-    });
   });
 
-  it('returns unchanged prompt when no current_note present', () => {
+  it('returns unchanged prompt when no note context is present', () => {
     const prompt = 'Just a regular prompt';
     expect(stripCurrentNoteContext(prompt)).toBe('Just a regular prompt');
   });
 
   it('prefers prefix format when both could match', () => {
     // This tests the function order: it tries prefix first
-    const prefixPrompt = '<current_note>\ntest.md\n</current_note>\n\nQuery';
+    const prefixPrompt = '<linked_note>\ntest.md\n</linked_note>\n\nQuery';
     expect(stripCurrentNoteContext(prefixPrompt)).toBe('Query');
   });
 });
 
 describe('XML_CONTEXT_PATTERN', () => {
-  it('matches current_note tag', () => {
+  it('matches linked_note tag', () => {
+    const text = 'Query\n\n<linked_note>\ntest.md\n</linked_note>';
+    expect(XML_CONTEXT_PATTERN.test(text)).toBe(true);
+  });
+
+  it('matches legacy current_note tag', () => {
     const text = 'Query\n\n<current_note>\ntest.md\n</current_note>';
     expect(XML_CONTEXT_PATTERN.test(text)).toBe(true);
   });
@@ -106,7 +123,7 @@ describe('XML_CONTEXT_PATTERN', () => {
   });
 
   it('does not match without double newline separator', () => {
-    const text = 'Query\n<current_note>\ntest.md\n</current_note>';
+    const text = 'Query\n<linked_note>\ntest.md\n</linked_note>';
     expect(XML_CONTEXT_PATTERN.test(text)).toBe(false);
   });
 
@@ -119,7 +136,7 @@ describe('XML_CONTEXT_PATTERN', () => {
 describe('extractContentBeforeXmlContext', () => {
   describe('legacy format with <query> tags', () => {
     it('extracts content from query tags', () => {
-      const prompt = '<current_note>\ntest.md\n</current_note>\n\n<query>\nUser question\n</query>';
+      const prompt = '<linked_note>\ntest.md\n</linked_note>\n\n<query>\nUser question\n</query>';
       expect(extractContentBeforeXmlContext(prompt)).toBe('User question');
     });
 
@@ -135,7 +152,12 @@ describe('extractContentBeforeXmlContext', () => {
   });
 
   describe('current format with user content first', () => {
-    it('extracts content before current_note tag', () => {
+    it('extracts content before linked_note tag', () => {
+      const prompt = 'User query\n\n<linked_note>\ntest.md\n</linked_note>';
+      expect(extractContentBeforeXmlContext(prompt)).toBe('User query');
+    });
+
+    it('extracts content before legacy current_note tag', () => {
       const prompt = 'User query\n\n<current_note>\ntest.md\n</current_note>';
       expect(extractContentBeforeXmlContext(prompt)).toBe('User query');
     });
@@ -156,7 +178,7 @@ describe('extractContentBeforeXmlContext', () => {
     });
 
     it('handles multiple context tags - extracts before first one', () => {
-      const prompt = 'Query\n\n<current_note>\ntest.md\n</current_note>\n\n<editor_selection path="x">\ny\n</editor_selection>';
+      const prompt = 'Query\n\n<linked_note>\ntest.md\n</linked_note>\n\n<editor_selection path="x">\ny\n</editor_selection>';
       expect(extractContentBeforeXmlContext(prompt)).toBe('Query');
     });
 
@@ -166,7 +188,7 @@ describe('extractContentBeforeXmlContext', () => {
     });
 
     it('trims whitespace from extracted content', () => {
-      const prompt = '  spaced query  \n\n<current_note>\ntest.md\n</current_note>';
+      const prompt = '  spaced query  \n\n<linked_note>\ntest.md\n</linked_note>';
       expect(extractContentBeforeXmlContext(prompt)).toBe('spaced query');
     });
   });
@@ -189,7 +211,7 @@ describe('extractContentBeforeXmlContext', () => {
 
 describe('extractUserDisplayContent', () => {
   it('extracts display content before XML context tags', () => {
-    expect(extractUserDisplayContent('Summarize this\n\n<current_note>\nnotes/today.md\n</current_note>'))
+    expect(extractUserDisplayContent('Summarize this\n\n<linked_note>\nnotes/today.md\n</linked_note>'))
       .toBe('Summarize this');
   });
 
@@ -211,13 +233,18 @@ describe('extractUserQuery', () => {
     });
 
     it('extracts content before XML context tags', () => {
-      const prompt = 'User query\n\n<current_note>\ntest.md\n</current_note>';
+      const prompt = 'User query\n\n<linked_note>\ntest.md\n</linked_note>';
       expect(extractUserQuery(prompt)).toBe('User query');
     });
   });
 
   describe('fallback tag stripping', () => {
-    it('strips current_note tags without structured format', () => {
+    it('strips linked_note tags without structured format', () => {
+      const prompt = 'Query <linked_note>test.md</linked_note> continues';
+      expect(extractUserQuery(prompt)).toBe('Query continues');
+    });
+
+    it('strips legacy current_note tags without structured format', () => {
       // Tag and trailing whitespace are replaced, leaving single space
       const prompt = 'Query <current_note>test.md</current_note> continues';
       expect(extractUserQuery(prompt)).toBe('Query continues');
@@ -249,7 +276,7 @@ describe('extractUserQuery', () => {
     });
 
     it('strips multiple tag types', () => {
-      const prompt = '<current_note>a.md</current_note>Query<context_files>b.md</context_files>';
+      const prompt = '<linked_note>a.md</linked_note>Query<context_files>b.md</context_files>';
       expect(extractUserQuery(prompt)).toBe('Query');
     });
   });

--- a/tests/unit/utils/session.test.ts
+++ b/tests/unit/utils/session.test.ts
@@ -684,7 +684,7 @@ describe('session utilities', () => {
       expect(result).toBe(historyContext);
     });
 
-    it('avoids duplication when XML-wrapped content matches display content', () => {
+    it('avoids duplication when legacy XML-wrapped content matches display content', () => {
       const prompt = [
         '<current_note>',
         'notes/file.md',
@@ -728,8 +728,8 @@ describe('session utilities', () => {
 
     describe('new format (user content before XML context)', () => {
       it('avoids duplication when actualPrompt matches last user message', () => {
-        const prompt = 'Explain this\n\n<current_note>\ntest.md\n</current_note>';
-        const actualPrompt = 'Explain this\n\n<current_note>\ntest.md\n</current_note>';
+        const prompt = 'Explain this\n\n<linked_note>\ntest.md\n</linked_note>';
+        const actualPrompt = 'Explain this\n\n<linked_note>\ntest.md\n</linked_note>';
         const messages: ChatMessage[] = [
           {
             id: 'msg-1',
@@ -747,8 +747,8 @@ describe('session utilities', () => {
       });
 
       it('appends prompt when actualPrompt differs from last user message', () => {
-        const oldPrompt = 'First question\n\n<current_note>\nold.md\n</current_note>';
-        const newPrompt = 'Second question\n\n<current_note>\nnew.md\n</current_note>';
+        const oldPrompt = 'First question\n\n<linked_note>\nold.md\n</linked_note>';
+        const newPrompt = 'Second question\n\n<linked_note>\nnew.md\n</linked_note>';
         const messages: ChatMessage[] = [
           {
             id: 'msg-1',
@@ -785,7 +785,7 @@ describe('session utilities', () => {
       });
 
       it('extracts user query from content with multiple XML context tags', () => {
-        const prompt = 'Update code\n\n<current_note>\ntest.md\n</current_note>\n\n<editor_selection path="test.md">\nselected\n</editor_selection>';
+        const prompt = 'Update code\n\n<linked_note>\ntest.md\n</linked_note>\n\n<editor_selection path="test.md">\nselected\n</editor_selection>';
         const messages: ChatMessage[] = [
           {
             id: 'msg-1',
@@ -803,7 +803,7 @@ describe('session utilities', () => {
       });
 
       it('falls back to extractUserQuery when displayContent is not available', () => {
-        const prompt = 'Help me\n\n<current_note>\nfile.md\n</current_note>';
+        const prompt = 'Help me\n\n<linked_note>\nfile.md\n</linked_note>';
         const messages: ChatMessage[] = [
           {
             id: 'msg-1',


### PR DESCRIPTION
Renames emitted note context XML from `<current_note>` to `<linked_note>` across provider prompt builders and session reconstruction. Keeps legacy `<current_note>` compatible for context detection, stripping, display extraction, and dedupe paths. Updates the main agent prompt to describe linked notes as session context and refreshes tests for new output plus legacy fixtures. Verification: `npm run typecheck`; `npm run lint`; `npm run test`; `npm run build`.