### PR TITLE
Fix per-conversation chat model selection

### DIFF
--- a/src/core/bootstrap/SessionStorage.ts
+++ b/src/core/bootstrap/SessionStorage.ts
@@ -114,6 +114,7 @@ export class SessionStorage {
       updatedAt: conversation.updatedAt,
       lastResponseAt: conversation.lastResponseAt,
       sessionId: conversation.sessionId,
+      selectedModel: conversation.selectedModel,
       providerState: providerState && Object.keys(providerState).length > 0 ? providerState : undefined,
       currentNote: conversation.currentNote,
       externalContextPaths: conversation.externalContextPaths,

--- a/src/core/providers/conversationModel.ts
+++ b/src/core/providers/conversationModel.ts
@@ -1,0 +1,144 @@
+import type { Conversation } from '../types';
+import { toProviderRuntimeModelId } from './modelSelection';
+import { ProviderRegistry } from './ProviderRegistry';
+import { ProviderSettingsCoordinator } from './ProviderSettingsCoordinator';
+import type { ProviderId } from './types';
+
+export type ConversationModelSource = 'selected' | 'usage' | 'default';
+
+export interface ConversationModelResolution {
+  model: string;
+  source: ConversationModelSource;
+  shouldPersist: boolean;
+}
+
+function trimModel(model: unknown): string {
+  return typeof model === 'string' ? model.trim() : '';
+}
+
+function findModelOption(
+  providerId: ProviderId,
+  model: string,
+  settings: Record<string, unknown>,
+): string | null {
+  const runtimeModel = toProviderRuntimeModelId(providerId, model);
+  const option = ProviderRegistry
+    .getChatUIConfig(providerId)
+    .getModelOptions(settings)
+    .find(candidate =>
+      candidate.value === model
+      || toProviderRuntimeModelId(providerId, candidate.value) === runtimeModel
+    );
+  return option?.value ?? null;
+}
+
+export function normalizeProviderModelSelection(
+  providerId: ProviderId,
+  settings: Record<string, unknown>,
+  model: unknown,
+): string | null {
+  const rawModel = trimModel(model);
+  if (!rawModel) {
+    return null;
+  }
+
+  const uiConfig = ProviderRegistry.getChatUIConfig(providerId);
+  const baseSettings = ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+    settings,
+    providerId,
+  );
+  const rawSettings = {
+    ...baseSettings,
+    model: rawModel,
+  };
+
+  const rawOption = findModelOption(providerId, rawModel, rawSettings);
+  if (rawOption) {
+    return rawOption;
+  }
+  if (uiConfig.ownsModel(rawModel, rawSettings)) {
+    return rawModel;
+  }
+
+  const normalizedModel = trimModel(uiConfig.normalizeModelVariant(rawModel, rawSettings));
+  if (!normalizedModel) {
+    return null;
+  }
+
+  const normalizedSettings = {
+    ...baseSettings,
+    model: normalizedModel,
+  };
+  const normalizedOption = findModelOption(providerId, normalizedModel, normalizedSettings);
+  if (normalizedOption) {
+    return normalizedOption;
+  }
+
+  return normalizedModel === rawModel && uiConfig.ownsModel(normalizedModel, normalizedSettings)
+    ? normalizedModel
+    : null;
+}
+
+export function resolveConversationModel(
+  settings: Record<string, unknown>,
+  providerId: ProviderId,
+  conversation?: Conversation | null,
+): ConversationModelResolution {
+  const selectedModel = normalizeProviderModelSelection(
+    providerId,
+    settings,
+    conversation?.selectedModel,
+  );
+  if (selectedModel) {
+    return {
+      model: selectedModel,
+      source: 'selected',
+      shouldPersist: selectedModel !== conversation?.selectedModel,
+    };
+  }
+
+  const usageModel = normalizeProviderModelSelection(
+    providerId,
+    settings,
+    conversation?.usage?.model,
+  );
+  if (usageModel) {
+    return {
+      model: usageModel,
+      source: 'usage',
+      shouldPersist: true,
+    };
+  }
+
+  const providerSettings = ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+    settings,
+    providerId,
+  );
+  const defaultModel = normalizeProviderModelSelection(
+    providerId,
+    settings,
+    providerSettings.model,
+  ) ?? trimModel(providerSettings.model);
+
+  return {
+    model: defaultModel,
+    source: 'default',
+    shouldPersist: false,
+  };
+}
+
+export function getProviderSettingsSnapshotWithModel<T extends Record<string, unknown>>(
+  settings: T,
+  providerId: ProviderId,
+  model?: string | null,
+): T {
+  const snapshot = ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+    settings,
+    providerId,
+  );
+  const normalizedModel = normalizeProviderModelSelection(providerId, snapshot, model);
+  if (normalizedModel) {
+    (snapshot as Record<string, unknown>)['model'] = normalizedModel;
+  }
+  return snapshot;
+}

--- a/src/core/providers/modelSelection.ts
+++ b/src/core/providers/modelSelection.ts
@@ -68,5 +68,5 @@ export function toProviderRuntimeModelId(
   value: string,
 ): string {
   const decoded = decodeProviderModelSelectionId(value);
-  return decoded?.providerId === providerId ? decoded.modelId : value;
+  return decoded && decoded.providerId === providerId ? decoded.modelId : value;
 }

--- a/src/core/runtime/types.ts
+++ b/src/core/runtime/types.ts
@@ -77,7 +77,7 @@ export interface ChatRuntimeEnsureReadyOptions {
 
 export type ChatRuntimeConversationState = Pick<
   Conversation,
-  'sessionId' | 'providerState'
+  'sessionId' | 'providerState' | 'selectedModel'
 >;
 
 export interface SessionUpdateResult {

--- a/src/core/types/chat.ts
+++ b/src/core/types/chat.ts
@@ -71,6 +71,8 @@ export interface Conversation {
   /** Timestamp when the last agent response completed. */
   lastResponseAt?: number;
   sessionId: string | null;
+  /** Conversation-owned model selection. Missing values are migrated lazily. */
+  selectedModel?: string;
   /** Opaque provider-owned state bag (session tracking, fork metadata, etc.). */
   providerState?: Record<string, unknown>;
   messages: ChatMessage[];
@@ -116,6 +118,8 @@ export interface SessionMetadata {
   lastResponseAt?: number;
   /** Session ID used for provider resume (may be cleared when invalidated). */
   sessionId?: string | null;
+  /** Conversation-owned model selection. */
+  selectedModel?: string;
   /** Opaque provider-owned state bag. */
   providerState?: Record<string, unknown>;
   currentNote?: string;

--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -2,6 +2,10 @@ import type { EventRef, WorkspaceLeaf } from 'obsidian';
 import { ItemView, Notice, Scope, setIcon } from 'obsidian';
 
 import { getHiddenProviderCommandSet } from '../../core/providers/commands/hiddenCommands';
+import {
+  getProviderSettingsSnapshotWithModel,
+  resolveConversationModel,
+} from '../../core/providers/conversationModel';
 import { ProviderRegistry } from '../../core/providers/ProviderRegistry';
 import { ProviderSettingsCoordinator } from '../../core/providers/ProviderSettingsCoordinator';
 import { DEFAULT_CHAT_PROVIDER_ID, type ProviderId } from '../../core/providers/types';
@@ -105,9 +109,18 @@ export class ClaudianView extends ItemView {
     for (const tab of this.tabManager?.getAllTabs() ?? []) {
       onProviderAvailabilityChanged(tab, this.plugin);
       const providerId = getTabProviderId(tab, this.plugin);
-      const providerSettings = ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+      const conversation = tab.conversationId
+        ? this.plugin.getConversationSync(tab.conversationId)
+        : null;
+      const modelOverride = conversation
+        ? resolveConversationModel(this.plugin.settings, providerId, conversation).model
+        : tab.lifecycleState === 'blank'
+        ? tab.draftModel
+        : tab.service?.getAuxiliaryModel?.() ?? null;
+      const providerSettings = getProviderSettingsSnapshotWithModel(
         this.plugin.settings,
         providerId,
+        modelOverride,
       );
       const model = providerSettings.model;
       const uiConfig = ProviderRegistry.getChatUIConfig(providerId);

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -48,6 +48,7 @@ export interface ConversationControllerDeps {
   getTitleGenerationService: () => TitleGenerationService | null;
   getStatusPanel: () => StatusPanel | null;
   getAgentService?: () => ChatRuntime | null;
+  getSelectedModel?: () => string | null;
   ensureServiceForConversation?: (conversation: Conversation | null) => Promise<void>;
   dismissPendingInlinePrompts?: () => void;
 }
@@ -410,9 +411,11 @@ export class ConversationController {
     // New conversations always use SDK-native storage.
     if (!state.currentConversationId && state.messages.length > 0) {
       const initialSessionId = agentService?.getSessionId() ?? undefined;
+      const selectedModel = this.deps.getSelectedModel?.() ?? undefined;
       const conversation = await plugin.createConversation({
         providerId: agentService?.providerId,
         sessionId: initialSessionId,
+        ...(selectedModel ? { selectedModel } : {}),
       });
       state.currentConversationId = conversation.id;
     }

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -22,6 +22,7 @@ import {
 import type {
   ApprovalCallbackOptions,
   ApprovalDecisionOption,
+  ChatRuntimeQueryOptions,
   ChatTurnRequest,
 } from '../../../core/runtime/types';
 import { TOOL_EXIT_PLAN_MODE } from '../../../core/tools/toolNames';
@@ -403,7 +404,11 @@ export class InputController {
       // Pass history WITHOUT current turn (userMsg + assistantMsg we just added)
       // This prevents duplication when rebuilding context for new sessions
       const previousMessages = state.messages.slice(0, -2);
-      for await (const chunk of agentService.query(preparedTurn, previousMessages)) {
+      const selectedModel = this.getAuxiliaryModel();
+      const queryOptions: ChatRuntimeQueryOptions | undefined = selectedModel
+        ? { model: selectedModel }
+        : undefined;
+      for await (const chunk of agentService.query(preparedTurn, previousMessages, queryOptions)) {
         if (state.streamGeneration !== streamGeneration) {
           wasInvalidated = true;
           break;
@@ -1121,9 +1126,11 @@ export class InputController {
 
     if (!state.currentConversationId) {
       const sessionId = this.getAgentService()?.getSessionId() ?? undefined;
+      const selectedModel = this.getAuxiliaryModel() ?? undefined;
       const conversation = await plugin.createConversation({
         providerId: this.getActiveProviderId(),
         sessionId,
+        ...(selectedModel ? { selectedModel } : {}),
       });
       state.currentConversationId = conversation.id;
     }

--- a/src/features/chat/controllers/StreamController.ts
+++ b/src/features/chat/controllers/StreamController.ts
@@ -1,5 +1,6 @@
 import { TFile } from 'obsidian';
 
+import { resolveConversationModel } from '../../../core/providers/conversationModel';
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import {
   DEFAULT_CHAT_PROVIDER_ID,
@@ -336,7 +337,24 @@ export class StreamController {
   }
 
   private getActiveProviderModel(): string | undefined {
-    const providerId = this.deps.getAgentService?.()?.providerId;
+    const conversation = this.deps.state.currentConversationId
+      ? this.deps.plugin.getConversationSync(this.deps.state.currentConversationId)
+      : null;
+    if (conversation) {
+      return resolveConversationModel(
+        this.deps.plugin.settings,
+        conversation.providerId,
+        conversation,
+      ).model;
+    }
+
+    const service = this.deps.getAgentService?.();
+    const serviceModel = service?.getAuxiliaryModel?.();
+    if (serviceModel) {
+      return serviceModel;
+    }
+
+    const providerId = service?.providerId;
     if (!providerId) {
       return undefined;
     }

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -4,6 +4,11 @@ import { Notice, Platform } from 'obsidian';
 import { getHiddenProviderCommandSet } from '../../../core/providers/commands/hiddenCommands';
 import type { ProviderCommandDropdownConfig } from '../../../core/providers/commands/ProviderCommandCatalog';
 import type { ProviderCommandEntry } from '../../../core/providers/commands/ProviderCommandEntry';
+import {
+  getProviderSettingsSnapshotWithModel,
+  normalizeProviderModelSelection,
+  resolveConversationModel,
+} from '../../../core/providers/conversationModel';
 import { getEnabledProviderForModel, getProviderForModel } from '../../../core/providers/modelRouting';
 import { ProviderRegistry } from '../../../core/providers/ProviderRegistry';
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
@@ -148,10 +153,49 @@ function getTabSettingsSnapshot(
   tab: TabProviderContext,
   plugin: ClaudianPlugin,
 ): TabProviderSettings {
+  const providerId = getTabProviderId(tab, plugin);
+  return getProviderSettingsSnapshotWithModel(
+    plugin.settings,
+    providerId,
+    getTabSelectedModel(tab, plugin),
+  ) as TabProviderSettings;
+}
+
+function getWritableTabSettingsSnapshot(
+  tab: TabProviderContext,
+  plugin: ClaudianPlugin,
+): TabProviderSettings {
   return ProviderSettingsCoordinator.getProviderSettingsSnapshot(
     plugin.settings,
     getTabProviderId(tab, plugin),
-  );
+  ) as TabProviderSettings;
+}
+
+function getTabConversation(
+  tab: TabProviderContext,
+  plugin: ClaudianPlugin,
+): Conversation | null {
+  return tab.conversationId ? plugin.getConversationSync(tab.conversationId) : null;
+}
+
+function getTabSelectedModel(
+  tab: TabProviderContext,
+  plugin: ClaudianPlugin,
+): string | null {
+  const providerId = getTabProviderId(tab, plugin);
+  if (tab.lifecycleState === 'blank') {
+    return normalizeProviderModelSelection(providerId, plugin.settings, tab.draftModel)
+      ?? tab.service?.getAuxiliaryModel?.()
+      ?? tab.draftModel
+      ?? null;
+  }
+
+  const conversation = getTabConversation(tab, plugin);
+  if (conversation) {
+    return resolveConversationModel(plugin.settings, providerId, conversation).model;
+  }
+
+  return tab.service?.getAuxiliaryModel?.() ?? null;
 }
 
 function getTabPermissionMode(
@@ -307,7 +351,7 @@ async function updateTabProviderSettings(
   update: (settings: TabProviderSettings) => void,
 ): Promise<TabProviderSettings> {
   const providerId = getTabProviderId(tab, plugin);
-  const snapshot = getTabSettingsSnapshot(tab, plugin);
+  const snapshot = getWritableTabSettingsSnapshot(tab, plugin);
   update(snapshot);
   ProviderSettingsCoordinator.commitProviderSettingsSnapshot(
     plugin.settings,
@@ -609,6 +653,9 @@ export async function initializeTabService(
       : null
   );
   const providerId = getTabProviderId(tab, plugin, conversation);
+  const selectedModel = conversation
+    ? resolveConversationModel(plugin.settings, providerId, conversation).model
+    : getTabSelectedModel(tab, plugin);
 
   if (tab.serviceInitialized && tab.service?.providerId === providerId) {
     return;
@@ -632,14 +679,13 @@ export async function initializeTabService(
 
     // Passive sync: set session state without starting the runtime process.
     // The runtime starts on demand when query() is called.
-    if (conversation) {
-      const hasMessages = conversation.messages.length > 0;
-      const externalContextPaths = hasMessages
-        ? conversation.externalContextPaths || []
-        : (plugin.settings.persistentExternalContextPaths || []);
-
-      runtime.syncConversationState(conversation, externalContextPaths);
-    }
+    const hasMessages = conversation ? conversation.messages.length > 0 : false;
+    const externalContextPaths = conversation && hasMessages
+      ? conversation.externalContextPaths || []
+      : (plugin.settings.persistentExternalContextPaths || []);
+    const runtimeConversationState = conversation
+      ?? (selectedModel ? { sessionId: null, selectedModel } : null);
+    runtime.syncConversationState(runtimeConversationState, externalContextPaths);
 
     // Re-check after async operations — tab may have been closed during init
     if (isClosingLifecycleState(tab.lifecycleState)) {
@@ -851,16 +897,15 @@ function initializeInputToolbar(
         }
         syncSlashCommandDropdownForProvider(tab, plugin, getProviderCatalogConfig);
 
-        // Update settings for the new provider
         const uiConfig = ProviderRegistry.getChatUIConfig(newProvider);
-        await updateTabProviderSettings(tab, plugin, (settings) => {
-          settings.model = model;
-          uiConfig.applyModelDefaults(model, settings);
-        });
         if (didProviderChange) {
           await onProviderChanged?.(newProvider);
         }
-        await uiConfig.prepareModelMetadata?.(model, plugin.settings, { plugin });
+        await uiConfig.prepareModelMetadata?.(
+          model,
+          getProviderSettingsSnapshotWithModel(plugin.settings, newProvider, model),
+          { plugin },
+        );
         tab.ui.thinkingBudgetSelector?.updateDisplay();
         tab.ui.serviceTierToggle?.updateDisplay();
         tab.ui.modelSelector?.updateDisplay();
@@ -882,11 +927,29 @@ function initializeInputToolbar(
       }
 
       const uiConfig: ProviderChatUIConfig = getTabChatUIConfig(tab, plugin);
-      const providerSettings = await updateTabProviderSettings(tab, plugin, (settings) => {
-        settings.model = model;
-        uiConfig.applyModelDefaults(model, settings);
-      });
-      await uiConfig.prepareModelMetadata?.(model, plugin.settings, { plugin });
+      const normalizedModel = normalizeProviderModelSelection(boundProvider, plugin.settings, model) ?? model;
+      const providerSettings = getProviderSettingsSnapshotWithModel(
+        plugin.settings,
+        boundProvider,
+        normalizedModel,
+      ) as TabProviderSettings;
+
+      if (tab.conversationId) {
+        await plugin.updateConversation(tab.conversationId, {
+          selectedModel: normalizedModel,
+        });
+        const updatedConversation = plugin.getConversationSync(tab.conversationId);
+        if (updatedConversation && tab.service?.providerId === boundProvider) {
+          const hasMessages = updatedConversation.messages.length > 0;
+          const externalContextPaths = tab.ui.externalContextSelector?.getExternalContexts()
+            ?? (hasMessages
+              ? updatedConversation.externalContextPaths ?? []
+              : plugin.settings.persistentExternalContextPaths ?? []);
+          tab.service.syncConversationState(updatedConversation, externalContextPaths);
+        }
+      }
+
+      await uiConfig.prepareModelMetadata?.(normalizedModel, providerSettings, { plugin });
       tab.ui.thinkingBudgetSelector?.updateDisplay();
       tab.ui.serviceTierToggle?.updateDisplay();
       tab.ui.modelSelector?.updateDisplay();
@@ -896,11 +959,11 @@ function initializeInputToolbar(
       const currentUsage = tab.state.usage;
       if (currentUsage) {
         const newContextWindow = uiConfig.getContextWindowSize(
-          model,
+          normalizedModel,
           providerSettings.customContextLimits,
           providerSettings,
         );
-        tab.state.usage = recalculateUsageForModel(currentUsage, model, newContextWindow);
+        tab.state.usage = recalculateUsageForModel(currentUsage, normalizedModel, newContextWindow);
       }
     },
     onModeChange: async (mode: string) => {
@@ -912,14 +975,16 @@ function initializeInputToolbar(
     },
     onThinkingBudgetChange: async (budget: string) => {
       await updateTabProviderSettings(tab, plugin, (settings) => {
+        const model = getTabSelectedModel(tab, plugin) ?? settings.model;
         settings.thinkingBudget = budget;
-        getTabChatUIConfig(tab, plugin).applyReasoningSelection?.(settings.model, budget, settings);
+        getTabChatUIConfig(tab, plugin).applyReasoningSelection?.(model, budget, settings);
       });
     },
     onEffortLevelChange: async (effort: string) => {
       await updateTabProviderSettings(tab, plugin, (settings) => {
+        const model = getTabSelectedModel(tab, plugin) ?? settings.model;
         settings.effortLevel = effort;
-        getTabChatUIConfig(tab, plugin).applyReasoningSelection?.(settings.model, effort, settings);
+        getTabChatUIConfig(tab, plugin).applyReasoningSelection?.(model, effort, settings);
       });
     },
     onServiceTierChange: async (serviceTier: string) => {
@@ -1048,6 +1113,7 @@ export interface ForkContext {
   providerId?: ProviderId;
   sourceSessionId: string;
   sourceProviderState?: Record<string, unknown>;
+  sourceSelectedModel?: string;
   resumeAt: string;
   sourceTitle?: string;
   /** 1-based index used for fork title suffix (counts only non-interrupt user messages). */
@@ -1075,6 +1141,7 @@ interface ForkSource {
   providerId?: ProviderId;
   sourceSessionId: string;
   sourceProviderState?: Record<string, unknown>;
+  sourceSelectedModel?: string;
   sourceTitle?: string;
   currentNote?: string;
 }
@@ -1102,10 +1169,15 @@ function resolveForkSource(tab: TabData, plugin: ClaudianPlugin): ForkSource | n
     return null;
   }
 
+  const providerId = getTabProviderId(tab, plugin, conversation);
+
   return {
-    providerId: getTabProviderId(tab, plugin, conversation),
+    providerId,
     sourceSessionId,
     sourceProviderState: conversation?.providerState,
+    sourceSelectedModel: conversation
+      ? resolveConversationModel(plugin.settings, providerId, conversation).model
+      : getTabSelectedModel(tab, plugin) ?? undefined,
     sourceTitle: conversation?.title,
     currentNote: conversation?.currentNote,
   };
@@ -1155,6 +1227,7 @@ async function handleForkRequest(
     providerId: source.providerId,
     sourceSessionId: source.sourceSessionId,
     sourceProviderState: source.sourceProviderState,
+    sourceSelectedModel: source.sourceSelectedModel,
     resumeAt: rewindCtx.prevAssistantUuid,
     sourceTitle: source.sourceTitle,
     forkAtUserMessage: countUserMessagesForForkTitle(msgs.slice(0, userIdx + 1)),
@@ -1206,6 +1279,7 @@ async function handleForkAll(
     providerId: source.providerId,
     sourceSessionId: source.sourceSessionId,
     sourceProviderState: source.sourceProviderState,
+    sourceSelectedModel: source.sourceSelectedModel,
     resumeAt: lastAssistantUuid,
     sourceTitle: source.sourceTitle,
     forkAtUserMessage: countUserMessagesForForkTitle(msgs) + 1,
@@ -1335,6 +1409,7 @@ export function initializeTabControllers(
       getTitleGenerationService: () => services.titleGenerationService,
       getStatusPanel: () => ui.statusPanel,
       getAgentService: () => tab.service, // Use tab's service instead of plugin's
+      getSelectedModel: () => getTabSelectedModel(tab, plugin),
       dismissPendingInlinePrompts: () => tab.controllers.inputController?.dismissPendingApproval(),
       ensureServiceForConversation: async (conversation) => {
         const nextProviderId = getTabProviderId(tab, plugin, conversation);
@@ -1411,7 +1486,7 @@ export function initializeTabControllers(
     resetInputHeight: () => {
       // Per-tab input height is managed by CSS, no dynamic adjustment needed
     },
-    getAuxiliaryModel: () => tab.service?.getAuxiliaryModel?.() ?? tab.draftModel ?? null,
+    getAuxiliaryModel: () => getTabSelectedModel(tab, plugin),
     getAgentService: () => tab.service,
     getSubagentManager: () => services.subagentManager,
     getTabProviderId: () => getTabProviderId(tab, plugin),
@@ -1865,7 +1940,7 @@ async function renderAutoTriggeredTurn(tab: TabData, result: AutoTurnResult): Pr
 
 export function updatePlanModeUI(tab: TabData, plugin: ClaudianPlugin, mode: string): void {
   const providerId = getTabProviderId(tab, plugin);
-  const snapshot = getTabSettingsSnapshot(tab, plugin);
+  const snapshot = getWritableTabSettingsSnapshot(tab, plugin);
   const uiConfig = ProviderRegistry.getChatUIConfig(providerId);
   if (uiConfig.applyPermissionMode) {
     uiConfig.applyPermissionMode(mode, snapshot);

--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -569,6 +569,7 @@ export class TabManager implements TabManagerInterface {
   private async createForkConversation(context: ForkContext): Promise<string> {
     const conversation = await this.plugin.createConversation({
       providerId: context.providerId,
+      ...(context.sourceSelectedModel ? { selectedModel: context.sourceSelectedModel } : {}),
     });
 
     const title = context.sourceTitle

--- a/src/features/inline-edit/ui/InlineEditModal.ts
+++ b/src/features/inline-edit/ui/InlineEditModal.ts
@@ -5,6 +5,7 @@ import type { App, Editor, MarkdownView } from 'obsidian';
 import { Notice } from 'obsidian';
 
 import { getHiddenProviderCommandSet } from '../../../core/providers/commands/hiddenCommands';
+import { resolveConversationModel } from '../../../core/providers/conversationModel';
 import { ProviderRegistry } from '../../../core/providers/ProviderRegistry';
 import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
 import { DEFAULT_CHAT_PROVIDER_ID, type InlineEditMode, type InlineEditService, type ProviderId } from '../../../core/providers/types';
@@ -347,7 +348,9 @@ class InlineEditController {
       ?? activeTab?.providerId
       ?? DEFAULT_CHAT_PROVIDER_ID;
     this.inlineEditService = ProviderRegistry.createInlineEditService(plugin, providerId);
-    const auxiliaryModel = activeTab?.service?.providerId === providerId
+    const auxiliaryModel = conversation
+      ? resolveConversationModel(plugin.settings, providerId, conversation).model
+      : activeTab?.service?.providerId === providerId
       ? activeTab.service.getAuxiliaryModel?.()
       : activeTab?.providerId === providerId
       ? activeTab?.draftModel

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,10 @@ import { DEFAULT_CLAUDIAN_SETTINGS } from './app/settings/defaultSettings';
 import { SharedStorageService } from './app/storage/SharedStorageService';
 import type { SharedAppStorage } from './core/bootstrap/storage';
 import {
+  normalizeProviderModelSelection,
+  resolveConversationModel,
+} from './core/providers/conversationModel';
+import {
   getEnvironmentVariablesForScope as getScopedEnvironmentVariables,
   getRuntimeEnvironmentText,
   setEnvironmentVariablesForScope,
@@ -326,6 +330,7 @@ export default class ClaudianPlugin extends Plugin {
         updatedAt: meta.updatedAt,
         lastResponseAt: meta.lastResponseAt,
         sessionId: resumeSessionId,
+        selectedModel: meta.selectedModel,
         providerState: meta.providerState,
         messages: [],
         currentNote: meta.currentNote,
@@ -594,6 +599,22 @@ export default class ClaudianPlugin extends Plugin {
     return previewText.substring(0, 50) + (previewText.length > 50 ? '...' : '');
   }
 
+  private async ensureConversationSelectedModel(conversation: Conversation): Promise<void> {
+    const resolved = resolveConversationModel(
+      this.settings,
+      conversation.providerId,
+      conversation,
+    );
+    if (!resolved.shouldPersist || !resolved.model || conversation.selectedModel === resolved.model) {
+      return;
+    }
+
+    conversation.selectedModel = resolved.model;
+    await this.storage.sessions.saveMetadata(
+      this.storage.sessions.toSessionMetadata(conversation)
+    );
+  }
+
   private async loadSdkMessagesForConversation(conversation: Conversation): Promise<void> {
     await ProviderRegistry
       .getConversationHistoryService(conversation.providerId)
@@ -603,9 +624,19 @@ export default class ClaudianPlugin extends Plugin {
   async createConversation(options?: {
     providerId?: ProviderId;
     sessionId?: string;
+    selectedModel?: string;
   }): Promise<Conversation> {
     const providerId = options?.providerId ?? DEFAULT_CHAT_PROVIDER_ID;
     const sessionId = options?.sessionId;
+    const providerSettings = ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+      this.settings,
+      providerId,
+    );
+    const selectedModel = normalizeProviderModelSelection(
+      providerId,
+      this.settings,
+      options?.selectedModel ?? providerSettings.model,
+    ) ?? undefined;
     const conversationId = sessionId ?? this.generateConversationId();
     const conversation: Conversation = {
       id: conversationId,
@@ -614,6 +645,7 @@ export default class ClaudianPlugin extends Plugin {
       createdAt: Date.now(),
       updatedAt: Date.now(),
       sessionId: sessionId ?? null,
+      selectedModel,
       messages: [],
     };
 
@@ -629,6 +661,7 @@ export default class ClaudianPlugin extends Plugin {
     const conversation = this.conversations.find(c => c.id === id);
     if (!conversation) return null;
 
+    await this.ensureConversationSelectedModel(conversation);
     await this.loadSdkMessagesForConversation(conversation);
 
     return conversation;
@@ -679,6 +712,18 @@ export default class ClaudianPlugin extends Plugin {
     // providerId is immutable — strip it from updates to prevent accidental mutation
     const safeUpdates = { ...updates };
     delete safeUpdates.providerId;
+    if ('selectedModel' in safeUpdates) {
+      const selectedModel = normalizeProviderModelSelection(
+        conversation.providerId,
+        this.settings,
+        safeUpdates.selectedModel,
+      );
+      if (selectedModel) {
+        safeUpdates.selectedModel = selectedModel;
+      } else {
+        delete safeUpdates.selectedModel;
+      }
+    }
     Object.assign(conversation, safeUpdates, { updatedAt: Date.now() });
 
     await this.storage.sessions.saveMetadata(
@@ -690,6 +735,7 @@ export default class ClaudianPlugin extends Plugin {
     const conversation = this.conversations.find(c => c.id === id) || null;
 
     if (conversation) {
+      await this.ensureConversationSelectedModel(conversation);
       await this.loadSdkMessagesForConversation(conversation);
     }
 

--- a/src/providers/claude/auxiliary/ClaudeInlineEditService.ts
+++ b/src/providers/claude/auxiliary/ClaudeInlineEditService.ts
@@ -5,7 +5,7 @@ import {
   getInlineEditSystemPrompt,
   parseInlineEditResponse,
 } from '../../../core/prompt/inlineEdit';
-import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
+import { getProviderSettingsSnapshotWithModel } from '../../../core/providers/conversationModel';
 import type {
   InlineEditRequest,
   InlineEditResult,
@@ -50,6 +50,7 @@ export function createReadOnlyHook(): HookCallbackMatcher {
 export class InlineEditService {
   private plugin: ClaudianPlugin;
   private abortController: AbortController | null = null;
+  private modelOverride: string | undefined;
   private sessionId: string | null = null;
 
   constructor(plugin: ClaudianPlugin) {
@@ -57,10 +58,16 @@ export class InlineEditService {
   }
 
   private getScopedSettings(): Record<string, unknown> {
-    return ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+    return getProviderSettingsSnapshotWithModel(
       this.plugin.settings,
       'claude',
+      this.modelOverride,
     );
+  }
+
+  setModelOverride(model?: string): void {
+    const trimmed = model?.trim();
+    this.modelOverride = trimmed ? trimmed : undefined;
   }
 
   resetConversation(): void {

--- a/src/providers/claude/runtime/ClaudeChatRuntime.ts
+++ b/src/providers/claude/runtime/ClaudeChatRuntime.ts
@@ -142,6 +142,7 @@ export class ClaudianService implements ChatRuntime {
   private permissionModeSyncCallback: ((sdkMode: string) => void) | null = null;
   private vaultPath: string | null = null;
   private currentExternalContextPaths: string[] = [];
+  private currentConversationModel: string | null = null;
   private readyStateListeners = new Set<(ready: boolean) => void>();
 
   // Modular components
@@ -225,6 +226,10 @@ export class ClaudianService implements ChatRuntime {
     return metadata;
   }
 
+  getAuxiliaryModel(): string | null {
+    return this.currentConversationModel;
+  }
+
   onReadyStateChange(listener: (ready: boolean) => void): () => void {
     this.readyStateListeners.add(listener);
     try {
@@ -293,6 +298,11 @@ export class ClaudianService implements ChatRuntime {
     return nextChunk;
   }
 
+  private setCurrentConversationModel(model: unknown): void {
+    const selectedModel = typeof model === 'string' ? model.trim() : '';
+    this.currentConversationModel = selectedModel || null;
+  }
+
   setPendingResumeAt(uuid: string | undefined): void {
     this.pendingResumeAt = uuid;
   }
@@ -319,12 +329,14 @@ export class ClaudianService implements ChatRuntime {
     externalContextPaths?: string[],
   ): void {
     if (!conversation) {
+      this.currentConversationModel = null;
       this.pendingForkSession = false;
       this.pendingResumeAt = undefined;
       this.setSessionId(null, externalContextPaths);
       return;
     }
 
+    this.setCurrentConversationModel(conversation.selectedModel);
     const resolvedSessionId = this.applyForkState(conversation);
     this.setSessionId(resolvedSessionId, externalContextPaths);
   }
@@ -633,10 +645,14 @@ export class ClaudianService implements ChatRuntime {
    * Builds the base query options context from current state.
    */
   private getScopedSettings(): ClaudianSettings {
-    return ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+    const settings = ProviderSettingsCoordinator.getProviderSettingsSnapshot(
       this.plugin.settings,
       this.providerId,
     );
+    if (this.currentConversationModel) {
+      settings.model = this.currentConversationModel;
+    }
+    return settings;
   }
 
   private buildQueryOptionsContext(vaultPath: string, cliPath: string): QueryOptionsContext {
@@ -1104,6 +1120,9 @@ export class ClaudianService implements ChatRuntime {
     const images = normalized.request.images;
     const conversationHistory = normalized.conversationHistory;
     const queryOptions = normalized.queryOptions;
+    if (queryOptions?.model) {
+      this.setCurrentConversationModel(queryOptions.model);
+    }
 
     const vaultPath = getVaultPath(this.plugin.app);
     if (!vaultPath) {

--- a/src/providers/codex/runtime/CodexChatRuntime.ts
+++ b/src/providers/codex/runtime/CodexChatRuntime.ts
@@ -137,6 +137,7 @@ export class CodexChatRuntime implements ChatRuntime {
   private autoTurnCallback: AutoTurnCallback | null = null;
   private resumeCheckpoint: string | undefined;
   private activeInputBundles = new Set<CodexInputBundle>();
+  private currentConversationModel: string | null = null;
 
   // Fork state
   private pendingFork: ForkSource | null = null;
@@ -179,6 +180,7 @@ export class CodexChatRuntime implements ChatRuntime {
     _externalContextPaths?: string[],
   ): void {
     if (!conversation) {
+      this.currentConversationModel = null;
       this.session.reset();
       this.loadedThreadId = null;
       this.currentThreadPath = null;
@@ -186,6 +188,7 @@ export class CodexChatRuntime implements ChatRuntime {
       return;
     }
 
+    this.setCurrentConversationModel(conversation.selectedModel);
     const state = getCodexState(conversation.providerState);
 
     // Pending fork: store fork metadata, don't set the source thread as our session
@@ -245,6 +248,9 @@ export class CodexChatRuntime implements ChatRuntime {
     _conversationHistory?: ChatMessage[],
     queryOptions?: ChatRuntimeQueryOptions,
   ): AsyncGenerator<StreamChunk> {
+    if (queryOptions?.model) {
+      this.setCurrentConversationModel(queryOptions.model);
+    }
     this.resetTurnMetadata();
     let turn = originalTurn;
     await this.ensureReady();
@@ -787,14 +793,23 @@ export class CodexChatRuntime implements ChatRuntime {
   }
 
   private getProviderSettings(): Record<string, unknown> {
-    return ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+    const settings = ProviderSettingsCoordinator.getProviderSettingsSnapshot(
       this.plugin.settings,
       this.providerId,
     );
+    if (this.currentConversationModel) {
+      settings.model = this.currentConversationModel;
+    }
+    return settings;
   }
 
   getAuxiliaryModel(): string | null {
-    return this.resolveModel() ?? null;
+    return this.currentConversationModel ?? this.resolveModel() ?? null;
+  }
+
+  private setCurrentConversationModel(model: unknown): void {
+    const selectedModel = typeof model === 'string' ? model.trim() : '';
+    this.currentConversationModel = selectedModel || null;
   }
 
   private resolveModel(queryOptions?: ChatRuntimeQueryOptions): string | undefined {

--- a/src/providers/opencode/runtime/OpencodeChatRuntime.ts
+++ b/src/providers/opencode/runtime/OpencodeChatRuntime.ts
@@ -19,6 +19,7 @@ import type {
   AutoTurnCallback,
   ChatRewindMode,
   ChatRewindResult,
+  ChatRuntimeConversationState,
   ChatRuntimeEnsureReadyOptions,
   ChatRuntimeQueryOptions,
   ChatTurnMetadata,
@@ -151,6 +152,7 @@ export class OpencodeChatRuntime implements ChatRuntime {
   private currentSessionEffortValue: string | null = null;
   private currentSessionEffortValues = new Set<string>();
   private currentSessionModelId: string | null = null;
+  private currentConversationModel: string | null = null;
   private currentSessionModeId: string | null = null;
   private currentTurnMetadata: ChatTurnMetadata = {};
   private loadedSessionId: string | null = null;
@@ -200,8 +202,9 @@ export class OpencodeChatRuntime implements ChatRuntime {
   setResumeCheckpoint(_checkpointId: string | undefined): void {}
 
   syncConversationState(
-    conversation: { providerState?: Record<string, unknown>; sessionId?: string | null } | null,
+    conversation: ChatRuntimeConversationState | null,
   ): void {
+    this.setCurrentConversationModel(conversation?.selectedModel);
     const previousSessionId = this.sessionId;
     const nextSessionId = conversation?.sessionId ?? null;
     if (this.sessionId !== nextSessionId) {
@@ -340,6 +343,9 @@ export class OpencodeChatRuntime implements ChatRuntime {
     conversationHistory?: ChatMessage[],
     queryOptions?: ChatRuntimeQueryOptions,
   ): AsyncGenerator<StreamChunk> {
+    if (queryOptions?.model) {
+      this.setCurrentConversationModel(queryOptions.model);
+    }
     const previousMessages = conversationHistory ?? [];
     const expectedSessionId = this.sessionId;
     let shouldBootstrapHistory = previousMessages.length > 0
@@ -693,10 +699,14 @@ export class OpencodeChatRuntime implements ChatRuntime {
   }
 
   private getProviderSettings(): Record<string, unknown> {
-    return ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+    const settings = ProviderSettingsCoordinator.getProviderSettingsSnapshot(
       this.plugin.settings,
       this.providerId,
     );
+    if (this.currentConversationModel) {
+      settings.model = this.currentConversationModel;
+    }
+    return settings;
   }
 
   private resolveSelectedRawModelId(queryOptions?: ChatRuntimeQueryOptions): string | null {
@@ -731,7 +741,12 @@ export class OpencodeChatRuntime implements ChatRuntime {
   }
 
   getAuxiliaryModel(): string | null {
-    return this.getActiveDisplayModel() ?? null;
+    return this.currentConversationModel ?? this.getActiveDisplayModel() ?? null;
+  }
+
+  private setCurrentConversationModel(model: unknown): void {
+    const selectedModel = typeof model === 'string' ? model.trim() : '';
+    this.currentConversationModel = selectedModel || null;
   }
 
   private getActiveDisplayModel(queryOptions?: ChatRuntimeQueryOptions): string | undefined {

--- a/src/providers/pi/runtime/PiChatRuntime.ts
+++ b/src/providers/pi/runtime/PiChatRuntime.ts
@@ -133,6 +133,7 @@ export class PiChatRuntime implements ChatRuntime {
 
   private activeTurn: ActiveTurn | null = null;
   private currentLaunchKey: string | null = null;
+  private currentConversationModel: string | null = null;
   private currentModel: string | null = null;
   private currentSessionTarget: string | null = null;
   private currentThinkingLevel: string | null = null;
@@ -183,7 +184,9 @@ export class PiChatRuntime implements ChatRuntime {
   setResumeCheckpoint(_checkpointId: string | undefined): void {}
 
   syncConversationState(conversation: ChatRuntimeConversationState | null): void {
+    this.setCurrentConversationModel(conversation?.selectedModel);
     if (!conversation) {
+      this.currentConversationModel = null;
       this.sessionId = null;
       this.sessionFile = null;
       this.leafEntryId = null;
@@ -289,6 +292,9 @@ export class PiChatRuntime implements ChatRuntime {
     conversationHistory?: ChatMessage[],
     queryOptions?: ChatRuntimeQueryOptions,
   ): AsyncGenerator<StreamChunk> {
+    if (queryOptions?.model) {
+      this.setCurrentConversationModel(queryOptions.model);
+    }
     this.currentTurnMetadata = {};
     let isReady: boolean;
     try {
@@ -427,7 +433,7 @@ export class PiChatRuntime implements ChatRuntime {
   }
 
   getAuxiliaryModel(): string | null {
-    return this.currentModel;
+    return this.currentConversationModel ?? this.currentModel;
   }
 
   cleanup(): void {
@@ -863,10 +869,19 @@ export class PiChatRuntime implements ChatRuntime {
   }
 
   private getProviderSettings(): Record<string, unknown> {
-    return ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+    const settings = ProviderSettingsCoordinator.getProviderSettingsSnapshot(
       this.plugin.settings,
       this.providerId,
     );
+    if (this.currentConversationModel) {
+      settings.model = this.currentConversationModel;
+    }
+    return settings;
+  }
+
+  private setCurrentConversationModel(model: unknown): void {
+    const selectedModel = typeof model === 'string' ? model.trim() : '';
+    this.currentConversationModel = selectedModel || null;
   }
 
   private resolveSelectedModel(

--- a/tests/integration/core/agent/ClaudianService.test.ts
+++ b/tests/integration/core/agent/ClaudianService.test.ts
@@ -600,14 +600,13 @@ describe('ClaudianService', () => {
   // MessageChannel tests moved to tests/unit/core/agent/MessageChannel.test.ts
 
   describe('persistent query updates', () => {
-    it('updates model on the active persistent query', async () => {
+    it('uses a query model override when starting the persistent query', async () => {
       const chunks: any[] = [];
       for await (const chunk of service.query('hello', undefined, undefined, { model: 'claude-opus-4-5' })) {
         chunks.push(chunk);
       }
 
-      const response = getLastResponse();
-      expect(response?.setModel).toHaveBeenCalledWith('claude-opus-4-5');
+      expect(getLastOptions()?.model).toBe('claude-opus-4-5');
     });
   });
 
@@ -1651,8 +1650,7 @@ describe('ClaudianService', () => {
         model: 'claude-opus-4-5',
       })) chunks2.push(c);
 
-      const response = getLastResponse();
-      expect(response?.setModel).toHaveBeenCalledWith('claude-opus-4-5');
+      expect(getLastOptions()?.model).toBe('claude-opus-4-5');
     });
 
     it('falls back to cold-start when restart fails during dynamic updates', async () => {

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -636,6 +636,66 @@ describe('ClaudianPlugin', () => {
       expect(fetched?.id).toBe(conv.id);
     });
 
+    it('should store the selected model in conversation metadata', async () => {
+      await plugin.onload();
+
+      const conv = await plugin.createConversation({ selectedModel: 'opus' });
+      const fetched = await plugin.getConversationById(conv.id);
+
+      expect(conv.selectedModel).toBe('opus');
+      expect(fetched?.selectedModel).toBe('opus');
+    });
+
+    it('should preserve custom selected models that are not in picker options', async () => {
+      await plugin.onload();
+
+      const conv = await plugin.createConversation({
+        providerId: 'codex',
+        selectedModel: 'gpt-5.4-experimental',
+      });
+      const fetched = await plugin.getConversationById(conv.id);
+
+      expect(conv.selectedModel).toBe('gpt-5.4-experimental');
+      expect(fetched?.selectedModel).toBe('gpt-5.4-experimental');
+    });
+
+    it('should lazily migrate missing selected model from usage metadata', async () => {
+      await plugin.onload();
+
+      const conv = await plugin.createConversation();
+      delete (conv as { selectedModel?: string }).selectedModel;
+      conv.usage = {
+        model: 'opus',
+        inputTokens: 1,
+        contextTokens: 1,
+        contextWindow: 200000,
+        percentage: 1,
+      };
+      const saveMetadataSpy = jest.spyOn(plugin.storage.sessions, 'saveMetadata');
+      saveMetadataSpy.mockClear();
+
+      const fetched = await plugin.getConversationById(conv.id);
+
+      expect(fetched?.selectedModel).toBe('opus');
+      expect(saveMetadataSpy).toHaveBeenCalledWith(expect.objectContaining({
+        selectedModel: 'opus',
+      }));
+    });
+
+    it('should not permanently default legacy conversations with unknown model metadata', async () => {
+      await plugin.onload();
+
+      const conv = await plugin.createConversation();
+      delete (conv as { selectedModel?: string }).selectedModel;
+      const saveMetadataSpy = jest.spyOn(plugin.storage.sessions, 'saveMetadata');
+      saveMetadataSpy.mockClear();
+
+      const fetched = await plugin.getConversationById(conv.id);
+
+      expect(fetched?.selectedModel).toBeUndefined();
+      expect(saveMetadataSpy).not.toHaveBeenCalled();
+    });
+
     it('should generate default title with timestamp', async () => {
       await plugin.onload();
 

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -1054,6 +1054,41 @@ describe('InputController - Message Queue', () => {
       expect(queryCall[0].mcpMentions).toBe(mcpMentions);
     });
 
+    it('should pass the selected model in runtime query options', async () => {
+      deps = createSendableDeps({
+        getAuxiliaryModel: () => 'opus',
+      });
+      (deps as any).mockAgentService.query = jest.fn().mockImplementation(() => createMockStream([{ type: 'done' }]));
+
+      inputEl = deps.getInputEl() as ReturnType<typeof createMockInputEl>;
+      inputEl.value = 'hello';
+      controller = new InputController(deps);
+
+      await controller.sendMessage();
+
+      const queryCall = ((deps as any).mockAgentService.query as jest.Mock).mock.calls[0];
+      expect(queryCall[2]).toEqual({ model: 'opus' });
+    });
+
+    it('should persist the selected model when title generation creates the first-send conversation', async () => {
+      deps = createSendableDeps({
+        getAuxiliaryModel: () => 'opus',
+      }, null);
+      (deps as any).mockAgentService.query = jest.fn().mockImplementation(() => createMockStream([{ type: 'done' }]));
+
+      inputEl = deps.getInputEl() as ReturnType<typeof createMockInputEl>;
+      inputEl.value = 'hello';
+      controller = new InputController(deps);
+
+      await controller.sendMessage();
+
+      expect(deps.plugin.createConversation).toHaveBeenCalledWith({
+        providerId: 'claude',
+        sessionId: undefined,
+        selectedModel: 'opus',
+      });
+    });
+
     it('should append browser selection context when available', async () => {
       const mockAgentService = createMockAgentService();
       const localDeps = createSendableDeps({

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -435,6 +435,7 @@ function createMockPlugin(overrides: Record<string, any> = {}): any {
     codexAgentMentionProvider,
     getConversationById: jest.fn().mockResolvedValue(null),
     getConversationSync: jest.fn().mockReturnValue(null),
+    updateConversation: jest.fn().mockResolvedValue(undefined),
     saveSettings: jest.fn().mockResolvedValue(undefined),
     getActiveEnvironmentVariables: jest.fn().mockReturnValue(''),
     ...overrides,
@@ -963,7 +964,7 @@ describe('Tab - Service Initialization', () => {
       expect(createTitleGenerationServiceSpy).not.toHaveBeenCalledWith(plugin, 'codex');
     });
 
-    it('surfaces provider-scoped model settings for inactive-provider tabs and saves back to that provider snapshot', async () => {
+    it('surfaces provider-scoped model settings for inactive-provider tabs and stores bound model changes on the conversation', async () => {
       const plugin = createMockPlugin({
         settings: {
           excludedTags: [],
@@ -1026,7 +1027,10 @@ describe('Tab - Service Initialization', () => {
         claude: 'claude-sonnet-4-5',
         codex: DEFAULT_CODEX_PRIMARY_MODEL,
       }));
-      expect(plugin.saveSettings).toHaveBeenCalled();
+      expect(plugin.updateConversation).toHaveBeenCalledWith('conv-codex-settings', {
+        selectedModel: DEFAULT_CODEX_PRIMARY_MODEL,
+      });
+      expect(plugin.saveSettings).not.toHaveBeenCalled();
     });
 
     it('maps shared permission mode selections onto managed OpenCode modes', async () => {
@@ -3580,7 +3584,10 @@ describe('Tab - Cross-Provider Model Rejection', () => {
     await toolbarCallbacks.onModelChange('opus');
 
     expect(Notice).not.toHaveBeenCalled();
-    expect(plugin.saveSettings).toHaveBeenCalled();
+    expect(plugin.updateConversation).toHaveBeenCalledWith('conv-1', {
+      selectedModel: 'opus',
+    });
+    expect(plugin.saveSettings).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/features/inline-edit/InlineEditService.test.ts
+++ b/tests/unit/features/inline-edit/InlineEditService.test.ts
@@ -413,6 +413,30 @@ describe('InlineEditService', () => {
       expect(options?.maxThinkingTokens).toBeUndefined();
     });
 
+    it('should use the model override when provided', async () => {
+      mockPlugin.settings.model = 'sonnet';
+      service = new InlineEditService(mockPlugin);
+      service.setModelOverride('opus');
+
+      setMockMessages([
+        { type: 'system', subtype: 'init', session_id: 'test-session' },
+        {
+          type: 'assistant',
+          message: { content: [{ type: 'text', text: '<replacement>fixed</replacement>' }] },
+        },
+        { type: 'result' },
+      ]);
+
+      await service.editText({
+        mode: 'selection',
+        selectedText: 'test',
+        instruction: 'fix',
+        notePath: 'test.md',
+      });
+
+      expect(getLastOptions()?.model).toBe('opus');
+    });
+
     it('should set adaptive thinking with effort for custom models', async () => {
       mockPlugin.settings.model = 'custom-model';
       mockPlugin.settings.thinkingBudget = 'medium';

--- a/tests/unit/features/inline-edit/ui/InlineEditModal.openAndWait.test.ts
+++ b/tests/unit/features/inline-edit/ui/InlineEditModal.openAndWait.test.ts
@@ -393,6 +393,120 @@ describe('InlineEditModal - openAndWait', () => {
     }
   });
 
+  it('passes the bound conversation model into inline edit services before runtime initialization', async () => {
+    const originalDocument = (global as any).document;
+    (global as any).document = {
+      body: createMockEl('body'),
+      createElement: (tagName: string) => createMockEl(tagName),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+
+    try {
+      const app = {
+        vault: {
+          getFiles: jest.fn().mockReturnValue([]),
+          getAllLoadedFiles: jest.fn().mockReturnValue([]),
+        },
+        workspace: {
+          getActiveViewOfType: jest.fn(),
+        },
+      } as any;
+      const inlineEditService = {
+        cancel: jest.fn(),
+        continueConversation: jest.fn(),
+        editText: jest.fn(),
+        resetConversation: jest.fn(),
+        setModelOverride: jest.fn(),
+      };
+      const providerSpy = jest
+        .spyOn(ProviderRegistry, 'createInlineEditService')
+        .mockReturnValue(inlineEditService as any);
+      const conversation = {
+        id: 'conv-1',
+        providerId: 'opencode',
+        selectedModel: 'opencode:anthropic/claude-sonnet-4',
+      };
+      const plugin = {
+        settings: {
+          hiddenProviderCommands: {
+            claude: [],
+            opencode: [],
+          },
+        },
+        getConversationSync: jest.fn().mockReturnValue(conversation),
+        getView: jest.fn().mockReturnValue({
+          getActiveTab: jest.fn().mockReturnValue({
+            conversationId: 'conv-1',
+            draftModel: null,
+            providerId: 'opencode',
+            service: null,
+          }),
+        }),
+      } as any;
+      const editor = {} as any;
+      const view = { editor } as any;
+
+      let widgetRef: any = null;
+      const dispatch = jest.fn((transaction: any) => {
+        const effects = Array.isArray(transaction?.effects)
+          ? transaction.effects
+          : transaction?.effects
+            ? [transaction.effects]
+            : [];
+        for (const effect of effects) {
+          const widget = effect?.value?.widget;
+          if (widget && typeof widget.createInputDOM === 'function') {
+            widgetRef = widget;
+            widget.createInputDOM();
+          }
+        }
+      });
+      const editorView = {
+        state: {
+          doc: {
+            line: jest.fn(() => ({ from: 0 })),
+            lineAt: jest.fn(() => ({ from: 0 })),
+          },
+        },
+        dispatch,
+        dom: {
+          ownerDocument: (global as any).document,
+          addEventListener: jest.fn(),
+          removeEventListener: jest.fn(),
+        },
+      } as any;
+
+      const getEditorViewSpy = jest
+        .spyOn(editorUtils, 'getEditorView')
+        .mockReturnValue(editorView);
+
+      const editContext: InlineEditContext = {
+        mode: 'cursor',
+        cursorContext: {
+          beforeCursor: '',
+          afterCursor: '',
+          isInbetween: true,
+          line: 0,
+          column: 0,
+        },
+      };
+
+      const modal = new InlineEditModal(app, plugin, editor, view, editContext, 'note.md');
+      const resultPromise = modal.openAndWait();
+
+      expect(providerSpy).toHaveBeenCalledWith(plugin, 'opencode');
+      expect(inlineEditService.setModelOverride).toHaveBeenCalledWith('opencode:anthropic/claude-sonnet-4');
+
+      widgetRef.reject();
+      await expect(resultPromise).resolves.toEqual({ decision: 'reject' });
+      getEditorViewSpy.mockRestore();
+      providerSpy.mockRestore();
+    } finally {
+      (global as any).document = originalDocument;
+    }
+  });
+
   it('shows a single notice and degrades gracefully when getFiles throws', async () => {
     const originalDocument = (global as any).document;
     (global as any).document = {

--- a/tests/unit/providers/claude/runtime/ClaudianService.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudianService.test.ts
@@ -15,6 +15,7 @@ const sdkMock = sdkModule as unknown as {
   setMockMessages: (messages: any[], options?: { appendResult?: boolean }) => void;
   resetMockMessages: () => void;
   simulateCrash: (afterChunks?: number) => void;
+  getLastOptions: () => { model?: string } | undefined;
   query: typeof sdkModule.query;
 };
 
@@ -233,6 +234,17 @@ describe('ClaudianService', () => {
 
       expect(result).toBe(true);
       expect(startPersistentQuerySpy).toHaveBeenCalled();
+    });
+
+    it('should use the synced conversation model when starting a persistent query', async () => {
+      service.syncConversationState({
+        sessionId: null,
+        selectedModel: 'claude-3-opus',
+      });
+
+      await service.ensureReady();
+
+      expect(sdkMock.getLastOptions()?.model).toBe('claude-3-opus');
     });
 
     it('should return false (no-op) when config unchanged and query running', async () => {


### PR DESCRIPTION
Stores the selected chat model in conversation session metadata and scopes tab/runtime model resolution to that conversation instead of global provider settings. Preserves first-send draft models, fork inheritance, custom model ids, and lazy migration from legacy usage metadata without defaulting unknown legacy sessions. Updates Claude, Codex, OpenCode, and Pi runtimes to consume the scoped model. Tests: npm run typecheck -- --pretty false; npm run test -- --runInBand.