### PR TITLE
fix: unify reasoning selector labels

### DIFF
--- a/src/core/providers/reasoning.ts
+++ b/src/core/providers/reasoning.ts
@@ -1,5 +1,18 @@
 export const DEFAULT_REASONING_VALUE = 'high';
 
+export function formatReasoningValueLabel(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  if (trimmed.toLowerCase() === 'xhigh') {
+    return 'xHigh';
+  }
+
+  return trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
+}
+
 export function resolvePreferredReasoningDefault(
   availableValues: readonly string[],
   fallbackValue: string,

--- a/src/providers/claude/types/models.ts
+++ b/src/providers/claude/types/models.ts
@@ -2,7 +2,10 @@
  * Model type definitions and constants.
  */
 
-import { DEFAULT_REASONING_VALUE } from '../../../core/providers/reasoning';
+import {
+  DEFAULT_REASONING_VALUE,
+  formatReasoningValueLabel,
+} from '../../../core/providers/reasoning';
 import { toClaudeRuntimeModelId } from '../modelSelection';
 import {
   CLAUDE_MODEL_TIER_DEFINITIONS,
@@ -26,13 +29,13 @@ export const DEFAULT_CLAUDE_MODELS: { value: ClaudeModel; label: string; descrip
 /** Effort levels for adaptive thinking models. */
 export type EffortLevel = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 
-export const EFFORT_LEVELS: { value: EffortLevel; label: string }[] = [
-  { value: 'low', label: 'Low' },
-  { value: 'medium', label: 'Med' },
-  { value: 'high', label: 'High' },
-  { value: 'xhigh', label: 'XHigh' },
-  { value: 'max', label: 'Max' },
-];
+const EFFORT_LEVEL_VALUES: EffortLevel[] = ['low', 'medium', 'high', 'xhigh', 'max'];
+
+export const EFFORT_LEVELS: { value: EffortLevel; label: string }[] =
+  EFFORT_LEVEL_VALUES.map(value => ({
+    value,
+    label: formatReasoningValueLabel(value),
+  }));
 
 /** Default effort level per model tier. */
 export const DEFAULT_EFFORT_LEVEL: Record<string, EffortLevel> = Object.fromEntries(

--- a/src/providers/codex/ui/CodexChatUIConfig.ts
+++ b/src/providers/codex/ui/CodexChatUIConfig.ts
@@ -1,4 +1,7 @@
-import { DEFAULT_REASONING_VALUE } from '../../../core/providers/reasoning';
+import {
+  DEFAULT_REASONING_VALUE,
+  formatReasoningValueLabel,
+} from '../../../core/providers/reasoning';
 import type {
   ProviderChatUIConfig,
   ProviderPermissionModeToggleConfig,
@@ -26,19 +29,12 @@ import {
 } from '../settings';
 
 const EFFORT_LEVELS: ProviderReasoningOption[] = [
-  { value: 'low', label: 'Low' },
-  { value: 'medium', label: 'Medium' },
-  { value: 'high', label: 'High' },
-  { value: 'xhigh', label: 'XHigh' },
-  { value: 'max', label: 'Max' },
-];
-
-function formatEffortLabel(value: string): string {
-  if (value.toLowerCase() === 'xhigh') {
-    return 'XHigh';
-  }
-  return value.charAt(0).toUpperCase() + value.slice(1);
-}
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+].map(value => ({ value, label: formatReasoningValueLabel(value) }));
 
 const CODEX_PERMISSION_MODE_TOGGLE: ProviderPermissionModeToggleConfig = {
   inactiveValue: 'normal',
@@ -102,7 +98,7 @@ export const codexChatUIConfig: ProviderChatUIConfig = {
 
     return model.supportedReasoningEfforts.map(option => ({
       value: option.value,
-      label: formatEffortLabel(option.value),
+      label: formatReasoningValueLabel(option.value),
       ...(option.description ? { description: option.description } : {}),
     }));
   },

--- a/src/providers/opencode/models.ts
+++ b/src/providers/opencode/models.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_REASONING_VALUE,
+  formatReasoningValueLabel,
   resolvePreferredReasoningDefault,
 } from '../../core/providers/reasoning';
 
@@ -141,7 +142,7 @@ export function normalizeOpencodeModelVariants(value: unknown): OpencodeModelVar
 
     variants.push({
       ...(description ? { description } : {}),
-      label: rawLabel || formatOpencodeThinkingLevelLabel(rawValue),
+      label: rawLabel || formatReasoningValueLabel(rawValue),
       value: rawValue,
     });
   }
@@ -291,7 +292,7 @@ export function buildOpencodeBaseModels(
 
         return [{
           ...(entry.description ? { description: entry.description } : {}),
-          label: formatOpencodeThinkingLevelLabel(variant),
+          label: formatReasoningValueLabel(variant),
           value: variant,
         }];
       });
@@ -313,19 +314,6 @@ export function getOpencodeModelVariants(
   const baseRawId = resolveOpencodeBaseModelRawId(rawId, models);
   return buildOpencodeBaseModels(models)
     .find((model) => model.rawId === baseRawId)?.variants ?? [];
-}
-
-function formatOpencodeThinkingLevelLabel(value: string): string {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return '';
-  }
-
-  if (trimmed.toLowerCase() === 'xhigh') {
-    return 'XHigh';
-  }
-
-  return trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
 }
 
 export function groupOpencodeDiscoveredModels(

--- a/src/providers/pi/ui/PiChatUIConfig.ts
+++ b/src/providers/pi/ui/PiChatUIConfig.ts
@@ -1,3 +1,4 @@
+import { formatReasoningValueLabel } from '../../../core/providers/reasoning';
 import type {
   ProviderChatUIConfig,
   ProviderPermissionModeToggleConfig,
@@ -107,7 +108,7 @@ export const piChatUIConfig: ProviderChatUIConfig = {
     const levels = piModel?.thinkingLevels
       ?? (decodePiModelId(model) ? DEFAULT_PI_REASONING_LEVELS : ['off']);
     return levels.map((level) => ({
-      label: formatThinkingLevelLabel(level),
+      label: formatReasoningValueLabel(level),
       value: level,
     }));
   },
@@ -258,12 +259,6 @@ function buildModelOption(model: PiDiscoveredModel, alias: string | undefined): 
 function formatFallbackLabel(encodedId: string): string {
   const decoded = decodePiModelId(encodedId);
   return decoded ? `${decoded.provider}/${decoded.modelId}` : 'Pi';
-}
-
-function formatThinkingLevelLabel(value: PiThinkingLevel): string {
-  return value === 'xhigh'
-    ? 'XHigh'
-    : value.charAt(0).toUpperCase() + value.slice(1);
 }
 
 function pushOption(

--- a/tests/unit/core/providers/reasoning.test.ts
+++ b/tests/unit/core/providers/reasoning.test.ts
@@ -1,0 +1,29 @@
+import {
+  formatReasoningValueLabel,
+  resolvePreferredReasoningDefault,
+} from '@/core/providers/reasoning';
+
+describe('provider reasoning helpers', () => {
+  describe('formatReasoningValueLabel', () => {
+    it.each([
+      ['low', 'Low'],
+      ['medium', 'Medium'],
+      ['xhigh', 'xHigh'],
+      [' XHIGH ', 'xHigh'],
+      ['', ''],
+    ])('formats %p as %p', (value, expected) => {
+      expect(formatReasoningValueLabel(value)).toBe(expected);
+    });
+  });
+
+  describe('resolvePreferredReasoningDefault', () => {
+    it('prefers high when it is available', () => {
+      expect(resolvePreferredReasoningDefault(['low', 'high'], 'low')).toBe('high');
+    });
+
+    it('uses the fallback or first available value when high is unavailable', () => {
+      expect(resolvePreferredReasoningDefault(['low', 'medium'], 'medium')).toBe('medium');
+      expect(resolvePreferredReasoningDefault(['low', 'medium'], 'max')).toBe('low');
+    });
+  });
+});

--- a/tests/unit/providers/claude/ui/ClaudeChatUIConfig.test.ts
+++ b/tests/unit/providers/claude/ui/ClaudeChatUIConfig.test.ts
@@ -161,6 +161,8 @@ describe('claudeChatUIConfig', () => {
       const options = claudeChatUIConfig.getReasoningOptions('claude-opus-4-7', {});
 
       expect(options.map(option => option.value)).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
+      expect(options.find(option => option.value === 'medium')?.label).toBe('Medium');
+      expect(options.find(option => option.value === 'xhigh')?.label).toBe('xHigh');
     });
 
     it('keeps xhigh on fable models', () => {

--- a/tests/unit/providers/codex/ui/CodexChatUIConfig.test.ts
+++ b/tests/unit/providers/codex/ui/CodexChatUIConfig.test.ts
@@ -326,19 +326,22 @@ describe('CodexChatUIConfig', () => {
 
   describe('getReasoningOptions', () => {
     it('keeps max available before the runtime catalog loads', () => {
-      expect(codexChatUIConfig.getReasoningOptions('gpt-runtime-model', {
+      const options = codexChatUIConfig.getReasoningOptions('gpt-runtime-model', {
         providerConfigs: {
           codex: {
             discoveredModels: [],
           },
         },
-      }).map(option => option.value)).toEqual([
+      });
+
+      expect(options.map(option => option.value)).toEqual([
         'low',
         'medium',
         'high',
         'xhigh',
         'max',
       ]);
+      expect(options.find(option => option.value === 'xhigh')?.label).toBe('xHigh');
     });
 
     it('uses the selected model effort levels from app-server', () => {

--- a/tests/unit/providers/opencode/models.test.ts
+++ b/tests/unit/providers/opencode/models.test.ts
@@ -81,7 +81,7 @@ describe('OpenCode base model derivation', () => {
           { label: 'Medium', value: 'medium' },
           { label: 'High', value: 'high' },
           { label: 'Max', value: 'max' },
-          { label: 'XHigh', value: 'xhigh' },
+          { label: 'xHigh', value: 'xhigh' },
         ],
       },
     ]);

--- a/tests/unit/providers/pi/ui/PiChatUIConfig.test.ts
+++ b/tests/unit/providers/pi/ui/PiChatUIConfig.test.ts
@@ -12,7 +12,7 @@ const settings: Record<string, unknown> = {
           label: 'Claude Sonnet 4',
           provider: 'anthropic',
           reasoning: true,
-          thinkingLevels: ['off', 'medium', 'high'],
+          thinkingLevels: ['off', 'medium', 'high', 'xhigh'],
         },
         {
           encodedId: 'pi:openai/gpt-5',
@@ -102,6 +102,7 @@ describe('PiChatUIConfig', () => {
       { label: 'Off', value: 'off' },
       { label: 'Medium', value: 'medium' },
       { label: 'High', value: 'high' },
+      { label: 'xHigh', value: 'xhigh' },
     ]);
     expect(piChatUIConfig.getDefaultReasoningValue('pi:anthropic/claude-sonnet-4', settings)).toBe('high');
   });


### PR DESCRIPTION
## Summary

- Centralize reasoning-value label formatting in the provider-neutral core module.
- Use consistent `Medium` and `xHigh` labels across Claude, Codex, OpenCode, and Pi selectors.
- Add shared formatter tests and provider-level regression coverage.

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm test` (6,100 tests)
- `npm run build`