### PR TITLE
fix: preserve Codex turn order after compaction

### DIFF
--- a/src/providers/codex/history/CodexHistoryStore.ts
+++ b/src/providers/codex/history/CodexHistoryStore.ts
@@ -1110,19 +1110,24 @@ function processEventMsg(
     }
 
     case 'context_compacted': {
-      // Close any active bubble so the boundary stays standalone
-      if (ctx.currentTurnId) {
-        const prevTurn = ctx.turns.get(ctx.currentTurnId);
-        if (prevTurn) closeAssistantBubble(prevTurn);
+      const activeTurnId = ctx.currentTurnId;
+      if (activeTurnId) {
+        const activeTurn = ctx.turns.get(activeTurnId);
+        if (activeTurn) closeAssistantBubble(activeTurn);
       }
 
-      // Create a dedicated turn for the compact boundary
-      const id = nextTurnId(ctx);
-      const turn = ensureTurn(ctx.turns, ctx.turnOrder, id, null, timestamp);
+      // Auto-compaction can occur in the middle of a running turn. Keep the
+      // boundary in that turn so later records retain their turn ownership.
+      const turn = ensureTurn(
+        ctx.turns,
+        ctx.turnOrder,
+        nextTurnId(ctx),
+        activeTurnId,
+        timestamp,
+      );
       const bubble = ensureAssistantBubble(turn, timestamp);
       bubble.contentBlocks.push({ type: 'context_compacted' });
       closeAssistantBubble(turn);
-      ctx.currentTurnId = null;
       break;
     }
 

--- a/tests/unit/providers/codex/history/CodexHistoryStore.test.ts
+++ b/tests/unit/providers/codex/history/CodexHistoryStore.test.ts
@@ -2356,6 +2356,142 @@ describe('CodexHistoryStore', () => {
   });
 
   describe('parseCodexSessionContent - context_compacted boundary', () => {
+    it('keeps post-compaction records in the active turn when auto-compaction happens mid-turn', () => {
+      const content = [
+        JSON.stringify({
+          timestamp: '2026-07-05T07:19:07.987Z',
+          type: 'event_msg',
+          payload: { type: 'task_started', turn_id: 'uuid-auto-compact' },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-05T07:19:10.303Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'input_text', text: 'Update the template.' }],
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-05T07:19:54.927Z',
+          type: 'event_msg',
+          payload: { type: 'agent_message', message: 'I will update the template.' },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-05T07:19:54.927Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'I will update the template.' }],
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-05T07:20:02.971Z',
+          type: 'response_item',
+          payload: {
+            type: 'function_call',
+            name: 'exec_command',
+            call_id: 'call-before-compact',
+            arguments: '{"cmd":"rg breadcrumb template"}',
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-05T07:20:03.061Z',
+          type: 'response_item',
+          payload: {
+            type: 'function_call_output',
+            call_id: 'call-before-compact',
+            output: 'Process exited with code 0\nOutput:\nmatch',
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-05T07:23:48.653Z',
+          type: 'compacted',
+          payload: { message: '', replacement_history: [] },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-05T07:23:48.660Z',
+          type: 'event_msg',
+          payload: { type: 'context_compacted' },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-05T07:23:52.499Z',
+          type: 'response_item',
+          payload: {
+            type: 'function_call',
+            name: 'exec_command',
+            call_id: 'call-after-compact',
+            arguments: '{"cmd":"npm test"}',
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-05T07:23:52.934Z',
+          type: 'response_item',
+          payload: {
+            type: 'function_call_output',
+            call_id: 'call-after-compact',
+            output: 'Process exited with code 0\nOutput:\npassed',
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-05T07:25:41.421Z',
+          type: 'event_msg',
+          payload: { type: 'agent_message', message: 'Template updated.' },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-05T07:25:41.424Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Template updated.' }],
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-05T07:25:41.432Z',
+          type: 'event_msg',
+          payload: { type: 'task_complete', turn_id: 'uuid-auto-compact' },
+        }),
+      ].join('\n');
+
+      const turns = parseCodexSessionTurns(content);
+
+      expect(turns).toHaveLength(1);
+      expect(turns[0].turnId).toBe('uuid-auto-compact');
+      expect(turns[0].messages.map(message => ({
+        role: message.role,
+        content: message.content,
+        blockTypes: message.contentBlocks?.map(block => block.type),
+        tools: message.toolCalls?.map(tool => tool.id),
+      }))).toEqual([
+        {
+          role: 'user',
+          content: 'Update the template.',
+          blockTypes: undefined,
+          tools: undefined,
+        },
+        {
+          role: 'assistant',
+          content: 'I will update the template.',
+          blockTypes: ['tool_use', 'text'],
+          tools: ['call-before-compact'],
+        },
+        {
+          role: 'assistant',
+          content: '',
+          blockTypes: ['context_compacted'],
+          tools: undefined,
+        },
+        {
+          role: 'assistant',
+          content: 'Template updated.',
+          blockTypes: ['tool_use', 'text'],
+          tools: ['call-after-compact'],
+        },
+      ]);
+    });
+
     it('preserves visible transcript records instead of replaying compacted replacement_history', () => {
       const content = [
         JSON.stringify({ timestamp: '2026-03-03T16:00:00.000Z', type: 'event_msg', payload: { type: 'task_started' } }),


### PR DESCRIPTION
## Summary

- keep auto-compaction boundaries inside the active Codex turn
- preserve post-compaction tool and assistant record ordering during history hydration
- add a regression test modeled on the real mid-turn compaction sequence

## Root cause

The history parser cleared the active turn when it encountered `context_compacted`. Codex can emit that boundary during a still-running turn, so later response records were reconstructed as separate synthetic turns and paired persisted events were no longer deduplicated.

## Testing

- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run build`