### PR TITLE
fix: honor Claude config directory

### DIFF
--- a/src/app/conversations/ConversationRepository.ts
+++ b/src/app/conversations/ConversationRepository.ts
@@ -2,7 +2,7 @@ import { normalizeProviderModelSelection, resolveConversationModel } from '../..
 import { getRuntimeEnvironmentVariables } from '../../core/providers/providerEnvironment';
 import { ProviderRegistry } from '../../core/providers/ProviderRegistry';
 import { ProviderSettingsCoordinator } from '../../core/providers/ProviderSettingsCoordinator';
-import type { AppSessionStorage } from '../../core/providers/types';
+import type { AppSessionStorage, ProviderHistoryPathContext } from '../../core/providers/types';
 import { DEFAULT_CHAT_PROVIDER_ID, type ProviderId } from '../../core/providers/types';
 import type { Conversation, ConversationMeta } from '../../core/types';
 import { extractUserDisplayContent } from '../../utils/context';
@@ -97,9 +97,14 @@ export class ConversationRepository {
     this.conversations.splice(index, 1);
 
     if (options.deleteProviderSession !== false) {
+      const vaultPath = this.deps.getVaultPath();
       await ProviderRegistry
         .getConversationHistoryService(conversation.providerId)
-        .deleteConversationSession(conversation, this.deps.getVaultPath());
+        .deleteConversationSession(
+          conversation,
+          vaultPath,
+          this.getHistoryPathContext(conversation.providerId, vaultPath),
+        );
     }
 
     await this.deps.sessions.deleteMetadata(id);
@@ -119,11 +124,13 @@ export class ConversationRepository {
     const previousSessionId = conversation.sessionId;
     const previousProviderState = conversation.providerState;
     const previousResumeAtMessageId = conversation.resumeAtMessageId;
+    const vaultPath = this.deps.getVaultPath();
     try {
       const resolution = await historyService.resolveMissingConversationSession(
         conversation,
-        this.deps.getVaultPath(),
+        vaultPath,
         missingProviderSessionId,
+        this.getHistoryPathContext(conversation.providerId, vaultPath),
       );
       if (resolution === 'delete') {
         await this.delete(id, { deleteProviderSession: false });
@@ -209,11 +216,14 @@ export class ConversationRepository {
     const historyService = ProviderRegistry.getConversationHistoryService(conversation.providerId);
     if (!historyService.getConversationSessionAvailability) return;
 
+    const vaultPath = this.deps.getVaultPath();
+    const pathContext = this.getHistoryPathContext(conversation.providerId, vaultPath);
     let availability;
     try {
       availability = await historyService.getConversationSessionAvailability(
         conversation,
-        this.deps.getVaultPath(),
+        vaultPath,
+        pathContext,
       );
     } catch {
       return;
@@ -224,7 +234,11 @@ export class ConversationRepository {
     const previousProviderState = conversation.providerState;
     const previousResumeAtMessageId = conversation.resumeAtMessageId;
     try {
-      if (await historyService.prepareRelocatedConversationSession(conversation, this.deps.getVaultPath())) {
+      if (await historyService.prepareRelocatedConversationSession(
+        conversation,
+        vaultPath,
+        pathContext,
+      )) {
         await this.save(conversation);
       }
     } catch {
@@ -247,19 +261,30 @@ export class ConversationRepository {
   }
 
   private async hydrate(conversation: Conversation): Promise<void> {
-    const settings = this.deps.getSettings();
     const vaultPath = this.deps.getVaultPath();
     await ProviderRegistry
       .getConversationHistoryService(conversation.providerId)
-      .hydrateConversationHistory(conversation, vaultPath, {
-        environment: {
-          ...process.env,
-          ...getRuntimeEnvironmentVariables(settings, conversation.providerId),
-        },
-        hostPlatform: process.platform,
-        settings,
+      .hydrateConversationHistory(
+        conversation,
         vaultPath,
-      });
+        this.getHistoryPathContext(conversation.providerId, vaultPath),
+      );
+  }
+
+  private getHistoryPathContext(
+    providerId: ProviderId,
+    vaultPath: string | null = this.deps.getVaultPath(),
+  ): ProviderHistoryPathContext {
+    const settings = this.deps.getSettings();
+    return {
+      environment: {
+        ...process.env,
+        ...getRuntimeEnvironmentVariables(settings, providerId),
+      },
+      hostPlatform: process.platform,
+      settings,
+      vaultPath,
+    };
   }
 
   private save(conversation: Conversation): Promise<void> {

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -438,17 +438,20 @@ export interface ProviderConversationHistoryService {
   getConversationSessionAvailability?(
     conversation: Conversation,
     vaultPath: string | null,
+    pathContext?: ProviderHistoryPathContext,
   ): Promise<ProviderConversationSessionAvailability>;
   /** Clears stale resume state so relocated provider history can rebuild natively. */
   prepareRelocatedConversationSession?(
     conversation: Conversation,
     vaultPath: string | null,
+    pathContext?: ProviderHistoryPathContext,
   ): Promise<boolean>;
   /** Decides whether a confirmed missing resume session makes the whole record disposable. */
   resolveMissingConversationSession?(
     conversation: Conversation,
     vaultPath: string | null,
     missingProviderSessionId?: string,
+    pathContext?: ProviderHistoryPathContext,
   ): Promise<'delete' | 'reset' | 'preserve'>;
   hydrateConversationHistory(
     conversation: Conversation,
@@ -458,6 +461,7 @@ export interface ProviderConversationHistoryService {
   deleteConversationSession(
     conversation: Conversation,
     vaultPath: string | null,
+    pathContext?: ProviderHistoryPathContext,
   ): Promise<void>;
   resolveSessionIdForConversation(conversation: Conversation | null): string | null;
   isPendingForkConversation(conversation: Conversation): boolean;

--- a/src/main.ts
+++ b/src/main.ts
@@ -449,6 +449,7 @@ export default class ClaudianPlugin extends Plugin {
             `${ProviderRegistry.getProviderDisplayName(providerId)}: ${result.diagnostics}`,
           );
         }
+        await ProviderWorkspaceRegistry.refreshAgentMentions(providerId);
       }
     }
     if (invalidatedConversations.length > 0) {
@@ -459,71 +460,19 @@ export default class ClaudianPlugin extends Plugin {
       }
     }
 
-    const view = this.getView();
-    const tabManager = view?.getTabManager();
-
-    if (tabManager) {
-      const affectedTabs = tabManager.getAllTabs().filter((tab) => (
-        affectedProviderIds.includes(tab.providerId ?? DEFAULT_CHAT_PROVIDER_ID)
-      ));
-      const syncTabRuntimeState = (tab: (typeof affectedTabs)[number]): void => {
-        if (!tab.service || !tab.serviceInitialized) {
-          return;
-        }
-
-        const conversation = tab.conversationId
-          ? this.getConversationSync(tab.conversationId)
-          : null;
-        const hasConversationContext = (conversation?.messages.length ?? 0) > 0;
-        const externalContextPaths = tab.ui.externalContextSelector?.getExternalContexts()
-          ?? (hasConversationContext
-            ? conversation?.externalContextPaths ?? []
-            : this.settings.persistentExternalContextPaths ?? []);
-
-        tab.service.syncConversationState(conversation, externalContextPaths);
-      };
-
-      for (const tab of affectedTabs) {
-        if (tab.state.isStreaming) {
-          tab.controllers.inputController?.cancelStreaming();
-        }
-      }
-
-      let failedTabs = 0;
-      if (changed) {
-        for (const tab of affectedTabs) {
-          if (!tab.service || !tab.serviceInitialized) {
-            continue;
-          }
-          try {
-            syncTabRuntimeState(tab);
-            tab.service.resetSession();
-            await tab.service.ensureReady();
-          } catch {
-            failedTabs++;
-          }
-        }
-      } else {
-        for (const tab of affectedTabs) {
-          if (!tab.service || !tab.serviceInitialized) {
-            continue;
-          }
-          try {
-            syncTabRuntimeState(tab);
-            await tab.service.ensureReady({ force: true });
-          } catch {
-            failedTabs++;
-          }
-        }
-      }
-      if (failedTabs > 0) {
-        new Notice(`Environment changes applied, but ${failedTabs} affected tab(s) failed to restart.`);
-      }
-    }
-
-    for (const openView of this.getAllViews()) {
+    const openViews = this.getAllViews();
+    let failedTabs = 0;
+    for (const openView of openViews) {
+      failedTabs += await this.restartEnvironmentAffectedRuntimes(
+        openView,
+        affectedProviderIds,
+        changed,
+      );
       openView.invalidateProviderCommandCaches(affectedProviderIds);
       openView.refreshModelSelector();
+    }
+    if (failedTabs > 0) {
+      new Notice(`Environment changes applied, but ${failedTabs} affected tab(s) failed to restart.`);
     }
 
     const noticeText = changed
@@ -533,6 +482,56 @@ export default class ClaudianPlugin extends Plugin {
     if (modelCatalogDiagnostics.length > 0) {
       new Notice(`Model catalog refresh failed:\n${modelCatalogDiagnostics.join('\n')}`);
     }
+  }
+
+  private async restartEnvironmentAffectedRuntimes(
+    view: ClaudianView,
+    affectedProviderIds: ProviderId[],
+    resetSessions: boolean,
+  ): Promise<number> {
+    const tabManager = view.getTabManager();
+    if (!tabManager) return 0;
+
+    const affectedTabs = tabManager.getAllTabs().filter((tab) => (
+      affectedProviderIds.includes(tab.providerId ?? DEFAULT_CHAT_PROVIDER_ID)
+    ));
+    const syncTabRuntimeState = (tab: (typeof affectedTabs)[number]): void => {
+      if (!tab.service || !tab.serviceInitialized) return;
+
+      const conversation = tab.conversationId
+        ? this.getConversationSync(tab.conversationId)
+        : null;
+      const hasConversationContext = (conversation?.messages.length ?? 0) > 0;
+      const externalContextPaths = tab.ui.externalContextSelector?.getExternalContexts()
+        ?? (hasConversationContext
+          ? conversation?.externalContextPaths ?? []
+          : this.settings.persistentExternalContextPaths ?? []);
+
+      tab.service.syncConversationState(conversation, externalContextPaths);
+    };
+
+    for (const tab of affectedTabs) {
+      if (tab.state.isStreaming) {
+        tab.controllers.inputController?.cancelStreaming();
+      }
+    }
+
+    let failedTabs = 0;
+    for (const tab of affectedTabs) {
+      if (!tab.service || !tab.serviceInitialized) continue;
+      try {
+        syncTabRuntimeState(tab);
+        if (resetSessions) {
+          tab.service.resetSession();
+          await tab.service.ensureReady();
+        } else {
+          await tab.service.ensureReady({ force: true });
+        }
+      } catch {
+        failedTabs++;
+      }
+    }
+    return failedTabs;
   }
 
   /** Returns the runtime environment variables (fixed at plugin load). */

--- a/src/providers/claude/agents/AgentManager.ts
+++ b/src/providers/claude/agents/AgentManager.ts
@@ -3,18 +3,17 @@
  * 0. Built-in agents: dynamically provided via SDK init message
  * 1. Plugin agents: {installPath}/agents/*.md (namespaced as plugin-name:agent-name)
  * 2. Vault agents: {vaultPath}/.claude/agents/*.md
- * 3. Global agents: ~/.claude/agents/*.md
+ * 3. Global agents: {CLAUDE_CONFIG_DIR}/agents/*.md
  */
 
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 
 import type { AgentDefinition, AgentFrontmatter } from '../../../core/types';
+import { resolveClaudeConfigDir } from '../config/ClaudeConfigDir';
 import type { PluginManager } from '../plugins/PluginManager';
 import { buildAgentFromFrontmatter, parseAgentFile } from './AgentStorage';
 
-const GLOBAL_AGENTS_DIR = path.join(os.homedir(), '.claude', 'agents');
 const VAULT_AGENTS_DIR = '.claude/agents';
 const PLUGIN_AGENTS_DIR = 'agents';
 
@@ -47,10 +46,16 @@ export class AgentManager {
   private builtinAgentNames: string[] = FALLBACK_BUILTIN_AGENT_NAMES;
   private vaultPath: string;
   private pluginManager: PluginManager;
+  private resolveConfigDir: () => string;
 
-  constructor(vaultPath: string, pluginManager: PluginManager) {
+  constructor(
+    vaultPath: string,
+    pluginManager: PluginManager,
+    configDir: string | (() => string) = () => resolveClaudeConfigDir(),
+  ) {
     this.vaultPath = vaultPath;
     this.pluginManager = pluginManager;
+    this.resolveConfigDir = typeof configDir === 'function' ? configDir : () => configDir;
   }
 
   /** Built-in agents are those from init that are NOT loaded from files. */
@@ -116,7 +121,7 @@ export class AgentManager {
   }
 
   private loadGlobalAgents(): void {
-    this.loadAgentsFromDirectory(GLOBAL_AGENTS_DIR, 'global');
+    this.loadAgentsFromDirectory(path.join(this.resolveConfigDir(), 'agents'), 'global');
   }
 
   private loadAgentsFromDirectory(

--- a/src/providers/claude/app/ClaudeWorkspaceServices.ts
+++ b/src/providers/claude/app/ClaudeWorkspaceServices.ts
@@ -12,10 +12,12 @@ import type {
   ProviderWorkspaceServices,
 } from '../../../core/providers/types';
 import type { VaultFileAdapter } from '../../../core/storage/VaultFileAdapter';
+import { parseEnvironmentVariables } from '../../../utils/env';
 import { getVaultPath } from '../../../utils/path';
 import { AgentManager } from '../agents/AgentManager';
 import { ClaudeCommandCatalog } from '../commands/ClaudeCommandCatalog';
 import { probeRuntimeCommands } from '../commands/probeRuntimeCommands';
+import { resolveClaudeConfigDir } from '../config/ClaudeConfigDir';
 import { PluginManager } from '../plugins/PluginManager';
 import { ClaudeCliResolver } from '../runtime/ClaudeCliResolver';
 import { StorageService } from '../storage/StorageService';
@@ -46,11 +48,23 @@ export async function createClaudeWorkspaceServices(
   await mcpManager.loadServers();
 
   const vaultPath = getVaultPath(plugin.app) ?? '';
-  const pluginManager = new PluginManager(vaultPath, claudeStorage.ccSettings);
+  const getClaudeConfigDir = () => resolveClaudeConfigDir({
+    environment: {
+      ...process.env,
+      ...parseEnvironmentVariables(plugin.getActiveEnvironmentVariables('claude')),
+    },
+    hostPlatform: process.platform,
+    vaultPath,
+  });
+  const pluginManager = new PluginManager(
+    vaultPath,
+    claudeStorage.ccSettings,
+    getClaudeConfigDir,
+  );
   await pluginManager.loadPlugins();
 
   const agentStorage = claudeStorage.agents;
-  const agentManager = new AgentManager(vaultPath, pluginManager);
+  const agentManager = new AgentManager(vaultPath, pluginManager, getClaudeConfigDir);
   await agentManager.loadAgents();
 
   const commandCatalog = new ClaudeCommandCatalog(
@@ -72,6 +86,7 @@ export async function createClaudeWorkspaceServices(
     agentMentionProvider: agentManager,
     settingsTabRenderer: claudeSettingsTabRenderer,
     refreshAgentMentions: async () => {
+      await pluginManager.loadPlugins();
       await agentManager.loadAgents();
     },
   };

--- a/src/providers/claude/config/ClaudeConfigDir.ts
+++ b/src/providers/claude/config/ClaudeConfigDir.ts
@@ -1,0 +1,52 @@
+import * as os from 'os';
+import * as path from 'path';
+
+export interface ClaudeConfigDirContext {
+  environment?: NodeJS.ProcessEnv;
+  hostPlatform?: NodeJS.Platform;
+  vaultPath?: string | null;
+}
+
+function resolveSdkHomeDir(
+  environment: NodeJS.ProcessEnv,
+  hostPlatform: NodeJS.Platform,
+): string {
+  if (hostPlatform === 'win32') {
+    if (environment.USERPROFILE !== undefined) {
+      return environment.USERPROFILE;
+    }
+    if (environment.HOMEDRIVE !== undefined && environment.HOMEPATH !== undefined) {
+      return `${environment.HOMEDRIVE}${environment.HOMEPATH}`;
+    }
+  } else if (environment.HOME !== undefined) {
+    return environment.HOME;
+  }
+
+  return os.homedir();
+}
+
+function resolveFromSdkWorkingDirectory(
+  value: string,
+  vaultPath?: string | null,
+): string {
+  const normalizedValue = value.normalize('NFC');
+  return path.isAbsolute(normalizedValue)
+    ? path.normalize(normalizedValue)
+    : path.resolve(vaultPath ?? process.cwd(), normalizedValue);
+}
+
+export function resolveClaudeConfigDir(context?: ClaudeConfigDirContext): string {
+  const environment = context?.environment ?? process.env;
+  const configuredDir = environment.CLAUDE_CONFIG_DIR;
+  if (configuredDir === undefined) {
+    const homeDir = context?.environment
+      ? resolveSdkHomeDir(environment, context.hostPlatform ?? process.platform)
+      : os.homedir();
+    return resolveFromSdkWorkingDirectory(
+      path.join(homeDir, '.claude'),
+      context?.vaultPath,
+    );
+  }
+
+  return resolveFromSdkWorkingDirectory(configuredDir, context?.vaultPath);
+}

--- a/src/providers/claude/history/ClaudeConversationHistoryService.ts
+++ b/src/providers/claude/history/ClaudeConversationHistoryService.ts
@@ -1,6 +1,7 @@
 import type {
   ProviderConversationHistoryService,
   ProviderConversationSessionAvailability,
+  ProviderHistoryPathContext,
 } from '../../../core/providers/types';
 import { isSubagentToolName, TOOL_TASK } from '../../../core/tools/toolNames';
 import type {
@@ -15,6 +16,8 @@ import type {
 import { type ClaudeProviderState, getClaudeState } from '../types/providerState';
 import {
   deleteSDKSession,
+  encodeVaultPathForSDK,
+  getSDKProjectsPath,
   loadSDKSessionMessages,
   loadSubagentToolCalls,
   locateSDKSession,
@@ -222,6 +225,7 @@ async function enrichAsyncSubagentToolCalls(
   vaultPath: string,
   sessionIds: string[],
   relocatedSessionPaths: Map<string, string>,
+  pathContext?: ProviderHistoryPathContext,
 ): Promise<void> {
   const uniqueSessionIds = [...new Set(sessionIds)];
   if (uniqueSessionIds.length === 0) return;
@@ -239,9 +243,22 @@ async function enrichAsyncSubagentToolCalls(
       let loader = loaderCache.get(cacheKey);
       if (!loader) {
         const relocatedSessionPath = relocatedSessionPaths.get(sessionId);
-        loader = relocatedSessionPath
-          ? loadSubagentToolCalls(vaultPath, sessionId, subagent.agentId, relocatedSessionPath)
-          : loadSubagentToolCalls(vaultPath, sessionId, subagent.agentId);
+        if (pathContext) {
+          loader = loadSubagentToolCalls(
+            vaultPath,
+            sessionId,
+            subagent.agentId,
+            relocatedSessionPath,
+            pathContext,
+          );
+        } else {
+          loader = loadSubagentToolCalls(
+            vaultPath,
+            sessionId,
+            subagent.agentId,
+            relocatedSessionPath,
+          );
+        }
         loaderCache.set(cacheKey, loader);
       }
 
@@ -369,6 +386,7 @@ function sanitizeProviderState(
 
 export class ClaudeConversationHistoryService implements ProviderConversationHistoryService {
   private hydratedConversationIds = new Set<string>();
+  private historyCacheKeysByConversation = new Map<string, string>();
   private pendingSessionLocationsByConversation = new Map<
     string,
     Map<string, SDKSessionLocation>
@@ -387,16 +405,43 @@ export class ClaudeConversationHistoryService implements ProviderConversationHis
     ].filter((id): id is string => !!id))];
   }
 
+  private synchronizeHistoryCache(
+    conversation: Conversation,
+    vaultPath: string,
+    pathContext?: ProviderHistoryPathContext,
+  ): void {
+    const state = getClaudeState(conversation.providerState);
+    const cacheKey = JSON.stringify([
+      getSDKProjectsPath(pathContext),
+      encodeVaultPathForSDK(vaultPath),
+      this.getConversationSessionIds(conversation),
+      conversation.resumeAtMessageId ?? null,
+      state.forkSource?.resumeAt ?? null,
+    ]);
+    const previousKey = this.historyCacheKeysByConversation.get(conversation.id);
+    if (previousKey !== undefined && previousKey !== cacheKey) {
+      this.hydratedConversationIds.delete(conversation.id);
+      this.pendingSessionLocationsByConversation.delete(conversation.id);
+      this.relocatedSessionPathsByConversation.delete(conversation.id);
+    }
+    this.historyCacheKeysByConversation.set(conversation.id, cacheKey);
+  }
+
   async getConversationSessionAvailability(
     conversation: Conversation,
     vaultPath: string | null,
+    pathContext?: ProviderHistoryPathContext,
   ): Promise<ProviderConversationSessionAvailability> {
     const sessionId = this.resolveSessionIdForConversation(conversation);
-    if (!vaultPath || !sessionId) {
+    if (!vaultPath) {
       return 'unknown';
     }
+    this.synchronizeHistoryCache(conversation, vaultPath, pathContext);
+    if (!sessionId) return 'unknown';
 
-    const location = await locateSDKSession(vaultPath, sessionId);
+    const location = await (pathContext
+      ? locateSDKSession(vaultPath, sessionId, pathContext)
+      : locateSDKSession(vaultPath, sessionId));
     this.pendingSessionLocationsByConversation.set(
       conversation.id,
       new Map([[sessionId, location]]),
@@ -430,13 +475,14 @@ export class ClaudeConversationHistoryService implements ProviderConversationHis
   async prepareRelocatedConversationSession(
     conversation: Conversation,
     vaultPath: string | null,
+    pathContext?: ProviderHistoryPathContext,
   ): Promise<boolean> {
     const sessionId = this.resolveSessionIdForConversation(conversation);
     if (!vaultPath || !sessionId) {
       return false;
     }
 
-    await this.hydrateConversationHistory(conversation, vaultPath);
+    await this.hydrateConversationHistory(conversation, vaultPath, pathContext);
     if (!this.hydratedConversationIds.has(conversation.id)) {
       return false;
     }
@@ -461,6 +507,7 @@ export class ClaudeConversationHistoryService implements ProviderConversationHis
     conversation: Conversation,
     vaultPath: string | null,
     missingProviderSessionId?: string,
+    pathContext?: ProviderHistoryPathContext,
   ): Promise<'delete' | 'reset' | 'preserve'> {
     const currentSessionId = this.resolveSessionIdForConversation(conversation);
     if (
@@ -472,8 +519,12 @@ export class ClaudeConversationHistoryService implements ProviderConversationHis
       return 'preserve';
     }
 
+    this.synchronizeHistoryCache(conversation, vaultPath, pathContext);
+
     const sessionIds = this.getConversationSessionIds(conversation);
-    const locations = await locateSDKSessions(vaultPath, sessionIds);
+    const locations = await (pathContext
+      ? locateSDKSessions(vaultPath, sessionIds, pathContext)
+      : locateSDKSessions(vaultPath, sessionIds));
     const preservedSessionIds = sessionIds.filter(
       sessionId => locations.get(sessionId)?.availability !== 'missing',
     );
@@ -543,10 +594,13 @@ export class ClaudeConversationHistoryService implements ProviderConversationHis
   async hydrateConversationHistory(
     conversation: Conversation,
     vaultPath: string | null,
+    pathContext?: ProviderHistoryPathContext,
   ): Promise<void> {
-    if (!vaultPath || this.hydratedConversationIds.has(conversation.id)) {
+    if (!vaultPath) {
       return;
     }
+    this.synchronizeHistoryCache(conversation, vaultPath, pathContext);
+    if (this.hydratedConversationIds.has(conversation.id)) return;
 
     const state = getClaudeState(conversation.providerState);
     const isPendingFork = this.isPendingForkConversation(conversation);
@@ -571,7 +625,9 @@ export class ClaudeConversationHistoryService implements ProviderConversationHis
     const unresolvedSessionIds = allSessionIds.filter(
       id => !relocatedSessionPaths.has(id) && !cachedLocations.has(id),
     );
-    const locatedSessions = await locateSDKSessions(vaultPath, unresolvedSessionIds);
+    const locatedSessions = await (pathContext
+      ? locateSDKSessions(vaultPath, unresolvedSessionIds, pathContext)
+      : locateSDKSessions(vaultPath, unresolvedSessionIds));
     const resolvedLocations = new Map([...cachedLocations, ...locatedSessions]);
     for (const [sessionId, location] of locatedSessions) {
       if (location.availability === 'relocated' && location.sessionPath) {
@@ -607,9 +663,17 @@ export class ClaudeConversationHistoryService implements ProviderConversationHis
         ? (isPendingFork ? state.forkSource!.resumeAt : conversation.resumeAtMessageId)
         : undefined;
       const sessionPathOverride = relocatedSessionPaths.get(sessionId);
-      const result = sessionPathOverride
-        ? await loadSDKSessionMessages(vaultPath, sessionId, truncateAt, sessionPathOverride)
-        : await loadSDKSessionMessages(vaultPath, sessionId, truncateAt);
+      const result = pathContext
+        ? await loadSDKSessionMessages(
+          vaultPath,
+          sessionId,
+          truncateAt,
+          sessionPathOverride,
+          pathContext,
+        )
+        : sessionPathOverride
+          ? await loadSDKSessionMessages(vaultPath, sessionId, truncateAt, sessionPathOverride)
+          : await loadSDKSessionMessages(vaultPath, sessionId, truncateAt);
 
       if (result.error) {
         errorCount++;
@@ -638,6 +702,7 @@ export class ClaudeConversationHistoryService implements ProviderConversationHis
         vaultPath,
         allSessionIds,
         relocatedSessionPaths,
+        pathContext,
       );
       applySubagentData(merged, state.subagentData);
     }
@@ -651,16 +716,22 @@ export class ClaudeConversationHistoryService implements ProviderConversationHis
   async deleteConversationSession(
     conversation: Conversation,
     vaultPath: string | null,
+    pathContext?: ProviderHistoryPathContext,
   ): Promise<void> {
     this.pendingSessionLocationsByConversation.delete(conversation.id);
     this.relocatedSessionPathsByConversation.delete(conversation.id);
     this.hydratedConversationIds.delete(conversation.id);
+    this.historyCacheKeysByConversation.delete(conversation.id);
     const state = getClaudeState(conversation.providerState);
     const sessionId = state.providerSessionId ?? conversation.sessionId;
     if (!vaultPath || !sessionId) {
       return;
     }
 
-    await deleteSDKSession(vaultPath, sessionId);
+    if (pathContext) {
+      await deleteSDKSession(vaultPath, sessionId, pathContext);
+    } else {
+      await deleteSDKSession(vaultPath, sessionId);
+    }
   }
 }

--- a/src/providers/claude/history/ClaudeHistoryStore.ts
+++ b/src/providers/claude/history/ClaudeHistoryStore.ts
@@ -1,3 +1,4 @@
+import type { ProviderHistoryPathContext } from '../../../core/providers/types';
 import { isSubagentToolName } from '../../../core/tools/toolNames';
 import type { ChatMessage, SubagentInfo, ToolCallInfo } from '../../../core/types';
 import { buildAsyncSubagentInfo } from './sdkAsyncSubagent';
@@ -70,10 +71,13 @@ export async function loadSDKSessionMessages(
   sessionId: string,
   resumeAtMessageId?: string,
   sessionPath?: string,
+  pathContext?: ProviderHistoryPathContext,
 ): Promise<SDKSessionLoadResult> {
   const result = sessionPath
     ? await readSDKSessionFile(sessionPath)
-    : await readSDKSession(vaultPath, sessionId);
+    : await (pathContext
+      ? readSDKSession(vaultPath, sessionId, pathContext)
+      : readSDKSession(vaultPath, sessionId));
 
   if (result.error) {
     return { messages: [], skippedLines: result.skippedLines, error: result.error };
@@ -154,15 +158,16 @@ export async function loadSDKSessionMessages(
 
           // Load tool calls from subagent sidecar JSONL in parallel
           if (subagent.agentId && isValidAgentId(subagent.agentId)) {
-            sidecarLoads.push({
-              subagent,
-              promise: loadSubagentToolCalls(
+            const promise = pathContext
+              ? loadSubagentToolCalls(
                 vaultPath,
                 sessionId,
                 subagent.agentId,
                 sessionPath,
-              ),
-            });
+                pathContext,
+              )
+              : loadSubagentToolCalls(vaultPath, sessionId, subagent.agentId, sessionPath);
+            sidecarLoads.push({ subagent, promise });
           }
         }
       }

--- a/src/providers/claude/history/sdkSessionPaths.ts
+++ b/src/providers/claude/history/sdkSessionPaths.ts
@@ -1,9 +1,10 @@
 import { existsSync } from 'fs';
 import * as fs from 'fs/promises';
-import * as os from 'os';
 import * as path from 'path';
 
 import type { ProviderConversationSessionAvailability } from '../../../core/providers/types';
+import type { ClaudeConfigDirContext } from '../config/ClaudeConfigDir';
+import { resolveClaudeConfigDir } from '../config/ClaudeConfigDir';
 import type { SDKNativeMessage, SDKSessionReadResult } from './sdkHistoryTypes';
 
 export interface SDKSessionLocation {
@@ -21,8 +22,8 @@ export function encodeVaultPathForSDK(vaultPath: string): string {
   return absolutePath.replace(/[^a-zA-Z0-9]/g, '-');
 }
 
-export function getSDKProjectsPath(): string {
-  return path.join(os.homedir(), '.claude', 'projects');
+export function getSDKProjectsPath(context?: ClaudeConfigDirContext): string {
+  return path.join(resolveClaudeConfigDir(context), 'projects');
 }
 
 /** Validates an identifier for safe use in filesystem paths (no traversal, bounded length). */
@@ -40,19 +41,27 @@ export function isValidSessionId(sessionId: string): boolean {
   return isPathSafeId(sessionId);
 }
 
-export function getSDKSessionPath(vaultPath: string, sessionId: string): string {
+export function getSDKSessionPath(
+  vaultPath: string,
+  sessionId: string,
+  context?: ClaudeConfigDirContext,
+): string {
   if (!isValidSessionId(sessionId)) {
     throw new Error(`Invalid session ID: ${sessionId}`);
   }
 
-  const projectsPath = getSDKProjectsPath();
+  const projectsPath = getSDKProjectsPath(context);
   const encodedVault = encodeVaultPathForSDK(vaultPath);
   return path.join(projectsPath, encodedVault, `${sessionId}.jsonl`);
 }
 
-export function sdkSessionExists(vaultPath: string, sessionId: string): boolean {
+export function sdkSessionExists(
+  vaultPath: string,
+  sessionId: string,
+  context?: ClaudeConfigDirContext,
+): boolean {
   try {
-    const sessionPath = getSDKSessionPath(vaultPath, sessionId);
+    const sessionPath = getSDKSessionPath(vaultPath, sessionId, context);
     return existsSync(sessionPath);
   } catch {
     return false;
@@ -69,6 +78,7 @@ function hasFileSystemErrorCode(error: unknown, code: string): boolean {
 export async function locateSDKSessions(
   vaultPath: string,
   sessionIds: string[],
+  context?: ClaudeConfigDirContext,
 ): Promise<Map<string, SDKSessionLocation>> {
   const locations = new Map<string, SDKSessionLocation>();
   const currentPaths = new Map<string, string>();
@@ -77,7 +87,7 @@ export async function locateSDKSessions(
   await Promise.all([...new Set(sessionIds)].map(async (sessionId) => {
     let sessionPath: string;
     try {
-      sessionPath = getSDKSessionPath(vaultPath, sessionId);
+      sessionPath = getSDKSessionPath(vaultPath, sessionId, context);
     } catch {
       locations.set(sessionId, { availability: 'unknown' });
       return;
@@ -103,7 +113,8 @@ export async function locateSDKSessions(
   const targetIdsByFileName = new Map(
     [...unresolvedIds].map(sessionId => [`${sessionId}.jsonl`, sessionId]),
   );
-  const pendingDirectories = [getSDKProjectsPath()];
+  const projectsPath = getSDKProjectsPath(context);
+  const pendingDirectories = [projectsPath];
   let rootExists = true;
   let scanComplete = true;
 
@@ -113,7 +124,7 @@ export async function locateSDKSessions(
     try {
       entries = await fs.readdir(directory, { withFileTypes: true });
     } catch (error) {
-      if (directory === getSDKProjectsPath() && hasFileSystemErrorCode(error, 'ENOENT')) {
+      if (directory === projectsPath && hasFileSystemErrorCode(error, 'ENOENT')) {
         rootExists = false;
       } else if (!hasFileSystemErrorCode(error, 'ENOENT')) {
         scanComplete = false;
@@ -154,21 +165,27 @@ export async function locateSDKSessions(
 export async function locateSDKSession(
   vaultPath: string,
   sessionId: string,
+  context?: ClaudeConfigDirContext,
 ): Promise<SDKSessionLocation> {
-  return (await locateSDKSessions(vaultPath, [sessionId])).get(sessionId)
+  return (await locateSDKSessions(vaultPath, [sessionId], context)).get(sessionId)
     ?? { availability: 'unknown' };
 }
 
 export async function getSDKSessionAvailability(
   vaultPath: string,
   sessionId: string,
+  context?: ClaudeConfigDirContext,
 ): Promise<ProviderConversationSessionAvailability> {
-  return (await locateSDKSession(vaultPath, sessionId)).availability;
+  return (await locateSDKSession(vaultPath, sessionId, context)).availability;
 }
 
-export async function deleteSDKSession(vaultPath: string, sessionId: string): Promise<void> {
+export async function deleteSDKSession(
+  vaultPath: string,
+  sessionId: string,
+  context?: ClaudeConfigDirContext,
+): Promise<void> {
   try {
-    const sessionPath = getSDKSessionPath(vaultPath, sessionId);
+    const sessionPath = getSDKSessionPath(vaultPath, sessionId, context);
     if (!existsSync(sessionPath)) {
       return;
     }
@@ -182,9 +199,10 @@ export async function deleteSDKSession(vaultPath: string, sessionId: string): Pr
 export async function readSDKSession(
   vaultPath: string,
   sessionId: string,
+  context?: ClaudeConfigDirContext,
 ): Promise<SDKSessionReadResult> {
   try {
-    const sessionPath = getSDKSessionPath(vaultPath, sessionId);
+    const sessionPath = getSDKSessionPath(vaultPath, sessionId, context);
     if (!existsSync(sessionPath)) {
       return { messages: [], skippedLines: 0 };
     }

--- a/src/providers/claude/history/sdkSubagentSidecar.ts
+++ b/src/providers/claude/history/sdkSubagentSidecar.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'fs';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
+import type { ProviderHistoryPathContext } from '../../../core/providers/types';
 import type { ToolCallInfo } from '../../../core/types';
 import { extractFinalResultFromSubagentJsonl } from '../../../utils/subagentJsonl';
 import { extractToolResultContent } from '../sdk/toolResultContent';
@@ -176,6 +177,7 @@ function getSubagentSidecarPath(
   sessionId: string,
   agentId: string,
   sessionPath?: string,
+  pathContext?: ProviderHistoryPathContext,
 ): string | null {
   if (!isValidSessionId(sessionId) || !isValidAgentId(agentId)) {
     return null;
@@ -183,7 +185,7 @@ function getSubagentSidecarPath(
 
   const projectPath = sessionPath
     ? path.dirname(sessionPath)
-    : path.join(getSDKProjectsPath(), encodeVaultPathForSDK(vaultPath));
+    : path.join(getSDKProjectsPath(pathContext), encodeVaultPathForSDK(vaultPath));
   return path.join(
     projectPath,
     sessionId,
@@ -197,8 +199,15 @@ export async function loadSubagentToolCalls(
   sessionId: string,
   agentId: string,
   sessionPath?: string,
+  pathContext?: ProviderHistoryPathContext,
 ): Promise<ToolCallInfo[]> {
-  const subagentFilePath = getSubagentSidecarPath(vaultPath, sessionId, agentId, sessionPath);
+  const subagentFilePath = getSubagentSidecarPath(
+    vaultPath,
+    sessionId,
+    agentId,
+    sessionPath,
+    pathContext,
+  );
   if (!subagentFilePath) {
     return [];
   }
@@ -246,8 +255,15 @@ export async function loadSubagentFinalResult(
   sessionId: string,
   agentId: string,
   sessionPath?: string,
+  pathContext?: ProviderHistoryPathContext,
 ): Promise<string | null> {
-  const subagentFilePath = getSubagentSidecarPath(vaultPath, sessionId, agentId, sessionPath);
+  const subagentFilePath = getSubagentSidecarPath(
+    vaultPath,
+    sessionId,
+    agentId,
+    sessionPath,
+    pathContext,
+  );
   if (!subagentFilePath) {
     return null;
   }

--- a/src/providers/claude/plugins/PluginManager.ts
+++ b/src/providers/claude/plugins/PluginManager.ts
@@ -2,21 +2,18 @@
  * PluginManager - Discover and manage Claude Code plugins.
  *
  * Plugins are discovered from two sources:
- * - installed_plugins.json: install paths for scanning agents
+ * - {CLAUDE_CONFIG_DIR}/plugins/installed_plugins.json: install paths for scanning agents
  * - settings.json: enabled state (project overrides global)
  */
 
 import * as fs from 'fs';
 import { Notice } from 'obsidian';
-import * as os from 'os';
 import * as path from 'path';
 
 import type { PluginInfo, PluginScope } from '../../../core/types';
+import { resolveClaudeConfigDir } from '../config/ClaudeConfigDir';
 import type { CCSettingsStorage } from '../storage/CCSettingsStorage';
 import type { InstalledPluginEntry, InstalledPluginsFile } from '../types/plugins';
-
-const INSTALLED_PLUGINS_PATH = path.join(os.homedir(), '.claude', 'plugins', 'installed_plugins.json');
-const GLOBAL_SETTINGS_PATH = path.join(os.homedir(), '.claude', 'settings.json');
 
 interface SettingsFile {
   enabledPlugins?: Record<string, boolean>;
@@ -73,16 +70,25 @@ function extractPluginName(pluginId: string): string {
 export class PluginManager {
   private ccSettingsStorage: CCSettingsStorage;
   private vaultPath: string;
+  private resolveConfigDir: () => string;
   private plugins: PluginInfo[] = [];
 
-  constructor(vaultPath: string, ccSettingsStorage: CCSettingsStorage) {
+  constructor(
+    vaultPath: string,
+    ccSettingsStorage: CCSettingsStorage,
+    configDir: string | (() => string) = () => resolveClaudeConfigDir(),
+  ) {
     this.vaultPath = vaultPath;
     this.ccSettingsStorage = ccSettingsStorage;
+    this.resolveConfigDir = typeof configDir === 'function' ? configDir : () => configDir;
   }
 
   async loadPlugins(): Promise<void> {
-    const installedPlugins = readJsonFile<InstalledPluginsFile>(INSTALLED_PLUGINS_PATH);
-    const globalSettings = readJsonFile<SettingsFile>(GLOBAL_SETTINGS_PATH);
+    const configDir = this.resolveConfigDir();
+    const installedPlugins = readJsonFile<InstalledPluginsFile>(
+      path.join(configDir, 'plugins', 'installed_plugins.json'),
+    );
+    const globalSettings = readJsonFile<SettingsFile>(path.join(configDir, 'settings.json'));
     const projectSettings = await this.loadProjectSettings();
 
     const globalEnabled = globalSettings?.enabledPlugins ?? {};

--- a/src/providers/claude/runtime/ClaudeChatRuntime.ts
+++ b/src/providers/claude/runtime/ClaudeChatRuntime.ts
@@ -30,6 +30,7 @@ import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSet
 import type {
   AppAgentManager,
   AppPluginManager,
+  ProviderHistoryPathContext,
 } from '../../../core/providers/types';
 import type { ChatRuntime } from '../../../core/runtime/ChatRuntime';
 import type {
@@ -486,14 +487,26 @@ export class ClaudianService implements ChatRuntime {
     const sessionId = this.getSessionId();
     const vaultPath = getVaultPath(this.plugin.app);
     if (!sessionId || !vaultPath) return [];
-    return loadSubagentToolCalls(vaultPath, sessionId, agentId);
+    return loadSubagentToolCalls(
+      vaultPath,
+      sessionId,
+      agentId,
+      undefined,
+      this.buildHistoryPathContext(vaultPath),
+    );
   }
 
   async loadSubagentFinalResult(agentId: string): Promise<string | null> {
     const sessionId = this.getSessionId();
     const vaultPath = getVaultPath(this.plugin.app);
     if (!sessionId || !vaultPath) return null;
-    return loadSubagentFinalResult(vaultPath, sessionId, agentId);
+    return loadSubagentFinalResult(
+      vaultPath,
+      sessionId,
+      agentId,
+      undefined,
+      this.buildHistoryPathContext(vaultPath),
+    );
   }
 
   async reloadMcpServers(): Promise<void> {
@@ -758,6 +771,18 @@ export class ClaudianService implements ChatRuntime {
       enhancedPath,
       mcpManager: this.mcpManager,
       pluginManager: this.requirePluginManager(),
+    };
+  }
+
+  private buildHistoryPathContext(vaultPath: string): ProviderHistoryPathContext {
+    const customEnv = parseEnvironmentVariables(
+      this.plugin.getActiveEnvironmentVariables(this.providerId),
+    );
+    return {
+      environment: { ...process.env, ...customEnv },
+      hostPlatform: process.platform,
+      settings: this.getScopedSettings(),
+      vaultPath,
     };
   }
 

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -402,7 +402,7 @@ describe('ClaudianPlugin', () => {
     it('broadcasts ensureReady with force when env changes without model change', async () => {
       await plugin.onload();
 
-      // Mock getView to return a view with tabManager
+      // Mock one open view with an initialized Claude runtime.
       const mockSyncConversationState = jest.fn();
       const mockEnsureReady = jest.fn().mockResolvedValue(true);
       const mockTabManager = {
@@ -423,13 +423,53 @@ describe('ClaudianPlugin', () => {
         invalidateProviderCommandCaches: jest.fn(),
         refreshModelSelector: jest.fn(),
       };
-      jest.spyOn(plugin, 'getView').mockReturnValue(mockView as any);
+      jest.spyOn(plugin, 'getAllViews').mockReturnValue([mockView as any]);
 
       // Change env but not in a way that affects model
       await plugin.applyEnvironmentVariables('shared', 'SOME_VAR=value');
 
       expect(mockSyncConversationState).toHaveBeenCalledWith(null, []);
       expect(mockEnsureReady).toHaveBeenCalledWith({ force: true });
+    });
+
+    it('restarts affected runtimes in every open Claudian view', async () => {
+      await plugin.onload();
+
+      const createView = () => {
+        const ensureReady = jest.fn().mockResolvedValue(true);
+        const tabManager = {
+          getAllTabs: jest.fn().mockReturnValue([{
+            providerId: 'claude',
+            conversationId: null,
+            state: { isStreaming: false },
+            serviceInitialized: true,
+            service: {
+              ensureReady,
+              syncConversationState: jest.fn(),
+            },
+            ui: { externalContextSelector: { getExternalContexts: jest.fn().mockReturnValue([]) } },
+          }]),
+        };
+        return {
+          ensureReady,
+          view: {
+            getTabManager: jest.fn().mockReturnValue(tabManager),
+            invalidateProviderCommandCaches: jest.fn(),
+            refreshModelSelector: jest.fn(),
+          },
+        };
+      };
+      const first = createView();
+      const second = createView();
+      jest.spyOn(plugin, 'getAllViews').mockReturnValue([
+        first.view as any,
+        second.view as any,
+      ]);
+
+      await plugin.applyEnvironmentVariables('shared', 'SOME_VAR=value');
+
+      expect(first.ensureReady).toHaveBeenCalledWith({ force: true });
+      expect(second.ensureReady).toHaveBeenCalledWith({ force: true });
     });
 
     it('syncs live external contexts before restarting invalidated Claude runtimes', async () => {
@@ -472,7 +512,7 @@ describe('ClaudianPlugin', () => {
         invalidateProviderCommandCaches: jest.fn(),
         refreshModelSelector: jest.fn(),
       };
-      jest.spyOn(plugin, 'getView').mockReturnValue(mockView as any);
+      jest.spyOn(plugin, 'getAllViews').mockReturnValue([mockView as any]);
 
       await plugin.applyEnvironmentVariables('provider:claude', 'ANTHROPIC_MODEL=claude-sonnet-4-5');
 
@@ -1372,7 +1412,9 @@ describe('ClaudianPlugin', () => {
       expect(loadSpy).toHaveBeenCalledWith(
         expect.any(String),
         'session-with-image',
-        undefined
+        undefined,
+        undefined,
+        expect.any(Object),
       );
       expect(loaded?.messages[0].images?.[0]).toMatchObject({
         id: 'img-blank',
@@ -1413,14 +1455,17 @@ describe('ClaudianPlugin', () => {
       // Should check existence of source session, not the conversation's own session
       expect(sdkSession.locateSDKSession).toHaveBeenCalledWith(
         expect.any(String),
-        'source-session-abc'
+        'source-session-abc',
+        expect.any(Object),
       );
 
       // Should load from forkSource.sessionId with forkSource.resumeAt as truncation point
       expect(loadSpy).toHaveBeenCalledWith(
         expect.any(String),
         'source-session-abc',
-        'asst-uuid-cutoff'
+        'asst-uuid-cutoff',
+        undefined,
+        expect.any(Object),
       );
 
       // Messages should be loaded
@@ -1452,7 +1497,8 @@ describe('ClaudianPlugin', () => {
       // Should load from own session, not forkSource session
       expect(sdkSession.locateSDKSession).toHaveBeenCalledWith(
         expect.any(String),
-        'own-session-id'
+        'own-session-id',
+        expect.any(Object),
       );
 
       existsSpy.mockRestore();
@@ -1518,7 +1564,9 @@ describe('ClaudianPlugin', () => {
       expect(loadSpy).toHaveBeenCalledWith(
         expect.any(String),
         'session-subagent-recovery',
-        undefined
+        undefined,
+        undefined,
+        expect.any(Object),
       );
       expect(loaded?.messages[0].toolCalls?.find(tc => tc.id === 'task-1')).toEqual(
         expect.objectContaining({
@@ -1591,7 +1639,9 @@ describe('ClaudianPlugin', () => {
       expect(loadSpy).toHaveBeenCalledWith(
         expect.any(String),
         'session-subagent-merge',
-        undefined
+        undefined,
+        undefined,
+        expect.any(Object),
       );
       expect(taskTool?.result).toBe('Full SDK result from queue-operation');
       expect(taskTool?.subagent?.result).toBe('Full SDK result from queue-operation');
@@ -1998,7 +2048,9 @@ describe('ClaudianPlugin', () => {
       expect(loadSubagentToolsSpy).toHaveBeenCalledWith(
         expect.any(String),
         'session-async-subagent-tools',
-        'agent-a123'
+        'agent-a123',
+        undefined,
+        expect.any(Object),
       );
       expect(taskTool?.subagent?.toolCalls).toEqual(
         expect.arrayContaining([

--- a/tests/unit/providers/claude/agents/AgentManager.test.ts
+++ b/tests/unit/providers/claude/agents/AgentManager.test.ts
@@ -75,6 +75,7 @@ describe('AgentManager', () => {
   const VAULT_PATH = '/test/vault';
   const HOME_DIR = '/home/user';
   const GLOBAL_AGENTS_DIR = path.join(HOME_DIR, '.claude', 'agents');
+  const CUSTOM_GLOBAL_AGENTS_DIR = '/custom/claude/agents';
   const VAULT_AGENTS_DIR = path.join(VAULT_PATH, '.claude/agents');
 
   beforeEach(() => {
@@ -160,6 +161,29 @@ describe('AgentManager', () => {
       const globalAgent = agents.find(a => a.id === 'MinimalAgent' && a.source === 'global');
       expect(globalAgent).toBeDefined();
       expect(globalAgent?.source).toBe('global');
+    });
+
+    it('loads global agents from the effective Claude config directory', async () => {
+      const manager = new AgentManager(
+        VAULT_PATH,
+        createMockPluginManager(),
+        '/custom/claude',
+      );
+
+      mockFs.existsSync.mockImplementation((p) => p === CUSTOM_GLOBAL_AGENTS_DIR);
+      (mockFs.readdirSync as jest.Mock).mockImplementation((dir: string) => {
+        if (dir === CUSTOM_GLOBAL_AGENTS_DIR) {
+          return [createMockDirent('global-agent.md', true)];
+        }
+        return [];
+      });
+      mockFs.readFileSync.mockReturnValue(MINIMAL_AGENT_FILE);
+
+      await manager.loadAgents();
+
+      expect(manager.getAvailableAgents()).toEqual(expect.arrayContaining([
+        expect.objectContaining({ id: 'MinimalAgent', source: 'global' }),
+      ]));
     });
 
     it('skips invalid agent files', async () => {

--- a/tests/unit/providers/claude/history/ClaudeConversationHistoryService.test.ts
+++ b/tests/unit/providers/claude/history/ClaudeConversationHistoryService.test.ts
@@ -45,6 +45,25 @@ describe('ClaudeConversationHistoryService', () => {
       availabilitySpy.mockRestore();
     });
 
+    it('uses the effective SDK environment when locating a native session', async () => {
+      const availabilitySpy = jest.spyOn(historyStore, 'locateSDKSession')
+        .mockResolvedValue({ availability: 'available', sessionPath: '/custom/session-1.jsonl' });
+      const service = new ClaudeConversationHistoryService();
+      const pathContext = {
+        environment: { CLAUDE_CONFIG_DIR: '/custom/claude' },
+        vaultPath: '/vault',
+      };
+
+      await service.getConversationSessionAvailability(
+        createConversation(),
+        '/vault',
+        pathContext,
+      );
+
+      expect(availabilitySpy).toHaveBeenCalledWith('/vault', 'session-1', pathContext);
+      availabilitySpy.mockRestore();
+    });
+
     it('reports a native session from a previous vault path as relocated', async () => {
       const availabilitySpy = jest.spyOn(historyStore, 'locateSDKSession')
         .mockResolvedValue({
@@ -208,6 +227,52 @@ describe('ClaudeConversationHistoryService', () => {
   });
 
   describe('hydrateConversationHistory', () => {
+    it('re-resolves history when the effective Claude config directory changes', async () => {
+      const service = new ClaudeConversationHistoryService();
+      const conversation = createConversation();
+      const contextA = {
+        environment: { CLAUDE_CONFIG_DIR: '/config-a' },
+        vaultPath: '/vault',
+      };
+      const contextB = {
+        environment: { CLAUDE_CONFIG_DIR: '/config-b' },
+        vaultPath: '/vault',
+      };
+      const locationSpy = jest.spyOn(historyStore, 'locateSDKSessions')
+        .mockImplementation(async (_vaultPath, sessionIds, pathContext) => new Map(
+          sessionIds.map(sessionId => [sessionId, {
+            availability: 'available' as const,
+            sessionPath: `${pathContext?.environment?.CLAUDE_CONFIG_DIR}/${sessionId}.jsonl`,
+          }]),
+        ));
+      const loadSpy = jest.spyOn(historyStore, 'loadSDKSessionMessages')
+        .mockImplementation(async (_vaultPath, _sessionId, _resumeAt, _sessionPath, pathContext) => {
+          const configDir = pathContext?.environment?.CLAUDE_CONFIG_DIR;
+          return {
+            messages: [{
+              id: `message-${configDir}`,
+              role: 'user',
+              content: configDir ?? '',
+              timestamp: configDir === '/config-a' ? 1 : 2,
+            }],
+            skippedLines: 0,
+          };
+        });
+
+      await service.hydrateConversationHistory(conversation, '/vault', contextA);
+      await service.hydrateConversationHistory(conversation, '/vault', contextB);
+
+      expect(conversation.messages.map(message => message.content)).toEqual([
+        '/config-a',
+        '/config-b',
+      ]);
+      expect(locationSpy).toHaveBeenCalledTimes(2);
+      expect(loadSpy).toHaveBeenCalledTimes(2);
+
+      locationSpy.mockRestore();
+      loadSpy.mockRestore();
+    });
+
     it('drops a stale relocated path after the session appears in the current project', async () => {
       const service = new ClaudeConversationHistoryService();
       const conversation = createConversation();

--- a/tests/unit/providers/claude/plugins/PluginManager.test.ts
+++ b/tests/unit/providers/claude/plugins/PluginManager.test.ts
@@ -34,6 +34,9 @@ function createMockCCSettingsStorage() {
 const installedPluginsPath = path.join(homeDir, '.claude', 'plugins', 'installed_plugins.json');
 const globalSettingsPath = path.join(homeDir, '.claude', 'settings.json');
 const projectSettingsPath = path.join(vaultPath, '.claude', 'settings.json');
+const customConfigDir = '/custom/claude';
+const customInstalledPluginsPath = path.join(customConfigDir, 'plugins', 'installed_plugins.json');
+const customGlobalSettingsPath = path.join(customConfigDir, 'settings.json');
 
 describe('PluginManager', () => {
   beforeEach(() => {
@@ -87,6 +90,43 @@ describe('PluginManager', () => {
       expect(plugins[0].enabled).toBe(true);
       expect(plugins[0].scope).toBe('user');
       expect(plugins[0].installPath).toBe('/path/to/test-plugin');
+    });
+
+    it('loads global plugin data from the effective Claude config directory', async () => {
+      const installedPlugins = {
+        version: 2,
+        plugins: {
+          'custom-plugin@marketplace': [{
+            scope: 'user',
+            installPath: '/path/to/custom-plugin',
+            version: '1.0.0',
+            installedAt: '2026-01-01T00:00:00.000Z',
+            lastUpdated: '2026-01-01T00:00:00.000Z',
+          }],
+        },
+      };
+      const globalSettings = {
+        enabledPlugins: { 'custom-plugin@marketplace': false },
+      };
+
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockImplementation((p: fs.PathOrFileDescriptor) => {
+        if (String(p) === customInstalledPluginsPath) return JSON.stringify(installedPlugins);
+        if (String(p) === customGlobalSettingsPath) return JSON.stringify(globalSettings);
+        return '{}';
+      });
+
+      const manager = new PluginManager(
+        vaultPath,
+        createMockCCSettingsStorage(),
+        customConfigDir,
+      );
+
+      await manager.loadPlugins();
+
+      expect(manager.getPlugins()).toEqual([
+        expect.objectContaining({ id: 'custom-plugin@marketplace', enabled: false }),
+      ]);
     });
 
     it('defaults to enabled for installed plugins not in settings', async () => {

--- a/tests/unit/providers/claude/runtime/ClaudianService.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudianService.test.ts
@@ -5,6 +5,7 @@ import { Notice } from 'obsidian';
 
 import type { McpServerManager } from '@/core/mcp/McpServerManager';
 import type ClaudianPlugin from '@/main';
+import * as historyStore from '@/providers/claude/history/ClaudeHistoryStore';
 import { ClaudianService } from '@/providers/claude/runtime/ClaudeChatRuntime';
 import { MessageChannel } from '@/providers/claude/runtime/ClaudeMessageChannel';
 import { createResponseHandler } from '@/providers/claude/runtime/types';
@@ -178,6 +179,38 @@ describe('ClaudianService', () => {
       service.setSessionId('test-session-123');
       service.setSessionId(null);
       expect(service.getSessionId()).toBeNull();
+    });
+
+    it('uses the effective SDK environment for live subagent sidecar recovery', async () => {
+      jest.mocked(mockPlugin.getActiveEnvironmentVariables!)
+        .mockReturnValue('CLAUDE_CONFIG_DIR=/custom/claude');
+      const toolCallsSpy = jest.spyOn(historyStore, 'loadSubagentToolCalls')
+        .mockResolvedValue([]);
+      const finalResultSpy = jest.spyOn(historyStore, 'loadSubagentFinalResult')
+        .mockResolvedValue(null);
+      service.setSessionId('session-custom');
+
+      await service.loadSubagentToolCalls('agent-1');
+      await service.loadSubagentFinalResult('agent-1');
+
+      const expectedContext = expect.objectContaining({
+        environment: expect.objectContaining({ CLAUDE_CONFIG_DIR: '/custom/claude' }),
+        vaultPath: '/mock/vault/path',
+      });
+      expect(toolCallsSpy).toHaveBeenCalledWith(
+        '/mock/vault/path',
+        'session-custom',
+        'agent-1',
+        undefined,
+        expectedContext,
+      );
+      expect(finalResultSpy).toHaveBeenCalledWith(
+        '/mock/vault/path',
+        'session-custom',
+        'agent-1',
+        undefined,
+        expectedContext,
+      );
     });
 
     it('should NOT call ensureReady when setting session ID (passive sync)', async () => {

--- a/tests/unit/utils/sdkSession.test.ts
+++ b/tests/unit/utils/sdkSession.test.ts
@@ -102,6 +102,72 @@ describe('sdkSession', () => {
       const projectsPath = getSDKProjectsPath();
       expect(projectsPath).toBe('/Users/test/.claude/projects');
     });
+
+    it('uses CLAUDE_CONFIG_DIR from the effective SDK environment', () => {
+      const projectsPath = getSDKProjectsPath({
+        environment: { CLAUDE_CONFIG_DIR: '/custom/claude' },
+        vaultPath: '/Users/test/vault',
+      });
+
+      expect(projectsPath).toBe('/custom/claude/projects');
+    });
+
+    it('resolves a relative CLAUDE_CONFIG_DIR from the SDK working directory', () => {
+      const projectsPath = getSDKProjectsPath({
+        environment: { CLAUDE_CONFIG_DIR: '.claude-custom' },
+        vaultPath: '/Users/test/vault',
+      });
+
+      expect(projectsPath).toBe('/Users/test/vault/.claude-custom/projects');
+    });
+
+    it('falls back to the default directory when CLAUDE_CONFIG_DIR is unset', () => {
+      const projectsPath = getSDKProjectsPath({
+        environment: {},
+        vaultPath: '/Users/test/vault',
+      });
+
+      expect(projectsPath).toBe('/Users/test/.claude/projects');
+    });
+
+    it('uses the effective SDK HOME when CLAUDE_CONFIG_DIR is unset', () => {
+      const projectsPath = getSDKProjectsPath({
+        environment: { HOME: '/custom/home' },
+        hostPlatform: 'linux',
+        vaultPath: '/Users/test/vault',
+      });
+
+      expect(projectsPath).toBe('/custom/home/.claude/projects');
+    });
+
+    it('uses the effective SDK USERPROFILE on Windows', () => {
+      const projectsPath = getSDKProjectsPath({
+        environment: { USERPROFILE: '/custom/windows-home' },
+        hostPlatform: 'win32',
+        vaultPath: '/Users/test/vault',
+      });
+
+      expect(projectsPath).toBe('/custom/windows-home/.claude/projects');
+    });
+
+    it('resolves an empty SDK HOME from the SDK working directory', () => {
+      const projectsPath = getSDKProjectsPath({
+        environment: { HOME: '' },
+        hostPlatform: 'linux',
+        vaultPath: '/Users/test/vault',
+      });
+
+      expect(projectsPath).toBe('/Users/test/vault/.claude/projects');
+    });
+
+    it('preserves an explicitly empty CLAUDE_CONFIG_DIR like the SDK', () => {
+      const projectsPath = getSDKProjectsPath({
+        environment: { CLAUDE_CONFIG_DIR: '' },
+        vaultPath: '/Users/test/vault',
+      });
+
+      expect(projectsPath).toBe('/Users/test/vault/projects');
+    });
   });
 
   describe('isValidSessionId', () => {
@@ -147,6 +213,15 @@ describe('sdkSession', () => {
 
     it('throws error for empty session ID', () => {
       expect(() => getSDKSessionPath('/Users/test/vault', '')).toThrow('Invalid session ID');
+    });
+
+    it('builds session paths under the effective Claude config directory', () => {
+      const sessionPath = getSDKSessionPath('/Users/test/vault', 'session-123', {
+        environment: { CLAUDE_CONFIG_DIR: '/custom/claude' },
+        vaultPath: '/Users/test/vault',
+      });
+
+      expect(sessionPath).toBe('/custom/claude/projects/-Users-test-vault/session-123.jsonl');
     });
   });
 
@@ -336,6 +411,20 @@ describe('sdkSession', () => {
 
       expect(mockFsPromises.unlink).not.toHaveBeenCalled();
     });
+
+    it('deletes from the effective Claude config directory', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockFsPromises.unlink.mockResolvedValue(undefined);
+
+      await deleteSDKSession('/Users/test/vault', 'session-custom', {
+        environment: { CLAUDE_CONFIG_DIR: '/custom/claude' },
+        vaultPath: '/Users/test/vault',
+      });
+
+      expect(mockFsPromises.unlink).toHaveBeenCalledWith(
+        '/custom/claude/projects/-Users-test-vault/session-custom.jsonl',
+      );
+    });
   });
 
   describe('readSDKSession', () => {
@@ -362,6 +451,24 @@ describe('sdkSession', () => {
       expect(result.messages[0].type).toBe('user');
       expect(result.messages[1].type).toBe('assistant');
       expect(result.skippedLines).toBe(0);
+    });
+
+    it('reads from the effective Claude config directory', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockFsPromises.readFile.mockResolvedValue(
+        '{"type":"user","uuid":"u1","message":{"content":"Hello"}}',
+      );
+
+      const result = await readSDKSession('/Users/test/vault', 'session-custom', {
+        environment: { CLAUDE_CONFIG_DIR: '/custom/claude' },
+        vaultPath: '/Users/test/vault',
+      });
+
+      expect(result.messages).toHaveLength(1);
+      expect(mockFsPromises.readFile).toHaveBeenCalledWith(
+        '/custom/claude/projects/-Users-test-vault/session-custom.jsonl',
+        'utf-8',
+      );
     });
 
     it('skips invalid JSON lines and reports count', async () => {


### PR DESCRIPTION
## Summary

- resolve Claude storage from the effective SDK environment, including `CLAUDE_CONFIG_DIR`, `HOME`, and `USERPROFILE`
- use the resolved root for session history, missing-session handling, deletion, subagent recovery, global agents, and plugins
- invalidate path-sensitive history caches and restart affected runtimes across all open views when the environment changes
- add regression coverage for custom roots, relative paths, root transitions, live sidecars, and multi-view restarts

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run test` (5,983 tests)
- `npm run build`
- `git diff --check`

Closes #910