### PR TITLE
fix: stop-hook no longer blocks turn-ends forever on leaked subagents

### DIFF
--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -357,6 +357,7 @@ export class InputController {
     let wasInvalidated = false;
     let didEnqueueToSdk = false;
     let planCompleted = false;
+    let streamErrored = false;
 
     // Lazy initialization: ensure service is ready before first query
     if (this.deps.ensureServiceInitialized) {
@@ -468,6 +469,7 @@ export class InputController {
         );
       }
     } catch (error) {
+      streamErrored = true;
       const errorMsg = error instanceof Error ? error.message : 'Unknown error';
       await streamController.appendText(`\n\n**Error:** ${errorMsg}`);
     } finally {
@@ -486,6 +488,21 @@ export class InputController {
         const didCancelThisTurn = wasInterrupted || state.cancelRequested;
         if (didCancelThisTurn && !state.pendingNewSessionPlan) {
           await streamController.appendText('\n\n<span class="claudian-interrupted">Interrupted</span> <span class="claudian-interrupted-hint">· What should Claudian do instead?</span>');
+        }
+
+        // Termination path for async subagents on interrupt/stream error.
+        // Interrupting the turn (or a query error) kills in-flight background
+        // tasks — without orphaning them here the leaked map entries keep
+        // hasRunningSubagents() true forever and the Stop hook blocks every
+        // subsequent turn-end.
+        // (approve-new-session sets cancelRequested as a control-flow signal;
+        // that path orphans via conversationController.createNew() instead.)
+        if ((didCancelThisTurn && !state.pendingNewSessionPlan) || streamErrored) {
+          this.deps.getSubagentManager().orphanAllActive(
+            streamErrored && !didCancelThisTurn
+              ? 'Stream error ended the turn before the background task completed'
+              : 'Interrupted before the background task completed'
+          );
         }
         streamController.hideThinkingIndicator();
         state.isStreaming = false;

--- a/src/features/chat/services/SubagentManager.ts
+++ b/src/features/chat/services/SubagentManager.ts
@@ -508,17 +508,17 @@ export class SubagentManager {
     this.pendingTasks.clear();
   }
 
-  public orphanAllActive(): SubagentInfo[] {
+  public orphanAllActive(reason?: string): SubagentInfo[] {
     const orphaned: SubagentInfo[] = [];
 
     for (const subagent of this.pendingAsyncSubagents.values()) {
-      this.markOrphaned(subagent);
+      this.markOrphaned(subagent, reason);
       orphaned.push(subagent);
     }
 
     for (const subagent of this.activeAsyncSubagents.values()) {
       if (subagent.asyncStatus === 'running') {
-        this.markOrphaned(subagent);
+        this.markOrphaned(subagent, reason);
         orphaned.push(subagent);
       }
     }
@@ -529,6 +529,35 @@ export class SubagentManager {
     this.outputToolIdToAgentId.clear();
 
     return orphaned;
+  }
+
+  /**
+   * Orphans a single async subagent by its agent id (per-agent termination
+   * path, e.g. a specific background task was killed or stalled). Removes it
+   * from all tracking maps so `hasRunningSubagents()` no longer counts it.
+   */
+  public orphanByAgentId(agentId: string, reason?: string): SubagentInfo | undefined {
+    const subagent = this.activeAsyncSubagents.get(agentId);
+    if (!subagent) return undefined;
+
+    this.activeAsyncSubagents.delete(agentId);
+
+    for (const [taskId, mappedAgentId] of this.taskIdToAgentId.entries()) {
+      if (mappedAgentId === agentId) {
+        this.taskIdToAgentId.delete(taskId);
+      }
+    }
+    for (const [toolId, mappedAgentId] of this.outputToolIdToAgentId.entries()) {
+      if (mappedAgentId === agentId) {
+        this.outputToolIdToAgentId.delete(toolId);
+      }
+    }
+
+    if (subagent.asyncStatus === 'running') {
+      this.markOrphaned(subagent, reason);
+    }
+
+    return subagent;
   }
 
   public clear(): void {
@@ -545,10 +574,10 @@ export class SubagentManager {
   // Private: State Transitions
   // ============================================
 
-  private markOrphaned(subagent: SubagentInfo): void {
+  private markOrphaned(subagent: SubagentInfo, reason?: string): void {
     subagent.asyncStatus = 'orphaned';
     subagent.status = 'error';
-    subagent.result = 'Conversation ended before task completed';
+    subagent.result = reason ?? 'Conversation ended before task completed';
     subagent.completedAt = Date.now();
     this.updateAsyncDomState(subagent);
     this.onStateChange(subagent);

--- a/src/providers/claude/hooks/SubagentHooks.ts
+++ b/src/providers/claude/hooks/SubagentHooks.ts
@@ -6,25 +6,63 @@ export type SubagentHookState = SubagentRuntimeState;
 
 const STOP_BLOCK_REASON = 'Background subagents are still running. Use `TaskOutput task_id="..." block=true` to wait for their results before ending your turn.';
 
+/**
+ * Maximum number of consecutive Stop blocks before the hook lets the turn end
+ * anyway. Acts as a safety net against stale subagent tracking state (e.g. a
+ * background subagent that was killed/stalled without its termination path
+ * running) which would otherwise block turn-ends forever.
+ */
+export const MAX_CONSECUTIVE_STOP_BLOCKS = 3;
+
 export function createStopSubagentHook(
   getState: () => SubagentHookState
 ): HookCallbackMatcher {
+  // Counts consecutive blocks. Reset whenever the state reports no running
+  // subagents (i.e. the block mechanism worked as intended).
+  let consecutiveBlocks = 0;
+
   return {
     hooks: [
       async () => {
         let hasRunning: boolean;
+        let stateCheckFailed = false;
         try {
-          hasRunning = getState().hasRunning;
-        } catch {
-          // Provider failed — assume subagents are running to be safe
+          const state = getState();
+          if (typeof state?.hasRunning === 'boolean') {
+            hasRunning = state.hasRunning;
+          } else {
+            // Provider returned an unexpected shape — treat like a failed
+            // state check: fail closed, bounded by the retry cap below.
+            console.warn('[Claudian] Stop hook received invalid subagent state shape:', state);
+            hasRunning = true;
+            stateCheckFailed = true;
+          }
+        } catch (err) {
+          // Provider failed — assume subagents are running to be safe.
+          // The retry cap below guarantees this can never block forever.
+          console.warn('[Claudian] Stop hook subagent state check failed:', err);
           hasRunning = true;
+          stateCheckFailed = true;
         }
 
-        if (hasRunning) {
-          return { decision: 'block' as const, reason: STOP_BLOCK_REASON };
+        if (!hasRunning) {
+          consecutiveBlocks = 0;
+          return {};
         }
 
-        return {};
+        if (consecutiveBlocks >= MAX_CONSECUTIVE_STOP_BLOCKS) {
+          console.warn(
+            `[Claudian] Stop hook still reports running subagents after ${consecutiveBlocks} consecutive blocks`
+            + `${stateCheckFailed ? ' (subagent state check failed)' : ''}`
+            + ' — allowing the turn to end to avoid an infinite block loop.'
+            + ' Subagent tracking state may be stale (killed/stalled background task).'
+          );
+          consecutiveBlocks = 0;
+          return {};
+        }
+
+        consecutiveBlocks++;
+        return { decision: 'block' as const, reason: STOP_BLOCK_REASON };
       },
     ],
   };

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -188,7 +188,7 @@ function createMockDeps(overrides: Partial<InputControllerDeps> = {}): InputCont
     generateId: () => `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
     resetInputHeight: jest.fn(),
     getAgentService: () => mockAgentService as any,
-    getSubagentManager: () => ({ resetSpawnedCount: jest.fn(), resetStreamingState: jest.fn() }) as any,
+    getSubagentManager: () => ({ resetSpawnedCount: jest.fn(), resetStreamingState: jest.fn(), orphanAllActive: jest.fn() }) as any,
     mockAgentService,
     ...overrides,
   };

--- a/tests/unit/features/chat/services/SubagentManager.test.ts
+++ b/tests/unit/features/chat/services/SubagentManager.test.ts
@@ -265,6 +265,55 @@ describe('SubagentManager', () => {
       expect(manager.getByTaskId('running-task')).toBeUndefined();
     });
 
+    it('uses custom orphan reason when provided', () => {
+      const { manager } = createManager();
+      const parentEl = createMockEl();
+
+      manager.handleTaskToolUse('reason-task', { description: 'Task', run_in_background: true }, parentEl);
+      manager.handleTaskToolResult('reason-task', JSON.stringify({ agent_id: 'agent-reason' }));
+
+      const orphaned = manager.orphanAllActive('Interrupted before the background task completed');
+
+      expect(orphaned).toHaveLength(1);
+      expect(orphaned[0].result).toBe('Interrupted before the background task completed');
+      expect(manager.hasRunningSubagents()).toBe(false);
+    });
+
+    it('orphans a single subagent by agent id and clears its tracking state', () => {
+      const { manager } = createManager();
+      const parentEl = createMockEl();
+
+      manager.handleTaskToolUse('task-a', { description: 'Task A', run_in_background: true }, parentEl);
+      manager.handleTaskToolResult('task-a', JSON.stringify({ agent_id: 'agent-a' }));
+      manager.handleTaskToolUse('task-b', { description: 'Task B', run_in_background: true }, parentEl);
+      manager.handleTaskToolResult('task-b', JSON.stringify({ agent_id: 'agent-b' }));
+
+      manager.handleAgentOutputToolUse({
+        id: 'output-a',
+        name: 'AgentOutputTool',
+        input: { agent_id: 'agent-a' },
+        status: 'running',
+        isExpanded: false,
+      });
+
+      const orphaned = manager.orphanByAgentId('agent-a', 'Background task was killed');
+
+      expect(orphaned?.asyncStatus).toBe('orphaned');
+      expect(orphaned?.result).toBe('Background task was killed');
+      expect(manager.getByTaskId('task-a')).toBeUndefined();
+      expect(manager.isLinkedAgentOutputTool('output-a')).toBe(false);
+
+      // Other subagent untouched
+      expect(manager.getByTaskId('task-b')?.asyncStatus).toBe('running');
+      expect(manager.hasRunningSubagents()).toBe(true);
+    });
+
+    it('returns undefined when orphaning an unknown agent id', () => {
+      const { manager } = createManager();
+
+      expect(manager.orphanByAgentId('agent-missing')).toBeUndefined();
+    });
+
     it('ignores Task results for unknown tasks', () => {
       const { manager } = createManager();
 

--- a/tests/unit/providers/claude/hooks/SubagentHooks.test.ts
+++ b/tests/unit/providers/claude/hooks/SubagentHooks.test.ts
@@ -1,5 +1,6 @@
 import {
   createStopSubagentHook,
+  MAX_CONSECUTIVE_STOP_BLOCKS,
   type SubagentHookState,
 } from '@/providers/claude/hooks/SubagentHooks';
 
@@ -56,21 +57,149 @@ describe('SubagentHooks', () => {
       expect(result2).toEqual({});
     });
 
-    it('fails closed when reading subagent state throws', async () => {
-      const hook = createStopSubagentHook(() => {
-        throw new Error('tab already torn down');
-      });
+    it('fails closed and logs the error when reading subagent state throws', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const error = new Error('tab already torn down');
+        const hook = createStopSubagentHook(() => {
+          throw error;
+        });
 
-      const result = await hook.hooks[0](
-        createHookInput(),
-        undefined,
-        { signal: new AbortController().signal }
-      );
+        const result = await hook.hooks[0](
+          createHookInput(),
+          undefined,
+          { signal: new AbortController().signal }
+        );
 
-      expect(result).toEqual({
-        decision: 'block',
-        reason: expect.stringContaining('still running'),
-      });
+        expect(result).toEqual({
+          decision: 'block',
+          reason: expect.stringContaining('still running'),
+        });
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('state check failed'),
+          error
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('fails closed and logs when subagent state has an invalid shape', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const hook = createStopSubagentHook(() => ({ hasRunning: 'yes' }) as any);
+        const opts = { signal: new AbortController().signal };
+
+        const result = await hook.hooks[0](createHookInput(), undefined, opts);
+
+        expect(result).toEqual({
+          decision: 'block',
+          reason: expect.stringContaining('still running'),
+        });
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('invalid subagent state shape'),
+          { hasRunning: 'yes' }
+        );
+
+        // Invalid shape is bounded by the same cap
+        for (let i = 1; i < MAX_CONSECUTIVE_STOP_BLOCKS; i++) {
+          const blocked = await hook.hooks[0](createHookInput(), undefined, opts);
+          expect((blocked as any).decision).toBe('block');
+        }
+        expect(await hook.hooks[0](createHookInput(), undefined, opts)).toEqual({});
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('fails closed and logs when subagent state is null/undefined', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const hook = createStopSubagentHook(() => null as any);
+
+        const result = await hook.hooks[0](
+          createHookInput(),
+          undefined,
+          { signal: new AbortController().signal }
+        );
+
+        expect(result).toEqual({
+          decision: 'block',
+          reason: expect.stringContaining('still running'),
+        });
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('invalid subagent state shape'),
+          null
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('stops blocking after the consecutive block cap when state stays running (stale tracking)', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const hook = createStopSubagentHook(() => ({ hasRunning: true }));
+        const opts = { signal: new AbortController().signal };
+
+        for (let i = 0; i < MAX_CONSECUTIVE_STOP_BLOCKS; i++) {
+          const result = await hook.hooks[0](createHookInput(), undefined, opts);
+          expect((result as any).decision).toBe('block');
+        }
+
+        // Cap reached — turn must be allowed to end despite hasRunning=true
+        const released = await hook.hooks[0](createHookInput(), undefined, opts);
+        expect(released).toEqual({});
+        expect(warnSpy).toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('stops blocking after the consecutive block cap when state check keeps throwing', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const hook = createStopSubagentHook(() => {
+          throw new Error('provider gone');
+        });
+        const opts = { signal: new AbortController().signal };
+
+        for (let i = 0; i < MAX_CONSECUTIVE_STOP_BLOCKS; i++) {
+          const result = await hook.hooks[0](createHookInput(), undefined, opts);
+          expect((result as any).decision).toBe('block');
+        }
+
+        const released = await hook.hooks[0](createHookInput(), undefined, opts);
+        expect(released).toEqual({});
+        expect(warnSpy).toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('resets the block counter once subagents finish, re-arming the cap', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        let running = true;
+        const hook = createStopSubagentHook(() => ({ hasRunning: running }));
+        const opts = { signal: new AbortController().signal };
+
+        // Two blocks, then subagents finish
+        await hook.hooks[0](createHookInput(), undefined, opts);
+        await hook.hooks[0](createHookInput(), undefined, opts);
+        running = false;
+        expect(await hook.hooks[0](createHookInput(), undefined, opts)).toEqual({});
+
+        // New running phase gets the full cap again
+        running = true;
+        for (let i = 0; i < MAX_CONSECUTIVE_STOP_BLOCKS; i++) {
+          const result = await hook.hooks[0](createHookInput(), undefined, opts);
+          expect((result as any).decision).toBe('block');
+        }
+        expect(await hook.hooks[0](createHookInput(), undefined, opts)).toEqual({});
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
 
     it('has no matcher (applies to all stop events)', () => {


### PR DESCRIPTION
**Problem** — Turn-ends get blocked forever with "Background subagents are still running" (#852; related history: #493, #513). Once a background subagent dies outside its normal completion path, the Stop hook blocks every subsequent turn-end with no escape — the hook even fails closed when reading state throws.

**Root cause** — Kill/interrupt/stream-error paths never clean `SubagentManager`'s `pendingAsyncSubagents`/`activeAsyncSubagents` maps, so `hasRunningSubagents()` stays true forever. `orphanAllActive()` existed but only ran on tab close / conversation switch / forced new chat.

**Changes**
1. `InputController.sendMessage`: user interrupt (cancel/Esc) and stream errors now orphan active async subagents via the existing `orphanAllActive()` mechanic (approve-new-session excluded — it orphans via `createNew()` already).
2. `createStopSubagentHook`: cap of 3 consecutive Stop blocks, then allow the turn to end with a warning. Covers the catch path (error now logged) and a new state-shape guard (`typeof state?.hasRunning === 'boolean'`). Counter re-arms once state reports no running subagents.
3. `SubagentManager`: `orphanAllActive()`/`markOrphaned()` take an optional reason; new per-agent `orphanByAgentId()` cleans a single agent from all tracking maps.

**No time-based eviction**: legitimately long-running subagents are never evicted; an agent is only orphaned when an actual termination path runs. The Stop-hook cap only ends the block loop, it never touches tracking state.

Tests: 5944 passed incl. 8 new regression tests. Fixes #852

🤖 Generated with [Claude Code](https://claude.com/claude-code)
