### PR TITLE
fix: allow xhigh effort level for Sonnet 5

### DIFF
--- a/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts
+++ b/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts
@@ -301,8 +301,8 @@ export class QueryOptionsBuilder {
   ): void {
     const effortLevel = resolveEffortLevel(model, settings.effortLevel);
     options.thinking = { type: 'adaptive' };
-    // SDK runtime accepts `xhigh` on Opus 4.7+ and silently falls back to
-    // `high` elsewhere, but its type definition lags our local EffortLevel.
+    // SDK runtime accepts `xhigh` on Opus 4.7+ and Sonnet 5+, and silently
+    // falls back to `high` elsewhere, but its type definition lags our local EffortLevel.
     options.effort = effortLevel;
   }
 

--- a/src/providers/claude/runtime/claudeColdStartQuery.ts
+++ b/src/providers/claude/runtime/claudeColdStartQuery.ts
@@ -118,8 +118,8 @@ export async function runColdStartQuery(
   if (!config.thinking?.disabled) {
     const effortLevel = resolveEffortLevel(selectedModel, settings.effortLevel);
     options.thinking = { type: 'adaptive' };
-    // SDK runtime accepts `xhigh` on Opus 4.7+ and silently falls back to
-    // `high` elsewhere, but its type definition lags our local EffortLevel.
+    // SDK runtime accepts `xhigh` on Opus 4.7+ and Sonnet 5+, and silently
+    // falls back to `high` elsewhere, but its type definition lags our local EffortLevel.
     options.effort = effortLevel;
   }
 

--- a/src/providers/claude/types/models.ts
+++ b/src/providers/claude/types/models.ts
@@ -81,13 +81,17 @@ export function isDefaultClaudeModel(model: string): boolean {
 }
 
 /**
- * Whether the model supports the `xhigh` effort level. Opus 4.7+ only — the SDK
- * silently falls back to `high` on other models.
+ * Whether the model supports the `xhigh` effort level. Supported on Opus 4.7+
+ * and Sonnet 5+ — the SDK silently falls back to `high` on other models.
  */
 export function supportsXHighEffort(model: string): boolean {
   const normalized = normalizeModelId(model);
   if (isBuiltInFamilyVariant(normalized, 'opus')) return true;
-  return /claude-opus-(4-[7-9]|[5-9])/.test(normalized);
+  if (isBuiltInFamilyVariant(normalized, 'sonnet')) return true;
+  return (
+    /claude-opus-(4-[7-9]|[5-9])/.test(normalized) ||
+    /claude-sonnet-(?:[5-9]|\d{2,})(?:-\d{8})?(?:-|$)/.test(normalized)
+  );
 }
 
 /** Clamp stored effort values to what the selected model actually supports. */

--- a/tests/unit/providers/claude/runtime/QueryOptionsBuilder.test.ts
+++ b/tests/unit/providers/claude/runtime/QueryOptionsBuilder.test.ts
@@ -267,7 +267,7 @@ describe('QueryOptionsBuilder', () => {
 
     it('normalizes unsupported xhigh effort for adaptive models', () => {
       const ctx = createMockContext({
-        settings: createMockSettings({ model: 'sonnet', effortLevel: 'xhigh' }),
+        settings: createMockSettings({ model: 'haiku', effortLevel: 'xhigh' }),
       });
       const config = QueryOptionsBuilder.buildPersistentQueryConfig(ctx);
 
@@ -438,7 +438,7 @@ describe('QueryOptionsBuilder', () => {
     it('clamps unsupported xhigh effort before building adaptive options', () => {
       const ctx = {
         ...createMockContext({
-          settings: createMockSettings({ model: 'sonnet', effortLevel: 'xhigh' }),
+          settings: createMockSettings({ model: 'haiku', effortLevel: 'xhigh' }),
         }),
         abortController: new AbortController(),
         hooks: {},

--- a/tests/unit/providers/claude/types/types.test.ts
+++ b/tests/unit/providers/claude/types/types.test.ts
@@ -700,9 +700,18 @@ describe('types.ts', () => {
       expect(supportsXHighEffort('claude-opus-5')).toBe(true);
     });
 
-    it('returns false for non-opus models and older opus ids', () => {
-      expect(supportsXHighEffort('sonnet')).toBe(false);
+    it('returns true for sonnet aliases and sonnet 5+ ids', () => {
+      expect(supportsXHighEffort('sonnet')).toBe(true);
+      expect(supportsXHighEffort('sonnet[1m]')).toBe(true);
+      expect(supportsXHighEffort('claude-sonnet-5')).toBe(true);
+      expect(supportsXHighEffort('claude-sonnet-5-20260101')).toBe(true);
+      expect(supportsXHighEffort('claude-sonnet-6')).toBe(true);
+    });
+
+    it('returns false for non-opus/non-sonnet-5 models and older ids', () => {
+      expect(supportsXHighEffort('haiku')).toBe(false);
       expect(supportsXHighEffort('claude-sonnet-4-5')).toBe(false);
+      expect(supportsXHighEffort('claude-sonnet-4-6')).toBe(false);
       expect(supportsXHighEffort('claude-opus-4-6')).toBe(false);
     });
   });


### PR DESCRIPTION
## Summary
- Claudian's model picker uses generic aliases (`haiku`/`sonnet`/`opus`) that the Claude Code CLI resolves server-side, so the "Sonnet" option already targets Sonnet 5 with no picker changes needed.
- `supportsXHighEffort()` only allow-listed Opus 4.7+, so the `xhigh` effort level stayed hidden for Sonnet even though Sonnet 5 is the first Sonnet-tier model to support it.
- Extends `supportsXHighEffort()` to recognize the built-in `sonnet`/`sonnet[1m]` aliases and explicit `claude-sonnet-5`+ ids, while still excluding `claude-sonnet-4-x`, which doesn't support `xhigh`.
- Updates two stale comments and the related unit tests accordingly.

Addresses the Sonnet 5 support question raised in #846.

Co authored with Sonnet 5 :P

## Test plan
- [x] `npm run test -- --selectProjects unit` — all previously-passing tests still pass; no new failures introduced (verified against a clean `main` baseline, which has 13 pre-existing unrelated failing suites on this Windows environment)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`