### PR TITLE
fix: preserve image attachment data in conversation history

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -684,18 +684,6 @@ export default class ClaudianPlugin extends Plugin {
     await this.storage.sessions.saveMetadata(
       this.storage.sessions.toSessionMetadata(conversation)
     );
-
-    // Clear image data from memory after save (data is persisted by SDK).
-    // Skip for pending forks: their deep-cloned images aren't in SDK storage yet.
-    if (!ProviderRegistry.getConversationHistoryService(conversation.providerId).isPendingForkConversation(conversation)) {
-      for (const msg of conversation.messages) {
-        if (msg.images) {
-          for (const img of msg.images) {
-            img.data = '';
-          }
-        }
-      }
-    }
   }
 
   async getConversationById(id: string): Promise<Conversation | null> {

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -738,6 +738,35 @@ describe('ClaudianPlugin', () => {
       expect(updated?.messages).toEqual(messages);
     });
 
+    it('should preserve image data when updating conversation messages', async () => {
+      await plugin.onload();
+
+      const conv = await plugin.createConversation();
+      const messages = [
+        {
+          id: 'msg-1',
+          role: 'user' as const,
+          content: 'See attached image',
+          timestamp: Date.now(),
+          images: [
+            {
+              id: 'img-1',
+              name: 'pasted.png',
+              mediaType: 'image/png' as const,
+              data: 'YmFzZTY0',
+              size: 10,
+              source: 'paste' as const,
+            },
+          ],
+        },
+      ];
+
+      await plugin.updateConversation(conv.id, { messages });
+
+      const updated = await plugin.getConversationById(conv.id);
+      expect(updated?.messages[0].images?.[0].data).toBe('YmFzZTY0');
+    });
+
     it('should update conversation sessionId', async () => {
       await plugin.onload();
 


### PR DESCRIPTION
## Summary

- Keep image attachment base64 data on conversation messages after metadata saves
- Add an integration regression test for `updateConversation` preserving pasted image data
- Align the main update flow with `ImageAttachment.data` being the single source of truth for chat UI image rendering

## Why

Pasted and dropped images render from `ChatMessage.images[].data` in the history UI and full-image modal. `updateConversation` was clearing that data after saving metadata, while metadata does not include messages, so opening the conversation later could leave the image source as an empty data URI.

This intentionally preserves image payloads on the in-memory conversation messages because the current chat UI contract treats `ImageAttachment.data` as the display source of truth. If memory pressure becomes a concern later, the safer follow-up would be to introduce a separate durable attachment store and update the renderer to resolve from that store, rather than blanking the only UI-readable payload after metadata saves.

Related prior work searched:
- #62 added image rendering in chat UI
- #106 moved session metadata toward SDK-native storage
- #226 added fork handling, including the previous special case around image data

I did not find an existing issue or PR that directly covers pasted images failing to open from history.

## Test plan

- `npm run test -- tests/integration/main.test.ts --runInBand`
- `npm run typecheck`
- `npm run lint`
- `npm run test -- --runInBand`
- `npm run build`
- `git diff --check`
