### PR TITLE
fix: rehydrate image attachments across providers

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -684,18 +684,6 @@ export default class ClaudianPlugin extends Plugin {
     await this.storage.sessions.saveMetadata(
       this.storage.sessions.toSessionMetadata(conversation)
     );
-
-    // Clear image data from memory after save (data is persisted by SDK).
-    // Skip for pending forks: their deep-cloned images aren't in SDK storage yet.
-    if (!ProviderRegistry.getConversationHistoryService(conversation.providerId).isPendingForkConversation(conversation)) {
-      for (const msg of conversation.messages) {
-        if (msg.images) {
-          for (const img of msg.images) {
-            img.data = '';
-          }
-        }
-      }
-    }
   }
 
   async getConversationById(id: string): Promise<Conversation | null> {

--- a/src/providers/claude/history/ClaudeConversationHistoryService.ts
+++ b/src/providers/claude/history/ClaudeConversationHistoryService.ts
@@ -5,6 +5,7 @@ import type {
   ChatMessage,
   Conversation,
   ForkSource,
+  ImageAttachment,
   SubagentInfo,
   ToolCallInfo,
 } from '../../../core/types';
@@ -151,13 +152,60 @@ function ensureTaskToolCall(
   return taskToolCall;
 }
 
+function hasImageData(image: ImageAttachment | undefined): boolean {
+  return typeof image?.data === 'string' && image.data.length > 0;
+}
+
+function mergeImageAttachments(
+  current: ImageAttachment[] | undefined,
+  incoming: ImageAttachment[] | undefined,
+): ImageAttachment[] | undefined {
+  if (!incoming?.length) {
+    return current;
+  }
+  if (!current?.length) {
+    return incoming;
+  }
+
+  const merged = [...current];
+  for (const [index, incomingImage] of incoming.entries()) {
+    const currentImage = merged[index];
+    if (!currentImage) {
+      merged.push(incomingImage);
+      continue;
+    }
+
+    if (!hasImageData(currentImage) && hasImageData(incomingImage)) {
+      merged[index] = {
+        ...currentImage,
+        data: incomingImage.data,
+        mediaType: incomingImage.mediaType,
+        name: currentImage.name || incomingImage.name,
+        size: incomingImage.size,
+        source: currentImage.source ?? incomingImage.source,
+      };
+    }
+  }
+
+  return merged;
+}
+
+function mergeDuplicateMessage(target: ChatMessage, incoming: ChatMessage): void {
+  target.images = mergeImageAttachments(target.images, incoming.images);
+}
+
 function dedupeMessages(messages: ChatMessage[]): ChatMessage[] {
-  const seen = new Set<string>();
+  const byId = new Map<string, ChatMessage>();
   const result: ChatMessage[] = [];
 
   for (const message of messages) {
-    if (seen.has(message.id)) continue;
-    seen.add(message.id);
+    const existing = byId.get(message.id);
+    if (existing) {
+      mergeDuplicateMessage(existing, message);
+      continue;
+    }
+
+    byId.set(message.id, message);
     result.push(message);
   }
 

--- a/src/providers/claude/history/sdkMessageParsing.ts
+++ b/src/providers/claude/history/sdkMessageParsing.ts
@@ -4,11 +4,14 @@ import type {
   ChatMessage,
   ContentBlock,
   ImageAttachment,
-  ImageMediaType,
   ToolCallInfo,
 } from '../../../core/types';
 import { extractUserDisplayContent } from '../../../utils/context';
 import { extractDiffData } from '../../../utils/diff';
+import {
+  buildImageAttachmentFromBase64,
+  parseImageDataUri,
+} from '../../../utils/imageAttachment';
 import { isCompactionCanceledStderr, isInterruptSignalText } from '../../../utils/interrupt';
 import { extractToolResultContent } from '../sdk/toolResultContent';
 import type {
@@ -42,7 +45,10 @@ function isRebuiltContextContent(textContent: string): boolean {
     || textContent.includes('\n\nA:');
 }
 
-function extractImages(content: string | SDKNativeContentBlock[] | undefined): ImageAttachment[] | undefined {
+function extractImages(
+  content: string | SDKNativeContentBlock[] | undefined,
+  messageId: string,
+): ImageAttachment[] | undefined {
   if (!content || typeof content === 'string') {
     return undefined;
   }
@@ -58,14 +64,18 @@ function extractImages(content: string | SDKNativeContentBlock[] | undefined): I
     return undefined;
   }
 
-  return imageBlocks.map((block, index) => ({
-    id: `sdk-img-${Date.now()}-${index}`,
-    name: `image-${index + 1}`,
-    mediaType: block.source.media_type as ImageMediaType,
-    data: block.source.data,
-    size: Math.ceil(block.source.data.length * 0.75),
-    source: 'paste' as const,
-  }));
+  const images = imageBlocks.flatMap((block, index): ImageAttachment[] => {
+    const parsedDataUri = parseImageDataUri(block.source.data);
+    const image = buildImageAttachmentFromBase64({
+      data: parsedDataUri?.data ?? block.source.data,
+      id: `sdk-img-${messageId}-${index}`,
+      mediaType: parsedDataUri?.mediaType ?? block.source.media_type,
+      name: `image-${index + 1}`,
+    });
+    return image ? [image] : [];
+  });
+
+  return images.length > 0 ? images : undefined;
 }
 
 function extractToolCalls(
@@ -177,7 +187,9 @@ export function parseSDKMessageToChat(
 
   const content = sdkMsg.message?.content;
   const textContent = extractTextContent(content);
-  const images = sdkMsg.type === 'user' ? extractImages(content) : undefined;
+  const timestamp = sdkMsg.timestamp ? new Date(sdkMsg.timestamp).getTime() : Date.now();
+  const messageId = sdkMsg.uuid || `sdk-${timestamp}`;
+  const images = sdkMsg.type === 'user' ? extractImages(content, messageId) : undefined;
 
   const hasToolUse = Array.isArray(content) && content.some(block => block.type === 'tool_use');
   const hasImages = !!images && images.length > 0;
@@ -185,7 +197,6 @@ export function parseSDKMessageToChat(
     return null;
   }
 
-  const timestamp = sdkMsg.timestamp ? new Date(sdkMsg.timestamp).getTime() : Date.now();
   const commandNameMatch = sdkMsg.type === 'user'
     ? textContent.match(/<command-name>(\/[^<]+)<\/command-name>/)
     : null;

--- a/src/providers/codex/codexUserText.ts
+++ b/src/providers/codex/codexUserText.ts
@@ -1,0 +1,28 @@
+const CODEX_IMAGE_OPEN_TAG_PATTERN = /^<image\b[^>]*>$/i;
+const CODEX_IMAGE_CLOSE_TAG_PATTERN = /^<\/image>$/i;
+const CODEX_EMPTY_IMAGE_TAG_PATTERN = /^<image\b[^>]*>\s*<\/image>$/i;
+const CODEX_EMPTY_IMAGE_TAG_PATTERN_GLOBAL = /<image\b[^>]*>\s*<\/image>\s*/gi;
+
+export function stripCodexImagePlaceholderText(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return text;
+  }
+
+  if (
+    CODEX_IMAGE_OPEN_TAG_PATTERN.test(trimmed)
+    || CODEX_IMAGE_CLOSE_TAG_PATTERN.test(trimmed)
+    || CODEX_EMPTY_IMAGE_TAG_PATTERN.test(trimmed)
+  ) {
+    return '';
+  }
+
+  return text.replace(CODEX_EMPTY_IMAGE_TAG_PATTERN_GLOBAL, '');
+}
+
+export function joinCodexUserTextParts(parts: readonly string[], separator = ''): string {
+  return parts
+    .map(stripCodexImagePlaceholderText)
+    .filter(text => text.length > 0)
+    .join(separator);
+}

--- a/src/providers/codex/history/CodexHistoryStore.ts
+++ b/src/providers/codex/history/CodexHistoryStore.ts
@@ -2,8 +2,16 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-import type { ChatMessage, ContentBlock, ToolCallInfo } from '../../../core/types';
+import type { ChatMessage, ContentBlock, ImageAttachment, ToolCallInfo } from '../../../core/types';
 import { extractUserDisplayContent } from '../../../utils/context';
+import {
+  buildImageAttachmentFromBase64,
+  parseImageDataUri,
+} from '../../../utils/imageAttachment';
+import {
+  joinCodexUserTextParts,
+  stripCodexImagePlaceholderText,
+} from '../codexUserText';
 import {
   isCodexToolOutputError,
   normalizeCodexMcpToolInput,
@@ -40,6 +48,7 @@ interface CodexItem {
 }
 
 interface PersistedMessagePart {
+  image_url?: string | { url?: string };
   type?: string;
   text?: string;
 }
@@ -138,6 +147,7 @@ interface CodexTurnState {
   lastEventAt: number;
   userTimestamp?: number;
   userChunks: string[];
+  userImages: ImageAttachment[];
   assistantBubbles: CodexAssistantBubble[];
   activeBubbleIndex: number | null;
 }
@@ -176,6 +186,7 @@ function newTurnState(id: string, timestamp: number): CodexTurnState {
     startedAt: timestamp,
     lastEventAt: timestamp,
     userChunks: [],
+    userImages: [],
     assistantBubbles: [],
     activeBubbleIndex: null,
   };
@@ -266,6 +277,22 @@ function appendUserChunk(turn: CodexTurnState, value: string, timestamp: number)
   appendUniqueChunk(turn.userChunks, value);
 
   if (turn.userChunks.length > chunkCountBefore && !turn.userTimestamp && timestamp > 0) {
+    turn.userTimestamp = timestamp;
+  }
+}
+
+function appendUserImages(
+  turn: CodexTurnState,
+  content: PersistedMessagePart[] | undefined,
+  timestamp: number,
+): void {
+  const images = extractMessageImages(content, `codex-img-${turn.id}`, turn.userImages.length);
+  if (images.length === 0) {
+    return;
+  }
+
+  turn.userImages.push(...images);
+  if (!turn.userTimestamp && timestamp > 0) {
     turn.userTimestamp = timestamp;
   }
 }
@@ -433,7 +460,7 @@ function stripLeadingCodexControlBlocks(text: string): string {
 }
 
 function extractCodexUserVisibleText(text: string): string | null {
-  const trimmed = text.trimStart();
+  const trimmed = stripCodexImagePlaceholderText(text).trimStart();
   if (!trimmed) {
     return null;
   }
@@ -442,7 +469,7 @@ function extractCodexUserVisibleText(text: string): string | null {
     return null;
   }
 
-  const visible = stripLeadingCodexControlBlocks(trimmed).trim();
+  const visible = stripCodexImagePlaceholderText(stripLeadingCodexControlBlocks(trimmed)).trim();
   return visible ? visible : null;
 }
 
@@ -454,6 +481,73 @@ function extractMessageText(content: PersistedMessagePart[] | undefined): string
   return content
     .map(part => (typeof part?.text === 'string' ? part.text : ''))
     .join('');
+}
+
+function extractUserMessageText(content: PersistedMessagePart[] | undefined): string {
+  if (!Array.isArray(content)) {
+    return '';
+  }
+
+  return joinCodexUserTextParts(
+    content.map(part => (typeof part?.text === 'string' ? part.text : '')),
+  );
+}
+
+function extractMessageImages(
+  content: PersistedMessagePart[] | undefined,
+  idPrefix: string,
+  startIndex = 0,
+): ImageAttachment[] {
+  if (!Array.isArray(content)) {
+    return [];
+  }
+
+  const images: ImageAttachment[] = [];
+  for (const part of content) {
+    if (part?.type !== 'input_image') {
+      continue;
+    }
+
+    const imageUrl = typeof part.image_url === 'string'
+      ? part.image_url
+      : typeof part.image_url?.url === 'string'
+        ? part.image_url.url
+        : null;
+    const parsed = parseImageDataUri(imageUrl);
+    if (!parsed) {
+      continue;
+    }
+
+    const image = buildImageAttachmentFromBase64({
+      data: parsed.data,
+      id: `${idPrefix}-${startIndex + images.length}`,
+      mediaType: parsed.mediaType,
+      name: `image-${startIndex + images.length + 1}.${parsed.mediaType.split('/')[1]}`,
+    });
+    if (image) {
+      images.push(image);
+    }
+  }
+
+  return images;
+}
+
+function hasMessageImages(content: PersistedMessagePart[] | undefined): boolean {
+  if (!Array.isArray(content)) {
+    return false;
+  }
+
+  return content.some((part) => {
+    if (part?.type !== 'input_image') {
+      return false;
+    }
+    const imageUrl = typeof part.image_url === 'string'
+      ? part.image_url
+      : typeof part.image_url?.url === 'string'
+        ? part.image_url.url
+        : null;
+    return parseImageDataUri(imageUrl) !== null;
+  });
 }
 
 function joinTextParts(parts: Array<{ text?: string } | string>): string {
@@ -898,11 +992,12 @@ function processPersistedPayload(
   switch (payload.type) {
     case 'message': {
       const messagePayload = payload as PersistedMessagePayload;
-      const text = extractMessageText(messagePayload.content);
 
       if (messagePayload.role === 'user') {
+        const text = extractUserMessageText(messagePayload.content);
         const visibleText = extractCodexUserVisibleText(text);
-        if (visibleText === null) break;
+        const hasImages = hasMessageImages(messagePayload.content);
+        if (visibleText === null && !hasImages) break;
 
         // Close any active bubble in the current turn before starting user content
         if (ctx.currentTurnId) {
@@ -914,8 +1009,12 @@ function processPersistedPayload(
         ctx.currentTurnId = null;
         const turn = ensureTurn(ctx.turns, ctx.turnOrder, nextTurnId(ctx), null, timestamp);
         ctx.currentTurnId = turn.id;
-        appendUserChunk(turn, visibleText, timestamp);
+        if (visibleText !== null) {
+          appendUserChunk(turn, visibleText, timestamp);
+        }
+        appendUserImages(turn, messagePayload.content, timestamp);
       } else if (messagePayload.role === 'assistant') {
+        const text = extractMessageText(messagePayload.content);
         const turn = ensureTurn(ctx.turns, ctx.turnOrder, nextTurnId(ctx), ctx.currentTurnId, timestamp);
         const bubble = ensureAssistantBubble(turn, timestamp);
         if (text) {
@@ -1083,13 +1182,15 @@ function flushBubbleTurnMessages(
   const messages: ChatMessage[] = [];
 
   const visibleUserText = extractCodexUserVisibleText(turn.userChunks.join('\n'));
-  if (visibleUserText) {
-    const displayContent = extractUserDisplayContent(visibleUserText);
+  const userImages = turn.userImages.length > 0 ? turn.userImages : undefined;
+  if (visibleUserText || userImages) {
+    const displayContent = visibleUserText ? extractUserDisplayContent(visibleUserText) : undefined;
     messages.push({
       id: `codex-msg-${msgIndex}`,
       role: 'user',
-      content: visibleUserText,
+      content: visibleUserText ?? '',
       ...(displayContent !== undefined ? { displayContent } : {}),
+      ...(userImages ? { images: userImages } : {}),
       ...(turn.serverTurnId ? { userMessageId: turn.serverTurnId } : {}),
       timestamp: turn.userTimestamp || turn.startedAt || Date.now(),
     });

--- a/src/providers/codex/runtime/CodexNotificationRouter.ts
+++ b/src/providers/codex/runtime/CodexNotificationRouter.ts
@@ -1,5 +1,6 @@
 import type { ChatTurnMetadata } from '../../../core/runtime/types';
 import type { StreamChunk, UsageInfo } from '../../../core/types';
+import { joinCodexUserTextParts } from '../codexUserText';
 import {
   isCodexToolOutputError,
   normalizeCodexToolInput,
@@ -736,10 +737,10 @@ export class CodexNotificationRouter {
   }
 
   private extractUserMessageText(content: UserInput[]): string {
-    return content
-      .map((part) => (part.type === 'text' ? part.text : ''))
-      .filter((text) => text.length > 0)
-      .join('\n\n');
+    return joinCodexUserTextParts(
+      content.map((part) => (part.type === 'text' ? part.text : '')),
+      '\n\n',
+    );
   }
 
   // -- turn/plan/updated (update_plan) ----------------------------------------

--- a/src/providers/opencode/history/OpencodeHistoryStore.ts
+++ b/src/providers/opencode/history/OpencodeHistoryStore.ts
@@ -2,9 +2,13 @@ import * as fs from 'node:fs';
 
 import { extractResolvedAnswersFromResultText } from '../../../core/tools/toolInput';
 import { isWriteEditTool, TOOL_ASK_USER_QUESTION } from '../../../core/tools/toolNames';
-import type { ChatMessage, ContentBlock, ToolCallInfo } from '../../../core/types';
+import type { ChatMessage, ContentBlock, ImageAttachment, ToolCallInfo } from '../../../core/types';
 import { extractUserQuery } from '../../../utils/context';
 import { extractDiffData } from '../../../utils/diff';
+import {
+  buildImageAttachmentFromBase64,
+  parseImageDataUri,
+} from '../../../utils/imageAttachment';
 import {
   normalizeOpencodeToolInput,
   normalizeOpencodeToolName,
@@ -146,10 +150,12 @@ function mapStoredMessage(
 
   if (role === 'user') {
     const promptText = extractUserQuery(getJoinedTextParts(message.parts));
+    const images = buildUserImages(message.parts, id);
     return {
       assistantMessageId: undefined,
       content: promptText,
       id,
+      ...(images.length > 0 ? { images } : {}),
       role: 'user',
       timestamp: createdAt,
       userMessageId: id,
@@ -398,6 +404,36 @@ function getJoinedTextParts(parts: StoredRow[]): string {
     .filter((part) => getString(part.type) === 'text' && !getBoolean(part.ignored))
     .map((part) => getString(part.text) ?? '')
     .join('');
+}
+
+function buildUserImages(parts: StoredRow[], messageId: string): ImageAttachment[] {
+  const images: ImageAttachment[] = [];
+
+  for (const part of parts) {
+    if (getString(part.type) !== 'file') {
+      continue;
+    }
+
+    const parsed = parseImageDataUri(getString(part.url));
+    const mime = getString(part.mime);
+    const mediaType = parsed?.mediaType ?? mime;
+    const data = parsed?.data;
+    if (!data || !mediaType) {
+      continue;
+    }
+
+    const image = buildImageAttachmentFromBase64({
+      data,
+      id: `opencode-img-${messageId}-${images.length}`,
+      mediaType,
+      name: getString(part.filename) ?? getString(part.name) ?? `image-${images.length + 1}.${String(mediaType).split('/')[1] ?? 'img'}`,
+    });
+    if (image) {
+      images.push(image);
+    }
+  }
+
+  return images;
 }
 
 function getDurationSeconds(part: StoredRow): number | undefined {

--- a/src/providers/pi/history/PiHistoryStore.ts
+++ b/src/providers/pi/history/PiHistoryStore.ts
@@ -5,8 +5,9 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { isWriteEditTool } from '../../../core/tools/toolNames';
-import type { ChatMessage, ContentBlock, ToolCallInfo } from '../../../core/types';
+import type { ChatMessage, ContentBlock, ImageAttachment, ToolCallInfo } from '../../../core/types';
 import { extractDiffData } from '../../../utils/diff';
+import { buildImageAttachmentFromBase64 } from '../../../utils/imageAttachment';
 import {
   extractPiToolTextContent,
   normalizePiToolInput,
@@ -388,9 +389,11 @@ function mapPiSessionEntry(
   const timestamp = getTimestamp(message.timestamp ?? entry.raw.timestamp);
 
   if (role === 'user') {
+    const images = extractUserImages(message.content ?? message.parts ?? message.blocks, entry.id ?? `pi-user-${messages.length}`);
     return {
       content: extractTextContent(message.content ?? message.text ?? message.message),
       id: entry.id ?? `pi-user-${messages.length}`,
+      ...(images.length > 0 ? { images } : {}),
       role: 'user',
       timestamp,
       userMessageId: entry.id,
@@ -484,6 +487,40 @@ function extractAssistantContentBlocks(value: unknown): ContentBlock[] {
   }
 
   return blocks;
+}
+
+function extractUserImages(value: unknown, messageId: string): ImageAttachment[] {
+  const parts = Array.isArray(value) ? value : [];
+  const images: ImageAttachment[] = [];
+
+  for (const part of parts) {
+    if (!isPlainObject(part)) {
+      continue;
+    }
+
+    const type = getString(part.type);
+    if (type !== 'image') {
+      continue;
+    }
+
+    const data = getString(part.data);
+    const mediaType = getString(part.mimeType) ?? getString(part.mime_type) ?? getString(part.mediaType);
+    if (!data || !mediaType) {
+      continue;
+    }
+
+    const image = buildImageAttachmentFromBase64({
+      data,
+      id: `pi-img-${messageId}-${images.length}`,
+      mediaType,
+      name: getString(part.name) ?? getString(part.filename) ?? `image-${images.length + 1}.${mediaType.split('/')[1] ?? 'img'}`,
+    });
+    if (image) {
+      images.push(image);
+    }
+  }
+
+  return images;
 }
 
 function extractAssistantToolCalls(value: unknown): ToolCallInfo[] {

--- a/src/utils/imageAttachment.ts
+++ b/src/utils/imageAttachment.ts
@@ -1,0 +1,80 @@
+import type { ImageAttachment, ImageMediaType } from '../core/types';
+
+const IMAGE_MEDIA_TYPES: Record<string, ImageMediaType> = {
+  'image/gif': 'image/gif',
+  'image/jpeg': 'image/jpeg',
+  'image/jpg': 'image/jpeg',
+  'image/png': 'image/png',
+  'image/webp': 'image/webp',
+};
+
+const IMAGE_EXTENSIONS: Record<ImageMediaType, string> = {
+  'image/gif': 'gif',
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+};
+
+export interface ParsedImageDataUri {
+  data: string;
+  mediaType: ImageMediaType;
+}
+
+export interface BuildImageAttachmentOptions {
+  data: string;
+  id: string;
+  mediaType: string;
+  name?: string;
+}
+
+export function normalizeImageMediaType(value: unknown): ImageMediaType | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  return IMAGE_MEDIA_TYPES[value.trim().toLowerCase()] ?? null;
+}
+
+export function parseImageDataUri(value: unknown): ParsedImageDataUri | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const match = value.trim().match(/^data:([^;,]+);base64,(.+)$/i);
+  if (!match) {
+    return null;
+  }
+
+  const mediaType = normalizeImageMediaType(match[1]);
+  const data = match[2]?.trim();
+  if (!mediaType || !data) {
+    return null;
+  }
+
+  return { data, mediaType };
+}
+
+export function buildImageAttachmentFromBase64(
+  options: BuildImageAttachmentOptions,
+): ImageAttachment | null {
+  const mediaType = normalizeImageMediaType(options.mediaType);
+  const data = options.data.trim();
+  if (!mediaType || !data) {
+    return null;
+  }
+
+  return {
+    data,
+    id: options.id,
+    mediaType,
+    name: options.name?.trim() || `image.${IMAGE_EXTENSIONS[mediaType]}`,
+    size: estimateBase64ByteLength(data),
+    source: 'paste',
+  };
+}
+
+function estimateBase64ByteLength(value: string): number {
+  const data = value.replace(/\s/g, '');
+  const padding = data.endsWith('==') ? 2 : data.endsWith('=') ? 1 : 0;
+  return Math.max(0, Math.floor((data.length * 3) / 4) - padding);
+}

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -738,6 +738,35 @@ describe('ClaudianPlugin', () => {
       expect(updated?.messages).toEqual(messages);
     });
 
+    it('should preserve image data when updating conversation messages', async () => {
+      await plugin.onload();
+
+      const conv = await plugin.createConversation();
+      const messages = [
+        {
+          id: 'msg-1',
+          role: 'user' as const,
+          content: 'See attached image',
+          timestamp: Date.now(),
+          images: [
+            {
+              id: 'img-1',
+              name: 'pasted.png',
+              mediaType: 'image/png' as const,
+              data: 'YmFzZTY0',
+              size: 10,
+              source: 'paste' as const,
+            },
+          ],
+        },
+      ];
+
+      await plugin.updateConversation(conv.id, { messages });
+
+      const updated = await plugin.getConversationById(conv.id);
+      expect(updated?.messages[0].images?.[0].data).toBe('YmFzZTY0');
+    });
+
     it('should update conversation sessionId', async () => {
       await plugin.onload();
 
@@ -1001,6 +1030,71 @@ describe('ClaudianPlugin', () => {
   });
 
   describe('loadSdkMessagesForConversation - fork branch', () => {
+    it('should repair blank image data from Claude SDK history during hydration', async () => {
+      await plugin.onload();
+
+      const conv = await plugin.createConversation();
+      await plugin.updateConversation(conv.id, {
+        providerState: {
+          providerSessionId: 'session-with-image',
+        },
+        messages: [
+          {
+            id: 'user-with-image',
+            role: 'user',
+            content: 'See attached image',
+            timestamp: 1000,
+            images: [{
+              id: 'img-blank',
+              name: 'pasted.png',
+              mediaType: 'image/png',
+              data: '',
+              size: 0,
+              source: 'paste',
+            }],
+          },
+        ],
+      });
+
+      const existsSpy = jest.spyOn(sdkSession, 'sdkSessionExists').mockReturnValue(true);
+      const loadSpy = jest.spyOn(sdkSession, 'loadSDKSessionMessages').mockResolvedValue({
+        messages: [
+          {
+            id: 'user-with-image',
+            role: 'user',
+            content: 'See attached image',
+            timestamp: 1000,
+            images: [{
+              id: 'sdk-img-user-with-image-0',
+              name: 'image-1',
+              mediaType: 'image/png',
+              data: 'aGVsbG8=',
+              size: 5,
+              source: 'paste',
+            }],
+          },
+        ],
+        skippedLines: 0,
+      });
+
+      const loaded = await plugin.getConversationById(conv.id);
+
+      expect(loadSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        'session-with-image',
+        undefined
+      );
+      expect(loaded?.messages[0].images?.[0]).toMatchObject({
+        id: 'img-blank',
+        data: 'aGVsbG8=',
+        mediaType: 'image/png',
+        size: 5,
+      });
+
+      existsSpy.mockRestore();
+      loadSpy.mockRestore();
+    });
+
     it('should load from forkSource.sessionId and truncate at forkSource.resumeAt for pending fork', async () => {
       await plugin.onload();
 

--- a/tests/unit/providers/codex/codexUserText.test.ts
+++ b/tests/unit/providers/codex/codexUserText.test.ts
@@ -1,0 +1,22 @@
+import {
+  joinCodexUserTextParts,
+  stripCodexImagePlaceholderText,
+} from '@/providers/codex/codexUserText';
+
+describe('codexUserText', () => {
+  it('strips inline generated image placeholder tags', () => {
+    expect(
+      stripCodexImagePlaceholderText('<image name=[Image #1] path="/tmp/1-image-1.png"></image>what was in this img?'),
+    ).toBe('what was in this img?');
+  });
+
+  it('strips generated image placeholder tags split across text parts', () => {
+    expect(
+      joinCodexUserTextParts([
+        '<image name=[Image #1] path="/tmp/1-image-1.png">',
+        '</image>',
+        'what was in this img?',
+      ], '\n\n'),
+    ).toBe('what was in this img?');
+  });
+});

--- a/tests/unit/providers/codex/history/CodexHistoryStore.test.ts
+++ b/tests/unit/providers/codex/history/CodexHistoryStore.test.ts
@@ -94,6 +94,49 @@ describe('CodexHistoryStore', () => {
         { type: 'text', content: 'Done.' },
       ]);
     });
+
+    it('rehydrates user images from persisted input_image parts', () => {
+      const content = [
+        JSON.stringify({
+          timestamp: '2026-07-06T00:00:00.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [
+              { type: 'input_text', text: '<image name=[Image #1] path="/tmp/1-image-1.png">' },
+              { type: 'input_image', image_url: 'data:image/png;base64,aGVsbG8=' },
+              { type: 'input_text', text: '</image>' },
+              { type: 'input_text', text: 'What is in this image?' },
+            ],
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-06T00:00:01.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'It says hello.' }],
+          },
+        }),
+      ].join('\n');
+
+      const messages = parseCodexSessionContent(content);
+
+      expect(messages[0]).toMatchObject({
+        content: 'What is in this image?',
+        images: [{
+          data: 'aGVsbG8=',
+          id: 'codex-img-turn-1-0',
+          mediaType: 'image/png',
+          name: 'image-1.png',
+          size: 5,
+          source: 'paste',
+        }],
+        role: 'user',
+      });
+    });
   });
 
   describe('parseCodexSessionFile - tools session', () => {

--- a/tests/unit/providers/codex/runtime/CodexNotificationRouter.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexNotificationRouter.test.ts
@@ -1197,6 +1197,27 @@ describe('CodexNotificationRouter', () => {
       ]);
     });
 
+    it('hides generated image placeholder tags from userMessage boundaries', () => {
+      router.handleNotification('item/started', {
+        item: {
+          type: 'userMessage',
+          id: 'u1',
+          content: [
+            { type: 'text', text: '<image name=[Image #1] path="/tmp/1-image-1.png">' },
+            { type: 'localImage', path: '/tmp/1-image-1.png' },
+            { type: 'text', text: '</image>' },
+            { type: 'text', text: 'what was in this img?' },
+          ],
+        },
+        threadId: 't1',
+        turnId: 'turn1',
+      });
+
+      expect(chunks).toEqual([
+        { type: 'user_message_start', itemId: 'u1', content: 'what was in this img?' },
+      ]);
+    });
+
     it('maps agentMessage item/started to an assistant_message_start chunk', () => {
       router.handleNotification('item/started', {
         item: { type: 'agentMessage', id: 'a1', text: '', phase: 'streaming', memoryCitation: null },

--- a/tests/unit/providers/opencode/OpencodeHistoryStore.test.ts
+++ b/tests/unit/providers/opencode/OpencodeHistoryStore.test.ts
@@ -91,6 +91,45 @@ describe('mapOpencodeMessages', () => {
     ]);
   });
 
+  it('rehydrates user file image parts', () => {
+    const messages = mapOpencodeMessages([
+      {
+        info: {
+          id: 'msg-user',
+          role: 'user',
+          time: { created: 1_000 },
+        },
+        parts: [
+          {
+            id: 'part-text',
+            text: 'What is in this image?',
+            type: 'text',
+          },
+          {
+            filename: 'screenshot.png',
+            id: 'part-image',
+            mime: 'image/png',
+            type: 'file',
+            url: 'data:image/png;base64,aGVsbG8=',
+          },
+        ],
+      },
+    ]);
+
+    expect(messages[0]).toMatchObject({
+      content: 'What is in this image?',
+      images: [{
+        data: 'aGVsbG8=',
+        id: 'opencode-img-msg-user-0',
+        mediaType: 'image/png',
+        name: 'screenshot.png',
+        size: 5,
+        source: 'paste',
+      }],
+      role: 'user',
+    });
+  });
+
   it('hydrates stored question tools with resolved answers', () => {
     const messages = mapOpencodeMessages([
       {

--- a/tests/unit/providers/pi/history/PiHistoryStore.test.ts
+++ b/tests/unit/providers/pi/history/PiHistoryStore.test.ts
@@ -69,6 +69,41 @@ describe('PiHistoryStore', () => {
     expect(messages[0].displayContent).toBeUndefined();
   });
 
+  it('rehydrates user image content parts', () => {
+    const content = [
+      JSON.stringify({
+        id: 'u1',
+        type: 'entry',
+        message: {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What is in this image?' },
+            {
+              type: 'image',
+              mimeType: 'image/png',
+              data: 'aGVsbG8=',
+            },
+          ],
+        },
+      }),
+    ].join('\n');
+
+    const messages = parsePiSessionContent(content);
+
+    expect(messages[0]).toMatchObject({
+      content: 'What is in this image?',
+      images: [{
+        data: 'aGVsbG8=',
+        id: 'pi-img-u1-0',
+        mediaType: 'image/png',
+        name: 'image-1.png',
+        size: 5,
+        source: 'paste',
+      }],
+      role: 'user',
+    });
+  });
+
   it('attaches tool results to the previous assistant tool call', () => {
     const content = [
       JSON.stringify({


### PR DESCRIPTION
## Summary

- Preserve image attachment base64 data instead of clearing the UI display source after metadata saves
- Rehydrate image attachments from Claude, Codex, Pi, and OpenCode persisted histories
- Hide Codex-generated `<image ...></image>` transport tags from rendered user messages while keeping the image attachment
- Add shared image data URI/base64 attachment helpers and provider regressions

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run test -- --runInBand`
- `npm run build`
- `git diff --check`

Supersedes #855 by fixing the original preserved-data issue plus provider-specific image rehydration after reload.