### PR TITLE
fix: align Promise handling with callback contracts

### DIFF
--- a/src/providers/codex/history/CodexHistoryStore.ts
+++ b/src/providers/codex/history/CodexHistoryStore.ts
@@ -1394,7 +1394,7 @@ async function runBeforeDeadline<T>(
       },
       (error) => {
         window.clearTimeout(timer);
-        reject(error);
+        reject(error instanceof Error ? error : new Error(String(error)));
       },
     );
   });

--- a/src/shared/settings/ProviderModelPicker.ts
+++ b/src/shared/settings/ProviderModelPicker.ts
@@ -97,8 +97,8 @@ export function renderProviderModelPicker(options: ProviderModelPickerOptions): 
     text: 'Discover',
   });
   catalogActionEl.setAttribute('type', 'button');
-  catalogActionEl.addEventListener('click', async () => {
-    await loadCatalog(true);
+  catalogActionEl.addEventListener('click', () => {
+    void loadCatalog(true);
   });
 
   const listEl = catalogEl.createDiv({ cls: 'claudian-provider-model-picker-list' });
@@ -177,8 +177,8 @@ export function renderProviderModelPicker(options: ProviderModelPickerOptions): 
     });
     clearAllButton.setAttribute('type', 'button');
     clearAllButton.setAttribute('aria-label', `Clear all selected ${options.providerName} models`);
-    clearAllButton.addEventListener('click', async () => {
-      await persistSelectedIds([]);
+    clearAllButton.addEventListener('click', () => {
+      void persistSelectedIds([]);
     });
 
     const rowsEl = selectedEl.createDiv({ cls: 'claudian-provider-model-picker-selected-rows' });
@@ -227,8 +227,8 @@ export function renderProviderModelPicker(options: ProviderModelPickerOptions): 
       aliasInput.value = state.aliases[model.id] ?? '';
       aliasInput.setAttribute('aria-label', `Alias for ${defaultLabel}`);
       aliasInput.title = 'Custom label shown in the model selector. Leave empty to use the default.';
-      aliasInput.addEventListener('blur', async () => {
-        await persistAlias(model.id, aliasInput.value);
+      aliasInput.addEventListener('blur', () => {
+        void persistAlias(model.id, aliasInput.value);
       });
       aliasInput.addEventListener('keydown', (event) => {
         if (event.key === 'Enter') {
@@ -247,8 +247,8 @@ export function renderProviderModelPicker(options: ProviderModelPickerOptions): 
       });
       removeButton.setAttribute('type', 'button');
       removeButton.setAttribute('aria-label', `Remove ${defaultLabel}`);
-      removeButton.addEventListener('click', async () => {
-        await persistSelectedIds(options.getState().selectedIds.filter(id => id !== model.id));
+      removeButton.addEventListener('click', () => {
+        void persistSelectedIds(options.getState().selectedIds.filter(id => id !== model.id));
       });
     }
   };
@@ -335,7 +335,7 @@ export function renderProviderModelPicker(options: ProviderModelPickerOptions): 
 
       const checkboxEl = rowEl.createEl('input', { type: 'checkbox' });
       checkboxEl.checked = isSelected;
-      checkboxEl.addEventListener('change', async () => {
+      const persistSelection = async (): Promise<void> => {
         const selecting = checkboxEl.checked;
         const currentIds = options.getState().selectedIds;
         const nextIds = selecting
@@ -345,6 +345,9 @@ export function renderProviderModelPicker(options: ProviderModelPickerOptions): 
         if (selecting) {
           await options.onModelSelected?.(model);
         }
+      };
+      checkboxEl.addEventListener('change', () => {
+        void persistSelection();
       });
 
       const textEl = rowEl.createDiv({ cls: 'claudian-provider-model-picker-row-text' });
@@ -405,9 +408,9 @@ export function renderProviderModelPicker(options: ProviderModelPickerOptions): 
   };
 
   renderAll();
-  catalogEl.addEventListener('toggle', async () => {
+  catalogEl.addEventListener('toggle', () => {
     if (catalogEl.open) {
-      await loadCatalog(false);
+      void loadCatalog(false);
     }
   });
   if (options.loadCatalogOnRender) {

--- a/tests/unit/providers/codex/ui/CodexModelPicker.test.ts
+++ b/tests/unit/providers/codex/ui/CodexModelPicker.test.ts
@@ -42,7 +42,7 @@ interface FakeElement {
   text: string;
   title: string;
   value: string;
-  addEventListener(event: string, handler: () => void): void;
+  addEventListener(event: string, handler: () => unknown): void;
   appendText(value: string): void;
   classList: { add(value: string): void };
   createDiv(options?: { cls?: string; text?: string }): FakeElement;
@@ -52,7 +52,7 @@ interface FakeElement {
   setAttribute(name: string, value: string): void;
   setText(value: string): void;
   toggleClass(value: string, force: boolean): void;
-  trigger(event: string): void;
+  trigger(event: string): unknown[];
 }
 
 function createElement(
@@ -60,7 +60,7 @@ function createElement(
   options: { cls?: string; text?: string; type?: string } = {},
   parent: FakeElement | null = null,
 ): FakeElement {
-  const listeners = new Map<string, Array<() => void>>();
+  const listeners = new Map<string, Array<() => unknown>>();
   const classes = new Set(options.cls?.split(/\s+/).filter(Boolean) ?? []);
   const element: FakeElement = {
     attrs: options.type ? { type: options.type } : {},
@@ -114,9 +114,7 @@ function createElement(
       }
     },
     trigger(event) {
-      for (const handler of listeners.get(event) ?? []) {
-        handler();
-      }
+      return (listeners.get(event) ?? []).map(handler => handler());
     },
   };
   elements.push(element);
@@ -200,6 +198,49 @@ describe('CodexModelPicker', () => {
     expect(getCodexProviderSettings(plugin.settings).visibleModels).toEqual([]);
     expect(plugin.saveSettings).toHaveBeenCalledTimes(1);
     expect(context.refreshModelSelectors).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers void-returning DOM event callbacks for asynchronous actions', async () => {
+    const plugin = createPlugin();
+    const context = createContext(plugin);
+    const refreshModelCatalog = jest.fn().mockResolvedValue({
+      changed: false,
+      persistedSettingsChanged: false,
+    });
+
+    renderCodexModelPicker(createElement() as any, context, { refreshModelCatalog } as any);
+
+    const actionButton = findElement(element =>
+      element.classes.has('claudian-provider-model-picker-action')
+    );
+    expect(actionButton.trigger('click')).toEqual([undefined]);
+
+    const catalog = findElement(element =>
+      element.classes.has('claudian-provider-model-picker-catalog')
+    );
+    catalog.open = true;
+    expect(catalog.trigger('toggle')).toEqual([undefined]);
+
+    const aliasInput = findElement(element =>
+      element.classes.has('claudian-provider-model-picker-selected-alias')
+    );
+    expect(aliasInput.trigger('blur')).toEqual([undefined]);
+
+    const checkbox = findElement(element => element.attrs.type === 'checkbox');
+    checkbox.checked = false;
+    expect(checkbox.trigger('change')).toEqual([undefined]);
+
+    const removeButton = findElement(element =>
+      element.classes.has('claudian-provider-model-picker-selected-remove')
+    );
+    expect(removeButton.trigger('click')).toEqual([undefined]);
+
+    const clearAllButton = findElement(element =>
+      element.attrs['aria-label'] === 'Clear all selected Codex models'
+    );
+    expect(clearAllButton.trigger('click')).toEqual([undefined]);
+
+    await flushPromises();
   });
 
   it('persists a catalog-ordered subset when a model is unchecked', async () => {

--- a/tests/unit/providers/opencode/OpencodeSettingsTab.test.ts
+++ b/tests/unit/providers/opencode/OpencodeSettingsTab.test.ts
@@ -420,6 +420,10 @@ function createContext(plugin: any) {
   };
 }
 
+async function flushPromises(): Promise<void> {
+  await new Promise<void>(resolve => setImmediate(resolve));
+}
+
 function findSetting(name: string): MockSettingRecord {
   const setting = createdSettings.find((candidate) => candidate.name === name);
   if (!setting) {
@@ -567,6 +571,7 @@ describe('OpencodeSettingsTab', () => {
     const catalogEl = findElement('details', 'claudian-provider-model-picker-catalog');
     catalogEl.open = true;
     await catalogEl.dispatchMockEvent('toggle');
+    await flushPromises();
 
     expect(mockRuntimeSyncConversationState).toHaveBeenCalledWith({
       providerState: { databasePath: ':memory:' },
@@ -688,8 +693,7 @@ describe('OpencodeSettingsTab', () => {
 
     checkboxEl.checked = true;
     await checkboxEl.dispatchMockEvent('change');
-    await Promise.resolve();
-    await Promise.resolve();
+    await flushPromises();
 
     expect(plugin.settings.providerConfigs.opencode.visibleModels).toEqual([
       'deepseek/deepseek-v4-pro',
@@ -720,6 +724,7 @@ describe('OpencodeSettingsTab', () => {
     const aliasInput = findElement('input', 'claudian-provider-model-picker-selected-alias');
     aliasInput.value = 'V4 Pro';
     await aliasInput.dispatchMockEvent('blur');
+    await flushPromises();
 
     expect(getOpencodeProviderSettings(plugin.settings).modelAliases).toEqual({
       'deepseek/deepseek-v4-pro': 'V4 Pro',

--- a/tests/unit/providers/pi/ui/PiSettingsTab.test.ts
+++ b/tests/unit/providers/pi/ui/PiSettingsTab.test.ts
@@ -343,6 +343,10 @@ function render(settings: Record<string, unknown>) {
   return context;
 }
 
+async function flushPromises(): Promise<void> {
+  await new Promise<void>(resolve => setImmediate(resolve));
+}
+
 function findSetting(name: string): MockSetting {
   const setting = [...createdSettings].reverse().find(entry => entry.name === name);
   if (!setting) {
@@ -450,6 +454,7 @@ describe('PiSettingsTab', () => {
     const context = render(settings);
 
     await findElement('button', 'claudian-provider-model-picker-action').dispatchMockEvent('click');
+    await flushPromises();
 
     expect(mockDiscoverModels).toHaveBeenCalledTimes(1);
     expect(getPiProviderSettings(settings).discoveredModels).toHaveLength(1);
@@ -458,6 +463,7 @@ describe('PiSettingsTab', () => {
 
     mockDiscoverModels.mockResolvedValueOnce({ diagnostics: 'not logged in', models: [] });
     await findElement('button', 'claudian-provider-model-picker-action').dispatchMockEvent('click');
+    await flushPromises();
     expect(mockNotices[0]).toContain('not logged in');
   });
 
@@ -483,11 +489,13 @@ describe('PiSettingsTab', () => {
 
     checkboxEl.checked = true;
     await checkboxEl.dispatchMockEvent('change');
+    await flushPromises();
     expect(getPiProviderSettings(settings).visibleModels).toEqual(['pi:anthropic/claude-sonnet-4']);
 
     const aliasInput = findElement('input', 'claudian-provider-model-picker-selected-alias');
     aliasInput.value = 'Sonnet';
     await aliasInput.dispatchMockEvent('blur');
+    await flushPromises();
 
     expect(getPiProviderSettings(settings).modelAliases).toEqual({
       'pi:anthropic/claude-sonnet-4': 'Sonnet',


### PR DESCRIPTION
## Summary
- Normalize unknown Codex history rejection values into Error instances.
- Register void-returning model-picker DOM callbacks while preserving asynchronous persistence and discovery behavior.
- Add regression coverage and update provider tests for real DOM event semantics.

## Verification
- npm run typecheck && npm run lint && npm run test && npm run build