### PR TITLE
Persist expanded tab title state

### DIFF
--- a/src/app/storage/SharedStorageService.ts
+++ b/src/app/storage/SharedStorageService.ts
@@ -4,6 +4,8 @@ import { Notice } from 'obsidian';
 import { SESSIONS_PATH, SessionStorage } from '../../core/bootstrap/SessionStorage';
 import type { SharedAppStorage } from '../../core/bootstrap/storage';
 import { CLAUDIAN_STORAGE_PATH } from '../../core/bootstrap/StoragePaths';
+import { normalizeTabManagerState } from '../../core/bootstrap/tabManagerState';
+import type { AppTabManagerState } from '../../core/providers/types';
 import { VaultFileAdapter } from '../../core/storage/VaultFileAdapter';
 import { ClaudianSettingsStorage, type StoredClaudianSettings } from '../settings/ClaudianSettingsStorage';
 
@@ -35,7 +37,7 @@ export class SharedStorageService implements SharedAppStorage {
     await this.claudianSettings.save(settings as StoredClaudianSettings);
   }
 
-  async setTabManagerState(state: { openTabs: Array<{ tabId: string; conversationId: string | null; draftModel?: string | null }>; activeTabId: string | null }): Promise<void> {
+  async setTabManagerState(state: AppTabManagerState): Promise<void> {
     try {
       const loaded: unknown = await this.plugin.loadData();
       const data = isRecord(loaded) ? loaded : {};
@@ -46,14 +48,14 @@ export class SharedStorageService implements SharedAppStorage {
     }
   }
 
-  async getTabManagerState(): Promise<{ openTabs: Array<{ tabId: string; conversationId: string | null; draftModel?: string | null }>; activeTabId: string | null } | null> {
+  async getTabManagerState(): Promise<AppTabManagerState | null> {
     try {
       const data: unknown = await this.plugin.loadData();
       if (!isRecord(data) || !data.tabManagerState) {
         return null;
       }
 
-      return this.validateTabManagerState(data.tabManagerState);
+      return normalizeTabManagerState(data.tabManagerState);
     } catch {
       return null;
     }
@@ -68,39 +70,4 @@ export class SharedStorageService implements SharedAppStorage {
     await this.adapter.ensureFolder(SESSIONS_PATH);
   }
 
-  private validateTabManagerState(data: unknown): { openTabs: Array<{ tabId: string; conversationId: string | null; draftModel?: string | null }>; activeTabId: string | null } | null {
-    if (!data || typeof data !== 'object') {
-      return null;
-    }
-
-    const state = data as Record<string, unknown>;
-    if (!Array.isArray(state.openTabs)) {
-      return null;
-    }
-
-    const validatedTabs: Array<{ tabId: string; conversationId: string | null; draftModel?: string | null }> = [];
-    for (const tab of state.openTabs) {
-      if (!tab || typeof tab !== 'object') {
-        continue;
-      }
-
-      const tabObj = tab as Record<string, unknown>;
-      if (typeof tabObj.tabId !== 'string') {
-        continue;
-      }
-
-      validatedTabs.push({
-        tabId: tabObj.tabId,
-        conversationId: typeof tabObj.conversationId === 'string' ? tabObj.conversationId : null,
-        ...(typeof tabObj.draftModel === 'string'
-          ? { draftModel: tabObj.draftModel }
-          : {}),
-      });
-    }
-
-    return {
-      openTabs: validatedTabs,
-      activeTabId: typeof state.activeTabId === 'string' ? state.activeTabId : null,
-    };
-  }
 }

--- a/src/core/bootstrap/tabManagerState.ts
+++ b/src/core/bootstrap/tabManagerState.ts
@@ -1,0 +1,51 @@
+import type { AppTabManagerState } from '../providers/types';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function normalizeTabManagerState(data: unknown): AppTabManagerState | null {
+  if (!isRecord(data) || !Array.isArray(data.openTabs)) {
+    return null;
+  }
+
+  const openTabs: AppTabManagerState['openTabs'] = [];
+  const openTabIds = new Set<string>();
+  for (const tab of data.openTabs) {
+    if (!isRecord(tab) || typeof tab.tabId !== 'string') {
+      continue;
+    }
+
+    openTabs.push({
+      tabId: tab.tabId,
+      conversationId: typeof tab.conversationId === 'string' ? tab.conversationId : null,
+      ...(typeof tab.draftModel === 'string'
+        ? { draftModel: tab.draftModel }
+        : {}),
+    });
+    openTabIds.add(tab.tabId);
+  }
+
+  const expandedTitleTabIds: string[] = [];
+  const seenExpandedTabIds = new Set<string>();
+  if (Array.isArray(data.expandedTitleTabIds)) {
+    for (const tabId of data.expandedTitleTabIds) {
+      if (
+        typeof tabId !== 'string'
+        || !openTabIds.has(tabId)
+        || seenExpandedTabIds.has(tabId)
+      ) {
+        continue;
+      }
+
+      expandedTitleTabIds.push(tabId);
+      seenExpandedTabIds.add(tabId);
+    }
+  }
+
+  return {
+    openTabs,
+    activeTabId: typeof data.activeTabId === 'string' ? data.activeTabId : null,
+    ...(expandedTitleTabIds.length > 0 ? { expandedTitleTabIds } : {}),
+  };
+}

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -88,6 +88,7 @@ export interface ProviderSettingsReconciler {
 export interface AppTabManagerState {
   openTabs: Array<{ tabId: string; conversationId: string | null; draftModel?: string | null }>;
   activeTabId: string | null;
+  expandedTitleTabIds?: string[];
 }
 
 /** Provider-neutral session metadata storage. */

--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -4,7 +4,7 @@ import { ItemView, Notice, Scope, setIcon } from 'obsidian';
 import { getHiddenProviderCommandSet } from '../../core/providers/commands/hiddenCommands';
 import { ProviderRegistry } from '../../core/providers/ProviderRegistry';
 import { ProviderSettingsCoordinator } from '../../core/providers/ProviderSettingsCoordinator';
-import { DEFAULT_CHAT_PROVIDER_ID, type ProviderId } from '../../core/providers/types';
+import { type AppTabManagerState, DEFAULT_CHAT_PROVIDER_ID, type ProviderId } from '../../core/providers/types';
 import { VIEW_TYPE_CLAUDIAN } from '../../core/types';
 import type ClaudianPlugin from '../../main';
 import { createProviderIconSvg } from '../../shared/icons';
@@ -293,6 +293,7 @@ export class ClaudianView extends ItemView {
       onNewTab: () => {
         void this.createNewTab().catch(() => new Notice('Failed to create tab'));
       },
+      onTitleExpansionChanged: () => this.persistTabState(),
     });
     fragment.appendChild(this.tabBarContainerEl);
 
@@ -704,6 +705,8 @@ export class ClaudianView extends ItemView {
     const persistedState = await this.plugin.storage.getTabManagerState();
     if (persistedState && persistedState.openTabs.length > 0) {
       await this.tabManager.restoreState(persistedState);
+      this.tabBar?.setExpandedTitleTabIds(persistedState.expandedTitleTabIds ?? []);
+      this.updateTabBar();
       return;
     }
 
@@ -719,8 +722,8 @@ export class ClaudianView extends ItemView {
     }
     this.pendingPersist = window.setTimeout(() => {
       this.pendingPersist = null;
-      if (!this.tabManager) return;
-      const state = this.tabManager.getPersistedState();
+      const state = this.getPersistedTabState();
+      if (!state) return;
       this.plugin.persistTabManagerState(state).catch(() => {
         // Silently ignore persistence errors
       });
@@ -734,9 +737,23 @@ export class ClaudianView extends ItemView {
       window.clearTimeout(this.pendingPersist);
       this.pendingPersist = null;
     }
-    if (!this.tabManager) return;
-    const state = this.tabManager.getPersistedState();
+    const state = this.getPersistedTabState();
+    if (!state) return;
     await this.plugin.persistTabManagerState(state);
+  }
+
+  private getPersistedTabState(): AppTabManagerState | null {
+    if (!this.tabManager) return null;
+
+    const state = this.tabManager.getPersistedState();
+    const openTabIds = new Set(state.openTabs.map(tab => tab.tabId));
+    const expandedTitleTabIds = (this.tabBar?.getExpandedTitleTabIds() ?? [])
+      .filter(tabId => openTabIds.has(tabId));
+
+    return {
+      ...state,
+      ...(expandedTitleTabIds.length > 0 ? { expandedTitleTabIds } : {}),
+    };
   }
 
   // ============================================

--- a/src/features/chat/tabs/TabBar.ts
+++ b/src/features/chat/tabs/TabBar.ts
@@ -14,6 +14,9 @@ export interface TabBarCallbacks {
 
   /** Called when the new tab button is clicked. */
   onNewTab: () => void;
+
+  /** Called when badge title expansion state changes. */
+  onTitleExpansionChanged?: (expandedTitleTabIds: TabId[]) => void;
 }
 
 /**
@@ -57,6 +60,14 @@ export class TabBar {
     }
 
     this.restoreScrollPosition();
+  }
+
+  getExpandedTitleTabIds(): TabId[] {
+    return Array.from(this.expandedTitleTabIds);
+  }
+
+  setExpandedTitleTabIds(tabIds: readonly TabId[]): void {
+    this.expandedTitleTabIds = new Set(tabIds);
   }
 
   /** Renders a single tab badge. */
@@ -158,6 +169,7 @@ export class TabBar {
     badgeEl.textContent = this.getBadgeLabel(item);
     badgeEl.toggleClass('claudian-tab-badge-expanded', isTitleExpanded);
     badgeEl.setAttribute('data-title-expanded', isTitleExpanded ? 'true' : 'false');
+    this.callbacks.onTitleExpansionChanged?.(this.getExpandedTitleTabIds());
   }
 
   private getBadgeLabel(item: TabBarItem): string {

--- a/src/features/chat/tabs/types.ts
+++ b/src/features/chat/tabs/types.ts
@@ -237,6 +237,7 @@ export interface PersistedTabState {
 export interface PersistedTabManagerState {
   openTabs: PersistedTabState[];
   activeTabId: TabId | null;
+  expandedTitleTabIds?: TabId[];
 }
 
 /**

--- a/src/providers/claude/storage/StorageService.ts
+++ b/src/providers/claude/storage/StorageService.ts
@@ -4,6 +4,8 @@ import { Notice } from 'obsidian';
 import { ClaudianSettingsStorage, type StoredClaudianSettings } from '../../../app/settings/ClaudianSettingsStorage';
 import { SESSIONS_PATH, SessionStorage } from '../../../core/bootstrap/SessionStorage';
 import { CLAUDIAN_STORAGE_PATH } from '../../../core/bootstrap/StoragePaths';
+import { normalizeTabManagerState } from '../../../core/bootstrap/tabManagerState';
+import type { AppTabManagerState } from '../../../core/providers/types';
 import { VaultFileAdapter } from '../../../core/storage/VaultFileAdapter';
 import type {
   SlashCommand,
@@ -120,51 +122,12 @@ export class StorageService {
     try {
       const data: unknown = await this.plugin.loadData();
       if (isRecord(data) && data.tabManagerState) {
-        return this.validateTabManagerState(data.tabManagerState);
+        return normalizeTabManagerState(data.tabManagerState);
       }
       return null;
     } catch {
       return null;
     }
-  }
-
-  private validateTabManagerState(data: unknown): TabManagerPersistedState | null {
-    if (!data || typeof data !== 'object') {
-      return null;
-    }
-
-    const state = data as Record<string, unknown>;
-
-    if (!Array.isArray(state.openTabs)) {
-      return null;
-    }
-
-    const validatedTabs: Array<{ tabId: string; conversationId: string | null; draftModel?: string | null }> = [];
-    for (const tab of state.openTabs) {
-      if (!tab || typeof tab !== 'object') {
-        continue; // Skip invalid entries
-      }
-      const tabObj = tab as Record<string, unknown>;
-      if (typeof tabObj.tabId !== 'string') {
-        continue; // Skip entries without valid tabId
-      }
-      validatedTabs.push({
-        tabId: tabObj.tabId,
-        conversationId:
-          typeof tabObj.conversationId === 'string' ? tabObj.conversationId : null,
-        ...(typeof tabObj.draftModel === 'string'
-          ? { draftModel: tabObj.draftModel }
-          : {}),
-      });
-    }
-
-    const activeTabId =
-      typeof state.activeTabId === 'string' ? state.activeTabId : null;
-
-    return {
-      openTabs: validatedTabs,
-      activeTabId,
-    };
   }
 
   async setTabManagerState(state: TabManagerPersistedState): Promise<void> {
@@ -179,7 +142,4 @@ export class StorageService {
   }
 }
 
-export interface TabManagerPersistedState {
-  openTabs: Array<{ tabId: string; conversationId: string | null; draftModel?: string | null }>;
-  activeTabId: string | null;
-}
+export type TabManagerPersistedState = AppTabManagerState;

--- a/tests/unit/core/bootstrap/tabManagerState.test.ts
+++ b/tests/unit/core/bootstrap/tabManagerState.test.ts
@@ -1,0 +1,36 @@
+import { normalizeTabManagerState } from '@/core/bootstrap/tabManagerState';
+
+describe('normalizeTabManagerState', () => {
+  it('preserves valid expanded title tab ids', () => {
+    const result = normalizeTabManagerState({
+      openTabs: [
+        { tabId: 'tab-1', conversationId: 'conv-1' },
+        { tabId: 'tab-2', conversationId: null },
+      ],
+      activeTabId: 'tab-2',
+      expandedTitleTabIds: ['tab-2', 'tab-1'],
+    });
+
+    expect(result).toEqual({
+      openTabs: [
+        { tabId: 'tab-1', conversationId: 'conv-1' },
+        { tabId: 'tab-2', conversationId: null },
+      ],
+      activeTabId: 'tab-2',
+      expandedTitleTabIds: ['tab-2', 'tab-1'],
+    });
+  });
+
+  it('drops invalid, stale, and duplicate expanded title tab ids', () => {
+    const result = normalizeTabManagerState({
+      openTabs: [
+        { tabId: 'tab-1', conversationId: null },
+        { tabId: 'tab-2', conversationId: null },
+      ],
+      activeTabId: 'tab-1',
+      expandedTitleTabIds: ['tab-2', 'missing-tab', 'tab-2', 7, 'tab-1'],
+    });
+
+    expect(result?.expandedTitleTabIds).toEqual(['tab-2', 'tab-1']);
+  });
+});

--- a/tests/unit/features/chat/ClaudianView.test.ts
+++ b/tests/unit/features/chat/ClaudianView.test.ts
@@ -174,6 +174,62 @@ describe('ClaudianView tab controls', () => {
 
     expect(historyDropdown.hasClass('visible')).toBe(false);
   });
+
+  it('persists expanded title tab ids with the tab layout snapshot', () => {
+    const view = Object.create(ClaudianView.prototype) as any;
+
+    view.tabManager = {
+      getPersistedState: jest.fn().mockReturnValue({
+        openTabs: [
+          { tabId: 'tab-1', conversationId: null },
+          { tabId: 'tab-2', conversationId: 'conv-2' },
+        ],
+        activeTabId: 'tab-2',
+      }),
+    };
+    view.tabBar = {
+      getExpandedTitleTabIds: jest.fn().mockReturnValue(['tab-2', 'closed-tab']),
+    };
+
+    expect(view.getPersistedTabState()).toEqual({
+      openTabs: [
+        { tabId: 'tab-1', conversationId: null },
+        { tabId: 'tab-2', conversationId: 'conv-2' },
+      ],
+      activeTabId: 'tab-2',
+      expandedTitleTabIds: ['tab-2'],
+    });
+  });
+
+  it('restores expanded title tab ids after restoring tabs', async () => {
+    const persistedState = {
+      openTabs: [{ tabId: 'tab-1', conversationId: null }],
+      activeTabId: 'tab-1',
+      expandedTitleTabIds: ['tab-1'],
+    };
+    const view = Object.create(ClaudianView.prototype) as any;
+
+    view.plugin = {
+      storage: {
+        getTabManagerState: jest.fn().mockResolvedValue(persistedState),
+      },
+    };
+    view.tabManager = {
+      restoreState: jest.fn().mockResolvedValue(undefined),
+      createTab: jest.fn(),
+    };
+    view.tabBar = {
+      setExpandedTitleTabIds: jest.fn(),
+    };
+    view.updateTabBar = jest.fn();
+
+    await view.restoreOrCreateTabs();
+
+    expect(view.tabManager.restoreState).toHaveBeenCalledWith(persistedState);
+    expect(view.tabBar.setExpandedTitleTabIds).toHaveBeenCalledWith(['tab-1']);
+    expect(view.updateTabBar).toHaveBeenCalledTimes(1);
+    expect(view.tabManager.createTab).not.toHaveBeenCalled();
+  });
 });
 
 describe('ClaudianView Escape handling', () => {

--- a/tests/unit/features/chat/tabs/TabBar.test.ts
+++ b/tests/unit/features/chat/tabs/TabBar.test.ts
@@ -136,6 +136,37 @@ describe('TabBar', () => {
       expect(badge.getAttribute('data-title-expanded')).toBe('false');
     });
 
+    it('should notify when title expansion state changes', () => {
+      const containerEl = createMockEl();
+      const callbacks = {
+        ...createMockCallbacks(),
+        onTitleExpansionChanged: jest.fn(),
+      };
+      const tabBar = new TabBar(containerEl, callbacks);
+
+      tabBar.update([createTabBarItem({ id: 'tab-2', index: 2, title: 'My Conversation' })]);
+
+      const badge = containerEl._children[0];
+      badge.dispatchEvent('dblclick', { preventDefault: jest.fn(), stopPropagation: jest.fn() });
+      badge.dispatchEvent('dblclick', { preventDefault: jest.fn(), stopPropagation: jest.fn() });
+
+      expect(callbacks.onTitleExpansionChanged).toHaveBeenNthCalledWith(1, ['tab-2']);
+      expect(callbacks.onTitleExpansionChanged).toHaveBeenNthCalledWith(2, []);
+    });
+
+    it('should render restored expanded title state', () => {
+      const containerEl = createMockEl();
+      const callbacks = createMockCallbacks();
+      const tabBar = new TabBar(containerEl, callbacks);
+
+      tabBar.setExpandedTitleTabIds(['tab-1']);
+      tabBar.update([createTabBarItem({ id: 'tab-1', index: 1, title: 'Restored Title' })]);
+
+      expect(containerEl._children[0].textContent).toBe('Restored Title');
+      expect(containerEl._children[0].getAttribute('data-title-expanded')).toBe('true');
+      expect(tabBar.getExpandedTitleTabIds()).toEqual(['tab-1']);
+    });
+
     it('should truncate expanded title labels with a literal ellipsis suffix', () => {
       const containerEl = createMockEl();
       const callbacks = createMockCallbacks();

--- a/tests/unit/providers/claude/storage/storageService.convenience.test.ts
+++ b/tests/unit/providers/claude/storage/storageService.convenience.test.ts
@@ -388,6 +388,24 @@ describe('StorageService convenience methods', () => {
       expect(result!.activeTabId).toBeNull();
     });
 
+    it('returns valid expanded title tab ids', async () => {
+      const state = {
+        openTabs: [
+          { tabId: 'tab-1', conversationId: 'conv-1' },
+          { tabId: 'tab-2', conversationId: null },
+        ],
+        activeTabId: 'tab-1',
+        expandedTitleTabIds: ['tab-2', 'missing-tab', 'tab-2', 'tab-1'],
+      };
+      const { plugin } = createMockPlugin({
+        dataJson: { tabManagerState: state },
+      });
+      const storage = new StorageService(plugin);
+
+      const result = await storage.getTabManagerState();
+      expect(result!.expandedTitleTabIds).toEqual(['tab-2', 'tab-1']);
+    });
+
     it('returns null when loadData throws', async () => {
       const { plugin } = createMockPlugin({});
       (plugin.loadData as jest.Mock).mockRejectedValue(new Error('Read error'));


### PR DESCRIPTION
## Summary
- Persists expanded tab title ids in tabManagerState and restores them when tabs reload.
- Adds shared tab manager state normalization for the shared and Claude storage paths.
- Covers normalization, tab bar restoration, view persistence, and storage validation.

## Tests
- npm run typecheck
- npm run lint
- npm run test
- npm run build