### PR TITLE
Fix Codex wrapped tool rendering and metadata filtering

### DIFF
--- a/src/providers/codex/codexUserText.ts
+++ b/src/providers/codex/codexUserText.ts
@@ -3,6 +3,77 @@ const CODEX_IMAGE_CLOSE_TAG_PATTERN = /^<\/image>$/i;
 const CODEX_EMPTY_IMAGE_TAG_PATTERN = /^<image\b[^>]*>\s*<\/image>$/i;
 const CODEX_EMPTY_IMAGE_TAG_PATTERN_GLOBAL = /<image\b[^>]*>\s*<\/image>\s*/gi;
 
+const CODEX_CONTROL_BLOCK_TAGS = [
+  'recommended_plugins',
+  'system_instruction',
+  'environment_context',
+  'turn_aborted',
+  'user-preferences',
+  'subagent_notification',
+  'skill',
+];
+
+const CODEX_AGENTS_INSTRUCTIONS_PREFIX = '# AGENTS.md instructions';
+const CODEX_AGENTS_INSTRUCTIONS_CLOSE_TAG = '</INSTRUCTIONS>';
+
+function stripLeadingTaggedBlock(text: string, tagName: string): string | null {
+  const openTag = `<${tagName}>`;
+  if (!text.startsWith(openTag)) {
+    return null;
+  }
+
+  const closeTag = `</${tagName}>`;
+  const closeIndex = text.indexOf(closeTag, openTag.length);
+  if (closeIndex === -1) {
+    return '';
+  }
+
+  return text.slice(closeIndex + closeTag.length);
+}
+
+function stripLeadingAgentsInstructions(text: string): string | null {
+  if (!text.startsWith(CODEX_AGENTS_INSTRUCTIONS_PREFIX)) {
+    return null;
+  }
+
+  const closeIndex = text.indexOf(CODEX_AGENTS_INSTRUCTIONS_CLOSE_TAG);
+  if (closeIndex === -1) {
+    return '';
+  }
+
+  return text.slice(closeIndex + CODEX_AGENTS_INSTRUCTIONS_CLOSE_TAG.length);
+}
+
+function stripLeadingCodexControlMetadata(text: string): string {
+  let remaining = text.trimStart();
+
+  while (remaining) {
+    const withoutAgentsInstructions = stripLeadingAgentsInstructions(remaining);
+    if (withoutAgentsInstructions !== null) {
+      remaining = withoutAgentsInstructions.trimStart();
+      continue;
+    }
+
+    let strippedTaggedBlock = false;
+    for (const tagName of CODEX_CONTROL_BLOCK_TAGS) {
+      const next = stripLeadingTaggedBlock(remaining, tagName);
+      if (next === null) {
+        continue;
+      }
+
+      remaining = next.trimStart();
+      strippedTaggedBlock = true;
+      break;
+    }
+
+    if (!strippedTaggedBlock) {
+      break;
+    }
+  }
+
+  return remaining;
+}
+
 export function stripCodexImagePlaceholderText(text: string): string {
   const trimmed = text.trim();
   if (!trimmed) {
@@ -25,4 +96,13 @@ export function joinCodexUserTextParts(parts: readonly string[], separator = '')
     .map(stripCodexImagePlaceholderText)
     .filter(text => text.length > 0)
     .join(separator);
+}
+
+export function extractCodexUserVisibleText(text: string): string | null {
+  const withoutImagePlaceholders = stripCodexImagePlaceholderText(text);
+  const visible = stripCodexImagePlaceholderText(
+    stripLeadingCodexControlMetadata(withoutImagePlaceholders),
+  ).trim();
+
+  return visible ? visible : null;
 }

--- a/src/providers/codex/history/CodexHistoryStore.ts
+++ b/src/providers/codex/history/CodexHistoryStore.ts
@@ -9,18 +9,23 @@ import {
   parseImageDataUri,
 } from '../../../utils/imageAttachment';
 import {
+  extractCodexUserVisibleText,
   joinCodexUserTextParts,
-  stripCodexImagePlaceholderText,
 } from '../codexUserText';
 import {
+  appendCodexCommandOutput,
+  extractCodexExecCellId,
   isCodexToolOutputError,
   normalizeCodexMcpToolInput,
   normalizeCodexMcpToolName,
   normalizeCodexMcpToolState,
+  normalizeCodexToolCall,
   normalizeCodexToolInput,
   normalizeCodexToolName,
   normalizeCodexToolResult,
   parseCodexArguments,
+  readCodexExecCellIdArgument,
+  stringifyCodexToolOutput,
 } from '../normalization/codexToolNormalization';
 
 interface CodexEvent {
@@ -201,6 +206,8 @@ function createPersistedParseContext(): PersistedParseContext {
     suppressedToolOutputIds: new Set(),
     terminalSessionToCommandId: new Map(),
     stdinCallToCommandId: new Map(),
+    execCellToCommandId: new Map(),
+    waitCallToCommand: new Map(),
     turnCounter: 0,
   };
 }
@@ -407,70 +414,6 @@ function parseSessionRecord(line: string): ParsedSessionRecord | null {
     event: parsed.event,
     payload: parsed.payload,
   };
-}
-
-const CODEX_SYSTEM_MESSAGE_PREFIXES = [
-  '# AGENTS.md instructions',
-];
-
-const CODEX_CONTROL_BLOCK_TAGS = [
-  'system_instruction',
-  'environment_context',
-  'turn_aborted',
-  'user-preferences',
-  'subagent_notification',
-  'skill',
-];
-
-function stripLeadingTaggedBlock(text: string, tagName: string): string | null {
-  const openTag = `<${tagName}>`;
-  if (!text.startsWith(openTag)) {
-    return null;
-  }
-
-  const closeTag = `</${tagName}>`;
-  const closeIndex = text.indexOf(closeTag, openTag.length);
-  if (closeIndex === -1) {
-    return '';
-  }
-
-  return text.slice(closeIndex + closeTag.length);
-}
-
-function stripLeadingCodexControlBlocks(text: string): string {
-  let remaining = text.trimStart();
-  let stripped = true;
-
-  while (stripped) {
-    stripped = false;
-
-    for (const tagName of CODEX_CONTROL_BLOCK_TAGS) {
-      const next = stripLeadingTaggedBlock(remaining, tagName);
-      if (next === null) {
-        continue;
-      }
-
-      remaining = next.trimStart();
-      stripped = true;
-      break;
-    }
-  }
-
-  return remaining;
-}
-
-function extractCodexUserVisibleText(text: string): string | null {
-  const trimmed = stripCodexImagePlaceholderText(text).trimStart();
-  if (!trimmed) {
-    return null;
-  }
-
-  if (CODEX_SYSTEM_MESSAGE_PREFIXES.some(prefix => trimmed.startsWith(prefix))) {
-    return null;
-  }
-
-  const visible = stripCodexImagePlaceholderText(stripLeadingCodexControlBlocks(trimmed)).trim();
-  return visible ? visible : null;
 }
 
 function extractMessageText(content: PersistedMessagePart[] | undefined): string {
@@ -696,6 +639,8 @@ interface PersistedParseContext {
   suppressedToolOutputIds: Set<string>;
   terminalSessionToCommandId: Map<string, string>;
   stdinCallToCommandId: Map<string, string>;
+  execCellToCommandId: Map<string, string>;
+  waitCallToCommand: Map<string, { commandCallId: string; cellId: string }>;
   turnCounter: number;
 }
 
@@ -712,8 +657,20 @@ function processPersistedToolCall(
   const callId = payload.call_id;
   if (!callId) return;
 
-  if (payload.name === 'write_stdin') {
-    const parsedArgs = parseCodexArguments(payload.arguments ?? payload.input);
+  const rawArgs = payload.arguments ?? payload.input;
+  const parsedArgs = parseCodexArguments(rawArgs);
+  const normalized = normalizeCodexToolCall(payload.name, parsedArgs);
+
+  if (normalized.name === 'wait') {
+    const cellId = readCodexExecCellIdArgument(normalized.input);
+    const commandCallId = cellId ? ctx.execCellToCommandId.get(cellId) : undefined;
+    if (cellId && commandCallId) {
+      ctx.waitCallToCommand.set(callId, { commandCallId, cellId });
+      return;
+    }
+  }
+
+  if (normalized.name === 'write_stdin') {
     if (isSilentWriteStdinInput(parsedArgs)) {
       const terminalSessionId = readTerminalSessionIdArgument(parsedArgs);
       const parentCallId = terminalSessionId
@@ -730,15 +687,10 @@ function processPersistedToolCall(
   const turn = ensureTurn(ctx.turns, ctx.turnOrder, nextTurnId(ctx), ctx.currentTurnId, timestamp);
   const bubble = ensureAssistantBubble(turn, timestamp);
 
-  const rawArgs = payload.arguments ?? payload.input;
-  const parsedArgs = parseCodexArguments(rawArgs);
-  const normalizedName = normalizeCodexToolName(payload.name);
-  const normalizedInput = normalizeCodexToolInput(payload.name, parsedArgs);
-
   const toolCall: ToolCallInfo = {
     id: callId,
-    name: normalizedName,
-    input: normalizedInput,
+    name: normalized.name,
+    input: normalized.input,
     status: 'running',
   };
 
@@ -759,11 +711,18 @@ function processPersistedToolOutput(
   if (!callId) return;
 
   // output can be a string or an array (e.g. view_image returns image objects)
-  const rawOutput = typeof payload.output === 'string'
-    ? payload.output
-    : Array.isArray(payload.output)
-      ? JSON.stringify(payload.output)
-      : '';
+  const rawOutput = stringifyCodexToolOutput(payload.output);
+
+  const waitCall = ctx.waitCallToCommand.get(callId);
+  if (waitCall) {
+    const parentToolCall = findPersistedToolCallById(ctx, waitCall.commandCallId);
+    ctx.execCellToCommandId.delete(waitCall.cellId);
+    if (parentToolCall) {
+      applyPersistedToolOutput(parentToolCall, payload.output, rawOutput, ctx);
+    }
+    ctx.waitCallToCommand.delete(callId);
+    return;
+  }
 
   const parentCommandId = ctx.stdinCallToCommandId.get(callId);
   if (parentCommandId) {
@@ -839,28 +798,24 @@ function isSilentWriteStdinInput(input: Record<string, unknown>): boolean {
   return typeof input.chars !== 'string' || input.chars.length === 0;
 }
 
-function appendCommandOutput(previous: string | undefined, next: string): string {
-  if (!next) return previous ?? '';
-  if (!previous) return next;
-  if (previous.endsWith('\n') || next.startsWith('\n')) return previous + next;
-  return `${previous}\n${next}`;
-}
-
 function readPersistedCommandToolResult(rawOutputText: string): {
   output: string;
   status: 'running' | 'completed' | 'unknown';
   exitCode?: number;
   terminalSessionId?: string;
+  execCellId?: string;
 } {
   const output = normalizeCodexToolResult('Bash', rawOutputText);
   const exitCodeMatch = rawOutputText.match(/(?:Exit code:|Process exited with code)\s*(-?\d+)/i);
   const runningMatch = rawOutputText.match(/Process running with session ID\s*([^\n]+)/i);
+  const execCellId = extractCodexExecCellId(rawOutputText);
 
   return {
     output,
-    status: exitCodeMatch ? 'completed' : runningMatch ? 'running' : 'unknown',
+    status: exitCodeMatch ? 'completed' : runningMatch || execCellId ? 'running' : 'unknown',
     ...(exitCodeMatch ? { exitCode: Number(exitCodeMatch[1] ?? 0) } : {}),
     ...(runningMatch ? { terminalSessionId: (runningMatch[1] ?? '').trim() } : {}),
+    ...(execCellId ? { execCellId } : {}),
   };
 }
 
@@ -873,9 +828,12 @@ function applyPersistedToolOutput(
 ): void {
   if (toolCall.name === 'Bash') {
     const commandResult = readPersistedCommandToolResult(rawOutputText);
-    toolCall.result = appendCommandOutput(toolCall.result, commandResult.output);
+    toolCall.result = appendCodexCommandOutput(toolCall.result, commandResult.output);
     if (commandResult.terminalSessionId) {
       ctx.terminalSessionToCommandId.set(commandResult.terminalSessionId, toolCall.id);
+    }
+    if (commandResult.execCellId) {
+      ctx.execCellToCommandId.set(commandResult.execCellId, toolCall.id);
     }
     if (commandResult.status === 'running') {
       toolCall.status = 'running';

--- a/src/providers/codex/normalization/codexToolNormalization.ts
+++ b/src/providers/codex/normalization/codexToolNormalization.ts
@@ -40,6 +40,291 @@ export function normalizeCodexToolName(rawName: string | undefined): string {
   return TOOL_NAME_MAP[rawName] ?? rawName;
 }
 
+export interface NormalizedCodexToolCall {
+  name: string;
+  input: Record<string, unknown>;
+}
+
+export function normalizeCodexToolCall(
+  rawName: string | undefined,
+  rawInput: Record<string, unknown>,
+): NormalizedCodexToolCall {
+  const nestedCall = rawName === 'exec' ? decodeExecEnvelope(rawInput) : null;
+  const effectiveName = nestedCall?.name ?? rawName;
+  const effectiveInput = nestedCall?.input ?? rawInput;
+
+  return {
+    name: normalizeCodexToolName(effectiveName),
+    input: normalizeCodexToolInput(effectiveName, effectiveInput),
+  };
+}
+
+function decodeExecEnvelope(input: Record<string, unknown>): {
+  name: string;
+  input: Record<string, unknown>;
+} | null {
+  const source = firstNonEmptyString(input.raw, input.value);
+  if (!source) return null;
+
+  const tokens = tokenizeExecEnvelope(source);
+  if (!tokens) return null;
+
+  const calls = findExecEnvelopeToolCalls(tokens);
+  if (!calls || calls.length !== 1) return null;
+
+  const call = calls[0];
+  if (!call) return null;
+
+  if (call.name === 'exec_command') {
+    const command = extractExecCommand(tokens, call);
+    return command ? { name: call.name, input: { cmd: command } } : null;
+  }
+
+  if (call.name === 'apply_patch') {
+    const patch = extractApplyPatch(tokens, call);
+    return patch ? { name: call.name, input: { patch } } : null;
+  }
+
+  return null;
+}
+
+type JavaScriptTokenKind = 'identifier' | 'string' | 'punctuation';
+
+interface JavaScriptToken {
+  kind: JavaScriptTokenKind;
+  value: string;
+}
+
+interface ExecEnvelopeToolCall {
+  name: string;
+  toolTokenIndex: number;
+  openParenTokenIndex: number;
+}
+
+function tokenizeExecEnvelope(source: string): JavaScriptToken[] | null {
+  const tokens: JavaScriptToken[] = [];
+
+  for (let index = 0; index < source.length;) {
+    const char = source[index] ?? '';
+    const next = source[index + 1] ?? '';
+
+    if (/\s/.test(char)) {
+      index += 1;
+      continue;
+    }
+
+    if (char === '/' && next === '/') {
+      const lineEnd = source.indexOf('\n', index + 2);
+      index = lineEnd === -1 ? source.length : lineEnd + 1;
+      continue;
+    }
+
+    if (char === '/' && next === '*') {
+      const commentEnd = source.indexOf('*/', index + 2);
+      if (commentEnd === -1) return null;
+      index = commentEnd + 2;
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      const stringToken = readJavaScriptStringToken(source, index);
+      if (!stringToken) return null;
+      tokens.push({ kind: 'string', value: stringToken.value });
+      index = stringToken.end;
+      continue;
+    }
+
+    // Template literals and slash expressions need a full JavaScript lexer.
+    // Preserve the generic exec envelope instead of guessing when they are present.
+    if (char === '`' || char === '/') {
+      return null;
+    }
+
+    if (/[A-Za-z_$]/.test(char)) {
+      let end = index + 1;
+      while (end < source.length && /[\w$]/.test(source[end] ?? '')) {
+        end += 1;
+      }
+      tokens.push({ kind: 'identifier', value: source.slice(index, end) });
+      index = end;
+      continue;
+    }
+
+    tokens.push({ kind: 'punctuation', value: char });
+    index += 1;
+  }
+
+  return tokens;
+}
+
+function readJavaScriptStringToken(
+  source: string,
+  startIndex: number,
+): { value: string; end: number } | null {
+  const quote = source[startIndex];
+  if (quote !== '"' && quote !== "'") return null;
+
+  for (let index = startIndex + 1; index < source.length; index += 1) {
+    if (source[index] === '\\') {
+      index += 1;
+      continue;
+    }
+    if (source[index] !== quote) continue;
+
+    const literal = source.slice(startIndex, index + 1);
+    if (quote === '"') {
+      try {
+        const parsed = JSON.parse(literal) as unknown;
+        return typeof parsed === 'string' ? { value: parsed, end: index + 1 } : null;
+      } catch {
+        return null;
+      }
+    }
+
+    return {
+      value: decodeSingleQuotedString(literal.slice(1, -1)),
+      end: index + 1,
+    };
+  }
+
+  return null;
+}
+
+function findExecEnvelopeToolCalls(
+  tokens: readonly JavaScriptToken[],
+): ExecEnvelopeToolCall[] | null {
+  const calls: ExecEnvelopeToolCall[] = [];
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const toolsToken = tokens[index];
+    const previousToken = tokens[index - 1];
+    if (
+      toolsToken?.kind !== 'identifier'
+      || toolsToken.value !== 'tools'
+      || previousToken?.value === '.'
+    ) {
+      continue;
+    }
+
+    const dotToken = tokens[index + 1];
+    const nameToken = tokens[index + 2];
+    const openParenToken = tokens[index + 3];
+    if (
+      dotToken?.value !== '.'
+      || nameToken?.kind !== 'identifier'
+      || openParenToken?.value !== '('
+    ) {
+      return null;
+    }
+
+    calls.push({
+      name: nameToken.value,
+      toolTokenIndex: index,
+      openParenTokenIndex: index + 3,
+    });
+  }
+
+  return calls;
+}
+
+function extractExecCommand(
+  tokens: readonly JavaScriptToken[],
+  call: ExecEnvelopeToolCall,
+): string | null {
+  const closeParenTokenIndex = findMatchingToken(tokens, call.openParenTokenIndex, '(', ')');
+  if (closeParenTokenIndex === null) return null;
+  if (tokens[call.openParenTokenIndex + 1]?.value !== '{') return null;
+
+  let objectDepth = 0;
+  for (let index = call.openParenTokenIndex + 1; index < closeParenTokenIndex; index += 1) {
+    const token = tokens[index];
+    if (token?.value === '{') {
+      objectDepth += 1;
+      continue;
+    }
+    if (token?.value === '}') {
+      objectDepth -= 1;
+      continue;
+    }
+    if (
+      objectDepth === 1
+      && token?.value === 'cmd'
+      && tokens[index + 1]?.value === ':'
+      && tokens[index + 2]?.kind === 'string'
+    ) {
+      return tokens[index + 2]?.value ?? null;
+    }
+  }
+
+  return null;
+}
+
+function extractApplyPatch(
+  tokens: readonly JavaScriptToken[],
+  call: ExecEnvelopeToolCall,
+): string | null {
+  const argumentToken = tokens[call.openParenTokenIndex + 1];
+  if (argumentToken?.kind === 'string') return argumentToken.value;
+  if (argumentToken?.kind !== 'identifier') return null;
+
+  let patch: string | null = null;
+  for (let index = 0; index <= call.toolTokenIndex - 4; index += 1) {
+    const declarationToken = tokens[index];
+    if (
+      declarationToken?.kind === 'identifier'
+      && (declarationToken.value === 'const'
+        || declarationToken.value === 'let'
+        || declarationToken.value === 'var')
+      && tokens[index + 1]?.value === argumentToken.value
+      && tokens[index + 2]?.value === '='
+      && tokens[index + 3]?.kind === 'string'
+    ) {
+      patch = tokens[index + 3]?.value ?? null;
+    }
+  }
+
+  return patch;
+}
+
+function findMatchingToken(
+  tokens: readonly JavaScriptToken[],
+  openTokenIndex: number,
+  open: string,
+  close: string,
+): number | null {
+  let depth = 0;
+
+  for (let index = openTokenIndex; index < tokens.length; index += 1) {
+    const value = tokens[index]?.value;
+    if (value === open) {
+      depth += 1;
+    } else if (value === close) {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+
+  return null;
+}
+
+function decodeSingleQuotedString(value: string): string {
+  return value.replace(/\\([\\'"nrtbfv0])/g, (_match, escaped: string) => {
+    const escapes: Record<string, string> = {
+      '\\': '\\',
+      "'": "'",
+      '"': '"',
+      n: '\n',
+      r: '\r',
+      t: '\t',
+      b: '\b',
+      f: '\f',
+      v: '\v',
+      0: '\0',
+    };
+    return escapes[escaped] ?? escaped;
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Tool input normalization
 // ---------------------------------------------------------------------------
@@ -319,6 +604,50 @@ export function normalizeCodexToolResult(
   if (!rawResult) return rawResult;
   if (!TERMINAL_RESULT_TOOLS.has(normalizedName)) return rawResult;
   return unwrapTerminalResult(rawResult);
+}
+
+export function stringifyCodexToolOutput(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value === undefined) return '';
+
+  if (Array.isArray(value)) {
+    const textParts = value
+      .map(part => {
+        if (!part || typeof part !== 'object' || Array.isArray(part)) return '';
+        const text = (part as Record<string, unknown>).text;
+        return typeof text === 'string' ? text : '';
+      })
+      .filter(Boolean);
+    if (textParts.length > 0) return textParts.join('');
+  }
+
+  try {
+    const result = JSON.stringify(value);
+    return typeof result === 'string' ? result : String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export function extractCodexExecCellId(output: string): string | undefined {
+  const match = output.trimStart().match(/^Script running with cell ID\s+([^\n]+)/i);
+  return match?.[1]?.trim() || undefined;
+}
+
+export function readCodexExecCellIdArgument(
+  input: Record<string, unknown>,
+): string | undefined {
+  const value = input.cell_id ?? input.cellId;
+  if (typeof value === 'string' && value) return value;
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  return undefined;
+}
+
+export function appendCodexCommandOutput(previous: string | undefined, next: string): string {
+  if (!next) return previous ?? '';
+  if (!previous) return next;
+  if (previous.endsWith('\n') || next.startsWith('\n')) return previous + next;
+  return `${previous}\n${next}`;
 }
 
 function unwrapTerminalResult(raw: string): string {

--- a/src/providers/codex/runtime/CodexNotificationRouter.ts
+++ b/src/providers/codex/runtime/CodexNotificationRouter.ts
@@ -1,12 +1,17 @@
 import type { ChatTurnMetadata } from '../../../core/runtime/types';
 import type { StreamChunk, UsageInfo } from '../../../core/types';
-import { joinCodexUserTextParts } from '../codexUserText';
+import { extractCodexUserVisibleText, joinCodexUserTextParts } from '../codexUserText';
 import {
+  appendCodexCommandOutput,
+  extractCodexExecCellId,
   isCodexToolOutputError,
+  normalizeCodexToolCall,
   normalizeCodexToolInput,
   normalizeCodexToolName,
   normalizeCodexToolResult,
   parseCodexArguments,
+  readCodexExecCellIdArgument,
+  stringifyCodexToolOutput,
 } from '../normalization/codexToolNormalization';
 import type {
   AgentMessageDeltaNotification,
@@ -40,6 +45,11 @@ interface RawToolResult {
   isError: boolean;
 }
 
+interface WrappedWaitCall {
+  commandCallId: string;
+  cellId: string;
+}
+
 const COLLAB_AGENT_TOOL_MAP: Record<string, string> = {
   spawnAgent: 'spawn_agent',
   wait: 'wait',
@@ -63,6 +73,10 @@ export class CodexNotificationRouter {
   private rawToolNamesByCallId = new Map<string, string>();
   private rawToolInputsByCallId = new Map<string, Record<string, unknown>>();
   private rawToolOutputsByCallId = new Map<string, RawToolResult>();
+  private immediateRawOutputCallIds = new Set<string>();
+  private wrappedCommandCallIdsByCellId = new Map<string, string>();
+  private wrappedCommandOutputByCallId = new Map<string, string>();
+  private wrappedWaitCallsByCallId = new Map<string, WrappedWaitCall>();
   private suppressedRawCallIds = new Set<string>();
   private fileChangeInputsById = new Map<string, Record<string, unknown>>();
 
@@ -127,6 +141,10 @@ export class CodexNotificationRouter {
     this.rawToolNamesByCallId.clear();
     this.rawToolInputsByCallId.clear();
     this.rawToolOutputsByCallId.clear();
+    this.immediateRawOutputCallIds.clear();
+    this.wrappedCommandCallIdsByCellId.clear();
+    this.wrappedCommandOutputByCallId.clear();
+    this.wrappedWaitCallsByCallId.clear();
     this.suppressedRawCallIds.clear();
     this.fileChangeInputsById.clear();
   }
@@ -142,6 +160,10 @@ export class CodexNotificationRouter {
     this.rawToolNamesByCallId.clear();
     this.rawToolInputsByCallId.clear();
     this.rawToolOutputsByCallId.clear();
+    this.immediateRawOutputCallIds.clear();
+    this.wrappedCommandCallIdsByCellId.clear();
+    this.wrappedCommandOutputByCallId.clear();
+    this.wrappedWaitCallsByCallId.clear();
     this.suppressedRawCallIds.clear();
     this.fileChangeInputsById.clear();
   }
@@ -372,6 +394,17 @@ export class CodexNotificationRouter {
     }
 
     const rawArguments = parseRawArguments(item);
+    if (rawName === 'wait') {
+      const cellId = readCodexExecCellIdArgument(rawArguments);
+      const commandCallId = cellId
+        ? this.wrappedCommandCallIdsByCellId.get(cellId)
+        : undefined;
+      if (cellId && commandCallId) {
+        this.wrappedWaitCallsByCallId.set(callId, { commandCallId, cellId });
+        return;
+      }
+    }
+
     if (rawName === 'write_stdin' && isSilentWriteStdinInput(rawArguments)) {
       this.suppressedRawCallIds.add(callId);
       return;
@@ -395,6 +428,8 @@ export class CodexNotificationRouter {
       return;
     }
 
+    // Generic custom tools have no semantic item/completed notification; their raw output is terminal.
+    this.immediateRawOutputCallIds.add(callId);
     this.emitRawToolUse(callId, rawName, item);
   }
 
@@ -404,31 +439,40 @@ export class CodexNotificationRouter {
     item: Record<string, unknown>,
     rawArguments?: Record<string, unknown>,
   ): void {
-    const normalizedName = normalizeCodexToolName(rawName);
-    const input = normalizeCodexToolInput(rawName, rawArguments ?? parseRawArguments(item));
+    const normalized = normalizeCodexToolCall(
+      rawName,
+      rawArguments ?? parseRawArguments(item),
+    );
 
     if (this.rawStartedCallIds.has(callId)) {
-      this.rawToolNamesByCallId.set(callId, normalizedName);
-      this.rawToolInputsByCallId.set(callId, input);
+      this.rawToolNamesByCallId.set(callId, normalized.name);
+      this.rawToolInputsByCallId.set(callId, normalized.input);
       return;
     }
 
     this.rawStartedCallIds.add(callId);
-    this.rawToolNamesByCallId.set(callId, normalizedName);
-    this.rawToolInputsByCallId.set(callId, input);
+    this.rawToolNamesByCallId.set(callId, normalized.name);
+    this.rawToolInputsByCallId.set(callId, normalized.input);
 
     this.resetAssistantSegmentText();
     this.emit({
       type: 'tool_use',
       id: callId,
-      name: normalizedName,
-      input,
+      name: normalized.name,
+      input: normalized.input,
     });
   }
 
   private handleRawToolOutput(item: Record<string, unknown>): void {
     const callId = readRawCallId(item);
     if (!callId) {
+      return;
+    }
+
+    const wrappedWaitCall = this.wrappedWaitCallsByCallId.get(callId);
+    if (wrappedWaitCall) {
+      this.wrappedWaitCallsByCallId.delete(callId);
+      this.handleWrappedWaitOutput(wrappedWaitCall, item.output);
       return;
     }
 
@@ -442,15 +486,72 @@ export class CodexNotificationRouter {
     }
 
     const rawOutput = item.output;
+    const rawOutputText = stringifyCodexToolOutput(rawOutput);
     const content = normalizeRawToolOutput(
       normalizedName,
       rawOutput,
       this.rawToolInputsByCallId.get(callId),
     );
-    this.rawToolOutputsByCallId.set(callId, {
+    const result = {
       content,
-      isError: isCodexToolOutputError(stringifyRawOutput(rawOutput)),
+      isError: isCodexToolOutputError(rawOutputText),
+    };
+
+    if (this.immediateRawOutputCallIds.delete(callId)) {
+      const execCellId = normalizedName === 'Bash'
+        ? extractCodexExecCellId(rawOutputText)
+        : undefined;
+      if (execCellId) {
+        this.wrappedCommandCallIdsByCellId.set(execCellId, callId);
+        this.appendWrappedCommandOutput(callId, content);
+        return;
+      }
+
+      this.emit({ type: 'tool_result', id: callId, ...result });
+      return;
+    }
+
+    this.rawToolOutputsByCallId.set(callId, result);
+  }
+
+  private handleWrappedWaitOutput(waitCall: WrappedWaitCall, rawOutput: unknown): void {
+    const rawOutputText = stringifyCodexToolOutput(rawOutput);
+    const content = normalizeRawToolOutput(
+      'Bash',
+      rawOutput,
+      this.rawToolInputsByCallId.get(waitCall.commandCallId),
+    );
+    const nextCellId = extractCodexExecCellId(rawOutputText);
+
+    if (nextCellId) {
+      this.wrappedCommandCallIdsByCellId.delete(waitCall.cellId);
+      this.wrappedCommandCallIdsByCellId.set(nextCellId, waitCall.commandCallId);
+      this.appendWrappedCommandOutput(waitCall.commandCallId, content);
+      return;
+    }
+
+    const previousOutput = this.wrappedCommandOutputByCallId.get(waitCall.commandCallId);
+    const completeOutput = appendCodexCommandOutput(previousOutput, content);
+    this.wrappedCommandOutputByCallId.delete(waitCall.commandCallId);
+    this.wrappedCommandCallIdsByCellId.delete(waitCall.cellId);
+    this.emit({
+      type: 'tool_result',
+      id: waitCall.commandCallId,
+      content: completeOutput,
+      isError: isCodexToolOutputError(rawOutputText),
     });
+  }
+
+  private appendWrappedCommandOutput(callId: string, content: string): void {
+    if (!content) return;
+
+    const previousOutput = this.wrappedCommandOutputByCallId.get(callId);
+    const completeOutput = appendCodexCommandOutput(previousOutput, content);
+    const delta = completeOutput.slice(previousOutput?.length ?? 0);
+    this.wrappedCommandOutputByCallId.set(callId, completeOutput);
+    if (delta) {
+      this.emit({ type: 'tool_output', id: callId, content: delta });
+    }
   }
 
   private emitMissingRawAgentMessageText(item: Record<string, unknown>): void {
@@ -706,11 +807,18 @@ export class CodexNotificationRouter {
       return;
     }
 
+    const rawContent = this.extractUserMessageText(item.content);
+    const visibleContent = extractCodexUserVisibleText(rawContent);
     this.startedUserMessageIds.add(item.id);
+
+    if (visibleContent === null && rawContent.trim()) {
+      return;
+    }
+
     this.emit({
       type: 'user_message_start',
       itemId: item.id,
-      content: this.extractUserMessageText(item.content),
+      content: visibleContent ?? rawContent,
     });
   }
 
@@ -863,23 +971,7 @@ function normalizeRawToolOutput(
     }
   }
 
-  return normalizeCodexToolResult(normalizedName, stringifyRawOutput(rawOutput));
-}
-
-function stringifyRawOutput(value: unknown): string {
-  if (typeof value === 'string') {
-    return value;
-  }
-  if (value === undefined) {
-    return '';
-  }
-
-  try {
-    const result = JSON.stringify(value);
-    return typeof result === 'string' ? result : String(value);
-  } catch {
-    return String(value);
-  }
+  return normalizeCodexToolResult(normalizedName, stringifyCodexToolOutput(rawOutput));
 }
 
 function buildFileChangeInput(changes: unknown): Record<string, unknown> {

--- a/tests/unit/providers/codex/history/CodexHistoryStore.test.ts
+++ b/tests/unit/providers/codex/history/CodexHistoryStore.test.ts
@@ -397,6 +397,164 @@ describe('CodexHistoryStore', () => {
       expect(patchTool!.status).toBe('completed');
     });
 
+    it('restores completed exec envelopes as their nested tools', () => {
+      const patch = '*** Begin Patch\n*** Update File: note.md\n*** End Patch';
+      const content = [
+        JSON.stringify({
+          timestamp: '2026-07-10T00:00:00.000Z',
+          type: 'event_msg',
+          payload: { type: 'task_started' },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-10T00:00:01.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'custom_tool_call',
+            name: 'exec',
+            call_id: 'call_exec_wrapper',
+            input: 'const r = await tools.exec_command({cmd:"ls -1",workdir:"/vault"}); text(r.output);',
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-10T00:00:02.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'custom_tool_call_output',
+            call_id: 'call_exec_wrapper',
+            output: [
+              { type: 'input_text', text: 'Script completed\nWall time 0.1 seconds\nOutput:\n' },
+              { type: 'input_text', text: 'file.txt\n' },
+            ],
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-10T00:00:03.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'custom_tool_call',
+            name: 'exec',
+            call_id: 'call_patch_wrapper',
+            input: `const patch = ${JSON.stringify(patch)};\ntext(await tools.apply_patch(patch));`,
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-10T00:00:04.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'custom_tool_call_output',
+            call_id: 'call_patch_wrapper',
+            output: [{ type: 'input_text', text: 'Script completed\nOutput:\nApplied patch' }],
+          },
+        }),
+      ].join('\n');
+
+      const messages = parseCodexSessionContent(content);
+      const toolCalls = messages.flatMap(message => message.toolCalls ?? []);
+
+      expect(toolCalls).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          id: 'call_exec_wrapper',
+          name: 'Bash',
+          input: { command: 'ls -1' },
+          status: 'completed',
+          result: 'file.txt\n',
+        }),
+        expect.objectContaining({
+          id: 'call_patch_wrapper',
+          name: 'apply_patch',
+          input: { patch },
+          status: 'completed',
+        }),
+      ]));
+    });
+
+    it('restores yielded exec envelopes as one completed Bash tool', () => {
+      const content = [
+        JSON.stringify({
+          timestamp: '2026-07-10T00:00:00.000Z',
+          type: 'event_msg',
+          payload: { type: 'task_started' },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-10T00:00:01.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'custom_tool_call',
+            name: 'exec',
+            call_id: 'call_exec_wrapper',
+            input: 'const r = await tools.exec_command({cmd:"npm test"}); text(r.output);',
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-10T00:00:02.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'custom_tool_call_output',
+            call_id: 'call_exec_wrapper',
+            output: [
+              { type: 'input_text', text: 'Script running with cell ID 42\nWall time 10.0 seconds\nOutput:\n' },
+              { type: 'input_text', text: 'tests started\n' },
+            ],
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-10T00:00:03.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'function_call',
+            name: 'wait',
+            call_id: 'call_wait_1',
+            arguments: '{"cell_id":"42","yield_time_ms":30000}',
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-10T00:00:04.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'function_call_output',
+            call_id: 'call_wait_1',
+            output: [
+              { type: 'input_text', text: 'Script running with cell ID 42\nWall time 30.0 seconds\nOutput:\n' },
+              { type: 'input_text', text: 'tests still running\n' },
+            ],
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-10T00:00:05.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'function_call',
+            name: 'wait',
+            call_id: 'call_wait_2',
+            arguments: '{"cell_id":"42","yield_time_ms":30000}',
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-10T00:00:06.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'function_call_output',
+            call_id: 'call_wait_2',
+            output: [
+              { type: 'input_text', text: 'Script completed\nWall time 0.1 seconds\nOutput:\n' },
+              { type: 'input_text', text: 'tests passed\n' },
+            ],
+          },
+        }),
+      ].join('\n');
+
+      const messages = parseCodexSessionContent(content);
+      const toolCalls = messages.flatMap(message => message.toolCalls ?? []);
+
+      expect(toolCalls).toEqual([expect.objectContaining({
+        id: 'call_exec_wrapper',
+        name: 'Bash',
+        input: { command: 'npm test' },
+        status: 'completed',
+        result: 'tests started\ntests still running\ntests passed\n',
+      })]);
+    });
+
     it('restores raw custom_tool_call apply_patch input as patch text', () => {
       const content = [
         JSON.stringify({
@@ -834,6 +992,46 @@ describe('CodexHistoryStore', () => {
         }),
         JSON.stringify({
           timestamp: '2026-03-27T00:00:00.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Ready.' }],
+          },
+        }),
+      ].join('\n');
+
+      const messages = parseCodexSessionContent(content);
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toMatchObject({ role: 'assistant', content: 'Ready.' });
+    });
+
+    it('should skip recommended plugin metadata before AGENTS.md instructions', () => {
+      const metadataText = [
+        '<recommended_plugins>',
+        'Install Google Drive when it would help.',
+        '</recommended_plugins>',
+        '# AGENTS.md instructions for /Users/test/project',
+        '',
+        '<INSTRUCTIONS>',
+        'Do good work.',
+        '</INSTRUCTIONS>',
+        '<environment_context>',
+        '  <cwd>/Users/test/project</cwd>',
+        '</environment_context>',
+      ].join('\n');
+      const content = [
+        JSON.stringify({
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'input_text', text: metadataText }],
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-10T00:00:00.000Z',
           type: 'response_item',
           payload: {
             type: 'message',

--- a/tests/unit/providers/codex/normalization/codexToolNormalization.test.ts
+++ b/tests/unit/providers/codex/normalization/codexToolNormalization.test.ts
@@ -3,6 +3,7 @@ import {
   normalizeCodexMcpToolInput,
   normalizeCodexMcpToolName,
   normalizeCodexMcpToolState,
+  normalizeCodexToolCall,
   normalizeCodexToolInput,
   normalizeCodexToolName,
   normalizeCodexToolResult,
@@ -194,6 +195,95 @@ describe('normalizeCodexToolInput', () => {
     const input = { message: 'Do something', agent_type: 'code-writer' };
     const result = normalizeCodexToolInput('spawn_agent', input);
     expect(result).toEqual(input);
+  });
+});
+
+describe('normalizeCodexToolCall', () => {
+  it('unwraps exec envelopes containing exec_command as Bash', () => {
+    const command = 'rg -n "TODO" src';
+    const source = `const r = await tools.exec_command({cmd:${JSON.stringify(command)},workdir:"/vault"}); text(r.output);`;
+
+    expect(normalizeCodexToolCall('exec', { raw: source })).toEqual({
+      name: 'Bash',
+      input: { command },
+    });
+  });
+
+  it('unwraps exec envelopes containing apply_patch as a native patch', () => {
+    const patch = '*** Begin Patch\n*** Update File: note.md\n@@\n-old\n+new\n*** End Patch';
+    const source = `const patch = ${JSON.stringify(patch)};\ntext(await tools.apply_patch(patch));`;
+
+    expect(normalizeCodexToolCall('exec', { raw: source })).toEqual({
+      name: 'apply_patch',
+      input: { patch },
+    });
+  });
+
+  it('preserves exec when an envelope contains multiple nested tool calls', () => {
+    const source = [
+      'const first = await tools.exec_command({cmd:"pwd"});',
+      'const second = await tools.exec_command({cmd:"ls"});',
+      'text(first.output + second.output);',
+    ].join('\n');
+
+    expect(normalizeCodexToolCall('exec', { raw: source })).toEqual({
+      name: 'exec',
+      input: { raw: source },
+    });
+  });
+
+  it('preserves exec when another nested tool accompanies exec_command', () => {
+    const source = [
+      'await tools.update_plan({plan:[]});',
+      'const result = await tools.exec_command({cmd:"pwd"});',
+      'text(result.output);',
+    ].join('\n');
+
+    expect(normalizeCodexToolCall('exec', { raw: source })).toEqual({
+      name: 'exec',
+      input: { raw: source },
+    });
+  });
+
+  it('preserves exec when unsupported tools access accompanies exec_command', () => {
+    const source = [
+      'await tools["update_plan"]({plan:[]});',
+      'const result = await tools.exec_command({cmd:"pwd"});',
+      'text(result.output);',
+    ].join('\n');
+
+    expect(normalizeCodexToolCall('exec', { raw: source })).toEqual({
+      name: 'exec',
+      input: { raw: source },
+    });
+  });
+
+  it('ignores tool-like text inside command string literals', () => {
+    const command = 'rg -n "tools.exec_command(" src';
+    const source = `const result = await tools.exec_command({cmd:${JSON.stringify(command)}}); text(result.output);`;
+
+    expect(normalizeCodexToolCall('exec', { raw: source })).toEqual({
+      name: 'Bash',
+      input: { command },
+    });
+  });
+
+  it('does not unwrap tool-like text that is never invoked', () => {
+    const source = 'const example = \'tools.exec_command({cmd:"pwd"})\'; text(example);';
+
+    expect(normalizeCodexToolCall('exec', { raw: source })).toEqual({
+      name: 'exec',
+      input: { raw: source },
+    });
+  });
+
+  it('does not read cmd from a later argument', () => {
+    const source = 'const options = {}; const result = await tools.exec_command(options, {cmd:"pwd"}); text(result.output);';
+
+    expect(normalizeCodexToolCall('exec', { raw: source })).toEqual({
+      name: 'exec',
+      input: { raw: source },
+    });
   });
 });
 

--- a/tests/unit/providers/codex/runtime/CodexNotificationRouter.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexNotificationRouter.test.ts
@@ -343,6 +343,175 @@ describe('CodexNotificationRouter', () => {
       expect(chunks[chunks.length - 1]).toEqual({ type: 'done' });
     });
 
+    it('unwraps exec envelopes and completes them when the raw output arrives', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_exec_wrapper',
+          input: 'const r = await tools.exec_command({cmd:"ls -1",workdir:"/workspace"}); text(r.output);',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_exec_wrapper',
+          output: [
+            { type: 'input_text', text: 'Script completed\nWall time 0.1 seconds\nOutput:\n' },
+            { type: 'input_text', text: 'file.txt\n' },
+          ],
+        },
+      });
+
+      expect(chunks).toEqual([
+        {
+          type: 'tool_use',
+          id: 'call_exec_wrapper',
+          name: 'Bash',
+          input: { command: 'ls -1' },
+        },
+        {
+          type: 'tool_result',
+          id: 'call_exec_wrapper',
+          content: 'file.txt\n',
+          isError: false,
+        },
+      ]);
+
+      router.handleNotification('turn/completed', {
+        threadId: 't1',
+        turn: { id: 'turn1', items: [], status: 'completed', error: null },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(1);
+      expect(chunks[chunks.length - 1]).toEqual({ type: 'done' });
+    });
+
+    it('keeps yielded exec envelopes running until their wait call completes', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_exec_wrapper',
+          input: 'const r = await tools.exec_command({cmd:"npm test"}); text(r.output);',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_exec_wrapper',
+          output: [
+            { type: 'input_text', text: 'Script running with cell ID 42\nWall time 10.0 seconds\nOutput:\n' },
+            { type: 'input_text', text: 'tests started\n' },
+          ],
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'function_call',
+          name: 'wait',
+          call_id: 'call_wait_1',
+          arguments: '{"cell_id":"42","yield_time_ms":30000}',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'function_call_output',
+          call_id: 'call_wait_1',
+          output: [
+            { type: 'input_text', text: 'Script running with cell ID 42\nWall time 30.0 seconds\nOutput:\n' },
+            { type: 'input_text', text: 'tests still running\n' },
+          ],
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'function_call',
+          name: 'wait',
+          call_id: 'call_wait_2',
+          arguments: '{"cell_id":"42","yield_time_ms":30000}',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'function_call_output',
+          call_id: 'call_wait_2',
+          output: [
+            { type: 'input_text', text: 'Script completed\nWall time 0.1 seconds\nOutput:\n' },
+            { type: 'input_text', text: 'tests passed\n' },
+          ],
+        },
+      });
+
+      expect(chunks).toEqual([
+        {
+          type: 'tool_use',
+          id: 'call_exec_wrapper',
+          name: 'Bash',
+          input: { command: 'npm test' },
+        },
+        {
+          type: 'tool_output',
+          id: 'call_exec_wrapper',
+          content: 'tests started\n',
+        },
+        {
+          type: 'tool_output',
+          id: 'call_exec_wrapper',
+          content: 'tests still running\n',
+        },
+        {
+          type: 'tool_result',
+          id: 'call_exec_wrapper',
+          content: 'tests started\ntests still running\ntests passed\n',
+          isError: false,
+        },
+      ]);
+    });
+
+    it('unwraps apply_patch inside exec envelopes', () => {
+      router.beginTurn({ isPlanTurn: false });
+      const patch = '*** Begin Patch\n*** Update File: note.md\n*** End Patch';
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_patch_wrapper',
+          input: `const patch = ${JSON.stringify(patch)};\ntext(await tools.apply_patch(patch));`,
+        },
+      });
+
+      expect(chunks).toEqual([{
+        type: 'tool_use',
+        id: 'call_patch_wrapper',
+        name: 'apply_patch',
+        input: { patch },
+      }]);
+    });
+
     it('does not normalize raw command output a second time when item/completed arrives', () => {
       router.beginTurn({ isPlanTurn: false });
 
@@ -1215,6 +1384,41 @@ describe('CodexNotificationRouter', () => {
 
       expect(chunks).toEqual([
         { type: 'user_message_start', itemId: 'u1', content: 'what was in this img?' },
+      ]);
+    });
+
+    it('hides recommended plugin metadata from userMessage boundaries', () => {
+      router.handleNotification('item/started', {
+        item: {
+          type: 'userMessage',
+          id: 'metadata',
+          content: [{
+            type: 'text',
+            text: [
+              '<recommended_plugins>',
+              'Install Google Drive when it would help.',
+              '</recommended_plugins>',
+              '# AGENTS.md instructions for /vault',
+              '<INSTRUCTIONS>',
+              'Do good work.',
+              '</INSTRUCTIONS>',
+              '<environment_context>',
+              '  <cwd>/vault</cwd>',
+              '</environment_context>',
+            ].join('\n'),
+          }],
+        },
+        threadId: 't1',
+        turnId: 'turn1',
+      });
+      router.handleNotification('item/started', {
+        item: { type: 'userMessage', id: 'u1', content: [{ type: 'text', text: 'fix it' }] },
+        threadId: 't1',
+        turnId: 'turn1',
+      });
+
+      expect(chunks).toEqual([
+        { type: 'user_message_start', itemId: 'u1', content: 'fix it' },
       ]);
     });
 


### PR DESCRIPTION
## Summary
- Normalize single-tool Codex `exec` envelopes into native Bash and apply-patch renderers while conservatively preserving ambiguous or multi-tool scripts.
- Keep yielded command output attached to its originating tool across `wait` calls in live streaming and history replay.
- Filter injected Codex control metadata from live and restored user messages.

## Validation
- `npm run typecheck && npm run lint && npm run test && npm run build`