### PR TITLE
fix: project writable tab settings against the tab's selected modelPatch 1

### DIFF
--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -168,11 +168,11 @@ function getWritableTabSettingsSnapshot(
   plugin: FeatureHost,
   settings: ClaudianSettings = plugin.settings,
 ): TabProviderSettings {
-  return ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+  return getProviderSettingsSnapshotWithModel(
     settings,
     getTabProviderId(tab, plugin),
+    getTabSelectedModel(tab, plugin),
   );
-}
 
 function getTabConversation(
   tab: TabProviderContext,

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -173,6 +173,7 @@ function getWritableTabSettingsSnapshot(
     getTabProviderId(tab, plugin),
     getTabSelectedModel(tab, plugin),
   );
+}
 
 function getTabConversation(
   tab: TabProviderContext,


### PR DESCRIPTION
Picking Max effort on a Codex tab snaps back to High. I hit this on gpt-5.6-sol: my saved provider model was still gpt-5.5, which tops out at xhigh, so Max kept getting rejected.

Toolbar changes build their snapshot with getWritableTabSettingsSnapshot(), which ignores the tab's selected model. The effort gets saved, then re-validated against the stale savedProviderModel and clamped back to the default. The read path (getTabSettingsSnapshot()) already projects the tab model, so this makes the write path do the same. The saved model now follows the tab the user actually touched, and old installs fix themselves on the first click.

Ran typecheck, lint, and the full suite locally (6,059 passing), and verified the fix in my own vault: Max now sticks on gpt-5.6-sol with a stale gpt-5.5 saved model.