### PR TITLE
fix: expose provider /compact command in slash discovery

### DIFF
--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -1822,7 +1822,7 @@ export class TabManager implements TabManagerInterface {
     const catalog = ProviderWorkspaceRegistry.getCommandCatalog(providerId);
     if (!catalog) return { status: 'empty' };
     const entries = await catalog.listDropdownEntries({
-      includeBuiltIns: false,
+      includeBuiltIns: true,
       ...(signal ? { signal } : {}),
       allowCachedCommandSnapshot: discovery.commandSnapshot !== undefined,
       ...(discovery.commandSnapshot !== undefined

--- a/src/features/chat/tabs/TabProviderState.ts
+++ b/src/features/chat/tabs/TabProviderState.ts
@@ -150,7 +150,7 @@ function getRegistryProviderCatalogInfo(providerId: ProviderId): ProviderCatalog
     config: catalog.getDropdownConfig(),
     discovery: new ProviderCommandDiscoveryStore(async signal =>
       normalizeProviderCommandDiscoveryItems(
-        await catalog.listDropdownEntries({ includeBuiltIns: false, signal }),
+        await catalog.listDropdownEntries({ includeBuiltIns: true, signal }),
       ),
     ),
   };

--- a/src/shared/composer-dropdown/SlashCommandSource.ts
+++ b/src/shared/composer-dropdown/SlashCommandSource.ts
@@ -77,7 +77,9 @@ export class SlashCommandSource implements ComposerDropdownSource {
       this.startDiscovery('load');
       result = { status: 'loading' };
     }
-    const providerEntries = result?.status === 'ready' ? result.items : [];
+    const providerEntries = result?.status === 'ready'
+      ? result.items.filter(entry => entry.displayPrefix === match.trigger)
+      : [];
     const includeBuiltIns = this.includeBuiltIns
       && match.atInputStart
       && match.trigger === '/';

--- a/tests/unit/features/chat/tabs/TabManager.test.ts
+++ b/tests/unit/features/chat/tabs/TabManager.test.ts
@@ -1752,6 +1752,17 @@ describe('TabManager provider execution orchestration', () => {
     expect(commandLoader.loadCommands.mock.calls[0][0]).not.toHaveProperty('runtime');
   });
 
+  it('requests provider built-ins for Main Chat command discovery', async () => {
+    const { manager } = createManager();
+    await manager.createTab();
+
+    await manager.getProviderCommandDiscovery();
+
+    expect(commandCatalog.listDropdownEntries).toHaveBeenCalledWith(
+      expect.objectContaining({ includeBuiltIns: true }),
+    );
+  });
+
   it('lets provider-owned command discovery outlive the shared deadline', async () => {
     jest.useFakeTimers();
     const commandResult = deferred<any>();

--- a/tests/unit/features/chat/tabs/TabManager.test.ts
+++ b/tests/unit/features/chat/tabs/TabManager.test.ts
@@ -1748,6 +1748,17 @@ describe('TabManager provider execution orchestration', () => {
     expect(commandLoader.loadCommands.mock.calls[0][0]).not.toHaveProperty('runtime');
   });
 
+  it('requests provider built-ins for Main Chat command discovery', async () => {
+    const { manager } = createManager();
+    await manager.createTab();
+
+    await manager.getProviderCommandDiscovery();
+
+    expect(commandCatalog.listDropdownEntries).toHaveBeenCalledWith(
+      expect.objectContaining({ includeBuiltIns: true }),
+    );
+  });
+
   it('rejects command context loaded for a conversation rebound during lookup', async () => {
     const firstLookup = deferred<any>();
     const conversationB = {

--- a/tests/unit/features/chat/tabs/TabProviderState.test.ts
+++ b/tests/unit/features/chat/tabs/TabProviderState.test.ts
@@ -1,0 +1,52 @@
+import { ProviderWorkspaceRegistry } from '@/core/providers/ProviderWorkspaceRegistry';
+import { syncComposerDropdownForProvider } from '@/features/chat/tabs/TabProviderState';
+
+jest.mock('@/core/providers/ProviderWorkspaceRegistry', () => ({
+  ProviderWorkspaceRegistry: {
+    getCommandCatalog: jest.fn(),
+  },
+}));
+
+describe('TabProviderState provider command discovery', () => {
+  it('requests provider built-ins from the Main Chat fallback catalog', async () => {
+    const listDropdownEntries = jest.fn().mockResolvedValue([]);
+    (ProviderWorkspaceRegistry.getCommandCatalog as jest.Mock).mockReturnValue({
+      getDropdownConfig: jest.fn().mockReturnValue({
+        builtInPrefix: '/',
+        commandPrefix: '/',
+        providerId: 'codex',
+        skillPrefix: '$',
+        triggerChars: ['/', '$'],
+      }),
+      listDropdownEntries,
+    });
+    let discovery: { load(): Promise<unknown> } | undefined;
+    const composerDropdown = {
+      clearProviderCatalog: jest.fn(),
+      setHiddenCommands: jest.fn(),
+      setProviderCatalog: jest.fn((_config, nextDiscovery) => {
+        discovery = nextDiscovery;
+      }),
+      setProviderId: jest.fn(),
+    };
+    const tab = {
+      conversationId: null,
+      draftModel: null,
+      lifecycleState: 'cold',
+      providerCatalogResolver: () => null,
+      providerId: 'codex',
+      ui: { composerDropdown },
+    } as any;
+    const plugin = {
+      getConversationSync: jest.fn().mockReturnValue(null),
+      settings: { hiddenProviderCommands: {} },
+    } as any;
+
+    syncComposerDropdownForProvider(tab, plugin);
+    await discovery?.load();
+
+    expect(listDropdownEntries).toHaveBeenCalledWith(expect.objectContaining({
+      includeBuiltIns: true,
+    }));
+  });
+});

--- a/tests/unit/features/inline-edit/ui/InlineEditModal.openAndWait.test.ts
+++ b/tests/unit/features/inline-edit/ui/InlineEditModal.openAndWait.test.ts
@@ -317,6 +317,7 @@ describe('InlineEditModal - openAndWait', () => {
         }),
       } as any;
       plugin.providerHost = plugin;
+      const listDropdownEntries = jest.fn().mockResolvedValue([]);
       jest.spyOn(ProviderWorkspaceRegistry, 'getCommandCatalog').mockReturnValue({
         getDropdownConfig: jest.fn().mockReturnValue({
           providerId: 'codex',
@@ -325,7 +326,7 @@ describe('InlineEditModal - openAndWait', () => {
           skillPrefix: '$',
           commandPrefix: '/',
         }),
-        listDropdownEntries: jest.fn().mockResolvedValue([]),
+        listDropdownEntries,
       } as any);
       const editor = {} as any;
       const view = { editor } as any;
@@ -385,6 +386,15 @@ describe('InlineEditModal - openAndWait', () => {
       expect(Array.from(widgetRef?.slashSource?.hiddenCommands ?? [])).toEqual(['analyze']);
       expect(widgetRef?.slashSource?.includeBuiltIns).toBe(false);
       expect(widgetRef?.slashSource?.discovery).toBeDefined();
+      widgetRef?.slashSource?.load(
+        { atInputStart: true, end: 1, query: '', start: 0, trigger: '/' },
+        new AbortController().signal,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(listDropdownEntries).toHaveBeenCalledWith(expect.objectContaining({
+        includeBuiltIns: false,
+      }));
 
       widgetRef?.reject();
       await expect(resultPromise).resolves.toEqual({ decision: 'reject' });

--- a/tests/unit/shared/composer-dropdown/SlashCommandSource.test.ts
+++ b/tests/unit/shared/composer-dropdown/SlashCommandSource.test.ts
@@ -78,6 +78,53 @@ describe('SlashCommandSource', () => {
     source.destroy();
   });
 
+  it('keeps slash commands and dollar-prefixed skills in separate trigger menus', async () => {
+    const compactEntry: ProviderCommandEntry = {
+      ...ENTRY,
+      description: 'Compact the current conversation',
+      displayPrefix: '/',
+      id: 'codex:command:compact',
+      insertPrefix: '/',
+      kind: 'command',
+      name: 'compact',
+    };
+    const source = new SlashCommandSource({
+      providerConfig: {
+        builtInPrefix: '/',
+        commandPrefix: '/',
+        providerId: 'codex',
+        skillPrefix: '$',
+        triggerChars: ['/', '$'],
+      },
+      providerDiscovery: discovery({ status: 'ready', items: [ENTRY, compactEntry] }),
+      providerId: 'codex',
+    });
+
+    const slashItems = await source.load(match('/'), new AbortController().signal);
+    const slashLabels = slashItems.map(item => item.label);
+    expect(slashLabels).toEqual(expect.arrayContaining(['/clear', '/compact']));
+    expect(slashLabels).not.toContain('$review');
+
+    const skillItems = await source.load(match('$'), new AbortController().signal);
+    const skillLabels = skillItems.map(item => item.label);
+    expect(skillLabels).toContain('$review');
+    expect(skillLabels).not.toContain('/clear');
+    expect(skillLabels).not.toContain('/compact');
+    source.destroy();
+  });
+
+  it('filters hidden provider commands from a ready discovery result', async () => {
+    const source = new SlashCommandSource({
+      hiddenCommands: new Set(['review']),
+      includeBuiltIns: false,
+      providerDiscovery: discovery(),
+      providerId: 'codex',
+    });
+
+    expect(source.load(match('$'), new AbortController().signal)).toEqual([]);
+    source.destroy();
+  });
+
   it('filters hidden provider commands and retries discovery only after explicit selection', async () => {
     const providerDiscovery = discovery({
       message: 'Could not load provider commands',

--- a/tests/unit/shared/composer-dropdown/SlashCommandSource.test.ts
+++ b/tests/unit/shared/composer-dropdown/SlashCommandSource.test.ts
@@ -78,6 +78,41 @@ describe('SlashCommandSource', () => {
     source.destroy();
   });
 
+  it('keeps slash commands and dollar-prefixed skills in separate trigger menus', async () => {
+    const compactEntry: ProviderCommandEntry = {
+      ...ENTRY,
+      description: 'Compact the current conversation',
+      displayPrefix: '/',
+      id: 'codex:command:compact',
+      insertPrefix: '/',
+      kind: 'command',
+      name: 'compact',
+    };
+    const source = new SlashCommandSource({
+      providerConfig: {
+        builtInPrefix: '/',
+        commandPrefix: '/',
+        providerId: 'codex',
+        skillPrefix: '$',
+        triggerChars: ['/', '$'],
+      },
+      providerDiscovery: discovery({ status: 'ready', items: [ENTRY, compactEntry] }),
+      providerId: 'codex',
+    });
+
+    const slashItems = await source.load(match('/'), new AbortController().signal);
+    const slashLabels = slashItems.map(item => item.label);
+    expect(slashLabels).toEqual(expect.arrayContaining(['/clear', '/compact']));
+    expect(slashLabels).not.toContain('$review');
+
+    const skillItems = await source.load(match('$'), new AbortController().signal);
+    const skillLabels = skillItems.map(item => item.label);
+    expect(skillLabels).toContain('$review');
+    expect(skillLabels).not.toContain('/clear');
+    expect(skillLabels).not.toContain('/compact');
+    source.destroy();
+  });
+
   it('filters hidden provider commands and retries discovery only after explicit selection', async () => {
     const providerDiscovery = discovery({
       message: 'Could not load provider commands',


### PR DESCRIPTION
## Why

Provider-owned slash commands are never reachable from the composer dropdown.

`TabManager` and `TabProviderState` both request provider command entries with `includeBuiltIns: false`. `CodexSkillCatalog` is the only catalog that reads that flag, and it uses it to gate its provider-owned `/compact` entry. The result is that Codex's `/compact` is invisible in the `/` dropdown even though sending `/compact` manually works fine: the command exists, but cannot be discovered.

Compaction is a core part of a long-running session. Requiring users to already know the command name defeats the purpose of having a command dropdown.

## What Changed

- `TabManager` and `TabProviderState` now request provider entries with `includeBuiltIns: true`, so provider-owned commands reach the Main Chat dropdown.
- `SlashCommandSource` filters provider entries by the active trigger character, so `/` shows only `/` entries and `$` shows only `$` entries.
- Inline Edit keeps `includeBuiltIns: false`; it has no provider command surface.

Net effect: Codex `/compact` appears under `/`, while `$` remains scoped to Codex skills.

## Why This Approach

The trigger character is composer state, while entry ownership is provider knowledge. Passing `includeBuiltIns` at the catalog boundary and filtering on `displayPrefix` at the dropdown keeps that split intact. `displayPrefix` is already required on `ProviderCommandEntry`, so this needs no new type, field, or provider-specific branch in Chat.

An alternative was to promote `/compact` to shared `BUILT_IN_COMMANDS` and delete `CODEX_COMPACT_COMMAND`. That would move provider-specific knowledge into the shared layer, require shared execution semantics, and force every provider to opt in. The provider already owns this command; only discovery was broken.

This PR deliberately does not change Claude's SDK-driven command discovery. Claude commands continue to come from `supportedCommands()`.

## Validation

- Focused command-discovery tests: 5 suites / 122 tests passed.
- `npm run typecheck` passed.
- `npm run lint` passed.
- `npm run build` passed.
- `npm run test:architecture`: 39 / 39 passed.
- `git diff --check` passed.
- `npm run test` completed with 606 suites and 8,881 tests passing; three unrelated Collab LAN/TLS integration tests timed out locally. The same `LanAuthorityTransferClient` timeouts reproduce on a clean `main@c73652ba` worktree, while its paired Local Project gate passes there, so the non-zero local exit is not introduced by this patch.

New and updated tests cover:

- `/` returns local `/clear` and provider `/compact`, but not `$skill`.
- `$` returns `$skill`, but not `/clear` or `/compact`.
- ready-state hidden commands, same-name deduplication, Retry, and non-leading slash behavior remain intact.
- both Main Chat catalog paths request provider built-ins.
- Inline Edit continues to request `includeBuiltIns: false`.

## Impact and Follow-ups

Only `CodexSkillCatalog` currently consumes `includeBuiltIns`; other provider catalogs are unchanged. There are no storage, execution-protocol, public-type, or `/model` changes.

Known limitation: this covers provider-owned entries only. If Claude's SDK does not report `/compact` for a cold tab, it still will not appear; that is a separate discovery path and out of scope.

Supersedes #1125, which started from a shared-built-in approach and bundled an unrelated `/model` picker. That PR is closed in favor of this narrower change.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
