### PR TITLE
feat: use Obsidian configDir for dynamic plugin storage path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ styles.css
 *.js.map
 dist/
 build/
+.history/
 
 # Dependencies
 node_modules/

--- a/src/app/settings/ClaudianSettingsStorage.ts
+++ b/src/app/settings/ClaudianSettingsStorage.ts
@@ -1,6 +1,6 @@
 import {
-  CLAUDIAN_SETTINGS_PATH,
   LEGACY_CLAUDIAN_SETTINGS_PATH,
+  OLD_CLAUDIAN_SETTINGS_PATH,
 } from '../../core/bootstrap/StoragePaths';
 import {
   normalizeHiddenCommandList,
@@ -40,8 +40,8 @@ import {
 import { DEFAULT_CLAUDIAN_SETTINGS } from './defaultSettings';
 
 export {
-  CLAUDIAN_SETTINGS_PATH,
   LEGACY_CLAUDIAN_SETTINGS_PATH,
+  OLD_CLAUDIAN_SETTINGS_PATH,
 };
 
 export type StoredClaudianSettings = ClaudianSettings;
@@ -272,7 +272,11 @@ function mergeLegacyClaudeHiddenCommands(
 }
 
 export class ClaudianSettingsStorage {
-  constructor(private adapter: VaultFileAdapter) {}
+  private readonly settingsPath: string;
+
+  constructor(private adapter: VaultFileAdapter) {
+    this.settingsPath = `${adapter.pluginStoragePath}/claudian-settings.json`;
+  }
 
   async load(): Promise<StoredClaudianSettings> {
     const settingsPath = await this.getLoadPath();
@@ -339,7 +343,7 @@ export class ClaudianSettingsStorage {
     );
 
     if (
-      settingsPath !== CLAUDIAN_SETTINGS_PATH
+      settingsPath !== this.settingsPath
       || (
       hasLegacyTopLevelProviderFields(stored)
       || 'show1MModel' in stored
@@ -371,12 +375,12 @@ export class ClaudianSettingsStorage {
       null,
       2,
     );
-    await this.adapter.write(CLAUDIAN_SETTINGS_PATH, content);
+    await this.adapter.write(this.settingsPath, content);
     await this.deleteLegacyFileIfPresent();
   }
 
   async exists(): Promise<boolean> {
-    if (await this.adapter.exists(CLAUDIAN_SETTINGS_PATH)) {
+    if (await this.adapter.exists(this.settingsPath)) {
       return true;
     }
 
@@ -416,8 +420,12 @@ export class ClaudianSettingsStorage {
   }
 
   private async getLoadPath(): Promise<string | null> {
-    if (await this.adapter.exists(CLAUDIAN_SETTINGS_PATH)) {
-      return CLAUDIAN_SETTINGS_PATH;
+    if (await this.adapter.exists(this.settingsPath)) {
+      return this.settingsPath;
+    }
+
+    if (await this.adapter.exists(OLD_CLAUDIAN_SETTINGS_PATH)) {
+      return OLD_CLAUDIAN_SETTINGS_PATH;
     }
 
     if (await this.adapter.exists(LEGACY_CLAUDIAN_SETTINGS_PATH)) {
@@ -428,6 +436,9 @@ export class ClaudianSettingsStorage {
   }
 
   private async deleteLegacyFileIfPresent(): Promise<void> {
+    if (await this.adapter.exists(OLD_CLAUDIAN_SETTINGS_PATH)) {
+      await this.adapter.delete(OLD_CLAUDIAN_SETTINGS_PATH);
+    }
     if (await this.adapter.exists(LEGACY_CLAUDIAN_SETTINGS_PATH)) {
       await this.adapter.delete(LEGACY_CLAUDIAN_SETTINGS_PATH);
     }

--- a/src/app/storage/SharedStorageService.ts
+++ b/src/app/storage/SharedStorageService.ts
@@ -1,9 +1,8 @@
 import type { Plugin } from 'obsidian';
 import { Notice } from 'obsidian';
 
-import { SESSIONS_PATH, SessionStorage } from '../../core/bootstrap/SessionStorage';
+import { SessionStorage } from '../../core/bootstrap/SessionStorage';
 import type { SharedAppStorage } from '../../core/bootstrap/storage';
-import { CLAUDIAN_STORAGE_PATH } from '../../core/bootstrap/StoragePaths';
 import { VaultFileAdapter } from '../../core/storage/VaultFileAdapter';
 import { ClaudianSettingsStorage, type StoredClaudianSettings } from '../settings/ClaudianSettingsStorage';
 
@@ -64,8 +63,8 @@ export class SharedStorageService implements SharedAppStorage {
   }
 
   private async ensureDirectories(): Promise<void> {
-    await this.adapter.ensureFolder(CLAUDIAN_STORAGE_PATH);
-    await this.adapter.ensureFolder(SESSIONS_PATH);
+    await this.adapter.ensureFolder(this.adapter.pluginStoragePath);
+    await this.adapter.ensureFolder(this.sessions.sessionStoragePath);
   }
 
   private validateTabManagerState(data: unknown): { openTabs: Array<{ tabId: string; conversationId: string | null; draftModel?: string | null }>; activeTabId: string | null } | null {

--- a/src/core/bootstrap/SessionStorage.ts
+++ b/src/core/bootstrap/SessionStorage.ts
@@ -6,22 +6,35 @@ import type {
   ConversationMeta,
   SessionMetadata,
 } from '../types';
-import { LEGACY_SESSIONS_PATH, SESSIONS_PATH } from './StoragePaths';
+import { LEGACY_SESSIONS_PATH, OLD_SESSIONS_PATH } from './StoragePaths';
 
 export {
   LEGACY_SESSIONS_PATH,
-  SESSIONS_PATH,
+  OLD_SESSIONS_PATH,
 };
 
 export class SessionStorage {
-  constructor(private adapter: VaultFileAdapter) {}
+  private readonly sessionsPath: string;
+
+  constructor(private adapter: VaultFileAdapter) {
+    this.sessionsPath = `${adapter.pluginStoragePath}/sessions`;
+  }
+
+  /** The vault-relative directory where session metadata is stored. */
+  get sessionStoragePath(): string {
+    return this.sessionsPath;
+  }
 
   getMetadataPath(id: string): string {
-    return `${SESSIONS_PATH}/${id}.meta.json`;
+    return `${this.sessionsPath}/${id}.meta.json`;
   }
 
   getLegacyMetadataPath(id: string): string {
     return `${LEGACY_SESSIONS_PATH}/${id}.meta.json`;
+  }
+
+  getOldMetadataPath(id: string): string {
+    return `${OLD_SESSIONS_PATH}/${id}.meta.json`;
   }
 
   async saveMetadata(metadata: SessionMetadata): Promise<void> {
@@ -68,7 +81,7 @@ export class SessionStorage {
         const raw = JSON.parse(content) as SessionMetadata;
         metas.push(raw);
 
-        if (filePath.startsWith(`${LEGACY_SESSIONS_PATH}/`)) {
+        if (filePath.startsWith(`${LEGACY_SESSIONS_PATH}/`) || filePath.startsWith(`${OLD_SESSIONS_PATH}/`)) {
           await this.saveMetadata(raw);
         }
       } catch {
@@ -129,6 +142,11 @@ export class SessionStorage {
       return filePath;
     }
 
+    const oldFilePath = this.getOldMetadataPath(id);
+    if (await this.adapter.exists(oldFilePath)) {
+      return oldFilePath;
+    }
+
     const legacyFilePath = this.getLegacyMetadataPath(id);
     if (await this.adapter.exists(legacyFilePath)) {
       return legacyFilePath;
@@ -138,6 +156,11 @@ export class SessionStorage {
   }
 
   private async deleteLegacyMetadataIfPresent(id: string): Promise<void> {
+    const oldFilePath = this.getOldMetadataPath(id);
+    if (await this.adapter.exists(oldFilePath)) {
+      await this.adapter.delete(oldFilePath);
+    }
+
     const legacyFilePath = this.getLegacyMetadataPath(id);
     if (await this.adapter.exists(legacyFilePath)) {
       await this.adapter.delete(legacyFilePath);
@@ -145,12 +168,20 @@ export class SessionStorage {
   }
 
   private async listUniqueMetadataFiles(): Promise<string[]> {
-    const preferredFiles = await this.listMetadataFiles(SESSIONS_PATH);
+    const preferredFiles = await this.listMetadataFiles(this.sessionsPath);
+    const oldFiles = await this.listMetadataFiles(OLD_SESSIONS_PATH);
     const fallbackFiles = await this.listMetadataFiles(LEGACY_SESSIONS_PATH);
     const filesByName = new Map<string, string>();
 
     for (const filePath of preferredFiles) {
       filesByName.set(this.getFileName(filePath), filePath);
+    }
+
+    for (const filePath of oldFiles) {
+      const fileName = this.getFileName(filePath);
+      if (!filesByName.has(fileName)) {
+        filesByName.set(fileName, filePath);
+      }
     }
 
     for (const filePath of fallbackFiles) {

--- a/src/core/bootstrap/StoragePaths.ts
+++ b/src/core/bootstrap/StoragePaths.ts
@@ -1,7 +1,11 @@
-export const CLAUDIAN_STORAGE_PATH = '.claudian';
-
+// Legacy / old vault-root paths that never change regardless of config dir.
+// These are used only for migration — data is read from them then deleted.
+export const OLD_CLAUDIAN_SETTINGS_PATH = '.claudian/claudian-settings.json';
 export const LEGACY_CLAUDIAN_SETTINGS_PATH = '.claude/claudian-settings.json';
-export const CLAUDIAN_SETTINGS_PATH = `${CLAUDIAN_STORAGE_PATH}/claudian-settings.json`;
-
 export const LEGACY_SESSIONS_PATH = '.claude/sessions';
-export const SESSIONS_PATH = `${CLAUDIAN_STORAGE_PATH}/sessions`;
+export const OLD_SESSIONS_PATH = '.claudian/sessions';
+
+/** Vault-relative path to this plugin's storage directory. */
+export function getClaudianPluginPath(configDir: string): string {
+  return `${configDir}/plugins/realclaudian`;
+}

--- a/src/core/storage/VaultFileAdapter.ts
+++ b/src/core/storage/VaultFileAdapter.ts
@@ -12,6 +12,11 @@ export class VaultFileAdapter {
 
   constructor(private app: App) {}
 
+  /** Vault-relative path to this plugin's storage directory, respecting Obsidian's config folder. */
+  get pluginStoragePath(): string {
+    return `${this.app.vault.configDir}/plugins/realclaudian`;
+  }
+
   async exists(path: string): Promise<boolean> {
     return this.app.vault.adapter.exists(path);
   }

--- a/src/core/types/settings.ts
+++ b/src/core/types/settings.ts
@@ -83,7 +83,7 @@ export type HostnameCliPaths = Record<string, string>;
 export type ProviderConfigMap = Partial<Record<string, Record<string, unknown>>>;
 
 /**
- * Application settings stored in .claudian/claudian-settings.json.
+ * Application settings stored under the plugin's config folder (respects Obsidian's config dir).
  *
  * Provider-specific fields (model, thinkingBudget, effortLevel, serviceTier, etc.) use
  * `string` here.  The active provider casts internally when it needs

--- a/src/providers/claude/storage/ClaudianSettingsStorage.ts
+++ b/src/providers/claude/storage/ClaudianSettingsStorage.ts
@@ -1,6 +1,6 @@
 export {
-  CLAUDIAN_SETTINGS_PATH,
   ClaudianSettingsStorage,
   LEGACY_CLAUDIAN_SETTINGS_PATH,
+  OLD_CLAUDIAN_SETTINGS_PATH,
   type StoredClaudianSettings,
 } from '../../../app/settings/ClaudianSettingsStorage';

--- a/src/providers/claude/storage/SessionStorage.ts
+++ b/src/providers/claude/storage/SessionStorage.ts
@@ -1,5 +1,5 @@
 export {
   LEGACY_SESSIONS_PATH,
-  SESSIONS_PATH,
+  OLD_SESSIONS_PATH,
   SessionStorage,
 } from '../../../core/bootstrap/SessionStorage';

--- a/src/providers/claude/storage/StorageService.ts
+++ b/src/providers/claude/storage/StorageService.ts
@@ -2,8 +2,7 @@ import type { App, Plugin } from 'obsidian';
 import { Notice } from 'obsidian';
 
 import { ClaudianSettingsStorage, type StoredClaudianSettings } from '../../../app/settings/ClaudianSettingsStorage';
-import { SESSIONS_PATH, SessionStorage } from '../../../core/bootstrap/SessionStorage';
-import { CLAUDIAN_STORAGE_PATH } from '../../../core/bootstrap/StoragePaths';
+import { SessionStorage } from '../../../core/bootstrap/SessionStorage';
 import { VaultFileAdapter } from '../../../core/storage/VaultFileAdapter';
 import type {
   SlashCommand,
@@ -67,10 +66,10 @@ export class StorageService {
 
   async ensureDirectories(): Promise<void> {
     await this.adapter.ensureFolder(CLAUDE_PATH);
-    await this.adapter.ensureFolder(CLAUDIAN_STORAGE_PATH);
+    await this.adapter.ensureFolder(this.adapter.pluginStoragePath);
     await this.adapter.ensureFolder(COMMANDS_PATH);
     await this.adapter.ensureFolder(SKILLS_PATH);
-    await this.adapter.ensureFolder(SESSIONS_PATH);
+    await this.adapter.ensureFolder(this.sessions.sessionStoragePath);
     await this.adapter.ensureFolder(AGENTS_PATH);
   }
 

--- a/src/providers/opencode/runtime/OpencodeAuxQueryRunner.ts
+++ b/src/providers/opencode/runtime/OpencodeAuxQueryRunner.ts
@@ -173,6 +173,7 @@ export class OpencodeAuxQueryRunner implements AuxQueryRunner {
     const auxAgentId = OPENCODE_AUX_AGENT_IDS[this.options.agentProfile];
     const artifacts = await prepareOpencodeLaunchArtifacts({
       artifactsSubdir: `opencode/auxiliary/${this.options.artifactPurpose}`,
+      configDir: this.plugin.app.vault.configDir,
       defaultAgentId: auxAgentId,
       managedAgents: [buildOpencodeAuxAgentConfig(this.options.agentProfile)],
       runtimeEnv,

--- a/src/providers/opencode/runtime/OpencodeChatRuntime.ts
+++ b/src/providers/opencode/runtime/OpencodeChatRuntime.ts
@@ -280,6 +280,7 @@ export class OpencodeChatRuntime implements ChatRuntime {
     );
     const promptSettings = this.getSystemPromptSettings(cwd);
     const artifacts = await prepareOpencodeLaunchArtifacts({
+      configDir: this.plugin.app.vault.configDir,
       runtimeEnv,
       settings: promptSettings,
       workspaceRoot: cwd,

--- a/src/providers/opencode/runtime/OpencodeLaunchArtifacts.ts
+++ b/src/providers/opencode/runtime/OpencodeLaunchArtifacts.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
-import { CLAUDIAN_STORAGE_PATH } from '../../../core/bootstrap/StoragePaths';
+import { getClaudianPluginPath } from '../../../core/bootstrap/StoragePaths';
 import {
   buildSystemPrompt,
   computeSystemPromptKey,
@@ -58,6 +58,8 @@ const DEFAULT_OPENCODE_MANAGED_AGENT_CONFIGS: readonly OpencodeManagedAgentConfi
 
 export interface PrepareOpencodeLaunchArtifactsParams {
   artifactsSubdir?: string;
+  /** Obsidian config directory relative to the vault root (e.g. ".obsidian"). */
+  configDir: string;
   defaultAgentId?: string;
   managedAgents?: readonly OpencodeManagedAgentConfig[];
   runtimeEnv: NodeJS.ProcessEnv;
@@ -73,7 +75,7 @@ export async function prepareOpencodeLaunchArtifacts(
 ): Promise<OpencodeLaunchArtifacts> {
   const artifactsDir = path.join(
     params.workspaceRoot,
-    CLAUDIAN_STORAGE_PATH,
+    getClaudianPluginPath(params.configDir),
     params.artifactsSubdir ?? 'opencode',
   );
   const systemPromptPath = path.join(artifactsDir, 'system.md');

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -33,6 +33,7 @@ describe('ClaudianPlugin', () => {
 
     mockApp = {
       vault: {
+        configDir: '.obsidian',
         adapter: {
           basePath: '/test/vault',
           exists: jest.fn().mockResolvedValue(false),
@@ -216,10 +217,10 @@ describe('ClaudianPlugin', () => {
     it('should merge saved data with defaults', async () => {
       // Mock claudian-settings.json exists with custom values (Claudian-specific settings)
       mockApp.vault.adapter.exists.mockImplementation(async (path: string) => {
-        return path === '.claudian/claudian-settings.json';
+        return path === '.obsidian/plugins/realclaudian/claudian-settings.json';
       });
       mockApp.vault.adapter.read.mockImplementation(async (path: string) => {
-        if (path === '.claudian/claudian-settings.json') {
+        if (path === '.obsidian/plugins/realclaudian/claudian-settings.json') {
           return JSON.stringify({
             userName: 'TestUser',
           });
@@ -235,10 +236,10 @@ describe('ClaudianPlugin', () => {
 
     it('should strip legacy blocklist fields when loading old settings', async () => {
       mockApp.vault.adapter.exists.mockImplementation(async (path: string) => {
-        return path === '.claudian/claudian-settings.json';
+        return path === '.obsidian/plugins/realclaudian/claudian-settings.json';
       });
       mockApp.vault.adapter.read.mockImplementation(async (path: string) => {
-        if (path === '.claudian/claudian-settings.json') {
+        if (path === '.obsidian/plugins/realclaudian/claudian-settings.json') {
           return JSON.stringify({
             enableBlocklist: false,
             blockedCommands: { unix: ['rm -rf', '  '] },
@@ -252,11 +253,11 @@ describe('ClaudianPlugin', () => {
       expect('enableBlocklist' in plugin.settings).toBe(false);
       expect('blockedCommands' in plugin.settings).toBe(false);
       expect(mockApp.vault.adapter.write).toHaveBeenCalledWith(
-        '.claudian/claudian-settings.json',
+        '.obsidian/plugins/realclaudian/claudian-settings.json',
         expect.any(String),
       );
       const writeCall = (mockApp.vault.adapter.write as jest.Mock).mock.calls.find(
-        ([path]) => path === '.claudian/claudian-settings.json',
+        ([path]) => path === '.obsidian/plugins/realclaudian/claudian-settings.json',
       );
       expect(writeCall).toBeDefined();
       const content = JSON.parse(writeCall[1]);
@@ -286,10 +287,10 @@ describe('ClaudianPlugin', () => {
 
     it('should migrate legacy openInMainTab true to main-tab placement', async () => {
       mockApp.vault.adapter.exists.mockImplementation(async (path: string) => {
-        return path === '.claudian/claudian-settings.json';
+        return path === '.obsidian/plugins/realclaudian/claudian-settings.json';
       });
       mockApp.vault.adapter.read.mockImplementation(async (path: string) => {
-        if (path === '.claudian/claudian-settings.json') {
+        if (path === '.obsidian/plugins/realclaudian/claudian-settings.json') {
           return JSON.stringify({ openInMainTab: true });
         }
         return '';
@@ -299,7 +300,7 @@ describe('ClaudianPlugin', () => {
 
       expect(plugin.settings.chatViewPlacement).toBe('main-tab');
       const writeCall = (mockApp.vault.adapter.write as jest.Mock).mock.calls.find(
-        ([path]) => path === '.claudian/claudian-settings.json',
+        ([path]) => path === '.obsidian/plugins/realclaudian/claudian-settings.json',
       );
       expect(writeCall).toBeDefined();
       const content = JSON.parse(writeCall[1]);
@@ -310,10 +311,10 @@ describe('ClaudianPlugin', () => {
     it('should reconcile model from environment and persist when changed', async () => {
       // Mock claudian-settings.json with environment variables
       mockApp.vault.adapter.exists.mockImplementation(async (path: string) => {
-        return path === '.claudian/claudian-settings.json';
+        return path === '.obsidian/plugins/realclaudian/claudian-settings.json';
       });
       mockApp.vault.adapter.read.mockImplementation(async (path: string) => {
-        if (path === '.claudian/claudian-settings.json') {
+        if (path === '.obsidian/plugins/realclaudian/claudian-settings.json') {
           return JSON.stringify({
             environmentVariables: 'ANTHROPIC_MODEL=custom-model',
             lastEnvHash: '',
@@ -338,13 +339,13 @@ describe('ClaudianPlugin', () => {
 
       // Claudian-specific settings should be written to .claudian/claudian-settings.json
       expect(mockApp.vault.adapter.write).toHaveBeenCalledWith(
-        '.claudian/claudian-settings.json',
+        '.obsidian/plugins/realclaudian/claudian-settings.json',
         expect.any(String)
       );
 
       // The written content should include state fields
       const writeCall = (mockApp.vault.adapter.write as jest.Mock).mock.calls.find(
-        ([path]) => path === '.claudian/claudian-settings.json'
+        ([path]) => path === '.obsidian/plugins/realclaudian/claudian-settings.json'
       );
       expect(writeCall).toBeDefined();
       const content = JSON.parse(writeCall[1]);
@@ -811,26 +812,26 @@ describe('ClaudianPlugin', () => {
       // Mock files exist
       mockApp.vault.adapter.exists.mockImplementation(async (path: string) => {
         // Session files
-        if (path === '.claudian/sessions' || path === '.claudian/sessions/conv-saved-1.meta.json') {
+        if (path === '.obsidian/plugins/realclaudian/sessions' || path === '.obsidian/plugins/realclaudian/sessions/conv-saved-1.meta.json') {
           return true;
         }
         // claudian-settings.json exists
-        if (path === '.claudian/claudian-settings.json') {
+        if (path === '.obsidian/plugins/realclaudian/claudian-settings.json') {
           return true;
         }
         return false;
       });
       mockApp.vault.adapter.list.mockImplementation(async (path: string) => {
-        if (path === '.claudian/sessions') {
-          return { files: ['.claudian/sessions/conv-saved-1.meta.json'], folders: [] };
+        if (path === '.obsidian/plugins/realclaudian/sessions') {
+          return { files: ['.obsidian/plugins/realclaudian/sessions/conv-saved-1.meta.json'], folders: [] };
         }
         return { files: [], folders: [] };
       });
       mockApp.vault.adapter.read.mockImplementation(async (path: string) => {
-        if (path === '.claudian/sessions/conv-saved-1.meta.json') {
+        if (path === '.obsidian/plugins/realclaudian/sessions/conv-saved-1.meta.json') {
           return sessionMeta;
         }
-        if (path === '.claudian/claudian-settings.json') {
+        if (path === '.obsidian/plugins/realclaudian/claudian-settings.json') {
           return JSON.stringify({});
         }
         return '';
@@ -857,25 +858,25 @@ describe('ClaudianPlugin', () => {
       });
 
       mockApp.vault.adapter.exists.mockImplementation(async (path: string) => {
-        return path === '.claudian/claudian-settings.json' ||
-          path === '.claudian/sessions' ||
-          path === '.claudian/sessions/conv-saved-1.meta.json';
+        return path === '.obsidian/plugins/realclaudian/claudian-settings.json' ||
+          path === '.obsidian/plugins/realclaudian/sessions' ||
+          path === '.obsidian/plugins/realclaudian/sessions/conv-saved-1.meta.json';
       });
       mockApp.vault.adapter.list.mockImplementation(async (path: string) => {
-        if (path === '.claudian/sessions') {
-          return { files: ['.claudian/sessions/conv-saved-1.meta.json'], folders: [] };
+        if (path === '.obsidian/plugins/realclaudian/sessions') {
+          return { files: ['.obsidian/plugins/realclaudian/sessions/conv-saved-1.meta.json'], folders: [] };
         }
         return { files: [], folders: [] };
       });
       mockApp.vault.adapter.read.mockImplementation(async (path: string) => {
-        if (path === '.claudian/claudian-settings.json') {
+        if (path === '.obsidian/plugins/realclaudian/claudian-settings.json') {
           // All these fields are now in claudian-settings.json
           return JSON.stringify({
             lastEnvHash: 'old-hash',
             environmentVariables: 'ANTHROPIC_BASE_URL=https://api.example.com',
           });
         }
-        if (path === '.claudian/sessions/conv-saved-1.meta.json') {
+        if (path === '.obsidian/plugins/realclaudian/sessions/conv-saved-1.meta.json') {
           return sessionMeta;
         }
         return '';
@@ -890,7 +891,7 @@ describe('ClaudianPlugin', () => {
       expect(loaded?.sessionId).toBeNull();
 
       const sessionWrite = (mockApp.vault.adapter.write as jest.Mock).mock.calls.find(
-        ([path]) => path === '.claudian/sessions/conv-saved-1.meta.json'
+        ([path]) => path === '.obsidian/plugins/realclaudian/sessions/conv-saved-1.meta.json'
       );
       expect(sessionWrite).toBeDefined();
       const meta = JSON.parse(sessionWrite?.[1] as string);
@@ -931,21 +932,21 @@ describe('ClaudianPlugin', () => {
       });
 
       mockApp.vault.adapter.exists.mockImplementation(async (path: string) => {
-        return path === '.claudian/claudian-settings.json' ||
-          path === '.claudian/sessions' ||
-          path === '.claudian/sessions/conv-multi-session.meta.json';
+        return path === '.obsidian/plugins/realclaudian/claudian-settings.json' ||
+          path === '.obsidian/plugins/realclaudian/sessions' ||
+          path === '.obsidian/plugins/realclaudian/sessions/conv-multi-session.meta.json';
       });
       mockApp.vault.adapter.list.mockImplementation(async (path: string) => {
-        if (path === '.claudian/sessions') {
-          return { files: ['.claudian/sessions/conv-multi-session.meta.json'], folders: [] };
+        if (path === '.obsidian/plugins/realclaudian/sessions') {
+          return { files: ['.obsidian/plugins/realclaudian/sessions/conv-multi-session.meta.json'], folders: [] };
         }
         return { files: [], folders: [] };
       });
       mockApp.vault.adapter.read.mockImplementation(async (path: string) => {
-        if (path === '.claudian/sessions/conv-multi-session.meta.json') {
+        if (path === '.obsidian/plugins/realclaudian/sessions/conv-multi-session.meta.json') {
           return sessionMeta;
         }
-        if (path === '.claudian/claudian-settings.json') {
+        if (path === '.obsidian/plugins/realclaudian/claudian-settings.json') {
           return JSON.stringify({});
         }
         return '';

--- a/tests/unit/providers/claude/storage/ClaudianSettingsStorage.test.ts
+++ b/tests/unit/providers/claude/storage/ClaudianSettingsStorage.test.ts
@@ -3,9 +3,9 @@ import '@/providers';
 import type { VaultFileAdapter } from '@/core/storage/VaultFileAdapter';
 import { getClaudeProviderSettings } from '@/providers/claude/settings';
 import {
-  CLAUDIAN_SETTINGS_PATH,
   ClaudianSettingsStorage,
   LEGACY_CLAUDIAN_SETTINGS_PATH,
+  OLD_CLAUDIAN_SETTINGS_PATH,
 } from '@/providers/claude/storage/ClaudianSettingsStorage';
 import { DEFAULT_SETTINGS } from '@/providers/claude/types/settings';
 import { getCodexProviderSettings } from '@/providers/codex/settings';
@@ -21,7 +21,11 @@ jest.mock('@/utils/env', () => ({
   getLegacyHostnameKey: () => mockGetLegacyHostnameKey(),
 }));
 
+const MOCK_PLUGIN_PATH = '.obsidian/plugins/realclaudian';
+const EXPECTED_SETTINGS_PATH = `${MOCK_PLUGIN_PATH}/claudian-settings.json`;
+
 const mockAdapter = {
+  pluginStoragePath: MOCK_PLUGIN_PATH,
   exists: jest.fn(),
   read: jest.fn(),
   write: jest.fn(),
@@ -56,7 +60,7 @@ describe('ClaudianSettingsStorage', () => {
       expect(mockAdapter.read).not.toHaveBeenCalled();
     });
 
-    it('loads legacy .claude settings and migrates them to .claudian', async () => {
+    it('loads legacy .claude settings and migrates them to the plugin folder', async () => {
       mockAdapter.exists.mockImplementation(async (path: string) => (
         path === LEGACY_CLAUDIAN_SETTINGS_PATH
       ));
@@ -75,10 +79,35 @@ describe('ClaudianSettingsStorage', () => {
       expect(result.model).toBe('claude-opus-4-5');
       expect(result.userName).toBe('MigratedUser');
       expect(mockAdapter.write).toHaveBeenCalledWith(
-        CLAUDIAN_SETTINGS_PATH,
+        EXPECTED_SETTINGS_PATH,
         expect.any(String),
       );
       expect(mockAdapter.delete).toHaveBeenCalledWith(LEGACY_CLAUDIAN_SETTINGS_PATH);
+    });
+
+    it('loads old .claudian settings and migrates them to the plugin folder', async () => {
+      mockAdapter.exists.mockImplementation(async (path: string) => (
+        path === OLD_CLAUDIAN_SETTINGS_PATH
+      ));
+      mockAdapter.read.mockImplementation(async (path: string) => {
+        if (path === OLD_CLAUDIAN_SETTINGS_PATH) {
+          return JSON.stringify({
+            model: 'claude-sonnet-4-5',
+            userName: 'OldPathUser',
+          });
+        }
+        return '{}';
+      });
+
+      const result = await storage.load();
+
+      expect(result.model).toBe('claude-sonnet-4-5');
+      expect(result.userName).toBe('OldPathUser');
+      expect(mockAdapter.write).toHaveBeenCalledWith(
+        EXPECTED_SETTINGS_PATH,
+        expect.any(String),
+      );
+      expect(mockAdapter.delete).toHaveBeenCalledWith(OLD_CLAUDIAN_SETTINGS_PATH);
     });
 
     it('should parse valid JSON and merge with defaults', async () => {
@@ -518,7 +547,7 @@ describe('ClaudianSettingsStorage', () => {
       await storage.save(settings);
 
       expect(mockAdapter.write).toHaveBeenCalledWith(
-        CLAUDIAN_SETTINGS_PATH,
+        EXPECTED_SETTINGS_PATH,
         expect.any(String)
       );
       const writtenContent = JSON.parse(mockAdapter.write.mock.calls[0][1]);
@@ -541,17 +570,18 @@ describe('ClaudianSettingsStorage', () => {
       expect(writtenContent).not.toHaveProperty('slashCommands');
     });
 
-    it('deletes the legacy settings file after writing the new path', async () => {
+    it('deletes legacy and old settings files after writing the new path', async () => {
       mockAdapter.exists.mockImplementation(async (path: string) => (
-        path === LEGACY_CLAUDIAN_SETTINGS_PATH
+        path === LEGACY_CLAUDIAN_SETTINGS_PATH || path === OLD_CLAUDIAN_SETTINGS_PATH
       ));
 
       await storage.save(DEFAULT_SETTINGS);
 
       expect(mockAdapter.write).toHaveBeenCalledWith(
-        CLAUDIAN_SETTINGS_PATH,
+        EXPECTED_SETTINGS_PATH,
         expect.any(String),
       );
+      expect(mockAdapter.delete).toHaveBeenCalledWith(OLD_CLAUDIAN_SETTINGS_PATH);
       expect(mockAdapter.delete).toHaveBeenCalledWith(LEGACY_CLAUDIAN_SETTINGS_PATH);
     });
 
@@ -565,24 +595,24 @@ describe('ClaudianSettingsStorage', () => {
   describe('exists', () => {
     it('should return true when the new file exists', async () => {
       mockAdapter.exists.mockImplementation(async (path: string) => (
-        path === CLAUDIAN_SETTINGS_PATH
+        path === EXPECTED_SETTINGS_PATH
       ));
 
       const result = await storage.exists();
 
       expect(result).toBe(true);
-      expect(mockAdapter.exists).toHaveBeenCalledWith(CLAUDIAN_SETTINGS_PATH);
+      expect(mockAdapter.exists).toHaveBeenCalledWith(EXPECTED_SETTINGS_PATH);
     });
 
-    it('should return true when only the legacy file exists', async () => {
+    it('should return true when only the legacy or old file exists', async () => {
       mockAdapter.exists.mockImplementation(async (path: string) => (
-        path === LEGACY_CLAUDIAN_SETTINGS_PATH
+        path === LEGACY_CLAUDIAN_SETTINGS_PATH || path === OLD_CLAUDIAN_SETTINGS_PATH
       ));
 
       const result = await storage.exists();
 
       expect(result).toBe(true);
-      expect(mockAdapter.exists).toHaveBeenCalledWith(CLAUDIAN_SETTINGS_PATH);
+      expect(mockAdapter.exists).toHaveBeenCalledWith(EXPECTED_SETTINGS_PATH);
       expect(mockAdapter.exists).toHaveBeenCalledWith(LEGACY_CLAUDIAN_SETTINGS_PATH);
     });
 

--- a/tests/unit/providers/claude/storage/SessionStorage.test.ts
+++ b/tests/unit/providers/claude/storage/SessionStorage.test.ts
@@ -5,9 +5,12 @@ import type { VaultFileAdapter } from '@/core/storage/VaultFileAdapter';
 import type { Conversation, SessionMetadata, UsageInfo } from '@/core/types';
 import {
   LEGACY_SESSIONS_PATH,
-  SESSIONS_PATH,
+  OLD_SESSIONS_PATH,
   SessionStorage,
 } from '@/providers/claude/storage/SessionStorage';
+
+const MOCK_PLUGIN_PATH = '.obsidian/plugins/realclaudian';
+const EXPECTED_SESSIONS_PATH = `${MOCK_PLUGIN_PATH}/sessions`;
 
 describe('SessionStorage', () => {
   let mockAdapter: jest.Mocked<VaultFileAdapter>;
@@ -15,6 +18,7 @@ describe('SessionStorage', () => {
 
   beforeEach(() => {
     mockAdapter = {
+      pluginStoragePath: MOCK_PLUGIN_PATH,
       exists: jest.fn(),
       read: jest.fn(),
       write: jest.fn(),
@@ -25,16 +29,16 @@ describe('SessionStorage', () => {
     storage = new SessionStorage(mockAdapter);
   });
 
-  describe('SESSIONS_PATH', () => {
-    it('should be .claudian/sessions', () => {
-      expect(SESSIONS_PATH).toBe('.claudian/sessions');
+  describe('sessionStoragePath', () => {
+    it('should derive from the plugin storage path', () => {
+      expect(storage.sessionStoragePath).toBe(EXPECTED_SESSIONS_PATH);
     });
   });
 
   describe('getMetadataPath', () => {
     it('returns correct file path for session id', () => {
       const path = storage.getMetadataPath('session-abc');
-      expect(path).toBe('.claudian/sessions/session-abc.meta.json');
+      expect(path).toBe(`${EXPECTED_SESSIONS_PATH}/session-abc.meta.json`);
     });
   });
 
@@ -53,7 +57,7 @@ describe('SessionStorage', () => {
       await storage.saveMetadata(metadata);
 
       expect(mockAdapter.write).toHaveBeenCalledWith(
-        '.claudian/sessions/session-456.meta.json',
+        `${EXPECTED_SESSIONS_PATH}/session-456.meta.json`,
         expect.any(String)
       );
 
@@ -107,7 +111,7 @@ describe('SessionStorage', () => {
       expect(result).toBeNull();
     });
 
-    it('loads legacy metadata and migrates it to .claudian', async () => {
+    it('loads legacy metadata and migrates it to the plugin folder', async () => {
       const metadata = {
         id: 'session-legacy',
         title: 'Legacy Session',
@@ -124,7 +128,7 @@ describe('SessionStorage', () => {
 
       expect(result).toEqual(metadata);
       expect(mockAdapter.write).toHaveBeenCalledWith(
-        '.claudian/sessions/session-legacy.meta.json',
+        `${EXPECTED_SESSIONS_PATH}/session-legacy.meta.json`,
         expect.any(String),
       );
       expect(mockAdapter.delete).toHaveBeenCalledWith(
@@ -188,8 +192,8 @@ describe('SessionStorage', () => {
   describe('listAllConversations - provider routing', () => {
     it('preserves providerId from metadata', async () => {
       mockAdapter.listFiles.mockResolvedValue([
-        '.claudian/sessions/claude-session.meta.json',
-        '.claudian/sessions/codex-session.meta.json',
+        `${EXPECTED_SESSIONS_PATH}/claude-session.meta.json`,
+        `${EXPECTED_SESSIONS_PATH}/codex-session.meta.json`,
       ]);
 
       mockAdapter.read.mockImplementation((path: string) => {
@@ -225,7 +229,7 @@ describe('SessionStorage', () => {
 
     it('defaults providerId to claude for legacy conversations', async () => {
       mockAdapter.listFiles.mockResolvedValue([
-        '.claudian/sessions/old.meta.json',
+        `${EXPECTED_SESSIONS_PATH}/old.meta.json`,
       ]);
 
       mockAdapter.read.mockResolvedValue(JSON.stringify({
@@ -306,15 +310,15 @@ describe('SessionStorage', () => {
     it('deletes the meta.json file', async () => {
       await storage.deleteMetadata('session-del');
 
-      expect(mockAdapter.delete).toHaveBeenCalledWith('.claudian/sessions/session-del.meta.json');
+      expect(mockAdapter.delete).toHaveBeenCalledWith(`${EXPECTED_SESSIONS_PATH}/session-del.meta.json`);
     });
   });
 
   describe('listMetadata', () => {
     it('returns metadata for .meta.json files', async () => {
       mockAdapter.listFiles.mockResolvedValue([
-        '.claudian/sessions/native-1.meta.json',
-        '.claudian/sessions/native-2.meta.json',
+        `${EXPECTED_SESSIONS_PATH}/native-1.meta.json`,
+        `${EXPECTED_SESSIONS_PATH}/native-2.meta.json`,
       ]);
 
       mockAdapter.read.mockImplementation((path: string) => {
@@ -362,8 +366,8 @@ describe('SessionStorage', () => {
 
     it('skips files that fail to load', async () => {
       mockAdapter.listFiles.mockResolvedValue([
-        '.claudian/sessions/good.meta.json',
-        '.claudian/sessions/bad.meta.json',
+        `${EXPECTED_SESSIONS_PATH}/good.meta.json`,
+        `${EXPECTED_SESSIONS_PATH}/bad.meta.json`,
       ]);
 
       mockAdapter.read.mockImplementation((path: string) => {
@@ -388,8 +392,8 @@ describe('SessionStorage', () => {
   describe('listAllConversations', () => {
     it('returns metadata from listMetadata as ConversationMeta[]', async () => {
       mockAdapter.listFiles.mockResolvedValue([
-        '.claudian/sessions/session-1.meta.json',
-        '.claudian/sessions/session-2.meta.json',
+        `${EXPECTED_SESSIONS_PATH}/session-1.meta.json`,
+        `${EXPECTED_SESSIONS_PATH}/session-2.meta.json`,
       ]);
 
       mockAdapter.read.mockImplementation((path: string) => {
@@ -439,7 +443,7 @@ describe('SessionStorage', () => {
 
     it('preserves titleGenerationStatus', async () => {
       mockAdapter.listFiles.mockResolvedValue([
-        '.claudian/sessions/session-status.meta.json',
+        `${EXPECTED_SESSIONS_PATH}/session-status.meta.json`,
       ]);
 
       mockAdapter.read.mockResolvedValue(JSON.stringify({

--- a/tests/unit/providers/claude/storage/SessionStorage.test.ts
+++ b/tests/unit/providers/claude/storage/SessionStorage.test.ts
@@ -136,6 +136,31 @@ describe('SessionStorage', () => {
       );
     });
 
+    it('loads old (.claudian) metadata and migrates it to the plugin folder', async () => {
+      const metadata = {
+        id: 'session-old',
+        title: 'Old Session',
+        createdAt: 1700000000,
+        updatedAt: 1700001000,
+      };
+
+      mockAdapter.exists.mockImplementation(async (path: string) => (
+        path === `${OLD_SESSIONS_PATH}/session-old.meta.json`
+      ));
+      mockAdapter.read.mockResolvedValue(JSON.stringify(metadata));
+
+      const result = await storage.loadMetadata('session-old');
+
+      expect(result).toEqual(metadata);
+      expect(mockAdapter.write).toHaveBeenCalledWith(
+        `${EXPECTED_SESSIONS_PATH}/session-old.meta.json`,
+        expect.any(String),
+      );
+      expect(mockAdapter.delete).toHaveBeenCalledWith(
+        `${OLD_SESSIONS_PATH}/session-old.meta.json`,
+      );
+    });
+
     it('loads and parses metadata from JSON file', async () => {
       const metadata = {
         id: 'session-abc',

--- a/tests/unit/providers/claude/storage/storageService.convenience.test.ts
+++ b/tests/unit/providers/claude/storage/storageService.convenience.test.ts
@@ -9,6 +9,7 @@ function createMockAdapter(initialFiles: Record<string, string> = {}) {
 
   return {
     adapter: {
+      pluginStoragePath: '.obsidian/plugins/realclaudian',
       exists: jest.fn(async (path: string) => files.has(path) || folders.has(path)),
       read: jest.fn(async (path: string) => {
         const content = files.get(path);
@@ -52,7 +53,7 @@ function createMockPlugin(options: {
 }) {
   const { adapter, files, folders } = createMockAdapter(options.initialFiles);
   const plugin = {
-    app: { vault: { adapter } },
+    app: { vault: { configDir: '.obsidian', adapter } },
     loadData: jest.fn().mockResolvedValue(options.dataJson ?? null),
     saveData: jest.fn().mockResolvedValue(undefined),
   };
@@ -175,7 +176,7 @@ describe('StorageService convenience methods', () => {
     it('updates partial claudian settings', async () => {
       const { plugin, files } = createMockPlugin({
         initialFiles: {
-          '.claudian/claudian-settings.json': claudianSettingsJson,
+          '.obsidian/plugins/realclaudian/claudian-settings.json': claudianSettingsJson,
         },
       });
       const storage = new StorageService(plugin);
@@ -183,7 +184,7 @@ describe('StorageService convenience methods', () => {
 
       await storage.updateClaudianSettings({ userName: 'NewUser' });
 
-      const saved = JSON.parse(files.get('.claudian/claudian-settings.json')!) as Record<string, unknown>;
+      const saved = JSON.parse(files.get('.obsidian/plugins/realclaudian/claudian-settings.json')!) as Record<string, unknown>;
       expect(saved.userName).toBe('NewUser');
     });
   });
@@ -192,7 +193,7 @@ describe('StorageService convenience methods', () => {
     it('saves full claudian settings', async () => {
       const { plugin, files } = createMockPlugin({
         initialFiles: {
-          '.claudian/claudian-settings.json': claudianSettingsJson,
+          '.obsidian/plugins/realclaudian/claudian-settings.json': claudianSettingsJson,
         },
       });
       const storage = new StorageService(plugin);
@@ -202,7 +203,7 @@ describe('StorageService convenience methods', () => {
       existing.userName = 'FullSave';
       await storage.saveClaudianSettings(existing);
 
-      const saved = JSON.parse(files.get('.claudian/claudian-settings.json')!) as Record<string, unknown>;
+      const saved = JSON.parse(files.get('.obsidian/plugins/realclaudian/claudian-settings.json')!) as Record<string, unknown>;
       expect(saved.userName).toBe('FullSave');
     });
   });
@@ -211,7 +212,7 @@ describe('StorageService convenience methods', () => {
     it('loads claudian settings', async () => {
       const { plugin } = createMockPlugin({
         initialFiles: {
-          '.claudian/claudian-settings.json': claudianSettingsJson,
+          '.obsidian/plugins/realclaudian/claudian-settings.json': claudianSettingsJson,
         },
       });
       const storage = new StorageService(plugin);
@@ -222,7 +223,7 @@ describe('StorageService convenience methods', () => {
       expect(settings.model).toBe('haiku');
     });
 
-    it('migrates legacy settings into .claudian during initialization', async () => {
+    it('migrates legacy settings into the plugin folder during initialization', async () => {
       const { plugin, files } = createMockPlugin({
         initialFiles: {
           '.claude/claudian-settings.json': claudianSettingsJson,
@@ -232,7 +233,7 @@ describe('StorageService convenience methods', () => {
 
       await storage.initialize();
 
-      expect(files.get('.claudian/claudian-settings.json')).toBeDefined();
+      expect(files.get('.obsidian/plugins/realclaudian/claudian-settings.json')).toBeDefined();
       expect(files.has('.claude/claudian-settings.json')).toBe(false);
     });
   });

--- a/tests/unit/providers/opencode/OpencodeLaunchArtifacts.test.ts
+++ b/tests/unit/providers/opencode/OpencodeLaunchArtifacts.test.ts
@@ -158,6 +158,7 @@ describe('prepareOpencodeLaunchArtifacts', () => {
     }), 'utf8');
 
     const result = await prepareOpencodeLaunchArtifacts({
+      configDir: '.obsidian',
       runtimeEnv: {
         HOME: tmpRoot,
         OPENCODE_CONFIG: baseConfigPath,
@@ -171,8 +172,8 @@ describe('prepareOpencodeLaunchArtifacts', () => {
       workspaceRoot: tmpRoot,
     });
 
-    expect(result.configPath).toBe(path.join(tmpRoot, '.claudian', 'opencode', 'config.json'));
-    expect(result.systemPromptPath).toBe(path.join(tmpRoot, '.claudian', 'opencode', 'system.md'));
+    expect(result.configPath).toBe(path.join(tmpRoot, '.obsidian', 'plugins', 'realclaudian', 'opencode', 'config.json'));
+    expect(result.systemPromptPath).toBe(path.join(tmpRoot, '.obsidian', 'plugins', 'realclaudian', 'opencode', 'system.md'));
     expect(result.configContent).toContain(`"prompt": "{file:${result.systemPromptPath}}"`);
     const generatedConfig = JSON.parse(await fs.readFile(result.configPath, 'utf8'));
     expect(generatedConfig).toMatchObject({
@@ -226,6 +227,7 @@ describe('prepareOpencodeLaunchArtifacts', () => {
     };
     const first = await prepareOpencodeLaunchArtifacts({
       ...baseParams,
+      configDir: '.obsidian',
       runtimeEnv: {
         HOME: tmpRoot,
       } as NodeJS.ProcessEnv,
@@ -233,6 +235,7 @@ describe('prepareOpencodeLaunchArtifacts', () => {
 
     const second = await prepareOpencodeLaunchArtifacts({
       ...baseParams,
+      configDir: '.obsidian',
       runtimeEnv: {
         HOME: tmpRoot,
         OPENCODE_DB: first.databasePath ?? undefined,
@@ -249,6 +252,7 @@ describe('prepareOpencodeLaunchArtifacts', () => {
     const databaseDir = path.join(xdgDataHome, 'opencode');
 
     const result = await prepareOpencodeLaunchArtifacts({
+      configDir: '.obsidian',
       runtimeEnv: {
         HOME: path.join(tmpRoot, 'home'),
         XDG_DATA_HOME: xdgDataHome,


### PR DESCRIPTION
## Problem
Claudian stores settings and session data at `.claudian/` in the vault root, but Obsidian allows configuring the config folder name (not always `.obsidian`).

This can cause issues when a vault is shared between machines or multiple users. With separate Obsidian config files, each user's plugins are cleanly isolated but Claudian settings in `.claudian/` are shared, creating conflicts and making customization difficult.

## Solution
Derive the plugin storage path dynamically from `app.vault.configDir` at runtime, placing settings under `{configDir}/plugins/realclaudian/`.

Migration checks are added to move data from `.claudian/` and the legacy `.claude/` location to the new path, so existing users can update without manually moving files or reconfiguring.

## Changes
- Added `pluginStoragePath` getter to `VaultFileAdapter`
- `ClaudianSettingsStorage` and `SessionStorage` compute paths from the adapter
- `OpencodeLaunchArtifacts` accepts `configDir` parameter
- Old `.claudian/` and `.claude/` data is migrated on first load

## Migration Behaviour 
On first load after updating, Claudian checks for settings in this order:

1. New path = `{configDir}/plugins/realclaudian/claudian-settings.json`
2. Old path = `.claudian/claudian-settings.json`
3. Legacy path = `.claude/claudian-settings.json`

Whichever is found first gets loaded. If the file wasn't already at the new path, settings are saved to the new location and the old files are deleted. Session metadata (`.meta.json` files) follows the same pattern.

The `.claude/` folder itself is not affected; only Claudian's own files within it are migrated and removed.

## Future consideration
Some users may prefer the original location. A setting to opt into a vault-root path (`.claudian/`) for portability would require a bootstrap setting in `data.json` to avoid circular path resolution.

Fixes #842
Fixes #627 