### PR TITLE
fix: preserve Pi effort preferences per model

### DIFF
--- a/src/core/providers/ProviderSettingsCoordinator.ts
+++ b/src/core/providers/ProviderSettingsCoordinator.ts
@@ -160,6 +160,7 @@ export class ProviderSettingsCoordinator {
   ): void {
     const uiConfig = ProviderRegistry.getChatUIConfig(providerId);
     settings.model = model;
+    uiConfig.applyModelProjectionDefaults?.(model, settings);
     normalizeModelDependentSettings(uiConfig, settings, model);
   }
 

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -286,6 +286,9 @@ export interface ProviderChatUIConfig {
   /** Apply model change side effects to settings (defaults, tracking). */
   applyModelDefaults(model: string, settings: unknown): void;
 
+  /** Apply model-scoped defaults to an ephemeral conversation settings projection. */
+  applyModelProjectionDefaults?(model: string, settings: unknown): void;
+
   /** Optional provider hook to discover model-scoped metadata after a model is selected. */
   prepareModelMetadata?(
     model: string,

--- a/src/providers/pi/runtime/PiChatRuntime.ts
+++ b/src/providers/pi/runtime/PiChatRuntime.ts
@@ -6,9 +6,9 @@ import {
   computeSystemPromptKey,
   type SystemPromptSettings,
 } from '../../../core/prompt/mainAgent';
+import { getProviderSettingsSnapshotWithModel } from '../../../core/providers/conversationModel';
 import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
 import type { ProviderHost } from '../../../core/providers/ProviderHost';
-import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type { ProviderCapabilities } from '../../../core/providers/types';
 import type { ChatRuntime } from '../../../core/runtime/ChatRuntime';
 import type {
@@ -1051,14 +1051,11 @@ export class PiChatRuntime implements ChatRuntime {
   }
 
   private getProviderSettings(): Record<string, unknown> {
-    const settings = ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+    return getProviderSettingsSnapshotWithModel(
       this.plugin.settings,
       this.providerId,
+      this.currentConversationModel,
     );
-    if (this.currentConversationModel) {
-      settings.model = this.currentConversationModel;
-    }
-    return settings;
   }
 
   private setCurrentConversationModel(model: unknown): void {

--- a/src/providers/pi/ui/PiChatUIConfig.ts
+++ b/src/providers/pi/ui/PiChatUIConfig.ts
@@ -129,20 +129,9 @@ export const piChatUIConfig: ProviderChatUIConfig = {
     return isPiModelSelectionId(model);
   },
 
-  applyModelDefaults(model: string, settings: unknown): void {
-    if (!settings || typeof settings !== 'object' || Array.isArray(settings)) {
-      return;
-    }
+  applyModelDefaults: applyPiModelDefaults,
 
-    const settingsBag = settings as Record<string, unknown>;
-    if (!decodePiModelId(model)) {
-      settingsBag.effortLevel = 'off';
-      return;
-    }
-
-    settingsBag.model = model;
-    settingsBag.effortLevel = getPiDefaultReasoningValue(model, settingsBag);
-  },
+  applyModelProjectionDefaults: applyPiModelProjectionDefaults,
 
   applyReasoningSelection(model: string, value: string, settings: unknown): void {
     if (!settings || typeof settings !== 'object' || Array.isArray(settings)) {
@@ -215,6 +204,33 @@ function getCachedModel(model: string, settings: Record<string, unknown>): PiDis
   }
 
   return getPiProviderSettings(settings).discoveredModels.find(entry => entry.encodedId === model) ?? null;
+}
+
+function applyPiModelDefaults(model: string, settings: unknown): void {
+  if (!settings || typeof settings !== 'object' || Array.isArray(settings)) {
+    return;
+  }
+
+  const settingsBag = settings as Record<string, unknown>;
+  if (!decodePiModelId(model)) {
+    settingsBag.effortLevel = 'off';
+    return;
+  }
+
+  settingsBag.model = model;
+  settingsBag.effortLevel = getPiDefaultReasoningValue(model, settingsBag);
+}
+
+function applyPiModelProjectionDefaults(model: string, settings: unknown): void {
+  if (!settings || typeof settings !== 'object' || Array.isArray(settings)) {
+    return;
+  }
+
+  const settingsBag = settings as Record<string, unknown>;
+  const preferredThinkingLevel = getPiProviderSettings(settingsBag).preferredThinkingByModel[model];
+  if (preferredThinkingLevel) {
+    settingsBag.effortLevel = preferredThinkingLevel;
+  }
 }
 
 function getPiDefaultReasoningValue(model: string, settings: Record<string, unknown>): string {

--- a/tests/unit/core/providers/ProviderSettingsCoordinator.test.ts
+++ b/tests/unit/core/providers/ProviderSettingsCoordinator.test.ts
@@ -35,6 +35,54 @@ describe('ProviderSettingsCoordinator', () => {
       expect(snapshot.effortLevel).toBe('low');
       expect(settings.effortLevel).toBe('low');
     });
+
+    it('uses a Pi conversation model preference before normalizing against the saved provider model', () => {
+      const deepSeekModel = 'pi:deepseek/deepseek-reasoner';
+      const gptModel = 'pi:openai/gpt-5';
+      const settings: Record<string, unknown> = {
+        effortLevel: 'minimal',
+        model: deepSeekModel,
+        providerConfigs: {
+          pi: {
+            discoveredModels: [
+              {
+                encodedId: deepSeekModel,
+                id: 'deepseek-reasoner',
+                input: ['text'],
+                label: 'DeepSeek Reasoner',
+                provider: 'deepseek',
+                reasoning: true,
+                thinkingLevels: ['off', 'high'],
+              },
+              {
+                encodedId: gptModel,
+                id: 'gpt-5',
+                input: ['text'],
+                label: 'GPT-5',
+                provider: 'openai',
+                reasoning: true,
+                thinkingLevels: ['off', 'minimal', 'low', 'medium', 'high', 'xhigh'],
+              },
+            ],
+            enabled: true,
+            preferredThinkingByModel: {
+              [deepSeekModel]: 'high',
+              [gptModel]: 'minimal',
+            },
+            visibleModels: [deepSeekModel, gptModel],
+          },
+        },
+        savedProviderEffort: { pi: 'minimal' },
+        savedProviderModel: { pi: deepSeekModel },
+        serviceTier: 'default',
+        settingsProvider: 'pi',
+      };
+
+      const snapshot = getProviderSettingsSnapshotWithModel(settings, 'pi', gptModel);
+
+      expect(snapshot.model).toBe(gptModel);
+      expect(snapshot.effortLevel).toBe('minimal');
+    });
   });
 
   describe('applyModelSelection', () => {

--- a/tests/unit/providers/pi/runtime/PiChatRuntime.test.ts
+++ b/tests/unit/providers/pi/runtime/PiChatRuntime.test.ts
@@ -623,6 +623,62 @@ describe('PiChatRuntime', () => {
     });
   });
 
+  it('applies the conversation model thinking preference instead of the saved Pi model restriction', async () => {
+    const deepSeekModel = 'pi:deepseek/deepseek-reasoner';
+    const gptModel = 'pi:openai/gpt-5';
+    const plugin = createPlugin();
+    plugin.settings.effortLevel = 'minimal';
+    plugin.settings.model = deepSeekModel;
+    plugin.settings.providerConfigs.pi = {
+      discoveredModels: [
+        {
+          encodedId: deepSeekModel,
+          id: 'deepseek-reasoner',
+          input: ['text'],
+          label: 'DeepSeek Reasoner',
+          provider: 'deepseek',
+          reasoning: true,
+          thinkingLevels: ['off', 'high'],
+        },
+        {
+          encodedId: gptModel,
+          id: 'gpt-5',
+          input: ['text'],
+          label: 'GPT-5',
+          provider: 'openai',
+          reasoning: true,
+          thinkingLevels: ['off', 'minimal', 'low', 'medium', 'high', 'xhigh'],
+        },
+      ],
+      enabled: true,
+      preferredThinkingByModel: {
+        [deepSeekModel]: 'high',
+        [gptModel]: 'minimal',
+      },
+      visibleModels: [deepSeekModel, gptModel],
+    };
+    plugin.settings.savedProviderEffort = { pi: 'minimal' };
+    plugin.settings.savedProviderModel = { pi: deepSeekModel };
+    plugin.settings.settingsProvider = 'pi';
+    const runtime = new PiChatRuntime(plugin);
+    runtime.syncConversationState({ selectedModel: gptModel, sessionId: null });
+    const chunks: unknown[] = [];
+    const promise = (async () => {
+      for await (const chunk of runtime.query(createTurn(runtime))) {
+        chunks.push(chunk);
+      }
+    })();
+
+    await flushPromises();
+    mockTransportInstances[0].eventHandlers[0]({ type: 'agent_end' });
+    await promise;
+
+    expect(chunks[chunks.length - 1]).toEqual({ type: 'done' });
+    expect(mockTransportInstances[0].request).toHaveBeenCalledWith('set_thinking_level', {
+      level: 'minimal',
+    });
+  });
+
   it('applies changed models over RPC without restarting the Pi process', async () => {
     const plugin = createPlugin();
     plugin.settings.providerConfigs.pi = {

--- a/tests/unit/providers/pi/ui/PiChatUIConfig.test.ts
+++ b/tests/unit/providers/pi/ui/PiChatUIConfig.test.ts
@@ -96,6 +96,25 @@ describe('PiChatUIConfig', () => {
     )).toBe('high');
   });
 
+  it('applies only an existing per-model preference to conversation projections', () => {
+    const withPreference = structuredClone(settings);
+    withPreference.effortLevel = 'medium';
+    piChatUIConfig.applyModelProjectionDefaults?.(
+      'pi:anthropic/claude-sonnet-4',
+      withPreference,
+    );
+    expect(withPreference.effortLevel).toBe('high');
+
+    const withoutPreference = structuredClone(settings);
+    (withoutPreference.providerConfigs as any).pi.preferredThinkingByModel = {};
+    withoutPreference.effortLevel = 'medium';
+    piChatUIConfig.applyModelProjectionDefaults?.(
+      'pi:anthropic/claude-sonnet-4',
+      withoutPreference,
+    );
+    expect(withoutPreference.effortLevel).toBe('medium');
+  });
+
   it('resolves context windows from cached Pi model metadata before falling back', () => {
     const contextSettings: Record<string, unknown> = {
       providerConfigs: {


### PR DESCRIPTION
Closes #896.

This adds a provider-owned model-projection hook so Pi restores the target model's saved thinking preference before shared normalization.
The Pi runtime now uses the same model-aware settings snapshot as the UI while preserving valid fallback effort when no per-model preference exists.
Regression coverage spans coordinator projection, Pi UI preference handling, and runtime RPC behavior; typecheck, lint, all 5,994 tests, architecture checks, and the production build pass.
