### PR TITLE
feat: add octo-agent provider integration

### DIFF
--- a/src/core/providers/modelSelection.ts
+++ b/src/core/providers/modelSelection.ts
@@ -5,6 +5,7 @@ const PROVIDER_MODEL_SELECTION_PREFIXES: Partial<Record<ProviderId, string>> = {
   codex: 'openai-codex/',
   opencode: 'opencode/',
   pi: 'pi/',
+  'octo-agent': 'octo-agent/',
 };
 
 export interface ProviderModelSelection {

--- a/src/core/runtime/ChatRuntime.ts
+++ b/src/core/runtime/ChatRuntime.ts
@@ -63,4 +63,5 @@ export interface ChatRuntime {
 
   loadSubagentToolCalls?(agentId: string): Promise<ToolCallInfo[]>;
   loadSubagentFinalResult?(agentId: string): Promise<string | null>;
+  loadHistory?(): Promise<ChatMessage[]>;
 }

--- a/src/core/runtime/ChatRuntime.ts
+++ b/src/core/runtime/ChatRuntime.ts
@@ -50,6 +50,7 @@ export interface ChatRuntime {
   setAskUserQuestionCallback(callback: AskUserQuestionCallback | null): void;
   setExitPlanModeCallback(callback: ExitPlanModeCallback | null): void;
   setPermissionModeSyncCallback(callback: ((sdkMode: string) => void) | null): void;
+  setPermissionMode?(mode: string): Promise<void>;
   setSubagentHookProvider(getState: () => SubagentRuntimeState): void;
   setAutoTurnCallback(callback: AutoTurnCallback | null): void;
   consumeTurnMetadata(): ChatTurnMetadata;

--- a/src/core/runtime/ChatRuntime.ts
+++ b/src/core/runtime/ChatRuntime.ts
@@ -51,6 +51,7 @@ export interface ChatRuntime {
   setExitPlanModeCallback(callback: ExitPlanModeCallback | null): void;
   setPermissionModeSyncCallback(callback: ((sdkMode: string) => void) | null): void;
   setPermissionMode?(mode: string): Promise<void>;
+  renameSession?(title: string): Promise<void>;
   setSubagentHookProvider(getState: () => SubagentRuntimeState): void;
   setAutoTurnCallback(callback: AutoTurnCallback | null): void;
   consumeTurnMetadata(): ChatTurnMetadata;

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -457,6 +457,18 @@ export class ConversationController {
 
     await plugin.updateConversation(state.currentConversationId!, updates);
     state.hasPendingConversationSave = false;
+
+    // Sync the final conversation title to the provider session when supported.
+    // Title generation runs before query() and therefore before the session id
+    // exists; this is the earliest point where the session id is guaranteed to be
+    // persisted.
+    if (conversation?.title) {
+      try {
+        await agentService?.renameSession?.(conversation.title);
+      } catch (error) {
+        console.error('Failed to sync conversation title to provider session:', error);
+      }
+    }
   }
 
   /**

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -919,6 +919,19 @@ export class ConversationController {
       try {
         const newTitle = input.value.trim() || currentTitle;
         await this.deps.plugin.renameConversation(convId, newTitle);
+
+        const conversation = this.deps.plugin.getConversationSync(convId);
+        if (conversation?.providerId === 'octo-agent' && conversation.sessionId) {
+          const agentService = this.deps.getAgentService?.();
+          if (agentService && typeof agentService.renameSession === 'function') {
+            try {
+              await agentService.renameSession(newTitle);
+            } catch (error) {
+              console.error('Failed to sync renamed title to octo-agent:', error);
+            }
+          }
+        }
+
         this.updateHistoryDropdown();
       } catch {
         new Notice('Failed to rename conversation');

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -237,7 +237,7 @@ export class ConversationController {
     }
 
     await this.deps.ensureServiceForConversation?.(conversation);
-    this.restoreConversation(conversation, { autoAttachFile: true });
+    await this.restoreConversation(conversation, { autoAttachFile: true });
     this.updateWelcomeVisibility();
 
     this.callbacks.onConversationLoaded?.();
@@ -271,7 +271,7 @@ export class ConversationController {
       this.deps.getInputEl().value = '';
       this.deps.clearQueuedMessage();
 
-      this.restoreConversation(conversation);
+      await this.restoreConversation(conversation);
 
       this.deps.getHistoryDropdown()?.removeClass('visible');
       this.updateWelcomeVisibility();
@@ -462,10 +462,10 @@ export class ConversationController {
    * Shared logic for restoring a conversation into the current tab.
    * Used by both loadActive() and switchTo() to avoid duplication.
    */
-  private restoreConversation(
+  private async restoreConversation(
     conversation: Conversation,
     options?: { autoAttachFile?: boolean }
-  ): void {
+  ): Promise<void> {
     const { plugin, state, renderer } = this.deps;
 
     state.currentConversationId = conversation.id;
@@ -510,6 +510,16 @@ export class ConversationController {
       () => this.getGreeting()
     );
     this.deps.setWelcomeEl(welcomeEl);
+
+    if (state.messages.length === 0 && conversation.sessionId) {
+      const agentService = this.getAgentService();
+      const serverMessages = await agentService?.loadHistory?.();
+      if (serverMessages && serverMessages.length > 0) {
+        state.messages = serverMessages;
+        renderer.renderMessages(state.messages, () => this.getGreeting());
+        void plugin.updateConversation(conversation.id, { messages: state.messages });
+      }
+    }
   }
 
   /**

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -50,6 +50,7 @@ export interface ConversationControllerDeps {
   getAgentService?: () => ChatRuntime | null;
   getSelectedModel?: () => string | null;
   ensureServiceForConversation?: (conversation: Conversation | null) => Promise<void>;
+  ensureServiceInitialized?: () => Promise<boolean>;
   dismissPendingInlinePrompts?: () => void;
 }
 
@@ -247,7 +248,7 @@ export class ConversationController {
   async switchTo(id: string): Promise<void> {
     const { plugin, state, subagentManager } = this.deps;
 
-    if (id === state.currentConversationId) return;
+    if (id === state.currentConversationId && state.messages.length > 0) return;
     if (state.isStreaming) return;
     if (state.isSwitchingConversation) return;
     if (state.isCreatingConversation) return;
@@ -512,7 +513,11 @@ export class ConversationController {
     this.deps.setWelcomeEl(welcomeEl);
 
     if (state.messages.length === 0 && conversation.sessionId) {
-      const agentService = this.getAgentService();
+      let agentService = this.getAgentService();
+      if (!agentService) {
+        await this.deps.ensureServiceInitialized?.();
+        agentService = this.getAgentService();
+      }
       const serverMessages = await agentService?.loadHistory?.();
       if (serverMessages && serverMessages.length > 0) {
         state.messages = serverMessages;

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -1002,6 +1002,11 @@ function initializeInputToolbar(
           settings.permissionMode = mode;
         }
       });
+      try {
+        await tab.service?.setPermissionMode?.(mode);
+      } catch (error) {
+        console.error('Failed to sync permission mode to runtime:', error);
+      }
       tab.ui.permissionToggle?.updateDisplay();
       dom.inputWrapper.toggleClass(
         'claudian-input-plan-mode',

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -1390,6 +1390,31 @@ export function initializeTabControllers(
     }
   );
 
+  const ensureServiceInitialized = async (): Promise<boolean> => {
+    if (tab.serviceInitialized && tab.lifecycleState === 'bound_active') {
+      return true;
+    }
+
+    try {
+      // For blank tabs on first send: derive provider from draft model
+      if (tab.lifecycleState === 'blank' && tab.draftModel) {
+        const derivedProvider = getEnabledProviderForModel(tab.draftModel, plugin.settings);
+        tab.providerId = derivedProvider;
+      }
+
+      await initializeTabService(tab, plugin);
+      setupServiceCallbacks(tab, plugin);
+
+      // Transition: lock model selector to bound provider
+      refreshTabProviderUI(tab, plugin);
+      applyProviderUIGating(tab, plugin);
+      return true;
+    } catch (error) {
+      new Notice(error instanceof Error ? error.message : 'Failed to initialize chat service');
+      return false;
+    }
+  };
+
   tab.controllers.conversationController = new ConversationController(
     {
       plugin,
@@ -1438,6 +1463,7 @@ export function initializeTabControllers(
         refreshTabProviderUI(tab, plugin);
         applyProviderUIGating(tab, plugin);
       },
+      ensureServiceInitialized,
     },
     {
       onNewConversation: () => {
@@ -1490,33 +1516,7 @@ export function initializeTabControllers(
     getAgentService: () => tab.service,
     getSubagentManager: () => services.subagentManager,
     getTabProviderId: () => getTabProviderId(tab, plugin),
-    ensureServiceInitialized: async () => {
-      if (tab.serviceInitialized && tab.lifecycleState === 'bound_active') {
-        return true;
-      }
-
-      try {
-        // For blank tabs on first send: derive provider from draft model
-        if (tab.lifecycleState === 'blank' && tab.draftModel) {
-          const derivedProvider = getEnabledProviderForModel(
-            tab.draftModel,
-            plugin.settings,
-          );
-          tab.providerId = derivedProvider;
-        }
-
-        await initializeTabService(tab, plugin);
-        setupServiceCallbacks(tab, plugin);
-
-        // Transition: lock model selector to bound provider
-        refreshTabProviderUI(tab, plugin);
-        applyProviderUIGating(tab, plugin);
-        return true;
-      } catch (error) {
-        new Notice(error instanceof Error ? error.message : 'Failed to initialize chat service');
-        return false;
-      }
-    },
+    ensureServiceInitialized,
     openConversation,
     onForkAll: forkRequestCallback
       ? () => handleForkAll(tab, plugin, forkRequestCallback)

--- a/src/providers/defaultProviderConfigs.ts
+++ b/src/providers/defaultProviderConfigs.ts
@@ -1,6 +1,7 @@
 import type { ProviderConfigMap } from '../core/types/settings';
 import { DEFAULT_CLAUDE_PROVIDER_SETTINGS } from './claude/settings';
 import { DEFAULT_CODEX_PROVIDER_CONFIG } from './codex/settings';
+import { DEFAULT_OCTO_AGENT_PROVIDER_SETTINGS } from './octo-agent/settings';
 import { DEFAULT_OPENCODE_PROVIDER_SETTINGS } from './opencode/settings';
 import { DEFAULT_PI_PROVIDER_SETTINGS } from './pi/settings';
 
@@ -10,5 +11,6 @@ export function getBuiltInProviderDefaultConfigs(): ProviderConfigMap {
     codex: { ...DEFAULT_CODEX_PROVIDER_CONFIG },
     opencode: { ...DEFAULT_OPENCODE_PROVIDER_SETTINGS },
     pi: { ...DEFAULT_PI_PROVIDER_SETTINGS },
+    'octo-agent': { ...DEFAULT_OCTO_AGENT_PROVIDER_SETTINGS },
   };
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -4,6 +4,8 @@ import { claudeWorkspaceRegistration } from './claude/app/ClaudeWorkspaceService
 import { claudeProviderRegistration } from './claude/registration';
 import { codexWorkspaceRegistration } from './codex/app/CodexWorkspaceServices';
 import { codexProviderRegistration } from './codex/registration';
+import { octoAgentWorkspaceRegistration } from './octo-agent/app/OctoAgentWorkspaceServices';
+import { octoAgentProviderRegistration } from './octo-agent/registration';
 import { opencodeWorkspaceRegistration } from './opencode/app/OpencodeWorkspaceServices';
 import { opencodeProviderRegistration } from './opencode/registration';
 import { piWorkspaceRegistration } from './pi/app/PiWorkspaceServices';
@@ -20,10 +22,12 @@ export function registerBuiltInProviders(): void {
   ProviderRegistry.register('codex', codexProviderRegistration);
   ProviderRegistry.register('opencode', opencodeProviderRegistration);
   ProviderRegistry.register('pi', piProviderRegistration);
+  ProviderRegistry.register('octo-agent', octoAgentProviderRegistration);
   ProviderWorkspaceRegistry.register('claude', claudeWorkspaceRegistration);
   ProviderWorkspaceRegistry.register('codex', codexWorkspaceRegistration);
   ProviderWorkspaceRegistry.register('opencode', opencodeWorkspaceRegistration);
   ProviderWorkspaceRegistry.register('pi', piWorkspaceRegistration);
+  ProviderWorkspaceRegistry.register('octo-agent', octoAgentWorkspaceRegistration);
   builtInProvidersRegistered = true;
 }
 

--- a/src/providers/octo-agent/app/OctoAgentWorkspaceServices.ts
+++ b/src/providers/octo-agent/app/OctoAgentWorkspaceServices.ts
@@ -1,0 +1,26 @@
+import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
+import type {
+  ProviderWorkspaceRegistration,
+  ProviderWorkspaceServices,
+} from '../../../core/providers/types';
+import { octoAgentSettingsTabRenderer } from '../ui/OctoAgentSettingsTab';
+
+export type OctoAgentWorkspaceServices = ProviderWorkspaceServices;
+
+export async function createOctoAgentWorkspaceServices(): Promise<OctoAgentWorkspaceServices> {
+  return {
+    settingsTabRenderer: octoAgentSettingsTabRenderer,
+  };
+}
+
+export const octoAgentWorkspaceRegistration: ProviderWorkspaceRegistration<OctoAgentWorkspaceServices> = {
+  initialize: async () => createOctoAgentWorkspaceServices(),
+};
+
+export function maybeGetOctoAgentWorkspaceServices(): OctoAgentWorkspaceServices | null {
+  return ProviderWorkspaceRegistry.getServices('octo-agent') as OctoAgentWorkspaceServices | null;
+}
+
+export function getOctoAgentWorkspaceServices(): OctoAgentWorkspaceServices {
+  return ProviderWorkspaceRegistry.requireServices('octo-agent') as OctoAgentWorkspaceServices;
+}

--- a/src/providers/octo-agent/auxiliary/OctoAgentInlineEditService.ts
+++ b/src/providers/octo-agent/auxiliary/OctoAgentInlineEditService.ts
@@ -1,32 +1,83 @@
-import type {
-  InlineEditRequest,
-  InlineEditResult,
-  InlineEditService,
-} from '../../../core/providers/types';
+import { buildInlineEditPrompt, getInlineEditSystemPrompt, parseInlineEditResponse } from '../../../core/prompt/inlineEdit';
+import type { InlineEditRequest, InlineEditResult, InlineEditService } from '../../../core/providers/types';
 import type ClaudianPlugin from '../../../main';
+import { appendContextFiles } from '../../../utils/context';
+import { runOctoAgentAuxQuery } from '../runtime/OctoAgentAuxQueryRunner';
 
 export class OctoAgentInlineEditService implements InlineEditService {
-  constructor(_plugin: ClaudianPlugin) {}
+  private plugin: ClaudianPlugin;
+  private abortController: AbortController | null = null;
+  private modelOverride: string | undefined;
+  private sessionId: string | null = null;
 
-  setModelOverride(): void {}
-  resetConversation(): void {}
+  constructor(plugin: ClaudianPlugin) {
+    this.plugin = plugin;
+  }
 
-  async editText(_request: InlineEditRequest): Promise<InlineEditResult> {
-    return {
-      clarification: 'Inline editing is not yet supported by Octo Agent.',
-      success: false,
-    };
+  setModelOverride(model?: string): void {
+    const trimmed = model?.trim();
+    this.modelOverride = trimmed ? trimmed : undefined;
+  }
+
+  resetConversation(): void {
+    this.sessionId = null;
+  }
+
+  async editText(request: InlineEditRequest): Promise<InlineEditResult> {
+    this.sessionId = null;
+    const prompt = buildInlineEditPrompt(request);
+    return this.sendMessage(prompt);
   }
 
   async continueConversation(
-    _message: string,
-    _contextFiles?: string[],
+    message: string,
+    contextFiles?: string[],
   ): Promise<InlineEditResult> {
-    return {
-      clarification: 'Inline editing is not yet supported by Octo Agent.',
-      success: false,
-    };
+    if (!this.sessionId) {
+      return { success: false, error: 'No active conversation to continue' };
+    }
+    let prompt = message;
+    if (contextFiles && contextFiles.length > 0) {
+      prompt = appendContextFiles(message, contextFiles);
+    }
+    return this.sendMessage(prompt, this.sessionId);
   }
 
-  cancel(): void {}
+  cancel(): void {
+    if (this.abortController) {
+      this.abortController.abort();
+      this.abortController = null;
+    }
+  }
+
+  private async sendMessage(
+    prompt: string,
+    resumeSessionId?: string,
+  ): Promise<InlineEditResult> {
+    this.abortController = new AbortController();
+
+    try {
+      const result = await runOctoAgentAuxQuery(
+        this.plugin,
+        {
+          abortController: this.abortController,
+          model: this.modelOverride,
+          permissionMode: 'interactive',
+          resumeSessionId,
+          source: 'claudian-inline-edit',
+          systemPrompt: getInlineEditSystemPrompt(),
+        },
+        prompt,
+      );
+      this.sessionId = result.sessionId;
+      return parseInlineEditResponse(result.text);
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    } finally {
+      this.abortController = null;
+    }
+  }
 }

--- a/src/providers/octo-agent/auxiliary/OctoAgentInlineEditService.ts
+++ b/src/providers/octo-agent/auxiliary/OctoAgentInlineEditService.ts
@@ -1,0 +1,32 @@
+import type {
+  InlineEditRequest,
+  InlineEditResult,
+  InlineEditService,
+} from '../../../core/providers/types';
+import type ClaudianPlugin from '../../../main';
+
+export class OctoAgentInlineEditService implements InlineEditService {
+  constructor(_plugin: ClaudianPlugin) {}
+
+  setModelOverride(): void {}
+  resetConversation(): void {}
+
+  async editText(_request: InlineEditRequest): Promise<InlineEditResult> {
+    return {
+      clarification: 'Inline editing is not yet supported by Octo Agent.',
+      success: false,
+    };
+  }
+
+  async continueConversation(
+    _message: string,
+    _contextFiles?: string[],
+  ): Promise<InlineEditResult> {
+    return {
+      clarification: 'Inline editing is not yet supported by Octo Agent.',
+      success: false,
+    };
+  }
+
+  cancel(): void {}
+}

--- a/src/providers/octo-agent/auxiliary/OctoAgentInstructionRefineService.ts
+++ b/src/providers/octo-agent/auxiliary/OctoAgentInstructionRefineService.ts
@@ -1,33 +1,100 @@
-import type { InstructionRefineService,RefineProgressCallback } from '../../../core/providers/types';
+import { buildRefineSystemPrompt } from '../../../core/prompt/instructionRefine';
+import type {
+  InstructionRefineService,
+  RefineProgressCallback,
+} from '../../../core/providers/types';
 import type { InstructionRefineResult } from '../../../core/types';
 import type ClaudianPlugin from '../../../main';
+import {
+  runOctoAgentAuxQuery,
+} from '../runtime/OctoAgentAuxQueryRunner';
 
 export class OctoAgentInstructionRefineService implements InstructionRefineService {
-  constructor(_plugin: ClaudianPlugin) {}
+  private plugin: ClaudianPlugin;
+  private abortController: AbortController | null = null;
+  private sessionId: string | null = null;
+  private existingInstructions = '';
 
-  setModelOverride(): void {}
-  resetConversation(): void {}
+  constructor(plugin: ClaudianPlugin) {
+    this.plugin = plugin;
+  }
+
+  resetConversation(): void {
+    this.sessionId = null;
+  }
 
   async refineInstruction(
     rawInstruction: string,
-    _existingInstructions: string,
-    _onProgress?: RefineProgressCallback,
+    existingInstructions: string,
+    onProgress?: RefineProgressCallback,
   ): Promise<InstructionRefineResult> {
-    return {
-      error: 'Instruction refinement is not yet supported by Octo Agent.',
-      success: false,
-    };
+    this.sessionId = null;
+    this.existingInstructions = existingInstructions;
+    const prompt = `Please refine this instruction: "${rawInstruction}"`;
+    return this.sendMessage(prompt, onProgress);
   }
 
   async continueConversation(
-    _message: string,
-    _onProgress?: RefineProgressCallback,
+    message: string,
+    onProgress?: RefineProgressCallback,
   ): Promise<InstructionRefineResult> {
-    return {
-      error: 'Instruction refinement is not yet supported by Octo Agent.',
-      success: false,
-    };
+    if (!this.sessionId) {
+      return { success: false, error: 'No active conversation to continue' };
+    }
+    return this.sendMessage(message, onProgress, this.sessionId);
   }
 
-  cancel(): void {}
+  cancel(): void {
+    if (this.abortController) {
+      this.abortController.abort();
+      this.abortController = null;
+    }
+  }
+
+  private async sendMessage(
+    prompt: string,
+    onProgress?: RefineProgressCallback,
+    resumeSessionId?: string,
+  ): Promise<InstructionRefineResult> {
+    this.abortController = new AbortController();
+
+    try {
+      const result = await runOctoAgentAuxQuery(
+        this.plugin,
+        {
+          abortController: this.abortController,
+          permissionMode: 'interactive',
+          resumeSessionId,
+          source: 'claudian-instruction-refine',
+          systemPrompt: buildRefineSystemPrompt(this.existingInstructions),
+        },
+        prompt,
+      );
+      this.sessionId = result.sessionId;
+      const parsed = this.parseResponse(result.text);
+      onProgress?.(parsed);
+      return parsed;
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    } finally {
+      this.abortController = null;
+    }
+  }
+
+  private parseResponse(responseText: string): InstructionRefineResult {
+    const instructionMatch = responseText.match(/\u003cinstruction\u003e([\s\S]*?)\u003c\/instruction\u003e/);
+    if (instructionMatch) {
+      return { success: true, refinedInstruction: instructionMatch[1].trim() };
+    }
+
+    const trimmed = responseText.trim();
+    if (trimmed) {
+      return { success: true, clarification: trimmed };
+    }
+
+    return { success: false, error: 'Empty response' };
+  }
 }

--- a/src/providers/octo-agent/auxiliary/OctoAgentInstructionRefineService.ts
+++ b/src/providers/octo-agent/auxiliary/OctoAgentInstructionRefineService.ts
@@ -1,0 +1,33 @@
+import type { InstructionRefineService,RefineProgressCallback } from '../../../core/providers/types';
+import type { InstructionRefineResult } from '../../../core/types';
+import type ClaudianPlugin from '../../../main';
+
+export class OctoAgentInstructionRefineService implements InstructionRefineService {
+  constructor(_plugin: ClaudianPlugin) {}
+
+  setModelOverride(): void {}
+  resetConversation(): void {}
+
+  async refineInstruction(
+    rawInstruction: string,
+    _existingInstructions: string,
+    _onProgress?: RefineProgressCallback,
+  ): Promise<InstructionRefineResult> {
+    return {
+      error: 'Instruction refinement is not yet supported by Octo Agent.',
+      success: false,
+    };
+  }
+
+  async continueConversation(
+    _message: string,
+    _onProgress?: RefineProgressCallback,
+  ): Promise<InstructionRefineResult> {
+    return {
+      error: 'Instruction refinement is not yet supported by Octo Agent.',
+      success: false,
+    };
+  }
+
+  cancel(): void {}
+}

--- a/src/providers/octo-agent/auxiliary/OctoAgentTaskResultInterpreter.ts
+++ b/src/providers/octo-agent/auxiliary/OctoAgentTaskResultInterpreter.ts
@@ -1,0 +1,29 @@
+import type {
+  ProviderTaskResultInterpreter,
+  ProviderTaskTerminalStatus,
+} from '../../../core/providers/types';
+
+export class OctoAgentTaskResultInterpreter implements ProviderTaskResultInterpreter {
+  hasAsyncLaunchMarker(_toolUseResult: unknown): boolean {
+    return false;
+  }
+
+  extractAgentId(_toolUseResult: unknown): string | null {
+    return null;
+  }
+
+  extractStructuredResult(_toolUseResult: unknown): string | null {
+    return null;
+  }
+
+  resolveTerminalStatus(
+    _toolUseResult: unknown,
+    fallbackStatus: ProviderTaskTerminalStatus,
+  ): ProviderTaskTerminalStatus {
+    return fallbackStatus;
+  }
+
+  extractTagValue(_payload: string, _tagName: string): string | null {
+    return null;
+  }
+}

--- a/src/providers/octo-agent/auxiliary/OctoAgentTitleGenerationService.ts
+++ b/src/providers/octo-agent/auxiliary/OctoAgentTitleGenerationService.ts
@@ -4,9 +4,11 @@ import type {
   TitleGenerationService,
 } from '../../../core/providers/types';
 import type ClaudianPlugin from '../../../main';
+import { OctoAgentClient } from '../runtime/OctoAgentClient';
+import { getOctoAgentProviderSettings } from '../settings';
 
 export class OctoAgentTitleGenerationService implements TitleGenerationService {
-  constructor(_plugin: ClaudianPlugin) {}
+  constructor(private readonly plugin: ClaudianPlugin) {}
 
   async generateTitle(
     conversationId: string,
@@ -18,7 +20,30 @@ export class OctoAgentTitleGenerationService implements TitleGenerationService {
     const result: TitleGenerationResult = title
       ? { success: true, title }
       : { success: false, error: 'Empty user message' };
+
+    if (result.success) {
+      await this.syncTitleToOctoAgent(conversationId, result.title);
+    }
+
     await callback(conversationId, result);
+  }
+
+  private async syncTitleToOctoAgent(conversationId: string, title: string): Promise<void> {
+    try {
+      const conversation = await this.plugin.getConversationById(conversationId);
+      if (!conversation || conversation.providerId !== 'octo-agent' || !conversation.sessionId) {
+        return;
+      }
+
+      const settings = getOctoAgentProviderSettings(this.plugin.settings as unknown as Record<string, unknown>);
+      const client = new OctoAgentClient({
+        baseUrl: `http://${settings.host}:${settings.port}`,
+        accessKey: settings.accessKey || undefined,
+      });
+      await client.renameSession(conversation.sessionId, title);
+    } catch (error) {
+      console.error('Failed to sync title to octo-agent:', error);
+    }
   }
 
   cancel(): void {

--- a/src/providers/octo-agent/auxiliary/OctoAgentTitleGenerationService.ts
+++ b/src/providers/octo-agent/auxiliary/OctoAgentTitleGenerationService.ts
@@ -4,8 +4,6 @@ import type {
   TitleGenerationService,
 } from '../../../core/providers/types';
 import type ClaudianPlugin from '../../../main';
-import { OctoAgentClient } from '../runtime/OctoAgentClient';
-import { getOctoAgentProviderSettings } from '../settings';
 
 export class OctoAgentTitleGenerationService implements TitleGenerationService {
   constructor(private readonly plugin: ClaudianPlugin) {}
@@ -22,45 +20,8 @@ export class OctoAgentTitleGenerationService implements TitleGenerationService {
       : { success: false, error: 'Empty user message' };
 
     await callback(conversationId, result);
-
-    // Sync after the callback has applied the title locally. At this point the
-    // octo-agent session id has been persisted by the runtime's buildSessionUpdates.
-    if (result.success) {
-      await this.syncTitleToOctoAgent(conversationId, result.title);
-    }
-  }
-
-  private async syncTitleToOctoAgent(conversationId: string, title: string): Promise<void> {
-    try {
-      const conversation = await this.plugin.getConversationById(conversationId);
-      if (!conversation || conversation.providerId !== 'octo-agent') {
-        return;
-      }
-
-      // Only sync if the generated title was actually applied locally. If the
-      // user manually renamed the conversation in the meantime, leave octo
-      // with whatever the local title will be (the manual rename path is
-      // responsible for syncing that change).
-      if (conversation.title !== title) {
-        return;
-      }
-
-      const sessionId =
-        conversation.sessionId
-        ?? ((conversation.providerState as Record<string, unknown> | undefined)?.sessionId as string | undefined);
-      if (!sessionId) {
-        return;
-      }
-
-      const settings = getOctoAgentProviderSettings(this.plugin.settings as unknown as Record<string, unknown>);
-      const client = new OctoAgentClient({
-        baseUrl: `http://${settings.host}:${settings.port}`,
-        accessKey: settings.accessKey || undefined,
-      });
-      await client.renameSession(sessionId, title);
-    } catch (error) {
-      console.error('Failed to sync title to octo-agent:', error);
-    }
+    // Title sync to octo-agent is handled in ConversationController.save after
+    // the session id has been persisted by the runtime.
   }
 
   cancel(): void {

--- a/src/providers/octo-agent/auxiliary/OctoAgentTitleGenerationService.ts
+++ b/src/providers/octo-agent/auxiliary/OctoAgentTitleGenerationService.ts
@@ -1,0 +1,27 @@
+import type {
+  TitleGenerationCallback,
+  TitleGenerationResult,
+  TitleGenerationService,
+} from '../../../core/providers/types';
+import type ClaudianPlugin from '../../../main';
+
+export class OctoAgentTitleGenerationService implements TitleGenerationService {
+  constructor(_plugin: ClaudianPlugin) {}
+
+  async generateTitle(
+    conversationId: string,
+    userMessage: string,
+    callback: TitleGenerationCallback,
+  ): Promise<void> {
+    const trimmed = userMessage.trim();
+    const title = trimmed.length > 40 ? `${trimmed.slice(0, 37).trimEnd()}...` : trimmed;
+    const result: TitleGenerationResult = title
+      ? { success: true, title }
+      : { success: false, error: 'Empty user message' };
+    await callback(conversationId, result);
+  }
+
+  cancel(): void {
+    // No-op.
+  }
+}

--- a/src/providers/octo-agent/auxiliary/OctoAgentTitleGenerationService.ts
+++ b/src/providers/octo-agent/auxiliary/OctoAgentTitleGenerationService.ts
@@ -21,17 +21,34 @@ export class OctoAgentTitleGenerationService implements TitleGenerationService {
       ? { success: true, title }
       : { success: false, error: 'Empty user message' };
 
+    await callback(conversationId, result);
+
+    // Sync after the callback has applied the title locally. At this point the
+    // octo-agent session id has been persisted by the runtime's buildSessionUpdates.
     if (result.success) {
       await this.syncTitleToOctoAgent(conversationId, result.title);
     }
-
-    await callback(conversationId, result);
   }
 
   private async syncTitleToOctoAgent(conversationId: string, title: string): Promise<void> {
     try {
       const conversation = await this.plugin.getConversationById(conversationId);
-      if (!conversation || conversation.providerId !== 'octo-agent' || !conversation.sessionId) {
+      if (!conversation || conversation.providerId !== 'octo-agent') {
+        return;
+      }
+
+      // Only sync if the generated title was actually applied locally. If the
+      // user manually renamed the conversation in the meantime, leave octo
+      // with whatever the local title will be (the manual rename path is
+      // responsible for syncing that change).
+      if (conversation.title !== title) {
+        return;
+      }
+
+      const sessionId =
+        conversation.sessionId
+        ?? ((conversation.providerState as Record<string, unknown> | undefined)?.sessionId as string | undefined);
+      if (!sessionId) {
         return;
       }
 
@@ -40,7 +57,7 @@ export class OctoAgentTitleGenerationService implements TitleGenerationService {
         baseUrl: `http://${settings.host}:${settings.port}`,
         accessKey: settings.accessKey || undefined,
       });
-      await client.renameSession(conversation.sessionId, title);
+      await client.renameSession(sessionId, title);
     } catch (error) {
       console.error('Failed to sync title to octo-agent:', error);
     }

--- a/src/providers/octo-agent/capabilities.ts
+++ b/src/providers/octo-agent/capabilities.ts
@@ -1,0 +1,16 @@
+import type { ProviderCapabilities } from '../../core/providers/types';
+
+export const OCTO_AGENT_PROVIDER_CAPABILITIES: Readonly<ProviderCapabilities> = Object.freeze({
+  providerId: 'octo-agent',
+  reasoningControl: 'effort',
+  supportsFork: true,
+  supportsImageAttachments: false,
+  supportsInstructionMode: true,
+  supportsMcpTools: false,
+  supportsPersistentRuntime: true,
+  supportsPlanMode: false,
+  supportsProviderCommands: false,
+  supportsRewind: false,
+  supportsNativeHistory: true,
+  supportsTurnSteer: false,
+});

--- a/src/providers/octo-agent/capabilities.ts
+++ b/src/providers/octo-agent/capabilities.ts
@@ -4,7 +4,7 @@ export const OCTO_AGENT_PROVIDER_CAPABILITIES: Readonly<ProviderCapabilities> = 
   providerId: 'octo-agent',
   reasoningControl: 'effort',
   supportsFork: true,
-  supportsImageAttachments: false,
+  supportsImageAttachments: true,
   supportsInstructionMode: true,
   supportsMcpTools: false,
   supportsPersistentRuntime: true,

--- a/src/providers/octo-agent/env/OctoAgentSettingsReconciler.ts
+++ b/src/providers/octo-agent/env/OctoAgentSettingsReconciler.ts
@@ -1,0 +1,39 @@
+import type { ProviderSettingsReconciler } from '../../../core/providers/types';
+import type { Conversation } from '../../../core/types';
+import { getOctoAgentProviderSettings } from '../settings';
+
+export const octoAgentSettingsReconciler: ProviderSettingsReconciler = {
+  handleEnvironmentChange(): boolean {
+    return false;
+  },
+
+  reconcileModelWithEnvironment(
+    settings: Record<string, unknown>,
+    conversations: Conversation[],
+  ): { changed: boolean; invalidatedConversations: Conversation[] } {
+    const octoSettings = getOctoAgentProviderSettings(settings);
+    const invalidatedConversations: Conversation[] = [];
+
+    if (!octoSettings.enabled) {
+      for (const conversation of conversations) {
+        if (conversation.providerId === 'octo-agent' && conversation.sessionId) {
+          conversation.sessionId = null;
+          conversation.providerState = undefined;
+          invalidatedConversations.push(conversation);
+        }
+      }
+      return { changed: invalidatedConversations.length > 0, invalidatedConversations };
+    }
+
+    return { changed: false, invalidatedConversations };
+  },
+
+  normalizeModelVariantSettings(settings: Record<string, unknown>): boolean {
+    const model = typeof settings.model === 'string' ? settings.model : '';
+    if (!model || model === 'octo-agent' || model.startsWith('octo-agent/')) {
+      return false;
+    }
+    // The current model does not belong to octo-agent; do not touch it.
+    return false;
+  },
+};

--- a/src/providers/octo-agent/env/OctoAgentSettingsReconciler.ts
+++ b/src/providers/octo-agent/env/OctoAgentSettingsReconciler.ts
@@ -1,6 +1,7 @@
 import type { ProviderSettingsReconciler } from '../../../core/providers/types';
 import type { Conversation } from '../../../core/types';
 import { getOctoAgentProviderSettings } from '../settings';
+import { octoAgentChatUIConfig } from '../ui/OctoAgentChatUIConfig';
 
 export const octoAgentSettingsReconciler: ProviderSettingsReconciler = {
   handleEnvironmentChange(): boolean {
@@ -30,10 +31,14 @@ export const octoAgentSettingsReconciler: ProviderSettingsReconciler = {
 
   normalizeModelVariantSettings(settings: Record<string, unknown>): boolean {
     const model = typeof settings.model === 'string' ? settings.model : '';
-    if (!model || model === 'octo-agent' || model.startsWith('octo-agent/')) {
+    if (!model || (!model.startsWith('octo-agent') && model !== 'octo-agent')) {
       return false;
     }
-    // The current model does not belong to octo-agent; do not touch it.
+    const normalized = octoAgentChatUIConfig.normalizeModelVariant(model, settings);
+    if (normalized !== model) {
+      settings.model = normalized;
+      return true;
+    }
     return false;
   },
 };

--- a/src/providers/octo-agent/history/OctoAgentConversationHistoryService.ts
+++ b/src/providers/octo-agent/history/OctoAgentConversationHistoryService.ts
@@ -1,0 +1,47 @@
+import type { ProviderConversationHistoryService } from '../../../core/providers/types';
+import type { Conversation } from '../../../core/types';
+import { buildPersistedOctoAgentState, getOctoAgentState } from '../types';
+
+export class OctoAgentConversationHistoryService implements ProviderConversationHistoryService {
+  // octo-agent stores conversation history on the server. Claudian keeps the
+  // session id in Conversation.providerState; the runtime re-subscribes to the
+  // session and continues from there. We do not eagerly hydrate the full history
+  // because the server is the source of truth and the client is owned by the runtime.
+  async hydrateConversationHistory(
+    _conversation: Conversation,
+    _vaultPath: string | null,
+  ): Promise<void> {
+    // No-op: history is server-resident and recovered through session continuity.
+  }
+
+  async deleteConversationSession(
+    _conversation: Conversation,
+    _vaultPath: string | null,
+  ): Promise<void> {
+    // octo-agent session deletion is not exposed through the public API yet.
+  }
+
+  resolveSessionIdForConversation(conversation: Conversation | null): string | null {
+    const state = getOctoAgentState(conversation?.providerState);
+    return state.sessionId ?? conversation?.sessionId ?? null;
+  }
+
+  isPendingForkConversation(conversation: Conversation): boolean {
+    const state = getOctoAgentState(conversation.providerState);
+    return !!state.sessionId && !conversation.sessionId;
+  }
+
+  buildForkProviderState(
+    sourceSessionId: string,
+    _resumeAt: string,
+    _sourceProviderState?: Record<string, unknown>,
+  ): Record<string, unknown> {
+    return buildPersistedOctoAgentState({ sessionId: sourceSessionId }) ?? {};
+  }
+
+  buildPersistedProviderState(
+    conversation: Conversation,
+  ): Record<string, unknown> | undefined {
+    return buildPersistedOctoAgentState(getOctoAgentState(conversation.providerState));
+  }
+}

--- a/src/providers/octo-agent/permissionMode.ts
+++ b/src/providers/octo-agent/permissionMode.ts
@@ -1,0 +1,51 @@
+/**
+ * Claudian uses a generic permission-mode vocabulary for the toggle UI:
+ *   yolo  -> tools run automatically
+ *   normal-> ask before executing tools
+ *   plan  -> plan mode
+ *
+ * octo-agent stores them as auto / interactive / plan. These helpers convert
+ * between the two value domains so the runtime talks to the server correctly
+ * while the UI and persisted settings remain provider-agnostic.
+ */
+
+export type OctoAgentPermissionMode = 'auto' | 'interactive' | 'plan';
+export type ClaudianPermissionMode = 'yolo' | 'normal' | 'plan';
+
+export function toOctoAgentPermissionMode(
+  mode: string | undefined,
+): OctoAgentPermissionMode {
+  switch (mode) {
+    case 'yolo':
+    case 'auto':
+      return 'auto';
+    case 'normal':
+    case 'interactive':
+      return 'interactive';
+    case 'plan':
+      return 'plan';
+    default:
+      return 'auto';
+  }
+}
+
+export function toClaudianPermissionMode(
+  mode: string | undefined,
+): ClaudianPermissionMode {
+  switch (mode) {
+    case 'auto':
+    case 'yolo':
+      return 'yolo';
+    case 'interactive':
+    case 'normal':
+      return 'normal';
+    case 'plan':
+      return 'plan';
+    default:
+      return 'yolo';
+  }
+}
+
+export function isValidClaudianPermissionMode(mode: string): mode is ClaudianPermissionMode {
+  return mode === 'yolo' || mode === 'normal' || mode === 'plan';
+}

--- a/src/providers/octo-agent/registration.ts
+++ b/src/providers/octo-agent/registration.ts
@@ -1,0 +1,29 @@
+import type { ProviderRegistration } from '../../core/providers/types';
+import { OctoAgentInlineEditService } from './auxiliary/OctoAgentInlineEditService';
+import { OctoAgentInstructionRefineService } from './auxiliary/OctoAgentInstructionRefineService';
+import { OctoAgentTaskResultInterpreter } from './auxiliary/OctoAgentTaskResultInterpreter';
+import { OctoAgentTitleGenerationService } from './auxiliary/OctoAgentTitleGenerationService';
+import { OCTO_AGENT_PROVIDER_CAPABILITIES } from './capabilities';
+import { octoAgentSettingsReconciler } from './env/OctoAgentSettingsReconciler';
+import { OctoAgentConversationHistoryService } from './history/OctoAgentConversationHistoryService';
+import { OctoAgentChatRuntime } from './runtime/OctoAgentChatRuntime';
+import { getOctoAgentProviderSettings } from './settings';
+import { octoAgentChatUIConfig } from './ui/OctoAgentChatUIConfig';
+
+export const octoAgentProviderRegistration: ProviderRegistration = {
+  blankTabOrder: 15,
+  capabilities: OCTO_AGENT_PROVIDER_CAPABILITIES,
+  chatUIConfig: octoAgentChatUIConfig,
+  createInlineEditService: (plugin) => new OctoAgentInlineEditService(plugin),
+  createInstructionRefineService: (plugin) => new OctoAgentInstructionRefineService(plugin),
+  createRuntime: ({ plugin }) => new OctoAgentChatRuntime(plugin),
+  createTitleGenerationService: (plugin) => new OctoAgentTitleGenerationService(plugin),
+  displayName: 'Octo Agent',
+  environmentKeyPatterns: [/^OCTO_/i],
+  historyService: new OctoAgentConversationHistoryService(),
+  isEnabled: (settings) => {
+    return getOctoAgentProviderSettings(settings).enabled;
+  },
+  settingsReconciler: octoAgentSettingsReconciler,
+  taskResultInterpreter: new OctoAgentTaskResultInterpreter(),
+};

--- a/src/providers/octo-agent/runtime/OctoAgentAuxQueryRunner.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentAuxQueryRunner.ts
@@ -1,4 +1,5 @@
 import type ClaudianPlugin from '../../../main';
+import { toOctoAgentPermissionMode } from '../permissionMode';
 import { getOctoAgentProviderSettings } from '../settings';
 import { OctoAgentClient } from './OctoAgentClient';
 
@@ -132,7 +133,7 @@ export async function runOctoAgentAuxQuery(
 
             await client.setPermissionMode(
               sessionId,
-              options.permissionMode ?? 'interactive',
+              toOctoAgentPermissionMode(options.permissionMode ?? 'interactive'),
             );
           }
 

--- a/src/providers/octo-agent/runtime/OctoAgentAuxQueryRunner.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentAuxQueryRunner.ts
@@ -1,0 +1,150 @@
+import type ClaudianPlugin from '../../../main';
+import { getOctoAgentProviderSettings } from '../settings';
+import { OctoAgentClient } from './OctoAgentClient';
+
+export interface OctoAgentAuxQueryOptions {
+  systemPrompt?: string;
+  model?: string;
+  permissionMode?: string;
+  resumeSessionId?: string;
+  abortController?: AbortController;
+  source?: string;
+}
+
+export interface OctoAgentAuxQueryResult {
+  text: string;
+  sessionId: string;
+}
+
+const QUERY_TIMEOUT_MS = 60_000;
+
+export async function runOctoAgentAuxQuery(
+  plugin: ClaudianPlugin,
+  options: OctoAgentAuxQueryOptions,
+  prompt: string,
+): Promise<OctoAgentAuxQueryResult> {
+  const settings = getOctoAgentProviderSettings(
+    plugin.settings as Record<string, unknown>,
+  );
+  const client = new OctoAgentClient({
+    accessKey: settings.accessKey || undefined,
+    baseUrl: `http://${settings.host}:${settings.port}`,
+  });
+
+  let sessionId = options.resumeSessionId ?? '';
+  let text = '';
+  let receivedDelta = false;
+  let completed = false;
+
+  return new Promise<OctoAgentAuxQueryResult>((resolve, reject) => {
+    const cleanup = (): void => {
+      window.clearTimeout(timeout);
+      options.abortController?.signal.removeEventListener('abort', onAbort);
+      client.disconnect();
+    };
+
+    const onAbort = (): void => {
+      cleanup();
+      reject(new Error('Aborted'));
+    };
+
+    const timeout = window.setTimeout(() => {
+      if (!completed) {
+        cleanup();
+        resolve({ text, sessionId });
+      }
+    }, QUERY_TIMEOUT_MS);
+
+    const finish = (finalText: string): void => {
+      if (completed) {
+        return;
+      }
+      completed = true;
+      cleanup();
+      resolve({ text: finalText, sessionId });
+    };
+
+    const fail = (error: Error): void => {
+      if (completed) {
+        return;
+      }
+      completed = true;
+      cleanup();
+      reject(error);
+    };
+
+    options.abortController?.signal.addEventListener('abort', onAbort);
+
+    client.connect({
+      onClose: () => {
+        if (!completed) {
+          finish(text);
+        }
+      },
+      onError: (error) => {
+        fail(error);
+      },
+      onEvent: (event) => {
+        switch (event.type) {
+          case 'text_delta': {
+            text += event.text;
+            receivedDelta = true;
+            break;
+          }
+          case 'output': {
+            text += event.content;
+            break;
+          }
+          case 'assistant_message': {
+            if (!receivedDelta) {
+              text = event.content;
+            }
+            break;
+          }
+          case 'complete': {
+            finish(text);
+            break;
+          }
+          case 'error': {
+            fail(new Error(event.message));
+            break;
+          }
+          default: {
+            // Ignore other events.
+          }
+        }
+      },
+      onOpen: async () => {
+        try {
+          if (!sessionId) {
+            const session = await client.createSession({
+              model: options.model ?? '',
+              source: options.source ?? 'claudian-aux',
+            });
+            sessionId = session.id;
+
+            if (options.model) {
+              const modelId = options.model.replace(/^octo-agent\//, '');
+              if (modelId && modelId !== 'octo-agent') {
+                await client.setModel(sessionId, modelId);
+              }
+            }
+
+            await client.setPermissionMode(
+              sessionId,
+              options.permissionMode ?? 'interactive',
+            );
+          }
+
+          client.subscribe(sessionId);
+          const fullPrompt = options.systemPrompt
+            ? `${options.systemPrompt}\n\n${prompt}`
+            : prompt;
+          client.sendMessage(sessionId, fullPrompt);
+        } catch (error) {
+          fail(error instanceof Error ? error : new Error(String(error)));
+        }
+      },
+    });
+  });
+}

--- a/src/providers/octo-agent/runtime/OctoAgentBinaryLocator.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentBinaryLocator.ts
@@ -1,0 +1,59 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const OCTO_BINARY_NAME = process.platform === 'win32' ? 'octo.exe' : 'octo';
+
+function getMacOSBundlePaths(): string[] {
+  const paths: string[] = [];
+  const applicationsDir = '/Applications';
+  try {
+    const entries = fs.readdirSync(applicationsDir);
+    for (const entry of entries) {
+      if (entry.toLowerCase().startsWith('octo') && entry.endsWith('.app')) {
+        paths.push(path.join(applicationsDir, entry, 'Contents', 'MacOS'));
+      }
+    }
+  } catch {
+    // Ignore unreadable /Applications
+  }
+  return paths;
+}
+
+function getSearchDirectories(): string[] {
+  const home = os.homedir();
+  const dirs = [
+    path.join(home, 'Library', 'Application Support', 'octo', 'bin'),
+    path.join(home, '.local', 'bin'),
+    '/usr/local/bin',
+    '/opt/homebrew/bin',
+    '/usr/bin',
+    '/bin',
+  ];
+
+  if (process.platform === 'darwin') {
+    dirs.unshift(...getMacOSBundlePaths());
+  }
+
+  return dirs;
+}
+
+export function resolveOctoAgentBinary(cliPath?: string): string | null {
+  const candidates = [cliPath, OCTO_BINARY_NAME].filter(Boolean) as string[];
+  const searchDirs = getSearchDirectories();
+
+  for (const dir of searchDirs) {
+    for (const candidate of candidates) {
+      const fullPath = path.isAbsolute(candidate) ? candidate : path.join(dir, candidate);
+      try {
+        if (fs.existsSync(fullPath) && fs.statSync(fullPath).isFile()) {
+          return fullPath;
+        }
+      } catch {
+        // Ignore inaccessible paths
+      }
+    }
+  }
+
+  return null;
+}

--- a/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
@@ -80,6 +80,7 @@ export class OctoAgentChatRuntime implements ChatRuntime {
   private supportedCommands: SlashCommand[] = [];
   private lastSyncedTitle: string | null = null;
   private sessionDeletedByRemote = false;
+  private shouldRetryAfterSessionNotFound = false;
   private serverStartPromise: Promise<boolean> | null = null;
 
   constructor(plugin: ClaudianPlugin) {
@@ -151,7 +152,7 @@ export class OctoAgentChatRuntime implements ChatRuntime {
   }
 
   async ensureReady(options?: ChatRuntimeEnsureReadyOptions): Promise<boolean> {
-    if (this.ready && this.client?.isConnected()) {
+    if (this.ready && this.client?.isConnected() && this.sessionId) {
       return true;
     }
 
@@ -254,11 +255,13 @@ export class OctoAgentChatRuntime implements ChatRuntime {
         this.buildImageFiles(turn.request.images),
       );
 
-      const timeout = window.setTimeout(() => {
+      let timeout = window.setTimeout(() => {
         if (this.activeQuery) {
           this.activeQuery.turnAborted = true;
         }
       }, QUERY_TIMEOUT_MS);
+
+      let retriedAfterSessionNotFound = false;
 
       while (!this.activeQuery.done && !this.activeQuery.turnAborted) {
         while (true) {
@@ -269,6 +272,42 @@ export class OctoAgentChatRuntime implements ChatRuntime {
               this.emittedText = true;
             }
             yield chunk;
+          }
+
+          if (this.shouldRetryAfterSessionNotFound && !retriedAfterSessionNotFound) {
+            this.shouldRetryAfterSessionNotFound = false;
+            retriedAfterSessionNotFound = true;
+            yield {
+              type: 'notice',
+              content: 'Previous session was deleted; creating a new session and retrying.',
+              level: 'info',
+            };
+            try {
+              const ready = await this.ensureReady({ force: true });
+              if (!ready || !this.client || !this.sessionId) {
+                yield { type: 'error', content: 'Failed to create a new session after the previous one was deleted.' };
+                this.activeQuery.turnAborted = true;
+                break;
+              }
+              this.client.sendMessage(
+                this.sessionId,
+                turn.prompt,
+                this.buildImageFiles(turn.request.images),
+              );
+              // Reset the inactivity timeout for the retried turn.
+              window.clearTimeout(timeout);
+              timeout = window.setTimeout(() => {
+                if (this.activeQuery) {
+                  this.activeQuery.turnAborted = true;
+                }
+              }, QUERY_TIMEOUT_MS);
+            } catch (error) {
+              yield {
+                type: 'error',
+                content: error instanceof Error ? error.message : 'Failed to retry after session deletion.',
+              };
+              this.activeQuery.turnAborted = true;
+            }
           }
         }
         await eventBuffer.wait(50);
@@ -284,6 +323,7 @@ export class OctoAgentChatRuntime implements ChatRuntime {
         }
       }
       this.sessionDeletedByRemote = false;
+      this.shouldRetryAfterSessionNotFound = false;
     } finally {
       this.activeQuery = null;
       this.currentTurnMetadata = {};
@@ -309,6 +349,7 @@ export class OctoAgentChatRuntime implements ChatRuntime {
     this.sessionInvalidated = false;
     this.lastSyncedTitle = null;
     this.sessionDeletedByRemote = false;
+    this.shouldRetryAfterSessionNotFound = false;
   }
 
   getSessionId(): string | null {
@@ -377,6 +418,7 @@ export class OctoAgentChatRuntime implements ChatRuntime {
     this.pendingQuestions.clear();
     this.lastSyncedTitle = null;
     this.sessionDeletedByRemote = false;
+    this.shouldRetryAfterSessionNotFound = false;
   }
 
   async rewind(
@@ -673,6 +715,24 @@ export class OctoAgentChatRuntime implements ChatRuntime {
     }
   }
 
+  private handleSessionNotFound(sessionId: string | undefined): void {
+    if (sessionId !== this.sessionId) {
+      return;
+    }
+    this.sessionInvalidated = true;
+    this.sessionId = null;
+    this.shouldRetryAfterSessionNotFound = true;
+  }
+
+  private isSessionNotFoundEvent(event: OctoAgentEvent): boolean {
+    if (event.type !== 'send_rejected' && event.type !== 'error') {
+      return false;
+    }
+    const message = (event as { message?: string }).message ?? '';
+    const lower = message.toLowerCase();
+    return lower.includes('session not found') || lower.includes('not found');
+  }
+
   private handleClientEvent(event: OctoAgentEvent): void {
     if (this.activeQuery) {
       // Handled by the active query loop through the event buffer.
@@ -689,6 +749,10 @@ export class OctoAgentChatRuntime implements ChatRuntime {
       void this.handleUserQuestion(event);
     } else if (event.type === 'session_deleted') {
       this.handleSessionDeleted(event);
+    } else if (event.type === 'send_rejected' || event.type === 'error') {
+      if (this.isSessionNotFoundEvent(event)) {
+        this.handleSessionNotFound((event as { session_id?: string }).session_id);
+      }
     }
   }
 
@@ -796,8 +860,13 @@ export class OctoAgentChatRuntime implements ChatRuntime {
         yield { type: 'notice', content: 'Session was deleted from another client.', level: 'error' };
         break;
       }
+      case 'send_rejected':
       case 'error': {
-        yield { type: 'error', content: event.message };
+        if (this.isSessionNotFoundEvent(event)) {
+          this.handleSessionNotFound(event.session_id);
+        } else {
+          yield { type: 'error', content: event.message };
+        }
         break;
       }
       case 'toast': {

--- a/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
@@ -36,6 +36,7 @@ import { OCTO_AGENT_PROVIDER_CAPABILITIES } from '../capabilities';
 import { getOctoAgentProviderSettings } from '../settings';
 import { getOctoAgentState } from '../types';
 import { OctoAgentClient, type OctoAgentEvent } from './OctoAgentClient';
+import { ensureOctoAgentServerRunning } from './OctoAgentServerLauncher';
 
 interface PendingQuestion {
   resolve: (answer: { choices: string[]; custom: string; cancelled: boolean }) => void;
@@ -73,7 +74,7 @@ export class OctoAgentChatRuntime implements ChatRuntime {
   private toolIndex = 0;
   private currentToolId: string | null = null;
   private supportedCommands: SlashCommand[] = [];
-  private serverStartPromise: Promise<void> | null = null;
+  private serverStartPromise: Promise<boolean> | null = null;
 
   constructor(plugin: ClaudianPlugin) {
     this.plugin = plugin;
@@ -143,6 +144,19 @@ export class OctoAgentChatRuntime implements ChatRuntime {
     );
     if (!settings.enabled) {
       return false;
+    }
+
+    // Auto-start octo serve if configured and not already running.
+    if (settings.autoStartServer && !this.serverStartPromise) {
+      this.serverStartPromise = ensureOctoAgentServerRunning({ plugin: this.plugin }).finally(() => {
+        this.serverStartPromise = null;
+      });
+    }
+    if (this.serverStartPromise) {
+      const started = await this.serverStartPromise;
+      if (!started) {
+        return false;
+      }
     }
 
     if (!this.client) {

--- a/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
@@ -372,6 +372,7 @@ export class OctoAgentChatRuntime implements ChatRuntime {
   }
 
   async loadHistory(): Promise<ChatMessage[]> {
+    console.log('[octo-agent] loadHistory called for session:', this.sessionId);
     if (!this.sessionId) {
       return [];
     }

--- a/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
@@ -642,6 +642,8 @@ export class OctoAgentChatRuntime implements ChatRuntime {
     // while no active query is running (e.g. after reconnect or background task).
     if (event.type === 'request_confirmation') {
       void this.handleConfirmation(event);
+    } else if (event.type === 'confirmation_complete') {
+      this.handleConfirmationComplete(event);
     } else if (event.type === 'request_user_question') {
       void this.handleUserQuestion(event);
     }
@@ -738,6 +740,10 @@ export class OctoAgentChatRuntime implements ChatRuntime {
         void this.handleConfirmation(event);
         break;
       }
+      case 'confirmation_complete': {
+        this.handleConfirmationComplete(event);
+        break;
+      }
       case 'request_user_question': {
         void this.handleUserQuestion(event);
         break;
@@ -764,31 +770,63 @@ export class OctoAgentChatRuntime implements ChatRuntime {
       return;
     }
 
+    // Avoid duplicate handling of the same confirmation.
+    if (this.pendingConfirmations.has(event.id)) {
+      return;
+    }
+
     const callback = this.approvalCallback;
     if (!callback) {
       this.client.confirm(event.id, 'no');
       return;
     }
 
+    let result = 'no';
     try {
-      const decision = await callback(
-        event.tool_name || 'octo-agent',
-        {
-          command: event.command,
-          diff: event.diff,
-          input: event.input,
-          kind: event.kind,
-        },
-        event.message,
-        {
-          decisionOptions: this.buildDecisionOptions(event.kind),
-        },
-      );
-      this.client.confirm(event.id, this.mapApprovalDecision(decision, event.kind));
+      result = await new Promise<string>((resolve, reject) => {
+        this.pendingConfirmations.set(event.id, { resolve });
+        callback(
+          event.tool_name || 'octo-agent',
+          {
+            command: event.command,
+            diff: event.diff,
+            input: event.input,
+            kind: event.kind,
+          },
+          event.message,
+          {
+            decisionOptions: this.buildDecisionOptions(event.kind),
+          },
+        )
+          .then((decision) => resolve(this.mapApprovalDecision(decision, event.kind)))
+          .catch(reject);
+      });
     } catch (error) {
       console.error('Error handling octo-agent confirmation:', error);
-      this.client.confirm(event.id, 'no');
+      result = 'no';
+    } finally {
+      if (this.pendingConfirmations.has(event.id)) {
+        // User answered locally; send the result to the server.
+        this.pendingConfirmations.delete(event.id);
+        this.client.confirm(event.id, result);
+      }
+      // If the entry was removed by confirmation_complete, another client
+      // already answered; do not send a duplicate result.
     }
+  }
+
+  private handleConfirmationComplete(
+    event: Extract<OctoAgentEvent, { type: 'confirmation_complete' }>,
+  ): void {
+    const pending = this.pendingConfirmations.get(event.id);
+    if (!pending) {
+      return;
+    }
+    this.pendingConfirmations.delete(event.id);
+    this.approvalDismisser?.();
+    // Resolve the local await so handleConfirmation exits cleanly. The finally
+    // block will see the confirmation is no longer pending and skip sending.
+    pending.resolve('no');
   }
 
   private buildDecisionOptions(

--- a/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
@@ -34,8 +34,10 @@ import type ClaudianPlugin from '../../../main';
 import { appendContextFiles, appendCurrentNote } from '../../../utils/context';
 import { getVaultPath } from '../../../utils/path';
 import { OCTO_AGENT_PROVIDER_CAPABILITIES } from '../capabilities';
+import { toClaudianPermissionMode, toOctoAgentPermissionMode } from '../permissionMode';
 import { getOctoAgentProviderSettings } from '../settings';
 import { getOctoAgentState } from '../types';
+import { octoAgentChatUIConfig } from '../ui/OctoAgentChatUIConfig';
 import { OctoAgentClient, type OctoAgentEvent, type OctoAgentMessage, type OctoAgentUserFile } from './OctoAgentClient';
 import { ensureOctoAgentServerRunning } from './OctoAgentServerLauncher';
 
@@ -74,6 +76,7 @@ export class OctoAgentChatRuntime implements ChatRuntime {
   private subagentHookProvider: (() => SubagentRuntimeState) | null = null;
   private toolIndex = 0;
   private currentToolId: string | null = null;
+  private emittedText = false;
   private supportedCommands: SlashCommand[] = [];
   private serverStartPromise: Promise<boolean> | null = null;
 
@@ -209,7 +212,16 @@ export class OctoAgentChatRuntime implements ChatRuntime {
       return;
     }
 
-    const ready = await this.ensureReady();
+    let ready: boolean;
+    try {
+      ready = await this.ensureReady();
+    } catch (error) {
+      yield {
+        type: 'error',
+        content: error instanceof Error ? error.message : 'Octo Agent failed to become ready.',
+      };
+      return;
+    }
     if (!ready || !this.client || !this.sessionId) {
       yield { type: 'error', content: 'Octo Agent is not ready or not connected.' };
       return;
@@ -219,13 +231,19 @@ export class OctoAgentChatRuntime implements ChatRuntime {
     this.currentTurnMetadata = {};
     this.toolIndex = 0;
     this.currentToolId = null;
+    this.emittedText = false;
+    const QUERY_TIMEOUT_MS = 120_000;
 
     const eventBuffer = new OctoAgentEventBuffer();
     const handler = (event: OctoAgentEvent): void => {
       eventBuffer.push(event);
     };
-    const onEvent = (event: OctoAgentEvent): void => handler(event);
-    this.client.onEvent = onEvent;
+    this.client.onEvent = handler;
+    this.client.setCloseListener(() => {
+      if (this.activeQuery) {
+        this.activeQuery.turnAborted = true;
+      }
+    });
 
     try {
       this.client.sendMessage(
@@ -234,23 +252,35 @@ export class OctoAgentChatRuntime implements ChatRuntime {
         this.buildImageFiles(turn.request.images),
       );
 
+      const timeout = window.setTimeout(() => {
+        if (this.activeQuery) {
+          this.activeQuery.turnAborted = true;
+        }
+      }, QUERY_TIMEOUT_MS);
+
       while (!this.activeQuery.done && !this.activeQuery.turnAborted) {
         while (true) {
           const event = eventBuffer.shift();
           if (!event) break;
           for (const chunk of this.handleEvent(event)) {
+            if (chunk.type === 'text' && chunk.content) {
+              this.emittedText = true;
+            }
             yield chunk;
           }
         }
         await eventBuffer.wait(50);
       }
 
-      if (this.activeQuery.turnAborted) {
-        yield { type: 'error', content: 'Turn was interrupted.' };
+      window.clearTimeout(timeout);
+
+      if (this.activeQuery.turnAborted && !this.activeQuery.done) {
+        yield { type: 'error', content: 'Turn was interrupted or timed out.' };
       }
     } finally {
       this.activeQuery = null;
       this.currentTurnMetadata = {};
+      this.client?.setCloseListener(null);
       this.client.onEvent = undefined;
     }
 
@@ -299,7 +329,6 @@ export class OctoAgentChatRuntime implements ChatRuntime {
       return;
     }
     const config = await this.client.getConfig();
-    console.log('[octo-agent] refreshConfig: models count:', config?.models.length ?? 0, 'defaultIdx:', config?.defaultModelIdx ?? 0);
     if (!config || config.models.length === 0) {
       return;
     }
@@ -326,10 +355,6 @@ export class OctoAgentChatRuntime implements ChatRuntime {
       ) {
         pluginSettings.model = defaultValue;
       }
-    }
-
-    if (config.permissionMode) {
-      pluginSettings.permissionMode = config.permissionMode;
     }
   }
 
@@ -376,8 +401,7 @@ export class OctoAgentChatRuntime implements ChatRuntime {
       return;
     }
     try {
-      await this.client.setPermissionMode(this.sessionId, mode);
-      console.log('[octo-agent] setPermissionMode synced:', mode);
+      await this.client.setPermissionMode(this.sessionId, toOctoAgentPermissionMode(mode));
     } catch (error) {
       console.error('Failed to set octo-agent permission mode:', error);
     }
@@ -425,19 +449,16 @@ export class OctoAgentChatRuntime implements ChatRuntime {
   }
 
   async loadHistory(): Promise<ChatMessage[]> {
-    console.log('[octo-agent] loadHistory called for session:', this.sessionId);
     if (!this.sessionId) {
       return [];
     }
 
     try {
       const ready = await this.ensureReady({ allowSessionCreation: false });
-      console.log('[octo-agent] loadHistory ensureReady result:', ready, 'client:', !!this.client);
       if (!ready || !this.client) {
         return [];
       }
       const messages = await this.client.getSessionMessages(this.sessionId);
-      console.log('[octo-agent] loadHistory raw messages count:', messages.length);
       return this.convertServerMessages(messages);
     } catch (error) {
       console.error('Failed to load octo-agent history:', error);
@@ -449,13 +470,12 @@ export class OctoAgentChatRuntime implements ChatRuntime {
     const result: ChatMessage[] = [];
     let timestamp = Date.now();
 
-    console.log('[octo-agent] convertServerMessages: raw messages count:', messages.length);
     for (let i = 0; i < messages.length; i++) {
       const message = messages[i];
       const eventType = (message.type as string) || (message.role as string) || '';
 
       let role: 'user' | 'assistant' | null = null;
-      if (eventType === 'history_user_message' || eventType === 'user') {
+      if (eventType === 'history_user_message' || eventType === 'user_message' || eventType === 'user') {
         role = 'user';
       } else if (eventType === 'assistant_message' || eventType === 'assistant') {
         role = 'assistant';
@@ -483,7 +503,6 @@ export class OctoAgentChatRuntime implements ChatRuntime {
       });
     }
 
-    console.log('[octo-agent] convertServerMessages: converted count:', result.length);
     return result;
   }
 
@@ -594,7 +613,7 @@ export class OctoAgentChatRuntime implements ChatRuntime {
     }
 
     const providerSettings = getOctoAgentProviderSettings(pluginSettings);
-    const permissionMode = providerSettings.permissionMode ?? 'auto';
+    const permissionMode = toOctoAgentPermissionMode(providerSettings.permissionMode ?? 'yolo');
     try {
       await this.client.setPermissionMode(sessionId, permissionMode);
     } catch (error) {
@@ -639,9 +658,11 @@ export class OctoAgentChatRuntime implements ChatRuntime {
         break;
       }
       case 'assistant_message': {
-        // The assistant_message event carries the final full response. If we already
-        // streamed deltas, we avoid duplicating content here. Deltas are preferred.
-        // In a future iteration we can compare and emit a final text chunk if needed.
+        // The assistant_message event carries the final full response. Use it as a
+        // fallback when the server did not stream any text deltas.
+        if (!this.emittedText && event.content) {
+          yield { type: 'text', content: event.content };
+        }
         break;
       }
       case 'output': {
@@ -707,6 +728,9 @@ export class OctoAgentChatRuntime implements ChatRuntime {
         const usage = this.buildUsageInfo(event);
         if (usage) {
           yield { type: 'usage', usage, sessionId: event.session_id };
+        }
+        if (event.permission_mode) {
+          this.permissionModeSyncCallback?.(toClaudianPermissionMode(event.permission_mode));
         }
         break;
       }
@@ -873,11 +897,24 @@ export class OctoAgentChatRuntime implements ChatRuntime {
   private buildUsageInfo(
     event: Extract<OctoAgentEvent, { type: 'session_update' }>,
   ): UsageInfo | null {
-    if (typeof event.context_usage !== 'number') {
+    if (typeof event.context_usage !== 'number' || event.context_usage < 0) {
       return null;
     }
 
-    const contextWindow = 200_000;
+    const pluginSettings = this.plugin.settings as unknown as Record<string, unknown>;
+    const customLimits =
+      pluginSettings.customContextLimits && typeof pluginSettings.customContextLimits === 'object' && !Array.isArray(pluginSettings.customContextLimits)
+        ? (pluginSettings.customContextLimits as Record<string, number>)
+        : undefined;
+    const contextWindow = octoAgentChatUIConfig.getContextWindowSize(
+      String(pluginSettings.model ?? ''),
+      customLimits,
+      pluginSettings,
+    );
+    if (contextWindow <= 0) {
+      return null;
+    }
+
     const contextTokens = event.context_usage;
     return {
       contextTokens,

--- a/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
@@ -31,6 +31,7 @@ import {
   type UsageInfo,
 } from '../../../core/types';
 import type ClaudianPlugin from '../../../main';
+import { appendContextFiles, appendCurrentNote } from '../../../utils/context';
 import { getVaultPath } from '../../../utils/path';
 import { OCTO_AGENT_PROVIDER_CAPABILITIES } from '../capabilities';
 import { getOctoAgentProviderSettings } from '../settings';
@@ -88,20 +89,30 @@ export class OctoAgentChatRuntime implements ChatRuntime {
     const text = request.text;
     const images = request.images ?? [];
 
-    const promptParts: string[] = [text];
+    let prompt = text;
+    if (request.currentNotePath) {
+      prompt = appendCurrentNote(prompt, request.currentNotePath);
+    }
+
+    const externalContextPaths = request.externalContextPaths?.filter(
+      (value): value is string => typeof value === 'string' && value.trim().length > 0,
+    );
+    if (externalContextPaths && externalContextPaths.length > 0) {
+      prompt = appendContextFiles(prompt, externalContextPaths);
+    }
+
     if (images.length > 0) {
-      promptParts.push(
-        ...(images as ImageAttachment[]).map(
-          (image, index) => `\n[Image ${index + 1}: ${image.mediaType ?? 'image'}]`,
-        ),
+      const imageParts = (images as ImageAttachment[]).map(
+        (image, index) => `[Image ${index + 1}: ${image.mediaType ?? 'image'}]`,
       );
+      prompt = `${prompt}\n\n${imageParts.join('\n')}`;
     }
 
     return {
       isCompact: false,
       mcpMentions: new Set(),
       persistedContent: text,
-      prompt: promptParts.join('\n'),
+      prompt,
       request,
     };
   }

--- a/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
@@ -407,6 +407,17 @@ export class OctoAgentChatRuntime implements ChatRuntime {
     }
   }
 
+  async renameSession(title: string): Promise<void> {
+    if (!this.client || !this.sessionId) {
+      return;
+    }
+    try {
+      await this.client.renameSession(this.sessionId, title);
+    } catch (error) {
+      console.error('Failed to rename octo-agent session:', error);
+    }
+  }
+
   setSubagentHookProvider(getState: () => SubagentRuntimeState): void {
     this.subagentHookProvider = getState;
   }

--- a/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
@@ -611,8 +611,9 @@ export class OctoAgentChatRuntime implements ChatRuntime {
       }
     }
 
-    const providerSettings = getOctoAgentProviderSettings(pluginSettings);
-    const permissionMode = toOctoAgentPermissionMode(providerSettings.permissionMode ?? 'yolo');
+    const permissionMode = toOctoAgentPermissionMode(
+      (this.plugin.settings.permissionMode as string | undefined) ?? 'yolo',
+    );
     try {
       await this.client.setPermissionMode(sessionId, permissionMode);
     } catch (error) {

--- a/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
@@ -78,6 +78,7 @@ export class OctoAgentChatRuntime implements ChatRuntime {
   private currentToolId: string | null = null;
   private emittedText = false;
   private supportedCommands: SlashCommand[] = [];
+  private lastSyncedTitle: string | null = null;
   private serverStartPromise: Promise<boolean> | null = null;
 
   constructor(plugin: ClaudianPlugin) {
@@ -300,6 +301,7 @@ export class OctoAgentChatRuntime implements ChatRuntime {
     }
     this.sessionId = null;
     this.sessionInvalidated = false;
+    this.lastSyncedTitle = null;
   }
 
   getSessionId(): string | null {
@@ -366,6 +368,7 @@ export class OctoAgentChatRuntime implements ChatRuntime {
     this.setReady(false);
     this.pendingConfirmations.clear();
     this.pendingQuestions.clear();
+    this.lastSyncedTitle = null;
   }
 
   async rewind(
@@ -411,8 +414,13 @@ export class OctoAgentChatRuntime implements ChatRuntime {
     if (!this.client || !this.sessionId) {
       return;
     }
+    const trimmed = title.trim();
+    if (!trimmed || trimmed === this.lastSyncedTitle) {
+      return;
+    }
     try {
-      await this.client.renameSession(this.sessionId, title);
+      await this.client.renameSession(this.sessionId, trimmed);
+      this.lastSyncedTitle = trimmed;
     } catch (error) {
       console.error('Failed to rename octo-agent session:', error);
     }
@@ -792,7 +800,7 @@ export class OctoAgentChatRuntime implements ChatRuntime {
       return;
     }
 
-    let result = 'no';
+    let result: string;
     try {
       result = await new Promise<string>((resolve, reject) => {
         this.pendingConfirmations.set(event.id, { resolve });

--- a/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
@@ -79,6 +79,7 @@ export class OctoAgentChatRuntime implements ChatRuntime {
   private emittedText = false;
   private supportedCommands: SlashCommand[] = [];
   private lastSyncedTitle: string | null = null;
+  private sessionDeletedByRemote = false;
   private serverStartPromise: Promise<boolean> | null = null;
 
   constructor(plugin: ClaudianPlugin) {
@@ -276,8 +277,13 @@ export class OctoAgentChatRuntime implements ChatRuntime {
       window.clearTimeout(timeout);
 
       if (this.activeQuery.turnAborted && !this.activeQuery.done) {
-        yield { type: 'error', content: 'Turn was interrupted or timed out.' };
+        if (this.sessionDeletedByRemote) {
+          yield { type: 'error', content: 'Session was deleted from another client.' };
+        } else {
+          yield { type: 'error', content: 'Turn was interrupted or timed out.' };
+        }
       }
+      this.sessionDeletedByRemote = false;
     } finally {
       this.activeQuery = null;
       this.currentTurnMetadata = {};
@@ -302,6 +308,7 @@ export class OctoAgentChatRuntime implements ChatRuntime {
     this.sessionId = null;
     this.sessionInvalidated = false;
     this.lastSyncedTitle = null;
+    this.sessionDeletedByRemote = false;
   }
 
   getSessionId(): string | null {
@@ -369,6 +376,7 @@ export class OctoAgentChatRuntime implements ChatRuntime {
     this.pendingConfirmations.clear();
     this.pendingQuestions.clear();
     this.lastSyncedTitle = null;
+    this.sessionDeletedByRemote = false;
   }
 
   async rewind(
@@ -651,6 +659,20 @@ export class OctoAgentChatRuntime implements ChatRuntime {
     }));
   }
 
+  private handleSessionDeleted(
+    event: Extract<OctoAgentEvent, { type: 'session_deleted' }>,
+  ): void {
+    if (event.session_id !== this.sessionId) {
+      return;
+    }
+    this.sessionDeletedByRemote = true;
+    this.sessionInvalidated = true;
+    this.sessionId = null;
+    if (this.activeQuery) {
+      this.activeQuery.turnAborted = true;
+    }
+  }
+
   private handleClientEvent(event: OctoAgentEvent): void {
     if (this.activeQuery) {
       // Handled by the active query loop through the event buffer.
@@ -665,6 +687,8 @@ export class OctoAgentChatRuntime implements ChatRuntime {
       this.handleConfirmationComplete(event);
     } else if (event.type === 'request_user_question') {
       void this.handleUserQuestion(event);
+    } else if (event.type === 'session_deleted') {
+      this.handleSessionDeleted(event);
     }
   }
 
@@ -765,6 +789,11 @@ export class OctoAgentChatRuntime implements ChatRuntime {
       }
       case 'request_user_question': {
         void this.handleUserQuestion(event);
+        break;
+      }
+      case 'session_deleted': {
+        this.handleSessionDeleted(event);
+        yield { type: 'notice', content: 'Session was deleted from another client.', level: 'error' };
         break;
       }
       case 'error': {

--- a/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
@@ -1,0 +1,769 @@
+ 
+import type {
+  ProviderCapabilities,
+  ProviderId,
+} from '../../../core/providers/types';
+import type { ChatRuntime } from '../../../core/runtime/ChatRuntime';
+import type {
+  ApprovalCallback,
+  AskUserQuestionCallback,
+  AutoTurnCallback,
+  ChatRewindMode,
+  ChatRewindResult,
+  ChatRuntimeConversationState,
+  ChatRuntimeEnsureReadyOptions,
+  ChatRuntimeQueryOptions,
+  ChatTurnMetadata,
+  ChatTurnRequest,
+  ExitPlanModeCallback,
+  PreparedChatTurn,
+  SessionUpdateResult,
+  SubagentRuntimeState,
+} from '../../../core/runtime/types';
+import {
+  type ApprovalDecision,
+  type ChatMessage,
+  type Conversation,
+  type ImageAttachment,
+  type SlashCommand,
+  type StreamChunk,
+  type ToolCallInfo,
+  type UsageInfo,
+} from '../../../core/types';
+import type ClaudianPlugin from '../../../main';
+import { getVaultPath } from '../../../utils/path';
+import { OCTO_AGENT_PROVIDER_CAPABILITIES } from '../capabilities';
+import { getOctoAgentProviderSettings } from '../settings';
+import { getOctoAgentState } from '../types';
+import { OctoAgentClient, type OctoAgentEvent } from './OctoAgentClient';
+
+interface PendingQuestion {
+  resolve: (answer: { choices: string[]; custom: string; cancelled: boolean }) => void;
+}
+
+interface PendingConfirmation {
+  resolve: (result: string) => void;
+}
+
+interface ActiveQuery {
+  done: boolean;
+  turnAborted: boolean;
+}
+
+export class OctoAgentChatRuntime implements ChatRuntime {
+  readonly providerId: ProviderId = 'octo-agent';
+
+  private plugin: ClaudianPlugin;
+  private client: OctoAgentClient | null = null;
+  private ready = false;
+  private readyListeners = new Set<(ready: boolean) => void>();
+  private sessionId: string | null = null;
+  private sessionInvalidated = false;
+  private activeQuery: ActiveQuery | null = null;
+  private currentTurnMetadata: ChatTurnMetadata = {};
+  private pendingConfirmations = new Map<string, PendingConfirmation>();
+  private pendingQuestions = new Map<string, PendingQuestion>();
+  private approvalCallback: ApprovalCallback | null = null;
+  private approvalDismisser: (() => void) | null = null;
+  private askUserQuestionCallback: AskUserQuestionCallback | null = null;
+  private exitPlanModeCallback: ExitPlanModeCallback | null = null;
+  private permissionModeSyncCallback: ((sdkMode: string) => void) | null = null;
+  private autoTurnCallback: AutoTurnCallback | null = null;
+  private subagentHookProvider: (() => SubagentRuntimeState) | null = null;
+  private toolIndex = 0;
+  private currentToolId: string | null = null;
+  private supportedCommands: SlashCommand[] = [];
+  private serverStartPromise: Promise<void> | null = null;
+
+  constructor(plugin: ClaudianPlugin) {
+    this.plugin = plugin;
+  }
+
+  getCapabilities(): Readonly<ProviderCapabilities> {
+    return OCTO_AGENT_PROVIDER_CAPABILITIES;
+  }
+
+  prepareTurn(request: ChatTurnRequest): PreparedChatTurn {
+    const text = request.text;
+    const images = request.images ?? [];
+
+    const promptParts: string[] = [text];
+    if (images.length > 0) {
+      promptParts.push(
+        ...(images as ImageAttachment[]).map(
+          (image, index) => `\n[Image ${index + 1}: ${image.mediaType ?? 'image'}]`,
+        ),
+      );
+    }
+
+    return {
+      isCompact: false,
+      mcpMentions: new Set(),
+      persistedContent: text,
+      prompt: promptParts.join('\n'),
+      request,
+    };
+  }
+
+  onReadyStateChange(listener: (ready: boolean) => void): () => void {
+    this.readyListeners.add(listener);
+    listener(this.ready);
+    return () => {
+      this.readyListeners.delete(listener);
+    };
+  }
+
+  setResumeCheckpoint(_checkpointId: string | undefined): void {
+    // octo-agent does not support resuming from a named checkpoint through this API.
+  }
+
+  syncConversationState(
+    conversation: ChatRuntimeConversationState | null,
+    _externalContextPaths?: string[],
+  ): void {
+    if (!conversation) {
+      this.sessionId = null;
+      return;
+    }
+    const state = getOctoAgentState(conversation.providerState);
+    this.sessionId = conversation.sessionId ?? state.sessionId ?? null;
+  }
+
+  async reloadMcpServers(): Promise<void> {
+    // octo-agent manages its own MCP servers; no action required.
+  }
+
+  async ensureReady(options?: ChatRuntimeEnsureReadyOptions): Promise<boolean> {
+    if (this.ready && this.client?.isConnected()) {
+      return true;
+    }
+
+    const settings = getOctoAgentProviderSettings(
+      this.plugin.settings as unknown as Record<string, unknown>,
+    );
+    if (!settings.enabled) {
+      return false;
+    }
+
+    if (!this.client) {
+      this.client = new OctoAgentClient({
+        accessKey: settings.accessKey || undefined,
+        baseUrl: this.getBaseUrl(),
+      });
+    }
+
+    if (!this.client.isConnected()) {
+      const connected = await this.connectClient();
+      if (!connected) {
+        return false;
+      }
+    }
+
+    if (options?.force || !this.sessionId) {
+      await this.createSessionIfNeeded(options?.allowSessionCreation !== false);
+    }
+
+    if (this.sessionId) {
+      this.client.subscribe(this.sessionId);
+      await this.applySettingsToSession(this.sessionId);
+    }
+
+    this.setReady(true);
+    return true;
+  }
+
+  async *query(
+    turn: PreparedChatTurn,
+    _conversationHistory?: ChatMessage[],
+    _queryOptions?: ChatRuntimeQueryOptions,
+  ): AsyncGenerator<StreamChunk> {
+    if (this.activeQuery) {
+      yield { type: 'error', content: 'A query is already in progress.' };
+      return;
+    }
+
+    const ready = await this.ensureReady();
+    if (!ready || !this.client || !this.sessionId) {
+      yield { type: 'error', content: 'Octo Agent is not ready or not connected.' };
+      return;
+    }
+
+    this.activeQuery = { done: false, turnAborted: false };
+    this.currentTurnMetadata = {};
+    this.toolIndex = 0;
+    this.currentToolId = null;
+
+    const eventBuffer = new OctoAgentEventBuffer();
+    const handler = (event: OctoAgentEvent): void => {
+      eventBuffer.push(event);
+    };
+    const onEvent = (event: OctoAgentEvent): void => handler(event);
+    this.client.onEvent = onEvent;
+
+    try {
+      this.client.sendMessage(this.sessionId, turn.prompt);
+
+      while (!this.activeQuery.done && !this.activeQuery.turnAborted) {
+        while (true) {
+          const event = eventBuffer.shift();
+          if (!event) break;
+          for (const chunk of this.handleEvent(event)) {
+            yield chunk;
+          }
+        }
+        await eventBuffer.wait(50);
+      }
+
+      if (this.activeQuery.turnAborted) {
+        yield { type: 'error', content: 'Turn was interrupted.' };
+      }
+    } finally {
+      this.activeQuery = null;
+      this.currentTurnMetadata = {};
+      this.client.onEvent = undefined;
+    }
+
+    yield { type: 'done' };
+  }
+
+  cancel(): void {
+    if (this.activeQuery && this.client && this.sessionId) {
+      this.activeQuery.turnAborted = true;
+      this.client.interrupt(this.sessionId);
+    }
+  }
+
+  resetSession(): void {
+    if (this.client && this.sessionId) {
+      this.client.unsubscribe(this.sessionId);
+    }
+    this.sessionId = null;
+    this.sessionInvalidated = false;
+  }
+
+  getSessionId(): string | null {
+    return this.sessionId;
+  }
+
+  consumeSessionInvalidation(): boolean {
+    const invalidated = this.sessionInvalidated;
+    this.sessionInvalidated = false;
+    return invalidated;
+  }
+
+  isReady(): boolean {
+    return this.ready && this.client?.isConnected() === true;
+  }
+
+  async getSupportedCommands(): Promise<SlashCommand[]> {
+    return this.supportedCommands;
+  }
+
+  getAuxiliaryModel(): string | null {
+    return null;
+  }
+
+  cleanup(): void {
+    if (this.client) {
+      this.client.disconnect();
+      this.client = null;
+    }
+    this.setReady(false);
+    this.pendingConfirmations.clear();
+    this.pendingQuestions.clear();
+  }
+
+  async rewind(
+    _userMessageId: string,
+    _assistantMessageId: string | undefined,
+    _mode?: ChatRewindMode,
+  ): Promise<ChatRewindResult> {
+    return { canRewind: false, error: 'Rewind is not supported by Octo Agent.' };
+  }
+
+  setApprovalCallback(callback: ApprovalCallback | null): void {
+    this.approvalCallback = callback;
+  }
+
+  setApprovalDismisser(dismisser: (() => void) | null): void {
+    this.approvalDismisser = dismisser;
+  }
+
+  setAskUserQuestionCallback(callback: AskUserQuestionCallback | null): void {
+    this.askUserQuestionCallback = callback;
+  }
+
+  setExitPlanModeCallback(callback: ExitPlanModeCallback | null): void {
+    this.exitPlanModeCallback = callback;
+  }
+
+  setPermissionModeSyncCallback(callback: ((sdkMode: string) => void) | null): void {
+    this.permissionModeSyncCallback = callback;
+  }
+
+  setSubagentHookProvider(getState: () => SubagentRuntimeState): void {
+    this.subagentHookProvider = getState;
+  }
+
+  setAutoTurnCallback(callback: AutoTurnCallback | null): void {
+    this.autoTurnCallback = callback;
+  }
+
+  consumeTurnMetadata(): ChatTurnMetadata {
+    const metadata = this.currentTurnMetadata;
+    this.currentTurnMetadata = {};
+    return metadata;
+  }
+
+  buildSessionUpdates(params: {
+    conversation: Conversation | null;
+    sessionInvalidated: boolean;
+  }): SessionUpdateResult {
+    const updates: Partial<Conversation> = {};
+    if (params.sessionInvalidated) {
+      updates.sessionId = null;
+      updates.providerState = undefined;
+    } else if (this.sessionId && params.conversation?.sessionId !== this.sessionId) {
+      updates.sessionId = this.sessionId;
+      updates.providerState = { sessionId: this.sessionId };
+    }
+    return { updates };
+  }
+
+  resolveSessionIdForFork(conversation: Conversation | null): string | null {
+    return conversation?.sessionId ?? null;
+  }
+
+  async loadSubagentToolCalls(): Promise<ToolCallInfo[]> {
+    return [];
+  }
+
+  async loadSubagentFinalResult(): Promise<string | null> {
+    return null;
+  }
+
+  private setReady(ready: boolean): void {
+    if (this.ready === ready) {
+      return;
+    }
+    this.ready = ready;
+    for (const listener of this.readyListeners) {
+      try {
+        listener(ready);
+      } catch (error) {
+        console.error('Error in OctoAgent ready listener:', error);
+      }
+    }
+  }
+
+  private getBaseUrl(): string {
+    const settings = getOctoAgentProviderSettings(
+      this.plugin.settings as unknown as Record<string, unknown>,
+    );
+    return `http://${settings.host}:${settings.port}`;
+  }
+
+  private connectClient(): Promise<boolean> {
+    return new Promise((resolve) => {
+      if (!this.client) {
+        resolve(false);
+        return;
+      }
+
+      let settled = false;
+      const timeout = window.setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          resolve(false);
+        }
+      }, 5000);
+
+      this.client.connect({
+        onClose: () => {
+          this.setReady(false);
+        },
+        onError: (error) => {
+          console.error('OctoAgent WebSocket error:', error);
+          if (!settled) {
+            settled = true;
+            window.clearTimeout(timeout);
+            resolve(false);
+          }
+        },
+        onEvent: (event) => {
+          this.handleClientEvent(event);
+        },
+        onOpen: () => {
+          if (!settled) {
+            settled = true;
+            window.clearTimeout(timeout);
+            resolve(true);
+          }
+        },
+      });
+    });
+  }
+
+  private async createSessionIfNeeded(allowCreation: boolean): Promise<void> {
+    if (this.sessionId) {
+      return;
+    }
+    if (!allowCreation) {
+      return;
+    }
+    if (!this.client) {
+      return;
+    }
+
+    const session = await this.client.createSession({
+      name: 'Claudian',
+      source: 'claudian',
+    });
+    this.sessionId = session.id;
+  }
+
+  private async applySettingsToSession(sessionId: string): Promise<void> {
+    if (!this.client) {
+      return;
+    }
+
+    const vaultPath = getVaultPath(this.plugin.app);
+    if (vaultPath) {
+      try {
+        await this.client.setWorkingDir(sessionId, vaultPath);
+      } catch (error) {
+        console.error('Failed to set octo-agent working directory:', error);
+      }
+    }
+
+    const settings = getOctoAgentProviderSettings(
+      this.plugin.settings as unknown as Record<string, unknown>,
+    );
+    if (this.plugin.settings.model) {
+      try {
+        const modelId = String(this.plugin.settings.model).replace(/^octo-agent\//, '');
+        if (modelId && modelId !== 'octo-agent') {
+          await this.client.setModel(sessionId, modelId);
+        }
+      } catch (error) {
+        console.error('Failed to set octo-agent model:', error);
+      }
+    }
+
+    const permissionMode = typeof settings.environmentVariables === 'string'
+      && settings.environmentVariables.includes('OCTO_PERMISSION_MODE=auto')
+      ? 'auto'
+      : 'interactive';
+    try {
+      await this.client.setPermissionMode(sessionId, permissionMode);
+    } catch (error) {
+      console.error('Failed to set octo-agent permission mode:', error);
+    }
+  }
+
+  private handleClientEvent(event: OctoAgentEvent): void {
+    if (this.activeQuery) {
+      // Handled by the active query loop through the event buffer.
+      return;
+    }
+
+    // Handle out-of-band events such as confirmations or questions that may arrive
+    // while no active query is running (e.g. after reconnect or background task).
+    if (event.type === 'request_confirmation') {
+      void this.handleConfirmation(event);
+    } else if (event.type === 'request_user_question') {
+      void this.handleUserQuestion(event);
+    }
+  }
+
+  private *handleEvent(event: OctoAgentEvent): Generator<StreamChunk> {
+    switch (event.type) {
+      case 'text_delta': {
+        yield { type: 'text', content: event.text };
+        break;
+      }
+      case 'thinking_delta': {
+        yield { type: 'thinking', content: event.text };
+        break;
+      }
+      case 'assistant_message': {
+        // The assistant_message event carries the final full response. If we already
+        // streamed deltas, we avoid duplicating content here. Deltas are preferred.
+        // In a future iteration we can compare and emit a final text chunk if needed.
+        break;
+      }
+      case 'output': {
+        yield { type: 'text', content: event.content };
+        break;
+      }
+      case 'tool_call': {
+        this.toolIndex += 1;
+        this.currentToolId = `tool-${this.toolIndex}`;
+        yield {
+          type: 'tool_use',
+          id: this.currentToolId,
+          name: event.name,
+          input: typeof event.args === 'object' && event.args !== null
+            ? (event.args as Record<string, unknown>)
+            : { arg: event.args },
+        };
+        break;
+      }
+      case 'tool_result': {
+        const toolId = this.currentToolId ?? 'tool-0';
+        yield {
+          type: 'tool_result',
+          id: toolId,
+          content: event.result,
+          isError: false,
+          toolUseResult: event.ui_payload,
+        };
+        this.currentToolId = null;
+        break;
+      }
+      case 'tool_error': {
+        const toolId = event.tool_id ?? this.currentToolId ?? 'tool-0';
+        yield {
+          type: 'tool_result',
+          id: toolId,
+          content: event.error,
+          isError: true,
+        };
+        this.currentToolId = null;
+        break;
+      }
+      case 'tool_stdout': {
+        const toolId = event.tool_id ?? this.currentToolId ?? 'tool-0';
+        for (const line of event.lines) {
+          yield { type: 'tool_output', id: toolId, content: line };
+        }
+        break;
+      }
+      case 'complete': {
+        if (this.activeQuery) {
+          this.activeQuery.done = true;
+        }
+        break;
+      }
+      case 'interrupted': {
+        if (this.activeQuery) {
+          this.activeQuery.turnAborted = true;
+        }
+        break;
+      }
+      case 'session_update': {
+        const usage = this.buildUsageInfo(event);
+        if (usage) {
+          yield { type: 'usage', usage, sessionId: event.session_id };
+        }
+        break;
+      }
+      case 'request_confirmation': {
+        void this.handleConfirmation(event);
+        break;
+      }
+      case 'request_user_question': {
+        void this.handleUserQuestion(event);
+        break;
+      }
+      case 'error': {
+        yield { type: 'error', content: event.message };
+        break;
+      }
+      case 'toast': {
+        yield { type: 'notice', content: event.message, level: 'info' };
+        break;
+      }
+      default: {
+        // Unknown events are ignored.
+        break;
+      }
+    }
+  }
+
+  private async handleConfirmation(
+    event: Extract<OctoAgentEvent, { type: 'request_confirmation' }>,
+  ): Promise<void> {
+    if (!this.client) {
+      return;
+    }
+
+    const callback = this.approvalCallback;
+    if (!callback) {
+      this.client.confirm(event.id, 'no');
+      return;
+    }
+
+    try {
+      const decision = await callback(
+        event.tool_name || 'octo-agent',
+        {
+          command: event.command,
+          diff: event.diff,
+          input: event.input,
+          kind: event.kind,
+        },
+        event.message,
+        {
+          decisionOptions: this.buildDecisionOptions(event.kind),
+        },
+      );
+      this.client.confirm(event.id, this.mapApprovalDecision(decision, event.kind));
+    } catch (error) {
+      console.error('Error handling octo-agent confirmation:', error);
+      this.client.confirm(event.id, 'no');
+    }
+  }
+
+  private buildDecisionOptions(
+    kind: string,
+  ): Array<{ label: string; value: string; description?: string }> | undefined {
+    if (kind === 'ok') {
+      return [{ label: 'OK', value: 'allow' }];
+    }
+    if (kind === 'yes_no_always') {
+      return [
+        { label: 'Yes', value: 'allow' },
+        { label: 'Always', value: 'allow-always' },
+        { label: 'No', value: 'deny' },
+      ];
+    }
+    return [
+      { label: 'Yes', value: 'allow' },
+      { label: 'No', value: 'deny' },
+    ];
+  }
+
+  private mapApprovalDecision(
+    decision: ApprovalDecision,
+    kind: string,
+  ): string {
+    if (decision === 'cancel' || decision === 'deny') {
+      return 'no';
+    }
+    if (decision === 'allow-always') {
+      return kind === 'yes_no' ? 'yes' : 'always';
+    }
+    if (decision === 'allow') {
+      return 'yes';
+    }
+    if (typeof decision === 'object' && decision.type === 'select-option') {
+      return decision.value;
+    }
+    return 'no';
+  }
+
+  private async handleUserQuestion(
+    event: Extract<OctoAgentEvent, { type: 'request_user_question' }>,
+  ): Promise<void> {
+    if (!this.client) {
+      return;
+    }
+
+    const callback = this.askUserQuestionCallback;
+    if (!callback) {
+      this.client.answerUserQuestion(event.question_id, [], '', true);
+      return;
+    }
+
+    try {
+      const result = await callback({
+        header: event.header,
+        questions: [
+          {
+            header: event.header || event.question,
+            id: event.question_id,
+            isOther: true,
+            multiSelect: event.multi_select,
+            options: event.options.map((option) => ({ description: '', label: option })),
+            question: event.question,
+          },
+        ],
+      });
+
+      if (result === null) {
+        this.client.answerUserQuestion(event.question_id, [], '', true);
+        return;
+      }
+
+      const answer = result[event.question_id] ?? result[event.question];
+      const { choices, custom } = this.normalizeAnswer(answer, event.options);
+      this.client.answerUserQuestion(event.question_id, choices, custom, false);
+    } catch (error) {
+      console.error('Error handling octo-agent user question:', error);
+      this.client.answerUserQuestion(event.question_id, [], '', true);
+    }
+  }
+
+  private normalizeAnswer(
+    answer: string | string[] | undefined,
+    options: string[],
+  ): { choices: string[]; custom: string } {
+    if (answer === undefined || answer === null) {
+      return { choices: [], custom: '' };
+    }
+
+    const values = Array.isArray(answer) ? answer : [answer];
+    const choices: string[] = [];
+    const custom: string[] = [];
+
+    for (const value of values) {
+      if (options.includes(value)) {
+        choices.push(value);
+      } else if (value.trim()) {
+        custom.push(value);
+      }
+    }
+
+    return { choices, custom: custom.join(', ') };
+  }
+
+  private buildUsageInfo(
+    event: Extract<OctoAgentEvent, { type: 'session_update' }>,
+  ): UsageInfo | null {
+    if (typeof event.context_usage !== 'number') {
+      return null;
+    }
+
+    const contextWindow = 200_000;
+    const contextTokens = event.context_usage;
+    return {
+      contextTokens,
+      contextWindow,
+      inputTokens: contextTokens,
+      percentage: Math.min(100, Math.round((contextTokens / contextWindow) * 1000) / 10),
+    };
+  }
+}
+
+class OctoAgentEventBuffer {
+  private events: OctoAgentEvent[] = [];
+  private resolvers: Array<() => void> = [];
+
+  push(event: OctoAgentEvent): void {
+    this.events.push(event);
+    const resolve = this.resolvers.shift();
+    if (resolve) {
+      resolve();
+    }
+  }
+
+  shift(): OctoAgentEvent | undefined {
+    return this.events.shift();
+  }
+
+  async wait(timeoutMs: number): Promise<void> {
+    await new Promise<void>((resolve) => {
+      const timer = window.setTimeout(() => {
+        this.resolvers = this.resolvers.filter((r) => r !== resolver);
+        resolve();
+      }, timeoutMs);
+      const resolver = () => {
+        window.clearTimeout(timer);
+        this.resolvers = this.resolvers.filter((r) => r !== resolver);
+        resolve();
+      };
+      this.resolvers.push(resolver);
+    });
+  }
+}

--- a/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
@@ -580,7 +580,6 @@ export class OctoAgentChatRuntime implements ChatRuntime {
     }
 
     const session = await this.client.createSession({
-      name: 'Claudian',
       source: 'claudian',
     });
     this.sessionId = session.id;

--- a/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
@@ -36,7 +36,7 @@ import { getVaultPath } from '../../../utils/path';
 import { OCTO_AGENT_PROVIDER_CAPABILITIES } from '../capabilities';
 import { getOctoAgentProviderSettings } from '../settings';
 import { getOctoAgentState } from '../types';
-import { OctoAgentClient, type OctoAgentEvent, type OctoAgentUserFile } from './OctoAgentClient';
+import { OctoAgentClient, type OctoAgentEvent, type OctoAgentMessage, type OctoAgentUserFile } from './OctoAgentClient';
 import { ensureOctoAgentServerRunning } from './OctoAgentServerLauncher';
 
 interface PendingQuestion {
@@ -369,6 +369,52 @@ export class OctoAgentChatRuntime implements ChatRuntime {
 
   async loadSubagentFinalResult(): Promise<string | null> {
     return null;
+  }
+
+  async loadHistory(): Promise<ChatMessage[]> {
+    if (!this.sessionId) {
+      return [];
+    }
+
+    try {
+      const ready = await this.ensureReady({ allowSessionCreation: false });
+      if (!ready || !this.client) {
+        return [];
+      }
+      const messages = await this.client.getSessionMessages(this.sessionId);
+      return this.convertServerMessages(messages);
+    } catch (error) {
+      console.error('Failed to load octo-agent history:', error);
+      return [];
+    }
+  }
+
+  private convertServerMessages(messages: OctoAgentMessage[]): ChatMessage[] {
+    const result: ChatMessage[] = [];
+    let timestamp = Date.now();
+
+    for (let i = 0; i < messages.length; i++) {
+      const message = messages[i];
+      const role = message.role === 'assistant' ? 'assistant' : message.role === 'user' ? 'user' : null;
+      if (!role) {
+        continue;
+      }
+
+      const content = typeof message.content === 'string' ? message.content : '';
+      if (!content && (!message.blocks || message.blocks.length === 0)) {
+        continue;
+      }
+
+      timestamp += 1;
+      result.push({
+        id: `octo-hist-${i}`,
+        role,
+        content,
+        timestamp,
+      });
+    }
+
+    return result;
   }
 
   private setReady(ready: boolean): void {

--- a/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
@@ -379,10 +379,12 @@ export class OctoAgentChatRuntime implements ChatRuntime {
 
     try {
       const ready = await this.ensureReady({ allowSessionCreation: false });
+      console.log('[octo-agent] loadHistory ensureReady result:', ready, 'client:', !!this.client);
       if (!ready || !this.client) {
         return [];
       }
       const messages = await this.client.getSessionMessages(this.sessionId);
+      console.log('[octo-agent] loadHistory raw messages count:', messages.length);
       return this.convertServerMessages(messages);
     } catch (error) {
       console.error('Failed to load octo-agent history:', error);
@@ -394,19 +396,32 @@ export class OctoAgentChatRuntime implements ChatRuntime {
     const result: ChatMessage[] = [];
     let timestamp = Date.now();
 
+    console.log('[octo-agent] convertServerMessages: raw messages count:', messages.length);
     for (let i = 0; i < messages.length; i++) {
       const message = messages[i];
-      const role = message.role === 'assistant' ? 'assistant' : message.role === 'user' ? 'user' : null;
+      const eventType = (message.type as string) || (message.role as string) || '';
+
+      let role: 'user' | 'assistant' | null = null;
+      if (eventType === 'history_user_message' || eventType === 'user') {
+        role = 'user';
+      } else if (eventType === 'assistant_message' || eventType === 'assistant') {
+        role = 'assistant';
+      }
       if (!role) {
         continue;
       }
 
       const content = typeof message.content === 'string' ? message.content : '';
-      if (!content && (!message.blocks || message.blocks.length === 0)) {
+      if (!content) {
         continue;
       }
 
-      timestamp += 1;
+      if (typeof message.created_at === 'number' && message.created_at > 1_000_000_000_000) {
+        timestamp = message.created_at;
+      } else {
+        timestamp += 1;
+      }
+
       result.push({
         id: `octo-hist-${i}`,
         role,
@@ -415,6 +430,7 @@ export class OctoAgentChatRuntime implements ChatRuntime {
       });
     }
 
+    console.log('[octo-agent] convertServerMessages: converted count:', result.length);
     return result;
   }
 

--- a/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
@@ -528,12 +528,10 @@ export class OctoAgentChatRuntime implements ChatRuntime {
       }
     }
 
-    const settings = getOctoAgentProviderSettings(
-      this.plugin.settings as unknown as Record<string, unknown>,
-    );
-    if (this.plugin.settings.model) {
+    const pluginSettings = this.plugin.settings as unknown as Record<string, unknown>;
+    if (pluginSettings.model) {
       try {
-        const modelId = String(this.plugin.settings.model).replace(/^octo-agent\//, '');
+        const modelId = String(pluginSettings.model).replace(/^octo-agent\//, '');
         if (modelId && modelId !== 'octo-agent') {
           await this.client.setModel(sessionId, modelId);
         }
@@ -542,10 +540,9 @@ export class OctoAgentChatRuntime implements ChatRuntime {
       }
     }
 
-    const permissionMode = typeof settings.environmentVariables === 'string'
-      && settings.environmentVariables.includes('OCTO_PERMISSION_MODE=auto')
-      ? 'auto'
-      : 'interactive';
+    const permissionMode = typeof pluginSettings.permissionMode === 'string'
+      ? pluginSettings.permissionMode
+      : 'auto';
     try {
       await this.client.setPermissionMode(sessionId, permissionMode);
     } catch (error) {

--- a/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
@@ -371,6 +371,18 @@ export class OctoAgentChatRuntime implements ChatRuntime {
     this.permissionModeSyncCallback = callback;
   }
 
+  async setPermissionMode(mode: string): Promise<void> {
+    if (!this.client || !this.sessionId) {
+      return;
+    }
+    try {
+      await this.client.setPermissionMode(this.sessionId, mode);
+      console.log('[octo-agent] setPermissionMode synced:', mode);
+    } catch (error) {
+      console.error('Failed to set octo-agent permission mode:', error);
+    }
+  }
+
   setSubagentHookProvider(getState: () => SubagentRuntimeState): void {
     this.subagentHookProvider = getState;
   }

--- a/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
@@ -184,6 +184,8 @@ export class OctoAgentChatRuntime implements ChatRuntime {
       }
     }
 
+    await this.refreshConfig();
+
     if (options?.force || !this.sessionId) {
       await this.createSessionIfNeeded(options?.allowSessionCreation !== false);
     }
@@ -290,6 +292,45 @@ export class OctoAgentChatRuntime implements ChatRuntime {
 
   getAuxiliaryModel(): string | null {
     return null;
+  }
+
+  private async refreshConfig(): Promise<void> {
+    if (!this.client) {
+      return;
+    }
+    const config = await this.client.getConfig();
+    console.log('[octo-agent] refreshConfig: models count:', config?.models.length ?? 0, 'defaultIdx:', config?.defaultModelIdx ?? 0);
+    if (!config || config.models.length === 0) {
+      return;
+    }
+
+    const pluginSettings = this.plugin.settings as unknown as Record<string, unknown>;
+    const options = config.models.map((entry, index) => {
+      const isDefault = index === config.defaultModelIdx;
+      return {
+        description: isDefault ? 'Default octo-agent model' : undefined,
+        label: entry.id || entry.model,
+        value: `octo-agent/${entry.model}`,
+      };
+    });
+    pluginSettings.octoAgentModels = options;
+
+    const defaultEntry = config.models[config.defaultModelIdx] ?? config.models[0];
+    if (defaultEntry) {
+      const defaultValue = `octo-agent/${defaultEntry.model}`;
+      const currentModel = pluginSettings.model;
+      if (
+        !currentModel
+        || typeof currentModel !== 'string'
+        || !options.some((option) => option.value === currentModel)
+      ) {
+        pluginSettings.model = defaultValue;
+      }
+    }
+
+    if (config.permissionMode) {
+      pluginSettings.permissionMode = config.permissionMode;
+    }
   }
 
   cleanup(): void {

--- a/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
@@ -793,20 +793,20 @@ export class OctoAgentChatRuntime implements ChatRuntime {
 
   private buildDecisionOptions(
     kind: string,
-  ): Array<{ label: string; value: string; description?: string }> | undefined {
+  ): Array<{ label: string; value: string; description?: string; decision?: ApprovalDecision }> | undefined {
     if (kind === 'ok') {
-      return [{ label: 'OK', value: 'allow' }];
+      return [{ label: 'OK', value: 'allow', decision: 'allow' }];
     }
     if (kind === 'yes_no_always') {
       return [
-        { label: 'Yes', value: 'allow' },
-        { label: 'Always', value: 'allow-always' },
-        { label: 'No', value: 'deny' },
+        { label: 'Yes', value: 'allow', decision: 'allow' },
+        { label: 'Always', value: 'allow-always', decision: 'allow-always' },
+        { label: 'No', value: 'deny', decision: 'deny' },
       ];
     }
     return [
-      { label: 'Yes', value: 'allow' },
-      { label: 'No', value: 'deny' },
+      { label: 'Yes', value: 'allow', decision: 'allow' },
+      { label: 'No', value: 'deny', decision: 'deny' },
     ];
   }
 

--- a/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
@@ -36,7 +36,7 @@ import { getVaultPath } from '../../../utils/path';
 import { OCTO_AGENT_PROVIDER_CAPABILITIES } from '../capabilities';
 import { getOctoAgentProviderSettings } from '../settings';
 import { getOctoAgentState } from '../types';
-import { OctoAgentClient, type OctoAgentEvent } from './OctoAgentClient';
+import { OctoAgentClient, type OctoAgentEvent, type OctoAgentUserFile } from './OctoAgentClient';
 import { ensureOctoAgentServerRunning } from './OctoAgentServerLauncher';
 
 interface PendingQuestion {
@@ -103,7 +103,7 @@ export class OctoAgentChatRuntime implements ChatRuntime {
 
     if (images.length > 0) {
       const imageParts = (images as ImageAttachment[]).map(
-        (image, index) => `[Image ${index + 1}: ${image.mediaType ?? 'image'}]`,
+        (image, index) => `[Attached image ${index + 1}: ${image.name}]`,
       );
       prompt = `${prompt}\n\n${imageParts.join('\n')}`;
     }
@@ -226,7 +226,11 @@ export class OctoAgentChatRuntime implements ChatRuntime {
     this.client.onEvent = onEvent;
 
     try {
-      this.client.sendMessage(this.sessionId, turn.prompt);
+      this.client.sendMessage(
+        this.sessionId,
+        turn.prompt,
+        this.buildImageFiles(turn.request.images),
+      );
 
       while (!this.activeQuery.done && !this.activeQuery.turnAborted) {
         while (true) {
@@ -484,6 +488,17 @@ export class OctoAgentChatRuntime implements ChatRuntime {
     } catch (error) {
       console.error('Failed to set octo-agent permission mode:', error);
     }
+  }
+
+  private buildImageFiles(images: ImageAttachment[] | undefined): OctoAgentUserFile[] | undefined {
+    if (!images || images.length === 0) {
+      return undefined;
+    }
+    return images.map((image) => ({
+      dataUrl: `data:${image.mediaType};base64,${image.data}`,
+      mimeType: image.mediaType,
+      name: image.name,
+    }));
   }
 
   private handleClientEvent(event: OctoAgentEvent): void {

--- a/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentChatRuntime.ts
@@ -581,9 +581,8 @@ export class OctoAgentChatRuntime implements ChatRuntime {
       }
     }
 
-    const permissionMode = typeof pluginSettings.permissionMode === 'string'
-      ? pluginSettings.permissionMode
-      : 'auto';
+    const providerSettings = getOctoAgentProviderSettings(pluginSettings);
+    const permissionMode = providerSettings.permissionMode ?? 'auto';
     try {
       await this.client.setPermissionMode(sessionId, permissionMode);
     } catch (error) {

--- a/src/providers/octo-agent/runtime/OctoAgentClient.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentClient.ts
@@ -30,6 +30,31 @@ export interface OctoAgentUserFile {
   mimeType?: string;
 }
 
+export interface OctoAgentModelEntry {
+  id: string;
+  model: string;
+  baseURL?: string;
+  apiKeyMasked?: string;
+  provider: string;
+  anthropicFormat?: boolean;
+  reasoningEffort?: string;
+  showReasoning?: boolean;
+  vision?: boolean;
+  type?: string;
+  permissionMode?: string;
+}
+
+export interface OctoAgentConfig {
+  models: OctoAgentModelEntry[];
+  defaultModelIdx: number;
+  fontSize: string;
+  language: string;
+  showReasoning: boolean;
+  coauthor?: boolean;
+  workspaceDir: string;
+  permissionMode: string;
+}
+
 export type OctoAgentEvent =
   | { type: 'text_delta'; session_id: string; text: string }
   | { type: 'thinking_delta'; session_id: string; text: string }
@@ -209,6 +234,43 @@ export class OctoAgentClient {
     const record = response as Record<string, any>;
     const sessions = Array.isArray(record.sessions) ? record.sessions : [];
     return sessions.map((session: any) => normalizeSession(session as Record<string, any>));
+  }
+
+  async getConfig(): Promise<OctoAgentConfig | null> {
+    try {
+      const response = await this.fetchJson('/api/config');
+      const record = response as Record<string, any>;
+      const models = Array.isArray(record.models)
+        ? (record.models as Record<string, any>[]).map((m) => ({
+            id: asString(m.id) ?? '',
+            model: asString(m.model) ?? '',
+            baseURL: asString(m.baseURL) ?? asString(m.base_url),
+            apiKeyMasked: asString(m.apiKeyMasked) ?? asString(m.api_key_masked),
+            provider: asString(m.provider) ?? '',
+            anthropicFormat: typeof m.anthropicFormat === 'boolean'
+              ? m.anthropicFormat
+              : undefined,
+            reasoningEffort: asString(m.reasoningEffort),
+            showReasoning: typeof m.showReasoning === 'boolean' ? m.showReasoning : undefined,
+            vision: typeof m.vision === 'boolean' ? m.vision : undefined,
+            type: asString(m.type),
+            permissionMode: asString(m.permissionMode),
+          }))
+        : [];
+      return {
+        coauthor: typeof record.coauthor === 'boolean' ? record.coauthor : undefined,
+        defaultModelIdx: typeof record.defaultModelIdx === 'number' ? record.defaultModelIdx : 0,
+        fontSize: asString(record.fontSize) ?? 'medium',
+        language: asString(record.language) ?? 'en',
+        models,
+        permissionMode: asString(record.permissionMode) ?? 'auto',
+        showReasoning: typeof record.showReasoning === 'boolean' ? record.showReasoning : false,
+        workspaceDir: asString(record.workspaceDir) ?? asString(record.workspace_dir) ?? '',
+      };
+    } catch (error) {
+      console.error('Failed to fetch octo-agent config:', error);
+      return null;
+    }
   }
 
   private openWebSocket(): void {

--- a/src/providers/octo-agent/runtime/OctoAgentClient.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentClient.ts
@@ -96,6 +96,7 @@ export class OctoAgentClient {
   private intentionallyClosed = false;
   private pendingSubscribes = new Set<string>();
   private baseUrl: string;
+  private closeListener: (() => void) | null = null;
 
   constructor(private readonly options: OctoAgentClientOptions) {
     this.baseUrl = options.baseUrl.replace(/\/$/, '');
@@ -105,6 +106,10 @@ export class OctoAgentClient {
     this.callbacks = callbacks;
     this.intentionallyClosed = false;
     this.openWebSocket();
+  }
+
+  setCloseListener(listener: (() => void) | null): void {
+    this.closeListener = listener;
   }
 
   disconnect(): void {
@@ -299,15 +304,25 @@ export class OctoAgentClient {
     this.ws.onclose = () => {
       this.ws = null;
       this.callbacks?.onClose?.();
+      this.closeListener?.();
       if (!this.intentionallyClosed) {
         this.scheduleReconnect();
       }
     };
 
     this.ws.onerror = (event) => {
-      this.callbacks?.onError?.(
-        new Error(event.type === 'error' ? 'WebSocket error' : 'WebSocket error'),
-      );
+      let message = 'WebSocket error';
+      try {
+        const eventMessage = (event as ErrorEvent).message;
+        if (eventMessage) {
+          message = `WebSocket error: ${eventMessage}`;
+        }
+      } catch {
+        // Ignore introspection errors.
+      }
+      const state = this.ws ? readyStateLabel(this.ws.readyState) : 'unknown';
+      const url = this.ws?.url ?? 'unknown';
+      this.callbacks?.onError?.(new Error(`${message} (readyState=${state}, url=${url})`));
     };
 
     this.ws.onmessage = (messageEvent) => {
@@ -505,6 +520,21 @@ function normalizeSession(record: Record<string, any>): OctoAgentSession {
     status: asString(record.status) ?? undefined,
     workingDir: asString(record.working_dir) ?? undefined,
   };
+}
+
+function readyStateLabel(readyState: number): string {
+  switch (readyState) {
+    case WebSocket.CONNECTING:
+      return 'CONNECTING';
+    case WebSocket.OPEN:
+      return 'OPEN';
+    case WebSocket.CLOSING:
+      return 'CLOSING';
+    case WebSocket.CLOSED:
+      return 'CLOSED';
+    default:
+      return String(readyState);
+  }
 }
 
 function asString(value: unknown): string | undefined {

--- a/src/providers/octo-agent/runtime/OctoAgentClient.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentClient.ts
@@ -77,6 +77,7 @@ export type OctoAgentEvent =
   | { type: 'interrupted'; session_id: string }
   | { type: 'subscribed'; session_id: string }
   | { type: 'toast'; session_id: string; message: string; level?: string }
+  | { type: 'send_rejected'; session_id: string; message: string }
   | { type: 'session_deleted'; session_id: string }
   | { type: 'session_activity'; session_id: string; kind: string }
   | { type: 'unknown'; session_id?: string; raw: any };
@@ -511,6 +512,12 @@ export class OctoAgentClient {
           question_id: asString(record.question_id) ?? '',
           session_id: sessionId,
           type: 'request_user_question',
+        };
+      case 'send_rejected':
+        return {
+          message: asString(record.message) ?? '',
+          session_id: sessionId,
+          type: 'send_rejected',
         };
       case 'dismiss_user_question':
         return {

--- a/src/providers/octo-agent/runtime/OctoAgentClient.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentClient.ts
@@ -234,6 +234,13 @@ export class OctoAgentClient {
     });
   }
 
+  async renameSession(sessionId: string, name: string): Promise<void> {
+    await this.fetchJson(`/api/sessions/${encodeURIComponent(sessionId)}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ name }),
+    });
+  }
+
   async listSessions(): Promise<OctoAgentSession[]> {
     const response = await this.fetchJson('/api/sessions');
     const record = response as Record<string, any>;

--- a/src/providers/octo-agent/runtime/OctoAgentClient.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentClient.ts
@@ -16,8 +16,10 @@ export interface OctoAgentSession {
 }
 
 export interface OctoAgentMessage {
-  role: string;
+  type?: string;
+  role?: string;
   content?: string;
+  created_at?: number;
   blocks?: unknown[];
 }
 

--- a/src/providers/octo-agent/runtime/OctoAgentClient.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentClient.ts
@@ -69,6 +69,7 @@ export type OctoAgentEvent =
   | { type: 'error'; session_id: string; message: string }
   | { type: 'session_update'; session_id: string; context_usage?: number; status?: string; working_dir?: string; permission_mode?: string; reasoning_effort?: string; show_reasoning?: boolean }
   | { type: 'request_confirmation'; session_id: string; id: string; message: string; kind: string; tool_name?: string; command?: string; diff?: string; input?: string }
+  | { type: 'confirmation_complete'; session_id: string; id: string; result: string }
   | { type: 'request_user_question'; session_id: string; question_id: string; question: string; options: string[]; multi_select: boolean; header?: string }
   | { type: 'dismiss_user_question'; session_id: string; question_id: string }
   | { type: 'history_user_message'; session_id: string; content: string; created_at?: number }
@@ -493,6 +494,13 @@ export class OctoAgentClient {
           session_id: sessionId,
           tool_name: asString(record.tool_name) ?? undefined,
           type: 'request_confirmation',
+        };
+      case 'confirmation_complete':
+        return {
+          id: asString(record.id) ?? '',
+          result: asString(record.result) ?? 'no',
+          session_id: sessionId,
+          type: 'confirmation_complete',
         };
       case 'request_user_question':
         return {

--- a/src/providers/octo-agent/runtime/OctoAgentClient.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentClient.ts
@@ -1,0 +1,448 @@
+ 
+export interface OctoAgentClientOptions {
+  baseUrl: string;
+  accessKey?: string;
+}
+
+export interface OctoAgentSession {
+  id: string;
+  name: string;
+  status?: string;
+  workingDir?: string;
+  permissionMode?: string;
+  reasoningEffort?: string;
+  showReasoning?: boolean;
+  contextUsage?: number;
+}
+
+export interface OctoAgentMessage {
+  role: string;
+  content?: string;
+  blocks?: unknown[];
+}
+
+export interface OctoAgentUserFile {
+  name: string;
+  dataUrl?: string;
+  path?: string;
+  mimeType?: string;
+}
+
+export type OctoAgentEvent =
+  | { type: 'text_delta'; session_id: string; text: string }
+  | { type: 'thinking_delta'; session_id: string; text: string }
+  | { type: 'assistant_message'; session_id: string; content: string; thinking?: string }
+  | { type: 'tool_call'; session_id: string; name: string; args: any; summary?: string }
+  | { type: 'tool_result'; session_id: string; result: string; tool_id?: string; ui_payload?: any }
+  | { type: 'tool_error'; session_id: string; error: string; tool_id?: string }
+  | { type: 'tool_stdout'; session_id: string; lines: string[]; tool_id?: string }
+  | { type: 'output'; session_id: string; content: string }
+  | { type: 'progress'; session_id: string; phase: string; message?: string; progress_type?: string }
+  | { type: 'complete'; session_id: string; iterations: number; awaiting_user_feedback?: boolean }
+  | { type: 'error'; session_id: string; message: string }
+  | { type: 'session_update'; session_id: string; context_usage?: number; status?: string; working_dir?: string; permission_mode?: string; reasoning_effort?: string; show_reasoning?: boolean }
+  | { type: 'request_confirmation'; session_id: string; id: string; message: string; kind: string; tool_name?: string; command?: string; diff?: string; input?: string }
+  | { type: 'request_user_question'; session_id: string; question_id: string; question: string; options: string[]; multi_select: boolean; header?: string }
+  | { type: 'dismiss_user_question'; session_id: string; question_id: string }
+  | { type: 'history_user_message'; session_id: string; content: string; created_at?: number }
+  | { type: 'history_reload'; session_id: string }
+  | { type: 'interrupted'; session_id: string }
+  | { type: 'subscribed'; session_id: string }
+  | { type: 'toast'; session_id: string; message: string; level?: string }
+  | { type: 'session_deleted'; session_id: string }
+  | { type: 'session_activity'; session_id: string; kind: string }
+  | { type: 'unknown'; session_id?: string; raw: any };
+
+export interface OctoAgentClientCallbacks {
+  onOpen?: () => void;
+  onClose?: (error?: Error) => void;
+  onError?: (error: Error) => void;
+  onEvent: (event: OctoAgentEvent) => void;
+}
+
+export class OctoAgentClient {
+  private ws: WebSocket | null = null;
+  private callbacks: OctoAgentClientCallbacks | null = null;
+  onEvent?: (event: OctoAgentEvent) => void;
+  private readonly reconnectDelayMs = 1000;
+  private reconnectTimer: number | null = null;
+  private intentionallyClosed = false;
+  private pendingSubscribes = new Set<string>();
+  private baseUrl: string;
+
+  constructor(private readonly options: OctoAgentClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/$/, '');
+  }
+
+  connect(callbacks: OctoAgentClientCallbacks): void {
+    this.callbacks = callbacks;
+    this.intentionallyClosed = false;
+    this.openWebSocket();
+  }
+
+  disconnect(): void {
+    this.intentionallyClosed = true;
+    if (this.reconnectTimer) {
+      window.clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.ws?.close();
+    this.ws = null;
+    this.callbacks = null;
+    this.pendingSubscribes.clear();
+  }
+
+  isConnected(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  subscribe(sessionId: string): void {
+    this.pendingSubscribes.add(sessionId);
+    this.send({ type: 'subscribe', session_id: sessionId });
+  }
+
+  unsubscribe(sessionId: string): void {
+    this.pendingSubscribes.delete(sessionId);
+    this.send({ type: 'unsubscribe', session_id: sessionId });
+  }
+
+  sendMessage(sessionId: string, message: string, files?: OctoAgentUserFile[]): void {
+    this.send({
+      type: 'user_message',
+      session_id: sessionId,
+      content: message,
+      ...(files?.length ? { files } : {}),
+    });
+  }
+
+  interrupt(sessionId: string): void {
+    this.send({ type: 'interrupt', session_id: sessionId });
+  }
+
+  retry(sessionId: string): void {
+    this.send({ type: 'retry', session_id: sessionId });
+  }
+
+  rollback(sessionId: string): void {
+    this.send({ type: 'rollback', session_id: sessionId });
+  }
+
+  confirm(id: string, result: string): void {
+    this.send({ type: 'confirmation', id, result });
+  }
+
+  answerUserQuestion(
+    questionId: string,
+    choices: string[],
+    custom: string,
+    cancelled: boolean,
+  ): void {
+    this.send({
+      type: 'user_question_answer',
+      question_id: questionId,
+      choices,
+      custom,
+      cancelled,
+    });
+  }
+
+  async createSession(options: {
+    name?: string;
+    model?: string;
+    agentProfile?: string;
+    source?: string;
+  } = {}): Promise<OctoAgentSession> {
+    const response = await this.fetchJson('/api/sessions', {
+      method: 'POST',
+      body: JSON.stringify({
+        name: options.name ?? '',
+        model: options.model ?? '',
+        agent_profile: options.agentProfile ?? 'general',
+        source: options.source ?? 'manual',
+      }),
+    });
+
+    const record = response as Record<string, any>;
+    if (record.session && typeof record.session === 'object') {
+      return normalizeSession(record.session as Record<string, any>);
+    }
+    throw new Error('Invalid session creation response');
+  }
+
+  async getSessionMessages(sessionId: string): Promise<OctoAgentMessage[]> {
+    const response = await this.fetchJson(`/api/sessions/${encodeURIComponent(sessionId)}/messages`);
+    const record = response as Record<string, any>;
+    if (Array.isArray(record.events)) {
+      return record.events as OctoAgentMessage[];
+    }
+    if (Array.isArray(record.messages)) {
+      return record.messages as OctoAgentMessage[];
+    }
+    return [];
+  }
+
+  async setWorkingDir(sessionId: string, workingDir: string): Promise<void> {
+    await this.fetchJson(`/api/sessions/${encodeURIComponent(sessionId)}/working_dir`, {
+      method: 'PATCH',
+      body: JSON.stringify({ working_dir: workingDir }),
+    });
+  }
+
+  async setModel(sessionId: string, modelId: string): Promise<void> {
+    await this.fetchJson(`/api/sessions/${encodeURIComponent(sessionId)}/model`, {
+      method: 'PATCH',
+      body: JSON.stringify({ model_id: modelId }),
+    });
+  }
+
+  async setPermissionMode(sessionId: string, mode: string): Promise<void> {
+    await this.fetchJson(`/api/sessions/${encodeURIComponent(sessionId)}/permission_mode`, {
+      method: 'PATCH',
+      body: JSON.stringify({ permission_mode: mode }),
+    });
+  }
+
+  async listSessions(): Promise<OctoAgentSession[]> {
+    const response = await this.fetchJson('/api/sessions');
+    const record = response as Record<string, any>;
+    const sessions = Array.isArray(record.sessions) ? record.sessions : [];
+    return sessions.map((session: any) => normalizeSession(session as Record<string, any>));
+  }
+
+  private openWebSocket(): void {
+    if (this.ws) {
+      return;
+    }
+
+    const url = this.buildWebSocketUrl('/ws');
+    try {
+      this.ws = new WebSocket(url);
+    } catch (error) {
+      this.callbacks?.onError?.(
+        error instanceof Error ? error : new Error('Failed to create WebSocket'),
+      );
+      this.scheduleReconnect();
+      return;
+    }
+
+    this.ws.onopen = () => {
+      this.callbacks?.onOpen?.();
+      for (const sessionId of this.pendingSubscribes) {
+        this.send({ type: 'subscribe', session_id: sessionId });
+      }
+    };
+
+    this.ws.onclose = () => {
+      this.ws = null;
+      this.callbacks?.onClose?.();
+      if (!this.intentionallyClosed) {
+        this.scheduleReconnect();
+      }
+    };
+
+    this.ws.onerror = (event) => {
+      this.callbacks?.onError?.(
+        new Error(event.type === 'error' ? 'WebSocket error' : 'WebSocket error'),
+      );
+    };
+
+    this.ws.onmessage = (messageEvent) => {
+      let raw: any;
+      try {
+        raw = JSON.parse(messageEvent.data as string);
+      } catch {
+        this.callbacks?.onError?.(new Error('Invalid WebSocket message'));
+        return;
+      }
+      const event = this.parseEvent(raw);
+      this.callbacks?.onEvent(event);
+      this.onEvent?.(event);
+    };
+  }
+
+  private scheduleReconnect(): void {
+    if (this.reconnectTimer) {
+      return;
+    }
+    this.reconnectTimer = window.setTimeout(() => {
+      this.reconnectTimer = null;
+      if (!this.intentionallyClosed) {
+        this.openWebSocket();
+      }
+    }, this.reconnectDelayMs);
+  }
+
+  private send(payload: any): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(payload));
+    }
+  }
+
+  private async fetchJson(path: string, init?: RequestInit): Promise<unknown> {
+    const url = `${this.baseUrl}${path}${this.buildAuthSuffix(path.includes('?') ? '&' : '?')}`;
+    const response = await fetch(url, {
+      ...init,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(init?.headers ?? {}),
+      },
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => 'Unknown error');
+      throw new Error(`HTTP ${response.status}: ${text}`);
+    }
+
+    return response.json();
+  }
+
+  private buildWebSocketUrl(path: string): string {
+    const baseUrl = new URL(this.baseUrl);
+    const protocol = baseUrl.protocol === 'https:' ? 'wss:' : 'ws:';
+    const wsUrl = `${protocol}//${baseUrl.host}${path}`;
+    return wsUrl + this.buildAuthSuffix('?');
+  }
+
+  private buildAuthSuffix(separator: string): string {
+    if (!this.options.accessKey) {
+      return '';
+    }
+    return `${separator}access_key=${encodeURIComponent(this.options.accessKey)}`;
+  }
+
+  private parseEvent(raw: any): OctoAgentEvent {
+    const record = raw as Record<string, any>;
+    const sessionId = typeof record.session_id === 'string' ? record.session_id : '';
+
+    const type = typeof record.type === 'string' ? record.type : '';
+    switch (type) {
+      case 'text_delta':
+      case 'thinking_delta':
+      case 'output':
+      case 'history_user_message':
+      case 'interrupted':
+      case 'history_reload':
+      case 'session_deleted':
+      case 'session_activity':
+      case 'subscribed':
+      case 'toast':
+        return { ...(raw as any), type } as OctoAgentEvent;
+      case 'assistant_message':
+        return {
+          content: asString(record.content) ?? '',
+          session_id: sessionId,
+          thinking: asString(record.thinking) ?? undefined,
+          type: 'assistant_message',
+        };
+      case 'tool_call':
+        return {
+          args: record.args,
+          name: asString(record.name) ?? '',
+          session_id: sessionId,
+          summary: asString(record.summary) ?? undefined,
+          type: 'tool_call',
+        };
+      case 'tool_result':
+        return {
+          result: asString(record.result) ?? '',
+          session_id: sessionId,
+          tool_id: asString(record.tool_id) ?? undefined,
+          type: 'tool_result',
+          ui_payload: record.ui_payload,
+        };
+      case 'tool_error':
+        return {
+          error: asString(record.error) ?? '',
+          session_id: sessionId,
+          tool_id: asString(record.tool_id) ?? undefined,
+          type: 'tool_error',
+        };
+      case 'tool_stdout':
+        return {
+          lines: Array.isArray(record.lines) ? record.lines.map(String) : [],
+          session_id: sessionId,
+          tool_id: asString(record.tool_id) ?? undefined,
+          type: 'tool_stdout',
+        };
+      case 'progress':
+        return {
+          message: asString(record.message) ?? undefined,
+          phase: asString(record.phase) ?? 'active',
+          progress_type: asString(record.progress_type) ?? undefined,
+          session_id: sessionId,
+          type: 'progress',
+        };
+      case 'complete':
+        return {
+          awaiting_user_feedback: record.awaiting_user_feedback === true,
+          iterations: Number(record.iterations) || 0,
+          session_id: sessionId,
+          type: 'complete',
+        };
+      case 'error':
+        return {
+          message: asString(record.message) ?? '',
+          session_id: sessionId,
+          type: 'error',
+        };
+      case 'session_update':
+        return {
+          context_usage: typeof record.context_usage === 'number' ? record.context_usage : undefined,
+          permission_mode: asString(record.permission_mode) ?? undefined,
+          reasoning_effort: asString(record.reasoning_effort) ?? undefined,
+          session_id: sessionId,
+          show_reasoning: typeof record.show_reasoning === 'boolean' ? record.show_reasoning : undefined,
+          status: asString(record.status) ?? undefined,
+          type: 'session_update',
+          working_dir: asString(record.working_dir) ?? undefined,
+        };
+      case 'request_confirmation':
+        return {
+          command: asString(record.command) ?? undefined,
+          diff: asString(record.diff) ?? undefined,
+          id: asString(record.id) ?? '',
+          input: asString(record.input) ?? undefined,
+          kind: asString(record.kind) ?? 'yes_no',
+          message: asString(record.message) ?? '',
+          session_id: sessionId,
+          tool_name: asString(record.tool_name) ?? undefined,
+          type: 'request_confirmation',
+        };
+      case 'request_user_question':
+        return {
+          header: asString(record.header) ?? undefined,
+          multi_select: record.multi_select === true,
+          options: Array.isArray(record.options) ? record.options.map(String) : [],
+          question: asString(record.question) ?? '',
+          question_id: asString(record.question_id) ?? '',
+          session_id: sessionId,
+          type: 'request_user_question',
+        };
+      case 'dismiss_user_question':
+        return {
+          question_id: asString(record.question_id) ?? '',
+          session_id: sessionId,
+          type: 'dismiss_user_question',
+        };
+      default:
+        return { raw: record as any, session_id: sessionId, type: 'unknown' };
+    }
+  }
+}
+
+function normalizeSession(record: Record<string, any>): OctoAgentSession {
+  return {
+    contextUsage: typeof record.context_usage === 'number' ? record.context_usage : undefined,
+    id: asString(record.id) ?? '',
+    name: asString(record.name) ?? '',
+    permissionMode: asString(record.permission_mode) ?? undefined,
+    reasoningEffort: asString(record.reasoning_effort) ?? undefined,
+    showReasoning: typeof record.show_reasoning === 'boolean' ? record.show_reasoning : undefined,
+    status: asString(record.status) ?? undefined,
+    workingDir: asString(record.working_dir) ?? undefined,
+  };
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}

--- a/src/providers/octo-agent/runtime/OctoAgentServerLauncher.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentServerLauncher.ts
@@ -1,0 +1,115 @@
+import { spawn } from 'node:child_process';
+
+import type ClaudianPlugin from '../../../main';
+import { getEnhancedPath, parseEnvironmentVariables } from '../../../utils/env';
+import { getVaultPath } from '../../../utils/path';
+import { getOctoAgentProviderSettings } from '../settings';
+
+const OBSIDIAN_ORIGIN = 'app://obsidian.md';
+const HEALTH_POLL_INTERVAL_MS = 300;
+const HEALTH_POLL_TIMEOUT_MS = 15_000;
+
+export interface OctoAgentServerLauncherOptions {
+  plugin: ClaudianPlugin;
+}
+
+export interface OctoAgentServerProbeResult {
+  running: boolean;
+}
+
+export async function probeOctoAgentServer(baseUrl: string): Promise<OctoAgentServerProbeResult> {
+  try {
+    const response = await fetch(`${baseUrl}/api/health`, {
+      method: 'GET',
+    });
+    return { running: response.ok };
+  } catch {
+    return { running: false };
+  }
+}
+
+async function waitForServer(baseUrl: string, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const { running } = await probeOctoAgentServer(baseUrl);
+    if (running) {
+      return true;
+    }
+    await new Promise((resolve) => window.setTimeout(resolve, HEALTH_POLL_INTERVAL_MS));
+  }
+  return false;
+}
+
+function parseEnvString(envText: string): Record<string, string> {
+  return parseEnvironmentVariables(envText);
+}
+
+export async function ensureOctoAgentServerRunning(options: OctoAgentServerLauncherOptions): Promise<boolean> {
+  const { plugin } = options;
+  const settingsBag = plugin.settings as unknown as Record<string, unknown>;
+  const settings = getOctoAgentProviderSettings(settingsBag);
+
+  if (!settings.enabled) {
+    return false;
+  }
+
+  const baseUrl = `http://${settings.host}:${settings.port}`;
+  const probe = await probeOctoAgentServer(baseUrl);
+  if (probe.running) {
+    return true;
+  }
+
+  if (!settings.autoStartServer) {
+    return false;
+  }
+
+  const cliPath = settings.cliPath.trim() || 'octo';
+  const args = ['serve', '-d', '--cors', OBSIDIAN_ORIGIN];
+
+  if (settings.accessKey) {
+    args.push('--access-key', settings.accessKey);
+  }
+
+  const cwd = getVaultPath(plugin.app) ?? undefined;
+  const customEnv = parseEnvString(settings.environmentVariables);
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...customEnv,
+    PATH: getEnhancedPath(process.env.PATH, cliPath),
+  };
+
+  return new Promise((resolve) => {
+    let exitError: Error | undefined;
+
+    const proc = spawn(cliPath, args, {
+      cwd,
+      detached: true,
+      env,
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+
+    proc.on('error', (error) => {
+      console.error('Failed to start octo serve:', error);
+      exitError = error;
+    });
+
+    proc.on('exit', (code, signal) => {
+      if (!exitError && code !== 0 && signal === null) {
+        console.error(`octo serve exited with code ${String(code)}`);
+      }
+    });
+
+    proc.unref();
+
+    // Daemon mode (-d) should fork into the background quickly; give it a moment
+    // before we start polling the health endpoint.
+    window.setTimeout(async () => {
+      const running = await waitForServer(baseUrl, HEALTH_POLL_TIMEOUT_MS);
+      if (!running) {
+        console.error('octo serve did not become ready after auto-start');
+      }
+      resolve(running);
+    }, 300);
+  });
+}

--- a/src/providers/octo-agent/runtime/OctoAgentServerLauncher.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentServerLauncher.ts
@@ -4,6 +4,7 @@ import type ClaudianPlugin from '../../../main';
 import { getEnhancedPath, parseEnvironmentVariables } from '../../../utils/env';
 import { getVaultPath } from '../../../utils/path';
 import { getOctoAgentProviderSettings } from '../settings';
+import { resolveOctoAgentBinary } from './OctoAgentBinaryLocator';
 
 const OBSIDIAN_ORIGIN = 'app://obsidian.md';
 const HEALTH_POLL_INTERVAL_MS = 300;
@@ -63,7 +64,8 @@ export async function ensureOctoAgentServerRunning(options: OctoAgentServerLaunc
     return false;
   }
 
-  const cliPath = settings.cliPath.trim() || 'octo';
+  const cliPathInput = settings.cliPath.trim();
+  const resolvedBinary = resolveOctoAgentBinary(cliPathInput) ?? (cliPathInput || 'octo');
   const args = ['serve', '-d', '--cors', OBSIDIAN_ORIGIN];
 
   if (settings.accessKey) {
@@ -75,13 +77,19 @@ export async function ensureOctoAgentServerRunning(options: OctoAgentServerLaunc
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     ...customEnv,
-    PATH: getEnhancedPath(process.env.PATH, cliPath),
+    PATH: getEnhancedPath(process.env.PATH, resolvedBinary),
   };
 
   return new Promise((resolve) => {
-    let exitError: Error | undefined;
+    let settled = false;
+    const settle = (value: boolean) => {
+      if (!settled) {
+        settled = true;
+        resolve(value);
+      }
+    };
 
-    const proc = spawn(cliPath, args, {
+    const proc = spawn(resolvedBinary, args, {
       cwd,
       detached: true,
       env,
@@ -91,11 +99,11 @@ export async function ensureOctoAgentServerRunning(options: OctoAgentServerLaunc
 
     proc.on('error', (error) => {
       console.error('Failed to start octo serve:', error);
-      exitError = error;
+      settle(false);
     });
 
     proc.on('exit', (code, signal) => {
-      if (!exitError && code !== 0 && signal === null) {
+      if (code !== 0 && signal === null) {
         console.error(`octo serve exited with code ${String(code)}`);
       }
     });
@@ -109,7 +117,7 @@ export async function ensureOctoAgentServerRunning(options: OctoAgentServerLaunc
       if (!running) {
         console.error('octo serve did not become ready after auto-start');
       }
-      resolve(running);
+      settle(running);
     }, 300);
   });
 }

--- a/src/providers/octo-agent/runtime/OctoAgentServerLauncher.ts
+++ b/src/providers/octo-agent/runtime/OctoAgentServerLauncher.ts
@@ -18,9 +18,10 @@ export interface OctoAgentServerProbeResult {
   running: boolean;
 }
 
-export async function probeOctoAgentServer(baseUrl: string): Promise<OctoAgentServerProbeResult> {
+export async function probeOctoAgentServer(baseUrl: string, accessKey?: string): Promise<OctoAgentServerProbeResult> {
   try {
-    const response = await fetch(`${baseUrl}/api/health`, {
+    const suffix = accessKey ? `?access_key=${encodeURIComponent(accessKey)}` : '';
+    const response = await fetch(`${baseUrl}/api/health${suffix}`, {
       method: 'GET',
     });
     return { running: response.ok };
@@ -29,10 +30,10 @@ export async function probeOctoAgentServer(baseUrl: string): Promise<OctoAgentSe
   }
 }
 
-async function waitForServer(baseUrl: string, timeoutMs: number): Promise<boolean> {
+async function waitForServer(baseUrl: string, accessKey: string | undefined, timeoutMs: number): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const { running } = await probeOctoAgentServer(baseUrl);
+    const { running } = await probeOctoAgentServer(baseUrl, accessKey);
     if (running) {
       return true;
     }
@@ -55,7 +56,8 @@ export async function ensureOctoAgentServerRunning(options: OctoAgentServerLaunc
   }
 
   const baseUrl = `http://${settings.host}:${settings.port}`;
-  const probe = await probeOctoAgentServer(baseUrl);
+  const accessKey = settings.accessKey || undefined;
+  const probe = await probeOctoAgentServer(baseUrl, accessKey);
   if (probe.running) {
     return true;
   }
@@ -68,8 +70,8 @@ export async function ensureOctoAgentServerRunning(options: OctoAgentServerLaunc
   const resolvedBinary = resolveOctoAgentBinary(cliPathInput) ?? (cliPathInput || 'octo');
   const args = ['serve', '-d', '--cors', OBSIDIAN_ORIGIN];
 
-  if (settings.accessKey) {
-    args.push('--access-key', settings.accessKey);
+  if (accessKey) {
+    args.push('--access-key', accessKey);
   }
 
   const cwd = getVaultPath(plugin.app) ?? undefined;
@@ -113,7 +115,7 @@ export async function ensureOctoAgentServerRunning(options: OctoAgentServerLaunc
     // Daemon mode (-d) should fork into the background quickly; give it a moment
     // before we start polling the health endpoint.
     window.setTimeout(async () => {
-      const running = await waitForServer(baseUrl, HEALTH_POLL_TIMEOUT_MS);
+      const running = await waitForServer(baseUrl, accessKey, HEALTH_POLL_TIMEOUT_MS);
       if (!running) {
         console.error('octo serve did not become ready after auto-start');
       }

--- a/src/providers/octo-agent/settings.ts
+++ b/src/providers/octo-agent/settings.ts
@@ -19,7 +19,7 @@ export const DEFAULT_OCTO_AGENT_PROVIDER_SETTINGS: Readonly<OctoAgentProviderSet
     enabled: false,
     environmentVariables: '',
     host: '127.0.0.1',
-    permissionMode: 'auto',
+    permissionMode: 'yolo',
     port: 8088,
   });
 

--- a/src/providers/octo-agent/settings.ts
+++ b/src/providers/octo-agent/settings.ts
@@ -1,0 +1,64 @@
+import { getProviderConfig } from '../../core/providers/providerConfig';
+
+export interface OctoAgentProviderSettings {
+  enabled: boolean;
+  host: string;
+  port: number;
+  autoStartServer: boolean;
+  cliPath: string;
+  accessKey: string;
+  environmentVariables: string;
+}
+
+export const DEFAULT_OCTO_AGENT_PROVIDER_SETTINGS: Readonly<OctoAgentProviderSettings> =
+  Object.freeze({
+    accessKey: '',
+    autoStartServer: true,
+    cliPath: 'octo',
+    enabled: false,
+    environmentVariables: '',
+    host: '127.0.0.1',
+    port: 8088,
+  });
+
+export function getOctoAgentProviderSettings(
+  settings: Record<string, unknown>,
+): OctoAgentProviderSettings {
+  const config = getProviderConfig(settings, 'octo-agent');
+  return {
+    accessKey: asString(config.accessKey) ?? DEFAULT_OCTO_AGENT_PROVIDER_SETTINGS.accessKey,
+    autoStartServer: asBoolean(config.autoStartServer)
+      ?? DEFAULT_OCTO_AGENT_PROVIDER_SETTINGS.autoStartServer,
+    cliPath: asString(config.cliPath) ?? DEFAULT_OCTO_AGENT_PROVIDER_SETTINGS.cliPath,
+    enabled: asBoolean(config.enabled) ?? DEFAULT_OCTO_AGENT_PROVIDER_SETTINGS.enabled,
+    environmentVariables: asString(config.environmentVariables)
+      ?? DEFAULT_OCTO_AGENT_PROVIDER_SETTINGS.environmentVariables,
+    host: asString(config.host) ?? DEFAULT_OCTO_AGENT_PROVIDER_SETTINGS.host,
+    port: asNumber(config.port) ?? DEFAULT_OCTO_AGENT_PROVIDER_SETTINGS.port,
+  };
+}
+
+export function updateOctoAgentProviderSettings(
+  settings: Record<string, unknown>,
+  updates: Partial<OctoAgentProviderSettings>,
+): OctoAgentProviderSettings {
+  const current = getOctoAgentProviderSettings(settings);
+  const next = { ...current, ...updates };
+   
+  (settings.providerConfigs as Record<string, unknown> | undefined) ??= {};
+   
+  (settings.providerConfigs as Record<string, unknown>)['octo-agent'] = next;
+  return next;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function asBoolean(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' ? value : undefined;
+}

--- a/src/providers/octo-agent/settings.ts
+++ b/src/providers/octo-agent/settings.ts
@@ -8,6 +8,7 @@ export interface OctoAgentProviderSettings {
   cliPath: string;
   accessKey: string;
   environmentVariables: string;
+  permissionMode?: string;
 }
 
 export const DEFAULT_OCTO_AGENT_PROVIDER_SETTINGS: Readonly<OctoAgentProviderSettings> =
@@ -18,6 +19,7 @@ export const DEFAULT_OCTO_AGENT_PROVIDER_SETTINGS: Readonly<OctoAgentProviderSet
     enabled: false,
     environmentVariables: '',
     host: '127.0.0.1',
+    permissionMode: 'auto',
     port: 8088,
   });
 
@@ -34,6 +36,7 @@ export function getOctoAgentProviderSettings(
     environmentVariables: asString(config.environmentVariables)
       ?? DEFAULT_OCTO_AGENT_PROVIDER_SETTINGS.environmentVariables,
     host: asString(config.host) ?? DEFAULT_OCTO_AGENT_PROVIDER_SETTINGS.host,
+    permissionMode: asString(config.permissionMode) ?? DEFAULT_OCTO_AGENT_PROVIDER_SETTINGS.permissionMode,
     port: asNumber(config.port) ?? DEFAULT_OCTO_AGENT_PROVIDER_SETTINGS.port,
   };
 }

--- a/src/providers/octo-agent/types.ts
+++ b/src/providers/octo-agent/types.ts
@@ -1,0 +1,25 @@
+export interface OctoAgentProviderState {
+  sessionId?: string;
+}
+
+export function getOctoAgentState(
+  providerState: Record<string, unknown> | undefined,
+): OctoAgentProviderState {
+  if (!providerState || typeof providerState !== 'object' || Array.isArray(providerState)) {
+    return {};
+  }
+
+  const state = providerState as OctoAgentProviderState;
+  return {
+    sessionId: typeof state.sessionId === 'string' ? state.sessionId : undefined,
+  };
+}
+
+export function buildPersistedOctoAgentState(
+  state: OctoAgentProviderState,
+): Record<string, unknown> | undefined {
+  if (!state.sessionId) {
+    return undefined;
+  }
+  return { sessionId: state.sessionId } as Record<string, unknown>;
+}

--- a/src/providers/octo-agent/ui/OctoAgentChatUIConfig.ts
+++ b/src/providers/octo-agent/ui/OctoAgentChatUIConfig.ts
@@ -1,0 +1,95 @@
+import type {
+  ProviderChatUIConfig,
+  ProviderPermissionModeToggleConfig,
+  ProviderReasoningOption,
+  ProviderUIOption,
+} from '../../../core/providers/types';
+import { OCTO_AGENT_PROVIDER_ICON } from '../../../shared/icons';
+
+const OCTO_AGENT_MODEL: ProviderUIOption = {
+  description: 'Runs through the local octo-agent server',
+  label: 'Octo Agent',
+  value: 'octo-agent/octo-agent',
+};
+
+const DEFAULT_CONTEXT_WINDOW = 200_000;
+
+const OCTO_AGENT_PERMISSION_MODE_TOGGLE: ProviderPermissionModeToggleConfig = {
+  activeLabel: 'All tools',
+  activeValue: 'auto',
+  inactiveLabel: 'Read-only',
+  inactiveValue: 'interactive',
+};
+
+export const octoAgentChatUIConfig: ProviderChatUIConfig = {
+  getModelOptions(): ProviderUIOption[] {
+    return [OCTO_AGENT_MODEL];
+  },
+
+  ownsModel(model: string): boolean {
+    return model === 'octo-agent' || model === 'octo-agent/octo-agent' || model.startsWith('octo-agent/');
+  },
+
+  isAdaptiveReasoningModel(): boolean {
+    return false;
+  },
+
+  getReasoningOptions(): ProviderReasoningOption[] {
+    return [];
+  },
+
+  getDefaultReasoningValue(): string {
+    return 'off';
+  },
+
+  getContextWindowSize(
+    _model: string,
+    customLimits?: Record<string, number>,
+  ): number {
+    return customLimits?.['octo-agent'] ?? DEFAULT_CONTEXT_WINDOW;
+  },
+
+  isDefaultModel(model: string): boolean {
+    return model === 'octo-agent' || model === 'octo-agent/octo-agent';
+  },
+
+  applyModelDefaults(model: string, settings: unknown): void {
+    if (!settings || typeof settings !== 'object' || Array.isArray(settings)) {
+      return;
+    }
+    const settingsBag = settings as Record<string, unknown>;
+    if (model === 'octo-agent' || model === 'octo-agent/octo-agent' || model.startsWith('octo-agent/')) {
+      settingsBag.model = model;
+    }
+  },
+
+  normalizeModelVariant(model: string, _settings: Record<string, unknown>): string {
+    if (model === 'octo-agent' || model === 'octo-agent/octo-agent' || model.startsWith('octo-agent/')) {
+      return model;
+    }
+    return 'octo-agent/octo-agent';
+  },
+
+  getCustomModelIds(): Set<string> {
+    return new Set<string>();
+  },
+
+  getPermissionModeToggle(): ProviderPermissionModeToggleConfig | null {
+    return OCTO_AGENT_PERMISSION_MODE_TOGGLE;
+  },
+
+  resolvePermissionMode(settings: Record<string, unknown>): string | null {
+    return typeof settings.permissionMode === 'string' ? settings.permissionMode : 'interactive';
+  },
+
+  applyPermissionMode(value: string, settings: unknown): void {
+    if (!settings || typeof settings !== 'object' || Array.isArray(settings)) {
+      return;
+    }
+    (settings as Record<string, unknown>).permissionMode = value;
+  },
+
+  getProviderIcon() {
+    return OCTO_AGENT_PROVIDER_ICON;
+  },
+};

--- a/src/providers/octo-agent/ui/OctoAgentChatUIConfig.ts
+++ b/src/providers/octo-agent/ui/OctoAgentChatUIConfig.ts
@@ -5,6 +5,10 @@ import type {
   ProviderUIOption,
 } from '../../../core/providers/types';
 import { OCTO_AGENT_PROVIDER_ICON } from '../../../shared/icons';
+import {
+  isValidClaudianPermissionMode,
+  toClaudianPermissionMode,
+} from '../permissionMode';
 
 const OCTO_AGENT_MODEL: ProviderUIOption = {
   description: 'Runs through the local octo-agent server',
@@ -16,9 +20,9 @@ const DEFAULT_CONTEXT_WINDOW = 200_000;
 
 const OCTO_AGENT_PERMISSION_MODE_TOGGLE: ProviderPermissionModeToggleConfig = {
   activeLabel: 'All tools',
-  activeValue: 'auto',
+  activeValue: 'yolo',
   inactiveLabel: 'Read-only',
-  inactiveValue: 'interactive',
+  inactiveValue: 'normal',
 };
 
 export const octoAgentChatUIConfig: ProviderChatUIConfig = {
@@ -30,25 +34,26 @@ export const octoAgentChatUIConfig: ProviderChatUIConfig = {
     return [OCTO_AGENT_MODEL];
   },
 
-  ownsModel(model: string): boolean {
+  ownsModel(model: string, _settings: Record<string, unknown>): boolean {
     return model === 'octo-agent' || model === 'octo-agent/octo-agent' || model.startsWith('octo-agent/');
   },
 
-  isAdaptiveReasoningModel(): boolean {
+  isAdaptiveReasoningModel(_model: string, _settings: Record<string, unknown>): boolean {
     return false;
   },
 
-  getReasoningOptions(): ProviderReasoningOption[] {
+  getReasoningOptions(_model: string, _settings: Record<string, unknown>): ProviderReasoningOption[] {
     return [];
   },
 
-  getDefaultReasoningValue(): string {
+  getDefaultReasoningValue(_model: string, _settings: Record<string, unknown>): string {
     return 'off';
   },
 
   getContextWindowSize(
     _model: string,
     customLimits?: Record<string, number>,
+    _settings?: Record<string, unknown>,
   ): number {
     return customLimits?.['octo-agent'] ?? DEFAULT_CONTEXT_WINDOW;
   },
@@ -70,10 +75,10 @@ export const octoAgentChatUIConfig: ProviderChatUIConfig = {
   normalizeModelVariant(model: string, settings: Record<string, unknown>): string {
     const cached = settings.octoAgentModels as ProviderUIOption[] | undefined;
     if (cached && cached.length > 0) {
-      if (model === 'octo-agent' || cached.some((option) => option.value === model)) {
+      if (cached.some((option) => option.value === model)) {
         return model;
       }
-      const defaultOption = cached[0];
+      const defaultOption = cached.find((option) => option.value === 'octo-agent/kimi-for-coding') ?? cached[0];
       return defaultOption?.value ?? 'octo-agent/kimi-for-coding';
     }
     if (model === 'octo-agent' || model === 'octo-agent/kimi-for-coding' || model.startsWith('octo-agent/')) {
@@ -82,7 +87,7 @@ export const octoAgentChatUIConfig: ProviderChatUIConfig = {
     return 'octo-agent/kimi-for-coding';
   },
 
-  getCustomModelIds(): Set<string> {
+  getCustomModelIds(_envVars: Record<string, string>): Set<string> {
     return new Set<string>();
   },
 
@@ -91,14 +96,21 @@ export const octoAgentChatUIConfig: ProviderChatUIConfig = {
   },
 
   resolvePermissionMode(settings: Record<string, unknown>): string | null {
-    return typeof settings.permissionMode === 'string' ? settings.permissionMode : 'auto';
+    const value = typeof settings.permissionMode === 'string' ? settings.permissionMode : 'yolo';
+    if (isValidClaudianPermissionMode(value)) {
+      return value;
+    }
+    return toClaudianPermissionMode(value);
   },
 
   applyPermissionMode(value: string, settings: unknown): void {
     if (!settings || typeof settings !== 'object' || Array.isArray(settings)) {
       return;
     }
-    (settings as Record<string, unknown>).permissionMode = value;
+    const normalized = isValidClaudianPermissionMode(value)
+      ? value
+      : toClaudianPermissionMode(value);
+    (settings as Record<string, unknown>).permissionMode = normalized;
   },
 
   getProviderIcon() {

--- a/src/providers/octo-agent/ui/OctoAgentChatUIConfig.ts
+++ b/src/providers/octo-agent/ui/OctoAgentChatUIConfig.ts
@@ -22,7 +22,11 @@ const OCTO_AGENT_PERMISSION_MODE_TOGGLE: ProviderPermissionModeToggleConfig = {
 };
 
 export const octoAgentChatUIConfig: ProviderChatUIConfig = {
-  getModelOptions(): ProviderUIOption[] {
+  getModelOptions(settings: Record<string, unknown>): ProviderUIOption[] {
+    const cached = settings.octoAgentModels as ProviderUIOption[] | undefined;
+    if (cached && cached.length > 0) {
+      return cached;
+    }
     return [OCTO_AGENT_MODEL];
   },
 
@@ -63,7 +67,15 @@ export const octoAgentChatUIConfig: ProviderChatUIConfig = {
     }
   },
 
-  normalizeModelVariant(model: string, _settings: Record<string, unknown>): string {
+  normalizeModelVariant(model: string, settings: Record<string, unknown>): string {
+    const cached = settings.octoAgentModels as ProviderUIOption[] | undefined;
+    if (cached && cached.length > 0) {
+      if (model === 'octo-agent' || cached.some((option) => option.value === model)) {
+        return model;
+      }
+      const defaultOption = cached[0];
+      return defaultOption?.value ?? 'octo-agent/kimi-for-coding';
+    }
     if (model === 'octo-agent' || model === 'octo-agent/kimi-for-coding' || model.startsWith('octo-agent/')) {
       return model;
     }

--- a/src/providers/octo-agent/ui/OctoAgentChatUIConfig.ts
+++ b/src/providers/octo-agent/ui/OctoAgentChatUIConfig.ts
@@ -9,7 +9,7 @@ import { OCTO_AGENT_PROVIDER_ICON } from '../../../shared/icons';
 const OCTO_AGENT_MODEL: ProviderUIOption = {
   description: 'Runs through the local octo-agent server',
   label: 'Octo Agent',
-  value: 'octo-agent/octo-agent',
+  value: 'octo-agent/kimi-for-coding',
 };
 
 const DEFAULT_CONTEXT_WINDOW = 200_000;
@@ -50,7 +50,7 @@ export const octoAgentChatUIConfig: ProviderChatUIConfig = {
   },
 
   isDefaultModel(model: string): boolean {
-    return model === 'octo-agent' || model === 'octo-agent/octo-agent';
+    return model === 'octo-agent' || model === 'octo-agent/kimi-for-coding';
   },
 
   applyModelDefaults(model: string, settings: unknown): void {
@@ -58,16 +58,16 @@ export const octoAgentChatUIConfig: ProviderChatUIConfig = {
       return;
     }
     const settingsBag = settings as Record<string, unknown>;
-    if (model === 'octo-agent' || model === 'octo-agent/octo-agent' || model.startsWith('octo-agent/')) {
+    if (model === 'octo-agent' || model === 'octo-agent/kimi-for-coding' || model.startsWith('octo-agent/')) {
       settingsBag.model = model;
     }
   },
 
   normalizeModelVariant(model: string, _settings: Record<string, unknown>): string {
-    if (model === 'octo-agent' || model === 'octo-agent/octo-agent' || model.startsWith('octo-agent/')) {
+    if (model === 'octo-agent' || model === 'octo-agent/kimi-for-coding' || model.startsWith('octo-agent/')) {
       return model;
     }
-    return 'octo-agent/octo-agent';
+    return 'octo-agent/kimi-for-coding';
   },
 
   getCustomModelIds(): Set<string> {
@@ -79,7 +79,7 @@ export const octoAgentChatUIConfig: ProviderChatUIConfig = {
   },
 
   resolvePermissionMode(settings: Record<string, unknown>): string | null {
-    return typeof settings.permissionMode === 'string' ? settings.permissionMode : 'interactive';
+    return typeof settings.permissionMode === 'string' ? settings.permissionMode : 'auto';
   },
 
   applyPermissionMode(value: string, settings: unknown): void {

--- a/src/providers/octo-agent/ui/OctoAgentSettingsTab.ts
+++ b/src/providers/octo-agent/ui/OctoAgentSettingsTab.ts
@@ -1,0 +1,111 @@
+import { Setting } from 'obsidian';
+
+import type { ProviderSettingsTabRenderer } from '../../../core/providers/types';
+import { renderEnvironmentSettingsSection } from '../../../features/settings/ui/EnvironmentSettingsSection';
+import {
+  getOctoAgentProviderSettings,
+  updateOctoAgentProviderSettings,
+} from '../settings';
+
+export const octoAgentSettingsTabRenderer: ProviderSettingsTabRenderer = {
+  render(container, context) {
+    const settingsBag = context.plugin.settings as unknown as Record<string, unknown>;
+    const settings = getOctoAgentProviderSettings(settingsBag);
+
+    new Setting(container).setName('Setup').setHeading();
+
+    new Setting(container)
+      .setName('Enable octo agent')
+      .setDesc('Connect to a local octo-agent server as a provider.')
+      .addToggle((toggle) =>
+        toggle
+          .setValue(settings.enabled)
+          .onChange(async (value) => {
+            updateOctoAgentProviderSettings(settingsBag, { enabled: value });
+            await context.plugin.saveSettings();
+            context.refreshModelSelectors();
+          })
+      );
+
+    new Setting(container)
+      .setName('Host')
+      .setDesc('Hostname of the octo-agent server.')
+      .addText((text) =>
+        text
+          .setPlaceholder('127.0.0.1')
+          .setValue(settings.host)
+          .onChange(async (value) => {
+            updateOctoAgentProviderSettings(settingsBag, {
+              host: value.trim() || '127.0.0.1',
+            });
+            await context.plugin.saveSettings();
+          })
+      );
+
+    new Setting(container)
+      .setName('Port')
+      .setDesc('Port of the octo-agent server.')
+      .addText((text) => {
+        text
+          .setPlaceholder('8088')
+          .setValue(String(settings.port))
+          .onChange(async (value) => {
+            const parsed = Number.parseInt(value.trim(), 10);
+            updateOctoAgentProviderSettings(settingsBag, {
+              port: Number.isNaN(parsed) ? 8088 : parsed,
+            });
+            await context.plugin.saveSettings();
+          });
+      });
+
+    new Setting(container)
+      .setName('Auto-start server')
+      .setDesc('Run `octo serve` automatically when Claudian needs a connection.')
+      .addToggle((toggle) =>
+        toggle
+          .setValue(settings.autoStartServer)
+          .onChange(async (value) => {
+            updateOctoAgentProviderSettings(settingsBag, { autoStartServer: value });
+            await context.plugin.saveSettings();
+          })
+      );
+
+    new Setting(container)
+      .setName('CLI path')
+      .setDesc('Command used to start the octo-agent server. Leave empty to use `octo` from PATH.')
+      .addText((text) =>
+        text
+          .setPlaceholder('/usr/local/bin/octo')
+          .setValue(settings.cliPath)
+          .onChange(async (value) => {
+            updateOctoAgentProviderSettings(settingsBag, {
+              cliPath: value.trim() || 'octo',
+            });
+            await context.plugin.saveSettings();
+          })
+      );
+
+    new Setting(container)
+      .setName('Access key')
+      .setDesc('Optional access key for non-loopback hosts. Leave empty when using 127.0.0.1.')
+      .addText((text) =>
+        text
+          .setPlaceholder('Octo_...')
+          .setValue(settings.accessKey)
+          .onChange(async (value) => {
+            updateOctoAgentProviderSettings(settingsBag, { accessKey: value.trim() });
+            await context.plugin.saveSettings();
+          })
+      );
+
+    renderEnvironmentSettingsSection({
+      container,
+      desc: 'Environment variables passed only to the octo-agent server process.',
+      heading: 'Environment',
+      name: 'Octo Agent environment variables',
+      placeholder: 'OCTO_MODEL=claude-sonnet-4',
+      plugin: context.plugin,
+      scope: 'provider:octo-agent',
+    });
+  },
+};

--- a/src/providers/octo-agent/ui/OctoAgentSettingsTab.ts
+++ b/src/providers/octo-agent/ui/OctoAgentSettingsTab.ts
@@ -28,6 +28,12 @@ export const octoAgentSettingsTabRenderer: ProviderSettingsTabRenderer = {
       );
 
     new Setting(container)
+      .setName('Server command')
+      .setDesc(
+        "Start octo-agent with: octo serve --cors 'app://obsidian.md'. Required so Obsidian can reach the REST and WebSocket endpoints.",
+      );
+
+    new Setting(container)
       .setName('Host')
       .setDesc('Hostname of the octo-agent server.')
       .addText((text) =>

--- a/src/shared/icons.ts
+++ b/src/shared/icons.ts
@@ -118,6 +118,11 @@ export const PI_PROVIDER_ICON: ProviderIconSvg = {
   ],
 };
 
+export const OCTO_AGENT_PROVIDER_ICON: ProviderIconSvg = {
+  viewBox: '0 0 100 100',
+  path: 'M20 25 h60 v55 h-60 z M28 38 h44 M28 50 h30 M28 62 h20 M25 22 v-8 h50 v8 M50 12 v6',
+};
+
 export interface CreateProviderIconSvgOptions {
   className?: string;
   dataProvider?: string;

--- a/tests/unit/features/chat/controllers/ConversationController.test.ts
+++ b/tests/unit/features/chat/controllers/ConversationController.test.ts
@@ -201,8 +201,9 @@ describe('ConversationController', () => {
         expect(deps.plugin.switchConversation).not.toHaveBeenCalled();
       });
 
-      it('should not switch to current conversation', async () => {
+      it('should not switch to current conversation when already loaded', async () => {
         deps.state.currentConversationId = 'same-conv';
+        deps.state.messages = [{ id: 'msg-1', role: 'user', content: 'hello', timestamp: Date.now() }];
 
         await controller.switchTo('same-conv');
 

--- a/tests/unit/providers/octo-agent/auxiliary/OctoAgentInlineEditService.test.ts
+++ b/tests/unit/providers/octo-agent/auxiliary/OctoAgentInlineEditService.test.ts
@@ -1,8 +1,6 @@
 import { OctoAgentInlineEditService } from '@/providers/octo-agent/auxiliary/OctoAgentInlineEditService';
 import { runOctoAgentAuxQuery } from '@/providers/octo-agent/runtime/OctoAgentAuxQueryRunner';
 
-import type ClaudianPlugin from '../../../main';
-
 jest.mock('@/providers/octo-agent/runtime/OctoAgentAuxQueryRunner');
 const mockedRunQuery = jest.mocked(runOctoAgentAuxQuery);
 
@@ -22,11 +20,11 @@ describe('OctoAgentInlineEditService', () => {
         },
       },
     },
-  } as unknown as ClaudianPlugin;
+  } as unknown as { settings: Record<string, unknown> };
 
   beforeEach(() => {
     jest.clearAllMocks();
-    service = new OctoAgentInlineEditService(mockPlugin);
+    service = new OctoAgentInlineEditService(mockPlugin as any);
   });
 
   it('returns parsed replacement from a selection request', async () => {
@@ -60,6 +58,7 @@ describe('OctoAgentInlineEditService', () => {
       cursorContext: {
         afterCursor: 'after',
         beforeCursor: 'before',
+        column: 0,
         isInbetween: false,
         line: 0,
       },

--- a/tests/unit/providers/octo-agent/auxiliary/OctoAgentInlineEditService.test.ts
+++ b/tests/unit/providers/octo-agent/auxiliary/OctoAgentInlineEditService.test.ts
@@ -1,0 +1,120 @@
+import { OctoAgentInlineEditService } from '@/providers/octo-agent/auxiliary/OctoAgentInlineEditService';
+import { runOctoAgentAuxQuery } from '@/providers/octo-agent/runtime/OctoAgentAuxQueryRunner';
+
+import type ClaudianPlugin from '../../../main';
+
+jest.mock('@/providers/octo-agent/runtime/OctoAgentAuxQueryRunner');
+const mockedRunQuery = jest.mocked(runOctoAgentAuxQuery);
+
+describe('OctoAgentInlineEditService', () => {
+  let service: OctoAgentInlineEditService;
+  const mockPlugin = {
+    settings: {
+      providerConfigs: {
+        'octo-agent': {
+          accessKey: '',
+          autoStartServer: false,
+          cliPath: 'octo',
+          enabled: true,
+          environmentVariables: '',
+          host: '127.0.0.1',
+          port: 8088,
+        },
+      },
+    },
+  } as unknown as ClaudianPlugin;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new OctoAgentInlineEditService(mockPlugin);
+  });
+
+  it('returns parsed replacement from a selection request', async () => {
+    mockedRunQuery.mockResolvedValue({
+      sessionId: 'session-1',
+      text: '<replacement>fixed text</replacement>',
+    });
+
+    const result = await service.editText({
+      instruction: 'fix grammar',
+      mode: 'selection',
+      notePath: 'notes/file.md',
+      selectedText: 'some text',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.editedText).toBe('fixed text');
+    expect(mockedRunQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns clarification when no tags are present', async () => {
+    mockedRunQuery.mockResolvedValue({
+      sessionId: 'session-2',
+      text: 'Could you clarify?',
+    });
+
+    const result = await service.editText({
+      instruction: 'improve',
+      mode: 'cursor',
+      notePath: 'notes/file.md',
+      cursorContext: {
+        afterCursor: 'after',
+        beforeCursor: 'before',
+        isInbetween: false,
+        line: 0,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.clarification).toBe('Could you clarify?');
+  });
+
+  it('returns an error when the query fails', async () => {
+    mockedRunQuery.mockRejectedValue(new Error('connection refused'));
+
+    const result = await service.editText({
+      instruction: 'fix',
+      mode: 'selection',
+      notePath: 'notes/file.md',
+      selectedText: 'text',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('connection refused');
+  });
+
+  it('continues a conversation using the same session', async () => {
+    mockedRunQuery.mockResolvedValue({
+      sessionId: 'session-3',
+      text: '<replacement>A</replacement>',
+    });
+
+    await service.editText({
+      instruction: 'capitalize',
+      mode: 'selection',
+      notePath: 'notes/file.md',
+      selectedText: 'a',
+    });
+
+    mockedRunQuery.mockResolvedValue({
+      sessionId: 'session-3',
+      text: '<replacement>B</replacement>',
+    });
+
+    const result = await service.continueConversation('now b');
+
+    expect(result.success).toBe(true);
+    expect(result.editedText).toBe('B');
+    expect(mockedRunQuery).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ resumeSessionId: 'session-3' }),
+      expect.any(String),
+    );
+  });
+
+  it('rejects continueConversation without an active session', async () => {
+    const result = await service.continueConversation('hello');
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('No active conversation to continue');
+  });
+});

--- a/tests/unit/providers/octo-agent/auxiliary/OctoAgentInstructionRefineService.test.ts
+++ b/tests/unit/providers/octo-agent/auxiliary/OctoAgentInstructionRefineService.test.ts
@@ -1,8 +1,6 @@
 import { OctoAgentInstructionRefineService } from '@/providers/octo-agent/auxiliary/OctoAgentInstructionRefineService';
 import { runOctoAgentAuxQuery } from '@/providers/octo-agent/runtime/OctoAgentAuxQueryRunner';
 
-import type ClaudianPlugin from '../../../main';
-
 jest.mock('@/providers/octo-agent/runtime/OctoAgentAuxQueryRunner');
 const mockedRunQuery = jest.mocked(runOctoAgentAuxQuery);
 
@@ -22,11 +20,11 @@ describe('OctoAgentInstructionRefineService', () => {
         },
       },
     },
-  } as unknown as ClaudianPlugin;
+  } as unknown as { settings: Record<string, unknown> };
 
   beforeEach(() => {
     jest.clearAllMocks();
-    service = new OctoAgentInstructionRefineService(mockPlugin);
+    service = new OctoAgentInstructionRefineService(mockPlugin as any);
   });
 
   it('returns refined instruction wrapped in tags', async () => {

--- a/tests/unit/providers/octo-agent/auxiliary/OctoAgentInstructionRefineService.test.ts
+++ b/tests/unit/providers/octo-agent/auxiliary/OctoAgentInstructionRefineService.test.ts
@@ -1,0 +1,112 @@
+import { OctoAgentInstructionRefineService } from '@/providers/octo-agent/auxiliary/OctoAgentInstructionRefineService';
+import { runOctoAgentAuxQuery } from '@/providers/octo-agent/runtime/OctoAgentAuxQueryRunner';
+
+import type ClaudianPlugin from '../../../main';
+
+jest.mock('@/providers/octo-agent/runtime/OctoAgentAuxQueryRunner');
+const mockedRunQuery = jest.mocked(runOctoAgentAuxQuery);
+
+describe('OctoAgentInstructionRefineService', () => {
+  let service: OctoAgentInstructionRefineService;
+  const mockPlugin = {
+    settings: {
+      providerConfigs: {
+        'octo-agent': {
+          accessKey: '',
+          autoStartServer: false,
+          cliPath: 'octo',
+          enabled: true,
+          environmentVariables: '',
+          host: '127.0.0.1',
+          port: 8088,
+        },
+      },
+    },
+  } as unknown as ClaudianPlugin;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new OctoAgentInstructionRefineService(mockPlugin);
+  });
+
+  it('returns refined instruction wrapped in tags', async () => {
+    mockedRunQuery.mockResolvedValue({
+      sessionId: 'session-1',
+      text: '<instruction>- Be concise.</instruction>',
+    });
+
+    const result = await service.refineInstruction('be concise', '');
+
+    expect(result.success).toBe(true);
+    expect(result.refinedInstruction).toBe('- Be concise.');
+    expect(mockedRunQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns clarification when no tags are present', async () => {
+    mockedRunQuery.mockResolvedValue({
+      sessionId: 'session-2',
+      text: 'What do you mean?',
+    });
+
+    const result = await service.refineInstruction('use that thing', '');
+
+    expect(result.success).toBe(true);
+    expect(result.clarification).toBe('What do you mean?');
+  });
+
+  it('returns an error when the query fails', async () => {
+    mockedRunQuery.mockRejectedValue(new Error('connection refused'));
+
+    const result = await service.refineInstruction('be concise', '');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('connection refused');
+  });
+
+  it('continues a conversation using the same session', async () => {
+    mockedRunQuery.mockResolvedValue({
+      sessionId: 'session-3',
+      text: '<instruction>A</instruction>',
+    });
+
+    await service.refineInstruction('a', '');
+
+    mockedRunQuery.mockResolvedValue({
+      sessionId: 'session-3',
+      text: '<instruction>B</instruction>',
+    });
+
+    const result = await service.continueConversation('now b');
+
+    expect(result.success).toBe(true);
+    expect(result.refinedInstruction).toBe('B');
+    expect(mockedRunQuery).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ resumeSessionId: 'session-3' }),
+      expect.any(String),
+    );
+  });
+
+  it('rejects continueConversation without an active session', async () => {
+    const result = await service.continueConversation('hello');
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('No active conversation to continue');
+  });
+
+  it('calls onProgress with the parsed result', async () => {
+    mockedRunQuery.mockResolvedValue({
+      sessionId: 'session-4',
+      text: '<instruction>- Test.</instruction>',
+    });
+
+    const onProgress = jest.fn();
+    await service.refineInstruction('test', '', onProgress);
+
+    expect(onProgress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        refinedInstruction: '- Test.',
+        success: true,
+      }),
+    );
+  });
+});

--- a/tests/unit/providers/octo-agent/capabilities.test.ts
+++ b/tests/unit/providers/octo-agent/capabilities.test.ts
@@ -6,7 +6,7 @@ describe('OCTO_AGENT_PROVIDER_CAPABILITIES', () => {
       providerId: 'octo-agent',
       reasoningControl: 'effort',
       supportsFork: true,
-      supportsImageAttachments: false,
+      supportsImageAttachments: true,
       supportsInstructionMode: true,
       supportsMcpTools: false,
       supportsPersistentRuntime: true,

--- a/tests/unit/providers/octo-agent/capabilities.test.ts
+++ b/tests/unit/providers/octo-agent/capabilities.test.ts
@@ -1,0 +1,19 @@
+import { OCTO_AGENT_PROVIDER_CAPABILITIES } from '@/providers/octo-agent/capabilities';
+
+describe('OCTO_AGENT_PROVIDER_CAPABILITIES', () => {
+  it('exposes the octo-agent capability contract', () => {
+    expect(OCTO_AGENT_PROVIDER_CAPABILITIES).toMatchObject({
+      providerId: 'octo-agent',
+      reasoningControl: 'effort',
+      supportsFork: true,
+      supportsImageAttachments: false,
+      supportsInstructionMode: true,
+      supportsMcpTools: false,
+      supportsPersistentRuntime: true,
+      supportsPlanMode: false,
+      supportsProviderCommands: false,
+      supportsRewind: false,
+      supportsTurnSteer: false,
+    });
+  });
+});

--- a/tests/unit/providers/octo-agent/env/OctoAgentSettingsReconciler.test.ts
+++ b/tests/unit/providers/octo-agent/env/OctoAgentSettingsReconciler.test.ts
@@ -1,0 +1,65 @@
+import type { Conversation } from '@/core/types';
+import { octoAgentSettingsReconciler } from '@/providers/octo-agent/env/OctoAgentSettingsReconciler';
+
+describe('octoAgentSettingsReconciler', () => {
+  describe('normalizeModelVariantSettings', () => {
+    it('returns false and leaves non-octo-agent models untouched', () => {
+      const settings: Record<string, unknown> = { model: 'claude-code/claude-sonnet-4-5' };
+      expect(octoAgentSettingsReconciler.normalizeModelVariantSettings(settings)).toBe(false);
+      expect(settings.model).toBe('claude-code/claude-sonnet-4-5');
+    });
+
+    it('returns false when the octo-agent model is already valid', () => {
+      const settings: Record<string, unknown> = { model: 'octo-agent/kimi-for-coding' };
+      expect(octoAgentSettingsReconciler.normalizeModelVariantSettings(settings)).toBe(false);
+      expect(settings.model).toBe('octo-agent/kimi-for-coding');
+    });
+
+    it('normalizes an invalid octo-agent model to the default and reports changed', () => {
+      const settings: Record<string, unknown> = {
+        model: 'octo-agent/unknown',
+        octoAgentModels: [
+          { value: 'octo-agent/kimi-for-coding', label: 'Kimi' },
+        ],
+      };
+      expect(octoAgentSettingsReconciler.normalizeModelVariantSettings(settings)).toBe(true);
+      expect(settings.model).toBe('octo-agent/kimi-for-coding');
+    });
+  });
+
+  describe('reconcileModelWithEnvironment', () => {
+    it('invalidates octo-agent conversations when the provider is disabled', () => {
+      const settings: Record<string, unknown> = {
+        providerConfigs: { 'octo-agent': { enabled: false } },
+      };
+      const conversation: Conversation = {
+        id: 'c1',
+        providerId: 'octo-agent',
+        sessionId: 's1',
+        providerState: { sessionId: 's1' },
+      } as unknown as Conversation;
+
+      const result = octoAgentSettingsReconciler.reconcileModelWithEnvironment(settings, [conversation]);
+
+      expect(result.changed).toBe(true);
+      expect(conversation.sessionId).toBeNull();
+      expect(conversation.providerState).toBeUndefined();
+    });
+
+    it('does nothing when the provider is enabled', () => {
+      const settings: Record<string, unknown> = {
+        providerConfigs: { 'octo-agent': { enabled: true } },
+      };
+      const conversation: Conversation = {
+        id: 'c1',
+        providerId: 'octo-agent',
+        sessionId: 's1',
+      } as unknown as Conversation;
+
+      const result = octoAgentSettingsReconciler.reconcileModelWithEnvironment(settings, [conversation]);
+
+      expect(result.changed).toBe(false);
+      expect(conversation.sessionId).toBe('s1');
+    });
+  });
+});

--- a/tests/unit/providers/octo-agent/permissionMode.test.ts
+++ b/tests/unit/providers/octo-agent/permissionMode.test.ts
@@ -1,0 +1,70 @@
+import {
+  isValidClaudianPermissionMode,
+  toClaudianPermissionMode,
+  toOctoAgentPermissionMode,
+} from '@/providers/octo-agent/permissionMode';
+
+describe('octo-agent permissionMode', () => {
+  describe('toOctoAgentPermissionMode', () => {
+    it('maps Claudian yolo to octo-agent auto', () => {
+      expect(toOctoAgentPermissionMode('yolo')).toBe('auto');
+    });
+
+    it('maps Claudian normal to octo-agent interactive', () => {
+      expect(toOctoAgentPermissionMode('normal')).toBe('interactive');
+    });
+
+    it('maps Claudian plan to octo-agent plan', () => {
+      expect(toOctoAgentPermissionMode('plan')).toBe('plan');
+    });
+
+    it('falls back to auto for unknown values', () => {
+      expect(toOctoAgentPermissionMode('unknown')).toBe('auto');
+      expect(toOctoAgentPermissionMode(undefined)).toBe('auto');
+    });
+
+    it('passes through server-native values', () => {
+      expect(toOctoAgentPermissionMode('auto')).toBe('auto');
+      expect(toOctoAgentPermissionMode('interactive')).toBe('interactive');
+    });
+  });
+
+  describe('toClaudianPermissionMode', () => {
+    it('maps octo-agent auto to Claudian yolo', () => {
+      expect(toClaudianPermissionMode('auto')).toBe('yolo');
+    });
+
+    it('maps octo-agent interactive to Claudian normal', () => {
+      expect(toClaudianPermissionMode('interactive')).toBe('normal');
+    });
+
+    it('maps octo-agent plan to Claudian plan', () => {
+      expect(toClaudianPermissionMode('plan')).toBe('plan');
+    });
+
+    it('falls back to yolo for unknown values', () => {
+      expect(toClaudianPermissionMode('unknown')).toBe('yolo');
+      expect(toClaudianPermissionMode(undefined)).toBe('yolo');
+    });
+
+    it('passes through UI-native values', () => {
+      expect(toClaudianPermissionMode('yolo')).toBe('yolo');
+      expect(toClaudianPermissionMode('normal')).toBe('normal');
+    });
+  });
+
+  describe('isValidClaudianPermissionMode', () => {
+    it('accepts yolo, normal, and plan', () => {
+      expect(isValidClaudianPermissionMode('yolo')).toBe(true);
+      expect(isValidClaudianPermissionMode('normal')).toBe(true);
+      expect(isValidClaudianPermissionMode('plan')).toBe(true);
+    });
+
+    it('rejects octo-agent values and unknown strings', () => {
+      expect(isValidClaudianPermissionMode('auto')).toBe(false);
+      expect(isValidClaudianPermissionMode('interactive')).toBe(false);
+      expect(isValidClaudianPermissionMode('')).toBe(false);
+      expect(isValidClaudianPermissionMode('unknown')).toBe(false);
+    });
+  });
+});

--- a/tests/unit/providers/octo-agent/runtime/OctoAgentClient.test.ts
+++ b/tests/unit/providers/octo-agent/runtime/OctoAgentClient.test.ts
@@ -1,0 +1,113 @@
+import { OctoAgentClient } from '@/providers/octo-agent/runtime/OctoAgentClient';
+
+describe('OctoAgentClient', () => {
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(() =>
+      Promise.resolve(new Response('{}', { status: 200 })),
+    );
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  describe('REST calls', () => {
+    it('includes the access key on every fetch when configured', async () => {
+      const client = new OctoAgentClient({ baseUrl: 'http://127.0.0.1:8088', accessKey: 'Octo_secret' });
+      await (client as any).fetchJson('/api/config');
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'http://127.0.0.1:8088/api/config?access_key=Octo_secret',
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
+        }),
+      );
+    });
+
+    it('does not append an access key when omitted', async () => {
+      const client = new OctoAgentClient({ baseUrl: 'http://127.0.0.1:8088' });
+      await (client as any).fetchJson('/api/config');
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'http://127.0.0.1:8088/api/config',
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('parseEvent', () => {
+    let client: OctoAgentClient;
+
+    beforeEach(() => {
+      client = new OctoAgentClient({ baseUrl: 'http://127.0.0.1:8088' });
+    });
+
+    it('parses text_delta events', () => {
+      const event = (client as any).parseEvent({ type: 'text_delta', session_id: 's1', text: 'hello' });
+      expect(event).toEqual({ type: 'text_delta', session_id: 's1', text: 'hello' });
+    });
+
+    it('parses assistant_message events with content', () => {
+      const event = (client as any).parseEvent({
+        type: 'assistant_message',
+        session_id: 's1',
+        content: 'final answer',
+        thinking: 'thought',
+      });
+      expect(event).toEqual({
+        type: 'assistant_message',
+        session_id: 's1',
+        content: 'final answer',
+        thinking: 'thought',
+      });
+    });
+
+    it('defaults missing assistant_message content to an empty string', () => {
+      const event = (client as any).parseEvent({
+        type: 'assistant_message',
+        session_id: 's1',
+      });
+      expect(event).toEqual({
+        type: 'assistant_message',
+        session_id: 's1',
+        content: '',
+      });
+    });
+
+    it('parses session_update events', () => {
+      const event = (client as any).parseEvent({
+        type: 'session_update',
+        session_id: 's1',
+        context_usage: 1234,
+        permission_mode: 'auto',
+      });
+      expect(event).toEqual({
+        type: 'session_update',
+        session_id: 's1',
+        context_usage: 1234,
+        permission_mode: 'auto',
+      });
+    });
+
+    it('parses history_user_message events', () => {
+      const event = (client as any).parseEvent({
+        type: 'history_user_message',
+        session_id: 's1',
+        content: 'previous user message',
+      });
+      expect(event).toEqual({
+        type: 'history_user_message',
+        session_id: 's1',
+        content: 'previous user message',
+      });
+    });
+
+    it('marks unknown event types as unknown', () => {
+      const raw = { type: 'custom_event', session_id: 's1', value: 42 };
+      const event = (client as any).parseEvent(raw);
+      expect(event).toEqual({ type: 'unknown', session_id: 's1', raw });
+    });
+  });
+});

--- a/tests/unit/providers/octo-agent/runtime/OctoAgentServerLauncher.test.ts
+++ b/tests/unit/providers/octo-agent/runtime/OctoAgentServerLauncher.test.ts
@@ -1,0 +1,46 @@
+import { probeOctoAgentServer } from '@/providers/octo-agent/runtime/OctoAgentServerLauncher';
+
+describe('OctoAgentServerLauncher', () => {
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(() =>
+      Promise.resolve(new Response('{}', { status: 200 })),
+    );
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  describe('probeOctoAgentServer', () => {
+    it('reports running when the health endpoint responds OK', async () => {
+      const result = await probeOctoAgentServer('http://127.0.0.1:8088');
+      expect(result).toEqual({ running: true });
+      expect(fetchSpy).toHaveBeenCalledWith('http://127.0.0.1:8088/api/health', { method: 'GET' });
+    });
+
+    it('includes the access key on the health probe when provided', async () => {
+      const result = await probeOctoAgentServer('http://127.0.0.1:8088', 'Octo_secret');
+      expect(result).toEqual({ running: true });
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'http://127.0.0.1:8088/api/health?access_key=Octo_secret',
+        { method: 'GET' },
+      );
+    });
+
+    it('reports not running when the health endpoint fails', async () => {
+      fetchSpy.mockImplementation(() =>
+        Promise.resolve(new Response('Internal Server Error', { status: 500 })),
+      );
+      const result = await probeOctoAgentServer('http://127.0.0.1:8088');
+      expect(result).toEqual({ running: false });
+    });
+
+    it('reports not running when fetch throws', async () => {
+      fetchSpy.mockImplementation(() => Promise.reject(new Error('Connection refused')));
+      const result = await probeOctoAgentServer('http://127.0.0.1:8088');
+      expect(result).toEqual({ running: false });
+    });
+  });
+});

--- a/tests/unit/providers/octo-agent/settings.test.ts
+++ b/tests/unit/providers/octo-agent/settings.test.ts
@@ -1,0 +1,36 @@
+import { getOctoAgentProviderSettings } from '@/providers/octo-agent/settings';
+
+describe('getOctoAgentProviderSettings', () => {
+  it('returns defaults when no provider config exists', () => {
+    const settings = getOctoAgentProviderSettings({});
+
+    expect(settings.enabled).toBe(false);
+    expect(settings.host).toBe('127.0.0.1');
+    expect(settings.port).toBe(8088);
+    expect(settings.autoStartServer).toBe(true);
+    expect(settings.cliPath).toBe('octo');
+    expect(settings.accessKey).toBe('');
+  });
+
+  it('reads values from the octo-agent provider config', () => {
+    const settings = getOctoAgentProviderSettings({
+      providerConfigs: {
+        'octo-agent': {
+          accessKey: 'octo_secret',
+          autoStartServer: false,
+          cliPath: '/opt/homebrew/bin/octo',
+          enabled: true,
+          host: '0.0.0.0',
+          port: 9999,
+        },
+      },
+    });
+
+    expect(settings.enabled).toBe(true);
+    expect(settings.host).toBe('0.0.0.0');
+    expect(settings.port).toBe(9999);
+    expect(settings.autoStartServer).toBe(false);
+    expect(settings.cliPath).toBe('/opt/homebrew/bin/octo');
+    expect(settings.accessKey).toBe('octo_secret');
+  });
+});

--- a/tests/unit/providers/octo-agent/ui/OctoAgentChatUIConfig.test.ts
+++ b/tests/unit/providers/octo-agent/ui/OctoAgentChatUIConfig.test.ts
@@ -1,0 +1,30 @@
+import { octoAgentChatUIConfig } from '@/providers/octo-agent/ui/OctoAgentChatUIConfig';
+
+describe('octoAgentChatUIConfig', () => {
+  it('exposes a single octo-agent model option', () => {
+    const options = octoAgentChatUIConfig.getModelOptions({});
+
+    expect(options).toHaveLength(1);
+    expect(options[0].value).toBe('octo-agent/octo-agent');
+  });
+
+  it('owns octo-agent model selection ids', () => {
+    expect(octoAgentChatUIConfig.ownsModel('octo-agent', {})).toBe(true);
+    expect(octoAgentChatUIConfig.ownsModel('octo-agent/octo-agent', {})).toBe(true);
+    expect(octoAgentChatUIConfig.ownsModel('octo-agent/claude-sonnet-4-5', {})).toBe(true);
+    expect(octoAgentChatUIConfig.ownsModel('claude-code/claude-sonnet-4-5', {})).toBe(false);
+  });
+
+  it('identifies the octo-agent default model', () => {
+    expect(octoAgentChatUIConfig.isDefaultModel('octo-agent/octo-agent')).toBe(true);
+    expect(octoAgentChatUIConfig.isDefaultModel('octo-agent')).toBe(true);
+    expect(octoAgentChatUIConfig.isDefaultModel('claude-code/claude-sonnet-4-5')).toBe(false);
+  });
+
+  it('normalizes unknown models to the octo-agent default', () => {
+    expect(octoAgentChatUIConfig.normalizeModelVariant('octo-agent/octo-agent', {})).toBe(
+      'octo-agent/octo-agent',
+    );
+    expect(octoAgentChatUIConfig.normalizeModelVariant('unknown', {})).toBe('octo-agent/octo-agent');
+  });
+});

--- a/tests/unit/providers/octo-agent/ui/OctoAgentChatUIConfig.test.ts
+++ b/tests/unit/providers/octo-agent/ui/OctoAgentChatUIConfig.test.ts
@@ -1,30 +1,138 @@
 import { octoAgentChatUIConfig } from '@/providers/octo-agent/ui/OctoAgentChatUIConfig';
 
 describe('octoAgentChatUIConfig', () => {
-  it('exposes a single octo-agent model option', () => {
-    const options = octoAgentChatUIConfig.getModelOptions({});
+  describe('getModelOptions', () => {
+    it('returns cached octo-agent models when available', () => {
+      const options = octoAgentChatUIConfig.getModelOptions({
+        octoAgentModels: [
+          { value: 'octo-agent/kimi-for-coding', label: 'Kimi for Coding' },
+          { value: 'octo-agent/claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
+        ],
+      });
 
-    expect(options).toHaveLength(1);
-    expect(options[0].value).toBe('octo-agent/kimi-for-coding');
+      expect(options.map((option) => option.value)).toEqual([
+        'octo-agent/kimi-for-coding',
+        'octo-agent/claude-sonnet-4-5',
+      ]);
+    });
+
+    it('falls back to the built-in default when no models are cached', () => {
+      const options = octoAgentChatUIConfig.getModelOptions({});
+
+      expect(options).toEqual([
+        {
+          description: 'Runs through the local octo-agent server',
+          label: 'Octo Agent',
+          value: 'octo-agent/kimi-for-coding',
+        },
+      ]);
+    });
   });
 
-  it('owns octo-agent model selection ids', () => {
-    expect(octoAgentChatUIConfig.ownsModel('octo-agent', {})).toBe(true);
-    expect(octoAgentChatUIConfig.ownsModel('octo-agent/octo-agent', {})).toBe(true);
-    expect(octoAgentChatUIConfig.ownsModel('octo-agent/claude-sonnet-4-5', {})).toBe(true);
-    expect(octoAgentChatUIConfig.ownsModel('claude-code/claude-sonnet-4-5', {})).toBe(false);
+  describe('ownsModel', () => {
+    it('owns octo-agent prefixed models', () => {
+      expect(octoAgentChatUIConfig.ownsModel('octo-agent/kimi-for-coding', {})).toBe(true);
+      expect(octoAgentChatUIConfig.ownsModel('octo-agent', {})).toBe(true);
+      expect(octoAgentChatUIConfig.ownsModel('octo-agent/octo-agent', {})).toBe(true);
+    });
+
+    it('does not own other providers', () => {
+      expect(octoAgentChatUIConfig.ownsModel('claude-sonnet-4-5', {})).toBe(false);
+      expect(octoAgentChatUIConfig.ownsModel('openai/gpt-4', {})).toBe(false);
+    });
   });
 
-  it('identifies the octo-agent default model', () => {
-    expect(octoAgentChatUIConfig.isDefaultModel('octo-agent/kimi-for-coding')).toBe(true);
-    expect(octoAgentChatUIConfig.isDefaultModel('octo-agent')).toBe(true);
-    expect(octoAgentChatUIConfig.isDefaultModel('claude-code/claude-sonnet-4-5')).toBe(false);
+  describe('normalizeModelVariant', () => {
+    it('keeps a model that is present in the cached list', () => {
+      const settings = {
+        octoAgentModels: [
+          { value: 'octo-agent/kimi-for-coding', label: 'Kimi' },
+          { value: 'octo-agent/claude-sonnet-4-5', label: 'Sonnet' },
+        ],
+      };
+
+      expect(octoAgentChatUIConfig.normalizeModelVariant('octo-agent/claude-sonnet-4-5', settings)).toBe(
+        'octo-agent/claude-sonnet-4-5',
+      );
+    });
+
+    it('falls back to the default when the model is not in the cached list', () => {
+      const settings = {
+        octoAgentModels: [
+          { value: 'octo-agent/kimi-for-coding', label: 'Kimi' },
+          { value: 'octo-agent/claude-sonnet-4-5', label: 'Sonnet' },
+        ],
+      };
+
+      expect(octoAgentChatUIConfig.normalizeModelVariant('octo-agent/unknown-model', settings)).toBe(
+        'octo-agent/kimi-for-coding',
+      );
+    });
+
+    it('falls back to the first cached option when no default is available', () => {
+      const settings = {
+        octoAgentModels: [
+          { value: 'octo-agent/claude-sonnet-4-5', label: 'Sonnet' },
+        ],
+      };
+
+      expect(octoAgentChatUIConfig.normalizeModelVariant('octo-agent/unknown-model', settings)).toBe(
+        'octo-agent/claude-sonnet-4-5',
+      );
+    });
+
+    it('keeps octo-agent prefixed models when there is no cache', () => {
+      expect(octoAgentChatUIConfig.normalizeModelVariant('octo-agent/custom', {})).toBe('octo-agent/custom');
+    });
+
+    it('normalizes non-octo-agent models to the default', () => {
+      expect(octoAgentChatUIConfig.normalizeModelVariant('claude-sonnet-4-5', {})).toBe('octo-agent/kimi-for-coding');
+    });
   });
 
-  it('normalizes unknown models to the octo-agent default', () => {
-    expect(octoAgentChatUIConfig.normalizeModelVariant('octo-agent/kimi-for-coding', {})).toBe(
-      'octo-agent/kimi-for-coding',
-    );
-    expect(octoAgentChatUIConfig.normalizeModelVariant('unknown', {})).toBe('octo-agent/kimi-for-coding');
+  describe('getContextWindowSize', () => {
+    it('returns the default 200k context window', () => {
+      expect(octoAgentChatUIConfig.getContextWindowSize('octo-agent/kimi-for-coding', undefined, {})).toBe(200_000);
+    });
+
+    it('returns a custom limit when configured', () => {
+      expect(
+        octoAgentChatUIConfig.getContextWindowSize('octo-agent/kimi-for-coding', { 'octo-agent': 128_000 }, {}),
+      ).toBe(128_000);
+    });
+  });
+
+  describe('resolvePermissionMode', () => {
+    it('returns a Claudian value from an octo-agent value', () => {
+      expect(octoAgentChatUIConfig.resolvePermissionMode?.({ permissionMode: 'auto' })).toBe('yolo');
+      expect(octoAgentChatUIConfig.resolvePermissionMode?.({ permissionMode: 'interactive' })).toBe('normal');
+    });
+
+    it('returns the stored Claudian value directly', () => {
+      expect(octoAgentChatUIConfig.resolvePermissionMode?.({ permissionMode: 'yolo' })).toBe('yolo');
+      expect(octoAgentChatUIConfig.resolvePermissionMode?.({ permissionMode: 'normal' })).toBe('normal');
+      expect(octoAgentChatUIConfig.resolvePermissionMode?.({ permissionMode: 'plan' })).toBe('plan');
+    });
+
+    it('falls back to yolo when no value is stored', () => {
+      expect(octoAgentChatUIConfig.resolvePermissionMode?.({})).toBe('yolo');
+    });
+  });
+
+  describe('applyPermissionMode', () => {
+    it('normalizes octo-agent values into Claudian values', () => {
+      const settings: Record<string, unknown> = {};
+      octoAgentChatUIConfig.applyPermissionMode?.('auto', settings);
+      expect(settings.permissionMode).toBe('yolo');
+
+      octoAgentChatUIConfig.applyPermissionMode?.('interactive', settings);
+      expect(settings.permissionMode).toBe('normal');
+    });
+
+    it('stores Claudian values as-is', () => {
+      const settings: Record<string, unknown> = {};
+      octoAgentChatUIConfig.applyPermissionMode?.('plan', settings);
+      expect(settings.permissionMode).toBe('plan');
+    });
   });
 });

--- a/tests/unit/providers/octo-agent/ui/OctoAgentChatUIConfig.test.ts
+++ b/tests/unit/providers/octo-agent/ui/OctoAgentChatUIConfig.test.ts
@@ -5,7 +5,7 @@ describe('octoAgentChatUIConfig', () => {
     const options = octoAgentChatUIConfig.getModelOptions({});
 
     expect(options).toHaveLength(1);
-    expect(options[0].value).toBe('octo-agent/octo-agent');
+    expect(options[0].value).toBe('octo-agent/kimi-for-coding');
   });
 
   it('owns octo-agent model selection ids', () => {
@@ -16,15 +16,15 @@ describe('octoAgentChatUIConfig', () => {
   });
 
   it('identifies the octo-agent default model', () => {
-    expect(octoAgentChatUIConfig.isDefaultModel('octo-agent/octo-agent')).toBe(true);
+    expect(octoAgentChatUIConfig.isDefaultModel('octo-agent/kimi-for-coding')).toBe(true);
     expect(octoAgentChatUIConfig.isDefaultModel('octo-agent')).toBe(true);
     expect(octoAgentChatUIConfig.isDefaultModel('claude-code/claude-sonnet-4-5')).toBe(false);
   });
 
   it('normalizes unknown models to the octo-agent default', () => {
-    expect(octoAgentChatUIConfig.normalizeModelVariant('octo-agent/octo-agent', {})).toBe(
-      'octo-agent/octo-agent',
+    expect(octoAgentChatUIConfig.normalizeModelVariant('octo-agent/kimi-for-coding', {})).toBe(
+      'octo-agent/kimi-for-coding',
     );
-    expect(octoAgentChatUIConfig.normalizeModelVariant('unknown', {})).toBe('octo-agent/octo-agent');
+    expect(octoAgentChatUIConfig.normalizeModelVariant('unknown', {})).toBe('octo-agent/kimi-for-coding');
   });
 });


### PR DESCRIPTION
Add a new Claudian provider that connects to a local [octo-agent](https://github.com/open-octo/octo-agent) server via HTTP REST and WebSocket.

### What’s included
- Provider registration, capabilities, settings tab, and UI config
- `OctoAgentClient`: REST + WebSocket client with auto-reconnect and event parsing
- `OctoAgentChatRuntime`: implements `ChatRuntime` with streaming query, session sync, approval callbacks, user-question handling, and history hydration
- `OctoAgentServerLauncher` + `OctoAgentBinaryLocator`: auto-start `octo serve` from common install paths when the provider is enabled and auto-start is on
- Prompt integration: passes the current note path and attached files via `appendCurrentNote` / `appendContextFiles`
- Image attachments: converts `ImageAttachment` to base64 data URLs and sends them through the WebSocket
- Server history sync: `loadHistory()` fetches messages from `/api/sessions/:id/messages` and renders them in Claudian
- Dynamic model list: fetches `/api/config` on connect, caches models, and uses the server default when creating sessions
- Auxiliary services: title generation, inline edit, and instruction refinement
- Unit tests covering capabilities, settings, UI config, inline edit, and instruction refine

### Verification
- `npm run typecheck` ✓
- `npm run lint` ✓
- `npm run test` ✓ (249 suites, 5838 tests)
- `npm run build` ✓

### Notes
- The runtime connects to `ws://127.0.0.1:8088/ws` by default. If the server is not running and auto-start is enabled, the provider spawns `octo serve -d --cors 'app://obsidian.md'`.
- Because Obsidian's origin is `app://obsidian.md`, `octo serve` must be started with `--cors 'app://obsidian.md'`.
