### PR TITLE
Feat (Codex): Render Structured Command Approvals with Readable Labels

### DIFF
--- a/src/core/runtime/types.ts
+++ b/src/core/runtime/types.ts
@@ -21,10 +21,22 @@ export interface ApprovalNetworkContext {
   protocol: string;
 }
 
+export interface ApprovalCommandDisplayAction {
+  label?: string;
+  command: string;
+}
+
+export interface ApprovalCommandDisplay {
+  actions: ApprovalCommandDisplayAction[];
+  exactCommand: string;
+}
+
 export interface ApprovalCallbackOptions {
   decisionReason?: string;
   blockedPath?: string;
   agentID?: string;
+  displayToolName?: string;
+  commandDisplay?: ApprovalCommandDisplay;
   decisionOptions?: ApprovalDecisionOption[];
   networkApprovalContext?: ApprovalNetworkContext;
   additionalPermissions?: unknown;

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -21,6 +21,7 @@ import {
 } from '../../../core/runtime/QueuedTurn';
 import type {
   ApprovalCallbackOptions,
+  ApprovalCommandDisplay,
   ApprovalDecisionOption,
   ChatRuntimeQueryOptions,
   ChatTurnRequest,
@@ -73,6 +74,91 @@ const DEFAULT_APPROVAL_DECISION_OPTIONS: ApprovalDecisionOption[] =
 
 function toError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
+}
+
+function renderApprovalCommandDisplay(
+  headerEl: HTMLElement,
+  display: ApprovalCommandDisplay,
+): void {
+  const suspicious = hasSuspiciousCommandText(display);
+  if (suspicious) {
+    headerEl.createDiv({
+      text: 'This command contains invisible or bidirectional control characters. Review the exact command carefully.',
+      cls: 'claudian-ask-approval-warning',
+    });
+  }
+
+  if (display.actions.length > 0) {
+    const actionListEl = headerEl.createDiv({
+      cls: 'claudian-ask-approval-command-list',
+    });
+    for (const action of display.actions) {
+      const actionEl = actionListEl.createDiv({
+        cls: 'claudian-ask-approval-command-action',
+      });
+      if (action.label) {
+        actionEl.createDiv({
+          text: action.label,
+          cls: 'claudian-ask-approval-command-label',
+        });
+      }
+      actionEl.createDiv({
+        text: action.command,
+        cls: 'claudian-ask-approval-readable-command',
+      });
+    }
+  }
+
+  if (!display.exactCommand) {
+    return;
+  }
+
+  if (display.actions.length === 0) {
+    headerEl.createDiv({
+      text: display.exactCommand,
+      cls: 'claudian-ask-approval-desc claudian-ask-approval-raw-command',
+    });
+    return;
+  }
+
+  const rawDetails = headerEl.createEl('details', {
+    cls: 'claudian-ask-approval-raw-details',
+  });
+  if (suspicious) {
+    rawDetails.setAttribute('open', '');
+  }
+  rawDetails.createEl('summary', {
+    text: 'Show exact command',
+    cls: 'claudian-ask-approval-raw-summary',
+  });
+  rawDetails.createDiv({
+    text: display.exactCommand,
+    cls: 'claudian-ask-approval-desc claudian-ask-approval-raw-command',
+  });
+}
+
+function hasSuspiciousCommandText(display: ApprovalCommandDisplay): boolean {
+  return [display.exactCommand, ...display.actions.map(action => action.command)]
+    .some(text => Array.from(text).some(isSuspiciousCommandCharacter));
+}
+
+function isSuspiciousCommandCharacter(character: string): boolean {
+  const codePoint = character.codePointAt(0);
+  if (codePoint === undefined) {
+    return false;
+  }
+
+  return codePoint <= 0x08
+    || codePoint === 0x0B
+    || codePoint === 0x0C
+    || (codePoint >= 0x0E && codePoint <= 0x1F)
+    || (codePoint >= 0x7F && codePoint <= 0x9F)
+    || codePoint === 0x061C
+    || (codePoint >= 0x200B && codePoint <= 0x200F)
+    || (codePoint >= 0x202A && codePoint <= 0x202E)
+    || codePoint === 0x2060
+    || (codePoint >= 0x2066 && codePoint <= 0x2069)
+    || codePoint === 0xFEFF;
 }
 
 export interface InputControllerDeps {
@@ -1458,7 +1544,10 @@ export class InputController {
     const iconEl = toolEl.createSpan({ cls: 'claudian-ask-approval-icon' });
     iconEl.setAttribute('aria-hidden', 'true');
     setToolIcon(iconEl, toolName);
-    toolEl.createSpan({ text: toolName, cls: 'claudian-ask-approval-tool-name' });
+    toolEl.createSpan({
+      text: approvalOptions?.displayToolName ?? toolName,
+      cls: 'claudian-ask-approval-tool-name',
+    });
 
     if (approvalOptions?.decisionReason) {
       headerEl.createDiv({ text: approvalOptions.decisionReason, cls: 'claudian-ask-approval-reason' });
@@ -1470,7 +1559,15 @@ export class InputController {
       headerEl.createDiv({ text: `Agent: ${approvalOptions.agentID}`, cls: 'claudian-ask-approval-agent' });
     }
 
-    headerEl.createDiv({ text: description, cls: 'claudian-ask-approval-desc' });
+    if (approvalOptions?.networkApprovalContext) {
+      headerEl.createDiv({ text: description, cls: 'claudian-ask-approval-desc' });
+    }
+
+    if (approvalOptions?.commandDisplay) {
+      renderApprovalCommandDisplay(headerEl, approvalOptions.commandDisplay);
+    } else if (!approvalOptions?.networkApprovalContext) {
+      headerEl.createDiv({ text: description, cls: 'claudian-ask-approval-desc' });
+    }
 
     const decisionOptions = approvalOptions?.decisionOptions ?? DEFAULT_APPROVAL_DECISION_OPTIONS;
     const optionDecisionMap = new Map<string, ApprovalDecision>();

--- a/src/providers/codex/runtime/CodexServerRequestRouter.ts
+++ b/src/providers/codex/runtime/CodexServerRequestRouter.ts
@@ -5,6 +5,7 @@ import type {
 } from '../../../core/runtime/types';
 import type { ApprovalDecision } from '../../../core/types';
 import { normalizeCodexToolName } from '../normalization/codexToolNormalization';
+import { buildCodexCommandApprovalDisplay } from './codexApprovalDisplay';
 import type {
   CommandApprovalRequest,
   CommandExecutionApprovalDecision,
@@ -88,6 +89,7 @@ export class CodexServerRequestRouter {
       proposedNetworkPolicyAmendments: params.proposedNetworkPolicyAmendments ?? null,
     };
     const description = describeCommandApproval(params);
+    const commandDisplay = buildCodexCommandApprovalDisplay(params);
 
     if (requestId !== undefined) {
       this.pendingApprovalRequests.set(requestId, params.threadId);
@@ -95,6 +97,8 @@ export class CodexServerRequestRouter {
 
     try {
       const decision = await this.approvalCallback(toolName, input, description, {
+        displayToolName: 'Command',
+        ...(commandDisplay ? { commandDisplay } : {}),
         ...(params.reason ? { decisionReason: params.reason } : {}),
         ...(params.networkApprovalContext ? { networkApprovalContext: params.networkApprovalContext } : {}),
         ...(params.additionalPermissions ? { additionalPermissions: params.additionalPermissions } : {}),

--- a/src/providers/codex/runtime/codexAppServerTypes.ts
+++ b/src/providers/codex/runtime/codexAppServerTypes.ts
@@ -153,10 +153,28 @@ export interface CommandExecutionItem {
   durationMs: number | null;
 }
 
-export interface CommandAction {
-  type: string;
-  command: string;
-}
+export type CommandAction =
+  | {
+    type: 'read';
+    command: string;
+    name: string;
+    path: string;
+  }
+  | {
+    type: 'listFiles';
+    command: string;
+    path: string | null;
+  }
+  | {
+    type: 'search';
+    command: string;
+    query: string | null;
+    path: string | null;
+  }
+  | {
+    type: 'unknown';
+    command: string;
+  };
 
 export interface FileChangeItem {
   type: 'fileChange';

--- a/src/providers/codex/runtime/codexApprovalDisplay.ts
+++ b/src/providers/codex/runtime/codexApprovalDisplay.ts
@@ -1,0 +1,62 @@
+import type {
+  ApprovalCommandDisplay,
+  ApprovalCommandDisplayAction,
+} from '../../../core/runtime/types';
+import type { CommandAction, CommandApprovalRequest } from './codexAppServerTypes';
+
+export function buildCodexCommandApprovalDisplay(
+  params: CommandApprovalRequest,
+): ApprovalCommandDisplay | undefined {
+  const exactCommand = params.command ?? '';
+  const actions = (params.commandActions ?? [])
+    .map(formatCommandAction)
+    .filter((action): action is ApprovalCommandDisplayAction => action !== null);
+
+  if (!exactCommand && actions.length === 0) {
+    return undefined;
+  }
+
+  return { actions, exactCommand };
+}
+
+function formatCommandAction(action: CommandAction): ApprovalCommandDisplayAction | null {
+  if (!action.command) {
+    return null;
+  }
+
+  switch (action.type) {
+    case 'read':
+      return {
+        label: action.name ? `Read ${action.name}` : 'Read file',
+        command: action.command,
+      };
+    case 'listFiles':
+      return {
+        label: action.path ? `List files in ${action.path}` : 'List files',
+        command: action.command,
+      };
+    case 'search':
+      return {
+        label: formatSearchLabel(action.query, action.path),
+        command: action.command,
+      };
+    case 'unknown':
+      return {
+        label: 'Command',
+        command: action.command,
+      };
+  }
+}
+
+function formatSearchLabel(query: string | null, path: string | null): string {
+  if (query && path) {
+    return `Search for ${query} in ${path}`;
+  }
+  if (query) {
+    return `Search for ${query}`;
+  }
+  if (path) {
+    return `Search in ${path}`;
+  }
+  return 'Search';
+}

--- a/src/style/features/ask-user-question.css
+++ b/src/style/features/ask-user-question.css
@@ -313,3 +313,54 @@
   color: var(--text-normal);
   word-break: break-all;
 }
+
+.claudian-ask-approval-warning {
+  padding: 8px 10px;
+  margin-bottom: 8px;
+  border: 1px solid var(--text-error);
+  border-radius: 6px;
+  color: var(--text-error);
+  font-size: 12px;
+}
+
+.claudian-ask-approval-command-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.claudian-ask-approval-command-action {
+  padding: 8px 10px;
+  background: var(--background-primary-alt);
+  border-radius: 6px;
+}
+
+.claudian-ask-approval-command-label {
+  margin-bottom: 4px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.claudian-ask-approval-readable-command,
+.claudian-ask-approval-raw-command {
+  font-family: var(--font-monospace);
+  font-size: 12px;
+  color: var(--text-normal);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.claudian-ask-approval-raw-details {
+  margin-top: 8px;
+}
+
+.claudian-ask-approval-raw-summary {
+  color: var(--text-muted);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.claudian-ask-approval-raw-details .claudian-ask-approval-raw-command {
+  margin-top: 6px;
+}

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -2524,6 +2524,105 @@ describe('InputController - Message Queue', () => {
       await approvalPromise;
     });
 
+    it('renders structured command actions with the exact command collapsed', async () => {
+      const parentEl = createMockEl();
+      const inputContainerEl = createMockEl();
+      (inputContainerEl as any).parentElement = parentEl;
+      deps.getInputContainerEl = () => inputContainerEl as any;
+
+      controller = new InputController(deps);
+
+      const approvalPromise = controller.handleApprovalRequest(
+        'Bash',
+        { command: 'powershell.exe -Command "Get-ChildItem -Force"' },
+        'Execute: powershell.exe -Command "Get-ChildItem -Force"',
+        {
+          displayToolName: 'Command',
+          commandDisplay: {
+            actions: [
+              { label: 'List files', command: 'Get-ChildItem -Force' },
+            ],
+            exactCommand: 'powershell.exe -Command "Get-ChildItem -Force"',
+          },
+        },
+      );
+
+      expect(parentEl.querySelector('claudian-ask-approval-tool-name')?.textContent)
+        .toBe('Command');
+      expect(parentEl.querySelector('claudian-ask-approval-command-label')?.textContent)
+        .toBe('List files');
+      expect(parentEl.querySelector('claudian-ask-approval-readable-command')?.textContent)
+        .toBe('Get-ChildItem -Force');
+      expect(parentEl.querySelector('claudian-ask-approval-raw-command')?.textContent)
+        .toBe('powershell.exe -Command "Get-ChildItem -Force"');
+      expect(parentEl.querySelector('claudian-ask-approval-warning')).toBeNull();
+
+      controller.dismissPendingApproval();
+      await approvalPromise;
+    });
+
+    it('shows unsupported commands neutrally without a security warning', async () => {
+      const parentEl = createMockEl();
+      const inputContainerEl = createMockEl();
+      (inputContainerEl as any).parentElement = parentEl;
+      deps.getInputContainerEl = () => inputContainerEl as any;
+
+      controller = new InputController(deps);
+
+      const approvalPromise = controller.handleApprovalRequest(
+        'Bash',
+        { command: 'Write-Output "hello"' },
+        'Execute: Write-Output "hello"',
+        {
+          commandDisplay: {
+            actions: [],
+            exactCommand: 'Write-Output "hello"',
+          },
+        },
+      );
+
+      expect(parentEl.querySelector('claudian-ask-approval-raw-command')?.textContent)
+        .toBe('Write-Output "hello"');
+      expect(parentEl.querySelector('claudian-ask-approval-warning')).toBeNull();
+
+      controller.dismissPendingApproval();
+      await approvalPromise;
+    });
+
+    it('exposes the exact command and warns for invisible spoofing characters', async () => {
+      const parentEl = createMockEl();
+      const inputContainerEl = createMockEl();
+      (inputContainerEl as any).parentElement = parentEl;
+      deps.getInputContainerEl = () => inputContainerEl as any;
+
+      controller = new InputController(deps);
+
+      const exactCommand = 'Write-Output safe\u202Etxt.exe';
+      const approvalPromise = controller.handleApprovalRequest(
+        'Bash',
+        { command: exactCommand },
+        `Execute: ${exactCommand}`,
+        {
+          commandDisplay: {
+            actions: [
+              { label: 'Command', command: 'Write-Output safe.txt' },
+            ],
+            exactCommand,
+          },
+        },
+      );
+
+      expect(parentEl.querySelector('claudian-ask-approval-warning')?.textContent)
+        .toContain('invisible or bidirectional');
+      expect(parentEl.querySelector('claudian-ask-approval-raw-details')?.getAttribute('open'))
+        .toBe('');
+      expect(parentEl.querySelector('claudian-ask-approval-raw-command')?.textContent)
+        .toBe(exactCommand);
+
+      controller.dismissPendingApproval();
+      await approvalPromise;
+    });
+
     it('should render provider-supplied approval options and network-specific context', async () => {
       const parentEl = createMockEl();
       const inputContainerEl = createMockEl();

--- a/tests/unit/providers/codex/runtime/CodexServerRequestRouter.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexServerRequestRouter.test.ts
@@ -31,14 +31,30 @@ describe('CodexServerRequestRouter', () => {
       mockApprovalCallback.mockResolvedValue('allow');
       const result = await router.handleServerRequest(
         'item/commandExecution/requestApproval',
-        baseParams,
+        {
+          ...baseParams,
+          command: 'powershell.exe -Command "Get-ChildItem -Force"',
+          commandActions: [
+            { type: 'listFiles', command: 'Get-ChildItem -Force', path: null },
+          ],
+        },
       );
 
       expect(mockApprovalCallback).toHaveBeenCalledWith(
         'Bash',
-        expect.objectContaining({ command: 'echo test' }),
+        expect.objectContaining({
+          command: 'powershell.exe -Command "Get-ChildItem -Force"',
+        }),
         expect.any(String),
-        expect.any(Object),
+        expect.objectContaining({
+          displayToolName: 'Command',
+          commandDisplay: {
+            actions: [
+              { label: 'List files', command: 'Get-ChildItem -Force' },
+            ],
+            exactCommand: 'powershell.exe -Command "Get-ChildItem -Force"',
+          },
+        }),
       );
       expect(result).toEqual({ decision: 'accept' });
     });

--- a/tests/unit/providers/codex/runtime/codexApprovalDisplay.test.ts
+++ b/tests/unit/providers/codex/runtime/codexApprovalDisplay.test.ts
@@ -1,0 +1,65 @@
+import { buildCodexCommandApprovalDisplay } from '@/providers/codex/runtime/codexApprovalDisplay';
+
+describe('buildCodexCommandApprovalDisplay', () => {
+  it('uses Codex command actions as the readable display and preserves the exact command', () => {
+    expect(buildCodexCommandApprovalDisplay({
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      itemId: 'item-1',
+      command: 'powershell.exe -Command "Get-ChildItem -Force"',
+      cwd: 'C:\\workspace',
+      commandActions: [
+        { type: 'listFiles', command: 'Get-ChildItem -Force', path: null },
+      ],
+    })).toEqual({
+      actions: [
+        { label: 'List files', command: 'Get-ChildItem -Force' },
+      ],
+      exactCommand: 'powershell.exe -Command "Get-ChildItem -Force"',
+    });
+  });
+
+  it('keeps multiple semantic actions in execution order', () => {
+    expect(buildCodexCommandApprovalDisplay({
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      itemId: 'item-1',
+      command: 'wrapped command',
+      cwd: '/workspace',
+      commandActions: [
+        {
+          type: 'search',
+          command: 'rg "TODO" src',
+          query: 'TODO',
+          path: 'src',
+        },
+        {
+          type: 'read',
+          command: 'Get-Content src/app.ts',
+          name: 'app.ts',
+          path: 'C:\\workspace\\src\\app.ts',
+        },
+      ],
+    })).toEqual({
+      actions: [
+        { label: 'Search for TODO in src', command: 'rg "TODO" src' },
+        { label: 'Read app.ts', command: 'Get-Content src/app.ts' },
+      ],
+      exactCommand: 'wrapped command',
+    });
+  });
+
+  it('returns only the exact command when Codex cannot parse semantic actions', () => {
+    expect(buildCodexCommandApprovalDisplay({
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      itemId: 'item-1',
+      command: 'Write-Output "hello"',
+      cwd: 'C:\\workspace',
+      commandActions: null,
+    })).toEqual({
+      actions: [],
+      exactCommand: 'Write-Output "hello"',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

A small, self-contained enhancement to how Codex command-execution approvals
are presented. Codex already sends structured `commandActions` with each
approval request, but they're currently typed loosely (`{ type: string;
command: string }`) and the approval dialog shows only the raw command string.
This adds the missing presentation layer, so the person approving a command
sees what it will actually do in plain language, with the exact command always
shown alongside.

## What changes

**Before:** the approval prompt shows the raw command text.

**After:** the prompt shows labeled actions derived from the structured data,
for example:

- "Read src/main.ts"
- "List files in ./src"
- "Search for TODO in ./src"

with the exact command rendered underneath, unchanged.

**Implementation:**

- Narrow `CommandAction` into a discriminated union that mirrors the real
  payload (`read` / `listFiles` / `search` / `unknown`), carrying the fields
  each variant provides (`name`, `path`, `query`).
- Add `buildCodexCommandApprovalDisplay` plus the `ApprovalCommandDisplay`
  runtime types that turn those actions into readable labels while preserving
  `exactCommand`.
- Pass the built `commandDisplay` through `CodexServerRequestRouter` into the
  approval callback, and render the labeled actions in the InputController
  approval dialog (with styles for the action list).

## Security note (please review this part)

This lives on the human-in-the-loop approval path, which is a sensitive trust
boundary: the labels are built from data the agent supplies, so a crafted
payload could in principle try to make a command read as more benign than it
is. The design mitigates that by **always rendering the exact command
(`exactCommand`) next to the friendly labels**, so the operator's decision is
anchored on the real command, never on the label alone. The `unknown` variant
is a deliberate catch-all: unrecognized action types fall back to the raw
command rather than being dropped or mislabeled.

I'd genuinely appreciate a careful look at this boundary, and I'm happy to
adjust the presentation (for example, making the exact command more prominent
than the labels) if you'd prefer a different emphasis.

## Testing

- `npm run typecheck`: clean.
- Unit tests added for `codexApprovalDisplay` (label formatting per action
  type plus the unknown fallback) and updated `CodexServerRequestRouter` /
  `InputController` tests. The Codex-related suites pass (160 tests).

## Notes

Backward-compatible with the existing consumer (`CodexNotificationRouter` still
reads `commandActions[0].command`). First time contributing to this area, so
happy to tweak naming, labels, or structure to fit the project's conventions.