### PR TITLE
fix: preserve IME composition in inline prompts

### DIFF
--- a/src/features/chat/rendering/InlineAskUserQuestion.ts
+++ b/src/features/chat/rendering/InlineAskUserQuestion.ts
@@ -552,6 +552,8 @@ export class InlineAskUserQuestion {
   }
 
   private handleKeyDown(e: KeyboardEvent): void {
+    if (e.isComposing) return;
+
     if (this.isInputFocused) {
       if (e.key === 'Escape') {
         e.preventDefault();

--- a/src/features/chat/rendering/InlineExitPlanMode.ts
+++ b/src/features/chat/rendering/InlineExitPlanMode.ts
@@ -164,6 +164,8 @@ export class InlineExitPlanMode {
   }
 
   private handleKeyDown(e: KeyboardEvent): void {
+    if (e.isComposing) return;
+
     if (this.isInputFocused) {
       if (e.key === 'Escape') {
         e.preventDefault();

--- a/src/features/chat/rendering/InlinePlanApproval.ts
+++ b/src/features/chat/rendering/InlinePlanApproval.ts
@@ -91,6 +91,8 @@ export class InlinePlanApproval {
   }
 
   private handleKeyDown(e: KeyboardEvent): void {
+    if (e.isComposing) return;
+
     if (this.isInputFocused) {
       if (e.key === 'Escape') {
         e.preventDefault();

--- a/tests/unit/features/chat/rendering/InlineAskUserQuestion.test.ts
+++ b/tests/unit/features/chat/rendering/InlineAskUserQuestion.test.ts
@@ -37,12 +37,13 @@ function renderWidget(
 function fireKeyDown(
   root: any,
   key: string,
-  opts: { shiftKey?: boolean } = {},
+  opts: { shiftKey?: boolean; isComposing?: boolean } = {},
 ): void {
   const event = {
     type: 'keydown',
     key,
     shiftKey: opts.shiftKey ?? false,
+    isComposing: opts.isComposing ?? false,
     preventDefault: jest.fn(),
     stopPropagation: jest.fn(),
   };
@@ -851,6 +852,25 @@ describe('InlineAskUserQuestion', () => {
       // Should be on Q2 tab
       const tabs = container.querySelectorAll('claudian-ask-tab');
       expect(tabs[1]?.hasClass('is-active')).toBe(true);
+    });
+
+    it('does not advance from custom input on Enter during IME composition', () => {
+      const input = makeInput([
+        { question: 'Q1', options: ['A'], isOther: true },
+        { question: 'Q2', options: ['B'] },
+      ]);
+      const { container, widget } = renderWidget(input);
+      const root = findRoot(container);
+      const customItem = findItems(container).find((item: any) =>
+        item.hasClass('claudian-ask-custom-item'),
+      );
+
+      customItem?.click();
+      fireKeyDown(root, 'Enter', { isComposing: true });
+
+      const tabs = container.querySelectorAll('claudian-ask-tab');
+      expect(tabs[0]?.hasClass('is-active')).toBe(true);
+      expect((widget as any).isInputFocused).toBe(true);
     });
   });
 });

--- a/tests/unit/features/chat/rendering/InlineExitPlanMode.test.ts
+++ b/tests/unit/features/chat/rendering/InlineExitPlanMode.test.ts
@@ -13,10 +13,11 @@ beforeAll(() => {
   (globalThis as any).document = { activeElement: null };
 });
 
-function fireKeyDown(root: any, key: string): void {
+function fireKeyDown(root: any, key: string, isComposing = false): void {
   root.dispatchEvent({
     type: 'keydown',
     key,
+    isComposing,
     preventDefault: jest.fn(),
     stopPropagation: jest.fn(),
   });
@@ -170,6 +171,23 @@ describe('InlineExitPlanMode', () => {
 
     fireKeyDown(root, 'Enter');
     expect(resolve).toHaveBeenCalledWith({ type: 'feedback', text: 'Please revise the plan' });
+  });
+
+  it('does not submit feedback on Enter during IME composition', () => {
+    const container = createMockEl();
+    const resolve = jest.fn();
+    const widget = new InlineExitPlanMode(container, {}, resolve);
+    widget.render();
+
+    const root = findRoot(container);
+    const feedbackInput = findItems(root)[2].querySelector('claudian-ask-custom-text');
+    feedbackInput.value = 'composing text';
+    feedbackInput.dispatchEvent('focus');
+
+    fireKeyDown(root, 'Enter', true);
+
+    expect(resolve).not.toHaveBeenCalled();
+    expect((widget as any).isInputFocused).toBe(true);
   });
 
   it('resolves null on abort and does not resolve twice', () => {

--- a/tests/unit/features/chat/rendering/InlinePlanApproval.test.ts
+++ b/tests/unit/features/chat/rendering/InlinePlanApproval.test.ts
@@ -16,7 +16,7 @@ function createApproval(): {
   approval: InlinePlanApproval;
   resolve: jest.Mock<void, [PlanApprovalDecision | null]>;
   container: ReturnType<typeof createMockEl>;
-  fireKey: (key: string) => void;
+  fireKey: (key: string, isComposing?: boolean) => void;
 } {
   const container = createMockEl();
   const resolve = jest.fn<void, [PlanApprovalDecision | null]>();
@@ -24,12 +24,13 @@ function createApproval(): {
   approval.render();
 
   // The component binds keydown to rootEl via addEventListener.
-  // Our mock's dispatchEvent forwards {type, key} objects to listeners.
-  const fireKey = (key: string) => {
+  // Our mock's dispatchEvent forwards keyboard event objects to listeners.
+  const fireKey = (key: string, isComposing = false) => {
     const rootEl = (approval as any).rootEl;
     rootEl.dispatchEvent({
       type: 'keydown',
       key,
+      isComposing,
       preventDefault: () => {},
       stopPropagation: () => {},
     });
@@ -69,6 +70,18 @@ describe('InlinePlanApproval', () => {
       fireKey('Enter');
 
       expect(resolve).toHaveBeenCalledWith({ type: 'revise', text: 'Add error handling' });
+    });
+
+    it('does not submit feedback on Enter during IME composition', () => {
+      const { approval, resolve, fireKey } = createApproval();
+      const feedbackInput = (approval as any).feedbackInput;
+      feedbackInput.value = 'composing text';
+      feedbackInput.dispatchEvent('focus');
+
+      fireKey('Enter', true);
+
+      expect(resolve).not.toHaveBeenCalled();
+      expect((approval as any).isInputFocused).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

- keep AskUserQuestion custom input focused when Enter confirms IME composition
- prevent composing Enter from submitting feedback in both plan-review renderers
- add regression coverage for all three keyboard paths

## Validation

- npm run typecheck
- npm run lint
- npm run test
- npm run build

Fixes #916