### PR TITLE
feat: add Claude Fable 5 to the default model picker

### DIFF
--- a/src/providers/claude/modelLabels.ts
+++ b/src/providers/claude/modelLabels.ts
@@ -50,7 +50,7 @@ function formatClaudeCustomModelLabel(labelSource: string): string | null {
   const candidate = claudePrefixIndex >= 0 ? without1M.slice(claudePrefixIndex) : without1M;
 
   const versionedMatch = candidate.match(
-    /^claude-(haiku|sonnet|opus)-(\d+)-(\d+)(?:-(\d{8}))?(?:-v\d+:\d+)?$/i,
+    /^claude-(haiku|sonnet|opus|fable)-(\d+)-(\d+)(?:-(\d{8}))?(?:-v\d+:\d+)?$/i,
   );
   if (versionedMatch) {
     const [, family, major, minor, date] = versionedMatch;
@@ -62,7 +62,7 @@ function formatClaudeCustomModelLabel(labelSource: string): string | null {
   }
 
   const majorOnlyMatch = candidate.match(
-    /^claude-(haiku|sonnet|opus)-(\d+)(?:-(\d{8}))?(?:-v\d+:\d+)?$/i,
+    /^claude-(haiku|sonnet|opus|fable)-(\d+)(?:-(\d{8}))?(?:-v\d+:\d+)?$/i,
   );
   if (majorOnlyMatch) {
     const [, family, major, date] = majorOnlyMatch;

--- a/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts
+++ b/src/providers/claude/runtime/ClaudeQueryOptionsBuilder.ts
@@ -301,8 +301,8 @@ export class QueryOptionsBuilder {
   ): void {
     const effortLevel = resolveEffortLevel(model, settings.effortLevel);
     options.thinking = { type: 'adaptive' };
-    // SDK runtime accepts `xhigh` on Opus 4.7+ and silently falls back to
-    // `high` elsewhere, but its type definition lags our local EffortLevel.
+    // SDK runtime accepts `xhigh` on Opus 4.7+ and Fable, and silently
+    // falls back to `high` elsewhere, but its type definition lags our local EffortLevel.
     options.effort = effortLevel;
   }
 

--- a/src/providers/claude/runtime/claudeColdStartQuery.ts
+++ b/src/providers/claude/runtime/claudeColdStartQuery.ts
@@ -118,8 +118,8 @@ export async function runColdStartQuery(
   if (!config.thinking?.disabled) {
     const effortLevel = resolveEffortLevel(selectedModel, settings.effortLevel);
     options.thinking = { type: 'adaptive' };
-    // SDK runtime accepts `xhigh` on Opus 4.7+ and silently falls back to
-    // `high` elsewhere, but its type definition lags our local EffortLevel.
+    // SDK runtime accepts `xhigh` on Opus 4.7+ and Fable, and silently
+    // falls back to `high` elsewhere, but its type definition lags our local EffortLevel.
     options.effort = effortLevel;
   }
 

--- a/src/providers/claude/stream/transformClaudeMessage.ts
+++ b/src/providers/claude/stream/transformClaudeMessage.ts
@@ -105,7 +105,7 @@ interface ContextWindowEntry {
 
 interface ClaudeModelSignature {
   normalizedModel: string;
-  family: 'haiku' | 'sonnet' | 'opus';
+  family: 'haiku' | 'sonnet' | 'opus' | 'fable';
   is1M: boolean;
   major?: string;
   minor?: string;
@@ -135,7 +135,7 @@ function parseClaudeModelSignature(model: string): ClaudeModelSignature | null {
   }
 
   const versionedMatch = normalized.match(
-    /^claude-(haiku|sonnet|opus)-(\d+)(?:-(\d+))?(?:-(\d{8}))?(?:-v\d+:\d+)?(\[1m\])?$/,
+    /^claude-(haiku|sonnet|opus|fable)-(\d+)(?:-(\d+))?(?:-(\d{8}))?(?:-v\d+:\d+)?(\[1m\])?$/,
   );
   if (versionedMatch) {
     const [, familyMatch, major, minor, date, oneMillionSuffix] = versionedMatch;

--- a/src/providers/claude/types/models.ts
+++ b/src/providers/claude/types/models.ts
@@ -13,6 +13,7 @@ export const DEFAULT_CLAUDE_MODELS: { value: ClaudeModel; label: string; descrip
   { value: 'sonnet[1m]', label: 'Sonnet 1M', description: 'Balanced performance (1M context window)' },
   { value: 'opus', label: 'Opus', description: 'Most capable' },
   { value: 'opus[1m]', label: 'Opus 1M', description: 'Most capable (1M context window)' },
+  { value: 'claude-fable-5', label: 'Fable 5 ($$$)', description: "Anthropic's most capable model — premium pricing above Opus" },
 ];
 
 /** Effort levels for adaptive thinking models. */
@@ -33,6 +34,7 @@ export const DEFAULT_EFFORT_LEVEL: Record<string, EffortLevel> = {
   'sonnet[1m]': 'high',
   'opus': 'high',
   'opus[1m]': 'high',
+  'claude-fable-5': 'high',
 };
 
 const ONE_M_SUFFIX = '[1m]';
@@ -49,6 +51,11 @@ function has1MContextSuffix(model: string): boolean {
 function isBuiltInFamilyVariant(model: string, family: 'sonnet' | 'opus'): boolean {
   const normalized = normalizeModelId(model);
   return normalized === family || normalized === `${family}${ONE_M_SUFFIX}`;
+}
+
+/** Fable is a standalone tier (not a haiku/sonnet/opus version bump) — always 1M context, no [1m] toggle. */
+function isFableModel(model: string): boolean {
+  return /claude-fable-\d+/.test(normalizeModelId(model));
 }
 
 function isValidContextLimit(limit: unknown): limit is number {
@@ -81,12 +88,13 @@ export function isDefaultClaudeModel(model: string): boolean {
 }
 
 /**
- * Whether the model supports the `xhigh` effort level. Opus 4.7+ only — the SDK
- * silently falls back to `high` on other models.
+ * Whether the model supports the `xhigh` effort level. Supported on Opus 4.7+
+ * and Fable — the SDK silently falls back to `high` on other models.
  */
 export function supportsXHighEffort(model: string): boolean {
   const normalized = normalizeModelId(model);
   if (isBuiltInFamilyVariant(normalized, 'opus')) return true;
+  if (isFableModel(normalized)) return true;
   return /claude-opus-(4-[7-9]|[5-9])/.test(normalized);
 }
 
@@ -160,7 +168,7 @@ export function getContextWindowSize(
     return customLimit;
   }
 
-  if (has1MContextSuffix(model)) {
+  if (has1MContextSuffix(model) || isFableModel(model)) {
     return CONTEXT_WINDOW_1M;
   }
 

--- a/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
+++ b/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
@@ -1252,6 +1252,40 @@ describe('transformSDKMessage', () => {
       ]);
     });
 
+    it('matches fable family against SDK modelUsage keys via a version-profile suffix', () => {
+      const message = msg({
+        type: 'result',
+        modelUsage: {
+          'claude-haiku-4-5-20251001': {
+            inputTokens: 1000,
+            outputTokens: 300,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            webSearchRequests: 0,
+            costUSD: 0.01,
+            contextWindow: 200000,
+            maxOutputTokens: 32000,
+          },
+          'claude-fable-5-v1:0': {
+            inputTokens: 1000,
+            outputTokens: 300,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            webSearchRequests: 0,
+            costUSD: 0.01,
+            contextWindow: 1000000,
+            maxOutputTokens: 32000,
+          },
+        },
+      });
+
+      const results = [...transformSDKMessage(message, { intendedModel: 'claude-fable-5' })];
+
+      expect(results).toEqual([
+        { type: 'context_window', contextWindow: 1000000 },
+      ]);
+    });
+
     it('matches provider-qualified custom model ids against SDK modelUsage keys', () => {
       const message = msg({
         type: 'result',

--- a/tests/unit/providers/claude/types/types.test.ts
+++ b/tests/unit/providers/claude/types/types.test.ts
@@ -648,25 +648,37 @@ describe('types.ts', () => {
       });
     });
 
+    describe('fable models', () => {
+      it('should default to 1M context window with no [1m] suffix needed', () => {
+        expect(getContextWindowSize('claude-fable-5')).toBe(CONTEXT_WINDOW_1M);
+        expect(getContextWindowSize('claude-fable-6')).toBe(CONTEXT_WINDOW_1M);
+      });
+
+      it('should prefer custom limits over the fable default', () => {
+        const customLimits = { 'claude-fable-5': 500000 };
+        expect(getContextWindowSize('claude-fable-5', customLimits)).toBe(500000);
+      });
+    });
+
     describe('filterVisibleModelOptions', () => {
       it('should hide 1M variants when toggles are disabled', () => {
         const models = filterVisibleModelOptions(DEFAULT_CLAUDE_MODELS, false, false).map((model) => model.value);
-        expect(models).toEqual(['haiku', 'sonnet', 'opus']);
+        expect(models).toEqual(['haiku', 'sonnet', 'opus', 'claude-fable-5']);
       });
 
       it('should swap in 1M variants when toggles are enabled', () => {
         const models = filterVisibleModelOptions(DEFAULT_CLAUDE_MODELS, true, true).map((model) => model.value);
-        expect(models).toEqual(['haiku', 'sonnet[1m]', 'opus[1m]']);
+        expect(models).toEqual(['haiku', 'sonnet[1m]', 'opus[1m]', 'claude-fable-5']);
       });
 
       it('should swap only opus when enableOpus1M is true and enableSonnet1M is false', () => {
         const models = filterVisibleModelOptions(DEFAULT_CLAUDE_MODELS, true, false).map((model) => model.value);
-        expect(models).toEqual(['haiku', 'sonnet', 'opus[1m]']);
+        expect(models).toEqual(['haiku', 'sonnet', 'opus[1m]', 'claude-fable-5']);
       });
 
       it('should swap only sonnet when enableSonnet1M is true and enableOpus1M is false', () => {
         const models = filterVisibleModelOptions(DEFAULT_CLAUDE_MODELS, false, true).map((model) => model.value);
-        expect(models).toEqual(['haiku', 'sonnet[1m]', 'opus']);
+        expect(models).toEqual(['haiku', 'sonnet[1m]', 'opus', 'claude-fable-5']);
       });
     });
 
@@ -704,6 +716,11 @@ describe('types.ts', () => {
       expect(supportsXHighEffort('sonnet')).toBe(false);
       expect(supportsXHighEffort('claude-sonnet-4-5')).toBe(false);
       expect(supportsXHighEffort('claude-opus-4-6')).toBe(false);
+    });
+
+    it('returns true for fable models', () => {
+      expect(supportsXHighEffort('claude-fable-5')).toBe(true);
+      expect(supportsXHighEffort('claude-fable-6')).toBe(true);
     });
   });
 

--- a/tests/unit/providers/claude/ui/ClaudeChatUIConfig.test.ts
+++ b/tests/unit/providers/claude/ui/ClaudeChatUIConfig.test.ts
@@ -15,6 +15,7 @@ describe('claudeChatUIConfig', () => {
         'haiku',
         'sonnet',
         'opus',
+        'claude-fable-5',
         'claude-code/claude-opus-4-6',
         'claude-code/claude-opus-4-6[1m]',
       ]);
@@ -45,6 +46,7 @@ describe('claudeChatUIConfig', () => {
         'haiku',
         'sonnet',
         'opus',
+        'claude-fable-5',
         'claude-code/claude-opus-4-6',
       ]);
     });
@@ -61,6 +63,22 @@ describe('claudeChatUIConfig', () => {
       expect(options.at(-1)).toEqual({
         value: 'claude-code/claude-opus-4-5-20251101',
         label: 'Opus 4.5 (2511)',
+        description: 'Custom model',
+      });
+    });
+
+    it('formats a future fable custom model id without the built-in default', () => {
+      const options = claudeChatUIConfig.getModelOptions({
+        providerConfigs: {
+          claude: {
+            customModels: 'claude-fable-6',
+          },
+        },
+      });
+
+      expect(options.at(-1)).toEqual({
+        value: 'claude-code/claude-fable-6',
+        label: 'Fable 6',
         description: 'Custom model',
       });
     });
@@ -134,6 +152,12 @@ describe('claudeChatUIConfig', () => {
 
     it('keeps xhigh on supported opus models', () => {
       const options = claudeChatUIConfig.getReasoningOptions('claude-opus-4-7', {});
+
+      expect(options.map(option => option.value)).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
+    });
+
+    it('keeps xhigh on fable models', () => {
+      const options = claudeChatUIConfig.getReasoningOptions('claude-fable-5', {});
 
       expect(options.map(option => option.value)).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
     });


### PR DESCRIPTION
## Summary
- Adds `claude-fable-5` as a built-in entry in the Claude model picker. Unlike Sonnet 5, Fable is a standalone tier rather than a version bump the generic `haiku`/`sonnet`/`opus` aliases would ever resolve to, so it needs an explicit entry.
- Labels it `Fable 5 ($$$)` with a tooltip noting its premium pricing, since it prices well above Opus and shouldn't be picked by accident.
- Extends the model-family-aware helpers so Fable is handled consistently now that it's first-class:
  - `supportsXHighEffort()` recognizes Fable (it supports `xhigh`/`max` effort)
  - `getContextWindowSize()` defaults Fable to 1M context (no `[1m]` toggle needed, unlike Opus/Sonnet)
  - `modelLabels.ts` formats future custom Fable ids (e.g. `claude-fable-6`) without a stray "Claude" prefix, matching the other families
  - `transformClaudeMessage.ts`'s model-signature matcher recognizes the Fable family for multi-model/subagent context-window disambiguation

Addresses the Fable 5 half of #846 (the Sonnet 5 half is #847).

## Test plan
- [x] `npm run test -- --selectProjects unit` — no regressions vs. the `main` baseline (same pre-existing, unrelated failing suites on this Windows environment); added coverage for `supportsXHighEffort`, `getContextWindowSize`, `filterVisibleModelOptions`, custom-model label formatting, and multi-model context-window signature matching
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] Live-verified in a running Obsidian instance: the picker renders `Fable 5 ($$$)` with the pricing tooltip, selecting it works end-to-end, and the effort dropdown correctly shows `XHigh` only once Fable is selected (confirmed it's absent for a model that doesn't support it, then reappears switching back to Fable on the same toolbar)