### PR TITLE
fix: keep the selected effort when projecting default Claude models

### DIFF
--- a/src/providers/claude/ui/ClaudeChatUIConfig.ts
+++ b/src/providers/claude/ui/ClaudeChatUIConfig.ts
@@ -101,9 +101,11 @@ export const claudeChatUIConfig: ProviderChatUIConfig = {
   applyModelProjectionDefaults(model: string, settings: unknown): void {
     const target = settings as Record<string, unknown>;
     const runtimeModel = normalizeLegacyClaudeModelAlias(toClaudeRuntimeModelId(model));
-    target.effortLevel = DEFAULT_CLAUDE_MODELS.some(candidate => candidate.value === runtimeModel)
-      ? DEFAULT_EFFORT_LEVEL[runtimeModel] ?? DEFAULT_REASONING_VALUE
-      : normalizeEffortLevel(runtimeModel, target.effortLevel);
+    // Projection is read-only display of the live effort. Preserve the user's
+    // selection (clamped to what the model supports) instead of resetting it to
+    // the tier default, which previously discarded effort changes for every
+    // default tier model except environment-mapped ones like Fable.
+    target.effortLevel = normalizeEffortLevel(runtimeModel, target.effortLevel);
   },
 
   applyTitleGenerationModelSelection(model: string, settings: unknown): void {

--- a/tests/unit/providers/claude/ui/ClaudeChatUIConfig.test.ts
+++ b/tests/unit/providers/claude/ui/ClaudeChatUIConfig.test.ts
@@ -248,4 +248,31 @@ describe('claudeChatUIConfig', () => {
       expect(settings.effortLevel).toBe('xhigh');
     });
   });
+
+  describe('applyModelProjectionDefaults', () => {
+    it('preserves a user-selected effort for default tier models', () => {
+      const settings: Record<string, unknown> = { effortLevel: 'low' };
+
+      claudeChatUIConfig.applyModelProjectionDefaults?.('opus', settings);
+
+      expect(settings.effortLevel).toBe('low');
+    });
+
+    it('preserves xhigh on the opus alias that supports it', () => {
+      const settings: Record<string, unknown> = { effortLevel: 'xhigh' };
+
+      claudeChatUIConfig.applyModelProjectionDefaults?.('opus', settings);
+
+      expect(settings.effortLevel).toBe('xhigh');
+    });
+
+    it('clamps an effort the projected model cannot use', () => {
+      const settings: Record<string, unknown> = { effortLevel: 'xhigh' };
+
+      // The haiku alias does not support xhigh -> fall back to the default.
+      claudeChatUIConfig.applyModelProjectionDefaults?.('haiku', settings);
+
+      expect(settings.effortLevel).toBe('high');
+    });
+  });
 });


### PR DESCRIPTION
## Problem

The effort selector is effectively frozen for every built-in Claude tier model (Haiku/Sonnet/Opus): clicking a different effort stores it, but the toolbar immediately re-renders at the tier default. Fable is the only model whose effort stays adjustable.

## Root cause

`ClaudeChatUIConfig.applyModelProjectionDefaults` resets `effortLevel` to the tier default for any model whose normalized id is in `DEFAULT_CLAUDE_MODELS`:

```ts
target.effortLevel = DEFAULT_CLAUDE_MODELS.some(candidate => candidate.value === runtimeModel)
  ? DEFAULT_EFFORT_LEVEL[runtimeModel] ?? DEFAULT_REASONING_VALUE
  : normalizeEffortLevel(runtimeModel, target.effortLevel);
```

This runs via `projectModelSelection` inside `getProviderSettingsSnapshotWithModel`, which builds the **read-only display snapshot** the toolbar reads on every render. So the live effort is discarded on display for `haiku`/`sonnet`/`opus`. Environment-mapped tiers like Fable normalize to a non-tier runtime id, miss the `.some()` match, take the `normalizeEffortLevel` branch, and are therefore the only ones that preserve the selection.

## Fix

Projection is a read-only view of the live effort, so preserve it (clamped to what the model supports) for all models:

```ts
target.effortLevel = normalizeEffortLevel(runtimeModel, target.effortLevel);
```

The provider-switch path (`projectProviderState`) re-derives effort from `savedProviderEffort`/current projection immediately after calling `applyModelProjectionDefaults`, so its behavior is unchanged.

## Tests

Added `applyModelProjectionDefaults` coverage in `ClaudeChatUIConfig.test.ts`: preserves a user-selected effort for a default tier model, preserves `xhigh` on the Opus alias, and still clamps an unsupported effort to the default. Full suite green (`npm run typecheck && npm run test && npm run build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)