### PR TITLE
fix: prefer current Codex installs and surface app-server stderr

### DIFF
--- a/src/providers/codex/runtime/CodexAppServerProcess.ts
+++ b/src/providers/codex/runtime/CodexAppServerProcess.ts
@@ -9,6 +9,7 @@ import {
 import type { CodexLaunchSpec } from './codexLaunchTypes';
 
 const SIGKILL_TIMEOUT_MS = 3_000;
+const STDERR_BUFFER_LIMIT = 8_192;
 
 type ExitCallback = (code: number | null, signal: string | null) => void;
 
@@ -17,6 +18,7 @@ export class CodexAppServerProcess {
   private alive = false;
   private exitCallbacks: ExitCallback[] = [];
   private resolvedSpawnSpec: WindowsCmdShimSpawnSpec | null = null;
+  private stderrBuffer = '';
 
   constructor(
     private readonly launchSpec: Pick<CodexLaunchSpec, 'command' | 'args' | 'spawnCwd' | 'env'>,
@@ -36,7 +38,11 @@ export class CodexAppServerProcess {
 
     this.alive = true;
 
-    this.proc.on('exit', (code, signal) => {
+    this.proc.on('exit', () => {
+      this.alive = false;
+    });
+
+    this.proc.on('close', (code, signal) => {
       this.alive = false;
       for (const cb of this.exitCallbacks) {
         cb(code, signal);
@@ -45,6 +51,11 @@ export class CodexAppServerProcess {
 
     this.proc.on('error', () => {
       this.alive = false;
+    });
+
+    this.proc.stderr?.on('data', (chunk: Buffer | string) => {
+      const text = Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk);
+      this.stderrBuffer = `${this.stderrBuffer}${text}`.slice(-STDERR_BUFFER_LIMIT);
     });
   }
 
@@ -65,6 +76,10 @@ export class CodexAppServerProcess {
 
   isAlive(): boolean {
     return this.alive;
+  }
+
+  getStderrSnapshot(): string {
+    return this.stderrBuffer.trim();
   }
 
   onExit(callback: ExitCallback): void {

--- a/src/providers/codex/runtime/CodexBinaryLocator.ts
+++ b/src/providers/codex/runtime/CodexBinaryLocator.ts
@@ -1,5 +1,10 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
 import { findCliBinaryPath, resolveConfiguredCliPath } from '../../../utils/cliBinaryLocator';
 import { parseEnvironmentVariables } from '../../../utils/env';
+import { expandHomePath } from '../../../utils/path';
 import type { CodexInstallationMethod } from '../settings';
 
 export function isWindowsStyleCliReference(value: string | null | undefined): boolean {
@@ -17,7 +22,107 @@ export function findCodexBinaryPath(
   additionalPath?: string,
   platform: NodeJS.Platform = process.platform,
 ): string | null {
+  const explicitPathBinary = findCodexBinaryInDirs(
+    parsePathEntriesForPlatform(additionalPath, platform),
+    platform,
+  );
+  if (explicitPathBinary) {
+    return explicitPathBinary;
+  }
+
+  const preferredBinary = findCodexBinaryInDirs(
+    getPreferredCodexBinaryDirs(platform),
+    platform,
+  );
+  if (preferredBinary) {
+    return preferredBinary;
+  }
+
   return findCliBinaryPath('codex', additionalPath, platform);
+}
+
+function getCodexBinaryNames(platform: NodeJS.Platform): string[] {
+  return platform === 'win32'
+    ? ['codex.exe', 'codex.cmd', 'codex']
+    : ['codex'];
+}
+
+function findCodexBinaryInDirs(dirs: string[], platform: NodeJS.Platform): string | null {
+  const binaryNames = getCodexBinaryNames(platform);
+
+  for (const dir of dirs) {
+    if (!dir) continue;
+
+    for (const binaryName of binaryNames) {
+      const candidate = path.join(dir, binaryName);
+      if (isExistingFile(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
+  return null;
+}
+
+function getPreferredCodexBinaryDirs(platform: NodeJS.Platform): string[] {
+  const home = getHomeDir();
+
+  if (platform === 'darwin') {
+    return [
+      path.join(home, 'Applications', 'Codex.app', 'Contents', 'Resources'),
+      '/Applications/Codex.app/Contents/Resources',
+      path.join(home, 'Applications', 'Codex.app', 'Contents', 'MacOS'),
+      '/Applications/Codex.app/Contents/MacOS',
+      path.join(home, '.local', 'bin'),
+    ];
+  }
+
+  if (platform !== 'win32') {
+    return [
+      path.join(home, '.local', 'bin'),
+    ];
+  }
+
+  return [];
+}
+
+function getHomeDir(): string {
+  return process.env.HOME || process.env.USERPROFILE || os.homedir();
+}
+
+function isExistingFile(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function parsePathEntriesForPlatform(pathValue: string | undefined, platform: NodeJS.Platform): string[] {
+  if (!pathValue) {
+    return [];
+  }
+
+  const delimiter = platform === 'win32' ? ';' : ':';
+  return pathValue
+    .split(delimiter)
+    .map(segment => stripSurroundingQuotes(segment.trim()))
+    .filter(segment => {
+      if (!segment) return false;
+      const upper = segment.toUpperCase();
+      return upper !== '$PATH' && upper !== '${PATH}' && upper !== '%PATH%';
+    })
+    .map(segment => expandHomePath(segment));
+}
+
+function stripSurroundingQuotes(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
 }
 
 export function resolveCodexCliPath(

--- a/src/providers/codex/runtime/CodexRpcTransport.ts
+++ b/src/providers/codex/runtime/CodexRpcTransport.ts
@@ -28,7 +28,7 @@ export class CodexRpcTransport {
     rl.on('line', (line) => this.handleLine(line));
 
     this.proc.onExit(() => {
-      this.rejectAllPending(new Error('App-server process exited'));
+      this.rejectAllPending(new Error(this.buildProcessExitMessage()));
     });
   }
 
@@ -167,5 +167,10 @@ export class CodexRpcTransport {
       pending.reject(error);
     }
     this.pending.clear();
+  }
+
+  private buildProcessExitMessage(): string {
+    const stderr = this.proc.getStderrSnapshot();
+    return stderr ? `App-server process exited\n\n${stderr}` : 'App-server process exited';
   }
 }

--- a/src/providers/codex/ui/CodexSettingsTab.ts
+++ b/src/providers/codex/ui/CodexSettingsTab.ts
@@ -78,7 +78,7 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
     const getCliPathCopy = (): { desc: string; placeholder: string } => {
       if (!isWindowsHost) {
         return {
-          desc: 'Custom path to the local Codex CLI. Leave empty for auto-detection from PATH.',
+          desc: 'Custom path to the local Codex CLI. Leave empty to prefer known Codex installs, then PATH.',
           placeholder: '/usr/local/bin/codex',
         };
       }
@@ -91,7 +91,7 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
       }
 
       return {
-        desc: 'Custom path to the local Codex CLI. Leave empty for auto-detection from PATH. Use the native Windows executable path, usually `codex.exe`.',
+        desc: 'Custom path to the local Codex CLI. Leave empty to auto-detect from PATH. Use the native Windows executable path, usually `codex.exe`.',
         placeholder: 'C:\\Users\\you\\AppData\\Roaming\\npm\\codex.exe',
       };
     };

--- a/tests/unit/providers/codex/runtime/CodexAppServerProcess.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexAppServerProcess.test.ts
@@ -155,14 +155,25 @@ describe('CodexAppServerProcess', () => {
     });
   });
 
+  describe('stderr snapshot', () => {
+    it('keeps a bounded stderr snapshot for startup failures', () => {
+      const server = new CodexAppServerProcess(createLaunchSpec());
+      server.start();
+
+      mockProc.stderr?.emit('data', 'failed to load configuration');
+
+      expect(server.getStderrSnapshot()).toContain('failed to load configuration');
+    });
+  });
+
   describe('onExit', () => {
-    it('calls registered exit callback when process exits', () => {
+    it('calls registered exit callback when process closes', () => {
       const server = new CodexAppServerProcess(createLaunchSpec());
       const exitCallback = jest.fn();
       server.onExit(exitCallback);
       server.start();
 
-      mockProc.emit('exit', 1, 'SIGTERM');
+      mockProc.emit('close', 1, 'SIGTERM');
 
       expect(exitCallback).toHaveBeenCalledWith(1, 'SIGTERM');
     });
@@ -174,9 +185,26 @@ describe('CodexAppServerProcess', () => {
       const exitCallback = jest.fn();
       server.onExit(exitCallback);
 
-      mockProc.emit('exit', 0, null);
+      mockProc.emit('close', 0, null);
 
       expect(exitCallback).toHaveBeenCalledWith(0, null);
+    });
+
+    it('waits for close before notifying so late stderr is included', () => {
+      const server = new CodexAppServerProcess(createLaunchSpec());
+      const exitCallback = jest.fn(() => {
+        expect(server.getStderrSnapshot()).toContain('unknown variant priority');
+      });
+      server.onExit(exitCallback);
+      server.start();
+
+      mockProc.emit('exit', 1, null);
+      mockProc.stderr?.emit('data', 'unknown variant priority');
+      expect(exitCallback).not.toHaveBeenCalled();
+
+      mockProc.emit('close', 1, null);
+
+      expect(exitCallback).toHaveBeenCalledWith(1, null);
     });
   });
 

--- a/tests/unit/providers/codex/runtime/CodexBinaryLocator.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexBinaryLocator.test.ts
@@ -9,12 +9,19 @@ import {
 
 describe('CodexBinaryLocator', () => {
   let tempDir: string;
+  const originalHome = process.env.HOME;
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-binary-locator-'));
   });
 
   afterEach(() => {
+    jest.restoreAllMocks();
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -34,6 +41,39 @@ describe('CodexBinaryLocator', () => {
     fs.writeFileSync(pathBinary, '');
 
     expect(findCodexBinaryPath(pathDir, 'win32')).toBe(pathBinary);
+  });
+
+  it('prefers the macOS Codex app bundle over generic PATH auto-detection', () => {
+    process.env.HOME = tempDir;
+    const appDir = path.join(tempDir, 'Applications', 'Codex.app', 'Contents', 'Resources');
+    const appBinary = path.join(appDir, 'codex');
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(appBinary, '');
+
+    expect(findCodexBinaryPath('', 'darwin')).toBe(appBinary);
+  });
+
+  it('honors an explicit runtime PATH before preferred macOS Codex locations', () => {
+    process.env.HOME = tempDir;
+    const explicitDir = path.join(tempDir, 'explicit-bin');
+    const explicitBinary = path.join(explicitDir, 'codex');
+    const appDir = path.join(tempDir, 'Applications', 'Codex.app', 'Contents', 'Resources');
+    fs.mkdirSync(explicitDir, { recursive: true });
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(explicitBinary, '');
+    fs.writeFileSync(path.join(appDir, 'codex'), '');
+
+    expect(findCodexBinaryPath(explicitDir, 'darwin')).toBe(explicitBinary);
+  });
+
+  it('prefers a user-local Codex binary before generic Unix PATH auto-detection', () => {
+    process.env.HOME = tempDir;
+    const localDir = path.join(tempDir, '.local', 'bin');
+    const localBinary = path.join(localDir, 'codex');
+    fs.mkdirSync(localDir, { recursive: true });
+    fs.writeFileSync(localBinary, '');
+
+    expect(findCodexBinaryPath('', 'linux')).toBe(localBinary);
   });
 
   it('prefers a hostname-specific configured path', () => {

--- a/tests/unit/providers/codex/runtime/CodexRpcTransport.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexRpcTransport.test.ts
@@ -24,6 +24,7 @@ function createMockServerProcess(): CodexAppServerProcess & {
     stderr: new Readable({ read() {} }),
     isAlive: jest.fn().mockReturnValue(true),
     onExit: jest.fn(),
+    getStderrSnapshot: jest.fn().mockReturnValue(''),
     _stdout: stdout,
     _stdin: stdin,
     _written: written,
@@ -201,6 +202,19 @@ describe('CodexRpcTransport', () => {
       exitCb(1, 'SIGTERM');
 
       await expect(promise).rejects.toThrow();
+    });
+
+    it('includes stderr when rejecting pending requests after process exit', async () => {
+      (proc.getStderrSnapshot as jest.Mock).mockReturnValue(
+        'failed to load configuration: ~/.codex/config.toml: unknown variant priority',
+      );
+      const exitCb = (proc.onExit as jest.Mock).mock.calls[0][0];
+
+      const promise = transport.request('initialize', {});
+
+      exitCb(1, null);
+
+      await expect(promise).rejects.toThrow('unknown variant priority');
     });
   });
 

--- a/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
+++ b/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
@@ -435,7 +435,7 @@ describe('CodexSettingsTab', () => {
     codexSettingsTabRenderer.render(createContainer(), createContext(plugin));
 
     const cliPathSetting = findSetting('Codex CLI path');
-    expect(cliPathSetting.desc).toBe('Custom path to the local Codex CLI. Leave empty for auto-detection from PATH.');
+    expect(cliPathSetting.desc).toBe('Custom path to the local Codex CLI. Leave empty to prefer known Codex installs, then PATH.');
     expect(cliPathSetting.textComponents[0].placeholder).toBe('/usr/local/bin/codex');
 
     await cliPathSetting.textComponents[0].onChangeCallback?.('codex');


### PR DESCRIPTION
## Summary

- Prefer known current Codex install locations during Codex CLI auto-detection before falling back to generic PATH search.
- Preserve explicit configured CLI paths and WSL behavior.
- Capture Codex app-server stderr and include it when pending JSON-RPC requests are rejected after process exit.
- Update Codex settings copy so the empty CLI path behavior matches the new auto-detection order.

## Why

On macOS it is common to have multiple `codex` binaries from different install channels. A GUI-launched Obsidian session can auto-detect an older `/usr/local/bin/codex` before the current Codex app bundle or user-local install. If the newer Codex config contains a newer `service_tier` value, the older CLI can fail during startup with errors such as:

```text
failed to load configuration: ~/.codex/config.toml: unknown variant priority, expected fast or flex
```

Previously the runtime often surfaced only `App-server process exited`, which hid the actionable stderr.

## Relation to other PRs

- #782 also touches Codex app-server process/transport while adding broad Claude WSL support and shared WSL utilities. This PR is intentionally narrower: it does not change WSL path mapping or Claude execution. The unique fix here is macOS/current Codex install preference during Codex CLI auto-detection, plus small Codex startup diagnostics.
- If #782 lands first, this PR may need a straightforward rebase around `CodexAppServerProcess` / `CodexRpcTransport`, but the macOS auto-detection behavior remains independent.

## Notes

- Explicit host-scoped and legacy configured CLI paths still win over auto-detection.
- WSL mode on Windows still returns the configured Linux-side command or `codex` without host filesystem validation.
- The app-server process now notifies listeners on `close` rather than `exit` so stderr has a chance to drain before errors are reported.
- A sub-agent reviewed the patch; its findings about stderr drain ordering and settings copy were addressed before opening this PR.

## Test plan

- `npm run test -- --selectProjects unit --runTestsByPath tests/unit/providers/codex/runtime/CodexBinaryLocator.test.ts tests/unit/providers/codex/runtime/CodexCliResolver.test.ts tests/unit/providers/codex/runtime/CodexAppServerProcess.test.ts tests/unit/providers/codex/runtime/CodexRpcTransport.test.ts tests/unit/providers/codex/ui/CodexSettingsTab.test.ts --runInBand`
- `npm run typecheck`
- `npm run lint`
- `npm run test -- --runInBand`
- `npm run build`
- `git diff --check`
