### PR TITLE
fix(claude): support Fable environment model mapping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.159",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.209",
         "@codemirror/state": "^6.5.0",
         "@codemirror/view": "^6.38.6",
         "@modelcontextprotocol/sdk": "~1.29.0",
@@ -40,22 +40,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.159",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.159.tgz",
-      "integrity": "sha512-Xh1oVMIK6N3KsiNIhqNH8ZK90zjRmAEL9d1Md8ZlGdHJE+HhdMYdBadujc3KEkV0uufsEUvYp+A3fDenfypGSA==",
+      "version": "0.3.209",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.209.tgz",
+      "integrity": "sha512-HdxLmpnIOd4CSYxdlD/4ShKFvHAuWefP1MTf/B+Mj0Oq8Tb9qzmhLuHCZMd5Pf21Knrt7jke/t4coYAtokFcuw==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.159",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.159",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.159",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.159",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.159",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.159",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.159",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.159"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.209",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.209",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.209",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.209",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.209",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.209",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.209",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.209"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -64,9 +64,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.159",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.159.tgz",
-      "integrity": "sha512-3nnH4yUNJVSyaU5DBlGw2yxc4zlnVvAnc9UOe+La47QVG7/dN+rWAgn4zCbqKk9bWFLDQ1Ek0r56EZE1Qo4UKQ==",
+      "version": "0.3.209",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.209.tgz",
+      "integrity": "sha512-08qu5ZImKxAsfyxQdXw2fHpIvTS39kAN/T6iWdRPY/1yicnqAxIl8R9PQ63TJaDnWTo7wWu6O26GKbEX9d7xDw==",
       "cpu": [
         "arm64"
       ],
@@ -77,9 +77,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.159",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.159.tgz",
-      "integrity": "sha512-iv+NRjz+t4Q1R2+kLdDbccSo3b0wedVJ9jMT3noznOVojZHzgkxVpTvt36/XkXV0rqIDQ5H18bBYIZZzOXu7mg==",
+      "version": "0.3.209",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.209.tgz",
+      "integrity": "sha512-p3egSQ75amhjOO0P21pNfs94SueEAbOc0s7IFrGy8CZKXcFMIrOzUXKoi2iTWtR8P9v4ayibf38AJRa2Rz7KPA==",
       "cpu": [
         "x64"
       ],
@@ -90,9 +90,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.159",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.159.tgz",
-      "integrity": "sha512-FlsS5M4GCpzsQVaNDFF8dRgFGR3QwyAHZFl/xM/2Y2BqVBH+NH17RpKQSJxr1qr41QnsNkinMnu2iSKoc33hKg==",
+      "version": "0.3.209",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.209.tgz",
+      "integrity": "sha512-eTgga/TuganOj9VAWUrjtt6BSqapeJau4ioCrQRw0RbDN/d/oLih/hdKzPeCn3yBw4Wdwwlip2z1cHKPNEggtQ==",
       "cpu": [
         "arm64"
       ],
@@ -103,9 +103,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.159",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.159.tgz",
-      "integrity": "sha512-WvwiQBWt3tdu5EwqjpDZszI6p2uetYsw4Cxc6ptO/SmLIYXcDienP8nmirZdsZrS+Gzk6imgY0IY5mmNaRhelQ==",
+      "version": "0.3.209",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.209.tgz",
+      "integrity": "sha512-jtoia0l10xgrsBWjA12n6Q0WxOyr/8qf1eUMOGSO7zdNau/7wABYBXS+VGF8utBEsF4NJjfCEEj2yhEB8uHjLA==",
       "cpu": [
         "arm64"
       ],
@@ -116,9 +116,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.159",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.159.tgz",
-      "integrity": "sha512-uNPEC/iRzVb4bEdzs0KAz1zV7i1PVGEZZnJTQyi1OtgVa81sAoH/H0CbbzDiTsquKdaESf+1DSSEkUlfZmMUEw==",
+      "version": "0.3.209",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.209.tgz",
+      "integrity": "sha512-XGhc23qmqk1yUwG633iZUxPM91iJjrX/a+DVy+Pz5X5J64aXFAsR9R+kNkJ1X5FDcm+MSYywUtQm9AmAZaiG2Q==",
       "cpu": [
         "x64"
       ],
@@ -129,9 +129,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.159",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.159.tgz",
-      "integrity": "sha512-kFH6RC2YJbPc8XWRNy/wL4YU7LzdJjSwAdH488sVzIif3q+TrvVrV5y/IW0+MLmta+CKIqtFYpGaucsJYvj7Eg==",
+      "version": "0.3.209",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.209.tgz",
+      "integrity": "sha512-GjxSlqk6yYCxb9BApVZvJ/Aq3OoI5mDRhpBpsZM23idNHg5/019sBBx4IGmkBjmfxTX5zzvu+m0fU18vl3W2Mg==",
       "cpu": [
         "x64"
       ],
@@ -142,9 +142,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.159",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.159.tgz",
-      "integrity": "sha512-WN1QEZGgWXz9GMl61QU6j9E+LEF5plki87bL2xsGwuCPzK+OeVPQU55pabuP8P+vFBFHUo3Y9OlTVyZHnUzmAQ==",
+      "version": "0.3.209",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.209.tgz",
+      "integrity": "sha512-LIMVnToVRmcTeN/dDAdFP/U60/aM0/qbKOWza+0BabhrGwF/3nPIIoGrMrkLsKPzOsfNWrl+kepexP1zWb1x5w==",
       "cpu": [
         "arm64"
       ],
@@ -155,9 +155,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.159",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.159.tgz",
-      "integrity": "sha512-Ty4seccD+dTDX5hhj89IUELZd/LkxO5O43Uiz5Mo8ZJktoX38SK4XMZlBS935QdqTFLRvPL0hvK4Lt4dTOqzPw==",
+      "version": "0.3.209",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.209.tgz",
+      "integrity": "sha512-tY5/+lmhqm7JQhvxLVTkhe2/UAw46gu8RnFrTwhoM0gEXDTmQhNlTM+m4F9LGeSfgKb2TElHpcQ237XNG1Ok6Q==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typescript": "^6.0.2"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.159",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.209",
     "@codemirror/state": "^6.5.0",
     "@codemirror/view": "^6.38.6",
     "@modelcontextprotocol/sdk": "~1.29.0",

--- a/src/core/providers/ProviderSettingsCoordinator.ts
+++ b/src/core/providers/ProviderSettingsCoordinator.ts
@@ -153,6 +153,17 @@ export class ProviderSettingsCoordinator {
     normalizeModelDependentSettings(uiConfig, settings, model);
   }
 
+  static applyTitleGenerationModelSelection(
+    settings: Record<string, unknown>,
+    model: string,
+  ): void {
+    settings.titleGenerationModel = model;
+    for (const providerId of ProviderRegistry.getRegisteredProviderIds()) {
+      ProviderRegistry.getChatUIConfig(providerId)
+        .applyTitleGenerationModelSelection?.(model, settings);
+    }
+  }
+
   static projectModelSelection(
     settings: Record<string, unknown>,
     providerId: ProviderId,
@@ -350,7 +361,11 @@ export class ProviderSettingsCoordinator {
 
     if (model) {
       settings.model = model;
-      uiConfig.applyModelDefaults(model, settings);
+      if (uiConfig.applyModelProjectionDefaults) {
+        uiConfig.applyModelProjectionDefaults(model, settings);
+      } else {
+        uiConfig.applyModelDefaults(model, settings);
+      }
     }
 
     const serviceTierToggle = uiConfig.getServiceTierToggle?.({

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -287,6 +287,9 @@ export interface ProviderChatUIConfig {
   /** Apply model change side effects to settings (defaults, tracking). */
   applyModelDefaults(model: string, settings: unknown): void;
 
+  /** Track provider-owned metadata when the global title-generation model changes. */
+  applyTitleGenerationModelSelection?(model: string, settings: unknown): void;
+
   /** Apply model-scoped defaults to an ephemeral conversation settings projection. */
   applyModelProjectionDefaults?(model: string, settings: unknown): void;
 

--- a/src/features/settings/ClaudianSettings.ts
+++ b/src/features/settings/ClaudianSettings.ts
@@ -6,6 +6,7 @@ import {
   normalizeHiddenCommandList,
 } from '../../core/providers/commands/hiddenCommands';
 import { ProviderRegistry } from '../../core/providers/ProviderRegistry';
+import { ProviderSettingsCoordinator } from '../../core/providers/ProviderSettingsCoordinator';
 import { ProviderWorkspaceRegistry } from '../../core/providers/ProviderWorkspaceRegistry';
 import type { ProviderId } from '../../core/providers/types';
 import type { ChatViewPlacement } from '../../core/types/settings';
@@ -334,7 +335,7 @@ export class ClaudianSettingTab extends PluginSettingTab {
           refreshOptions();
           dropdown.onChange(async (value) => {
             await this.plugin.mutateSettings((settings) => {
-              settings.titleGenerationModel = value;
+              ProviderSettingsCoordinator.applyTitleGenerationModelSelection(settings, value);
             });
           });
         });

--- a/src/providers/claude/agents/AgentStorage.ts
+++ b/src/providers/claude/agents/AgentStorage.ts
@@ -1,5 +1,6 @@
 import type { AgentDefinition, AgentFrontmatter } from '../../../core/types';
 import { extractStringArray, isRecord, normalizeStringArray, parseFrontmatter } from '../../../utils/frontmatter';
+import { type ClaudeModelTier, isClaudeModelTier } from '../modelTiers';
 import { AGENT_PERMISSION_MODES, type AgentPermissionMode } from '../types/agent';
 
 const KNOWN_AGENT_KEYS = new Set([
@@ -66,13 +67,13 @@ export function parsePermissionMode(mode?: string): AgentPermissionMode | undefi
   return undefined;
 }
 
-const VALID_MODELS = ['sonnet', 'opus', 'haiku', 'inherit'] as const;
+export type ClaudeAgentModel = ClaudeModelTier | 'inherit';
 
-export function parseModel(model?: string): 'sonnet' | 'opus' | 'haiku' | 'inherit' {
+export function parseModel(model?: string): ClaudeAgentModel {
   if (!model) return 'inherit';
   const normalized = model.toLowerCase().trim();
-  if (VALID_MODELS.includes(normalized as typeof VALID_MODELS[number])) {
-    return normalized as 'sonnet' | 'opus' | 'haiku' | 'inherit';
+  if (normalized === 'inherit' || isClaudeModelTier(normalized)) {
+    return normalized;
   }
   return 'inherit';
 }

--- a/src/providers/claude/env/ClaudeSettingsReconciler.ts
+++ b/src/providers/claude/env/ClaudeSettingsReconciler.ts
@@ -2,27 +2,69 @@ import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvir
 import type { ProviderSettingsReconciler } from '../../../core/providers/types';
 import type { Conversation } from '../../../core/types';
 import { parseEnvironmentVariables } from '../../../utils/env';
-import { resolveClaudeModelSelection } from '../modelOptions';
+import {
+  findClaudeModelOptionForEnvironmentType,
+  getClaudeModelOptions,
+  resolveClaudeModelEnvironmentTypePreference,
+  resolveClaudeModelSelection,
+} from '../modelOptions';
+import { toClaudeRuntimeModelId } from '../modelSelection';
+import { isClaudeModelTier } from '../modelTiers';
 import { getClaudeProviderSettings, updateClaudeProviderSettings } from '../settings';
+import { normalizeLegacyClaudeModelAlias } from '../types/models';
 import { clearClaudeResumeState } from '../types/providerState';
 import { claudeChatUIConfig } from '../ui/ClaudeChatUIConfig';
+import {
+  CLAUDE_MODEL_ENV_KEYS,
+  type ClaudeModelEnvType,
+  getModelsFromEnvironment,
+} from './claudeModelEnv';
 
-const ENV_HASH_MODEL_KEYS = [
-  'ANTHROPIC_MODEL',
-  'ANTHROPIC_DEFAULT_OPUS_MODEL',
-  'ANTHROPIC_DEFAULT_SONNET_MODEL',
-  'ANTHROPIC_DEFAULT_HAIKU_MODEL',
-];
 const ENV_HASH_PROVIDER_KEYS = ['ANTHROPIC_BASE_URL'];
 
 function computeEnvHash(envText: string): string {
   const envVars = parseEnvironmentVariables(envText || '');
-  const allKeys = [...ENV_HASH_MODEL_KEYS, ...ENV_HASH_PROVIDER_KEYS];
+  const allKeys = [...CLAUDE_MODEL_ENV_KEYS, ...ENV_HASH_PROVIDER_KEYS];
   return allKeys
     .filter(key => envVars[key])
     .map(key => `${key}=${envVars[key]}`)
     .sort()
     .join('|');
+}
+
+function getModelEnvironmentFromHash(environmentHash: string): Record<string, string> {
+  const envVars: Record<string, string> = {};
+  for (const key of CLAUDE_MODEL_ENV_KEYS) {
+    const match = environmentHash.match(new RegExp(`(?:^|\\|)${key}=([^|]*)`));
+    if (match?.[1]) {
+      envVars[key] = match[1];
+    }
+  }
+  return envVars;
+}
+
+function inferPreviousModelEnvironmentType(
+  environmentHash: string,
+  currentModel: string,
+  lastModel: string = '',
+): ClaudeModelEnvType | undefined {
+  const runtimeModel = toClaudeRuntimeModelId(currentModel);
+  const previousOption = getModelsFromEnvironment(
+    getModelEnvironmentFromHash(environmentHash),
+  ).find(option => option.value === runtimeModel);
+  if (!previousOption) {
+    return undefined;
+  }
+
+  const normalizedLastModel = normalizeLegacyClaudeModelAlias(toClaudeRuntimeModelId(lastModel));
+  if (
+    isClaudeModelTier(normalizedLastModel)
+    && previousOption.environmentTypes.includes(normalizedLastModel)
+  ) {
+    return normalizedLastModel;
+  }
+
+  return previousOption.environmentTypes[0];
 }
 
 export const claudeSettingsReconciler: ProviderSettingsReconciler = {
@@ -46,12 +88,72 @@ export const claudeSettingsReconciler: ProviderSettingsReconciler = {
     }
 
     const currentModel = typeof settings.model === 'string' ? settings.model : '';
-    const nextModel = resolveClaudeModelSelection(settings, currentModel);
+    const claudeSettings = getClaudeProviderSettings(settings);
+    const modelOptions = getClaudeModelOptions(settings);
+    const savedProviderModel = settings.savedProviderModel as Record<string, unknown> | undefined;
+    const historicalModel = settings.settingsProvider !== 'claude'
+      && typeof savedProviderModel?.claude === 'string'
+      ? savedProviderModel.claude
+      : currentModel;
+    const previousEnvironmentType = claudeSettings.modelEnvironmentType
+      || inferPreviousModelEnvironmentType(
+        savedHash,
+        historicalModel,
+        claudeSettings.lastModel,
+      );
+    const nextModel = resolveClaudeModelSelection(
+      settings,
+      currentModel,
+      previousEnvironmentType,
+    );
     if (nextModel) {
       settings.model = nextModel;
     }
 
-    updateClaudeProviderSettings(settings, { environmentHash: currentHash });
+    const derivedEnvironmentType = nextModel
+      ? resolveClaudeModelEnvironmentTypePreference(
+        modelOptions,
+        nextModel,
+        previousEnvironmentType ?? '',
+      )
+      : null;
+    const selectedEnvironmentType = previousEnvironmentType ?? derivedEnvironmentType;
+    const selectedTier = selectedEnvironmentType && isClaudeModelTier(selectedEnvironmentType)
+      ? selectedEnvironmentType
+      : undefined;
+
+    const titleModel = typeof settings.titleGenerationModel === 'string'
+      ? settings.titleGenerationModel
+      : '';
+    const previousTitleEnvironmentType = claudeSettings.titleModelEnvironmentType
+      || (titleModel
+        ? inferPreviousModelEnvironmentType(savedHash, titleModel)
+        : undefined);
+    if (previousTitleEnvironmentType) {
+      const titleOption = findClaudeModelOptionForEnvironmentType(
+        modelOptions,
+        previousTitleEnvironmentType,
+      );
+      if (titleOption) {
+        settings.titleGenerationModel = titleOption.value;
+      }
+    }
+    const derivedTitleEnvironmentType = titleModel
+      ? resolveClaudeModelEnvironmentTypePreference(
+        modelOptions,
+        titleModel,
+        previousTitleEnvironmentType ?? '',
+      )
+      : null;
+    const selectedTitleEnvironmentType = previousTitleEnvironmentType
+      ?? derivedTitleEnvironmentType;
+
+    updateClaudeProviderSettings(settings, {
+      environmentHash: currentHash,
+      modelEnvironmentType: selectedEnvironmentType ?? '',
+      titleModelEnvironmentType: selectedTitleEnvironmentType ?? '',
+      ...(selectedTier ? { lastModel: selectedTier } : {}),
+    });
     return { changed: true, invalidatedConversations };
   },
 
@@ -59,30 +161,86 @@ export const claudeSettingsReconciler: ProviderSettingsReconciler = {
     let changed = false;
 
     const normalize = (model: string): string => claudeChatUIConfig.normalizeModelVariant(model, settings);
+    const claudeSettings = getClaudeProviderSettings(settings);
+    const modelOptions = getClaudeModelOptions(settings);
+    const environmentChanged = computeEnvHash(
+      getRuntimeEnvironmentText(settings, 'claude'),
+    ) !== claudeSettings.environmentHash;
+    const hasEnvironmentModelOptions = modelOptions.some(option => option.environmentTypes);
 
     const model = settings.model as string;
-    const normalizedModel = normalize(model);
+    const shouldInferPrimaryEnvironmentType = settings.settingsProvider === undefined
+      || settings.settingsProvider === 'claude';
+    const historicalModelEnvironmentType = environmentChanged
+      ? inferPreviousModelEnvironmentType(
+        claudeSettings.environmentHash,
+        model,
+        claudeSettings.lastModel,
+      )
+      : undefined;
+    const modelEnvironmentType = claudeSettings.modelEnvironmentType
+      || (shouldInferPrimaryEnvironmentType
+        ? historicalModelEnvironmentType
+          || (hasEnvironmentModelOptions
+            ? resolveClaudeModelEnvironmentTypePreference(modelOptions, model)
+            : null)
+        : null);
+    const normalizedModel = (
+      modelEnvironmentType
+        ? findClaudeModelOptionForEnvironmentType(modelOptions, modelEnvironmentType)?.value
+        : undefined
+    ) ?? normalize(model);
     if (model !== normalizedModel) {
       settings.model = normalizedModel;
       changed = true;
     }
 
-    const titleModel = settings.titleGenerationModel as string;
-    if (titleModel) {
-      const normalizedTitleModel = normalize(titleModel);
-      if (titleModel !== normalizedTitleModel) {
-        settings.titleGenerationModel = normalizedTitleModel;
-        changed = true;
-      }
+    const titleModel = typeof settings.titleGenerationModel === 'string'
+      ? settings.titleGenerationModel
+      : '';
+    const historicalTitleModelEnvironmentType = environmentChanged && titleModel
+      ? inferPreviousModelEnvironmentType(claudeSettings.environmentHash, titleModel)
+      : undefined;
+    const titleModelEnvironmentType = claudeSettings.titleModelEnvironmentType
+      || (titleModel
+        ? historicalTitleModelEnvironmentType
+          || (hasEnvironmentModelOptions
+            ? resolveClaudeModelEnvironmentTypePreference(modelOptions, titleModel)
+            : null)
+        : null);
+    const normalizedTitleModel = (
+      titleModelEnvironmentType
+        ? findClaudeModelOptionForEnvironmentType(
+          modelOptions,
+          titleModelEnvironmentType,
+        )?.value
+        : undefined
+    ) ?? (titleModel ? normalize(titleModel) : '');
+    if (titleModel !== normalizedTitleModel) {
+      settings.titleGenerationModel = normalizedTitleModel;
+      changed = true;
     }
 
-    const lastClaudeModel = getClaudeProviderSettings(settings).lastModel;
+    const lastClaudeModel = claudeSettings.lastModel;
     if (lastClaudeModel) {
-      const normalizedLastClaudeModel = normalize(lastClaudeModel);
+      const normalizedLastClaudeModel = normalizeLegacyClaudeModelAlias(
+        toClaudeRuntimeModelId(lastClaudeModel),
+      );
       if (lastClaudeModel !== normalizedLastClaudeModel) {
         updateClaudeProviderSettings(settings, { lastModel: normalizedLastClaudeModel });
         changed = true;
       }
+    }
+
+    if (
+      claudeSettings.modelEnvironmentType !== (modelEnvironmentType ?? '')
+      || claudeSettings.titleModelEnvironmentType !== (titleModelEnvironmentType ?? '')
+    ) {
+      updateClaudeProviderSettings(settings, {
+        modelEnvironmentType: modelEnvironmentType ?? '',
+        titleModelEnvironmentType: titleModelEnvironmentType ?? '',
+      });
+      changed = true;
     }
 
     return changed;

--- a/src/providers/claude/env/claudeModelEnv.ts
+++ b/src/providers/claude/env/claudeModelEnv.ts
@@ -1,25 +1,46 @@
 import { formatCustomModelLabel } from '../modelLabels';
+import {
+  CLAUDE_MODEL_TIER_DEFINITIONS,
+  type ClaudeModelEnvironmentType,
+  type ClaudeModelTierEnvironmentKey,
+  getClaudeModelTierDefinition,
+} from '../modelTiers';
 
-const CUSTOM_MODEL_ENV_KEYS = [
+export type ClaudeModelEnvKey = 'ANTHROPIC_MODEL' | ClaudeModelTierEnvironmentKey;
+export type ClaudeModelEnvType = ClaudeModelEnvironmentType;
+
+export const CLAUDE_MODEL_ENV_KEYS: readonly ClaudeModelEnvKey[] = [
   'ANTHROPIC_MODEL',
-  'ANTHROPIC_DEFAULT_OPUS_MODEL',
-  'ANTHROPIC_DEFAULT_SONNET_MODEL',
-  'ANTHROPIC_DEFAULT_HAIKU_MODEL',
-] as const;
+  ...CLAUDE_MODEL_TIER_DEFINITIONS.map(definition => definition.environmentKey),
+];
 
-function getModelTypeFromEnvKey(envKey: string): string {
-  if (envKey === 'ANTHROPIC_MODEL') return 'model';
-  const match = envKey.match(/ANTHROPIC_DEFAULT_(\w+)_MODEL/);
-  return match ? match[1].toLowerCase() : envKey;
+export interface ClaudeEnvironmentModel {
+  value: string;
+  label: string;
+  description: string;
+  environmentTypes: ClaudeModelEnvType[];
+}
+
+function getModelTypeFromEnvKey(envKey: ClaudeModelEnvKey): ClaudeModelEnvType {
+  if (envKey === 'ANTHROPIC_MODEL') {
+    return 'model';
+  }
+  return CLAUDE_MODEL_TIER_DEFINITIONS.find(definition => definition.environmentKey === envKey)!.id;
+}
+
+function getModelTypePriority(type: ClaudeModelEnvType): number {
+  return type === 'model'
+    ? CLAUDE_MODEL_TIER_DEFINITIONS.length + 1
+    : getClaudeModelTierDefinition(type).environmentPriority;
 }
 
 export function getModelsFromEnvironment(
   envVars: Record<string, string>,
   modelAliases: Record<string, string> = {},
-): { value: string; label: string; description: string }[] {
-  const modelMap = new Map<string, { types: string[]; label: string }>();
+): ClaudeEnvironmentModel[] {
+  const modelMap = new Map<string, { types: ClaudeModelEnvType[]; label: string }>();
 
-  for (const envKey of CUSTOM_MODEL_ENV_KEYS) {
+  for (const envKey of CLAUDE_MODEL_ENV_KEYS) {
     const type = getModelTypeFromEnvKey(envKey);
     const modelValue = envVars[envKey];
     if (modelValue) {
@@ -33,25 +54,24 @@ export function getModelsFromEnvironment(
     }
   }
 
-  const models: { value: string; label: string; description: string }[] = [];
-  const typePriority = { 'model': 4, 'haiku': 3, 'sonnet': 2, 'opus': 1 };
+  const models: ClaudeEnvironmentModel[] = [];
 
   const sortedEntries = Array.from(modelMap.entries()).sort(([, aInfo], [, bInfo]) => {
-    const aPriority = Math.max(...aInfo.types.map(t => typePriority[t as keyof typeof typePriority] || 0));
-    const bPriority = Math.max(...bInfo.types.map(t => typePriority[t as keyof typeof typePriority] || 0));
+    const aPriority = Math.max(...aInfo.types.map(getModelTypePriority));
+    const bPriority = Math.max(...bInfo.types.map(getModelTypePriority));
     return bPriority - aPriority;
   });
 
   for (const [modelValue, info] of sortedEntries) {
     const sortedTypes = info.types.sort((a, b) =>
-      (typePriority[b as keyof typeof typePriority] || 0) -
-      (typePriority[a as keyof typeof typePriority] || 0)
+      getModelTypePriority(b) - getModelTypePriority(a)
     );
 
     models.push({
       value: modelValue,
       label: info.label,
-      description: `Custom model (${sortedTypes.join(', ')})`
+      description: `Custom model (${sortedTypes.join(', ')})`,
+      environmentTypes: [...sortedTypes],
     });
   }
 
@@ -59,24 +79,18 @@ export function getModelsFromEnvironment(
 }
 
 export function getCurrentModelFromEnvironment(envVars: Record<string, string>): string | null {
-  if (envVars.ANTHROPIC_MODEL) {
-    return envVars.ANTHROPIC_MODEL;
-  }
-  if (envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL) {
-    return envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL;
-  }
-  if (envVars.ANTHROPIC_DEFAULT_SONNET_MODEL) {
-    return envVars.ANTHROPIC_DEFAULT_SONNET_MODEL;
-  }
-  if (envVars.ANTHROPIC_DEFAULT_OPUS_MODEL) {
-    return envVars.ANTHROPIC_DEFAULT_OPUS_MODEL;
+  for (const envKey of CLAUDE_MODEL_ENV_KEYS) {
+    const modelId = envVars[envKey];
+    if (modelId) {
+      return modelId;
+    }
   }
   return null;
 }
 
 export function getCustomModelIds(envVars: Record<string, string>): Set<string> {
   const modelIds = new Set<string>();
-  for (const envKey of CUSTOM_MODEL_ENV_KEYS) {
+  for (const envKey of CLAUDE_MODEL_ENV_KEYS) {
     const modelId = envVars[envKey];
     if (modelId) {
       modelIds.add(modelId);

--- a/src/providers/claude/modelLabels.ts
+++ b/src/providers/claude/modelLabels.ts
@@ -1,5 +1,11 @@
-function getFamilyDisplayName(family: string): string {
-  return family.charAt(0).toUpperCase() + family.slice(1).toLowerCase();
+import {
+  CLAUDE_MODEL_TIER_PATTERN,
+  type ClaudeModelTier,
+  getClaudeModelTierDefinition,
+} from './modelTiers';
+
+function getFamilyDisplayName(family: ClaudeModelTier): string {
+  return getClaudeModelTierDefinition(family).agentLabel;
 }
 
 function formatClaudeModelDateTag(date: string | undefined): string | null {
@@ -49,28 +55,31 @@ function formatClaudeCustomModelLabel(labelSource: string): string | null {
   const claudePrefixIndex = without1M.toLowerCase().indexOf('claude-');
   const candidate = claudePrefixIndex >= 0 ? without1M.slice(claudePrefixIndex) : without1M;
 
-  const versionedMatch = candidate.match(
-    /^claude-(haiku|sonnet|opus|fable)-(\d+)-(\d+)(?:-(\d{8}))?(?:-v\d+:\d+)?$/i,
-  );
+  const versionedMatch = candidate.match(new RegExp(
+    `^claude-(${CLAUDE_MODEL_TIER_PATTERN})-(\\d+)-(\\d+)`
+    + '(?:-(\\d{8}))?(?:-v\\d+:\\d+)?$',
+    'i',
+  ));
   if (versionedMatch) {
     const [, family, major, minor, date] = versionedMatch;
     const suffixes = [
       formatClaudeModelDateTag(date),
       is1M ? '(1M)' : null,
     ].filter(Boolean).join(' ');
-    return `${getFamilyDisplayName(family)} ${major}.${minor}${suffixes ? ` ${suffixes}` : ''}`;
+    return `${getFamilyDisplayName(family as ClaudeModelTier)} ${major}.${minor}${suffixes ? ` ${suffixes}` : ''}`;
   }
 
-  const majorOnlyMatch = candidate.match(
-    /^claude-(haiku|sonnet|opus|fable)-(\d+)(?:-(\d{8}))?(?:-v\d+:\d+)?$/i,
-  );
+  const majorOnlyMatch = candidate.match(new RegExp(
+    `^claude-(${CLAUDE_MODEL_TIER_PATTERN})-(\\d+)(?:-(\\d{8}))?(?:-v\\d+:\\d+)?$`,
+    'i',
+  ));
   if (majorOnlyMatch) {
     const [, family, major, date] = majorOnlyMatch;
     const suffixes = [
       formatClaudeModelDateTag(date),
       is1M ? '(1M)' : null,
     ].filter(Boolean).join(' ');
-    return `${getFamilyDisplayName(family)} ${major}${suffixes ? ` ${suffixes}` : ''}`;
+    return `${getFamilyDisplayName(family as ClaudeModelTier)} ${major}${suffixes ? ` ${suffixes}` : ''}`;
   }
 
   return null;

--- a/src/providers/claude/modelOptions.ts
+++ b/src/providers/claude/modelOptions.ts
@@ -1,10 +1,18 @@
 import { getRuntimeEnvironmentVariables } from '../../core/providers/providerEnvironment';
 import type { ProviderUIOption } from '../../core/providers/types';
-import { getModelsFromEnvironment } from './env/claudeModelEnv';
+import {
+  type ClaudeModelEnvType,
+  getModelsFromEnvironment,
+} from './env/claudeModelEnv';
 import { formatCustomModelLabel } from './modelLabels';
 import { encodeClaudeModelSelectionId, toClaudeRuntimeModelId } from './modelSelection';
+import { isClaudeModelTier } from './modelTiers';
 import { getClaudeProviderSettings } from './settings';
-import { DEFAULT_CLAUDE_MODELS, normalizeLegacy1MModelAlias } from './types/models';
+import { DEFAULT_CLAUDE_MODELS, normalizeLegacyClaudeModelAlias } from './types/models';
+
+export interface ClaudeModelOption extends ProviderUIOption {
+  environmentTypes?: readonly ClaudeModelEnvType[];
+}
 
 function parseConfiguredCustomModelIds(value: string): string[] {
   const modelIds: string[] = [];
@@ -43,7 +51,7 @@ function normalizeCustomModelAliases(value: unknown): Record<string, string> {
   return aliases;
 }
 
-export function getClaudeModelOptions(settings: Record<string, unknown>): ProviderUIOption[] {
+export function getClaudeModelOptions(settings: Record<string, unknown>): ClaudeModelOption[] {
   const customModelAliases = normalizeCustomModelAliases(settings.customModelAliases);
   const customModels = getModelsFromEnvironment(
     getRuntimeEnvironmentVariables(settings, 'claude'),
@@ -59,14 +67,17 @@ export function getClaudeModelOptions(settings: Record<string, unknown>): Provid
   const claudeSettings = getClaudeProviderSettings(settings);
   const models = [...DEFAULT_CLAUDE_MODELS];
 
-  const seenModelIds = new Set(models.map(model => toClaudeRuntimeModelId(model.value)));
+  const seenModelIds = new Set(models.map(model =>
+    normalizeLegacyClaudeModelAlias(toClaudeRuntimeModelId(model.value))
+  ));
   for (const configuredModelId of parseConfiguredCustomModelIds(claudeSettings.customModels)) {
     const modelId = toClaudeRuntimeModelId(configuredModelId);
-    if (seenModelIds.has(modelId)) {
+    const normalizedModelId = normalizeLegacyClaudeModelAlias(modelId);
+    if (seenModelIds.has(normalizedModelId)) {
       continue;
     }
 
-    seenModelIds.add(modelId);
+    seenModelIds.add(normalizedModelId);
     models.push({
       value: encodeClaudeModelSelectionId(modelId),
       label: customModelAliases[modelId] ?? formatCustomModelLabel(modelId),
@@ -77,17 +88,119 @@ export function getClaudeModelOptions(settings: Record<string, unknown>): Provid
   return models;
 }
 
+export function findClaudeModelOption(
+  modelOptions: readonly ClaudeModelOption[],
+  model: string,
+): ClaudeModelOption | undefined {
+  const runtimeModel = toClaudeRuntimeModelId(model);
+  const exactOption = modelOptions.find(option =>
+    option.value === model || toClaudeRuntimeModelId(option.value) === runtimeModel
+  );
+  if (exactOption) {
+    return exactOption;
+  }
+
+  const normalizedRuntimeModel = normalizeLegacyClaudeModelAlias(toClaudeRuntimeModelId(model));
+  if (isClaudeModelTier(normalizedRuntimeModel)) {
+    const tierOption = modelOptions.find(option =>
+      option.environmentTypes?.includes(normalizedRuntimeModel)
+    );
+    if (tierOption) {
+      return tierOption;
+    }
+  }
+
+  return modelOptions.find(option =>
+    normalizeLegacyClaudeModelAlias(toClaudeRuntimeModelId(option.value)) === normalizedRuntimeModel
+  );
+}
+
+export function findClaudeModelOptionForEnvironmentType(
+  modelOptions: readonly ClaudeModelOption[],
+  environmentType: ClaudeModelEnvType,
+): ClaudeModelOption | undefined {
+  const environmentOption = modelOptions.find(option =>
+    option.environmentTypes?.includes(environmentType)
+  );
+  if (environmentOption || environmentType === 'model') {
+    return environmentOption;
+  }
+
+  return modelOptions.find(option =>
+    !option.environmentTypes
+    && normalizeLegacyClaudeModelAlias(toClaudeRuntimeModelId(option.value)) === environmentType
+  );
+}
+
+export function resolveClaudeModelEnvironmentTypePreference(
+  modelOptions: readonly ClaudeModelOption[],
+  model: string,
+  previousEnvironmentType: ClaudeModelEnvType | '' = '',
+): ClaudeModelEnvType | null {
+  const exactEnvironmentTypes = modelOptions.find(option => option.value === model)
+    ?.environmentTypes;
+  if (exactEnvironmentTypes) {
+    if (
+      previousEnvironmentType
+      && exactEnvironmentTypes.includes(previousEnvironmentType)
+    ) {
+      return previousEnvironmentType;
+    }
+    return exactEnvironmentTypes.length === 1 ? exactEnvironmentTypes[0] : null;
+  }
+
+  const runtimeModel = toClaudeRuntimeModelId(model);
+  const runtimeEnvironmentTypes = modelOptions.find(option =>
+    toClaudeRuntimeModelId(option.value) === runtimeModel
+  )?.environmentTypes;
+  if (runtimeEnvironmentTypes) {
+    if (
+      previousEnvironmentType
+      && runtimeEnvironmentTypes.includes(previousEnvironmentType)
+    ) {
+      return previousEnvironmentType;
+    }
+    return runtimeEnvironmentTypes.length === 1 ? runtimeEnvironmentTypes[0] : null;
+  }
+
+  const normalizedModel = normalizeLegacyClaudeModelAlias(runtimeModel);
+  if (isClaudeModelTier(normalizedModel)) {
+    return normalizedModel;
+  }
+
+  const environmentTypes = findClaudeModelOption(modelOptions, model)?.environmentTypes;
+  if (!environmentTypes) {
+    return null;
+  }
+
+  if (
+    previousEnvironmentType
+    && environmentTypes.includes(previousEnvironmentType)
+  ) {
+    return previousEnvironmentType;
+  }
+
+  return environmentTypes.length === 1 ? environmentTypes[0] : null;
+}
+
 export function resolveClaudeModelSelection(
   settings: Record<string, unknown>,
   currentModel: string,
+  preferredEnvironmentType?: ClaudeModelEnvType,
 ): string | null {
   const modelOptions = getClaudeModelOptions(settings);
-  if (currentModel) {
-    const currentRuntimeModel = normalizeLegacy1MModelAlias(toClaudeRuntimeModelId(currentModel));
-    const currentOption = modelOptions.find(option =>
-      option.value === currentModel
-      || toClaudeRuntimeModelId(option.value) === currentRuntimeModel
+  if (preferredEnvironmentType) {
+    const preferredOption = findClaudeModelOptionForEnvironmentType(
+      modelOptions,
+      preferredEnvironmentType,
     );
+    if (preferredOption) {
+      return preferredOption.value;
+    }
+  }
+
+  if (currentModel) {
+    const currentOption = findClaudeModelOption(modelOptions, currentModel);
     if (currentOption) {
       return currentOption.value;
     }
@@ -95,11 +208,7 @@ export function resolveClaudeModelSelection(
 
   const lastModel = getClaudeProviderSettings(settings).lastModel;
   if (lastModel) {
-    const lastRuntimeModel = normalizeLegacy1MModelAlias(toClaudeRuntimeModelId(lastModel));
-    const lastOption = modelOptions.find(option =>
-      option.value === lastModel
-      || toClaudeRuntimeModelId(option.value) === lastRuntimeModel
-    );
+    const lastOption = findClaudeModelOption(modelOptions, lastModel);
     if (lastOption) {
       return lastOption.value;
     }

--- a/src/providers/claude/modelTiers.ts
+++ b/src/providers/claude/modelTiers.ts
@@ -1,0 +1,108 @@
+interface ClaudeModelVersion {
+  major: number;
+  minor: number;
+}
+
+export const CLAUDE_MODEL_TIER_DEFINITIONS = [
+  {
+    id: 'haiku',
+    label: 'Haiku',
+    agentLabel: 'Haiku',
+    description: 'Fast and efficient',
+    environmentKey: 'ANTHROPIC_DEFAULT_HAIKU_MODEL',
+    environmentPriority: 4,
+    agentOrder: 3,
+    legacyAliases: [],
+    supportsOneMillionSuffix: false,
+    aliasHasOneMillionContext: false,
+    versionedOneMillionContextFrom: null,
+    aliasSupportsXHigh: false,
+    versionedXHighFrom: null,
+  },
+  {
+    id: 'sonnet',
+    label: 'Sonnet',
+    agentLabel: 'Sonnet',
+    description: 'Balanced performance',
+    environmentKey: 'ANTHROPIC_DEFAULT_SONNET_MODEL',
+    environmentPriority: 3,
+    agentOrder: 1,
+    legacyAliases: ['sonnet[1m]'],
+    supportsOneMillionSuffix: true,
+    aliasHasOneMillionContext: true,
+    versionedOneMillionContextFrom: { major: 4, minor: 6 },
+    aliasSupportsXHigh: true,
+    versionedXHighFrom: { major: 5, minor: 0 },
+  },
+  {
+    id: 'opus',
+    label: 'Opus',
+    agentLabel: 'Opus',
+    description: 'Most capable',
+    environmentKey: 'ANTHROPIC_DEFAULT_OPUS_MODEL',
+    environmentPriority: 2,
+    agentOrder: 2,
+    legacyAliases: ['opus[1m]'],
+    supportsOneMillionSuffix: true,
+    aliasHasOneMillionContext: true,
+    versionedOneMillionContextFrom: { major: 4, minor: 6 },
+    aliasSupportsXHigh: true,
+    versionedXHighFrom: { major: 4, minor: 7 },
+  },
+  {
+    id: 'fable',
+    label: 'Fable 5 ($$$)',
+    agentLabel: 'Fable',
+    description: "Anthropic's most capable model — premium pricing above Opus",
+    environmentKey: 'ANTHROPIC_DEFAULT_FABLE_MODEL',
+    environmentPriority: 1,
+    agentOrder: 4,
+    legacyAliases: ['claude-fable-5'],
+    supportsOneMillionSuffix: false,
+    aliasHasOneMillionContext: true,
+    versionedOneMillionContextFrom: { major: 0, minor: 0 },
+    aliasSupportsXHigh: true,
+    versionedXHighFrom: { major: 0, minor: 0 },
+  },
+] as const;
+
+export type ClaudeModelTier = typeof CLAUDE_MODEL_TIER_DEFINITIONS[number]['id'];
+export type ClaudeModelEnvironmentType = 'model' | ClaudeModelTier;
+export type ClaudeModelTierDefinition = typeof CLAUDE_MODEL_TIER_DEFINITIONS[number];
+export type ClaudeModelTierEnvironmentKey = ClaudeModelTierDefinition['environmentKey'];
+
+export const CLAUDE_MODEL_TIER_PATTERN = CLAUDE_MODEL_TIER_DEFINITIONS
+  .map(definition => definition.id)
+  .join('|');
+
+export function isClaudeModelTier(value: string): value is ClaudeModelTier {
+  return CLAUDE_MODEL_TIER_DEFINITIONS.some(definition => definition.id === value);
+}
+
+export function isClaudeModelEnvironmentType(value: string): value is ClaudeModelEnvironmentType {
+  return value === 'model' || isClaudeModelTier(value);
+}
+
+export function getClaudeModelTierDefinition(tier: ClaudeModelTier): ClaudeModelTierDefinition {
+  return CLAUDE_MODEL_TIER_DEFINITIONS.find(definition => definition.id === tier)!;
+}
+
+export function resolveClaudeModelTierAlias(value: string): ClaudeModelTier | null {
+  const normalized = value.trim().toLowerCase();
+  const definition = CLAUDE_MODEL_TIER_DEFINITIONS.find(candidate =>
+    candidate.id === normalized
+    || (candidate.legacyAliases as readonly string[]).includes(normalized)
+  );
+  return definition?.id ?? null;
+}
+
+export function isVersionAtLeast(
+  major: number,
+  minor: number,
+  minimum: ClaudeModelVersion | null,
+): boolean {
+  if (!minimum) {
+    return false;
+  }
+  return major > minimum.major || (major === minimum.major && minor >= minimum.minor);
+}

--- a/src/providers/claude/settings.ts
+++ b/src/providers/claude/settings.ts
@@ -6,6 +6,10 @@ import {
   getLegacyHostnameKey,
   migrateLegacyHostnameKeyedMap,
 } from '../../utils/env';
+import {
+  type ClaudeModelEnvironmentType,
+  isClaudeModelEnvironmentType,
+} from './modelTiers';
 
 export const CLAUDE_SAFE_MODES = ['acceptEdits', 'auto', 'default'] as const;
 export type ClaudeSafeMode = typeof CLAUDE_SAFE_MODES[number];
@@ -20,6 +24,8 @@ export interface ClaudeProviderSettings {
   enableBangBash: boolean;
   customModels: string;
   lastModel: string;
+  modelEnvironmentType: ClaudeModelEnvironmentType | '';
+  titleModelEnvironmentType: ClaudeModelEnvironmentType | '';
   environmentVariables: string;
   environmentHash: string;
 }
@@ -33,6 +39,8 @@ export const DEFAULT_CLAUDE_PROVIDER_SETTINGS: Readonly<ClaudeProviderSettings> 
   enableBangBash: false,
   customModels: '',
   lastModel: 'haiku',
+  modelEnvironmentType: '',
+  titleModelEnvironmentType: '',
   environmentVariables: '',
   environmentHash: '',
 });
@@ -55,6 +63,14 @@ function normalizeClaudeSafeMode(value: unknown): ClaudeSafeMode | undefined {
   return (CLAUDE_SAFE_MODES as readonly unknown[]).includes(value)
     ? value as ClaudeSafeMode
     : undefined;
+}
+
+function normalizeClaudeModelEnvironmentType(
+  value: unknown,
+): ClaudeModelEnvironmentType | '' {
+  return typeof value === 'string' && isClaudeModelEnvironmentType(value)
+    ? value
+    : '';
 }
 
 export function getClaudeProviderSettings(
@@ -94,6 +110,10 @@ export function getClaudeProviderSettings(
     lastModel: (config.lastModel as string | undefined)
       ?? (settings.lastClaudeModel as string | undefined)
       ?? DEFAULT_CLAUDE_PROVIDER_SETTINGS.lastModel,
+    modelEnvironmentType: normalizeClaudeModelEnvironmentType(config.modelEnvironmentType),
+    titleModelEnvironmentType: normalizeClaudeModelEnvironmentType(
+      config.titleModelEnvironmentType,
+    ),
     environmentVariables: (config.environmentVariables as string | undefined)
       ?? getProviderEnvironmentVariables(settings, 'claude')
       ?? DEFAULT_CLAUDE_PROVIDER_SETTINGS.environmentVariables,

--- a/src/providers/claude/stream/transformClaudeMessage.ts
+++ b/src/providers/claude/stream/transformClaudeMessage.ts
@@ -1,6 +1,12 @@
 import type { SDKMessage, SDKResultError } from '@anthropic-ai/claude-agent-sdk';
 
 import type { SDKToolUseResult, StreamChunk, UsageInfo } from '../../../core/types';
+import {
+  CLAUDE_MODEL_TIER_PATTERN,
+  type ClaudeModelTier,
+  getClaudeModelTierDefinition,
+  isClaudeModelTier,
+} from '../modelTiers';
 import { isBlockedMessage } from '../sdk/messages';
 import { extractToolResultContent } from '../sdk/toolResultContent';
 import type { TransformEvent } from '../sdk/types';
@@ -107,7 +113,7 @@ interface ContextWindowEntry {
 
 interface ClaudeModelSignature {
   normalizedModel: string;
-  family: 'haiku' | 'sonnet' | 'opus' | 'fable';
+  family: ClaudeModelTier;
   is1M: boolean;
   major?: string;
   minor?: string;
@@ -126,22 +132,23 @@ function normalizeClaudeModelId(model: string): string {
 
 function parseClaudeModelSignature(model: string): ClaudeModelSignature | null {
   const normalized = normalizeClaudeModelId(model);
-  if (normalized === 'haiku') {
-    return { normalizedModel: normalized, family: 'haiku', is1M: false };
-  }
-  if (normalized === 'sonnet' || normalized === 'sonnet[1m]') {
-    return { normalizedModel: normalized, family: 'sonnet', is1M: normalized.endsWith('[1m]') };
-  }
-  if (normalized === 'opus' || normalized === 'opus[1m]') {
-    return { normalizedModel: normalized, family: 'opus', is1M: normalized.endsWith('[1m]') };
+  const aliasMatch = normalized.match(/^(\w+?)(\[1m\])?$/);
+  if (aliasMatch && isClaudeModelTier(aliasMatch[1])) {
+    const family = aliasMatch[1];
+    const hasOneMillionSuffix = aliasMatch[2] !== undefined;
+    if (hasOneMillionSuffix && !getClaudeModelTierDefinition(family).supportsOneMillionSuffix) {
+      return null;
+    }
+    return { normalizedModel: normalized, family, is1M: hasOneMillionSuffix };
   }
 
-  const versionedMatch = normalized.match(
-    /^claude-(haiku|sonnet|opus|fable)-(\d+)(?:-(\d+))?(?:-(\d{8}))?(?:-v\d+:\d+)?(\[1m\])?$/,
-  );
+  const versionedMatch = normalized.match(new RegExp(
+    `^claude-(${CLAUDE_MODEL_TIER_PATTERN})-(\\d+)(?:-(\\d+))?`
+    + '(?:-(\\d{8}))?(?:-v\\d+:\\d+)?(\\[1m\\])?$',
+  ));
   if (versionedMatch) {
     const [, familyMatch, major, minor, date, oneMillionSuffix] = versionedMatch;
-    const family = familyMatch as ClaudeModelSignature['family'];
+    const family = familyMatch as ClaudeModelTier;
     return {
       normalizedModel: normalized,
       family,

--- a/src/providers/claude/types/models.ts
+++ b/src/providers/claude/types/models.ts
@@ -4,16 +4,24 @@
 
 import { DEFAULT_REASONING_VALUE } from '../../../core/providers/reasoning';
 import { toClaudeRuntimeModelId } from '../modelSelection';
+import {
+  CLAUDE_MODEL_TIER_DEFINITIONS,
+  CLAUDE_MODEL_TIER_PATTERN,
+  type ClaudeModelTier,
+  getClaudeModelTierDefinition,
+  isVersionAtLeast,
+  resolveClaudeModelTierAlias,
+} from '../modelTiers';
 
 /** Model identifier (string to support custom models via environment variables). */
 export type ClaudeModel = string;
 
-export const DEFAULT_CLAUDE_MODELS: { value: ClaudeModel; label: string; description: string }[] = [
-  { value: 'haiku', label: 'Haiku', description: 'Fast and efficient' },
-  { value: 'sonnet', label: 'Sonnet', description: 'Balanced performance' },
-  { value: 'opus', label: 'Opus', description: 'Most capable' },
-  { value: 'claude-fable-5', label: 'Fable 5 ($$$)', description: "Anthropic's most capable model — premium pricing above Opus" },
-];
+export const DEFAULT_CLAUDE_MODELS: { value: ClaudeModel; label: string; description: string }[] =
+  CLAUDE_MODEL_TIER_DEFINITIONS.map(({ id, label, description }) => ({
+    value: id,
+    label,
+    description,
+  }));
 
 /** Effort levels for adaptive thinking models. */
 export type EffortLevel = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
@@ -27,38 +35,40 @@ export const EFFORT_LEVELS: { value: EffortLevel; label: string }[] = [
 ];
 
 /** Default effort level per model tier. */
-export const DEFAULT_EFFORT_LEVEL: Record<string, EffortLevel> = {
-  'haiku': DEFAULT_REASONING_VALUE,
-  'sonnet': DEFAULT_REASONING_VALUE,
-  'opus': DEFAULT_REASONING_VALUE,
-  'claude-fable-5': DEFAULT_REASONING_VALUE,
-};
-
-const ONE_M_SUFFIX = '[1m]';
-const DEFAULT_MODEL_VALUES = new Set(DEFAULT_CLAUDE_MODELS.map(m => m.value.toLowerCase()));
+export const DEFAULT_EFFORT_LEVEL: Record<string, EffortLevel> = Object.fromEntries(
+  CLAUDE_MODEL_TIER_DEFINITIONS.map(definition => [definition.id, DEFAULT_REASONING_VALUE]),
+);
 
 function normalizeModelId(model: string): string {
   return toClaudeRuntimeModelId(model).trim().toLowerCase();
 }
 
-function isBuiltInFamilyVariant(model: string, family: 'sonnet' | 'opus'): boolean {
+export function normalizeLegacyClaudeModelAlias(model: string): string {
+  return resolveClaudeModelTierAlias(normalizeModelId(model)) ?? model;
+}
+
+interface VersionedClaudeModel {
+  tier: ClaudeModelTier;
+  major: number;
+  minor: number;
+}
+
+function parseVersionedClaudeModel(model: string): VersionedClaudeModel | null {
   const normalized = normalizeModelId(model);
-  return normalized === family || normalized === `${family}${ONE_M_SUFFIX}`;
-}
-
-export function normalizeLegacy1MModelAlias(model: string): string {
-  if (isBuiltInFamilyVariant(model, 'sonnet')) {
-    return 'sonnet';
+  const canonicalStart = normalized.indexOf('claude-');
+  const canonical = canonicalStart >= 0 ? normalized.slice(canonicalStart) : normalized;
+  const match = canonical.match(
+    new RegExp(`^claude-(${CLAUDE_MODEL_TIER_PATTERN})-(\\d+)(?:-(\\d+))?`),
+  );
+  if (!match) {
+    return null;
   }
-  if (isBuiltInFamilyVariant(model, 'opus')) {
-    return 'opus';
-  }
-  return model;
-}
 
-/** Fable is a standalone tier (not a haiku/sonnet/opus version bump) — always 1M context, no [1m] toggle. */
-function isFableModel(model: string): boolean {
-  return /claude-fable-\d+/.test(normalizeModelId(model));
+  return {
+    tier: match[1] as ClaudeModelTier,
+    major: Number(match[2]),
+    minor: match[3] === undefined ? 0 : Number(match[3]),
+  };
 }
 
 function isValidContextLimit(limit: unknown): limit is number {
@@ -78,16 +88,20 @@ function resolveCustomContextLimit(
     return exactLimit;
   }
 
-  const normalizedModel = normalizeModelId(model);
+  const normalizedModel = normalizeLegacyClaudeModelAlias(normalizeModelId(model));
   const matchingLimits = Object.entries(customLimits)
-    .filter(([key, limit]) => key !== model && normalizeModelId(key) === normalizedModel && isValidContextLimit(limit))
+    .filter(([key, limit]) =>
+      key !== model
+      && normalizeLegacyClaudeModelAlias(normalizeModelId(key)) === normalizedModel
+      && isValidContextLimit(limit)
+    )
     .map(([, limit]) => limit);
 
   return matchingLimits.length === 1 ? matchingLimits[0] : null;
 }
 
 export function isDefaultClaudeModel(model: string): boolean {
-  return DEFAULT_MODEL_VALUES.has(normalizeModelId(normalizeLegacy1MModelAlias(model)));
+  return resolveClaudeModelTierAlias(normalizeModelId(model)) !== null;
 }
 
 /**
@@ -96,12 +110,20 @@ export function isDefaultClaudeModel(model: string): boolean {
  */
 export function supportsXHighEffort(model: string): boolean {
   const normalized = normalizeModelId(model);
-  if (isBuiltInFamilyVariant(normalized, 'opus')) return true;
-  if (isBuiltInFamilyVariant(normalized, 'sonnet')) return true;
-  if (isFableModel(normalized)) return true;
-  return (
-    /claude-opus-(4-[7-9]|[5-9])/.test(normalized) ||
-    /claude-sonnet-(?:[5-9]|\d{2,})(?:-\d{8})?(?:-|$)/.test(normalized)
+  const aliasTier = resolveClaudeModelTierAlias(normalized);
+  if (aliasTier) {
+    return getClaudeModelTierDefinition(aliasTier).aliasSupportsXHigh;
+  }
+
+  const versionedModel = parseVersionedClaudeModel(normalized);
+  if (!versionedModel) {
+    return false;
+  }
+  const definition = getClaudeModelTierDefinition(versionedModel.tier);
+  return isVersionAtLeast(
+    versionedModel.major,
+    versionedModel.minor,
+    definition.versionedXHighFrom,
   );
 }
 
@@ -119,7 +141,8 @@ export function normalizeEffortLevel(
     return effortLevel as EffortLevel;
   }
 
-  return DEFAULT_EFFORT_LEVEL[normalizeModelId(model)] ?? DEFAULT_REASONING_VALUE;
+  const modelTier = resolveClaudeModelTierAlias(normalizeModelId(model));
+  return (modelTier && DEFAULT_EFFORT_LEVEL[modelTier]) ?? DEFAULT_REASONING_VALUE;
 }
 
 export function resolveEffortLevel(
@@ -140,21 +163,22 @@ export interface ContextWindowResolution {
 }
 
 function isCurrentOneMillionContextModel(model: string): boolean {
-  const normalized = normalizeModelId(normalizeLegacy1MModelAlias(model));
-  if (normalized === 'opus' || normalized === 'sonnet' || isFableModel(normalized)) {
-    return true;
+  const normalized = normalizeModelId(model);
+  const aliasTier = resolveClaudeModelTierAlias(normalized);
+  if (aliasTier) {
+    return getClaudeModelTierDefinition(aliasTier).aliasHasOneMillionContext;
   }
 
-  const canonicalStart = normalized.indexOf('claude-');
-  const canonical = canonicalStart >= 0 ? normalized.slice(canonicalStart) : normalized;
-  const versionMatch = canonical.match(/^claude-(opus|sonnet)-(\d+)(?:-(\d+))?/);
-  if (!versionMatch) {
+  const versionedModel = parseVersionedClaudeModel(normalized);
+  if (!versionedModel) {
     return false;
   }
-
-  const major = Number(versionMatch[2]);
-  const minor = versionMatch[3] === undefined ? 0 : Number(versionMatch[3]);
-  return major > 4 || (major === 4 && minor >= 6);
+  const definition = getClaudeModelTierDefinition(versionedModel.tier);
+  return isVersionAtLeast(
+    versionedModel.major,
+    versionedModel.minor,
+    definition.versionedOneMillionContextFrom,
+  );
 }
 
 export function getContextWindowSize(

--- a/src/providers/claude/ui/AgentSettings.ts
+++ b/src/providers/claude/ui/AgentSettings.ts
@@ -9,13 +9,14 @@ import type { AgentDefinition } from '../../../core/types';
 import { t } from '../../../i18n/i18n';
 import { confirmDelete } from '../../../shared/modals/ConfirmModal';
 import { validateAgentName } from '../../../utils/agent';
+import { CLAUDE_MODEL_TIER_DEFINITIONS } from '../modelTiers';
 
 const MODEL_OPTIONS = [
   { value: 'inherit', label: 'Inherit' },
-  { value: 'sonnet', label: 'Sonnet' },
-  { value: 'opus', label: 'Opus' },
-  { value: 'haiku', label: 'Haiku' },
-] as const;
+  ...[...CLAUDE_MODEL_TIER_DEFINITIONS]
+    .sort((a, b) => a.agentOrder - b.agentOrder)
+    .map(definition => ({ value: definition.id, label: definition.agentLabel })),
+];
 
 class AgentModal extends Modal {
   private existingAgent: AgentDefinition | null;

--- a/src/providers/claude/ui/ClaudeChatUIConfig.ts
+++ b/src/providers/claude/ui/ClaudeChatUIConfig.ts
@@ -7,8 +7,13 @@ import type {
 } from '../../../core/providers/types';
 import { CLAUDE_PROVIDER_ICON } from '../../../shared/icons';
 import { getCustomModelIds } from '../env/claudeModelEnv';
-import { getClaudeModelOptions } from '../modelOptions';
+import {
+  findClaudeModelOption,
+  getClaudeModelOptions,
+  resolveClaudeModelEnvironmentTypePreference,
+} from '../modelOptions';
 import { toClaudeRuntimeModelId } from '../modelSelection';
+import { isClaudeModelTier } from '../modelTiers';
 import { getClaudeProviderSettings, updateClaudeProviderSettings } from '../settings';
 import {
   DEFAULT_CLAUDE_MODELS,
@@ -16,7 +21,7 @@ import {
   EFFORT_LEVELS,
   getContextWindowSize,
   normalizeEffortLevel,
-  normalizeLegacy1MModelAlias,
+  normalizeLegacyClaudeModelAlias,
   supportsXHighEffort,
 } from '../types/models';
 
@@ -62,29 +67,63 @@ export const claudeChatUIConfig: ProviderChatUIConfig = {
   },
 
   isDefaultModel(model: string): boolean {
-    const runtimeModel = normalizeLegacy1MModelAlias(toClaudeRuntimeModelId(model));
+    const runtimeModel = normalizeLegacyClaudeModelAlias(toClaudeRuntimeModelId(model));
     return DEFAULT_CLAUDE_MODELS.some(m => m.value === runtimeModel);
   },
 
   applyModelDefaults(model: string, settings: unknown): void {
     const target = settings as Record<string, unknown>;
 
-    const runtimeModel = normalizeLegacy1MModelAlias(toClaudeRuntimeModelId(model));
-    if (DEFAULT_CLAUDE_MODELS.some(m => m.value === runtimeModel)) {
-      target.effortLevel = DEFAULT_EFFORT_LEVEL[runtimeModel] ?? DEFAULT_REASONING_VALUE;
-      updateClaudeProviderSettings(target, { lastModel: runtimeModel });
+    const runtimeModel = normalizeLegacyClaudeModelAlias(toClaudeRuntimeModelId(model));
+    const claudeSettings = getClaudeProviderSettings(target);
+    const modelEnvironmentType = resolveClaudeModelEnvironmentTypePreference(
+      getClaudeModelOptions(target),
+      model,
+      claudeSettings.modelEnvironmentType,
+    );
+    if (modelEnvironmentType && isClaudeModelTier(modelEnvironmentType)) {
+      target.effortLevel = runtimeModel === modelEnvironmentType
+        ? DEFAULT_EFFORT_LEVEL[modelEnvironmentType] ?? DEFAULT_REASONING_VALUE
+        : normalizeEffortLevel(runtimeModel, target.effortLevel);
+      updateClaudeProviderSettings(target, {
+        lastModel: modelEnvironmentType,
+        modelEnvironmentType,
+      });
     } else {
       target.lastCustomModel = model;
       target.effortLevel = normalizeEffortLevel(runtimeModel, target.effortLevel);
+      updateClaudeProviderSettings(target, {
+        modelEnvironmentType: modelEnvironmentType ?? '',
+      });
     }
   },
 
+  applyModelProjectionDefaults(model: string, settings: unknown): void {
+    const target = settings as Record<string, unknown>;
+    const runtimeModel = normalizeLegacyClaudeModelAlias(toClaudeRuntimeModelId(model));
+    target.effortLevel = DEFAULT_CLAUDE_MODELS.some(candidate => candidate.value === runtimeModel)
+      ? DEFAULT_EFFORT_LEVEL[runtimeModel] ?? DEFAULT_REASONING_VALUE
+      : normalizeEffortLevel(runtimeModel, target.effortLevel);
+  },
+
+  applyTitleGenerationModelSelection(model: string, settings: unknown): void {
+    const target = settings as Record<string, unknown>;
+    const claudeSettings = getClaudeProviderSettings(target);
+    const environmentType = model
+      ? resolveClaudeModelEnvironmentTypePreference(
+        getClaudeModelOptions(target),
+        model,
+        claudeSettings.titleModelEnvironmentType,
+      )
+      : null;
+    updateClaudeProviderSettings(target, {
+      titleModelEnvironmentType: environmentType ?? '',
+    });
+  },
+
   normalizeModelVariant(model: string, settings) {
-    const normalizedRuntimeModel = normalizeLegacy1MModelAlias(toClaudeRuntimeModelId(model));
-    const option = getClaudeModelOptions(settings).find(candidate =>
-      candidate.value === normalizedRuntimeModel
-      || toClaudeRuntimeModelId(candidate.value) === normalizedRuntimeModel
-    );
+    const normalizedRuntimeModel = normalizeLegacyClaudeModelAlias(toClaudeRuntimeModelId(model));
+    const option = findClaudeModelOption(getClaudeModelOptions(settings), model);
     return option?.value ?? normalizedRuntimeModel;
   },
 

--- a/tests/unit/core/providers/ProviderSettingsCoordinator.test.ts
+++ b/tests/unit/core/providers/ProviderSettingsCoordinator.test.ts
@@ -245,6 +245,27 @@ describe('ProviderSettingsCoordinator', () => {
   });
 
   describe('reconcileTitleGenerationModelSelection', () => {
+    it('persists Claude environment provenance when selecting a title model', () => {
+      const settings: Record<string, unknown> = {
+        titleGenerationModel: '',
+        providerConfigs: {
+          claude: {
+            ...DEFAULT_CLAUDE_PROVIDER_SETTINGS,
+            environmentVariables: 'ANTHROPIC_DEFAULT_FABLE_MODEL=gpt-4.1',
+          },
+        },
+      };
+
+      ProviderSettingsCoordinator.applyTitleGenerationModelSelection(
+        settings,
+        'claude-code/gpt-4.1',
+      );
+
+      expect(settings.titleGenerationModel).toBe('claude-code/gpt-4.1');
+      expect((settings.providerConfigs as Record<string, Record<string, unknown>>).claude)
+        .toMatchObject({ titleModelEnvironmentType: 'fable' });
+    });
+
     it('migrates available Claude custom title models to provider-qualified ids', () => {
       const settings: Record<string, unknown> = {
         titleGenerationModel: 'claude-opus-4-6',
@@ -328,6 +349,131 @@ describe('ProviderSettingsCoordinator', () => {
         ProviderSettingsCoordinator.reconcileTitleGenerationModelSelection(settings),
       ).toBe(true);
       expect(settings.titleGenerationModel).toBe('openai-codex/my-custom-model');
+    });
+  });
+
+  describe('Claude environment reconciliation', () => {
+    it('preserves Fable provenance while projecting an inactive Claude provider', () => {
+      const settings: Record<string, unknown> = {
+        settingsProvider: 'codex',
+        model: TEST_CODEX_MODEL,
+        effortLevel: 'high',
+        serviceTier: 'default',
+        thinkingBudget: 'off',
+        savedProviderModel: {
+          claude: 'claude-code/fable-v1',
+          codex: TEST_CODEX_MODEL,
+        },
+        providerConfigs: {
+          claude: {
+            ...DEFAULT_CLAUDE_PROVIDER_SETTINGS,
+            lastModel: 'fable',
+            modelEnvironmentType: 'fable',
+            environmentVariables: [
+              'ANTHROPIC_DEFAULT_HAIKU_MODEL=haiku-v2',
+              'ANTHROPIC_DEFAULT_FABLE_MODEL=fable-v2',
+            ].join('\n'),
+            environmentHash: [
+              'ANTHROPIC_DEFAULT_FABLE_MODEL=fable-v1',
+              'ANTHROPIC_DEFAULT_HAIKU_MODEL=haiku-v1',
+            ].join('|'),
+          },
+          codex: {
+            enabled: true,
+            discoveredModels: TEST_CODEX_CATALOG,
+          },
+        },
+      };
+
+      ProviderSettingsCoordinator.reconcileProviders(settings, [], ['claude']);
+
+      expect(settings.savedProviderModel).toMatchObject({
+        claude: 'claude-code/fable-v2',
+      });
+      expect((settings.providerConfigs as Record<string, Record<string, unknown>>).claude)
+        .toMatchObject({
+          lastModel: 'fable',
+          modelEnvironmentType: 'fable',
+        });
+    });
+
+    it('migrates legacy inactive Fable state before provider projection replaces it', () => {
+      const settings: Record<string, unknown> = {
+        settingsProvider: 'codex',
+        model: TEST_CODEX_MODEL,
+        effortLevel: 'high',
+        serviceTier: 'default',
+        thinkingBudget: 'off',
+        savedProviderModel: {
+          claude: 'claude-code/fable-old',
+          codex: TEST_CODEX_MODEL,
+        },
+        providerConfigs: {
+          claude: {
+            ...DEFAULT_CLAUDE_PROVIDER_SETTINGS,
+            lastModel: 'fable',
+            modelEnvironmentType: '',
+            environmentVariables: [
+              'ANTHROPIC_DEFAULT_HAIKU_MODEL=haiku-new',
+              'ANTHROPIC_DEFAULT_FABLE_MODEL=fable-new',
+            ].join('\n'),
+            environmentHash: 'ANTHROPIC_DEFAULT_FABLE_MODEL=fable-old',
+          },
+          codex: {
+            enabled: true,
+            discoveredModels: TEST_CODEX_CATALOG,
+          },
+        },
+      };
+
+      ProviderSettingsCoordinator.reconcileProviders(settings, [], ['claude']);
+
+      expect(settings.savedProviderModel).toMatchObject({
+        claude: 'claude-code/fable-new',
+      });
+      expect((settings.providerConfigs as Record<string, Record<string, unknown>>).claude)
+        .toMatchObject({
+          lastModel: 'fable',
+          modelEnvironmentType: 'fable',
+        });
+    });
+
+    it('restores a title model after its environment source returns', () => {
+      const settings: Record<string, unknown> = {
+        settingsProvider: 'claude',
+        model: 'claude-code/custom-haiku',
+        titleGenerationModel: 'claude-code/fable-old',
+        providerConfigs: {
+          claude: {
+            ...DEFAULT_CLAUDE_PROVIDER_SETTINGS,
+            lastModel: 'haiku',
+            modelEnvironmentType: 'haiku',
+            titleModelEnvironmentType: 'fable',
+            environmentVariables: 'ANTHROPIC_DEFAULT_HAIKU_MODEL=custom-haiku',
+            environmentHash: [
+              'ANTHROPIC_DEFAULT_FABLE_MODEL=fable-old',
+              'ANTHROPIC_DEFAULT_HAIKU_MODEL=custom-haiku',
+            ].join('|'),
+          },
+        },
+      };
+
+      ProviderSettingsCoordinator.reconcileProviders(settings, [], ['claude']);
+
+      expect(settings.titleGenerationModel).toBe('');
+      expect((settings.providerConfigs as Record<string, Record<string, unknown>>).claude)
+        .toMatchObject({ titleModelEnvironmentType: 'fable' });
+
+      (settings.providerConfigs as Record<string, Record<string, unknown>>).claude.environmentVariables = [
+        'ANTHROPIC_DEFAULT_HAIKU_MODEL=custom-haiku',
+        'ANTHROPIC_DEFAULT_FABLE_MODEL=fable-new',
+      ].join('\n');
+
+      ProviderSettingsCoordinator.reconcileProviders(settings, [], ['claude']);
+
+      expect(settings.titleGenerationModel).toBe('claude-code/fable-new');
+      expect((settings.providerConfigs as Record<string, Record<string, unknown>>).claude)
+        .toMatchObject({ titleModelEnvironmentType: 'fable' });
     });
   });
 

--- a/tests/unit/providers/claude/agents/AgentStorage.test.ts
+++ b/tests/unit/providers/claude/agents/AgentStorage.test.ts
@@ -300,6 +300,10 @@ describe('parseModel', () => {
     expect(parseModel('haiku')).toBe('haiku');
   });
 
+  it('returns fable for valid fable input', () => {
+    expect(parseModel('fable')).toBe('fable');
+  });
+
   it('returns inherit for valid inherit input', () => {
     expect(parseModel('inherit')).toBe('inherit');
   });
@@ -308,6 +312,7 @@ describe('parseModel', () => {
     expect(parseModel('SONNET')).toBe('sonnet');
     expect(parseModel('Opus')).toBe('opus');
     expect(parseModel('HAIKU')).toBe('haiku');
+    expect(parseModel('FABLE')).toBe('fable');
     expect(parseModel('INHERIT')).toBe('inherit');
   });
 

--- a/tests/unit/providers/claude/env/ClaudeSettingsReconciler.test.ts
+++ b/tests/unit/providers/claude/env/ClaudeSettingsReconciler.test.ts
@@ -128,9 +128,393 @@ describe('claudeSettingsReconciler', () => {
       expect(result.invalidatedConversations).toEqual([conversation]);
       expect(conversation.providerState).toBeUndefined();
     });
+
+    it('reconciles the Fable alias to its tier mapping when all tier mappings change', () => {
+      const conversation = {
+        providerId: 'claude',
+        sessionId: 'fable-session',
+        messages: [],
+      } as unknown as Conversation;
+      const settings: Record<string, unknown> = {
+        model: 'claude-fable-5',
+        providerConfigs: {
+          claude: {
+            environmentVariables: [
+              'ANTHROPIC_DEFAULT_OPUS_MODEL=glm-5.2[1M]',
+              'ANTHROPIC_DEFAULT_SONNET_MODEL=MiniMax-M3',
+              'ANTHROPIC_DEFAULT_HAIKU_MODEL=DeepSeek-V4-Pro',
+              'ANTHROPIC_DEFAULT_FABLE_MODEL=gpt-4.1',
+            ].join('\n'),
+            environmentHash: '',
+          },
+        },
+      };
+
+      const result = claudeSettingsReconciler.reconcileModelWithEnvironment(settings, [conversation]);
+
+      expect(result.changed).toBe(true);
+      expect(result.invalidatedConversations).toEqual([conversation]);
+      expect(conversation.sessionId).toBeNull();
+      expect(settings.model).toBe('claude-code/gpt-4.1');
+      expect(getClaudeProviderSettings(settings).lastModel).toBe('fable');
+      expect(getClaudeProviderSettings(settings).environmentHash).toBe(
+        [
+          'ANTHROPIC_DEFAULT_FABLE_MODEL=gpt-4.1',
+          'ANTHROPIC_DEFAULT_HAIKU_MODEL=DeepSeek-V4-Pro',
+          'ANTHROPIC_DEFAULT_OPUS_MODEL=glm-5.2[1M]',
+          'ANTHROPIC_DEFAULT_SONNET_MODEL=MiniMax-M3',
+        ].join('|'),
+      );
+    });
+
+    it('preserves the Fable tier when its environment mapping changes value', () => {
+      const settings: Record<string, unknown> = {
+        model: 'claude-fable-5',
+        providerConfigs: {
+          claude: {
+            lastModel: 'claude-fable-5',
+            environmentVariables: [
+              'ANTHROPIC_DEFAULT_OPUS_MODEL=glm-5.2[1M]',
+              'ANTHROPIC_DEFAULT_SONNET_MODEL=MiniMax-M3',
+              'ANTHROPIC_DEFAULT_HAIKU_MODEL=DeepSeek-V4-Pro',
+              'ANTHROPIC_DEFAULT_FABLE_MODEL=gpt-4.1',
+            ].join('\n'),
+            environmentHash: '',
+          },
+        },
+      };
+
+      claudeSettingsReconciler.reconcileModelWithEnvironment(settings, []);
+      claudeSettingsReconciler.normalizeModelVariantSettings(settings);
+
+      expect(settings.model).toBe('claude-code/gpt-4.1');
+      expect(getClaudeProviderSettings(settings).lastModel).toBe('fable');
+
+      (settings.providerConfigs as Record<string, Record<string, unknown>>).claude.environmentVariables = [
+        'ANTHROPIC_DEFAULT_OPUS_MODEL=glm-5.2[1M]',
+        'ANTHROPIC_DEFAULT_SONNET_MODEL=MiniMax-M3',
+        'ANTHROPIC_DEFAULT_HAIKU_MODEL=DeepSeek-V4-Pro',
+        'ANTHROPIC_DEFAULT_FABLE_MODEL=gpt-4.2',
+      ].join('\n');
+
+      claudeSettingsReconciler.reconcileModelWithEnvironment(settings, []);
+
+      expect(settings.model).toBe('claude-code/gpt-4.2');
+      expect(getClaudeProviderSettings(settings).lastModel).toBe('fable');
+    });
+
+    it('preserves the Fable tier when its previous target becomes another tier mapping', () => {
+      const settings: Record<string, unknown> = {
+        model: 'claude-code/gpt-4.1',
+        providerConfigs: {
+          claude: {
+            lastModel: 'fable',
+            environmentVariables: [
+              'ANTHROPIC_DEFAULT_HAIKU_MODEL=gpt-4.1',
+              'ANTHROPIC_DEFAULT_FABLE_MODEL=gpt-4.2',
+            ].join('\n'),
+            environmentHash: [
+              'ANTHROPIC_DEFAULT_FABLE_MODEL=gpt-4.1',
+              'ANTHROPIC_DEFAULT_HAIKU_MODEL=DeepSeek-V4-Pro',
+            ].join('|'),
+          },
+        },
+      };
+
+      claudeSettingsReconciler.reconcileModelWithEnvironment(settings, []);
+
+      expect(settings.model).toBe('claude-code/gpt-4.2');
+      expect(getClaudeProviderSettings(settings).lastModel).toBe('fable');
+    });
+
+    it('preserves an ANTHROPIC_MODEL selection when tier mappings also exist', () => {
+      const settings: Record<string, unknown> = {
+        model: 'claude-code/gpt-4.1',
+        providerConfigs: {
+          claude: {
+            lastModel: 'fable',
+            modelEnvironmentType: 'model',
+            environmentVariables: [
+              'ANTHROPIC_MODEL=gpt-4.2',
+              'ANTHROPIC_DEFAULT_FABLE_MODEL=fable-target-2',
+            ].join('\n'),
+            environmentHash: [
+              'ANTHROPIC_DEFAULT_FABLE_MODEL=gpt-4.1',
+              'ANTHROPIC_MODEL=gpt-4.1',
+            ].join('|'),
+          },
+        },
+      };
+
+      claudeSettingsReconciler.reconcileModelWithEnvironment(settings, []);
+
+      expect(settings.model).toBe('claude-code/gpt-4.2');
+    });
+
+    it('preserves Fable when it previously shared a target with ANTHROPIC_MODEL', () => {
+      const settings: Record<string, unknown> = {
+        model: 'claude-code/gpt-4.1',
+        providerConfigs: {
+          claude: {
+            lastModel: 'fable',
+            modelEnvironmentType: 'fable',
+            environmentVariables: [
+              'ANTHROPIC_MODEL=gpt-4.2',
+              'ANTHROPIC_DEFAULT_FABLE_MODEL=fable-target-2',
+            ].join('\n'),
+            environmentHash: [
+              'ANTHROPIC_DEFAULT_FABLE_MODEL=gpt-4.1',
+              'ANTHROPIC_MODEL=gpt-4.1',
+            ].join('|'),
+          },
+        },
+      };
+
+      claudeSettingsReconciler.reconcileModelWithEnvironment(settings, []);
+
+      expect(settings.model).toBe('claude-code/fable-target-2');
+      expect(getClaudeProviderSettings(settings).modelEnvironmentType).toBe('fable');
+    });
+
+    it('retains explicit Fable provenance while its environment source is unavailable', () => {
+      const settings: Record<string, unknown> = {
+        model: 'claude-code/shared-target',
+        providerConfigs: {
+          claude: {
+            lastModel: 'fable',
+            modelEnvironmentType: 'fable',
+            environmentVariables: 'ANTHROPIC_DEFAULT_HAIKU_MODEL=shared-target',
+            environmentHash: 'ANTHROPIC_DEFAULT_FABLE_MODEL=shared-target',
+          },
+        },
+      };
+
+      claudeSettingsReconciler.reconcileModelWithEnvironment(settings, []);
+
+      expect(settings.model).toBe('claude-code/shared-target');
+      expect(getClaudeProviderSettings(settings)).toMatchObject({
+        lastModel: 'fable',
+        modelEnvironmentType: 'fable',
+      });
+
+      (settings.providerConfigs as Record<string, Record<string, unknown>>).claude.environmentVariables = [
+        'ANTHROPIC_DEFAULT_HAIKU_MODEL=haiku-target-2',
+        'ANTHROPIC_DEFAULT_FABLE_MODEL=fable-target-2',
+      ].join('\n');
+
+      claudeSettingsReconciler.reconcileModelWithEnvironment(settings, []);
+
+      expect(settings.model).toBe('claude-code/fable-target-2');
+      expect(getClaudeProviderSettings(settings).modelEnvironmentType).toBe('fable');
+    });
+
+    it('remaps an environment-derived Fable title model independently', () => {
+      const settings: Record<string, unknown> = {
+        model: 'claude-code/custom-haiku',
+        titleGenerationModel: 'claude-code/gpt-4.1',
+        providerConfigs: {
+          claude: {
+            lastModel: 'haiku',
+            modelEnvironmentType: 'haiku',
+            titleModelEnvironmentType: 'fable',
+            environmentVariables: [
+              'ANTHROPIC_DEFAULT_HAIKU_MODEL=custom-haiku',
+              'ANTHROPIC_DEFAULT_FABLE_MODEL=gpt-4.2',
+            ].join('\n'),
+            environmentHash: [
+              'ANTHROPIC_DEFAULT_FABLE_MODEL=gpt-4.1',
+              'ANTHROPIC_DEFAULT_HAIKU_MODEL=custom-haiku',
+            ].join('|'),
+          },
+        },
+      };
+
+      claudeSettingsReconciler.reconcileModelWithEnvironment(settings, []);
+
+      expect(settings.model).toBe('claude-code/custom-haiku');
+      expect(settings.titleGenerationModel).toBe('claude-code/gpt-4.2');
+      expect(getClaudeProviderSettings(settings).titleModelEnvironmentType).toBe('fable');
+    });
+
+    it('infers legacy Fable provenance from the old hash after startup normalization', () => {
+      const settings: Record<string, unknown> = {
+        model: 'claude-code/shared-target',
+        titleGenerationModel: 'claude-code/shared-target',
+        providerConfigs: {
+          claude: {
+            lastModel: 'fable',
+            environmentVariables: [
+              'ANTHROPIC_DEFAULT_HAIKU_MODEL=shared-target',
+              'ANTHROPIC_DEFAULT_FABLE_MODEL=fable-new',
+            ].join('\n'),
+            environmentHash: 'ANTHROPIC_DEFAULT_FABLE_MODEL=shared-target',
+          },
+        },
+      };
+
+      claudeSettingsReconciler.normalizeModelVariantSettings(settings);
+
+      expect(settings.model).toBe('claude-code/fable-new');
+      expect(settings.titleGenerationModel).toBe('claude-code/fable-new');
+      expect(getClaudeProviderSettings(settings)).toMatchObject({
+        modelEnvironmentType: 'fable',
+        titleModelEnvironmentType: 'fable',
+      });
+
+      claudeSettingsReconciler.reconcileModelWithEnvironment(settings, []);
+
+      expect(settings.model).toBe('claude-code/fable-new');
+      expect(settings.titleGenerationModel).toBe('claude-code/fable-new');
+      expect(getClaudeProviderSettings(settings)).toMatchObject({
+        lastModel: 'fable',
+        modelEnvironmentType: 'fable',
+        titleModelEnvironmentType: 'fable',
+      });
+    });
+
+    it('preserves an environment-derived concrete Fable selection during reconciliation', () => {
+      const settings: Record<string, unknown> = {
+        model: 'claude-fable-5',
+        providerConfigs: {
+          claude: {
+            environmentVariables: [
+              'ANTHROPIC_DEFAULT_HAIKU_MODEL=custom-haiku',
+              'ANTHROPIC_DEFAULT_FABLE_MODEL=claude-fable-5',
+            ].join('\n'),
+            environmentHash: '',
+          },
+        },
+      };
+
+      const result = claudeSettingsReconciler.reconcileModelWithEnvironment(settings, []);
+
+      expect(result.changed).toBe(true);
+      expect(settings.model).toBe('claude-code/claude-fable-5');
+    });
   });
 
   describe('normalizeModelVariantSettings', () => {
+    it('does not infer environment provenance for pristine built-in defaults', () => {
+      const settings: Record<string, unknown> = {
+        settingsProvider: 'claude',
+        model: 'haiku',
+        titleGenerationModel: '',
+        providerConfigs: {
+          claude: {
+            lastModel: 'haiku',
+            modelEnvironmentType: '',
+            titleModelEnvironmentType: '',
+            environmentVariables: '',
+            environmentHash: '',
+          },
+        },
+      };
+
+      expect(claudeSettingsReconciler.normalizeModelVariantSettings(settings)).toBe(false);
+      expect(getClaudeProviderSettings(settings)).toMatchObject({
+        modelEnvironmentType: '',
+        titleModelEnvironmentType: '',
+      });
+    });
+
+    it('uses source ownership when a different tier target is a Fable alias', () => {
+      const settings: Record<string, unknown> = {
+        settingsProvider: 'claude',
+        model: 'claude-code/gpt-4.1',
+        titleGenerationModel: 'claude-code/gpt-4.1',
+        providerConfigs: {
+          claude: {
+            lastModel: 'fable',
+            modelEnvironmentType: 'fable',
+            titleModelEnvironmentType: 'fable',
+            environmentVariables: [
+              'ANTHROPIC_DEFAULT_HAIKU_MODEL=fable',
+              'ANTHROPIC_DEFAULT_FABLE_MODEL=gpt-4.1',
+            ].join('\n'),
+            environmentHash: [
+              'ANTHROPIC_DEFAULT_FABLE_MODEL=gpt-4.1',
+              'ANTHROPIC_DEFAULT_HAIKU_MODEL=fable',
+            ].join('|'),
+          },
+        },
+      };
+
+      expect(claudeSettingsReconciler.normalizeModelVariantSettings(settings)).toBe(false);
+      expect(settings.model).toBe('claude-code/gpt-4.1');
+      expect(settings.titleGenerationModel).toBe('claude-code/gpt-4.1');
+    });
+
+    it('prefers exact environment ownership over an unqualified legacy Fable alias', () => {
+      const settings: Record<string, unknown> = {
+        settingsProvider: 'claude',
+        model: 'claude-fable-5',
+        titleGenerationModel: 'claude-fable-5',
+        providerConfigs: {
+          claude: {
+            lastModel: 'fable',
+            environmentVariables: 'ANTHROPIC_DEFAULT_HAIKU_MODEL=claude-fable-5',
+            environmentHash: 'ANTHROPIC_DEFAULT_HAIKU_MODEL=claude-fable-5',
+          },
+        },
+      };
+
+      expect(claudeSettingsReconciler.normalizeModelVariantSettings(settings)).toBe(true);
+      expect(settings.model).toBe('claude-code/claude-fable-5');
+      expect(settings.titleGenerationModel).toBe('claude-code/claude-fable-5');
+      expect(getClaudeProviderSettings(settings)).toMatchObject({
+        modelEnvironmentType: 'haiku',
+        titleModelEnvironmentType: 'haiku',
+      });
+    });
+
+    it('uses the historical hash before an old Fable target disappears', () => {
+      const settings: Record<string, unknown> = {
+        settingsProvider: 'claude',
+        model: 'claude-code/gpt-4.1',
+        titleGenerationModel: 'claude-code/gpt-4.1',
+        providerConfigs: {
+          claude: {
+            lastModel: 'fable',
+            environmentVariables: [
+              'ANTHROPIC_DEFAULT_HAIKU_MODEL=custom-haiku',
+              'ANTHROPIC_DEFAULT_FABLE_MODEL=gpt-4.2',
+            ].join('\n'),
+            environmentHash: 'ANTHROPIC_DEFAULT_FABLE_MODEL=gpt-4.1',
+          },
+        },
+      };
+
+      expect(claudeSettingsReconciler.normalizeModelVariantSettings(settings)).toBe(true);
+      expect(settings.model).toBe('claude-code/gpt-4.2');
+      expect(settings.titleGenerationModel).toBe('claude-code/gpt-4.2');
+      expect(getClaudeProviderSettings(settings)).toMatchObject({
+        modelEnvironmentType: 'fable',
+        titleModelEnvironmentType: 'fable',
+      });
+    });
+
+    it('remaps a persisted Fable title before global title validation runs', () => {
+      const settings: Record<string, unknown> = {
+        model: 'claude-code/custom-haiku',
+        titleGenerationModel: 'claude-code/gpt-4.1',
+        providerConfigs: {
+          claude: {
+            lastModel: 'haiku',
+            modelEnvironmentType: 'haiku',
+            titleModelEnvironmentType: 'fable',
+            environmentVariables: [
+              'ANTHROPIC_DEFAULT_HAIKU_MODEL=custom-haiku',
+              'ANTHROPIC_DEFAULT_FABLE_MODEL=gpt-4.2',
+            ].join('\n'),
+          },
+        },
+      };
+
+      expect(claudeSettingsReconciler.normalizeModelVariantSettings(settings)).toBe(true);
+      expect(settings.titleGenerationModel).toBe('claude-code/gpt-4.2');
+      expect(getClaudeProviderSettings(settings).titleModelEnvironmentType).toBe('fable');
+    });
+
     it('migrates legacy built-in 1M aliases across Claude model settings', () => {
       const settings: Record<string, unknown> = {
         model: 'claude-code/opus[1m]',
@@ -146,6 +530,42 @@ describe('claudeSettingsReconciler', () => {
       expect(settings.model).toBe('opus');
       expect(settings.titleGenerationModel).toBe('sonnet');
       expect(getClaudeProviderSettings(settings).lastModel).toBe('opus');
+    });
+
+    it('migrates the legacy concrete Fable model to the SDK alias', () => {
+      const settings: Record<string, unknown> = {
+        model: 'claude-fable-5',
+        titleGenerationModel: 'claude-fable-5',
+        providerConfigs: {
+          claude: {
+            lastModel: 'claude-fable-5',
+          },
+        },
+      };
+
+      expect(claudeSettingsReconciler.normalizeModelVariantSettings(settings)).toBe(true);
+      expect(settings.model).toBe('fable');
+      expect(settings.titleGenerationModel).toBe('fable');
+      expect(getClaudeProviderSettings(settings).lastModel).toBe('fable');
+    });
+
+    it('preserves concrete Fable selections while retaining the tier preference', () => {
+      const concreteSelection = 'claude-code/claude-fable-5';
+      const settings: Record<string, unknown> = {
+        model: concreteSelection,
+        titleGenerationModel: concreteSelection,
+        providerConfigs: {
+          claude: {
+            lastModel: concreteSelection,
+            environmentVariables: 'ANTHROPIC_DEFAULT_FABLE_MODEL=claude-fable-5',
+          },
+        },
+      };
+
+      expect(claudeSettingsReconciler.normalizeModelVariantSettings(settings)).toBe(true);
+      expect(settings.model).toBe(concreteSelection);
+      expect(settings.titleGenerationModel).toBe(concreteSelection);
+      expect(getClaudeProviderSettings(settings).lastModel).toBe('fable');
     });
   });
 });

--- a/tests/unit/providers/claude/env/claudeModelEnv.test.ts
+++ b/tests/unit/providers/claude/env/claudeModelEnv.test.ts
@@ -21,11 +21,13 @@ describe('getCustomModelIds', () => {
       ANTHROPIC_DEFAULT_OPUS_MODEL: 'my-opus',
       ANTHROPIC_DEFAULT_SONNET_MODEL: 'my-sonnet',
       ANTHROPIC_DEFAULT_HAIKU_MODEL: 'my-haiku',
+      ANTHROPIC_DEFAULT_FABLE_MODEL: 'my-fable',
     });
-    expect(result.size).toBe(3);
+    expect(result.size).toBe(4);
     expect(result.has('my-opus')).toBe(true);
     expect(result.has('my-sonnet')).toBe(true);
     expect(result.has('my-haiku')).toBe(true);
+    expect(result.has('my-fable')).toBe(true);
   });
 
   it('should deduplicate when multiple env vars point to same model', () => {
@@ -132,11 +134,14 @@ describe('getModelsFromEnvironment', () => {
       ANTHROPIC_DEFAULT_OPUS_MODEL: 'my-opus',
       ANTHROPIC_DEFAULT_SONNET_MODEL: 'my-sonnet',
       ANTHROPIC_DEFAULT_HAIKU_MODEL: 'my-haiku',
+      ANTHROPIC_DEFAULT_FABLE_MODEL: 'my-fable',
     });
-    expect(result).toHaveLength(3);
+    expect(result).toHaveLength(4);
     expect(result.map(m => m.value)).toContain('my-opus');
     expect(result.map(m => m.value)).toContain('my-sonnet');
     expect(result.map(m => m.value)).toContain('my-haiku');
+    expect(result.map(m => m.value)).toContain('my-fable');
+    expect(result.find(m => m.value === 'my-fable')?.environmentTypes).toEqual(['fable']);
   });
 
   it('deduplicates when multiple env vars point to same model', () => {
@@ -148,17 +153,20 @@ describe('getModelsFromEnvironment', () => {
     expect(result[0].value).toBe('shared-model');
     expect(result[0].description).toContain('model');
     expect(result[0].description).toContain('sonnet');
+    expect(result[0].environmentTypes).toEqual(['model', 'sonnet']);
   });
 
-  it('sorts by type priority (model > haiku > sonnet > opus)', () => {
+  it('sorts by type priority (model > haiku > sonnet > opus > fable)', () => {
     const result = getModelsFromEnvironment({
       ANTHROPIC_DEFAULT_OPUS_MODEL: 'opus-v1',
       ANTHROPIC_MODEL: 'main-model',
       ANTHROPIC_DEFAULT_HAIKU_MODEL: 'haiku-v1',
+      ANTHROPIC_DEFAULT_FABLE_MODEL: 'fable-v1',
     });
     expect(result[0].value).toBe('main-model');
     expect(result[1].value).toBe('haiku-v1');
     expect(result[2].value).toBe('opus-v1');
+    expect(result[3].value).toBe('fable-v1');
   });
 
   it('ignores unrelated env vars', () => {
@@ -217,6 +225,12 @@ describe('getCurrentModelFromEnvironment', () => {
     expect(getCurrentModelFromEnvironment({
       ANTHROPIC_DEFAULT_OPUS_MODEL: 'opus-model',
     })).toBe('opus-model');
+  });
+
+  it('falls back to ANTHROPIC_DEFAULT_FABLE_MODEL', () => {
+    expect(getCurrentModelFromEnvironment({
+      ANTHROPIC_DEFAULT_FABLE_MODEL: 'fable-model',
+    })).toBe('fable-model');
   });
 
   it('returns null when only unrelated vars set', () => {

--- a/tests/unit/providers/claude/modelTiers.test.ts
+++ b/tests/unit/providers/claude/modelTiers.test.ts
@@ -1,0 +1,42 @@
+import {
+  CLAUDE_MODEL_TIER_DEFINITIONS,
+  getClaudeModelTierDefinition,
+  isClaudeModelTier,
+  resolveClaudeModelTierAlias,
+} from '@/providers/claude/modelTiers';
+
+describe('Claude model tiers', () => {
+  it('defines every SDK model tier once', () => {
+    expect(CLAUDE_MODEL_TIER_DEFINITIONS.map(definition => definition.id)).toEqual([
+      'haiku',
+      'sonnet',
+      'opus',
+      'fable',
+    ]);
+  });
+
+  it('recognizes every tier through the shared guard', () => {
+    for (const definition of CLAUDE_MODEL_TIER_DEFINITIONS) {
+      expect(isClaudeModelTier(definition.id)).toBe(true);
+    }
+    expect(isClaudeModelTier('model')).toBe(false);
+  });
+
+  it('resolves legacy aliases through the owning tier definition', () => {
+    expect(resolveClaudeModelTierAlias('sonnet[1M]')).toBe('sonnet');
+    expect(resolveClaudeModelTierAlias('opus[1m]')).toBe('opus');
+    expect(resolveClaudeModelTierAlias('claude-fable-5')).toBe('fable');
+    expect(resolveClaudeModelTierAlias('claude-fable-6')).toBeNull();
+  });
+
+  it('keeps tier-specific capabilities explicit in the descriptor', () => {
+    const fable = getClaudeModelTierDefinition('fable');
+    const haiku = getClaudeModelTierDefinition('haiku');
+
+    expect(fable.aliasHasOneMillionContext).toBe(true);
+    expect(fable.supportsOneMillionSuffix).toBe(false);
+    expect(fable.aliasSupportsXHigh).toBe(true);
+    expect(haiku.aliasHasOneMillionContext).toBe(false);
+    expect(haiku.aliasSupportsXHigh).toBe(false);
+  });
+});

--- a/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
+++ b/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
@@ -1355,7 +1355,7 @@ describe('transformSDKMessage', () => {
         },
       });
 
-      const results = [...transformSDKMessage(message, { intendedModel: 'claude-fable-5' })];
+      const results = [...transformSDKMessage(message, { intendedModel: 'fable' })];
 
       expect(results).toEqual([
         { type: 'context_window', contextWindow: 1000000 },

--- a/tests/unit/providers/claude/types/types.test.ts
+++ b/tests/unit/providers/claude/types/types.test.ts
@@ -16,7 +16,8 @@ import {
   CONTEXT_WINDOW_STANDARD,
   getContextWindowSize,
   normalizeEffortLevel,
-  normalizeLegacy1MModelAlias,
+  normalizeLegacyClaudeModelAlias,
+  resolveContextWindowSize,
   supportsXHighEffort,
 } from '@/providers/claude/types/models';
 import {
@@ -51,6 +52,11 @@ describe('types.ts', () => {
 
     it('should have lastClaudeModel set to haiku by default', () => {
       expect(getClaudeProviderSettings(DEFAULT_SETTINGS).lastModel).toBe('haiku');
+    });
+
+    it('should have no Claude model environment source by default', () => {
+      expect(getClaudeProviderSettings(DEFAULT_SETTINGS).modelEnvironmentType).toBe('');
+      expect(getClaudeProviderSettings(DEFAULT_SETTINGS).titleModelEnvironmentType).toBe('');
     });
 
     it('should have empty custom Claude models by default', () => {
@@ -651,6 +657,7 @@ describe('types.ts', () => {
 
     describe('fable models', () => {
       it('should default to 1M context window with no [1m] suffix needed', () => {
+        expect(getContextWindowSize('fable')).toBe(CONTEXT_WINDOW_1M);
         expect(getContextWindowSize('claude-fable-5')).toBe(CONTEXT_WINDOW_1M);
         expect(getContextWindowSize('claude-fable-6')).toBe(CONTEXT_WINDOW_1M);
       });
@@ -659,21 +666,33 @@ describe('types.ts', () => {
         const customLimits = { 'claude-fable-5': 500000 };
         expect(getContextWindowSize('claude-fable-5', customLimits)).toBe(500000);
       });
+
+      it('should preserve legacy Fable custom limits after alias migration', () => {
+        const customLimits = { 'claude-fable-5': 500000 };
+
+        expect(getContextWindowSize('fable', customLimits)).toBe(500000);
+        expect(resolveContextWindowSize('fable', customLimits, 1000000)).toEqual({
+          contextWindow: 500000,
+          source: 'custom',
+        });
+      });
     });
 
-    describe('normalizeLegacy1MModelAlias', () => {
+    describe('normalizeLegacyClaudeModelAlias', () => {
       it('should migrate legacy built-in variants to the current aliases', () => {
-        expect(normalizeLegacy1MModelAlias('sonnet[1m]')).toBe('sonnet');
-        expect(normalizeLegacy1MModelAlias('sonnet[1M]')).toBe('sonnet');
-        expect(normalizeLegacy1MModelAlias('opus[1m]')).toBe('opus');
-        expect(normalizeLegacy1MModelAlias('opus[1M]')).toBe('opus');
+        expect(normalizeLegacyClaudeModelAlias('sonnet[1m]')).toBe('sonnet');
+        expect(normalizeLegacyClaudeModelAlias('sonnet[1M]')).toBe('sonnet');
+        expect(normalizeLegacyClaudeModelAlias('opus[1m]')).toBe('opus');
+        expect(normalizeLegacyClaudeModelAlias('opus[1M]')).toBe('opus');
+        expect(normalizeLegacyClaudeModelAlias('claude-fable-5')).toBe('fable');
       });
 
       it('should leave explicit and custom model ids unchanged', () => {
-        expect(normalizeLegacy1MModelAlias('')).toBe('');
-        expect(normalizeLegacy1MModelAlias('haiku')).toBe('haiku');
-        expect(normalizeLegacy1MModelAlias('claude-opus-4-6[1m]')).toBe('claude-opus-4-6[1m]');
-        expect(normalizeLegacy1MModelAlias('custom-model')).toBe('custom-model');
+        expect(normalizeLegacyClaudeModelAlias('')).toBe('');
+        expect(normalizeLegacyClaudeModelAlias('haiku')).toBe('haiku');
+        expect(normalizeLegacyClaudeModelAlias('claude-opus-4-6[1m]')).toBe('claude-opus-4-6[1m]');
+        expect(normalizeLegacyClaudeModelAlias('claude-fable-6')).toBe('claude-fable-6');
+        expect(normalizeLegacyClaudeModelAlias('custom-model')).toBe('custom-model');
       });
     });
   });
@@ -703,6 +722,7 @@ describe('types.ts', () => {
     });
 
     it('returns true for fable models', () => {
+      expect(supportsXHighEffort('fable')).toBe(true);
       expect(supportsXHighEffort('claude-fable-5')).toBe(true);
       expect(supportsXHighEffort('claude-fable-6')).toBe(true);
     });

--- a/tests/unit/providers/claude/ui/ClaudeChatUIConfig.test.ts
+++ b/tests/unit/providers/claude/ui/ClaudeChatUIConfig.test.ts
@@ -20,7 +20,7 @@ describe('claudeChatUIConfig', () => {
         'haiku',
         'sonnet',
         'opus',
-        'claude-fable-5',
+        'fable',
         'claude-code/claude-opus-4-6',
         'claude-code/claude-opus-4-6[1m]',
       ]);
@@ -42,7 +42,7 @@ describe('claudeChatUIConfig', () => {
       const options = claudeChatUIConfig.getModelOptions({
         providerConfigs: {
           claude: {
-            customModels: 'haiku\nclaude-opus-4-6\nclaude-opus-4-6\n',
+            customModels: 'haiku\nclaude-fable-5\nclaude-opus-4-6\nclaude-opus-4-6\n',
           },
         },
       });
@@ -51,7 +51,7 @@ describe('claudeChatUIConfig', () => {
         'haiku',
         'sonnet',
         'opus',
-        'claude-fable-5',
+        'fable',
         'claude-code/claude-opus-4-6',
       ]);
     });
@@ -122,6 +122,7 @@ describe('claudeChatUIConfig', () => {
           value: 'claude-code/claude-sonnet-4-5',
           label: 'Sonnet 4.5',
           description: 'Custom model (model)',
+          environmentTypes: ['model'],
         },
       ]);
     });
@@ -143,6 +144,7 @@ describe('claudeChatUIConfig', () => {
           value: 'claude-code/claude-sonnet-4-5',
           label: 'Gateway Sonnet',
           description: 'Custom model (model)',
+          environmentTypes: ['model'],
         },
       ]);
     });
@@ -162,7 +164,7 @@ describe('claudeChatUIConfig', () => {
     });
 
     it('keeps xhigh on fable models', () => {
-      const options = claudeChatUIConfig.getReasoningOptions('claude-fable-5', {});
+      const options = claudeChatUIConfig.getReasoningOptions('fable', {});
 
       expect(options.map(option => option.value)).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
     });
@@ -176,6 +178,53 @@ describe('claudeChatUIConfig', () => {
   });
 
   describe('applyModelDefaults', () => {
+    it('persists the tier identity of an environment-mapped model', () => {
+      const settings: Record<string, unknown> = {
+        effortLevel: 'high',
+        providerConfigs: {
+          claude: {
+            lastModel: 'haiku',
+            environmentVariables: [
+              'ANTHROPIC_DEFAULT_HAIKU_MODEL=custom-haiku',
+              'ANTHROPIC_DEFAULT_FABLE_MODEL=gpt-4.1',
+            ].join('\n'),
+          },
+        },
+      };
+
+      claudeChatUIConfig.applyModelDefaults('claude-code/gpt-4.1', settings);
+
+      expect((settings.providerConfigs as Record<string, Record<string, unknown>>).claude.lastModel)
+        .toBe('fable');
+      expect((settings.providerConfigs as Record<string, Record<string, unknown>>).claude.modelEnvironmentType)
+        .toBe('fable');
+      expect(settings.lastCustomModel).toBeUndefined();
+    });
+
+    it('preserves the environment tier of a concrete legacy Fable ID', () => {
+      const settings: Record<string, unknown> = {
+        effortLevel: 'high',
+        providerConfigs: {
+          claude: {
+            lastModel: 'fable',
+            modelEnvironmentType: 'fable',
+            environmentVariables: [
+              'ANTHROPIC_DEFAULT_HAIKU_MODEL=claude-fable-5',
+              'ANTHROPIC_DEFAULT_FABLE_MODEL=gpt-4.1',
+            ].join('\n'),
+          },
+        },
+      };
+
+      claudeChatUIConfig.applyModelDefaults('claude-code/claude-fable-5', settings);
+
+      expect((settings.providerConfigs as Record<string, Record<string, unknown>>).claude)
+        .toMatchObject({
+          lastModel: 'haiku',
+          modelEnvironmentType: 'haiku',
+        });
+    });
+
     it('clamps stale xhigh effort when switching to a custom sonnet model', () => {
       const settings: Record<string, unknown> = {
         effortLevel: 'xhigh',


### PR DESCRIPTION
Closes #925.

Updates the Claude Agent SDK to 0.3.209 and treats Fable as the same descriptor-driven tier as Haiku, Sonnet, and Opus.
Preserves primary and title model source identity across environment remapping, duplicate concrete targets, inactive-provider projection, temporary mapping removal, and legacy aliases or context limits.
Adds regression coverage for four-tier configurations, remapping changes, ownership collisions, migrations, and provider coordinator hooks.
Validation: typecheck, lint, 263 suites with 6,045 tests, build, and diff checks all pass.