### PR TITLE
fix: expose Codex workspace dependencies

### DIFF
--- a/src/providers/codex/history/CodexConversationHistoryService.ts
+++ b/src/providers/codex/history/CodexConversationHistoryService.ts
@@ -208,6 +208,11 @@ export class CodexConversationHistoryService implements ProviderConversationHist
       ?? deriveCodexSessionsRootFromSessionPath(sourceState.sessionFilePath);
     const providerState: CodexProviderState = {
       forkSource: { sessionId: sourceSessionId, resumeAt },
+      ...(
+        sourceState.workspaceDependencyToolVersion !== undefined
+          ? { workspaceDependencyToolVersion: sourceState.workspaceDependencyToolVersion }
+          : {}
+      ),
       ...(sourceState.sessionFilePath ? { forkSourceSessionFilePath: sourceState.sessionFilePath } : {}),
       ...(
         sourceTranscriptRootPath

--- a/src/providers/codex/runtime/CodexChatRuntime.ts
+++ b/src/providers/codex/runtime/CodexChatRuntime.ts
@@ -69,12 +69,19 @@ import type {
   TurnSteerResult,
   UserInput,
 } from './codexAppServerTypes';
+import { CodexDynamicToolRegistry } from './CodexDynamicToolRegistry';
 import type { CodexLaunchSpec } from './codexLaunchTypes';
 import { CodexNotificationRouter } from './CodexNotificationRouter';
 import { CodexRpcTransport } from './CodexRpcTransport';
 import { type CodexRuntimeContext, createCodexRuntimeContext } from './CodexRuntimeContext';
 import { CodexServerRequestRouter } from './CodexServerRequestRouter';
 import { CodexSessionManager } from './CodexSessionManager';
+import {
+  CODEX_WORKSPACE_DEPENDENCY_TOOL_NAME,
+  CODEX_WORKSPACE_DEPENDENCY_TOOL_NAMESPACE,
+  CODEX_WORKSPACE_DEPENDENCY_TOOL_VERSION,
+  createCodexWorkspaceDependencyTool,
+} from './CodexWorkspaceDependencyTool';
 
 function resolveCodexSandboxConfig(
   permissionMode: string,
@@ -123,6 +130,7 @@ export class CodexChatRuntime implements ChatRuntime {
   private runtimeContext: CodexRuntimeContext | null = null;
   private notificationRouter: CodexNotificationRouter | null = null;
   private serverRequestRouter = new CodexServerRequestRouter();
+  private dynamicToolRegistry = new CodexDynamicToolRegistry();
   private ready = false;
   private readinessFlight: { key: string; promise: Promise<boolean> } | null = null;
   private disposed = false;
@@ -133,6 +141,7 @@ export class CodexChatRuntime implements ChatRuntime {
   private currentQueryThreadId: string | null = null;
   private loadedThreadId: string | null = null;
   private currentThreadPath: string | null = null;
+  private workspaceDependencyToolVersion: number | null = null;
   private pendingTurnNotifications: Array<{ method: string; params: unknown }> = [];
 
   // Chunk buffer: notifications push here, query() drains
@@ -194,12 +203,14 @@ export class CodexChatRuntime implements ChatRuntime {
       this.session.reset();
       this.loadedThreadId = null;
       this.currentThreadPath = null;
+      this.workspaceDependencyToolVersion = null;
       this.pendingFork = null;
       return;
     }
 
     this.setCurrentConversationModel(conversation.selectedModel);
     const state = getCodexState(conversation.providerState);
+    this.workspaceDependencyToolVersion = state.workspaceDependencyToolVersion ?? null;
 
     // Pending fork: store fork metadata, don't set the source thread as our session
     if (state.forkSource && !state.threadId && !conversation.sessionId) {
@@ -340,8 +351,23 @@ export class CodexChatRuntime implements ChatRuntime {
       let threadPath: string | null = null;
       let threadTargetPath: string | null = null;
       let completedPendingFork = false;
+      const shouldMigrateLegacyThread = !turn.isCompact
+        && (this.pendingFork !== null || existingThreadId !== null)
+        && this.workspaceDependencyToolVersion !== CODEX_WORKSPACE_DEPENDENCY_TOOL_VERSION
+        && this.dynamicToolRegistry.isIncludedInThreadStart(
+          CODEX_WORKSPACE_DEPENDENCY_TOOL_NAMESPACE,
+          CODEX_WORKSPACE_DEPENDENCY_TOOL_NAME,
+        );
 
-      if (this.pendingFork) {
+      if (shouldMigrateLegacyThread) {
+        const startResult = await this.startThread(model, providerSettings, promptText);
+        threadId = startResult.thread.id;
+        threadTargetPath = startResult.thread.path ?? null;
+        threadPath = this.toHostSessionPath(threadTargetPath);
+        this.loadedThreadId = threadId;
+        this.pendingFork = null;
+        turn = this.prependHistoryContext(turn, _conversationHistory);
+      } else if (this.pendingFork) {
         // Pending fork: fork the source thread, optionally roll back, then start a turn
         const fork = this.pendingFork;
 
@@ -421,17 +447,7 @@ export class CodexChatRuntime implements ChatRuntime {
         threadId = existingThreadId;
       } else {
         // New thread
-        const permissionMode = this.resolveSandboxConfig();
-        const startResult = await this.transport!.request<ThreadStartResult>('thread/start', {
-          ...(model ? { model } : {}),
-          cwd: this.launchSpec?.targetCwd ?? getVaultPath(this.plugin.app) ?? undefined,
-          approvalPolicy: permissionMode.approvalPolicy,
-          sandbox: permissionMode.sandbox,
-          serviceTier: resolveCodexServiceTier(providerSettings.serviceTier, model, providerSettings),
-          baseInstructions: promptText,
-          experimentalRawEvents: true,
-          persistExtendedHistory: true,
-        });
+        const startResult = await this.startThread(model, providerSettings, promptText);
         threadId = startResult.thread.id;
         threadTargetPath = startResult.thread.path ?? null;
         threadPath = this.toHostSessionPath(threadTargetPath);
@@ -738,6 +754,11 @@ export class CodexChatRuntime implements ChatRuntime {
       ),
       ...(existingState?.forkSource ? { forkSource: existingState.forkSource } : {}),
       ...(
+        this.workspaceDependencyToolVersion !== null
+          ? { workspaceDependencyToolVersion: this.workspaceDependencyToolVersion }
+          : {}
+      ),
+      ...(
         existingState?.forkSourceSessionFilePath
           ? { forkSourceSessionFilePath: existingState.forkSourceSessionFilePath }
           : {}
@@ -782,6 +803,7 @@ export class CodexChatRuntime implements ChatRuntime {
     this.runtimeContext = null;
     this.loadedThreadId = null;
     this.currentThreadPath = null;
+    this.workspaceDependencyToolVersion = null;
     this.currentTurnId = null;
     this.currentQueryThreadId = null;
     this.pendingTurnNotifications = [];
@@ -901,7 +923,53 @@ export class CodexChatRuntime implements ChatRuntime {
 
     const initializeResult = await initializeCodexAppServerTransport(this.transport);
     this.runtimeContext = createCodexRuntimeContext(launchSpec, initializeResult);
+    this.dynamicToolRegistry = new CodexDynamicToolRegistry();
+    const workspaceDependencyTool = await createCodexWorkspaceDependencyTool(this.runtimeContext);
+    this.dynamicToolRegistry.register(workspaceDependencyTool);
+    this.serverRequestRouter.setDynamicToolRegistry(this.dynamicToolRegistry);
     this.clientConfigKey = clientConfigKey;
+  }
+
+  private async startThread(
+    model: string | undefined,
+    providerSettings: Record<string, unknown>,
+    baseInstructions: string,
+  ): Promise<ThreadStartResult> {
+    const permissionMode = this.resolveSandboxConfig();
+    const dynamicTools = this.dynamicToolRegistry.getThreadStartSpecs();
+    const startResult = await this.transport!.request<ThreadStartResult>('thread/start', {
+      ...(model ? { model } : {}),
+      cwd: this.launchSpec?.targetCwd ?? getVaultPath(this.plugin.app) ?? undefined,
+      approvalPolicy: permissionMode.approvalPolicy,
+      sandbox: permissionMode.sandbox,
+      serviceTier: resolveCodexServiceTier(providerSettings.serviceTier, model, providerSettings),
+      baseInstructions,
+      experimentalRawEvents: true,
+      persistExtendedHistory: true,
+      ...(dynamicTools.length > 0 ? { dynamicTools } : {}),
+    });
+    this.workspaceDependencyToolVersion = this.dynamicToolRegistry.isIncludedInThreadStart(
+      CODEX_WORKSPACE_DEPENDENCY_TOOL_NAMESPACE,
+      CODEX_WORKSPACE_DEPENDENCY_TOOL_NAME,
+    )
+      ? CODEX_WORKSPACE_DEPENDENCY_TOOL_VERSION
+      : null;
+    return startResult;
+  }
+
+  private prependHistoryContext(
+    turn: PreparedChatTurn,
+    conversationHistory?: ChatMessage[],
+  ): PreparedChatTurn {
+    const historyContext = conversationHistory
+      ? buildContextFromHistory(conversationHistory)
+      : '';
+    if (!historyContext.trim()) return turn;
+
+    return {
+      ...turn,
+      prompt: `${historyContext}\n\nUser: ${turn.prompt}`,
+    };
   }
 
   private wireTransportHandlers(): void {
@@ -944,12 +1012,13 @@ export class CodexChatRuntime implements ChatRuntime {
       });
     }
 
-    // Server requests (approvals, ask-user)
+    // Server requests (approvals, ask-user, client-hosted dynamic tools)
     const requestMethods = [
       'item/commandExecution/requestApproval',
       'item/fileChange/requestApproval',
       'item/permissions/requestApproval',
       'item/tool/requestUserInput',
+      'item/tool/call',
     ];
 
     for (const method of requestMethods) {
@@ -970,6 +1039,8 @@ export class CodexChatRuntime implements ChatRuntime {
     }
     this.launchSpec = null;
     this.runtimeContext = null;
+    this.dynamicToolRegistry = new CodexDynamicToolRegistry();
+    this.serverRequestRouter.setDynamicToolRegistry(null);
     this.notificationRouter = null;
     this.currentTurnId = null;
     this.currentQueryThreadId = null;

--- a/src/providers/codex/runtime/CodexChatRuntime.ts
+++ b/src/providers/codex/runtime/CodexChatRuntime.ts
@@ -119,6 +119,12 @@ function resolveCodexServiceTier(
   return model.defaultServiceTier;
 }
 
+const LEGACY_WORKSPACE_DEPENDENCY_NOTICE =
+  'This conversation was created before Claudian added Codex workspace dependency tools. It can continue for other tasks, but skills that require load_workspace_dependencies are unavailable in this thread. Start a new conversation to use them.';
+
+const LEGACY_WORKSPACE_DEPENDENCY_INSTRUCTIONS =
+  'This thread predates Claudian client-hosted workspace dependency tools. If the user requests a skill that requires load_workspace_dependencies, explain that they must start a new conversation in Claudian. Do not emulate the tool, search for dependency paths, or install replacement dependencies.';
+
 export class CodexChatRuntime implements ChatRuntime {
   readonly providerId: ProviderId = 'codex';
 
@@ -142,6 +148,7 @@ export class CodexChatRuntime implements ChatRuntime {
   private loadedThreadId: string | null = null;
   private currentThreadPath: string | null = null;
   private workspaceDependencyToolVersion: number | null = null;
+  private legacyWorkspaceDependencyNoticeKeys = new Set<string>();
   private pendingTurnNotifications: Array<{ method: string; params: unknown }> = [];
 
   // Chunk buffer: notifications push here, query() drains
@@ -351,23 +358,32 @@ export class CodexChatRuntime implements ChatRuntime {
       let threadPath: string | null = null;
       let threadTargetPath: string | null = null;
       let completedPendingFork = false;
-      const shouldMigrateLegacyThread = !turn.isCompact
-        && (this.pendingFork !== null || existingThreadId !== null)
-        && this.workspaceDependencyToolVersion !== CODEX_WORKSPACE_DEPENDENCY_TOOL_VERSION
-        && this.dynamicToolRegistry.isIncludedInThreadStart(
-          CODEX_WORKSPACE_DEPENDENCY_TOOL_NAMESPACE,
-          CODEX_WORKSPACE_DEPENDENCY_TOOL_NAME,
-        );
+      const isLegacyWorkspaceDependencyThread = (
+        this.pendingFork !== null || existingThreadId !== null
+      ) && (
+        this.workspaceDependencyToolVersion === null
+        || this.workspaceDependencyToolVersion < CODEX_WORKSPACE_DEPENDENCY_TOOL_VERSION
+      );
+      const baseInstructions = isLegacyWorkspaceDependencyThread
+        ? `${promptText}\n\n${LEGACY_WORKSPACE_DEPENDENCY_INSTRUCTIONS}`
+        : promptText;
+      const legacyNoticeKey = this.pendingFork
+        ? `fork:${this.pendingFork.sessionId}:${this.pendingFork.resumeAt}`
+        : existingThreadId
+          ? `thread:${existingThreadId}`
+          : null;
 
-      if (shouldMigrateLegacyThread) {
-        const startResult = await this.startThread(model, providerSettings, promptText);
-        threadId = startResult.thread.id;
-        threadTargetPath = startResult.thread.path ?? null;
-        threadPath = this.toHostSessionPath(threadTargetPath);
-        this.loadedThreadId = threadId;
-        this.pendingFork = null;
-        turn = this.prependHistoryContext(turn, _conversationHistory);
-      } else if (this.pendingFork) {
+      if (
+        !turn.isCompact
+        && isLegacyWorkspaceDependencyThread
+        && legacyNoticeKey
+        && !this.legacyWorkspaceDependencyNoticeKeys.has(legacyNoticeKey)
+      ) {
+        this.legacyWorkspaceDependencyNoticeKeys.add(legacyNoticeKey);
+        yield { type: 'notice', level: 'warning', content: LEGACY_WORKSPACE_DEPENDENCY_NOTICE };
+      }
+
+      if (this.pendingFork) {
         // Pending fork: fork the source thread, optionally roll back, then start a turn
         const fork = this.pendingFork;
 
@@ -394,7 +410,7 @@ export class CodexChatRuntime implements ChatRuntime {
           approvalPolicy: permissionMode.approvalPolicy,
           sandbox: permissionMode.sandbox,
           serviceTier: resolveCodexServiceTier(providerSettings.serviceTier, model, providerSettings),
-          baseInstructions: promptText,
+          baseInstructions,
           experimentalRawEvents: true,
           persistExtendedHistory: true,
         });
@@ -408,6 +424,9 @@ export class CodexChatRuntime implements ChatRuntime {
 
         this.loadedThreadId = threadId;
         completedPendingFork = true;
+        if (isLegacyWorkspaceDependencyThread) {
+          this.legacyWorkspaceDependencyNoticeKeys.add(`thread:${threadId}`);
+        }
 
         // Build replay suffix from conversation history after the checkpoint
         if (_conversationHistory && _conversationHistory.length > 0) {
@@ -434,7 +453,7 @@ export class CodexChatRuntime implements ChatRuntime {
           approvalPolicy: permissionMode.approvalPolicy,
           sandbox: permissionMode.sandbox,
           serviceTier: resolveCodexServiceTier(providerSettings.serviceTier, model, providerSettings),
-          baseInstructions: promptText,
+          baseInstructions,
           experimentalRawEvents: true,
           persistExtendedHistory: true,
         });
@@ -804,6 +823,7 @@ export class CodexChatRuntime implements ChatRuntime {
     this.loadedThreadId = null;
     this.currentThreadPath = null;
     this.workspaceDependencyToolVersion = null;
+    this.legacyWorkspaceDependencyNoticeKeys.clear();
     this.currentTurnId = null;
     this.currentQueryThreadId = null;
     this.pendingTurnNotifications = [];
@@ -924,7 +944,7 @@ export class CodexChatRuntime implements ChatRuntime {
     const initializeResult = await initializeCodexAppServerTransport(this.transport);
     this.runtimeContext = createCodexRuntimeContext(launchSpec, initializeResult);
     this.dynamicToolRegistry = new CodexDynamicToolRegistry();
-    const workspaceDependencyTool = await createCodexWorkspaceDependencyTool(this.runtimeContext);
+    const workspaceDependencyTool = createCodexWorkspaceDependencyTool(this.runtimeContext);
     this.dynamicToolRegistry.register(workspaceDependencyTool);
     this.serverRequestRouter.setDynamicToolRegistry(this.dynamicToolRegistry);
     this.clientConfigKey = clientConfigKey;
@@ -955,21 +975,6 @@ export class CodexChatRuntime implements ChatRuntime {
       ? CODEX_WORKSPACE_DEPENDENCY_TOOL_VERSION
       : null;
     return startResult;
-  }
-
-  private prependHistoryContext(
-    turn: PreparedChatTurn,
-    conversationHistory?: ChatMessage[],
-  ): PreparedChatTurn {
-    const historyContext = conversationHistory
-      ? buildContextFromHistory(conversationHistory)
-      : '';
-    if (!historyContext.trim()) return turn;
-
-    return {
-      ...turn,
-      prompt: `${historyContext}\n\nUser: ${turn.prompt}`,
-    };
   }
 
   private wireTransportHandlers(): void {

--- a/src/providers/codex/runtime/CodexDynamicToolRegistry.ts
+++ b/src/providers/codex/runtime/CodexDynamicToolRegistry.ts
@@ -1,0 +1,94 @@
+import type {
+  DynamicToolCallParams,
+  DynamicToolCallResponse,
+  DynamicToolFunctionSpec,
+  DynamicToolSpec,
+} from './codexAppServerTypes';
+
+export type CodexDynamicToolHandler = (
+  params: DynamicToolCallParams,
+) => Promise<DynamicToolCallResponse>;
+
+export interface CodexDynamicToolRegistration {
+  includeInThreadStart: boolean;
+  namespace?: {
+    name: string;
+    description: string;
+  };
+  tool: DynamicToolFunctionSpec;
+  handler: CodexDynamicToolHandler;
+}
+
+function registrationKey(namespace: string | null | undefined, tool: string): string {
+  return `${namespace ?? ''}\u0000${tool}`;
+}
+
+export class CodexDynamicToolRegistry {
+  private registrations = new Map<string, CodexDynamicToolRegistration>();
+
+  register(registration: CodexDynamicToolRegistration): void {
+    const key = registrationKey(registration.namespace?.name, registration.tool.name);
+    if (this.registrations.has(key)) {
+      throw new Error(`Duplicate dynamic tool registration: ${registration.tool.name}`);
+    }
+    this.registrations.set(key, registration);
+  }
+
+  getThreadStartSpecs(): DynamicToolSpec[] {
+    const rootTools: DynamicToolFunctionSpec[] = [];
+    const namespaces = new Map<string, {
+      description: string;
+      tools: DynamicToolFunctionSpec[];
+    }>();
+
+    for (const registration of this.registrations.values()) {
+      if (!registration.includeInThreadStart) continue;
+
+      if (!registration.namespace) {
+        rootTools.push(registration.tool);
+        continue;
+      }
+
+      const existing = namespaces.get(registration.namespace.name);
+      if (existing) {
+        if (existing.description !== registration.namespace.description) {
+          throw new Error(
+            `Conflicting dynamic tool namespace description: ${registration.namespace.name}`,
+          );
+        }
+        existing.tools.push(registration.tool);
+      } else {
+        namespaces.set(registration.namespace.name, {
+          description: registration.namespace.description,
+          tools: [registration.tool],
+        });
+      }
+    }
+
+    return [
+      ...rootTools,
+      ...Array.from(namespaces, ([name, namespace]) => ({
+        type: 'namespace' as const,
+        name,
+        description: namespace.description,
+        tools: namespace.tools,
+      })),
+    ];
+  }
+
+  isIncludedInThreadStart(namespace: string | null, tool: string): boolean {
+    return this.registrations.get(registrationKey(namespace, tool))?.includeInThreadStart === true;
+  }
+
+  async execute(params: DynamicToolCallParams): Promise<DynamicToolCallResponse> {
+    const registration = this.registrations.get(registrationKey(params.namespace, params.tool));
+    if (!registration) {
+      const qualifiedName = params.namespace
+        ? `${params.namespace}.${params.tool}`
+        : params.tool;
+      throw new Error(`Unsupported dynamic tool: ${qualifiedName}`);
+    }
+
+    return registration.handler(params);
+  }
+}

--- a/src/providers/codex/runtime/CodexDynamicToolRegistry.ts
+++ b/src/providers/codex/runtime/CodexDynamicToolRegistry.ts
@@ -2,7 +2,7 @@ import type {
   DynamicToolCallParams,
   DynamicToolCallResponse,
   DynamicToolFunctionSpec,
-  DynamicToolSpec,
+  LegacyDynamicToolSpec,
 } from './codexAppServerTypes';
 
 export type CodexDynamicToolHandler = (
@@ -34,46 +34,37 @@ export class CodexDynamicToolRegistry {
     this.registrations.set(key, registration);
   }
 
-  getThreadStartSpecs(): DynamicToolSpec[] {
-    const rootTools: DynamicToolFunctionSpec[] = [];
-    const namespaces = new Map<string, {
-      description: string;
-      tools: DynamicToolFunctionSpec[];
-    }>();
+  getThreadStartSpecs(): LegacyDynamicToolSpec[] {
+    const specs: LegacyDynamicToolSpec[] = [];
+    const namespaceDescriptions = new Map<string, string>();
 
     for (const registration of this.registrations.values()) {
       if (!registration.includeInThreadStart) continue;
 
-      if (!registration.namespace) {
-        rootTools.push(registration.tool);
-        continue;
-      }
-
-      const existing = namespaces.get(registration.namespace.name);
-      if (existing) {
-        if (existing.description !== registration.namespace.description) {
+      if (registration.namespace) {
+        const existingDescription = namespaceDescriptions.get(registration.namespace.name);
+        if (
+          existingDescription !== undefined
+          && existingDescription !== registration.namespace.description
+        ) {
           throw new Error(
             `Conflicting dynamic tool namespace description: ${registration.namespace.name}`,
           );
         }
-        existing.tools.push(registration.tool);
-      } else {
-        namespaces.set(registration.namespace.name, {
-          description: registration.namespace.description,
-          tools: [registration.tool],
-        });
+        namespaceDescriptions.set(registration.namespace.name, registration.namespace.description);
       }
+
+      const { name, description, inputSchema, deferLoading } = registration.tool;
+      specs.push({
+        ...(registration.namespace ? { namespace: registration.namespace.name } : {}),
+        name,
+        description,
+        inputSchema,
+        ...(deferLoading !== undefined ? { deferLoading } : {}),
+      });
     }
 
-    return [
-      ...rootTools,
-      ...Array.from(namespaces, ([name, namespace]) => ({
-        type: 'namespace' as const,
-        name,
-        description: namespace.description,
-        tools: namespace.tools,
-      })),
-    ];
+    return specs;
   }
 
   isIncludedInThreadStart(namespace: string | null, tool: string): boolean {

--- a/src/providers/codex/runtime/CodexNotificationRouter.ts
+++ b/src/providers/codex/runtime/CodexNotificationRouter.ts
@@ -19,6 +19,7 @@ import type {
   CollabAgentToolCallItem,
   CommandExecutionItem,
   ContextCompactionItem,
+  DynamicToolCallItem,
   ErrorNotification,
   FileChangeItem,
   FileChangePatchUpdatedNotification,
@@ -74,6 +75,7 @@ export class CodexNotificationRouter {
   private rawToolInputsByCallId = new Map<string, Record<string, unknown>>();
   private rawToolOutputsByCallId = new Map<string, RawToolResult>();
   private immediateRawOutputCallIds = new Set<string>();
+  private emittedImmediateToolResultIds = new Set<string>();
   private wrappedCommandCallIdsByCellId = new Map<string, string>();
   private wrappedCommandOutputByCallId = new Map<string, string>();
   private wrappedWaitCallsByCallId = new Map<string, WrappedWaitCall>();
@@ -142,6 +144,7 @@ export class CodexNotificationRouter {
     this.rawToolInputsByCallId.clear();
     this.rawToolOutputsByCallId.clear();
     this.immediateRawOutputCallIds.clear();
+    this.emittedImmediateToolResultIds.clear();
     this.wrappedCommandCallIdsByCellId.clear();
     this.wrappedCommandOutputByCallId.clear();
     this.wrappedWaitCallsByCallId.clear();
@@ -161,6 +164,7 @@ export class CodexNotificationRouter {
     this.rawToolInputsByCallId.clear();
     this.rawToolOutputsByCallId.clear();
     this.immediateRawOutputCallIds.clear();
+    this.emittedImmediateToolResultIds.clear();
     this.wrappedCommandCallIdsByCellId.clear();
     this.wrappedCommandOutputByCallId.clear();
     this.wrappedWaitCallsByCallId.clear();
@@ -282,6 +286,10 @@ export class CodexNotificationRouter {
         this.emitToolUseFromMcp(item);
         break;
 
+      case 'dynamicToolCall':
+        this.emitToolUseFromDynamic(item);
+        break;
+
       default:
         break;
     }
@@ -326,6 +334,10 @@ export class CodexNotificationRouter {
 
       case 'mcpToolCall':
         this.emitToolResultFromMcp(item);
+        break;
+
+      case 'dynamicToolCall':
+        this.emitToolResultFromDynamic(item);
         break;
 
       case 'contextCompaction':
@@ -428,7 +440,7 @@ export class CodexNotificationRouter {
       return;
     }
 
-    // Generic custom tools have no semantic item/completed notification; their raw output is terminal.
+    // Raw custom output is terminal unless a canonical dynamic-tool completion also arrives.
     this.immediateRawOutputCallIds.add(callId);
     this.emitRawToolUse(callId, rawName, item);
   }
@@ -507,7 +519,10 @@ export class CodexNotificationRouter {
         return;
       }
 
-      this.emit({ type: 'tool_result', id: callId, ...result });
+      if (!this.emittedImmediateToolResultIds.has(callId)) {
+        this.emittedImmediateToolResultIds.add(callId);
+        this.emit({ type: 'tool_result', id: callId, ...result });
+      }
       return;
     }
 
@@ -795,6 +810,35 @@ export class CodexNotificationRouter {
       id: item.id,
       content,
       isError: item.status === 'failed' || item.status === 'error',
+    });
+  }
+
+  // -- dynamicToolCall --------------------------------------------------------
+
+  private emitToolUseFromDynamic(item: DynamicToolCallItem): void {
+    this.emitRawToolUse(
+      item.id,
+      item.tool,
+      {},
+      asRecord(item.arguments) ?? {},
+    );
+  }
+
+  private emitToolResultFromDynamic(item: DynamicToolCallItem): void {
+    if (this.emittedImmediateToolResultIds.has(item.id)) return;
+    this.emittedImmediateToolResultIds.add(item.id);
+
+    const content = (item.contentItems ?? [])
+      .map(contentItem => contentItem.type === 'inputText'
+        ? contentItem.text
+        : contentItem.imageUrl)
+      .filter(Boolean)
+      .join('\n');
+    this.emit({
+      type: 'tool_result',
+      id: item.id,
+      content: content || (item.success === false ? 'Failed' : 'Completed'),
+      isError: item.success === false || item.status === 'failed',
     });
   }
 

--- a/src/providers/codex/runtime/CodexServerRequestRouter.ts
+++ b/src/providers/codex/runtime/CodexServerRequestRouter.ts
@@ -9,6 +9,8 @@ import type {
   CommandApprovalRequest,
   CommandExecutionApprovalDecision,
   CommandExecutionApprovalResponse,
+  DynamicToolCallParams,
+  DynamicToolCallResponse,
   FileChangeApprovalDecision,
   FileChangeApprovalRequest,
   FileChangeApprovalResponse,
@@ -18,6 +20,7 @@ import type {
   UserInputRequest,
   UserInputResponse,
 } from './codexAppServerTypes';
+import type { CodexDynamicToolRegistry } from './CodexDynamicToolRegistry';
 
 export class CodexServerRequestRouter {
   private approvalCallback: ApprovalCallback | null = null;
@@ -26,6 +29,7 @@ export class CodexServerRequestRouter {
   private askUserAbortController: AbortController | null = null;
   private pendingAskUserRequestId: RequestId | null = null;
   private pendingAskUserThreadId: string | null = null;
+  private dynamicToolRegistry: CodexDynamicToolRegistry | null = null;
 
   setApprovalCallback(callback: ApprovalCallback | null): void {
     this.approvalCallback = callback;
@@ -33,6 +37,10 @@ export class CodexServerRequestRouter {
 
   setAskUserCallback(callback: AskUserQuestionCallback | null): void {
     this.askUserCallback = callback;
+  }
+
+  setDynamicToolRegistry(registry: CodexDynamicToolRegistry | null): void {
+    this.dynamicToolRegistry = registry;
   }
 
   async handleServerRequest(
@@ -58,9 +66,21 @@ export class CodexServerRequestRouter {
       case 'item/tool/requestUserInput':
         return this.handleUserInputRequest(requestId, params as UserInputRequest);
 
+      case 'item/tool/call':
+        return this.handleDynamicToolCall(params as DynamicToolCallParams);
+
       default:
         throw new Error(`Unsupported server request: ${method}`);
     }
+  }
+
+  private async handleDynamicToolCall(
+    params: DynamicToolCallParams,
+  ): Promise<DynamicToolCallResponse> {
+    if (!this.dynamicToolRegistry) {
+      throw new Error(`Unsupported dynamic tool: ${params.tool}`);
+    }
+    return this.dynamicToolRegistry.execute(params);
   }
 
   hasPendingApprovalRequest(requestId: RequestId, threadId: string): boolean {

--- a/src/providers/codex/runtime/CodexWorkspaceDependencyResolver.ts
+++ b/src/providers/codex/runtime/CodexWorkspaceDependencyResolver.ts
@@ -1,0 +1,353 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import type { CodexRuntimeContext } from './CodexRuntimeContext';
+
+const RUNTIME_DEPENDENCY_ENV_KEYS = [
+  'CODEX_RUNTIME_DEPENDENCIES',
+  'CODEX_WORKSPACE_DEPENDENCIES',
+  'CODEX_DEPENDENCIES',
+] as const;
+
+interface RuntimeManifest {
+  bundleVersion?: unknown;
+  targetPlatform?: unknown;
+}
+
+interface PackageManifest {
+  version?: unknown;
+}
+
+export interface CodexWorkspaceDependencies {
+  bundleVersion: string;
+  artifactToolVersion: string;
+  runtimeRoot: string;
+  dependenciesRoot: string;
+  gitExecutable: string | null;
+  nodeExecutable: string;
+  nodePackages: string;
+  pnpmExecutable: string | null;
+  pythonExecutable: string;
+  pythonPackages: string;
+  overrideBinaries: string;
+  fallbackBinaries: string;
+}
+
+function targetPathApi(context: CodexRuntimeContext): typeof path.posix | typeof path.win32 {
+  return context.launchSpec.target.platformFamily === 'windows' ? path.win32 : path.posix;
+}
+
+function normalizeTargetPath(context: CodexRuntimeContext, value: string): string {
+  const targetPath = targetPathApi(context);
+  return targetPath === path.posix
+    ? targetPath.normalize(value.replace(/\\/g, '/'))
+    : targetPath.normalize(value);
+}
+
+function joinTargetPath(context: CodexRuntimeContext, ...parts: string[]): string {
+  const targetPath = targetPathApi(context);
+  return targetPath === path.posix
+    ? targetPath.join(...parts.map(part => part.replace(/\\/g, '/')))
+    : targetPath.join(...parts);
+}
+
+function readEnvironmentValue(
+  environment: Record<string, string>,
+  key: string,
+): string | undefined {
+  const exact = environment[key]?.trim();
+  if (exact) return exact;
+
+  const matchingKey = Object.keys(environment).find(
+    candidate => candidate.toLowerCase() === key.toLowerCase(),
+  );
+  const value = matchingKey ? environment[matchingKey]?.trim() : undefined;
+  return value || undefined;
+}
+
+function environmentPathToTarget(
+  context: CodexRuntimeContext,
+  value: string,
+): string | null {
+  if (context.launchSpec.target.method !== 'wsl') {
+    return normalizeTargetPath(context, value);
+  }
+
+  if (value.startsWith('/')) {
+    return normalizeTargetPath(context, value);
+  }
+
+  const targetPath = context.launchSpec.pathMapper.toTargetPath(value);
+  return targetPath ? normalizeTargetPath(context, targetPath) : null;
+}
+
+function resolveTargetHome(context: CodexRuntimeContext): string | null {
+  if (context.launchSpec.target.method !== 'wsl') {
+    const homeKey = context.launchSpec.target.platformFamily === 'windows'
+      ? 'USERPROFILE'
+      : 'HOME';
+    const home = readEnvironmentValue(context.launchSpec.env, homeKey);
+    if (home) return normalizeTargetPath(context, home);
+  }
+
+  const codexHome = context.codexHomeTarget;
+  if (!codexHome) return null;
+
+  const targetPath = targetPathApi(context);
+  return targetPath.basename(codexHome).toLowerCase() === '.codex'
+    ? targetPath.dirname(codexHome)
+    : null;
+}
+
+function resolveDependencyCandidates(context: CodexRuntimeContext): Array<{
+  runtimeRoot: string;
+  dependenciesRoot: string;
+}> {
+  const candidates: Array<{ runtimeRoot: string; dependenciesRoot: string }> = [];
+  const seen = new Set<string>();
+  const addCandidate = (dependenciesRoot: string): void => {
+    const normalizedDependencies = normalizeTargetPath(context, dependenciesRoot);
+    if (seen.has(normalizedDependencies)) return;
+    seen.add(normalizedDependencies);
+    candidates.push({
+      runtimeRoot: targetPathApi(context).dirname(normalizedDependencies),
+      dependenciesRoot: normalizedDependencies,
+    });
+  };
+
+  for (const key of RUNTIME_DEPENDENCY_ENV_KEYS) {
+    const configuredPath = readEnvironmentValue(context.launchSpec.env, key);
+    const targetPath = configuredPath
+      ? environmentPathToTarget(context, configuredPath)
+      : null;
+    if (targetPath) addCandidate(targetPath);
+  }
+
+  const targetHome = resolveTargetHome(context);
+  if (targetHome) {
+    addCandidate(joinTargetPath(
+      context,
+      targetHome,
+      '.cache',
+      'codex-runtimes',
+      'codex-primary-runtime',
+      'dependencies',
+    ));
+  }
+
+  return candidates;
+}
+
+function toHostPath(context: CodexRuntimeContext, targetPath: string): string | null {
+  return context.launchSpec.pathMapper.toHostPath(targetPath);
+}
+
+async function isFile(context: CodexRuntimeContext, targetPath: string): Promise<boolean> {
+  const hostPath = toHostPath(context, targetPath);
+  if (!hostPath) return false;
+  try {
+    return (await fs.promises.stat(hostPath)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function isDirectory(context: CodexRuntimeContext, targetPath: string): Promise<boolean> {
+  const hostPath = toHostPath(context, targetPath);
+  if (!hostPath) return false;
+  try {
+    return (await fs.promises.stat(hostPath)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function readJson<T>(
+  context: CodexRuntimeContext,
+  targetPath: string,
+): Promise<T | null> {
+  const hostPath = toHostPath(context, targetPath);
+  if (!hostPath) return null;
+  try {
+    return JSON.parse(await fs.promises.readFile(hostPath, 'utf8')) as T;
+  } catch {
+    return null;
+  }
+}
+
+function expectedManifestPlatform(context: CodexRuntimeContext): string {
+  switch (context.launchSpec.target.platformOs) {
+    case 'macos':
+      return 'darwin';
+    case 'windows':
+      return 'win32';
+    default:
+      return 'linux';
+  }
+}
+
+function executableNames(
+  context: CodexRuntimeContext,
+  name: string,
+): string[] {
+  return context.launchSpec.target.platformFamily === 'windows'
+    ? [`${name}.exe`, `${name}.cmd`, name]
+    : [name];
+}
+
+async function findFile(
+  context: CodexRuntimeContext,
+  directory: string,
+  names: string[],
+): Promise<string | null> {
+  for (const name of names) {
+    const candidate = joinTargetPath(context, directory, name);
+    if (await isFile(context, candidate)) return candidate;
+  }
+  return null;
+}
+
+async function findBundledCommand(
+  context: CodexRuntimeContext,
+  dependenciesRoot: string,
+  name: string,
+): Promise<string | null> {
+  const directories = [
+    joinTargetPath(context, dependenciesRoot, 'bin', 'override'),
+    joinTargetPath(context, dependenciesRoot, 'bin', 'fallback'),
+    joinTargetPath(context, dependenciesRoot, 'bin'),
+  ];
+  const names = executableNames(context, name);
+
+  for (const directory of directories) {
+    const executable = await findFile(context, directory, names);
+    if (executable) return executable;
+  }
+  return null;
+}
+
+async function resolveCandidate(
+  context: CodexRuntimeContext,
+  candidate: { runtimeRoot: string; dependenciesRoot: string },
+): Promise<CodexWorkspaceDependencies | null> {
+  const manifest = await readJson<RuntimeManifest>(
+    context,
+    joinTargetPath(context, candidate.runtimeRoot, 'runtime.json'),
+  );
+  if (
+    !manifest
+    || typeof manifest.bundleVersion !== 'string'
+    || !manifest.bundleVersion.trim()
+    || (
+      typeof manifest.targetPlatform === 'string'
+      && manifest.targetPlatform !== expectedManifestPlatform(context)
+    )
+  ) {
+    return null;
+  }
+
+  const nodeRoot = joinTargetPath(context, candidate.dependenciesRoot, 'node');
+  const nodePackages = joinTargetPath(context, nodeRoot, 'node_modules');
+  const pythonPackages = joinTargetPath(context, candidate.dependenciesRoot, 'python');
+  const overrideBinaries = joinTargetPath(context, candidate.dependenciesRoot, 'bin', 'override');
+  const fallbackBinaries = joinTargetPath(context, candidate.dependenciesRoot, 'bin', 'fallback');
+  const artifactManifestPath = joinTargetPath(
+    context,
+    nodePackages,
+    '@oai',
+    'artifact-tool',
+    'package.json',
+  );
+
+  const nodeExecutable = await findFile(
+    context,
+    joinTargetPath(context, nodeRoot, 'bin'),
+    executableNames(context, 'node'),
+  );
+  const pythonExecutable = await findFile(
+    context,
+    joinTargetPath(context, pythonPackages, 'bin'),
+    context.launchSpec.target.platformFamily === 'windows'
+      ? ['python.exe', 'python3.exe', 'python']
+      : ['python3', 'python'],
+  ) ?? await findFile(
+    context,
+    pythonPackages,
+    context.launchSpec.target.platformFamily === 'windows' ? ['python.exe'] : [],
+  );
+  const artifactManifest = await readJson<PackageManifest>(context, artifactManifestPath);
+  const requiredDirectoriesExist = await Promise.all([
+    isDirectory(context, nodePackages),
+    isDirectory(context, pythonPackages),
+    isDirectory(context, overrideBinaries),
+    isDirectory(context, fallbackBinaries),
+  ]);
+
+  if (
+    !nodeExecutable
+    || !pythonExecutable
+    || requiredDirectoriesExist.some(exists => !exists)
+    || !artifactManifest
+    || typeof artifactManifest.version !== 'string'
+    || !artifactManifest.version.trim()
+  ) {
+    return null;
+  }
+
+  return {
+    bundleVersion: manifest.bundleVersion,
+    artifactToolVersion: artifactManifest.version,
+    runtimeRoot: candidate.runtimeRoot,
+    dependenciesRoot: candidate.dependenciesRoot,
+    gitExecutable: await findBundledCommand(context, candidate.dependenciesRoot, 'git'),
+    nodeExecutable,
+    nodePackages,
+    pnpmExecutable: await findBundledCommand(context, candidate.dependenciesRoot, 'pnpm'),
+    pythonExecutable,
+    pythonPackages,
+    overrideBinaries,
+    fallbackBinaries,
+  };
+}
+
+export async function resolveCodexWorkspaceDependencies(
+  context: CodexRuntimeContext,
+): Promise<CodexWorkspaceDependencies | null> {
+  for (const candidate of resolveDependencyCandidates(context)) {
+    const dependencies = await resolveCandidate(context, candidate);
+    if (dependencies) return dependencies;
+  }
+  return null;
+}
+
+export function formatCodexWorkspaceDependencies(
+  dependencies: CodexWorkspaceDependencies,
+): string {
+  const lines = [
+    'Workspace dependencies are available for this local Claudian Codex thread.',
+    '',
+    '### Workspace Dependencies',
+    'Use these bundled paths for sheets, slides, documents, PDFs, images, or browser automation:',
+    `- Bundle version: \`${dependencies.bundleVersion}\``,
+    `- Artifact tool version: \`${dependencies.artifactToolVersion}\``,
+  ];
+
+  if (dependencies.gitExecutable) {
+    lines.push(`- Git executable: \`${dependencies.gitExecutable}\``);
+  }
+  lines.push(
+    `- Node.js executable: \`${dependencies.nodeExecutable}\``,
+    `- Node.js packages: \`${dependencies.nodePackages}\``,
+  );
+  if (dependencies.pnpmExecutable) {
+    lines.push(`- pnpm executable: \`${dependencies.pnpmExecutable}\``);
+  }
+  lines.push(
+    `- Python executable: \`${dependencies.pythonExecutable}\``,
+    `- Python packages: \`${dependencies.pythonPackages}\``,
+    `- Override binaries: \`${dependencies.overrideBinaries}\``,
+    `- Fallback binaries: \`${dependencies.fallbackBinaries}\``,
+  );
+
+  return lines.join('\n');
+}

--- a/src/providers/codex/runtime/CodexWorkspaceDependencyTool.ts
+++ b/src/providers/codex/runtime/CodexWorkspaceDependencyTool.ts
@@ -1,0 +1,67 @@
+import type { CodexDynamicToolRegistration } from './CodexDynamicToolRegistry';
+import type { CodexRuntimeContext } from './CodexRuntimeContext';
+import {
+  formatCodexWorkspaceDependencies,
+  resolveCodexWorkspaceDependencies,
+} from './CodexWorkspaceDependencyResolver';
+
+export const CODEX_WORKSPACE_DEPENDENCY_TOOL_NAMESPACE = 'codex_app';
+export const CODEX_WORKSPACE_DEPENDENCY_TOOL_NAME = 'load_workspace_dependencies';
+export const CODEX_WORKSPACE_DEPENDENCY_TOOL_VERSION = 1;
+
+export async function createCodexWorkspaceDependencyTool(
+  context: CodexRuntimeContext,
+): Promise<CodexDynamicToolRegistration> {
+  return {
+    includeInThreadStart: await resolveCodexWorkspaceDependencies(context) !== null,
+    namespace: {
+      name: CODEX_WORKSPACE_DEPENDENCY_TOOL_NAMESPACE,
+      description: 'Tools provided by the Claudian Codex host.',
+    },
+    tool: {
+      type: 'function',
+      name: CODEX_WORKSPACE_DEPENDENCY_TOOL_NAME,
+      description: 'Locate the configured bundled workspace dependency runtime paths for this local Claudian Codex thread, including Node.js, Python, and useful libraries for working with spreadsheets, slide decks, Word documents, and PDFs. This is read-only and takes no arguments.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+    },
+    handler: async (params) => {
+      if (
+        params.arguments
+        && typeof params.arguments === 'object'
+        && !Array.isArray(params.arguments)
+        && Object.keys(params.arguments).length > 0
+      ) {
+        return {
+          success: false,
+          contentItems: [{
+            type: 'inputText',
+            text: `${CODEX_WORKSPACE_DEPENDENCY_TOOL_NAME} does not accept arguments.`,
+          }],
+        };
+      }
+
+      const dependencies = await resolveCodexWorkspaceDependencies(context);
+      if (!dependencies) {
+        return {
+          success: false,
+          contentItems: [{
+            type: 'inputText',
+            text: 'The bundled Codex workspace dependency runtime is no longer available. Report this as a blocker and do not guess or install replacement dependencies.',
+          }],
+        };
+      }
+
+      return {
+        success: true,
+        contentItems: [{
+          type: 'inputText',
+          text: formatCodexWorkspaceDependencies(dependencies),
+        }],
+      };
+    },
+  };
+}

--- a/src/providers/codex/runtime/CodexWorkspaceDependencyTool.ts
+++ b/src/providers/codex/runtime/CodexWorkspaceDependencyTool.ts
@@ -9,11 +9,11 @@ export const CODEX_WORKSPACE_DEPENDENCY_TOOL_NAMESPACE = 'codex_app';
 export const CODEX_WORKSPACE_DEPENDENCY_TOOL_NAME = 'load_workspace_dependencies';
 export const CODEX_WORKSPACE_DEPENDENCY_TOOL_VERSION = 1;
 
-export async function createCodexWorkspaceDependencyTool(
+export function createCodexWorkspaceDependencyTool(
   context: CodexRuntimeContext,
-): Promise<CodexDynamicToolRegistration> {
+): CodexDynamicToolRegistration {
   return {
-    includeInThreadStart: await resolveCodexWorkspaceDependencies(context) !== null,
+    includeInThreadStart: true,
     namespace: {
       name: CODEX_WORKSPACE_DEPENDENCY_TOOL_NAMESPACE,
       description: 'Tools provided by the Claudian Codex host.',
@@ -50,7 +50,7 @@ export async function createCodexWorkspaceDependencyTool(
           success: false,
           contentItems: [{
             type: 'inputText',
-            text: 'The bundled Codex workspace dependency runtime is no longer available. Report this as a blocker and do not guess or install replacement dependencies.',
+            text: 'The bundled Codex workspace dependency runtime is unavailable. Report this as a blocker and do not guess or install replacement dependencies.',
           }],
         };
       }

--- a/src/providers/codex/runtime/codexAppServerTypes.ts
+++ b/src/providers/codex/runtime/codexAppServerTypes.ts
@@ -364,7 +364,7 @@ export interface ThreadStartParams {
   experimentalRawEvents?: boolean;
   persistExtendedHistory?: boolean;
   sandboxPolicy?: SandboxPolicy;
-  dynamicTools?: DynamicToolSpec[];
+  dynamicTools?: LegacyDynamicToolSpec[];
 }
 
 export interface DynamicToolFunctionSpec {
@@ -375,14 +375,17 @@ export interface DynamicToolFunctionSpec {
   deferLoading?: boolean;
 }
 
-export interface DynamicToolNamespaceSpec {
-  type: 'namespace';
+/**
+ * Flat dynamic-tool request shape accepted by Codex before explicit namespace
+ * specs and retained as a backwards-compatible input by current app servers.
+ */
+export interface LegacyDynamicToolSpec {
+  namespace?: string | null;
   name: string;
   description: string;
-  tools: DynamicToolFunctionSpec[];
+  inputSchema: unknown;
+  deferLoading?: boolean;
 }
-
-export type DynamicToolSpec = DynamicToolFunctionSpec | DynamicToolNamespaceSpec;
 
 export interface DynamicToolCallParams {
   threadId: string;

--- a/src/providers/codex/runtime/codexAppServerTypes.ts
+++ b/src/providers/codex/runtime/codexAppServerTypes.ts
@@ -1,6 +1,6 @@
 // Local protocol subset for Codex app-server stdio JSON-RPC.
 // Field names match the wire format (camelCase).
-// Validated against the generated codex-cli 0.144.1 schema on 2026-07-10.
+// Validated against the generated codex-cli 0.144.5 schema on 2026-07-16.
 
 // ---------------------------------------------------------------------------
 // JSON-RPC base
@@ -110,6 +110,7 @@ export type ThreadItem =
   | WebSearchItem
   | CollabAgentToolCallItem
   | McpToolCallItem
+  | DynamicToolCallItem
   | ContextCompactionItem;
 
 export interface UserMessageItem {
@@ -220,6 +221,18 @@ export interface McpToolCallItem {
   arguments?: Record<string, unknown>;
   result?: { content?: Array<{ type?: string; text?: string }> } | null;
   error?: string | null;
+  durationMs?: number | null;
+}
+
+export interface DynamicToolCallItem {
+  type: 'dynamicToolCall';
+  id: string;
+  namespace?: string | null;
+  tool: string;
+  arguments: unknown;
+  status: 'inProgress' | 'completed' | 'failed';
+  contentItems?: DynamicToolCallOutputContentItem[] | null;
+  success?: boolean | null;
   durationMs?: number | null;
 }
 
@@ -351,6 +364,42 @@ export interface ThreadStartParams {
   experimentalRawEvents?: boolean;
   persistExtendedHistory?: boolean;
   sandboxPolicy?: SandboxPolicy;
+  dynamicTools?: DynamicToolSpec[];
+}
+
+export interface DynamicToolFunctionSpec {
+  type: 'function';
+  name: string;
+  description: string;
+  inputSchema: unknown;
+  deferLoading?: boolean;
+}
+
+export interface DynamicToolNamespaceSpec {
+  type: 'namespace';
+  name: string;
+  description: string;
+  tools: DynamicToolFunctionSpec[];
+}
+
+export type DynamicToolSpec = DynamicToolFunctionSpec | DynamicToolNamespaceSpec;
+
+export interface DynamicToolCallParams {
+  threadId: string;
+  turnId: string;
+  callId: string;
+  namespace?: string | null;
+  tool: string;
+  arguments: unknown;
+}
+
+export type DynamicToolCallOutputContentItem =
+  | { type: 'inputText'; text: string }
+  | { type: 'inputImage'; imageUrl: string };
+
+export interface DynamicToolCallResponse {
+  success: boolean;
+  contentItems: DynamicToolCallOutputContentItem[];
 }
 
 export interface ThreadStartResult {

--- a/src/providers/codex/types/index.ts
+++ b/src/providers/codex/types/index.ts
@@ -7,6 +7,7 @@ export interface CodexProviderState {
   forkSourceSessionFilePath?: string;
   forkSourceTranscriptRootPath?: string;
   forkSource?: ForkSource;
+  workspaceDependencyToolVersion?: number;
 }
 
 export function getCodexState(

--- a/tests/unit/providers/codex/history/CodexConversationHistoryService.test.ts
+++ b/tests/unit/providers/codex/history/CodexConversationHistoryService.test.ts
@@ -352,6 +352,20 @@ describe('CodexConversationHistoryService', () => {
       });
     });
 
+    it('preserves workspace dependency tool provenance from the source thread', () => {
+      const service = new CodexConversationHistoryService();
+      const result = service.buildForkProviderState(
+        'source-thread-id',
+        'turn-uuid-2',
+        { workspaceDependencyToolVersion: 1 },
+      );
+
+      expect(result).toEqual({
+        forkSource: { sessionId: 'source-thread-id', resumeAt: 'turn-uuid-2' },
+        workspaceDependencyToolVersion: 1,
+      });
+    });
+
     it('derives the source transcript root from sessionFilePath when only the session path is stored', () => {
       const service = new CodexConversationHistoryService();
       const result = service.buildForkProviderState(

--- a/tests/unit/providers/codex/runtime/CodexChatRuntime.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexChatRuntime.test.ts
@@ -638,13 +638,10 @@ describe('CodexChatRuntime', () => {
         await collectChunks(runtime.query(createTurn('create a workbook')));
 
         expect(findCall('thread/start')[1].dynamicTools).toEqual([{
-          type: 'namespace',
-          name: 'codex_app',
+          namespace: 'codex_app',
+          name: 'load_workspace_dependencies',
           description: expect.any(String),
-          tools: [expect.objectContaining({
-            type: 'function',
-            name: 'load_workspace_dependencies',
-          })],
+          inputSchema: expect.any(Object),
         }]);
 
         const response = await emitServerRequest('item/tool/call', 'request-1', {
@@ -672,10 +669,15 @@ describe('CodexChatRuntime', () => {
       }
     });
 
-    it('does not advertise the workspace dependency tool for an incomplete runtime', async () => {
+    it('advertises the workspace dependency tool and returns a blocker for an incomplete runtime', async () => {
       await collectChunks(runtime.query(createTurn('hi')));
 
-      expect(findCall('thread/start')[1].dynamicTools).toBeUndefined();
+      expect(findCall('thread/start')[1].dynamicTools).toEqual([
+        expect.objectContaining({
+          namespace: 'codex_app',
+          name: 'load_workspace_dependencies',
+        }),
+      ]);
       expect(serverRequestHandlers.has('item/tool/call')).toBe(true);
 
       const response = await emitServerRequest('item/tool/call', 'request-missing-runtime', {
@@ -689,9 +691,65 @@ describe('CodexChatRuntime', () => {
       expect(response).toEqual(expect.objectContaining({
         success: false,
         contentItems: [expect.objectContaining({
-          text: expect.stringContaining('no longer available'),
+          text: expect.stringContaining('is unavailable'),
         })],
       }));
+    });
+
+    it('refreshes workspace dependency availability without restarting the app server', async () => {
+      const workspaceRuntime = createTestWorkspaceRuntime();
+      useTestWorkspaceRuntime(workspaceRuntime);
+      const artifactManifest = path.join(
+        workspaceRuntime.dependenciesRoot,
+        'node',
+        'node_modules',
+        '@oai',
+        'artifact-tool',
+        'package.json',
+      );
+      fs.rmSync(artifactManifest);
+      mockTransportRequest.mockImplementation(async (method: string) => {
+        if (method === 'initialize') return workspaceRuntimeInitializeResponse(workspaceRuntime);
+        if (method === 'thread/start') return threadStartResponse('thread-runtime-refresh');
+        if (method === 'turn/start') {
+          setTimeout(() => {
+            emitNotification('turn/completed', {
+              threadId: 'thread-runtime-refresh',
+              turn: { id: 'turn-runtime-refresh', items: [], status: 'completed', error: null },
+            });
+          }, 0);
+          return turnStartResponse('turn-runtime-refresh');
+        }
+        return {};
+      });
+
+      try {
+        await collectChunks(runtime.query(createTurn('create a workbook')));
+
+        const unavailableResponse = await emitServerRequest('item/tool/call', 'request-before-install', {
+          threadId: 'thread-runtime-refresh',
+          turnId: 'turn-runtime-refresh',
+          callId: 'call-before-install',
+          namespace: 'codex_app',
+          tool: 'load_workspace_dependencies',
+          arguments: {},
+        });
+        expect(unavailableResponse).toEqual(expect.objectContaining({ success: false }));
+
+        fs.writeFileSync(artifactManifest, JSON.stringify({ version: 'test-artifact' }));
+
+        const availableResponse = await emitServerRequest('item/tool/call', 'request-after-install', {
+          threadId: 'thread-runtime-refresh',
+          turnId: 'turn-runtime-refresh',
+          callId: 'call-after-install',
+          namespace: 'codex_app',
+          tool: 'load_workspace_dependencies',
+          arguments: {},
+        });
+        expect(availableResponse).toEqual(expect.objectContaining({ success: true }));
+      } finally {
+        fs.rmSync(workspaceRuntime.home, { recursive: true, force: true });
+      }
     });
 
     it('handles host-native initialize responses that omit codexHome', async () => {
@@ -976,7 +1034,7 @@ describe('CodexChatRuntime', () => {
       expect(resumeCall).toBeUndefined();
     });
 
-    it('migrates a legacy thread to a tool-capable thread and replays its history', async () => {
+    it('preserves a legacy thread and surfaces its dynamic-tool limitation', async () => {
       const workspaceRuntime = createTestWorkspaceRuntime();
       useTestWorkspaceRuntime(workspaceRuntime);
       runtime.syncConversationState({
@@ -985,32 +1043,86 @@ describe('CodexChatRuntime', () => {
       });
       mockTransportRequest.mockImplementation(async (method: string) => {
         if (method === 'initialize') return workspaceRuntimeInitializeResponse(workspaceRuntime);
-        if (method === 'thread/start') return threadStartResponse('thread-migrated');
+        if (method === 'thread/resume') return threadStartResponse('thread-legacy');
         if (method === 'turn/start') {
           setTimeout(() => {
             emitNotification('turn/completed', {
-              threadId: 'thread-migrated',
-              turn: { id: 'turn-migrated', items: [], status: 'completed', error: null },
+              threadId: 'thread-legacy',
+              turn: { id: 'turn-legacy-next', items: [], status: 'completed', error: null },
             });
           }, 0);
-          return turnStartResponse('turn-migrated');
+          return turnStartResponse('turn-legacy-next');
         }
         return {};
       });
       const history = [
-        { id: 'u1', role: 'user' as const, content: 'Earlier question', timestamp: 1 },
+        {
+          id: 'u1',
+          role: 'user' as const,
+          content: 'Earlier question with an image',
+          timestamp: 1,
+          images: [{
+            id: 'image-1',
+            name: 'chart.png',
+            mediaType: 'image/png' as const,
+            data: 'aW1hZ2U=',
+            size: 5,
+            source: 'paste' as const,
+          }],
+        },
         { id: 'a1', role: 'assistant' as const, content: 'Earlier answer', timestamp: 2 },
       ];
 
       try {
-        await collectChunks(runtime.query(createTurn('create a workbook'), history));
+        const chunks = await collectChunks(runtime.query(createTurn('create a workbook'), history));
 
-        expect(findCall('thread/resume')).toBeUndefined();
-        expect(findCall('thread/start')[1].dynamicTools).toBeDefined();
-        expect(JSON.stringify(findCall('turn/start')[1].input)).toContain('Earlier question');
-        expect(runtime.getSessionId()).toBe('thread-migrated');
+        expect(findCall('thread/start')).toBeUndefined();
+        expect(findCall('thread/resume')[1]).toEqual(expect.objectContaining({
+          threadId: 'thread-legacy',
+          baseInstructions: expect.stringMatching(/load_workspace_dependencies[\s\S]*new conversation/i),
+        }));
+        expect(JSON.stringify(findCall('turn/start')[1].input)).not.toContain('Earlier question');
+        expect(runtime.getSessionId()).toBe('thread-legacy');
+        expect(chunks).toContainEqual({
+          type: 'notice',
+          level: 'warning',
+          content: expect.stringMatching(/new conversation/i),
+        });
         expect(runtime.buildSessionUpdates({ conversation: null, sessionInvalidated: false }).updates.providerState)
-          .toEqual(expect.objectContaining({ workspaceDependencyToolVersion: 1 }));
+          .not.toEqual(expect.objectContaining({ workspaceDependencyToolVersion: 1 }));
+      } finally {
+        fs.rmSync(workspaceRuntime.home, { recursive: true, force: true });
+      }
+    });
+
+    it('retains a legacy session when turn/start fails', async () => {
+      const workspaceRuntime = createTestWorkspaceRuntime();
+      useTestWorkspaceRuntime(workspaceRuntime);
+      runtime.syncConversationState({
+        sessionId: 'thread-legacy-failure',
+        providerState: {
+          threadId: 'thread-legacy-failure',
+          sessionFilePath: '/tmp/legacy-failure.jsonl',
+        },
+      });
+      mockTransportRequest.mockImplementation(async (method: string) => {
+        if (method === 'initialize') return workspaceRuntimeInitializeResponse(workspaceRuntime);
+        if (method === 'thread/resume') return threadStartResponse('thread-legacy-failure');
+        if (method === 'turn/start') throw new Error('turn rejected');
+        return {};
+      });
+
+      try {
+        const chunks = await collectChunks(runtime.query(createTurn('retry-safe request')));
+
+        expect(chunks).toContainEqual({ type: 'error', content: 'turn rejected' });
+        expect(findCall('thread/start')).toBeUndefined();
+        expect(runtime.getSessionId()).toBe('thread-legacy-failure');
+        expect(runtime.buildSessionUpdates({ conversation: null, sessionInvalidated: false }).updates)
+          .toEqual(expect.objectContaining({
+            sessionId: 'thread-legacy-failure',
+            providerState: expect.not.objectContaining({ workspaceDependencyToolVersion: 1 }),
+          }));
       } finally {
         fs.rmSync(workspaceRuntime.home, { recursive: true, force: true });
       }
@@ -1061,7 +1173,7 @@ describe('CodexChatRuntime', () => {
       expect(toolResponse).toEqual(expect.objectContaining({
         success: false,
         contentItems: [expect.objectContaining({
-          text: expect.stringContaining('no longer available'),
+          text: expect.stringContaining('is unavailable'),
         })],
       }));
     });
@@ -2292,7 +2404,7 @@ describe('CodexChatRuntime', () => {
       expect(runtime.getSessionId()).toBe('fork-thread-1');
     });
 
-    it('migrates a fork from a legacy source to a tool-capable thread', async () => {
+    it('preserves a fork from a legacy source and surfaces its dynamic-tool limitation', async () => {
       const workspaceRuntime = createTestWorkspaceRuntime();
       useTestWorkspaceRuntime(workspaceRuntime);
       runtime.syncConversationState({
@@ -2301,31 +2413,41 @@ describe('CodexChatRuntime', () => {
       });
       mockTransportRequest.mockImplementation(async (method: string) => {
         if (method === 'initialize') return workspaceRuntimeInitializeResponse(workspaceRuntime);
-        if (method === 'thread/start') return threadStartResponse('fork-migrated');
+        if (method === 'thread/fork') {
+          const response = threadStartResponse('fork-legacy');
+          response.thread.turns = [
+            { id: 'turn-legacy', items: [], status: 'completed', error: null },
+          ];
+          return response;
+        }
+        if (method === 'thread/resume') return threadStartResponse('fork-legacy');
         if (method === 'turn/start') {
           setTimeout(() => {
             emitNotification('turn/completed', {
-              threadId: 'fork-migrated',
-              turn: { id: 'turn-fork-migrated', items: [], status: 'completed', error: null },
+              threadId: 'fork-legacy',
+              turn: { id: 'turn-fork-legacy', items: [], status: 'completed', error: null },
             });
           }, 0);
-          return turnStartResponse('turn-fork-migrated');
+          return turnStartResponse('turn-fork-legacy');
         }
         return {};
       });
-      const history = [
-        { id: 'u1', role: 'user' as const, content: 'Source question', timestamp: 1 },
-        { id: 'a1', role: 'assistant' as const, content: 'Source answer', timestamp: 2 },
-      ];
 
       try {
-        await collectChunks(runtime.query(createTurn('forked workbook request'), history));
+        const chunks = await collectChunks(runtime.query(createTurn('forked workbook request')));
 
-        expect(findCall('thread/fork')).toBeUndefined();
-        expect(findCall('thread/resume')).toBeUndefined();
-        expect(findCall('thread/start')[1].dynamicTools).toBeDefined();
-        expect(JSON.stringify(findCall('turn/start')[1].input)).toContain('Source question');
-        expect(runtime.getSessionId()).toBe('fork-migrated');
+        expect(findCall('thread/start')).toBeUndefined();
+        expect(findCall('thread/fork')[1].threadId).toBe('legacy-source');
+        expect(findCall('thread/resume')[1]).toEqual(expect.objectContaining({
+          threadId: 'fork-legacy',
+          baseInstructions: expect.stringMatching(/load_workspace_dependencies[\s\S]*new conversation/i),
+        }));
+        expect(runtime.getSessionId()).toBe('fork-legacy');
+        expect(chunks).toContainEqual({
+          type: 'notice',
+          level: 'warning',
+          content: expect.stringMatching(/new conversation/i),
+        });
       } finally {
         fs.rmSync(workspaceRuntime.home, { recursive: true, force: true });
       }

--- a/tests/unit/providers/codex/runtime/CodexChatRuntime.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexChatRuntime.test.ts
@@ -249,6 +249,81 @@ function createWslLaunchSpec(overrides: Record<string, unknown> = {}) {
   };
 }
 
+interface TestWorkspaceRuntime {
+  home: string;
+  runtimeRoot: string;
+  dependenciesRoot: string;
+}
+
+function createTestWorkspaceRuntime(): TestWorkspaceRuntime {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'claudian-chat-runtime-'));
+  const runtimeRoot = path.join(
+    home,
+    '.cache',
+    'codex-runtimes',
+    'codex-primary-runtime',
+  );
+  const dependenciesRoot = path.join(runtimeRoot, 'dependencies');
+  fs.mkdirSync(path.join(dependenciesRoot, 'node', 'bin'), { recursive: true });
+  fs.mkdirSync(
+    path.join(dependenciesRoot, 'node', 'node_modules', '@oai', 'artifact-tool'),
+    { recursive: true },
+  );
+  fs.mkdirSync(path.join(dependenciesRoot, 'python', 'bin'), { recursive: true });
+  fs.mkdirSync(path.join(dependenciesRoot, 'bin', 'override'), { recursive: true });
+  fs.mkdirSync(path.join(dependenciesRoot, 'bin', 'fallback'), { recursive: true });
+  fs.writeFileSync(path.join(runtimeRoot, 'runtime.json'), JSON.stringify({
+    bundleFormatVersion: 2,
+    bundleVersion: 'test-bundle',
+    targetPlatform: 'darwin',
+  }));
+  fs.writeFileSync(path.join(dependenciesRoot, 'node', 'bin', 'node'), '');
+  fs.writeFileSync(path.join(dependenciesRoot, 'python', 'bin', 'python3'), '');
+  fs.writeFileSync(path.join(dependenciesRoot, 'bin', 'fallback', 'git'), '');
+  fs.writeFileSync(path.join(dependenciesRoot, 'bin', 'fallback', 'pnpm'), '');
+  fs.writeFileSync(
+    path.join(dependenciesRoot, 'node', 'node_modules', '@oai', 'artifact-tool', 'package.json'),
+    JSON.stringify({ version: 'test-artifact' }),
+  );
+
+  return { home, runtimeRoot, dependenciesRoot };
+}
+
+function useTestWorkspaceRuntime(workspaceRuntime: TestWorkspaceRuntime): void {
+  mockResolveLaunchSpec.mockImplementation((plugin: any) => ({
+    target: {
+      method: 'host-native',
+      platformFamily: 'unix',
+      platformOs: 'macos',
+    },
+    command: plugin.getResolvedProviderCliPath('codex') ?? 'codex',
+    args: ['app-server', '--listen', 'stdio://'],
+    spawnCwd: '/test/vault',
+    targetCwd: '/test/vault',
+    env: { HOME: workspaceRuntime.home },
+    pathMapper: {
+      target: {
+        method: 'host-native',
+        platformFamily: 'unix',
+        platformOs: 'macos',
+      },
+      toTargetPath: (value: string) => value,
+      toHostPath: (value: string) => value,
+      mapTargetPathList: (values: string[]) => values,
+      canRepresentHostPath: () => true,
+    },
+  }));
+}
+
+function workspaceRuntimeInitializeResponse(workspaceRuntime: TestWorkspaceRuntime) {
+  return {
+    userAgent: 'test/0.1',
+    codexHome: path.join(workspaceRuntime.home, '.codex'),
+    platformFamily: 'unix',
+    platformOs: 'macos',
+  };
+}
+
 async function collectChunks(gen: AsyncGenerator<StreamChunk>): Promise<StreamChunk[]> {
   const chunks: StreamChunk[] = [];
   for await (const chunk of gen) {
@@ -539,6 +614,86 @@ describe('CodexChatRuntime', () => {
       expect(chunks).toContainEqual({ type: 'done' });
     });
 
+    it('registers the workspace dependency tool when the bundled runtime is available', async () => {
+      const workspaceRuntime = createTestWorkspaceRuntime();
+      useTestWorkspaceRuntime(workspaceRuntime);
+      mockTransportRequest.mockImplementation(async (method: string) => {
+        if (method === 'initialize') {
+          return workspaceRuntimeInitializeResponse(workspaceRuntime);
+        }
+        if (method === 'thread/start') return threadStartResponse('thread-dynamic-tool');
+        if (method === 'turn/start') {
+          setTimeout(() => {
+            emitNotification('turn/completed', {
+              threadId: 'thread-dynamic-tool',
+              turn: { id: 'turn-dynamic-tool', items: [], status: 'completed', error: null },
+            });
+          }, 0);
+          return turnStartResponse('turn-dynamic-tool');
+        }
+        return {};
+      });
+
+      try {
+        await collectChunks(runtime.query(createTurn('create a workbook')));
+
+        expect(findCall('thread/start')[1].dynamicTools).toEqual([{
+          type: 'namespace',
+          name: 'codex_app',
+          description: expect.any(String),
+          tools: [expect.objectContaining({
+            type: 'function',
+            name: 'load_workspace_dependencies',
+          })],
+        }]);
+
+        const response = await emitServerRequest('item/tool/call', 'request-1', {
+          threadId: 'thread-dynamic-tool',
+          turnId: 'turn-dynamic-tool',
+          callId: 'call-1',
+          namespace: 'codex_app',
+          tool: 'load_workspace_dependencies',
+          arguments: {},
+        });
+        expect(response).toEqual(expect.objectContaining({
+          success: true,
+          contentItems: [expect.objectContaining({
+            type: 'inputText',
+            text: expect.stringContaining(path.join(workspaceRuntime.dependenciesRoot, 'node', 'node_modules')),
+          })],
+        }));
+
+        const updates = runtime.buildSessionUpdates({ conversation: null, sessionInvalidated: false });
+        expect(updates.updates.providerState).toEqual(expect.objectContaining({
+          workspaceDependencyToolVersion: 1,
+        }));
+      } finally {
+        fs.rmSync(workspaceRuntime.home, { recursive: true, force: true });
+      }
+    });
+
+    it('does not advertise the workspace dependency tool for an incomplete runtime', async () => {
+      await collectChunks(runtime.query(createTurn('hi')));
+
+      expect(findCall('thread/start')[1].dynamicTools).toBeUndefined();
+      expect(serverRequestHandlers.has('item/tool/call')).toBe(true);
+
+      const response = await emitServerRequest('item/tool/call', 'request-missing-runtime', {
+        threadId: 'thread-001',
+        turnId: 'turn-001',
+        callId: 'call-missing-runtime',
+        namespace: 'codex_app',
+        tool: 'load_workspace_dependencies',
+        arguments: {},
+      });
+      expect(response).toEqual(expect.objectContaining({
+        success: false,
+        contentItems: [expect.objectContaining({
+          text: expect.stringContaining('no longer available'),
+        })],
+      }));
+    });
+
     it('handles host-native initialize responses that omit codexHome', async () => {
       mockTransportRequest.mockImplementation(async (method: string) => {
         switch (method) {
@@ -819,6 +974,96 @@ describe('CodexChatRuntime', () => {
       const resumeCall = findCall('thread/resume');
       expect(startCall).toBeUndefined();
       expect(resumeCall).toBeUndefined();
+    });
+
+    it('migrates a legacy thread to a tool-capable thread and replays its history', async () => {
+      const workspaceRuntime = createTestWorkspaceRuntime();
+      useTestWorkspaceRuntime(workspaceRuntime);
+      runtime.syncConversationState({
+        sessionId: 'thread-legacy',
+        providerState: { threadId: 'thread-legacy', sessionFilePath: '/tmp/legacy.jsonl' },
+      });
+      mockTransportRequest.mockImplementation(async (method: string) => {
+        if (method === 'initialize') return workspaceRuntimeInitializeResponse(workspaceRuntime);
+        if (method === 'thread/start') return threadStartResponse('thread-migrated');
+        if (method === 'turn/start') {
+          setTimeout(() => {
+            emitNotification('turn/completed', {
+              threadId: 'thread-migrated',
+              turn: { id: 'turn-migrated', items: [], status: 'completed', error: null },
+            });
+          }, 0);
+          return turnStartResponse('turn-migrated');
+        }
+        return {};
+      });
+      const history = [
+        { id: 'u1', role: 'user' as const, content: 'Earlier question', timestamp: 1 },
+        { id: 'a1', role: 'assistant' as const, content: 'Earlier answer', timestamp: 2 },
+      ];
+
+      try {
+        await collectChunks(runtime.query(createTurn('create a workbook'), history));
+
+        expect(findCall('thread/resume')).toBeUndefined();
+        expect(findCall('thread/start')[1].dynamicTools).toBeDefined();
+        expect(JSON.stringify(findCall('turn/start')[1].input)).toContain('Earlier question');
+        expect(runtime.getSessionId()).toBe('thread-migrated');
+        expect(runtime.buildSessionUpdates({ conversation: null, sessionInvalidated: false }).updates.providerState)
+          .toEqual(expect.objectContaining({ workspaceDependencyToolVersion: 1 }));
+      } finally {
+        fs.rmSync(workspaceRuntime.home, { recursive: true, force: true });
+      }
+    });
+
+    it('keeps a persisted dynamic-tool handler on resume when the runtime is missing', async () => {
+      runtime.syncConversationState({
+        sessionId: 'thread-tool-capable',
+        providerState: {
+          threadId: 'thread-tool-capable',
+          workspaceDependencyToolVersion: 1,
+        },
+      });
+      let toolResponse: unknown;
+      let toolError: unknown;
+      mockTransportRequest.mockImplementation(async (method: string) => {
+        if (method === 'initialize') {
+          return { userAgent: 'test/0.1', codexHome: '/tmp', platformFamily: 'unix', platformOs: 'macos' };
+        }
+        if (method === 'thread/resume') return threadStartResponse('thread-tool-capable');
+        if (method === 'turn/start') {
+          setTimeout(() => {
+            void emitServerRequest('item/tool/call', 'request-resumed-tool', {
+              threadId: 'thread-tool-capable',
+              turnId: 'turn-resumed-tool',
+              callId: 'call-resumed-tool',
+              namespace: 'codex_app',
+              tool: 'load_workspace_dependencies',
+              arguments: {},
+            }).then(
+              response => { toolResponse = response; },
+              error => { toolError = error; },
+            ).finally(() => {
+              emitNotification('turn/completed', {
+                threadId: 'thread-tool-capable',
+                turn: { id: 'turn-resumed-tool', items: [], status: 'completed', error: null },
+              });
+            });
+          }, 0);
+          return turnStartResponse('turn-resumed-tool');
+        }
+        return {};
+      });
+
+      await collectChunks(runtime.query(createTurn('create a workbook')));
+
+      expect(toolError).toBeUndefined();
+      expect(toolResponse).toEqual(expect.objectContaining({
+        success: false,
+        contentItems: [expect.objectContaining({
+          text: expect.stringContaining('no longer available'),
+        })],
+      }));
     });
   });
 
@@ -2045,6 +2290,45 @@ describe('CodexChatRuntime', () => {
 
       // After fork, session should be the fork thread
       expect(runtime.getSessionId()).toBe('fork-thread-1');
+    });
+
+    it('migrates a fork from a legacy source to a tool-capable thread', async () => {
+      const workspaceRuntime = createTestWorkspaceRuntime();
+      useTestWorkspaceRuntime(workspaceRuntime);
+      runtime.syncConversationState({
+        sessionId: null,
+        providerState: { forkSource: { sessionId: 'legacy-source', resumeAt: 'turn-legacy' } },
+      });
+      mockTransportRequest.mockImplementation(async (method: string) => {
+        if (method === 'initialize') return workspaceRuntimeInitializeResponse(workspaceRuntime);
+        if (method === 'thread/start') return threadStartResponse('fork-migrated');
+        if (method === 'turn/start') {
+          setTimeout(() => {
+            emitNotification('turn/completed', {
+              threadId: 'fork-migrated',
+              turn: { id: 'turn-fork-migrated', items: [], status: 'completed', error: null },
+            });
+          }, 0);
+          return turnStartResponse('turn-fork-migrated');
+        }
+        return {};
+      });
+      const history = [
+        { id: 'u1', role: 'user' as const, content: 'Source question', timestamp: 1 },
+        { id: 'a1', role: 'assistant' as const, content: 'Source answer', timestamp: 2 },
+      ];
+
+      try {
+        await collectChunks(runtime.query(createTurn('forked workbook request'), history));
+
+        expect(findCall('thread/fork')).toBeUndefined();
+        expect(findCall('thread/resume')).toBeUndefined();
+        expect(findCall('thread/start')[1].dynamicTools).toBeDefined();
+        expect(JSON.stringify(findCall('turn/start')[1].input)).toContain('Source question');
+        expect(runtime.getSessionId()).toBe('fork-migrated');
+      } finally {
+        fs.rmSync(workspaceRuntime.home, { recursive: true, force: true });
+      }
     });
 
     it('skips rollback when resumeAt is the last turn', async () => {

--- a/tests/unit/providers/codex/runtime/CodexNotificationRouter.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexNotificationRouter.test.ts
@@ -1189,6 +1189,108 @@ describe('CodexNotificationRouter', () => {
     });
   });
 
+  describe('dynamicToolCall', () => {
+    it('maps canonical dynamic tool lifecycle events to tool chunks', () => {
+      router.handleNotification('item/started', {
+        item: {
+          type: 'dynamicToolCall',
+          id: 'call_dynamic1',
+          namespace: 'codex_app',
+          tool: 'load_workspace_dependencies',
+          arguments: {},
+          status: 'inProgress',
+          contentItems: null,
+          success: null,
+          durationMs: null,
+        },
+        threadId: 't1',
+        turnId: 'turn1',
+      });
+      router.handleNotification('item/completed', {
+        item: {
+          type: 'dynamicToolCall',
+          id: 'call_dynamic1',
+          namespace: 'codex_app',
+          tool: 'load_workspace_dependencies',
+          arguments: {},
+          status: 'completed',
+          contentItems: [{ type: 'inputText', text: 'Workspace dependencies are available.' }],
+          success: true,
+          durationMs: 12,
+        },
+        threadId: 't1',
+        turnId: 'turn1',
+      });
+
+      expect(chunks).toEqual([
+        {
+          type: 'tool_use',
+          id: 'call_dynamic1',
+          name: 'load_workspace_dependencies',
+          input: {},
+        },
+        {
+          type: 'tool_result',
+          id: 'call_dynamic1',
+          content: 'Workspace dependencies are available.',
+          isError: false,
+        },
+      ]);
+    });
+
+    it('does not duplicate dynamic tool chunks also emitted as raw items', () => {
+      router.handleNotification('item/started', {
+        item: {
+          type: 'dynamicToolCall',
+          id: 'call_dynamic2',
+          namespace: 'codex_app',
+          tool: 'load_workspace_dependencies',
+          arguments: {},
+          status: 'inProgress',
+        },
+        threadId: 't1',
+        turnId: 'turn1',
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        item: {
+          type: 'custom_tool_call',
+          name: 'load_workspace_dependencies',
+          call_id: 'call_dynamic2',
+          input: '{}',
+        },
+        threadId: 't1',
+        turnId: 'turn1',
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_dynamic2',
+          output: 'Workspace dependencies are available.',
+        },
+        threadId: 't1',
+        turnId: 'turn1',
+      });
+      router.handleNotification('item/completed', {
+        item: {
+          type: 'dynamicToolCall',
+          id: 'call_dynamic2',
+          namespace: 'codex_app',
+          tool: 'load_workspace_dependencies',
+          arguments: {},
+          status: 'completed',
+          contentItems: [{ type: 'inputText', text: 'Workspace dependencies are available.' }],
+          success: true,
+          durationMs: 12,
+        },
+        threadId: 't1',
+        turnId: 'turn1',
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_use')).toHaveLength(1);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(1);
+    });
+  });
+
   describe('plan_completed emission', () => {
     it('records plan completion metadata before done on successful plan turn with plan deltas', () => {
       router.beginTurn({ isPlanTurn: true });

--- a/tests/unit/providers/codex/runtime/CodexServerRequestRouter.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexServerRequestRouter.test.ts
@@ -1,4 +1,5 @@
 import type { ApprovalCallback, AskUserQuestionCallback } from '@/core/runtime/types';
+import { CodexDynamicToolRegistry } from '@/providers/codex/runtime/CodexDynamicToolRegistry';
 import { CodexServerRequestRouter } from '@/providers/codex/runtime/CodexServerRequestRouter';
 
 describe('CodexServerRequestRouter', () => {
@@ -520,6 +521,64 @@ describe('CodexServerRequestRouter', () => {
       deferred.resolve!(null);
       const result = await resultPromise;
       expect(result).toEqual({ answers: {} });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Dynamic tools
+  // -----------------------------------------------------------------------
+
+  describe('dynamic tools', () => {
+    it('routes registered dynamic tool calls and returns app-server content items', async () => {
+      const registry = new CodexDynamicToolRegistry();
+      const handler = jest.fn().mockResolvedValue({
+        success: true,
+        contentItems: [{ type: 'inputText', text: 'workspace paths' }],
+      });
+      registry.register({
+        includeInThreadStart: true,
+        namespace: {
+          name: 'codex_app',
+          description: 'Codex host tools',
+        },
+        tool: {
+          type: 'function',
+          name: 'load_workspace_dependencies',
+          description: 'Load workspace dependencies',
+          inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+        },
+        handler,
+      });
+      router.setDynamicToolRegistry(registry);
+
+      const params = {
+        threadId: 't1',
+        turnId: 'turn1',
+        callId: 'call1',
+        namespace: 'codex_app',
+        tool: 'load_workspace_dependencies',
+        arguments: {},
+      };
+      const result = await router.handleServerRequest('item/tool/call', params);
+
+      expect(handler).toHaveBeenCalledWith(params);
+      expect(result).toEqual({
+        success: true,
+        contentItems: [{ type: 'inputText', text: 'workspace paths' }],
+      });
+    });
+
+    it('rejects dynamic tool calls that were not registered', async () => {
+      router.setDynamicToolRegistry(new CodexDynamicToolRegistry());
+
+      await expect(router.handleServerRequest('item/tool/call', {
+        threadId: 't1',
+        turnId: 'turn1',
+        callId: 'call1',
+        namespace: 'codex_app',
+        tool: 'unknown',
+        arguments: {},
+      })).rejects.toThrow('Unsupported dynamic tool');
     });
   });
 

--- a/tests/unit/providers/codex/runtime/CodexServerRequestRouter.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexServerRequestRouter.test.ts
@@ -551,6 +551,13 @@ describe('CodexServerRequestRouter', () => {
       });
       router.setDynamicToolRegistry(registry);
 
+      expect(registry.getThreadStartSpecs()).toEqual([{
+        namespace: 'codex_app',
+        name: 'load_workspace_dependencies',
+        description: 'Load workspace dependencies',
+        inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+      }]);
+
       const params = {
         threadId: 't1',
         turnId: 'turn1',

--- a/tests/unit/providers/codex/runtime/CodexWorkspaceDependencyResolver.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexWorkspaceDependencyResolver.test.ts
@@ -1,0 +1,185 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import type { CodexRuntimeContext } from '@/providers/codex/runtime/CodexRuntimeContext';
+import {
+  formatCodexWorkspaceDependencies,
+  resolveCodexWorkspaceDependencies,
+} from '@/providers/codex/runtime/CodexWorkspaceDependencyResolver';
+
+function createRuntimeBundle(home: string): string {
+  const runtimeRoot = path.join(
+    home,
+    '.cache',
+    'codex-runtimes',
+    'codex-primary-runtime',
+  );
+  const dependenciesRoot = path.join(runtimeRoot, 'dependencies');
+
+  fs.mkdirSync(path.join(dependenciesRoot, 'node', 'bin'), { recursive: true });
+  fs.mkdirSync(
+    path.join(dependenciesRoot, 'node', 'node_modules', '@oai', 'artifact-tool'),
+    { recursive: true },
+  );
+  fs.mkdirSync(path.join(dependenciesRoot, 'python', 'bin'), { recursive: true });
+  fs.mkdirSync(path.join(dependenciesRoot, 'bin', 'override'), { recursive: true });
+  fs.mkdirSync(path.join(dependenciesRoot, 'bin', 'fallback'), { recursive: true });
+
+  fs.writeFileSync(path.join(runtimeRoot, 'runtime.json'), JSON.stringify({
+    bundleFormatVersion: 2,
+    bundleVersion: '26.715.12143',
+    targetPlatform: 'darwin',
+  }));
+  fs.writeFileSync(path.join(dependenciesRoot, 'node', 'bin', 'node'), '');
+  fs.writeFileSync(path.join(dependenciesRoot, 'python', 'bin', 'python3'), '');
+  fs.writeFileSync(path.join(dependenciesRoot, 'bin', 'fallback', 'git'), '');
+  fs.writeFileSync(path.join(dependenciesRoot, 'bin', 'fallback', 'pnpm'), '');
+  fs.writeFileSync(
+    path.join(dependenciesRoot, 'node', 'node_modules', '@oai', 'artifact-tool', 'package.json'),
+    JSON.stringify({ version: '2.8.24' }),
+  );
+
+  return runtimeRoot;
+}
+
+function createHostRuntimeContext(
+  home: string,
+  env: Record<string, string> = { HOME: home },
+): CodexRuntimeContext {
+  const target = {
+    method: 'host-native' as const,
+    platformFamily: 'unix' as const,
+    platformOs: 'macos' as const,
+  };
+
+  return {
+    launchSpec: {
+      target,
+      command: 'codex',
+      args: [],
+      spawnCwd: '/vault',
+      targetCwd: '/vault',
+      env,
+      pathMapper: {
+        target,
+        toTargetPath: value => value,
+        toHostPath: value => value,
+        mapTargetPathList: values => values,
+        canRepresentHostPath: () => true,
+      },
+    },
+    initializeResult: {
+      userAgent: 'test',
+      codexHome: path.join(home, '.codex'),
+      platformFamily: 'unix',
+      platformOs: 'macos',
+    },
+    codexHomeTarget: path.join(home, '.codex'),
+    codexHomeHost: path.join(home, '.codex'),
+    sessionsDirTarget: path.join(home, '.codex', 'sessions'),
+    sessionsDirHost: path.join(home, '.codex', 'sessions'),
+    memoriesDirTarget: path.join(home, '.codex', 'memories'),
+  };
+}
+
+describe('CodexWorkspaceDependencyResolver', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claudian-codex-runtime-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('resolves and describes the validated primary runtime bundle', async () => {
+    const runtimeRoot = createRuntimeBundle(tempDir);
+
+    const result = await resolveCodexWorkspaceDependencies(
+      createHostRuntimeContext(tempDir),
+    );
+
+    expect(result).toEqual(expect.objectContaining({
+      bundleVersion: '26.715.12143',
+      artifactToolVersion: '2.8.24',
+      runtimeRoot,
+      nodeExecutable: path.join(runtimeRoot, 'dependencies', 'node', 'bin', 'node'),
+      nodePackages: path.join(runtimeRoot, 'dependencies', 'node', 'node_modules'),
+      pythonExecutable: path.join(runtimeRoot, 'dependencies', 'python', 'bin', 'python3'),
+      pythonPackages: path.join(runtimeRoot, 'dependencies', 'python'),
+      gitExecutable: path.join(runtimeRoot, 'dependencies', 'bin', 'fallback', 'git'),
+      pnpmExecutable: path.join(runtimeRoot, 'dependencies', 'bin', 'fallback', 'pnpm'),
+    }));
+
+    expect(formatCodexWorkspaceDependencies(result!)).toContain(
+      `- Node.js packages: \`${path.join(runtimeRoot, 'dependencies', 'node', 'node_modules')}\``,
+    );
+  });
+
+  it('prefers an explicitly configured dependency root', async () => {
+    const defaultHome = path.join(tempDir, 'default-home');
+    const explicitHome = path.join(tempDir, 'explicit-home');
+    createRuntimeBundle(defaultHome);
+    const explicitRuntimeRoot = createRuntimeBundle(explicitHome);
+    const explicitDependencies = path.join(explicitRuntimeRoot, 'dependencies');
+
+    const result = await resolveCodexWorkspaceDependencies(createHostRuntimeContext(
+      defaultHome,
+      {
+        HOME: defaultHome,
+        CODEX_RUNTIME_DEPENDENCIES: explicitDependencies,
+      },
+    ));
+
+    expect(result?.runtimeRoot).toBe(explicitRuntimeRoot);
+  });
+
+  it('does not expose a partial bundle without artifact-tool', async () => {
+    const runtimeRoot = createRuntimeBundle(tempDir);
+    fs.rmSync(
+      path.join(runtimeRoot, 'dependencies', 'node', 'node_modules', '@oai', 'artifact-tool'),
+      { recursive: true },
+    );
+
+    await expect(resolveCodexWorkspaceDependencies(
+      createHostRuntimeContext(tempDir),
+    )).resolves.toBeNull();
+  });
+
+  it('returns target paths while validating mapped host paths for WSL', async () => {
+    const runtimeRoot = createRuntimeBundle(tempDir);
+    const targetHome = '/home/tester';
+    const targetRuntimeRoot = `${targetHome}/.cache/codex-runtimes/codex-primary-runtime`;
+    const context = createHostRuntimeContext(tempDir) as CodexRuntimeContext;
+    context.launchSpec.target = {
+      method: 'wsl',
+      platformFamily: 'unix',
+      platformOs: 'linux',
+      distroName: 'Ubuntu',
+    };
+    context.launchSpec.pathMapper.target = context.launchSpec.target;
+    context.launchSpec.pathMapper.toHostPath = value => value.replace(targetRuntimeRoot, runtimeRoot);
+    context.launchSpec.pathMapper.toTargetPath = value => value.replace(runtimeRoot, targetRuntimeRoot);
+    context.launchSpec.env = {};
+    context.initializeResult = {
+      userAgent: 'test',
+      codexHome: `${targetHome}/.codex`,
+      platformFamily: 'unix',
+      platformOs: 'linux',
+    };
+    context.codexHomeTarget = `${targetHome}/.codex`;
+    context.codexHomeHost = path.join(tempDir, '.codex');
+    fs.writeFileSync(path.join(runtimeRoot, 'runtime.json'), JSON.stringify({
+      bundleFormatVersion: 2,
+      bundleVersion: '26.715.12143',
+      targetPlatform: 'linux',
+    }));
+
+    const result = await resolveCodexWorkspaceDependencies(context);
+
+    expect(result?.runtimeRoot).toBe(targetRuntimeRoot);
+    expect(result?.nodePackages).toBe(`${targetRuntimeRoot}/dependencies/node/node_modules`);
+  });
+});


### PR DESCRIPTION
Fixes #940.

Registers a client-hosted `load_workspace_dependencies` dynamic tool using the backwards-compatible flat app-server schema and validates bundled Node.js, Python, and `@oai/artifact-tool` paths across native and WSL targets, resolving availability on every call. Persists tool-capability provenance, warns legacy resumed or forked conversations without replacing their provider-native context, and returns an explicit blocker when the runtime is unavailable. Normalizes canonical dynamic-tool lifecycle events and adds regression coverage; typecheck, lint, 6,078 tests, build, and `git diff --check` pass.