### PR TITLE
feat: support environment snippet selection in model dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -237,7 +237,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -673,6 +672,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -737,7 +737,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
       "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -747,7 +746,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
       "integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
@@ -843,7 +841,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -867,7 +864,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2250,7 +2246,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -2569,7 +2564,6 @@
       "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.59.3",
@@ -2599,7 +2593,6 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -3093,7 +3086,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3601,7 +3593,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4568,7 +4559,6 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5131,7 +5121,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5676,7 +5665,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6339,7 +6327,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
       "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7115,7 +7102,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -7748,7 +7734,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -7825,6 +7810,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "ts-algebra": "^2.0.0"
@@ -8683,7 +8669,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10023,7 +10008,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -10797,7 +10783,6 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11486,7 +11471,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -20,7 +20,7 @@ import {
 import type { ChatRuntime } from '../../../core/runtime/ChatRuntime';
 import type { AutoTurnResult } from '../../../core/runtime/types';
 import { TOOL_AGENT_OUTPUT } from '../../../core/tools/toolNames';
-import type { ChatMessage, ClaudianSettings, Conversation, StreamChunk } from '../../../core/types';
+import type { ChatMessage, ClaudianSettings, Conversation, StreamChunk, EnvironmentScope } from '../../../core/types';
 import { t } from '../../../i18n/i18n';
 import type ClaudianPlugin from '../../../main';
 import { SlashCommandDropdown } from '../../../shared/components/SlashCommandDropdown';
@@ -825,7 +825,73 @@ function initializeInputToolbar(
     getCapabilities: () => getTabCapabilities(tab, plugin),
     getSettings: () => getTabSettingsSnapshot(tab, plugin),
     getEnvironmentVariables: () => plugin.getActiveEnvironmentVariables(),
+    getEnvSnippets: () => plugin.settings.envSnippets,
+    getProviderId: () => tab.providerId ?? DEFAULT_CHAT_PROVIDER_ID,
     onModelChange: async (model: string) => {
+      if (model.startsWith('snippet:')) {
+        const snippetId = model.slice('snippet:'.length);
+        const snippet = plugin.settings.envSnippets.find(s => s.id === snippetId);
+        if (snippet) {
+          try {
+            const currentProvider = tab.providerId;
+            const scope: EnvironmentScope = tab.providerId ? `provider:${tab.providerId}` : 'shared';
+            
+            await plugin.applyEnvSnippet(snippet, scope);
+            
+            const newModel = plugin.settings.model;
+            const newProvider = getEnabledProviderForModel(newModel, plugin.settings);
+            
+            if (tab.lifecycleState === 'blank') {
+              tab.draftModel = newModel;
+              const didProviderChange = newProvider !== currentProvider;
+              if (tab.service) {
+                cleanupTabRuntime(tab);
+              }
+              tab.providerId = newProvider;
+              if (didProviderChange) {
+                syncTabProviderServices(tab, plugin);
+              }
+              syncSlashCommandDropdownForProvider(tab, plugin, getProviderCatalogConfig);
+            } else {
+              if (newProvider !== currentProvider) {
+                new Notice('Cannot switch provider on a bound session. Start a new tab instead.');
+                return;
+              }
+            }
+            
+            new Notice(`Applied environment snippet "${snippet.name}"`);
+            
+            const uiConfig = getTabChatUIConfig(tab, plugin);
+            const providerSettings = getTabSettingsSnapshot(tab, plugin);
+            await uiConfig.prepareModelMetadata?.(newModel, plugin.settings, { plugin });
+            
+            tab.ui.thinkingBudgetSelector?.updateDisplay();
+            tab.ui.serviceTierToggle?.updateDisplay();
+            tab.ui.modelSelector?.updateDisplay();
+            tab.ui.modeSelector?.updateDisplay();
+            tab.ui.modelSelector?.renderOptions();
+            tab.ui.modeSelector?.renderOptions();
+            
+            if (tab.lifecycleState !== 'blank') {
+              const currentUsage = tab.state.usage;
+              if (currentUsage) {
+                const newContextWindow = uiConfig.getContextWindowSize(
+                  newModel,
+                  providerSettings.customContextLimits,
+                  providerSettings,
+                );
+                tab.state.usage = recalculateUsageForModel(currentUsage, newModel, newContextWindow);
+              }
+            } else {
+              applyProviderUIGating(tab, plugin);
+            }
+          } catch (e) {
+            new Notice('Failed to apply environment snippet');
+          }
+        }
+        return;
+      }
+
       // For blank tabs, update draft model and derive provider
       if (tab.lifecycleState === 'blank') {
         const previousProvider = tab.providerId;

--- a/src/features/chat/ui/FileContext.ts
+++ b/src/features/chat/ui/FileContext.ts
@@ -1,5 +1,5 @@
 import type { App, EventRef } from 'obsidian';
-import { Notice, TFile } from 'obsidian';
+import { Notice, TFile, TFolder } from 'obsidian';
 
 import type { McpServerManager } from '../../../core/mcp/McpServerManager';
 import type { AgentMentionProvider } from '../../../shared/mention/MentionDropdownController';
@@ -36,6 +36,7 @@ export class FileContextManager {
   private mentionDropdown: MentionDropdownController;
   private deleteEventRef: EventRef | null = null;
   private renameEventRef: EventRef | null = null;
+  private dropOverlay: HTMLElement | null = null;
 
   // Current note (shown as chip)
   private currentNotePath: string | null = null;
@@ -108,6 +109,8 @@ export class FileContextManager {
     this.renameEventRef = this.app.vault.on('rename', (file, oldPath) => {
       if (file instanceof TFile) this.handleFileRenamed(oldPath, file.path);
     });
+
+    this.setupDragAndDrop();
   }
 
   /** Returns the current note path (shown as chip). */
@@ -259,6 +262,183 @@ export class FileContextManager {
     if (this.renameEventRef) this.app.vault.offref(this.renameEventRef);
     this.mentionDropdown.destroy();
     this.chipsView.destroy();
+  }
+
+  private setupDragAndDrop() {
+    const inputWrapper = this.inputEl.closest('.claudian-input-wrapper') as HTMLElement;
+    if (!inputWrapper) return;
+
+    const ownerDocument = inputWrapper.ownerDocument ?? window.document;
+    this.dropOverlay = inputWrapper.createDiv({ cls: 'claudian-file-drop-overlay' });
+    const dropContent = this.dropOverlay.createDiv({ cls: 'claudian-file-drop-content' });
+
+    const svg = ownerDocument.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 24 24');
+    svg.setAttribute('width', '32');
+    svg.setAttribute('height', '32');
+    svg.setAttribute('fill', 'none');
+    svg.setAttribute('stroke', 'currentColor');
+    svg.setAttribute('stroke-width', '2');
+    const pathEl = ownerDocument.createElementNS('http://www.w3.org/2000/svg', 'path');
+    pathEl.setAttribute('d', 'M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z');
+    svg.appendChild(pathEl);
+    dropContent.appendChild(svg);
+    dropContent.createSpan({ text: 'Drop file or folder here' });
+
+    const dropZone = inputWrapper;
+
+    dropZone.addEventListener('dragenter', (e) => this.handleDragEnter(e));
+    dropZone.addEventListener('dragover', (e) => this.handleDragOver(e));
+    dropZone.addEventListener('dragleave', (e) => this.handleDragLeave(e));
+    dropZone.addEventListener('drop', (e) => {
+      void this.handleDrop(e);
+    });
+  }
+
+  private handleDragEnter(e: DragEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const draggedItems = (this.app as any).dragManager?.draggedItems;
+    const hasDraggedFiles = draggedItems && draggedItems.length > 0 && draggedItems.some((item: any) => item.file);
+    const hasExternalFiles = e.dataTransfer?.types.includes('Files');
+    const hasInternalUri = e.dataTransfer?.types.includes('text/uri-list');
+
+    if (hasDraggedFiles || hasExternalFiles || hasInternalUri) {
+      this.dropOverlay?.addClass('visible');
+    }
+  }
+
+  private handleDragOver(e: DragEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
+  private handleDragLeave(e: DragEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const inputWrapper = this.inputEl.closest('.claudian-input-wrapper');
+    if (!inputWrapper) {
+      this.dropOverlay?.removeClass('visible');
+      return;
+    }
+
+    const rect = inputWrapper.getBoundingClientRect();
+    if (
+      e.clientX <= rect.left ||
+      e.clientX >= rect.right ||
+      e.clientY <= rect.top ||
+      e.clientY >= rect.bottom
+    ) {
+      this.dropOverlay?.removeClass('visible');
+    }
+  }
+
+  private async handleDrop(e: DragEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    this.dropOverlay?.removeClass('visible');
+
+    const addedPaths: string[] = [];
+    let hasResolvedInternal = false;
+
+    // 1. Resolve internal Obsidian file/folder drags via dataTransfer URIs
+    const plainText = typeof e.dataTransfer?.getData === 'function'
+      ? e.dataTransfer.getData('text/plain') || ''
+      : '';
+    if (plainText.includes('obsidian://open')) {
+      const lines = plainText.split(/\r?\n/);
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed.startsWith('obsidian://open')) {
+          try {
+            const url = new URL(trimmed);
+            const fileParam = url.searchParams.get('file');
+            if (fileParam) {
+              const decodedPath = decodeURIComponent(fileParam);
+              const normalizedPath = this.normalizePathForVault(decodedPath);
+              if (normalizedPath) {
+                this.state.attachFile(normalizedPath);
+                const abstractFile = this.app.vault.getAbstractFileByPath(normalizedPath);
+                const isFolder = abstractFile instanceof TFolder;
+                const formatted = isFolder ? `${normalizedPath}/` : normalizedPath;
+                addedPaths.push(formatted);
+                hasResolvedInternal = true;
+              }
+            }
+          } catch (err) {
+            // Ignore invalid URIs
+          }
+        }
+      }
+    }
+
+    // 2. Fallback to app.dragManager (just in case)
+    if (!hasResolvedInternal) {
+      const draggedItems = (this.app as any).dragManager?.draggedItems;
+      if (draggedItems && draggedItems.length > 0) {
+        for (const item of draggedItems) {
+          if (item.file) {
+            const rawPath = item.file.path;
+            const normalizedPath = this.normalizePathForVault(rawPath);
+            if (normalizedPath) {
+              this.state.attachFile(normalizedPath);
+              const isFolder = item.file instanceof TFolder;
+              const formatted = isFolder ? `${normalizedPath}/` : normalizedPath;
+              addedPaths.push(formatted);
+              hasResolvedInternal = true;
+            }
+          }
+        }
+      }
+    }
+
+    // 3. Resolve external OS drags
+    if (!hasResolvedInternal) {
+      const files = e.dataTransfer?.files;
+      if (files && files.length > 0) {
+        for (let i = 0; i < files.length; i++) {
+          const file = files[i];
+          let rawPath = (file as any).path || '';
+          if (!rawPath && (window as any).electron?.webUtils) {
+            rawPath = (window as any).electron.webUtils.getPathForFile(file);
+          }
+          if (rawPath) {
+            const normalizedPath = this.normalizePathForVault(rawPath);
+            if (normalizedPath) {
+              this.state.attachFile(normalizedPath);
+              addedPaths.push(normalizedPath);
+            }
+          }
+        }
+      }
+    }
+
+    if (addedPaths.length > 0) {
+      const textToInsert = addedPaths.map(p => `@${p}`).join(' ') + ' ';
+      this.insertTextAtCursor(textToInsert);
+      this.callbacks.onChipsChanged?.();
+    }
+  }
+
+  private insertTextAtCursor(textToInsert: string) {
+    const input = this.inputEl;
+    const start = input.selectionStart || 0;
+    const end = input.selectionEnd || 0;
+    const value = input.value;
+
+    let prefix = '';
+    if (start > 0 && !/\s/.test(value[start - 1])) {
+      prefix = ' ';
+    }
+
+    input.value = value.substring(0, start) + prefix + textToInsert + value.substring(end);
+    const newCursorPos = start + prefix.length + textToInsert.length;
+    input.selectionStart = input.selectionEnd = newCursorPos;
+
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.focus();
   }
 
   /** Normalizes a file path to be vault-relative with forward slashes. */

--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -15,7 +15,9 @@ import type {
 import type {
   ManagedMcpServer,
   UsageInfo,
+  EnvSnippet,
 } from '../../../core/types';
+import { t } from '../../../i18n/i18n';
 import { appendCheckIcon, appendMcpIcon, createProviderIconSvg } from '../../../shared/icons';
 import { filterValidPaths, findConflictingPath, isDuplicatePath, isValidDirectoryPath, validateDirectoryPath } from '../../../utils/externalContext';
 import { expandHomePath, normalizePathForFilesystem } from '../../../utils/path';
@@ -57,6 +59,8 @@ export interface ToolbarCallbacks {
   getEnvironmentVariables?: () => string;
   getUIConfig: () => ProviderChatUIConfig;
   getCapabilities: () => ProviderCapabilities;
+  getEnvSnippets?: () => EnvSnippet[];
+  getProviderId?: () => string;
 }
 
 export class ModelSelector {
@@ -73,10 +77,35 @@ export class ModelSelector {
   private getAvailableModels() {
     const settings = this.callbacks.getSettings();
     const uiConfig = this.callbacks.getUIConfig();
-    return uiConfig.getModelOptions({
+    const models = uiConfig.getModelOptions({
       ...settings,
       environmentVariables: this.callbacks.getEnvironmentVariables?.(),
     });
+
+    if (this.callbacks.getEnvSnippets && this.callbacks.getProviderId) {
+      const providerId = this.callbacks.getProviderId();
+      const scope = `provider:${providerId}`;
+      const snippets = this.callbacks.getEnvSnippets().filter((snippet) => {
+        if (!snippet.scope || snippet.scope === 'shared') {
+          return true;
+        }
+        return snippet.scope === scope;
+      });
+
+      if (snippets.length > 0) {
+        const groupName = t('settings.envSnippets.name');
+        for (const snippet of snippets) {
+          models.push({
+            value: `snippet:${snippet.id}`,
+            label: snippet.name,
+            description: snippet.description || 'Apply environment variables',
+            group: groupName,
+          });
+        }
+      }
+    }
+
+    return models;
   }
 
   private render() {
@@ -124,14 +153,19 @@ export class ModelSelector {
         option.addClass('selected');
       }
 
-      const icon = model.providerIcon ?? this.callbacks.getUIConfig().getProviderIcon?.();
-      if (icon) {
-        option.appendChild(createProviderIconSvg(icon, {
-          className: 'claudian-model-provider-icon',
-          height: 12,
-          ownerDocument: option.ownerDocument,
-          width: 12,
-        }));
+      if (model.value.startsWith('snippet:')) {
+        const iconEl = option.createSpan({ cls: 'claudian-model-provider-icon claudian-snippet-icon' });
+        setIcon(iconEl, 'clipboard-paste');
+      } else {
+        const icon = model.providerIcon ?? this.callbacks.getUIConfig().getProviderIcon?.();
+        if (icon) {
+          option.appendChild(createProviderIconSvg(icon, {
+            className: 'claudian-model-provider-icon',
+            height: 12,
+            ownerDocument: option.ownerDocument,
+            width: 12,
+          }));
+        }
       }
       option.createSpan({ text: model.label });
       if (model.description) {

--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -18,6 +18,7 @@ import type {
   EnvSnippet,
 } from '../../../core/types';
 import { t } from '../../../i18n/i18n';
+import { parseEnvironmentVariables } from '../../../utils/env';
 import { appendCheckIcon, appendMcpIcon, createProviderIconSvg } from '../../../shared/icons';
 import { filterValidPaths, findConflictingPath, isDuplicatePath, isValidDirectoryPath, validateDirectoryPath } from '../../../utils/externalContext';
 import { expandHomePath, normalizePathForFilesystem } from '../../../utils/path';
@@ -116,20 +117,43 @@ export class ModelSelector {
 
     this.dropdownEl = this.container.createDiv({ cls: 'claudian-model-dropdown' });
     this.renderOptions();
+
+    this.container.addEventListener('mouseleave', () => {
+      this.dropdownEl?.removeClass('hidden');
+    });
   }
 
   updateDisplay() {
     if (!this.buttonEl) return;
     const currentModel = this.callbacks.getSettings().model;
     const models = this.getAvailableModels();
-    const modelInfo = models.find(m => m.value === currentModel);
 
+    let activeSnippetLabel: string | undefined;
+    const snippets = this.callbacks.getEnvSnippets?.() || [];
+    const currentEnvText = this.callbacks.getEnvironmentVariables?.() || '';
+    if (snippets.length > 0 && currentEnvText) {
+      for (const snippet of snippets) {
+        const snippetVars = parseEnvironmentVariables(snippet.envVars);
+        const currentVars = parseEnvironmentVariables(currentEnvText);
+        const keys = Object.keys(snippetVars).filter(k => k !== 'PATH');
+        if (keys.length > 0 && keys.every(k => currentVars[k] === snippetVars[k])) {
+          activeSnippetLabel = snippet.name;
+          break;
+        }
+      }
+    }
+
+    const modelInfo = models.find(m => m.value === currentModel);
     const displayModel = modelInfo || models[0];
 
     this.buttonEl.empty();
 
     const labelEl = this.buttonEl.createSpan({ cls: 'claudian-model-label' });
-    labelEl.setText(displayModel?.label || 'Unknown');
+    let labelText = displayModel?.label || 'Unknown';
+    if (activeSnippetLabel) {
+      labelText = `${activeSnippetLabel} (${labelText})`;
+    }
+    labelEl.setText(labelText);
   }
 
   renderOptions() {
@@ -140,6 +164,9 @@ export class ModelSelector {
     const models = this.getAvailableModels();
     const reversed = [...models].reverse();
 
+    const snippets = this.callbacks.getEnvSnippets?.() || [];
+    const currentEnvText = this.callbacks.getEnvironmentVariables?.() || '';
+
     let lastGroup: string | undefined;
     for (const model of reversed) {
       if (model.group && model.group !== lastGroup) {
@@ -149,7 +176,22 @@ export class ModelSelector {
       }
 
       const option = this.dropdownEl.createDiv({ cls: 'claudian-model-option' });
-      if (model.value === currentModel) {
+
+      let isSelected = model.value === currentModel;
+      if (model.value.startsWith('snippet:')) {
+        const snippetId = model.value.slice('snippet:'.length);
+        const snippet = snippets.find(s => s.id === snippetId);
+        if (snippet && currentEnvText) {
+          const snippetVars = parseEnvironmentVariables(snippet.envVars);
+          const currentVars = parseEnvironmentVariables(currentEnvText);
+          const keys = Object.keys(snippetVars).filter(k => k !== 'PATH');
+          if (keys.length > 0 && keys.every(k => currentVars[k] === snippetVars[k])) {
+            isSelected = true;
+          }
+        }
+      }
+
+      if (isSelected) {
         option.addClass('selected');
       }
 
@@ -174,6 +216,7 @@ export class ModelSelector {
 
       option.addEventListener('click', (e) => {
         e.stopPropagation();
+        this.dropdownEl?.addClass('hidden');
         runToolbarAction(async () => {
           await this.callbacks.onModelChange(model.value);
           this.updateDisplay();

--- a/src/features/settings/ui/EnvSnippetManager.ts
+++ b/src/features/settings/ui/EnvSnippetManager.ts
@@ -384,7 +384,16 @@ export class EnvSnippetManager {
       return !snippet.scope || snippet.scope === 'shared';
     }
 
-    return snippet.scope === this.scope;
+    if (snippet.scope === this.scope) {
+      return true;
+    }
+
+    if (!snippet.scope) {
+      const updates = getEnvironmentScopeUpdates(snippet.envVars);
+      return updates.some(u => u.scope === this.scope);
+    }
+
+    return false;
   }
 
   private syncTextareaValue(scope: EnvironmentScope, value: string): void {

--- a/src/features/settings/ui/EnvSnippetManager.ts
+++ b/src/features/settings/ui/EnvSnippetManager.ts
@@ -339,45 +339,12 @@ export class EnvSnippetManager {
       snippet.scope ?? this.scope,
     );
 
-    if (updates.length === 1) {
-      const [update] = updates;
+    for (const update of updates) {
       this.syncTextareaValue(update.scope, update.envText);
-      await this.plugin.applyEnvironmentVariables(update.scope, update.envText);
-    } else if (updates.length > 1) {
-      for (const update of updates) {
-        this.syncTextareaValue(update.scope, update.envText);
-      }
-      await this.plugin.applyEnvironmentVariablesBatch(updates);
     }
 
-    // Legacy snippets without contextLimits don't modify limits
-    if (snippet.contextLimits) {
-      this.plugin.settings.customContextLimits = {
-        ...this.plugin.settings.customContextLimits,
-        ...snippet.contextLimits,
-      };
-    }
-
-    // Legacy snippets without modelAliases don't modify aliases. Snippets saved
-    // with alias fields clear aliases for their own model IDs when left empty.
-    if (snippet.modelAliases) {
-      const modelIds = ProviderRegistry.getCustomModelIds(parseEnvironmentVariables(snippet.envVars));
-      const nextAliases = { ...(this.plugin.settings.customModelAliases ?? {}) };
-      for (const modelId of modelIds) {
-        const alias = snippet.modelAliases[modelId]?.trim();
-        if (alias) {
-          nextAliases[modelId] = alias;
-        } else {
-          delete nextAliases[modelId];
-        }
-      }
-      this.plugin.settings.customModelAliases = nextAliases;
-    }
-    await this.plugin.saveSettings();
-
+    await this.plugin.applyEnvSnippet(snippet, this.scope);
     this.onContextLimitsChange?.();
-    const view = this.plugin.app.workspace.getLeavesOfType('claudian-view')[0]?.view as ClaudianView | undefined;
-    view?.refreshModelSelector();
   }
 
   private editSnippet(snippet: EnvSnippet) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { MarkdownView, Notice, Plugin } from 'obsidian';
 import { DEFAULT_CLAUDIAN_SETTINGS } from './app/settings/defaultSettings';
 import { SharedStorageService } from './app/storage/SharedStorageService';
 import type { SharedAppStorage } from './core/bootstrap/storage';
+import { getEnvironmentScopeUpdates } from './core/providers/providerEnvironment';
 import {
   getEnvironmentVariablesForScope as getScopedEnvironmentVariables,
   getRuntimeEnvironmentText,
@@ -25,7 +26,10 @@ import type {
   ClaudianSettings,
   Conversation,
   ConversationMeta,
+  EnvSnippet,
 } from './core/types';
+import { parseEnvironmentVariables } from './utils/env';
+import { getCurrentModelFromEnvironment } from './providers/claude/env/claudeModelEnv';
 import {
   VIEW_TYPE_CLAUDIAN,
 } from './core/types';
@@ -729,6 +733,74 @@ export default class ClaudianPlugin extends Plugin {
   async persistTabManagerState(state: AppTabManagerState): Promise<void> {
     this.lastKnownTabManagerState = state;
     await this.storage.setTabManagerState(state);
+  }
+
+  async applyEnvSnippet(snippet: EnvSnippet, fallbackScope: EnvironmentScope): Promise<void> {
+    const snippetContent = snippet.envVars.trim();
+    const updates = getEnvironmentScopeUpdates(
+      snippetContent,
+      snippet.scope ?? fallbackScope,
+    );
+
+    if (updates.length === 1) {
+      const [update] = updates;
+      await this.applyEnvironmentVariables(update.scope, update.envText);
+    } else if (updates.length > 1) {
+      await this.applyEnvironmentVariablesBatch(updates);
+    }
+
+    if (snippet.contextLimits) {
+      this.settings.customContextLimits = {
+        ...this.settings.customContextLimits,
+        ...snippet.contextLimits,
+      };
+    }
+
+    if (snippet.modelAliases) {
+      const modelIds = ProviderRegistry.getCustomModelIds(parseEnvironmentVariables(snippet.envVars));
+      const nextAliases = { ...(this.settings.customModelAliases ?? {}) };
+      for (const modelId of modelIds) {
+        const alias = snippet.modelAliases[modelId]?.trim();
+        if (alias) {
+          nextAliases[modelId] = alias;
+        } else {
+          delete nextAliases[modelId];
+        }
+      }
+      this.settings.customModelAliases = nextAliases;
+    }
+
+    // Try to auto-select the model defined in the environment variables
+    const envVars = parseEnvironmentVariables(snippet.envVars);
+    const resolvedModel = getCurrentModelFromEnvironment(envVars) || envVars.OPENAI_MODEL;
+    if (resolvedModel) {
+      const settingsBag = this.settings as unknown as Record<string, unknown>;
+      const providerId = ProviderRegistry.resolveProviderForModel(resolvedModel, settingsBag);
+      const uiConfig = ProviderRegistry.getChatUIConfig(providerId);
+
+      const snapshot = ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+        settingsBag,
+        providerId,
+      );
+      snapshot.model = resolvedModel;
+      uiConfig.applyModelDefaults(resolvedModel, snapshot);
+
+      ProviderSettingsCoordinator.commitProviderSettingsSnapshot(
+        settingsBag,
+        providerId,
+        snapshot,
+      );
+
+      // If this is the active settings provider, also update the top-level projected model
+      if (this.settings.settingsProvider === providerId) {
+        this.settings.model = resolvedModel;
+      }
+    }
+
+    await this.saveSettings();
+
+    const view = this.getView();
+    view?.refreshModelSelector();
   }
 
   getView(): ClaudianView | null {

--- a/src/providers/claude/env/claudeModelEnv.ts
+++ b/src/providers/claude/env/claudeModelEnv.ts
@@ -2,13 +2,14 @@ import { formatCustomModelLabel } from '../modelLabels';
 
 const CUSTOM_MODEL_ENV_KEYS = [
   'ANTHROPIC_MODEL',
+  'CLAUDE_CODE_LLM_MODEL',
   'ANTHROPIC_DEFAULT_OPUS_MODEL',
   'ANTHROPIC_DEFAULT_SONNET_MODEL',
   'ANTHROPIC_DEFAULT_HAIKU_MODEL',
 ] as const;
 
 function getModelTypeFromEnvKey(envKey: string): string {
-  if (envKey === 'ANTHROPIC_MODEL') return 'model';
+  if (envKey === 'ANTHROPIC_MODEL' || envKey === 'CLAUDE_CODE_LLM_MODEL') return 'model';
   const match = envKey.match(/ANTHROPIC_DEFAULT_(\w+)_MODEL/);
   return match ? match[1].toLowerCase() : envKey;
 }
@@ -61,6 +62,9 @@ export function getModelsFromEnvironment(
 export function getCurrentModelFromEnvironment(envVars: Record<string, string>): string | null {
   if (envVars.ANTHROPIC_MODEL) {
     return envVars.ANTHROPIC_MODEL;
+  }
+  if (envVars.CLAUDE_CODE_LLM_MODEL) {
+    return envVars.CLAUDE_CODE_LLM_MODEL;
   }
   if (envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL) {
     return envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL;

--- a/src/style/features/file-context.css
+++ b/src/style/features/file-context.css
@@ -186,3 +186,42 @@
   white-space: nowrap;
   min-width: 0;
 }
+
+/* Drag and drop for files/folders overlay */
+.claudian-file-drop-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(var(--claudian-brand-rgb), 0.08);
+  border: 2px dashed var(--claudian-brand);
+  border-radius: 6px;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  pointer-events: none;
+}
+
+.claudian-file-drop-overlay.visible {
+  display: flex;
+}
+
+.claudian-file-drop-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  color: var(--claudian-brand);
+}
+
+.claudian-file-drop-content svg {
+  opacity: 0.7;
+}
+
+.claudian-file-drop-content span {
+  font-size: 12px;
+  font-weight: 500;
+}
+

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -332,10 +332,23 @@ export function parseEnvironmentVariables(input: string): Record<string, string>
     if (eqIndex > 0) {
       const key = normalized.substring(0, eqIndex).trim();
       let value = normalized.substring(eqIndex + 1).trim();
-      if ((value.startsWith('"') && value.endsWith('"')) ||
-          (value.startsWith("'") && value.endsWith("'"))) {
-        value = value.slice(1, -1);
+      
+      // Define matching pairs of quotes to strip
+      const quotePairs = [
+        ['"', '"'],
+        ["'", "'"],
+        ['“', '”'],
+        ['\\"', '\\"'],
+        ['\\"', '”'], // handles escaped leading quote + curved trailing quote
+      ];
+      
+      for (const [start, end] of quotePairs) {
+        if (value.startsWith(start) && value.endsWith(end)) {
+          value = value.substring(start.length, value.length - end.length);
+          break;
+        }
       }
+      
       if (key) {
         result[key] = value;
       }

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -332,14 +332,14 @@ export function parseEnvironmentVariables(input: string): Record<string, string>
     if (eqIndex > 0) {
       const key = normalized.substring(0, eqIndex).trim();
       let value = normalized.substring(eqIndex + 1).trim();
-      
       // Define matching pairs of quotes to strip
       const quotePairs = [
         ['"', '"'],
         ["'", "'"],
         ['“', '”'],
+        ['"', '”'],  // mixed standard leading and curved trailing double quote
+        ['“', '"'],  // mixed curved leading and standard trailing double quote
         ['\\"', '\\"'],
-        ['\\"', '”'], // handles escaped leading quote + curved trailing quote
       ];
       
       for (const [start, end] of quotePairs) {

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -471,7 +471,36 @@ describe('ClaudianPlugin', () => {
         ['/live/context'],
       );
       expect(mockResetSession).toHaveBeenCalledTimes(1);
-      expect(mockEnsureReady).toHaveBeenCalledWith();
+    });
+  });
+
+  describe('applyEnvSnippet', () => {
+    it('applies env snippet variables, merges context limits/aliases, and auto-selects the model', async () => {
+      await plugin.onload();
+
+      const snippet = {
+        id: 'test-snippet',
+        name: 'Test Snippet',
+        description: 'A test env snippet',
+        envVars: [
+          'ANTHROPIC_BASE_URL=https://api.test.com',
+          'ANTHROPIC_MODEL=test-model-id',
+        ].join('\n'),
+        scope: 'provider:claude',
+        contextLimits: {
+          'test-model-id': 100000,
+        },
+        modelAliases: {
+          'test-model-id': 'Test Model Alias',
+        },
+      };
+
+      await plugin.applyEnvSnippet(snippet as any, 'provider:claude');
+
+      expect(plugin.getEnvironmentVariablesForScope('provider:claude')).toContain('ANTHROPIC_BASE_URL=https://api.test.com');
+      expect(plugin.settings.customContextLimits).toHaveProperty('test-model-id', 100000);
+      expect(plugin.settings.customModelAliases).toHaveProperty('test-model-id', 'Test Model Alias');
+      expect(plugin.settings.model).toBe('test-model-id');
     });
   });
 

--- a/tests/unit/features/chat/ui/FileContextManager.test.ts
+++ b/tests/unit/features/chat/ui/FileContextManager.test.ts
@@ -112,6 +112,7 @@ function createMockCallbacks(options: {
 describe('FileContextManager', () => {
   let containerEl: MockElement;
   let inputEl: HTMLTextAreaElement;
+  let mockInputWrapper: MockElement;
 
   beforeEach(() => {
     jest.useFakeTimers();
@@ -119,12 +120,20 @@ describe('FileContextManager', () => {
     mockVaultPath = '/vault';
     mockScanPaths.mockReturnValue([]);
     containerEl = createMockEl();
-    inputEl = {
-      value: '',
-      selectionStart: 0,
-      selectionEnd: 0,
-      focus: jest.fn(),
-    } as unknown as HTMLTextAreaElement;
+    mockInputWrapper = createMockEl();
+    mockInputWrapper.className = 'claudian-input-wrapper';
+
+    const mockInput = createMockEl('textarea');
+    mockInput.value = '';
+    mockInput.selectionStart = 0;
+    mockInput.selectionEnd = 0;
+    mockInput.focus = jest.fn();
+    mockInput.closest = jest.fn((selector) => {
+      if (selector === '.claudian-input-wrapper') return mockInputWrapper;
+      return null;
+    });
+
+    inputEl = mockInput;
   });
 
   afterEach(() => {
@@ -870,6 +879,182 @@ describe('FileContextManager', () => {
 
       await openCallback('notes/missing.md');
       expect(NoticeMock).toHaveBeenCalledWith(expect.stringContaining('Could not open file'));
+      manager.destroy();
+    });
+  });
+
+  describe('drag and drop', () => {
+    it('should show drop overlay on dragenter with valid files', () => {
+      const app = createMockApp();
+      const manager = new FileContextManager(
+        app, containerEl as any, inputEl, createMockCallbacks()
+      );
+
+      const dragEnterHandler = mockInputWrapper._eventListeners.get('dragenter')?.[0];
+      expect(dragEnterHandler).toBeDefined();
+
+      // Mock internal Obsidian draggedItems
+      (app as any).dragManager = {
+        draggedItems: [{ file: createMockTFile('notes/drop.md') }],
+      };
+
+      const event = {
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+        dataTransfer: {
+          types: [],
+        },
+      } as any;
+
+      dragEnterHandler!(event);
+
+      const overlay = mockInputWrapper.querySelector('.claudian-file-drop-overlay');
+      expect(overlay).toBeDefined();
+      expect(overlay?.hasClass('visible')).toBe(true);
+
+      manager.destroy();
+    });
+
+    it('should hide drop overlay on dragleave', () => {
+      const app = createMockApp();
+      const manager = new FileContextManager(
+        app, containerEl as any, inputEl, createMockCallbacks()
+      );
+
+      const dragLeaveHandler = mockInputWrapper._eventListeners.get('dragleave')?.[0];
+      const overlay = mockInputWrapper.querySelector('.claudian-file-drop-overlay');
+      overlay?.addClass('visible');
+
+      // Mock bounding box so dragleave client position is outside the wrapper
+      mockInputWrapper.getBoundingClientRect = () => ({
+        top: 10,
+        left: 10,
+        width: 100,
+        height: 100,
+        right: 110,
+        bottom: 110,
+        x: 10,
+        y: 10,
+        toJSON: () => {},
+      });
+
+      const event = {
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+        clientX: 5,
+        clientY: 5,
+      } as any;
+
+      dragLeaveHandler!(event);
+      expect(overlay?.hasClass('visible')).toBe(false);
+
+      manager.destroy();
+    });
+
+    it('should attach file and insert text on drop from internal explorer', async () => {
+      const app = createMockApp();
+      const manager = new FileContextManager(
+        app, containerEl as any, inputEl, createMockCallbacks()
+      );
+
+      const dropHandler = mockInputWrapper._eventListeners.get('drop')?.[0];
+      expect(dropHandler).toBeDefined();
+
+      // Mock internal Obsidian draggedItems (including folder and file)
+      const mockFile = createMockTFile('notes/alpha.md');
+      const mockFolder = new (jest.requireMock('obsidian').TFolder)('notes/sub');
+
+      (app as any).dragManager = {
+        draggedItems: [
+          { file: mockFile },
+          { file: mockFolder },
+        ],
+      };
+
+      const event = {
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+        dataTransfer: {
+          types: [],
+          files: [],
+        },
+      } as any;
+
+      await dropHandler!(event);
+
+      expect(inputEl.value).toBe('@notes/alpha.md @notes/sub/ ');
+      expect(manager.getAttachedFiles().has('notes/alpha.md')).toBe(true);
+      expect(manager.getAttachedFiles().has('notes/sub')).toBe(true);
+
+      manager.destroy();
+    });
+
+    it('should attach file and insert text on drop from internal explorer using dataTransfer URIs', async () => {
+      const app = createMockApp();
+      const manager = new FileContextManager(
+        app, containerEl as any, inputEl, createMockCallbacks()
+      );
+
+      const dropHandler = mockInputWrapper._eventListeners.get('drop')?.[0];
+      expect(dropHandler).toBeDefined();
+
+      const event = {
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+        dataTransfer: {
+          types: ['text/plain', 'text/uri-list'],
+          getData: jest.fn((type) => {
+            if (type === 'text/plain') {
+              return 'obsidian://open?vault=DragonXing&file=notes%2Falpha.md\nobsidian://open?vault=DragonXing&file=notes%2Fsub';
+            }
+            return '';
+          }),
+        },
+      } as any;
+
+      // Mock TFolder for folder check
+      const TFolderMock = jest.requireMock('obsidian').TFolder;
+      const folderMock = new TFolderMock('notes/sub');
+      app.vault.getAbstractFileByPath = jest.fn((p) => {
+        if (p === 'notes/alpha.md') return createMockTFile('notes/alpha.md');
+        if (p === 'notes/sub') return folderMock;
+        return null;
+      });
+
+      await dropHandler!(event);
+
+      expect(inputEl.value).toBe('@notes/alpha.md @notes/sub/ ');
+      expect(manager.getAttachedFiles().has('notes/alpha.md')).toBe(true);
+      expect(manager.getAttachedFiles().has('notes/sub')).toBe(true);
+
+      manager.destroy();
+    });
+
+    it('should attach file and insert text on drop from external OS drag', async () => {
+      const app = createMockApp();
+      const manager = new FileContextManager(
+        app, containerEl as any, inputEl, createMockCallbacks()
+      );
+
+      const dropHandler = mockInputWrapper._eventListeners.get('drop')?.[0];
+
+      // Mock external file
+      const event = {
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+        dataTransfer: {
+          types: ['Files'],
+          files: [
+            { path: '/vault/notes/external.md', name: 'external.md' },
+          ],
+        },
+      } as any;
+
+      await dropHandler!(event);
+
+      expect(inputEl.value).toBe('@notes/external.md ');
+      expect(manager.getAttachedFiles().has('notes/external.md')).toBe(true);
+
       manager.destroy();
     });
   });


### PR DESCRIPTION
Allows selecting and applying environment snippets directly from the Chat View model selection dropdown, making switching between different provider endpoints (such as DeepSeek, Gemini, and MiniMax/Kimi) one-click seamless.