### PR TITLE
fix: honor provider enablement in settings and discovery

### DIFF
--- a/src/core/providers/ProviderRegistry.ts
+++ b/src/core/providers/ProviderRegistry.ts
@@ -15,6 +15,7 @@ import {
   type ProviderSettingsStorageAdapter,
   type ProviderSubagentLifecycleAdapter,
   type ProviderTaskResultInterpreter,
+  type ProviderUIOption,
   type TitleGenerationCallback,
   type TitleGenerationService,
 } from './types';
@@ -67,6 +68,7 @@ export class ProviderRegistry {
 
     return this.resolveProviderForModel(titleModel, settings, {
       fallbackProviderId: DEFAULT_CHAT_PROVIDER_ID,
+      onlyEnabledProviders: true,
     });
   }
 
@@ -108,6 +110,29 @@ export class ProviderRegistry {
     return this.getProviderRegistration(providerId).chatUIConfig;
   }
 
+  static getTitleGenerationModelOptions(
+    settings: Record<string, unknown>,
+  ): ProviderUIOption[] {
+    const options: ProviderUIOption[] = [];
+    const seenValues = new Set<string>();
+
+    for (const providerId of this.getRegisteredProviderIds()) {
+      if (!this.isEnabled(providerId, settings)) {
+        continue;
+      }
+
+      for (const option of this.getChatUIConfig(providerId).getModelOptions(settings)) {
+        if (seenValues.has(option.value)) {
+          continue;
+        }
+        seenValues.add(option.value);
+        options.push(option);
+      }
+    }
+
+    return options;
+  }
+
   static getSettingsReconciler(providerId: ProviderId = DEFAULT_CHAT_PROVIDER_ID): ProviderSettingsReconciler {
     return this.getProviderRegistration(providerId).settingsReconciler;
   }
@@ -138,6 +163,22 @@ export class ProviderRegistry {
 
   static isEnabled(providerId: ProviderId, settings: Record<string, unknown>): boolean {
     return this.getProviderRegistration(providerId).isEnabled(settings);
+  }
+
+  static setEnabled(
+    providerId: ProviderId,
+    settings: Record<string, unknown>,
+    enabled: boolean,
+  ): void {
+    const registration = this.getProviderRegistration(providerId);
+    if (registration.setEnabled) {
+      registration.setEnabled(settings, enabled);
+      return;
+    }
+
+    if (registration.isEnabled(settings) !== enabled) {
+      throw new Error(`Provider "${providerId}" enablement is not configurable.`);
+    }
   }
 
   static resolveSettingsProviderId(settings: Record<string, unknown>): ProviderId {

--- a/src/core/providers/ProviderSettingsCoordinator.ts
+++ b/src/core/providers/ProviderSettingsCoordinator.ts
@@ -187,6 +187,10 @@ export class ProviderSettingsCoordinator {
     }
 
     for (const providerId of ProviderRegistry.getRegisteredProviderIds()) {
+      if (!ProviderRegistry.isEnabled(providerId, settings)) {
+        continue;
+      }
+
       const uiConfig = ProviderRegistry.getChatUIConfig(providerId);
       if (!uiConfig.ownsModel(currentModel, settings)) {
         continue;
@@ -223,6 +227,16 @@ export class ProviderSettingsCoordinator {
 
     settings.settingsProvider = next;
     return true;
+  }
+
+  static applyProviderEnablement(
+    settings: Record<string, unknown>,
+    providerId: ProviderId,
+    enabled: boolean,
+  ): void {
+    ProviderRegistry.setEnabled(providerId, settings, enabled);
+    this.normalizeProviderSelection(settings);
+    this.reconcileTitleGenerationModelSelection(settings);
   }
 
   static getProviderSettingsSnapshot<T extends Record<string, unknown>>(

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -56,6 +56,7 @@ export interface ProviderRegistration {
   displayName: string;
   blankTabOrder: number;
   isEnabled: (settings: Record<string, unknown>) => boolean;
+  setEnabled?: (settings: Record<string, unknown>, enabled: boolean) => void;
   capabilities: ProviderCapabilities;
   environmentKeyPatterns?: RegExp[];
   chatUIConfig: ProviderChatUIConfig;
@@ -412,6 +413,7 @@ export interface ProviderSettingsTabRendererContext {
     copy: { name: string; desc: string; placeholder: string },
   ): void;
   refreshModelSelectors(): void;
+  refreshTitleGenerationModelOptions(): void;
   renderCustomContextLimits(container: HTMLElement, providerId?: ProviderId): void;
 }
 

--- a/src/features/settings/ClaudianSettings.ts
+++ b/src/features/settings/ClaudianSettings.ts
@@ -107,6 +107,7 @@ function addHotkeySettingRow(
 export class ClaudianSettingTab extends PluginSettingTab {
   plugin: FeatureHost;
   private activeTab: SettingsTabId = 'general';
+  private refreshTitleModelOptions: (() => void) | null = null;
 
   constructor(app: App, plugin: FeatureHost & Plugin) {
     super(app, plugin);
@@ -117,6 +118,7 @@ export class ClaudianSettingTab extends PluginSettingTab {
     const { containerEl } = this;
     containerEl.empty();
     containerEl.addClass('claudian-settings');
+    this.refreshTitleModelOptions = null;
 
     setLocale(this.plugin.settings.locale as Locale);
 
@@ -175,6 +177,7 @@ export class ClaudianSettingTab extends PluginSettingTab {
             view.refreshModelSelector();
           }
         },
+        refreshTitleGenerationModelOptions: () => this.refreshTitleModelOptions?.(),
         renderCustomContextLimits: (target, providerId) => this.renderCustomContextLimits(target, providerId),
       });
     }
@@ -316,27 +319,24 @@ export class ClaudianSettingTab extends PluginSettingTab {
         .setName(t('settings.titleModel.name'))
         .setDesc(t('settings.titleModel.desc'))
         .addDropdown((dropdown) => {
-          dropdown.addOption('', t('settings.titleModel.auto'));
+          const refreshOptions = (): void => {
+            dropdown.selectEl.replaceChildren();
+            dropdown.addOption('', t('settings.titleModel.auto'));
 
-          const settingsBag = this.plugin.settings as unknown as Record<string, unknown>;
-          const seenValues = new Set<string>();
-          for (const providerId of ProviderRegistry.getRegisteredProviderIds()) {
-            const uiConfig = ProviderRegistry.getChatUIConfig(providerId);
-            for (const model of uiConfig.getModelOptions(settingsBag)) {
-              if (!seenValues.has(model.value)) {
-                seenValues.add(model.value);
-                dropdown.addOption(model.value, model.label);
-              }
+            const settingsBag = this.plugin.settings as unknown as Record<string, unknown>;
+            for (const model of ProviderRegistry.getTitleGenerationModelOptions(settingsBag)) {
+              dropdown.addOption(model.value, model.label);
             }
-          }
+            dropdown.setValue(this.plugin.settings.titleGenerationModel || '');
+          };
 
-          dropdown
-            .setValue(this.plugin.settings.titleGenerationModel || '')
-            .onChange(async (value) => {
-              await this.plugin.mutateSettings((settings) => {
-                settings.titleGenerationModel = value;
-              });
+          this.refreshTitleModelOptions = refreshOptions;
+          refreshOptions();
+          dropdown.onChange(async (value) => {
+            await this.plugin.mutateSettings((settings) => {
+              settings.titleGenerationModel = value;
             });
+          });
         });
     }
 

--- a/src/providers/codex/app/CodexWorkspaceServices.ts
+++ b/src/providers/codex/app/CodexWorkspaceServices.ts
@@ -70,6 +70,9 @@ export async function createCodexWorkspaceServices(
     },
     refreshModelCatalog: async () => {
       const result = await modelDiscovery.discoverModels();
+      if (result.kind === 'skipped') {
+        return { changed: false };
+      }
       if (result.diagnostics) {
         return { changed: false, diagnostics: result.diagnostics };
       }

--- a/src/providers/codex/registration.ts
+++ b/src/providers/codex/registration.ts
@@ -9,7 +9,11 @@ import { codexSettingsReconciler } from './env/CodexSettingsReconciler';
 import { CodexConversationHistoryService } from './history/CodexConversationHistoryService';
 import { codexSubagentLifecycleAdapter } from './normalization/codexSubagentNormalization';
 import { CodexChatRuntime } from './runtime/CodexChatRuntime';
-import { getCodexProviderSettings, normalizeCodexStoredConfig } from './settings';
+import {
+  getCodexProviderSettings,
+  normalizeCodexStoredConfig,
+  updateCodexProviderSettings,
+} from './settings';
 import { codexChatUIConfig } from './ui/CodexChatUIConfig';
 
 export const codexProviderRegistration: ProviderModule = {
@@ -17,6 +21,7 @@ export const codexProviderRegistration: ProviderModule = {
   displayName: 'Codex',
   blankTabOrder: 15,
   isEnabled: (settings) => getCodexProviderSettings(settings).enabled,
+  setEnabled: (settings, enabled) => updateCodexProviderSettings(settings, { enabled }),
   capabilities: CODEX_PROVIDER_CAPABILITIES,
   environmentKeyPatterns: [/^OPENAI_/i, /^CODEX_/i],
   chatUIConfig: codexChatUIConfig,

--- a/src/providers/codex/runtime/CodexModelDiscoveryService.ts
+++ b/src/providers/codex/runtime/CodexModelDiscoveryService.ts
@@ -3,6 +3,7 @@ import {
   type CodexDiscoveredModel,
   normalizeCodexDiscoveredModels,
 } from '../models';
+import { getCodexProviderSettings } from '../settings';
 import { CodexAppServerProcess } from './CodexAppServerProcess';
 import {
   initializeCodexAppServerTransport,
@@ -11,10 +12,16 @@ import {
 import type { ModelListResult } from './codexAppServerTypes';
 import { CodexRpcTransport } from './CodexRpcTransport';
 
-export interface CodexModelDiscoveryResult {
-  diagnostics?: string;
-  models: CodexDiscoveredModel[];
-}
+export type CodexModelDiscoveryResult =
+  | {
+    kind: 'completed';
+    diagnostics?: string;
+    models: CodexDiscoveredModel[];
+  }
+  | {
+    kind: 'skipped';
+    reason: 'provider-disabled';
+  };
 
 const MODEL_LIST_PAGE_SIZE = 100;
 
@@ -22,6 +29,10 @@ export class CodexModelDiscoveryService {
   constructor(private readonly plugin: ProviderHost) {}
 
   async discoverModels(): Promise<CodexModelDiscoveryResult> {
+    if (!getCodexProviderSettings(this.plugin.settings).enabled) {
+      return { kind: 'skipped', reason: 'provider-disabled' };
+    }
+
     let process: CodexAppServerProcess | null = null;
     let transport: CodexRpcTransport | null = null;
 
@@ -56,12 +67,16 @@ export class CodexModelDiscoveryService {
         cursor = nextCursor;
       } while (cursor);
 
-      return { models: normalizeCodexDiscoveredModels(entries) };
+      return {
+        kind: 'completed',
+        models: normalizeCodexDiscoveredModels(entries),
+      };
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Codex model discovery failed';
       const stderr = process?.getStderrSnapshot() ?? '';
       return {
         diagnostics: stderr ? `${message}\n\n${stderr}` : message,
+        kind: 'completed',
         models: [],
       };
     } finally {

--- a/src/providers/codex/ui/CodexSettingsTab.ts
+++ b/src/providers/codex/ui/CodexSettingsTab.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import { Notice, Setting } from 'obsidian';
 
+import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type { ProviderSettingsTabRenderer } from '../../../core/providers/types';
 import { t } from '../../../i18n/i18n';
 import { renderEnvironmentSettingsSection } from '../../../shared/settings/EnvironmentSettingsSection';
@@ -44,12 +45,13 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
           .setValue(codexSettings.enabled)
           .onChange(async (value) => {
             await context.plugin.mutateSettings((settings) => {
-              updateCodexProviderSettings(settings, { enabled: value });
+              ProviderSettingsCoordinator.applyProviderEnablement(settings, 'codex', value);
             });
             if (value) {
               await refreshCodexModelCatalog();
             }
             context.refreshModelSelectors();
+            context.refreshTitleGenerationModelOptions();
           })
       );
 

--- a/src/providers/opencode/registration.ts
+++ b/src/providers/opencode/registration.ts
@@ -24,6 +24,7 @@ export const opencodeProviderRegistration: ProviderModule = {
   environmentKeyPatterns: [/^OPENCODE_/i],
   historyService: new OpencodeConversationHistoryService(),
   isEnabled: (settings) => getOpencodeProviderSettings(settings).enabled,
+  setEnabled: (settings, enabled) => updateOpencodeProviderSettings(settings, { enabled }),
   settingsReconciler: opencodeSettingsReconciler,
   settingsStorage: {
     hostScopedFields: ['cliPathsByHost'],

--- a/src/providers/opencode/ui/OpencodeSettingsTab.ts
+++ b/src/providers/opencode/ui/OpencodeSettingsTab.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import { Setting } from 'obsidian';
 
+import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type {
   ProviderSettingsTabRenderer,
   ProviderSettingsTabRendererContext,
@@ -50,9 +51,10 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
           .setValue(opencodeSettings.enabled)
           .onChange(async (value) => {
             await context.plugin.mutateSettings((settings) => {
-              updateOpencodeProviderSettings(settings, { enabled: value });
+              ProviderSettingsCoordinator.applyProviderEnablement(settings, 'opencode', value);
             });
             context.refreshModelSelectors();
+            context.refreshTitleGenerationModelOptions();
           })
       );
 

--- a/src/providers/pi/registration.ts
+++ b/src/providers/pi/registration.ts
@@ -27,6 +27,7 @@ export const piProviderRegistration: ProviderModule = {
   environmentKeyPatterns: [/^PI_/i],
   historyService: new PiConversationHistoryService(),
   isEnabled: (settings) => getPiProviderSettings(settings).enabled,
+  setEnabled: (settings, enabled) => updatePiProviderSettings(settings, { enabled }),
   settingsReconciler: piSettingsReconciler,
   settingsStorage: {
     hostScopedFields: ['cliPathsByHost'],

--- a/src/providers/pi/runtime/PiModelDiscoveryService.ts
+++ b/src/providers/pi/runtime/PiModelDiscoveryService.ts
@@ -11,16 +11,26 @@ import { buildPiLaunchSpec } from './PiLaunchSpec';
 import { PiRpcTransport } from './PiRpcTransport';
 import { PiSubprocess } from './PiSubprocess';
 
-export interface PiModelDiscoveryResult {
-  diagnostics?: string;
-  models: PiDiscoveredModel[];
-}
+export type PiModelDiscoveryResult =
+  | {
+    kind: 'completed';
+    diagnostics?: string;
+    models: PiDiscoveredModel[];
+  }
+  | {
+    kind: 'skipped';
+    reason: 'provider-disabled';
+  };
 
 export class PiModelDiscoveryService {
   constructor(private readonly plugin: ProviderHost) {}
 
   async discoverModels(): Promise<PiModelDiscoveryResult> {
     const settings = getPiProviderSettings(this.plugin.settings);
+    if (!settings.enabled) {
+      return { kind: 'skipped', reason: 'provider-disabled' };
+    }
+
     const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
     const command = this.plugin.getResolvedProviderCliPath('pi') ?? 'pi';
     const envText = getRuntimeEnvironmentText(this.plugin.settings, 'pi');
@@ -64,12 +74,13 @@ export class PiModelDiscoveryService {
       });
       const response = await transport.request('get_available_models', {}, 20_000);
       const models = normalizePiDiscoveredModels(extractModels(response));
-      return { models };
+      return { kind: 'completed', models };
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Pi model discovery failed';
       const stderr = subprocess.getStderrSnapshot();
       return {
         diagnostics: stderr ? `${message}\n\n${stderr}` : message,
+        kind: 'completed',
         models: [],
       };
     } finally {

--- a/src/providers/pi/ui/PiSettingsTab.ts
+++ b/src/providers/pi/ui/PiSettingsTab.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 
 import { Notice, Setting } from 'obsidian';
 
+import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type {
   ProviderSettingsTabRenderer,
   ProviderSettingsTabRendererContext,
@@ -41,9 +42,10 @@ export const piSettingsTabRenderer: ProviderSettingsTabRenderer = {
           .setValue(piSettings.enabled)
           .onChange(async (value) => {
             await context.plugin.mutateSettings((settings) => {
-              updatePiProviderSettings(settings, { enabled: value });
+              ProviderSettingsCoordinator.applyProviderEnablement(settings, 'pi', value);
             });
             context.refreshModelSelectors();
+            context.refreshTitleGenerationModelOptions();
           })
       );
 
@@ -143,6 +145,9 @@ function renderPiModelPicker(
     getState,
     async loadCatalog() {
       const result = await new PiModelDiscoveryService(context.plugin).discoverModels();
+      if (result.kind === 'skipped') {
+        return getPiProviderSettings(settingsBag).discoveredModels.length > 0 ? 'loaded' : 'empty';
+      }
       if (result.diagnostics) {
         new Notice(`Pi discovery failed: ${result.diagnostics}`);
         return 'failed';

--- a/tests/unit/core/providers/ProviderRegistry.test.ts
+++ b/tests/unit/core/providers/ProviderRegistry.test.ts
@@ -1,6 +1,6 @@
 import '@/providers';
 
-import { TEST_CODEX_MODEL } from '@test/helpers/codexModels';
+import { TEST_CODEX_CATALOG, TEST_CODEX_MODEL } from '@test/helpers/codexModels';
 
 import { ProviderRegistry } from '@/core/providers/ProviderRegistry';
 import { ProviderWorkspaceRegistry } from '@/core/providers/ProviderWorkspaceRegistry';
@@ -133,6 +133,34 @@ describe('ProviderRegistry', () => {
     })).toEqual(['opencode', 'pi', 'codex', 'claude']);
   });
 
+  it('exposes title generation models only from enabled providers', () => {
+    const disabledSettings = {
+      providerConfigs: {
+        codex: {
+          discoveredModels: TEST_CODEX_CATALOG,
+          enabled: false,
+        },
+      },
+    };
+    const enabledSettings = {
+      providerConfigs: {
+        codex: {
+          discoveredModels: TEST_CODEX_CATALOG,
+          enabled: true,
+        },
+      },
+    };
+
+    expect(
+      ProviderRegistry.getTitleGenerationModelOptions(disabledSettings)
+        .some(option => option.value === TEST_CODEX_MODEL),
+    ).toBe(false);
+    expect(
+      ProviderRegistry.getTitleGenerationModelOptions(enabledSettings)
+        .some(option => option.value === TEST_CODEX_MODEL),
+    ).toBe(true);
+  });
+
   it('returns the display name from provider registration metadata', () => {
     expect(ProviderRegistry.getProviderDisplayName('claude')).toBe('Claude');
     expect(ProviderRegistry.getProviderDisplayName('codex')).toBe('Codex');
@@ -198,6 +226,35 @@ describe('ProviderRegistry', () => {
       success: true,
       title: 'codex title',
     });
+  });
+
+  it('does not route title generation through a disabled model provider', async () => {
+    const providerCalls: ProviderId[] = [];
+    const originalCreate = ProviderRegistry.createTitleGenerationService.bind(ProviderRegistry);
+    jest.spyOn(ProviderRegistry, 'createTitleGenerationService')
+      .mockImplementation((plugin: any, providerId?: ProviderId) => {
+        if (!providerId) {
+          return originalCreate(plugin);
+        }
+        providerCalls.push(providerId);
+        return createMockTitleService(providerId);
+      });
+
+    const service = ProviderRegistry.createTitleGenerationService({
+      settings: {
+        titleGenerationModel: TEST_CODEX_MODEL,
+        providerConfigs: {
+          codex: {
+            discoveredModels: TEST_CODEX_CATALOG,
+            enabled: false,
+          },
+        },
+      },
+    } as any);
+
+    await service.generateTitle('conv-1', 'hello', jest.fn());
+
+    expect(providerCalls).toEqual(['claude']);
   });
 
   it('suppresses stale callbacks when a newer title generation replaces the old one', async () => {

--- a/tests/unit/core/providers/ProviderSettingsCoordinator.test.ts
+++ b/tests/unit/core/providers/ProviderSettingsCoordinator.test.ts
@@ -165,6 +165,27 @@ describe('ProviderSettingsCoordinator', () => {
     });
   });
 
+  describe('applyProviderEnablement', () => {
+    it('atomically disables a provider and clears dependent shared selections', () => {
+      const settings: Record<string, unknown> = {
+        settingsProvider: 'codex',
+        titleGenerationModel: TEST_CODEX_MODEL,
+        providerConfigs: {
+          codex: {
+            discoveredModels: TEST_CODEX_CATALOG,
+            enabled: true,
+          },
+        },
+      };
+
+      ProviderSettingsCoordinator.applyProviderEnablement(settings, 'codex', false);
+
+      expect(ProviderRegistry.isEnabled('codex', settings)).toBe(false);
+      expect(settings.settingsProvider).toBe('claude');
+      expect(settings.titleGenerationModel).toBe('');
+    });
+  });
+
   describe('reconcileAllProviders', () => {
     it('delegates to each registered provider reconciler with its own conversations', () => {
       const settings: Record<string, unknown> = { model: 'haiku' };
@@ -265,6 +286,23 @@ describe('ProviderSettingsCoordinator', () => {
           codex: {
             enabled: true,
             customModels: '',
+          },
+        },
+      };
+
+      expect(
+        ProviderSettingsCoordinator.reconcileTitleGenerationModelSelection(settings),
+      ).toBe(true);
+      expect(settings.titleGenerationModel).toBe('');
+    });
+
+    it('clears title models owned by a disabled provider', () => {
+      const settings: Record<string, unknown> = {
+        titleGenerationModel: TEST_CODEX_MODEL,
+        providerConfigs: {
+          codex: {
+            discoveredModels: TEST_CODEX_CATALOG,
+            enabled: false,
           },
         },
       };

--- a/tests/unit/providers/claude/ui/ClaudeSettingsTab.test.ts
+++ b/tests/unit/providers/claude/ui/ClaudeSettingsTab.test.ts
@@ -374,6 +374,7 @@ function createContext(plugin: any) {
   return {
     plugin,
     refreshModelSelectors: jest.fn(),
+    refreshTitleGenerationModelOptions: jest.fn(),
     renderHiddenProviderCommandSetting: jest.fn(),
     renderCustomContextLimits: jest.fn(),
   };

--- a/tests/unit/providers/codex/app/CodexWorkspaceServices.test.ts
+++ b/tests/unit/providers/codex/app/CodexWorkspaceServices.test.ts
@@ -95,7 +95,7 @@ describe('CodexWorkspaceServices', () => {
   it('loads the app-server catalog in memory without rewriting settings during startup', async () => {
     const plugin = createPlugin(true);
     const sol = makeDiscoveredModel('gpt-5.6-sol');
-    mockDiscoverModels.mockResolvedValue({ models: [sol] });
+    mockDiscoverModels.mockResolvedValue({ kind: 'completed', models: [sol] });
 
     await createCodexWorkspaceServices(plugin, {} as any, {} as any);
 
@@ -107,7 +107,10 @@ describe('CodexWorkspaceServices', () => {
 
   it('persists a selection normalization caused by startup discovery', async () => {
     const plugin = createPlugin(true);
-    mockDiscoverModels.mockResolvedValue({ models: [makeDiscoveredModel('gpt-5.6-sol')] });
+    mockDiscoverModels.mockResolvedValue({
+      kind: 'completed',
+      models: [makeDiscoveredModel('gpt-5.6-sol')],
+    });
     mockNormalizeAllModelVariants.mockReturnValueOnce(true);
 
     await createCodexWorkspaceServices(plugin, {} as any, {} as any);
@@ -124,11 +127,26 @@ describe('CodexWorkspaceServices', () => {
     expect(plugin.saveSettings).not.toHaveBeenCalled();
   });
 
+  it('treats a disabled catalog refresh as skipped without diagnostics', async () => {
+    const cached = makeDiscoveredModel('gpt-5.5');
+    const plugin = createPlugin(false, [cached]);
+    mockDiscoverModels.mockResolvedValue({
+      kind: 'skipped',
+      reason: 'provider-disabled',
+    });
+    const services = await createCodexWorkspaceServices(plugin, {} as any, {} as any);
+
+    await expect(services.refreshModelCatalog!()).resolves.toEqual({ changed: false });
+    expect(getCodexProviderSettings(plugin.settings).discoveredModels).toEqual([cached]);
+    expect(plugin.saveSettings).not.toHaveBeenCalled();
+  });
+
   it('keeps the last successful catalog when a refresh fails', async () => {
     const cached = makeDiscoveredModel('gpt-5.5');
     const plugin = createPlugin(false, [cached]);
     mockDiscoverModels.mockResolvedValue({
       diagnostics: 'Method not found',
+      kind: 'completed',
       models: [],
     });
     const services = await createCodexWorkspaceServices(plugin, {} as any, {} as any);
@@ -144,7 +162,7 @@ describe('CodexWorkspaceServices', () => {
     const oldModel = makeDiscoveredModel('gpt-5.4');
     const currentModel = makeDiscoveredModel('gpt-5.5');
     const plugin = createPlugin(false, [oldModel, currentModel], ['gpt-5.4', 'gpt-5.5']);
-    mockDiscoverModels.mockResolvedValue({ models: [currentModel] });
+    mockDiscoverModels.mockResolvedValue({ kind: 'completed', models: [currentModel] });
     const services = await createCodexWorkspaceServices(plugin, {} as any, {} as any);
 
     await services.refreshModelCatalog!();

--- a/tests/unit/providers/codex/runtime/CodexModelDiscoveryService.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexModelDiscoveryService.test.ts
@@ -54,6 +54,16 @@ function makeWireModel(model: string, isDefault = false) {
   };
 }
 
+function createPlugin(enabled = true) {
+  return {
+    settings: {
+      providerConfigs: {
+        codex: { enabled },
+      },
+    },
+  } as any;
+}
+
 describe('CodexModelDiscoveryService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -64,6 +74,16 @@ describe('CodexModelDiscoveryService', () => {
       spawnCwd: '/workspace',
       env: {},
     });
+  });
+
+  it('does not launch Codex when the provider is disabled', async () => {
+    const result = await new CodexModelDiscoveryService(createPlugin(false)).discoverModels();
+
+    expect(result).toEqual({ kind: 'skipped', reason: 'provider-disabled' });
+    expect(mockResolveLaunchSpec).not.toHaveBeenCalled();
+    expect(mockProcessStart).not.toHaveBeenCalled();
+    expect(mockTransportStart).not.toHaveBeenCalled();
+    expect(mockTransportRequest).not.toHaveBeenCalled();
   });
 
   it('loads all visible model/list pages through a short-lived app-server', async () => {
@@ -77,8 +97,12 @@ describe('CodexModelDiscoveryService', () => {
         nextCursor: null,
       });
 
-    const result = await new CodexModelDiscoveryService({} as any).discoverModels();
+    const result = await new CodexModelDiscoveryService(createPlugin()).discoverModels();
 
+    expect(result.kind).toBe('completed');
+    if (result.kind !== 'completed') {
+      throw new Error('Expected completed Codex model discovery');
+    }
     expect(result.diagnostics).toBeUndefined();
     expect(result.models.map(model => model.model)).toEqual([
       'gpt-5.6-sol',
@@ -101,10 +125,11 @@ describe('CodexModelDiscoveryService', () => {
     mockTransportRequest.mockRejectedValueOnce(new Error('Method not found'));
     mockProcessStderr.mockReturnValueOnce('codex app-server stderr');
 
-    const result = await new CodexModelDiscoveryService({} as any).discoverModels();
+    const result = await new CodexModelDiscoveryService(createPlugin()).discoverModels();
 
     expect(result).toEqual({
       diagnostics: 'Method not found\n\ncodex app-server stderr',
+      kind: 'completed',
       models: [],
     });
     expect(mockTransportDispose).toHaveBeenCalledTimes(1);
@@ -117,9 +142,10 @@ describe('CodexModelDiscoveryService', () => {
     });
 
     await expect(
-      new CodexModelDiscoveryService({} as any).discoverModels(),
+      new CodexModelDiscoveryService(createPlugin()).discoverModels(),
     ).resolves.toEqual({
       diagnostics: 'Unable to determine the WSL distro',
+      kind: 'completed',
       models: [],
     });
     expect(mockProcessStart).not.toHaveBeenCalled();

--- a/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
+++ b/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
@@ -13,6 +13,10 @@ const mockRefreshModelCatalog = jest.fn().mockResolvedValue({ changed: false });
 jest.mock('fs');
 jest.mock('@/core/providers/ProviderSettingsCoordinator', () => ({
   ProviderSettingsCoordinator: {
+    applyProviderEnablement: jest.fn((settings: Record<string, unknown>, _providerId: string, enabled: boolean) => {
+      const providerConfigs = settings.providerConfigs as { codex: { enabled: boolean } };
+      providerConfigs.codex.enabled = enabled;
+    }),
     reconcileTitleGenerationModelSelection: jest.fn((settings: Record<string, unknown>) => {
       const titleGenerationModel = settings.titleGenerationModel;
       const customModels = (
@@ -371,6 +375,7 @@ function createContext(plugin: any) {
     plugin,
     renderHiddenProviderCommandSetting: jest.fn(),
     refreshModelSelectors: jest.fn(),
+    refreshTitleGenerationModelOptions: jest.fn(),
     renderCustomContextLimits: jest.fn(),
   };
 }
@@ -421,6 +426,17 @@ describe('CodexSettingsTab', () => {
 
     expect(findOptionalSetting('Installation method')).toBeUndefined();
     expect(findOptionalSetting('WSL distro override')).toBeUndefined();
+  });
+
+  it('refreshes title model options after Codex enablement changes', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const plugin = createPlugin();
+    const context = createContext(plugin);
+
+    codexSettingsTabRenderer.render(createContainer(), context);
+    await findSetting('Enable Codex provider').toggleComponents[0].onChangeCallback?.(false);
+
+    expect(context.refreshTitleGenerationModelOptions).toHaveBeenCalledTimes(1);
   });
 
   it('renders the app-server model visibility picker', () => {

--- a/tests/unit/providers/opencode/OpencodeSettingsTab.test.ts
+++ b/tests/unit/providers/opencode/OpencodeSettingsTab.test.ts
@@ -27,6 +27,14 @@ const mockCreatedAgentSettings: Array<{
 }> = [];
 
 jest.mock('fs');
+jest.mock('@/core/providers/ProviderSettingsCoordinator', () => ({
+  ProviderSettingsCoordinator: {
+    applyProviderEnablement: jest.fn((settings: Record<string, unknown>, providerId: string, enabled: boolean) => {
+      const providerConfigs = settings.providerConfigs as Record<string, { enabled: boolean }>;
+      providerConfigs[providerId].enabled = enabled;
+    }),
+  },
+}));
 jest.mock('obsidian', () => {
   class MockSetting {
     public name = '';
@@ -416,6 +424,7 @@ function createContext(plugin: any) {
     plugin,
     renderHiddenProviderCommandSetting: jest.fn(),
     refreshModelSelectors: jest.fn(),
+    refreshTitleGenerationModelOptions: jest.fn(),
     renderCustomContextLimits: jest.fn(),
   };
 }
@@ -454,6 +463,16 @@ describe('OpencodeSettingsTab', () => {
     mockRuntimeWarmModelMetadata.mockResolvedValue(false);
     mockedExistsSync.mockReturnValue(false);
     mockedStatSync.mockReturnValue({ isFile: () => true } as fs.Stats);
+  });
+
+  it('refreshes title model options after OpenCode enablement changes', async () => {
+    const plugin = createPlugin();
+    const context = createContext(plugin);
+
+    opencodeSettingsTabRenderer.render(createContainer(), context);
+    await findSetting('Enable OpenCode').toggleComponents[0].onChangeCallback?.(false);
+
+    expect(context.refreshTitleGenerationModelOptions).toHaveBeenCalledTimes(1);
   });
 
   it('stores the CLI path per host and resets active runtime state across all views', async () => {

--- a/tests/unit/providers/pi/runtime/PiModelDiscoveryService.test.ts
+++ b/tests/unit/providers/pi/runtime/PiModelDiscoveryService.test.ts
@@ -66,6 +66,19 @@ describe('PiModelDiscoveryService', () => {
     });
   });
 
+  it('does not launch Pi when the provider is disabled', async () => {
+    const plugin = createPlugin();
+    plugin.settings.providerConfigs.pi.enabled = false;
+
+    const result = await new PiModelDiscoveryService(plugin).discoverModels();
+
+    expect(result).toEqual({ kind: 'skipped', reason: 'provider-disabled' });
+    expect(plugin.getResolvedProviderCliPath).not.toHaveBeenCalled();
+    expect(mockProcessStart).not.toHaveBeenCalled();
+    expect(mockTransportStart).not.toHaveBeenCalled();
+    expect(mockTransportRequest).not.toHaveBeenCalled();
+  });
+
   it('discovers and normalizes Pi models through a short-lived no-session runtime', async () => {
     mockTransportRequest.mockResolvedValue({
       models: [{
@@ -81,6 +94,10 @@ describe('PiModelDiscoveryService', () => {
 
     const result = await new PiModelDiscoveryService(createPlugin()).discoverModels();
 
+    expect(result.kind).toBe('completed');
+    if (result.kind !== 'completed') {
+      throw new Error('Expected completed Pi model discovery');
+    }
     expect(result.diagnostics).toBeUndefined();
     expect(result.models).toEqual([{
       contextWindow: 200000,
@@ -127,6 +144,7 @@ describe('PiModelDiscoveryService', () => {
 
     expect(result).toEqual({
       diagnostics: 'not logged in\n\nPi stderr',
+      kind: 'completed',
       models: [],
     });
     expect(mockTransportDispose).toHaveBeenCalled();

--- a/tests/unit/providers/pi/ui/PiSettingsTab.test.ts
+++ b/tests/unit/providers/pi/ui/PiSettingsTab.test.ts
@@ -5,6 +5,15 @@ const mockCliResolverReset = jest.fn();
 const mockDiscoverModels = jest.fn();
 const mockNotices: string[] = [];
 
+jest.mock('@/core/providers/ProviderSettingsCoordinator', () => ({
+  ProviderSettingsCoordinator: {
+    applyProviderEnablement: jest.fn((settings: Record<string, unknown>, providerId: string, enabled: boolean) => {
+      const providerConfigs = settings.providerConfigs as Record<string, { enabled: boolean }>;
+      providerConfigs[providerId].enabled = enabled;
+    }),
+  },
+}));
+
 interface MockToggleComponent {
   onChangeCallback: ((value: boolean) => Promise<void> | void) | null;
   setValue: jest.Mock;
@@ -333,6 +342,7 @@ function createContext(settings: Record<string, unknown>) {
       }),
     },
     refreshModelSelectors: jest.fn(),
+    refreshTitleGenerationModelOptions: jest.fn(),
     renderHiddenProviderCommandSetting: jest.fn(),
   };
 }
@@ -384,6 +394,7 @@ describe('PiSettingsTab', () => {
     mockedExists.mockReturnValue(true);
     mockedStat.mockReturnValue({ isFile: () => true });
     mockDiscoverModels.mockResolvedValue({
+      kind: 'completed',
       models: [],
     });
   });
@@ -397,6 +408,7 @@ describe('PiSettingsTab', () => {
     expect(getPiProviderSettings(settings).enabled).toBe(true);
     expect(context.plugin.saveSettings).toHaveBeenCalled();
     expect(context.refreshModelSelectors).toHaveBeenCalled();
+    expect(context.refreshTitleGenerationModelOptions).toHaveBeenCalled();
   });
 
   it('does not render hidden command settings for Pi', () => {
@@ -434,6 +446,7 @@ describe('PiSettingsTab', () => {
 
   it('discovers models through PiModelDiscoveryService and reports failures', async () => {
     mockDiscoverModels.mockResolvedValueOnce({
+      kind: 'completed',
       models: [{
         encodedId: 'pi:anthropic/claude-sonnet-4',
         id: 'claude-sonnet-4',
@@ -461,10 +474,46 @@ describe('PiSettingsTab', () => {
     expect(getPiProviderSettings(settings).visibleModels).toEqual(['pi:anthropic/claude-sonnet-4']);
     expect(context.refreshModelSelectors).toHaveBeenCalled();
 
-    mockDiscoverModels.mockResolvedValueOnce({ diagnostics: 'not logged in', models: [] });
+    mockDiscoverModels.mockResolvedValueOnce({
+      diagnostics: 'not logged in',
+      kind: 'completed',
+      models: [],
+    });
     await findElement('button', 'claudian-provider-model-picker-action').dispatchMockEvent('click');
     await flushPromises();
     expect(mockNotices[0]).toContain('not logged in');
+  });
+
+  it('preserves cached models when discovery is skipped for a disabled provider', async () => {
+    const cachedModel = {
+      encodedId: 'pi:anthropic/claude-sonnet-4',
+      id: 'claude-sonnet-4',
+      input: ['text'],
+      label: 'Claude Sonnet 4',
+      provider: 'anthropic',
+      reasoning: true,
+      thinkingLevels: ['off', 'medium'],
+    };
+    const settings: Record<string, unknown> = {
+      providerConfigs: {
+        pi: {
+          discoveredModels: [cachedModel],
+          enabled: false,
+          visibleModels: [cachedModel.encodedId],
+        },
+      },
+    };
+    const context = render(settings);
+    mockDiscoverModels.mockResolvedValueOnce({
+      kind: 'skipped',
+      reason: 'provider-disabled',
+    });
+
+    await findElement('button', 'claudian-provider-model-picker-action').dispatchMockEvent('click');
+    await flushPromises();
+
+    expect(getPiProviderSettings(settings).discoveredModels).toEqual([cachedModel]);
+    expect(context.plugin.saveSettings).not.toHaveBeenCalled();
   });
 
   it('persists visible model choices and aliases', async () => {


### PR DESCRIPTION
Closes #927 by centralizing optional-provider enablement so title-generation model options, routing, and settings fallback honor disabled providers. Disabled Pi and Codex discovery now returns explicit skipped results before CLI resolution, preserving cached catalogs and avoiding false failure notices. Provider toggles refresh only title-generation model options, avoiding cross-provider settings side effects, with regression coverage for routing, discovery, and persistence. Validation: `npm run typecheck && npm run lint && npm run test && npm run build` (262 suites, 6,012 tests).