### PR TITLE
fix: avoid Codex Windows install settings on non-Windows hosts

### DIFF
--- a/src/providers/codex/settings.ts
+++ b/src/providers/codex/settings.ts
@@ -22,6 +22,17 @@ function normalizeOptionalString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
 }
 
+function shouldPersistCodexInstallationSettings(): boolean {
+  return process.platform === 'win32';
+}
+
+function omitCurrentHost<T>(entries: Record<string, T>, hostnameKey: string): Record<string, T> {
+  const next = { ...entries };
+  delete next[hostnameKey];
+  delete next[getLegacyHostnameKey()];
+  return next;
+}
+
 export interface CodexProviderSettings {
   enabled: boolean;
   safeMode: CodexSafeMode;
@@ -175,32 +186,41 @@ export function updateCodexProviderSettings(
 ): CodexProviderSettings {
   const current = getCodexProviderSettings(settings);
   const hostnameKey = getHostnameKey();
-  const installationMethodsByHost = 'installationMethodsByHost' in updates
+  const persistInstallationSettings = shouldPersistCodexInstallationSettings();
+  const updatedInstallationMethodsByHost = 'installationMethodsByHost' in updates
     ? normalizeInstallationMethodsByHost(updates.installationMethodsByHost)
     : { ...current.installationMethodsByHost };
-  const wslDistroOverridesByHost = 'wslDistroOverridesByHost' in updates
+  const updatedWslDistroOverridesByHost = 'wslDistroOverridesByHost' in updates
     ? normalizeHostnameCliPaths(updates.wslDistroOverridesByHost)
     : { ...current.wslDistroOverridesByHost };
+  const installationMethodsByHost = persistInstallationSettings
+    ? updatedInstallationMethodsByHost
+    : omitCurrentHost(updatedInstallationMethodsByHost, hostnameKey);
+  const wslDistroOverridesByHost = persistInstallationSettings
+    ? updatedWslDistroOverridesByHost
+    : omitCurrentHost(updatedWslDistroOverridesByHost, hostnameKey);
 
   if (
-    Object.keys(installationMethodsByHost).length === 0
+    persistInstallationSettings
+    && Object.keys(installationMethodsByHost).length === 0
     && current.installationMethod !== DEFAULT_CODEX_PROVIDER_SETTINGS.installationMethod
   ) {
     installationMethodsByHost[hostnameKey] = current.installationMethod;
   }
 
   if (
-    Object.keys(wslDistroOverridesByHost).length === 0
+    persistInstallationSettings
+    && Object.keys(wslDistroOverridesByHost).length === 0
     && current.wslDistroOverride
   ) {
     wslDistroOverridesByHost[hostnameKey] = current.wslDistroOverride;
   }
 
-  if ('installationMethod' in updates) {
+  if (persistInstallationSettings && 'installationMethod' in updates) {
     installationMethodsByHost[hostnameKey] = normalizeCodexInstallationMethod(updates.installationMethod);
   }
 
-  if ('wslDistroOverride' in updates) {
+  if (persistInstallationSettings && 'wslDistroOverride' in updates) {
     const normalizedDistroOverride = normalizeOptionalString(updates.wslDistroOverride);
     if (normalizedDistroOverride) {
       wslDistroOverridesByHost[hostnameKey] = normalizedDistroOverride;
@@ -212,11 +232,13 @@ export function updateCodexProviderSettings(
   const next: CodexProviderSettings = {
     ...current,
     ...updates,
-    installationMethod: installationMethodsByHost[hostnameKey]
-      ?? DEFAULT_CODEX_PROVIDER_SETTINGS.installationMethod,
+    installationMethod: persistInstallationSettings
+      ? installationMethodsByHost[hostnameKey] ?? DEFAULT_CODEX_PROVIDER_SETTINGS.installationMethod
+      : DEFAULT_CODEX_PROVIDER_SETTINGS.installationMethod,
     installationMethodsByHost,
-    wslDistroOverride: wslDistroOverridesByHost[hostnameKey]
-      ?? DEFAULT_CODEX_PROVIDER_SETTINGS.wslDistroOverride,
+    wslDistroOverride: persistInstallationSettings
+      ? wslDistroOverridesByHost[hostnameKey] ?? DEFAULT_CODEX_PROVIDER_SETTINGS.wslDistroOverride
+      : DEFAULT_CODEX_PROVIDER_SETTINGS.wslDistroOverride,
     wslDistroOverridesByHost,
   };
 

--- a/tests/unit/providers/claude/storage/ClaudianSettingsStorage.test.ts
+++ b/tests/unit/providers/claude/storage/ClaudianSettingsStorage.test.ts
@@ -14,6 +14,7 @@ import { getPiProviderSettings } from '@/providers/pi/settings';
 
 const mockGetHostnameKey = jest.fn(() => 'host-a');
 const mockGetLegacyHostnameKey = jest.fn(() => 'legacy-host');
+const originalPlatform = process.platform;
 
 jest.mock('@/utils/env', () => ({
   ...jest.requireActual('@/utils/env'),
@@ -33,6 +34,7 @@ describe('ClaudianSettingsStorage', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
     // Reset mock implementations to default resolved values
     mockAdapter.exists.mockResolvedValue(false);
     mockAdapter.read.mockResolvedValue('{}');
@@ -41,6 +43,10 @@ describe('ClaudianSettingsStorage', () => {
     mockGetHostnameKey.mockReturnValue('host-a');
     mockGetLegacyHostnameKey.mockReturnValue('legacy-host');
     storage = new ClaudianSettingsStorage(mockAdapter);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
   });
 
   describe('load', () => {
@@ -198,6 +204,7 @@ describe('ClaudianSettingsStorage', () => {
     });
 
     it('migrates current legacy hostname-scoped provider settings to the opaque device key', async () => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
       mockGetHostnameKey.mockReturnValue('device:current');
       mockGetLegacyHostnameKey.mockReturnValue('host-a');
       mockAdapter.exists.mockResolvedValue(true);
@@ -296,6 +303,48 @@ describe('ClaudianSettingsStorage', () => {
       expect(writtenContent.providerConfigs.pi.cliPathsByHost).toEqual({
         'device:current': '/custom/pi-a',
         'host-b': '/custom/pi-b',
+      });
+    });
+
+    it('clears Codex Windows installation settings on non-Windows hosts during normalization', async () => {
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+      mockAdapter.exists.mockResolvedValue(true);
+      mockAdapter.read.mockResolvedValue(JSON.stringify({
+        providerConfigs: {
+          codex: {
+            cliPathsByHost: {
+              'host-a': '/opt/homebrew/bin/codex',
+            },
+            installationMethodsByHost: {
+              'host-a': 'native-windows',
+              'host-b': 'wsl',
+            },
+            wslDistroOverridesByHost: {
+              'host-a': 'Ubuntu',
+              'host-b': 'Debian',
+            },
+          },
+        },
+      }));
+
+      const result = await storage.load();
+      const codexSettings = getCodexProviderSettings(result);
+      const writtenContent = JSON.parse(mockAdapter.write.mock.calls[0][1]);
+
+      expect(codexSettings.cliPathsByHost).toEqual({
+        'host-a': '/opt/homebrew/bin/codex',
+      });
+      expect(codexSettings.installationMethodsByHost).toEqual({
+        'host-b': 'wsl',
+      });
+      expect(codexSettings.wslDistroOverridesByHost).toEqual({
+        'host-b': 'Debian',
+      });
+      expect(writtenContent.providerConfigs.codex.installationMethodsByHost).toEqual({
+        'host-b': 'wsl',
+      });
+      expect(writtenContent.providerConfigs.codex.wslDistroOverridesByHost).toEqual({
+        'host-b': 'Debian',
       });
     });
 

--- a/tests/unit/providers/codex/settings.test.ts
+++ b/tests/unit/providers/codex/settings.test.ts
@@ -9,6 +9,7 @@ import { CODEX_SPARK_MODEL } from '@/providers/codex/types/models';
 
 const mockGetHostnameKey = jest.fn(() => 'host-a');
 const mockGetLegacyHostnameKey = jest.fn(() => 'legacy-host');
+const originalPlatform = process.platform;
 
 jest.mock('@/utils/env', () => ({
   ...jest.requireActual('@/utils/env'),
@@ -21,6 +22,10 @@ describe('codex settings', () => {
     jest.clearAllMocks();
     mockGetHostnameKey.mockReturnValue('host-a');
     mockGetLegacyHostnameKey.mockReturnValue('legacy-host');
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
   });
 
   it('defaults installationMethod to native-windows and leaves wslDistroOverride empty', () => {
@@ -107,6 +112,7 @@ describe('codex settings', () => {
   });
 
   it('round-trips installationMethod and trims wslDistroOverride on update for the current host', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
     const settingsBag: Record<string, unknown> = {
       providerConfigs: {
         codex: {},
@@ -133,6 +139,7 @@ describe('codex settings', () => {
   });
 
   it('preserves another host installation settings when updating the current host', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
     const settingsBag: Record<string, unknown> = {
       providerConfigs: {
         codex: {
@@ -156,6 +163,44 @@ describe('codex settings', () => {
       'host-a': 'native-windows',
     });
     expect(next.wslDistroOverridesByHost).toEqual({
+      'host-b': 'Debian',
+    });
+  });
+
+  it('does not persist Windows installation settings on non-Windows hosts', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const settingsBag: Record<string, unknown> = {
+      providerConfigs: {
+        codex: {
+          installationMethodsByHost: {
+            'host-a': 'wsl',
+            'host-b': 'wsl',
+          },
+          wslDistroOverridesByHost: {
+            'host-a': 'Ubuntu-24.04',
+            'host-b': 'Debian',
+          },
+        },
+      },
+    };
+
+    const next = updateCodexProviderSettings(
+      settingsBag,
+      getCodexProviderSettings(settingsBag),
+    );
+
+    expect(next.installationMethod).toBe(DEFAULT_CODEX_PROVIDER_SETTINGS.installationMethod);
+    expect(next.installationMethodsByHost).toEqual({
+      'host-b': 'wsl',
+    });
+    expect(next.wslDistroOverride).toBe(DEFAULT_CODEX_PROVIDER_SETTINGS.wslDistroOverride);
+    expect(next.wslDistroOverridesByHost).toEqual({
+      'host-b': 'Debian',
+    });
+    expect(getCodexProviderSettings(settingsBag).installationMethodsByHost).toEqual({
+      'host-b': 'wsl',
+    });
+    expect(getCodexProviderSettings(settingsBag).wslDistroOverridesByHost).toEqual({
       'host-b': 'Debian',
     });
   });


### PR DESCRIPTION
## Summary
- stop persisting Codex `installationMethodsByHost` / `wslDistroOverridesByHost` for the current host when Claudian is running on non-Windows platforms
- keep other hosts' persisted install settings intact so synced Windows WSL/native preferences are not erased by macOS/Linux normalization
- add regression coverage for both direct Codex settings updates and storage normalization

## Context
This targets the settings pollution reported in #471 and the related config portion of #648, where macOS vault settings can end up with `native-windows` / `wsl` Codex installation state. Codex execution already resolves non-Windows hosts to host-native execution; this patch keeps the persisted host-scoped Windows/WSL install settings aligned with that behavior.

This does not attempt to fix the separate model selector / restored session-state concern mentioned in #648.

## Testing
- npm run test -- tests/unit/providers/codex/settings.test.ts tests/unit/providers/claude/storage/ClaudianSettingsStorage.test.ts tests/unit/providers/codex/ui/CodexSettingsTab.test.ts tests/unit/providers/codex/runtime/CodexExecutionTargetResolver.test.ts --runInBand
- npm run typecheck
- npm run lint
- npm run test -- --runInBand
- npm run build
- git diff --check
