### PR TITLE
feat(tabs): add "Show tab titles by default" setting

### DIFF
--- a/src/app/settings/defaultSettings.ts
+++ b/src/app/settings/defaultSettings.ts
@@ -48,6 +48,7 @@ export const DEFAULT_CLAUDIAN_SETTINGS: ClaudianSettings = {
   enableAutoScroll: true,
   deferMathRenderingDuringStreaming: true,
   expandFileEditsByDefault: false,
+  showTabTitlesByDefault: false,
   chatViewPlacement: 'right-sidebar',
 
   hiddenProviderCommands: getDefaultHiddenProviderCommands(),

--- a/src/core/types/settings.ts
+++ b/src/core/types/settings.ts
@@ -142,6 +142,7 @@ export interface ClaudianSettings {
   enableAutoScroll: boolean;
   deferMathRenderingDuringStreaming: boolean;
   expandFileEditsByDefault: boolean;
+  showTabTitlesByDefault: boolean;
   chatViewPlacement: ChatViewPlacement;
 
   // Provider command visibility

--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -438,6 +438,9 @@ export class ClaudianView extends ItemView {
 
   /** Public hook to re-render the tab bar (e.g. after a relevant setting change). */
   refreshTabBar(): void {
+    // The tab item list is unchanged when only a rendering setting flips, so
+    // force the bar to rebuild rather than skip as a no-op.
+    this.tabBar?.invalidate();
     this.updateTabBar();
   }
 

--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -293,6 +293,8 @@ export class ClaudianView extends ItemView {
       onNewTab: () => {
         void this.createNewTab().catch(() => new Notice('Failed to create tab'));
       },
+    }, {
+      getShowTitlesByDefault: () => this.plugin.settings.showTabTitlesByDefault ?? false,
     });
     fragment.appendChild(this.tabBarContainerEl);
 
@@ -432,6 +434,11 @@ export class ClaudianView extends ItemView {
       return;
     }
     this.updateTabBarVisibility();
+  }
+
+  /** Public hook to re-render the tab bar (e.g. after a relevant setting change). */
+  refreshTabBar(): void {
+    this.updateTabBar();
   }
 
   private updateTabBar(): void {

--- a/src/features/chat/tabs/TabBar.ts
+++ b/src/features/chat/tabs/TabBar.ts
@@ -36,6 +36,12 @@ export class TabBar {
   // Tabs whose display the user has flipped away from the current default via
   // double-click (title <-> number). Interpreted relative to the default mode.
   private toggledTabIds = new Set<TabId>();
+  // Signature of the last rendered items; used to skip redundant rebuilds.
+  // Rebuilding empties the container and recreates badge nodes, which destroys
+  // the element mid-gesture and breaks native double-click. Skipping no-op
+  // rebuilds (e.g. clicking the already-active tab) keeps badge nodes stable.
+  private lastRenderSignature: string | null = null;
+  private forceNextRender = false;
   private lastKnownScrollLeft = 0;
   private readonly handleScroll = (): void => {
     this.captureScrollPosition();
@@ -59,8 +65,20 @@ export class TabBar {
    * @param items Tab items to render.
    */
   update(items: TabBarItem[]): void {
-    this.captureStableScrollPosition();
     this.pruneExpandedTitleState(items);
+
+    // Skip redundant rebuilds: recreating badge nodes on every call (e.g. when
+    // clicking the already-active tab) destroys the element a double-click is
+    // landing on, which breaks the title/number toggle. Only rebuild when the
+    // rendered inputs actually changed, or when a refresh was forced.
+    const signature = this.computeRenderSignature(items);
+    if (!this.forceNextRender && signature === this.lastRenderSignature) {
+      return;
+    }
+    this.forceNextRender = false;
+    this.lastRenderSignature = signature;
+
+    this.captureStableScrollPosition();
 
     // Clear existing badges
     this.containerEl.empty();
@@ -71,6 +89,32 @@ export class TabBar {
     }
 
     this.restoreScrollPosition();
+  }
+
+  /**
+   * Forces the next update() to rebuild even if the item signature is unchanged.
+   * Used when a rendering input outside the item list changes (e.g. the
+   * "show tab titles by default" setting).
+   */
+  invalidate(): void {
+    this.forceNextRender = true;
+    this.lastRenderSignature = null;
+  }
+
+  /** Builds a stable signature of every input that affects badge rendering. */
+  private computeRenderSignature(items: TabBarItem[]): string {
+    return items
+      .map(item => [
+        item.id,
+        item.index,
+        item.title,
+        item.providerId,
+        item.isActive ? 1 : 0,
+        item.isStreaming ? 1 : 0,
+        item.needsAttention ? 1 : 0,
+        item.canClose ? 1 : 0,
+      ].join(''))
+      .join('');
   }
 
   /** Renders a single tab badge. */
@@ -127,6 +171,8 @@ export class TabBar {
     this.containerEl.removeClass('claudian-tab-badges');
     this.containerEl.removeEventListener('scroll', this.handleScroll);
     this.toggledTabIds.clear();
+    this.lastRenderSignature = null;
+    this.forceNextRender = false;
     this.lastKnownScrollLeft = 0;
   }
 

--- a/src/features/chat/tabs/TabBar.ts
+++ b/src/features/chat/tabs/TabBar.ts
@@ -16,21 +16,35 @@ export interface TabBarCallbacks {
   onNewTab: () => void;
 }
 
+/** Optional configuration for TabBar rendering. */
+export interface TabBarOptions {
+  /**
+   * Whether badges should display the conversation title by default
+   * instead of the tab number. Read lazily so the setting applies live.
+   * Defaults to `false` (number-first, legacy behavior).
+   */
+  getShowTitlesByDefault?: () => boolean;
+}
+
 /**
  * TabBar renders minimal numbered badge navigation.
  */
 export class TabBar {
   private containerEl: HTMLElement;
   private callbacks: TabBarCallbacks;
-  private expandedTitleTabIds = new Set<TabId>();
+  private readonly getShowTitlesByDefault: () => boolean;
+  // Tabs whose display the user has flipped away from the current default via
+  // double-click (title <-> number). Interpreted relative to the default mode.
+  private toggledTabIds = new Set<TabId>();
   private lastKnownScrollLeft = 0;
   private readonly handleScroll = (): void => {
     this.captureScrollPosition();
   };
 
-  constructor(containerEl: HTMLElement, callbacks: TabBarCallbacks) {
+  constructor(containerEl: HTMLElement, callbacks: TabBarCallbacks, options?: TabBarOptions) {
     this.containerEl = containerEl;
     this.callbacks = callbacks;
+    this.getShowTitlesByDefault = options?.getShowTitlesByDefault ?? (() => false);
     this.build();
   }
 
@@ -71,12 +85,12 @@ export class TabBar {
       stateClass = 'claudian-tab-badge-streaming';
     }
 
-    const isTitleExpanded = this.expandedTitleTabIds.has(item.id);
+    const showTitle = this.shouldShowTitle(item);
     const badgeEl = this.containerEl.createDiv({
       cls: [
         'claudian-tab-badge',
         stateClass,
-        isTitleExpanded ? 'claudian-tab-badge-expanded' : '',
+        showTitle ? 'claudian-tab-badge-expanded' : '',
       ].filter(Boolean).join(' '),
       text: this.getBadgeLabel(item),
     });
@@ -84,7 +98,7 @@ export class TabBar {
     // Obsidian uses aria-label for hover tooltips here; adding title causes duplicate tooltip text.
     badgeEl.setAttribute('aria-label', item.title);
     badgeEl.setAttribute('data-provider', item.providerId);
-    badgeEl.setAttribute('data-title-expanded', isTitleExpanded ? 'true' : 'false');
+    badgeEl.setAttribute('data-title-expanded', showTitle ? 'true' : 'false');
 
     // Click handler to switch tab
     badgeEl.addEventListener('click', () => {
@@ -112,7 +126,7 @@ export class TabBar {
     this.containerEl.empty();
     this.containerEl.removeClass('claudian-tab-badges');
     this.containerEl.removeEventListener('scroll', this.handleScroll);
-    this.expandedTitleTabIds.clear();
+    this.toggledTabIds.clear();
     this.lastKnownScrollLeft = 0;
   }
 
@@ -140,28 +154,48 @@ export class TabBar {
 
   private pruneExpandedTitleState(items: TabBarItem[]): void {
     const visibleTabIds = new Set(items.map(item => item.id));
-    for (const tabId of this.expandedTitleTabIds) {
+    for (const tabId of this.toggledTabIds) {
       if (!visibleTabIds.has(tabId)) {
-        this.expandedTitleTabIds.delete(tabId);
+        this.toggledTabIds.delete(tabId);
       }
     }
   }
 
   private toggleBadgeTitle(item: TabBarItem, badgeEl: HTMLElement): void {
-    if (this.expandedTitleTabIds.has(item.id)) {
-      this.expandedTitleTabIds.delete(item.id);
+    // A tab with no displayable title can only ever show its number, so nothing to toggle.
+    if (!this.hasDisplayableTitle(item)) return;
+
+    if (this.toggledTabIds.has(item.id)) {
+      this.toggledTabIds.delete(item.id);
     } else {
-      this.expandedTitleTabIds.add(item.id);
+      this.toggledTabIds.add(item.id);
     }
 
-    const isTitleExpanded = this.expandedTitleTabIds.has(item.id);
+    const showTitle = this.shouldShowTitle(item);
     badgeEl.textContent = this.getBadgeLabel(item);
-    badgeEl.toggleClass('claudian-tab-badge-expanded', isTitleExpanded);
-    badgeEl.setAttribute('data-title-expanded', isTitleExpanded ? 'true' : 'false');
+    badgeEl.toggleClass('claudian-tab-badge-expanded', showTitle);
+    badgeEl.setAttribute('data-title-expanded', showTitle ? 'true' : 'false');
+  }
+
+  /** Whether the item has a meaningful title worth displaying (not empty / placeholder). */
+  private hasDisplayableTitle(item: TabBarItem): boolean {
+    const title = item.title?.trim();
+    return Boolean(title) && title !== 'New Chat';
+  }
+
+  /**
+   * Resolves whether a badge shows its title (vs its number).
+   * Starts from the configured default, then flips for any tab the user
+   * toggled via double-click. Tabs without a real title always show the number.
+   */
+  private shouldShowTitle(item: TabBarItem): boolean {
+    if (!this.hasDisplayableTitle(item)) return false;
+    const base = this.getShowTitlesByDefault();
+    return this.toggledTabIds.has(item.id) ? !base : base;
   }
 
   private getBadgeLabel(item: TabBarItem): string {
-    if (!this.expandedTitleTabIds.has(item.id)) {
+    if (!this.shouldShowTitle(item)) {
       return String(item.index);
     }
 

--- a/src/features/settings/ClaudianSettings.ts
+++ b/src/features/settings/ClaudianSettings.ts
@@ -287,6 +287,20 @@ export class ClaudianSettingTab extends PluginSettingTab {
           })
       );
 
+    new Setting(container)
+      .setName(t('settings.showTabTitlesByDefault.name'))
+      .setDesc(t('settings.showTabTitlesByDefault.desc'))
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.showTabTitlesByDefault ?? false)
+          .onChange(async (value) => {
+            this.plugin.settings.showTabTitlesByDefault = value;
+            await this.plugin.saveSettings();
+            // Reflect the change immediately in any open chat view.
+            this.plugin.getAllViews().forEach((view) => view.refreshTabBar());
+          })
+      );
+
     // --- Conversations ---
 
     new Setting(container).setName(t('settings.conversations')).setHeading();

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -297,6 +297,10 @@
       "name": "Dateibearbeitungen standardmäßig ausklappen",
       "desc": "Write- und Edit-Diffs beim ersten Erscheinen ausgeklappt anzeigen."
     },
+    "showTabTitlesByDefault": {
+      "name": "Show tab titles by default",
+      "desc": "Display the conversation title on tab badges instead of the tab number. Double-click a tab to switch the other way."
+    },
     "chatViewPlacement": {
       "name": "Claudian öffnen in",
       "desc": "Wählen Sie, wo das Chat-Panel beim Erstellen geöffnet wird",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -297,6 +297,10 @@
       "name": "Expand file edits by default",
       "desc": "Show Write and Edit diffs expanded when they first appear."
     },
+    "showTabTitlesByDefault": {
+      "name": "Show tab titles by default",
+      "desc": "Display the conversation title on tab badges instead of the tab number. Double-click a tab to switch the other way."
+    },
     "chatViewPlacement": {
       "name": "Open Claudian in",
       "desc": "Choose where the chat panel opens when it is created",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -297,6 +297,10 @@
       "name": "Expandir ediciones de archivo por defecto",
       "desc": "Mostrar los diffs de Write y Edit expandidos cuando aparecen por primera vez."
     },
+    "showTabTitlesByDefault": {
+      "name": "Show tab titles by default",
+      "desc": "Display the conversation title on tab badges instead of the tab number. Double-click a tab to switch the other way."
+    },
     "chatViewPlacement": {
       "name": "Abrir Claudian en",
       "desc": "Elige dónde se abre el panel de chat cuando se crea",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -297,6 +297,10 @@
       "name": "Développer les modifications de fichiers par défaut",
       "desc": "Afficher les diffs Write et Edit développés lors de leur première apparition."
     },
+    "showTabTitlesByDefault": {
+      "name": "Afficher les titres d'onglets par défaut",
+      "desc": "Afficher le titre de la conversation sur les onglets au lieu du numéro. Double-cliquez sur un onglet pour basculer dans l'autre sens."
+    },
     "chatViewPlacement": {
       "name": "Ouvrir Claudian dans",
       "desc": "Choisissez où le panneau de chat s'ouvre lors de sa création",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -297,6 +297,10 @@
       "name": "ファイル編集をデフォルトで展開",
       "desc": "Write と Edit の diff が最初に表示されるとき、展開した状態で表示します。"
     },
+    "showTabTitlesByDefault": {
+      "name": "Show tab titles by default",
+      "desc": "Display the conversation title on tab badges instead of the tab number. Double-click a tab to switch the other way."
+    },
     "chatViewPlacement": {
       "name": "Claudian を開く場所",
       "desc": "チャットパネルを作成するときに開く場所を選択します",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -297,6 +297,10 @@
       "name": "파일 편집을 기본적으로 펼치기",
       "desc": "Write 및 Edit diff가 처음 표시될 때 펼친 상태로 보여줍니다."
     },
+    "showTabTitlesByDefault": {
+      "name": "Show tab titles by default",
+      "desc": "Display the conversation title on tab badges instead of the tab number. Double-click a tab to switch the other way."
+    },
     "chatViewPlacement": {
       "name": "Claudian 열 위치",
       "desc": "채팅 패널이 생성될 때 열릴 위치를 선택합니다",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -297,6 +297,10 @@
       "name": "Expandir edições de arquivo por padrão",
       "desc": "Mostrar os diffs de Write e Edit expandidos quando aparecerem pela primeira vez."
     },
+    "showTabTitlesByDefault": {
+      "name": "Show tab titles by default",
+      "desc": "Display the conversation title on tab badges instead of the tab number. Double-click a tab to switch the other way."
+    },
     "chatViewPlacement": {
       "name": "Abrir Claudian em",
       "desc": "Escolha onde o painel de chat abre quando é criado",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -297,6 +297,10 @@
       "name": "Раскрывать правки файлов по умолчанию",
       "desc": "Показывать diff для Write и Edit раскрытым при первом появлении."
     },
+    "showTabTitlesByDefault": {
+      "name": "Show tab titles by default",
+      "desc": "Display the conversation title on tab badges instead of the tab number. Double-click a tab to switch the other way."
+    },
     "chatViewPlacement": {
       "name": "Открывать Claudian в",
       "desc": "Выберите, где открывается панель чата при создании",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -297,6 +297,10 @@
       "name": "默认展开文件编辑",
       "desc": "Write 和 Edit diff 首次出现时以展开状态显示。"
     },
+    "showTabTitlesByDefault": {
+      "name": "Show tab titles by default",
+      "desc": "Display the conversation title on tab badges instead of the tab number. Double-click a tab to switch the other way."
+    },
     "chatViewPlacement": {
       "name": "Claudian 打开位置",
       "desc": "选择新建聊天面板时的打开位置",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -297,6 +297,10 @@
       "name": "預設展開檔案編輯",
       "desc": "Write 和 Edit diff 首次出現時以展開狀態顯示。"
     },
+    "showTabTitlesByDefault": {
+      "name": "Show tab titles by default",
+      "desc": "Display the conversation title on tab badges instead of the tab number. Double-click a tab to switch the other way."
+    },
     "chatViewPlacement": {
       "name": "Claudian 開啟位置",
       "desc": "選擇新建聊天面板時的開啟位置",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -231,6 +231,8 @@ export type TranslationKey =
   | 'settings.deferMathRenderingDuringStreaming.desc'
   | 'settings.expandFileEditsByDefault.name'
   | 'settings.expandFileEditsByDefault.desc'
+  | 'settings.showTabTitlesByDefault.name'
+  | 'settings.showTabTitlesByDefault.desc'
   | 'settings.chatViewPlacement.name'
   | 'settings.chatViewPlacement.desc'
   | 'settings.chatViewPlacement.rightSidebar'

--- a/tests/unit/features/chat/tabs/TabBar.titlesByDefault.test.ts
+++ b/tests/unit/features/chat/tabs/TabBar.titlesByDefault.test.ts
@@ -1,0 +1,83 @@
+import { createMockEl } from '@test/helpers/mockElement';
+
+import { TabBar, type TabBarCallbacks, type TabBarOptions } from '@/features/chat/tabs/TabBar';
+import type { TabBarItem } from '@/features/chat/tabs/types';
+
+function cbs(): TabBarCallbacks {
+  return { onTabClick: jest.fn(), onTabClose: jest.fn(), onNewTab: jest.fn() };
+}
+function item(o: Partial<TabBarItem> = {}): TabBarItem {
+  return { id: 'tab-1', index: 1, title: 'My Chat', providerId: 'claude',
+    isActive: true, isStreaming: false, needsAttention: false, canClose: true, ...o };
+}
+const dbl = () => ({ preventDefault: jest.fn(), stopPropagation: jest.fn() });
+
+describe('TabBar — titles by default', () => {
+  it('shows the title by default when the option is on', () => {
+    const el = createMockEl();
+    const opts: TabBarOptions = { getShowTitlesByDefault: () => true };
+    const bar = new TabBar(el, cbs(), opts);
+    bar.update([item()]);
+    expect(el._children[0].textContent).toBe('My Chat');
+  });
+
+  it('double-click toggles title <-> number both ways (title default)', () => {
+    const el = createMockEl();
+    const bar = new TabBar(el, cbs(), { getShowTitlesByDefault: () => true });
+    bar.update([item()]);
+    const b = el._children[0];
+    expect(b.textContent).toBe('My Chat');
+    b.dispatchEvent('dblclick', dbl());
+    expect(b.textContent).toBe('1');
+    b.dispatchEvent('dblclick', dbl());
+    expect(b.textContent).toBe('My Chat');
+  });
+
+  it('placeholder tabs (New Chat) always show the number even when titles default on', () => {
+    const el = createMockEl();
+    const bar = new TabBar(el, cbs(), { getShowTitlesByDefault: () => true });
+    bar.update([item({ title: 'New Chat' })]);
+    expect(el._children[0].textContent).toBe('1');
+  });
+});
+
+describe('TabBar — redundant rebuild guard (double-click stability)', () => {
+  it('does NOT recreate badge nodes when items are unchanged', () => {
+    const el = createMockEl();
+    const bar = new TabBar(el, cbs());
+    bar.update([item()]);
+    const firstNode = el._children[0];
+    // Same items again (e.g. clicking the already-active tab -> updateTabBar)
+    bar.update([item()]);
+    expect(el._children[0]).toBe(firstNode); // node identity preserved -> dblclick survives
+  });
+
+  it('rebuilds when an item actually changes', () => {
+    const el = createMockEl();
+    const bar = new TabBar(el, cbs());
+    bar.update([item({ isActive: false })]);
+    const firstNode = el._children[0];
+    bar.update([item({ isActive: true })]);
+    expect(el._children[0]).not.toBe(firstNode);
+  });
+
+  it('invalidate() forces a rebuild even with identical items', () => {
+    const el = createMockEl();
+    const bar = new TabBar(el, cbs());
+    bar.update([item()]);
+    const firstNode = el._children[0];
+    bar.invalidate();
+    bar.update([item()]);
+    expect(el._children[0]).not.toBe(firstNode);
+  });
+
+  it('toggle survives a subsequent no-op update (unchanged items)', () => {
+    const el = createMockEl();
+    const bar = new TabBar(el, cbs(), { getShowTitlesByDefault: () => true });
+    bar.update([item()]);
+    el._children[0].dispatchEvent('dblclick', dbl()); // -> number
+    expect(el._children[0].textContent).toBe('1');
+    bar.update([item()]); // no-op, must not revert
+    expect(el._children[0].textContent).toBe('1');
+  });
+});

--- a/tests/unit/providers/claude/types/types.test.ts
+++ b/tests/unit/providers/claude/types/types.test.ts
@@ -104,6 +104,7 @@ describe('types.ts', () => {
         enableAutoScroll: true,
         deferMathRenderingDuringStreaming: true,
         expandFileEditsByDefault: false,
+        showTabTitlesByDefault: false,
         chatViewPlacement: 'right-sidebar',
         hiddenProviderCommands: {
           claude: [],
@@ -158,6 +159,7 @@ describe('types.ts', () => {
         enableAutoScroll: true,
         deferMathRenderingDuringStreaming: true,
         expandFileEditsByDefault: false,
+        showTabTitlesByDefault: false,
         chatViewPlacement: 'right-sidebar',
         hiddenProviderCommands: {
           claude: [],
@@ -213,6 +215,7 @@ describe('types.ts', () => {
         enableAutoScroll: false,
         deferMathRenderingDuringStreaming: true,
         expandFileEditsByDefault: true,
+        showTabTitlesByDefault: true,
         chatViewPlacement: 'right-sidebar',
         hiddenProviderCommands: {
           claude: [],


### PR DESCRIPTION
## Summary

Tab badges currently show the **tab number** by default; the generated conversation title is only reachable via double-click (or hover tooltip). This PR adds an **opt-in setting** to invert that default so badges display the conversation title instead of the number.

Motivation: with several tabs open, numbers (`1 2 3`) carry no information about which conversation is which. Showing the title makes tabs self-describing.

## What changed

- **New setting `showTabTitlesByDefault`** (default: `false` → **no behavior change for existing users**), added under *UI preferences* next to `expandFileEditsByDefault`.
- **`TabBar`** now resolves title-vs-number from the configured default, keeping a per-tab override set for double-click toggles. The toggle works **both directions**:
  - default = number → double-click shows title (existing behavior)
  - default = title → double-click shows number
- Tabs **without a real title** (empty / `"New Chat"`) always show the number, regardless of the setting.
- Changing the setting **refreshes open chat views live** (`ClaudianView.refreshTabBar()`).
- **i18n**: `en` + `fr` translated; the 8 other locales get the key with English text (runtime already falls back to English).

## Implementation notes

- `TabBar` receives a lazy getter (`getShowTitlesByDefault`) rather than a snapshot, so the setting applies without reconstructing the bar.
- The existing `claudian-tab-badge-expanded` CSS class (auto width + left align) is reused for the title state — no CSS changes.

## Testing

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` ✅ (5797 tests)
- Manual: toggled the setting on/off with multiple tabs open, verified live refresh, double-click both directions, and `New Chat` fallback.

## Notes

Opened as a **draft** for maintainer feedback on the approach (setting name/placement, default) before finalizing. Happy to adjust naming, add translations, or change defaults.