### PR TITLE
Fix Codex JSONL rehydration parity

### DIFF
--- a/src/providers/codex/history/CodexHistoryStore.ts
+++ b/src/providers/codex/history/CodexHistoryStore.ts
@@ -16,6 +16,7 @@ import {
 } from '../codexUserText';
 import {
   appendCodexCommandOutput,
+  decodeCodexExecEnvelope,
   extractCodexExecCellId,
   isCodexToolOutputError,
   normalizeCodexMcpToolInput,
@@ -209,6 +210,7 @@ function createPersistedParseContext(): PersistedParseContext {
     terminalSessionToCommandId: new Map(),
     stdinCallToCommandId: new Map(),
     execCellToCommandId: new Map(),
+    execEnvelopeToolCallIds: new Map(),
     waitCallToCommand: new Map(),
     turnCounter: 0,
   };
@@ -274,11 +276,45 @@ function appendUniqueChunk(chunks: string[], value: string): void {
   chunks.push(trimmed);
 }
 
-function replaceLatestChunk(chunks: string[], value: string): void {
+function appendOrderedTextChunk(
+  bubble: CodexAssistantBubble,
+  type: 'text' | 'thinking',
+  value: string,
+): void {
   const trimmed = value.trim();
   if (!trimmed) return;
-  chunks.length = 0;
+
+  const chunks = type === 'text' ? bubble.contentChunks : bubble.thinkingChunks;
+  const lastBlock = bubble.contentBlocks[bubble.contentBlocks.length - 1];
+  if (lastBlock?.type === type) {
+    if (chunks[chunks.length - 1] === trimmed) return;
+
+    chunks.push(trimmed);
+    lastBlock.content = `${lastBlock.content}\n\n${trimmed}`;
+    return;
+  }
+
   chunks.push(trimmed);
+  bubble.contentBlocks.push({ type, content: trimmed });
+}
+
+function replaceLatestOrderedTextChunk(
+  bubble: CodexAssistantBubble,
+  type: 'text' | 'thinking',
+  value: string,
+): void {
+  const trimmed = value.trim();
+  if (!trimmed) return;
+
+  const chunks = type === 'text' ? bubble.contentChunks : bubble.thinkingChunks;
+  const lastBlock = bubble.contentBlocks[bubble.contentBlocks.length - 1];
+  if (lastBlock?.type !== type || chunks.length === 0) {
+    appendOrderedTextChunk(bubble, type, trimmed);
+    return;
+  }
+
+  chunks[chunks.length - 1] = trimmed;
+  lastBlock.content = trimmed;
 }
 
 function appendUserChunk(turn: CodexTurnState, value: string, timestamp: number): void {
@@ -642,6 +678,7 @@ interface PersistedParseContext {
   terminalSessionToCommandId: Map<string, string>;
   stdinCallToCommandId: Map<string, string>;
   execCellToCommandId: Map<string, string>;
+  execEnvelopeToolCallIds: Map<string, string[]>;
   waitCallToCommand: Map<string, { commandCallId: string; cellId: string }>;
   turnCounter: number;
 }
@@ -661,6 +698,19 @@ function processPersistedToolCall(
 
   const rawArgs = payload.arguments ?? payload.input;
   const parsedArgs = parseCodexArguments(rawArgs);
+  const execEnvelopeCalls = payload.name === 'exec'
+    ? decodeCodexExecEnvelope(parsedArgs)
+    : null;
+  if (execEnvelopeCalls && execEnvelopeCalls.length > 1) {
+    const toolCallIds = execEnvelopeCalls.map((call, index) => {
+      const nestedCallId = `${callId}:${index + 1}`;
+      pushPersistedNormalizedToolCall(nestedCallId, call, timestamp, ctx);
+      return nestedCallId;
+    });
+    ctx.execEnvelopeToolCallIds.set(callId, toolCallIds);
+    return;
+  }
+
   const normalized = normalizeCodexToolCall(payload.name, parsedArgs);
 
   if (normalized.name === 'wait') {
@@ -686,7 +736,22 @@ function processPersistedToolCall(
     }
   }
 
-  const turn = ensureTurn(ctx.turns, ctx.turnOrder, nextTurnId(ctx), ctx.currentTurnId, timestamp);
+  pushPersistedNormalizedToolCall(callId, normalized, timestamp, ctx);
+}
+
+function pushPersistedNormalizedToolCall(
+  callId: string,
+  normalized: { name: string; input: Record<string, unknown> },
+  timestamp: number,
+  ctx: PersistedParseContext,
+): void {
+  const turn = ensureTurn(
+    ctx.turns,
+    ctx.turnOrder,
+    nextTurnId(ctx),
+    ctx.currentTurnId,
+    timestamp,
+  );
   const bubble = ensureAssistantBubble(turn, timestamp);
 
   const toolCall: ToolCallInfo = {
@@ -714,6 +779,18 @@ function processPersistedToolOutput(
 
   // output can be a string or an array (e.g. view_image returns image objects)
   const rawOutput = stringifyCodexToolOutput(payload.output);
+
+  const execEnvelopeToolCallIds = ctx.execEnvelopeToolCallIds.get(callId);
+  if (execEnvelopeToolCallIds) {
+    applyPersistedExecEnvelopeOutput(
+      execEnvelopeToolCallIds,
+      payload.output,
+      rawOutput,
+      ctx,
+    );
+    ctx.execEnvelopeToolCallIds.delete(callId);
+    return;
+  }
 
   const waitCall = ctx.waitCallToCommand.get(callId);
   if (waitCall) {
@@ -787,6 +864,69 @@ function findPersistedToolCallById(ctx: PersistedParseContext, callId: string): 
   }
 
   return turn.assistantBubbles[origin.bubbleIndex].toolCalls.find(tool => tool.id === callId) ?? null;
+}
+
+function applyPersistedExecEnvelopeOutput(
+  toolCallIds: string[],
+  rawOutputValue: string | unknown[] | undefined,
+  rawOutputText: string,
+  ctx: PersistedParseContext,
+): void {
+  const toolCalls = toolCallIds
+    .map(toolCallId => findPersistedToolCallById(ctx, toolCallId))
+    .filter((toolCall): toolCall is ToolCallInfo => toolCall !== null);
+  if (toolCalls.length === 0) return;
+
+  const outputParts = splitPersistedExecEnvelopeOutput(rawOutputValue, toolCalls.length);
+  if (outputParts) {
+    for (const [index, toolCall] of toolCalls.entries()) {
+      const outputPart = outputParts[index] ?? '';
+      applyPersistedToolOutput(toolCall, outputPart, outputPart, ctx);
+    }
+    return;
+  }
+
+  // Without one output item per nested call, preserve the aggregate result on
+  // the final card instead of inventing a per-command split.
+  const isError = isCodexToolOutputError(rawOutputText);
+  for (const toolCall of toolCalls) {
+    toolCall.status = isError ? 'error' : 'completed';
+  }
+
+  const lastToolCall = toolCalls[toolCalls.length - 1];
+  if (lastToolCall) {
+    lastToolCall.result = normalizeCodexToolResult(lastToolCall.name, rawOutputText);
+  }
+}
+
+function splitPersistedExecEnvelopeOutput(
+  rawOutputValue: string | unknown[] | undefined,
+  toolCallCount: number,
+): string[] | null {
+  if (!Array.isArray(rawOutputValue)) return null;
+
+  const outputParts: string[] = [];
+  for (const part of rawOutputValue) {
+    if (!part || typeof part !== 'object' || Array.isArray(part)) return null;
+    const text = (part as Record<string, unknown>).text;
+    if (typeof text !== 'string') return null;
+    outputParts.push(text);
+  }
+
+  // The outer exec transport prepends its own completion header before values
+  // emitted by each text(...) call in the envelope.
+  if (
+    outputParts.length === toolCallCount + 1
+    && isPersistedExecEnvelopeHeader(outputParts[0] ?? '')
+  ) {
+    return outputParts.slice(1);
+  }
+
+  return outputParts.length === toolCallCount ? outputParts : null;
+}
+
+function isPersistedExecEnvelopeHeader(value: string): boolean {
+  return value.startsWith('Script ') && value.endsWith('Output:\n');
 }
 
 function readTerminalSessionIdArgument(input: Record<string, unknown>): string | undefined {
@@ -978,7 +1118,7 @@ function processPersistedPayload(
         const turn = ensureTurn(ctx.turns, ctx.turnOrder, nextTurnId(ctx), ctx.currentTurnId, timestamp);
         const bubble = ensureAssistantBubble(turn, timestamp);
         if (text) {
-          appendUniqueChunk(bubble.contentChunks, text);
+          appendOrderedTextChunk(bubble, 'text', text);
         }
       }
       break;
@@ -991,7 +1131,7 @@ function processPersistedPayload(
 
       const turn = ensureTurn(ctx.turns, ctx.turnOrder, nextTurnId(ctx), ctx.currentTurnId, timestamp);
       const bubble = ensureAssistantBubble(turn, timestamp);
-      appendUniqueChunk(bubble.thinkingChunks, text);
+      appendOrderedTextChunk(bubble, 'thinking', text);
       break;
     }
 
@@ -1094,7 +1234,7 @@ function processEventMsg(
       const bubble = ensureAssistantBubble(turn, timestamp);
       const msg = payload.message;
       if (typeof msg === 'string') {
-        appendUniqueChunk(bubble.contentChunks, msg);
+        appendOrderedTextChunk(bubble, 'text', msg);
       }
       break;
     }
@@ -1105,7 +1245,7 @@ function processEventMsg(
 
       const turn = ensureTurn(ctx.turns, ctx.turnOrder, nextTurnId(ctx), ctx.currentTurnId, timestamp);
       const bubble = ensureAssistantBubble(turn, timestamp);
-      appendUniqueChunk(bubble.thinkingChunks, text);
+      appendOrderedTextChunk(bubble, 'thinking', text);
       break;
     }
 
@@ -1187,14 +1327,7 @@ function flushBubbleTurnMessages(
       continue;
     }
 
-    const contentBlocks: ContentBlock[] = [];
-    if (hasThinking) {
-      contentBlocks.push({ type: 'thinking', content: thinkingText.trim() });
-    }
-    contentBlocks.push(...bubble.contentBlocks);
-    if (hasContent) {
-      contentBlocks.push({ type: 'text', content: contentText.trim() });
-    }
+    const contentBlocks = bubble.contentBlocks;
 
     const msg: ChatMessage = {
       id: `codex-msg-${msgIndex}`,
@@ -1643,7 +1776,7 @@ function processLegacyItemInModernContext(
       if ((eventType === 'item.updated' || eventType === 'item.completed') && item.text) {
         const turn = ensureTurn(ctx.turns, ctx.turnOrder, nextTurnId(ctx), ctx.currentTurnId, timestamp);
         const bubble = ensureAssistantBubble(turn, timestamp);
-        replaceLatestChunk(bubble.contentChunks, item.text);
+        replaceLatestOrderedTextChunk(bubble, 'text', item.text);
       }
       break;
     }
@@ -1652,7 +1785,7 @@ function processLegacyItemInModernContext(
       if ((eventType === 'item.updated' || eventType === 'item.completed') && item.text) {
         const turn = ensureTurn(ctx.turns, ctx.turnOrder, nextTurnId(ctx), ctx.currentTurnId, timestamp);
         const bubble = ensureAssistantBubble(turn, timestamp);
-        replaceLatestChunk(bubble.thinkingChunks, item.text);
+        replaceLatestOrderedTextChunk(bubble, 'thinking', item.text);
       }
       break;
     }

--- a/src/providers/codex/normalization/codexToolNormalization.ts
+++ b/src/providers/codex/normalization/codexToolNormalization.ts
@@ -49,20 +49,20 @@ export function normalizeCodexToolCall(
   rawName: string | undefined,
   rawInput: Record<string, unknown>,
 ): NormalizedCodexToolCall {
-  const nestedCall = rawName === 'exec' ? decodeExecEnvelope(rawInput) : null;
-  const effectiveName = nestedCall?.name ?? rawName;
-  const effectiveInput = nestedCall?.input ?? rawInput;
+  const nestedCalls = rawName === 'exec' ? decodeCodexExecEnvelope(rawInput) : null;
+  if (nestedCalls?.length === 1) {
+    return nestedCalls[0];
+  }
 
   return {
-    name: normalizeCodexToolName(effectiveName),
-    input: normalizeCodexToolInput(effectiveName, effectiveInput),
+    name: normalizeCodexToolName(rawName),
+    input: normalizeCodexToolInput(rawName, rawInput),
   };
 }
 
-function decodeExecEnvelope(input: Record<string, unknown>): {
-  name: string;
-  input: Record<string, unknown>;
-} | null {
+export function decodeCodexExecEnvelope(
+  input: Record<string, unknown>,
+): NormalizedCodexToolCall[] | null {
   const source = firstNonEmptyString(input.raw, input.value);
   if (!source) return null;
 
@@ -70,22 +70,28 @@ function decodeExecEnvelope(input: Record<string, unknown>): {
   if (!tokens) return null;
 
   const calls = findExecEnvelopeToolCalls(tokens);
-  if (!calls || calls.length !== 1) return null;
+  if (!calls || calls.length === 0) return null;
 
-  const call = calls[0];
-  if (!call) return null;
+  const decodedCalls: NormalizedCodexToolCall[] = [];
+  for (const call of calls) {
+    if (call.name === 'exec_command') {
+      const command = extractExecCommand(tokens, call);
+      if (!command) return null;
+      decodedCalls.push({ name: 'Bash', input: { command } });
+      continue;
+    }
 
-  if (call.name === 'exec_command') {
-    const command = extractExecCommand(tokens, call);
-    return command ? { name: call.name, input: { cmd: command } } : null;
+    if (call.name === 'apply_patch') {
+      const patch = extractApplyPatch(tokens, call);
+      if (!patch) return null;
+      decodedCalls.push({ name: 'apply_patch', input: { patch } });
+      continue;
+    }
+
+    return null;
   }
 
-  if (call.name === 'apply_patch') {
-    const patch = extractApplyPatch(tokens, call);
-    return patch ? { name: call.name, input: { patch } } : null;
-  }
-
-  return null;
+  return decodedCalls;
 }
 
 type JavaScriptTokenKind = 'identifier' | 'string' | 'punctuation';

--- a/tests/unit/providers/codex/history/CodexHistoryStore.test.ts
+++ b/tests/unit/providers/codex/history/CodexHistoryStore.test.ts
@@ -120,6 +120,105 @@ describe('CodexHistoryStore', () => {
       ]);
     });
 
+    it('preserves interleaved reasoning, tools, and assistant text in transcript order', () => {
+      const content = [
+        JSON.stringify({
+          timestamp: '2026-07-13T00:00:00.000Z',
+          type: 'event_msg',
+          payload: { type: 'task_started' },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-13T00:00:01.000Z',
+          type: 'event_msg',
+          payload: { type: 'agent_reasoning', text: 'Inspecting the note.' },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-13T00:00:01.001Z',
+          type: 'response_item',
+          payload: {
+            type: 'reasoning',
+            summary: [{ type: 'summary_text', text: 'Inspecting the note.' }],
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-13T00:00:02.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'custom_tool_call',
+            name: 'exec',
+            call_id: 'call_read',
+            input: 'const r = await tools.exec_command({cmd:"sed -n \'1,20p\' DEMO.md"}); text(r.output);',
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-13T00:00:03.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'custom_tool_call_output',
+            call_id: 'call_read',
+            output: 'Script completed\nOutput:\nDemo content',
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-13T00:00:04.000Z',
+          type: 'event_msg',
+          payload: { type: 'agent_reasoning', text: 'Verifying the edit.' },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-13T00:00:04.001Z',
+          type: 'response_item',
+          payload: {
+            type: 'reasoning',
+            summary: [{ type: 'summary_text', text: 'Verifying the edit.' }],
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-13T00:00:05.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'custom_tool_call',
+            name: 'exec',
+            call_id: 'call_verify',
+            input: 'const r = await tools.exec_command({cmd:"tail -n 2 DEMO.md"}); text(r.output);',
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-13T00:00:06.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'custom_tool_call_output',
+            call_id: 'call_verify',
+            output: 'Script completed\nOutput:\nEdited',
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-13T00:00:07.000Z',
+          type: 'event_msg',
+          payload: { type: 'agent_message', message: 'Done.' },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-13T00:00:07.001Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'Done.' }],
+          },
+        }),
+      ].join('\n');
+
+      const messages = parseCodexSessionContent(content);
+      const assistantMessage = messages.find(message => message.role === 'assistant');
+
+      expect(assistantMessage?.contentBlocks).toEqual([
+        { type: 'thinking', content: 'Inspecting the note.' },
+        { type: 'tool_use', toolId: 'call_read' },
+        { type: 'thinking', content: 'Verifying the edit.' },
+        { type: 'tool_use', toolId: 'call_verify' },
+        { type: 'text', content: 'Done.' },
+      ]);
+    });
+
     it('rehydrates user images from persisted input_image parts', () => {
       const content = [
         JSON.stringify({
@@ -491,6 +590,79 @@ describe('CodexHistoryStore', () => {
           status: 'completed',
         }),
       ]));
+    });
+
+    it('restores every command from a multi-command exec envelope', () => {
+      const content = [
+        JSON.stringify({
+          timestamp: '2026-07-13T00:00:00.000Z',
+          type: 'event_msg',
+          payload: { type: 'task_started' },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-13T00:00:01.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'custom_tool_call',
+            name: 'exec',
+            call_id: 'call_exec_group',
+            input: [
+              'const first = await tools.exec_command({cmd:"pwd",workdir:"/vault"});',
+              'text(first.output);',
+              'const second = await tools.exec_command({cmd:"printf edit",workdir:"/vault"});',
+              'text(second.output);',
+              'const third = await tools.exec_command({cmd:"wc -l note.md",workdir:"/vault"});',
+              'text(third.output);',
+            ].join('\n'),
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-13T00:00:02.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'custom_tool_call_output',
+            call_id: 'call_exec_group',
+            output: [
+              { type: 'input_text', text: 'Script completed\nWall time 0.1 seconds\nOutput:\n' },
+              { type: 'input_text', text: '/vault\n' },
+              { type: 'input_text', text: '' },
+              { type: 'input_text', text: '80 note.md\n' },
+            ],
+          },
+        }),
+      ].join('\n');
+
+      const messages = parseCodexSessionContent(content);
+      const assistantMessage = messages.find(message => message.role === 'assistant');
+
+      expect(assistantMessage?.toolCalls).toEqual([
+        expect.objectContaining({
+          id: 'call_exec_group:1',
+          name: 'Bash',
+          input: { command: 'pwd' },
+          result: '/vault\n',
+          status: 'completed',
+        }),
+        expect.objectContaining({
+          id: 'call_exec_group:2',
+          name: 'Bash',
+          input: { command: 'printf edit' },
+          result: '',
+          status: 'completed',
+        }),
+        expect.objectContaining({
+          id: 'call_exec_group:3',
+          name: 'Bash',
+          input: { command: 'wc -l note.md' },
+          result: '80 note.md\n',
+          status: 'completed',
+        }),
+      ]);
+      expect(assistantMessage?.contentBlocks).toEqual([
+        { type: 'tool_use', toolId: 'call_exec_group:1' },
+        { type: 'tool_use', toolId: 'call_exec_group:2' },
+        { type: 'tool_use', toolId: 'call_exec_group:3' },
+      ]);
     });
 
     it('restores yielded exec envelopes as one completed Bash tool', () => {
@@ -2474,7 +2646,7 @@ describe('CodexHistoryStore', () => {
         {
           role: 'assistant',
           content: 'I will update the template.',
-          blockTypes: ['tool_use', 'text'],
+          blockTypes: ['text', 'tool_use'],
           tools: ['call-before-compact'],
         },
         {

--- a/tests/unit/providers/codex/normalization/codexToolNormalization.test.ts
+++ b/tests/unit/providers/codex/normalization/codexToolNormalization.test.ts
@@ -1,4 +1,5 @@
 import {
+  decodeCodexExecEnvelope,
   isCodexToolOutputError,
   normalizeCodexMcpToolInput,
   normalizeCodexMcpToolName,
@@ -230,6 +231,20 @@ describe('normalizeCodexToolCall', () => {
       name: 'exec',
       input: { raw: source },
     });
+  });
+
+  it('decodes every supported tool from a multi-call exec envelope', () => {
+    const source = [
+      'const first = await tools.exec_command({cmd:"pwd"});',
+      'const second = await tools.exec_command({cmd:"ls"});',
+      'text(first.output);',
+      'text(second.output);',
+    ].join('\n');
+
+    expect(decodeCodexExecEnvelope({ raw: source })).toEqual([
+      { name: 'Bash', input: { command: 'pwd' } },
+      { name: 'Bash', input: { command: 'ls' } },
+    ]);
   });
 
   it('preserves exec when another nested tool accompanies exec_command', () => {


### PR DESCRIPTION
## Summary
- Preserve persisted thinking, tool, and assistant-text blocks in transcript order while deduplicating mirrored Codex records.
- Decode multi-command `exec` envelopes into stable native tool cards and associate persisted output segments with each nested command.
- Add regression coverage for interleaved replay order, single-command envelopes, and multi-command hydration.

## Validation
- `npm run typecheck && npm run lint && npm run test && npm run build` (262 suites, 5,997 tests)