### PR TITLE
fix: render LaTeX math delimiters from agent responses

### DIFF
--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -17,7 +17,10 @@ import { extractUserDisplayContent } from '../../../utils/context';
 import { formatDurationMmSs } from '../../../utils/date';
 import { processFileLinks, registerFileLinkHandler } from '../../../utils/fileLink';
 import { replaceImageEmbedsWithHtml } from '../../../utils/imageEmbed';
-import { escapeMathDelimitersForStreaming } from '../../../utils/markdownMath';
+import {
+  escapeMathDelimitersForStreaming,
+  normalizeLatexMathDelimiters,
+} from '../../../utils/markdownMath';
 import type { FeatureHost } from '../../FeatureHost';
 import { findRewindContext } from '../rewind';
 import { formatConversationDirectoryTitle } from '../utils/conversationDirectoryTitle';
@@ -665,9 +668,10 @@ export class MessageRenderer {
     el.empty();
 
     try {
+      const normalizedMarkdown = normalizeLatexMathDelimiters(markdown);
       const renderMarkdown = options?.deferMath
-        ? escapeMathDelimitersForStreaming(markdown)
-        : markdown;
+        ? escapeMathDelimitersForStreaming(normalizedMarkdown)
+        : normalizedMarkdown;
       // Normalize embeds before MarkdownRenderer consumes them.
       const processedMarkdown = replaceImageEmbedsWithHtml(
         renderMarkdown,

--- a/src/features/inline-edit/ui/inlineEditMarkdownPreview.ts
+++ b/src/features/inline-edit/ui/inlineEditMarkdownPreview.ts
@@ -3,6 +3,7 @@ import { MarkdownRenderer } from 'obsidian';
 
 import { processFileLinks } from '../../../utils/fileLink';
 import { replaceImageEmbedsWithHtml } from '../../../utils/imageEmbed';
+import { normalizeLatexMathDelimiters } from '../../../utils/markdownMath';
 
 interface RenderInlineEditMarkdownPreviewOptions {
   app: App;
@@ -39,7 +40,8 @@ export async function renderInlineEditMarkdownPreview({
   emptyElement(container);
 
   try {
-    const processedMarkdown = replaceImageEmbedsWithHtml(markdown, app, {
+    const normalizedMarkdown = normalizeLatexMathDelimiters(markdown);
+    const processedMarkdown = replaceImageEmbedsWithHtml(normalizedMarkdown, app, {
       mediaFolder,
       sourcePath,
     });

--- a/src/utils/markdownMath.ts
+++ b/src/utils/markdownMath.ts
@@ -3,128 +3,412 @@ interface FenceState {
   length: number;
 }
 
+interface MarkdownSegment {
+  text: string;
+  transformable: boolean;
+  sealed?: boolean;
+}
+
+const RAW_HTML_TAG_PATTERN = /^ {0,3}<(pre|script|style|textarea)(?=[\t >]|$)/i;
+
 function getFenceRun(line: string): string | null {
-  const match = line.match(/^ {0,3}(`{3,}|~{3,})/);
-  return match?.[1] ?? null;
+  const match = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
+  const run = match?.[1] ?? null;
+  if (!run || (run[0] === '`' && match?.[2].includes('`'))) {
+    return null;
+  }
+  return run;
 }
 
 function isClosingFence(line: string, fence: FenceState): boolean {
-  const run = getFenceRun(line);
+  const match = line.match(/^ {0,3}(`{3,}|~{3,})[ \t]*$/);
+  const run = match?.[1];
   return !!run && run[0] === fence.marker && run.length >= fence.length;
 }
 
-function isHtmlTagStart(line: string, index: number): boolean {
-  const next = line[index + 1];
-  return !!next && /[A-Za-z/!?]/.test(next);
-}
-
-function readBacktickRun(line: string, index: number): number {
+function readBacktickRun(text: string, index: number): number {
   let length = 0;
-  while (line[index + length] === '`') {
+  while (text[index + length] === '`') {
     length += 1;
   }
   return length;
 }
 
-function escapeMathDelimitersInLine(line: string): string {
-  let escaped = '';
-  let inlineCodeRunLength = 0;
-  let inHtmlTag = false;
+function isBackslashEscaped(text: string, index: number): boolean {
+  let backslashes = 0;
+  for (let cursor = index - 1; cursor >= 0 && text[cursor] === '\\'; cursor -= 1) {
+    backslashes += 1;
+  }
+  return backslashes % 2 === 1;
+}
+
+function appendSegment(
+  segments: MarkdownSegment[],
+  text: string,
+  transformable: boolean,
+): void {
+  if (!text) {
+    return;
+  }
+
+  const previous = segments[segments.length - 1];
+  if (previous?.transformable === transformable && !previous.sealed) {
+    previous.text += text;
+  } else {
+    segments.push({ text, transformable });
+  }
+}
+
+function sealLastSegment(segments: MarkdownSegment[]): void {
+  const previous = segments[segments.length - 1];
+  if (previous) {
+    previous.sealed = true;
+  }
+}
+
+function findMatchingBacktickRun(line: string, start: number, runLength: number): number | null {
+  for (let index = start + runLength; index < line.length; index += 1) {
+    if (line[index] !== '`') {
+      continue;
+    }
+
+    const candidateLength = readBacktickRun(line, index);
+    if (candidateLength === runLength) {
+      return index + runLength - 1;
+    }
+    index += candidateLength - 1;
+  }
+  return null;
+}
+
+function findWikilinkEnd(line: string, start: number): number | null {
+  if (!line.startsWith('[[', start) || isBackslashEscaped(line, start)) {
+    return null;
+  }
+
+  const closingStart = line.indexOf(']]', start + 2);
+  return closingStart === -1 ? null : closingStart + 1;
+}
+
+function findLinkDestinationEnd(line: string, start: number): number | null {
+  if (line[start] !== '(') {
+    return null;
+  }
+
+  let depth = 0;
+  let quote: '"' | "'" | null = null;
+  for (let index = start; index < line.length; index += 1) {
+    const char = line[index];
+    if (char === '\\' && line[index + 1]) {
+      index += 1;
+    } else if (quote) {
+      if (char === quote) {
+        quote = null;
+      }
+    } else if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === '(') {
+      depth += 1;
+    } else if (char === ')') {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    } else if (char === '\n') {
+      return null;
+    }
+  }
+  return null;
+}
+
+function findAutolinkEnd(line: string, start: number): number | null {
+  const end = line.indexOf('>', start + 1);
+  if (end === -1) {
+    return null;
+  }
+
+  const destination = line.slice(start + 1, end);
+  if (!destination || /[\s<>\\()[\]]/.test(destination)) {
+    return null;
+  }
+
+  const uri = /^[A-Za-z][A-Za-z0-9+.-]{1,31}:/.test(destination);
+  const email = /^[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9.-]+$/.test(destination);
+  return uri || email ? end : null;
+}
+
+function findHtmlEnd(line: string, start: number): number | null {
+  const specialTerminators: Array<[string, string]> = [
+    ['<!--', '-->'],
+    ['<![CDATA[', ']]>'],
+    ['<?', '?>'],
+  ];
+  for (const [opener, closer] of specialTerminators) {
+    if (line.startsWith(opener, start)) {
+      const end = line.indexOf(closer, start + opener.length);
+      return end === -1 ? null : end + closer.length - 1;
+    }
+  }
+
+  let index = start + 1;
+  if (line[index] === '/') {
+    index += 1;
+  }
+  if (!/[A-Za-z]/.test(line[index] ?? '')) {
+    return null;
+  }
+
+  let quote: '"' | "'" | null = null;
+  for (; index < line.length; index += 1) {
+    const char = line[index];
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      }
+    } else if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === '>') {
+      return index;
+    }
+  }
+  return null;
+}
+
+function splitInlineMarkdown(line: string, segments: MarkdownSegment[]): void {
+  let segmentStart = 0;
+  let bracketDepth = 0;
 
   for (let index = 0; index < line.length; index += 1) {
     const char = line[index];
 
     if (char === '`') {
       const runLength = readBacktickRun(line, index);
-      escaped += line.slice(index, index + runLength);
-      index += runLength - 1;
-      if (inlineCodeRunLength === 0) {
-        inlineCodeRunLength = runLength;
-      } else if (runLength === inlineCodeRunLength) {
-        inlineCodeRunLength = 0;
+      const end = findMatchingBacktickRun(line, index, runLength);
+      if (end !== null) {
+        appendSegment(segments, line.slice(segmentStart, index), true);
+        appendSegment(segments, line.slice(index, end + 1), false);
+        segmentStart = end + 1;
+        index = end;
+      } else {
+        index += runLength - 1;
       }
       continue;
     }
 
-    if (inlineCodeRunLength > 0) {
-      escaped += char;
-      continue;
-    }
-
-    if (inHtmlTag) {
-      escaped += char;
-      if (char === '>') {
-        inHtmlTag = false;
+    if (char === '[') {
+      const wikilinkEnd = findWikilinkEnd(line, index);
+      if (wikilinkEnd !== null) {
+        appendSegment(segments, line.slice(segmentStart, index), true);
+        appendSegment(segments, line.slice(index, wikilinkEnd + 1), false);
+        segmentStart = wikilinkEnd + 1;
+        index = wikilinkEnd;
+      } else if (!isBackslashEscaped(line, index)) {
+        bracketDepth += 1;
       }
       continue;
     }
 
-    if (char === '<' && isHtmlTagStart(line, index)) {
-      inHtmlTag = true;
-      escaped += char;
+    if (char === ']' && !isBackslashEscaped(line, index) && bracketDepth > 0) {
+      bracketDepth -= 1;
+      if (line[index + 1] === '(') {
+        const destinationEnd = findLinkDestinationEnd(line, index + 1);
+        if (destinationEnd !== null) {
+          appendSegment(segments, line.slice(segmentStart, index + 1), true);
+          appendSegment(segments, line.slice(index + 1, destinationEnd + 1), false);
+          segmentStart = destinationEnd + 1;
+          index = destinationEnd;
+        }
+      }
       continue;
     }
 
-    if (char === '\\' && line[index + 1] === '$') {
-      escaped += '\\$';
-      index += 1;
-      continue;
+    if (char === '<') {
+      const end = findAutolinkEnd(line, index) ?? findHtmlEnd(line, index);
+      if (end !== null) {
+        appendSegment(segments, line.slice(segmentStart, index), true);
+        appendSegment(segments, line.slice(index, end + 1), false);
+        segmentStart = end + 1;
+        index = end;
+      }
     }
-
-    escaped += char === '$' ? '\\$' : char;
   }
 
-  return escaped;
+  appendSegment(segments, line.slice(segmentStart), true);
 }
 
-/**
- * Escapes dollar math delimiters outside code spans and fenced code blocks.
- * Used only for transient streaming renders so MarkdownRenderer does not hand
- * incomplete math to Obsidian's math renderer on every frame.
- */
-export function escapeMathDelimitersForStreaming(markdown: string): string {
-  if (!markdown.includes('$')) {
-    return markdown;
-  }
-
-  let result = '';
+function splitMarkdown(markdown: string): MarkdownSegment[] {
+  const segments: MarkdownSegment[] = [];
   let fence: FenceState | null = null;
+  let rawHtmlTag: string | null = null;
   let lineStart = 0;
 
   while (lineStart < markdown.length) {
     const newlineIndex = markdown.indexOf('\n', lineStart);
     const lineEnd = newlineIndex === -1 ? markdown.length : newlineIndex + 1;
     const line = markdown.slice(lineStart, lineEnd);
-    const lineWithoutNewline = line.endsWith('\n') ? line.slice(0, -1) : line;
+    const lineWithoutNewline = line.replace(/\r?\n$/, '');
 
     if (fence) {
-      result += line;
+      appendSegment(segments, line, false);
       if (isClosingFence(lineWithoutNewline, fence)) {
         fence = null;
+        sealLastSegment(segments);
       }
-    } else {
-      const fenceRun = getFenceRun(lineWithoutNewline);
-      if (fenceRun) {
-        result += line;
-        fence = {
-          marker: fenceRun[0] as '`' | '~',
-          length: fenceRun.length,
-        };
-      } else {
-        result += escapeMathDelimitersInLine(line);
-      }
+      lineStart = lineEnd;
+      continue;
     }
 
+    if (rawHtmlTag) {
+      appendSegment(segments, line, false);
+      if (new RegExp(`<\\/${rawHtmlTag}>`, 'i').test(lineWithoutNewline)) {
+        rawHtmlTag = null;
+        sealLastSegment(segments);
+      }
+      lineStart = lineEnd;
+      continue;
+    }
+
+    if (/^[ \t]*$/.test(lineWithoutNewline)) {
+      appendSegment(segments, line, true);
+      sealLastSegment(segments);
+      lineStart = lineEnd;
+      continue;
+    }
+
+    if (/^(?: {4}|\t)/.test(lineWithoutNewline)) {
+      appendSegment(segments, line, false);
+      sealLastSegment(segments);
+      lineStart = lineEnd;
+      continue;
+    }
+
+    const fenceRun = getFenceRun(lineWithoutNewline);
+    if (fenceRun) {
+      appendSegment(segments, line, false);
+      fence = {
+        marker: fenceRun[0] as '`' | '~',
+        length: fenceRun.length,
+      };
+      lineStart = lineEnd;
+      continue;
+    }
+
+    const rawHtmlMatch = lineWithoutNewline.match(RAW_HTML_TAG_PATTERN);
+    if (rawHtmlMatch) {
+      appendSegment(segments, line, false);
+      const tag = rawHtmlMatch[1].toLowerCase();
+      if (!new RegExp(`<\\/${tag}>`, 'i').test(lineWithoutNewline)) {
+        rawHtmlTag = tag;
+      } else {
+        sealLastSegment(segments);
+      }
+      lineStart = lineEnd;
+      continue;
+    }
+
+    splitInlineMarkdown(line, segments);
     lineStart = lineEnd;
   }
 
-  return result;
+  return segments;
+}
+
+function normalizeLatexMathInText(text: string): string {
+  const openers = new Map<'inline' | 'display', number>();
+  const replacements = new Map<number, string>();
+
+  for (let index = 0; index < text.length - 1; index += 1) {
+    if (text[index] !== '\\' || isBackslashEscaped(text, index)) {
+      continue;
+    }
+
+    const delimiter = text[index + 1];
+    const kind = delimiter === '(' || delimiter === ')'
+      ? 'inline'
+      : delimiter === '[' || delimiter === ']'
+        ? 'display'
+        : null;
+    if (!kind) {
+      continue;
+    }
+
+    if (delimiter === '(' || delimiter === '[') {
+      if (!openers.has(kind)) {
+        openers.set(kind, index);
+      }
+    } else {
+      const opener = openers.get(kind);
+      if (opener !== undefined) {
+        const replacement = kind === 'display' ? '$$' : '$';
+        replacements.set(opener, replacement);
+        replacements.set(index, replacement);
+        openers.delete(kind);
+      }
+    }
+    index += 1;
+  }
+
+  if (replacements.size === 0) {
+    return text;
+  }
+
+  let normalized = '';
+  for (let index = 0; index < text.length; index += 1) {
+    const replacement = replacements.get(index);
+    if (replacement) {
+      normalized += replacement;
+      index += 1;
+    } else {
+      normalized += text[index];
+    }
+  }
+  return normalized;
+}
+
+/** Converts matched LaTeX math delimiters to Obsidian's dollar delimiters. */
+export function normalizeLatexMathDelimiters(markdown: string): string {
+  if (!markdown.includes('\\')) {
+    return markdown;
+  }
+
+  return splitMarkdown(markdown)
+    .map(segment => segment.transformable ? normalizeLatexMathInText(segment.text) : segment.text)
+    .join('');
+}
+
+function escapeMathDelimitersInText(text: string): string {
+  let escaped = '';
+  let precedingBackslashes = 0;
+
+  for (const char of text) {
+    if (char === '\\') {
+      escaped += char;
+      precedingBackslashes += 1;
+      continue;
+    }
+
+    escaped += char === '$' && precedingBackslashes % 2 === 0 ? '\\$' : char;
+    precedingBackslashes = 0;
+  }
+  return escaped;
+}
+
+/** Escapes visible dollar math during transient streaming renders. */
+export function escapeMathDelimitersForStreaming(markdown: string): string {
+  if (!markdown.includes('$')) {
+    return markdown;
+  }
+
+  return splitMarkdown(markdown)
+    .map(segment => segment.transformable ? escapeMathDelimitersInText(segment.text) : segment.text)
+    .join('');
 }
 
 export function hasStreamingMathDelimiters(markdown: string): boolean {
-  if (!markdown.includes('$')) {
+  if (!markdown.includes('$') && !markdown.includes('\\')) {
     return false;
   }
 
-  return escapeMathDelimitersForStreaming(markdown) !== markdown;
+  const normalized = normalizeLatexMathDelimiters(markdown);
+  return escapeMathDelimitersForStreaming(normalized) !== normalized;
 }

--- a/tests/unit/features/chat/controllers/StreamController.test.ts
+++ b/tests/unit/features/chat/controllers/StreamController.test.ts
@@ -269,6 +269,21 @@ describe('StreamController - Text Content', () => {
       );
     });
 
+    it('should defer LaTeX-delimited math during live text renders', async () => {
+      deps.state.currentTextEl = createMockEl();
+
+      await controller.appendText('Euler: \\(e^{i\\pi} + 1 = 0\\)');
+
+      jest.advanceTimersByTime(16);
+      await Promise.resolve();
+
+      expect(deps.renderer.renderContent).toHaveBeenCalledWith(
+        deps.state.currentTextEl,
+        'Euler: \\(e^{i\\pi} + 1 = 0\\)',
+        { deferMath: true }
+      );
+    });
+
     it('should honor disabled deferred math rendering setting during live text renders', async () => {
       (deps.plugin.settings as any).deferMathRenderingDuringStreaming = false;
       deps.state.currentTextEl = createMockEl();

--- a/tests/unit/features/chat/rendering/MessageRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/MessageRenderer.test.ts
@@ -1357,6 +1357,21 @@ describe('MessageRenderer', () => {
     );
   });
 
+  it('renderContent normalizes LaTeX math delimiters before rendering', async () => {
+    const { MarkdownRenderer } = await import('obsidian');
+    const { renderer } = createRenderer();
+    const el = createMockEl();
+
+    await renderer.renderContent(el, 'Inline \\(x<y\\).\n\\[y^2\\]');
+
+    expect(MarkdownRenderer.renderMarkdown).toHaveBeenCalledWith(
+      'Inline $x<y$.\n$$y^2$$',
+      el,
+      '',
+      expect.anything()
+    );
+  });
+
   // ============================================
   // addTextCopyButton - click behavior
   // ============================================

--- a/tests/unit/features/inline-edit/ui/inlineEditMarkdownPreview.test.ts
+++ b/tests/unit/features/inline-edit/ui/inlineEditMarkdownPreview.test.ts
@@ -29,6 +29,27 @@ describe('renderInlineEditMarkdownPreview', () => {
     );
   });
 
+  it('normalizes LaTeX math delimiters before rendering', async () => {
+    const app = { vault: {}, metadataCache: {} } as any;
+    const component = {} as any;
+    const container = createMockEl();
+
+    await renderInlineEditMarkdownPreview({
+      app,
+      component,
+      container,
+      markdown: 'Inline \\(x<y\\).\n\\[y^2\\]',
+      sourcePath: 'math/note.md',
+    });
+
+    expect(MarkdownRenderer.renderMarkdown).toHaveBeenCalledWith(
+      'Inline $x<y$.\n$$y^2$$',
+      container,
+      'math/note.md',
+      component
+    );
+  });
+
   it('resolves image embeds using the note source path before rendering', async () => {
     const imageFile = {
       path: 'math/assets/image.png',

--- a/tests/unit/utils/markdownMath.test.ts
+++ b/tests/unit/utils/markdownMath.test.ts
@@ -1,24 +1,91 @@
 import {
   escapeMathDelimitersForStreaming,
   hasStreamingMathDelimiters,
+  normalizeLatexMathDelimiters,
 } from '@/utils/markdownMath';
 
 describe('markdownMath', () => {
+  describe('normalizeLatexMathDelimiters', () => {
+    it('normalizes inline and display LaTeX delimiters', () => {
+      const markdown = [
+        'Inline \\(x<y\\).',
+        '\\[',
+        'y^2',
+        '\\]',
+      ].join('\n');
+
+      expect(normalizeLatexMathDelimiters(markdown)).toBe([
+        'Inline $x<y$.',
+        '$$',
+        'y^2',
+        '$$',
+      ].join('\n'));
+    });
+
+    it('preserves existing dollars and unmatched or escaped LaTeX delimiters', () => {
+      expect(
+        normalizeLatexMathDelimiters('Keep $x$ and $$y$$. Unmatched \\(z. Escaped \\\\(x\\\\).')
+      ).toBe(
+        'Keep $x$ and $$y$$. Unmatched \\(z. Escaped \\\\(x\\\\).'
+      );
+    });
+
+    it('preserves delimiters in inline, fenced, and indented code', () => {
+      const markdown = [
+        '`inline \\(code\\)` and \\(math\\)',
+        '```tex',
+        '\\[fenced\\]',
+        '```',
+        '    \\(indented\\)',
+      ].join('\n');
+
+      expect(normalizeLatexMathDelimiters(markdown)).toBe([
+        '`inline \\(code\\)` and $math$',
+        '```tex',
+        '\\[fenced\\]',
+        '```',
+        '    \\(indented\\)',
+      ].join('\n'));
+    });
+
+    it('preserves link destinations, autolinks, wikilinks, and HTML tags', () => {
+      const markdown = [
+        '[\\(label\\)](https://host/a\\(b\\))',
+        '<https://host/a\\(b\\)>',
+        '[[page\\(id\\)]]',
+        '<span title="\\(raw\\)">\\(visible\\)</span>',
+      ].join('\n');
+
+      expect(normalizeLatexMathDelimiters(markdown)).toBe([
+        '[$label$](https://host/a\\(b\\))',
+        '<https://host/a\\(b\\)>',
+        '[[page\\(id\\)]]',
+        '<span title="\\(raw\\)">$visible$</span>',
+      ].join('\n'));
+    });
+
+    it('preserves raw HTML bodies', () => {
+      const markdown = '<pre>\n\\(literal\\)\n</pre>\n\\(visible\\)';
+      expect(normalizeLatexMathDelimiters(markdown)).toBe(
+        '<pre>\n\\(literal\\)\n</pre>\n$visible$'
+      );
+    });
+  });
+
   describe('escapeMathDelimitersForStreaming', () => {
-    it('escapes inline and display math delimiters outside code', () => {
+    it('escapes inline and display math outside code', () => {
       expect(escapeMathDelimitersForStreaming('Use $x + y$ and $$z^2$$.')).toBe(
         'Use \\$x + y\\$ and \\$\\$z^2\\$\\$.'
       );
     });
 
-    it('preserves inline code and fenced code dollars', () => {
+    it('preserves inline and fenced code dollars', () => {
       const markdown = [
         'Text $x$',
         '`echo $PATH`',
         '```bash',
         'echo "$HOME"',
         '```',
-        'Done $$y$$',
       ].join('\n');
 
       expect(escapeMathDelimitersForStreaming(markdown)).toBe([
@@ -27,17 +94,16 @@ describe('markdownMath', () => {
         '```bash',
         'echo "$HOME"',
         '```',
-        'Done \\$\\$y\\$\\$',
       ].join('\n'));
     });
 
-    it('keeps already escaped dollars unchanged', () => {
-      expect(escapeMathDelimitersForStreaming('Cost is \\$5, math is $x$.')).toBe(
-        'Cost is \\$5, math is \\$x\\$.'
+    it('keeps odd-backslash dollar escapes and escapes after even runs', () => {
+      expect(escapeMathDelimitersForStreaming(String.raw`\$5 \\$x$`)).toBe(
+        String.raw`\$5 \\\$x\$`
       );
     });
 
-    it('does not alter dollars inside raw html tag attributes', () => {
+    it('does not alter dollars inside HTML attributes', () => {
       expect(escapeMathDelimitersForStreaming('<span title="$x$">value $y$</span>')).toBe(
         '<span title="$x$">value \\$y\\$</span>'
       );
@@ -45,9 +111,12 @@ describe('markdownMath', () => {
   });
 
   describe('hasStreamingMathDelimiters', () => {
-    it('detects unescaped dollars outside code', () => {
+    it('detects dollar and LaTeX math outside code', () => {
       expect(hasStreamingMathDelimiters('math $x$')).toBe(true);
+      expect(hasStreamingMathDelimiters('math \\(x<y\\)')).toBe(true);
+      expect(hasStreamingMathDelimiters('math \\[x\\]')).toBe(true);
       expect(hasStreamingMathDelimiters('`echo $PATH`')).toBe(false);
+      expect(hasStreamingMathDelimiters('`raw \\(x\\)`')).toBe(false);
       expect(hasStreamingMathDelimiters('\\$5')).toBe(false);
     });
   });


### PR DESCRIPTION
Adds render-time normalization for LaTeX `\(...\)` and `\[...\]` delimiters while preserving existing dollar math and stored provider text. Applies normalization to sidebar chat and inline-edit previews, with basic protection for code, destinations, wikilinks, autolinks, and HTML. Extends streaming math detection and focused integration/unit coverage for both delimiter styles. Validation passed with typecheck, lint, build, and all 262 test suites / 6,059 tests. Closes #937.