### PR TITLE
Expose XHigh effort for custom Claude models

### DIFF
--- a/src/providers/claude/types/models.ts
+++ b/src/providers/claude/types/models.ts
@@ -105,8 +105,9 @@ export function isDefaultClaudeModel(model: string): boolean {
 }
 
 /**
- * Whether the model supports the `xhigh` effort level. Supported on Opus 4.7+,
- * Sonnet 5+, and Fable — the SDK silently falls back to `high` on other models.
+ * Whether the model supports the `xhigh` effort level. Known Claude models use
+ * their versioned capability boundary. Opaque custom models are assumed to
+ * support it because their gateway capabilities cannot be inferred locally.
  */
 export function supportsXHighEffort(model: string): boolean {
   const normalized = normalizeModelId(model);
@@ -117,7 +118,7 @@ export function supportsXHighEffort(model: string): boolean {
 
   const versionedModel = parseVersionedClaudeModel(normalized);
   if (!versionedModel) {
-    return false;
+    return true;
   }
   const definition = getClaudeModelTierDefinition(versionedModel.tier);
   return isVersionAtLeast(

--- a/tests/unit/providers/claude/types/types.test.ts
+++ b/tests/unit/providers/claude/types/types.test.ts
@@ -698,6 +698,11 @@ describe('types.ts', () => {
   });
 
   describe('supportsXHighEffort', () => {
+    it('returns true for opaque custom model ids', () => {
+      expect(supportsXHighEffort('custom-model')).toBe(true);
+      expect(supportsXHighEffort('gateway/gpt-4.2')).toBe(true);
+    });
+
     it('returns true for opus aliases and 4.7+ opus ids', () => {
       expect(supportsXHighEffort('opus')).toBe(true);
       expect(supportsXHighEffort('opus[1m]')).toBe(true);
@@ -732,6 +737,7 @@ describe('types.ts', () => {
     it('preserves supported effort levels', () => {
       expect(normalizeEffortLevel('claude-opus-4-7', 'xhigh')).toBe('xhigh');
       expect(normalizeEffortLevel('claude-sonnet-4-5', 'max')).toBe('max');
+      expect(normalizeEffortLevel('custom-model', 'xhigh')).toBe('xhigh');
     });
 
     it('clamps unsupported xhigh values to the model default', () => {

--- a/tests/unit/providers/claude/ui/ClaudeChatUIConfig.test.ts
+++ b/tests/unit/providers/claude/ui/ClaudeChatUIConfig.test.ts
@@ -172,7 +172,13 @@ describe('claudeChatUIConfig', () => {
     it('uses effort options for custom model ids', () => {
       const options = claudeChatUIConfig.getReasoningOptions('custom-model', {});
 
-      expect(options.map(option => option.value)).toEqual(['low', 'medium', 'high', 'max']);
+      expect(options.map(option => option.value)).toEqual([
+        'low',
+        'medium',
+        'high',
+        'xhigh',
+        'max',
+      ]);
       expect(options.some(option => option.tokens !== undefined)).toBe(false);
     });
   });


### PR DESCRIPTION
## Summary

- Treat opaque custom Claude model IDs as supporting XHigh effort while retaining version-based capability checks for known Claude models.
- Expose XHigh in the effort selector and preserve the selection during normalization.
- Add unit coverage for custom model capabilities, normalization, and selector options.

## Testing

- npm run typecheck && npm run lint && npm run test && npm run build