### PR TITLE
fix: enforce safer TypeScript type usage

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -101,7 +101,11 @@ export default defineConfig([
     plugins: {
       obsidianmd,
     },
-    rules: stagedObsidianRules,
+    rules: {
+      ...stagedObsidianRules,
+      '@typescript-eslint/no-unsafe-argument': 'error',
+      '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+    },
   },
   {
     files: [

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -158,7 +158,7 @@ function getTabSettingsSnapshot(
     plugin.settings,
     providerId,
     getTabSelectedModel(tab, plugin),
-  ) as TabProviderSettings;
+  );
 }
 
 function getWritableTabSettingsSnapshot(
@@ -168,7 +168,7 @@ function getWritableTabSettingsSnapshot(
   return ProviderSettingsCoordinator.getProviderSettingsSnapshot(
     plugin.settings,
     getTabProviderId(tab, plugin),
-  ) as TabProviderSettings;
+  );
 }
 
 function getTabConversation(

--- a/src/providers/codex/models.ts
+++ b/src/providers/codex/models.ts
@@ -109,7 +109,7 @@ function normalizeInputModalities(value: unknown): Array<'text' | 'image'> {
 
   const modalities = new Set<'text' | 'image'>();
   for (const entry of value) {
-    if (entry === 'text' || entry === 'image') {
+    if (typeof entry === 'string' && (entry === 'text' || entry === 'image')) {
       modalities.add(entry);
     }
   }


### PR DESCRIPTION
## Summary

- Remove redundant provider settings type assertions.
- Narrow Codex input modality values before passing them to typed APIs.
- Enforce `no-unsafe-argument` and `no-unnecessary-type-assertion` for production TypeScript.

## Verification

- `npm run typecheck && npm run lint && npm run test && npm run build`