### PR TITLE
Reset composer height after sending long prompts

### DIFF
--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -1519,7 +1519,7 @@ export function initializeTabControllers(
     getStatusPanel: () => ui.statusPanel,
     generateId: generateMessageId,
     resetInputHeight: () => {
-      // Per-tab input height is managed by CSS, no dynamic adjustment needed
+      autoResizeTextarea(dom.inputEl);
     },
     getAuxiliaryModel: () => getTabSelectedModel(tab, plugin),
     getAgentService: () => tab.service,

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -28,6 +28,7 @@ import {
   updatePlanModeUI,
   wireTabInputEvents,
 } from '@/features/chat/tabs/Tab';
+import { TEXTAREA_BASE_MIN_HEIGHT } from '@/features/chat/ui/textareaResize';
 import * as envUtils from '@/utils/env';
 
 // Mock ResizeObserver (not available in jsdom)
@@ -2862,6 +2863,26 @@ describe('Tab - Controller Configuration', () => {
       expect(config.getInstructionModeManager()).toBe(tab.ui.instructionModeManager);
       expect(config.getInstructionRefineService()).toBe(tab.services.instructionRefineService);
       expect(config.getTitleGenerationService()).toBe(tab.services.titleGenerationService);
+    });
+
+    it('should reset a grown composer to its default height after the input is cleared', () => {
+      const { InputController } = jest.requireMock('@/features/chat/controllers/InputController');
+      const options = createMockOptions();
+      const tab = createTab(options);
+
+      initializeTabUI(tab, options.plugin);
+      initializeTabControllers(tab, options.plugin, {} as any, options.mcpManager);
+
+      const constructorCall = InputController.mock.calls[0];
+      const config = constructorCall[0];
+      const inputStyle = tab.dom.inputEl.style as unknown as Record<string, string>;
+      tab.dom.inputEl.value = '';
+      inputStyle['--claudian-textarea-min-height'] = '240px';
+
+      config.resetInputHeight();
+
+      expect(inputStyle['--claudian-textarea-min-height'])
+        .toBe(`${TEXTAREA_BASE_MIN_HEIGHT}px`);
     });
 
   });


### PR DESCRIPTION
## Summary
Resets the chat composer through the existing autosize routine whenever sending clears the input, so long prompts no longer leave it expanded.
Adds an integration regression test covering a grown composer returning to its base height.

## Testing
`npm run typecheck && npm run lint && npm run test && npm run build`