### PR TITLE
Fix TypeScript lint warnings

### DIFF
--- a/src/core/providers/ProviderRegistry.ts
+++ b/src/core/providers/ProviderRegistry.ts
@@ -218,7 +218,7 @@ class RoutedTitleGenerationService implements TitleGenerationService {
     callback: TitleGenerationCallback,
   ): Promise<void> {
     const providerId = ProviderRegistry.resolveTitleGenerationProviderId(
-      this.plugin.settings as unknown as Record<string, unknown>,
+      this.plugin.settings,
     );
     const service = ProviderRegistry.createTitleGenerationService(this.plugin, providerId);
     const generation = { service };

--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -69,7 +69,7 @@ export class ClaudianView extends ItemView {
     // overwritten by prototype patching. Hover Editor patches ClaudianView.prototype.load
     // after our class is defined, but instance methods take precedence over prototype methods.
     const prototype = Object.getPrototypeOf(this) as LoadableView;
-    const originalLoad = prototype.load.bind(this) as () => Promise<void> | void;
+    const originalLoad = prototype.load.bind(this);
     Object.defineProperty(this, 'load', {
       value: async () => {
         // Ensure containerEl exists before any patched load code tries to use it

--- a/src/features/chat/ui/StatusPanel.ts
+++ b/src/features/chat/ui/StatusPanel.ts
@@ -331,7 +331,7 @@ export class StatusPanel {
   addBashOutput(info: PanelBashOutput): void {
     this.currentBashOutputs.set(info.id, info);
     while (this.currentBashOutputs.size > MAX_BASH_OUTPUTS) {
-      const oldest = this.currentBashOutputs.keys().next().value as string | undefined;
+      const oldest = this.currentBashOutputs.keys().next().value;
       if (!oldest) break;
       this.currentBashOutputs.delete(oldest);
       this.bashEntryExpanded.delete(oldest);

--- a/src/providers/claude/auxiliary/ClaudeTitleGenerationService.ts
+++ b/src/providers/claude/auxiliary/ClaudeTitleGenerationService.ts
@@ -78,7 +78,7 @@ export class TitleGenerationService {
     const titleModel = this.plugin.settings.titleGenerationModel;
     if (titleModel && claudeChatUIConfig.ownsModel(
       titleModel,
-      this.plugin.settings as unknown as Record<string, unknown>,
+      this.plugin.settings,
     )) {
       return toClaudeRuntimeModelId(titleModel);
     }

--- a/src/providers/claude/runtime/customSpawn.ts
+++ b/src/providers/claude/runtime/customSpawn.ts
@@ -73,9 +73,9 @@ function installTreeAwareKill(child: ChildProcess, spawnSpec: WindowsCmdShimSpaw
     return;
   }
 
-  const originalKill = child.kill;
+  const originalKill = child.kill.bind(child);
   const callOriginalKill = (signal?: NodeJS.Signals | number): boolean =>
-    originalKill.call(child, signal);
+    originalKill(signal);
   const killableChild = {
     get pid(): number | undefined {
       return child.pid;

--- a/src/providers/pi/internal/providerProjection.ts
+++ b/src/providers/pi/internal/providerProjection.ts
@@ -1,18 +1,37 @@
-export function ensureProviderProjectionMap(
-  settings: Record<string, unknown>,
-  key:
+type ProviderProjectionKey =
   | 'savedProviderEffort'
   | 'savedProviderModel'
   | 'savedProviderPermissionMode'
   | 'savedProviderServiceTier'
-  | 'savedProviderThinkingBudget',
-): Partial<Record<string, string>> {
-  const current = settings[key];
-  if (current && typeof current === 'object' && !Array.isArray(current)) {
-    return current as Partial<Record<string, string>>;
+  | 'savedProviderThinkingBudget';
+
+type ProviderProjectionMap = Partial<Record<string, string>>;
+
+function normalizeProviderProjectionMap(value: unknown): ProviderProjectionMap | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
   }
 
-  const next: Partial<Record<string, string>> = {};
+  const normalized: ProviderProjectionMap = {};
+  for (const [providerId, projectedValue] of Object.entries(value)) {
+    if (typeof projectedValue === 'string') {
+      normalized[providerId] = projectedValue;
+    }
+  }
+  return normalized;
+}
+
+export function ensureProviderProjectionMap(
+  settings: Record<string, unknown>,
+  key: ProviderProjectionKey,
+): ProviderProjectionMap {
+  const current = normalizeProviderProjectionMap(settings[key]);
+  if (current) {
+    settings[key] = current;
+    return current;
+  }
+
+  const next: ProviderProjectionMap = {};
   settings[key] = next;
   return next;
 }

--- a/src/providers/pi/runtime/PiAuxQueryRunner.ts
+++ b/src/providers/pi/runtime/PiAuxQueryRunner.ts
@@ -205,7 +205,7 @@ export class PiAuxQueryRunner implements AuxQueryRunner {
     }
 
     const projectedSettings = ProviderSettingsCoordinator.getProviderSettingsSnapshot(
-      this.plugin.settings as unknown as Record<string, unknown>,
+      this.plugin.settings,
       'pi',
     );
     const selectedModel = typeof projectedSettings.model === 'string'

--- a/src/providers/pi/runtime/PiChatRuntime.ts
+++ b/src/providers/pi/runtime/PiChatRuntime.ts
@@ -218,7 +218,7 @@ export class PiChatRuntime implements ChatRuntime {
   async reloadMcpServers(): Promise<void> {}
 
   async ensureReady(options?: ChatRuntimeEnsureReadyOptions): Promise<boolean> {
-    const settings = getPiProviderSettings(this.plugin.settings as unknown as Record<string, unknown>);
+    const settings = getPiProviderSettings(this.plugin.settings);
     if (!settings.enabled) {
       this.setReady(false);
       return false;
@@ -227,7 +227,7 @@ export class PiChatRuntime implements ChatRuntime {
     const allowSessionCreation = options?.allowSessionCreation !== false;
     const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
     const resolvedCliPath = this.plugin.getResolvedProviderCliPath('pi') ?? 'pi';
-    const runtimeEnvText = getRuntimeEnvironmentText(this.plugin.settings as unknown as Record<string, unknown>, 'pi');
+    const runtimeEnvText = getRuntimeEnvironmentText(this.plugin.settings, 'pi');
     if (allowSessionCreation) {
       await this.materializePendingFork(cwd, runtimeEnvText);
     }
@@ -864,7 +864,7 @@ export class PiChatRuntime implements ChatRuntime {
 
   private getProviderSettings(): Record<string, unknown> {
     return ProviderSettingsCoordinator.getProviderSettingsSnapshot(
-      this.plugin.settings as unknown as Record<string, unknown>,
+      this.plugin.settings,
       this.providerId,
     );
   }

--- a/src/providers/pi/runtime/PiModelDiscoveryService.ts
+++ b/src/providers/pi/runtime/PiModelDiscoveryService.ts
@@ -20,10 +20,10 @@ export class PiModelDiscoveryService {
   constructor(private readonly plugin: ClaudianPlugin) {}
 
   async discoverModels(): Promise<PiModelDiscoveryResult> {
-    const settings = getPiProviderSettings(this.plugin.settings as unknown as Record<string, unknown>);
+    const settings = getPiProviderSettings(this.plugin.settings);
     const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
     const command = this.plugin.getResolvedProviderCliPath('pi') ?? 'pi';
-    const envText = getRuntimeEnvironmentText(this.plugin.settings as unknown as Record<string, unknown>, 'pi');
+    const envText = getRuntimeEnvironmentText(this.plugin.settings, 'pi');
     const env = {
       ...process.env,
       ...parseEnvironmentVariables(envText),


### PR DESCRIPTION
## Summary
- Remove redundant TypeScript assertions around plugin settings and UI helpers.
- Normalize Pi provider projection maps before returning typed string maps.
- Bind the Claude spawn kill handler before passing it to process-tree termination.

## Tests
- npm run lint
- npm run typecheck
- npm run test (passed on rerun after one transient SQLite lock)
- npm run build