### PR TITLE
Feat (Approvals): Warn on Invisible or Bidirectional Characters in Commands

### DIFF
--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -55,6 +55,10 @@ import type { CanvasSelectionController } from './CanvasSelectionController';
 import type { ConversationController } from './ConversationController';
 import type { SelectionController } from './SelectionController';
 import type { StreamController } from './StreamController';
+import {
+  hasSuspiciousCommandText,
+  SUSPICIOUS_COMMAND_WARNING,
+} from './suspiciousCommandText';
 import type { ActiveTurnOwner } from './TurnCoordinator';
 import { TurnCoordinator } from './TurnCoordinator';
 
@@ -1468,6 +1472,13 @@ export class InputController {
     }
     if (approvalOptions?.agentID) {
       headerEl.createDiv({ text: `Agent: ${approvalOptions.agentID}`, cls: 'claudian-ask-approval-agent' });
+    }
+
+    if (hasSuspiciousCommandText(description)) {
+      headerEl.createDiv({
+        text: SUSPICIOUS_COMMAND_WARNING,
+        cls: 'claudian-ask-approval-warning',
+      });
     }
 
     headerEl.createDiv({ text: description, cls: 'claudian-ask-approval-desc' });

--- a/src/features/chat/controllers/suspiciousCommandText.ts
+++ b/src/features/chat/controllers/suspiciousCommandText.ts
@@ -1,0 +1,36 @@
+/**
+ * Detects invisible, control, and bidirectional-spoofing characters in a
+ * command string so the approval UI can warn before the user approves.
+ *
+ * This is a provider-independent display safeguard only. It does not parse or
+ * interpret shell syntax and never changes what gets executed; it simply flags
+ * text whose visible rendering may not match its actual bytes.
+ */
+
+export const SUSPICIOUS_COMMAND_WARNING =
+  'This command contains invisible or bidirectional control characters. Review the command carefully.';
+
+export function hasSuspiciousCommandText(text: string): boolean {
+  return Array.from(text).some(isSuspiciousCommandCharacter);
+}
+
+export function isSuspiciousCommandCharacter(character: string): boolean {
+  const codePoint = character.codePointAt(0);
+  if (codePoint === undefined) {
+    return false;
+  }
+
+  return (
+    codePoint <= 0x08 // C0 controls (excluding tab/newline/carriage return)
+    || codePoint === 0x0b
+    || codePoint === 0x0c
+    || (codePoint >= 0x0e && codePoint <= 0x1f)
+    || (codePoint >= 0x7f && codePoint <= 0x9f) // DEL + C1 controls
+    || codePoint === 0x061c // Arabic letter mark
+    || (codePoint >= 0x200b && codePoint <= 0x200f) // zero-width + LRM/RLM
+    || (codePoint >= 0x202a && codePoint <= 0x202e) // bidi embeddings/overrides
+    || codePoint === 0x2060 // word joiner
+    || (codePoint >= 0x2066 && codePoint <= 0x2069) // bidi isolates
+    || codePoint === 0xfeff // zero-width no-break space / BOM
+  );
+}

--- a/src/style/features/ask-user-question.css
+++ b/src/style/features/ask-user-question.css
@@ -304,6 +304,15 @@
   margin-bottom: 6px;
 }
 
+.claudian-ask-approval-warning {
+  padding: 6px 10px;
+  margin-bottom: 6px;
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--text-on-accent);
+  background: var(--text-error);
+}
+
 .claudian-ask-approval-desc {
   padding: 8px 10px;
   background: var(--background-primary-alt);

--- a/tests/unit/features/chat/controllers/suspiciousCommandText.test.ts
+++ b/tests/unit/features/chat/controllers/suspiciousCommandText.test.ts
@@ -1,0 +1,55 @@
+import {
+  hasSuspiciousCommandText,
+  isSuspiciousCommandCharacter,
+} from '@/features/chat/controllers/suspiciousCommandText';
+
+const cp = (codePoint: number): string => String.fromCodePoint(codePoint);
+
+describe('suspiciousCommandText', () => {
+  describe('isSuspiciousCommandCharacter', () => {
+    it('flags C0 control characters (excluding tab/newline/carriage return)', () => {
+      expect(isSuspiciousCommandCharacter(cp(0x00))).toBe(true);
+      expect(isSuspiciousCommandCharacter(cp(0x08))).toBe(true);
+      expect(isSuspiciousCommandCharacter(cp(0x1b))).toBe(true); // ESC
+    });
+
+    it('flags DEL and C1 control characters', () => {
+      expect(isSuspiciousCommandCharacter(cp(0x7f))).toBe(true);
+      expect(isSuspiciousCommandCharacter(cp(0x9f))).toBe(true);
+    });
+
+    it('flags zero-width, bidi, and BOM characters', () => {
+      expect(isSuspiciousCommandCharacter(cp(0x200b))).toBe(true); // zero-width space
+      expect(isSuspiciousCommandCharacter(cp(0x200e))).toBe(true); // LRM
+      expect(isSuspiciousCommandCharacter(cp(0x202e))).toBe(true); // RLO
+      expect(isSuspiciousCommandCharacter(cp(0x2066))).toBe(true); // LRI
+      expect(isSuspiciousCommandCharacter(cp(0x061c))).toBe(true); // ALM
+      expect(isSuspiciousCommandCharacter(cp(0x2060))).toBe(true); // word joiner
+      expect(isSuspiciousCommandCharacter(cp(0xfeff))).toBe(true); // BOM
+    });
+
+    it('does not flag ordinary command characters or common whitespace', () => {
+      for (const char of 'git commit -m "hello world" | grep foo\t\r\n') {
+        expect(isSuspiciousCommandCharacter(char)).toBe(false);
+      }
+    });
+  });
+
+  describe('hasSuspiciousCommandText', () => {
+    it('returns false for a normal command', () => {
+      expect(hasSuspiciousCommandText('rm -rf ./build && npm run ship')).toBe(false);
+    });
+
+    it('returns true when a bidi override is hidden in the command', () => {
+      expect(hasSuspiciousCommandText(`rm ${cp(0x202e)}harmless.txt`)).toBe(true);
+    });
+
+    it('returns true for an embedded zero-width space', () => {
+      expect(hasSuspiciousCommandText(`npm${cp(0x200b)} install left-pad`)).toBe(true);
+    });
+
+    it('returns false for an empty string', () => {
+      expect(hasSuspiciousCommandText('')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Splitting the independently-useful piece out of #911 as suggested.

Command approval requests render the command string directly. That text can carry invisible controls or bidirectional overrides (Trojan Source style) so the visible rendering differs from what would actually run. This adds a provider-independent warning above the command when such characters are present, prompting the user to review the exact command before approving.

No shell parsing, no heuristic boundary, and no change to what executes: it only flags text whose appearance may not match its content.
Detector covers C0/C1 controls, DEL, zero-width, LRM/RLM/ALM, bidi embeddings/overrides/isolates, word joiner, and BOM.
Pure detector in its own module with focused unit tests.