### PR TITLE
Fix native tool cards in Codex JSONL replay

### DIFF
--- a/src/providers/codex/history/CodexHistoryStore.ts
+++ b/src/providers/codex/history/CodexHistoryStore.ts
@@ -881,7 +881,12 @@ function applyPersistedExecEnvelopeOutput(
   if (outputParts) {
     for (const [index, toolCall] of toolCalls.entries()) {
       const outputPart = outputParts[index] ?? '';
-      applyPersistedToolOutput(toolCall, outputPart, outputPart, ctx);
+      applyPersistedToolOutput(
+        toolCall,
+        outputPart,
+        stringifyCodexToolOutput(outputPart),
+        ctx,
+      );
     }
     return;
   }
@@ -902,22 +907,22 @@ function applyPersistedExecEnvelopeOutput(
 function splitPersistedExecEnvelopeOutput(
   rawOutputValue: string | unknown[] | undefined,
   toolCallCount: number,
-): string[] | null {
+): Array<string | unknown[]> | null {
   if (!Array.isArray(rawOutputValue)) return null;
 
-  const outputParts: string[] = [];
+  const outputParts: Array<string | unknown[]> = [];
   for (const part of rawOutputValue) {
     if (!part || typeof part !== 'object' || Array.isArray(part)) return null;
     const text = (part as Record<string, unknown>).text;
-    if (typeof text !== 'string') return null;
-    outputParts.push(text);
+    outputParts.push(typeof text === 'string' ? text : [part]);
   }
 
   // The outer exec transport prepends its own completion header before values
   // emitted by each text(...) call in the envelope.
   if (
     outputParts.length === toolCallCount + 1
-    && isPersistedExecEnvelopeHeader(outputParts[0] ?? '')
+    && typeof outputParts[0] === 'string'
+    && isPersistedExecEnvelopeHeader(outputParts[0])
   ) {
     return outputParts.slice(1);
   }

--- a/src/providers/codex/normalization/codexToolNormalization.ts
+++ b/src/providers/codex/normalization/codexToolNormalization.ts
@@ -74,27 +74,18 @@ export function decodeCodexExecEnvelope(
 
   const decodedCalls: NormalizedCodexToolCall[] = [];
   for (const call of calls) {
-    if (call.name === 'exec_command') {
-      const command = extractExecCommand(tokens, call);
-      if (!command) return null;
-      decodedCalls.push({ name: 'Bash', input: { command } });
-      continue;
-    }
-
-    if (call.name === 'apply_patch') {
-      const patch = extractApplyPatch(tokens, call);
-      if (!patch) return null;
-      decodedCalls.push({ name: 'apply_patch', input: { patch } });
-      continue;
-    }
-
-    return null;
+    const rawInput = decodeExecEnvelopeToolInput(tokens, call);
+    if (!rawInput) return null;
+    decodedCalls.push({
+      name: normalizeCodexToolName(call.name),
+      input: normalizeCodexToolInput(call.name, rawInput),
+    });
   }
 
   return decodedCalls;
 }
 
-type JavaScriptTokenKind = 'identifier' | 'string' | 'punctuation';
+type JavaScriptTokenKind = 'identifier' | 'number' | 'string' | 'punctuation';
 
 interface JavaScriptToken {
   kind: JavaScriptTokenKind;
@@ -153,6 +144,14 @@ function tokenizeExecEnvelope(source: string): JavaScriptToken[] | null {
       }
       tokens.push({ kind: 'identifier', value: source.slice(index, end) });
       index = end;
+      continue;
+    }
+
+    if (/\d/.test(char)) {
+      const numberMatch = source.slice(index).match(/^\d+(?:\.\d+)?(?:[eE][+-]?\d+)?/);
+      if (!numberMatch) return null;
+      tokens.push({ kind: 'number', value: numberMatch[0] });
+      index += numberMatch[0].length;
       continue;
     }
 
@@ -233,33 +232,137 @@ function findExecEnvelopeToolCalls(
   return calls;
 }
 
-function extractExecCommand(
+function decodeExecEnvelopeToolInput(
   tokens: readonly JavaScriptToken[],
   call: ExecEnvelopeToolCall,
-): string | null {
+): Record<string, unknown> | null {
+  if (call.name === 'apply_patch') {
+    const patch = extractApplyPatch(tokens, call);
+    return patch ? { patch } : null;
+  }
+
   const closeParenTokenIndex = findMatchingToken(tokens, call.openParenTokenIndex, '(', ')');
   if (closeParenTokenIndex === null) return null;
-  if (tokens[call.openParenTokenIndex + 1]?.value !== '{') return null;
+  if (call.openParenTokenIndex + 1 === closeParenTokenIndex) return {};
 
-  let objectDepth = 0;
-  for (let index = call.openParenTokenIndex + 1; index < closeParenTokenIndex; index += 1) {
-    const token = tokens[index];
-    if (token?.value === '{') {
-      objectDepth += 1;
-      continue;
-    }
+  const parsedArgument = parseStaticJavaScriptValue(tokens, call.openParenTokenIndex + 1);
+  if (!parsedArgument || parsedArgument.nextTokenIndex !== closeParenTokenIndex) return null;
+
+  if (
+    parsedArgument.value
+    && typeof parsedArgument.value === 'object'
+    && !Array.isArray(parsedArgument.value)
+  ) {
+    return parsedArgument.value as Record<string, unknown>;
+  }
+
+  return { value: parsedArgument.value };
+}
+
+interface ParsedStaticJavaScriptValue {
+  value: unknown;
+  nextTokenIndex: number;
+}
+
+function parseStaticJavaScriptValue(
+  tokens: readonly JavaScriptToken[],
+  tokenIndex: number,
+): ParsedStaticJavaScriptValue | null {
+  const token = tokens[tokenIndex];
+  if (!token) return null;
+
+  if (token.kind === 'string') {
+    return { value: token.value, nextTokenIndex: tokenIndex + 1 };
+  }
+
+  if (token.kind === 'number') {
+    const value = Number(token.value);
+    return Number.isFinite(value)
+      ? { value, nextTokenIndex: tokenIndex + 1 }
+      : null;
+  }
+
+  if (token.kind === 'identifier') {
+    if (token.value === 'true') return { value: true, nextTokenIndex: tokenIndex + 1 };
+    if (token.value === 'false') return { value: false, nextTokenIndex: tokenIndex + 1 };
+    if (token.value === 'null') return { value: null, nextTokenIndex: tokenIndex + 1 };
+    return null;
+  }
+
+  if (token.value === '-') {
+    const numberToken = tokens[tokenIndex + 1];
+    if (numberToken?.kind !== 'number') return null;
+    const value = -Number(numberToken.value);
+    return Number.isFinite(value)
+      ? { value, nextTokenIndex: tokenIndex + 2 }
+      : null;
+  }
+
+  if (token.value === '{') {
+    return parseStaticJavaScriptObject(tokens, tokenIndex);
+  }
+
+  if (token.value === '[') {
+    return parseStaticJavaScriptArray(tokens, tokenIndex);
+  }
+
+  return null;
+}
+
+function parseStaticJavaScriptObject(
+  tokens: readonly JavaScriptToken[],
+  openTokenIndex: number,
+): ParsedStaticJavaScriptValue | null {
+  const value: Record<string, unknown> = {};
+  let tokenIndex = openTokenIndex + 1;
+
+  while (tokenIndex < tokens.length) {
+    const token = tokens[tokenIndex];
     if (token?.value === '}') {
-      objectDepth -= 1;
+      return { value, nextTokenIndex: tokenIndex + 1 };
+    }
+    if (token?.kind !== 'identifier' && token?.kind !== 'string') return null;
+    if (tokens[tokenIndex + 1]?.value !== ':') return null;
+
+    const parsedValue = parseStaticJavaScriptValue(tokens, tokenIndex + 2);
+    if (!parsedValue) return null;
+    value[token.value] = parsedValue.value;
+    tokenIndex = parsedValue.nextTokenIndex;
+
+    const separator = tokens[tokenIndex]?.value;
+    if (separator === ',') {
+      tokenIndex += 1;
       continue;
     }
-    if (
-      objectDepth === 1
-      && token?.value === 'cmd'
-      && tokens[index + 1]?.value === ':'
-      && tokens[index + 2]?.kind === 'string'
-    ) {
-      return tokens[index + 2]?.value ?? null;
+    if (separator !== '}') return null;
+  }
+
+  return null;
+}
+
+function parseStaticJavaScriptArray(
+  tokens: readonly JavaScriptToken[],
+  openTokenIndex: number,
+): ParsedStaticJavaScriptValue | null {
+  const value: unknown[] = [];
+  let tokenIndex = openTokenIndex + 1;
+
+  while (tokenIndex < tokens.length) {
+    if (tokens[tokenIndex]?.value === ']') {
+      return { value, nextTokenIndex: tokenIndex + 1 };
     }
+
+    const parsedValue = parseStaticJavaScriptValue(tokens, tokenIndex);
+    if (!parsedValue) return null;
+    value.push(parsedValue.value);
+    tokenIndex = parsedValue.nextTokenIndex;
+
+    const separator = tokens[tokenIndex]?.value;
+    if (separator === ',') {
+      tokenIndex += 1;
+      continue;
+    }
+    if (separator !== ']') return null;
   }
 
   return null;

--- a/tests/unit/providers/codex/history/CodexHistoryStore.test.ts
+++ b/tests/unit/providers/codex/history/CodexHistoryStore.test.ts
@@ -665,6 +665,64 @@ describe('CodexHistoryStore', () => {
       ]);
     });
 
+    it('restores every image view from a multi-call exec envelope', () => {
+      const content = [
+        JSON.stringify({
+          timestamp: '2026-07-13T00:00:00.000Z',
+          type: 'event_msg',
+          payload: { type: 'task_started' },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-13T00:00:01.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'custom_tool_call',
+            name: 'exec',
+            call_id: 'call_image_group',
+            input: [
+              'const first = await tools.view_image({path:"/tmp/first.png",detail:"original"});',
+              'image(first.image_url);',
+              'const second = await tools.view_image({path:"/tmp/second.png",detail:"original"});',
+              'image(second.image_url);',
+            ].join('\n'),
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-13T00:00:02.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'custom_tool_call_output',
+            call_id: 'call_image_group',
+            output: [
+              { type: 'input_text', text: 'Script completed\nWall time 0.0 seconds\nOutput:\n' },
+              { type: 'input_image', image_url: 'data:image/png;base64,Zmlyc3Q=' },
+              { type: 'input_image', image_url: 'data:image/png;base64,c2Vjb25k' },
+            ],
+          },
+        }),
+      ].join('\n');
+
+      const messages = parseCodexSessionContent(content);
+      const assistantMessage = messages.find(message => message.role === 'assistant');
+
+      expect(assistantMessage?.toolCalls).toEqual([
+        expect.objectContaining({
+          id: 'call_image_group:1',
+          name: 'Read',
+          input: expect.objectContaining({ file_path: '/tmp/first.png' }),
+          result: '/tmp/first.png',
+          status: 'completed',
+        }),
+        expect.objectContaining({
+          id: 'call_image_group:2',
+          name: 'Read',
+          input: expect.objectContaining({ file_path: '/tmp/second.png' }),
+          result: '/tmp/second.png',
+          status: 'completed',
+        }),
+      ]);
+    });
+
     it('restores yielded exec envelopes as one completed Bash tool', () => {
       const content = [
         JSON.stringify({

--- a/tests/unit/providers/codex/normalization/codexToolNormalization.test.ts
+++ b/tests/unit/providers/codex/normalization/codexToolNormalization.test.ts
@@ -247,6 +247,48 @@ describe('normalizeCodexToolCall', () => {
     ]);
   });
 
+  it('decodes static view_image calls from an exec envelope', () => {
+    const source = [
+      'const first = await tools.view_image({path:"/tmp/first.png",detail:"original"});',
+      'image(first.image_url);',
+      'const second = await tools.view_image({path:"/tmp/second.png",detail:"high"});',
+      'image(second.image_url);',
+    ].join('\n');
+
+    expect(decodeCodexExecEnvelope({ raw: source })).toEqual([
+      {
+        name: 'Read',
+        input: { path: '/tmp/first.png', detail: 'original', file_path: '/tmp/first.png' },
+      },
+      {
+        name: 'Read',
+        input: { path: '/tmp/second.png', detail: 'high', file_path: '/tmp/second.png' },
+      },
+    ]);
+  });
+
+  it('decodes static update_plan calls from an exec envelope', () => {
+    const source = [
+      'const result = await tools.update_plan({',
+      '  explanation:"Starting work",',
+      '  plan:[{step:"Inspect files",status:"in_progress"}]',
+      '});',
+      'text(result);',
+    ].join('\n');
+
+    expect(decodeCodexExecEnvelope({ raw: source })).toEqual([{
+      name: 'TodoWrite',
+      input: {
+        todos: [{
+          id: '',
+          content: 'Inspect files',
+          activeForm: 'Inspect files',
+          status: 'in_progress',
+        }],
+      },
+    }]);
+  });
+
   it('preserves exec when another nested tool accompanies exec_command', () => {
     const source = [
       'await tools.update_plan({plan:[]});',


### PR DESCRIPTION
## Summary

- Decode statically safe direct `tools.*` calls in persisted Codex `exec` envelopes, including `view_image` and `update_plan`, through the shared normalization boundary.
- Preserve non-text outputs so multi-image envelopes rehydrate as separate native `Read` cards instead of a bare `exec` card.
- Add normalization and history regressions based on the affected session JSONL.

## Verification

- `npm run typecheck && npm run lint && npm run test && npm run build`