### PR TITLE
fix: never lose async subagent completion notifications

### DIFF
--- a/src/core/types/chat.ts
+++ b/src/core/types/chat.ts
@@ -156,7 +156,7 @@ export type StreamChunk =
   | { type: 'done' }
   | { type: 'usage'; usage: UsageInfo; sessionId?: string | null }
   | { type: 'context_compacted' }
-  | { type: 'async_subagent_result'; agentId: string; status: 'completed' | 'error'; result?: string }
+  | { type: 'async_subagent_result'; agentId: string; status: 'completed' | 'error'; result?: string; toolUseId?: string }
   | { type: 'subagent_tool_use'; subagentId: string; id: string; name: string; input: Record<string, unknown> }
   | { type: 'subagent_tool_result'; subagentId: string; id: string; content: string; isError?: boolean; toolUseResult?: SDKToolUseResult };
 

--- a/src/features/chat/controllers/StreamController.ts
+++ b/src/features/chat/controllers/StreamController.ts
@@ -1175,7 +1175,8 @@ export class StreamController {
     const handled = this.deps.subagentManager.handleAsyncSubagentResult(
       chunk.agentId,
       chunk.status,
-      chunk.result
+      chunk.result,
+      chunk.toolUseId
     );
 
     await this.hydrateAsyncSubagentToolCalls(handled);

--- a/src/features/chat/services/SubagentManager.ts
+++ b/src/features/chat/services/SubagentManager.ts
@@ -59,6 +59,10 @@ function parseJsonValue(value: string): unknown {
   }
 }
 
+function resolveAsyncResultText(status: 'completed' | 'error', result?: string): string {
+  return result?.trim() || (status === 'error' ? 'Background task failed.' : 'Background task completed.');
+}
+
 export class SubagentManager {
   private static readonly TRUSTED_OUTPUT_EXT = '.output';
   private static readonly TRUSTED_TMP_ROOTS = SubagentManager.resolveTrustedTmpRoots();
@@ -428,25 +432,44 @@ export class SubagentManager {
   public handleAsyncSubagentResult(
     agentId: string,
     status: 'completed' | 'error',
-    result?: string
+    result?: string,
+    toolUseId?: string
   ): SubagentInfo | undefined {
-    const subagent = this.activeAsyncSubagents.get(agentId);
-    if (!subagent || subagent.asyncStatus !== 'running') {
+    let resolvedId = agentId;
+    let subagent = this.activeAsyncSubagents.get(resolvedId);
+
+    // The completion notification arrives exactly once, so a missed lookup
+    // leaks a "running" entry forever and the Stop hook then blocks every
+    // turn-end. The notification id may be the Task tool id rather than the
+    // agent id the entry was registered under — resolve it (and the SDK's
+    // tool_use_id, when carried) before giving up.
+    if (!subagent) {
+      const mappedAgentId = this.taskIdToAgentId.get(agentId)
+        ?? (toolUseId ? this.taskIdToAgentId.get(toolUseId) : undefined);
+      if (mappedAgentId) {
+        resolvedId = mappedAgentId;
+        subagent = this.activeAsyncSubagents.get(mappedAgentId);
+      }
+    }
+
+    if (!subagent) {
+      return this.completePendingAsyncSubagent(agentId, status, result, toolUseId);
+    }
+
+    if (subagent.asyncStatus !== 'running') {
+      // Already terminal but never removed from the maps — reconcile it out
+      // instead of leaving it to keep hasRunningSubagents() true forever.
+      this.clearAsyncTracking(resolvedId);
       return undefined;
     }
 
-    subagent.agentId = subagent.agentId || agentId;
+    subagent.agentId = subagent.agentId || resolvedId;
     subagent.asyncStatus = status;
     subagent.status = status;
-    subagent.result = result?.trim() || (status === 'error' ? 'Background task failed.' : 'Background task completed.');
+    subagent.result = resolveAsyncResultText(status, result);
     subagent.completedAt = Date.now();
 
-    this.activeAsyncSubagents.delete(agentId);
-    for (const [toolId, mappedAgentId] of this.outputToolIdToAgentId.entries()) {
-      if (mappedAgentId === agentId) {
-        this.outputToolIdToAgentId.delete(toolId);
-      }
-    }
+    this.clearAsyncTracking(resolvedId);
 
     this.updateAsyncDomState(subagent);
     this.onStateChange(subagent);
@@ -562,6 +585,54 @@ export class SubagentManager {
     this.pendingAsyncSubagents.delete(taskToolId);
     this.updateAsyncDomState(subagent);
     this.onStateChange(subagent);
+  }
+
+  /**
+   * Terminal transition for a completion notification whose task was never
+   * promoted to active (its Task tool result never yielded an agent id).
+   * Without this, the pending entry lingers and hasRunningSubagents() stays
+   * true forever.
+   */
+  private completePendingAsyncSubagent(
+    notificationId: string,
+    status: 'completed' | 'error',
+    result?: string,
+    toolUseId?: string
+  ): SubagentInfo | undefined {
+    let pendingKey = notificationId;
+    let pending = this.pendingAsyncSubagents.get(pendingKey);
+    if (!pending && toolUseId) {
+      pendingKey = toolUseId;
+      pending = this.pendingAsyncSubagents.get(toolUseId);
+    }
+    if (!pending) {
+      return undefined;
+    }
+
+    pending.asyncStatus = status;
+    pending.status = status;
+    pending.result = resolveAsyncResultText(status, result);
+    pending.completedAt = Date.now();
+
+    this.pendingAsyncSubagents.delete(pendingKey);
+    this.updateAsyncDomState(pending);
+    this.onStateChange(pending);
+    return pending;
+  }
+
+  /** Removes an async subagent from every tracking map. */
+  private clearAsyncTracking(agentId: string): void {
+    this.activeAsyncSubagents.delete(agentId);
+    for (const [taskId, mappedAgentId] of this.taskIdToAgentId.entries()) {
+      if (mappedAgentId === agentId) {
+        this.taskIdToAgentId.delete(taskId);
+      }
+    }
+    for (const [toolId, mappedAgentId] of this.outputToolIdToAgentId.entries()) {
+      if (mappedAgentId === agentId) {
+        this.outputToolIdToAgentId.delete(toolId);
+      }
+    }
   }
 
   // ============================================

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -1940,8 +1940,33 @@ function hasVisibleAutoTurnMessageContent(msg: ChatMessage): boolean {
   ) ?? false;
 }
 
+/**
+ * Applies the subagent state transitions carried by `async_subagent_result`
+ * chunks directly, bypassing rendering. The completion notification arrives
+ * exactly once — if it is dropped (detached tab DOM, render failure), the
+ * subagent stays tracked as running forever and the Stop hook blocks every
+ * subsequent turn-end.
+ */
+export function applyAsyncSubagentResultChunks(
+  subagentManager: SubagentManager,
+  chunks: StreamChunk[],
+): void {
+  for (const chunk of chunks) {
+    if (chunk.type !== 'async_subagent_result') {
+      continue;
+    }
+    try {
+      subagentManager.handleAsyncSubagentResult(chunk.agentId, chunk.status, chunk.result, chunk.toolUseId);
+    } catch {
+      // One failed transition must not drop the remaining completions.
+    }
+  }
+}
+
 async function renderAutoTriggeredTurn(tab: TabData, result: AutoTurnResult): Promise<void> {
   if (!tab.dom.contentEl.isConnected) {
+    // The turn cannot render, but completion state must still be applied.
+    applyAsyncSubagentResultChunks(tab.services.subagentManager, result.chunks);
     return;
   }
 
@@ -1987,9 +2012,11 @@ async function renderAutoTriggeredTurn(tab: TabData, result: AutoTurnResult): Pr
     }
   }
 
+  let processedChunkCount = 0;
   try {
     for (const chunk of chunks) {
       await tab.controllers.streamController?.handleStreamChunk(chunk, assistantMsg);
+      processedChunkCount++;
     }
 
     if (hasVisibleContent && !hasVisibleAutoTurnMessageContent(assistantMsg)) {
@@ -2002,6 +2029,15 @@ async function renderAutoTriggeredTurn(tab: TabData, result: AutoTurnResult): Pr
       await tab.controllers.streamController?.finalizeCurrentThinkingBlock(assistantMsg);
       await tab.controllers.streamController?.finalizeCurrentTextBlock(assistantMsg);
     }
+  } catch (error) {
+    // A render failure must not drop the completion state of the remaining
+    // chunks. Re-driving the failed chunk itself is safe: the state update
+    // runs before rendering and re-applying a terminal transition is a no-op.
+    applyAsyncSubagentResultChunks(
+      tab.services.subagentManager,
+      chunks.slice(processedChunkCount),
+    );
+    throw error;
   } finally {
     if (hasVisibleContent) {
       tab.controllers.streamController?.hideThinkingIndicator();

--- a/src/providers/claude/stream/transformClaudeMessage.ts
+++ b/src/providers/claude/stream/transformClaudeMessage.ts
@@ -57,11 +57,15 @@ function transformTaskNotification(message: SDKMessage): StreamChunk | null {
   }
 
   const status = normalizeTaskNotificationStatus(record.status);
+  const toolUseId = record.tool_use_id;
   return {
     type: 'async_subagent_result',
     agentId: taskId,
     status,
     result: normalizeTaskNotificationResult(status, record.summary),
+    // The launching Task tool_use id, when the SDK provides it — the exact
+    // key subagent tracking may have registered the task under.
+    ...(typeof toolUseId === 'string' && toolUseId.length > 0 ? { toolUseId } : {}),
   };
 }
 

--- a/tests/unit/features/chat/controllers/StreamController.test.ts
+++ b/tests/unit/features/chat/controllers/StreamController.test.ts
@@ -1839,7 +1839,8 @@ describe('StreamController - Text Content', () => {
       expect(deps.subagentManager.handleAsyncSubagentResult).toHaveBeenCalledWith(
         'agent-1',
         'completed',
-        'Notification summary'
+        'Notification summary',
+        undefined
       );
       expect(runtime.loadSubagentToolCalls).toHaveBeenCalledWith('agent-1');
       expect(runtime.loadSubagentFinalResult).toHaveBeenCalledWith('agent-1');

--- a/tests/unit/features/chat/services/SubagentManager.test.ts
+++ b/tests/unit/features/chat/services/SubagentManager.test.ts
@@ -455,6 +455,113 @@ describe('SubagentManager', () => {
   });
 
   // ============================================
+  // Completion Notification Robustness
+  // ============================================
+
+  describe('handleAsyncSubagentResult robustness', () => {
+    it('resolves a notification carrying the Task tool id instead of the agent id', () => {
+      const { manager, updates } = createManager();
+      const parentEl = createMockEl();
+
+      manager.handleTaskToolUse('task-1', { description: 'Background', run_in_background: true }, parentEl);
+      manager.handleTaskToolResult('task-1', JSON.stringify({ agent_id: 'agent-1' }));
+
+      const handled = manager.handleAsyncSubagentResult('task-1', 'completed', 'All done');
+
+      expect(handled?.asyncStatus).toBe('completed');
+      expect(handled?.result).toBe('All done');
+      expect(manager.hasRunningSubagents()).toBe(false);
+      expect(updates[updates.length - 1].asyncStatus).toBe('completed');
+    });
+
+    it('clears every tracking map on completion', () => {
+      const { manager } = createManager();
+      const parentEl = createMockEl();
+      const internal = manager as any;
+
+      manager.handleTaskToolUse('task-2', { description: 'Background', run_in_background: true }, parentEl);
+      manager.handleTaskToolResult('task-2', JSON.stringify({ agent_id: 'agent-2' }));
+      manager.handleAgentOutputToolUse({
+        id: 'output-2',
+        name: 'AgentOutputTool',
+        input: { agent_id: 'agent-2' },
+        status: 'running',
+        isExpanded: false,
+      });
+
+      manager.handleAsyncSubagentResult('agent-2', 'completed');
+
+      expect(internal.activeAsyncSubagents.size).toBe(0);
+      expect(internal.taskIdToAgentId.size).toBe(0);
+      expect(internal.outputToolIdToAgentId.size).toBe(0);
+    });
+
+    it('completes a pending entry whose task was never promoted to active', () => {
+      const { manager, updates } = createManager();
+      const parentEl = createMockEl();
+
+      manager.handleTaskToolUse('task-3', { description: 'Background', run_in_background: true }, parentEl);
+      // No handleTaskToolResult: the entry stays pending, awaiting an agent id.
+
+      const handled = manager.handleAsyncSubagentResult('task-3', 'error', 'crashed');
+
+      expect(handled?.asyncStatus).toBe('error');
+      expect(handled?.result).toBe('crashed');
+      expect(manager.getByTaskId('task-3')).toBeUndefined();
+      expect(manager.hasRunningSubagents()).toBe(false);
+      expect(updates[updates.length - 1].asyncStatus).toBe('error');
+    });
+
+    it('reconciles an already-terminal entry out of the maps instead of leaking it', () => {
+      const { manager } = createManager();
+      const internal = manager as any;
+      internal.activeAsyncSubagents.set('agent-stale', {
+        id: 'task-stale',
+        mode: 'async',
+        status: 'completed',
+        asyncStatus: 'completed',
+      });
+
+      expect(manager.handleAsyncSubagentResult('agent-stale', 'completed')).toBeUndefined();
+
+      expect(internal.activeAsyncSubagents.size).toBe(0);
+      expect(manager.hasRunningSubagents()).toBe(false);
+    });
+
+    it('resolves a notification via the SDK tool_use_id when the task id matches nothing', () => {
+      const { manager } = createManager();
+      const parentEl = createMockEl();
+
+      manager.handleTaskToolUse('task-4', { description: 'Background', run_in_background: true }, parentEl);
+      manager.handleTaskToolResult('task-4', JSON.stringify({ agent_id: 'agent-4' }));
+
+      const handled = manager.handleAsyncSubagentResult('skewed-task-id', 'completed', 'done', 'task-4');
+
+      expect(handled?.asyncStatus).toBe('completed');
+      expect(manager.hasRunningSubagents()).toBe(false);
+    });
+
+    it('completes a never-promoted pending entry via the SDK tool_use_id', () => {
+      const { manager } = createManager();
+      const parentEl = createMockEl();
+
+      manager.handleTaskToolUse('task-5', { description: 'Background', run_in_background: true }, parentEl);
+
+      const handled = manager.handleAsyncSubagentResult('skewed-task-id', 'error', 'crashed', 'task-5');
+
+      expect(handled?.asyncStatus).toBe('error');
+      expect(manager.hasRunningSubagents()).toBe(false);
+    });
+
+    it('still ignores notifications for entirely unknown agents', () => {
+      const { manager, updates } = createManager();
+
+      expect(manager.handleAsyncSubagentResult('agent-unknown', 'completed')).toBeUndefined();
+      expect(updates).toHaveLength(0);
+    });
+  });
+
+  // ============================================
   // Async Parsing Edge Cases (via public API)
   // ============================================
 

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -10,10 +10,12 @@ import { Notice, Platform } from 'obsidian';
 
 import { ProviderRegistry } from '@/core/providers/ProviderRegistry';
 import { ProviderWorkspaceRegistry } from '@/core/providers/ProviderWorkspaceRegistry';
+import type { StreamChunk } from '@/core/types';
 import { SelectionController } from '@/features/chat/controllers/SelectionController';
 import { ChatState } from '@/features/chat/state/ChatState';
 import {
   activateTab,
+  applyAsyncSubagentResultChunks,
   createTab,
   deactivateTab,
   destroyTab,
@@ -4410,5 +4412,48 @@ describe('Tab - InputController getTabProviderId wiring', () => {
     // For a blank tab with default model, should resolve to claude
     const result = config.getTabProviderId();
     expect(result).toBe('claude');
+  });
+});
+
+describe('applyAsyncSubagentResultChunks', () => {
+  it('forwards only async_subagent_result chunks to the subagent manager', () => {
+    const subagentManager = { handleAsyncSubagentResult: jest.fn() };
+    const chunks: StreamChunk[] = [
+      { type: 'text', content: 'hello' },
+      { type: 'async_subagent_result', agentId: 'agent-1', status: 'completed', result: 'done', toolUseId: 'task-1' },
+      { type: 'done' },
+      { type: 'async_subagent_result', agentId: 'agent-2', status: 'error' },
+    ];
+
+    applyAsyncSubagentResultChunks(subagentManager as any, chunks);
+
+    expect(subagentManager.handleAsyncSubagentResult).toHaveBeenCalledTimes(2);
+    expect(subagentManager.handleAsyncSubagentResult).toHaveBeenNthCalledWith(1, 'agent-1', 'completed', 'done', 'task-1');
+    expect(subagentManager.handleAsyncSubagentResult).toHaveBeenNthCalledWith(2, 'agent-2', 'error', undefined, undefined);
+  });
+
+  it('applies the remaining completions when one transition throws', () => {
+    const subagentManager = {
+      handleAsyncSubagentResult: jest.fn().mockImplementationOnce(() => {
+        throw new Error('DOM finalize failed');
+      }),
+    };
+    const chunks: StreamChunk[] = [
+      { type: 'async_subagent_result', agentId: 'agent-1', status: 'completed' },
+      { type: 'async_subagent_result', agentId: 'agent-2', status: 'completed' },
+    ];
+
+    expect(() => applyAsyncSubagentResultChunks(subagentManager as any, chunks)).not.toThrow();
+
+    expect(subagentManager.handleAsyncSubagentResult).toHaveBeenCalledTimes(2);
+    expect(subagentManager.handleAsyncSubagentResult).toHaveBeenLastCalledWith('agent-2', 'completed', undefined, undefined);
+  });
+
+  it('is a no-op for chunk lists without async results', () => {
+    const subagentManager = { handleAsyncSubagentResult: jest.fn() };
+
+    applyAsyncSubagentResultChunks(subagentManager as any, [{ type: 'text', content: 'hi' }]);
+
+    expect(subagentManager.handleAsyncSubagentResult).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
**Problem** — A background subagent's completion arrives as a single `system/task_notification` → `async_subagent_result` chunk. If `SubagentManager` misses it, the entry stays tracked as `running` forever, `hasRunningSubagents()` never clears, and the Stop hook blocks every subsequent turn-end with an unfulfillable instruction (`TaskList` is empty and `TaskOutput` reports the task as not found). Observed in the field: one evening session logged 82 consecutive identical stop-blocks. Related: #852, #493.

**Root cause** — Several paths can drop the one-shot completion signal:

1. `handleAsyncSubagentResult()` only did a direct `activeAsyncSubagents.get(agentId)`; a notification carrying the Task tool id (or any id-namespace skew) missed the lookup and was silently dropped.
2. A completion for a task still in `pendingAsyncSubagents` (its Task tool result never yielded an agent id) had no path to clear it at all.
3. An entry already in a terminal state was left in the maps by the `asyncStatus !== 'running'` guard — and `hasRunningSubagents()` counts raw map size.
4. `renderAutoTriggeredTurn()` returned early on a detached tab DOM, dropping the buffered chunks' state along with their rendering.
5. A throw inside the auto-turn render loop lands in `flushAutoTurnBuffer()`'s catch, which shows a Notice and permanently dropped the decrements of all unprocessed chunks.

**Changes**

1. `SubagentManager.handleAsyncSubagentResult()`: resolve the notification id through `taskIdToAgentId` when the direct lookup misses; complete a matching never-promoted pending entry; reconcile already-terminal leftovers out of the maps; sweep `taskIdToAgentId`/`outputToolIdToAgentId` on completion (new `clearAsyncTracking()`).
2. Carry the SDK's `tool_use_id` (`SDKTaskNotificationMessage` provides it) through the `async_subagent_result` chunk and try it during resolution — the exact key the task may have been registered under, instead of relying only on id-match heuristics.
3. `Tab.ts`: new `applyAsyncSubagentResultChunks()` applies completion state transitions without rendering, isolated per chunk. `renderAutoTriggeredTurn()` uses it when the tab DOM is detached, and re-drives unprocessed chunks' state when the render loop throws (idempotent — re-applying a terminal transition is a no-op — then rethrows so the existing Notice still appears).

**Safety** — Strictly notification-driven: entries are only ever touched when the CLI itself declared the task finished, so a genuinely running subagent can never be orphaned by this change. Deliberately no TTL/staleness sweep: there is no liveness oracle over the control protocol, so any TTL would eventually orphan a long-running background agent and silently drop its later result.

Complements (no overlap with) #900, which handles the termination paths (interrupt/stream-error) plus a stop-block cap, and #705, which reconciles the symptom in `hasRunningSubagents()`. This PR fixes the completion path itself so entries don't go stale in the first place.

**Tests** — `SubagentManager`: task-tool-id resolution, never-promoted pending completion, terminal reconciliation, full tracking-map cleanup, unknown-agent no-op. `Tab`: `applyAsyncSubagentResultChunks` forwards only async result chunks. Full suite passes (`typecheck`, `lint`, `test`, `build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
