### PR TITLE
Fix custom Claude context limit precedence

### DIFF
--- a/src/providers/claude/runtime/ClaudeChatRuntime.ts
+++ b/src/providers/claude/runtime/ClaudeChatRuntime.ts
@@ -82,6 +82,7 @@ import {
   createTransformUsageState,
   transformSDKMessage,
 } from '../stream/transformClaudeMessage';
+import { resolveContextWindowSize } from '../types/models';
 import { type ClaudeProviderState, getClaudeState } from '../types/providerState';
 import { createClaudeApprovalCallback } from './ClaudeApprovalHandler';
 import { applyClaudeDynamicUpdates } from './ClaudeDynamicUpdates';
@@ -308,18 +309,30 @@ export class ClaudianService implements ChatRuntime {
     }
 
     const usage = this.bufferedUsageChunk.usage;
+    const settings = this.getScopedSettings();
+    const contextWindowResolution = resolveContextWindowSize(
+      usage.model ?? settings.model,
+      settings.customContextLimits,
+      contextWindow,
+    );
+    const effectiveContextWindow = contextWindowResolution.contextWindow;
     const percentage = Math.min(
       100,
-      Math.max(0, Math.round((usage.contextTokens / contextWindow) * 100)),
+      Math.max(0, Math.round((usage.contextTokens / effectiveContextWindow) * 100)),
     );
+    const nextUsage = {
+      ...usage,
+      contextWindow: effectiveContextWindow,
+      percentage,
+    };
+    if (contextWindowResolution.source === 'runtime') {
+      nextUsage.contextWindowIsAuthoritative = true;
+    } else {
+      delete nextUsage.contextWindowIsAuthoritative;
+    }
     const nextChunk: Extract<StreamChunk, { type: 'usage' }> = {
       ...this.bufferedUsageChunk,
-      usage: {
-        ...usage,
-        contextWindow,
-        contextWindowIsAuthoritative: true,
-        percentage,
-      },
+      usage: nextUsage,
     };
     this.bufferedUsageChunk = nextChunk;
     return nextChunk;

--- a/src/providers/claude/stream/transformClaudeMessage.ts
+++ b/src/providers/claude/stream/transformClaudeMessage.ts
@@ -4,7 +4,7 @@ import type { SDKToolUseResult, StreamChunk, UsageInfo } from '../../../core/typ
 import { isBlockedMessage } from '../sdk/messages';
 import { extractToolResultContent } from '../sdk/toolResultContent';
 import type { TransformEvent } from '../sdk/types';
-import { getContextWindowSize, isDefaultClaudeModel } from '../types/models';
+import { isDefaultClaudeModel, resolveContextWindowSize } from '../types/models';
 import { createTransformStreamState, type TransformStreamState } from './toolInputStreamState';
 
 type ToolUseFields = { id: string; name: string; input: Record<string, unknown> };
@@ -305,12 +305,12 @@ function samePromptUsage(a: PromptUsageSnapshot, b: PromptUsageSnapshot): boolea
 
 function buildUsageInfo(promptUsage: PromptUsageSnapshot, options?: TransformOptions): UsageInfo {
   const model = options?.intendedModel ?? 'sonnet';
-  const hasAuthoritativeContextWindow = typeof options?.authoritativeContextWindow === 'number'
-    && options.authoritativeContextWindow > 0
-    && Number.isFinite(options.authoritativeContextWindow);
-  const contextWindow = hasAuthoritativeContextWindow
-    ? options.authoritativeContextWindow!
-    : getContextWindowSize(model, options?.customContextLimits);
+  const contextWindowResolution = resolveContextWindowSize(
+    model,
+    options?.customContextLimits,
+    options?.authoritativeContextWindow,
+  );
+  const { contextWindow } = contextWindowResolution;
   const percentage = Math.min(100, Math.max(0, Math.round((promptUsage.contextTokens / contextWindow) * 100)));
 
   return {
@@ -319,7 +319,7 @@ function buildUsageInfo(promptUsage: PromptUsageSnapshot, options?: TransformOpt
     cacheCreationInputTokens: promptUsage.cacheCreationInputTokens,
     cacheReadInputTokens: promptUsage.cacheReadInputTokens,
     contextWindow,
-    ...(hasAuthoritativeContextWindow ? { contextWindowIsAuthoritative: true } : {}),
+    ...(contextWindowResolution.source === 'runtime' ? { contextWindowIsAuthoritative: true } : {}),
     contextTokens: promptUsage.contextTokens,
     percentage,
   };

--- a/src/providers/claude/types/models.ts
+++ b/src/providers/claude/types/models.ts
@@ -132,6 +132,13 @@ export function resolveEffortLevel(
 export const CONTEXT_WINDOW_STANDARD = 200_000;
 export const CONTEXT_WINDOW_1M = 1_000_000;
 
+export type ContextWindowSource = 'custom' | 'runtime' | 'model-default';
+
+export interface ContextWindowResolution {
+  contextWindow: number;
+  source: ContextWindowSource;
+}
+
 function isCurrentOneMillionContextModel(model: string): boolean {
   const normalized = normalizeModelId(normalizeLegacy1MModelAlias(model));
   if (normalized === 'opus' || normalized === 'sonnet' || isFableModel(normalized)) {
@@ -164,4 +171,25 @@ export function getContextWindowSize(
   }
 
   return CONTEXT_WINDOW_STANDARD;
+}
+
+export function resolveContextWindowSize(
+  model: string,
+  customLimits?: Record<string, number>,
+  runtimeContextWindow?: number,
+): ContextWindowResolution {
+  // Explicit overrides describe custom gateway capabilities that the Claude runtime may not recognize.
+  const customLimit = resolveCustomContextLimit(model, customLimits);
+  if (customLimit !== null) {
+    return { contextWindow: customLimit, source: 'custom' };
+  }
+
+  if (isValidContextLimit(runtimeContextWindow)) {
+    return { contextWindow: runtimeContextWindow, source: 'runtime' };
+  }
+
+  return {
+    contextWindow: getContextWindowSize(model),
+    source: 'model-default',
+  };
 }

--- a/tests/unit/providers/claude/runtime/ClaudianService.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudianService.test.ts
@@ -267,6 +267,66 @@ describe('ClaudianService', () => {
       expect((service as any).getTransformOptions('sonnet').authoritativeContextWindow).toBe(1_000_000);
     });
 
+    it('should preserve an explicit custom-model limit when result metadata reports another window', () => {
+      Object.assign(mockPlugin.settings!, {
+        model: 'custom-model',
+        customContextLimits: { 'custom-model': 1_000_000 },
+      });
+      (service as any).bufferedUsageChunk = {
+        type: 'usage',
+        usage: {
+          model: 'custom-model',
+          inputTokens: 250_000,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+          contextWindow: 1_000_000,
+          contextTokens: 250_000,
+          percentage: 25,
+        },
+      };
+
+      const updated = (service as any).updateBufferedUsageContextWindow(200_000);
+
+      expect(updated.usage).toEqual({
+        model: 'custom-model',
+        inputTokens: 250_000,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+        contextWindow: 1_000_000,
+        contextTokens: 250_000,
+        percentage: 25,
+      });
+    });
+
+    it('should apply result metadata when no explicit custom-model limit exists', () => {
+      Object.assign(mockPlugin.settings!, { model: 'custom-model', customContextLimits: {} });
+      (service as any).bufferedUsageChunk = {
+        type: 'usage',
+        usage: {
+          model: 'custom-model',
+          inputTokens: 100_000,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+          contextWindow: 1_000_000,
+          contextTokens: 100_000,
+          percentage: 10,
+        },
+      };
+
+      const updated = (service as any).updateBufferedUsageContextWindow(200_000);
+
+      expect(updated.usage).toEqual({
+        model: 'custom-model',
+        inputTokens: 100_000,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+        contextWindow: 200_000,
+        contextWindowIsAuthoritative: true,
+        contextTokens: 100_000,
+        percentage: 50,
+      });
+    });
+
     it('should coalesce concurrent context-window discovery for the same query and model', async () => {
       let resolveContextUsage!: (value: { rawMaxTokens: number }) => void;
       const mockQuery = {

--- a/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
+++ b/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
@@ -1034,6 +1034,44 @@ describe('transformSDKMessage', () => {
       ]);
     });
 
+    it('prefers an explicit custom-model context limit over the SDK runtime window', () => {
+      const usageState = createTransformUsageState();
+      const assistantMessage = msg({
+        type: 'assistant',
+        parent_tool_use_id: null,
+        message: {
+          content: [{ type: 'text', text: 'Hello' }],
+          usage: {
+            input_tokens: 250000,
+            output_tokens: 4,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          },
+        },
+      });
+
+      expect([...transformSDKMessage(assistantMessage, {
+        intendedModel: 'custom-model',
+        customContextLimits: { 'custom-model': 1_000_000 },
+        authoritativeContextWindow: 200_000,
+        usageState,
+      })]).toEqual([
+        { type: 'text', content: 'Hello' },
+        {
+          type: 'usage',
+          usage: {
+            model: 'custom-model',
+            inputTokens: 250000,
+            cacheCreationInputTokens: 0,
+            cacheReadInputTokens: 0,
+            contextWindow: 1_000_000,
+            contextTokens: 250000,
+            percentage: 25,
+          },
+        },
+      ]);
+    });
+
     it('emits message_start prompt usage at result when no assistant usage arrives', () => {
       const usageState = createTransformUsageState();
       const startMessage = msg({


### PR DESCRIPTION
Preserves explicit custom-model context limits when the Claude SDK reports a generic runtime window, while continuing to trust SDK metadata when no override exists. Centralizes the precedence rule and applies it during both stream calculation and result-time reconciliation. Adds regression coverage for explicit overrides and runtime fallback behavior. Verification: typecheck, lint, all 6,005 tests, and the production build pass. Addresses the custom-model failure mode in #924.