### PR TITLE
refactor: separate Codex host launch settings

### DIFF
--- a/src/app/settings/ClaudianSettingsStorage.ts
+++ b/src/app/settings/ClaudianSettingsStorage.ts
@@ -6,6 +6,7 @@ import {
   normalizeHiddenCommandList,
   normalizeHiddenProviderCommands,
 } from '../../core/providers/commands/hiddenCommands';
+import { setProviderConfig } from '../../core/providers/providerConfig';
 import {
   getSharedEnvironmentVariables,
   inferEnvironmentSnippetScope,
@@ -26,8 +27,7 @@ import {
   updateClaudeProviderSettings,
 } from '../../providers/claude/settings';
 import {
-  getCodexProviderSettings,
-  updateCodexProviderSettings,
+  normalizeCodexStoredConfig,
 } from '../../providers/codex/settings';
 import {
   getOpencodeProviderSettings,
@@ -321,10 +321,8 @@ export class ClaudianSettingsStorage {
       merged,
       getClaudeProviderSettings(legacyProviderSettings),
     );
-    updateCodexProviderSettings(
-      merged,
-      getCodexProviderSettings(legacyProviderSettings),
-    );
+    const codexConfigNormalization = normalizeCodexStoredConfig(legacyProviderSettings);
+    setProviderConfig(merged, 'codex', codexConfigNormalization.config);
     updateOpencodeProviderSettings(
       merged,
       getOpencodeProviderSettings(legacyProviderSettings),
@@ -356,6 +354,7 @@ export class ClaudianSettingsStorage {
         'customModelAliases' in stored
         && JSON.stringify(customModelAliases) !== JSON.stringify(stored.customModelAliases ?? {})
       )
+      || codexConfigNormalization.changed
       || didNormalizeHostScopedProviderConfigs
       )
     ) {

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -312,8 +312,15 @@ export interface ProviderChatUIConfig {
 // Provider-owned boundary services
 // ---------------------------------------------------------------------------
 
+export interface ProviderCliResolutionContext {
+  executionTarget?: unknown;
+}
+
 export interface ProviderCliResolver {
-  resolveFromSettings(settings: Record<string, unknown>): string | null;
+  resolveFromSettings(
+    settings: Record<string, unknown>,
+    context?: ProviderCliResolutionContext,
+  ): string | null;
   reset(): void;
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ import {
 import { ProviderRegistry } from './core/providers/ProviderRegistry';
 import { ProviderSettingsCoordinator } from './core/providers/ProviderSettingsCoordinator';
 import { ProviderWorkspaceRegistry } from './core/providers/ProviderWorkspaceRegistry';
-import type { ProviderId } from './core/providers/types';
+import type { ProviderCliResolutionContext, ProviderId } from './core/providers/types';
 import type { AppTabManagerState } from './core/providers/types';
 import { DEFAULT_CHAT_PROVIDER_ID } from './core/providers/types';
 import type {
@@ -528,13 +528,16 @@ export default class ClaudianPlugin extends Plugin {
     );
   }
 
-  getResolvedProviderCliPath(providerId: ProviderId): string | null {
+  getResolvedProviderCliPath(
+    providerId: ProviderId,
+    context?: ProviderCliResolutionContext,
+  ): string | null {
     const cliResolver = ProviderWorkspaceRegistry.getCliResolver(providerId);
     if (!cliResolver) {
       return null;
     }
 
-    return cliResolver.resolveFromSettings(this.settings);
+    return cliResolver.resolveFromSettings(this.settings, context);
   }
 
   private reconcileModelWithEnvironment(providerIds: ProviderId[] = ProviderRegistry.getRegisteredProviderIds()): {

--- a/src/providers/codex/runtime/CodexBinaryLocator.ts
+++ b/src/providers/codex/runtime/CodexBinaryLocator.ts
@@ -6,6 +6,7 @@ import { findCliBinaryPath, resolveConfiguredCliPath } from '../../../utils/cliB
 import { parseEnvironmentVariables } from '../../../utils/env';
 import { expandHomePath } from '../../../utils/path';
 import type { CodexInstallationMethod } from '../settings';
+import type { CodexExecutionTarget } from './codexLaunchTypes';
 
 export function isWindowsStyleCliReference(value: string | null | undefined): boolean {
   const trimmed = (value ?? '').trim();
@@ -129,10 +130,18 @@ export function resolveCodexCliPath(
   hostnamePath: string | undefined,
   legacyPath: string | undefined,
   envText: string,
-  options: { installationMethod?: CodexInstallationMethod; hostPlatform?: NodeJS.Platform } = {},
+  options: {
+    executionTarget?: CodexExecutionTarget;
+    installationMethod?: CodexInstallationMethod;
+    hostPlatform?: NodeJS.Platform;
+  } = {},
 ): string | null {
   const hostPlatform = options.hostPlatform ?? process.platform;
-  if (hostPlatform === 'win32' && options.installationMethod === 'wsl') {
+  const isWslTarget = options.executionTarget
+    ? options.executionTarget.method === 'wsl'
+    : hostPlatform === 'win32' && options.installationMethod === 'wsl';
+
+  if (isWslTarget) {
     const configuredCommand = [hostnamePath, legacyPath]
       .map(value => (value ?? '').trim())
       .find(value => value.length > 0 && !isWindowsStyleCliReference(value));

--- a/src/providers/codex/runtime/CodexCliResolver.ts
+++ b/src/providers/codex/runtime/CodexCliResolver.ts
@@ -1,31 +1,39 @@
 import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import type { ProviderCliResolutionContext } from '../../../core/providers/types';
 import type { HostnameCliPaths } from '../../../core/types/settings';
 import { getHostnameKey } from '../../../utils/env';
 import type { CodexInstallationMethod } from '../settings';
 import { getCodexProviderSettings } from '../settings';
 import { resolveCodexCliPath } from './CodexBinaryLocator';
+import { resolveCodexExecutionTarget } from './CodexExecutionTargetResolver';
+import type { CodexExecutionTarget } from './codexLaunchTypes';
 
 export class CodexCliResolver {
   private resolvedPath: string | null = null;
   private lastHostnamePath = '';
   private lastLegacyPath = '';
   private lastEnvText = '';
-  private lastInstallationMethod = '';
+  private lastExecutionTargetKey = '';
   private readonly cachedHostname = getHostnameKey();
 
-  resolveFromSettings(settings: Record<string, unknown>): string | null {
+  resolveFromSettings(
+    settings: Record<string, unknown>,
+    context: ProviderCliResolutionContext = {},
+  ): string | null {
     const codexSettings = getCodexProviderSettings(settings);
     const hostnamePath = (codexSettings.cliPathsByHost[this.cachedHostname] ?? '').trim();
     const legacyPath = codexSettings.cliPath.trim();
     const envText = getRuntimeEnvironmentText(settings, 'codex');
-    const installationMethod = codexSettings.installationMethod;
+    const executionTarget = getCodexExecutionTargetFromContext(context)
+      ?? resolveCodexExecutionTarget({ settings });
+    const executionTargetKey = getCodexExecutionTargetCacheKey(executionTarget);
 
     if (
       this.resolvedPath &&
       hostnamePath === this.lastHostnamePath &&
       legacyPath === this.lastLegacyPath &&
       envText === this.lastEnvText &&
-      installationMethod === this.lastInstallationMethod
+      executionTargetKey === this.lastExecutionTargetKey
     ) {
       return this.resolvedPath;
     }
@@ -33,10 +41,10 @@ export class CodexCliResolver {
     this.lastHostnamePath = hostnamePath;
     this.lastLegacyPath = legacyPath;
     this.lastEnvText = envText;
-    this.lastInstallationMethod = installationMethod;
+    this.lastExecutionTargetKey = executionTargetKey;
 
     this.resolvedPath = resolveCodexCliPath(hostnamePath, legacyPath, envText, {
-      installationMethod,
+      executionTarget,
     });
     return this.resolvedPath;
   }
@@ -47,6 +55,7 @@ export class CodexCliResolver {
     envText: string,
     options: {
       installationMethod?: CodexInstallationMethod;
+      executionTarget?: CodexExecutionTarget;
       hostPlatform?: NodeJS.Platform;
     } = {},
   ): string | null {
@@ -60,6 +69,34 @@ export class CodexCliResolver {
     this.lastHostnamePath = '';
     this.lastLegacyPath = '';
     this.lastEnvText = '';
-    this.lastInstallationMethod = '';
+    this.lastExecutionTargetKey = '';
   }
+}
+
+function isCodexExecutionTarget(value: unknown): value is CodexExecutionTarget {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Partial<CodexExecutionTarget>;
+  return candidate.method === 'host-native'
+    || candidate.method === 'native-windows'
+    || candidate.method === 'wsl';
+}
+
+function getCodexExecutionTargetFromContext(
+  context: ProviderCliResolutionContext,
+): CodexExecutionTarget | null {
+  return isCodexExecutionTarget(context.executionTarget)
+    ? context.executionTarget
+    : null;
+}
+
+function getCodexExecutionTargetCacheKey(target: CodexExecutionTarget): string {
+  return [
+    target.method,
+    target.platformFamily,
+    target.platformOs,
+    target.distroName ?? '',
+  ].join(':');
 }

--- a/src/providers/codex/runtime/CodexLaunchSpecBuilder.ts
+++ b/src/providers/codex/runtime/CodexLaunchSpecBuilder.ts
@@ -2,7 +2,7 @@ import {
   inferWslDistroFromWindowsPath,
   resolveCodexExecutionTarget,
 } from './CodexExecutionTargetResolver';
-import type { CodexLaunchSpec } from './codexLaunchTypes';
+import type { CodexExecutionTarget, CodexLaunchSpec } from './codexLaunchTypes';
 import { createCodexPathMapper } from './CodexPathMapper';
 
 export interface BuildCodexLaunchSpecOptions {
@@ -10,6 +10,7 @@ export interface BuildCodexLaunchSpecOptions {
   resolvedCliCommand: string | null;
   hostVaultPath: string | null;
   env: Record<string, string>;
+  executionTarget?: CodexExecutionTarget;
   hostPlatform?: NodeJS.Platform;
   resolveDefaultWslDistro?: () => string | undefined;
 }
@@ -19,7 +20,7 @@ const CODEX_APP_SERVER_ARGS = Object.freeze(['app-server', '--listen', 'stdio://
 export function buildCodexLaunchSpec(
   options: BuildCodexLaunchSpecOptions,
 ): CodexLaunchSpec {
-  const target = resolveCodexExecutionTarget({
+  const target = options.executionTarget ?? resolveCodexExecutionTarget({
     settings: options.settings,
     hostPlatform: options.hostPlatform,
     hostVaultPath: options.hostVaultPath,

--- a/src/providers/codex/runtime/codexAppServerSupport.ts
+++ b/src/providers/codex/runtime/codexAppServerSupport.ts
@@ -3,6 +3,7 @@ import type ClaudianPlugin from '../../../main';
 import { getEnhancedPath, parseEnvironmentVariables } from '../../../utils/env';
 import { getVaultPath } from '../../../utils/path';
 import type { InitializeResult } from './codexAppServerTypes';
+import { resolveCodexExecutionTarget } from './CodexExecutionTargetResolver';
 import { buildCodexLaunchSpec } from './CodexLaunchSpecBuilder';
 import type { CodexLaunchSpec } from './codexLaunchTypes';
 import type { CodexRpcTransport } from './CodexRpcTransport';
@@ -37,11 +38,18 @@ export function resolveCodexAppServerLaunchSpec(
   plugin: ClaudianPlugin,
   providerId: ProviderId = 'codex',
 ): CodexLaunchSpec {
+  const hostVaultPath = getCodexAppServerWorkingDirectory(plugin);
+  const executionTarget = resolveCodexExecutionTarget({
+    settings: plugin.settings,
+    hostVaultPath,
+  });
+
   return buildCodexLaunchSpec({
     settings: plugin.settings,
-    resolvedCliCommand: plugin.getResolvedProviderCliPath(providerId),
-    hostVaultPath: getCodexAppServerWorkingDirectory(plugin),
+    resolvedCliCommand: plugin.getResolvedProviderCliPath(providerId, { executionTarget }),
+    hostVaultPath,
     env: buildCodexAppServerEnvironment(plugin, providerId),
+    executionTarget,
   });
 }
 

--- a/src/providers/codex/settings.ts
+++ b/src/providers/codex/settings.ts
@@ -14,6 +14,30 @@ export type CodexReasoningSummary = 'auto' | 'concise' | 'detailed' | 'none';
 export type CodexInstallationMethod = 'native-windows' | 'wsl';
 export type HostnameInstallationMethods = Record<string, CodexInstallationMethod>;
 
+export interface CodexProviderConfig {
+  enabled: boolean;
+  safeMode: CodexSafeMode;
+  cliPath: string;
+  cliPathsByHost: HostnameCliPaths;
+  customModels: string;
+  reasoningSummary: CodexReasoningSummary;
+  environmentVariables: string;
+  environmentHash: string;
+  installationMethodsByHost: HostnameInstallationMethods;
+  wslDistroOverridesByHost: HostnameCliPaths;
+}
+
+export interface NormalizeCodexStoredConfigContext {
+  platform?: NodeJS.Platform;
+  hostnameKey?: string;
+  legacyHostnameKey?: string;
+}
+
+export interface NormalizeCodexStoredConfigResult {
+  config: CodexProviderConfig & Record<string, unknown>;
+  changed: boolean;
+}
+
 function normalizeCodexInstallationMethod(value: unknown): CodexInstallationMethod {
   return value === 'wsl' ? 'wsl' : 'native-windows';
 }
@@ -34,21 +58,21 @@ function omitCurrentHost<T>(entries: Record<string, T>, hostnameKey: string): Re
 }
 
 export interface CodexProviderSettings {
-  enabled: boolean;
-  safeMode: CodexSafeMode;
-  cliPath: string;
-  cliPathsByHost: HostnameCliPaths;
-  customModels: string;
-  reasoningSummary: CodexReasoningSummary;
-  environmentVariables: string;
-  environmentHash: string;
+  enabled: CodexProviderConfig['enabled'];
+  safeMode: CodexProviderConfig['safeMode'];
+  cliPath: CodexProviderConfig['cliPath'];
+  cliPathsByHost: CodexProviderConfig['cliPathsByHost'];
+  customModels: CodexProviderConfig['customModels'];
+  reasoningSummary: CodexProviderConfig['reasoningSummary'];
+  environmentVariables: CodexProviderConfig['environmentVariables'];
+  environmentHash: CodexProviderConfig['environmentHash'];
   installationMethod: CodexInstallationMethod;
-  installationMethodsByHost: HostnameInstallationMethods;
+  installationMethodsByHost: CodexProviderConfig['installationMethodsByHost'];
   wslDistroOverride: string;
-  wslDistroOverridesByHost: HostnameCliPaths;
+  wslDistroOverridesByHost: CodexProviderConfig['wslDistroOverridesByHost'];
 }
 
-export const DEFAULT_CODEX_PROVIDER_SETTINGS: Readonly<CodexProviderSettings> = Object.freeze({
+export const DEFAULT_CODEX_PROVIDER_CONFIG: Readonly<CodexProviderConfig> = Object.freeze({
   enabled: false,
   safeMode: 'workspace-write',
   cliPath: '',
@@ -57,10 +81,14 @@ export const DEFAULT_CODEX_PROVIDER_SETTINGS: Readonly<CodexProviderSettings> = 
   reasoningSummary: 'detailed',
   environmentVariables: '',
   environmentHash: '',
-  installationMethod: 'native-windows',
   installationMethodsByHost: {},
-  wslDistroOverride: '',
   wslDistroOverridesByHost: {},
+});
+
+export const DEFAULT_CODEX_PROVIDER_SETTINGS: Readonly<CodexProviderSettings> = Object.freeze({
+  ...DEFAULT_CODEX_PROVIDER_CONFIG,
+  installationMethod: 'native-windows',
+  wslDistroOverride: '',
 });
 
 export function shouldDisableCodexReasoningSummary(model: string | undefined): boolean {
@@ -115,68 +143,157 @@ function normalizeInstallationMethodsByHost(value: unknown): HostnameInstallatio
   return result;
 }
 
+function hasOwnEntry<T>(entries: Record<string, T>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(entries, key);
+}
+
+function getCodexStoredConfig(
+  settings: Record<string, unknown>,
+  hostnameKey: string,
+  legacyHostnameKey: string,
+): CodexProviderConfig {
+  const config = getProviderConfig(settings, 'codex');
+  const normalizedCliPathsByHost = normalizeHostnameCliPaths(config.cliPathsByHost ?? settings.codexCliPathsByHost);
+  const normalizedInstallationMethodsByHost = normalizeInstallationMethodsByHost(config.installationMethodsByHost);
+  const normalizedWslDistroOverridesByHost = normalizeHostnameCliPaths(config.wslDistroOverridesByHost);
+  const cliPathsByHost = migrateLegacyHostnameKeyedMap(normalizedCliPathsByHost, hostnameKey, legacyHostnameKey);
+  const installationMethodsByHost = migrateLegacyHostnameKeyedMap(
+    normalizedInstallationMethodsByHost,
+    hostnameKey,
+    legacyHostnameKey,
+  );
+  const wslDistroOverridesByHost = migrateLegacyHostnameKeyedMap(
+    normalizedWslDistroOverridesByHost,
+    hostnameKey,
+    legacyHostnameKey,
+  );
+
+  return {
+    enabled: (config.enabled as boolean | undefined)
+      ?? (settings.codexEnabled as boolean | undefined)
+      ?? DEFAULT_CODEX_PROVIDER_CONFIG.enabled,
+    safeMode: (config.safeMode as CodexSafeMode | undefined)
+      ?? (settings.codexSafeMode as CodexSafeMode | undefined)
+      ?? DEFAULT_CODEX_PROVIDER_CONFIG.safeMode,
+    cliPath: (config.cliPath as string | undefined)
+      ?? (settings.codexCliPath as string | undefined)
+      ?? DEFAULT_CODEX_PROVIDER_CONFIG.cliPath,
+    cliPathsByHost,
+    customModels: (config.customModels as string | undefined)
+      ?? DEFAULT_CODEX_PROVIDER_CONFIG.customModels,
+    reasoningSummary: (config.reasoningSummary as CodexReasoningSummary | undefined)
+      ?? (settings.codexReasoningSummary as CodexReasoningSummary | undefined)
+      ?? DEFAULT_CODEX_PROVIDER_CONFIG.reasoningSummary,
+    environmentVariables: (config.environmentVariables as string | undefined)
+      ?? getProviderEnvironmentVariables(settings, 'codex')
+      ?? DEFAULT_CODEX_PROVIDER_CONFIG.environmentVariables,
+    environmentHash: (config.environmentHash as string | undefined)
+      ?? (settings.lastCodexEnvHash as string | undefined)
+      ?? DEFAULT_CODEX_PROVIDER_CONFIG.environmentHash,
+    installationMethodsByHost,
+    wslDistroOverridesByHost,
+  };
+}
+
+function getNormalizedCodexStoredConfigContext(
+  context: NormalizeCodexStoredConfigContext,
+): Required<NormalizeCodexStoredConfigContext> {
+  return {
+    platform: context.platform ?? process.platform,
+    hostnameKey: context.hostnameKey ?? getHostnameKey(),
+    legacyHostnameKey: context.legacyHostnameKey ?? getLegacyHostnameKey(),
+  };
+}
+
+function projectStoredCodexConfigNormalization(
+  originalConfig: Record<string, unknown>,
+  normalizedConfig: Record<string, unknown>,
+): Record<string, unknown> {
+  const projected = { ...originalConfig };
+  for (const key of Object.keys(DEFAULT_CODEX_PROVIDER_CONFIG)) {
+    if (key in originalConfig) {
+      projected[key] = normalizedConfig[key];
+    }
+  }
+  delete projected.installationMethod;
+  delete projected.wslDistroOverride;
+  return projected;
+}
+
+export function normalizeCodexStoredConfig(
+  settings: Record<string, unknown>,
+  context: NormalizeCodexStoredConfigContext = {},
+): NormalizeCodexStoredConfigResult {
+  const originalConfig = getProviderConfig(settings, 'codex');
+  const {
+    platform,
+    hostnameKey,
+    legacyHostnameKey,
+  } = getNormalizedCodexStoredConfigContext(context);
+  const storedConfig = getCodexStoredConfig(settings, hostnameKey, legacyHostnameKey);
+  const installationMethodsByHost = { ...storedConfig.installationMethodsByHost };
+  const wslDistroOverridesByHost = { ...storedConfig.wslDistroOverridesByHost };
+
+  if (platform === 'win32') {
+    if (!hasOwnEntry(installationMethodsByHost, hostnameKey) && 'installationMethod' in originalConfig) {
+      installationMethodsByHost[hostnameKey] = normalizeCodexInstallationMethod(originalConfig.installationMethod);
+    }
+
+    if (!hasOwnEntry(wslDistroOverridesByHost, hostnameKey) && 'wslDistroOverride' in originalConfig) {
+      const normalizedDistroOverride = normalizeOptionalString(originalConfig.wslDistroOverride);
+      if (normalizedDistroOverride) {
+        wslDistroOverridesByHost[hostnameKey] = normalizedDistroOverride;
+      }
+    }
+  } else {
+    delete installationMethodsByHost[hostnameKey];
+    delete installationMethodsByHost[legacyHostnameKey];
+    delete wslDistroOverridesByHost[hostnameKey];
+    delete wslDistroOverridesByHost[legacyHostnameKey];
+  }
+
+  const normalizedConfig: CodexProviderConfig & Record<string, unknown> = {
+    ...originalConfig,
+    ...storedConfig,
+    installationMethodsByHost,
+    wslDistroOverridesByHost,
+  };
+  delete normalizedConfig.installationMethod;
+  delete normalizedConfig.wslDistroOverride;
+
+  const projectedConfig = projectStoredCodexConfigNormalization(originalConfig, normalizedConfig);
+  return {
+    config: normalizedConfig,
+    changed: JSON.stringify(projectedConfig) !== JSON.stringify(originalConfig),
+  };
+}
+
 export function getCodexProviderSettings(
   settings: Record<string, unknown>,
 ): CodexProviderSettings {
   const config = getProviderConfig(settings, 'codex');
   const hostnameKey = getHostnameKey();
-  const normalizedCliPathsByHost = normalizeHostnameCliPaths(config.cliPathsByHost ?? settings.codexCliPathsByHost);
-  const normalizedInstallationMethodsByHost = normalizeInstallationMethodsByHost(config.installationMethodsByHost);
-  const normalizedWslDistroOverridesByHost = normalizeHostnameCliPaths(config.wslDistroOverridesByHost);
-  const hasLegacyHostnameKeyedSettings = Object.keys(normalizedCliPathsByHost).length > 0
-    || Object.keys(normalizedInstallationMethodsByHost).length > 0
-    || Object.keys(normalizedWslDistroOverridesByHost).length > 0;
-  const legacyHostnameKey = hasLegacyHostnameKeyedSettings ? getLegacyHostnameKey() : '';
-  const cliPathsByHost = hasLegacyHostnameKeyedSettings
-    ? migrateLegacyHostnameKeyedMap(normalizedCliPathsByHost, hostnameKey, legacyHostnameKey)
-    : normalizedCliPathsByHost;
-  const installationMethodsByHost = hasLegacyHostnameKeyedSettings
-    ? migrateLegacyHostnameKeyedMap(normalizedInstallationMethodsByHost, hostnameKey, legacyHostnameKey)
-    : normalizedInstallationMethodsByHost;
-  const wslDistroOverridesByHost = hasLegacyHostnameKeyedSettings
-    ? migrateLegacyHostnameKeyedMap(normalizedWslDistroOverridesByHost, hostnameKey, legacyHostnameKey)
-    : normalizedWslDistroOverridesByHost;
-  const hasHostScopedInstallationMethods = Object.keys(installationMethodsByHost).length > 0;
-  const hasHostScopedWslDistroOverrides = Object.keys(wslDistroOverridesByHost).length > 0;
+  const legacyHostnameKey = getLegacyHostnameKey();
+  const storedConfig = getCodexStoredConfig(settings, hostnameKey, legacyHostnameKey);
+  const hasHostScopedInstallationMethods = Object.keys(storedConfig.installationMethodsByHost).length > 0;
+  const hasHostScopedWslDistroOverrides = Object.keys(storedConfig.wslDistroOverridesByHost).length > 0;
   const legacyInstallationMethod = normalizeCodexInstallationMethod(config.installationMethod);
   const legacyWslDistroOverride = normalizeOptionalString(config.wslDistroOverride);
 
   return {
-    enabled: (config.enabled as boolean | undefined)
-      ?? (settings.codexEnabled as boolean | undefined)
-      ?? DEFAULT_CODEX_PROVIDER_SETTINGS.enabled,
-    safeMode: (config.safeMode as CodexSafeMode | undefined)
-      ?? (settings.codexSafeMode as CodexSafeMode | undefined)
-      ?? DEFAULT_CODEX_PROVIDER_SETTINGS.safeMode,
-    cliPath: (config.cliPath as string | undefined)
-      ?? (settings.codexCliPath as string | undefined)
-      ?? DEFAULT_CODEX_PROVIDER_SETTINGS.cliPath,
-    cliPathsByHost,
-    customModels: (config.customModels as string | undefined)
-      ?? DEFAULT_CODEX_PROVIDER_SETTINGS.customModels,
-    reasoningSummary: (config.reasoningSummary as CodexReasoningSummary | undefined)
-      ?? (settings.codexReasoningSummary as CodexReasoningSummary | undefined)
-      ?? DEFAULT_CODEX_PROVIDER_SETTINGS.reasoningSummary,
-    environmentVariables: (config.environmentVariables as string | undefined)
-      ?? getProviderEnvironmentVariables(settings, 'codex')
-      ?? DEFAULT_CODEX_PROVIDER_SETTINGS.environmentVariables,
-    environmentHash: (config.environmentHash as string | undefined)
-      ?? (settings.lastCodexEnvHash as string | undefined)
-      ?? DEFAULT_CODEX_PROVIDER_SETTINGS.environmentHash,
-    installationMethod: installationMethodsByHost[hostnameKey]
+    ...storedConfig,
+    installationMethod: storedConfig.installationMethodsByHost[hostnameKey]
       ?? (
         hasHostScopedInstallationMethods
           ? DEFAULT_CODEX_PROVIDER_SETTINGS.installationMethod
           : legacyInstallationMethod
       ),
-    installationMethodsByHost,
-    wslDistroOverride: wslDistroOverridesByHost[hostnameKey]
+    wslDistroOverride: storedConfig.wslDistroOverridesByHost[hostnameKey]
       ?? (
         hasHostScopedWslDistroOverrides
           ? DEFAULT_CODEX_PROVIDER_SETTINGS.wslDistroOverride
           : legacyWslDistroOverride
       ),
-    wslDistroOverridesByHost,
   };
 }
 

--- a/src/providers/defaultProviderConfigs.ts
+++ b/src/providers/defaultProviderConfigs.ts
@@ -1,13 +1,13 @@
 import type { ProviderConfigMap } from '../core/types/settings';
 import { DEFAULT_CLAUDE_PROVIDER_SETTINGS } from './claude/settings';
-import { DEFAULT_CODEX_PROVIDER_SETTINGS } from './codex/settings';
+import { DEFAULT_CODEX_PROVIDER_CONFIG } from './codex/settings';
 import { DEFAULT_OPENCODE_PROVIDER_SETTINGS } from './opencode/settings';
 import { DEFAULT_PI_PROVIDER_SETTINGS } from './pi/settings';
 
 export function getBuiltInProviderDefaultConfigs(): ProviderConfigMap {
   return {
     claude: { ...DEFAULT_CLAUDE_PROVIDER_SETTINGS },
-    codex: { ...DEFAULT_CODEX_PROVIDER_SETTINGS },
+    codex: { ...DEFAULT_CODEX_PROVIDER_CONFIG },
     opencode: { ...DEFAULT_OPENCODE_PROVIDER_SETTINGS },
     pi: { ...DEFAULT_PI_PROVIDER_SETTINGS },
   };

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -3511,6 +3511,29 @@ describe('Tab - Blank Tab Model Selector', () => {
       ...claudeModels.map(m => ({ ...m, group: 'Claude' })),
     ]);
   });
+
+  it('includes Codex models for blank tabs even when saved provider state is Claude-only', () => {
+    const result = getBlankTabModelOptions({
+      settingsProvider: 'claude',
+      model: 'haiku',
+      savedProviderModel: {
+        claude: 'haiku',
+      },
+      providerConfigs: {
+        claude: {},
+        codex: {
+          enabled: true,
+        },
+      },
+    });
+
+    expect(result).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        value: DEFAULT_CODEX_PRIMARY_MODEL,
+        group: 'Codex',
+      }),
+    ]));
+  });
 });
 
 describe('Tab - Cross-Provider Model Rejection', () => {

--- a/tests/unit/providers/claude/storage/ClaudianSettingsStorage.test.ts
+++ b/tests/unit/providers/claude/storage/ClaudianSettingsStorage.test.ts
@@ -348,6 +348,34 @@ describe('ClaudianSettingsStorage', () => {
       });
     });
 
+    it('strips legacy Codex installation scalar fields from non-Windows provider config', async () => {
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+      mockAdapter.exists.mockResolvedValue(true);
+      mockAdapter.read.mockResolvedValue(JSON.stringify({
+        providerConfigs: {
+          codex: {
+            enabled: true,
+            installationMethod: 'wsl',
+            wslDistroOverride: 'Ubuntu',
+            cliPathsByHost: {
+              'host-a': '/opt/homebrew/bin/codex',
+            },
+          },
+        },
+      }));
+
+      const result = await storage.load();
+      const codexConfig = result.providerConfigs.codex as Record<string, unknown>;
+      const writtenContent = JSON.parse(mockAdapter.write.mock.calls[0][1]);
+
+      expect(getCodexProviderSettings(result).installationMethod).toBe('native-windows');
+      expect(getCodexProviderSettings(result).wslDistroOverride).toBe('');
+      expect(codexConfig).not.toHaveProperty('installationMethod');
+      expect(codexConfig).not.toHaveProperty('wslDistroOverride');
+      expect(writtenContent.providerConfigs.codex).not.toHaveProperty('installationMethod');
+      expect(writtenContent.providerConfigs.codex).not.toHaveProperty('wslDistroOverride');
+    });
+
     it('should preserve legacy codexCliPath field', async () => {
       mockAdapter.exists.mockResolvedValue(true);
       mockAdapter.read.mockResolvedValue(JSON.stringify({
@@ -572,7 +600,9 @@ describe('ClaudianSettingsStorage', () => {
       );
       const writtenContent = JSON.parse(mockAdapter.write.mock.calls[0][1]);
       expect(writtenContent.model).toBe('claude-opus-4-5');
+      expect(writtenContent.providerConfigs.codex).not.toHaveProperty('installationMethod');
       expect(writtenContent.providerConfigs.codex.installationMethodsByHost).toEqual({});
+      expect(writtenContent.providerConfigs.codex).not.toHaveProperty('wslDistroOverride');
       expect(writtenContent.providerConfigs.codex.wslDistroOverridesByHost).toEqual({});
     });
 

--- a/tests/unit/providers/codex/runtime/CodexCliResolver.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexCliResolver.test.ts
@@ -100,4 +100,34 @@ describe('CodexCliResolver', () => {
 
     expect(resolved).toBe('codex');
   });
+
+  it('uses the supplied execution target when resolving from settings', () => {
+    mockedExists.mockReturnValue(false);
+
+    const resolver = new CodexCliResolver();
+    const resolved = resolver.resolveFromSettings(
+      {
+        providerConfigs: {
+          codex: {
+            installationMethodsByHost: {
+              'current-host': 'native-windows',
+            },
+            cliPathsByHost: {
+              'current-host': 'C:\\Users\\user\\AppData\\Roaming\\npm\\codex.exe',
+            },
+          },
+        },
+      },
+      {
+        executionTarget: {
+          method: 'wsl',
+          platformFamily: 'unix',
+          platformOs: 'linux',
+          distroName: 'Ubuntu',
+        },
+      },
+    );
+
+    expect(resolved).toBe('codex');
+  });
 });

--- a/tests/unit/providers/codex/settings.test.ts
+++ b/tests/unit/providers/codex/settings.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_CODEX_PROVIDER_SETTINGS,
   getCodexProviderSettings,
   getEffectiveCodexReasoningSummary,
+  normalizeCodexStoredConfig,
   updateCodexProviderSettings,
 } from '@/providers/codex/settings';
 import { CODEX_SPARK_MODEL } from '@/providers/codex/types/models';
@@ -203,6 +204,74 @@ describe('codex settings', () => {
     expect(getCodexProviderSettings(settingsBag).wslDistroOverridesByHost).toEqual({
       'host-b': 'Debian',
     });
+  });
+
+  it('normalizes stored Codex config without treating effective defaults as persisted fields', () => {
+    const result = normalizeCodexStoredConfig(
+      {
+        providerConfigs: {
+          codex: {
+            enabled: true,
+            installationMethod: 'native-windows',
+            wslDistroOverride: '',
+            installationMethodsByHost: {
+              'host-a': 'wsl',
+              'host-b': 'wsl',
+            },
+            wslDistroOverridesByHost: {
+              'host-a': 'Ubuntu-24.04',
+              'host-b': 'Debian',
+            },
+          },
+        },
+      },
+      {
+        platform: 'darwin',
+        hostnameKey: 'host-a',
+        legacyHostnameKey: 'legacy-host',
+      },
+    );
+
+    expect(result.changed).toBe(true);
+    expect(result.config).toMatchObject({
+      enabled: true,
+      installationMethodsByHost: {
+        'host-b': 'wsl',
+      },
+      wslDistroOverridesByHost: {
+        'host-b': 'Debian',
+      },
+    });
+    expect(result.config).not.toHaveProperty('installationMethod');
+    expect(result.config).not.toHaveProperty('wslDistroOverride');
+  });
+
+  it('migrates legacy Windows Codex installation scalars into current host maps', () => {
+    const result = normalizeCodexStoredConfig(
+      {
+        providerConfigs: {
+          codex: {
+            installationMethod: 'wsl',
+            wslDistroOverride: ' Ubuntu ',
+          },
+        },
+      },
+      {
+        platform: 'win32',
+        hostnameKey: 'host-a',
+        legacyHostnameKey: 'legacy-host',
+      },
+    );
+
+    expect(result.changed).toBe(true);
+    expect(result.config.installationMethodsByHost).toEqual({
+      'host-a': 'wsl',
+    });
+    expect(result.config.wslDistroOverridesByHost).toEqual({
+      'host-a': 'Ubuntu',
+    });
+    expect(result.config).not.toHaveProperty('installationMethod');
+    expect(result.config).not.toHaveProperty('wslDistroOverride');
   });
 
   it('forces reasoning summary off for GPT-5.3 Codex Spark', () => {


### PR DESCRIPTION
## Summary
- separate persisted Codex provider config from effective runtime launch settings
- normalize Codex stored config directly during settings load so non-Windows hosts drop current-host Windows/WSL launch state while preserving other hosts
- pass a resolved Codex execution target into CLI resolution and launch building, and cover blank-tab Codex model visibility

## Testing
- npm run test -- tests/unit/providers/codex/settings.test.ts tests/unit/providers/claude/storage/ClaudianSettingsStorage.test.ts tests/unit/providers/codex/runtime/CodexCliResolver.test.ts tests/unit/providers/codex/runtime/CodexLaunchSpecBuilder.test.ts tests/unit/features/chat/tabs/Tab.test.ts --runInBand
- npm run typecheck
- npm run lint
- npm run test -- --runInBand
- npm run build