### PR TITLE
Fix Windows WSL distro discovery and startup failure

### DIFF
--- a/src/providers/codex/runtime/CodexExecutionTargetResolver.ts
+++ b/src/providers/codex/runtime/CodexExecutionTargetResolver.ts
@@ -40,8 +40,43 @@ export function inferWslDistroFromWindowsPath(hostPath: string | null | undefine
   return match?.[1] || undefined;
 }
 
-export function parseDefaultWslDistroListOutput(output: string): string | undefined {
-  for (const line of output.replace(/\uFEFF/g, '').split(/\r?\n/)) {
+function looksLikeUtf16Le(output: Buffer): boolean {
+  const sampleLength = Math.min(output.length - (output.length % 2), 512);
+  if (sampleLength < 4) {
+    return false;
+  }
+
+  let evenNullBytes = 0;
+  let oddNullBytes = 0;
+  for (let index = 0; index < sampleLength; index += 2) {
+    if (output[index] === 0) {
+      evenNullBytes += 1;
+    }
+    if (output[index + 1] === 0) {
+      oddNullBytes += 1;
+    }
+  }
+
+  const bytePairs = sampleLength / 2;
+  return oddNullBytes / bytePairs >= 0.2 && oddNullBytes > evenNullBytes * 2;
+}
+
+function decodeWslListOutput(output: string | Buffer): string {
+  if (typeof output === 'string') {
+    return output;
+  }
+
+  const hasUtf16LeBom = output.length >= 2 && output[0] === 0xFF && output[1] === 0xFE;
+  if (hasUtf16LeBom || looksLikeUtf16Le(output)) {
+    return output.toString('utf16le');
+  }
+
+  return output.toString('utf8');
+}
+
+export function parseDefaultWslDistroListOutput(output: string | Buffer): string | undefined {
+  const decodedOutput = decodeWslListOutput(output);
+  for (const line of decodedOutput.replace(/\uFEFF/g, '').split(/\r?\n/)) {
     const trimmed = line.trimStart();
     if (!trimmed.startsWith('*')) {
       continue;
@@ -59,7 +94,6 @@ export function parseDefaultWslDistroListOutput(output: string): string | undefi
 function resolveDefaultWslDistroName(): string | undefined {
   try {
     const output = execFileSync('wsl.exe', ['--list', '--verbose'], {
-      encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
       windowsHide: true,
     });

--- a/src/providers/codex/runtime/CodexModelDiscoveryService.ts
+++ b/src/providers/codex/runtime/CodexModelDiscoveryService.ts
@@ -22,11 +22,12 @@ export class CodexModelDiscoveryService {
   constructor(private readonly plugin: ClaudianPlugin) {}
 
   async discoverModels(): Promise<CodexModelDiscoveryResult> {
-    const launchSpec = resolveCodexAppServerLaunchSpec(this.plugin, 'codex');
-    const process = new CodexAppServerProcess(launchSpec);
+    let process: CodexAppServerProcess | null = null;
     let transport: CodexRpcTransport | null = null;
 
     try {
+      const launchSpec = resolveCodexAppServerLaunchSpec(this.plugin, 'codex');
+      process = new CodexAppServerProcess(launchSpec);
       process.start();
       transport = new CodexRpcTransport(process);
       transport.start();
@@ -58,14 +59,16 @@ export class CodexModelDiscoveryService {
       return { models: normalizeCodexDiscoveredModels(entries) };
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Codex model discovery failed';
-      const stderr = process.getStderrSnapshot();
+      const stderr = process?.getStderrSnapshot() ?? '';
       return {
         diagnostics: stderr ? `${message}\n\n${stderr}` : message,
         models: [],
       };
     } finally {
       transport?.dispose();
-      await process.shutdown().catch(() => {});
+      if (process) {
+        await process.shutdown().catch(() => {});
+      }
     }
   }
 }

--- a/tests/unit/providers/codex/runtime/CodexExecutionTargetResolver.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexExecutionTargetResolver.test.ts
@@ -87,12 +87,26 @@ describe('resolveCodexExecutionTarget', () => {
 });
 
 describe('parseDefaultWslDistroListOutput', () => {
-  it('extracts the starred default distro from wsl --list --verbose output', () => {
-    expect(parseDefaultWslDistroListOutput(`
+  const distroListOutput = `
   NAME              STATE           VERSION
 * Ubuntu-24.04      Running         2
   Debian            Stopped         2
-`)).toBe('Ubuntu-24.04');
+`;
+
+  it('extracts the starred default distro from wsl --list --verbose output', () => {
+    expect(parseDefaultWslDistroListOutput(distroListOutput)).toBe('Ubuntu-24.04');
+  });
+
+  it('decodes the native UTF-16LE output emitted by wsl.exe list commands', () => {
+    expect(parseDefaultWslDistroListOutput(
+      Buffer.from(distroListOutput, 'utf16le'),
+    )).toBe('Ubuntu-24.04');
+  });
+
+  it('continues to accept UTF-8 output when WSL_UTF8 is enabled', () => {
+    expect(parseDefaultWslDistroListOutput(
+      Buffer.from(distroListOutput, 'utf8'),
+    )).toBe('Ubuntu-24.04');
   });
 
   it('returns undefined when no default distro marker is present', () => {

--- a/tests/unit/providers/codex/runtime/CodexModelDiscoveryService.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexModelDiscoveryService.test.ts
@@ -110,4 +110,19 @@ describe('CodexModelDiscoveryService', () => {
     expect(mockTransportDispose).toHaveBeenCalledTimes(1);
     expect(mockProcessShutdown).toHaveBeenCalledTimes(1);
   });
+
+  it('returns diagnostics when launch-spec resolution fails before process startup', async () => {
+    mockResolveLaunchSpec.mockImplementationOnce(() => {
+      throw new Error('Unable to determine the WSL distro');
+    });
+
+    await expect(
+      new CodexModelDiscoveryService({} as any).discoverModels(),
+    ).resolves.toEqual({
+      diagnostics: 'Unable to determine the WSL distro',
+      models: [],
+    });
+    expect(mockProcessStart).not.toHaveBeenCalled();
+    expect(mockProcessShutdown).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

- Decode raw `wsl.exe --list --verbose` output as UTF-16LE or UTF-8 so the configured default distro is detected reliably.
- Contain Codex launch-spec failures as model-discovery diagnostics so provider initialization cannot abort plugin startup.
- Add regression coverage for both Windows encoding variants and pre-process discovery failures.

Fixes #895.