### PR TITLE
fix: recover or remove stale Claude sessions

### DIFF
--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -414,6 +414,26 @@ export interface ProviderWorkspaceRegistration<
 }
 
 export interface ProviderConversationHistoryService {
+  /**
+   * Reports whether the provider-native session needed to resume a persisted
+   * conversation is still available. Providers that cannot distinguish a
+   * missing session from an inaccessible history store should return unknown.
+   */
+  getConversationSessionAvailability?(
+    conversation: Conversation,
+    vaultPath: string | null,
+  ): Promise<ProviderConversationSessionAvailability>;
+  /** Clears stale resume state so relocated provider history can rebuild natively. */
+  prepareRelocatedConversationSession?(
+    conversation: Conversation,
+    vaultPath: string | null,
+  ): Promise<boolean>;
+  /** Decides whether a confirmed missing resume session makes the whole record disposable. */
+  resolveMissingConversationSession?(
+    conversation: Conversation,
+    vaultPath: string | null,
+    missingProviderSessionId?: string,
+  ): Promise<'delete' | 'reset' | 'preserve'>;
   hydrateConversationHistory(
     conversation: Conversation,
     vaultPath: string | null,
@@ -433,6 +453,12 @@ export interface ProviderConversationHistoryService {
   /** Adds provider-owned persisted metadata to Conversation.providerState before session save. */
   buildPersistedProviderState?(conversation: Conversation): Record<string, unknown> | undefined;
 }
+
+export type ProviderConversationSessionAvailability =
+  | 'available'
+  | 'relocated'
+  | 'missing'
+  | 'unknown';
 
 export type ProviderTaskTerminalStatus = Extract<ToolCallInfo['status'], 'completed' | 'error'>;
 

--- a/src/core/types/chat.ts
+++ b/src/core/types/chat.ts
@@ -146,7 +146,12 @@ export type StreamChunk =
   | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
   | { type: 'tool_result'; id: string; content: string; isError?: boolean; toolUseResult?: SDKToolUseResult }
   | { type: 'tool_output'; id: string; content: string }
-  | { type: 'error'; content: string }
+  | {
+      type: 'error';
+      content: string;
+      code?: 'provider_session_missing';
+      providerSessionId?: string;
+    }
   | { type: 'notice'; content: string; level?: 'info' | 'warning' }
   | { type: 'done' }
   | { type: 'usage'; usage: UsageInfo; sessionId?: string | null }

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -418,6 +418,33 @@ export class InputController {
           break;
         }
 
+        if (chunk.type === 'error' && chunk.code === 'provider_session_missing') {
+          const staleConversationId = state.currentConversationId;
+          const resolution = staleConversationId
+            ? await plugin.handleMissingProviderSession(
+                staleConversationId,
+                chunk.providerSessionId,
+              )
+            : 'not_found';
+          if (shouldUseInput) {
+            inputEl.value = content;
+            this.deps.resetInputHeight();
+            if (imagesForMessage) {
+              imageContextManager?.setImages(imagesForMessage);
+            }
+          }
+          const notice = resolution === 'deleted'
+            ? 'The provider session no longer exists. Its Claudian record was removed; send again to start a new session.'
+            : resolution === 'reset'
+              ? 'The provider session no longer exists. Claudian preserved the recoverable history; send again to rebuild the session.'
+              : resolution === 'preserved'
+                ? 'The provider session no longer exists. Claudian preserved its record because the remaining history could not be verified.'
+                : 'The provider session no longer exists. Send again to start a new session.';
+          new Notice(notice);
+          wasInvalidated = true;
+          break;
+        }
+
         if (await this.handleProviderMessageBoundaryChunk(chunk)) {
           continue;
         }

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -310,6 +310,8 @@ export class InputController {
         canvasContextOverride: options?.canvasContextOverride,
       });
     const { displayContent, turnRequest } = turnSubmission;
+    const messagesBeforeTurn = state.messages;
+    const hadPendingConversationSave = state.hasPendingConversationSave;
 
     fileContextManager?.markCurrentNoteSent();
 
@@ -419,6 +421,15 @@ export class InputController {
         }
 
         if (chunk.type === 'error' && chunk.code === 'provider_session_missing') {
+          const retryMessage = this.createQueuedMessage(displayContent, {
+            ...turnRequest,
+            images: imagesForMessage ?? turnRequest.images,
+          });
+          const pendingMessagesToRestore = this.mergePendingMessages(
+            this.pendingSteerMessage,
+            state.queuedMessage,
+          );
+          const composerDraftToRestore = this.captureComposerDraft();
           const staleConversationId = state.currentConversationId;
           const resolution = staleConversationId
             ? await plugin.handleMissingProviderSession(
@@ -426,12 +437,14 @@ export class InputController {
                 chunk.providerSessionId,
               )
             : 'not_found';
-          if (shouldUseInput) {
-            inputEl.value = content;
-            this.deps.resetInputHeight();
-            if (imagesForMessage) {
-              imageContextManager?.setImages(imagesForMessage);
-            }
+          if (resolution === 'deleted') {
+            this.restoreMessageToInput(composerDraftToRestore, { mergeWithComposer: true });
+            this.restoreMessageToInput(pendingMessagesToRestore, { mergeWithComposer: true });
+            this.restoreMessageToInput(retryMessage, { mergeWithComposer: true });
+          } else {
+            this.restoreMessageToInput(retryMessage, { mergeWithComposer: true });
+            this.restorePendingSteerMessageToQueue();
+            this.rollbackFailedTurn(messagesBeforeTurn, hadPendingConversationSave);
           }
           const notice = resolution === 'deleted'
             ? 'The provider session no longer exists. Its Claudian record was removed; send again to start a new session.'
@@ -699,6 +712,20 @@ export class InputController {
     }
     this.deps.resetInputHeight();
     inputEl.focus();
+  }
+
+  private captureComposerDraft(): QueuedMessage | null {
+    const content = this.deps.getInputEl().value;
+    const attachedImages = this.deps.getImageContextManager()?.getAttachedImages() ?? [];
+    const images = attachedImages.length > 0 ? [...attachedImages] : undefined;
+    if (!content.trim() && !images) {
+      return null;
+    }
+
+    return this.createQueuedMessage(content, {
+      text: content,
+      images,
+    });
   }
 
   private restorePendingMessagesToInput(): void {
@@ -1134,6 +1161,35 @@ export class InputController {
     state.currentTextEl = null;
     state.currentTextContent = '';
     state.currentThinkingState = null;
+  }
+
+  private rollbackFailedTurn(
+    messagesBeforeTurn: ChatMessage[],
+    hadPendingConversationSave: boolean,
+  ): void {
+    const { state, renderer, streamController } = this.deps;
+    const retainedMessageIds = new Set(messagesBeforeTurn.map(message => message.id));
+    for (const message of state.messages) {
+      if (!retainedMessageIds.has(message.id)) {
+        renderer.removeMessage(message.id);
+      }
+    }
+
+    state.messages = messagesBeforeTurn;
+    state.hasPendingConversationSave = hadPendingConversationSave;
+    streamController.hideThinkingIndicator();
+    state.isStreaming = false;
+    state.cancelRequested = false;
+    state.currentContentEl = null;
+    state.currentTextEl = null;
+    state.currentTextContent = '';
+    state.currentThinkingState = null;
+    state.responseStartTime = null;
+    this.deps.getSubagentManager().resetStreamingState();
+
+    if (messagesBeforeTurn.length === 0) {
+      this.deps.getWelcomeEl()?.removeClass('claudian-hidden');
+    }
   }
 
   // ============================================

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,11 @@ import {
 import { ProviderRegistry } from './core/providers/ProviderRegistry';
 import { ProviderSettingsCoordinator } from './core/providers/ProviderSettingsCoordinator';
 import { ProviderWorkspaceRegistry } from './core/providers/ProviderWorkspaceRegistry';
-import type { ProviderCliResolutionContext, ProviderId } from './core/providers/types';
+import type {
+  ProviderCliResolutionContext,
+  ProviderConversationSessionAvailability,
+  ProviderId,
+} from './core/providers/types';
 import type { AppTabManagerState } from './core/providers/types';
 import { DEFAULT_CHAT_PROVIDER_ID } from './core/providers/types';
 import type {
@@ -365,6 +369,54 @@ export default class ClaudianPlugin extends Plugin {
     }
   }
 
+  private async reconcileConversationProviderSession(
+    conversation: Conversation,
+  ): Promise<void> {
+    const historyService = ProviderRegistry.getConversationHistoryService(
+      conversation.providerId,
+    );
+    if (!historyService.getConversationSessionAvailability) {
+      return;
+    }
+
+    const vaultPath = getVaultPath(this.app);
+    let availability: ProviderConversationSessionAvailability;
+    try {
+      availability = await historyService.getConversationSessionAvailability(
+        conversation,
+        vaultPath,
+      );
+    } catch {
+      return;
+    }
+
+    if (
+      availability !== 'relocated'
+      || !historyService.prepareRelocatedConversationSession
+    ) {
+      return;
+    }
+
+    const previousSessionId = conversation.sessionId;
+    const previousProviderState = conversation.providerState;
+    const previousResumeAtMessageId = conversation.resumeAtMessageId;
+    try {
+      const changed = await historyService.prepareRelocatedConversationSession(
+        conversation,
+        vaultPath,
+      );
+      if (changed) {
+        await this.storage.sessions.saveMetadata(
+          this.storage.sessions.toSessionMetadata(conversation),
+        );
+      }
+    } catch {
+      conversation.sessionId = previousSessionId;
+      conversation.providerState = previousProviderState;
+      conversation.resumeAtMessageId = previousResumeAtMessageId;
+    }
+  }
+
   private backfillConversationResponseTimestamps(): Conversation[] {
     const updated: Conversation[] = [];
     for (const conv of this.conversations) {
@@ -677,6 +729,7 @@ export default class ClaudianPlugin extends Plugin {
   async switchConversation(id: string): Promise<Conversation | null> {
     const conversation = this.conversations.find(c => c.id === id);
     if (!conversation) return null;
+    await this.reconcileConversationProviderSession(conversation);
 
     await this.ensureConversationSelectedModel(conversation);
     await this.loadSdkMessagesForConversation(conversation);
@@ -684,16 +737,21 @@ export default class ClaudianPlugin extends Plugin {
     return conversation;
   }
 
-  async deleteConversation(id: string): Promise<void> {
+  async deleteConversation(
+    id: string,
+    options: { deleteProviderSession?: boolean } = {},
+  ): Promise<void> {
     const index = this.conversations.findIndex(c => c.id === id);
     if (index === -1) return;
 
     const conversation = this.conversations[index];
     this.conversations.splice(index, 1);
 
-    await ProviderRegistry
-      .getConversationHistoryService(conversation.providerId)
-      .deleteConversationSession(conversation, getVaultPath(this.app));
+    if (options.deleteProviderSession !== false) {
+      await ProviderRegistry
+        .getConversationHistoryService(conversation.providerId)
+        .deleteConversationSession(conversation, getVaultPath(this.app));
+    }
 
     await this.storage.sessions.deleteMetadata(id);
 
@@ -707,6 +765,51 @@ export default class ClaudianPlugin extends Plugin {
           await tab.controllers.conversationController?.createNew({ force: true });
         }
       }
+    }
+  }
+
+  async handleMissingProviderSession(
+    id: string,
+    missingProviderSessionId?: string,
+  ): Promise<'deleted' | 'reset' | 'preserved' | 'not_found'> {
+    const conversation = this.conversations.find(item => item.id === id);
+    if (!conversation) {
+      return 'not_found';
+    }
+
+    const historyService = ProviderRegistry.getConversationHistoryService(
+      conversation.providerId,
+    );
+    if (!historyService.resolveMissingConversationSession) {
+      await this.deleteConversation(id, { deleteProviderSession: false });
+      return 'deleted';
+    }
+
+    const previousSessionId = conversation.sessionId;
+    const previousProviderState = conversation.providerState;
+    const previousResumeAtMessageId = conversation.resumeAtMessageId;
+    try {
+      const resolution = await historyService.resolveMissingConversationSession(
+        conversation,
+        getVaultPath(this.app),
+        missingProviderSessionId,
+      );
+      if (resolution === 'delete') {
+        await this.deleteConversation(id, { deleteProviderSession: false });
+        return 'deleted';
+      }
+      if (resolution === 'reset') {
+        await this.storage.sessions.saveMetadata(
+          this.storage.sessions.toSessionMetadata(conversation),
+        );
+        return 'reset';
+      }
+      return 'preserved';
+    } catch {
+      conversation.sessionId = previousSessionId;
+      conversation.providerState = previousProviderState;
+      conversation.resumeAtMessageId = previousResumeAtMessageId;
+      return 'preserved';
     }
   }
 
@@ -752,6 +855,7 @@ export default class ClaudianPlugin extends Plugin {
     const conversation = this.conversations.find(c => c.id === id) || null;
 
     if (conversation) {
+      await this.reconcileConversationProviderSession(conversation);
       await this.ensureConversationSelectedModel(conversation);
       await this.loadSdkMessagesForConversation(conversation);
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -781,8 +781,7 @@ export default class ClaudianPlugin extends Plugin {
       conversation.providerId,
     );
     if (!historyService.resolveMissingConversationSession) {
-      await this.deleteConversation(id, { deleteProviderSession: false });
-      return 'deleted';
+      return 'preserved';
     }
 
     const previousSessionId = conversation.sessionId;

--- a/src/providers/claude/history/ClaudeConversationHistoryService.ts
+++ b/src/providers/claude/history/ClaudeConversationHistoryService.ts
@@ -402,10 +402,27 @@ export class ClaudeConversationHistoryService implements ProviderConversationHis
       new Map([[sessionId, location]]),
     );
     if (location.availability === 'relocated' && location.sessionPath) {
+      const relocatedSessionPaths = new Map(
+        this.relocatedSessionPathsByConversation.get(conversation.id) ?? [],
+      );
+      relocatedSessionPaths.set(sessionId, location.sessionPath);
       this.relocatedSessionPathsByConversation.set(
         conversation.id,
-        new Map([[sessionId, location.sessionPath]]),
+        relocatedSessionPaths,
       );
+    } else if (location.availability !== 'unknown') {
+      const relocatedSessionPaths = new Map(
+        this.relocatedSessionPathsByConversation.get(conversation.id) ?? [],
+      );
+      relocatedSessionPaths.delete(sessionId);
+      if (relocatedSessionPaths.size > 0) {
+        this.relocatedSessionPathsByConversation.set(
+          conversation.id,
+          relocatedSessionPaths,
+        );
+      } else {
+        this.relocatedSessionPathsByConversation.delete(conversation.id);
+      }
     }
     return location.availability;
   }

--- a/src/providers/claude/history/ClaudeConversationHistoryService.ts
+++ b/src/providers/claude/history/ClaudeConversationHistoryService.ts
@@ -1,4 +1,7 @@
-import type { ProviderConversationHistoryService } from '../../../core/providers/types';
+import type {
+  ProviderConversationHistoryService,
+  ProviderConversationSessionAvailability,
+} from '../../../core/providers/types';
 import { isSubagentToolName, TOOL_TASK } from '../../../core/tools/toolNames';
 import type {
   AsyncSubagentStatus,
@@ -14,8 +17,10 @@ import {
   deleteSDKSession,
   loadSDKSessionMessages,
   loadSubagentToolCalls,
-  sdkSessionExists,
+  locateSDKSession,
+  locateSDKSessions,
 } from './ClaudeHistoryStore';
+import type { SDKSessionLocation } from './sdkSessionPaths';
 
 function chooseRicherResult(sdkResult?: string, cachedResult?: string): string | undefined {
   const sdkText = typeof sdkResult === 'string' ? sdkResult.trim() : '';
@@ -216,6 +221,7 @@ async function enrichAsyncSubagentToolCalls(
   subagentData: Record<string, SubagentInfo>,
   vaultPath: string,
   sessionIds: string[],
+  relocatedSessionPaths: Map<string, string>,
 ): Promise<void> {
   const uniqueSessionIds = [...new Set(sessionIds)];
   if (uniqueSessionIds.length === 0) return;
@@ -232,7 +238,10 @@ async function enrichAsyncSubagentToolCalls(
 
       let loader = loaderCache.get(cacheKey);
       if (!loader) {
-        loader = loadSubagentToolCalls(vaultPath, sessionId, subagent.agentId);
+        const relocatedSessionPath = relocatedSessionPaths.get(sessionId);
+        loader = relocatedSessionPath
+          ? loadSubagentToolCalls(vaultPath, sessionId, subagent.agentId, relocatedSessionPath)
+          : loadSubagentToolCalls(vaultPath, sessionId, subagent.agentId);
         loaderCache.set(cacheKey, loader);
       }
 
@@ -360,6 +369,118 @@ function sanitizeProviderState(
 
 export class ClaudeConversationHistoryService implements ProviderConversationHistoryService {
   private hydratedConversationIds = new Set<string>();
+  private pendingSessionLocationsByConversation = new Map<
+    string,
+    Map<string, SDKSessionLocation>
+  >();
+  private relocatedSessionPathsByConversation = new Map<string, Map<string, string>>();
+
+  private getConversationSessionIds(conversation: Conversation): string[] {
+    const state = getClaudeState(conversation.providerState);
+    if (this.isPendingForkConversation(conversation)) {
+      return [state.forkSource!.sessionId];
+    }
+
+    return [...new Set([
+      ...(state.previousProviderSessionIds || []),
+      state.providerSessionId ?? conversation.sessionId,
+    ].filter((id): id is string => !!id))];
+  }
+
+  async getConversationSessionAvailability(
+    conversation: Conversation,
+    vaultPath: string | null,
+  ): Promise<ProviderConversationSessionAvailability> {
+    const sessionId = this.resolveSessionIdForConversation(conversation);
+    if (!vaultPath || !sessionId) {
+      return 'unknown';
+    }
+
+    const location = await locateSDKSession(vaultPath, sessionId);
+    this.pendingSessionLocationsByConversation.set(
+      conversation.id,
+      new Map([[sessionId, location]]),
+    );
+    if (location.availability === 'relocated' && location.sessionPath) {
+      this.relocatedSessionPathsByConversation.set(
+        conversation.id,
+        new Map([[sessionId, location.sessionPath]]),
+      );
+    }
+    return location.availability;
+  }
+
+  async prepareRelocatedConversationSession(
+    conversation: Conversation,
+    vaultPath: string | null,
+  ): Promise<boolean> {
+    const sessionId = this.resolveSessionIdForConversation(conversation);
+    if (!vaultPath || !sessionId) {
+      return false;
+    }
+
+    await this.hydrateConversationHistory(conversation, vaultPath);
+    if (!this.hydratedConversationIds.has(conversation.id)) {
+      return false;
+    }
+
+    const state = { ...getClaudeState(conversation.providerState) };
+    state.previousProviderSessionIds = [
+      ...new Set([...(state.previousProviderSessionIds || []), sessionId]),
+    ];
+    delete state.providerSessionId;
+
+    if (state.forkSource?.sessionId === sessionId) {
+      conversation.resumeAtMessageId = state.forkSource.resumeAt;
+      delete state.forkSource;
+    }
+
+    conversation.sessionId = null;
+    conversation.providerState = sanitizeProviderState(state);
+    return true;
+  }
+
+  async resolveMissingConversationSession(
+    conversation: Conversation,
+    vaultPath: string | null,
+    missingProviderSessionId?: string,
+  ): Promise<'delete' | 'reset' | 'preserve'> {
+    const currentSessionId = this.resolveSessionIdForConversation(conversation);
+    if (
+      !vaultPath
+      || !currentSessionId
+      || (missingProviderSessionId
+        && missingProviderSessionId.toLowerCase() !== currentSessionId.toLowerCase())
+    ) {
+      return 'preserve';
+    }
+
+    const sessionIds = this.getConversationSessionIds(conversation);
+    const locations = await locateSDKSessions(vaultPath, sessionIds);
+    const preservedSessionIds = sessionIds.filter(
+      sessionId => locations.get(sessionId)?.availability !== 'missing',
+    );
+    if (preservedSessionIds.length === 0) {
+      this.pendingSessionLocationsByConversation.delete(conversation.id);
+      this.relocatedSessionPathsByConversation.delete(conversation.id);
+      this.hydratedConversationIds.delete(conversation.id);
+      return 'delete';
+    }
+
+    const state = { ...getClaudeState(conversation.providerState) };
+    state.previousProviderSessionIds = preservedSessionIds;
+    delete state.providerSessionId;
+    if (state.forkSource?.sessionId === currentSessionId) {
+      conversation.resumeAtMessageId = state.forkSource.resumeAt;
+      delete state.forkSource;
+    }
+
+    conversation.sessionId = null;
+    conversation.providerState = sanitizeProviderState(state);
+    this.pendingSessionLocationsByConversation.delete(conversation.id);
+    this.hydratedConversationIds.delete(conversation.id);
+    return 'reset';
+  }
 
   isPendingForkConversation(conversation: Conversation): boolean {
     const state = getClaudeState(conversation.providerState);
@@ -412,12 +533,7 @@ export class ClaudeConversationHistoryService implements ProviderConversationHis
 
     const state = getClaudeState(conversation.providerState);
     const isPendingFork = this.isPendingForkConversation(conversation);
-    const allSessionIds: string[] = isPendingFork
-      ? [state.forkSource!.sessionId]
-      : [
-          ...(state.previousProviderSessionIds || []),
-          state.providerSessionId ?? conversation.sessionId,
-        ].filter((id): id is string => !!id);
+    const allSessionIds = this.getConversationSessionIds(conversation);
 
     if (allSessionIds.length === 0) {
       return;
@@ -425,24 +541,58 @@ export class ClaudeConversationHistoryService implements ProviderConversationHis
 
     const allSdkMessages: ChatMessage[] = [];
     let missingSessionCount = 0;
+    let unknownSessionCount = 0;
     let errorCount = 0;
     let successCount = 0;
+    const relocatedSessionPaths = new Map(
+      this.relocatedSessionPathsByConversation.get(conversation.id) ?? [],
+    );
+    const cachedLocations = new Map(
+      this.pendingSessionLocationsByConversation.get(conversation.id) ?? [],
+    );
+    this.pendingSessionLocationsByConversation.delete(conversation.id);
+    const unresolvedSessionIds = allSessionIds.filter(
+      id => !relocatedSessionPaths.has(id) && !cachedLocations.has(id),
+    );
+    const locatedSessions = await locateSDKSessions(vaultPath, unresolvedSessionIds);
+    const resolvedLocations = new Map([...cachedLocations, ...locatedSessions]);
+    for (const [sessionId, location] of locatedSessions) {
+      if (location.availability === 'relocated' && location.sessionPath) {
+        relocatedSessionPaths.set(sessionId, location.sessionPath);
+      }
+    }
+    if (relocatedSessionPaths.size > 0) {
+      this.relocatedSessionPathsByConversation.set(conversation.id, relocatedSessionPaths);
+    }
 
-    const currentSessionId = isPendingFork
+    const resumableSessionId = isPendingFork
       ? state.forkSource!.sessionId
       : (state.providerSessionId ?? conversation.sessionId);
+    const checkpointSessionId = resumableSessionId
+      ?? (conversation.resumeAtMessageId ? allSessionIds[allSessionIds.length - 1] : null);
 
     for (const sessionId of allSessionIds) {
-      if (!sdkSessionExists(vaultPath, sessionId)) {
-        missingSessionCount++;
+      const relocatedSessionPath = relocatedSessionPaths.get(sessionId);
+      const location = relocatedSessionPath
+        ? { availability: 'relocated' as const, sessionPath: relocatedSessionPath }
+        : resolvedLocations.get(sessionId) ?? { availability: 'unknown' as const };
+      if (!location.sessionPath) {
+        if (location.availability === 'missing') {
+          missingSessionCount++;
+        } else {
+          unknownSessionCount++;
+        }
         continue;
       }
 
-      const isCurrentSession = sessionId === currentSessionId;
-      const truncateAt = isCurrentSession
+      const isCheckpointSession = sessionId === checkpointSessionId;
+      const truncateAt = isCheckpointSession
         ? (isPendingFork ? state.forkSource!.resumeAt : conversation.resumeAtMessageId)
         : undefined;
-      const result = await loadSDKSessionMessages(vaultPath, sessionId, truncateAt);
+      const sessionPathOverride = relocatedSessionPaths.get(sessionId);
+      const result = sessionPathOverride
+        ? await loadSDKSessionMessages(vaultPath, sessionId, truncateAt, sessionPathOverride)
+        : await loadSDKSessionMessages(vaultPath, sessionId, truncateAt);
 
       if (result.error) {
         errorCount++;
@@ -454,8 +604,7 @@ export class ClaudeConversationHistoryService implements ProviderConversationHis
     }
 
     const allSessionsMissing = missingSessionCount === allSessionIds.length;
-    const hasLoadErrors = errorCount > 0 && successCount === 0 && !allSessionsMissing;
-    if (hasLoadErrors) {
+    if (successCount === 0 || allSessionsMissing) {
       return;
     }
 
@@ -471,18 +620,24 @@ export class ClaudeConversationHistoryService implements ProviderConversationHis
         state.subagentData,
         vaultPath,
         allSessionIds,
+        relocatedSessionPaths,
       );
       applySubagentData(merged, state.subagentData);
     }
 
     conversation.messages = merged;
-    this.hydratedConversationIds.add(conversation.id);
+    if (errorCount === 0 && unknownSessionCount === 0) {
+      this.hydratedConversationIds.add(conversation.id);
+    }
   }
 
   async deleteConversationSession(
     conversation: Conversation,
     vaultPath: string | null,
   ): Promise<void> {
+    this.pendingSessionLocationsByConversation.delete(conversation.id);
+    this.relocatedSessionPathsByConversation.delete(conversation.id);
+    this.hydratedConversationIds.delete(conversation.id);
     const state = getClaudeState(conversation.providerState);
     const sessionId = state.providerSessionId ?? conversation.sessionId;
     if (!vaultPath || !sessionId) {

--- a/src/providers/claude/history/ClaudeHistoryStore.ts
+++ b/src/providers/claude/history/ClaudeHistoryStore.ts
@@ -18,9 +18,13 @@ import {
   deleteSDKSession,
   encodeVaultPathForSDK,
   getSDKProjectsPath,
+  getSDKSessionAvailability,
   getSDKSessionPath,
   isValidSessionId,
+  locateSDKSession,
+  locateSDKSessions,
   readSDKSession,
+  readSDKSessionFile,
   sdkSessionExists,
 } from './sdkSessionPaths';
 import {
@@ -44,12 +48,16 @@ export {
   extractXmlTag,
   filterActiveBranch,
   getSDKProjectsPath,
+  getSDKSessionAvailability,
   getSDKSessionPath,
   isValidSessionId,
   loadSubagentFinalResult,
   loadSubagentToolCalls,
+  locateSDKSession,
+  locateSDKSessions,
   parseSDKMessageToChat,
   readSDKSession,
+  readSDKSessionFile,
   sdkSessionExists,
 };
 export {
@@ -60,9 +68,12 @@ export {
 export async function loadSDKSessionMessages(
   vaultPath: string,
   sessionId: string,
-  resumeAtMessageId?: string
+  resumeAtMessageId?: string,
+  sessionPath?: string,
 ): Promise<SDKSessionLoadResult> {
-  const result = await readSDKSession(vaultPath, sessionId);
+  const result = sessionPath
+    ? await readSDKSessionFile(sessionPath)
+    : await readSDKSession(vaultPath, sessionId);
 
   if (result.error) {
     return { messages: [], skippedLines: result.skippedLines, error: result.error };

--- a/src/providers/claude/history/ClaudeHistoryStore.ts
+++ b/src/providers/claude/history/ClaudeHistoryStore.ts
@@ -156,7 +156,12 @@ export async function loadSDKSessionMessages(
           if (subagent.agentId && isValidAgentId(subagent.agentId)) {
             sidecarLoads.push({
               subagent,
-              promise: loadSubagentToolCalls(vaultPath, sessionId, subagent.agentId),
+              promise: loadSubagentToolCalls(
+                vaultPath,
+                sessionId,
+                subagent.agentId,
+                sessionPath,
+              ),
             });
           }
         }

--- a/src/providers/claude/history/sdkSessionPaths.ts
+++ b/src/providers/claude/history/sdkSessionPaths.ts
@@ -134,6 +134,10 @@ export async function locateSDKSessions(
         }
       } else if (entry.isDirectory() && entry.name !== 'subagents') {
         pendingDirectories.push(entryPath);
+      } else if (!entry.isDirectory()) {
+        // Do not follow symlinks or special files during a global history scan.
+        // Their contents remain unverified, so absence cannot be definitive.
+        scanComplete = false;
       }
     }
   }

--- a/src/providers/claude/history/sdkSessionPaths.ts
+++ b/src/providers/claude/history/sdkSessionPaths.ts
@@ -3,7 +3,13 @@ import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 
+import type { ProviderConversationSessionAvailability } from '../../../core/providers/types';
 import type { SDKNativeMessage, SDKSessionReadResult } from './sdkHistoryTypes';
+
+export interface SDKSessionLocation {
+  availability: ProviderConversationSessionAvailability;
+  sessionPath?: string;
+}
 
 /**
  * Encodes a vault path for the SDK project directory name.
@@ -53,6 +59,109 @@ export function sdkSessionExists(vaultPath: string, sessionId: string): boolean 
   }
 }
 
+function hasFileSystemErrorCode(error: unknown, code: string): boolean {
+  return !!error
+    && typeof error === 'object'
+    && 'code' in error
+    && error.code === code;
+}
+
+export async function locateSDKSessions(
+  vaultPath: string,
+  sessionIds: string[],
+): Promise<Map<string, SDKSessionLocation>> {
+  const locations = new Map<string, SDKSessionLocation>();
+  const currentPaths = new Map<string, string>();
+  const unresolvedIds = new Set<string>();
+
+  await Promise.all([...new Set(sessionIds)].map(async (sessionId) => {
+    let sessionPath: string;
+    try {
+      sessionPath = getSDKSessionPath(vaultPath, sessionId);
+    } catch {
+      locations.set(sessionId, { availability: 'unknown' });
+      return;
+    }
+
+    currentPaths.set(sessionId, sessionPath);
+    try {
+      await fs.access(sessionPath);
+      locations.set(sessionId, { availability: 'available', sessionPath });
+    } catch (error) {
+      if (hasFileSystemErrorCode(error, 'ENOENT')) {
+        unresolvedIds.add(sessionId);
+      } else {
+        locations.set(sessionId, { availability: 'unknown' });
+      }
+    }
+  }));
+
+  if (unresolvedIds.size === 0) {
+    return locations;
+  }
+
+  const targetIdsByFileName = new Map(
+    [...unresolvedIds].map(sessionId => [`${sessionId}.jsonl`, sessionId]),
+  );
+  const pendingDirectories = [getSDKProjectsPath()];
+  let rootExists = true;
+  let scanComplete = true;
+
+  while (pendingDirectories.length > 0 && unresolvedIds.size > 0) {
+    const directory = pendingDirectories.shift()!;
+    let entries;
+    try {
+      entries = await fs.readdir(directory, { withFileTypes: true });
+    } catch (error) {
+      if (directory === getSDKProjectsPath() && hasFileSystemErrorCode(error, 'ENOENT')) {
+        rootExists = false;
+      } else if (!hasFileSystemErrorCode(error, 'ENOENT')) {
+        scanComplete = false;
+      }
+      continue;
+    }
+
+    for (const entry of entries) {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isFile()) {
+        const sessionId = targetIdsByFileName.get(entry.name);
+        if (sessionId && unresolvedIds.has(sessionId)) {
+          const availability = entryPath === currentPaths.get(sessionId)
+            ? 'available'
+            : 'relocated';
+          locations.set(sessionId, { availability, sessionPath: entryPath });
+          unresolvedIds.delete(sessionId);
+        }
+      } else if (entry.isDirectory() && entry.name !== 'subagents') {
+        pendingDirectories.push(entryPath);
+      }
+    }
+  }
+
+  for (const sessionId of unresolvedIds) {
+    locations.set(sessionId, {
+      availability: rootExists && scanComplete ? 'missing' : 'unknown',
+    });
+  }
+
+  return locations;
+}
+
+export async function locateSDKSession(
+  vaultPath: string,
+  sessionId: string,
+): Promise<SDKSessionLocation> {
+  return (await locateSDKSessions(vaultPath, [sessionId])).get(sessionId)
+    ?? { availability: 'unknown' };
+}
+
+export async function getSDKSessionAvailability(
+  vaultPath: string,
+  sessionId: string,
+): Promise<ProviderConversationSessionAvailability> {
+  return (await locateSDKSession(vaultPath, sessionId)).availability;
+}
+
 export async function deleteSDKSession(vaultPath: string, sessionId: string): Promise<void> {
   try {
     const sessionPath = getSDKSessionPath(vaultPath, sessionId);
@@ -75,7 +184,15 @@ export async function readSDKSession(
     if (!existsSync(sessionPath)) {
       return { messages: [], skippedLines: 0 };
     }
+    return readSDKSessionFile(sessionPath);
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    return { messages: [], skippedLines: 0, error: errorMsg };
+  }
+}
 
+export async function readSDKSessionFile(sessionPath: string): Promise<SDKSessionReadResult> {
+  try {
     const content = await fs.readFile(sessionPath, 'utf-8');
     const lines = content.split('\n').filter(line => line.trim());
     const messages: SDKNativeMessage[] = [];
@@ -83,8 +200,7 @@ export async function readSDKSession(
 
     for (const line of lines) {
       try {
-        const msg = JSON.parse(line) as SDKNativeMessage;
-        messages.push(msg);
+        messages.push(JSON.parse(line) as SDKNativeMessage);
       } catch {
         skippedLines++;
       }

--- a/src/providers/claude/history/sdkSubagentSidecar.ts
+++ b/src/providers/claude/history/sdkSubagentSidecar.ts
@@ -175,15 +175,17 @@ function getSubagentSidecarPath(
   vaultPath: string,
   sessionId: string,
   agentId: string,
+  sessionPath?: string,
 ): string | null {
   if (!isValidSessionId(sessionId) || !isValidAgentId(agentId)) {
     return null;
   }
 
-  const encodedVault = encodeVaultPathForSDK(vaultPath);
+  const projectPath = sessionPath
+    ? path.dirname(sessionPath)
+    : path.join(getSDKProjectsPath(), encodeVaultPathForSDK(vaultPath));
   return path.join(
-    getSDKProjectsPath(),
-    encodedVault,
+    projectPath,
     sessionId,
     'subagents',
     `agent-${agentId}.jsonl`,
@@ -194,8 +196,9 @@ export async function loadSubagentToolCalls(
   vaultPath: string,
   sessionId: string,
   agentId: string,
+  sessionPath?: string,
 ): Promise<ToolCallInfo[]> {
-  const subagentFilePath = getSubagentSidecarPath(vaultPath, sessionId, agentId);
+  const subagentFilePath = getSubagentSidecarPath(vaultPath, sessionId, agentId, sessionPath);
   if (!subagentFilePath) {
     return [];
   }
@@ -242,8 +245,9 @@ export async function loadSubagentFinalResult(
   vaultPath: string,
   sessionId: string,
   agentId: string,
+  sessionPath?: string,
 ): Promise<string | null> {
-  const subagentFilePath = getSubagentSidecarPath(vaultPath, sessionId, agentId);
+  const subagentFilePath = getSubagentSidecarPath(vaultPath, sessionId, agentId, sessionPath);
   if (!subagentFilePath) {
     return null;
   }

--- a/src/providers/claude/runtime/ClaudeChatRuntime.ts
+++ b/src/providers/claude/runtime/ClaudeChatRuntime.ts
@@ -777,8 +777,10 @@ export class ClaudianService implements ChatRuntime {
           const errorInstance = error instanceof Error ? error : new Error(String(error));
           const messageToReplay = this.lastSentMessage;
 
-          if (this.toProviderSessionMissingChunk(errorInstance)) {
+          const missingSessionChunk = this.toProviderSessionMissingChunk(errorInstance);
+          if (missingSessionChunk) {
             handler?.onError(errorInstance);
+            this.closePersistentQuery('provider session missing', { preserveHandlers: true });
             return;
           }
 

--- a/src/providers/claude/runtime/ClaudeChatRuntime.ts
+++ b/src/providers/claude/runtime/ClaudeChatRuntime.ts
@@ -64,7 +64,9 @@ import {
   buildContextFromHistory,
   buildPromptWithHistoryContext,
   getLastUserMessage,
+  getMissingSessionId,
   isSessionExpiredError,
+  isSessionMissingError,
 } from '../../../utils/session';
 import { CLAUDE_PROVIDER_CAPABILITIES } from '../capabilities';
 import { loadSubagentFinalResult, loadSubagentToolCalls } from '../history/ClaudeHistoryStore';
@@ -187,6 +189,20 @@ export class ClaudianService implements ChatRuntime {
   private bufferedUsageChunk: StreamChunk & { type: 'usage' } | null = null;
   private streamTransformState = createTransformStreamState();
   private usageTransformState = createTransformUsageState();
+
+  private toProviderSessionMissingChunk(error: unknown): (StreamChunk & { type: 'error' }) | null {
+    if (!isSessionMissingError(error, this.sessionManager.getSessionId() ?? undefined)) {
+      return null;
+    }
+
+    this.sessionManager.invalidateSession();
+    return {
+      type: 'error',
+      content: error instanceof Error ? error.message : 'Provider session not found',
+      code: 'provider_session_missing',
+      providerSessionId: getMissingSessionId(error) ?? undefined,
+    };
+  }
 
   private getLegacyPluginDeps(): ClaudianPlugin & {
     agentManager?: Pick<AppAgentManager, 'setBuiltinAgentNames'>;
@@ -761,6 +777,11 @@ export class ClaudianService implements ChatRuntime {
           const errorInstance = error instanceof Error ? error : new Error(String(error));
           const messageToReplay = this.lastSentMessage;
 
+          if (this.toProviderSessionMissingChunk(errorInstance)) {
+            handler?.onError(errorInstance);
+            return;
+          }
+
           if (!this.crashRecoveryAttempted && messageToReplay && handler && !handler.sawAnyChunk) {
             this.crashRecoveryAttempted = true;
             try {
@@ -1223,12 +1244,21 @@ export class ClaudianService implements ChatRuntime {
                 effectiveQueryOptions
               );
             } catch (retryError) {
-              const msg = retryError instanceof Error ? retryError.message : 'Unknown error';
-              yield { type: 'error', content: msg };
+              const missingSessionChunk = this.toProviderSessionMissingChunk(retryError);
+              yield missingSessionChunk ?? {
+                type: 'error',
+                content: retryError instanceof Error ? retryError.message : 'Unknown error',
+              };
             } finally {
               this.coldStartInProgress = false;
               this.abortController = null;
             }
+            return;
+          }
+
+          const missingSessionChunk = this.toProviderSessionMissingChunk(error);
+          if (missingSessionChunk) {
+            yield missingSessionChunk;
             return;
           }
 
@@ -1259,9 +1289,18 @@ export class ClaudianService implements ChatRuntime {
             effectiveQueryOptions
           );
         } catch (retryError) {
-          const msg = retryError instanceof Error ? retryError.message : 'Unknown error';
-          yield { type: 'error', content: msg };
+          const missingSessionChunk = this.toProviderSessionMissingChunk(retryError);
+          yield missingSessionChunk ?? {
+            type: 'error',
+            content: retryError instanceof Error ? retryError.message : 'Unknown error',
+          };
         }
+        return;
+      }
+
+      const missingSessionChunk = this.toProviderSessionMissingChunk(error);
+      if (missingSessionChunk) {
+        yield missingSessionChunk;
         return;
       }
 

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -14,10 +14,23 @@ import { extractUserQuery, formatCurrentNote } from './context';
 const SESSION_ERROR_PATTERNS = [
   'session expired',
   'session not found',
+  'no conversation found with session id',
   'invalid session',
   'session invalid',
   'process exited with code',
 ] as const;
+
+export function getMissingSessionId(error: unknown): string | null {
+  const message = error instanceof Error ? error.message : '';
+  const match = message.match(/no conversation found with session id:\s*([a-z0-9_-]+)/i);
+  return match?.[1] ?? null;
+}
+
+export function isSessionMissingError(error: unknown, expectedSessionId?: string): boolean {
+  const missingSessionId = getMissingSessionId(error);
+  return !!missingSessionId
+    && (!expectedSessionId || missingSessionId.toLowerCase() === expectedSessionId.toLowerCase());
+}
 
 const SESSION_ERROR_COMPOUND_PATTERNS = [
   { includes: ['session', 'expired'] },

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -30,6 +30,16 @@ describe('ClaudianPlugin', () => {
   beforeEach(() => {
     // Reset mocks
     jest.clearAllMocks();
+    jest.spyOn(sdkSession, 'locateSDKSession').mockImplementation(async (_vaultPath, sessionId) => ({
+      availability: 'available',
+      sessionPath: `/test/claude-project/${sessionId}.jsonl`,
+    }));
+    jest.spyOn(sdkSession, 'locateSDKSessions').mockImplementation(async (_vaultPath, sessionIds) => new Map(
+      sessionIds.map(sessionId => [sessionId, {
+        availability: 'available' as const,
+        sessionPath: `/test/claude-project/${sessionId}.jsonl`,
+      }]),
+    ));
 
     mockApp = {
       vault: {
@@ -730,6 +740,77 @@ describe('ClaudianPlugin', () => {
 
       expect(result).toBeNull();
     });
+
+    it('should preserve a conversation when local Claude history is missing', async () => {
+      await plugin.onload();
+      const conversation = await plugin.createConversation({
+        sessionId: 'session-removed-after-startup',
+      });
+      const availabilitySpy = jest.mocked(sdkSession.locateSDKSession)
+        .mockResolvedValue({ availability: 'missing' });
+
+      const result = await plugin.switchConversation(conversation.id);
+
+      expect(result?.id).toBe(conversation.id);
+      expect(plugin.getConversationList()).toHaveLength(1);
+      expect(mockApp.vault.adapter.remove).not.toHaveBeenCalledWith(
+        '.claudian/sessions/session-removed-after-startup.meta.json',
+      );
+      availabilitySpy.mockRestore();
+    });
+
+    it('should preserve a conversation whose Claude session belongs to a previous vault path', async () => {
+      await plugin.onload();
+      const conversation = await plugin.createConversation({
+        sessionId: 'session-from-previous-vault-path',
+      });
+      const availabilitySpy = jest.mocked(sdkSession.locateSDKSession)
+        .mockResolvedValue({
+          availability: 'relocated',
+          sessionPath: '/old-project/session-from-previous-vault-path.jsonl',
+        });
+      const loadSpy = jest.spyOn(sdkSession, 'loadSDKSessionMessages')
+        .mockResolvedValue({ messages: [], skippedLines: 0 });
+
+      const result = await plugin.switchConversation(conversation.id);
+
+      expect(result?.id).toBe(conversation.id);
+      expect(plugin.getConversationList()).toHaveLength(1);
+      expect(result?.sessionId).toBeNull();
+      expect(result?.providerState).toEqual(expect.objectContaining({
+        previousProviderSessionIds: ['session-from-previous-vault-path'],
+      }));
+      expect(mockApp.vault.adapter.remove).not.toHaveBeenCalledWith(
+        '.claudian/sessions/session-from-previous-vault-path.meta.json',
+      );
+      availabilitySpy.mockRestore();
+      loadSpy.mockRestore();
+    });
+
+    it('should restore resume metadata when relocated-state persistence fails', async () => {
+      await plugin.onload();
+      const conversation = await plugin.createConversation({
+        sessionId: 'session-relocation-save-failure',
+      });
+      const availabilitySpy = jest.mocked(sdkSession.locateSDKSession)
+        .mockResolvedValue({
+          availability: 'relocated',
+          sessionPath: '/old-project/session-relocation-save-failure.jsonl',
+        });
+      const loadSpy = jest.spyOn(sdkSession, 'loadSDKSessionMessages')
+        .mockResolvedValue({ messages: [], skippedLines: 0 });
+      const saveSpy = jest.spyOn(plugin.storage.sessions, 'saveMetadata')
+        .mockRejectedValueOnce(new Error('Write failed'));
+
+      const result = await plugin.switchConversation(conversation.id);
+
+      expect(result?.sessionId).toBe('session-relocation-save-failure');
+      expect(result?.providerState).toBeUndefined();
+
+      availabilitySpy.mockRestore();
+      loadSpy.mockRestore();
+      saveSpy.mockRestore();
+    });
   });
 
   describe('deleteConversation', () => {
@@ -756,6 +837,97 @@ describe('ClaudianPlugin', () => {
 
       const list = plugin.getConversationList();
       expect(list.find(c => c.id === conv.id)).toBeUndefined();
+    });
+
+    it('should preserve the provider-native session when requested', async () => {
+      await plugin.onload();
+      const conv = await plugin.createConversation({ sessionId: 'provider-session-1' });
+      const deleteNativeSpy = jest.spyOn(sdkSession, 'deleteSDKSession');
+
+      await plugin.deleteConversation(conv.id, { deleteProviderSession: false });
+
+      expect(deleteNativeSpy).not.toHaveBeenCalled();
+      expect(plugin.getConversationList().find(item => item.id === conv.id)).toBeUndefined();
+      deleteNativeSpy.mockRestore();
+    });
+
+    it('should reset every open tab that references the deleted conversation', async () => {
+      await plugin.onload();
+      const conv = await plugin.createConversation();
+      const cancelStreaming = jest.fn();
+      const createNew = jest.fn().mockResolvedValue(undefined);
+      mockApp.workspace.getLeavesOfType.mockReturnValue([{
+        view: {
+          getTabManager: () => ({
+            getAllTabs: () => [{
+              conversationId: conv.id,
+              controllers: {
+                inputController: { cancelStreaming },
+                conversationController: { createNew },
+              },
+            }],
+          }),
+        },
+      }]);
+
+      await plugin.deleteConversation(conv.id, { deleteProviderSession: false });
+
+      expect(cancelStreaming).toHaveBeenCalledTimes(1);
+      expect(createNew).toHaveBeenCalledWith({ force: true });
+    });
+  });
+
+  describe('handleMissingProviderSession', () => {
+    it('removes the record when every provider transcript segment is missing', async () => {
+      await plugin.onload();
+      const conv = await plugin.createConversation({ sessionId: 'missing-current' });
+      jest.mocked(sdkSession.locateSDKSessions).mockResolvedValue(new Map([
+        ['missing-current', { availability: 'missing' }],
+      ]));
+
+      await expect(plugin.handleMissingProviderSession(
+        conv.id,
+        'missing-current',
+      )).resolves.toBe('deleted');
+      expect(plugin.getConversationList().find(item => item.id === conv.id)).toBeUndefined();
+    });
+
+    it('preserves the record and clears resume state when older history is inaccessible', async () => {
+      await plugin.onload();
+      const conv = await plugin.createConversation({ sessionId: 'missing-current' });
+      await plugin.updateConversation(conv.id, {
+        providerState: {
+          providerSessionId: 'missing-current',
+          previousProviderSessionIds: ['temporarily-inaccessible'],
+        },
+      });
+      jest.mocked(sdkSession.locateSDKSessions).mockResolvedValue(new Map([
+        ['temporarily-inaccessible', { availability: 'unknown' }],
+        ['missing-current', { availability: 'missing' }],
+      ]));
+
+      await expect(plugin.handleMissingProviderSession(
+        conv.id,
+        'missing-current',
+      )).resolves.toBe('reset');
+
+      const preserved = plugin.getConversationSync(conv.id);
+      expect(preserved?.sessionId).toBeNull();
+      expect(preserved?.providerState).toEqual({
+        previousProviderSessionIds: ['temporarily-inaccessible'],
+      });
+    });
+
+    it('preserves metadata when the missing-session disposition cannot be read', async () => {
+      await plugin.onload();
+      const conv = await plugin.createConversation({ sessionId: 'missing-current' });
+      jest.mocked(sdkSession.locateSDKSessions).mockRejectedValueOnce(new Error('EACCES'));
+
+      await expect(plugin.handleMissingProviderSession(
+        conv.id,
+        'missing-current',
+      )).resolves.toBe('preserved');
+      expect(plugin.getConversationSync(conv.id)?.sessionId).toBe('missing-current');
     });
   });
 
@@ -887,7 +1059,48 @@ describe('ClaudianPlugin', () => {
   });
 
   describe('loadSettings with conversations', () => {
+    it('should preserve Claude metadata during startup when local native history is missing', async () => {
+      const timestamp = Date.now();
+      const sessionMeta = JSON.stringify({
+        id: 'conv-stale-1',
+        providerId: 'claude',
+        title: 'Stale Chat',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        sessionId: 'missing-session',
+      });
+
+      mockApp.vault.adapter.exists.mockImplementation(async (path: string) => {
+        return path === '.claudian/claudian-settings.json'
+          || path === '.claudian/sessions'
+          || path === '.claudian/sessions/conv-stale-1.meta.json';
+      });
+      mockApp.vault.adapter.list.mockImplementation(async (path: string) => {
+        if (path === '.claudian/sessions') {
+          return { files: ['.claudian/sessions/conv-stale-1.meta.json'], folders: [] };
+        }
+        return { files: [], folders: [] };
+      });
+      mockApp.vault.adapter.read.mockImplementation(async (path: string) => {
+        if (path === '.claudian/sessions/conv-stale-1.meta.json') {
+          return sessionMeta;
+        }
+        if (path === '.claudian/claudian-settings.json') {
+          return JSON.stringify({});
+        }
+        return '';
+      });
+
+      await plugin.loadSettings();
+
+      expect(plugin.getConversationList()).toHaveLength(1);
+      expect(mockApp.vault.adapter.remove).not.toHaveBeenCalledWith(
+        '.claudian/sessions/conv-stale-1.meta.json',
+      );
+    });
+
     it('should load saved conversations from metadata files', async () => {
+      const existsSpy = jest.spyOn(sdkSession, 'sdkSessionExists').mockReturnValue(true);
       const timestamp = Date.now();
       const sessionMeta = JSON.stringify({
         id: 'conv-saved-1',
@@ -933,6 +1146,7 @@ describe('ClaudianPlugin', () => {
       const loaded = await plugin.getConversationById('conv-saved-1');
       expect(loaded?.id).toBe('conv-saved-1');
       expect(loaded?.title).toBe('Saved Chat');
+      existsSpy.mockRestore();
     });
 
     it('should clear session IDs when provider base URL changes', async () => {
@@ -1004,6 +1218,7 @@ describe('ClaudianPlugin', () => {
 
   describe('Multi-session message loading', () => {
     it('should load messages from previousProviderSessionIds when present', async () => {
+      const existsSpy = jest.spyOn(sdkSession, 'sdkSessionExists').mockReturnValue(true);
       const timestamp = Date.now();
 
       // Setup conversation with previousProviderSessionIds
@@ -1047,6 +1262,7 @@ describe('ClaudianPlugin', () => {
       const loaded = await plugin.getConversationById('conv-multi-session');
       expect((loaded?.providerState as any)?.previousProviderSessionIds).toEqual(['session-A']);
       expect((loaded?.providerState as any)?.providerSessionId).toBe('session-B');
+      existsSpy.mockRestore();
     });
 
     it('should preserve previousProviderSessionIds through conversation updates', async () => {
@@ -1181,7 +1397,7 @@ describe('ClaudianPlugin', () => {
       const loaded = await plugin.getConversationById(conv.id);
 
       // Should check existence of source session, not the conversation's own session
-      expect(existsSpy).toHaveBeenCalledWith(
+      expect(sdkSession.locateSDKSession).toHaveBeenCalledWith(
         expect.any(String),
         'source-session-abc'
       );
@@ -1220,7 +1436,7 @@ describe('ClaudianPlugin', () => {
       await plugin.getConversationById(conv.id);
 
       // Should load from own session, not forkSource session
-      expect(existsSpy).toHaveBeenCalledWith(
+      expect(sdkSession.locateSDKSession).toHaveBeenCalledWith(
         expect.any(String),
         'own-session-id'
       );

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -878,6 +878,20 @@ describe('ClaudianPlugin', () => {
   });
 
   describe('handleMissingProviderSession', () => {
+    it('preserves the record when the provider cannot verify a safe disposition', async () => {
+      await plugin.onload();
+      const conv = await plugin.createConversation({
+        providerId: 'codex',
+        sessionId: 'unverified-provider-session',
+      });
+
+      await expect(plugin.handleMissingProviderSession(
+        conv.id,
+        'unverified-provider-session',
+      )).resolves.toBe('preserved');
+      expect(plugin.getConversationSync(conv.id)).toBe(conv);
+    });
+
     it('removes the record when every provider transcript segment is missing', async () => {
       await plugin.onload();
       const conv = await plugin.createConversation({ sessionId: 'missing-current' });

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -217,10 +217,11 @@ function createSendableDeps(
 }
 
 describe('InputController - Missing provider session', () => {
-  it('removes only the Claudian record and restores unsent input', async () => {
+  it('rolls back the failed turn and restores unsent input after resume state is reset', async () => {
     const deps = createSendableDeps();
     const inputEl = deps.getInputEl();
     inputEl.value = 'retry this prompt';
+    (deps.plugin.handleMissingProviderSession as jest.Mock).mockResolvedValue('reset');
     deps.mockAgentService.query.mockReturnValue(createMockStream([{
       type: 'error',
       content: 'No conversation found with session ID: missing-session',
@@ -235,7 +236,44 @@ describe('InputController - Missing provider session', () => {
       undefined,
     );
     expect(inputEl.value).toBe('retry this prompt');
+    expect(deps.state.messages).toEqual([]);
+    expect(deps.state.isStreaming).toBe(false);
+    expect(deps.state.hasPendingConversationSave).toBe(false);
+    expect(deps.streamController.hideThinkingIndicator).toHaveBeenCalled();
+    expect(deps.renderer.removeMessage).toHaveBeenCalledTimes(2);
+    expect(deps.conversationController.save).not.toHaveBeenCalled();
     expect(deps.streamController.handleStreamChunk).not.toHaveBeenCalled();
+  });
+
+  it('restores a programmatic queued turn without overwriting a newer draft', async () => {
+    const deps = createSendableDeps();
+    const inputEl = deps.getInputEl();
+    const retryImage = {
+      id: 'retry-image',
+      name: 'retry.png',
+      mediaType: 'image/png' as const,
+      data: 'cmV0cnk=',
+      size: 5,
+      source: 'paste' as const,
+    };
+    inputEl.value = 'newer draft';
+    (deps.plugin.handleMissingProviderSession as jest.Mock).mockResolvedValue('reset');
+    deps.mockAgentService.query.mockReturnValue(createMockStream([{
+      type: 'error',
+      content: 'No conversation found with session ID: missing-session',
+      code: 'provider_session_missing',
+    }]));
+
+    await new InputController(deps).sendMessage({
+      content: 'queued prompt',
+      images: [retryImage],
+      turnRequestOverride: { text: 'provider-ready prompt' },
+    });
+
+    expect(inputEl.value).toBe('queued prompt\n\nnewer draft');
+    expect(deps.getImageContextManager()?.setImages).toHaveBeenCalledWith([retryImage]);
+    expect(deps.state.messages).toEqual([]);
+    expect(deps.state.isStreaming).toBe(false);
   });
 
   it('does not claim a record was removed when no conversation is active', async () => {
@@ -277,6 +315,37 @@ describe('InputController - Missing provider session', () => {
     expect(mockNotice).toHaveBeenLastCalledWith(
       'The provider session no longer exists. Claudian preserved the recoverable history; send again to rebuild the session.',
     );
+  });
+
+  it('preserves drafts and queued follow-ups when deleting the stale record resets the tab', async () => {
+    const deps = createSendableDeps();
+    const inputEl = deps.getInputEl();
+    const imageContextManager = deps.getImageContextManager()!;
+    deps.mockAgentService.query.mockImplementation(() => (async function* () {
+      inputEl.value = 'newer draft';
+      deps.state.queuedMessage = {
+        content: 'queued follow-up',
+        images: undefined,
+        editorContext: null,
+        browserContext: null,
+        canvasContext: null,
+      };
+      yield {
+        type: 'error',
+        content: 'No conversation found with session ID: missing-session',
+        code: 'provider_session_missing',
+      };
+    })());
+    (deps.plugin.handleMissingProviderSession as jest.Mock).mockImplementation(async () => {
+      inputEl.value = '';
+      deps.state.queuedMessage = null;
+      imageContextManager.clearImages();
+      return 'deleted';
+    });
+
+    await new InputController(deps).sendMessage({ content: 'failed prompt' });
+
+    expect(inputEl.value).toBe('failed prompt\n\nqueued follow-up\n\nnewer draft');
   });
 });
 

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -135,6 +135,8 @@ function createMockDeps(overrides: Partial<InputControllerDeps> = {}): InputCont
       getConversationSync: jest.fn().mockReturnValue(null),
       getConversationById: jest.fn().mockResolvedValue(null),
       createConversation: jest.fn().mockResolvedValue({ id: 'conv-1' }),
+      deleteConversation: jest.fn().mockResolvedValue(undefined),
+      handleMissingProviderSession: jest.fn().mockResolvedValue('deleted'),
     } as any,
     state,
     renderer: {
@@ -213,6 +215,70 @@ function createSendableDeps(
   }
   return result;
 }
+
+describe('InputController - Missing provider session', () => {
+  it('removes only the Claudian record and restores unsent input', async () => {
+    const deps = createSendableDeps();
+    const inputEl = deps.getInputEl();
+    inputEl.value = 'retry this prompt';
+    deps.mockAgentService.query.mockReturnValue(createMockStream([{
+      type: 'error',
+      content: 'No conversation found with session ID: missing-session',
+      code: 'provider_session_missing',
+    }]));
+    const controller = new InputController(deps);
+
+    await controller.sendMessage();
+
+    expect(deps.plugin.handleMissingProviderSession).toHaveBeenCalledWith(
+      'conv-1',
+      undefined,
+    );
+    expect(inputEl.value).toBe('retry this prompt');
+    expect(deps.streamController.handleStreamChunk).not.toHaveBeenCalled();
+  });
+
+  it('does not claim a record was removed when no conversation is active', async () => {
+    const deps = createSendableDeps({}, null);
+    deps.state.currentConversationId = null;
+    (deps.plugin.createConversation as jest.Mock).mockResolvedValue({ id: '' });
+    deps.getInputEl().value = 'retry this prompt';
+    deps.mockAgentService.query.mockReturnValue(createMockStream([{
+      type: 'error',
+      content: 'No conversation found with session ID: missing-session',
+      code: 'provider_session_missing',
+    }]));
+
+    await new InputController(deps).sendMessage();
+
+    expect(deps.plugin.handleMissingProviderSession).not.toHaveBeenCalled();
+    expect(mockNotice).toHaveBeenLastCalledWith(
+      'The provider session no longer exists. Send again to start a new session.',
+    );
+  });
+
+  it('reports that recoverable history was preserved after resetting resume state', async () => {
+    const deps = createSendableDeps();
+    deps.getInputEl().value = 'retry this prompt';
+    (deps.plugin.handleMissingProviderSession as jest.Mock).mockResolvedValue('reset');
+    deps.mockAgentService.query.mockReturnValue(createMockStream([{
+      type: 'error',
+      content: 'No conversation found with session ID: missing-session',
+      code: 'provider_session_missing',
+      providerSessionId: 'missing-session',
+    }]));
+
+    await new InputController(deps).sendMessage();
+
+    expect(deps.plugin.handleMissingProviderSession).toHaveBeenCalledWith(
+      'conv-1',
+      'missing-session',
+    );
+    expect(mockNotice).toHaveBeenLastCalledWith(
+      'The provider session no longer exists. Claudian preserved the recoverable history; send again to rebuild the session.',
+    );
+  });
+});
 
 describe('InputController - Message Queue', () => {
   let controller: InputController;

--- a/tests/unit/providers/claude/history/ClaudeConversationHistoryService.test.ts
+++ b/tests/unit/providers/claude/history/ClaudeConversationHistoryService.test.ts
@@ -208,6 +208,64 @@ describe('ClaudeConversationHistoryService', () => {
   });
 
   describe('hydrateConversationHistory', () => {
+    it('drops a stale relocated path after the session appears in the current project', async () => {
+      const service = new ClaudeConversationHistoryService();
+      const conversation = createConversation();
+      const currentLocationSpy = jest.spyOn(historyStore, 'locateSDKSession')
+        .mockResolvedValueOnce({
+          availability: 'relocated',
+          sessionPath: '/old-project/session-1.jsonl',
+        })
+        .mockResolvedValueOnce({
+          availability: 'available',
+          sessionPath: '/vault/session-1.jsonl',
+        });
+      const locationsSpy = jest.spyOn(historyStore, 'locateSDKSessions')
+        .mockResolvedValue(new Map());
+      const loadSpy = jest.spyOn(historyStore, 'loadSDKSessionMessages')
+        .mockResolvedValue({ messages: [], skippedLines: 0 });
+
+      await service.getConversationSessionAvailability(conversation, '/vault');
+      await service.getConversationSessionAvailability(conversation, '/vault');
+      await service.hydrateConversationHistory(conversation, '/vault');
+
+      expect(loadSpy).toHaveBeenCalledWith('/vault', 'session-1', undefined);
+
+      currentLocationSpy.mockRestore();
+      locationsSpy.mockRestore();
+      loadSpy.mockRestore();
+    });
+
+    it('retains a known relocated path when a later availability check is inconclusive', async () => {
+      const service = new ClaudeConversationHistoryService();
+      const conversation = createConversation();
+      const currentLocationSpy = jest.spyOn(historyStore, 'locateSDKSession')
+        .mockResolvedValueOnce({
+          availability: 'relocated',
+          sessionPath: '/old-project/session-1.jsonl',
+        })
+        .mockResolvedValueOnce({ availability: 'unknown' });
+      const locationsSpy = jest.spyOn(historyStore, 'locateSDKSessions')
+        .mockResolvedValue(new Map());
+      const loadSpy = jest.spyOn(historyStore, 'loadSDKSessionMessages')
+        .mockResolvedValue({ messages: [], skippedLines: 0 });
+
+      await service.getConversationSessionAvailability(conversation, '/vault');
+      await service.getConversationSessionAvailability(conversation, '/vault');
+      await service.hydrateConversationHistory(conversation, '/vault');
+
+      expect(loadSpy).toHaveBeenCalledWith(
+        '/vault',
+        'session-1',
+        undefined,
+        '/old-project/session-1.jsonl',
+      );
+
+      currentLocationSpy.mockRestore();
+      locationsSpy.mockRestore();
+      loadSpy.mockRestore();
+    });
+
     it('replays every relocated session segment from its discovered path', async () => {
       const service = new ClaudeConversationHistoryService();
       const conversation = createConversation({

--- a/tests/unit/providers/claude/history/ClaudeConversationHistoryService.test.ts
+++ b/tests/unit/providers/claude/history/ClaudeConversationHistoryService.test.ts
@@ -1,0 +1,382 @@
+import type { Conversation } from '@/core/types';
+import { ClaudeConversationHistoryService } from '@/providers/claude/history/ClaudeConversationHistoryService';
+import * as historyStore from '@/providers/claude/history/ClaudeHistoryStore';
+import type { SDKSessionLocation } from '@/providers/claude/history/sdkSessionPaths';
+
+function createConversation(overrides: Partial<Conversation> = {}): Conversation {
+  return {
+    id: 'conversation-1',
+    providerId: 'claude',
+    title: 'Conversation',
+    createdAt: 1,
+    updatedAt: 1,
+    sessionId: 'session-1',
+    messages: [],
+    ...overrides,
+  };
+}
+
+describe('ClaudeConversationHistoryService', () => {
+  describe('getConversationSessionAvailability', () => {
+    it('reports a missing native session', async () => {
+      const availabilitySpy = jest.spyOn(historyStore, 'locateSDKSession')
+        .mockResolvedValue({ availability: 'missing' });
+      const service = new ClaudeConversationHistoryService();
+
+      await expect(service.getConversationSessionAvailability(
+        createConversation(),
+        '/vault',
+      )).resolves.toBe('missing');
+      expect(availabilitySpy).toHaveBeenCalledWith('/vault', 'session-1');
+
+      availabilitySpy.mockRestore();
+    });
+
+    it('reports an available native session', async () => {
+      const availabilitySpy = jest.spyOn(historyStore, 'locateSDKSession')
+        .mockResolvedValue({ availability: 'available', sessionPath: '/vault/session-1.jsonl' });
+      const service = new ClaudeConversationHistoryService();
+
+      await expect(service.getConversationSessionAvailability(
+        createConversation(),
+        '/vault',
+      )).resolves.toBe('available');
+
+      availabilitySpy.mockRestore();
+    });
+
+    it('reports a native session from a previous vault path as relocated', async () => {
+      const availabilitySpy = jest.spyOn(historyStore, 'locateSDKSession')
+        .mockResolvedValue({
+          availability: 'relocated',
+          sessionPath: '/old-vault/session-1.jsonl',
+        });
+      const service = new ClaudeConversationHistoryService();
+
+      await expect(service.getConversationSessionAvailability(
+        createConversation(),
+        '/vault',
+      )).resolves.toBe('relocated');
+
+      availabilitySpy.mockRestore();
+    });
+
+    it('preserves conversations without a resumable session', async () => {
+      const availabilitySpy = jest.spyOn(historyStore, 'locateSDKSession');
+      const service = new ClaudeConversationHistoryService();
+
+      await expect(service.getConversationSessionAvailability(
+        createConversation({ sessionId: null }),
+        '/vault',
+      )).resolves.toBe('unknown');
+      expect(availabilitySpy).not.toHaveBeenCalled();
+
+      availabilitySpy.mockRestore();
+    });
+
+    it('checks the source session for a pending fork', async () => {
+      const availabilitySpy = jest.spyOn(historyStore, 'locateSDKSession')
+        .mockResolvedValue({ availability: 'missing' });
+      const service = new ClaudeConversationHistoryService();
+
+      await expect(service.getConversationSessionAvailability(
+        createConversation({
+          sessionId: null,
+          providerState: {
+            forkSource: { sessionId: 'source-session', resumeAt: 'assistant-1' },
+          },
+        }),
+        '/vault',
+      )).resolves.toBe('missing');
+      expect(availabilitySpy).toHaveBeenCalledWith('/vault', 'source-session');
+
+      availabilitySpy.mockRestore();
+    });
+  });
+
+  describe('prepareRelocatedConversationSession', () => {
+    it('clears the resume pointer and retains the session for history replay', async () => {
+      const service = new ClaudeConversationHistoryService();
+      const conversation = createConversation({
+        providerState: {
+          providerSessionId: 'session-1',
+          previousProviderSessionIds: ['session-previous'],
+        },
+      });
+      const locationSpy = jest.spyOn(historyStore, 'locateSDKSessions')
+        .mockImplementation(async (_vaultPath, sessionIds) => new Map(
+          sessionIds.map(sessionId => [sessionId, {
+            availability: 'available' as const,
+            sessionPath: `/vault/${sessionId}.jsonl`,
+          }]),
+        ));
+      const loadSpy = jest.spyOn(historyStore, 'loadSDKSessionMessages')
+        .mockResolvedValue({ messages: [], skippedLines: 0 });
+
+      await expect(service.prepareRelocatedConversationSession(
+        conversation,
+        '/vault',
+      )).resolves.toBe(true);
+      expect(conversation.sessionId).toBeNull();
+      expect(conversation.providerState).toEqual({
+        previousProviderSessionIds: ['session-previous', 'session-1'],
+      });
+
+      locationSpy.mockRestore();
+      loadSpy.mockRestore();
+    });
+
+    it('does not clear resume metadata while an older segment is inaccessible', async () => {
+      const service = new ClaudeConversationHistoryService();
+      const conversation = createConversation({
+        providerState: {
+          providerSessionId: 'session-1',
+          previousProviderSessionIds: ['session-previous'],
+        },
+      });
+      const currentLocationSpy = jest.spyOn(historyStore, 'locateSDKSession')
+        .mockResolvedValue({
+          availability: 'relocated',
+          sessionPath: '/old-project/session-1.jsonl',
+        });
+      const locationSpy = jest.spyOn(historyStore, 'locateSDKSessions')
+        .mockResolvedValue(new Map([['session-previous', { availability: 'unknown' }]]));
+      const loadSpy = jest.spyOn(historyStore, 'loadSDKSessionMessages')
+        .mockResolvedValue({ messages: [], skippedLines: 0 });
+
+      await service.getConversationSessionAvailability(conversation, '/vault');
+      await expect(service.prepareRelocatedConversationSession(
+        conversation,
+        '/vault',
+      )).resolves.toBe(false);
+
+      expect(conversation.sessionId).toBe('session-1');
+      expect(conversation.providerState).toEqual({
+        providerSessionId: 'session-1',
+        previousProviderSessionIds: ['session-previous'],
+      });
+
+      currentLocationSpy.mockRestore();
+      locationSpy.mockRestore();
+      loadSpy.mockRestore();
+    });
+  });
+
+  describe('resolveMissingConversationSession', () => {
+    it('deletes only when every transcript segment is definitively missing', async () => {
+      const service = new ClaudeConversationHistoryService();
+      const conversation = createConversation();
+      const locationSpy = jest.spyOn(historyStore, 'locateSDKSessions')
+        .mockResolvedValue(new Map([['session-1', { availability: 'missing' }]]));
+
+      await expect(service.resolveMissingConversationSession(
+        conversation,
+        '/vault',
+        'session-1',
+      )).resolves.toBe('delete');
+      expect(conversation.sessionId).toBe('session-1');
+
+      locationSpy.mockRestore();
+    });
+
+    it('resets the resume pointer when an older segment is inaccessible', async () => {
+      const service = new ClaudeConversationHistoryService();
+      const conversation = createConversation({
+        providerState: {
+          providerSessionId: 'session-1',
+          previousProviderSessionIds: ['session-previous'],
+        },
+      });
+      const locationSpy = jest.spyOn(historyStore, 'locateSDKSessions')
+        .mockResolvedValue(new Map([
+          ['session-previous', { availability: 'unknown' }],
+          ['session-1', { availability: 'missing' }],
+        ]));
+
+      await expect(service.resolveMissingConversationSession(
+        conversation,
+        '/vault',
+        'session-1',
+      )).resolves.toBe('reset');
+      expect(conversation.sessionId).toBeNull();
+      expect(conversation.providerState).toEqual({
+        previousProviderSessionIds: ['session-previous'],
+      });
+
+      locationSpy.mockRestore();
+    });
+  });
+
+  describe('hydrateConversationHistory', () => {
+    it('replays every relocated session segment from its discovered path', async () => {
+      const service = new ClaudeConversationHistoryService();
+      const conversation = createConversation({
+        sessionId: null,
+        providerState: {
+          previousProviderSessionIds: ['session-previous', 'session-current'],
+        },
+      });
+      const locationSpy = jest.spyOn(historyStore, 'locateSDKSessions')
+        .mockImplementation(async (_vaultPath, sessionIds) => new Map(
+          sessionIds.map(sessionId => [sessionId, {
+            availability: 'relocated' as const,
+            sessionPath: `/old-project/${sessionId}.jsonl`,
+          }]),
+        ));
+      const loadSpy = jest.spyOn(historyStore, 'loadSDKSessionMessages')
+        .mockImplementation(async (_vaultPath, sessionId) => ({
+          messages: [{
+            id: `message-${sessionId}`,
+            role: 'user',
+            content: sessionId,
+            timestamp: sessionId === 'session-previous' ? 1 : 2,
+          }],
+          skippedLines: 0,
+        }));
+
+      await service.hydrateConversationHistory(conversation, '/vault');
+
+      expect(conversation.messages.map(message => message.content)).toEqual([
+        'session-previous',
+        'session-current',
+      ]);
+      expect(loadSpy).toHaveBeenCalledWith(
+        '/vault',
+        'session-previous',
+        undefined,
+        '/old-project/session-previous.jsonl',
+      );
+      expect(loadSpy).toHaveBeenCalledWith(
+        '/vault',
+        'session-current',
+        undefined,
+        '/old-project/session-current.jsonl',
+      );
+
+      locationSpy.mockRestore();
+      loadSpy.mockRestore();
+    });
+
+    it('retries hydration after an all-missing result', async () => {
+      const service = new ClaudeConversationHistoryService();
+      const conversation = createConversation();
+      const locationSpy = jest.spyOn(historyStore, 'locateSDKSessions')
+        .mockResolvedValueOnce(new Map([['session-1', { availability: 'missing' }]]))
+        .mockResolvedValue(new Map([['session-1', {
+          availability: 'relocated',
+          sessionPath: '/old-project/session-1.jsonl',
+        }]]));
+      const loadSpy = jest.spyOn(historyStore, 'loadSDKSessionMessages')
+        .mockResolvedValue({
+          messages: [{
+            id: 'recovered-message',
+            role: 'user',
+            content: 'Recovered',
+            timestamp: 1,
+          }],
+          skippedLines: 0,
+        });
+
+      await service.hydrateConversationHistory(conversation, '/vault');
+      await service.hydrateConversationHistory(conversation, '/vault');
+
+      expect(conversation.messages).toHaveLength(1);
+      expect(locationSpy).toHaveBeenCalledTimes(2);
+
+      locationSpy.mockRestore();
+      loadSpy.mockRestore();
+    });
+
+    it('retries hydration when one session segment has a transient read error', async () => {
+      const service = new ClaudeConversationHistoryService();
+      const conversation = createConversation({
+        providerState: {
+          previousProviderSessionIds: ['session-previous'],
+          providerSessionId: 'session-1',
+        },
+      });
+      const locationSpy = jest.spyOn(historyStore, 'locateSDKSessions')
+        .mockImplementation(async (_vaultPath, sessionIds) => new Map(
+          sessionIds.map(sessionId => [sessionId, {
+            availability: 'available' as const,
+            sessionPath: `/vault/${sessionId}.jsonl`,
+          }]),
+        ));
+      let currentAttempts = 0;
+      const loadSpy = jest.spyOn(historyStore, 'loadSDKSessionMessages')
+        .mockImplementation(async (_vaultPath, sessionId) => {
+          if (sessionId === 'session-1' && currentAttempts++ === 0) {
+            return { messages: [], skippedLines: 0, error: 'EIO' };
+          }
+          return {
+            messages: [{
+              id: `message-${sessionId}`,
+              role: 'user',
+              content: sessionId,
+              timestamp: sessionId === 'session-previous' ? 1 : 2,
+            }],
+            skippedLines: 0,
+          };
+        });
+
+      await service.hydrateConversationHistory(conversation, '/vault');
+      await service.hydrateConversationHistory(conversation, '/vault');
+
+      expect(conversation.messages.map(message => message.content)).toEqual([
+        'session-previous',
+        'session-1',
+      ]);
+      expect(locationSpy).toHaveBeenCalledTimes(2);
+      expect(loadSpy).toHaveBeenCalledTimes(4);
+
+      locationSpy.mockRestore();
+      loadSpy.mockRestore();
+    });
+
+    it('retries hydration when one session segment has unknown availability', async () => {
+      const service = new ClaudeConversationHistoryService();
+      const conversation = createConversation({
+        providerState: {
+          previousProviderSessionIds: ['session-previous'],
+          providerSessionId: 'session-1',
+        },
+      });
+      const available = (sessionId: string) => ({
+        availability: 'available' as const,
+        sessionPath: `/vault/${sessionId}.jsonl`,
+      });
+      const locationSpy = jest.spyOn(historyStore, 'locateSDKSessions')
+        .mockResolvedValueOnce(new Map<string, SDKSessionLocation>([
+          ['session-previous', { availability: 'unknown' }],
+          ['session-1', available('session-1')],
+        ]))
+        .mockResolvedValueOnce(new Map<string, SDKSessionLocation>([
+          ['session-previous', available('session-previous')],
+          ['session-1', available('session-1')],
+        ]));
+      const loadSpy = jest.spyOn(historyStore, 'loadSDKSessionMessages')
+        .mockImplementation(async (_vaultPath, sessionId) => ({
+          messages: [{
+            id: `message-${sessionId}`,
+            role: 'user',
+            content: sessionId,
+            timestamp: sessionId === 'session-previous' ? 1 : 2,
+          }],
+          skippedLines: 0,
+        }));
+
+      await service.hydrateConversationHistory(conversation, '/vault');
+      await service.hydrateConversationHistory(conversation, '/vault');
+
+      expect(conversation.messages.map(message => message.content)).toEqual([
+        'session-previous',
+        'session-1',
+      ]);
+      expect(locationSpy).toHaveBeenCalledTimes(2);
+      expect(loadSpy).toHaveBeenCalledTimes(3);
+
+      locationSpy.mockRestore();
+      loadSpy.mockRestore();
+    });
+  });
+});

--- a/tests/unit/providers/claude/runtime/ClaudianService.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudianService.test.ts
@@ -2288,6 +2288,36 @@ describe('ClaudianService', () => {
       expect(errorChunks).toHaveLength(1);
       expect(errorChunks[0].content).toContain('session expired');
     });
+
+    it('should classify a confirmed missing session from the cold-start retry', async () => {
+      jest.spyOn(sdkModule, 'query' as any).mockImplementation(() => {
+        // eslint-disable-next-line require-yield
+        const gen = (async function* () {
+          throw new Error('No conversation found with session ID: old-session');
+        })() as any;
+        gen.interrupt = jest.fn();
+        gen.setModel = jest.fn();
+        gen.setMaxThinkingTokens = jest.fn();
+        gen.setPermissionMode = jest.fn();
+        gen.setMcpServers = jest.fn();
+        return gen;
+      });
+
+      service.setSessionId('old-session');
+      const history: any[] = [
+        { id: '1', role: 'user', content: 'Previous', timestamp: 1000 },
+      ];
+
+      const chunks = await collectChunks(
+        service.query('follow up', undefined, history, { forceColdStart: true })
+      );
+
+      expect(chunks).toContainEqual(expect.objectContaining({
+        type: 'error',
+        code: 'provider_session_missing',
+        providerSessionId: 'old-session',
+      }));
+    });
   });
 
   describe('applyDynamicUpdates - cliPath null', () => {
@@ -2935,6 +2965,36 @@ describe('ClaudianService', () => {
       expect(errorChunks[0].content).toContain('retry also failed');
     });
 
+    it('should classify a confirmed missing session from the persistent retry', async () => {
+      service.setSessionId('old-persistent-session');
+      const history: any[] = [
+        { id: '1', role: 'user', content: 'Previous question', timestamp: 1000 },
+      ];
+
+      jest.spyOn(service as any, 'queryViaPersistent').mockImplementation(
+        // eslint-disable-next-line require-yield
+        async function* () {
+          throw new Error('session expired');
+        }
+      );
+      jest.spyOn(service as any, 'queryViaSDK').mockImplementation(
+        // eslint-disable-next-line require-yield
+        async function* () {
+          throw new Error('No conversation found with session ID: old-persistent-session');
+        }
+      );
+      (service as any).persistentQuery = { interrupt: jest.fn().mockResolvedValue(undefined) };
+      (service as any).shuttingDown = false;
+
+      const chunks = await collectChunks(service.query('follow up', undefined, history));
+
+      expect(chunks).toContainEqual(expect.objectContaining({
+        type: 'error',
+        code: 'provider_session_missing',
+        providerSessionId: 'old-persistent-session',
+      }));
+    });
+
     it('should re-throw non-session-expired errors from persistent path', async () => {
       jest.spyOn(service as any, 'queryViaPersistent').mockImplementation(
         // eslint-disable-next-line require-yield
@@ -2967,6 +3027,27 @@ describe('ClaudianService', () => {
       await expect(async () => {
         await collectChunks(service.query('hello'));
       }).rejects.toThrow('session expired');
+    });
+
+    it('should classify a confirmed missing session without rendering a generic error', async () => {
+      jest.spyOn(service as any, 'queryViaPersistent').mockImplementation(
+        // eslint-disable-next-line require-yield
+        async function* () {
+          throw new Error('No conversation found with session ID: missing-session');
+        }
+      );
+
+      (service as any).persistentQuery = { interrupt: jest.fn().mockResolvedValue(undefined) };
+      (service as any).shuttingDown = false;
+
+      const chunks = await collectChunks(service.query('hello'));
+
+      expect(chunks).toContainEqual(expect.objectContaining({
+        type: 'error',
+        code: 'provider_session_missing',
+        providerSessionId: 'missing-session',
+      }));
+      expect(service.getSessionId()).toBeNull();
     });
   });
 

--- a/tests/unit/providers/claude/runtime/ClaudianService.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudianService.test.ts
@@ -3168,6 +3168,44 @@ describe('ClaudianService', () => {
   });
 
   describe('startResponseConsumer - crash recovery', () => {
+    it('closes a persistent query whose resume session is confirmed missing', async () => {
+      const missingSessionError = new Error(
+        'No conversation found with session ID: missing-session',
+      );
+      const mockPQ = {
+        [Symbol.asyncIterator]() { return this; },
+        async next() {
+          throw missingSessionError;
+        },
+        async return() { return { done: true, value: undefined }; },
+        interrupt: jest.fn().mockResolvedValue(undefined),
+      };
+      const onError = jest.fn();
+      const handler = createResponseHandler({
+        id: 'missing-session-test',
+        onChunk: jest.fn(),
+        onDone: jest.fn(),
+        onError,
+      });
+
+      (service as any).sessionManager.setSessionId('missing-session', 'claude-sonnet-4-5');
+      (service as any).persistentQuery = mockPQ;
+      (service as any).messageChannel = { close: jest.fn() };
+      (service as any).queryAbortController = { abort: jest.fn() };
+      (service as any).responseHandlers = [handler];
+      (service as any).shuttingDown = false;
+      (service as any).coldStartInProgress = false;
+      (service as any).responseConsumerRunning = false;
+
+      (service as any).startResponseConsumer();
+      const consumerPromise = (service as any).responseConsumerPromise;
+      await consumerPromise;
+
+      expect(onError).toHaveBeenCalledWith(missingSessionError);
+      expect((service as any).persistentQuery).toBeNull();
+      expect(service.getSessionId()).toBeNull();
+    });
+
     it('should attempt crash recovery when error occurs before any chunks', async () => {
       // Set up persistent query that will throw on iteration
       const crashError = new Error('process crashed');

--- a/tests/unit/utils/sdkSession.test.ts
+++ b/tests/unit/utils/sdkSession.test.ts
@@ -8,6 +8,7 @@ import {
   encodeVaultPathForSDK,
   filterActiveBranch,
   getSDKProjectsPath,
+  getSDKSessionAvailability,
   getSDKSessionPath,
   isValidSessionId,
   loadSDKSessionMessages,
@@ -174,6 +175,114 @@ describe('sdkSession', () => {
       const exists = sdkSessionExists('/Users/test/vault', 'session-err');
 
       expect(exists).toBe(false);
+    });
+  });
+
+  describe('getSDKSessionAvailability', () => {
+    it('reports an available session', async () => {
+      mockFsPromises.access.mockResolvedValue(undefined);
+
+      await expect(getSDKSessionAvailability(
+        '/Users/test/vault',
+        'session-abc',
+      )).resolves.toBe('available');
+      expect(mockFsPromises.access).toHaveBeenCalledWith(
+        '/Users/test/.claude/projects/-Users-test-vault/session-abc.jsonl',
+      );
+    });
+
+    it('reports a missing session when a complete scan finds no transcript', async () => {
+      mockFsPromises.access.mockRejectedValue(
+        Object.assign(new Error('Missing'), { code: 'ENOENT' }),
+      );
+      mockFsPromises.readdir.mockResolvedValue([]);
+
+      await expect(getSDKSessionAvailability(
+        '/Users/test/vault',
+        'session-missing',
+      )).resolves.toBe('missing');
+    });
+
+    it('reports a session found under a previous vault project as relocated', async () => {
+      mockFsPromises.access.mockRejectedValue(
+        Object.assign(new Error('Missing'), { code: 'ENOENT' }),
+      );
+      mockFsPromises.readdir
+        .mockResolvedValueOnce([{
+          isDirectory: () => true,
+          isFile: () => false,
+          name: '-Users-test-previous-vault',
+        }] as any)
+        .mockResolvedValueOnce([{
+          isDirectory: () => false,
+          isFile: () => true,
+          name: 'session-relocated.jsonl',
+        }] as any);
+
+      await expect(getSDKSessionAvailability(
+        '/Users/test/vault',
+        'session-relocated',
+      )).resolves.toBe('relocated');
+    });
+
+    it('finds relocated sessions in nested project directories', async () => {
+      mockFsPromises.access.mockRejectedValue(
+        Object.assign(new Error('Missing'), { code: 'ENOENT' }),
+      );
+      mockFsPromises.readdir
+        .mockResolvedValueOnce([{
+          isDirectory: () => true,
+          isFile: () => false,
+          name: '-Users-test-current-project',
+        }] as any)
+        .mockResolvedValueOnce([{
+          isDirectory: () => true,
+          isFile: () => false,
+          name: '-Users-test-previous-vault',
+        }] as any)
+        .mockResolvedValueOnce([{
+          isDirectory: () => false,
+          isFile: () => true,
+          name: 'session-nested.jsonl',
+        }] as any);
+
+      await expect(getSDKSessionAvailability(
+        '/Users/test/vault',
+        'session-nested',
+      )).resolves.toBe('relocated');
+    });
+
+    it('reports unknown when the local Claude projects root is absent', async () => {
+      mockFsPromises.access.mockRejectedValue(
+        Object.assign(new Error('Missing'), { code: 'ENOENT' }),
+      );
+      mockFsPromises.readdir.mockRejectedValue(
+        Object.assign(new Error('Missing root'), { code: 'ENOENT' }),
+      );
+
+      await expect(getSDKSessionAvailability(
+        '/Users/test/vault',
+        'session-on-another-machine',
+      )).resolves.toBe('unknown');
+    });
+
+    it('reports unknown for other filesystem failures', async () => {
+      mockFsPromises.access.mockRejectedValue(
+        Object.assign(new Error('Permission denied'), { code: 'EACCES' }),
+      );
+
+      await expect(getSDKSessionAvailability(
+        '/Users/test/vault',
+        'session-inaccessible',
+      )).resolves.toBe('unknown');
+    });
+
+    it('reports unknown for an invalid session ID', async () => {
+      await expect(getSDKSessionAvailability(
+        '/Users/test/vault',
+        '../invalid',
+      )).resolves.toBe('unknown');
+      expect(mockFsPromises.access).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/utils/sdkSession.test.ts
+++ b/tests/unit/utils/sdkSession.test.ts
@@ -277,6 +277,23 @@ describe('sdkSession', () => {
       )).resolves.toBe('unknown');
     });
 
+    it('reports unknown when an unscanned symlink could contain the transcript', async () => {
+      mockFsPromises.access.mockRejectedValue(
+        Object.assign(new Error('Missing'), { code: 'ENOENT' }),
+      );
+      mockFsPromises.readdir.mockResolvedValue([{
+        isDirectory: () => false,
+        isFile: () => false,
+        isSymbolicLink: () => true,
+        name: 'linked-project',
+      }] as any);
+
+      await expect(getSDKSessionAvailability(
+        '/Users/test/vault',
+        'session-in-linked-project',
+      )).resolves.toBe('unknown');
+    });
+
     it('reports unknown for an invalid session ID', async () => {
       await expect(getSDKSessionAvailability(
         '/Users/test/vault',
@@ -2463,6 +2480,44 @@ describe('sdkSession', () => {
       expect(taskToolCall.subagent!.toolCalls).toHaveLength(1);
       expect(taskToolCall.subagent!.toolCalls[0].name).toBe('Grep');
       expect(taskToolCall.subagent!.toolCalls[0].result).toBe('3 matches found');
+    });
+
+    it('loads subagent tool calls beside a relocated session transcript', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockFsPromises.readFile.mockImplementation(async (filePath: any) => {
+        const p = String(filePath);
+        if (p === '/old-project/session-sidecar.jsonl') {
+          return [
+            '{"type":"user","uuid":"u1","timestamp":"2024-01-15T10:00:00Z","message":{"content":"Review"}}',
+            '{"type":"assistant","uuid":"a1","timestamp":"2024-01-15T10:01:00Z","message":{"content":[{"type":"tool_use","id":"task-1","name":"Task","input":{"description":"Review","prompt":"check","run_in_background":true}}]}}',
+            '{"type":"user","uuid":"u2","timestamp":"2024-01-15T10:01:01Z","toolUseResult":{"isAsync":true,"agentId":"ae5eb9a"},"message":{"content":[{"type":"tool_result","tool_use_id":"task-1","content":"Launched"}]}}',
+          ].join('\n');
+        }
+        if (p === '/old-project/session-sidecar/subagents/agent-ae5eb9a.jsonl') {
+          return [
+            '{"type":"assistant","timestamp":"2024-01-15T10:02:00Z","message":{"content":[{"type":"tool_use","id":"sub-tool-1","name":"Grep","input":{"pattern":"TODO"}}]}}',
+            '{"type":"user","timestamp":"2024-01-15T10:02:01Z","message":{"content":[{"type":"tool_result","tool_use_id":"sub-tool-1","content":"3 matches found"}]}}',
+          ].join('\n');
+        }
+        return '';
+      });
+
+      const result = await loadSDKSessionMessages(
+        '/Users/test/vault',
+        'session-sidecar',
+        undefined,
+        '/old-project/session-sidecar.jsonl',
+      );
+
+      const assistantMsg = result.messages.find(m => m.toolCalls?.some(tc => tc.name === 'Task'));
+      const taskToolCall = assistantMsg!.toolCalls!.find(tc => tc.name === 'Task')!;
+      expect(mockFsPromises.readFile).toHaveBeenCalledWith(
+        '/old-project/session-sidecar/subagents/agent-ae5eb9a.jsonl',
+        'utf-8',
+      );
+      expect(taskToolCall.subagent!.toolCalls).toEqual([
+        expect.objectContaining({ name: 'Grep', result: '3 matches found' }),
+      ]);
     });
   });
 });

--- a/tests/unit/utils/session.test.ts
+++ b/tests/unit/utils/session.test.ts
@@ -6,6 +6,7 @@ import {
   formatToolCallForContext,
   getLastUserMessage,
   isSessionExpiredError,
+  isSessionMissingError,
   truncateToolResult,
 } from '@/utils/session';
 
@@ -19,6 +20,19 @@ describe('session utilities', () => {
     it('returns true for "session not found" error', () => {
       const error = new Error('Session not found');
       expect(isSessionExpiredError(error)).toBe(true);
+    });
+
+    it('returns true for the Claude missing-conversation error', () => {
+      const error = new Error('No conversation found with session ID: session-123');
+      expect(isSessionExpiredError(error)).toBe(true);
+      expect(isSessionMissingError(error)).toBe(true);
+      expect(isSessionMissingError(error, 'session-123')).toBe(true);
+      expect(isSessionMissingError(error, 'different-session')).toBe(false);
+    });
+
+    it('does not classify generic not-found wording as confirmed provider deletion', () => {
+      expect(isSessionMissingError(new Error('Session not found'))).toBe(false);
+      expect(isSessionMissingError(new Error('No conversation found'))).toBe(false);
     });
 
     it('returns true for "invalid session" error', () => {


### PR DESCRIPTION
## Summary

- discover Claude transcripts after a vault move and replay them from their relocated paths
- persist cleared resume metadata so recoverable conversations rebuild seamlessly on the next send
- remove a Claudian record only after every tracked provider transcript is definitively missing
- preserve records when older history is available, relocated, inaccessible, or otherwise unverified
- classify Claude missing-session errors explicitly and reset every open tab referencing a removed conversation

Closes #876.

## Testing

- `npm run typecheck`
- `npm run lint`
- `npm run test` (249 suites, 5,928 tests)
- `npm run build`
- `git diff --check`