### PR TITLE
perf: defer startup work across providers and conversations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,4 +74,4 @@ jobs:
         run: npm ci
 
       - name: Build
-        run: npm run build
+        run: npm run build && npm run check:performance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         run: node scripts/check-release-version.mjs "${{ github.ref_name }}"
 
       - name: Build
-        run: npm run build
+        run: npm run build && npm run check:performance
 
       - name: Generate artifact attestations
         uses: actions/attest@v4

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -29,6 +29,7 @@ if (existsSync('.env.local')) {
 }
 
 const prod = process.argv[2] === 'production';
+const PRODUCTION_BUNDLE_BUDGET_BYTES = 2_800_000;
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -95,29 +96,54 @@ const patchSdkImportMeta = {
   },
 };
 
-const patchRendererUnsafeUnref = {
-  name: 'patch-renderer-unsafe-unref',
+function createPatchRendererUnsafeUnref(outputPaths) {
+  return {
+    name: 'patch-renderer-unsafe-unref',
+    setup(build) {
+      build.onEnd(async (result) => {
+        if (result.errors.length > 0) return;
+
+        for (const outputPath of outputPaths) {
+          if (!existsSync(outputPath)) continue;
+          const bundlePath = path.join(process.cwd(), outputPath);
+          const originalContents = await fsPromises.readFile(bundlePath, 'utf8');
+          const patchedBundle = patchRendererUnsafeUnrefSites(originalContents);
+
+          if (patchedBundle.contents !== originalContents) {
+            await fsPromises.writeFile(bundlePath, patchedBundle.contents, 'utf8');
+          }
+
+          const unsafeMatches = findUnsafeTimerUnrefSites(patchedBundle.contents);
+          if (unsafeMatches.length > 0) {
+            const details = unsafeMatches
+              .slice(0, 5)
+              .map((match) => `line ${match.line}: ${match.snippet}`)
+              .join('\n');
+
+            throw new Error(
+              `Renderer-unsafe timer .unref() calls remain in ${outputPath}:\n${details}`,
+            );
+          }
+        }
+      });
+    },
+  };
+}
+
+const enforceProductionBundleBudget = {
+  name: 'enforce-production-bundle-budget',
   setup(build) {
+    if (!prod) return;
+
     build.onEnd(async (result) => {
       if (result.errors.length > 0 || !existsSync('main.js')) return;
 
       const bundlePath = path.join(process.cwd(), 'main.js');
-      const originalContents = await fsPromises.readFile(bundlePath, 'utf8');
-      const patchedBundle = patchRendererUnsafeUnrefSites(originalContents);
+      const { size } = await fsPromises.stat(bundlePath);
 
-      if (patchedBundle.contents !== originalContents) {
-        await fsPromises.writeFile(bundlePath, patchedBundle.contents, 'utf8');
-      }
-
-      const unsafeMatches = findUnsafeTimerUnrefSites(patchedBundle.contents);
-      if (unsafeMatches.length > 0) {
-        const details = unsafeMatches
-          .slice(0, 5)
-          .map((match) => `line ${match.line}: ${match.snippet}`)
-          .join('\n');
-
+      if (size > PRODUCTION_BUNDLE_BUDGET_BYTES) {
         throw new Error(
-          `Renderer-unsafe timer .unref() calls remain in main.js:\n${details}`,
+          `Production main.js is ${size} bytes; budget is ${PRODUCTION_BUNDLE_BUDGET_BYTES} bytes.`,
         );
       }
     });
@@ -158,38 +184,46 @@ const copyToObsidian = {
   }
 };
 
-const context = await esbuild.context({
+const external = [
+  'obsidian',
+  'electron',
+  '@codemirror/autocomplete',
+  '@codemirror/collab',
+  '@codemirror/commands',
+  '@codemirror/language',
+  '@codemirror/lint',
+  '@codemirror/search',
+  '@codemirror/state',
+  '@codemirror/view',
+  '@lezer/common',
+  '@lezer/highlight',
+  '@lezer/lr',
+  ...builtinModules,
+  ...builtinModules.map(m => `node:${m}`),
+];
+
+const mainContext = await esbuild.context({
   entryPoints: ['src/main.ts'],
   bundle: true,
-  plugins: [patchSdkImportMeta, patchRendererUnsafeUnref, copyToObsidian],
-  external: [
-    'obsidian',
-    'electron',
-    '@codemirror/autocomplete',
-    '@codemirror/collab',
-    '@codemirror/commands',
-    '@codemirror/language',
-    '@codemirror/lint',
-    '@codemirror/search',
-    '@codemirror/state',
-    '@codemirror/view',
-    '@lezer/common',
-    '@lezer/highlight',
-    '@lezer/lr',
-    ...builtinModules,
-    ...builtinModules.map(m => `node:${m}`),
+  plugins: [
+    patchSdkImportMeta,
+    createPatchRendererUnsafeUnref(['main.js']),
+    enforceProductionBundleBudget,
+    copyToObsidian,
   ],
+  external,
   format: 'cjs',
   target: 'es2018',
   logLevel: 'info',
+  minify: prod,
   sourcemap: prod ? false : 'inline',
   treeShaking: true,
   outfile: 'main.js',
 });
 
 if (prod) {
-  await context.rebuild();
+  await mainContext.rebuild();
   process.exit(0);
 } else {
-  await context.watch();
+  await mainContext.watch();
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:css": "node scripts/build-css.mjs",
     "dev": "npm run build:css && node esbuild.config.mjs",
     "build": "node scripts/build.mjs production",
+    "check:performance": "node scripts/check-startup-performance.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"{src,tests}/**/*.ts\"",
     "lint:fix": "npm run lint -- --fix",

--- a/scripts/build-css.mjs
+++ b/scripts/build-css.mjs
@@ -113,7 +113,6 @@ function build() {
 
   const output = parts.join('\n');
   writeFileSync(OUTPUT, output);
-  console.log(`Built styles.css (${(output.length / 1024).toFixed(1)} KB)`);
 }
 
 build();

--- a/scripts/check-startup-performance.mjs
+++ b/scripts/check-startup-performance.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const mainPath = path.join(root, 'main.js');
+const requiredArtifacts = ['main.js', 'manifest.json', 'styles.css'];
+const mainBudgetBytes = 2_800_000;
+const evaluationBudgetMs = 50;
+
+for (const relativePath of requiredArtifacts) {
+  const artifactPath = path.join(root, relativePath);
+  if (!existsSync(artifactPath)) {
+    throw new Error(`Missing production artifact: ${relativePath}`);
+  }
+  if (relativePath.endsWith('.js')) {
+    const syntaxCheck = spawnSync(process.execPath, ['--check', artifactPath], {
+      cwd: root,
+      encoding: 'utf8',
+    });
+    if (syntaxCheck.status !== 0) {
+      throw new Error(`Invalid production artifact ${relativePath}: ${syntaxCheck.stderr}`);
+    }
+  }
+}
+
+const mainContents = readFileSync(mainPath, 'utf8');
+const unsupportedChunkReferences = [
+  './chunks/providers/',
+  './chunks/locales/',
+  './chunks/optional/',
+].filter(reference => mainContents.includes(reference));
+if (unsupportedChunkReferences.length > 0) {
+  throw new Error(
+    `main.js depends on files the Obsidian Community Plugin installer does not fetch: ${unsupportedChunkReferences.join(', ')}`,
+  );
+}
+
+const mainBytes = statSync(mainPath).size;
+if (mainBytes > mainBudgetBytes) {
+  throw new Error(`main.js is ${mainBytes} bytes; budget is ${mainBudgetBytes} bytes.`);
+}
+
+const childScript = String.raw`
+const Module = require('node:module');
+const { performance } = require('node:perf_hooks');
+const mainPath = process.argv[1];
+let universal;
+universal = new Proxy(function () { return universal; }, {
+  construct() { return {}; },
+  get(_target, property) {
+    if (property === 'isWin' || property === 'isMacOS' || property === 'isLinux') return false;
+    if (property === 'then') return undefined;
+    return universal;
+  },
+});
+const obsidian = new Proxy({}, {
+  get(_target, property) {
+    if (property === 'Platform') return { isWin: false, isMacOS: true, isLinux: false };
+    if (property === 'normalizePath') return value => value;
+    if (property === 'setIcon') return () => {};
+    return universal;
+  },
+});
+const originalLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+  if (request === 'obsidian') return obsidian;
+  if (request === 'electron') return { shell: universal };
+  return originalLoad.call(this, request, parent, isMain);
+};
+const startedAt = performance.now();
+require(mainPath);
+process.stdout.write(String(performance.now() - startedAt));
+`;
+
+const samples = [];
+for (let index = 0; index < 7; index += 1) {
+  const result = spawnSync(process.execPath, ['-e', childScript, mainPath], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    throw new Error(`Module evaluation harness failed: ${result.stderr || result.stdout}`);
+  }
+  samples.push(Number(result.stdout));
+}
+samples.sort((left, right) => left - right);
+const medianMs = samples[Math.floor(samples.length / 2)];
+
+console.log(`main.js ${(mainBytes / 1024 / 1024).toFixed(2)} MiB; median cold evaluation ${medianMs.toFixed(1)} ms`);
+if (medianMs > evaluationBudgetMs) {
+  console.warn(
+    `Performance warning: median cold module evaluation is ${medianMs.toFixed(1)} ms; indicator is ${evaluationBudgetMs} ms.`,
+  );
+}

--- a/scripts/check-startup-performance.mjs
+++ b/scripts/check-startup-performance.mjs
@@ -10,7 +10,7 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const mainPath = path.join(root, 'main.js');
 const requiredArtifacts = ['main.js', 'manifest.json', 'styles.css'];
 const mainBudgetBytes = 2_800_000;
-const evaluationBudgetMs = 50;
+const evaluationIndicatorMs = 50;
 
 for (const relativePath of requiredArtifacts) {
   const artifactPath = path.join(root, relativePath);
@@ -96,8 +96,8 @@ samples.sort((left, right) => left - right);
 const medianMs = samples[Math.floor(samples.length / 2)];
 
 console.log(`main.js ${(mainBytes / 1024 / 1024).toFixed(2)} MiB; median cold evaluation ${medianMs.toFixed(1)} ms`);
-if (medianMs > evaluationBudgetMs) {
-  throw new Error(
-    `Median cold module evaluation is ${medianMs.toFixed(1)} ms; budget is ${evaluationBudgetMs} ms.`,
+if (medianMs > evaluationIndicatorMs) {
+  console.warn(
+    `Performance warning: median cold module evaluation is ${medianMs.toFixed(1)} ms; indicator is ${evaluationIndicatorMs} ms.`,
   );
 }

--- a/scripts/check-startup-performance.mjs
+++ b/scripts/check-startup-performance.mjs
@@ -86,14 +86,18 @@ for (let index = 0; index < 7; index += 1) {
   if (result.status !== 0) {
     throw new Error(`Module evaluation harness failed: ${result.stderr || result.stdout}`);
   }
-  samples.push(Number(result.stdout));
+  const sample = Number(result.stdout.trim());
+  if (!Number.isFinite(sample)) {
+    throw new Error(`Module evaluation harness returned an invalid duration: ${JSON.stringify(result.stdout)}`);
+  }
+  samples.push(sample);
 }
 samples.sort((left, right) => left - right);
 const medianMs = samples[Math.floor(samples.length / 2)];
 
 console.log(`main.js ${(mainBytes / 1024 / 1024).toFixed(2)} MiB; median cold evaluation ${medianMs.toFixed(1)} ms`);
 if (medianMs > evaluationBudgetMs) {
-  console.warn(
-    `Performance warning: median cold module evaluation is ${medianMs.toFixed(1)} ms; indicator is ${evaluationBudgetMs} ms.`,
+  throw new Error(
+    `Median cold module evaluation is ${medianMs.toFixed(1)} ms; budget is ${evaluationBudgetMs} ms.`,
   );
 }

--- a/scripts/rendererSafeUnref.js
+++ b/scripts/rendererSafeUnref.js
@@ -99,6 +99,14 @@ function patchRendererUnsafeUnrefSites(contents) {
     appliedPatches.push({ name: patch.name, count: matchCount });
   }
 
+  const directTimerUnrefs = findUnsafeTimerUnrefRanges(nextContents);
+  for (const site of directTimerUnrefs.sort((left, right) => right.unrefStartIndex - left.unrefStartIndex)) {
+    nextContents = `${nextContents.slice(0, site.unrefStartIndex)}.unref?.()${nextContents.slice(site.unrefEndIndex)}`;
+  }
+  if (directTimerUnrefs.length > 0) {
+    appliedPatches.push({ name: 'direct-timer-unref-guard', count: directTimerUnrefs.length });
+  }
+
   return {
     contents: nextContents,
     appliedPatches,
@@ -106,6 +114,10 @@ function patchRendererUnsafeUnrefSites(contents) {
 }
 
 function findUnsafeTimerUnrefSites(contents) {
+  return findUnsafeTimerUnrefRanges(contents).map(({ line, snippet }) => ({ line, snippet }));
+}
+
+function findUnsafeTimerUnrefRanges(contents) {
   const matches = [];
 
   let searchIndex = 0;
@@ -125,16 +137,17 @@ function findUnsafeTimerUnrefSites(contents) {
     if (unrefMatch) {
       const startIndex = timerStart.startIndex;
       const endIndex = callEnd + 1 + unrefMatch[0].length;
+      const unrefStartIndex = callEnd + 1 + unrefMatch[0].indexOf('.');
       const line = contents.slice(0, startIndex).split('\n').length;
       matches.push({
         line,
         snippet: contents.slice(startIndex, endIndex),
+        unrefStartIndex,
+        unrefEndIndex: unrefStartIndex + '.unref()'.length,
       });
-      searchIndex = endIndex;
-      continue;
     }
 
-    searchIndex = callEnd + 1;
+    searchIndex = timerStart.startIndex + timerStart.prefix.length;
   }
 
   return matches;

--- a/src/app/conversations/ConversationRepository.ts
+++ b/src/app/conversations/ConversationRepository.ts
@@ -18,11 +18,17 @@ export class ConversationRepository {
   private conversations: Conversation[] = [];
   private hydratedConversationIds = new Set<string>();
   private hydrationPromises = new Map<string, Promise<Conversation | null>>();
+  private conversationGenerations = new Map<string, number>();
+  private deletedConversationIds = new Set<string>();
 
   constructor(private readonly deps: ConversationRepositoryDeps) {}
 
   replaceAll(conversations: Conversation[]): void {
+    for (const conversation of this.conversations) {
+      this.invalidateConversation(conversation.id);
+    }
     this.conversations = conversations;
+    this.deletedConversationIds.clear();
     this.hydratedConversationIds = new Set(
       conversations.filter((conversation) => conversation.messages.length > 0).map(({ id }) => id),
     );
@@ -31,7 +37,9 @@ export class ConversationRepository {
 
   mergeMetadataConversations(conversations: Conversation[]): Conversation[] {
     const existingIds = new Set(this.conversations.map(({ id }) => id));
-    const added = conversations.filter(({ id }) => !existingIds.has(id));
+    const added = conversations.filter(({ id }) => (
+      !existingIds.has(id) && !this.deletedConversationIds.has(id)
+    ));
     if (added.length === 0) {
       return [];
     }
@@ -98,6 +106,7 @@ export class ConversationRepository {
       messages: [],
     };
 
+    this.deletedConversationIds.delete(conversation.id);
     this.conversations.unshift(conversation);
     if (!sessionId) {
       this.hydratedConversationIds.add(conversation.id);
@@ -118,9 +127,16 @@ export class ConversationRepository {
     if (index === -1) return;
 
     const conversation = this.conversations[index];
+    const pendingHydration = this.hydrationPromises.get(id) ?? null;
+    this.deletedConversationIds.add(id);
     this.conversations.splice(index, 1);
     this.hydratedConversationIds.delete(id);
     this.hydrationPromises.delete(id);
+    this.invalidateConversation(id);
+
+    if (pendingHydration) {
+      await Promise.allSettled([pendingHydration]);
+    }
 
     if (options.deleteProviderSession !== false) {
       const vaultPath = this.deps.getVaultPath();
@@ -209,6 +225,7 @@ export class ConversationRepository {
       || 'resumeAtMessageId' in safeUpdates
     ) {
       this.hydratedConversationIds.delete(id);
+      this.invalidateConversation(id);
     }
     await this.save(conversation);
   }
@@ -244,17 +261,16 @@ export class ConversationRepository {
     if (!conversation) {
       return null;
     }
-    if (this.hydratedConversationIds.has(id)) {
-      await this.ensureSelectedModel(conversation);
-      return conversation;
-    }
 
     const existing = this.hydrationPromises.get(id);
     if (existing) {
       return existing;
     }
 
-    const promise = this.hydrateConversation(id);
+    const generation = this.getConversationGeneration(id);
+    const promise = this.hydratedConversationIds.has(id)
+      ? this.reconcileHydratedConversation(conversation, generation)
+      : this.hydrateConversation(id, generation);
     this.hydrationPromises.set(id, promise);
     try {
       return await promise;
@@ -265,15 +281,29 @@ export class ConversationRepository {
     }
   }
 
-  async hydrateConversation(id: string): Promise<Conversation | null> {
+  private async reconcileHydratedConversation(
+    conversation: Conversation,
+    generation: number,
+  ): Promise<Conversation | null> {
+    await this.ensureSelectedModel(conversation);
+    return this.isConversationCurrent(conversation, generation) ? conversation : null;
+  }
+
+  private async hydrateConversation(
+    id: string,
+    generation: number,
+  ): Promise<Conversation | null> {
     const conversation = this.getSync(id);
     if (!conversation) {
       return null;
     }
 
     await this.reconcileProviderSession(conversation);
+    if (!this.isConversationCurrent(conversation, generation)) return null;
     await this.ensureSelectedModel(conversation);
+    if (!this.isConversationCurrent(conversation, generation)) return null;
     await this.hydrateProviderHistory(conversation);
+    if (!this.isConversationCurrent(conversation, generation)) return null;
     this.hydratedConversationIds.add(id);
     return conversation;
   }
@@ -377,6 +407,19 @@ export class ConversationRepository {
 
   private save(conversation: Conversation): Promise<void> {
     return this.deps.sessions.saveMetadata(this.deps.sessions.toSessionMetadata(conversation));
+  }
+
+  private getConversationGeneration(id: string): number {
+    return this.conversationGenerations.get(id) ?? 0;
+  }
+
+  private invalidateConversation(id: string): void {
+    this.conversationGenerations.set(id, this.getConversationGeneration(id) + 1);
+  }
+
+  private isConversationCurrent(conversation: Conversation, generation: number): boolean {
+    return this.getSync(conversation.id) === conversation
+      && this.getConversationGeneration(conversation.id) === generation;
   }
 
   private generateId(): string {

--- a/src/app/conversations/ConversationRepository.ts
+++ b/src/app/conversations/ConversationRepository.ts
@@ -16,11 +16,38 @@ export interface ConversationRepositoryDeps {
 
 export class ConversationRepository {
   private conversations: Conversation[] = [];
+  private hydratedConversationIds = new Set<string>();
+  private hydrationPromises = new Map<string, Promise<Conversation | null>>();
 
   constructor(private readonly deps: ConversationRepositoryDeps) {}
 
   replaceAll(conversations: Conversation[]): void {
     this.conversations = conversations;
+    this.hydratedConversationIds = new Set(
+      conversations.filter((conversation) => conversation.messages.length > 0).map(({ id }) => id),
+    );
+    this.hydrationPromises.clear();
+  }
+
+  mergeMetadataConversations(conversations: Conversation[]): Conversation[] {
+    const existingIds = new Set(this.conversations.map(({ id }) => id));
+    const added = conversations.filter(({ id }) => !existingIds.has(id));
+    if (added.length === 0) {
+      return [];
+    }
+
+    this.conversations.push(...added);
+    this.conversations.sort(
+      (left, right) => (
+        (right.lastResponseAt ?? right.updatedAt) - (left.lastResponseAt ?? left.updatedAt)
+      ),
+    );
+    for (const conversation of added) {
+      if (conversation.messages.length > 0) {
+        this.hydratedConversationIds.add(conversation.id);
+      }
+    }
+    return added;
   }
 
   getAll(): Conversation[] {
@@ -72,18 +99,15 @@ export class ConversationRepository {
     };
 
     this.conversations.unshift(conversation);
+    if (!sessionId) {
+      this.hydratedConversationIds.add(conversation.id);
+    }
     await this.save(conversation);
     return conversation;
   }
 
   async switchTo(id: string): Promise<Conversation | null> {
-    const conversation = this.getSync(id);
-    if (!conversation) return null;
-
-    await this.reconcileProviderSession(conversation);
-    await this.ensureSelectedModel(conversation);
-    await this.hydrate(conversation);
-    return conversation;
+    return this.ensureHydrated(id);
   }
 
   async delete(
@@ -95,6 +119,8 @@ export class ConversationRepository {
 
     const conversation = this.conversations[index];
     this.conversations.splice(index, 1);
+    this.hydratedConversationIds.delete(id);
+    this.hydrationPromises.delete(id);
 
     if (options.deleteProviderSession !== false) {
       const vaultPath = this.deps.getVaultPath();
@@ -177,16 +203,78 @@ export class ConversationRepository {
       }
     }
     Object.assign(conversation, safeUpdates, { updatedAt: Date.now() });
+    if (
+      'sessionId' in safeUpdates
+      || 'providerState' in safeUpdates
+      || 'resumeAtMessageId' in safeUpdates
+    ) {
+      this.hydratedConversationIds.delete(id);
+    }
     await this.save(conversation);
   }
 
   async getById(id: string): Promise<Conversation | null> {
+    return this.ensureHydrated(id);
+  }
+
+  getCachedConversation(id: string): Conversation | null {
+    return this.getSync(id);
+  }
+
+  getMetadata(id: string): ConversationMeta | null {
     const conversation = this.getSync(id);
-    if (conversation) {
-      await this.reconcileProviderSession(conversation);
-      await this.ensureSelectedModel(conversation);
-      await this.hydrate(conversation);
+    if (!conversation) {
+      return null;
     }
+    return {
+      id: conversation.id,
+      providerId: conversation.providerId,
+      title: conversation.title,
+      createdAt: conversation.createdAt,
+      updatedAt: conversation.updatedAt,
+      lastResponseAt: conversation.lastResponseAt,
+      messageCount: conversation.messages.length,
+      preview: this.getPreview(conversation),
+      titleGenerationStatus: conversation.titleGenerationStatus,
+    };
+  }
+
+  async ensureHydrated(id: string): Promise<Conversation | null> {
+    const conversation = this.getSync(id);
+    if (!conversation) {
+      return null;
+    }
+    if (this.hydratedConversationIds.has(id)) {
+      await this.ensureSelectedModel(conversation);
+      return conversation;
+    }
+
+    const existing = this.hydrationPromises.get(id);
+    if (existing) {
+      return existing;
+    }
+
+    const promise = this.hydrateConversation(id);
+    this.hydrationPromises.set(id, promise);
+    try {
+      return await promise;
+    } finally {
+      if (this.hydrationPromises.get(id) === promise) {
+        this.hydrationPromises.delete(id);
+      }
+    }
+  }
+
+  async hydrateConversation(id: string): Promise<Conversation | null> {
+    const conversation = this.getSync(id);
+    if (!conversation) {
+      return null;
+    }
+
+    await this.reconcileProviderSession(conversation);
+    await this.ensureSelectedModel(conversation);
+    await this.hydrateProviderHistory(conversation);
+    this.hydratedConversationIds.add(id);
     return conversation;
   }
 
@@ -260,7 +348,7 @@ export class ConversationRepository {
     await this.save(conversation);
   }
 
-  private async hydrate(conversation: Conversation): Promise<void> {
+  private async hydrateProviderHistory(conversation: Conversation): Promise<void> {
     const vaultPath = this.deps.getVaultPath();
     await ProviderRegistry
       .getConversationHistoryService(conversation.providerId)

--- a/src/app/providers/ClaudianProviderHost.ts
+++ b/src/app/providers/ClaudianProviderHost.ts
@@ -70,10 +70,10 @@ export class ClaudianProviderHost implements ProviderHost {
     return this.plugin.applyEnvironmentVariablesBatch(updates);
   }
 
-  getResolvedProviderCliPath(
+  async getResolvedProviderCliPath(
     providerId: ProviderId,
     context?: ProviderCliResolutionContext,
-  ): string | null {
+  ): Promise<string | null> {
     return this.plugin.getResolvedProviderCliPath(providerId, context);
   }
 

--- a/src/app/settings/defaultSettings.ts
+++ b/src/app/settings/defaultSettings.ts
@@ -42,6 +42,7 @@ export const DEFAULT_CLAUDIAN_SETTINGS: ClaudianSettings = {
   savedProviderServiceTier: {},
   savedProviderThinkingBudget: {},
   savedProviderPermissionMode: {},
+  pendingProviderSessionInvalidations: {},
 
   lastCustomModel: '',
 

--- a/src/app/storage/SharedStorageService.ts
+++ b/src/app/storage/SharedStorageService.ts
@@ -41,8 +41,9 @@ export class SharedStorageService implements SharedAppStorage {
       const data = isRecord(loaded) ? loaded : {};
       data.tabManagerState = state;
       await this.plugin.saveData(data);
-    } catch {
+    } catch (error) {
       new Notice('Failed to save tab layout');
+      throw error;
     }
   }
 

--- a/src/app/storage/SharedStorageService.ts
+++ b/src/app/storage/SharedStorageService.ts
@@ -1,9 +1,8 @@
 import type { Plugin } from 'obsidian';
 import { Notice } from 'obsidian';
 
-import { SESSIONS_PATH, SessionStorage } from '../../core/bootstrap/SessionStorage';
+import { SessionStorage } from '../../core/bootstrap/SessionStorage';
 import type { SharedAppStorage } from '../../core/bootstrap/storage';
-import { CLAUDIAN_STORAGE_PATH } from '../../core/bootstrap/StoragePaths';
 import { normalizeTabManagerState } from '../../core/bootstrap/tabManagerState';
 import type { AppTabManagerState } from '../../core/providers/types';
 import { VaultFileAdapter } from '../../core/storage/VaultFileAdapter';
@@ -28,7 +27,6 @@ export class SharedStorageService implements SharedAppStorage {
   }
 
   async initialize(): Promise<{ claudian: Record<string, unknown> }> {
-    await this.ensureDirectories();
     const claudian = await this.claudianSettings.load();
     return { claudian };
   }
@@ -64,10 +62,4 @@ export class SharedStorageService implements SharedAppStorage {
   getAdapter(): VaultFileAdapter {
     return this.adapter;
   }
-
-  private async ensureDirectories(): Promise<void> {
-    await this.adapter.ensureFolder(CLAUDIAN_STORAGE_PATH);
-    await this.adapter.ensureFolder(SESSIONS_PATH);
-  }
-
 }

--- a/src/core/bootstrap/SessionStorage.ts
+++ b/src/core/bootstrap/SessionStorage.ts
@@ -101,6 +101,7 @@ export class SessionStorage {
   ): Promise<SessionMetadataScanResult> {
     const fileListing = await this.listUniqueMetadataFiles();
     let complete = fileListing.complete;
+    let invalidMetadataCount = 0;
     const pendingBatch: SessionMetadata[] = [];
     const batchSize = Math.max(1, options.batchSize ?? SESSION_METADATA_PUBLISH_BATCH_SIZE);
     const publish = (metadata: SessionMetadata): void => {
@@ -115,16 +116,29 @@ export class SessionStorage {
       if (!fileId || !isValidSessionMetadataId(fileId)) {
         return null;
       }
-      let raw: SessionMetadata;
+      let content: string;
       try {
-        const content = await this.adapter.read(filePath);
-        raw = JSON.parse(content) as SessionMetadata;
-        if (raw.id !== fileId || !isValidSessionMetadataId(raw.id)) {
-          return null;
-        }
+        content = await this.adapter.read(filePath);
       } catch {
         complete = false;
-        // Skip files that fail to load.
+        // A later scan may recover a transient I/O failure.
+        return null;
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(content);
+      } catch {
+        invalidMetadataCount += 1;
+        return null;
+      }
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        invalidMetadataCount += 1;
+        return null;
+      }
+      const raw = parsed as SessionMetadata;
+      if (raw.id !== fileId || !isValidSessionMetadataId(raw.id)) {
+        invalidMetadataCount += 1;
         return null;
       }
 
@@ -146,6 +160,7 @@ export class SessionStorage {
     return {
       metadata: metas.filter((meta): meta is SessionMetadata => meta !== null),
       complete,
+      invalidMetadataCount,
     };
   }
 

--- a/src/core/bootstrap/SessionStorage.ts
+++ b/src/core/bootstrap/SessionStorage.ts
@@ -1,5 +1,6 @@
+import { mapWithConcurrency } from '../../utils/concurrency';
 import { ProviderRegistry } from '../providers/ProviderRegistry';
-import { DEFAULT_CHAT_PROVIDER_ID } from '../providers/types';
+import { DEFAULT_CHAT_PROVIDER_ID, type SessionMetadataListOptions } from '../providers/types';
 import type { VaultFileAdapter } from '../storage/VaultFileAdapter';
 import type {
   Conversation,
@@ -14,6 +15,8 @@ export {
 };
 
 const SAFE_METADATA_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const SESSION_METADATA_READ_CONCURRENCY = 8;
+const SESSION_METADATA_PUBLISH_BATCH_SIZE = 16;
 
 export function isValidSessionMetadataId(id: string): boolean {
   return SAFE_METADATA_ID_PATTERN.test(id)
@@ -80,33 +83,45 @@ export class SessionStorage {
     await this.deleteLegacyMetadataIfPresent(id);
   }
 
-  async listMetadata(): Promise<SessionMetadata[]> {
-    const metas: SessionMetadata[] = [];
-
+  async listMetadata(options: SessionMetadataListOptions = {}): Promise<SessionMetadata[]> {
     const files = await this.listUniqueMetadataFiles();
-
-    for (const filePath of files) {
+    const pendingBatch: SessionMetadata[] = [];
+    const batchSize = Math.max(1, options.batchSize ?? SESSION_METADATA_PUBLISH_BATCH_SIZE);
+    const publish = (metadata: SessionMetadata): void => {
+      if (!options.onBatch) return;
+      pendingBatch.push(metadata);
+      if (pendingBatch.length >= batchSize) {
+        options.onBatch(pendingBatch.splice(0, pendingBatch.length));
+      }
+    };
+    const metas = await mapWithConcurrency(files, async (filePath) => {
       const fileId = this.getMetadataIdFromPath(filePath);
       if (!fileId || !isValidSessionMetadataId(fileId)) {
-        continue;
+        return null;
       }
       try {
         const content = await this.adapter.read(filePath);
         const raw = JSON.parse(content) as SessionMetadata;
         if (raw.id !== fileId || !isValidSessionMetadataId(raw.id)) {
-          continue;
+          return null;
         }
-        metas.push(raw);
 
         if (filePath.startsWith(`${LEGACY_SESSIONS_PATH}/`)) {
           await this.saveMetadata(raw);
         }
+        publish(raw);
+        return raw;
       } catch {
         // Skip files that fail to load.
+        return null;
       }
+    }, SESSION_METADATA_READ_CONCURRENCY);
+
+    if (pendingBatch.length > 0) {
+      options.onBatch?.(pendingBatch.splice(0, pendingBatch.length));
     }
 
-    return metas;
+    return metas.filter((meta): meta is SessionMetadata => meta !== null);
   }
 
   async listAllConversations(): Promise<ConversationMeta[]> {

--- a/src/core/bootstrap/SessionStorage.ts
+++ b/src/core/bootstrap/SessionStorage.ts
@@ -1,6 +1,10 @@
 import { mapWithConcurrency } from '../../utils/concurrency';
 import { ProviderRegistry } from '../providers/ProviderRegistry';
-import { DEFAULT_CHAT_PROVIDER_ID, type SessionMetadataListOptions } from '../providers/types';
+import {
+  DEFAULT_CHAT_PROVIDER_ID,
+  type SessionMetadataListOptions,
+  type SessionMetadataScanResult,
+} from '../providers/types';
 import type { VaultFileAdapter } from '../storage/VaultFileAdapter';
 import type {
   Conversation,
@@ -89,7 +93,14 @@ export class SessionStorage {
   }
 
   async listMetadata(options: SessionMetadataListOptions = {}): Promise<SessionMetadata[]> {
-    const files = await this.listUniqueMetadataFiles();
+    return (await this.scanMetadata(options)).metadata;
+  }
+
+  async scanMetadata(
+    options: SessionMetadataListOptions = {},
+  ): Promise<SessionMetadataScanResult> {
+    const fileListing = await this.listUniqueMetadataFiles();
+    let complete = fileListing.complete;
     const pendingBatch: SessionMetadata[] = [];
     const batchSize = Math.max(1, options.batchSize ?? SESSION_METADATA_PUBLISH_BATCH_SIZE);
     const publish = (metadata: SessionMetadata): void => {
@@ -99,7 +110,7 @@ export class SessionStorage {
         options.onBatch(pendingBatch.splice(0, pendingBatch.length));
       }
     };
-    const metas = await mapWithConcurrency(files, async (filePath) => {
+    const metas = await mapWithConcurrency(fileListing.files, async (filePath) => {
       const fileId = this.getMetadataIdFromPath(filePath);
       if (!fileId || !isValidSessionMetadataId(fileId)) {
         return null;
@@ -112,6 +123,7 @@ export class SessionStorage {
           return null;
         }
       } catch {
+        complete = false;
         // Skip files that fail to load.
         return null;
       }
@@ -131,7 +143,10 @@ export class SessionStorage {
       options.onBatch?.(pendingBatch.splice(0, pendingBatch.length));
     }
 
-    return metas.filter((meta): meta is SessionMetadata => meta !== null);
+    return {
+      metadata: metas.filter((meta): meta is SessionMetadata => meta !== null),
+      complete,
+    };
   }
 
   async listAllConversations(): Promise<ConversationMeta[]> {
@@ -200,31 +215,39 @@ export class SessionStorage {
     }
   }
 
-  private async listUniqueMetadataFiles(): Promise<string[]> {
+  private async listUniqueMetadataFiles(): Promise<{ files: string[]; complete: boolean }> {
     const preferredFiles = await this.listMetadataFiles(SESSIONS_PATH);
     const fallbackFiles = await this.listMetadataFiles(LEGACY_SESSIONS_PATH);
     const filesByName = new Map<string, string>();
 
-    for (const filePath of preferredFiles) {
+    for (const filePath of preferredFiles.files) {
       filesByName.set(this.getFileName(filePath), filePath);
     }
 
-    for (const filePath of fallbackFiles) {
+    for (const filePath of fallbackFiles.files) {
       const fileName = this.getFileName(filePath);
       if (!filesByName.has(fileName)) {
         filesByName.set(fileName, filePath);
       }
     }
 
-    return Array.from(filesByName.values());
+    return {
+      files: Array.from(filesByName.values()),
+      complete: preferredFiles.complete && fallbackFiles.complete,
+    };
   }
 
-  private async listMetadataFiles(folderPath: string): Promise<string[]> {
+  private async listMetadataFiles(
+    folderPath: string,
+  ): Promise<{ files: string[]; complete: boolean }> {
     try {
       const files = await this.adapter.listFiles(folderPath);
-      return files.filter((filePath) => filePath.endsWith('.meta.json'));
+      return {
+        files: files.filter((filePath) => filePath.endsWith('.meta.json')),
+        complete: true,
+      };
     } catch {
-      return [];
+      return { files: [], complete: false };
     }
   }
 

--- a/src/core/bootstrap/SessionStorage.ts
+++ b/src/core/bootstrap/SessionStorage.ts
@@ -55,27 +55,32 @@ export class SessionStorage {
     if (!isValidSessionMetadataId(id)) {
       return null;
     }
-    const filePath = await this.getLoadPath(id);
-
+    let filePath: string | null;
+    let metadata: SessionMetadata;
     try {
+      filePath = await this.getLoadPath(id);
       if (!filePath) {
         return null;
       }
 
       const content = await this.adapter.read(filePath);
-      const metadata = JSON.parse(content) as SessionMetadata;
+      metadata = JSON.parse(content) as SessionMetadata;
       if (metadata.id !== id || !isValidSessionMetadataId(metadata.id)) {
         return null;
       }
-
-      if (filePath !== this.getMetadataPath(id)) {
-        await this.saveMetadata(metadata);
-      }
-
-      return metadata;
     } catch {
       return null;
     }
+
+    if (filePath !== this.getMetadataPath(id)) {
+      try {
+        await this.saveMetadata(metadata);
+      } catch {
+        // Migration is best-effort; keep valid legacy metadata visible.
+      }
+    }
+
+    return metadata;
   }
 
   async deleteMetadata(id: string): Promise<void> {
@@ -99,22 +104,27 @@ export class SessionStorage {
       if (!fileId || !isValidSessionMetadataId(fileId)) {
         return null;
       }
+      let raw: SessionMetadata;
       try {
         const content = await this.adapter.read(filePath);
-        const raw = JSON.parse(content) as SessionMetadata;
+        raw = JSON.parse(content) as SessionMetadata;
         if (raw.id !== fileId || !isValidSessionMetadataId(raw.id)) {
           return null;
         }
-
-        if (filePath.startsWith(`${LEGACY_SESSIONS_PATH}/`)) {
-          await this.saveMetadata(raw);
-        }
-        publish(raw);
-        return raw;
       } catch {
         // Skip files that fail to load.
         return null;
       }
+
+      if (filePath.startsWith(`${LEGACY_SESSIONS_PATH}/`)) {
+        try {
+          await this.saveMetadata(raw);
+        } catch {
+          // Migration is best-effort; keep valid legacy metadata visible.
+        }
+      }
+      publish(raw);
+      return raw;
     }, SESSION_METADATA_READ_CONCURRENCY);
 
     if (pendingBatch.length > 0) {

--- a/src/core/mcp/McpServerManager.ts
+++ b/src/core/mcp/McpServerManager.ts
@@ -9,13 +9,40 @@ export interface McpStorageAdapter {
 export class McpServerManager {
   private servers: ManagedMcpServer[] = [];
   private storage: McpStorageAdapter;
+  private loadPromise: Promise<void> | null = null;
+  private loaded = false;
 
   constructor(storage: McpStorageAdapter) {
     this.storage = storage;
   }
 
   async loadServers(): Promise<void> {
-    this.servers = await this.storage.load();
+    if (this.loadPromise) {
+      return this.loadPromise;
+    }
+    const promise = this.storage.load().then((servers) => {
+      this.servers = servers;
+      this.loaded = true;
+    });
+    this.loadPromise = promise;
+    try {
+      await promise;
+    } finally {
+      if (this.loadPromise === promise) {
+        this.loadPromise = null;
+      }
+    }
+  }
+
+  async ensureLoaded(): Promise<void> {
+    if (this.loaded) {
+      return;
+    }
+    await this.loadServers();
+  }
+
+  isLoaded(): boolean {
+    return this.loaded;
   }
 
   getServers(): ManagedMcpServer[] {

--- a/src/core/performance/StartupProfiler.ts
+++ b/src/core/performance/StartupProfiler.ts
@@ -1,0 +1,168 @@
+/**
+ * Lightweight, in-memory startup profiler.
+ *
+ * Records spans and counts during plugin startup without writing files or
+ * emitting console output. Diagnostics are only materialized when a command
+ * explicitly requests them.
+ */
+
+export interface StartupSpan {
+  name: string;
+  start: number;
+  end?: number;
+}
+
+export interface StartupReportSpan {
+  name: string;
+  durationMs: number;
+}
+
+export interface StartupReport {
+  moduleEvalTime: number;
+  onloadStartTime: number;
+  onloadEndTime?: number;
+  totalDurationMs?: number;
+  spans: StartupReportSpan[];
+  counts: Record<string, number>;
+}
+
+interface StartupProfilerState {
+  moduleEvalTime: number;
+  onloadStartTime: number;
+  onloadEndTime?: number;
+  spans: StartupSpan[];
+  counts: Record<string, number>;
+  frozen: boolean;
+}
+
+const state: StartupProfilerState = {
+  moduleEvalTime: 0,
+  onloadStartTime: 0,
+  spans: [],
+  counts: {},
+  frozen: false,
+};
+
+function now(): number {
+  return performance.now();
+}
+
+const moduleEvaluationStartedAt = now();
+
+function finishSpan(span: StartupSpan): void {
+  if (span.end === undefined) {
+    span.end = now();
+  }
+}
+
+export class StartupProfiler {
+  static finishModuleEvaluation(): void {
+    StartupProfiler.setModuleEvalTime(now() - moduleEvaluationStartedAt);
+  }
+
+  static setModuleEvalTime(time: number): void {
+    if (state.frozen) return;
+    state.moduleEvalTime = time;
+  }
+
+  static startOnload(): void {
+    if (state.frozen) return;
+    state.onloadStartTime = now();
+  }
+
+  static finishOnload(): void {
+    if (state.frozen) return;
+    state.onloadEndTime = now();
+  }
+
+  static start(name: string): StartupSpan {
+    if (state.frozen) {
+      return { name, start: now() };
+    }
+    const span: StartupSpan = { name, start: now() };
+    state.spans.push(span);
+    return span;
+  }
+
+  static finish(span: StartupSpan): void {
+    if (state.frozen) return;
+    finishSpan(span);
+  }
+
+  static run<T>(name: string, fn: () => T): T {
+    const span = StartupProfiler.start(name);
+    try {
+      return fn();
+    } finally {
+      StartupProfiler.finish(span);
+    }
+  }
+
+  static async runAsync<T>(name: string, fn: () => Promise<T>): Promise<T> {
+    const span = StartupProfiler.start(name);
+    try {
+      return await fn();
+    } finally {
+      StartupProfiler.finish(span);
+    }
+  }
+
+  static recordCount(name: string, value: number): void {
+    if (state.frozen) return;
+    state.counts[name] = value;
+  }
+
+  static increment(name: string, delta = 1): void {
+    if (state.frozen) return;
+    state.counts[name] = (state.counts[name] ?? 0) + delta;
+  }
+
+  static freeze(): void {
+    state.frozen = true;
+  }
+
+  static reset(): void {
+    state.moduleEvalTime = 0;
+    state.onloadStartTime = 0;
+    state.onloadEndTime = undefined;
+    state.spans = [];
+    state.counts = {};
+    state.frozen = false;
+  }
+
+  static getReport(): StartupReport {
+    // Finish any unclosed spans using the current time so the report is complete.
+    const spans: StartupReportSpan[] = state.spans.map((span) => ({
+      name: span.name,
+      durationMs: (span.end ?? now()) - span.start,
+    }));
+
+    const report: StartupReport = {
+      moduleEvalTime: state.moduleEvalTime,
+      onloadStartTime: state.onloadStartTime,
+      onloadEndTime: state.onloadEndTime,
+      spans,
+      counts: { ...state.counts },
+    };
+
+    if (state.onloadEndTime !== undefined && state.onloadStartTime > 0) {
+      report.totalDurationMs = state.onloadEndTime - state.onloadStartTime;
+    }
+
+    return report;
+  }
+
+  static toJSON(): string {
+    return JSON.stringify(StartupProfiler.getReport(), null, 2);
+  }
+
+  static async copyToClipboard(): Promise<boolean> {
+    const json = StartupProfiler.toJSON();
+    try {
+      await navigator.clipboard.writeText(json);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/core/providers/ProviderHost.ts
+++ b/src/core/providers/ProviderHost.ts
@@ -39,7 +39,7 @@ export interface ProviderHost {
   getResolvedProviderCliPath(
     providerId: ProviderId,
     context?: ProviderCliResolutionContext,
-  ): string | null;
+  ): Promise<string | null>;
 
   refreshModelSelectors?(): void;
   broadcastToActiveViewRuntimes?(

--- a/src/core/providers/ProviderInitializationBoundary.ts
+++ b/src/core/providers/ProviderInitializationBoundary.ts
@@ -1,0 +1,123 @@
+/**
+ * Lazy, memoized initialization boundary for provider workspace services.
+ *
+ * Providers are initialized only on first use. Each provider owns a single
+ * initialization promise so concurrent callers cannot repeat work.
+ */
+
+import type { ProviderHost } from './ProviderHost';
+import type {
+  ProviderId,
+  ProviderWorkspaceInitContext,
+  ProviderWorkspaceRegistration,
+  ProviderWorkspaceServices,
+} from './types';
+
+export class ProviderInitializationBoundary {
+  private registrations: Partial<Record<ProviderId, ProviderWorkspaceRegistration>> = {};
+  private services: Partial<Record<ProviderId, ProviderWorkspaceServices>> = {};
+  private initPromises: Partial<Record<ProviderId, Promise<void>>> = {};
+  private generation = 0;
+
+  getRegisteredProviderIds(): ProviderId[] {
+    return Object.keys(this.registrations);
+  }
+
+  setServices(
+    providerId: ProviderId,
+    services: ProviderWorkspaceServices | undefined,
+  ): void {
+    if (services) {
+      this.services[providerId] = services;
+    } else {
+      delete this.services[providerId];
+      delete this.initPromises[providerId];
+    }
+  }
+
+  register(
+    providerId: ProviderId,
+    registration: ProviderWorkspaceRegistration,
+  ): void {
+    this.registrations[providerId] = registration;
+  }
+
+  async ensureInitialized(
+    plugin: ProviderHost,
+    providerId: ProviderId,
+    _reason: string,
+  ): Promise<void> {
+    if (this.services[providerId]) {
+      return;
+    }
+
+    const existing = this.initPromises[providerId];
+    if (existing) {
+      return existing;
+    }
+
+    const promise = this.runInitialize(plugin, providerId, this.generation);
+    this.initPromises[providerId] = promise;
+    try {
+      await promise;
+    } finally {
+      if (this.initPromises[providerId] === promise) {
+        delete this.initPromises[providerId];
+      }
+    }
+  }
+
+  getIfInitialized(providerId: ProviderId): ProviderWorkspaceServices | null {
+    return this.services[providerId] ?? null;
+  }
+
+  async disposeInitialized(): Promise<void> {
+    this.generation += 1;
+    const promises: Promise<void>[] = [];
+    for (const [providerId, services] of Object.entries(this.services)) {
+      if (!services) continue;
+      const dispose = services.dispose;
+      if (typeof dispose === 'function') {
+        promises.push(Promise.resolve().then(() => dispose.call(services)));
+      }
+      delete this.services[providerId];
+    }
+    this.initPromises = {};
+    await Promise.allSettled(promises);
+  }
+
+  private async runInitialize(
+    plugin: ProviderHost,
+    providerId: ProviderId,
+    generation: number,
+  ): Promise<void> {
+    const registration = this.registrations[providerId];
+    if (!registration) {
+      throw new Error(`Provider workspace "${providerId}" is not registered.`);
+    }
+
+    const storage = plugin.storage;
+    const vaultAdapter = storage.getAdapter();
+    const { HomeFileAdapter } = await import('../storage/HomeFileAdapter');
+    const homeAdapter = new HomeFileAdapter();
+
+    const context: ProviderWorkspaceInitContext = {
+      plugin,
+      storage,
+      vaultAdapter,
+      homeAdapter,
+    };
+
+    const services = await registration.initialize(context);
+    if (generation !== this.generation) {
+      if (typeof services.dispose === 'function') {
+        await Promise.resolve()
+          .then(() => services.dispose?.())
+          .catch(() => undefined);
+      }
+      return;
+    }
+
+    this.services[providerId] = services;
+  }
+}

--- a/src/core/providers/ProviderSettingsCoordinator.ts
+++ b/src/core/providers/ProviderSettingsCoordinator.ts
@@ -5,6 +5,7 @@ import type { ProviderChatUIConfig, ProviderId } from './types';
 
 export interface SettingsReconciliationResult {
   changed: boolean;
+  environmentChangedProviderIds: ProviderId[];
   invalidatedConversations: Conversation[];
 }
 
@@ -457,6 +458,7 @@ export class ProviderSettingsCoordinator {
   ): SettingsReconciliationResult {
     let anyChanged = false;
     const allInvalidated: Conversation[] = [];
+    const environmentChangedProviderIds: ProviderId[] = [];
     const settingsProvider = getSettingsProviderId(settings);
 
     for (const providerId of providerIds) {
@@ -477,6 +479,7 @@ export class ProviderSettingsCoordinator {
 
       if (changed) {
         anyChanged = true;
+        environmentChangedProviderIds.push(providerId);
         this.persistProjectedProviderState(targetSettings, providerId);
         if (providerId !== settingsProvider) {
           mergeProviderSettings(settings, targetSettings);
@@ -489,7 +492,26 @@ export class ProviderSettingsCoordinator {
       anyChanged = true;
     }
 
-    return { changed: anyChanged, invalidatedConversations: allInvalidated };
+    return {
+      changed: anyChanged,
+      environmentChangedProviderIds,
+      invalidatedConversations: allInvalidated,
+    };
+  }
+
+  static invalidateConversationSessions(
+    conversations: Conversation[],
+    providerIds: ProviderId[],
+  ): Conversation[] {
+    const invalidatedConversations: Conversation[] = [];
+    for (const providerId of new Set(providerIds)) {
+      const providerConversations = conversations.filter(c => c.providerId === providerId);
+      invalidatedConversations.push(
+        ...ProviderRegistry.getSettingsReconciler(providerId)
+          .invalidateConversationSessions(providerConversations),
+      );
+    }
+    return invalidatedConversations;
   }
 
   static normalizeAllModelVariants(settings: Record<string, unknown>): boolean {

--- a/src/core/providers/ProviderWorkspaceRegistry.ts
+++ b/src/core/providers/ProviderWorkspaceRegistry.ts
@@ -1,6 +1,7 @@
-import { HomeFileAdapter } from '../storage/HomeFileAdapter';
+import { StartupProfiler } from '../performance/StartupProfiler';
 import type { ProviderCommandCatalog } from './commands/ProviderCommandCatalog';
 import type { ProviderHost } from './ProviderHost';
+import { ProviderInitializationBoundary } from './ProviderInitializationBoundary';
 import type {
   AgentMentionProvider,
   ProviderCliResolver,
@@ -19,61 +20,73 @@ import type {
  * Unlike `ProviderRegistry`, this boundary owns app-level provider services such
  * as command catalogs, mention providers, MCP/plugin/agent managers, and
  * provider-specific storage adaptors.
+ *
+ * Initialization is lazy: providers are only initialized when something first
+ * asks for them via `ensureInitialized`. `getServices` returns already-initialized
+ * services (or null) so callers can keep synchronous access patterns after they
+ * have awaited initialization.
  */
 export class ProviderWorkspaceRegistry {
-  private static registrations: Partial<Record<ProviderId, ProviderWorkspaceRegistration>> = {};
-  private static services: Partial<Record<ProviderId, ProviderWorkspaceServices>> = {};
+  private static boundary = new ProviderInitializationBoundary();
 
   static register(
     providerId: ProviderId,
     registration: ProviderWorkspaceRegistration,
   ): void {
-    this.registrations[providerId] = registration;
-  }
-
-  private static getWorkspaceRegistration(providerId: ProviderId): ProviderWorkspaceRegistration {
-    const registration = this.registrations[providerId];
-    if (!registration) {
-      throw new Error(`Provider workspace "${providerId}" is not registered.`);
-    }
-    return registration;
+    this.boundary.register(providerId, registration);
   }
 
   static async initializeAll(plugin: ProviderHost): Promise<void> {
-    const providerIds = Object.keys(this.registrations);
-    const storage = plugin.storage;
-    const vaultAdapter = storage.getAdapter();
-    const homeAdapter = new HomeFileAdapter();
-
-    for (const providerId of providerIds) {
-      this.services[providerId] = await this.getWorkspaceRegistration(providerId).initialize({
-        plugin,
-        storage,
-        vaultAdapter,
-        homeAdapter,
-      });
+    for (const providerId of this.boundary.getRegisteredProviderIds()) {
+      try {
+        await this.ensureInitialized(plugin, providerId, 'startup');
+      } catch {
+        // Compatibility path only: one provider must not block the remaining providers.
+      }
     }
+  }
+
+  static async ensureInitialized(
+    plugin: ProviderHost,
+    providerId: ProviderId,
+    reason: string,
+  ): Promise<void> {
+    const span = StartupProfiler.start(`provider-init:${providerId}`);
+    try {
+      await this.boundary.ensureInitialized(plugin, providerId, reason);
+    } catch (error) {
+      StartupProfiler.increment('provider-init-failures');
+      throw error;
+    } finally {
+      StartupProfiler.finish(span);
+    }
+  }
+
+  static getIfInitialized(
+    providerId: ProviderId,
+  ): ProviderWorkspaceServices | null {
+    return this.boundary.getIfInitialized(providerId);
+  }
+
+  static async disposeInitialized(): Promise<void> {
+    await this.boundary.disposeInitialized();
   }
 
   static setServices(
     providerId: ProviderId,
     services: ProviderWorkspaceServices | undefined,
   ): void {
-    if (services) {
-      this.services[providerId] = services;
-    } else {
-      delete this.services[providerId];
-    }
+    this.boundary.setServices(providerId, services);
   }
 
   static clear(): void {
-    this.services = {};
+    this.boundary = new ProviderInitializationBoundary();
   }
 
   static getServices(
     providerId: ProviderId,
   ): ProviderWorkspaceServices | null {
-    return this.services[providerId] ?? null;
+    return this.getIfInitialized(providerId);
   }
 
   static requireServices(
@@ -122,5 +135,9 @@ export class ProviderWorkspaceRegistry {
 
   static getSettingsTabRenderer(providerId: ProviderId): ProviderSettingsTabRenderer | null {
     return this.getServices(providerId)?.settingsTabRenderer ?? null;
+  }
+
+  static async prepareSettings(providerId: ProviderId): Promise<void> {
+    await this.getServices(providerId)?.prepareSettings?.();
   }
 }

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -117,7 +117,14 @@ export interface SessionMetadataListOptions {
   batchSize?: number;
 }
 
+export interface SessionMetadataScanResult {
+  metadata: SessionMetadata[];
+  /** False when any metadata directory or listed metadata file could not be read. */
+  complete: boolean;
+}
+
 export interface AppSessionStorage {
+  scanMetadata(options?: SessionMetadataListOptions): Promise<SessionMetadataScanResult>;
   listMetadata(options?: SessionMetadataListOptions): Promise<SessionMetadata[]>;
   loadMetadata(id: string): Promise<SessionMetadata | null>;
   saveMetadata(meta: SessionMetadata): Promise<void>;

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -121,6 +121,8 @@ export interface SessionMetadataScanResult {
   metadata: SessionMetadata[];
   /** False when any metadata directory or listed metadata file could not be read. */
   complete: boolean;
+  /** Files that were read successfully but did not contain valid session metadata. */
+  invalidMetadataCount: number;
 }
 
 export interface AppSessionStorage {

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -109,8 +109,15 @@ export interface AppTabManagerState {
 }
 
 /** Provider-neutral session metadata storage. */
+export interface SessionMetadataListOptions {
+  /** Receives successful reads incrementally. Batches may follow completion order. */
+  onBatch?: (metadata: SessionMetadata[]) => void;
+  batchSize?: number;
+}
+
 export interface AppSessionStorage {
-  listMetadata(): Promise<SessionMetadata[]>;
+  listMetadata(options?: SessionMetadataListOptions): Promise<SessionMetadata[]>;
+  loadMetadata(id: string): Promise<SessionMetadata | null>;
   saveMetadata(meta: SessionMetadata): Promise<void>;
   deleteMetadata(id: string): Promise<void>;
   toSessionMetadata(conv: Conversation): SessionMetadata;
@@ -150,6 +157,8 @@ export interface AppAgentStorage {
 export type AgentMentionSource = AgentDefinition['source'];
 
 export interface AgentMentionProvider {
+  ensureLoaded?(): Promise<void>;
+  isLoaded?(): boolean;
   searchAgents(query: string): Array<{
     id: string;
     name: string;
@@ -346,7 +355,7 @@ export interface ProviderCliResolver {
   resolveFromSettings(
     settings: Record<string, unknown>,
     context?: ProviderCliResolutionContext,
-  ): string | null;
+  ): string | null | Promise<string | null>;
   reset(): void;
 }
 
@@ -398,6 +407,8 @@ export interface ProviderWorkspaceServices {
   settingsTabRenderer?: ProviderSettingsTabRenderer | null;
   refreshAgentMentions?(): Promise<void>;
   refreshModelCatalog?(): Promise<ProviderModelCatalogRefreshResult>;
+  prepareSettings?(): Promise<void>;
+  dispose?(): Promise<void> | void;
 }
 
 export interface ProviderModelCatalogRefreshResult {

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -89,6 +89,8 @@ export interface ProviderSettingsStorageAdapter {
 export interface ProviderSettingsReconciler {
   handleEnvironmentChange?(settings: Record<string, unknown>): boolean;
 
+  invalidateConversationSessions(conversations: Conversation[]): Conversation[];
+
   reconcileModelWithEnvironment(
     settings: Record<string, unknown>,
     conversations: Conversation[],

--- a/src/core/runtime/ChatRuntime.ts
+++ b/src/core/runtime/ChatRuntime.ts
@@ -21,6 +21,8 @@ export interface ChatRuntime {
   readonly providerId: ProviderId;
 
   getCapabilities(): Readonly<ProviderCapabilities>;
+  /** Loads provider-owned state required for synchronous turn encoding. Must be idempotent. */
+  prepareForTurn?(): Promise<void>;
   prepareTurn(request: ChatTurnRequest): PreparedChatTurn;
   onReadyStateChange(listener: (ready: boolean) => void): () => void;
   setResumeCheckpoint(checkpointId: string | undefined): void;

--- a/src/core/storage/VaultFileAdapter.ts
+++ b/src/core/storage/VaultFileAdapter.ts
@@ -9,6 +9,7 @@ import type { App } from 'obsidian';
 
 export class VaultFileAdapter {
   private writeQueue: Promise<void> = Promise.resolve();
+  private folderCreationPromises = new Map<string, Promise<void>>();
 
   constructor(private app: App) {}
 
@@ -102,15 +103,43 @@ export class VaultFileAdapter {
 
   /** Ensure a folder exists, creating it and parent folders if needed. */
   async ensureFolder(path: string): Promise<void> {
-    if (await this.exists(path)) return;
-
-    // Create parent folders recursively
     const parts = path.split('/').filter(Boolean);
     let current = '';
     for (const part of parts) {
       current = current ? `${current}/${part}` : part;
-      if (!(await this.exists(current))) {
-        await this.app.vault.adapter.mkdir(current);
+      await this.ensureSingleFolder(current);
+    }
+  }
+
+  private async ensureSingleFolder(path: string): Promise<void> {
+    const existing = this.folderCreationPromises.get(path);
+    if (existing) {
+      await existing;
+      return;
+    }
+    if (await this.exists(path)) return;
+
+    const pendingAfterCheck = this.folderCreationPromises.get(path);
+    if (pendingAfterCheck) {
+      await pendingAfterCheck;
+      return;
+    }
+
+    const creation = (async () => {
+      try {
+        await this.app.vault.adapter.mkdir(path);
+      } catch (error) {
+        if (!(await this.exists(path))) {
+          throw error;
+        }
+      }
+    })();
+    this.folderCreationPromises.set(path, creation);
+    try {
+      await creation;
+    } finally {
+      if (this.folderCreationPromises.get(path) === creation) {
+        this.folderCreationPromises.delete(path);
       }
     }
   }

--- a/src/core/types/settings.ts
+++ b/src/core/types/settings.ts
@@ -134,6 +134,9 @@ export interface ClaudianSettings {
   savedProviderThinkingBudget: Partial<Record<string, string>>;
   savedProviderPermissionMode: Partial<Record<string, string>>;
 
+  // Internal lifecycle state. Entries remain until all affected session metadata is durable.
+  pendingProviderSessionInvalidations: Partial<Record<string, number>>;
+
   // State (provider-specific, round-tripped opaquely)
   lastCustomModel?: string;
 

--- a/src/features/FeatureHost.ts
+++ b/src/features/FeatureHost.ts
@@ -52,6 +52,7 @@ export interface FeatureHost {
   renameConversation(id: string, title: string): Promise<void>;
   updateConversation(id: string, updates: Partial<Conversation>): Promise<void>;
   getConversationById(id: string): Promise<Conversation | null>;
+  getCachedConversation(id: string): Conversation | null;
   getConversationSync(id: string): Conversation | null;
   getConversationList(): ConversationMeta[];
 

--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -284,17 +284,24 @@ export class ClaudianView extends ItemView {
     }
     this.eventRefs = [];
 
-    await this.persistTabStateImmediate();
-    this.tabStatePersistence.dispose();
+    try {
+      await this.persistTabStateImmediate();
+    } catch {
+      // The storage boundary already reports the failure. View teardown must still complete cleanly.
+    } finally {
+      this.tabStatePersistence.dispose();
+      try {
+        this.restoreActiveInputToTabContent();
+        await this.tabManager?.destroy();
+      } finally {
+        this.tabManager = null;
+        this.mentionCacheCoordinator = null;
 
-    this.restoreActiveInputToTabContent();
-    await this.tabManager?.destroy();
-    this.tabManager = null;
-    this.mentionCacheCoordinator = null;
-
-    this.tabBar?.destroy();
-    this.tabBar = null;
-    this.scope = null;
+        this.tabBar?.destroy();
+        this.tabBar = null;
+        this.scope = null;
+      }
+    }
   }
 
   // ============================================
@@ -817,7 +824,7 @@ export class ClaudianView extends ItemView {
     await this.tabStatePersistence.flush();
   }
 
-  private getPersistedTabState(): AppTabManagerState | null {
+  getPersistedTabState(): AppTabManagerState | null {
     if (!this.tabManager) return null;
 
     const state = this.tabManager.getPersistedState();

--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -1,6 +1,7 @@
 import type { EventRef, WorkspaceLeaf } from 'obsidian';
 import { ItemView, Notice, Scope, setIcon } from 'obsidian';
 
+import { StartupProfiler } from '../../core/performance/StartupProfiler';
 import { getHiddenProviderCommandSet } from '../../core/providers/commands/hiddenCommands';
 import {
   getProviderSettingsSnapshotWithModel,
@@ -19,6 +20,7 @@ import {
 import type { FeatureHost } from '../FeatureHost';
 import type { HistoryConversationStatus } from './controllers/ConversationController';
 import { MentionCacheCoordinator } from './services/MentionCacheCoordinator';
+import { TabStatePersistenceCoordinator } from './services/TabStatePersistenceCoordinator';
 import {
   getTabProviderId,
   onProviderAvailabilityChanged,
@@ -57,6 +59,7 @@ export class ClaudianView extends ItemView {
 
   // Header elements
   private historyDropdown: HTMLElement | null = null;
+  private historyRenderAbortController: AbortController | null = null;
 
   // Event refs for cleanup
   private eventRefs: EventRef[] = [];
@@ -64,12 +67,14 @@ export class ClaudianView extends ItemView {
   // Debouncing for tab bar updates
   private pendingTabBarUpdate: ScheduledAnimationFrame | null = null;
 
-  // Debouncing for tab state persistence
-  private pendingPersist: number | null = null;
+  private tabStatePersistence: TabStatePersistenceCoordinator;
 
   constructor(leaf: WorkspaceLeaf, plugin: FeatureHost) {
     super(leaf);
     this.plugin = plugin;
+    this.tabStatePersistence = new TabStatePersistenceCoordinator(
+      state => this.plugin.persistTabManagerState(state),
+    );
 
     // Hover Editor compatibility: Define load as an instance method that can't be
     // overwritten by prototype patching. Hover Editor patches ClaudianView.prototype.load
@@ -167,6 +172,15 @@ export class ClaudianView extends ItemView {
   }
 
   async onOpen() {
+    const span = StartupProfiler.start('view-open');
+    try {
+      await this.onOpenImpl();
+    } finally {
+      StartupProfiler.finish(span);
+    }
+  }
+
+  private async onOpenImpl() {
     // Guard: Hover Editor and similar plugins may call onOpen before DOM is ready.
     // containerEl must exist before we can access contentEl or create elements.
     if (!this.containerEl) {
@@ -256,10 +270,10 @@ export class ClaudianView extends ItemView {
     this.attachNavRowContentToInputFooter();
     this.updateInputLocation();
     this.updateTabBarVisibility();
-    this.tabManager?.primeProviderRuntime();
   }
 
   async onClose() {
+    this.cancelHistoryRendering();
     if (this.pendingTabBarUpdate !== null) {
       cancelScheduledAnimationFrame(this.pendingTabBarUpdate);
       this.pendingTabBarUpdate = null;
@@ -271,6 +285,7 @@ export class ClaudianView extends ItemView {
     this.eventRefs = [];
 
     await this.persistTabStateImmediate();
+    this.tabStatePersistence.dispose();
 
     this.restoreActiveInputToTabContent();
     await this.tabManager?.destroy();
@@ -536,32 +551,60 @@ export class ClaudianView extends ItemView {
     const isVisible = this.historyDropdown.hasClass('visible');
     if (isVisible) {
       this.historyDropdown.removeClass('visible');
+      this.cancelHistoryRendering();
     } else {
-      this.updateHistoryDropdown();
       this.historyDropdown.addClass('visible');
+      this.renderHistoryDropdown();
     }
   }
 
+  private historyDropdownDirty = true;
+  private historyDropdownRendered = false;
+
   private updateHistoryDropdown(): void {
-    if (!this.historyDropdown) return;
-    this.historyDropdown.empty();
+    this.historyDropdownDirty = true;
+    if (this.historyDropdown?.hasClass('visible')) {
+      this.renderHistoryDropdown();
+    }
+  }
 
-    const activeTab = this.tabManager?.getActiveTab();
-    const conversationController = activeTab?.controllers.conversationController;
+  private renderHistoryDropdown(): void {
+    if (!this.historyDropdown || !this.historyDropdownDirty) return;
 
-    if (conversationController) {
-      conversationController.renderHistoryDropdown(this.historyDropdown, {
-        onSelectConversation: (id) => this.openHistoryConversation(id),
-        onOpenConversationInNewTab: (id, activate) =>
-          this.openHistoryConversationInNewTab(id, activate),
-        getConversationStatus: (id) => this.getHistoryConversationStatus(id),
-      });
+    this.cancelHistoryRendering();
+    const abortController = new AbortController();
+    this.historyRenderAbortController = abortController;
+
+    const span = this.historyDropdownRendered ? null : StartupProfiler.start('history-list-render');
+    this.historyDropdownRendered = true;
+
+    try {
+      this.historyDropdown.empty();
+
+      const activeTab = this.tabManager?.getActiveTab();
+      const conversationController = activeTab?.controllers.conversationController;
+
+      if (conversationController) {
+        conversationController.renderHistoryDropdown(this.historyDropdown, {
+          onSelectConversation: (id) => this.openHistoryConversation(id),
+          onOpenConversationInNewTab: (id, activate) =>
+            this.openHistoryConversationInNewTab(id, activate),
+          getConversationStatus: (id) => this.getHistoryConversationStatus(id),
+          signal: abortController.signal,
+        });
+      }
+      this.historyDropdownDirty = false;
+    } finally {
+      if (span) {
+        StartupProfiler.finish(span);
+      }
     }
   }
 
   private async openHistoryConversation(conversationId: string): Promise<void> {
     await this.tabManager?.openConversation(conversationId);
     this.historyDropdown?.removeClass('visible');
+    this.cancelHistoryRendering();
   }
 
   private async openHistoryConversationInNewTab(
@@ -573,6 +616,12 @@ export class ClaudianView extends ItemView {
       activate,
     });
     this.historyDropdown?.removeClass('visible');
+    this.cancelHistoryRendering();
+  }
+
+  private cancelHistoryRendering(): void {
+    this.historyRenderAbortController?.abort();
+    this.historyRenderAbortController = null;
   }
 
   private getHistoryConversationStatus(conversationId: string): HistoryConversationStatus {
@@ -733,47 +782,39 @@ export class ClaudianView extends ItemView {
   // ============================================
 
   private async restoreOrCreateTabs(): Promise<void> {
-    if (!this.tabManager) return;
+    const span = StartupProfiler.start('tab-restore');
+    try {
+      if (!this.tabManager) return;
 
-    // Try to restore from persisted state
-    const persistedState = await this.plugin.storage.getTabManagerState();
-    if (persistedState && persistedState.openTabs.length > 0) {
-      await this.tabManager.restoreState(persistedState);
-      this.tabBar?.setExpandedTitleTabIds(persistedState.expandedTitleTabIds ?? []);
-      this.updateTabBar();
-      return;
+      // Try to restore from persisted state
+      const persistedState = await this.plugin.storage.getTabManagerState();
+      if (persistedState && persistedState.openTabs.length > 0) {
+        StartupProfiler.recordCount('restored-tab-count', persistedState.openTabs.length);
+        await StartupProfiler.runAsync('tab-restore-internal', () => this.tabManager!.restoreState(persistedState));
+        this.tabBar?.setExpandedTitleTabIds(persistedState.expandedTitleTabIds ?? []);
+        this.updateTabBar();
+        return;
+      }
+
+      // Fallback: create a new empty tab
+      await this.tabManager.createTab();
+    } finally {
+      StartupProfiler.finish(span);
     }
-
-    // Fallback: create a new empty tab
-    await this.tabManager.createTab();
   }
 
   private persistTabState(): void {
-
-    // Debounce persistence to avoid rapid writes (300ms delay)
-    if (this.pendingPersist !== null) {
-      window.clearTimeout(this.pendingPersist);
-    }
-    this.pendingPersist = window.setTimeout(() => {
-      this.pendingPersist = null;
-      const state = this.getPersistedTabState();
-      if (!state) return;
-      this.plugin.persistTabManagerState(state).catch(() => {
-        // Silently ignore persistence errors
-      });
-    }, 300);
+    const state = this.getPersistedTabState();
+    if (!state) return;
+    this.tabStatePersistence.update(state);
   }
 
   /** Force immediate persistence (for onClose/onunload). */
   private async persistTabStateImmediate(): Promise<void> {
-    // Cancel any pending debounced persist
-    if (this.pendingPersist !== null) {
-      window.clearTimeout(this.pendingPersist);
-      this.pendingPersist = null;
-    }
     const state = this.getPersistedTabState();
     if (!state) return;
-    await this.plugin.persistTabManagerState(state);
+    this.tabStatePersistence.update(state);
+    await this.tabStatePersistence.flush();
   }
 
   private getPersistedTabState(): AppTabManagerState | null {
@@ -797,6 +838,10 @@ export class ClaudianView extends ItemView {
   /** Gets the currently active tab. */
   getActiveTab(): TabData | null {
     return this.tabManager?.getActiveTab() ?? null;
+  }
+
+  notifyConversationListChanged(): void {
+    this.updateHistoryDropdown();
   }
 
   /** Gets the tab manager. */

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -24,6 +24,8 @@ function runConversationAction(action: () => Promise<void>, failureMessage: stri
   });
 }
 
+const DEFAULT_HISTORY_PAGE_SIZE = 100;
+
 export interface ConversationCallbacks {
   onNewConversation?: () => void;
   onConversationLoaded?: () => void;
@@ -52,6 +54,8 @@ export interface ConversationControllerDeps {
   ensureServiceForConversation?: (conversation: Conversation | null) => Promise<void>;
   dismissPendingInlinePrompts?: () => void;
   awaitBackgroundWork?: () => Promise<void>;
+  /** True once the owning tab has begun teardown. */
+  isDisposed?: () => boolean;
 }
 
 type SaveOptions = {
@@ -74,6 +78,9 @@ type HistoryRenderOptions = {
   getConversationOpenState?: (id: string) => HistoryConversationOpenState;
   getConversationStatus?: (id: string) => HistoryConversationStatus;
   onRerender: () => void;
+  signal?: AbortSignal;
+  pageSize?: number;
+  visibleCount?: number;
 };
 
 export class ConversationController {
@@ -253,6 +260,7 @@ export class ConversationController {
   async switchTo(id: string): Promise<void> {
     const { plugin, state, subagentManager } = this.deps;
 
+    if (this.deps.isDisposed?.()) return;
     if (id === state.currentConversationId) return;
     if (state.isStreaming) return;
     if (state.isSwitchingConversation) return;
@@ -265,17 +273,20 @@ export class ConversationController {
       if (this.deps.awaitBackgroundWork) {
         await this.deps.awaitBackgroundWork();
       }
+      if (this.deps.isDisposed?.()) return;
       subagentManager.orphanAllActive();
       await this.save();
+      if (this.deps.isDisposed?.()) return;
 
       subagentManager.clear();
 
       const conversation = await plugin.switchConversation(id);
-      if (!conversation) {
+      if (!conversation || this.deps.isDisposed?.()) {
         return;
       }
 
       await this.deps.ensureServiceForConversation?.(conversation);
+      if (this.deps.isDisposed?.()) return;
 
       this.deps.getInputEl().value = '';
       this.deps.clearQueuedMessage();
@@ -583,6 +594,7 @@ export class ConversationController {
     options: HistoryRenderOptions
   ): void {
     const { plugin, state } = this.deps;
+    if (options.signal?.aborted) return;
 
     container.empty();
 
@@ -601,8 +613,12 @@ export class ConversationController {
     const conversations = [...allConversations].sort((a, b) => {
       return (b.lastResponseAt ?? b.createdAt) - (a.lastResponseAt ?? a.createdAt);
     });
+    const pageSize = Math.max(1, options.pageSize ?? DEFAULT_HISTORY_PAGE_SIZE);
+    const visibleCount = Math.max(pageSize, options.visibleCount ?? pageSize);
+    const visibleConversations = conversations.slice(0, visibleCount);
 
-    for (const conv of conversations) {
+    for (const conv of visibleConversations) {
+      if (options.signal?.aborted) return;
       const fallbackOpenState: HistoryConversationOpenState =
         conv.id === state.currentConversationId ? 'current' : 'closed';
       const conversationStatus = this.getHistoryConversationStatus(conv.id, fallbackOpenState, options);
@@ -739,6 +755,20 @@ export class ConversationController {
           ),
           'Failed to delete conversation',
         );
+      });
+    }
+
+    if (visibleConversations.length < conversations.length && !options.signal?.aborted) {
+      const loadMoreButton = list.createEl('button', {
+        cls: 'claudian-history-load-more',
+        text: `Load more (${conversations.length - visibleConversations.length} remaining)`,
+      });
+      loadMoreButton.addEventListener('click', () => {
+        if (options.signal?.aborted) return;
+        this.renderHistoryItems(container, {
+          ...options,
+          visibleCount: visibleCount + pageSize,
+        });
       });
     }
   }

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -419,6 +419,7 @@ export class InputController {
     }
 
     try {
+      await agentService.prepareForTurn?.();
       const preparedTurn = agentService.prepareTurn(turnRequest);
       userMsg.content = preparedTurn.persistedContent;
       userMsg.currentNote = preparedTurn.isCompact
@@ -1001,6 +1002,7 @@ export class InputController {
     try {
       const { displayContent, request } = this.toQueuedChatTurn(queuedMessage);
 
+      await agentService.prepareForTurn?.();
       const preparedTurn = agentService.prepareTurn(request);
       const accepted = await agentService.steer(preparedTurn);
       if (state.cancelRequested || !this.pendingSteerMessage) {

--- a/src/features/chat/services/TabStatePersistenceCoordinator.ts
+++ b/src/features/chat/services/TabStatePersistenceCoordinator.ts
@@ -1,0 +1,89 @@
+import type { AppTabManagerState } from '../../../core/providers/types';
+
+type TimerHost = Pick<Window, 'clearTimeout' | 'setTimeout'>;
+
+/**
+ * Owns the latest tab-layout snapshot and serializes persistence writes.
+ */
+export class TabStatePersistenceCoordinator {
+  private timer: number | null = null;
+  private latestState: AppTabManagerState | null = null;
+  private latestSerialized: string | null = null;
+  private acknowledgedSerialized: string | null = null;
+  private writePromise: Promise<void> | null = null;
+  private disposed = false;
+
+  constructor(
+    private readonly persist: (state: AppTabManagerState) => Promise<void>,
+    private readonly timerHost: TimerHost = window,
+    private readonly debounceMs = 300,
+  ) {}
+
+  update(state: AppTabManagerState): void {
+    if (this.disposed) return;
+
+    const serialized = JSON.stringify(state);
+    this.latestSerialized = serialized;
+    this.latestState = JSON.parse(serialized) as AppTabManagerState;
+    this.cancelTimer();
+
+    if (serialized === this.acknowledgedSerialized) return;
+    this.timer = this.timerHost.setTimeout(() => {
+      this.timer = null;
+      void this.flush().catch(() => {
+        // Keep the unacknowledged snapshot available for a later update or close flush.
+      });
+    }, this.debounceMs);
+  }
+
+  async flush(): Promise<void> {
+    this.cancelTimer();
+
+    while (
+      this.latestState
+      && this.latestSerialized
+      && this.latestSerialized !== this.acknowledgedSerialized
+    ) {
+      const activeWrite = this.writePromise ?? this.startWriteLoop();
+      await activeWrite;
+    }
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.cancelTimer();
+  }
+
+  private startWriteLoop(): Promise<void> {
+    const run = this.writeLatestUntilCurrent();
+    this.writePromise = run;
+    void run.then(
+      () => {
+        if (this.writePromise === run) this.writePromise = null;
+      },
+      () => {
+        if (this.writePromise === run) this.writePromise = null;
+      },
+    );
+    return run;
+  }
+
+  private async writeLatestUntilCurrent(): Promise<void> {
+    while (
+      this.latestState
+      && this.latestSerialized
+      && this.latestSerialized !== this.acknowledgedSerialized
+    ) {
+      const state = this.latestState;
+      const serialized = this.latestSerialized;
+      await this.persist(state);
+      this.acknowledgedSerialized = serialized;
+    }
+  }
+
+  private cancelTimer(): void {
+    if (this.timer === null) return;
+    this.timerHost.clearTimeout(this.timer);
+    this.timer = null;
+  }
+}

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -411,6 +411,13 @@ function applyProviderUIGating(tab: TabData, plugin: FeatureHost): void {
   tab.ui.contextUsageMeter?.update(tab.state.usage);
 }
 
+export function refreshTabWorkspaceServices(tab: TabData, plugin: FeatureHost): void {
+  const providerId = getTabProviderId(tab, plugin);
+  tab.ui.mcpServerSelector?.setMcpManager(getProviderMcpManager(providerId));
+  syncSlashCommandDropdownForProvider(tab, plugin);
+  applyProviderUIGating(tab, plugin);
+}
+
 function syncTabProviderServices(
   tab: TabData,
   plugin: FeatureHost,
@@ -553,6 +560,7 @@ export function createTab(options: TabCreateOptions): TabData {
     set lifecycleState(value) {
       session.lifecycleState = value;
     },
+    hydrationState: isBound ? 'idle' : 'ready',
     get draftModel() {
       return session.draftModel;
     },
@@ -699,6 +707,8 @@ export async function initializeTabService(
       : null
   );
   const providerId = getTabProviderId(tab, plugin, conversation);
+  await ProviderWorkspaceRegistry.ensureInitialized(plugin.providerHost, providerId, 'tab-runtime');
+  refreshTabWorkspaceServices(tab, plugin);
   const selectedModel = conversation
     ? resolveConversationModel(plugin.settings, providerId, conversation).model
     : getTabSelectedModel(tab, plugin);
@@ -1447,6 +1457,7 @@ export function initializeTabControllers(
       getSelectedModel: () => getTabSelectedModel(tab, plugin),
       dismissPendingInlinePrompts: () => tab.controllers.inputController?.dismissPendingApproval(),
       awaitBackgroundWork: () => tab.session.awaitBackgroundWork(),
+      isDisposed: () => tab.lifecycleState === 'closing',
       ensureServiceForConversation: async (conversation) => {
         const nextProviderId = getTabProviderId(tab, plugin, conversation);
         const providerChanged = tab.providerId !== nextProviderId;

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -706,8 +706,14 @@ export async function initializeTabService(
       ? await plugin.getConversationById(tab.conversationId)
       : null
   );
+  if (isClosingLifecycleState(tab.lifecycleState)) {
+    return;
+  }
   const providerId = getTabProviderId(tab, plugin, conversation);
   await ProviderWorkspaceRegistry.ensureInitialized(plugin.providerHost, providerId, 'tab-runtime');
+  if (isClosingLifecycleState(tab.lifecycleState)) {
+    return;
+  }
   refreshTabWorkspaceServices(tab, plugin);
   const selectedModel = conversation
     ? resolveConversationModel(plugin.settings, providerId, conversation).model
@@ -1554,6 +1560,9 @@ export function initializeTabControllers(
         }
 
         await initializeTabService(tab, plugin);
+        if (isClosingLifecycleState(tab.lifecycleState)) {
+          return false;
+        }
         setupServiceCallbacks(tab, plugin);
 
         // Transition: lock model selector to bound provider

--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -174,71 +174,71 @@ export class TabManager implements TabManagerInterface {
     try {
       const { activate = true, draftModel } = options;
 
-    const conversation = conversationId
-      ? this.plugin.getCachedConversation(conversationId)
-      : undefined;
+      const conversation = conversationId
+        ? this.plugin.getCachedConversation(conversationId)
+        : undefined;
 
-    // Inherit the active tab's provider so the new blank tab picks up its model
-    const activeTab = this.getActiveTab();
-    const defaultProviderId = conversation
-      ? undefined
-      : (activeTab ? getTabProviderId(activeTab, this.plugin) : undefined);
+      // Inherit the active tab's provider so the new blank tab picks up its model
+      const activeTab = this.getActiveTab();
+      const defaultProviderId = conversation
+        ? undefined
+        : (activeTab ? getTabProviderId(activeTab, this.plugin) : undefined);
 
-    const tab = createTab({
-      plugin: this.plugin,
-      containerEl: this.containerEl,
-      conversation: conversation ?? undefined,
-      tabId,
-      ...(typeof draftModel === 'string' ? { draftModel } : {}),
-      defaultProviderId,
-      onStreamingChanged: (isStreaming) => {
-        this.callbacks.onTabStreamingChanged?.(tab.id, isStreaming);
-      },
-      onTitleChanged: (title) => {
-        this.callbacks.onTabTitleChanged?.(tab.id, title);
-      },
-      onAttentionChanged: (needsAttention) => {
-        this.callbacks.onTabAttentionChanged?.(tab.id, needsAttention);
-      },
-      onConversationIdChanged: (conversationId) => {
-        // Sync tab.conversationId when conversation is lazily created
-        tab.conversationId = conversationId;
-        this.callbacks.onTabConversationChanged?.(tab.id, conversationId);
-      },
-    });
+      const tab = createTab({
+        plugin: this.plugin,
+        containerEl: this.containerEl,
+        conversation: conversation ?? undefined,
+        tabId,
+        ...(typeof draftModel === 'string' ? { draftModel } : {}),
+        defaultProviderId,
+        onStreamingChanged: (isStreaming) => {
+          this.callbacks.onTabStreamingChanged?.(tab.id, isStreaming);
+        },
+        onTitleChanged: (title) => {
+          this.callbacks.onTabTitleChanged?.(tab.id, title);
+        },
+        onAttentionChanged: (needsAttention) => {
+          this.callbacks.onTabAttentionChanged?.(tab.id, needsAttention);
+        },
+        onConversationIdChanged: (conversationId) => {
+          // Sync tab.conversationId when conversation is lazily created
+          tab.conversationId = conversationId;
+          this.callbacks.onTabConversationChanged?.(tab.id, conversationId);
+        },
+      });
 
-    // Initialize UI components with provider catalog
-    initializeTabUI(tab, this.plugin, {
-      getProviderCatalogConfig: () => this.getProviderCatalogConfig(tab),
-      onProviderChanged: (providerId) => {
-        this.callbacks.onTabProviderChanged?.(tab.id, providerId);
-        void this.ensureTabWorkspaceServices(tab, providerId, 'provider-selection')
-          .catch(() => {
-            // Provider selection remains usable even when optional workspace services fail.
-          });
-      },
-    });
+      // Initialize UI components with provider catalog
+      initializeTabUI(tab, this.plugin, {
+        getProviderCatalogConfig: () => this.getProviderCatalogConfig(tab),
+        onProviderChanged: (providerId) => {
+          this.callbacks.onTabProviderChanged?.(tab.id, providerId);
+          void this.ensureTabWorkspaceServices(tab, providerId, 'provider-selection')
+            .catch(() => {
+              // Provider selection remains usable even when optional workspace services fail.
+            });
+        },
+      });
 
-    initializeTabControllers(
-      tab,
-      this.plugin,
-      this.view,
-      (forkContext) => this.handleForkRequest(forkContext),
-      (conversationId) => this.openConversation(conversationId),
-      () => this.getProviderCatalogConfig(tab),
-    );
+      initializeTabControllers(
+        tab,
+        this.plugin,
+        this.view,
+        (forkContext) => this.handleForkRequest(forkContext),
+        (conversationId) => this.openConversation(conversationId),
+        () => this.getProviderCatalogConfig(tab),
+      );
 
-    // Wire input event handlers
-    wireTabInputEvents(tab, this.plugin);
+      // Wire input event handlers
+      wireTabInputEvents(tab, this.plugin);
 
-    this.tabs.set(tab.id, tab);
-    this.pendingTabCreations -= 1;
-    reservationHeld = false;
-    this.callbacks.onTabCreated?.(tab);
+      this.tabs.set(tab.id, tab);
+      this.pendingTabCreations -= 1;
+      reservationHeld = false;
+      this.callbacks.onTabCreated?.(tab);
 
-    if (!this.isRestoringState && (activate || !this.activeTabId)) {
-      await this.switchToTab(tab.id);
-    }
+      if (!this.isRestoringState && (activate || !this.activeTabId)) {
+        await this.switchToTab(tab.id);
+      }
 
       return tab;
     } finally {
@@ -282,7 +282,7 @@ export class TabManager implements TabManagerInterface {
       this.callbacks.onActiveTabChanged?.(previousTabId, tabId);
 
       const providerId = tab.service?.providerId ?? tab.providerId;
-      const needsHydration = !!tab.conversationId && tab.state.messages.length === 0;
+      const needsHydration = !!tab.conversationId && tab.hydrationState !== 'ready';
       if (needsHydration) {
         tab.hydrationState = 'loading';
         this.renderTabHydrationState(tab);
@@ -291,7 +291,9 @@ export class TabManager implements TabManagerInterface {
       }
 
       try {
-        await this.ensureTabWorkspaceServices(tab, providerId, 'tab-activation');
+        if (!await this.ensureTabWorkspaceServices(tab, providerId, 'tab-activation')) {
+          return;
+        }
 
         // Load conversation if not already loaded
         if (needsHydration && tab.conversationId) {
@@ -331,7 +333,7 @@ export class TabManager implements TabManagerInterface {
           tab.hydrationState = 'ready';
         }
       } catch (error) {
-        if (!needsHydration || !this.isTabAlive(tab)) throw error;
+        if (!this.isTabAlive(tab)) return;
         tab.hydrationState = 'failed';
         this.renderTabHydrationState(tab, error);
         return;
@@ -898,7 +900,7 @@ export class TabManager implements TabManagerInterface {
     tab: TabData,
     providerId: ProviderId,
     reason: string,
-  ): Promise<void> {
+  ): Promise<boolean> {
     if (!ProviderWorkspaceRegistry.getIfInitialized(providerId)) {
       await ProviderWorkspaceRegistry.ensureInitialized(
         this.plugin.providerHost,
@@ -906,7 +908,11 @@ export class TabManager implements TabManagerInterface {
         reason,
       );
     }
+    if (!this.isTabAlive(tab)) {
+      return false;
+    }
     refreshTabWorkspaceServices(tab, this.plugin);
+    return true;
   }
 
   private isProviderCommandLoaderAvailable(providerId: ProviderId): boolean {
@@ -942,6 +948,9 @@ export class TabManager implements TabManagerInterface {
   ): Promise<void> {
     if (!context.runtime || context.runtime.providerId !== providerId || !tab.serviceInitialized) {
       await initializeTabService(tab, this.plugin, context.conversation);
+      if (!this.isTabAlive(tab)) {
+        return;
+      }
       setupServiceCallbacks(tab, this.plugin);
     }
 

--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -1,5 +1,6 @@
 import { Notice } from 'obsidian';
 
+import { StartupProfiler } from '../../../core/performance/StartupProfiler';
 import { ProviderRegistry } from '../../../core/providers/ProviderRegistry';
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
@@ -12,6 +13,7 @@ import type { ChatRuntime } from '../../../core/runtime/ChatRuntime';
 import type { Conversation, SlashCommand } from '../../../core/types';
 import { t } from '../../../i18n/i18n';
 import { chooseForkTarget } from '../../../shared/modals/ForkTargetModal';
+import { scheduleAnimationFrame } from '../../../utils/animationFrame';
 import { revealWorkspaceLeaf } from '../../../utils/obsidianCompat';
 import type { FeatureHost } from '../../FeatureHost';
 import { getTabProviderId } from './providerResolution';
@@ -26,6 +28,7 @@ import {
   initializeTabService,
   initializeTabUI,
   recycleTabRuntime,
+  refreshTabWorkspaceServices,
   setupServiceCallbacks,
   wireTabInputEvents,
 } from './Tab';
@@ -100,6 +103,7 @@ export class TabManager implements TabManagerInterface {
   private isSwitchingTab = false;
   private pendingSwitchTabId: TabId | null = null;
   private pendingTabCreations = 0;
+  private profiledFirstHydration = false;
 
   /**
    * Gets the current max tabs limit from settings.
@@ -171,7 +175,7 @@ export class TabManager implements TabManagerInterface {
       const { activate = true, draftModel } = options;
 
     const conversation = conversationId
-      ? await this.plugin.getConversationById(conversationId)
+      ? this.plugin.getCachedConversation(conversationId)
       : undefined;
 
     // Inherit the active tab's provider so the new blank tab picks up its model
@@ -208,9 +212,10 @@ export class TabManager implements TabManagerInterface {
       getProviderCatalogConfig: () => this.getProviderCatalogConfig(tab),
       onProviderChanged: (providerId) => {
         this.callbacks.onTabProviderChanged?.(tab.id, providerId);
-        void this.prewarmProviderTab(tab).catch(() => {
-          // Keep provider switching non-blocking even if command warmup fails.
-        });
+        void this.ensureTabWorkspaceServices(tab, providerId, 'provider-selection')
+          .catch(() => {
+            // Provider selection remains usable even when optional workspace services fail.
+          });
       },
     });
 
@@ -233,8 +238,6 @@ export class TabManager implements TabManagerInterface {
 
     if (!this.isRestoringState && (activate || !this.activeTabId)) {
       await this.switchToTab(tab.id);
-    } else if (!this.isRestoringState) {
-      this.maybePrimeProviderRuntime(tab);
     }
 
       return tab;
@@ -278,34 +281,64 @@ export class TabManager implements TabManagerInterface {
       activateTab(tab);
       this.callbacks.onActiveTabChanged?.(previousTabId, tabId);
 
-      // Load conversation if not already loaded
-      if (tab.conversationId && tab.state.messages.length === 0) {
-        await tab.controllers.conversationController?.switchTo(tab.conversationId);
-      } else if (
-        tab.conversationId
-        && tab.state.messages.length > 0
-        && tab.service
-        && !tab.state.isStreaming
-        && !tab.state.isSwitchingConversation
-        && !tab.state.hasPendingConversationSave
-      ) {
-        // Passive sync is only safe once local tab state has been persisted.
-        const conversation = this.plugin.getConversationSync(tab.conversationId);
-        if (conversation) {
-          const hasMessages = conversation.messages.length > 0;
-          const externalContextPaths = hasMessages
-            ? conversation.externalContextPaths || []
-            : (this.plugin.settings.persistentExternalContextPaths || []);
-
-          tab.service.syncConversationState(conversation, externalContextPaths);
-        }
-      } else if (!tab.conversationId && tab.state.messages.length === 0) {
-        // New tab with no conversation - initialize welcome greeting
-        tab.controllers.conversationController?.initializeWelcome();
+      const providerId = tab.service?.providerId ?? tab.providerId;
+      const needsHydration = !!tab.conversationId && tab.state.messages.length === 0;
+      if (needsHydration) {
+        tab.hydrationState = 'loading';
+        this.renderTabHydrationState(tab);
+        await this.waitForTabPaint(tab);
+        if (!this.isTabAlive(tab)) return;
       }
 
+      try {
+        await this.ensureTabWorkspaceServices(tab, providerId, 'tab-activation');
+
+        // Load conversation if not already loaded
+        if (needsHydration && tab.conversationId) {
+          const span = this.profiledFirstHydration ? null : StartupProfiler.start('active-hydration');
+          this.profiledFirstHydration = true;
+          try {
+            await tab.controllers.conversationController?.switchTo(tab.conversationId);
+          } finally {
+            if (span) {
+              StartupProfiler.finish(span);
+            }
+          }
+          if (!this.isTabAlive(tab)) return;
+          tab.hydrationState = 'ready';
+        } else if (
+          tab.conversationId
+          && tab.state.messages.length > 0
+          && tab.service
+          && !tab.state.isStreaming
+          && !tab.state.isSwitchingConversation
+          && !tab.state.hasPendingConversationSave
+        ) {
+          // Passive sync is only safe once local tab state has been persisted.
+          const conversation = this.plugin.getConversationSync(tab.conversationId);
+          if (conversation) {
+            const hasMessages = conversation.messages.length > 0;
+            const externalContextPaths = hasMessages
+              ? conversation.externalContextPaths || []
+              : (this.plugin.settings.persistentExternalContextPaths || []);
+
+            tab.service.syncConversationState(conversation, externalContextPaths);
+          }
+          tab.hydrationState = 'ready';
+        } else if (!tab.conversationId && tab.state.messages.length === 0) {
+          // New tab with no conversation - initialize welcome greeting
+          tab.controllers.conversationController?.initializeWelcome();
+          tab.hydrationState = 'ready';
+        }
+      } catch (error) {
+        if (!needsHydration || !this.isTabAlive(tab)) throw error;
+        tab.hydrationState = 'failed';
+        this.renderTabHydrationState(tab, error);
+        return;
+      }
+
+      if (!this.isTabAlive(tab)) return;
       this.callbacks.onTabSwitched?.(previousTabId, tabId);
-      this.maybePrimeProviderRuntime(tab);
     } finally {
       this.isSwitchingTab = false;
       const pendingTabId = this.pendingSwitchTabId;
@@ -338,6 +371,9 @@ export class TabManager implements TabManagerInterface {
     if (this.tabs.size === 1 && !tab.conversationId && tab.state.messages.length === 0) {
       return false;
     }
+
+    // Prevent in-flight hydration from mutating this tab while close awaits persistence.
+    tab.lifecycleState = 'closing';
 
     // Save conversation before closing. Cleanup remains mandatory if save fails.
     let saveError: unknown;
@@ -383,6 +419,43 @@ export class TabManager implements TabManagerInterface {
       throw saveError;
     }
     return true;
+  }
+
+  private isTabAlive(tab: TabData): boolean {
+    return tab.lifecycleState !== 'closing' && this.tabs.get(tab.id) === tab;
+  }
+
+  private waitForTabPaint(tab: TabData): Promise<void> {
+    return new Promise(resolve => {
+      scheduleAnimationFrame(resolve, tab.dom.contentEl.ownerDocument?.defaultView ?? null);
+    });
+  }
+
+  private renderTabHydrationState(tab: TabData, error?: unknown): void {
+    const messagesEl = tab.dom.messagesEl;
+    messagesEl.empty();
+
+    const statusEl = messagesEl.createDiv({ cls: 'claudian-tab-hydration' });
+    if (!error) {
+      statusEl.createDiv({
+        cls: 'claudian-tab-hydration-loading',
+        text: 'Loading conversation…',
+      });
+      return;
+    }
+
+    statusEl.createDiv({
+      cls: 'claudian-tab-hydration-error',
+      text: error instanceof Error ? error.message : 'Failed to load conversation',
+    });
+    const retryButton = statusEl.createEl('button', {
+      cls: 'mod-cta claudian-tab-hydration-retry',
+      text: 'Retry',
+    });
+    retryButton.addEventListener('click', () => {
+      if (!this.isTabAlive(tab)) return;
+      void this.switchToTab(tab.id);
+    });
   }
 
   // ============================================
@@ -507,7 +580,6 @@ export class TabManager implements TabManagerInterface {
       await activeTab.controllers.conversationController?.createNew();
       // Sync tab.conversationId with the newly created conversation
       activeTab.conversationId = activeTab.state.currentConversationId;
-      this.maybePrimeProviderRuntime(activeTab);
     }
   }
 
@@ -727,6 +799,10 @@ export class TabManager implements TabManagerInterface {
     }
 
     const providerId = getTabProviderId(targetTab, this.plugin);
+    if (!ProviderWorkspaceRegistry.getIfInitialized(providerId)) {
+      await ProviderWorkspaceRegistry.ensureInitialized(this.plugin.providerHost, providerId, 'command-picker');
+    }
+
     const staticCapabilities = ProviderRegistry.getCapabilities(providerId);
     if (!staticCapabilities.supportsProviderCommands) {
       return [];
@@ -818,6 +894,21 @@ export class TabManager implements TabManagerInterface {
     void this.prewarmProviderTab(tab).catch(() => {});
   }
 
+  private async ensureTabWorkspaceServices(
+    tab: TabData,
+    providerId: ProviderId,
+    reason: string,
+  ): Promise<void> {
+    if (!ProviderWorkspaceRegistry.getIfInitialized(providerId)) {
+      await ProviderWorkspaceRegistry.ensureInitialized(
+        this.plugin.providerHost,
+        providerId,
+        reason,
+      );
+    }
+    refreshTabWorkspaceServices(tab, this.plugin);
+  }
+
   private isProviderCommandLoaderAvailable(providerId: ProviderId): boolean {
     const loader = ProviderWorkspaceRegistry.getRuntimeCommandLoader(providerId);
     if (!loader) return false;
@@ -826,11 +917,11 @@ export class TabManager implements TabManagerInterface {
 
   private async prewarmProviderTab(tab: TabData): Promise<void> {
     const providerId = tab.service?.providerId ?? tab.providerId;
-    const context = await this.buildProviderWarmupContext(tab, providerId);
     const hasReadyRuntime = tab.service?.providerId === providerId && tab.service.isReady();
     if (!hasReadyRuntime && tab.id !== this.activeTabId) {
       return;
     }
+    const context = await this.buildProviderWarmupContext(tab, providerId);
 
     switch (context.warmupMode) {
       case 'commands':

--- a/src/features/chat/tabs/types.ts
+++ b/src/features/chat/tabs/types.ts
@@ -172,6 +172,9 @@ export interface TabDOMElements {
  */
 export type TabLifecycleState = 'blank' | 'bound_cold' | 'bound_active' | 'closing';
 
+/** Conversation hydration state, independent from runtime activation. */
+export type TabHydrationState = 'idle' | 'loading' | 'ready' | 'failed';
+
 /**
  * Represents a single tab in the multi-tab system.
  * Each tab is an independent chat session with its own runtime instance.
@@ -184,6 +187,9 @@ export interface TabData {
 
   /** Explicit lifecycle state. */
   lifecycleState: TabLifecycleState;
+
+  /** State of loading the provider-owned conversation into the tab UI. */
+  hydrationState: TabHydrationState;
 
   /**
    * Draft model selected in a blank tab (before first send).

--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -986,7 +986,10 @@ export class McpServerSelector {
     this.container.addEventListener('mouseenter', () => {
       const load = this.mcpManager?.ensureLoaded?.();
       if (load) {
-        void load.then(() => this.renderDropdown()).catch(() => {
+        void load.then(() => {
+          this.updateDisplay();
+          this.renderDropdown();
+        }).catch(() => {
           // Keep the selector usable with its last known state when config loading fails.
         });
       } else {
@@ -1085,7 +1088,8 @@ export class McpServerSelector {
     if (!this.iconEl || !this.badgeEl) return;
 
     const count = this.enabledServers.size;
-    const hasServers = (this.mcpManager?.getServers().length || 0) > 0;
+    const isPendingLazyLoad = this.mcpManager?.isLoaded?.() === false;
+    const hasServers = isPendingLazyLoad || (this.mcpManager?.getServers().length || 0) > 0;
 
     // Show/hide container based on whether there are servers and visibility
     if (!hasServers || !this.visible) {

--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -953,6 +953,7 @@ export class McpServerSelector {
 
   private pruneEnabledServers(): void {
     if (!this.mcpManager) return;
+    if (this.mcpManager.isLoaded?.() === false) return;
     const activeNames = new Set(this.mcpManager.getServers().filter((s) => s.enabled).map((s) => s.name));
     let changed = false;
     for (const name of this.enabledServers) {
@@ -983,7 +984,14 @@ export class McpServerSelector {
 
     // Re-render dropdown content on hover (CSS handles visibility)
     this.container.addEventListener('mouseenter', () => {
-      this.renderDropdown();
+      const load = this.mcpManager?.ensureLoaded?.();
+      if (load) {
+        void load.then(() => this.renderDropdown()).catch(() => {
+          // Keep the selector usable with its last known state when config loading fails.
+        });
+      } else {
+        this.renderDropdown();
+      }
     });
   }
 

--- a/src/features/inline-edit/ui/InlineEditModal.ts
+++ b/src/features/inline-edit/ui/InlineEditModal.ts
@@ -58,6 +58,13 @@ const hideInlineEdit = StateEffect.define<null>();
 
 let activeController: InlineEditSession | null = null;
 
+function rejectActiveController(): boolean {
+  const controller = activeController;
+  if (!controller) return false;
+  controller.reject();
+  return true;
+}
+
 class InputWidget extends WidgetType {
   constructor(private controller: InlineEditSession) {
     super();
@@ -260,6 +267,35 @@ interface InlineEditSourceSnapshot {
   to: number;
 }
 
+interface InlineEditProviderContext {
+  modelOverride?: string;
+  providerId: ProviderId;
+}
+
+function resolveInlineEditProviderContext(plugin: InlineEditHost): InlineEditProviderContext {
+  const activeView = typeof plugin.getView === 'function' ? plugin.getView() : null;
+  const activeTab = activeView?.getActiveTab();
+  const conversation = activeTab?.conversationId
+    ? plugin.getConversationSync(activeTab.conversationId)
+    : null;
+  const providerId = conversation?.providerId
+    ?? activeTab?.service?.providerId
+    ?? activeTab?.providerId
+    ?? DEFAULT_CHAT_PROVIDER_ID;
+  const modelOverride = conversation
+    ? resolveConversationModel(plugin.settings, providerId, conversation).model
+    : activeTab?.service?.providerId === providerId
+    ? activeTab.service.getAuxiliaryModel?.()
+    : activeTab?.providerId === providerId
+    ? activeTab.draftModel
+    : null;
+
+  return {
+    modelOverride: modelOverride ?? undefined,
+    providerId,
+  };
+}
+
 export class InlineEditModal {
   private controller: InlineEditSession | null = null;
 
@@ -274,8 +310,7 @@ export class InlineEditModal {
   ) {}
 
   async openAndWait(): Promise<{ decision: InlineEditDecision; editedText?: string }> {
-    if (activeController) {
-      activeController.reject();
+    if (rejectActiveController()) {
       return { decision: 'reject' };
     }
 
@@ -295,6 +330,22 @@ export class InlineEditModal {
       return { decision: 'reject' };
     }
 
+    const providerContext = resolveInlineEditProviderContext(this.plugin);
+    try {
+      await ProviderWorkspaceRegistry.ensureInitialized(
+        this.plugin.providerHost,
+        providerContext.providerId,
+        'inline-edit',
+      );
+    } catch {
+      new Notice(`Inline edit unavailable: failed to initialize the ${providerContext.providerId} provider.`);
+      return { decision: 'reject' };
+    }
+
+    if (rejectActiveController()) {
+      return { decision: 'reject' };
+    }
+
     return new Promise((resolve) => {
       this.controller = new InlineEditSession(
         this.app,
@@ -304,7 +355,8 @@ export class InlineEditModal {
         this.editContext,
         this.notePath,
         this.getExternalContexts,
-        resolve
+        resolve,
+        providerContext,
       );
       activeController = this.controller;
       this.controller.show();
@@ -346,31 +398,16 @@ export class InlineEditSession {
     editContext: InlineEditContext,
     private notePath: string,
     private getExternalContexts: () => string[],
-    private resolve: (result: { decision: InlineEditDecision; editedText?: string }) => void
+    private resolve: (result: { decision: InlineEditDecision; editedText?: string }) => void,
+    providerContext?: InlineEditProviderContext,
   ) {
-    const activeView = typeof plugin.getView === 'function'
-      ? plugin.getView()
-      : null;
-    const activeTab = activeView?.getActiveTab();
-    const conversation = activeTab?.conversationId
-      ? plugin.getConversationSync(activeTab.conversationId)
-      : null;
-    const providerId: ProviderId = conversation?.providerId as ProviderId
-      ?? activeTab?.service?.providerId
-      ?? activeTab?.providerId
-      ?? DEFAULT_CHAT_PROVIDER_ID;
+    const resolvedProviderContext = providerContext ?? resolveInlineEditProviderContext(plugin);
+    const providerId = resolvedProviderContext.providerId;
     this.inlineEditService = ProviderRegistry.createInlineEditService(
       plugin.providerHost,
       providerId,
     );
-    const auxiliaryModel = conversation
-      ? resolveConversationModel(plugin.settings, providerId, conversation).model
-      : activeTab?.service?.providerId === providerId
-      ? activeTab.service.getAuxiliaryModel?.()
-      : activeTab?.providerId === providerId
-      ? activeTab?.draftModel
-      : null;
-    this.inlineEditService.setModelOverride?.(auxiliaryModel ?? undefined);
+    this.inlineEditService.setModelOverride?.(resolvedProviderContext.modelOverride);
     this.resolvedProviderId = providerId;
     this.mentionDataProvider = new VaultMentionDataProvider(this.app, {
       onFileLoadError: () => {

--- a/src/features/settings/ClaudianSettings.ts
+++ b/src/features/settings/ClaudianSettings.ts
@@ -109,6 +109,7 @@ export class ClaudianSettingTab extends PluginSettingTab {
   plugin: FeatureHost;
   private activeTab: SettingsTabId = 'general';
   private refreshTitleModelOptions: (() => void) | null = null;
+  private displayGeneration = 0;
 
   constructor(app: App, plugin: FeatureHost & Plugin) {
     super(app, plugin);
@@ -116,6 +117,7 @@ export class ClaudianSettingTab extends PluginSettingTab {
   }
 
   display(): void {
+    const displayGeneration = ++this.displayGeneration;
     const { containerEl } = this;
     containerEl.empty();
     containerEl.addClass('claudian-settings');
@@ -132,6 +134,71 @@ export class ClaudianSettingTab extends PluginSettingTab {
     const tabBar = containerEl.createDiv({ cls: 'claudian-settings-tabs' });
     const tabButtons = new Map<SettingsTabId, HTMLButtonElement>();
     const tabContents = new Map<SettingsTabId, HTMLDivElement>();
+    const renderedProviderTabs = new Set<ProviderId>();
+
+    const renderProviderTab = async (providerId: ProviderId): Promise<void> => {
+      if (renderedProviderTabs.has(providerId)) {
+        return;
+      }
+      renderedProviderTabs.add(providerId);
+
+      const content = tabContents.get(providerId);
+      if (!content) {
+        return;
+      }
+      content.empty();
+      content.createDiv({
+        cls: 'claudian-settings-provider-loading',
+        text: `Loading ${ProviderRegistry.getProviderDisplayName(providerId)} settings...`,
+      });
+
+      try {
+        await ProviderWorkspaceRegistry.ensureInitialized(
+          this.plugin.providerHost,
+          providerId,
+          'settings-tab',
+        );
+        await ProviderWorkspaceRegistry.prepareSettings(providerId);
+        if (displayGeneration !== this.displayGeneration) {
+          return;
+        }
+
+        content.empty();
+        const renderer = ProviderWorkspaceRegistry.getSettingsTabRenderer(providerId);
+        if (!renderer) {
+          content.createDiv({ text: 'Provider settings are unavailable.' });
+          return;
+        }
+        renderer.render(content, {
+          plugin: this.plugin.providerHost,
+          renderHiddenProviderCommandSetting: (
+            target,
+            targetProviderId,
+            copy,
+          ) => this.renderHiddenProviderCommandSetting(target, targetProviderId, copy),
+          refreshModelSelectors: () => {
+            for (const view of this.plugin.getAllViews()) {
+              view.refreshModelSelector();
+            }
+          },
+          refreshTitleGenerationModelOptions: () => this.refreshTitleModelOptions?.(),
+          renderCustomContextLimits: (target, targetProviderId) => (
+            this.renderCustomContextLimits(target, targetProviderId)
+          ),
+        });
+      } catch (error) {
+        if (displayGeneration !== this.displayGeneration) {
+          return;
+        }
+        renderedProviderTabs.delete(providerId);
+        content.empty();
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        content.createDiv({
+          cls: 'claudian-setting-validation claudian-setting-validation-error',
+          text: `Could not load provider settings: ${message}`,
+        });
+      }
+    };
 
     for (const id of tabIds) {
       const label = id === 'general'
@@ -147,6 +214,9 @@ export class ClaudianSettingTab extends PluginSettingTab {
           tabButtons.get(tabId)?.toggleClass('claudian-settings-tab--active', tabId === id);
           tabContents.get(tabId)?.toggleClass('claudian-settings-tab-content--active', tabId === id);
         }
+        if (id !== 'general') {
+          void renderProviderTab(id);
+        }
       });
       tabButtons.set(id, button);
     }
@@ -160,27 +230,8 @@ export class ClaudianSettingTab extends PluginSettingTab {
 
     this.renderGeneralTab(tabContents.get('general')!);
 
-    for (const providerId of providerTabs) {
-      const content = tabContents.get(providerId);
-      if (!content) {
-        continue;
-      }
-
-      ProviderWorkspaceRegistry.getSettingsTabRenderer(providerId)?.render(content, {
-        plugin: this.plugin.providerHost,
-        renderHiddenProviderCommandSetting: (
-          target,
-          targetProviderId,
-          copy,
-        ) => this.renderHiddenProviderCommandSetting(target, targetProviderId, copy),
-        refreshModelSelectors: () => {
-          for (const view of this.plugin.getAllViews()) {
-            view.refreshModelSelector();
-          }
-        },
-        refreshTitleGenerationModelOptions: () => this.refreshTitleModelOptions?.(),
-        renderCustomContextLimits: (target, providerId) => this.renderCustomContextLimits(target, providerId),
-      });
+    if (this.activeTab !== 'general') {
+      void renderProviderTab(this.activeTab);
     }
   }
 

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -5,30 +5,61 @@
  * Supports 10 locales with English as the default fallback.
  */
 
-import * as de from './locales/de.json';
 import * as en from './locales/en.json';
-import * as es from './locales/es.json';
-import * as fr from './locales/fr.json';
-import * as ja from './locales/ja.json';
-import * as ko from './locales/ko.json';
-import * as pt from './locales/pt.json';
-import * as ru from './locales/ru.json';
-import * as zhCN from './locales/zh-CN.json';
-import * as zhTW from './locales/zh-TW.json';
 import type { Locale, TranslationKey } from './types';
 
-const translations: Record<Locale, typeof en> = {
-  en,
-  'zh-CN': zhCN,
-  'zh-TW': zhTW,
-  ja,
-  ko,
-  de,
-  fr,
-  es,
-  ru,
-  pt,
-};
+type TranslationDictionary = typeof en;
+
+const AVAILABLE_LOCALES: readonly Locale[] = [
+  'en',
+  'zh-CN',
+  'zh-TW',
+  'ja',
+  'ko',
+  'de',
+  'fr',
+  'es',
+  'ru',
+  'pt',
+];
+
+const translations: Partial<Record<Locale, TranslationDictionary>> = { en };
+
+function loadTranslation(locale: Locale): TranslationDictionary | undefined {
+  switch (locale) {
+    case 'en':
+      return en;
+    case 'zh-CN':
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- Keep bundled locale initialization lazy.
+      return require('./locales/zh-CN.json') as TranslationDictionary;
+    case 'zh-TW':
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- Keep bundled locale initialization lazy.
+      return require('./locales/zh-TW.json') as TranslationDictionary;
+    case 'ja':
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- Keep bundled locale initialization lazy.
+      return require('./locales/ja.json') as TranslationDictionary;
+    case 'ko':
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- Keep bundled locale initialization lazy.
+      return require('./locales/ko.json') as TranslationDictionary;
+    case 'de':
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- Keep bundled locale initialization lazy.
+      return require('./locales/de.json') as TranslationDictionary;
+    case 'fr':
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- Keep bundled locale initialization lazy.
+      return require('./locales/fr.json') as TranslationDictionary;
+    case 'es':
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- Keep bundled locale initialization lazy.
+      return require('./locales/es.json') as TranslationDictionary;
+    case 'ru':
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- Keep bundled locale initialization lazy.
+      return require('./locales/ru.json') as TranslationDictionary;
+    case 'pt':
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- Keep bundled locale initialization lazy.
+      return require('./locales/pt.json') as TranslationDictionary;
+    default:
+      return undefined;
+  }
+}
 
 const DEFAULT_LOCALE: Locale = 'en';
 let currentLocale: Locale = DEFAULT_LOCALE;
@@ -37,7 +68,7 @@ let currentLocale: Locale = DEFAULT_LOCALE;
  * Get a translation by key with optional parameters
  */
 export function t(key: TranslationKey, params?: Record<string, string | number>): string {
-  const dict = translations[currentLocale];
+  const dict = translations[currentLocale] ?? en;
 
   const keys = key.split('.');
   let value: unknown = dict;
@@ -68,7 +99,7 @@ export function t(key: TranslationKey, params?: Record<string, string | number>)
 }
 
 function tFallback(key: TranslationKey, params?: Record<string, string | number>): string {
-  const dict = translations[DEFAULT_LOCALE];
+  const dict = en;
   const keys = key.split('.');
   let value: unknown = dict;
 
@@ -99,9 +130,11 @@ function tFallback(key: TranslationKey, params?: Record<string, string | number>
  * @returns true if locale was set successfully, false if locale is invalid
  */
 export function setLocale(locale: Locale): boolean {
-  if (!translations[locale]) {
+  const translation = translations[locale] ?? loadTranslation(locale);
+  if (!translation) {
     return false;
   }
+  translations[locale] = translation;
   currentLocale = locale;
   return true;
 }
@@ -117,7 +150,7 @@ export function getLocale(): Locale {
  * Get all available locales
  */
 export function getAvailableLocales(): Locale[] {
-  return Object.keys(translations) as Locale[];
+  return [...AVAILABLE_LOCALES];
 }
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,6 +60,49 @@ function isClaudianView(value: unknown): value is ClaudianView {
     && typeof (value as { getTabManager?: unknown }).getTabManager === 'function';
 }
 
+function readPendingProviderSessionInvalidations(
+  settings: Record<string, unknown>,
+): Map<ProviderId, number> {
+  const registeredProviderIds = new Set(ProviderRegistry.getRegisteredProviderIds());
+  const value = settings.pendingProviderSessionInvalidations;
+  const pending = new Map<ProviderId, number>();
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return pending;
+  }
+
+  for (const [providerId, generation] of Object.entries(value)) {
+    if (
+      registeredProviderIds.has(providerId)
+      && typeof generation === 'number'
+      && Number.isSafeInteger(generation)
+      && generation > 0
+    ) {
+      pending.set(providerId, generation);
+    }
+  }
+  return pending;
+}
+
+function serializePendingProviderSessionInvalidations(
+  pending: ReadonlyMap<ProviderId, number>,
+): Partial<Record<string, number>> {
+  return Object.fromEntries(
+    Array.from(pending.entries()).sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function hasSamePendingProviderSessionInvalidations(
+  value: unknown,
+  pending: ReadonlyMap<ProviderId, number>,
+): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const entries = Object.entries(value);
+  return entries.length === pending.size
+    && entries.every(([providerId, generation]) => pending.get(providerId) === generation);
+}
+
 export default class ClaudianPlugin extends Plugin {
   settings!: ClaudianSettings;
   storage!: SharedAppStorage;
@@ -68,8 +111,9 @@ export default class ClaudianPlugin extends Plugin {
   private conversationRepository!: ConversationRepository;
   private lastKnownTabManagerState: AppTabManagerState | null = null;
   private pendingSessionMetadataScan = false;
-  private pendingEnvironmentInvalidationProviderIds = new Set<ProviderId>();
+  private pendingEnvironmentInvalidationGenerations = new Map<ProviderId, number>();
   private isLoadingRemainingSessionMetadata = false;
+  private hasLoadedAllSessionMetadata = false;
   private sessionMetadataLoadTimer: number | null = null;
   private remainingSessionMetadataLoad: Promise<void> | null = null;
   private isUnloading = false;
@@ -219,7 +263,6 @@ export default class ClaudianPlugin extends Plugin {
 
   onunload(): void {
     this.isUnloading = true;
-    this.pendingEnvironmentInvalidationProviderIds.clear();
     if (this.sessionMetadataLoadTimer !== null) {
       window.clearTimeout(this.sessionMetadataLoadTimer);
       this.sessionMetadataLoadTimer = null;
@@ -319,6 +362,7 @@ export default class ClaudianPlugin extends Plugin {
   }
 
   async loadSettings(options: { deferNonRestoredSessionMetadata?: boolean } = {}) {
+    this.hasLoadedAllSessionMetadata = false;
     this.storage = new SharedStorageService(this);
     const { claudian } = await this.storage.initialize();
     this.lastKnownTabManagerState = await this.storage.getTabManagerState();
@@ -335,6 +379,7 @@ export default class ClaudianPlugin extends Plugin {
         await this.storage.saveClaudianSettings(settings);
       },
     );
+    const didNormalizePendingSessionInvalidations = this.syncPendingSessionInvalidations();
     this.conversationRepository = new ConversationRepository({
       getSettings: () => this.settings,
       getVaultPath: () => getVaultPath(this.app),
@@ -391,32 +436,45 @@ export default class ClaudianPlugin extends Plugin {
 
     const backfilledConversations = this.conversationRepository.backfillResponseTimestamps();
 
-    const {
-      changed,
-      environmentChangedProviderIds,
-      invalidatedConversations,
-    } = this.reconcileModelWithEnvironment();
-    this.pendingEnvironmentInvalidationProviderIds.clear();
-    if (deferRemainingMetadata) {
-      for (const providerId of environmentChangedProviderIds) {
-        this.pendingEnvironmentInvalidationProviderIds.add(providerId);
-      }
-    }
+    const reconciliation = this.reconcileModelWithEnvironment();
+    this.markPendingSessionInvalidations(
+      this.settings,
+      reconciliation.environmentChangedProviderIds,
+    );
+    const pendingInvalidatedConversations = ProviderSettingsCoordinator
+      .invalidateConversationSessions(
+        this.conversationRepository.getAll(),
+        Array.from(this.pendingEnvironmentInvalidationGenerations.keys()),
+      );
+    const completedInvalidationGenerations = deferRemainingMetadata
+      ? new Map<ProviderId, number>()
+      : new Map(this.pendingEnvironmentInvalidationGenerations);
 
     ProviderSettingsCoordinator.projectActiveProviderState(
       this.settings,
     );
 
-    if (changed || didNormalizeModelVariants || didNormalizeProviderSelection) {
+    if (
+      reconciliation.changed
+      || didNormalizeModelVariants
+      || didNormalizeProviderSelection
+      || didNormalizePendingSessionInvalidations
+    ) {
       await this.saveSettings();
     }
 
-    const conversationsToSave = new Set([...backfilledConversations, ...invalidatedConversations]);
+    const conversationsToSave = new Set([
+      ...backfilledConversations,
+      ...reconciliation.invalidatedConversations,
+      ...pendingInvalidatedConversations,
+    ]);
     for (const conv of conversationsToSave) {
       await this.storage.sessions.saveMetadata(
         this.storage.sessions.toSessionMetadata(conv)
       );
     }
+    await this.completePendingSessionInvalidations(completedInvalidationGenerations);
+    this.hasLoadedAllSessionMetadata = !deferRemainingMetadata;
     this.pendingSessionMetadataScan = deferRemainingMetadata;
   }
 
@@ -479,6 +537,9 @@ export default class ClaudianPlugin extends Plugin {
   }
 
   private async loadRemainingSessionMetadata(): Promise<void> {
+    const scanInvalidationGenerations = new Map(
+      this.pendingEnvironmentInvalidationGenerations,
+    );
     this.isLoadingRemainingSessionMetadata = true;
     try {
       const addedConversations: Conversation[] = [];
@@ -489,7 +550,7 @@ export default class ClaudianPlugin extends Plugin {
         const shells = metadata.map(meta => this.createConversationMetadataShell(meta));
         const invalidatedShells = ProviderSettingsCoordinator.invalidateConversationSessions(
           shells,
-          Array.from(this.pendingEnvironmentInvalidationProviderIds),
+          Array.from(this.pendingEnvironmentInvalidationGenerations.keys()),
         );
         const invalidatedIds = new Set(invalidatedShells.map(({ id }) => id));
         const added = this.conversationRepository.mergeMetadataConversations(shells);
@@ -523,9 +584,88 @@ export default class ClaudianPlugin extends Plugin {
           this.storage.sessions.toSessionMetadata(conversation),
         );
       }
+      this.hasLoadedAllSessionMetadata = true;
+      if (!this.isUnloading) {
+        await this.completePendingSessionInvalidations(scanInvalidationGenerations);
+      }
     } finally {
       this.isLoadingRemainingSessionMetadata = false;
-      this.pendingEnvironmentInvalidationProviderIds.clear();
+    }
+  }
+
+  private syncPendingSessionInvalidations(): boolean {
+    const pending = readPendingProviderSessionInvalidations(this.settings);
+    const changed = !hasSamePendingProviderSessionInvalidations(
+      this.settings.pendingProviderSessionInvalidations,
+      pending,
+    );
+    this.settings.pendingProviderSessionInvalidations =
+      serializePendingProviderSessionInvalidations(pending);
+    this.pendingEnvironmentInvalidationGenerations = pending;
+    return changed;
+  }
+
+  private markPendingSessionInvalidations(
+    settings: ClaudianSettings,
+    providerIds: ProviderId[],
+  ): Map<ProviderId, number> {
+    const pending = readPendingProviderSessionInvalidations(settings);
+    const marked = new Map<ProviderId, number>();
+    for (const providerId of new Set(providerIds)) {
+      const previousGeneration = Math.max(
+        pending.get(providerId) ?? 0,
+        this.pendingEnvironmentInvalidationGenerations.get(providerId) ?? 0,
+      );
+      const generation = Math.max(Date.now(), previousGeneration + 1);
+      pending.set(providerId, generation);
+      this.pendingEnvironmentInvalidationGenerations.set(providerId, generation);
+      marked.set(providerId, generation);
+    }
+    settings.pendingProviderSessionInvalidations =
+      serializePendingProviderSessionInvalidations(pending);
+    return marked;
+  }
+
+  private async completePendingSessionInvalidations(
+    completedGenerations: ReadonlyMap<ProviderId, number>,
+  ): Promise<void> {
+    if (completedGenerations.size === 0) {
+      return;
+    }
+
+    const removed = new Map<ProviderId, number>();
+    try {
+      await this.mutateSettingsConditionally((settings) => {
+        const pending = readPendingProviderSessionInvalidations(settings);
+        for (const [providerId, generation] of completedGenerations) {
+          if (pending.get(providerId) === generation) {
+            pending.delete(providerId);
+            removed.set(providerId, generation);
+          }
+        }
+        if (removed.size === 0) {
+          return false;
+        }
+        settings.pendingProviderSessionInvalidations =
+          serializePendingProviderSessionInvalidations(pending);
+        return true;
+      });
+    } catch (error) {
+      const pending = readPendingProviderSessionInvalidations(this.settings);
+      for (const [providerId, generation] of removed) {
+        if (this.pendingEnvironmentInvalidationGenerations.get(providerId) === generation) {
+          pending.set(providerId, generation);
+        }
+      }
+      this.settings.pendingProviderSessionInvalidations =
+        serializePendingProviderSessionInvalidations(pending);
+      throw error;
+    }
+
+    for (const [providerId, generation] of removed) {
+      if (this.pendingEnvironmentInvalidationGenerations.get(providerId) === generation) {
+        this.pendingEnvironmentInvalidationGenerations.delete(providerId);
+      }
     }
   }
 
@@ -586,6 +726,8 @@ export default class ClaudianPlugin extends Plugin {
     let affectedProviderIds: ProviderId[] = [];
     let changed = false;
     let invalidatedConversations: Conversation[] = [];
+    let invalidationGenerations = new Map<ProviderId, number>();
+    let canCompleteInvalidationsImmediately = false;
     await this.mutateSettings((settings) => {
       const settingsBag = settings as unknown as Record<string, unknown>;
       const changedScopes: EnvironmentScope[] = [];
@@ -601,11 +743,12 @@ export default class ClaudianPlugin extends Plugin {
       const reconciliation = this.reconcileModelWithEnvironment(affectedProviderIds);
       changed = reconciliation.changed;
       invalidatedConversations = reconciliation.invalidatedConversations;
-      if (this.pendingSessionMetadataScan || this.isLoadingRemainingSessionMetadata) {
-        for (const providerId of reconciliation.environmentChangedProviderIds) {
-          this.pendingEnvironmentInvalidationProviderIds.add(providerId);
-        }
-      }
+      invalidationGenerations = this.markPendingSessionInvalidations(
+        settings,
+        reconciliation.environmentChangedProviderIds,
+      );
+      canCompleteInvalidationsImmediately = this.hasLoadedAllSessionMetadata
+        && !this.isLoadingRemainingSessionMetadata;
     });
 
     if (affectedProviderIds.length === 0) {
@@ -630,6 +773,9 @@ export default class ClaudianPlugin extends Plugin {
           this.storage.sessions.toSessionMetadata(conv)
         );
       }
+    }
+    if (canCompleteInvalidationsImmediately && !this.isUnloading) {
+      await this.completePendingSessionInvalidations(invalidationGenerations);
     }
 
     const openViews = this.getAllViews();

--- a/src/main.ts
+++ b/src/main.ts
@@ -112,6 +112,7 @@ export default class ClaudianPlugin extends Plugin {
   private lastKnownTabManagerState: AppTabManagerState | null = null;
   private pendingSessionMetadataScan = false;
   private pendingEnvironmentInvalidationGenerations = new Map<ProviderId, number>();
+  private blockedEnvironmentInvalidationGenerations = new Map<ProviderId, number>();
   private isLoadingRemainingSessionMetadata = false;
   private hasLoadedAllSessionMetadata = false;
   private sessionMetadataLoadTimer: number | null = null;
@@ -419,12 +420,13 @@ export default class ClaudianPlugin extends Plugin {
     const didNormalizeModelVariants = this.normalizeModelVariantSettings();
 
     const deferRemainingMetadata = options.deferNonRestoredSessionMetadata === true;
-    const initialMetadata = await StartupProfiler.runAsync(
+    const initialMetadataScan = await StartupProfiler.runAsync(
       deferRemainingMetadata ? 'restored-session-metadata-load' : 'session-metadata-load',
-      () => deferRemainingMetadata
-        ? this.loadRestoredSessionMetadata()
-        : this.storage.sessions.listMetadata(),
+      async () => deferRemainingMetadata
+        ? { metadata: await this.loadRestoredSessionMetadata(), complete: false }
+        : this.storage.sessions.scanMetadata(),
     );
+    const initialMetadata = initialMetadataScan.metadata;
     StartupProfiler.recordCount('restored-session-metadata-count', initialMetadata.length);
     StartupProfiler.recordCount('session-metadata-count', initialMetadata.length);
     this.conversationRepository.replaceAll(initialMetadata.map(meta => (
@@ -446,9 +448,9 @@ export default class ClaudianPlugin extends Plugin {
         this.conversationRepository.getAll(),
         Array.from(this.pendingEnvironmentInvalidationGenerations.keys()),
       );
-    const completedInvalidationGenerations = deferRemainingMetadata
-      ? new Map<ProviderId, number>()
-      : new Map(this.pendingEnvironmentInvalidationGenerations);
+    const completedInvalidationGenerations = initialMetadataScan.complete
+      ? new Map(this.pendingEnvironmentInvalidationGenerations)
+      : new Map<ProviderId, number>();
 
     ProviderSettingsCoordinator.projectActiveProviderState(
       this.settings,
@@ -474,7 +476,7 @@ export default class ClaudianPlugin extends Plugin {
       );
     }
     await this.completePendingSessionInvalidations(completedInvalidationGenerations);
-    this.hasLoadedAllSessionMetadata = !deferRemainingMetadata;
+    this.hasLoadedAllSessionMetadata = initialMetadataScan.complete;
     this.pendingSessionMetadataScan = deferRemainingMetadata;
   }
 
@@ -537,9 +539,6 @@ export default class ClaudianPlugin extends Plugin {
   }
 
   private async loadRemainingSessionMetadata(): Promise<void> {
-    const scanInvalidationGenerations = new Map(
-      this.pendingEnvironmentInvalidationGenerations,
-    );
     this.isLoadingRemainingSessionMetadata = true;
     try {
       const addedConversations: Conversation[] = [];
@@ -564,11 +563,12 @@ export default class ClaudianPlugin extends Plugin {
           view.notifyConversationListChanged();
         }
       };
-      const allMetadata = await this.storage.sessions.listMetadata({ onBatch: publishBatch });
+      const scan = await this.storage.sessions.scanMetadata({ onBatch: publishBatch });
       if (this.isUnloading) {
         return;
       }
 
+      const allMetadata = scan.metadata;
       StartupProfiler.recordCount('session-metadata-count', allMetadata.length);
       // Custom storage implementations may not support incremental publication yet.
       publishBatch(allMetadata);
@@ -584,9 +584,13 @@ export default class ClaudianPlugin extends Plugin {
           this.storage.sessions.toSessionMetadata(conversation),
         );
       }
-      this.hasLoadedAllSessionMetadata = true;
-      if (!this.isUnloading) {
-        await this.completePendingSessionInvalidations(scanInvalidationGenerations);
+      if (scan.complete) {
+        this.hasLoadedAllSessionMetadata = true;
+        if (!this.isUnloading) {
+          await this.completePendingSessionInvalidations(
+            this.getCompletablePendingSessionInvalidations(),
+          );
+        }
       }
     } finally {
       this.isLoadingRemainingSessionMetadata = false;
@@ -624,6 +628,33 @@ export default class ClaudianPlugin extends Plugin {
     settings.pendingProviderSessionInvalidations =
       serializePendingProviderSessionInvalidations(pending);
     return marked;
+  }
+
+  private blockEnvironmentInvalidationCompletion(
+    generations: ReadonlyMap<ProviderId, number>,
+  ): void {
+    for (const [providerId, generation] of generations) {
+      this.blockedEnvironmentInvalidationGenerations.set(providerId, generation);
+    }
+  }
+
+  private releaseEnvironmentInvalidationCompletion(
+    generations: ReadonlyMap<ProviderId, number>,
+  ): void {
+    for (const [providerId, generation] of generations) {
+      if (this.blockedEnvironmentInvalidationGenerations.get(providerId) === generation) {
+        this.blockedEnvironmentInvalidationGenerations.delete(providerId);
+      }
+    }
+  }
+
+  private getCompletablePendingSessionInvalidations(): Map<ProviderId, number> {
+    return new Map(Array.from(
+      this.pendingEnvironmentInvalidationGenerations,
+      ([providerId, generation]) => [providerId, generation] as const,
+    ).filter(([providerId, generation]) => (
+      this.blockedEnvironmentInvalidationGenerations.get(providerId) !== generation
+    )));
   }
 
   private async completePendingSessionInvalidations(
@@ -727,7 +758,6 @@ export default class ClaudianPlugin extends Plugin {
     let changed = false;
     let invalidatedConversations: Conversation[] = [];
     let invalidationGenerations = new Map<ProviderId, number>();
-    let canCompleteInvalidationsImmediately = false;
     await this.mutateSettings((settings) => {
       const settingsBag = settings as unknown as Record<string, unknown>;
       const changedScopes: EnvironmentScope[] = [];
@@ -747,8 +777,7 @@ export default class ClaudianPlugin extends Plugin {
         settings,
         reconciliation.environmentChangedProviderIds,
       );
-      canCompleteInvalidationsImmediately = this.hasLoadedAllSessionMetadata
-        && !this.isLoadingRemainingSessionMetadata;
+      this.blockEnvironmentInvalidationCompletion(invalidationGenerations);
     });
 
     if (affectedProviderIds.length === 0) {
@@ -774,7 +803,8 @@ export default class ClaudianPlugin extends Plugin {
         );
       }
     }
-    if (canCompleteInvalidationsImmediately && !this.isUnloading) {
+    this.releaseEnvironmentInvalidationCompletion(invalidationGenerations);
+    if (this.hasLoadedAllSessionMetadata && !this.isUnloading) {
       await this.completePendingSessionInvalidations(invalidationGenerations);
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,10 @@ import {
   setEnvironmentVariablesForScope,
 } from './core/providers/providerEnvironment';
 import { ProviderRegistry } from './core/providers/ProviderRegistry';
-import { ProviderSettingsCoordinator } from './core/providers/ProviderSettingsCoordinator';
+import {
+  ProviderSettingsCoordinator,
+  type SettingsReconciliationResult,
+} from './core/providers/ProviderSettingsCoordinator';
 import { ProviderWorkspaceRegistry } from './core/providers/ProviderWorkspaceRegistry';
 import type {
   ProviderCliResolutionContext,
@@ -65,6 +68,8 @@ export default class ClaudianPlugin extends Plugin {
   private conversationRepository!: ConversationRepository;
   private lastKnownTabManagerState: AppTabManagerState | null = null;
   private pendingSessionMetadataScan = false;
+  private pendingEnvironmentInvalidationProviderIds = new Set<ProviderId>();
+  private isLoadingRemainingSessionMetadata = false;
   private sessionMetadataLoadTimer: number | null = null;
   private remainingSessionMetadataLoad: Promise<void> | null = null;
   private isUnloading = false;
@@ -214,6 +219,7 @@ export default class ClaudianPlugin extends Plugin {
 
   onunload(): void {
     this.isUnloading = true;
+    this.pendingEnvironmentInvalidationProviderIds.clear();
     if (this.sessionMetadataLoadTimer !== null) {
       window.clearTimeout(this.sessionMetadataLoadTimer);
       this.sessionMetadataLoadTimer = null;
@@ -385,7 +391,17 @@ export default class ClaudianPlugin extends Plugin {
 
     const backfilledConversations = this.conversationRepository.backfillResponseTimestamps();
 
-    const { changed, invalidatedConversations } = this.reconcileModelWithEnvironment();
+    const {
+      changed,
+      environmentChangedProviderIds,
+      invalidatedConversations,
+    } = this.reconcileModelWithEnvironment();
+    this.pendingEnvironmentInvalidationProviderIds.clear();
+    if (deferRemainingMetadata) {
+      for (const providerId of environmentChangedProviderIds) {
+        this.pendingEnvironmentInvalidationProviderIds.add(providerId);
+      }
+    }
 
     ProviderSettingsCoordinator.projectActiveProviderState(
       this.settings,
@@ -463,51 +479,53 @@ export default class ClaudianPlugin extends Plugin {
   }
 
   private async loadRemainingSessionMetadata(): Promise<void> {
-    const addedConversations: Conversation[] = [];
-    const publishBatch = (metadata: SessionMetadata[]): void => {
-      if (this.isUnloading || metadata.length === 0) return;
+    this.isLoadingRemainingSessionMetadata = true;
+    try {
+      const addedConversations: Conversation[] = [];
+      const invalidatedConversations: Conversation[] = [];
+      const publishBatch = (metadata: SessionMetadata[]): void => {
+        if (this.isUnloading || metadata.length === 0) return;
 
-      const added = this.conversationRepository.mergeMetadataConversations(
-        metadata.map(meta => this.createConversationMetadataShell(meta)),
-      );
-      if (added.length === 0) return;
+        const shells = metadata.map(meta => this.createConversationMetadataShell(meta));
+        const invalidatedShells = ProviderSettingsCoordinator.invalidateConversationSessions(
+          shells,
+          Array.from(this.pendingEnvironmentInvalidationProviderIds),
+        );
+        const invalidatedIds = new Set(invalidatedShells.map(({ id }) => id));
+        const added = this.conversationRepository.mergeMetadataConversations(shells);
+        if (added.length === 0) return;
 
-      addedConversations.push(...added);
-      for (const view of this.getAllViews()) {
-        view.notifyConversationListChanged();
+        addedConversations.push(...added);
+        invalidatedConversations.push(
+          ...added.filter(conversation => invalidatedIds.has(conversation.id)),
+        );
+        for (const view of this.getAllViews()) {
+          view.notifyConversationListChanged();
+        }
+      };
+      const allMetadata = await this.storage.sessions.listMetadata({ onBatch: publishBatch });
+      if (this.isUnloading) {
+        return;
       }
-    };
-    const allMetadata = await this.storage.sessions.listMetadata({ onBatch: publishBatch });
-    if (this.isUnloading) {
-      return;
-    }
 
-    StartupProfiler.recordCount('session-metadata-count', allMetadata.length);
-    // Custom storage implementations may not support incremental publication yet.
-    publishBatch(allMetadata);
-    const currentAddedConversations = addedConversations.filter((conversation) => (
-      this.conversationRepository.getCachedConversation(conversation.id) === conversation
-    ));
-    StartupProfiler.recordCount('background-session-metadata-count', currentAddedConversations.length);
-    if (currentAddedConversations.length === 0) {
-      return;
-    }
-
-    const { changed, invalidatedConversations } = ProviderSettingsCoordinator.reconcileProviders(
-      this.settings,
-      currentAddedConversations,
-      ProviderRegistry.getRegisteredProviderIds(),
-    );
-    if (changed) {
-      await this.saveSettings();
-    }
-    for (const conversation of invalidatedConversations) {
-      if (this.conversationRepository.getCachedConversation(conversation.id) !== conversation) {
-        continue;
+      StartupProfiler.recordCount('session-metadata-count', allMetadata.length);
+      // Custom storage implementations may not support incremental publication yet.
+      publishBatch(allMetadata);
+      const currentAddedConversations = addedConversations.filter((conversation) => (
+        this.conversationRepository.getCachedConversation(conversation.id) === conversation
+      ));
+      StartupProfiler.recordCount('background-session-metadata-count', currentAddedConversations.length);
+      for (const conversation of invalidatedConversations) {
+        if (this.conversationRepository.getCachedConversation(conversation.id) !== conversation) {
+          continue;
+        }
+        await this.storage.sessions.saveMetadata(
+          this.storage.sessions.toSessionMetadata(conversation),
+        );
       }
-      await this.storage.sessions.saveMetadata(
-        this.storage.sessions.toSessionMetadata(conversation),
-      );
+    } finally {
+      this.isLoadingRemainingSessionMetadata = false;
+      this.pendingEnvironmentInvalidationProviderIds.clear();
     }
   }
 
@@ -583,6 +601,11 @@ export default class ClaudianPlugin extends Plugin {
       const reconciliation = this.reconcileModelWithEnvironment(affectedProviderIds);
       changed = reconciliation.changed;
       invalidatedConversations = reconciliation.invalidatedConversations;
+      if (this.pendingSessionMetadataScan || this.isLoadingRemainingSessionMetadata) {
+        for (const providerId of reconciliation.environmentChangedProviderIds) {
+          this.pendingEnvironmentInvalidationProviderIds.add(providerId);
+        }
+      }
     });
 
     if (affectedProviderIds.length === 0) {
@@ -715,10 +738,9 @@ export default class ClaudianPlugin extends Plugin {
     return cliResolver.resolveFromSettings(this.settings, context);
   }
 
-  private reconcileModelWithEnvironment(providerIds: ProviderId[] = ProviderRegistry.getRegisteredProviderIds()): {
-    changed: boolean;
-    invalidatedConversations: Conversation[];
-  } {
+  private reconcileModelWithEnvironment(
+    providerIds: ProviderId[] = ProviderRegistry.getRegisteredProviderIds(),
+  ): SettingsReconciliationResult {
     return ProviderSettingsCoordinator.reconcileProviders(
       this.settings,
       this.conversationRepository.getAll(),

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,10 @@ patchSetMaxListenersForElectron();
 
 import './providers';
 
+import { StartupProfiler } from './core/performance/StartupProfiler';
+
+StartupProfiler.finishModuleEvaluation();
+
 import type { Editor, WorkspaceLeaf } from 'obsidian';
 import { MarkdownView, Notice, Plugin } from 'obsidian';
 
@@ -32,6 +36,7 @@ import type {
   ClaudianSettings,
   Conversation,
   ConversationMeta,
+  SessionMetadata,
 } from './core/types';
 import {
   VIEW_TYPE_CLAUDIAN,
@@ -60,145 +65,162 @@ export default class ClaudianPlugin extends Plugin {
   private settingsCoordinator!: SettingsCoordinator<ClaudianSettings>;
   private conversationRepository!: ConversationRepository;
   private lastKnownTabManagerState: AppTabManagerState | null = null;
+  private pendingSessionMetadataScan = false;
+  private sessionMetadataLoadTimer: number | null = null;
+  private remainingSessionMetadataLoad: Promise<void> | null = null;
+  private isUnloading = false;
 
   async onload() {
-    await this.loadSettings();
-    await ProviderWorkspaceRegistry.initializeAll(this.providerHost);
+    StartupProfiler.startOnload();
+    try {
+      await StartupProfiler.runAsync(
+        'settings-load',
+        () => this.loadSettings({ deferNonRestoredSessionMetadata: true }),
+      );
+      // Provider workspace services are initialized lazily on first use.
 
-    this.registerView(
-      VIEW_TYPE_CLAUDIAN,
-      (leaf) => new ClaudianView(leaf, this)
-    );
+      this.registerView(
+        VIEW_TYPE_CLAUDIAN,
+        (leaf) => new ClaudianView(leaf, this)
+      );
 
-    this.addRibbonIcon('bot', 'Open Claudian', () => {
-      void this.activateView();
-    });
-
-    this.addCommand({
-      id: 'open-view',
-      name: 'Open chat view',
-      callback: () => {
+      this.addRibbonIcon('bot', 'Open Claudian', () => {
         void this.activateView();
-      },
-    });
+      });
 
-    this.addCommand({
-      id: 'inline-edit',
-      name: 'Inline edit',
-      editorCallback: async (editor: Editor, ctx) => {
-        const view = ctx instanceof MarkdownView
-          ? ctx
-          : this.app.workspace.getActiveViewOfType(MarkdownView);
-        if (!view) {
-          new Notice('Inline edit unavailable: could not access the active Markdown view.');
-          return;
-        }
+      this.addCommand({
+        id: 'open-view',
+        name: 'Open chat view',
+        callback: () => {
+          void this.activateView();
+        },
+      });
 
-        const selectedText = editor.getSelection();
-        const notePath = view.file?.path || 'unknown';
-
-        let editContext: InlineEditContext;
-        if (selectedText.trim()) {
-          editContext = { mode: 'selection', selectedText };
-        } else {
-          const cursor = editor.getCursor();
-          const cursorContext = buildCursorContext(
-            (line) => editor.getLine(line),
-            editor.lineCount(),
-            cursor.line,
-            cursor.ch
-          );
-          editContext = { mode: 'cursor', cursorContext };
-        }
-
-        const modal = new InlineEditModal(
-          this.app,
-          this,
-          editor,
-          view,
-          editContext,
-          notePath,
-          () => this.getView()?.getActiveTab()?.ui.externalContextSelector?.getExternalContexts() ?? []
-        );
-        const result = await modal.openAndWait();
-
-        if (result.decision === 'accept' && result.editedText !== undefined) {
-          new Notice(editContext.mode === 'cursor' ? 'Inserted' : 'Edit applied');
-        }
-      },
-    });
-
-    this.addCommand({
-      id: 'new-tab',
-      name: 'New tab',
-      checkCallback: (checking: boolean) => {
-        if (!this.canCreateNewTab()) return false;
-
-        if (!checking) {
-          void this.openNewTab();
-        }
-        return true;
-      },
-    });
-
-    this.addCommand({
-      id: 'new-session',
-      name: 'New session (in current tab)',
-      checkCallback: (checking: boolean) => {
-        const view = this.getView();
-        if (!view) return false;
-
-        const tabManager = view.getTabManager();
-        if (!tabManager) return false;
-
-        const activeTab = tabManager.getActiveTab();
-        if (!activeTab) return false;
-
-        if (activeTab.state.isStreaming) return false;
-
-        if (!checking) {
-          void tabManager.createNewConversation();
-        }
-        return true;
-      },
-    });
-
-    this.addCommand({
-      id: 'close-current-tab',
-      name: 'Close current tab',
-      checkCallback: (checking: boolean) => {
-        const view = this.getView();
-        if (!view) return false;
-
-        const tabManager = view.getTabManager();
-        if (!tabManager) return false;
-
-        if (!checking) {
-          const activeTabId = tabManager.getActiveTabId();
-          if (activeTabId) {
-            void tabManager.closeTab(activeTabId);
+      this.addCommand({
+        id: 'inline-edit',
+        name: 'Inline edit',
+        editorCallback: async (editor: Editor, ctx) => {
+          const view = ctx instanceof MarkdownView
+            ? ctx
+            : this.app.workspace.getActiveViewOfType(MarkdownView);
+          if (!view) {
+            new Notice('Inline edit unavailable: could not access the active Markdown view.');
+            return;
           }
-        }
-        return true;
-      },
-    });
 
-    this.addSettingTab(new ClaudianSettingTab(this.app, this));
+          const selectedText = editor.getSelection();
+          const notePath = view.file?.path || 'unknown';
+
+          let editContext: InlineEditContext;
+          if (selectedText.trim()) {
+            editContext = { mode: 'selection', selectedText };
+          } else {
+            const cursor = editor.getCursor();
+            const cursorContext = buildCursorContext(
+              (line) => editor.getLine(line),
+              editor.lineCount(),
+              cursor.line,
+              cursor.ch
+            );
+            editContext = { mode: 'cursor', cursorContext };
+          }
+
+          const modal = new InlineEditModal(
+            this.app,
+            this,
+            editor,
+            view,
+            editContext,
+            notePath,
+            () => this.getView()?.getActiveTab()?.ui.externalContextSelector?.getExternalContexts() ?? []
+          );
+          const result = await modal.openAndWait();
+
+          if (result.decision === 'accept' && result.editedText !== undefined) {
+            new Notice(editContext.mode === 'cursor' ? 'Inserted' : 'Edit applied');
+          }
+        },
+      });
+
+      this.addCommand({
+        id: 'new-tab',
+        name: 'New tab',
+        checkCallback: (checking: boolean) => {
+          if (!this.canCreateNewTab()) return false;
+
+          if (!checking) {
+            void this.openNewTab();
+          }
+          return true;
+        },
+      });
+
+      this.addCommand({
+        id: 'new-session',
+        name: 'New session (in current tab)',
+        checkCallback: (checking: boolean) => {
+          const view = this.getView();
+          if (!view) return false;
+
+          const tabManager = view.getTabManager();
+          if (!tabManager) return false;
+
+          const activeTab = tabManager.getActiveTab();
+          if (!activeTab) return false;
+
+          if (activeTab.state.isStreaming) return false;
+
+          if (!checking) {
+            void tabManager.createNewConversation();
+          }
+          return true;
+        },
+      });
+
+      this.addCommand({
+        id: 'close-current-tab',
+        name: 'Close current tab',
+        checkCallback: (checking: boolean) => {
+          const view = this.getView();
+          if (!view) return false;
+
+          const tabManager = view.getTabManager();
+          if (!tabManager) return false;
+
+          if (!checking) {
+            const activeTabId = tabManager.getActiveTabId();
+            if (activeTabId) {
+              void tabManager.closeTab(activeTabId);
+            }
+          }
+          return true;
+        },
+      });
+
+      this.addCommand({
+        id: 'copy-startup-diagnostics',
+        name: 'Copy startup diagnostics',
+        callback: async () => {
+          const copied = await StartupProfiler.copyToClipboard();
+          new Notice(copied ? 'Startup diagnostics copied to clipboard.' : 'Failed to copy startup diagnostics.');
+        },
+      });
+
+      this.addSettingTab(new ClaudianSettingTab(this.app, this));
+      this.scheduleRemainingSessionMetadataLoad();
+    } finally {
+      StartupProfiler.finishOnload();
+    }
   }
 
   onunload(): void {
-    void this.persistOpenTabStates();
-  }
-
-  private async persistOpenTabStates(): Promise<void> {
-    // Ensures state is saved even if Obsidian quits without calling onClose()
-    for (const view of this.getAllViews()) {
-      const tabManager = view.getTabManager();
-      if (tabManager) {
-        const state = tabManager.getPersistedState();
-        await this.persistTabManagerState(state);
-      }
+    this.isUnloading = true;
+    if (this.sessionMetadataLoadTimer !== null) {
+      window.clearTimeout(this.sessionMetadataLoadTimer);
+      this.sessionMetadataLoadTimer = null;
     }
+    StartupProfiler.freeze();
+    void ProviderWorkspaceRegistry.disposeInitialized();
   }
 
   async activateView() {
@@ -281,7 +303,7 @@ export default class ClaudianPlugin extends Plugin {
     await view.createNewTab();
   }
 
-  async loadSettings() {
+  async loadSettings(options: { deferNonRestoredSessionMetadata?: boolean } = {}) {
     this.storage = new SharedStorageService(this);
     const { claudian } = await this.storage.initialize();
     this.lastKnownTabManagerState = await this.storage.getTabManagerState();
@@ -336,29 +358,18 @@ export default class ClaudianPlugin extends Plugin {
     );
     const didNormalizeModelVariants = this.normalizeModelVariantSettings();
 
-    const allMetadata = await this.storage.sessions.listMetadata();
-    this.conversationRepository.replaceAll(allMetadata.map(meta => {
-      const resumeSessionId = meta.sessionId !== undefined ? meta.sessionId : meta.id;
-
-      return {
-        id: meta.id,
-        providerId: meta.providerId ?? DEFAULT_CHAT_PROVIDER_ID,
-        title: meta.title,
-        createdAt: meta.createdAt,
-        updatedAt: meta.updatedAt,
-        lastResponseAt: meta.lastResponseAt,
-        sessionId: resumeSessionId,
-        selectedModel: meta.selectedModel,
-        providerState: meta.providerState,
-        messages: [],
-        currentNote: meta.currentNote,
-        externalContextPaths: meta.externalContextPaths,
-        enabledMcpServers: meta.enabledMcpServers,
-        usage: meta.usage,
-        titleGenerationStatus: meta.titleGenerationStatus,
-        resumeAtMessageId: meta.resumeAtMessageId,
-      };
-    }).sort(
+    const deferRemainingMetadata = options.deferNonRestoredSessionMetadata === true;
+    const initialMetadata = await StartupProfiler.runAsync(
+      deferRemainingMetadata ? 'restored-session-metadata-load' : 'session-metadata-load',
+      () => deferRemainingMetadata
+        ? this.loadRestoredSessionMetadata()
+        : this.storage.sessions.listMetadata(),
+    );
+    StartupProfiler.recordCount('restored-session-metadata-count', initialMetadata.length);
+    StartupProfiler.recordCount('session-metadata-count', initialMetadata.length);
+    this.conversationRepository.replaceAll(initialMetadata.map(meta => (
+      this.createConversationMetadataShell(meta)
+    )).sort(
       (a, b) => (b.lastResponseAt ?? b.updatedAt) - (a.lastResponseAt ?? a.updatedAt)
     ));
     setLocale(this.settings.locale as Locale);
@@ -381,6 +392,129 @@ export default class ClaudianPlugin extends Plugin {
         this.storage.sessions.toSessionMetadata(conv)
       );
     }
+    this.pendingSessionMetadataScan = deferRemainingMetadata;
+  }
+
+  private async loadRestoredSessionMetadata(): Promise<SessionMetadata[]> {
+    const restoredConversationIds = Array.from(new Set(
+      (this.lastKnownTabManagerState?.openTabs ?? [])
+        .map(({ conversationId }) => conversationId)
+        .filter((conversationId): conversationId is string => conversationId !== null),
+    ));
+    const metadata = await Promise.all(
+      restoredConversationIds.map(id => this.storage.sessions.loadMetadata(id)),
+    );
+    return metadata.filter((item): item is SessionMetadata => item !== null);
+  }
+
+  private scheduleRemainingSessionMetadataLoad(): void {
+    if (!this.pendingSessionMetadataScan || this.isUnloading) {
+      return;
+    }
+
+    const schedule = (): void => {
+      if (!this.pendingSessionMetadataScan || this.isUnloading) {
+        return;
+      }
+      this.sessionMetadataLoadTimer = window.setTimeout(() => {
+        this.sessionMetadataLoadTimer = null;
+        this.startRemainingSessionMetadataLoad();
+      }, 0);
+    };
+
+    const onLayoutReady = this.app.workspace.onLayoutReady;
+    if (typeof onLayoutReady === 'function') {
+      onLayoutReady.call(this.app.workspace, schedule);
+    } else {
+      schedule();
+    }
+  }
+
+  private startRemainingSessionMetadataLoad(): void {
+    if (
+      !this.pendingSessionMetadataScan
+      || this.isUnloading
+      || this.remainingSessionMetadataLoad
+    ) {
+      return;
+    }
+
+    this.pendingSessionMetadataScan = false;
+    const load = StartupProfiler.runAsync(
+      'session-metadata-background-load',
+      () => this.loadRemainingSessionMetadata(),
+    ).catch(() => {
+      StartupProfiler.increment('session-metadata-background-failures');
+    }).finally(() => {
+      if (this.remainingSessionMetadataLoad === load) {
+        this.remainingSessionMetadataLoad = null;
+      }
+    });
+    this.remainingSessionMetadataLoad = load;
+  }
+
+  private async loadRemainingSessionMetadata(): Promise<void> {
+    const addedConversations: Conversation[] = [];
+    const publishBatch = (metadata: SessionMetadata[]): void => {
+      if (this.isUnloading || metadata.length === 0) return;
+
+      const added = this.conversationRepository.mergeMetadataConversations(
+        metadata.map(meta => this.createConversationMetadataShell(meta)),
+      );
+      if (added.length === 0) return;
+
+      addedConversations.push(...added);
+      for (const view of this.getAllViews()) {
+        view.notifyConversationListChanged();
+      }
+    };
+    const allMetadata = await this.storage.sessions.listMetadata({ onBatch: publishBatch });
+    if (this.isUnloading) {
+      return;
+    }
+
+    StartupProfiler.recordCount('session-metadata-count', allMetadata.length);
+    // Custom storage implementations may not support incremental publication yet.
+    publishBatch(allMetadata);
+    StartupProfiler.recordCount('background-session-metadata-count', addedConversations.length);
+    if (addedConversations.length === 0) {
+      return;
+    }
+
+    const { changed, invalidatedConversations } = ProviderSettingsCoordinator.reconcileProviders(
+      this.settings,
+      addedConversations,
+      ProviderRegistry.getRegisteredProviderIds(),
+    );
+    if (changed) {
+      await this.saveSettings();
+    }
+    for (const conversation of invalidatedConversations) {
+      await this.storage.sessions.saveMetadata(
+        this.storage.sessions.toSessionMetadata(conversation),
+      );
+    }
+  }
+
+  private createConversationMetadataShell(meta: SessionMetadata): Conversation {
+    return {
+      id: meta.id,
+      providerId: meta.providerId ?? DEFAULT_CHAT_PROVIDER_ID,
+      title: meta.title,
+      createdAt: meta.createdAt,
+      updatedAt: meta.updatedAt,
+      lastResponseAt: meta.lastResponseAt,
+      sessionId: meta.sessionId !== undefined ? meta.sessionId : meta.id,
+      selectedModel: meta.selectedModel,
+      providerState: meta.providerState,
+      messages: [],
+      currentNote: meta.currentNote,
+      externalContextPaths: meta.externalContextPaths,
+      enabledMcpServers: meta.enabledMcpServers,
+      usage: meta.usage,
+      titleGenerationStatus: meta.titleGenerationStatus,
+      resumeAtMessageId: meta.resumeAtMessageId,
+    };
   }
 
   normalizeModelVariantSettings(): boolean {
@@ -553,10 +687,11 @@ export default class ClaudianPlugin extends Plugin {
     );
   }
 
-  getResolvedProviderCliPath(
+  async getResolvedProviderCliPath(
     providerId: ProviderId,
     context?: ProviderCliResolutionContext,
-  ): string | null {
+  ): Promise<string | null> {
+    await ProviderWorkspaceRegistry.ensureInitialized(this.providerHost, providerId, 'cli-resolution');
     const cliResolver = ProviderWorkspaceRegistry.getCliResolver(providerId);
     if (!cliResolver) {
       return null;
@@ -647,6 +782,10 @@ export default class ClaudianPlugin extends Plugin {
 
   async getConversationById(id: string): Promise<Conversation | null> {
     return this.conversationRepository.getById(id);
+  }
+
+  getCachedConversation(id: string): Conversation | null {
+    return this.conversationRepository.getCachedConversation(id);
   }
 
   getConversationSync(id: string): Conversation | null {

--- a/src/main.ts
+++ b/src/main.ts
@@ -113,6 +113,7 @@ export default class ClaudianPlugin extends Plugin {
   private pendingSessionMetadataScan = false;
   private pendingEnvironmentInvalidationGenerations = new Map<ProviderId, number>();
   private blockedEnvironmentInvalidationGenerations = new Map<ProviderId, number>();
+  private environmentUpdateTail: Promise<void> = Promise.resolve();
   private isLoadingRemainingSessionMetadata = false;
   private hasLoadedAllSessionMetadata = false;
   private sessionMetadataLoadTimer: number | null = null;
@@ -423,12 +424,20 @@ export default class ClaudianPlugin extends Plugin {
     const initialMetadataScan = await StartupProfiler.runAsync(
       deferRemainingMetadata ? 'restored-session-metadata-load' : 'session-metadata-load',
       async () => deferRemainingMetadata
-        ? { metadata: await this.loadRestoredSessionMetadata(), complete: false }
+        ? {
+          metadata: await this.loadRestoredSessionMetadata(),
+          complete: false,
+          invalidMetadataCount: 0,
+        }
         : this.storage.sessions.scanMetadata(),
     );
     const initialMetadata = initialMetadataScan.metadata;
     StartupProfiler.recordCount('restored-session-metadata-count', initialMetadata.length);
     StartupProfiler.recordCount('session-metadata-count', initialMetadata.length);
+    StartupProfiler.recordCount(
+      'invalid-session-metadata-count',
+      initialMetadataScan.invalidMetadataCount,
+    );
     this.conversationRepository.replaceAll(initialMetadata.map(meta => (
       this.createConversationMetadataShell(meta)
     )).sort(
@@ -570,6 +579,10 @@ export default class ClaudianPlugin extends Plugin {
 
       const allMetadata = scan.metadata;
       StartupProfiler.recordCount('session-metadata-count', allMetadata.length);
+      StartupProfiler.recordCount(
+        'invalid-session-metadata-count',
+        scan.invalidMetadataCount,
+      );
       // Custom storage implementations may not support incremental publication yet.
       publishBatch(allMetadata);
       const currentAddedConversations = addedConversations.filter((conversation) => (
@@ -749,6 +762,17 @@ export default class ClaudianPlugin extends Plugin {
   async applyEnvironmentVariablesBatch(
     updates: Array<{ scope: EnvironmentScope; envText: string }>,
   ): Promise<void> {
+    const queuedUpdates = updates.map(update => ({ ...update }));
+    const apply = this.environmentUpdateTail.then(
+      () => this.applyEnvironmentVariablesBatchNow(queuedUpdates),
+    );
+    this.environmentUpdateTail = apply.catch(() => undefined);
+    await apply;
+  }
+
+  private async applyEnvironmentVariablesBatchNow(
+    updates: Array<{ scope: EnvironmentScope; envText: string }>,
+  ): Promise<void> {
     const nextEnvironmentByScope = new Map<EnvironmentScope, string>();
     for (const update of updates) {
       nextEnvironmentByScope.set(update.scope, update.envText);
@@ -756,7 +780,6 @@ export default class ClaudianPlugin extends Plugin {
 
     let affectedProviderIds: ProviderId[] = [];
     let changed = false;
-    let invalidatedConversations: Conversation[] = [];
     let invalidationGenerations = new Map<ProviderId, number>();
     await this.mutateSettings((settings) => {
       const settingsBag = settings as unknown as Record<string, unknown>;
@@ -772,7 +795,6 @@ export default class ClaudianPlugin extends Plugin {
       ProviderSettingsCoordinator.handleEnvironmentChange(settingsBag, affectedProviderIds);
       const reconciliation = this.reconcileModelWithEnvironment(affectedProviderIds);
       changed = reconciliation.changed;
-      invalidatedConversations = reconciliation.invalidatedConversations;
       invalidationGenerations = this.markPendingSessionInvalidations(
         settings,
         reconciliation.environmentChangedProviderIds,
@@ -796,8 +818,15 @@ export default class ClaudianPlugin extends Plugin {
         await ProviderWorkspaceRegistry.refreshAgentMentions(providerId);
       }
     }
-    if (invalidatedConversations.length > 0) {
-      for (const conv of invalidatedConversations) {
+    if (invalidationGenerations.size > 0) {
+      const invalidatedProviderIds = new Set(invalidationGenerations.keys());
+      const conversationsToPersist = this.conversationRepository.getAll().filter(
+        conversation => invalidatedProviderIds.has(conversation.providerId),
+      );
+      for (const conv of conversationsToPersist) {
+        if (this.conversationRepository.getCachedConversation(conv.id) !== conv) {
+          continue;
+        }
         await this.storage.sessions.saveMetadata(
           this.storage.sessions.toSessionMetadata(conv)
         );

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,9 @@
+import { StartupProfiler } from './core/performance/StartupProfiler';
 // Must run before any SDK imports to patch Electron/Node.js realm incompatibility
 import { patchSetMaxListenersForElectron } from './utils/electronCompat';
 patchSetMaxListenersForElectron();
 
 import './providers';
-
-import { StartupProfiler } from './core/performance/StartupProfiler';
 
 StartupProfiler.finishModuleEvaluation();
 
@@ -220,7 +219,17 @@ export default class ClaudianPlugin extends Plugin {
       this.sessionMetadataLoadTimer = null;
     }
     StartupProfiler.freeze();
+    void this.persistOpenTabStates().catch(() => undefined);
     void ProviderWorkspaceRegistry.disposeInitialized();
+  }
+
+  private async persistOpenTabStates(): Promise<void> {
+    for (const view of this.getAllViews()) {
+      const state = view.getPersistedTabState();
+      if (state) {
+        await this.persistTabManagerState(state);
+      }
+    }
   }
 
   async activateView() {
@@ -476,20 +485,26 @@ export default class ClaudianPlugin extends Plugin {
     StartupProfiler.recordCount('session-metadata-count', allMetadata.length);
     // Custom storage implementations may not support incremental publication yet.
     publishBatch(allMetadata);
-    StartupProfiler.recordCount('background-session-metadata-count', addedConversations.length);
-    if (addedConversations.length === 0) {
+    const currentAddedConversations = addedConversations.filter((conversation) => (
+      this.conversationRepository.getCachedConversation(conversation.id) === conversation
+    ));
+    StartupProfiler.recordCount('background-session-metadata-count', currentAddedConversations.length);
+    if (currentAddedConversations.length === 0) {
       return;
     }
 
     const { changed, invalidatedConversations } = ProviderSettingsCoordinator.reconcileProviders(
       this.settings,
-      addedConversations,
+      currentAddedConversations,
       ProviderRegistry.getRegisteredProviderIds(),
     );
     if (changed) {
       await this.saveSettings();
     }
     for (const conversation of invalidatedConversations) {
+      if (this.conversationRepository.getCachedConversation(conversation.id) !== conversation) {
+        continue;
+      }
       await this.storage.sessions.saveMetadata(
         this.storage.sessions.toSessionMetadata(conversation),
       );

--- a/src/providers/claude/agents/AgentManager.ts
+++ b/src/providers/claude/agents/AgentManager.ts
@@ -6,16 +6,18 @@
  * 3. Global agents: {CLAUDE_CONFIG_DIR}/agents/*.md
  */
 
-import * as fs from 'fs';
+import { promises as fs } from 'fs';
 import * as path from 'path';
 
 import type { AgentDefinition, AgentFrontmatter } from '../../../core/types';
+import { mapWithConcurrency } from '../../../utils/concurrency';
 import { resolveClaudeConfigDir } from '../config/ClaudeConfigDir';
 import type { PluginManager } from '../plugins/PluginManager';
 import { buildAgentFromFrontmatter, parseAgentFile } from './AgentStorage';
 
 const VAULT_AGENTS_DIR = '.claude/agents';
 const PLUGIN_AGENTS_DIR = 'agents';
+const AGENT_FILE_READ_CONCURRENCY = 8;
 
 // Fallback built-in agent names for before the init message arrives.
 const FALLBACK_BUILTIN_AGENT_NAMES = ['Explore', 'Plan', 'Bash', 'general-purpose'];
@@ -42,11 +44,13 @@ function normalizePluginName(name: string): string {
 }
 
 export class AgentManager {
-  private agents: AgentDefinition[] = [];
+  private agents: AgentDefinition[] = FALLBACK_BUILTIN_AGENT_NAMES.map(makeBuiltinAgent);
   private builtinAgentNames: string[] = FALLBACK_BUILTIN_AGENT_NAMES;
   private vaultPath: string;
   private pluginManager: PluginManager;
   private resolveConfigDir: () => string;
+  private loaded = false;
+  private loadPromise: Promise<void> | null = null;
 
   constructor(
     vaultPath: string,
@@ -73,15 +77,43 @@ export class AgentManager {
   }
 
   async loadAgents(): Promise<void> {
+    if (this.loadPromise) {
+      return this.loadPromise;
+    }
+    const promise = this.loadAgentsInternal();
+    this.loadPromise = promise;
+    try {
+      await promise;
+    } finally {
+      if (this.loadPromise === promise) {
+        this.loadPromise = null;
+      }
+    }
+  }
+
+  async ensureLoaded(): Promise<void> {
+    if (this.loaded) {
+      return;
+    }
+    await this.pluginManager.loadPlugins?.();
+    await this.loadAgents();
+  }
+
+  isLoaded(): boolean {
+    return this.loaded;
+  }
+
+  private async loadAgentsInternal(): Promise<void> {
     this.agents = [];
 
     for (const name of this.builtinAgentNames) {
       this.addAgent(makeBuiltinAgent(name));
     }
 
-    try { this.loadPluginAgents(); } catch { /* non-critical */ }
-    try { this.loadVaultAgents(); } catch { /* non-critical */ }
-    try { this.loadGlobalAgents(); } catch { /* non-critical */ }
+    try { await this.loadPluginAgents(); } catch { /* non-critical */ }
+    try { await this.loadVaultAgents(); } catch { /* non-critical */ }
+    try { await this.loadGlobalAgents(); } catch { /* non-critical */ }
+    this.loaded = true;
   }
 
   getAvailableAgents(): AgentDefinition[] {
@@ -102,62 +134,51 @@ export class AgentManager {
     );
   }
 
-  private loadPluginAgents(): void {
+  private async loadPluginAgents(): Promise<void> {
     for (const plugin of this.pluginManager.getPlugins()) {
       if (!plugin.enabled) continue;
 
       const agentsDir = path.join(plugin.installPath, PLUGIN_AGENTS_DIR);
-      if (!fs.existsSync(agentsDir)) continue;
-
-      this.loadAgentsFromFiles(
-        this.listMarkdownFiles(agentsDir),
+      await this.loadAgentsFromFiles(
+        await this.listMarkdownFiles(agentsDir),
         (filePath) => this.parsePluginAgentFromFile(filePath, plugin.name),
       );
     }
   }
 
-  private loadVaultAgents(): void {
-    this.loadAgentsFromDirectory(path.join(this.vaultPath, VAULT_AGENTS_DIR), 'vault');
+  private async loadVaultAgents(): Promise<void> {
+    await this.loadAgentsFromDirectory(path.join(this.vaultPath, VAULT_AGENTS_DIR), 'vault');
   }
 
-  private loadGlobalAgents(): void {
-    this.loadAgentsFromDirectory(path.join(this.resolveConfigDir(), 'agents'), 'global');
+  private async loadGlobalAgents(): Promise<void> {
+    await this.loadAgentsFromDirectory(path.join(this.resolveConfigDir(), 'agents'), 'global');
   }
 
-  private loadAgentsFromDirectory(
+  private async loadAgentsFromDirectory(
     dir: string,
     source: 'vault' | 'global'
-  ): void {
-    if (!fs.existsSync(dir)) return;
-
-    this.loadAgentsFromFiles(
-      this.listMarkdownFiles(dir),
+  ): Promise<void> {
+    await this.loadAgentsFromFiles(
+      await this.listMarkdownFiles(dir),
       (filePath) => this.parseAgentFromFile(filePath, source),
     );
   }
 
-  private listMarkdownFiles(dir: string): string[] {
-    const files: string[] = [];
-
+  private async listMarkdownFiles(dir: string): Promise<string[]> {
     try {
-      const entries = fs.readdirSync(dir, { withFileTypes: true });
-
-      for (const entry of entries) {
-        if (entry.isFile() && entry.name.endsWith('.md')) {
-          files.push(path.join(dir, entry.name));
-        }
-      }
+      const entries = await fs.readdir(dir, { withFileTypes: true });
+      return entries
+        .filter(entry => entry.isFile() && entry.name.endsWith('.md'))
+        .map(entry => path.join(dir, entry.name));
     } catch {
-      // Non-critical: directory may be unreadable
+      return [];
     }
-
-    return files;
   }
 
-  private parsePluginAgentFromFile(
+  private async parsePluginAgentFromFile(
     filePath: string,
     pluginName: string
-  ): AgentDefinition | null {
+  ): Promise<AgentDefinition | null> {
     return this.parseAgentDefinition(
       filePath,
       (agentName) => `${normalizePluginName(pluginName)}:${agentName}`,
@@ -170,10 +191,10 @@ export class AgentManager {
     );
   }
 
-  private parseAgentFromFile(
+  private async parseAgentFromFile(
     filePath: string,
     source: 'vault' | 'global'
-  ): AgentDefinition | null {
+  ): Promise<AgentDefinition | null> {
     return this.parseAgentDefinition(
       filePath,
       (agentName) => agentName,
@@ -185,12 +206,17 @@ export class AgentManager {
     );
   }
 
-  private loadAgentsFromFiles(
+  private async loadAgentsFromFiles(
     filePaths: string[],
-    loadAgent: (filePath: string) => AgentDefinition | null,
-  ): void {
-    for (const filePath of filePaths) {
-      this.addAgent(loadAgent(filePath));
+    loadAgent: (filePath: string) => Promise<AgentDefinition | null>,
+  ): Promise<void> {
+    const agents = await mapWithConcurrency(
+      filePaths,
+      filePath => loadAgent(filePath),
+      AGENT_FILE_READ_CONCURRENCY,
+    );
+    for (const agent of agents) {
+      this.addAgent(agent);
     }
   }
 
@@ -204,7 +230,7 @@ export class AgentManager {
     this.agents.push(agent);
   }
 
-  private parseAgentDefinition(
+  private async parseAgentDefinition(
     filePath: string,
     buildId: (agentName: string) => string,
     buildAgent: (
@@ -212,9 +238,9 @@ export class AgentManager {
       body: string,
       id: string,
     ) => AgentDefinition,
-  ): AgentDefinition | null {
+  ): Promise<AgentDefinition | null> {
     try {
-      const content = fs.readFileSync(filePath, 'utf-8');
+      const content = await fs.readFile(filePath, 'utf-8');
       const parsed = parseAgentFile(content);
 
       if (!parsed) {

--- a/src/providers/claude/app/ClaudeWorkspaceServices.ts
+++ b/src/providers/claude/app/ClaudeWorkspaceServices.ts
@@ -40,12 +40,10 @@ export async function createClaudeWorkspaceServices(
   adapter: VaultFileAdapter,
 ): Promise<ClaudeWorkspaceServices> {
   const claudeStorage = new StorageService(plugin, adapter);
-  await claudeStorage.ensureDirectories();
 
   const cliResolver = new ClaudeCliResolver();
   const mcpStorage = claudeStorage.mcp;
   const mcpManager = new McpServerManager(mcpStorage);
-  await mcpManager.loadServers();
 
   const vaultPath = getVaultPath(plugin.app) ?? '';
   const getClaudeConfigDir = () => resolveClaudeConfigDir({
@@ -61,11 +59,9 @@ export async function createClaudeWorkspaceServices(
     claudeStorage.ccSettings,
     getClaudeConfigDir,
   );
-  await pluginManager.loadPlugins();
 
   const agentStorage = claudeStorage.agents;
   const agentManager = new AgentManager(vaultPath, pluginManager, getClaudeConfigDir);
-  await agentManager.loadAgents();
 
   const commandCatalog = new ClaudeCommandCatalog(
     claudeStorage.commands,
@@ -87,6 +83,13 @@ export async function createClaudeWorkspaceServices(
     settingsTabRenderer: claudeSettingsTabRenderer,
     refreshAgentMentions: async () => {
       await pluginManager.loadPlugins();
+      await agentManager.loadAgents();
+    },
+    prepareSettings: async () => {
+      await Promise.all([
+        mcpManager.loadServers(),
+        pluginManager.loadPlugins(),
+      ]);
       await agentManager.loadAgents();
     },
   };

--- a/src/providers/claude/claudeAgentQueryModule.ts
+++ b/src/providers/claude/claudeAgentQueryModule.ts
@@ -1,0 +1,1 @@
+export { query } from '@anthropic-ai/claude-agent-sdk';

--- a/src/providers/claude/cli/findClaudeCLIPath.ts
+++ b/src/providers/claude/cli/findClaudeCLIPath.ts
@@ -36,14 +36,10 @@ function findFirstExistingPath(entries: string[], candidates: string[]): string 
 
 function isExistingFile(filePath: string): boolean {
   try {
-    if (fs.existsSync(filePath)) {
-      const stat = fs.statSync(filePath);
-      return stat.isFile();
-    }
+    return fs.existsSync(filePath) && fs.statSync(filePath).isFile();
   } catch {
-    // Inaccessible path
+    return false;
   }
-  return false;
 }
 
 function findClaudeCodeNodeEntrypoint(packageRoot: string): string | null {

--- a/src/providers/claude/commands/probeRuntimeCommands.ts
+++ b/src/providers/claude/commands/probeRuntimeCommands.ts
@@ -33,7 +33,7 @@ export async function probeRuntimeCommands(plugin: ProviderHost): Promise<SlashC
   const vaultPath = getVaultPath(plugin.app);
   if (!vaultPath) return [];
 
-  const cliPath = plugin.getResolvedProviderCliPath('claude');
+  const cliPath = await plugin.getResolvedProviderCliPath('claude');
   if (!cliPath) return [];
 
   const customEnv = parseEnvironmentVariables(

--- a/src/providers/claude/commands/probeRuntimeCommands.ts
+++ b/src/providers/claude/commands/probeRuntimeCommands.ts
@@ -1,10 +1,10 @@
 import type { SlashCommand as SDKSlashCommand } from '@anthropic-ai/claude-agent-sdk';
-import { query as agentQuery } from '@anthropic-ai/claude-agent-sdk';
 
 import type { ProviderHost } from '../../../core/providers/ProviderHost';
 import type { SlashCommand } from '../../../core/types';
 import { getEnhancedPath, parseEnvironmentVariables } from '../../../utils/env';
 import { getVaultPath } from '../../../utils/path';
+import { loadClaudeAgentQuery } from '../loadClaudeAgentSdk';
 import { createCustomSpawnFunction } from '../runtime/customSpawn';
 import {
   getClaudeProviderSettings,
@@ -52,6 +52,7 @@ export async function probeRuntimeCommands(plugin: ProviderHost): Promise<SlashC
   };
 
   try {
+    const agentQuery = await loadClaudeAgentQuery();
     const conversation = agentQuery({
       prompt: '',
       options: {

--- a/src/providers/claude/env/ClaudeSettingsReconciler.ts
+++ b/src/providers/claude/env/ClaudeSettingsReconciler.ts
@@ -67,7 +67,15 @@ function inferPreviousModelEnvironmentType(
   return previousOption.environmentTypes[0];
 }
 
+function invalidateClaudeConversationSessions(conversations: Conversation[]): Conversation[] {
+  return conversations.filter(conv => (
+    conv.providerId === 'claude' && clearClaudeResumeState(conv)
+  ));
+}
+
 export const claudeSettingsReconciler: ProviderSettingsReconciler = {
+  invalidateConversationSessions: invalidateClaudeConversationSessions,
+
   reconcileModelWithEnvironment(
     settings: Record<string, unknown>,
     conversations: Conversation[],
@@ -80,12 +88,7 @@ export const claudeSettingsReconciler: ProviderSettingsReconciler = {
       return { changed: false, invalidatedConversations: [] };
     }
 
-    const invalidatedConversations: Conversation[] = [];
-    for (const conv of conversations) {
-      if (conv.providerId === 'claude' && clearClaudeResumeState(conv)) {
-        invalidatedConversations.push(conv);
-      }
-    }
+    const invalidatedConversations = invalidateClaudeConversationSessions(conversations);
 
     const currentModel = typeof settings.model === 'string' ? settings.model : '';
     const claudeSettings = getClaudeProviderSettings(settings);

--- a/src/providers/claude/loadClaudeAgentSdk.ts
+++ b/src/providers/claude/loadClaudeAgentSdk.ts
@@ -1,0 +1,10 @@
+import type { query as claudeAgentQuery } from '@anthropic-ai/claude-agent-sdk';
+
+import type * as ClaudeAgentQueryModule from './claudeAgentQueryModule';
+
+let modulePromise: Promise<typeof ClaudeAgentQueryModule> | undefined;
+
+export function loadClaudeAgentQuery(): Promise<typeof claudeAgentQuery> {
+  modulePromise ??= import('./claudeAgentQueryModule');
+  return modulePromise.then(({ query }) => query);
+}

--- a/src/providers/claude/plugins/PluginManager.ts
+++ b/src/providers/claude/plugins/PluginManager.ts
@@ -6,7 +6,7 @@
  * - settings.json: enabled state (project overrides global)
  */
 
-import * as fs from 'fs';
+import { promises as fs } from 'fs';
 import { Notice } from 'obsidian';
 import * as path from 'path';
 
@@ -19,21 +19,17 @@ interface SettingsFile {
   enabledPlugins?: Record<string, boolean>;
 }
 
-function readJsonFile<T>(filePath: string): T | null {
+async function readJsonFile<T>(filePath: string): Promise<T | null> {
   try {
-    if (!fs.existsSync(filePath)) {
-      return null;
-    }
-    const content = fs.readFileSync(filePath, 'utf-8');
-    return JSON.parse(content) as T;
+    return JSON.parse(await fs.readFile(filePath, 'utf-8')) as T;
   } catch {
     return null;
   }
 }
 
-function normalizePathForComparison(p: string): string {
+async function normalizePathForComparison(p: string): Promise<string> {
   try {
-    const resolved = fs.realpathSync(p);
+    const resolved = await fs.realpath(p);
     if (typeof resolved === 'string' && resolved.length > 0) {
       return resolved;
     }
@@ -44,14 +40,14 @@ function normalizePathForComparison(p: string): string {
   return path.resolve(p);
 }
 
-function selectInstalledPluginEntry(
+async function selectInstalledPluginEntry(
   entries: InstalledPluginEntry[],
   normalizedVaultPath: string
-): InstalledPluginEntry | null {
+): Promise<InstalledPluginEntry | null> {
   for (const entry of entries) {
     if (entry.scope !== 'project') continue;
     if (!entry.projectPath) continue;
-    if (normalizePathForComparison(entry.projectPath) === normalizedVaultPath) {
+    if (await normalizePathForComparison(entry.projectPath) === normalizedVaultPath) {
       return entry;
     }
   }
@@ -72,6 +68,7 @@ export class PluginManager {
   private vaultPath: string;
   private resolveConfigDir: () => string;
   private plugins: PluginInfo[] = [];
+  private loadPromise: Promise<void> | null = null;
 
   constructor(
     vaultPath: string,
@@ -84,19 +81,33 @@ export class PluginManager {
   }
 
   async loadPlugins(): Promise<void> {
+    if (this.loadPromise) {
+      return this.loadPromise;
+    }
+    const promise = this.loadPluginsInternal();
+    this.loadPromise = promise;
+    try {
+      await promise;
+    } finally {
+      if (this.loadPromise === promise) {
+        this.loadPromise = null;
+      }
+    }
+  }
+
+  private async loadPluginsInternal(): Promise<void> {
     const configDir = this.resolveConfigDir();
-    const installedPlugins = readJsonFile<InstalledPluginsFile>(
-      path.join(configDir, 'plugins', 'installed_plugins.json'),
-    );
-    const globalSettings = readJsonFile<SettingsFile>(path.join(configDir, 'settings.json'));
-    const projectSettings = await this.loadProjectSettings();
+    const [installedPlugins, globalSettings, projectSettings, normalizedVaultPath] = await Promise.all([
+      readJsonFile<InstalledPluginsFile>(path.join(configDir, 'plugins', 'installed_plugins.json')),
+      readJsonFile<SettingsFile>(path.join(configDir, 'settings.json')),
+      this.loadProjectSettings(),
+      normalizePathForComparison(this.vaultPath),
+    ]);
 
     const globalEnabled = globalSettings?.enabledPlugins ?? {};
     const projectEnabled = projectSettings?.enabledPlugins ?? {};
 
     const plugins: PluginInfo[] = [];
-    const normalizedVaultPath = normalizePathForComparison(this.vaultPath);
-
     if (installedPlugins?.plugins) {
       for (const [pluginId, entries] of Object.entries(installedPlugins.plugins)) {
         if (!entries || entries.length === 0) continue;
@@ -105,7 +116,7 @@ export class PluginManager {
         if (!Array.isArray(entries)) {
           new Notice(`Claudian: plugin "${pluginId}" has malformed entry in installed_plugins.json (expected array, got ${typeof entries})`);
         }
-        const entry = selectInstalledPluginEntry(entriesArray, normalizedVaultPath);
+        const entry = await selectInstalledPluginEntry(entriesArray, normalizedVaultPath);
         if (!entry) continue;
 
         const scope: PluginScope = entry.scope === 'project' ? 'project' : 'user';

--- a/src/providers/claude/registration.ts
+++ b/src/providers/claude/registration.ts
@@ -49,15 +49,14 @@ export const claudeProviderRegistration: ProviderModule = {
   },
   createRuntime: ({ plugin }) => {
     const workspace = getClaudeWorkspaceServices();
-    const resolvedMcpManager = workspace?.mcpManager;
-    if (!resolvedMcpManager) {
+    if (!workspace?.mcpManager) {
       throw new Error('Claude workspace services are not initialized.');
     }
 
     return new ClaudeChatRuntime(plugin, {
-      mcpManager: resolvedMcpManager,
-      pluginManager: workspace?.pluginManager,
-      agentManager: workspace?.agentManager,
+      mcpManager: workspace.mcpManager,
+      pluginManager: workspace.pluginManager,
+      agentManager: workspace.agentManager,
     });
   },
   createTitleGenerationService: (plugin) => new ClaudeTitleGenerationService(plugin),

--- a/src/providers/claude/runtime/ClaudeChatRuntime.ts
+++ b/src/providers/claude/runtime/ClaudeChatRuntime.ts
@@ -21,7 +21,6 @@ import type {
   SDKUserMessage,
   SlashCommand as SDKSlashCommand,
 } from '@anthropic-ai/claude-agent-sdk';
-import { query as agentQuery } from '@anthropic-ai/claude-agent-sdk';
 import { Notice } from 'obsidian';
 
 import type { McpServerManager } from '../../../core/mcp/McpServerManager';
@@ -73,6 +72,7 @@ import {
 } from '../../../utils/session';
 import { CLAUDE_PROVIDER_CAPABILITIES } from '../capabilities';
 import { loadSubagentFinalResult, loadSubagentToolCalls } from '../history/ClaudeHistoryStore';
+import { loadClaudeAgentQuery } from '../loadClaudeAgentSdk';
 import { toClaudeRuntimeModelId } from '../modelSelection';
 import { encodeClaudeTurn } from '../prompt/ClaudeTurnEncoder';
 import {
@@ -167,6 +167,7 @@ export class ClaudianService implements ChatRuntime {
   private responseConsumerRunning = false;
   private responseConsumerPromise: Promise<void> | null = null;
   private shuttingDown = false;
+  private persistentQueryGeneration = 0;
 
   // Tracked configuration for detecting changes that require restart
   private currentConfig: PersistentQueryConfig | null = null;
@@ -626,6 +627,15 @@ export class ClaudianService implements ChatRuntime {
       return;
     }
 
+    const startGeneration = ++this.persistentQueryGeneration;
+    const agentQuery = await loadClaudeAgentQuery();
+    if (
+      startGeneration !== this.persistentQueryGeneration
+      || this.persistentQuery
+    ) {
+      return;
+    }
+
     this.shuttingDown = false;
     this.vaultPath = vaultPath;
 
@@ -693,6 +703,7 @@ export class ClaudianService implements ChatRuntime {
    * Closes the persistent query and cleans up resources.
    */
   closePersistentQuery(_reason?: string, options?: ClosePersistentQueryOptions): void {
+    this.persistentQueryGeneration += 1;
     if (!this.persistentQuery) {
       return;
     }
@@ -1722,6 +1733,10 @@ export class ClaudianService implements ChatRuntime {
     const streamState = createTransformStreamState();
     const usageState = createTransformUsageState();
     try {
+      const agentQuery = await loadClaudeAgentQuery();
+      if (ctx.abortController?.signal.aborted) {
+        return;
+      }
       const response = agentQuery({ prompt: queryPrompt, options });
       this.recordTurnMetadata({ wasSent: true });
       let streamSessionId: string | null = this.sessionManager.getSessionId();

--- a/src/providers/claude/runtime/ClaudeChatRuntime.ts
+++ b/src/providers/claude/runtime/ClaudeChatRuntime.ts
@@ -249,6 +249,10 @@ export class ClaudianService implements ChatRuntime {
     return CLAUDE_PROVIDER_CAPABILITIES;
   }
 
+  async prepareForTurn(): Promise<void> {
+    await this.mcpManager.ensureLoaded();
+  }
+
   prepareTurn(request: ChatTurnRequest): PreparedChatTurn {
     return encodeClaudeTurn(request, this.mcpManager);
   }
@@ -568,7 +572,7 @@ export class ClaudianService implements ChatRuntime {
     // Case 1: Not running → try to start
     if (!this.persistentQuery) {
       if (!vaultPath) return false;
-      const cliPath = this.plugin.getResolvedProviderCliPath('claude');
+      const cliPath = await this.plugin.getResolvedProviderCliPath('claude');
       if (!cliPath) return false;
       await this.startPersistentQuery(vaultPath, cliPath, effectiveSessionId, externalContextPaths);
       return true;
@@ -579,7 +583,7 @@ export class ClaudianService implements ChatRuntime {
     if (options?.force) {
       this.closePersistentQuery('forced restart', { preserveHandlers: options.preserveHandlers });
       if (!vaultPath) return false;
-      const cliPath = this.plugin.getResolvedProviderCliPath('claude');
+      const cliPath = await this.plugin.getResolvedProviderCliPath('claude');
       if (!cliPath) return false;
       await this.startPersistentQuery(vaultPath, cliPath, effectiveSessionId, externalContextPaths);
       return true;
@@ -588,7 +592,7 @@ export class ClaudianService implements ChatRuntime {
     // Case 3: Check if config changed → restart if needed
     // We need vaultPath and cliPath to build config for comparison
     if (!vaultPath) return false;
-    const cliPath = this.plugin.getResolvedProviderCliPath('claude');
+    const cliPath = await this.plugin.getResolvedProviderCliPath('claude');
     if (!cliPath) return false;
 
     const newConfig = this.buildPersistentQueryConfig(vaultPath, cliPath, externalContextPaths);
@@ -596,7 +600,7 @@ export class ClaudianService implements ChatRuntime {
       // Close FIRST, then try to start new one (allows fallback if CLI unavailable)
       this.closePersistentQuery('config changed', { preserveHandlers: options?.preserveHandlers });
       // Re-check CLI path as it might have changed during close
-      const cliPathAfterClose = this.plugin.getResolvedProviderCliPath('claude');
+      const cliPathAfterClose = await this.plugin.getResolvedProviderCliPath('claude');
       if (cliPathAfterClose) {
         await this.startPersistentQuery(vaultPath, cliPathAfterClose, effectiveSessionId, externalContextPaths);
         return true;
@@ -1273,7 +1277,7 @@ export class ClaudianService implements ChatRuntime {
       return;
     }
 
-    const resolvedClaudePath = this.plugin.getResolvedProviderCliPath('claude');
+    const resolvedClaudePath = await this.plugin.getResolvedProviderCliPath('claude');
     if (!resolvedClaudePath) {
       yield { type: 'error', content: 'Claude CLI not found. Please install Claude Code CLI.' };
       return;

--- a/src/providers/claude/runtime/ClaudeDynamicUpdates.ts
+++ b/src/providers/claude/runtime/ClaudeDynamicUpdates.ts
@@ -24,7 +24,7 @@ export interface ClaudeDynamicUpdateDeps {
   getCurrentConfig: () => PersistentQueryConfig | null;
   mutateCurrentConfig: (mutate: (config: PersistentQueryConfig) => void) => void;
   getVaultPath: () => string | null;
-  getCliPath: () => string | null;
+  getCliPath: () => Promise<string | null>;
   getScopedSettings: () => ClaudianSettings;
   getPermissionMode: () => PermissionMode;
   resolveSDKPermissionMode: (mode: PermissionMode) => SDKPermissionMode;
@@ -56,7 +56,7 @@ export async function applyClaudeDynamicUpdates(
     return;
   }
 
-  const cliPath = deps.getCliPath();
+  const cliPath = await deps.getCliPath();
   if (!cliPath) {
     return;
   }

--- a/src/providers/claude/runtime/claudeColdStartQuery.ts
+++ b/src/providers/claude/runtime/claudeColdStartQuery.ts
@@ -54,7 +54,7 @@ export async function runColdStartQuery(
     throw new Error('Could not determine vault path');
   }
 
-  const resolvedClaudePath = config.plugin.getResolvedProviderCliPath('claude');
+  const resolvedClaudePath = await config.plugin.getResolvedProviderCliPath('claude');
   if (!resolvedClaudePath) {
     throw new Error('Claude CLI not found');
   }

--- a/src/providers/claude/runtime/claudeColdStartQuery.ts
+++ b/src/providers/claude/runtime/claudeColdStartQuery.ts
@@ -1,11 +1,11 @@
 import type { Options } from '@anthropic-ai/claude-agent-sdk';
-import { query as agentQuery } from '@anthropic-ai/claude-agent-sdk';
 
 import type { ProviderHost } from '../../../core/providers/ProviderHost';
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import { getEnhancedPath, getMissingNodeError, parseEnvironmentVariables } from '../../../utils/env';
 import { getVaultPath } from '../../../utils/path';
 import { extractAssistantText } from '../auxiliary/extractAssistantText';
+import { loadClaudeAgentQuery } from '../loadClaudeAgentSdk';
 import { toClaudeRuntimeModelId } from '../modelSelection';
 import {
   getClaudeProviderSettings,
@@ -123,6 +123,10 @@ export async function runColdStartQuery(
     options.effort = effortLevel;
   }
 
+  const agentQuery = await loadClaudeAgentQuery();
+  if (config.abortController?.signal.aborted) {
+    throw new Error('Cancelled');
+  }
   const response = agentQuery({ prompt, options });
   let responseText = '';
   let sessionId: string | null = null;

--- a/src/providers/codex/agents/CodexAgentMentionProvider.ts
+++ b/src/providers/codex/agents/CodexAgentMentionProvider.ts
@@ -4,11 +4,37 @@ import type { CodexSubagentDefinition } from '../types/subagent';
 
 export class CodexAgentMentionProvider implements AgentMentionProvider {
   private agents: CodexSubagentDefinition[] = [];
+  private loaded = false;
+  private loadPromise: Promise<void> | null = null;
 
   constructor(private storage: CodexSubagentStorage) {}
 
   async loadAgents(): Promise<void> {
-    this.agents = await this.storage.loadAll();
+    if (this.loadPromise) {
+      return this.loadPromise;
+    }
+    const promise = this.storage.loadAll().then((agents) => {
+      this.agents = agents;
+      this.loaded = true;
+    });
+    this.loadPromise = promise;
+    try {
+      await promise;
+    } finally {
+      if (this.loadPromise === promise) {
+        this.loadPromise = null;
+      }
+    }
+  }
+
+  async ensureLoaded(): Promise<void> {
+    if (!this.loaded) {
+      await this.loadAgents();
+    }
+  }
+
+  isLoaded(): boolean {
+    return this.loaded;
   }
 
   searchAgents(query: string): Array<{

--- a/src/providers/codex/app/CodexWorkspaceServices.ts
+++ b/src/providers/codex/app/CodexWorkspaceServices.ts
@@ -1,6 +1,5 @@
 import type { ProviderCommandCatalog } from '../../../core/providers/commands/ProviderCommandCatalog';
 import type { ProviderHost } from '../../../core/providers/ProviderHost';
-import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
 import type {
   ProviderCliResolver,
@@ -13,12 +12,9 @@ import { getVaultPath } from '../../../utils/path';
 import { CodexAgentMentionProvider } from '../agents/CodexAgentMentionProvider';
 import { CodexSkillCatalog } from '../commands/CodexSkillCatalog';
 import { CodexCliResolver } from '../runtime/CodexCliResolver';
+import { CodexModelCatalogCoordinator } from '../runtime/CodexModelCatalogCoordinator';
 import { CodexModelDiscoveryService } from '../runtime/CodexModelDiscoveryService';
-import {
-  getCodexProviderSettings,
-  normalizeCodexVisibleModels,
-  updateCodexProviderSettings,
-} from '../settings';
+import { getCodexProviderSettings } from '../settings';
 import { CodexSkillListingService } from '../skills/CodexSkillListingService';
 import { CodexSkillStorage } from '../storage/CodexSkillStorage';
 import { CodexSubagentStorage } from '../storage/CodexSubagentStorage';
@@ -29,10 +25,7 @@ export interface CodexWorkspaceServices extends ProviderWorkspaceServices {
   commandCatalog: ProviderCommandCatalog;
   agentMentionProvider: CodexAgentMentionProvider;
   cliResolver: ProviderCliResolver;
-}
-
-function sameCatalog(left: unknown, right: unknown): boolean {
-  return JSON.stringify(left) === JSON.stringify(right);
+  modelCatalogCoordinator: CodexModelCatalogCoordinator;
 }
 
 function createCodexCliResolver(): ProviderCliResolver {
@@ -46,10 +39,10 @@ export async function createCodexWorkspaceServices(
 ): Promise<CodexWorkspaceServices> {
   const subagentStorage = new CodexSubagentStorage(vaultAdapter);
   const agentMentionProvider = new CodexAgentMentionProvider(subagentStorage);
-  await agentMentionProvider.loadAgents();
 
   const skillListProvider = new CodexSkillListingService(plugin);
   const modelDiscovery = new CodexModelDiscoveryService(plugin);
+  const modelCatalogCoordinator = new CodexModelCatalogCoordinator(plugin, modelDiscovery);
   const commandCatalog = new CodexSkillCatalog(
     new CodexSkillStorage(
       vaultAdapter,
@@ -59,60 +52,26 @@ export async function createCodexWorkspaceServices(
     getVaultPath(plugin.app),
   );
 
-  const services: CodexWorkspaceServices = {
+  if (getCodexProviderSettings(plugin.settings).enabled) {
+    plugin.app.workspace.onLayoutReady(() => {
+      void modelCatalogCoordinator.ensureFresh('layout-ready');
+    });
+  }
+
+  return {
     subagentStorage,
     commandCatalog,
     agentMentionProvider,
     cliResolver: createCodexCliResolver(),
+    modelCatalogCoordinator,
     settingsTabRenderer: codexSettingsTabRenderer,
     refreshAgentMentions: async () => {
       await agentMentionProvider.loadAgents();
     },
-    refreshModelCatalog: async () => {
-      const result = await modelDiscovery.discoverModels();
-      if (result.kind === 'skipped') {
-        return { changed: false };
-      }
-      if (result.diagnostics) {
-        return { changed: false, diagnostics: result.diagnostics };
-      }
-      if (result.models.length === 0) {
-        return { changed: false, diagnostics: 'Codex app-server returned no visible models' };
-      }
-
-      let refreshResult = { changed: false, persistedSettingsChanged: false };
-      await plugin.mutateSettingsConditionally((settings) => {
-        const currentSettings = getCodexProviderSettings(settings);
-        const currentModels = currentSettings.discoveredModels;
-        const visibleModels = normalizeCodexVisibleModels(
-          currentSettings.visibleModels,
-          result.models,
-        );
-        const catalogChanged = !sameCatalog(currentModels, result.models);
-        const visibilityChanged = !sameCatalog(currentSettings.visibleModels, visibleModels);
-        if (catalogChanged || visibilityChanged) {
-          updateCodexProviderSettings(settings, {
-            discoveredModels: result.models,
-            visibleModels,
-          });
-        }
-        const selectionChanged = ProviderSettingsCoordinator.normalizeAllModelVariants(settings);
-        const persistedSettingsChanged = visibilityChanged || selectionChanged;
-        refreshResult = {
-          changed: catalogChanged || persistedSettingsChanged,
-          persistedSettingsChanged,
-        };
-        return persistedSettingsChanged;
-      });
-      return refreshResult;
-    },
+    refreshModelCatalog: async () => modelCatalogCoordinator.refreshModelCatalog(),
+    prepareSettings: async () => agentMentionProvider.loadAgents(),
+    dispose: () => modelCatalogCoordinator.cancel(),
   };
-
-  if (getCodexProviderSettings(plugin.settings).enabled) {
-    await services.refreshModelCatalog!();
-  }
-
-  return services;
 }
 
 export const codexWorkspaceRegistration: ProviderWorkspaceRegistration<CodexWorkspaceServices> = {

--- a/src/providers/codex/app/CodexWorkspaceServices.ts
+++ b/src/providers/codex/app/CodexWorkspaceServices.ts
@@ -70,7 +70,7 @@ export async function createCodexWorkspaceServices(
     },
     refreshModelCatalog: async () => modelCatalogCoordinator.refreshModelCatalog(),
     prepareSettings: async () => agentMentionProvider.loadAgents(),
-    dispose: () => modelCatalogCoordinator.cancel(),
+    dispose: () => modelCatalogCoordinator.dispose(),
   };
 }
 

--- a/src/providers/codex/env/CodexSettingsReconciler.ts
+++ b/src/providers/codex/env/CodexSettingsReconciler.ts
@@ -9,7 +9,7 @@ import { codexChatUIConfig } from '../ui/CodexChatUIConfig';
 
 const ENV_HASH_KEYS = ['OPENAI_MODEL', 'OPENAI_BASE_URL', 'OPENAI_API_KEY'];
 
-function computeCodexEnvHash(envText: string): string {
+export function computeCodexEnvHash(envText: string): string {
   const envVars = parseEnvironmentVariables(envText || '');
   return ENV_HASH_KEYS
     .filter(key => envVars[key])

--- a/src/providers/codex/env/CodexSettingsReconciler.ts
+++ b/src/providers/codex/env/CodexSettingsReconciler.ts
@@ -18,7 +18,22 @@ export function computeCodexEnvHash(envText: string): string {
     .join('|');
 }
 
+function invalidateCodexConversationSessions(conversations: Conversation[]): Conversation[] {
+  const invalidatedConversations: Conversation[] = [];
+  for (const conversation of conversations) {
+    const state = getCodexState(conversation.providerState);
+    if (conversation.providerId === 'codex' && (conversation.sessionId || state.threadId)) {
+      conversation.sessionId = null;
+      conversation.providerState = undefined;
+      invalidatedConversations.push(conversation);
+    }
+  }
+  return invalidatedConversations;
+}
+
 export const codexSettingsReconciler: ProviderSettingsReconciler = {
+  invalidateConversationSessions: invalidateCodexConversationSessions,
+
   reconcileModelWithEnvironment(
     settings: Record<string, unknown>,
     conversations: Conversation[],
@@ -31,15 +46,7 @@ export const codexSettingsReconciler: ProviderSettingsReconciler = {
       return { changed: false, invalidatedConversations: [] };
     }
 
-    const invalidatedConversations: Conversation[] = [];
-    for (const conv of conversations) {
-      const state = getCodexState(conv.providerState);
-      if (conv.providerId === 'codex' && (conv.sessionId || state.threadId)) {
-        conv.sessionId = null;
-        conv.providerState = undefined;
-        invalidatedConversations.push(conv);
-      }
-    }
+    const invalidatedConversations = invalidateCodexConversationSessions(conversations);
 
     const currentModel = typeof settings.model === 'string' ? settings.model : '';
     const nextModel = resolveCodexModelSelection(settings, currentModel);

--- a/src/providers/codex/registration.ts
+++ b/src/providers/codex/registration.ts
@@ -36,7 +36,6 @@ export const codexProviderRegistration: ProviderModule = {
       'codexEnabled',
       'lastCodexEnvHash',
     ],
-    runtimeOnlyFields: ['discoveredModels'],
     normalizeStored(target, stored) {
       const normalization = normalizeCodexStoredConfig(stored);
       target.providerConfigs ??= {};

--- a/src/providers/codex/runtime/CodexAuxQueryRunner.ts
+++ b/src/providers/codex/runtime/CodexAuxQueryRunner.ts
@@ -169,7 +169,7 @@ export class CodexAuxQueryRunner {
   }
 
   private async startProcess(): Promise<void> {
-    this.launchSpec = resolveCodexAppServerLaunchSpec(this.plugin, 'codex');
+    this.launchSpec = await resolveCodexAppServerLaunchSpec(this.plugin, 'codex');
     this.process = new CodexAppServerProcess(this.launchSpec);
     this.process.start();
 

--- a/src/providers/codex/runtime/CodexChatRuntime.ts
+++ b/src/providers/codex/runtime/CodexChatRuntime.ts
@@ -275,7 +275,7 @@ export class CodexChatRuntime implements ChatRuntime {
     this.assertLifecycleCurrent(generation);
     const promptSettings = this.getSystemPromptSettings();
     const promptKey = computeSystemPromptKey(promptSettings);
-    const launchSpec = resolveCodexAppServerLaunchSpec(this.plugin, this.providerId);
+    const launchSpec = await resolveCodexAppServerLaunchSpec(this.plugin, this.providerId);
     const clientConfigKey = [promptKey, JSON.stringify({
       command: launchSpec.command,
       args: launchSpec.args,

--- a/src/providers/codex/runtime/CodexCliResolver.ts
+++ b/src/providers/codex/runtime/CodexCliResolver.ts
@@ -5,7 +5,7 @@ import { getHostnameKey } from '../../../utils/env';
 import type { CodexInstallationMethod } from '../settings';
 import { getCodexProviderSettings } from '../settings';
 import { resolveCodexCliPath } from './CodexBinaryLocator';
-import { resolveCodexExecutionTarget } from './CodexExecutionTargetResolver';
+import { resolveCodexExecutionTargetAsync } from './CodexExecutionTargetResolver';
 import type { CodexExecutionTarget } from './codexLaunchTypes';
 
 export class CodexCliResolver {
@@ -19,34 +19,19 @@ export class CodexCliResolver {
   resolveFromSettings(
     settings: Record<string, unknown>,
     context: ProviderCliResolutionContext = {},
-  ): string | null {
+  ): string | null | Promise<string | null> {
     const codexSettings = getCodexProviderSettings(settings);
     const hostnamePath = (codexSettings.cliPathsByHost[this.cachedHostname] ?? '').trim();
     const legacyPath = codexSettings.cliPath.trim();
     const envText = getRuntimeEnvironmentText(settings, 'codex');
-    const executionTarget = getCodexExecutionTargetFromContext(context)
-      ?? resolveCodexExecutionTarget({ settings });
-    const executionTargetKey = getCodexExecutionTargetCacheKey(executionTarget);
-
-    if (
-      this.resolvedPath &&
-      hostnamePath === this.lastHostnamePath &&
-      legacyPath === this.lastLegacyPath &&
-      envText === this.lastEnvText &&
-      executionTargetKey === this.lastExecutionTargetKey
-    ) {
-      return this.resolvedPath;
+    const executionTarget = getCodexExecutionTargetFromContext(context);
+    if (executionTarget) {
+      return this.resolveAndCache(hostnamePath, legacyPath, envText, executionTarget);
     }
 
-    this.lastHostnamePath = hostnamePath;
-    this.lastLegacyPath = legacyPath;
-    this.lastEnvText = envText;
-    this.lastExecutionTargetKey = executionTargetKey;
-
-    this.resolvedPath = resolveCodexCliPath(hostnamePath, legacyPath, envText, {
-      executionTarget,
-    });
-    return this.resolvedPath;
+    return resolveCodexExecutionTargetAsync({ settings }).then((resolvedTarget) => (
+      this.resolveAndCache(hostnamePath, legacyPath, envText, resolvedTarget)
+    ));
   }
 
   resolve(
@@ -70,6 +55,35 @@ export class CodexCliResolver {
     this.lastLegacyPath = '';
     this.lastEnvText = '';
     this.lastExecutionTargetKey = '';
+  }
+
+  private resolveAndCache(
+    hostnamePath: string,
+    legacyPath: string,
+    envText: string,
+    executionTarget: CodexExecutionTarget,
+  ): string | null {
+    const executionTargetKey = getCodexExecutionTargetCacheKey(executionTarget);
+
+    if (
+      this.resolvedPath &&
+      hostnamePath === this.lastHostnamePath &&
+      legacyPath === this.lastLegacyPath &&
+      envText === this.lastEnvText &&
+      executionTargetKey === this.lastExecutionTargetKey
+    ) {
+      return this.resolvedPath;
+    }
+
+    this.lastHostnamePath = hostnamePath;
+    this.lastLegacyPath = legacyPath;
+    this.lastEnvText = envText;
+    this.lastExecutionTargetKey = executionTargetKey;
+
+    this.resolvedPath = resolveCodexCliPath(hostnamePath, legacyPath, envText, {
+      executionTarget,
+    });
+    return this.resolvedPath;
   }
 }
 

--- a/src/providers/codex/runtime/CodexExecutionTargetResolver.ts
+++ b/src/providers/codex/runtime/CodexExecutionTargetResolver.ts
@@ -1,4 +1,5 @@
-import { execFileSync } from 'child_process';
+import { execFile, execFileSync } from 'child_process';
+import { promisify } from 'util';
 
 import { getCodexProviderSettings } from '../settings';
 import type {
@@ -91,13 +92,29 @@ export function parseDefaultWslDistroListOutput(output: string | Buffer): string
   return undefined;
 }
 
+const execFileAsync = promisify(execFile);
+
 function resolveDefaultWslDistroName(): string | undefined {
   try {
     const output = execFileSync('wsl.exe', ['--list', '--verbose'], {
       stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5_000,
       windowsHide: true,
     });
     return parseDefaultWslDistroListOutput(output);
+  } catch {
+    return undefined;
+  }
+}
+
+async function resolveDefaultWslDistroNameAsync(): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync('wsl.exe', ['--list', '--verbose'], {
+      encoding: null,
+      timeout: 5_000,
+      windowsHide: true,
+    });
+    return parseDefaultWslDistroListOutput(stdout);
   } catch {
     return undefined;
   }
@@ -121,6 +138,42 @@ export function resolveCodexExecutionTarget(
       || inferWslDistroFromWindowsPath(options.hostVaultPath)
       || options.resolveDefaultWslDistro?.()
       || resolveDefaultWslDistroName();
+
+    return {
+      method: 'wsl',
+      platformFamily: 'unix',
+      platformOs: 'linux',
+      distroName,
+    };
+  }
+
+  return {
+    method: 'native-windows',
+    platformFamily: 'windows',
+    platformOs: 'windows',
+  };
+}
+
+export async function resolveCodexExecutionTargetAsync(
+  options: ResolveCodexExecutionTargetOptions,
+): Promise<CodexExecutionTarget> {
+  const hostPlatform = options.hostPlatform ?? process.platform;
+  if (hostPlatform !== 'win32') {
+    return {
+      method: 'host-native',
+      platformFamily: resolveHostPlatformFamily(hostPlatform),
+      platformOs: resolveHostPlatformOs(hostPlatform),
+    };
+  }
+
+  const codexSettings = getCodexProviderSettings(options.settings);
+  if (codexSettings.installationMethod === 'wsl') {
+    const distroName = codexSettings.wslDistroOverride
+      || inferWslDistroFromWindowsPath(options.hostVaultPath)
+      || (options.resolveDefaultWslDistro
+        ? await Promise.resolve(options.resolveDefaultWslDistro())
+        : undefined)
+      || await resolveDefaultWslDistroNameAsync();
 
     return {
       method: 'wsl',

--- a/src/providers/codex/runtime/CodexLaunchSpecBuilder.ts
+++ b/src/providers/codex/runtime/CodexLaunchSpecBuilder.ts
@@ -26,6 +26,7 @@ export function buildCodexLaunchSpec(
     hostVaultPath: options.hostVaultPath,
     resolveDefaultWslDistro: options.resolveDefaultWslDistro,
   });
+
   const pathMapper = createCodexPathMapper(target);
   const spawnCwd = options.hostVaultPath ?? process.cwd();
 

--- a/src/providers/codex/runtime/CodexModelCatalogCoordinator.ts
+++ b/src/providers/codex/runtime/CodexModelCatalogCoordinator.ts
@@ -49,6 +49,7 @@ export class CodexModelCatalogCoordinator {
   private state: CodexCatalogState = 'idle';
   private inFlightRefresh: Promise<CodexCatalogResult> | null = null;
   private abortController: AbortController | null = null;
+  private disposed = false;
 
   constructor(
     private readonly plugin: ProviderHost,
@@ -86,6 +87,9 @@ export class CodexModelCatalogCoordinator {
     _reason: string,
     options: { force?: boolean } = {},
   ): Promise<CodexCatalogEnsureResult> {
+    if (this.disposed) {
+      return { kind: 'skipped', models: this.getCachedCatalog(), refreshed: false };
+    }
     const settings = getCodexProviderSettings(this.plugin.settings);
     if (!settings.enabled) {
       return { kind: 'skipped', models: this.getCachedCatalog(), refreshed: false };
@@ -122,6 +126,9 @@ export class CodexModelCatalogCoordinator {
   }
 
   async refresh(): Promise<CodexCatalogResult> {
+    if (this.disposed) {
+      return { kind: 'skipped', models: this.getCachedCatalog(), refreshed: false };
+    }
     if (this.inFlightRefresh) {
       return this.inFlightRefresh;
     }
@@ -135,9 +142,27 @@ export class CodexModelCatalogCoordinator {
   }
 
   async refreshModelCatalog(): Promise<ProviderModelCatalogRefreshResult> {
-    const result = await this.refresh();
+    let result = await this.refresh();
+    let changed = result.kind === 'completed' && result.refreshed;
+    if (
+      result.kind === 'completed'
+      && !result.diagnostics
+      && result.models.length > 0
+      && !this.disposed
+    ) {
+      let status: 'missing' | 'stale' | 'fresh' = 'fresh';
+      try {
+        status = await this.getStatus();
+      } catch {
+        // Keep the completed refresh result when fingerprint verification is unavailable.
+      }
+      if (status !== 'fresh') {
+        result = await this.refresh();
+        changed = changed || (result.kind === 'completed' && result.refreshed);
+      }
+    }
     if (result.kind === 'skipped') {
-      return { changed: false };
+      return { changed };
     }
     if (result.diagnostics) {
       return { changed: false, diagnostics: result.diagnostics };
@@ -145,11 +170,16 @@ export class CodexModelCatalogCoordinator {
     if (result.models.length === 0) {
       return { changed: false, diagnostics: 'Codex app-server returned no visible models' };
     }
-    return { changed: result.refreshed };
+    return { changed };
   }
 
   cancel(): void {
     this.abortController?.abort();
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.cancel();
   }
 
   private async runRefresh(): Promise<CodexCatalogResult> {
@@ -160,7 +190,24 @@ export class CodexModelCatalogCoordinator {
 
     const span = StartupProfiler.start('codex-model-discovery');
     try {
+      let catalogFingerprint: string | null = null;
+      let catalogFingerprintError: unknown;
+      try {
+        catalogFingerprint = await computeCodexCatalogFingerprint(this.plugin);
+      } catch (error) {
+        catalogFingerprintError = error;
+      }
+      if (this.disposed) {
+        this.state = 'idle';
+        return { kind: 'skipped', models: this.getCachedCatalog(), refreshed: false };
+      }
+
       const discoveryResult = await this.discovery.discoverModels(abortController.signal);
+
+      if (this.disposed) {
+        this.state = 'idle';
+        return { kind: 'skipped', models: this.getCachedCatalog(), refreshed: false };
+      }
 
       if (discoveryResult.kind === 'skipped') {
         const cached = this.getCachedCatalog();
@@ -178,7 +225,17 @@ export class CodexModelCatalogCoordinator {
         };
       }
 
-      const persistedResult = await this.persistCatalog(discoveryResult.models);
+      if (!catalogFingerprint) {
+        throw catalogFingerprintError ?? new Error('Codex catalog fingerprint resolution failed');
+      }
+      const persistedResult = await this.persistCatalog(
+        discoveryResult.models,
+        catalogFingerprint,
+      );
+      if (this.disposed) {
+        this.state = 'idle';
+        return { kind: 'skipped', models: this.getCachedCatalog(), refreshed: false };
+      }
       this.state = 'ready';
       return {
         kind: 'completed',
@@ -186,6 +243,10 @@ export class CodexModelCatalogCoordinator {
         refreshed: persistedResult.changed,
       };
     } catch (error) {
+      if (this.disposed) {
+        this.state = 'idle';
+        return { kind: 'skipped', models: this.getCachedCatalog(), refreshed: false };
+      }
       const message = error instanceof Error ? error.message : 'Codex model discovery failed';
       this.state = 'failed';
       return {
@@ -204,12 +265,15 @@ export class CodexModelCatalogCoordinator {
 
   private async persistCatalog(
     models: CodexDiscoveredModel[],
+    fingerprint: string,
   ): Promise<{ changed: boolean; persistedSettingsChanged: boolean }> {
-    const fingerprint = await computeCodexCatalogFingerprint(this.plugin);
     const timestamp = Date.now();
 
     let refreshResult = { changed: false, persistedSettingsChanged: false };
     await this.plugin.mutateSettingsConditionally((settings) => {
+      if (this.disposed) {
+        return false;
+      }
       const currentSettings = getCodexProviderSettings(settings);
       const currentModels = currentSettings.discoveredModels;
       const visibleModels = normalizeCodexVisibleModels(

--- a/src/providers/codex/runtime/CodexModelCatalogCoordinator.ts
+++ b/src/providers/codex/runtime/CodexModelCatalogCoordinator.ts
@@ -1,0 +1,248 @@
+/**
+ * Stale-while-revalidate coordinator for the Codex model catalog.
+ *
+ * The coordinator owns Codex model discovery lifecycle:
+ *   - Load cached models immediately.
+ *   - Complete plugin activation without launching Codex.
+ *   - Schedule a background refresh after layout-ready.
+ *   - Ensure freshness when the model picker opens.
+ *   - Preserve cached models if refresh fails.
+ */
+
+import { StartupProfiler } from '../../../core/performance/StartupProfiler';
+import type { ProviderHost } from '../../../core/providers/ProviderHost';
+import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
+import type { ProviderModelCatalogRefreshResult } from '../../../core/providers/types';
+import {
+  getCodexProviderSettings,
+  normalizeCodexVisibleModels,
+  updateCodexProviderSettings,
+} from '../settings';
+import type { CodexDiscoveredModel } from './../models';
+import {
+  computeCodexCatalogFingerprint,
+} from './CodexModelCatalogFingerprint';
+import type {
+  CodexModelDiscoveryServiceLike,
+} from './CodexModelDiscoveryService';
+
+export type CodexCatalogState = 'idle' | 'refreshing' | 'ready' | 'failed';
+
+export interface CodexCatalogResult {
+  kind: 'completed' | 'skipped';
+  models: CodexDiscoveredModel[];
+  refreshed: boolean;
+  diagnostics?: string;
+}
+
+export interface CodexCatalogEnsureResult extends CodexCatalogResult {
+  backgroundRefresh?: Promise<CodexCatalogResult>;
+}
+
+const CATALOG_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+function sameCatalog(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export class CodexModelCatalogCoordinator {
+  private state: CodexCatalogState = 'idle';
+  private inFlightRefresh: Promise<CodexCatalogResult> | null = null;
+  private abortController: AbortController | null = null;
+
+  constructor(
+    private readonly plugin: ProviderHost,
+    private readonly discovery: CodexModelDiscoveryServiceLike,
+  ) {}
+
+  getCachedCatalog(): CodexDiscoveredModel[] {
+    return getCodexProviderSettings(this.plugin.settings).discoveredModels;
+  }
+
+  getState(): CodexCatalogState {
+    return this.state;
+  }
+
+  async getStatus(): Promise<'missing' | 'stale' | 'fresh'> {
+    const settings = getCodexProviderSettings(this.plugin.settings);
+    if (settings.discoveredModels.length === 0 || !settings.catalogFingerprint) {
+      return 'missing';
+    }
+
+    const currentFingerprint = await computeCodexCatalogFingerprint(this.plugin);
+    if (currentFingerprint !== settings.catalogFingerprint) {
+      return 'stale';
+    }
+
+    const ageMs = Date.now() - settings.catalogTimestamp;
+    if (ageMs > CATALOG_TTL_MS) {
+      return 'stale';
+    }
+
+    return 'fresh';
+  }
+
+  async ensureFresh(
+    _reason: string,
+    options: { force?: boolean } = {},
+  ): Promise<CodexCatalogEnsureResult> {
+    const settings = getCodexProviderSettings(this.plugin.settings);
+    if (!settings.enabled) {
+      return { kind: 'skipped', models: this.getCachedCatalog(), refreshed: false };
+    }
+
+    if (options.force) {
+      const result = await this.refresh();
+      return { ...result, backgroundRefresh: undefined };
+    }
+
+    let status: 'missing' | 'stale' | 'fresh';
+    try {
+      status = await this.getStatus();
+    } catch {
+      status = this.getCachedCatalog().length > 0 ? 'stale' : 'missing';
+    }
+    if (status === 'fresh') {
+      return { kind: 'completed', models: this.getCachedCatalog(), refreshed: false };
+    }
+
+    if (status === 'missing') {
+      const result = await this.refresh();
+      return { ...result, backgroundRefresh: undefined };
+    }
+
+    // Stale: return cached immediately and refresh in the background.
+    const backgroundRefresh = this.refresh();
+    return {
+      kind: 'completed',
+      models: this.getCachedCatalog(),
+      refreshed: false,
+      backgroundRefresh,
+    };
+  }
+
+  async refresh(): Promise<CodexCatalogResult> {
+    if (this.inFlightRefresh) {
+      return this.inFlightRefresh;
+    }
+
+    this.inFlightRefresh = this.runRefresh();
+    try {
+      return await this.inFlightRefresh;
+    } finally {
+      this.inFlightRefresh = null;
+    }
+  }
+
+  async refreshModelCatalog(): Promise<ProviderModelCatalogRefreshResult> {
+    const result = await this.refresh();
+    if (result.kind === 'skipped') {
+      return { changed: false };
+    }
+    if (result.diagnostics) {
+      return { changed: false, diagnostics: result.diagnostics };
+    }
+    if (result.models.length === 0) {
+      return { changed: false, diagnostics: 'Codex app-server returned no visible models' };
+    }
+    return { changed: result.refreshed };
+  }
+
+  cancel(): void {
+    this.abortController?.abort();
+  }
+
+  private async runRefresh(): Promise<CodexCatalogResult> {
+    this.abortController?.abort();
+    const abortController = new AbortController();
+    this.abortController = abortController;
+    this.state = 'refreshing';
+
+    const span = StartupProfiler.start('codex-model-discovery');
+    try {
+      const discoveryResult = await this.discovery.discoverModels(abortController.signal);
+
+      if (discoveryResult.kind === 'skipped') {
+        const cached = this.getCachedCatalog();
+        this.state = cached.length > 0 ? 'ready' : 'idle';
+        return { kind: 'skipped', models: cached, refreshed: false };
+      }
+
+      if (discoveryResult.diagnostics || discoveryResult.models.length === 0) {
+        this.state = 'failed';
+        return {
+          kind: 'completed',
+          models: this.getCachedCatalog(),
+          refreshed: false,
+          diagnostics: discoveryResult.diagnostics ?? 'Codex app-server returned no visible models',
+        };
+      }
+
+      const persistedResult = await this.persistCatalog(discoveryResult.models);
+      this.state = 'ready';
+      return {
+        kind: 'completed',
+        models: discoveryResult.models,
+        refreshed: persistedResult.changed,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Codex model discovery failed';
+      this.state = 'failed';
+      return {
+        kind: 'completed',
+        models: this.getCachedCatalog(),
+        refreshed: false,
+        diagnostics: message,
+      };
+    } finally {
+      StartupProfiler.finish(span);
+      if (this.abortController === abortController) {
+        this.abortController = null;
+      }
+    }
+  }
+
+  private async persistCatalog(
+    models: CodexDiscoveredModel[],
+  ): Promise<{ changed: boolean; persistedSettingsChanged: boolean }> {
+    const fingerprint = await computeCodexCatalogFingerprint(this.plugin);
+    const timestamp = Date.now();
+
+    let refreshResult = { changed: false, persistedSettingsChanged: false };
+    await this.plugin.mutateSettingsConditionally((settings) => {
+      const currentSettings = getCodexProviderSettings(settings);
+      const currentModels = currentSettings.discoveredModels;
+      const visibleModels = normalizeCodexVisibleModels(
+        currentSettings.visibleModels,
+        models,
+      );
+      const catalogChanged = !sameCatalog(currentModels, models);
+      const visibilityChanged = !sameCatalog(currentSettings.visibleModels, visibleModels);
+      const fingerprintChanged = currentSettings.catalogFingerprint !== fingerprint;
+      const timestampChanged = currentSettings.catalogTimestamp !== timestamp;
+
+      if (catalogChanged || visibilityChanged || fingerprintChanged || timestampChanged) {
+        updateCodexProviderSettings(settings, {
+          discoveredModels: models,
+          visibleModels,
+          catalogFingerprint: fingerprint,
+          catalogTimestamp: timestamp,
+        });
+      }
+
+      const selectionChanged = ProviderSettingsCoordinator.normalizeAllModelVariants(settings);
+      const selectorStateChanged = visibilityChanged || selectionChanged;
+      const shouldPersist = catalogChanged
+        || selectorStateChanged
+        || fingerprintChanged
+        || timestampChanged;
+      refreshResult = {
+        changed: catalogChanged || selectorStateChanged,
+        persistedSettingsChanged: shouldPersist,
+      };
+      return shouldPersist;
+    });
+
+    return refreshResult;
+  }
+}

--- a/src/providers/codex/runtime/CodexModelCatalogFingerprint.ts
+++ b/src/providers/codex/runtime/CodexModelCatalogFingerprint.ts
@@ -1,0 +1,74 @@
+/**
+ * Cache fingerprint for the Codex model catalog.
+ *
+ * The fingerprint captures the inputs that affect which models the Codex
+ * app-server will report. When any input changes, the cached catalog is
+ * considered stale and will be refreshed.
+ */
+
+import { createHash } from 'node:crypto';
+
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import type { ProviderHost } from '../../../core/providers/ProviderHost';
+import { getVaultPath } from '../../../utils/path';
+import { computeCodexEnvHash } from '../env/CodexSettingsReconciler';
+import { getCodexProviderSettings } from '../settings';
+import { resolveCodexExecutionTargetAsync } from './CodexExecutionTargetResolver';
+
+const CATALOG_FINGERPRINT_VERSION = '1';
+
+export interface CodexCatalogFingerprintInputs {
+  resolvedCliCommand: string | null;
+  executionTargetKey: string;
+  envHash: string;
+}
+
+export function buildCodexCatalogFingerprint(
+  inputs: CodexCatalogFingerprintInputs,
+): string {
+  const parts = [
+    CATALOG_FINGERPRINT_VERSION,
+    inputs.resolvedCliCommand ?? '',
+    inputs.executionTargetKey,
+    inputs.envHash,
+  ];
+  return `${CATALOG_FINGERPRINT_VERSION}:${createHash('sha256')
+    .update(JSON.stringify(parts))
+    .digest('hex')}`;
+}
+
+export async function computeCodexCatalogFingerprint(plugin: ProviderHost): Promise<string> {
+  const settings = plugin.settings;
+  const hostVaultPath = getVaultPath(plugin.app) ?? null;
+  const executionTarget = await resolveCodexExecutionTargetAsync({
+    settings,
+    hostVaultPath,
+  });
+  const resolvedCliCommand = await plugin.getResolvedProviderCliPath('codex', { executionTarget });
+  const executionTargetKey = [
+    executionTarget.method,
+    executionTarget.platformFamily,
+    executionTarget.platformOs,
+    executionTarget.distroName ?? '',
+  ].join(':');
+  const envText = getRuntimeEnvironmentText(settings, 'codex');
+  const envHash = computeCodexEnvHash(envText);
+
+  return buildCodexCatalogFingerprint({
+    resolvedCliCommand,
+    executionTargetKey,
+    envHash,
+  });
+}
+
+export function getCodexCatalogFingerprintFromSettings(
+  settings: Record<string, unknown>,
+): string {
+  return getCodexProviderSettings(settings).catalogFingerprint;
+}
+
+export function getCodexCatalogTimestampFromSettings(
+  settings: Record<string, unknown>,
+): number {
+  return getCodexProviderSettings(settings).catalogTimestamp;
+}

--- a/src/providers/codex/runtime/CodexModelDiscoveryService.ts
+++ b/src/providers/codex/runtime/CodexModelDiscoveryService.ts
@@ -51,6 +51,13 @@ export class CodexModelDiscoveryService implements CodexModelDiscoveryServiceLik
 
     try {
       const launchSpec = await resolveCodexAppServerLaunchSpec(this.plugin, 'codex');
+      if (signal?.aborted) {
+        return {
+          kind: 'completed',
+          diagnostics: 'Codex model discovery was cancelled',
+          models: [],
+        };
+      }
       process = new CodexAppServerProcess(launchSpec);
       process.start();
       transport = new CodexRpcTransport(process);

--- a/src/providers/codex/runtime/CodexModelDiscoveryService.ts
+++ b/src/providers/codex/runtime/CodexModelDiscoveryService.ts
@@ -23,26 +23,56 @@ export type CodexModelDiscoveryResult =
     reason: 'provider-disabled';
   };
 
+export interface CodexModelDiscoveryServiceLike {
+  discoverModels(signal?: AbortSignal): Promise<CodexModelDiscoveryResult>;
+}
+
 const MODEL_LIST_PAGE_SIZE = 100;
 
-export class CodexModelDiscoveryService {
+export class CodexModelDiscoveryService implements CodexModelDiscoveryServiceLike {
   constructor(private readonly plugin: ProviderHost) {}
 
-  async discoverModels(): Promise<CodexModelDiscoveryResult> {
+  async discoverModels(signal?: AbortSignal): Promise<CodexModelDiscoveryResult> {
     if (!getCodexProviderSettings(this.plugin.settings).enabled) {
       return { kind: 'skipped', reason: 'provider-disabled' };
     }
 
+    if (signal?.aborted) {
+      return {
+        kind: 'completed',
+        diagnostics: 'Codex model discovery was cancelled',
+        models: [],
+      };
+    }
+
     let process: CodexAppServerProcess | null = null;
     let transport: CodexRpcTransport | null = null;
+    let abortListener: (() => void) | null = null;
 
     try {
-      const launchSpec = resolveCodexAppServerLaunchSpec(this.plugin, 'codex');
+      const launchSpec = await resolveCodexAppServerLaunchSpec(this.plugin, 'codex');
       process = new CodexAppServerProcess(launchSpec);
       process.start();
       transport = new CodexRpcTransport(process);
       transport.start();
+
+      abortListener = () => {
+        transport?.dispose();
+        if (process) {
+          void process.shutdown().catch(() => {});
+        }
+      };
+      signal?.addEventListener('abort', abortListener, { once: true });
+
       await initializeCodexAppServerTransport(transport);
+
+      if (signal?.aborted) {
+        return {
+          kind: 'completed',
+          diagnostics: 'Codex model discovery was cancelled',
+          models: [],
+        };
+      }
 
       const entries: unknown[] = [];
       const seenCursors = new Set<string>();
@@ -65,6 +95,14 @@ export class CodexModelDiscoveryService {
           seenCursors.add(nextCursor);
         }
         cursor = nextCursor;
+
+        if (signal?.aborted) {
+          return {
+            kind: 'completed',
+            diagnostics: 'Codex model discovery was cancelled',
+            models: [],
+          };
+        }
       } while (cursor);
 
       return {
@@ -72,6 +110,13 @@ export class CodexModelDiscoveryService {
         models: normalizeCodexDiscoveredModels(entries),
       };
     } catch (error) {
+      if (signal?.aborted) {
+        return {
+          kind: 'completed',
+          diagnostics: 'Codex model discovery was cancelled',
+          models: [],
+        };
+      }
       const message = error instanceof Error ? error.message : 'Codex model discovery failed';
       const stderr = process?.getStderrSnapshot() ?? '';
       return {
@@ -80,6 +125,9 @@ export class CodexModelDiscoveryService {
         models: [],
       };
     } finally {
+      if (abortListener && signal) {
+        signal.removeEventListener('abort', abortListener);
+      }
       transport?.dispose();
       if (process) {
         await process.shutdown().catch(() => {});

--- a/src/providers/codex/runtime/codexAppServerSupport.ts
+++ b/src/providers/codex/runtime/codexAppServerSupport.ts
@@ -3,7 +3,7 @@ import type { ProviderId } from '../../../core/providers/types';
 import { getEnhancedPath, parseEnvironmentVariables } from '../../../utils/env';
 import { getVaultPath } from '../../../utils/path';
 import type { InitializeResult } from './codexAppServerTypes';
-import { resolveCodexExecutionTarget } from './CodexExecutionTargetResolver';
+import { resolveCodexExecutionTargetAsync } from './CodexExecutionTargetResolver';
 import { buildCodexLaunchSpec } from './CodexLaunchSpecBuilder';
 import type { CodexLaunchSpec } from './codexLaunchTypes';
 import type { CodexRpcTransport } from './CodexRpcTransport';
@@ -34,19 +34,19 @@ export function buildCodexAppServerEnvironment(
   };
 }
 
-export function resolveCodexAppServerLaunchSpec(
+export async function resolveCodexAppServerLaunchSpec(
   plugin: ProviderHost,
   providerId: ProviderId = 'codex',
-): CodexLaunchSpec {
+): Promise<CodexLaunchSpec> {
   const hostVaultPath = getCodexAppServerWorkingDirectory(plugin);
-  const executionTarget = resolveCodexExecutionTarget({
+  const executionTarget = await resolveCodexExecutionTargetAsync({
     settings: plugin.settings,
     hostVaultPath,
   });
 
   return buildCodexLaunchSpec({
     settings: plugin.settings,
-    resolvedCliCommand: plugin.getResolvedProviderCliPath(providerId, { executionTarget }),
+    resolvedCliCommand: await plugin.getResolvedProviderCliPath(providerId, { executionTarget }),
     hostVaultPath,
     env: buildCodexAppServerEnvironment(plugin, providerId),
     executionTarget,

--- a/src/providers/codex/settings.ts
+++ b/src/providers/codex/settings.ts
@@ -34,6 +34,8 @@ export interface CodexProviderConfig {
   reasoningSummary: CodexReasoningSummary;
   environmentVariables: string;
   environmentHash: string;
+  catalogTimestamp: number;
+  catalogFingerprint: string;
   installationMethodsByHost: HostnameInstallationMethods;
   wslDistroOverridesByHost: HostnameCliPaths;
 }
@@ -99,6 +101,8 @@ export interface CodexProviderSettings {
   reasoningSummary: CodexProviderConfig['reasoningSummary'];
   environmentVariables: CodexProviderConfig['environmentVariables'];
   environmentHash: CodexProviderConfig['environmentHash'];
+  catalogTimestamp: CodexProviderConfig['catalogTimestamp'];
+  catalogFingerprint: CodexProviderConfig['catalogFingerprint'];
   installationMethod: CodexInstallationMethod;
   installationMethodsByHost: CodexProviderConfig['installationMethodsByHost'];
   wslDistroOverride: string;
@@ -117,6 +121,8 @@ export const DEFAULT_CODEX_PROVIDER_CONFIG: Readonly<CodexProviderConfig> = Obje
   reasoningSummary: 'detailed',
   environmentVariables: '',
   environmentHash: '',
+  catalogTimestamp: 0,
+  catalogFingerprint: '',
   installationMethodsByHost: {},
   wslDistroOverridesByHost: {},
 });
@@ -402,6 +408,12 @@ function getCodexStoredConfig(
     environmentHash: (config.environmentHash as string | undefined)
       ?? (settings.lastCodexEnvHash as string | undefined)
       ?? DEFAULT_CODEX_PROVIDER_CONFIG.environmentHash,
+    catalogTimestamp: typeof config.catalogTimestamp === 'number'
+      ? config.catalogTimestamp
+      : DEFAULT_CODEX_PROVIDER_CONFIG.catalogTimestamp,
+    catalogFingerprint: typeof config.catalogFingerprint === 'string'
+      ? config.catalogFingerprint
+      : DEFAULT_CODEX_PROVIDER_CONFIG.catalogFingerprint,
     installationMethodsByHost,
     wslDistroOverridesByHost,
   };
@@ -597,6 +609,8 @@ export function updateCodexProviderSettings(
     reasoningSummary: next.reasoningSummary,
     environmentVariables: next.environmentVariables,
     environmentHash: next.environmentHash,
+    catalogTimestamp: next.catalogTimestamp,
+    catalogFingerprint: next.catalogFingerprint,
     installationMethodsByHost,
     wslDistroOverridesByHost,
   });

--- a/src/providers/codex/skills/CodexSkillListingService.ts
+++ b/src/providers/codex/skills/CodexSkillListingService.ts
@@ -140,7 +140,7 @@ export class CodexSkillListingService implements CodexSkillListProvider {
   }
 
   private async fetchSkills(forceReload: boolean): Promise<SkillMetadata[]> {
-    const launchSpec = resolveCodexAppServerLaunchSpec(this.plugin, 'codex');
+    const launchSpec = await resolveCodexAppServerLaunchSpec(this.plugin, 'codex');
     const process = new CodexAppServerProcess(launchSpec);
     process.start();
 

--- a/src/providers/codex/ui/CodexModelPicker.ts
+++ b/src/providers/codex/ui/CodexModelPicker.ts
@@ -95,12 +95,15 @@ export function renderCodexModelPicker(
     failedCatalogText: 'Could not load models from Codex app-server. Check the CLI path and login state, then try again.',
     getState,
     initiallyOpen: getCodexProviderSettings(settingsBag).discoveredModels.length === 0,
-    async loadCatalog() {
-      if (!workspace.refreshModelCatalog) {
+    async loadCatalog(force) {
+      if (!workspace.modelCatalogCoordinator) {
         return 'failed';
       }
 
-      const result = await workspace.refreshModelCatalog();
+      const result = await workspace.modelCatalogCoordinator.ensureFresh('model-picker', { force });
+      if (result.backgroundRefresh) {
+        void result.backgroundRefresh.then(() => context.refreshModelSelectors());
+      }
       if (result.diagnostics) {
         new Notice(`Codex model discovery failed: ${result.diagnostics}`);
         return 'failed';

--- a/src/providers/codex/ui/CodexModelPicker.ts
+++ b/src/providers/codex/ui/CodexModelPicker.ts
@@ -89,7 +89,9 @@ export function renderCodexModelPicker(
     context.refreshModelSelectors();
   };
 
-  renderProviderModelPicker({
+  let refreshPicker = (): void => {};
+  const picker = renderProviderModelPicker({
+    checkCatalogFreshnessWhenCached: true,
     container,
     emptyCatalogText: 'No Codex models discovered yet. Click Discover to query app-server.',
     failedCatalogText: 'Could not load models from Codex app-server. Check the CLI path and login state, then try again.',
@@ -102,7 +104,13 @@ export function renderCodexModelPicker(
 
       const result = await workspace.modelCatalogCoordinator.ensureFresh('model-picker', { force });
       if (result.backgroundRefresh) {
-        void result.backgroundRefresh.then(() => context.refreshModelSelectors());
+        void result.backgroundRefresh.then(
+          () => {
+            context.refreshModelSelectors();
+            refreshPicker();
+          },
+          () => refreshPicker(),
+        );
       }
       if (result.diagnostics) {
         new Notice(`Codex model discovery failed: ${result.diagnostics}`);
@@ -124,4 +132,5 @@ export function renderCodexModelPicker(
     searchPlaceholder: 'Filter by model name, description, or ID...',
     settingDescription: 'Choose which app-server models appear in the Codex selector. Existing session models stay pinned even when hidden here.',
   });
+  refreshPicker = picker.refresh;
 }

--- a/src/providers/opencode/agents/OpencodeAgentMentionProvider.ts
+++ b/src/providers/opencode/agents/OpencodeAgentMentionProvider.ts
@@ -4,11 +4,37 @@ import type { OpencodeAgentDefinition } from '../types/agent';
 
 export class OpencodeAgentMentionProvider implements AgentMentionProvider {
   private agents: OpencodeAgentDefinition[] = [];
+  private loaded = false;
+  private loadPromise: Promise<void> | null = null;
 
   constructor(private storage: OpencodeAgentStorage) {}
 
   async loadAgents(): Promise<void> {
-    this.agents = await this.storage.loadAll();
+    if (this.loadPromise) {
+      return this.loadPromise;
+    }
+    const promise = this.storage.loadAll().then((agents) => {
+      this.agents = agents;
+      this.loaded = true;
+    });
+    this.loadPromise = promise;
+    try {
+      await promise;
+    } finally {
+      if (this.loadPromise === promise) {
+        this.loadPromise = null;
+      }
+    }
+  }
+
+  async ensureLoaded(): Promise<void> {
+    if (!this.loaded) {
+      await this.loadAgents();
+    }
+  }
+
+  isLoaded(): boolean {
+    return this.loaded;
   }
 
   searchAgents(query: string): Array<{

--- a/src/providers/opencode/app/OpencodeWorkspaceServices.ts
+++ b/src/providers/opencode/app/OpencodeWorkspaceServices.ts
@@ -30,7 +30,6 @@ export async function createOpencodeWorkspaceServices(
 ): Promise<OpencodeWorkspaceServices> {
   const agentStorage = new OpencodeAgentStorage(vaultAdapter);
   const agentMentionProvider = new OpencodeAgentMentionProvider(agentStorage);
-  await agentMentionProvider.loadAgents();
 
   return {
     agentStorage,
@@ -43,6 +42,7 @@ export async function createOpencodeWorkspaceServices(
     refreshAgentMentions: async () => {
       await agentMentionProvider.loadAgents();
     },
+    prepareSettings: async () => agentMentionProvider.loadAgents(),
   };
 }
 

--- a/src/providers/opencode/env/OpencodeSettingsReconciler.ts
+++ b/src/providers/opencode/env/OpencodeSettingsReconciler.ts
@@ -43,10 +43,31 @@ function computeOpencodeEnvHash(envText: string): string {
     .join('|');
 }
 
+function invalidateOpencodeConversationSessions(conversations: Conversation[]): Conversation[] {
+  const invalidatedConversations: Conversation[] = [];
+  for (const conversation of conversations) {
+    if (conversation.providerId !== 'opencode') {
+      continue;
+    }
+
+    const state = getOpencodeState(conversation.providerState);
+    if (!conversation.sessionId && !state.databasePath) {
+      continue;
+    }
+
+    conversation.sessionId = null;
+    conversation.providerState = undefined;
+    invalidatedConversations.push(conversation);
+  }
+  return invalidatedConversations;
+}
+
 export const opencodeSettingsReconciler: ProviderSettingsReconciler = {
   handleEnvironmentChange(settings: Record<string, unknown>): boolean {
     return clearOpencodeDiscoveryState(settings);
   },
+
+  invalidateConversationSessions: invalidateOpencodeConversationSessions,
 
   reconcileModelWithEnvironment(
     settings: Record<string, unknown>,
@@ -60,21 +81,7 @@ export const opencodeSettingsReconciler: ProviderSettingsReconciler = {
       return { changed: false, invalidatedConversations: [] };
     }
 
-    const invalidatedConversations: Conversation[] = [];
-    for (const conversation of conversations) {
-      if (conversation.providerId !== 'opencode') {
-        continue;
-      }
-
-      const state = getOpencodeState(conversation.providerState);
-      if (!conversation.sessionId && !state.databasePath) {
-        continue;
-      }
-
-      conversation.sessionId = null;
-      conversation.providerState = undefined;
-      invalidatedConversations.push(conversation);
-    }
+    const invalidatedConversations = invalidateOpencodeConversationSessions(conversations);
 
     updateOpencodeProviderSettings(settings, { environmentHash: currentHash });
     return { changed: true, invalidatedConversations };

--- a/src/providers/opencode/runtime/OpencodeAuxQueryRunner.ts
+++ b/src/providers/opencode/runtime/OpencodeAuxQueryRunner.ts
@@ -166,7 +166,7 @@ export class OpencodeAuxQueryRunner implements AuxQueryRunner {
   }
 
   private async ensureReady(cwd: string, systemPrompt: string): Promise<void> {
-    const resolvedCliPath = this.plugin.getResolvedProviderCliPath('opencode') ?? 'opencode';
+    const resolvedCliPath = await this.plugin.getResolvedProviderCliPath('opencode') ?? 'opencode';
 
     const settings = this.plugin.settings as unknown as Record<string, unknown>;
     const runtimeEnv = buildOpencodeRuntimeEnv(settings, resolvedCliPath);

--- a/src/providers/opencode/runtime/OpencodeChatRuntime.ts
+++ b/src/providers/opencode/runtime/OpencodeChatRuntime.ts
@@ -333,7 +333,7 @@ export class OpencodeChatRuntime implements ChatRuntime {
 
     const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
     const targetSessionId = this.sessionId;
-    const resolvedCliPath = this.plugin.getResolvedProviderCliPath('opencode') ?? 'opencode';
+    const resolvedCliPath = await this.plugin.getResolvedProviderCliPath('opencode') ?? 'opencode';
     const runtimeEnv = this.buildRuntimeEnv(
       resolvedCliPath,
       this.currentDatabasePath,

--- a/src/providers/pi/env/PiSettingsReconciler.ts
+++ b/src/providers/pi/env/PiSettingsReconciler.ts
@@ -37,6 +37,25 @@ function computePiEnvHash(envText: string): string {
     .join('|');
 }
 
+function invalidatePiConversationSessions(conversations: Conversation[]): Conversation[] {
+  const invalidatedConversations: Conversation[] = [];
+  for (const conversation of conversations) {
+    if (conversation.providerId !== 'pi') {
+      continue;
+    }
+
+    const state = getPiState(conversation.providerState);
+    if (!conversation.sessionId && !state.sessionId && !state.sessionFile) {
+      continue;
+    }
+
+    conversation.sessionId = null;
+    conversation.providerState = undefined;
+    invalidatedConversations.push(conversation);
+  }
+  return invalidatedConversations;
+}
+
 export const piSettingsReconciler: ProviderSettingsReconciler = {
   handleEnvironmentChange(settings: Record<string, unknown>): boolean {
     const current = getPiProviderSettings(settings);
@@ -48,6 +67,8 @@ export const piSettingsReconciler: ProviderSettingsReconciler = {
     });
     return true;
   },
+
+  invalidateConversationSessions: invalidatePiConversationSessions,
 
   reconcileModelWithEnvironment(
     settings: Record<string, unknown>,
@@ -61,21 +82,7 @@ export const piSettingsReconciler: ProviderSettingsReconciler = {
       return { changed: false, invalidatedConversations: [] };
     }
 
-    const invalidatedConversations: Conversation[] = [];
-    for (const conversation of conversations) {
-      if (conversation.providerId !== 'pi') {
-        continue;
-      }
-
-      const state = getPiState(conversation.providerState);
-      if (!conversation.sessionId && !state.sessionId && !state.sessionFile) {
-        continue;
-      }
-
-      conversation.sessionId = null;
-      conversation.providerState = undefined;
-      invalidatedConversations.push(conversation);
-    }
+    const invalidatedConversations = invalidatePiConversationSessions(conversations);
 
     updatePiProviderSettings(settings, { environmentHash: currentHash });
     return { changed: true, invalidatedConversations };

--- a/src/providers/pi/runtime/PiAuxQueryRunner.ts
+++ b/src/providers/pi/runtime/PiAuxQueryRunner.ts
@@ -156,7 +156,7 @@ export class PiAuxQueryRunner implements AuxQueryRunner {
   private async ensureReady(systemPrompt: string): Promise<void> {
     const settingsBag = this.plugin.settings as unknown as Record<string, unknown>;
     const settings = getPiProviderSettings(settingsBag);
-    const command = this.plugin.getResolvedProviderCliPath('pi') ?? 'pi';
+    const command = await this.plugin.getResolvedProviderCliPath('pi') ?? 'pi';
     const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
     const envText = getRuntimeEnvironmentText(settingsBag, 'pi');
     const env = {

--- a/src/providers/pi/runtime/PiChatRuntime.ts
+++ b/src/providers/pi/runtime/PiChatRuntime.ts
@@ -287,7 +287,7 @@ export class PiChatRuntime implements ChatRuntime {
 
     const allowSessionCreation = options?.allowSessionCreation !== false;
     const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
-    const resolvedCliPath = this.plugin.getResolvedProviderCliPath('pi') ?? 'pi';
+    const resolvedCliPath = await this.plugin.getResolvedProviderCliPath('pi') ?? 'pi';
     const runtimeEnvText = getRuntimeEnvironmentText(this.plugin.settings, 'pi');
     if (allowSessionCreation) {
       const materialized = await this.materializePendingFork(

--- a/src/providers/pi/runtime/PiModelDiscoveryService.ts
+++ b/src/providers/pi/runtime/PiModelDiscoveryService.ts
@@ -32,7 +32,7 @@ export class PiModelDiscoveryService {
     }
 
     const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
-    const command = this.plugin.getResolvedProviderCliPath('pi') ?? 'pi';
+    const command = await this.plugin.getResolvedProviderCliPath('pi') ?? 'pi';
     const envText = getRuntimeEnvironmentText(this.plugin.settings, 'pi');
     const env = {
       ...process.env,

--- a/src/shared/mention/MentionDropdownController.ts
+++ b/src/shared/mention/MentionDropdownController.ts
@@ -32,7 +32,9 @@ export interface MentionDropdownCallbacks {
 }
 
 export interface McpMentionProvider {
+  ensureLoaded?: () => Promise<void>;
   getContextSavingServers: () => Array<{ name: string }>;
+  isLoaded?: () => boolean;
 }
 
 export class MentionDropdownController {
@@ -47,12 +49,15 @@ export class MentionDropdownController {
   private activeContextFilter: { folderName: string; contextRoot: string } | null = null;
   private activeAgentFilter = false;
   private mcpManager: McpMentionProvider | null = null;
+  private mcpLoadPromise: Promise<void> | null = null;
+  private loadedMcpServices = new WeakSet<object>();
   private agentService: AgentMentionProvider | null = null;
   private agentLoadPromise: Promise<void> | null = null;
   private loadedAgentServices = new WeakSet<object>();
   private activeMentionSearchText: string | null = null;
   private fixed: boolean;
   private debounceTimer: number | null = null;
+  private destroyed = false;
 
   constructor(
     containerEl: HTMLElement,
@@ -76,6 +81,7 @@ export class MentionDropdownController {
 
   setMcpManager(manager: McpMentionProvider | null): void {
     this.mcpManager = manager;
+    this.mcpLoadPromise = null;
   }
 
   setAgentService(service: AgentMentionProvider | null): void {
@@ -114,9 +120,18 @@ export class MentionDropdownController {
   }
 
   destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
     if (this.debounceTimer !== null) {
       window.clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
     }
+    this.activeMentionSearchText = null;
+    this.mentionStartIndex = -1;
+    this.agentLoadPromise = null;
+    this.mcpLoadPromise = null;
+    this.agentService = null;
+    this.mcpManager = null;
     this.dropdown.destroy();
   }
 
@@ -203,7 +218,9 @@ export class MentionDropdownController {
   }
 
   private showMentionDropdown(searchText: string): void {
+    if (this.destroyed) return;
     this.ensureAgentServiceLoaded();
+    this.ensureMcpServiceLoaded();
     const searchLower = searchText.toLowerCase();
     this.filteredMentionItems = [];
     this.filteredContextFiles = [];
@@ -368,6 +385,8 @@ export class MentionDropdownController {
     void promise.then(() => {
       this.loadedAgentServices.add(service);
       if (
+        !this.destroyed
+        &&
         this.agentService === service
         && this.activeMentionSearchText !== null
         && this.mentionStartIndex >= 0
@@ -379,6 +398,39 @@ export class MentionDropdownController {
     }).finally(() => {
       if (this.agentLoadPromise === promise) {
         this.agentLoadPromise = null;
+      }
+    });
+  }
+
+  private ensureMcpServiceLoaded(): void {
+    const service = this.mcpManager;
+    if (
+      this.destroyed
+      || !service?.ensureLoaded
+      || service.isLoaded?.() === true
+      || this.loadedMcpServices.has(service)
+      || this.mcpLoadPromise
+    ) {
+      return;
+    }
+
+    const promise = service.ensureLoaded();
+    this.mcpLoadPromise = promise;
+    void promise.then(() => {
+      this.loadedMcpServices.add(service);
+      if (
+        !this.destroyed
+        && this.mcpManager === service
+        && this.activeMentionSearchText !== null
+        && this.mentionStartIndex >= 0
+      ) {
+        this.showMentionDropdown(this.activeMentionSearchText);
+      }
+    }).catch(() => {
+      // Keep cached MCP entries available if a lazy load fails.
+    }).finally(() => {
+      if (this.mcpLoadPromise === promise) {
+        this.mcpLoadPromise = null;
       }
     });
   }

--- a/src/shared/mention/MentionDropdownController.ts
+++ b/src/shared/mention/MentionDropdownController.ts
@@ -48,6 +48,9 @@ export class MentionDropdownController {
   private activeAgentFilter = false;
   private mcpManager: McpMentionProvider | null = null;
   private agentService: AgentMentionProvider | null = null;
+  private agentLoadPromise: Promise<void> | null = null;
+  private loadedAgentServices = new WeakSet<object>();
+  private activeMentionSearchText: string | null = null;
   private fixed: boolean;
   private debounceTimer: number | null = null;
 
@@ -80,6 +83,7 @@ export class MentionDropdownController {
       this.hide();
     }
     this.agentService = service;
+    this.agentLoadPromise = null;
   }
 
   preScanExternalContexts(): void {
@@ -102,6 +106,7 @@ export class MentionDropdownController {
   hide(): void {
     this.dropdown.hide();
     this.mentionStartIndex = -1;
+    this.activeMentionSearchText = null;
   }
 
   containsElement(el: Node): boolean {
@@ -157,6 +162,7 @@ export class MentionDropdownController {
       const searchText = textBeforeCursor.substring(lastAtIndex + 1);
 
       this.mentionStartIndex = lastAtIndex;
+      this.activeMentionSearchText = searchText;
       this.showMentionDropdown(searchText);
     }, 200);
   }
@@ -197,6 +203,7 @@ export class MentionDropdownController {
   }
 
   private showMentionDropdown(searchText: string): void {
+    this.ensureAgentServiceLoaded();
     const searchLower = searchText.toLowerCase();
     this.filteredMentionItems = [];
     this.filteredContextFiles = [];
@@ -343,6 +350,37 @@ export class MentionDropdownController {
     this.selectedMentionIndex = vaultItemCount > 0 ? firstVaultItemIndex : 0;
 
     this.renderMentionDropdown();
+  }
+
+  private ensureAgentServiceLoaded(): void {
+    const service = this.agentService;
+    if (
+      !service?.ensureLoaded
+      || service.isLoaded?.() === true
+      || this.loadedAgentServices.has(service)
+      || this.agentLoadPromise
+    ) {
+      return;
+    }
+
+    const promise = service.ensureLoaded();
+    this.agentLoadPromise = promise;
+    void promise.then(() => {
+      this.loadedAgentServices.add(service);
+      if (
+        this.agentService === service
+        && this.activeMentionSearchText !== null
+        && this.mentionStartIndex >= 0
+      ) {
+        this.showMentionDropdown(this.activeMentionSearchText);
+      }
+    }).catch(() => {
+      // Keep cached agent entries available if a lazy scan fails.
+    }).finally(() => {
+      if (this.agentLoadPromise === promise) {
+        this.agentLoadPromise = null;
+      }
+    });
   }
 
   private appendVaultItems(searchLower: string): number {

--- a/src/shared/settings/McpSettingsManager.ts
+++ b/src/shared/settings/McpSettingsManager.ts
@@ -2,7 +2,6 @@ import type { App } from 'obsidian';
 import { Notice, setIcon } from 'obsidian';
 
 import { tryParseClipboardConfig } from '../../core/mcp/McpConfigParser';
-import { testMcpServer } from '../../core/mcp/McpTester';
 import type { AppMcpStorage } from '../../core/providers/types';
 import { isNotifiedMutationError } from '../../core/storage/NotifiedMutationError';
 import type { ManagedMcpServer, McpServerConfig, McpServerType } from '../../core/types';
@@ -188,6 +187,7 @@ export class McpSettingsManager {
     modal.open();
 
     try {
+      const { testMcpServer } = await import('../../core/mcp/McpTester');
       const result = await testMcpServer(server);
       modal.setResult(result);
     } catch (error) {

--- a/src/shared/settings/ProviderModelPicker.ts
+++ b/src/shared/settings/ProviderModelPicker.ts
@@ -22,7 +22,12 @@ export interface ProviderModelPickerState {
   selectedIds: string[];
 }
 
+export interface ProviderModelPickerController {
+  refresh(): void;
+}
+
 export interface ProviderModelPickerOptions {
+  checkCatalogFreshnessWhenCached?: boolean;
   container: HTMLElement;
   emptyCatalogText: string;
   failedCatalogText: string;
@@ -40,7 +45,9 @@ export interface ProviderModelPickerOptions {
   settingDescription: string;
 }
 
-export function renderProviderModelPicker(options: ProviderModelPickerOptions): void {
+export function renderProviderModelPicker(
+  options: ProviderModelPickerOptions,
+): ProviderModelPickerController {
   new Setting(options.container)
     .setName('Visible models')
     .setDesc(options.settingDescription);
@@ -390,7 +397,14 @@ export function renderProviderModelPicker(options: ProviderModelPickerOptions): 
   };
 
   const loadCatalog = async (force: boolean): Promise<void> => {
-    if (loadingCatalog || (!force && options.getState().discoveredCount > 0)) {
+    if (
+      loadingCatalog
+      || (
+        !force
+        && !options.checkCatalogFreshnessWhenCached
+        && options.getState().discoveredCount > 0
+      )
+    ) {
       return;
     }
 
@@ -416,4 +430,5 @@ export function renderProviderModelPicker(options: ProviderModelPickerOptions): 
   if (options.loadCatalogOnRender) {
     void loadCatalog(false);
   }
+  return { refresh: renderAll };
 }

--- a/src/style/components/history.css
+++ b/src/style/components/history.css
@@ -219,3 +219,19 @@
   opacity: 0.6;
   cursor: default;
 }
+
+.claudian-history-load-more {
+  width: calc(100% - 16px);
+  margin: 8px;
+  padding: 8px 12px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.claudian-history-load-more:hover {
+  background: var(--background-modifier-hover);
+  color: var(--text-normal);
+}

--- a/src/style/components/messages.css
+++ b/src/style/components/messages.css
@@ -260,3 +260,32 @@
   font-size: 11px;
   white-space: nowrap;
 }
+
+.claudian-tab-hydration {
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.claudian-tab-hydration-loading::before {
+  content: '';
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  margin-right: 8px;
+  border: 2px solid var(--background-modifier-border);
+  border-top-color: var(--interactive-accent);
+  border-radius: 50%;
+  animation: claudian-spin 0.8s linear infinite;
+  vertical-align: -2px;
+}
+
+.claudian-tab-hydration-error {
+  max-width: 420px;
+  color: var(--text-error, var(--claudian-error));
+}

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -1,0 +1,30 @@
+/**
+ * Map over an array with a bounded number of concurrent invocations.
+ */
+export async function mapWithConcurrency<T, U>(
+  items: T[],
+  fn: (item: T, index: number) => Promise<U>,
+  concurrency: number,
+): Promise<U[]> {
+  if (concurrency < 1) {
+    throw new Error('Concurrency must be at least 1');
+  }
+
+  const results: U[] = new Array(items.length);
+  let index = 0;
+
+  async function worker(): Promise<void> {
+    while (index < items.length) {
+      const currentIndex = index++;
+      results[currentIndex] = await fn(items[currentIndex], currentIndex);
+    }
+  }
+
+  const workers: Promise<void>[] = [];
+  for (let i = 0; i < Math.min(concurrency, items.length); i++) {
+    workers.push(worker());
+  }
+
+  await Promise.all(workers);
+  return results;
+}

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -151,8 +151,8 @@ describe('ClaudianPlugin', () => {
     });
 
     it('loads restored-tab metadata without waiting for the full history scan', async () => {
-      let finishHistoryScan!: (value: []) => void;
-      const historyScan = new Promise<[]>((resolve) => {
+      let finishHistoryScan!: (value: { metadata: []; complete: true }) => void;
+      const historyScan = new Promise<{ metadata: []; complete: true }>((resolve) => {
         finishHistoryScan = resolve;
       });
       const restoredMetadata = {
@@ -162,7 +162,7 @@ describe('ClaudianPlugin', () => {
         createdAt: 1,
         updatedAt: 2,
       };
-      const listSpy = jest.spyOn(SessionStorage.prototype, 'listMetadata')
+      const listSpy = jest.spyOn(SessionStorage.prototype, 'scanMetadata')
         .mockReturnValue(historyScan);
       const loadSpy = jest.spyOn(SessionStorage.prototype, 'loadMetadata')
         .mockResolvedValue(restoredMetadata);
@@ -178,7 +178,7 @@ describe('ClaudianPlugin', () => {
         onloadPromise.then(() => true),
         new Promise<boolean>(resolve => setTimeout(() => resolve(false), 20)),
       ]);
-      finishHistoryScan([]);
+      finishHistoryScan({ metadata: [], complete: true });
       await onloadPromise;
       const cachedConversation = plugin.getCachedConversation(restoredMetadata.id);
       const didLoadRestoredMetadata = loadSpy.mock.calls.some(
@@ -204,8 +204,8 @@ describe('ClaudianPlugin', () => {
       mockApp.workspace.onLayoutReady = jest.fn((callback: () => void) => {
         layoutReady = callback;
       });
-      const listSpy = jest.spyOn(SessionStorage.prototype, 'listMetadata')
-        .mockResolvedValue([backgroundMetadata]);
+      const listSpy = jest.spyOn(SessionStorage.prototype, 'scanMetadata')
+        .mockResolvedValue({ metadata: [backgroundMetadata], complete: true });
 
       await plugin.onload();
       const beforeLayoutReady = plugin.getCachedConversation(backgroundMetadata.id);
@@ -268,10 +268,10 @@ describe('ClaudianPlugin', () => {
       });
       const loadSpy = jest.spyOn(SessionStorage.prototype, 'loadMetadata')
         .mockResolvedValue(restoredMetadata);
-      const listSpy = jest.spyOn(SessionStorage.prototype, 'listMetadata')
+      const listSpy = jest.spyOn(SessionStorage.prototype, 'scanMetadata')
         .mockImplementation(async (options) => {
           options?.onBatch?.([restoredMetadata, deferredMetadata]);
-          return [restoredMetadata, deferredMetadata];
+          return { metadata: [restoredMetadata, deferredMetadata], complete: true };
         });
 
       await plugin.onload();
@@ -323,13 +323,13 @@ describe('ClaudianPlugin', () => {
       });
 
       await plugin.onload();
-      const listSpy = jest.spyOn(SessionStorage.prototype, 'listMetadata')
+      const listSpy = jest.spyOn(SessionStorage.prototype, 'scanMetadata')
         .mockImplementation(async (options) => {
           options?.onBatch?.([firstMetadata]);
           markFirstBatchPublished();
           await laterBatchRelease;
           options?.onBatch?.([laterMetadata]);
-          return [firstMetadata, laterMetadata];
+          return { metadata: [firstMetadata, laterMetadata], complete: true };
         });
 
       const load = (plugin as any).loadRemainingSessionMetadata();
@@ -350,8 +350,130 @@ describe('ClaudianPlugin', () => {
       expect(first?.providerState).toBeUndefined();
       expect(later?.sessionId).toBeNull();
       expect(later?.providerState).toBeUndefined();
+      expect(pendingGeneration).toEqual(expect.any(Number));
+      expect(plugin.settings.pendingProviderSessionInvalidations.claude)
+        .toBeUndefined();
+    });
+
+    it('waits for an environment metadata write before completing its scan generation', async () => {
+      const firstMetadata = {
+        id: 'pending-environment-write-session',
+        providerId: 'claude' as const,
+        title: 'Pending environment write session',
+        createdAt: 1,
+        updatedAt: 2,
+        sessionId: 'pending-environment-write-session-id',
+        providerState: { providerSessionId: 'pending-environment-write-provider-session-id' },
+      };
+      const laterMetadata = {
+        id: 'later-environment-write-session',
+        providerId: 'claude' as const,
+        title: 'Later environment write session',
+        createdAt: 1,
+        updatedAt: 1,
+        sessionId: 'later-environment-write-session-id',
+        providerState: { providerSessionId: 'later-environment-write-provider-session-id' },
+      };
+      let markFirstBatchPublished!: () => void;
+      const firstBatchPublished = new Promise<void>((resolve) => {
+        markFirstBatchPublished = resolve;
+      });
+      let finishScan!: () => void;
+      const scanRelease = new Promise<void>((resolve) => {
+        finishScan = resolve;
+      });
+      let markEnvironmentWriteStarted!: () => void;
+      const environmentWriteStarted = new Promise<void>((resolve) => {
+        markEnvironmentWriteStarted = resolve;
+      });
+      let finishEnvironmentWrite!: () => void;
+      const environmentWriteRelease = new Promise<void>((resolve) => {
+        finishEnvironmentWrite = resolve;
+      });
+
+      await plugin.onload();
+      const scanSpy = jest.spyOn(SessionStorage.prototype, 'scanMetadata')
+        .mockImplementation(async (options) => {
+          options?.onBatch?.([firstMetadata]);
+          markFirstBatchPublished();
+          await scanRelease;
+          options?.onBatch?.([laterMetadata]);
+          return { metadata: [firstMetadata, laterMetadata], complete: true };
+        });
+      let blockedEnvironmentWrite = false;
+      const saveMetadataSpy = jest.spyOn(plugin.storage.sessions, 'saveMetadata')
+        .mockImplementation(async () => {
+          if (!blockedEnvironmentWrite) {
+            blockedEnvironmentWrite = true;
+            markEnvironmentWriteStarted();
+            await environmentWriteRelease;
+          }
+        });
+
+      const load = (plugin as any).loadRemainingSessionMetadata();
+      await firstBatchPublished;
+      const apply = plugin.applyEnvironmentVariables(
+        'provider:claude',
+        'ANTHROPIC_BASE_URL=https://pending-write.example.com',
+      );
+      await environmentWriteStarted;
+      const pendingGeneration = plugin.settings.pendingProviderSessionInvalidations.claude;
+      finishScan();
+      await load;
+
       expect(plugin.settings.pendingProviderSessionInvalidations.claude)
         .toBe(pendingGeneration);
+
+      finishEnvironmentWrite();
+      await apply;
+      scanSpy.mockRestore();
+      saveMetadataSpy.mockRestore();
+
+      expect(pendingGeneration).toEqual(expect.any(Number));
+      expect(plugin.settings.pendingProviderSessionInvalidations.claude)
+        .toBeUndefined();
+    });
+
+    it('keeps a pending provider invalidation after an incomplete metadata scan', async () => {
+      const settingsPath = '.claudian/claudian-settings.json';
+      const pendingGeneration = 11;
+      const deferredMetadata = {
+        id: 'incomplete-scan-session',
+        providerId: 'claude' as const,
+        title: 'Incomplete scan session',
+        createdAt: 1,
+        updatedAt: 2,
+        sessionId: 'incomplete-scan-session-id',
+        providerState: { providerSessionId: 'incomplete-scan-provider-session-id' },
+      };
+      const files = installVaultFiles({
+        [settingsPath]: JSON.stringify({
+          pendingProviderSessionInvalidations: { claude: pendingGeneration },
+          providerConfigs: {
+            claude: {
+              environmentHash: 'ANTHROPIC_BASE_URL=https://same.example.com',
+              environmentVariables: 'ANTHROPIC_BASE_URL=https://same.example.com',
+            },
+          },
+        }),
+      });
+
+      await plugin.onload();
+      const scanSpy = jest.spyOn(SessionStorage.prototype, 'scanMetadata')
+        .mockImplementation(async (options) => {
+          options?.onBatch?.([deferredMetadata]);
+          return { metadata: [deferredMetadata], complete: false };
+        });
+      (plugin as any).pendingSessionMetadataScan = false;
+
+      await (plugin as any).loadRemainingSessionMetadata();
+
+      const persistedSettings = JSON.parse(files.get(settingsPath) ?? '{}');
+      scanSpy.mockRestore();
+
+      expect(persistedSettings.pendingProviderSessionInvalidations?.claude)
+        .toBe(pendingGeneration);
+      expect((plugin as any).hasLoadedAllSessionMetadata).toBe(false);
     });
 
     it('does not persist a background metadata shell deleted before reconciliation', async () => {
@@ -372,11 +494,11 @@ describe('ClaudianPlugin', () => {
       };
 
       await plugin.onload();
-      const listSpy = jest.spyOn(SessionStorage.prototype, 'listMetadata').mockImplementation(async (options) => {
+      const listSpy = jest.spyOn(SessionStorage.prototype, 'scanMetadata').mockImplementation(async (options) => {
         options?.onBatch?.([backgroundMetadata]);
         markBatchPublished();
         await scanRelease;
-        return [backgroundMetadata];
+        return { metadata: [backgroundMetadata], complete: true };
       });
       const invalidateSpy = jest.spyOn(
         ProviderSettingsCoordinator,
@@ -432,10 +554,10 @@ describe('ClaudianPlugin', () => {
       plugin.onunload();
       const restartedPlugin = new ClaudianPlugin(mockApp, mockManifest);
       (restartedPlugin.loadData as jest.Mock).mockResolvedValue({});
-      const listSpy = jest.spyOn(SessionStorage.prototype, 'listMetadata')
+      const listSpy = jest.spyOn(SessionStorage.prototype, 'scanMetadata')
         .mockImplementation(async (options) => {
           options?.onBatch?.([deferredMetadata]);
-          return [deferredMetadata];
+          return { metadata: [deferredMetadata], complete: true };
         });
 
       await restartedPlugin.onload();
@@ -480,10 +602,10 @@ describe('ClaudianPlugin', () => {
       });
 
       await plugin.onload();
-      const listSpy = jest.spyOn(SessionStorage.prototype, 'listMetadata')
+      const listSpy = jest.spyOn(SessionStorage.prototype, 'scanMetadata')
         .mockImplementation(async (options) => {
           options?.onBatch?.([deferredMetadata]);
-          return [deferredMetadata];
+          return { metadata: [deferredMetadata], complete: true };
         });
       const saveMetadataSpy = jest.spyOn(plugin.storage.sessions, 'saveMetadata')
         .mockRejectedValueOnce(new Error('metadata write failed'));

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -29,6 +29,31 @@ describe('ClaudianPlugin', () => {
     return call[0];
   }
 
+  function installVaultFiles(initialFiles: Record<string, string>): Map<string, string> {
+    const files = new Map(Object.entries(initialFiles));
+    const folders = new Set<string>(['.claudian']);
+    mockApp.vault.adapter.exists.mockImplementation(async (path: string) => (
+      files.has(path) || folders.has(path)
+    ));
+    mockApp.vault.adapter.read.mockImplementation(async (path: string) => {
+      const content = files.get(path);
+      if (content === undefined) {
+        throw new Error(`Missing test file: ${path}`);
+      }
+      return content;
+    });
+    mockApp.vault.adapter.write.mockImplementation(async (path: string, content: string) => {
+      files.set(path, content);
+    });
+    mockApp.vault.adapter.remove.mockImplementation(async (path: string) => {
+      files.delete(path);
+    });
+    mockApp.vault.adapter.mkdir.mockImplementation(async (path: string) => {
+      folders.add(path);
+    });
+    return files;
+  }
+
   beforeEach(() => {
     // Reset mocks
     jest.clearAllMocks();
@@ -313,6 +338,7 @@ describe('ClaudianPlugin', () => {
         'provider:claude',
         'ANTHROPIC_BASE_URL=https://changed-during-scan.example.com',
       );
+      const pendingGeneration = plugin.settings.pendingProviderSessionInvalidations.claude;
       releaseLaterBatch();
       await load;
 
@@ -324,6 +350,8 @@ describe('ClaudianPlugin', () => {
       expect(first?.providerState).toBeUndefined();
       expect(later?.sessionId).toBeNull();
       expect(later?.providerState).toBeUndefined();
+      expect(plugin.settings.pendingProviderSessionInvalidations.claude)
+        .toBe(pendingGeneration);
     });
 
     it('does not persist a background metadata shell deleted before reconciliation', async () => {
@@ -371,6 +399,118 @@ describe('ClaudianPlugin', () => {
       expect(invalidationCallCount).toBeGreaterThan(0);
       expect(saveMetadataCallCount).toBe(0);
       expect(plugin.getCachedConversation(backgroundMetadata.id)).toBeNull();
+    });
+
+    it('retries a pending provider invalidation after unload and restart', async () => {
+      const settingsPath = '.claudian/claudian-settings.json';
+      const deferredMetadata = {
+        id: 'restart-deferred-session',
+        providerId: 'claude' as const,
+        title: 'Restart deferred session',
+        createdAt: 1,
+        updatedAt: 2,
+        sessionId: 'restart-session-id',
+        providerState: { providerSessionId: 'restart-provider-session-id' },
+      };
+      const files = installVaultFiles({
+        [settingsPath]: JSON.stringify({
+          providerConfigs: {
+            claude: {
+              environmentHash: 'ANTHROPIC_BASE_URL=https://old.example.com',
+              environmentVariables: 'ANTHROPIC_BASE_URL=https://new.example.com',
+            },
+          },
+        }),
+      });
+
+      await plugin.onload();
+      const firstRunSettings = JSON.parse(files.get(settingsPath) ?? '{}');
+      const pendingGeneration = firstRunSettings.pendingProviderSessionInvalidations?.claude;
+
+      expect(pendingGeneration).toEqual(expect.any(Number));
+
+      plugin.onunload();
+      const restartedPlugin = new ClaudianPlugin(mockApp, mockManifest);
+      (restartedPlugin.loadData as jest.Mock).mockResolvedValue({});
+      const listSpy = jest.spyOn(SessionStorage.prototype, 'listMetadata')
+        .mockImplementation(async (options) => {
+          options?.onBatch?.([deferredMetadata]);
+          return [deferredMetadata];
+        });
+
+      await restartedPlugin.onload();
+      await (restartedPlugin as any).loadRemainingSessionMetadata();
+
+      const restartedConversation = restartedPlugin.getCachedConversation(deferredMetadata.id);
+      const persistedMetadata = JSON.parse(
+        files.get('.claudian/sessions/restart-deferred-session.meta.json') ?? '{}',
+      );
+      const restartedSettings = JSON.parse(files.get(settingsPath) ?? '{}');
+      listSpy.mockRestore();
+
+      expect(restartedConversation?.sessionId).toBeNull();
+      expect(restartedConversation?.providerState).toBeUndefined();
+      expect(persistedMetadata.sessionId).toBeNull();
+      expect(persistedMetadata).not.toHaveProperty('providerState');
+      expect(restartedSettings.pendingProviderSessionInvalidations?.claude).toBeUndefined();
+    });
+
+    it('keeps a pending provider invalidation when a metadata write fails', async () => {
+      const settingsPath = '.claudian/claudian-settings.json';
+      const pendingGeneration = 7;
+      const deferredMetadata = {
+        id: 'failed-write-session',
+        providerId: 'claude' as const,
+        title: 'Failed write session',
+        createdAt: 1,
+        updatedAt: 2,
+        sessionId: 'failed-write-session-id',
+        providerState: { providerSessionId: 'failed-write-provider-session-id' },
+      };
+      const files = installVaultFiles({
+        [settingsPath]: JSON.stringify({
+          pendingProviderSessionInvalidations: { claude: pendingGeneration },
+          providerConfigs: {
+            claude: {
+              environmentHash: 'ANTHROPIC_BASE_URL=https://same.example.com',
+              environmentVariables: 'ANTHROPIC_BASE_URL=https://same.example.com',
+            },
+          },
+        }),
+      });
+
+      await plugin.onload();
+      const listSpy = jest.spyOn(SessionStorage.prototype, 'listMetadata')
+        .mockImplementation(async (options) => {
+          options?.onBatch?.([deferredMetadata]);
+          return [deferredMetadata];
+        });
+      const saveMetadataSpy = jest.spyOn(plugin.storage.sessions, 'saveMetadata')
+        .mockRejectedValueOnce(new Error('metadata write failed'));
+      (plugin as any).pendingSessionMetadataScan = false;
+
+      let loadError: unknown;
+      try {
+        await (plugin as any).loadRemainingSessionMetadata();
+      } catch (error) {
+        loadError = error;
+      }
+      listSpy.mockRestore();
+      saveMetadataSpy.mockRestore();
+
+      expect(loadError).toEqual(new Error('metadata write failed'));
+      const persistedSettings = JSON.parse(files.get(settingsPath) ?? '{}');
+      expect(persistedSettings.pendingProviderSessionInvalidations?.claude)
+        .toBe(pendingGeneration);
+
+      await plugin.applyEnvironmentVariables(
+        'provider:claude',
+        'ANTHROPIC_BASE_URL=https://next.example.com',
+      );
+
+      const settingsAfterEnvironmentChange = JSON.parse(files.get(settingsPath) ?? '{}');
+      expect(settingsAfterEnvironmentChange.pendingProviderSessionInvalidations?.claude)
+        .toEqual(expect.any(Number));
     });
 
   });

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -198,6 +198,134 @@ describe('ClaudianPlugin', () => {
       expect(afterBackgroundLoad?.title).toBe(backgroundMetadata.title);
     });
 
+    it('invalidates restored and deferred sessions after a provider environment change', async () => {
+      const restoredMetadata = {
+        id: 'restored-environment-session',
+        providerId: 'claude' as const,
+        title: 'Restored environment session',
+        createdAt: 1,
+        updatedAt: 3,
+        sessionId: 'restored-session-id',
+        providerState: { providerSessionId: 'restored-provider-session-id' },
+        resumeAtMessageId: 'restored-message-id',
+      };
+      const deferredMetadata = {
+        id: 'deferred-environment-session',
+        providerId: 'claude' as const,
+        title: 'Deferred environment session',
+        createdAt: 1,
+        updatedAt: 2,
+        sessionId: 'deferred-session-id',
+        providerState: { providerSessionId: 'deferred-provider-session-id' },
+        resumeAtMessageId: 'deferred-message-id',
+      };
+      mockApp.vault.adapter.exists.mockImplementation(async (path: string) => (
+        path === '.claudian/claudian-settings.json'
+      ));
+      mockApp.vault.adapter.read.mockImplementation(async (path: string) => {
+        if (path === '.claudian/claudian-settings.json') {
+          return JSON.stringify({
+            providerConfigs: {
+              claude: {
+                environmentHash: 'ANTHROPIC_BASE_URL=https://old.example.com',
+                environmentVariables: 'ANTHROPIC_BASE_URL=https://new.example.com',
+              },
+            },
+          });
+        }
+        return '';
+      });
+      (plugin.loadData as jest.Mock).mockResolvedValue({
+        tabManagerState: {
+          openTabs: [{ tabId: 'tab-1', conversationId: restoredMetadata.id }],
+          activeTabId: 'tab-1',
+        },
+      });
+      const loadSpy = jest.spyOn(SessionStorage.prototype, 'loadMetadata')
+        .mockResolvedValue(restoredMetadata);
+      const listSpy = jest.spyOn(SessionStorage.prototype, 'listMetadata')
+        .mockImplementation(async (options) => {
+          options?.onBatch?.([restoredMetadata, deferredMetadata]);
+          return [restoredMetadata, deferredMetadata];
+        });
+
+      await plugin.onload();
+      await (plugin as any).loadRemainingSessionMetadata();
+
+      const restored = plugin.getCachedConversation(restoredMetadata.id);
+      const deferred = plugin.getCachedConversation(deferredMetadata.id);
+      loadSpy.mockRestore();
+      listSpy.mockRestore();
+
+      expect(restored).toEqual(expect.objectContaining({
+        sessionId: null,
+        providerState: undefined,
+      }));
+      expect(restored).not.toHaveProperty('resumeAtMessageId');
+      expect(deferred).toEqual(expect.objectContaining({
+        sessionId: null,
+        providerState: undefined,
+      }));
+      expect(deferred).not.toHaveProperty('resumeAtMessageId');
+    });
+
+    it('invalidates later metadata batches when the environment changes during the scan', async () => {
+      const firstMetadata = {
+        id: 'first-scanned-session',
+        providerId: 'claude' as const,
+        title: 'First scanned session',
+        createdAt: 1,
+        updatedAt: 2,
+        sessionId: 'first-session-id',
+        providerState: { providerSessionId: 'first-provider-session-id' },
+      };
+      const laterMetadata = {
+        id: 'later-scanned-session',
+        providerId: 'claude' as const,
+        title: 'Later scanned session',
+        createdAt: 1,
+        updatedAt: 1,
+        sessionId: 'later-session-id',
+        providerState: { providerSessionId: 'later-provider-session-id' },
+      };
+      let markFirstBatchPublished!: () => void;
+      const firstBatchPublished = new Promise<void>((resolve) => {
+        markFirstBatchPublished = resolve;
+      });
+      let releaseLaterBatch!: () => void;
+      const laterBatchRelease = new Promise<void>((resolve) => {
+        releaseLaterBatch = resolve;
+      });
+
+      await plugin.onload();
+      const listSpy = jest.spyOn(SessionStorage.prototype, 'listMetadata')
+        .mockImplementation(async (options) => {
+          options?.onBatch?.([firstMetadata]);
+          markFirstBatchPublished();
+          await laterBatchRelease;
+          options?.onBatch?.([laterMetadata]);
+          return [firstMetadata, laterMetadata];
+        });
+
+      const load = (plugin as any).loadRemainingSessionMetadata();
+      await firstBatchPublished;
+      await plugin.applyEnvironmentVariables(
+        'provider:claude',
+        'ANTHROPIC_BASE_URL=https://changed-during-scan.example.com',
+      );
+      releaseLaterBatch();
+      await load;
+
+      const first = plugin.getCachedConversation(firstMetadata.id);
+      const later = plugin.getCachedConversation(laterMetadata.id);
+      listSpy.mockRestore();
+
+      expect(first?.sessionId).toBeNull();
+      expect(first?.providerState).toBeUndefined();
+      expect(later?.sessionId).toBeNull();
+      expect(later?.providerState).toBeUndefined();
+    });
+
     it('does not persist a background metadata shell deleted before reconciliation', async () => {
       let finishScan!: () => void;
       let markBatchPublished!: () => void;
@@ -222,11 +350,10 @@ describe('ClaudianPlugin', () => {
         await scanRelease;
         return [backgroundMetadata];
       });
-      const reconcileSpy = jest.spyOn(ProviderSettingsCoordinator, 'reconcileProviders')
-        .mockImplementation((_settings, conversations) => ({
-          changed: false,
-          invalidatedConversations: [...conversations],
-        }));
+      const invalidateSpy = jest.spyOn(
+        ProviderSettingsCoordinator,
+        'invalidateConversationSessions',
+      ).mockImplementation((conversations) => [...conversations]);
       const saveMetadataSpy = jest.spyOn(plugin.storage.sessions, 'saveMetadata');
 
       const load = (plugin as any).loadRemainingSessionMetadata();
@@ -235,13 +362,13 @@ describe('ClaudianPlugin', () => {
       saveMetadataSpy.mockClear();
       finishScan();
       await load;
-      const reconcileCallCount = reconcileSpy.mock.calls.length;
+      const invalidationCallCount = invalidateSpy.mock.calls.length;
       const saveMetadataCallCount = saveMetadataSpy.mock.calls.length;
       listSpy.mockRestore();
-      reconcileSpy.mockRestore();
+      invalidateSpy.mockRestore();
       saveMetadataSpy.mockRestore();
 
-      expect(reconcileCallCount).toBe(0);
+      expect(invalidationCallCount).toBeGreaterThan(0);
       expect(saveMetadataCallCount).toBe(0);
       expect(plugin.getCachedConversation(backgroundMetadata.id)).toBeNull();
     });

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -151,8 +151,13 @@ describe('ClaudianPlugin', () => {
     });
 
     it('loads restored-tab metadata without waiting for the full history scan', async () => {
-      let finishHistoryScan!: (value: { metadata: []; complete: true }) => void;
-      const historyScan = new Promise<{ metadata: []; complete: true }>((resolve) => {
+      type EmptyMetadataScan = {
+        metadata: [];
+        complete: true;
+        invalidMetadataCount: 0;
+      };
+      let finishHistoryScan!: (value: EmptyMetadataScan) => void;
+      const historyScan = new Promise<EmptyMetadataScan>((resolve) => {
         finishHistoryScan = resolve;
       });
       const restoredMetadata = {
@@ -178,7 +183,7 @@ describe('ClaudianPlugin', () => {
         onloadPromise.then(() => true),
         new Promise<boolean>(resolve => setTimeout(() => resolve(false), 20)),
       ]);
-      finishHistoryScan({ metadata: [], complete: true });
+      finishHistoryScan({ metadata: [], complete: true, invalidMetadataCount: 0 });
       await onloadPromise;
       const cachedConversation = plugin.getCachedConversation(restoredMetadata.id);
       const didLoadRestoredMetadata = loadSpy.mock.calls.some(
@@ -205,7 +210,11 @@ describe('ClaudianPlugin', () => {
         layoutReady = callback;
       });
       const listSpy = jest.spyOn(SessionStorage.prototype, 'scanMetadata')
-        .mockResolvedValue({ metadata: [backgroundMetadata], complete: true });
+        .mockResolvedValue({
+          metadata: [backgroundMetadata],
+          complete: true,
+          invalidMetadataCount: 0,
+        });
 
       await plugin.onload();
       const beforeLayoutReady = plugin.getCachedConversation(backgroundMetadata.id);
@@ -271,7 +280,11 @@ describe('ClaudianPlugin', () => {
       const listSpy = jest.spyOn(SessionStorage.prototype, 'scanMetadata')
         .mockImplementation(async (options) => {
           options?.onBatch?.([restoredMetadata, deferredMetadata]);
-          return { metadata: [restoredMetadata, deferredMetadata], complete: true };
+          return {
+            metadata: [restoredMetadata, deferredMetadata],
+            complete: true,
+            invalidMetadataCount: 0,
+          };
         });
 
       await plugin.onload();
@@ -329,7 +342,11 @@ describe('ClaudianPlugin', () => {
           markFirstBatchPublished();
           await laterBatchRelease;
           options?.onBatch?.([laterMetadata]);
-          return { metadata: [firstMetadata, laterMetadata], complete: true };
+          return {
+            metadata: [firstMetadata, laterMetadata],
+            complete: true,
+            invalidMetadataCount: 0,
+          };
         });
 
       const load = (plugin as any).loadRemainingSessionMetadata();
@@ -398,7 +415,11 @@ describe('ClaudianPlugin', () => {
           markFirstBatchPublished();
           await scanRelease;
           options?.onBatch?.([laterMetadata]);
-          return { metadata: [firstMetadata, laterMetadata], complete: true };
+          return {
+            metadata: [firstMetadata, laterMetadata],
+            complete: true,
+            invalidMetadataCount: 0,
+          };
         });
       let blockedEnvironmentWrite = false;
       const saveMetadataSpy = jest.spyOn(plugin.storage.sessions, 'saveMetadata')
@@ -462,7 +483,11 @@ describe('ClaudianPlugin', () => {
       const scanSpy = jest.spyOn(SessionStorage.prototype, 'scanMetadata')
         .mockImplementation(async (options) => {
           options?.onBatch?.([deferredMetadata]);
-          return { metadata: [deferredMetadata], complete: false };
+          return {
+            metadata: [deferredMetadata],
+            complete: false,
+            invalidMetadataCount: 0,
+          };
         });
       (plugin as any).pendingSessionMetadataScan = false;
 
@@ -498,7 +523,11 @@ describe('ClaudianPlugin', () => {
         options?.onBatch?.([backgroundMetadata]);
         markBatchPublished();
         await scanRelease;
-        return { metadata: [backgroundMetadata], complete: true };
+        return {
+          metadata: [backgroundMetadata],
+          complete: true,
+          invalidMetadataCount: 0,
+        };
       });
       const invalidateSpy = jest.spyOn(
         ProviderSettingsCoordinator,
@@ -557,7 +586,11 @@ describe('ClaudianPlugin', () => {
       const listSpy = jest.spyOn(SessionStorage.prototype, 'scanMetadata')
         .mockImplementation(async (options) => {
           options?.onBatch?.([deferredMetadata]);
-          return { metadata: [deferredMetadata], complete: true };
+          return {
+            metadata: [deferredMetadata],
+            complete: true,
+            invalidMetadataCount: 0,
+          };
         });
 
       await restartedPlugin.onload();
@@ -605,7 +638,11 @@ describe('ClaudianPlugin', () => {
       const listSpy = jest.spyOn(SessionStorage.prototype, 'scanMetadata')
         .mockImplementation(async (options) => {
           options?.onBatch?.([deferredMetadata]);
-          return { metadata: [deferredMetadata], complete: true };
+          return {
+            metadata: [deferredMetadata],
+            complete: true,
+            invalidMetadataCount: 0,
+          };
         });
       const saveMetadataSpy = jest.spyOn(plugin.storage.sessions, 'saveMetadata')
         .mockRejectedValueOnce(new Error('metadata write failed'));
@@ -930,6 +967,82 @@ describe('ClaudianPlugin', () => {
       const updated = await plugin.getConversationById(conv.id);
       expect(updated?.sessionId).toBeNull();
       expect(saveMetadataSpy).toHaveBeenCalled();
+    });
+
+    it('serializes overlapping environment invalidation writes', async () => {
+      await plugin.onload();
+      (plugin as any).hasLoadedAllSessionMetadata = true;
+      await plugin.createConversation({ sessionId: 'overlapping-session' });
+      let finishFirstWrite!: () => void;
+      const firstWriteRelease = new Promise<void>((resolve) => {
+        finishFirstWrite = resolve;
+      });
+      let markFirstWriteStarted!: () => void;
+      const firstWriteStarted = new Promise<void>((resolve) => {
+        markFirstWriteStarted = resolve;
+      });
+      let blockedFirstWrite = false;
+      const saveMetadataSpy = jest.spyOn(plugin.storage.sessions, 'saveMetadata')
+        .mockImplementation(async () => {
+          if (!blockedFirstWrite) {
+            blockedFirstWrite = true;
+            markFirstWriteStarted();
+            await firstWriteRelease;
+          }
+        });
+
+      const firstUpdate = plugin.applyEnvironmentVariables(
+        'provider:claude',
+        'ANTHROPIC_BASE_URL=https://first-overlap.example.com',
+      );
+      await firstWriteStarted;
+      let secondUpdateSettled = false;
+      const secondUpdate = plugin.applyEnvironmentVariables(
+        'provider:claude',
+        'ANTHROPIC_BASE_URL=https://second-overlap.example.com',
+      ).finally(() => {
+        secondUpdateSettled = true;
+      });
+      await new Promise(resolve => setTimeout(resolve, 1));
+      const markerWhileFirstWritePending =
+        plugin.settings.pendingProviderSessionInvalidations.claude;
+      const secondSettledWhileFirstWritePending = secondUpdateSettled;
+
+      finishFirstWrite();
+      await Promise.all([firstUpdate, secondUpdate]);
+      saveMetadataSpy.mockRestore();
+
+      expect(markerWhileFirstWritePending).toEqual(expect.any(Number));
+      expect(secondSettledWhileFirstWritePending).toBe(false);
+      expect(plugin.settings.pendingProviderSessionInvalidations.claude)
+        .toBeUndefined();
+    });
+
+    it('flushes already-invalidated sessions after an earlier environment write fails', async () => {
+      await plugin.onload();
+      (plugin as any).hasLoadedAllSessionMetadata = true;
+      await plugin.createConversation({ sessionId: 'failed-overlap-session' });
+      const saveMetadataSpy = jest.spyOn(plugin.storage.sessions, 'saveMetadata')
+        .mockRejectedValueOnce(new Error('metadata write failed'));
+
+      await expect(plugin.applyEnvironmentVariables(
+        'provider:claude',
+        'ANTHROPIC_BASE_URL=https://failed-write.example.com',
+      )).rejects.toThrow('metadata write failed');
+      await plugin.applyEnvironmentVariables(
+        'provider:claude',
+        'ANTHROPIC_BASE_URL=https://retry-write.example.com',
+      );
+      const saveCallCount = saveMetadataSpy.mock.calls.length;
+      const retriedMetadata = saveMetadataSpy.mock.calls[1]?.[0];
+      saveMetadataSpy.mockRestore();
+
+      expect(saveCallCount).toBe(2);
+      expect(retriedMetadata).toEqual(expect.objectContaining({
+        sessionId: null,
+      }));
+      expect(plugin.settings.pendingProviderSessionInvalidations.claude)
+        .toBeUndefined();
     });
 
     it('broadcasts ensureReady with force when env changes without model change', async () => {

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -1,4 +1,5 @@
 
+import { ProviderSettingsCoordinator } from '@/core/providers/ProviderSettingsCoordinator';
 import { TOOL_SUBAGENT } from '@/core/tools/toolNames';
 import { VIEW_TYPE_CLAUDIAN } from '@/core/types';
 import * as sdkSession from '@/providers/claude/history/ClaudeHistoryStore';
@@ -197,14 +198,82 @@ describe('ClaudianPlugin', () => {
       expect(afterBackgroundLoad?.title).toBe(backgroundMetadata.title);
     });
 
+    it('does not persist a background metadata shell deleted before reconciliation', async () => {
+      let finishScan!: () => void;
+      let markBatchPublished!: () => void;
+      const scanRelease = new Promise<void>((resolve) => {
+        finishScan = resolve;
+      });
+      const batchPublished = new Promise<void>((resolve) => {
+        markBatchPublished = resolve;
+      });
+      const backgroundMetadata = {
+        id: 'deleted-background-conversation',
+        providerId: 'claude' as const,
+        title: 'Deleted background conversation',
+        createdAt: 1,
+        updatedAt: 2,
+      };
+
+      await plugin.onload();
+      const listSpy = jest.spyOn(SessionStorage.prototype, 'listMetadata').mockImplementation(async (options) => {
+        options?.onBatch?.([backgroundMetadata]);
+        markBatchPublished();
+        await scanRelease;
+        return [backgroundMetadata];
+      });
+      const reconcileSpy = jest.spyOn(ProviderSettingsCoordinator, 'reconcileProviders')
+        .mockImplementation((_settings, conversations) => ({
+          changed: false,
+          invalidatedConversations: [...conversations],
+        }));
+      const saveMetadataSpy = jest.spyOn(plugin.storage.sessions, 'saveMetadata');
+
+      const load = (plugin as any).loadRemainingSessionMetadata();
+      await batchPublished;
+      await plugin.deleteConversation(backgroundMetadata.id, { deleteProviderSession: false });
+      saveMetadataSpy.mockClear();
+      finishScan();
+      await load;
+      const reconcileCallCount = reconcileSpy.mock.calls.length;
+      const saveMetadataCallCount = saveMetadataSpy.mock.calls.length;
+      listSpy.mockRestore();
+      reconcileSpy.mockRestore();
+      saveMetadataSpy.mockRestore();
+
+      expect(reconcileCallCount).toBe(0);
+      expect(saveMetadataCallCount).toBe(0);
+      expect(plugin.getCachedConversation(backgroundMetadata.id)).toBeNull();
+    });
+
   });
 
   describe('onunload', () => {
-    // Note: With multi-tab, cleanup is handled per-tab via ClaudianView.onClose()
     it('should complete without error', async () => {
       await plugin.onload();
 
       expect(() => plugin.onunload()).not.toThrow();
+    });
+
+    it('keeps the latest open-tab snapshot when views are not closed first', async () => {
+      await plugin.onload();
+      const state = {
+        openTabs: [{ tabId: 'tab-1', conversationId: 'conversation-1' }],
+        activeTabId: 'tab-1',
+      };
+      const persistSpy = jest.spyOn(plugin, 'persistTabManagerState').mockResolvedValue(undefined);
+      mockApp.workspace.getLeavesOfType.mockReturnValue([{
+        view: {
+          getPersistedTabState: jest.fn().mockReturnValue(state),
+          getTabManager: jest.fn(),
+        },
+      }]);
+
+      plugin.onunload();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(persistSpy).toHaveBeenCalledWith(state);
     });
   });
 

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -2,6 +2,7 @@
 import { TOOL_SUBAGENT } from '@/core/tools/toolNames';
 import { VIEW_TYPE_CLAUDIAN } from '@/core/types';
 import * as sdkSession from '@/providers/claude/history/ClaudeHistoryStore';
+import { SessionStorage } from '@/providers/claude/storage/SessionStorage';
 import { DEFAULT_SETTINGS } from '@/providers/claude/types/settings';
 
 // Mock fs for ClaudianService
@@ -56,6 +57,7 @@ describe('ClaudianPlugin', () => {
         },
       },
       workspace: {
+        onLayoutReady: jest.fn(),
         getLeavesOfType: jest.fn().mockReturnValue([]),
         getRightLeaf: jest.fn().mockReturnValue({
           setViewState: jest.fn().mockResolvedValue(undefined),
@@ -120,6 +122,79 @@ describe('ClaudianPlugin', () => {
         name: 'Open chat view',
         callback: expect.any(Function),
       });
+    });
+
+    it('loads restored-tab metadata without waiting for the full history scan', async () => {
+      let finishHistoryScan!: (value: []) => void;
+      const historyScan = new Promise<[]>((resolve) => {
+        finishHistoryScan = resolve;
+      });
+      const restoredMetadata = {
+        id: 'restored-conversation',
+        providerId: 'claude' as const,
+        title: 'Restored conversation',
+        createdAt: 1,
+        updatedAt: 2,
+      };
+      const listSpy = jest.spyOn(SessionStorage.prototype, 'listMetadata')
+        .mockReturnValue(historyScan);
+      const loadSpy = jest.spyOn(SessionStorage.prototype, 'loadMetadata')
+        .mockResolvedValue(restoredMetadata);
+      (plugin.loadData as jest.Mock).mockResolvedValue({
+        tabManagerState: {
+          openTabs: [{ tabId: 'tab-1', conversationId: restoredMetadata.id }],
+          activeTabId: 'tab-1',
+        },
+      });
+
+      const onloadPromise = plugin.onload();
+      const completedBeforeHistoryScan = await Promise.race([
+        onloadPromise.then(() => true),
+        new Promise<boolean>(resolve => setTimeout(() => resolve(false), 20)),
+      ]);
+      finishHistoryScan([]);
+      await onloadPromise;
+      const cachedConversation = plugin.getCachedConversation(restoredMetadata.id);
+      const didLoadRestoredMetadata = loadSpy.mock.calls.some(
+        ([id]) => id === restoredMetadata.id,
+      );
+      listSpy.mockRestore();
+      loadSpy.mockRestore();
+
+      expect(completedBeforeHistoryScan).toBe(true);
+      expect(didLoadRestoredMetadata).toBe(true);
+      expect(cachedConversation?.title).toBe(restoredMetadata.title);
+    });
+
+    it('publishes the remaining conversation metadata after layout readiness', async () => {
+      let layoutReady!: () => void;
+      const backgroundMetadata = {
+        id: 'background-conversation',
+        providerId: 'claude' as const,
+        title: 'Background conversation',
+        createdAt: 1,
+        updatedAt: 2,
+      };
+      mockApp.workspace.onLayoutReady = jest.fn((callback: () => void) => {
+        layoutReady = callback;
+      });
+      const listSpy = jest.spyOn(SessionStorage.prototype, 'listMetadata')
+        .mockResolvedValue([backgroundMetadata]);
+
+      await plugin.onload();
+      const beforeLayoutReady = plugin.getCachedConversation(backgroundMetadata.id);
+      layoutReady();
+      for (let attempt = 0; attempt < 10; attempt += 1) {
+        if (plugin.getCachedConversation(backgroundMetadata.id)) break;
+        await new Promise(resolve => setTimeout(resolve, 1));
+      }
+      const afterBackgroundLoad = plugin.getCachedConversation(backgroundMetadata.id);
+      const listCallCount = listSpy.mock.calls.length;
+      listSpy.mockRestore();
+
+      expect(beforeLayoutReady).toBeNull();
+      expect(listCallCount).toBe(1);
+      expect(afterBackgroundLoad?.title).toBe(backgroundMetadata.title);
     });
 
   });

--- a/tests/integration/startup/StartupOptimization.test.ts
+++ b/tests/integration/startup/StartupOptimization.test.ts
@@ -1,0 +1,110 @@
+import { StartupProfiler } from '@/core/performance/StartupProfiler';
+import type { ProviderHost } from '@/core/providers/ProviderHost';
+import { ProviderWorkspaceRegistry } from '@/core/providers/ProviderWorkspaceRegistry';
+import type { ProviderWorkspaceServices } from '@/core/providers/types';
+import type { CodexDiscoveredModel } from '@/providers/codex/models';
+import { CodexModelCatalogCoordinator } from '@/providers/codex/runtime/CodexModelCatalogCoordinator';
+import type {
+  CodexModelDiscoveryResult,
+  CodexModelDiscoveryServiceLike,
+} from '@/providers/codex/runtime/CodexModelDiscoveryService';
+import { DEFAULT_CODEX_PROVIDER_SETTINGS } from '@/providers/codex/settings';
+
+function makeModel(model: string, displayName = model): CodexDiscoveredModel {
+  return {
+    model,
+    displayName,
+    description: `${model} description`,
+    supportedReasoningEfforts: [{ value: 'medium', description: 'Balanced' }],
+    defaultReasoningEffort: 'medium',
+    serviceTiers: [],
+    defaultServiceTier: null,
+    inputModalities: ['text', 'image'],
+    isDefault: false,
+  };
+}
+
+function createFakeHost(): ProviderHost {
+  return {
+    app: {
+      vault: { adapter: { basePath: '/vault' } },
+      workspace: {
+        onLayoutReady: jest.fn(),
+      },
+    },
+    settings: {
+      providerConfigs: {
+        codex: {
+          ...DEFAULT_CODEX_PROVIDER_SETTINGS,
+          enabled: true,
+        },
+      },
+      environmentVariables: {},
+    },
+    storage: {
+      getAdapter: jest.fn(),
+    } as unknown as ProviderHost['storage'],
+    getResolvedProviderCliPath: jest.fn(() => '/usr/bin/codex'),
+    getActiveEnvironmentVariables: jest.fn(() => 'OPENAI_API_KEY=test'),
+    mutateSettingsConditionally: jest.fn(async () => false),
+  } as unknown as ProviderHost;
+}
+
+describe('Startup optimization', () => {
+  beforeEach(() => {
+    StartupProfiler.reset();
+    ProviderWorkspaceRegistry.clear();
+  });
+
+  afterEach(() => {
+    ProviderWorkspaceRegistry.clear();
+    StartupProfiler.reset();
+  });
+
+  it('workspace registry initializeAll resolves before Codex discovery completes', async () => {
+    let discoveryResolved = false;
+    const discovery: CodexModelDiscoveryServiceLike = {
+      discoverModels: jest.fn(async () => {
+        await new Promise((res) => setTimeout(res, 50));
+        discoveryResolved = true;
+        return {
+          kind: 'completed',
+          models: [makeModel('gpt-4o')],
+        } as CodexModelDiscoveryResult;
+      }),
+    };
+
+    ProviderWorkspaceRegistry.register('codex', {
+      initialize: async ({ plugin }) => ({
+        modelCatalogCoordinator: new CodexModelCatalogCoordinator(plugin, discovery),
+      } as unknown as ProviderWorkspaceServices),
+    });
+
+    const host = createFakeHost();
+    const initPromise = ProviderWorkspaceRegistry.initializeAll(host);
+    expect(discoveryResolved).toBe(false);
+
+    await initPromise;
+    expect(discoveryResolved).toBe(false);
+
+    const services = ProviderWorkspaceRegistry.getServices('codex') as {
+      modelCatalogCoordinator: CodexModelCatalogCoordinator;
+    };
+    await services.modelCatalogCoordinator.refresh();
+    expect(discoveryResolved).toBe(true);
+  });
+
+  it('profiler captures provider initialization span', async () => {
+    ProviderWorkspaceRegistry.register('codex', {
+      initialize: async () => ({
+        modelCatalogCoordinator: null,
+      } as unknown as ProviderWorkspaceServices),
+    });
+
+    const host = createFakeHost();
+    await ProviderWorkspaceRegistry.initializeAll(host);
+
+    const report = StartupProfiler.getReport();
+    expect(report.spans.some((span) => span.name === 'provider-init:codex')).toBe(true);
+  });
+});

--- a/tests/unit/app/conversations/ConversationRepository.test.ts
+++ b/tests/unit/app/conversations/ConversationRepository.test.ts
@@ -91,6 +91,91 @@ describe('ConversationRepository hydration', () => {
     expect(hydrateConversationHistory).toHaveBeenCalledTimes(2);
   });
 
+  it('does not return a conversation deleted while hydration is in flight', async () => {
+    let releaseHydration!: () => void;
+    const hydrateConversationHistory = jest.fn(async () => {
+      await new Promise<void>((resolve) => {
+        releaseHydration = resolve;
+      });
+    });
+    jest.spyOn(ProviderRegistry, 'getConversationHistoryService').mockReturnValue({
+      hydrateConversationHistory,
+    } as any);
+    const conversation = createConversation();
+    const { repository, sessions } = createRepository(conversation);
+
+    const hydration = repository.ensureHydrated(conversation.id);
+    await Promise.resolve();
+    await Promise.resolve();
+    const deletion = repository.delete(conversation.id, { deleteProviderSession: false });
+
+    releaseHydration();
+
+    await expect(hydration).resolves.toBeNull();
+    await expect(deletion).resolves.toBeUndefined();
+    expect(repository.getCachedConversation(conversation.id)).toBeNull();
+    expect(sessions.deleteMetadata).toHaveBeenCalledWith(conversation.id);
+  });
+
+  it('does not return an already hydrated conversation deleted while model reconciliation is in flight', async () => {
+    let markReconciliationStarted!: () => void;
+    let releaseReconciliation!: () => void;
+    const reconciliationStarted = new Promise<void>((resolve) => {
+      markReconciliationStarted = resolve;
+    });
+    const reconciliationRelease = new Promise<void>((resolve) => {
+      releaseReconciliation = resolve;
+    });
+    const conversation = createConversation();
+    conversation.messages = [{ id: 'message-1', role: 'user', content: 'kept', timestamp: 1 }];
+    const { repository, sessions } = createRepository(conversation);
+    jest.spyOn(repository as any, 'ensureSelectedModel').mockImplementation(async () => {
+      markReconciliationStarted();
+      await reconciliationRelease;
+    });
+
+    const hydration = repository.ensureHydrated(conversation.id);
+    await reconciliationStarted;
+    const deletion = repository.delete(conversation.id, { deleteProviderSession: false });
+    releaseReconciliation();
+
+    await expect(hydration).resolves.toBeNull();
+    await expect(deletion).resolves.toBeUndefined();
+    expect(repository.getCachedConversation(conversation.id)).toBeNull();
+    expect(sessions.deleteMetadata).toHaveBeenCalledWith(conversation.id);
+  });
+
+  it('restarts hydration when provider session identity changes in flight', async () => {
+    let markFirstHydrationStarted!: () => void;
+    let releaseFirstHydration!: () => void;
+    const firstHydrationStarted = new Promise<void>((resolve) => {
+      markFirstHydrationStarted = resolve;
+    });
+    const firstHydrationRelease = new Promise<void>((resolve) => {
+      releaseFirstHydration = resolve;
+    });
+    const hydrateConversationHistory = jest.fn()
+      .mockImplementationOnce(async () => {
+        markFirstHydrationStarted();
+        await firstHydrationRelease;
+      })
+      .mockResolvedValueOnce(undefined);
+    jest.spyOn(ProviderRegistry, 'getConversationHistoryService').mockReturnValue({
+      hydrateConversationHistory,
+    } as any);
+    const conversation = createConversation();
+    const { repository } = createRepository(conversation);
+
+    const staleHydration = repository.ensureHydrated(conversation.id);
+    await firstHydrationStarted;
+    await repository.update(conversation.id, { sessionId: 'session-2' });
+    releaseFirstHydration();
+
+    await expect(staleHydration).resolves.toBeNull();
+    await expect(repository.ensureHydrated(conversation.id)).resolves.toBe(conversation);
+    expect(hydrateConversationHistory).toHaveBeenCalledTimes(2);
+  });
+
   it('merges background metadata without replacing an already hydrated conversation', () => {
     const existing = createConversation('existing');
     existing.messages = [{ id: 'message-1', role: 'user', content: 'kept', timestamp: 1 }];
@@ -105,5 +190,18 @@ describe('ConversationRepository hydration', () => {
     expect(repository.getCachedConversation('existing')).toBe(existing);
     expect(repository.getCachedConversation('existing')?.messages).toHaveLength(1);
     expect(repository.getAll().map(conversation => conversation.id)).toEqual(['added', 'existing']);
+  });
+
+  it('does not resurrect a deleted conversation from a late background metadata batch', async () => {
+    const conversation = createConversation('deleted');
+    const { repository } = createRepository(conversation);
+    await repository.delete(conversation.id, { deleteProviderSession: false });
+
+    const merged = repository.mergeMetadataConversations([
+      createConversation(conversation.id),
+    ]);
+
+    expect(merged).toEqual([]);
+    expect(repository.getCachedConversation(conversation.id)).toBeNull();
   });
 });

--- a/tests/unit/app/conversations/ConversationRepository.test.ts
+++ b/tests/unit/app/conversations/ConversationRepository.test.ts
@@ -1,0 +1,109 @@
+import '@/providers';
+
+import { ConversationRepository } from '@/app/conversations/ConversationRepository';
+import { ProviderRegistry } from '@/core/providers/ProviderRegistry';
+import type { Conversation } from '@/core/types';
+
+function createConversation(id = 'conversation-1'): Conversation {
+  return {
+    id,
+    providerId: 'claude',
+    title: 'Conversation',
+    createdAt: 1,
+    updatedAt: 1,
+    sessionId: 'session-1',
+    messages: [],
+  };
+}
+
+function createRepository(conversation = createConversation()) {
+  const sessions = {
+    saveMetadata: jest.fn().mockResolvedValue(undefined),
+    deleteMetadata: jest.fn().mockResolvedValue(undefined),
+    toSessionMetadata: jest.fn((value) => value),
+  };
+  const repository = new ConversationRepository({
+    getSettings: () => ({}),
+    getVaultPath: () => '/vault',
+    sessions: sessions as any,
+    onConversationDeleted: jest.fn().mockResolvedValue(undefined),
+  });
+  repository.replaceAll([conversation]);
+  return { repository, sessions };
+}
+
+describe('ConversationRepository hydration', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns cached metadata without hydrating provider history', () => {
+    const hydrateConversationHistory = jest.fn();
+    jest.spyOn(ProviderRegistry, 'getConversationHistoryService').mockReturnValue({
+      hydrateConversationHistory,
+    } as any);
+    const conversation = createConversation();
+    const { repository } = createRepository(conversation);
+
+    expect(repository.getCachedConversation(conversation.id)).toBe(conversation);
+    expect(hydrateConversationHistory).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates concurrent hydration and does not reread an empty transcript', async () => {
+    let release!: () => void;
+    const hydrateConversationHistory = jest.fn(async () => {
+      await new Promise<void>((resolve) => {
+        release = resolve;
+      });
+    });
+    jest.spyOn(ProviderRegistry, 'getConversationHistoryService').mockReturnValue({
+      hydrateConversationHistory,
+    } as any);
+    const conversation = createConversation();
+    const { repository } = createRepository(conversation);
+
+    const first = repository.ensureHydrated(conversation.id);
+    const second = repository.ensureHydrated(conversation.id);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(hydrateConversationHistory).toHaveBeenCalledTimes(1);
+
+    release();
+    await expect(Promise.all([first, second])).resolves.toEqual([conversation, conversation]);
+    await repository.ensureHydrated(conversation.id);
+
+    expect(hydrateConversationHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows hydration to retry after a provider history failure', async () => {
+    const hydrateConversationHistory = jest.fn()
+      .mockRejectedValueOnce(new Error('temporary failure'))
+      .mockResolvedValueOnce(undefined);
+    jest.spyOn(ProviderRegistry, 'getConversationHistoryService').mockReturnValue({
+      hydrateConversationHistory,
+    } as any);
+    const conversation = createConversation();
+    const { repository } = createRepository(conversation);
+
+    await expect(repository.ensureHydrated(conversation.id)).rejects.toThrow('temporary failure');
+    await expect(repository.ensureHydrated(conversation.id)).resolves.toBe(conversation);
+
+    expect(hydrateConversationHistory).toHaveBeenCalledTimes(2);
+  });
+
+  it('merges background metadata without replacing an already hydrated conversation', () => {
+    const existing = createConversation('existing');
+    existing.messages = [{ id: 'message-1', role: 'user', content: 'kept', timestamp: 1 }];
+    const { repository } = createRepository(existing);
+    const duplicate = createConversation('existing');
+    const added = createConversation('added');
+    added.updatedAt = 2;
+
+    const merged = repository.mergeMetadataConversations([duplicate, added]);
+
+    expect(merged).toEqual([added]);
+    expect(repository.getCachedConversation('existing')).toBe(existing);
+    expect(repository.getCachedConversation('existing')?.messages).toHaveLength(1);
+    expect(repository.getAll().map(conversation => conversation.id)).toEqual(['added', 'existing']);
+  });
+});

--- a/tests/unit/app/providers/ClaudianProviderHost.test.ts
+++ b/tests/unit/app/providers/ClaudianProviderHost.test.ts
@@ -37,7 +37,7 @@ describe('ClaudianProviderHost', () => {
 
     await host.saveSettings();
     await host.applyEnvironmentVariables('provider:codex', 'OPENAI_API_KEY=test');
-    expect(host.getResolvedProviderCliPath('codex')).toBe('/usr/bin/codex');
+    await expect(host.getResolvedProviderCliPath('codex')).resolves.toBe('/usr/bin/codex');
 
     expect(trace).toEqual(['save', 'environment', 'cli']);
     expect('registerView' in host).toBe(false);

--- a/tests/unit/app/storage/SharedStorageService.test.ts
+++ b/tests/unit/app/storage/SharedStorageService.test.ts
@@ -1,0 +1,21 @@
+import { SharedStorageService } from '@/app/storage/SharedStorageService';
+
+describe('SharedStorageService', () => {
+  it('does not create storage directories during read-only initialization', async () => {
+    const adapter = {
+      exists: jest.fn().mockResolvedValue(false),
+      read: jest.fn(),
+      write: jest.fn(),
+      mkdir: jest.fn(),
+    };
+    const plugin = {
+      app: { vault: { adapter } },
+    } as any;
+    const storage = new SharedStorageService(plugin);
+
+    await storage.initialize();
+
+    expect(adapter.mkdir).not.toHaveBeenCalled();
+    expect(adapter.write).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/app/storage/SharedStorageService.test.ts
+++ b/tests/unit/app/storage/SharedStorageService.test.ts
@@ -1,3 +1,5 @@
+import { Notice } from 'obsidian';
+
 import { SharedStorageService } from '@/app/storage/SharedStorageService';
 
 describe('SharedStorageService', () => {
@@ -17,5 +19,21 @@ describe('SharedStorageService', () => {
 
     expect(adapter.mkdir).not.toHaveBeenCalled();
     expect(adapter.write).not.toHaveBeenCalled();
+  });
+
+  it('reports and propagates tab layout persistence failures', async () => {
+    const error = new Error('disk full');
+    const plugin = {
+      app: { vault: { adapter: {} } },
+      loadData: jest.fn().mockResolvedValue({ existing: true }),
+      saveData: jest.fn().mockRejectedValue(error),
+    } as any;
+    const storage = new SharedStorageService(plugin);
+
+    await expect(storage.setTabManagerState({
+      activeTabId: null,
+      openTabs: [],
+    })).rejects.toBe(error);
+    expect(Notice).toHaveBeenCalledWith('Failed to save tab layout');
   });
 });

--- a/tests/unit/core/mcp/McpServerManager.test.ts
+++ b/tests/unit/core/mcp/McpServerManager.test.ts
@@ -401,5 +401,29 @@ describe('McpServerManager', () => {
       await manager.loadServers();
       expect(manager.getServers()).toEqual(servers);
     });
+
+    it('deduplicates concurrent loads and retries after failure', async () => {
+      const load = jest.fn()
+        .mockRejectedValueOnce(new Error('temporary failure'))
+        .mockResolvedValueOnce([]);
+      const manager = new McpServerManager({ load });
+
+      const first = manager.loadServers();
+      await expect(first).rejects.toThrow('temporary failure');
+      await expect(manager.loadServers()).resolves.toBeUndefined();
+
+      expect(load).toHaveBeenCalledTimes(2);
+      expect(manager.isLoaded()).toBe(true);
+    });
+
+    it('does not reload storage when ensureLoaded already has data', async () => {
+      const load = jest.fn().mockResolvedValue([]);
+      const manager = new McpServerManager({ load });
+
+      await manager.ensureLoaded();
+      await manager.ensureLoaded();
+
+      expect(load).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/tests/unit/core/performance/StartupProfiler.test.ts
+++ b/tests/unit/core/performance/StartupProfiler.test.ts
@@ -1,0 +1,97 @@
+import { StartupProfiler } from '@/core/performance/StartupProfiler';
+
+describe('StartupProfiler', () => {
+  beforeEach(() => {
+    StartupProfiler.reset();
+  });
+
+  afterEach(() => {
+    StartupProfiler.reset();
+  });
+
+  it('records module eval and onload times', () => {
+    StartupProfiler.setModuleEvalTime(1);
+    StartupProfiler.startOnload();
+    StartupProfiler.finishOnload();
+
+    const report = StartupProfiler.getReport();
+    expect(report.moduleEvalTime).toBe(1);
+    expect(report.onloadStartTime).toBeGreaterThan(0);
+    expect(report.onloadEndTime).toBeGreaterThanOrEqual(report.onloadStartTime);
+    expect(report.totalDurationMs).toBeDefined();
+  });
+
+  it('records spans', () => {
+    const span = StartupProfiler.start('test-span');
+    StartupProfiler.finish(span);
+
+    const report = StartupProfiler.getReport();
+    expect(report.spans).toHaveLength(1);
+    expect(report.spans[0].name).toBe('test-span');
+    expect(report.spans[0].durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('records counts', () => {
+    StartupProfiler.recordCount('session-metadata-count', 42);
+    StartupProfiler.increment('provider-init-failures');
+    StartupProfiler.increment('provider-init-failures', 2);
+
+    const report = StartupProfiler.getReport();
+    expect(report.counts['session-metadata-count']).toBe(42);
+    expect(report.counts['provider-init-failures']).toBe(3);
+  });
+
+  it('returns JSON report', () => {
+    StartupProfiler.startOnload();
+    StartupProfiler.finishOnload();
+    StartupProfiler.recordCount('restored-tab-count', 3);
+
+    const json = StartupProfiler.toJSON();
+    const parsed = JSON.parse(json);
+    expect(parsed.counts['restored-tab-count']).toBe(3);
+    expect(parsed.spans).toEqual([]);
+  });
+
+  it('copies report to clipboard', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.assign(global.navigator, { clipboard: { writeText } });
+
+    StartupProfiler.recordCount('session-metadata-count', 5);
+    const copied = await StartupProfiler.copyToClipboard();
+
+    expect(copied).toBe(true);
+    expect(writeText).toHaveBeenCalledTimes(1);
+    const written = writeText.mock.calls[0][0] as string;
+    expect(JSON.parse(written).counts['session-metadata-count']).toBe(5);
+  });
+
+  it('returns false when clipboard write fails', async () => {
+    Object.assign(global.navigator, {
+      clipboard: { writeText: jest.fn().mockRejectedValue(new Error('denied')) },
+    });
+
+    const copied = await StartupProfiler.copyToClipboard();
+    expect(copied).toBe(false);
+  });
+
+  it('stops recording after freeze', () => {
+    StartupProfiler.freeze();
+    StartupProfiler.recordCount('ignored', 1);
+    StartupProfiler.increment('ignored');
+
+    const report = StartupProfiler.getReport();
+    expect(report.counts['ignored']).toBeUndefined();
+  });
+
+  it('run helper wraps synchronous functions', () => {
+    const result = StartupProfiler.run('sync-span', () => 42);
+    expect(result).toBe(42);
+    expect(StartupProfiler.getReport().spans[0].name).toBe('sync-span');
+  });
+
+  it('runAsync helper wraps asynchronous functions', async () => {
+    const result = await StartupProfiler.runAsync('async-span', async () => 'value');
+    expect(result).toBe('value');
+    expect(StartupProfiler.getReport().spans[0].name).toBe('async-span');
+  });
+});

--- a/tests/unit/core/providers/ProviderWorkspaceRegistry.test.ts
+++ b/tests/unit/core/providers/ProviderWorkspaceRegistry.test.ts
@@ -1,6 +1,17 @@
 import '@/providers';
 
+import type { ProviderHost } from '@/core/providers/ProviderHost';
 import { ProviderWorkspaceRegistry } from '@/core/providers/ProviderWorkspaceRegistry';
+
+function createProviderHost(): ProviderHost {
+  return {
+    app: {},
+    settings: {},
+    storage: {
+      getAdapter: jest.fn().mockReturnValue({}),
+    },
+  } as unknown as ProviderHost;
+}
 
 describe('ProviderWorkspaceRegistry', () => {
   afterEach(() => {
@@ -80,5 +91,109 @@ describe('ProviderWorkspaceRegistry', () => {
     });
 
     expect(ProviderWorkspaceRegistry.getTabWarmupPolicy('opencode')).toBe(tabWarmupPolicy);
+  });
+
+  it('deduplicates concurrent provider initialization', async () => {
+    const initialize = jest.fn(async () => ({ commandCatalog: {} as any }));
+    ProviderWorkspaceRegistry.register('codex', { initialize });
+    const host = createProviderHost();
+
+    await Promise.all([
+      ProviderWorkspaceRegistry.ensureInitialized(host, 'codex', 'first'),
+      ProviderWorkspaceRegistry.ensureInitialized(host, 'codex', 'second'),
+    ]);
+
+    expect(initialize).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows provider initialization to retry after failure', async () => {
+    const initialize = jest.fn()
+      .mockRejectedValueOnce(new Error('temporary failure'))
+      .mockResolvedValueOnce({ commandCatalog: {} as any });
+    ProviderWorkspaceRegistry.register('codex', { initialize });
+    const host = createProviderHost();
+
+    await expect(
+      ProviderWorkspaceRegistry.ensureInitialized(host, 'codex', 'first'),
+    ).rejects.toThrow('temporary failure');
+    await expect(
+      ProviderWorkspaceRegistry.ensureInitialized(host, 'codex', 'retry'),
+    ).resolves.toBeUndefined();
+
+    expect(initialize).toHaveBeenCalledTimes(2);
+    expect(ProviderWorkspaceRegistry.getIfInitialized('codex')).not.toBeNull();
+  });
+
+  it('keeps registrations available after disposing initialized services', async () => {
+    const dispose = jest.fn();
+    const initialize = jest.fn(async () => ({ dispose }));
+    ProviderWorkspaceRegistry.register('codex', { initialize });
+    const host = createProviderHost();
+
+    await ProviderWorkspaceRegistry.ensureInitialized(host, 'codex', 'first');
+    await ProviderWorkspaceRegistry.disposeInitialized();
+    await ProviderWorkspaceRegistry.ensureInitialized(host, 'codex', 'second');
+
+    expect(dispose).toHaveBeenCalledTimes(1);
+    expect(initialize).toHaveBeenCalledTimes(2);
+  });
+
+  it('reinitializes a provider after its assigned services are cleared', async () => {
+    const initialize = jest.fn(async () => ({ commandCatalog: {} as any }));
+    ProviderWorkspaceRegistry.register('codex', { initialize });
+    const host = createProviderHost();
+
+    await ProviderWorkspaceRegistry.ensureInitialized(host, 'codex', 'first');
+    ProviderWorkspaceRegistry.setServices('codex', undefined);
+    await ProviderWorkspaceRegistry.ensureInitialized(host, 'codex', 'second');
+
+    expect(initialize).toHaveBeenCalledTimes(2);
+    expect(ProviderWorkspaceRegistry.getIfInitialized('codex')).not.toBeNull();
+  });
+
+  it('disposes every initialized provider even when one cleanup fails', async () => {
+    const disposeClaude = jest.fn().mockRejectedValue(new Error('cleanup failed'));
+    const disposeCodex = jest.fn().mockResolvedValue(undefined);
+    ProviderWorkspaceRegistry.setServices('claude', { dispose: disposeClaude });
+    ProviderWorkspaceRegistry.setServices('codex', { dispose: disposeCodex });
+
+    await expect(ProviderWorkspaceRegistry.disposeInitialized()).resolves.toBeUndefined();
+
+    expect(disposeClaude).toHaveBeenCalledTimes(1);
+    expect(disposeCodex).toHaveBeenCalledTimes(1);
+    expect(ProviderWorkspaceRegistry.getIfInitialized('claude')).toBeNull();
+    expect(ProviderWorkspaceRegistry.getIfInitialized('codex')).toBeNull();
+  });
+
+  it('disposes services that finish initializing after provider disposal', async () => {
+    let finishInitialization!: (services: { dispose: jest.Mock }) => void;
+    const dispose = jest.fn().mockResolvedValue(undefined);
+    const initialize = jest.fn(() => new Promise<{ dispose: jest.Mock }>((resolve) => {
+      finishInitialization = resolve;
+    }));
+    ProviderWorkspaceRegistry.register('codex', { initialize });
+    const host = createProviderHost();
+
+    const initialization = ProviderWorkspaceRegistry.ensureInitialized(
+      host,
+      'codex',
+      'cold-start',
+    );
+    await Promise.resolve();
+    await ProviderWorkspaceRegistry.disposeInitialized();
+    finishInitialization({ dispose });
+    await initialization;
+
+    expect(dispose).toHaveBeenCalledTimes(1);
+    expect(ProviderWorkspaceRegistry.getIfInitialized('codex')).toBeNull();
+  });
+
+  it('prepares provider settings through initialized workspace services', async () => {
+    const prepareSettings = jest.fn().mockResolvedValue(undefined);
+    ProviderWorkspaceRegistry.setServices('codex', { prepareSettings });
+
+    await ProviderWorkspaceRegistry.prepareSettings('codex');
+
+    expect(prepareSettings).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/core/storage/VaultFileAdapter.test.ts
+++ b/tests/unit/core/storage/VaultFileAdapter.test.ts
@@ -462,6 +462,27 @@ describe('VaultFileAdapter', () => {
       expect(mockAdapter.mkdir).toHaveBeenCalledWith('folder');
       expect(mockAdapter.mkdir).toHaveBeenCalledWith('folder/nested');
     });
+
+    it('deduplicates concurrent creation of the same missing folder', async () => {
+      const existingFolders = new Set<string>();
+      mockAdapter.exists.mockImplementation(async (path: string) => existingFolders.has(path));
+      mockAdapter.mkdir.mockImplementation(async (path: string) => {
+        await Promise.resolve();
+        if (existingFolders.has(path)) {
+          throw new Error(`EEXIST: ${path}`);
+        }
+        existingFolders.add(path);
+      });
+
+      await expect(Promise.all([
+        vaultAdapter.ensureFolder('.claudian/sessions'),
+        vaultAdapter.ensureFolder('.claudian/sessions'),
+      ])).resolves.toEqual([undefined, undefined]);
+
+      expect(mockAdapter.mkdir).toHaveBeenCalledTimes(2);
+      expect(mockAdapter.mkdir).toHaveBeenNthCalledWith(1, '.claudian');
+      expect(mockAdapter.mkdir).toHaveBeenNthCalledWith(2, '.claudian/sessions');
+    });
   });
 
   describe('rename', () => {

--- a/tests/unit/features/chat/ClaudianView.test.ts
+++ b/tests/unit/features/chat/ClaudianView.test.ts
@@ -175,6 +175,44 @@ describe('ClaudianView tab controls', () => {
     expect(historyDropdown.hasClass('visible')).toBe(false);
   });
 
+  it('defers hidden history rendering and coalesces invalidations until the dropdown opens', () => {
+    const historyDropdown = createMockEl();
+    const renderHistoryDropdown = jest.fn();
+    const view = Object.create(ClaudianView.prototype) as any;
+
+    view.historyDropdown = historyDropdown;
+    view.historyDropdownDirty = true;
+    view.historyDropdownRendered = false;
+    view.tabManager = {
+      getActiveTab: jest.fn().mockReturnValue({
+        controllers: {
+          conversationController: { renderHistoryDropdown },
+        },
+      }),
+    };
+
+    view.updateHistoryDropdown();
+    view.updateHistoryDropdown();
+
+    expect(renderHistoryDropdown).not.toHaveBeenCalled();
+
+    view.toggleHistoryDropdown();
+
+    expect(renderHistoryDropdown).toHaveBeenCalledTimes(1);
+    const firstRenderSignal = renderHistoryDropdown.mock.calls[0][1].signal as AbortSignal;
+    expect(firstRenderSignal.aborted).toBe(false);
+
+    view.updateHistoryDropdown();
+
+    expect(renderHistoryDropdown).toHaveBeenCalledTimes(2);
+
+    view.toggleHistoryDropdown();
+    expect(firstRenderSignal.aborted).toBe(true);
+    view.updateHistoryDropdown();
+
+    expect(renderHistoryDropdown).toHaveBeenCalledTimes(2);
+  });
+
   it('persists expanded title tab ids with the tab layout snapshot', () => {
     const view = Object.create(ClaudianView.prototype) as any;
 

--- a/tests/unit/features/chat/ClaudianView.test.ts
+++ b/tests/unit/features/chat/ClaudianView.test.ts
@@ -270,6 +270,39 @@ describe('ClaudianView tab controls', () => {
   });
 });
 
+describe('ClaudianView shutdown', () => {
+  it('disposes view resources when the final tab-state flush fails', async () => {
+    const error = new Error('disk full');
+    const view = Object.create(ClaudianView.prototype) as any;
+    const destroy = jest.fn().mockResolvedValue(undefined);
+    const tabBarDestroy = jest.fn();
+    const persistenceDispose = jest.fn();
+
+    Object.assign(view, {
+      cancelHistoryRendering: jest.fn(),
+      eventRefs: [],
+      mentionCacheCoordinator: {},
+      pendingTabBarUpdate: null,
+      persistTabStateImmediate: jest.fn().mockRejectedValue(error),
+      plugin: { app: { vault: { offref: jest.fn() } } },
+      restoreActiveInputToTabContent: jest.fn(),
+      scope: {},
+      tabBar: { destroy: tabBarDestroy },
+      tabManager: { destroy },
+      tabStatePersistence: { dispose: persistenceDispose },
+    });
+
+    await expect(view.onClose()).resolves.toBeUndefined();
+
+    expect(persistenceDispose).toHaveBeenCalledTimes(1);
+    expect(view.restoreActiveInputToTabContent).toHaveBeenCalledTimes(1);
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(tabBarDestroy).toHaveBeenCalledTimes(1);
+    expect(view.tabManager).toBeNull();
+    expect(view.scope).toBeNull();
+  });
+});
+
 describe('ClaudianView Escape handling', () => {
   beforeEach(() => {
     MockScope.instances.length = 0;

--- a/tests/unit/features/chat/controllers/ConversationController.test.ts
+++ b/tests/unit/features/chat/controllers/ConversationController.test.ts
@@ -777,6 +777,46 @@ describe('ConversationController', () => {
         expect(container.children.length).toBe(2); // header + list
       });
 
+      it('paginates large history lists and loads the next bounded page on demand', () => {
+        const container = createMockEl();
+        (deps.plugin.getConversationList as jest.Mock).mockReturnValue(
+          Array.from({ length: 125 }, (_, index) => ({
+            id: `conv-${index}`,
+            title: `Conversation ${index}`,
+            createdAt: 125 - index,
+          })),
+        );
+
+        controller.renderHistoryDropdown(container, {
+          onSelectConversation: jest.fn(),
+          pageSize: 25,
+        });
+
+        let list = container.children[1];
+        expect(list.querySelectorAll('.claudian-history-item')).toHaveLength(25);
+        const loadMore = list.querySelector('.claudian-history-load-more');
+        expect(loadMore).not.toBeNull();
+
+        loadMore!.click();
+        list = container.children[1];
+        expect(list.querySelectorAll('.claudian-history-item')).toHaveLength(50);
+        expect(list.querySelector('.claudian-history-load-more')).not.toBeNull();
+      });
+
+      it('does not render when the history render signal is already aborted', () => {
+        const container = createMockEl();
+        container.createDiv({ cls: 'sentinel' });
+        const abortController = new AbortController();
+        abortController.abort();
+
+        controller.renderHistoryDropdown(container, {
+          onSelectConversation: jest.fn(),
+          signal: abortController.signal,
+        });
+
+        expect(container.querySelector('.sentinel')).not.toBeNull();
+      });
+
       it('should highlight conversations already open in a tab', () => {
         const container = createMockEl();
 

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -1098,6 +1098,34 @@ describe('InputController - Message Queue', () => {
       expect(deps.state.isStreaming).toBe(false);
     });
 
+    it('awaits provider turn preparation before encoding the first message', async () => {
+      const calls: string[] = [];
+      deps = createSendableDeps();
+      (deps as any).mockAgentService.prepareForTurn = jest.fn(async () => {
+        calls.push('prepareForTurn');
+      });
+      (deps as any).mockAgentService.prepareTurn = jest.fn().mockImplementation((request: any) => {
+        calls.push('prepareTurn');
+        return {
+          request,
+          persistedContent: request.text,
+          prompt: request.text,
+          isCompact: false,
+          mcpMentions: new Set(),
+        };
+      });
+      (deps as any).mockAgentService.query = jest.fn().mockImplementation(() => (
+        createMockStream([{ type: 'done' }])
+      ));
+      inputEl = deps.getInputEl() as ReturnType<typeof createMockInputEl>;
+      inputEl.value = '@server-a hello';
+      controller = new InputController(deps);
+
+      await controller.sendMessage();
+
+      expect(calls).toEqual(['prepareForTurn', 'prepareTurn']);
+    });
+
     it('should persist replay-safe user content instead of transport-only prompt', async () => {
       deps = createSendableDeps();
       (deps as any).mockAgentService.prepareTurn = jest.fn().mockReturnValue({

--- a/tests/unit/features/chat/services/TabStatePersistenceCoordinator.test.ts
+++ b/tests/unit/features/chat/services/TabStatePersistenceCoordinator.test.ts
@@ -1,0 +1,78 @@
+import { TabStatePersistenceCoordinator } from '@/features/chat/services/TabStatePersistenceCoordinator';
+
+describe('TabStatePersistenceCoordinator', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('coalesces rapid updates into one write of the latest serialized state', async () => {
+    const persist = jest.fn().mockResolvedValue(undefined);
+    const coordinator = new TabStatePersistenceCoordinator(persist, window, 300);
+
+    coordinator.update({ openTabs: [], activeTabId: null });
+    coordinator.update({
+      openTabs: [{ tabId: 'tab-1', conversationId: 'conv-1' }],
+      activeTabId: 'tab-1',
+    });
+    jest.advanceTimersByTime(300);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(persist).toHaveBeenCalledTimes(1);
+    expect(persist).toHaveBeenCalledWith({
+      openTabs: [{ tabId: 'tab-1', conversationId: 'conv-1' }],
+      activeTabId: 'tab-1',
+    });
+  });
+
+  it('serializes writes and persists an update received during an in-flight write', async () => {
+    let finishFirstWrite!: () => void;
+    const firstWrite = new Promise<void>(resolve => {
+      finishFirstWrite = resolve;
+    });
+    const persist = jest.fn()
+      .mockReturnValueOnce(firstWrite)
+      .mockResolvedValueOnce(undefined);
+    const coordinator = new TabStatePersistenceCoordinator(persist, window, 300);
+
+    coordinator.update({ openTabs: [], activeTabId: null });
+    jest.advanceTimersByTime(300);
+    await Promise.resolve();
+    coordinator.update({
+      openTabs: [{ tabId: 'tab-2', conversationId: null }],
+      activeTabId: 'tab-2',
+    });
+
+    expect(persist).toHaveBeenCalledTimes(1);
+    finishFirstWrite();
+    await coordinator.flush();
+
+    expect(persist).toHaveBeenCalledTimes(2);
+    expect(persist).toHaveBeenLastCalledWith({
+      openTabs: [{ tabId: 'tab-2', conversationId: null }],
+      activeTabId: 'tab-2',
+    });
+  });
+
+  it('flushes the latest state once and does not rewrite an acknowledged snapshot', async () => {
+    const persist = jest.fn().mockResolvedValue(undefined);
+    const coordinator = new TabStatePersistenceCoordinator(persist, window, 300);
+    const state = {
+      openTabs: [{ tabId: 'tab-1', conversationId: null }],
+      activeTabId: 'tab-1',
+    };
+
+    coordinator.update(state);
+    await coordinator.flush();
+    await coordinator.flush();
+    coordinator.update(state);
+    jest.advanceTimersByTime(300);
+    await Promise.resolve();
+
+    expect(persist).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -801,10 +801,9 @@ describe('Tab - Service Initialization', () => {
 
     it('should sync existing conversations with saved external contexts', async () => {
       const mockSyncConversationState = jest.fn();
-      const runtimeModule = jest.requireMock('@/providers/claude/runtime/ClaudeChatRuntime') as { ClaudianService: jest.Mock };
-      runtimeModule.ClaudianService.mockImplementationOnce(() => createMockClaudianService({
+      jest.spyOn(ProviderRegistry, 'createChatRuntime').mockReturnValue(createMockClaudianService({
         syncConversationState: mockSyncConversationState,
-      }));
+      }) as any);
 
       const conversation = {
         id: 'conv-1',
@@ -1374,8 +1373,9 @@ describe('Tab - Destruction', () => {
       const unsubscribeFn = jest.fn();
       const mockOnReadyStateChange = jest.fn(() => unsubscribeFn);
 
-      const runtimeModule = jest.requireMock('@/providers/claude/runtime/ClaudeChatRuntime') as { ClaudianService: jest.Mock };
-      runtimeModule.ClaudianService.mockImplementationOnce(() => createMockClaudianService({ onReadyStateChange: mockOnReadyStateChange }));
+      jest.spyOn(ProviderRegistry, 'createChatRuntime').mockReturnValue(createMockClaudianService({
+        onReadyStateChange: mockOnReadyStateChange,
+      }) as any);
 
       const options = createMockOptions();
       const tab = createTab(options);

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -713,6 +713,27 @@ describe('Tab - Service Initialization', () => {
       expect(tab.serviceInitialized).toBe(true);
     });
 
+    it('does not create a runtime when the tab closes during workspace initialization', async () => {
+      let finishInitialization!: () => void;
+      const initialization = new Promise<void>((resolve) => {
+        finishInitialization = resolve;
+      });
+      jest.spyOn(ProviderWorkspaceRegistry, 'ensureInitialized').mockReturnValue(initialization);
+      const createChatRuntimeSpy = jest.spyOn(ProviderRegistry, 'createChatRuntime');
+      const options = createMockOptions();
+      const tab = createTab(options);
+
+      const serviceInitialization = initializeTabService(tab, options.plugin, options.mcpManager);
+      await Promise.resolve();
+      tab.lifecycleState = 'closing';
+      finishInitialization();
+      await serviceInitialization;
+
+      expect(createChatRuntimeSpy).not.toHaveBeenCalled();
+      expect(tab.service).toBeNull();
+      expect(tab.serviceInitialized).toBe(false);
+    });
+
     it('should create the runtime for the conversation provider', async () => {
       const createChatRuntimeSpy = jest.spyOn(ProviderRegistry, 'createChatRuntime');
       const mockRuntime = createMockClaudianService({ providerId: 'codex' });

--- a/tests/unit/features/chat/tabs/TabManager.test.ts
+++ b/tests/unit/features/chat/tabs/TabManager.test.ts
@@ -394,6 +394,7 @@ describe('TabManager - Tab Lifecycle', () => {
       });
 
       tab1!.conversationId = 'conv-1';
+      tab1!.hydrationState = 'idle';
       tab1!.state.messages = [];
       tab1!.controllers.conversationController!.switchTo = jest.fn().mockReturnValue(pendingSwitch);
       jest.clearAllMocks();
@@ -414,6 +415,7 @@ describe('TabManager - Tab Lifecycle', () => {
       const tab1 = await manager.createTab();
       await manager.createTab();
       tab1!.conversationId = 'conv-1';
+      tab1!.hydrationState = 'idle';
       tab1!.state.messages = [];
 
       const switchPromise = manager.switchToTab(tab1!.id);
@@ -428,11 +430,34 @@ describe('TabManager - Tab Lifecycle', () => {
       expect(tab1!.controllers.conversationController!.switchTo).toHaveBeenCalledWith('conv-1');
     });
 
+    it('does not rehydrate an already-ready conversation with an empty transcript', async () => {
+      const manager = createManager();
+      const tab1 = await manager.createTab();
+      const tab2 = await manager.createTab();
+      tab1!.conversationId = 'conv-empty';
+      tab1!.lifecycleState = 'bound_cold';
+      tab1!.hydrationState = 'idle';
+      tab1!.state.messages = [];
+
+      await manager.switchToTab(tab1!.id);
+      await manager.switchToTab(tab2!.id);
+      tab1!.dom.messagesEl.empty();
+      const readyMarker = tab1!.dom.messagesEl.createDiv({ cls: 'empty-conversation-ready' });
+      (tab1!.controllers.conversationController!.switchTo as jest.Mock).mockClear();
+
+      await manager.switchToTab(tab1!.id);
+
+      expect(tab1!.controllers.conversationController!.switchTo).not.toHaveBeenCalled();
+      expect(tab1!.dom.messagesEl.querySelector('.claudian-tab-hydration')).toBeNull();
+      expect(tab1!.dom.messagesEl.contains(readyMarker)).toBe(true);
+    });
+
     it('keeps hydration failures local and retries from the tab error state', async () => {
       const manager = createManager();
       const tab1 = await manager.createTab();
       await manager.createTab();
       tab1!.conversationId = 'conv-1';
+      tab1!.hydrationState = 'idle';
       tab1!.state.messages = [];
       (tab1!.controllers.conversationController!.switchTo as jest.Mock)
         .mockRejectedValueOnce(new Error('Hydration failed'))
@@ -449,6 +474,51 @@ describe('TabManager - Tab Lifecycle', () => {
 
       expect(tab1!.controllers.conversationController!.switchTo).toHaveBeenCalledTimes(2);
       expect(tab1!.hydrationState).toBe('ready');
+    });
+
+    it('keeps provider initialization failures local and retryable for blank tabs', async () => {
+      const manager = createManager();
+      (ProviderWorkspaceRegistry.ensureInitialized as jest.Mock)
+        .mockRejectedValueOnce(new Error('Provider initialization failed'));
+
+      const tab = await manager.createTab();
+
+      expect(tab).not.toBeNull();
+      expect(tab!.hydrationState).toBe('failed');
+      expect(tab!.controllers.conversationController!.initializeWelcome).not.toHaveBeenCalled();
+      const retryButton = tab!.dom.messagesEl.querySelector('.claudian-tab-hydration-retry');
+      expect(retryButton).not.toBeNull();
+
+      (retryButton as HTMLElement).click();
+      await new Promise(resolve => window.setTimeout(resolve, 20));
+
+      expect(tab!.hydrationState).toBe('ready');
+      expect(tab!.controllers.conversationController!.initializeWelcome).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not refresh or hydrate a tab closed during provider initialization', async () => {
+      const manager = createManager();
+      const tab1 = await manager.createTab();
+      await manager.createTab();
+      tab1!.conversationId = 'conv-1';
+      tab1!.hydrationState = 'idle';
+      tab1!.state.messages = [];
+      let finishInitialization!: () => void;
+      const initialization = new Promise<void>((resolve) => {
+        finishInitialization = resolve;
+      });
+      (ProviderWorkspaceRegistry.ensureInitialized as jest.Mock)
+        .mockReturnValueOnce(initialization);
+      jest.clearAllMocks();
+
+      const switchPromise = manager.switchToTab(tab1!.id);
+      await flushMicrotasks();
+      await manager.closeTab(tab1!.id);
+      finishInitialization();
+      await switchPromise;
+
+      expect(mockRefreshTabWorkspaceServices).not.toHaveBeenCalledWith(tab1, expect.anything());
+      expect(tab1!.controllers.conversationController!.switchTo).not.toHaveBeenCalled();
     });
   });
 
@@ -943,6 +1013,7 @@ describe('TabManager - Persistence', () => {
         tabFactory: (index) => createMockTabData({
           id: `restored-${index}`,
           conversationId: `conversation-${index}`,
+          hydrationState: 'idle',
           lifecycleState: 'bound_cold',
           controllers: {
             conversationController: {
@@ -2291,6 +2362,7 @@ describe('TabManager - Concurrent Switch Guard', () => {
       resolveSwitchTo = resolve;
     });
     tab1!.conversationId = 'conv-1';
+    tab1!.hydrationState = 'idle';
     tab1!.state.messages = [];
     tab1!.controllers.conversationController!.switchTo = jest.fn().mockReturnValue(hangingPromise);
 

--- a/tests/unit/features/chat/tabs/TabManager.test.ts
+++ b/tests/unit/features/chat/tabs/TabManager.test.ts
@@ -17,6 +17,7 @@ const mockDeactivateTab = jest.fn();
 const mockInitializeTabUI = jest.fn();
 const mockInitializeTabControllers = jest.fn();
 const mockInitializeTabService = jest.fn().mockResolvedValue(undefined);
+const mockRefreshTabWorkspaceServices = jest.fn();
 const mockSetupServiceCallbacks = jest.fn();
 const mockRecycleTabRuntime = jest.fn(async (tab: any) => {
   tab.runtimeSupervisor.cleanup();
@@ -40,6 +41,7 @@ jest.mock('@/features/chat/tabs/Tab', () => ({
   initializeTabUI: (...args: any[]) => mockInitializeTabUI(...args),
   initializeTabControllers: (...args: any[]) => mockInitializeTabControllers(...args),
   initializeTabService: (...args: any[]) => mockInitializeTabService(...args),
+  refreshTabWorkspaceServices: (...args: any[]) => mockRefreshTabWorkspaceServices(...args),
   setupServiceCallbacks: (...args: any[]) => mockSetupServiceCallbacks(...args),
   recycleTabRuntime: (tab: any) => mockRecycleTabRuntime(tab),
   wireTabInputEvents: (...args: any[]) => mockWireTabInputEvents(...args),
@@ -88,6 +90,13 @@ jest.mock('@/core/providers/ProviderRegistry', () => ({
 
 jest.mock('@/core/providers/ProviderWorkspaceRegistry', () => ({
   ProviderWorkspaceRegistry: {
+    ensureInitialized: jest.fn().mockResolvedValue(undefined),
+    getIfInitialized: (providerId: string) => (
+      mockCommandCatalogs[providerId]
+      || mockRuntimeCommandLoaders[providerId]
+      || mockTabWarmupPolicies[providerId]
+      || null
+    ),
     getCommandCatalog: (providerId: string) => mockCommandCatalogs[providerId] ?? null,
     getRuntimeCommandLoader: (providerId: string) => mockRuntimeCommandLoaders[providerId] ?? null,
     getTabWarmupPolicy: (providerId: string) => mockTabWarmupPolicies[providerId] ?? null,
@@ -130,6 +139,7 @@ function createMockPlugin(overrides: Record<string, any> = {}): any {
       ...(overrides.settings || {}),
     },
     getConversationById: jest.fn().mockResolvedValue(null),
+    getCachedConversation: jest.fn().mockReturnValue(null),
     getConversationSync: jest.fn().mockReturnValue(null),
     getConversationList: jest.fn().mockReturnValue([]),
     findConversationAcrossViews: jest.fn().mockReturnValue(null),
@@ -179,6 +189,8 @@ function createMockTabData(overrides: Record<string, any> = {}): any {
 
   return {
     id: `tab-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
+    lifecycleState: 'blank',
+    hydrationState: 'ready',
     providerId: 'claude',
     conversationId: null,
     service: null,
@@ -193,6 +205,7 @@ function createMockTabData(overrides: Record<string, any> = {}): any {
     },
     dom: {
       contentEl: createMockEl(),
+      messagesEl: createMockEl(),
     },
     ui: {
       externalContextSelector: null,
@@ -394,6 +407,48 @@ describe('TabManager - Tab Lifecycle', () => {
       await switchPromise;
 
       expect(callbacks.onTabSwitched).toHaveBeenCalledWith(tab2!.id, tab1!.id);
+    });
+
+    it('paints a loading shell before hydrating a cold conversation', async () => {
+      const manager = createManager();
+      const tab1 = await manager.createTab();
+      await manager.createTab();
+      tab1!.conversationId = 'conv-1';
+      tab1!.state.messages = [];
+
+      const switchPromise = manager.switchToTab(tab1!.id);
+
+      expect(tab1!.hydrationState).toBe('loading');
+      expect(tab1!.dom.messagesEl.querySelector('.claudian-tab-hydration')).not.toBeNull();
+      expect(tab1!.controllers.conversationController!.switchTo).not.toHaveBeenCalled();
+
+      await switchPromise;
+
+      expect(tab1!.hydrationState).toBe('ready');
+      expect(tab1!.controllers.conversationController!.switchTo).toHaveBeenCalledWith('conv-1');
+    });
+
+    it('keeps hydration failures local and retries from the tab error state', async () => {
+      const manager = createManager();
+      const tab1 = await manager.createTab();
+      await manager.createTab();
+      tab1!.conversationId = 'conv-1';
+      tab1!.state.messages = [];
+      (tab1!.controllers.conversationController!.switchTo as jest.Mock)
+        .mockRejectedValueOnce(new Error('Hydration failed'))
+        .mockResolvedValueOnce(undefined);
+
+      await manager.switchToTab(tab1!.id);
+
+      expect(tab1!.hydrationState).toBe('failed');
+      const retryButton = tab1!.dom.messagesEl.querySelector('.claudian-tab-hydration-retry');
+      expect(retryButton).not.toBeNull();
+
+      (retryButton as HTMLElement).click();
+      await new Promise(resolve => window.setTimeout(resolve, 20));
+
+      expect(tab1!.controllers.conversationController!.switchTo).toHaveBeenCalledTimes(2);
+      expect(tab1!.hydrationState).toBe('ready');
     });
   });
 
@@ -756,6 +811,7 @@ describe('TabManager - Conversation Management', () => {
 
     it('should create new tab when preferNewTab is true', async () => {
       plugin.getConversationById.mockResolvedValue({ id: 'conv-new' });
+      plugin.getCachedConversation.mockReturnValue({ id: 'conv-new' });
 
       await manager.openConversation('conv-new', true);
 
@@ -768,6 +824,7 @@ describe('TabManager - Conversation Management', () => {
 
     it('should create a background tab without switching focus', async () => {
       plugin.getConversationById.mockResolvedValue({ id: 'conv-background' });
+      plugin.getCachedConversation.mockReturnValue({ id: 'conv-background' });
       const initialActiveTabId = manager.getActiveTabId();
 
       await manager.openConversation('conv-background', {
@@ -870,6 +927,46 @@ describe('TabManager - Persistence', () => {
       await manager.restoreState(persistedState);
 
       expect(mockCreateTab).toHaveBeenCalledTimes(2);
+    });
+
+    it('hydrates only the active conversation when restoring three tab shells', async () => {
+      const switchToByTab = [jest.fn(), jest.fn(), jest.fn()];
+      const plugin = createMockPlugin({
+        getCachedConversation: jest.fn((id: string) => ({
+          id,
+          providerId: 'claude',
+          messages: [],
+        })),
+      });
+      const restoreManager = createManager({
+        plugin,
+        tabFactory: (index) => createMockTabData({
+          id: `restored-${index}`,
+          conversationId: `conversation-${index}`,
+          lifecycleState: 'bound_cold',
+          controllers: {
+            conversationController: {
+              save: jest.fn().mockResolvedValue(undefined),
+              switchTo: switchToByTab[index - 1].mockResolvedValue(undefined),
+            },
+          },
+        }),
+      });
+
+      await restoreManager.restoreState({
+        openTabs: [
+          { tabId: 'restored-1', conversationId: 'conversation-1' },
+          { tabId: 'restored-2', conversationId: 'conversation-2' },
+          { tabId: 'restored-3', conversationId: 'conversation-3' },
+        ],
+        activeTabId: 'restored-2',
+      });
+
+      expect(switchToByTab[0]).not.toHaveBeenCalled();
+      expect(switchToByTab[1]).toHaveBeenCalledTimes(1);
+      expect(switchToByTab[1]).toHaveBeenCalledWith('conversation-2');
+      expect(switchToByTab[2]).not.toHaveBeenCalled();
+      expect(plugin.getConversationById).not.toHaveBeenCalled();
     });
 
     it('should restore draftModel for blank tabs', async () => {
@@ -1354,18 +1451,6 @@ describe('TabManager - SDK Commands', () => {
           id: 'conv-opencode',
           messages: [{ id: 'm1' }],
           providerState: { databasePath: '/persisted/opencode.db' },
-          sessionId: 'session-1',
-        })
-        .mockResolvedValueOnce({
-          id: 'conv-opencode',
-          messages: [{ id: 'm1' }],
-          providerState: { databasePath: '/persisted/opencode.db' },
-          sessionId: 'session-1',
-        })
-        .mockResolvedValueOnce({
-          id: 'conv-opencode',
-          messages: [{ id: 'm1' }],
-          providerState: { databasePath: '/persisted/opencode.db' },
           sessionId: 'session-2',
         }),
     });
@@ -1405,7 +1490,7 @@ describe('TabManager - SDK Commands', () => {
     expect(resetSdkSkillsCache).not.toHaveBeenCalled();
   });
 
-  it('should prime active blank OpenCode tabs automatically', async () => {
+  it('should load commands on demand for an active blank OpenCode tab', async () => {
     const supportedCommands = [{ id: 'acp:review', name: 'review', content: '' }];
     const mockCatalog = {
       setRuntimeCommands: jest.fn(),
@@ -1448,13 +1533,17 @@ describe('TabManager - SDK Commands', () => {
     const tab = await manager.createTab();
     await flushMicrotasks();
 
+    expect(runtimeCommandLoader.loadCommands).not.toHaveBeenCalled();
+
+    await expect(manager.getSdkCommands(tab!.id)).resolves.toEqual(supportedCommands);
+
     expect(runtimeCommandLoader.loadCommands).toHaveBeenCalledTimes(1);
     expect(mockCatalog.setRuntimeCommands).toHaveBeenLastCalledWith(supportedCommands);
     expect(tab!.lifecycleState).toBe('blank');
     expect(tab!.serviceInitialized).toBe(false);
   });
 
-  it('should prime the active restored OpenCode conversation tab automatically', async () => {
+  it('should load commands on demand for an active restored OpenCode conversation tab', async () => {
     const supportedCommands = [{ id: 'acp:review', name: 'review', content: '' }];
     const mockCatalog = {
       setRuntimeCommands: jest.fn(),
@@ -1502,14 +1591,18 @@ describe('TabManager - SDK Commands', () => {
       }),
     });
 
-    await manager.createTab('conv-opencode', 'tab-opencode-restored', { activate: false });
+    const tab = await manager.createTab('conv-opencode', 'tab-opencode-restored', { activate: false });
     await flushMicrotasks();
+
+    expect(runtimeCommandLoader.loadCommands).not.toHaveBeenCalled();
+
+    await expect(manager.getSdkCommands(tab!.id)).resolves.toEqual(supportedCommands);
 
     expect(runtimeCommandLoader.loadCommands).toHaveBeenCalledTimes(1);
     expect(mockCatalog.setRuntimeCommands).toHaveBeenLastCalledWith(supportedCommands);
   });
 
-  it('should prime the active restored pre-session OpenCode conversation tab automatically', async () => {
+  it('should load commands on demand for an active pre-session OpenCode conversation tab', async () => {
     const supportedCommands = [{ id: 'acp:review', name: 'review', content: '' }];
     const mockCatalog = {
       setRuntimeCommands: jest.fn(),
@@ -1557,8 +1650,12 @@ describe('TabManager - SDK Commands', () => {
       }),
     });
 
-    await manager.createTab('conv-opencode', 'tab-opencode-pre-session', { activate: false });
+    const tab = await manager.createTab('conv-opencode', 'tab-opencode-pre-session', { activate: false });
     await flushMicrotasks();
+
+    expect(runtimeCommandLoader.loadCommands).not.toHaveBeenCalled();
+
+    await expect(manager.getSdkCommands(tab!.id)).resolves.toEqual(supportedCommands);
 
     expect(runtimeCommandLoader.loadCommands).toHaveBeenCalledTimes(1);
     expect(mockCatalog.setRuntimeCommands).toHaveBeenLastCalledWith(supportedCommands);
@@ -1927,30 +2024,22 @@ describe('TabManager - Provider Command Catalog', () => {
     expect(claudeCatalog.setRuntimeCommands).toHaveBeenCalledWith([]);
   });
 
-  it('starts blank-tab provider warmup in the background from the provider-change callback', async () => {
+  it('initializes provider services without starting command warmup on provider change', async () => {
     const manager = createManager();
-    const tab = await manager.createTab();
+    await manager.createTab();
     const options = mockInitializeTabUI.mock.calls[0][2];
+    const prewarmSpy = jest.spyOn(manager as any, 'prewarmProviderTab');
 
-    let releaseWarmup!: () => void;
-    const prewarmSpy = jest.spyOn(manager as any, 'prewarmProviderTab').mockImplementation(
-      () => new Promise<void>((resolve) => {
-        releaseWarmup = resolve;
-      }),
+    options.onProviderChanged('opencode');
+
+    await flushMicrotasks();
+
+    expect(ProviderWorkspaceRegistry.ensureInitialized).toHaveBeenCalledWith(
+      undefined,
+      'opencode',
+      'provider-selection',
     );
-
-    let settled = false;
-    const callbackPromise = Promise.resolve(options.onProviderChanged('opencode')).then(() => {
-      settled = true;
-    });
-
-    await Promise.resolve();
-
-    expect(prewarmSpy).toHaveBeenCalledWith(tab);
-    await callbackPromise;
-    expect(settled).toBe(true);
-
-    releaseWarmup();
+    expect(prewarmSpy).not.toHaveBeenCalled();
   });
 
   it('should return null catalog config when provider has no catalog', async () => {

--- a/tests/unit/features/chat/ui/InputToolbar.test.ts
+++ b/tests/unit/features/chat/ui/InputToolbar.test.ts
@@ -868,6 +868,18 @@ describe('McpServerSelector', () => {
     expect(selector.getEnabledServers().size).toBe(2);
   });
 
+  it('preserves persisted selections until a lazy manager finishes loading', () => {
+    const manager = {
+      getServers: jest.fn().mockReturnValue([]),
+      isLoaded: jest.fn().mockReturnValue(false),
+    } as any;
+
+    selector.setMcpManager(manager);
+    selector.setEnabledServers(['server1']);
+
+    expect(selector.getEnabledServers()).toEqual(new Set(['server1']));
+  });
+
   it('should prune enabled servers that no longer exist in manager', () => {
     selector.setMcpManager(createMockMcpManager([
       { name: 'server1', enabled: true },

--- a/tests/unit/features/chat/ui/InputToolbar.test.ts
+++ b/tests/unit/features/chat/ui/InputToolbar.test.ts
@@ -820,6 +820,29 @@ describe('McpServerSelector', () => {
     expect(container?.hasClass('claudian-hidden')).toBe(false);
   });
 
+  it('keeps a lazy selector reachable and loads servers on first hover', async () => {
+    let loaded = false;
+    const manager = {
+      ensureLoaded: jest.fn(async () => {
+        loaded = true;
+      }),
+      getServers: jest.fn(() => loaded
+        ? [{ name: 'lazy-server', enabled: true, contextSaving: false }]
+        : []),
+      isLoaded: jest.fn(() => loaded),
+    } as any;
+
+    selector.setMcpManager(manager);
+    const container = parentEl.querySelector('.claudian-mcp-selector');
+
+    expect(container?.hasClass('claudian-hidden')).toBe(false);
+    await container?.dispatchEvent('mouseenter');
+    await Promise.resolve();
+
+    expect(manager.ensureLoaded).toHaveBeenCalledTimes(1);
+    expect(parentEl.querySelector('.claudian-mcp-selector-item')).not.toBeNull();
+  });
+
   it('should show empty message when all servers are disabled', () => {
     selector.setMcpManager(createMockMcpManager([{ name: 'test', enabled: false }]));
     const empty = parentEl.querySelector('.claudian-mcp-selector-empty');

--- a/tests/unit/features/inline-edit/ui/InlineEditModal.openAndWait.test.ts
+++ b/tests/unit/features/inline-edit/ui/InlineEditModal.openAndWait.test.ts
@@ -4,6 +4,7 @@ import { createMockEl } from '@test/helpers/mockElement';
 import { MarkdownRenderer, Notice } from 'obsidian';
 
 import { ProviderRegistry } from '@/core/providers/ProviderRegistry';
+import { ProviderWorkspaceRegistry } from '@/core/providers/ProviderWorkspaceRegistry';
 import { type InlineEditContext, InlineEditModal } from '@/features/inline-edit/ui/InlineEditModal';
 import { VaultFolderCache } from '@/shared/mention/VaultMentionCache';
 import * as editorUtils from '@/utils/editor';
@@ -44,6 +45,11 @@ function createDeferred(): { promise: Promise<void>; resolve: () => void } {
 describe('InlineEditModal - openAndWait', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(ProviderWorkspaceRegistry, 'ensureInitialized').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('uses editorCallback references first and falls back to view.editor before rejecting', async () => {
@@ -170,6 +176,7 @@ describe('InlineEditModal - openAndWait', () => {
 
       const modal = new InlineEditModal(app, plugin, editor, view, editContext, 'note.md');
       const resultPromise = modal.openAndWait();
+      await Promise.resolve();
 
       expect(mentionDropdownCtor).toHaveBeenCalled();
       const callbacks = mentionDropdownCtor.mock.calls[0]?.[2];
@@ -271,8 +278,14 @@ describe('InlineEditModal - openAndWait', () => {
 
       const modal = new InlineEditModal(app, plugin, editor, view, editContext, 'note.md');
       const resultPromise = modal.openAndWait();
+      await Promise.resolve();
 
       const { SlashCommandDropdown } = jest.requireMock('@/shared/components/SlashCommandDropdown');
+      expect(ProviderWorkspaceRegistry.ensureInitialized).toHaveBeenCalledWith(
+        plugin,
+        'codex',
+        'inline-edit',
+      );
       const constructorCall = SlashCommandDropdown.mock.calls[0];
       expect(Array.from(constructorCall[3].hiddenCommands)).toEqual(['analyze']);
 
@@ -383,6 +396,7 @@ describe('InlineEditModal - openAndWait', () => {
 
       const modal = new InlineEditModal(app, plugin, editor, view, editContext, 'note.md');
       const resultPromise = modal.openAndWait();
+      await Promise.resolve();
 
       expect(providerSpy).toHaveBeenCalledWith(plugin, 'opencode');
       expect(inlineEditService.setModelOverride).toHaveBeenCalledWith('opencode:openai/gpt-5.4');
@@ -498,6 +512,7 @@ describe('InlineEditModal - openAndWait', () => {
 
       const modal = new InlineEditModal(app, plugin, editor, view, editContext, 'note.md');
       const resultPromise = modal.openAndWait();
+      await Promise.resolve();
 
       expect(providerSpy).toHaveBeenCalledWith(plugin, 'opencode');
       expect(inlineEditService.setModelOverride).toHaveBeenCalledWith('opencode:anthropic/claude-sonnet-4');
@@ -617,6 +632,7 @@ describe('InlineEditModal - openAndWait', () => {
         () => ['/external']
       );
       const resultPromise = modal.openAndWait();
+      await Promise.resolve();
 
       const callbacks = mentionDropdownCtor.mock.calls[0]?.[2];
       expect(callbacks.getCachedVaultFiles()).toEqual([]);
@@ -736,6 +752,7 @@ describe('InlineEditModal - openAndWait', () => {
 
       const modal = new InlineEditModal(app, plugin, editor, view, editContext, 'note.md');
       const resultPromise = modal.openAndWait();
+      await Promise.resolve();
 
       const editTextMock = jest.fn().mockResolvedValue({
         success: true,
@@ -866,6 +883,7 @@ describe('InlineEditModal - openAndWait', () => {
         () => ['/external']
       );
       const resultPromise = modal.openAndWait();
+      await Promise.resolve();
 
       const editTextMock = jest.fn().mockResolvedValue({
         success: true,
@@ -974,6 +992,7 @@ describe('InlineEditModal - openAndWait', () => {
 
       const modal = new InlineEditModal(app, plugin, editor, view, editContext, 'note.md');
       const resultPromise = modal.openAndWait();
+      await Promise.resolve();
 
       const editTextMock = jest.fn().mockResolvedValue({
         success: true,
@@ -1104,6 +1123,7 @@ describe('InlineEditModal - openAndWait', () => {
         () => ['/external']
       );
       const resultPromise = modal.openAndWait();
+      await Promise.resolve();
 
       const editTextMock = jest.fn().mockResolvedValue({
         success: true,
@@ -1210,6 +1230,7 @@ describe('InlineEditModal - openAndWait', () => {
 
       const modal = new InlineEditModal(app, plugin, editor, view, editContext, 'math/note.md');
       const resultPromise = modal.openAndWait();
+      await Promise.resolve();
 
       (MarkdownRenderer.renderMarkdown as jest.Mock).mockClear();
       widgetRef.showAgentReply('Should this use $Z(f)$?');
@@ -1323,6 +1344,7 @@ describe('InlineEditModal - openAndWait', () => {
 
       const modal = new InlineEditModal(app, plugin, editor, view, editContext, 'math/note.md');
       const resultPromise = modal.openAndWait();
+      await Promise.resolve();
 
       widgetRef.showAgentReply('First clarification');
       widgetRef.showAgentReply('Second clarification');
@@ -1431,6 +1453,7 @@ describe('InlineEditModal - openAndWait', () => {
 
       const modal = new InlineEditModal(app, plugin, editor, view, editContext, 'math/note.md');
       const resultPromise = modal.openAndWait();
+      await Promise.resolve();
 
       const rejectSpy = jest.spyOn(widgetRef, 'reject').mockImplementation(() => {});
       const acceptSpy = jest.spyOn(widgetRef, 'accept').mockImplementation(() => {});
@@ -1552,6 +1575,7 @@ describe('InlineEditModal - openAndWait', () => {
 
       const modal = new InlineEditModal(app, plugin, editor, view, editContext, 'math/note.md');
       const resultPromise = modal.openAndWait();
+      await Promise.resolve();
       widgetRef.inlineEditService = {
         editText: jest.fn().mockResolvedValue({
           success: true,

--- a/tests/unit/providers/claude/agents/AgentManager.test.ts
+++ b/tests/unit/providers/claude/agents/AgentManager.test.ts
@@ -2,7 +2,20 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 // Mock fs and os modules BEFORE importing AgentManager
-jest.mock('fs');
+jest.mock('fs', () => {
+  const actual = jest.requireActual('fs');
+  return {
+    ...actual,
+    existsSync: jest.fn(),
+    readdirSync: jest.fn(),
+    readFileSync: jest.fn(),
+    promises: {
+      ...actual.promises,
+      readdir: jest.fn(),
+      readFile: jest.fn(),
+    },
+  };
+});
 jest.mock('os', () => ({
   homedir: jest.fn().mockReturnValue('/home/user'),
 }));
@@ -11,6 +24,7 @@ import { AgentManager } from '@/providers/claude/agents/AgentManager';
 import type { PluginManager } from '@/providers/claude/plugins/PluginManager';
 
 const mockFs = jest.mocked(fs);
+const mockFsPromises = jest.mocked(fs.promises);
 
 // Create a mock PluginManager
 function createMockPluginManager(plugins: Array<{ name: string; enabled: boolean; installPath: string }> = []): PluginManager {
@@ -83,6 +97,12 @@ describe('AgentManager', () => {
     // os.homedir is already mocked to return HOME_DIR
     mockFs.existsSync.mockReturnValue(false);
     mockFs.readdirSync.mockReturnValue([]);
+    (mockFsPromises.readdir as jest.Mock).mockImplementation(
+      async (...args: Parameters<typeof fs.readdirSync>) => mockFs.readdirSync(...args),
+    );
+    (mockFsPromises.readFile as jest.Mock).mockImplementation(
+      async (...args: Parameters<typeof fs.readFileSync>) => mockFs.readFileSync(...args),
+    );
   });
 
   describe('constructor', () => {

--- a/tests/unit/providers/claude/plugins/PluginManager.test.ts
+++ b/tests/unit/providers/claude/plugins/PluginManager.test.ts
@@ -10,7 +10,20 @@ jest.mock('os', () => ({
 }));
 
 // Mock fs module
-jest.mock('fs');
+jest.mock('fs', () => {
+  const actual = jest.requireActual('fs');
+  return {
+    ...actual,
+    existsSync: jest.fn(),
+    readFileSync: jest.fn(),
+    realpathSync: jest.fn(),
+    promises: {
+      ...actual.promises,
+      readFile: jest.fn(),
+      realpath: jest.fn(),
+    },
+  };
+});
 
 // Mock obsidian
 jest.mock('obsidian', () => ({
@@ -22,6 +35,7 @@ import { Notice } from 'obsidian';
 import { PluginManager } from '@/providers/claude/plugins/PluginManager';
 
 const mockFs = fs as jest.Mocked<typeof fs>;
+const mockFsPromises = jest.mocked(fs.promises);
 
 // Create a mock CCSettingsStorage
 function createMockCCSettingsStorage() {
@@ -41,6 +55,19 @@ const customGlobalSettingsPath = path.join(customConfigDir, 'settings.json');
 describe('PluginManager', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (mockFsPromises.readFile as jest.Mock).mockImplementation(
+      async (...args: Parameters<typeof fs.readFileSync>) => {
+        if (!mockFs.existsSync(args[0] as fs.PathLike)) throw new Error('ENOENT');
+        return mockFs.readFileSync(...args);
+      },
+    );
+    (mockFsPromises.realpath as jest.Mock).mockImplementation(
+      async (filePath: fs.PathLike) => {
+        const resolved = mockFs.realpathSync(filePath);
+        if (!resolved) throw new Error('ENOENT');
+        return resolved;
+      },
+    );
   });
 
   describe('loadPlugins', () => {

--- a/tests/unit/providers/claude/runtime/ClaudianService.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudianService.test.ts
@@ -6,6 +6,7 @@ import { Notice } from 'obsidian';
 import type { McpServerManager } from '@/core/mcp/McpServerManager';
 import type ClaudianPlugin from '@/main';
 import * as historyStore from '@/providers/claude/history/ClaudeHistoryStore';
+import * as sdkLoader from '@/providers/claude/loadClaudeAgentSdk';
 import { ClaudianService } from '@/providers/claude/runtime/ClaudeChatRuntime';
 import { MessageChannel } from '@/providers/claude/runtime/ClaudeMessageChannel';
 import { createResponseHandler } from '@/providers/claude/runtime/types';
@@ -2182,6 +2183,45 @@ describe('ClaudianService', () => {
       await (service as any).startPersistentQuery('/vault', '/cli', 'session');
 
       expect(buildOptsSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not finish starting after cleanup while the SDK is loading', async () => {
+      let resolveQuery!: (query: typeof sdkModule.query) => void;
+      const loadingQuery = new Promise<typeof sdkModule.query>((resolve) => {
+        resolveQuery = resolve;
+      });
+      const loaderSpy = jest.spyOn(sdkLoader, 'loadClaudeAgentQuery').mockReturnValue(loadingQuery);
+
+      const startPromise = (service as any).startPersistentQuery('/vault', '/cli', 'session');
+      service.cleanup();
+      resolveQuery(sdkMock.query);
+      await startPromise;
+      loaderSpy.mockRestore();
+
+      expect((service as any).persistentQuery).toBeNull();
+      expect((service as any).messageChannel).toBeNull();
+    });
+  });
+
+  describe('cold-start query guard', () => {
+    it('does not start a query after cleanup while the SDK is loading', async () => {
+      let resolveQuery!: (query: typeof sdkModule.query) => void;
+      const loadingQuery = new Promise<typeof sdkModule.query>((resolve) => {
+        resolveQuery = resolve;
+      });
+      const loaderSpy = jest.spyOn(sdkLoader, 'loadClaudeAgentQuery').mockReturnValue(loadingQuery);
+      const agentQuery = jest.fn() as unknown as typeof sdkModule.query;
+      (service as any).abortController = new AbortController();
+
+      const generator = (service as any).queryViaSDK('prompt', '/vault', '/cli');
+      const firstChunk = generator.next();
+      await Promise.resolve();
+      service.cleanup();
+      resolveQuery(agentQuery);
+      await firstChunk;
+      loaderSpy.mockRestore();
+
+      expect(agentQuery).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/providers/claude/runtime/ClaudianService.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudianService.test.ts
@@ -70,6 +70,7 @@ describe('ClaudianService', () => {
 
     mockMcpManager = {
       loadServers: jest.fn().mockResolvedValue(undefined),
+      ensureLoaded: jest.fn().mockResolvedValue(undefined),
       getAllDisallowedMcpTools: jest.fn().mockReturnValue([]),
       getActiveServers: jest.fn().mockReturnValue({}),
       getDisallowedMcpTools: jest.fn().mockReturnValue([]),
@@ -81,6 +82,12 @@ describe('ClaudianService', () => {
   });
 
   describe('prepareTurn', () => {
+    it('loads MCP configuration before the first turn is encoded', async () => {
+      await service.prepareForTurn();
+
+      expect(mockMcpManager.ensureLoaded).toHaveBeenCalledTimes(1);
+    });
+
     it('should return PreparedChatTurn with encoded prompt', () => {
       const result = service.prepareTurn({ text: 'hello world' });
       expect(result.request.text).toBe('hello world');

--- a/tests/unit/providers/claude/runtime/claudeColdStartQuery.test.ts
+++ b/tests/unit/providers/claude/runtime/claudeColdStartQuery.test.ts
@@ -1,5 +1,6 @@
 import * as sdkModule from '@anthropic-ai/claude-agent-sdk';
 
+import * as sdkLoader from '@/providers/claude/loadClaudeAgentSdk';
 import { type ColdStartQueryConfig, runColdStartQuery } from '@/providers/claude/runtime/claudeColdStartQuery';
 
 const sdkMock = sdkModule as unknown as {
@@ -284,6 +285,28 @@ describe('runColdStartQuery', () => {
   });
 
   describe('abort handling', () => {
+    it('does not start a query when aborted while the SDK is loading', async () => {
+      let resolveQuery!: (query: typeof sdkModule.query) => void;
+      const loadingQuery = new Promise<typeof sdkModule.query>((resolve) => {
+        resolveQuery = resolve;
+      });
+      const loaderSpy = jest.spyOn(sdkLoader, 'loadClaudeAgentQuery').mockReturnValue(loadingQuery);
+      const agentQuery = jest.fn() as unknown as typeof sdkModule.query;
+      const abortController = new AbortController();
+
+      const result = runColdStartQuery(createConfig({ abortController }), 'hi');
+      await Promise.resolve();
+      abortController.abort();
+      resolveQuery(agentQuery);
+
+      try {
+        await expect(result).rejects.toThrow('Cancelled');
+        expect(agentQuery).not.toHaveBeenCalled();
+      } finally {
+        loaderSpy.mockRestore();
+      }
+    });
+
     it('throws Cancelled when aborted mid-stream', async () => {
       const abortController = new AbortController();
 

--- a/tests/unit/providers/claude/storage/ClaudianSettingsStorage.test.ts
+++ b/tests/unit/providers/claude/storage/ClaudianSettingsStorage.test.ts
@@ -402,7 +402,7 @@ describe('ClaudianSettingsStorage', () => {
       expect(getCodexProviderSettings(result).wslDistroOverride).toBe('');
     });
 
-    it('drops a persisted Codex runtime catalog while preserving hand-picked model IDs', async () => {
+    it('loads a persisted Codex model catalog with hand-picked model IDs', async () => {
       mockAdapter.exists.mockResolvedValue(true);
       mockAdapter.read.mockResolvedValue(JSON.stringify({
         providerConfigs: {
@@ -416,12 +416,9 @@ describe('ClaudianSettingsStorage', () => {
 
       const result = await storage.load();
       const codexSettings = getCodexProviderSettings(result);
-      const writtenContent = JSON.parse(mockAdapter.write.mock.calls[0][1]);
 
-      expect(codexSettings.discoveredModels).toEqual([]);
+      expect(codexSettings.discoveredModels).toEqual(TEST_CODEX_CATALOG);
       expect(codexSettings.visibleModels).toEqual(['gpt-5.4-mini']);
-      expect(writtenContent.providerConfigs.codex).not.toHaveProperty('discoveredModels');
-      expect(writtenContent.providerConfigs.codex.visibleModels).toEqual(['gpt-5.4-mini']);
     });
 
     it('normalizes invalid Codex installation fields from provider config', async () => {
@@ -677,7 +674,7 @@ describe('ClaudianSettingsStorage', () => {
       expect(writtenContent).not.toHaveProperty('slashCommands');
     });
 
-    it('persists hand-picked Codex model IDs without the runtime catalog', async () => {
+    it('persists the Codex catalog with hand-picked model IDs', async () => {
       const settings = {
         ...DEFAULT_SETTINGS,
         providerConfigs: {
@@ -693,12 +690,12 @@ describe('ClaudianSettingsStorage', () => {
       await storage.save(settings);
 
       const writtenContent = JSON.parse(mockAdapter.write.mock.calls[0][1]);
-      expect(writtenContent.providerConfigs.codex).not.toHaveProperty('discoveredModels');
+      expect(writtenContent.providerConfigs.codex.discoveredModels).toEqual(TEST_CODEX_CATALOG);
       expect(writtenContent.providerConfigs.codex.visibleModels).toEqual(['gpt-5.4-mini']);
       expect(getCodexProviderSettings(settings).discoveredModels).toEqual(TEST_CODEX_CATALOG);
     });
 
-    it('preserves Codex model aliases across restart without the runtime catalog', async () => {
+    it('preserves Codex model aliases and catalog across restart', async () => {
       const settings = {
         ...DEFAULT_SETTINGS,
         providerConfigs: {
@@ -717,7 +714,7 @@ describe('ClaudianSettingsStorage', () => {
       await storage.save(settings);
       const persistedContent = mockAdapter.write.mock.calls[0][1];
       const persistedSettings = JSON.parse(persistedContent);
-      expect(persistedSettings.providerConfigs.codex).not.toHaveProperty('discoveredModels');
+      expect(persistedSettings.providerConfigs.codex.discoveredModels).toEqual(TEST_CODEX_CATALOG);
       expect(persistedSettings.providerConfigs.codex.modelAliases).toEqual({
         'gpt-5.5': 'Primary',
       });
@@ -729,6 +726,7 @@ describe('ClaudianSettingsStorage', () => {
       expect(getCodexProviderSettings(reloaded).modelAliases).toEqual({
         'gpt-5.5': 'Primary',
       });
+      expect(getCodexProviderSettings(reloaded).discoveredModels).toEqual(TEST_CODEX_CATALOG);
       updateCodexProviderSettings(reloaded, { discoveredModels: TEST_CODEX_CATALOG as any });
       expect(getCodexProviderSettings(reloaded).modelAliases).toEqual({
         'gpt-5.5': 'Primary',

--- a/tests/unit/providers/claude/storage/SessionStorage.test.ts
+++ b/tests/unit/providers/claude/storage/SessionStorage.test.ts
@@ -140,6 +140,24 @@ describe('SessionStorage', () => {
       );
     });
 
+    it('keeps valid legacy metadata visible when migration fails', async () => {
+      const metadata = {
+        id: 'session-legacy',
+        title: 'Legacy Session',
+        createdAt: 1700000000,
+        updatedAt: 1700001000,
+      };
+
+      mockAdapter.exists.mockImplementation(async (path: string) => (
+        path === `${LEGACY_SESSIONS_PATH}/session-legacy.meta.json`
+      ));
+      mockAdapter.read.mockResolvedValue(JSON.stringify(metadata));
+      mockAdapter.write.mockRejectedValue(new Error('EEXIST: .claudian/sessions'));
+
+      await expect(storage.loadMetadata('session-legacy')).resolves.toEqual(metadata);
+      expect(mockAdapter.delete).not.toHaveBeenCalled();
+    });
+
     it('skips mismatched legacy metadata without migrating or modifying it', async () => {
       mockAdapter.exists.mockImplementation(async (path: string) => (
         path === `${LEGACY_SESSIONS_PATH}/session-requested.meta.json`
@@ -406,6 +424,26 @@ describe('SessionStorage', () => {
 
       expect(metas).toHaveLength(1);
       expect(metas[0].id).toBe('good');
+    });
+
+    it('keeps valid legacy metadata visible when best-effort migration fails', async () => {
+      mockAdapter.listFiles.mockImplementation(async (path: string) => (
+        path === LEGACY_SESSIONS_PATH
+          ? [`${LEGACY_SESSIONS_PATH}/legacy.meta.json`]
+          : []
+      ));
+      mockAdapter.read.mockResolvedValue(JSON.stringify({
+        id: 'legacy',
+        title: 'Legacy session',
+        createdAt: 1,
+        updatedAt: 2,
+      }));
+      mockAdapter.write.mockRejectedValue(new Error('EEXIST: .claudian/sessions'));
+
+      await expect(storage.listMetadata()).resolves.toEqual([
+        expect.objectContaining({ id: 'legacy', title: 'Legacy session' }),
+      ]);
+      expect(mockAdapter.delete).not.toHaveBeenCalled();
     });
 
     it('skips metadata whose JSON id does not match the filename without modifying it', async () => {

--- a/tests/unit/providers/claude/storage/SessionStorage.test.ts
+++ b/tests/unit/providers/claude/storage/SessionStorage.test.ts
@@ -402,6 +402,15 @@ describe('SessionStorage', () => {
       expect(metas).toEqual([]);
     });
 
+    it('reports an incomplete scan when a metadata directory cannot be listed', async () => {
+      mockAdapter.listFiles.mockRejectedValue(new Error('List error'));
+
+      await expect(storage.scanMetadata()).resolves.toEqual({
+        metadata: [],
+        complete: false,
+      });
+    });
+
     it('skips files that fail to load', async () => {
       mockAdapter.listFiles.mockResolvedValue([
         '.claudian/sessions/good.meta.json',
@@ -424,6 +433,33 @@ describe('SessionStorage', () => {
 
       expect(metas).toHaveLength(1);
       expect(metas[0].id).toBe('good');
+    });
+
+    it('reports an incomplete scan when a metadata file cannot be read', async () => {
+      mockAdapter.listFiles.mockImplementation(async (path: string) => (
+        path === SESSIONS_PATH
+          ? [
+            `${SESSIONS_PATH}/good.meta.json`,
+            `${SESSIONS_PATH}/bad.meta.json`,
+          ]
+          : []
+      ));
+      mockAdapter.read.mockImplementation(async (path: string) => {
+        if (path.endsWith('/bad.meta.json')) {
+          throw new Error('Read error');
+        }
+        return JSON.stringify({
+          id: 'good',
+          title: 'Good',
+          createdAt: 1,
+          updatedAt: 2,
+        });
+      });
+
+      await expect(storage.scanMetadata()).resolves.toEqual({
+        metadata: [expect.objectContaining({ id: 'good' })],
+        complete: false,
+      });
     });
 
     it('keeps valid legacy metadata visible when best-effort migration fails', async () => {

--- a/tests/unit/providers/claude/storage/SessionStorage.test.ts
+++ b/tests/unit/providers/claude/storage/SessionStorage.test.ts
@@ -408,6 +408,7 @@ describe('SessionStorage', () => {
       await expect(storage.scanMetadata()).resolves.toEqual({
         metadata: [],
         complete: false,
+        invalidMetadataCount: 0,
       });
     });
 
@@ -459,6 +460,22 @@ describe('SessionStorage', () => {
       await expect(storage.scanMetadata()).resolves.toEqual({
         metadata: [expect.objectContaining({ id: 'good' })],
         complete: false,
+        invalidMetadataCount: 0,
+      });
+    });
+
+    it('reports malformed metadata without making the I/O scan incomplete', async () => {
+      mockAdapter.listFiles.mockImplementation(async (path: string) => (
+        path === SESSIONS_PATH
+          ? [`${SESSIONS_PATH}/malformed.meta.json`]
+          : []
+      ));
+      mockAdapter.read.mockResolvedValue('{"id":');
+
+      await expect(storage.scanMetadata()).resolves.toEqual({
+        metadata: [],
+        complete: true,
+        invalidMetadataCount: 1,
       });
     });
 

--- a/tests/unit/providers/claude/storage/SessionStorage.test.ts
+++ b/tests/unit/providers/claude/storage/SessionStorage.test.ts
@@ -426,6 +426,66 @@ describe('SessionStorage', () => {
       expect(mockAdapter.write).not.toHaveBeenCalled();
       expect(mockAdapter.delete).not.toHaveBeenCalled();
     });
+
+    it('reads metadata with bounded concurrency while preserving file order', async () => {
+      const ids = Array.from({ length: 12 }, (_, index) => `session-${index}`);
+      let activeReads = 0;
+      let maxActiveReads = 0;
+
+      mockAdapter.listFiles.mockImplementation(async (path: string) => (
+        path === SESSIONS_PATH
+          ? ids.map(id => `${SESSIONS_PATH}/${id}.meta.json`)
+          : []
+      ));
+      mockAdapter.read.mockImplementation(async (path: string) => {
+        activeReads += 1;
+        maxActiveReads = Math.max(maxActiveReads, activeReads);
+        await new Promise(resolve => setTimeout(resolve, 1));
+        activeReads -= 1;
+        const id = path.split('/').pop()!.replace('.meta.json', '');
+        return JSON.stringify({ id, title: id, createdAt: 1, updatedAt: 1 });
+      });
+
+      const metas = await storage.listMetadata();
+
+      expect(maxActiveReads).toBeGreaterThan(1);
+      expect(maxActiveReads).toBeLessThanOrEqual(8);
+      expect(metas.map(meta => meta.id)).toEqual(ids);
+    });
+
+    it('publishes completed metadata batches before the full scan settles', async () => {
+      const ids = Array.from({ length: 12 }, (_, index) => `session-${index}`);
+      const blockedIds = new Set(ids.slice(4));
+      let releaseBlockedReads!: () => void;
+      const blockedReads = new Promise<void>(resolve => {
+        releaseBlockedReads = resolve;
+      });
+      const onBatch = jest.fn();
+      mockAdapter.listFiles.mockImplementation(async (path: string) => (
+        path === SESSIONS_PATH
+          ? ids.map(id => `${SESSIONS_PATH}/${id}.meta.json`)
+          : []
+      ));
+      mockAdapter.read.mockImplementation(async (path: string) => {
+        const id = path.split('/').pop()!.replace('.meta.json', '');
+        if (blockedIds.has(id)) {
+          await blockedReads;
+        }
+        return JSON.stringify({ id, title: id, createdAt: 1, updatedAt: 1 });
+      });
+
+      const scan = storage.listMetadata({ onBatch, batchSize: 4 });
+      for (let attempt = 0; attempt < 10 && onBatch.mock.calls.length === 0; attempt += 1) {
+        await Promise.resolve();
+      }
+
+      expect(onBatch).toHaveBeenCalledWith(expect.arrayContaining([
+        expect.objectContaining({ id: 'session-0' }),
+      ]));
+
+      releaseBlockedReads();
+      await expect(scan).resolves.toHaveLength(ids.length);
+    });
   });
 
   describe('listAllConversations', () => {

--- a/tests/unit/providers/claude/types/types.test.ts
+++ b/tests/unit/providers/claude/types/types.test.ts
@@ -119,6 +119,7 @@ describe('types.ts', () => {
         savedProviderServiceTier: {},
         savedProviderThinkingBudget: {},
         savedProviderPermissionMode: {},
+        pendingProviderSessionInvalidations: {},
       };
 
       expect(settings.permissionMode).toBe('yolo');
@@ -171,6 +172,7 @@ describe('types.ts', () => {
         savedProviderServiceTier: {},
         savedProviderThinkingBudget: {},
         savedProviderPermissionMode: {},
+        pendingProviderSessionInvalidations: {},
       };
 
       expect(settings.model).toBe('anthropic/custom-model-v1');
@@ -224,6 +226,7 @@ describe('types.ts', () => {
         savedProviderServiceTier: {},
         savedProviderThinkingBudget: {},
         savedProviderPermissionMode: {},
+        pendingProviderSessionInvalidations: {},
       };
 
       expect(settings.lastClaudeModel).toBe('opus');

--- a/tests/unit/providers/codex/app/CodexWorkspaceServices.test.ts
+++ b/tests/unit/providers/codex/app/CodexWorkspaceServices.test.ts
@@ -75,6 +75,9 @@ function createPlugin(
       vault: {
         adapter: { basePath: '/workspace' },
       },
+      workspace: {
+        onLayoutReady: jest.fn(),
+      },
     },
   };
   plugin.mutateSettingsConditionally = jest.fn(async (
@@ -92,17 +95,22 @@ describe('CodexWorkspaceServices', () => {
     jest.clearAllMocks();
   });
 
-  it('loads the app-server catalog in memory without rewriting settings during startup', async () => {
+  it('defers discovery during initialization and persists an explicitly refreshed catalog', async () => {
     const plugin = createPlugin(true);
     const sol = makeDiscoveredModel('gpt-5.6-sol');
     mockDiscoverModels.mockResolvedValue({ kind: 'completed', models: [sol] });
 
-    await createCodexWorkspaceServices(plugin, {} as any, {} as any);
+    const services = await createCodexWorkspaceServices(plugin, {} as any, {} as any);
+
+    expect(mockDiscoverModels).not.toHaveBeenCalled();
+    expect(plugin.saveSettings).not.toHaveBeenCalled();
+
+    await services.refreshModelCatalog!();
 
     expect(mockDiscoverModels).toHaveBeenCalledTimes(1);
     expect(getCodexProviderSettings(plugin.settings).discoveredModels).toEqual([sol]);
     expect(mockNormalizeAllModelVariants).toHaveBeenCalledWith(plugin.settings);
-    expect(plugin.saveSettings).not.toHaveBeenCalled();
+    expect(plugin.saveSettings).toHaveBeenCalledTimes(1);
   });
 
   it('persists a selection normalization caused by startup discovery', async () => {
@@ -113,7 +121,8 @@ describe('CodexWorkspaceServices', () => {
     });
     mockNormalizeAllModelVariants.mockReturnValueOnce(true);
 
-    await createCodexWorkspaceServices(plugin, {} as any, {} as any);
+    const services = await createCodexWorkspaceServices(plugin, {} as any, {} as any);
+    await services.refreshModelCatalog!();
 
     expect(plugin.saveSettings).toHaveBeenCalledTimes(1);
   });

--- a/tests/unit/providers/codex/app/CodexWorkspaceServices.test.ts
+++ b/tests/unit/providers/codex/app/CodexWorkspaceServices.test.ts
@@ -136,6 +136,23 @@ describe('CodexWorkspaceServices', () => {
     expect(plugin.saveSettings).not.toHaveBeenCalled();
   });
 
+  it('does not run deferred layout discovery after workspace disposal', async () => {
+    const plugin = createPlugin(true);
+    mockDiscoverModels.mockResolvedValue({
+      kind: 'completed',
+      models: [makeDiscoveredModel('gpt-5.6-sol')],
+    });
+    const services = await createCodexWorkspaceServices(plugin, {} as any, {} as any);
+    const layoutReadyCallback = plugin.app.workspace.onLayoutReady.mock.calls[0][0];
+
+    await services.dispose?.();
+    layoutReadyCallback();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(mockDiscoverModels).not.toHaveBeenCalled();
+    expect(plugin.saveSettings).not.toHaveBeenCalled();
+  });
+
   it('treats a disabled catalog refresh as skipped without diagnostics', async () => {
     const cached = makeDiscoveredModel('gpt-5.5');
     const plugin = createPlugin(false, [cached]);

--- a/tests/unit/providers/codex/runtime/CodexModelCatalogCoordinator.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexModelCatalogCoordinator.test.ts
@@ -1,0 +1,339 @@
+import type { ProviderHost } from '@/core/providers/ProviderHost';
+import type { CodexDiscoveredModel } from '@/providers/codex/models';
+import { CodexModelCatalogCoordinator } from '@/providers/codex/runtime/CodexModelCatalogCoordinator';
+import { buildCodexCatalogFingerprint } from '@/providers/codex/runtime/CodexModelCatalogFingerprint';
+import type {
+  CodexModelDiscoveryResult,
+  CodexModelDiscoveryServiceLike,
+} from '@/providers/codex/runtime/CodexModelDiscoveryService';
+import { DEFAULT_CODEX_PROVIDER_SETTINGS } from '@/providers/codex/settings';
+
+jest.mock('@/core/providers/ProviderSettingsCoordinator', () => ({
+  ProviderSettingsCoordinator: {
+    normalizeAllModelVariants: jest.fn(() => false),
+  },
+}));
+
+function makeModel(model: string, displayName = model): CodexDiscoveredModel {
+  return {
+    model,
+    displayName,
+    description: `${model} description`,
+    supportedReasoningEfforts: [{ value: 'medium', description: 'Balanced' }],
+    defaultReasoningEffort: 'medium',
+    serviceTiers: [],
+    defaultServiceTier: null,
+    inputModalities: ['text', 'image'],
+    isDefault: false,
+  };
+}
+
+const PLATFORM_OS = process.platform === 'win32' ? 'windows' : process.platform === 'darwin' ? 'macos' : 'linux';
+const FAKE_FINGERPRINT = buildCodexCatalogFingerprint({
+  resolvedCliCommand: '/usr/bin/codex',
+  executionTargetKey: `host-native:unix:${PLATFORM_OS}:`,
+  envHash: 'OPENAI_API_KEY=secret',
+});
+
+function createFakeHost(overrides: {
+  enabled?: boolean;
+  discoveredModels?: CodexDiscoveredModel[];
+  catalogFingerprint?: string;
+  catalogTimestamp?: number;
+  resolvedCliPath?: string | null;
+  envText?: string;
+} = {}): ProviderHost {
+  const {
+    enabled = true,
+    discoveredModels = [],
+    catalogFingerprint = discoveredModels.length > 0 ? FAKE_FINGERPRINT : '',
+    catalogTimestamp = discoveredModels.length > 0 ? Date.now() : 0,
+    resolvedCliPath = '/usr/bin/codex',
+    envText = 'OPENAI_API_KEY=secret',
+  } = overrides;
+
+  return {
+    app: {
+      vault: {
+        adapter: {
+          basePath: '/vault',
+        },
+      },
+      workspace: {
+        onLayoutReady: jest.fn(),
+      },
+    },
+    settings: {
+      providerConfigs: {
+        codex: {
+          ...DEFAULT_CODEX_PROVIDER_SETTINGS,
+          enabled,
+          discoveredModels,
+          visibleModels: null,
+          catalogFingerprint,
+          catalogTimestamp,
+          environmentVariables: envText,
+        },
+      },
+      environmentVariables: {},
+    },
+    getResolvedProviderCliPath: jest.fn(() => resolvedCliPath),
+    getActiveEnvironmentVariables: jest.fn(() => envText),
+    mutateSettingsConditionally: jest.fn(async (mutation) => {
+      return mutation({
+        ...DEFAULT_CODEX_PROVIDER_SETTINGS,
+        providerConfigs: {
+          codex: {
+            ...DEFAULT_CODEX_PROVIDER_SETTINGS,
+            enabled,
+            discoveredModels,
+            visibleModels: null,
+            catalogFingerprint,
+            catalogTimestamp,
+            environmentVariables: envText,
+          },
+        },
+        environmentVariables: {},
+      } as unknown as Record<string, unknown>);
+    }),
+  } as unknown as ProviderHost;
+}
+
+function createDiscovery(result: CodexModelDiscoveryResult): CodexModelDiscoveryServiceLike {
+  return {
+    discoverModels: jest.fn(async () => result),
+  };
+}
+
+function createHangingDiscovery(): {
+  discovery: CodexModelDiscoveryServiceLike;
+} {
+  const discovery: CodexModelDiscoveryServiceLike = {
+    discoverModels: jest.fn(async (signal?: AbortSignal) => {
+      await new Promise<void>((resolve, reject) => {
+        const check = () => {
+          if (signal?.aborted) {
+            reject(new Error('Cancelled'));
+            return;
+          }
+          setTimeout(check, 5);
+        };
+        check();
+        signal?.addEventListener('abort', () => reject(new Error('Cancelled')), { once: true });
+      });
+      return { kind: 'completed', models: [] } as CodexModelDiscoveryResult;
+    }),
+  };
+  return { discovery };
+}
+
+describe('CodexModelCatalogCoordinator', () => {
+  it('does not expose environment secrets in the catalog fingerprint', () => {
+    expect(FAKE_FINGERPRINT).not.toContain('secret');
+    expect(FAKE_FINGERPRINT).toMatch(/^1:[a-f0-9]{64}$/);
+  });
+
+  it('returns cached models immediately when cache is fresh', async () => {
+    const host = createFakeHost({
+      discoveredModels: [makeModel('gpt-4o')],
+    });
+    const discovery = createDiscovery({ kind: 'completed', models: [] });
+    const coordinator = new CodexModelCatalogCoordinator(host, discovery);
+
+    const result = await coordinator.ensureFresh('test');
+
+    expect(result.refreshed).toBe(false);
+    expect(result.models).toEqual([makeModel('gpt-4o')]);
+    expect(discovery.discoverModels).not.toHaveBeenCalled();
+  });
+
+  it('runs blocking refresh when cache is missing', async () => {
+    const host = createFakeHost();
+    const discovery = createDiscovery({
+      kind: 'completed',
+      models: [makeModel('gpt-4o')],
+    });
+    const coordinator = new CodexModelCatalogCoordinator(host, discovery);
+
+    const result = await coordinator.ensureFresh('test');
+
+    expect(result.refreshed).toBe(true);
+    expect(result.models).toEqual([makeModel('gpt-4o')]);
+    expect(discovery.discoverModels).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for an explicitly forced refresh even when cache is fresh', async () => {
+    const host = createFakeHost({
+      discoveredModels: [makeModel('gpt-4o')],
+    });
+    const discovery = createDiscovery({
+      kind: 'completed',
+      diagnostics: 'interactive failure',
+      models: [],
+    });
+    const coordinator = new CodexModelCatalogCoordinator(host, discovery);
+
+    const result = await coordinator.ensureFresh('model-picker', { force: true });
+
+    expect(result.backgroundRefresh).toBeUndefined();
+    expect(result.diagnostics).toBe('interactive failure');
+    expect(discovery.discoverModels).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns cached models and refreshes in the background when cache is stale', async () => {
+    const host = createFakeHost({
+      discoveredModels: [makeModel('gpt-4o')],
+      catalogTimestamp: 1, // ancient, will be stale
+    });
+    const discovery = createDiscovery({
+      kind: 'completed',
+      models: [makeModel('gpt-4o-mini')],
+    });
+    const coordinator = new CodexModelCatalogCoordinator(host, discovery);
+
+    const result = await coordinator.ensureFresh('test');
+
+    expect(result.refreshed).toBe(false);
+    expect(result.models).toEqual([makeModel('gpt-4o')]);
+    expect(result.backgroundRefresh).toBeDefined();
+    await result.backgroundRefresh;
+    expect(discovery.discoverModels).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves cached models when cache fingerprint resolution fails', async () => {
+    const cachedModel = makeModel('gpt-4o');
+    const host = createFakeHost({ discoveredModels: [cachedModel] });
+    (host.getResolvedProviderCliPath as jest.Mock).mockRejectedValue(new Error('CLI lookup failed'));
+    const discovery = createDiscovery({
+      kind: 'completed',
+      diagnostics: 'app-server unavailable',
+      models: [],
+    });
+    const coordinator = new CodexModelCatalogCoordinator(host, discovery);
+
+    const result = await coordinator.ensureFresh('layout-ready');
+
+    expect(result.models).toEqual([cachedModel]);
+    expect(result.backgroundRefresh).toBeDefined();
+    await expect(result.backgroundRefresh).resolves.toMatchObject({
+      diagnostics: 'app-server unavailable',
+      models: [cachedModel],
+    });
+  });
+
+  it('skips refresh when provider is disabled', async () => {
+    const host = createFakeHost({ enabled: false });
+    const discovery = createDiscovery({ kind: 'completed', models: [] });
+    const coordinator = new CodexModelCatalogCoordinator(host, discovery);
+
+    const result = await coordinator.ensureFresh('test');
+
+    expect(result.kind).toBe('skipped');
+    expect(discovery.discoverModels).not.toHaveBeenCalled();
+  });
+
+  it('preserves cached models when refresh fails', async () => {
+    const host = createFakeHost({
+      discoveredModels: [makeModel('gpt-4o')],
+      catalogFingerprint: 'stale-fingerprint',
+    });
+    const discovery = createDiscovery({
+      kind: 'completed',
+      diagnostics: 'app-server unreachable',
+      models: [],
+    });
+    const coordinator = new CodexModelCatalogCoordinator(host, discovery);
+
+    const result = await coordinator.refresh();
+
+    expect(result.models).toEqual([makeModel('gpt-4o')]);
+    expect(result.diagnostics).toBe('app-server unreachable');
+    expect(coordinator.getState()).toBe('failed');
+  });
+
+  it('deduplicates concurrent refresh requests', async () => {
+    const host = createFakeHost();
+    let calls = 0;
+    const discovery: CodexModelDiscoveryServiceLike = {
+      discoverModels: jest.fn(async () => {
+        calls += 1;
+        return { kind: 'completed', models: [makeModel('gpt-4o')] } as CodexModelDiscoveryResult;
+      }),
+    };
+    const coordinator = new CodexModelCatalogCoordinator(host, discovery);
+
+    const [first, second] = await Promise.all([
+      coordinator.refresh(),
+      coordinator.refresh(),
+    ]);
+
+    expect(calls).toBe(1);
+    expect(first.models).toEqual(second.models);
+  });
+
+  it('invalidates cache when resolved CLI path changes', async () => {
+    const host = createFakeHost({
+      discoveredModels: [makeModel('gpt-4o')],
+      resolvedCliPath: '/other/codex',
+    });
+    const discovery = createDiscovery({
+      kind: 'completed',
+      models: [makeModel('gpt-4o')],
+    });
+    const coordinator = new CodexModelCatalogCoordinator(host, discovery);
+
+    const result = await coordinator.ensureFresh('test');
+
+    expect(result.refreshed).toBe(false);
+    expect(result.backgroundRefresh).toBeDefined();
+    await result.backgroundRefresh;
+    expect(discovery.discoverModels).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels an in-progress refresh', async () => {
+    const host = createFakeHost();
+    const { discovery } = createHangingDiscovery();
+    const coordinator = new CodexModelCatalogCoordinator(host, discovery);
+
+    const refreshPromise = coordinator.refresh();
+    coordinator.cancel();
+
+    const result = await refreshPromise;
+    expect(result.diagnostics).toMatch(/cancelled/i);
+  });
+
+  it('persists catalog after successful refresh', async () => {
+    const host = createFakeHost();
+    const discovery = createDiscovery({
+      kind: 'completed',
+      models: [makeModel('gpt-4o')],
+    });
+    const coordinator = new CodexModelCatalogCoordinator(host, discovery);
+
+    await coordinator.refresh();
+
+    expect(host.mutateSettingsConditionally).toHaveBeenCalled();
+    await expect(
+      (host.mutateSettingsConditionally as jest.Mock).mock.results[0].value,
+    ).resolves.toBe(true);
+  });
+
+  it('startup resolves before discovery resolves', async () => {
+    const host = createFakeHost();
+    let resolved = false;
+    const discovery: CodexModelDiscoveryServiceLike = {
+      discoverModels: jest.fn(async () => {
+        await new Promise((res) => setTimeout(res, 10));
+        resolved = true;
+        return { kind: 'completed', models: [makeModel('gpt-4o')] } as CodexModelDiscoveryResult;
+      }),
+    };
+    const coordinator = new CodexModelCatalogCoordinator(host, discovery);
+
+    const refreshPromise = coordinator.refresh();
+    expect(resolved).toBe(false);
+
+    await refreshPromise;
+    expect(resolved).toBe(true);
+  });
+});

--- a/tests/unit/providers/codex/runtime/CodexModelCatalogCoordinator.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexModelCatalogCoordinator.test.ts
@@ -6,7 +6,10 @@ import type {
   CodexModelDiscoveryResult,
   CodexModelDiscoveryServiceLike,
 } from '@/providers/codex/runtime/CodexModelDiscoveryService';
-import { DEFAULT_CODEX_PROVIDER_SETTINGS } from '@/providers/codex/settings';
+import {
+  DEFAULT_CODEX_PROVIDER_SETTINGS,
+  getCodexProviderSettings,
+} from '@/providers/codex/settings';
 
 jest.mock('@/core/providers/ProviderSettingsCoordinator', () => ({
   ProviderSettingsCoordinator: {
@@ -271,6 +274,74 @@ describe('CodexModelCatalogCoordinator', () => {
     expect(first.models).toEqual(second.models);
   });
 
+  it('persists the fingerprint captured before model discovery starts', async () => {
+    const host = createFakeHost();
+    let signalDiscoveryStarted!: () => void;
+    let resolveDiscovery!: (result: CodexModelDiscoveryResult) => void;
+    const discoveryStarted = new Promise<void>((resolve) => {
+      signalDiscoveryStarted = resolve;
+    });
+    const discoveryResult = new Promise<CodexModelDiscoveryResult>((resolve) => {
+      resolveDiscovery = resolve;
+    });
+    const discovery: CodexModelDiscoveryServiceLike = {
+      discoverModels: jest.fn(async () => {
+        signalDiscoveryStarted();
+        return discoveryResult;
+      }),
+    };
+    (host.mutateSettingsConditionally as jest.Mock).mockImplementation(async (mutation) => {
+      await mutation(host.settings);
+    });
+    const coordinator = new CodexModelCatalogCoordinator(host, discovery);
+
+    const refresh = coordinator.refresh();
+    await discoveryStarted;
+    const codexConfig = (host.settings.providerConfigs as Record<string, Record<string, unknown>>).codex;
+    codexConfig.environmentVariables = 'OPENAI_API_KEY=rotated';
+    resolveDiscovery({ kind: 'completed', models: [makeModel('gpt-4o')] });
+    await refresh;
+
+    expect(getCodexProviderSettings(host.settings).catalogFingerprint).toBe(FAKE_FINGERPRINT);
+    await expect(coordinator.getStatus()).resolves.toBe('stale');
+  });
+
+  it('retries an explicit refresh when its discovery inputs change in flight', async () => {
+    const host = createFakeHost();
+    let signalFirstDiscoveryStarted!: () => void;
+    let resolveFirstDiscovery!: (result: CodexModelDiscoveryResult) => void;
+    const firstDiscoveryStarted = new Promise<void>((resolve) => {
+      signalFirstDiscoveryStarted = resolve;
+    });
+    const firstDiscoveryResult = new Promise<CodexModelDiscoveryResult>((resolve) => {
+      resolveFirstDiscovery = resolve;
+    });
+    const refreshedModel = makeModel('gpt-4o-mini');
+    const discovery: CodexModelDiscoveryServiceLike = {
+      discoverModels: jest.fn()
+        .mockImplementationOnce(async () => {
+          signalFirstDiscoveryStarted();
+          return firstDiscoveryResult;
+        })
+        .mockResolvedValueOnce({ kind: 'completed', models: [refreshedModel] }),
+    };
+    (host.mutateSettingsConditionally as jest.Mock).mockImplementation(async (mutation) => {
+      await mutation(host.settings);
+    });
+    const coordinator = new CodexModelCatalogCoordinator(host, discovery);
+
+    const refresh = coordinator.refreshModelCatalog();
+    await firstDiscoveryStarted;
+    const codexConfig = (host.settings.providerConfigs as Record<string, Record<string, unknown>>).codex;
+    codexConfig.environmentVariables = 'OPENAI_API_KEY=rotated';
+    resolveFirstDiscovery({ kind: 'completed', models: [makeModel('gpt-4o')] });
+
+    await expect(refresh).resolves.toEqual({ changed: true });
+    expect(discovery.discoverModels).toHaveBeenCalledTimes(2);
+    expect(getCodexProviderSettings(host.settings).discoveredModels).toEqual([refreshedModel]);
+    await expect(coordinator.getStatus()).resolves.toBe('fresh');
+  });
+
   it('invalidates cache when resolved CLI path changes', async () => {
     const host = createFakeHost({
       discoveredModels: [makeModel('gpt-4o')],
@@ -300,6 +371,22 @@ describe('CodexModelCatalogCoordinator', () => {
 
     const result = await refreshPromise;
     expect(result.diagnostics).toMatch(/cancelled/i);
+  });
+
+  it('does not refresh after disposal', async () => {
+    const host = createFakeHost();
+    const discovery = createDiscovery({
+      kind: 'completed',
+      models: [makeModel('gpt-4o')],
+    });
+    const coordinator = new CodexModelCatalogCoordinator(host, discovery);
+
+    coordinator.dispose();
+    const result = await coordinator.ensureFresh('layout-ready');
+
+    expect(result.kind).toBe('skipped');
+    expect(discovery.discoverModels).not.toHaveBeenCalled();
+    expect(host.mutateSettingsConditionally).not.toHaveBeenCalled();
   });
 
   it('persists catalog after successful refresh', async () => {

--- a/tests/unit/providers/codex/runtime/CodexModelDiscoveryService.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexModelDiscoveryService.test.ts
@@ -7,6 +7,7 @@ const mockProcessStart = jest.fn();
 const mockProcessShutdown = jest.fn().mockResolvedValue(undefined);
 const mockProcessStderr = jest.fn().mockReturnValue('');
 const mockResolveLaunchSpec = jest.fn();
+const mockInitializeTransport = jest.fn();
 
 jest.mock('@/providers/codex/runtime/CodexRpcTransport', () => ({
   CodexRpcTransport: jest.fn().mockImplementation(() => ({
@@ -26,12 +27,7 @@ jest.mock('@/providers/codex/runtime/CodexAppServerProcess', () => ({
 }));
 
 jest.mock('@/providers/codex/runtime/codexAppServerSupport', () => ({
-  initializeCodexAppServerTransport: jest.fn().mockResolvedValue({
-    userAgent: 'test/0.1',
-    codexHome: '/home/user/.codex',
-    platformFamily: 'unix',
-    platformOs: 'linux',
-  }),
+  initializeCodexAppServerTransport: (...args: unknown[]) => mockInitializeTransport(...args),
   resolveCodexAppServerLaunchSpec: (...args: unknown[]) => mockResolveLaunchSpec(...args),
 }));
 
@@ -67,6 +63,12 @@ function createPlugin(enabled = true) {
 describe('CodexModelDiscoveryService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockInitializeTransport.mockResolvedValue({
+      userAgent: 'test/0.1',
+      codexHome: '/home/user/.codex',
+      platformFamily: 'unix',
+      platformOs: 'linux',
+    });
     mockResolveLaunchSpec.mockReturnValue({
       targetCwd: '/workspace',
       command: 'codex',
@@ -153,13 +155,28 @@ describe('CodexModelDiscoveryService', () => {
   });
 
   it('disposes transport and shuts down process when aborted', async () => {
-    mockTransportRequest.mockImplementationOnce(() => new Promise(() => {}));
+    let finishInitialization!: (value: {
+      codexHome: string;
+      platformFamily: string;
+      platformOs: string;
+      userAgent: string;
+    }) => void;
+    mockInitializeTransport.mockReturnValueOnce(new Promise((resolve) => {
+      finishInitialization = resolve;
+    }));
 
     const service = new CodexModelDiscoveryService(createPlugin());
     const controller = new AbortController();
 
     const discoveryPromise = service.discoverModels(controller.signal);
+    await new Promise<void>((resolve) => setImmediate(resolve));
     controller.abort();
+    finishInitialization({
+      userAgent: 'test/0.1',
+      codexHome: '/home/user/.codex',
+      platformFamily: 'unix',
+      platformOs: 'linux',
+    });
 
     const result = await discoveryPromise;
     if (result.kind !== 'completed') {
@@ -183,5 +200,39 @@ describe('CodexModelDiscoveryService', () => {
     expect(result.diagnostics).toMatch(/cancelled/i);
     expect(mockResolveLaunchSpec).not.toHaveBeenCalled();
     expect(mockProcessStart).not.toHaveBeenCalled();
+  });
+
+  it('does not start Codex when aborted during launch-spec resolution', async () => {
+    let resolveLaunchSpec!: (value: {
+      args: string[];
+      command: string;
+      env: Record<string, string>;
+      spawnCwd: string;
+      targetCwd: string;
+    }) => void;
+    mockResolveLaunchSpec.mockReturnValueOnce(new Promise((resolve) => {
+      resolveLaunchSpec = resolve;
+    }));
+
+    const service = new CodexModelDiscoveryService(createPlugin());
+    const controller = new AbortController();
+    const discoveryPromise = service.discoverModels(controller.signal);
+
+    controller.abort();
+    resolveLaunchSpec({
+      targetCwd: '/workspace',
+      command: 'codex',
+      args: ['app-server', '--listen', 'stdio://'],
+      spawnCwd: '/workspace',
+      env: {},
+    });
+
+    await expect(discoveryPromise).resolves.toEqual({
+      kind: 'completed',
+      diagnostics: 'Codex model discovery was cancelled',
+      models: [],
+    });
+    expect(mockProcessStart).not.toHaveBeenCalled();
+    expect(mockTransportStart).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/providers/codex/runtime/CodexModelDiscoveryService.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexModelDiscoveryService.test.ts
@@ -151,4 +151,37 @@ describe('CodexModelDiscoveryService', () => {
     expect(mockProcessStart).not.toHaveBeenCalled();
     expect(mockProcessShutdown).not.toHaveBeenCalled();
   });
+
+  it('disposes transport and shuts down process when aborted', async () => {
+    mockTransportRequest.mockImplementationOnce(() => new Promise(() => {}));
+
+    const service = new CodexModelDiscoveryService(createPlugin());
+    const controller = new AbortController();
+
+    const discoveryPromise = service.discoverModels(controller.signal);
+    controller.abort();
+
+    const result = await discoveryPromise;
+    if (result.kind !== 'completed') {
+      throw new Error('Expected completed Codex model discovery');
+    }
+    expect(result.diagnostics).toMatch(/cancelled/i);
+    expect(mockTransportDispose).toHaveBeenCalled();
+    expect(mockProcessShutdown).toHaveBeenCalled();
+  });
+
+  it('returns cancellation diagnostics when already aborted before start', async () => {
+    const service = new CodexModelDiscoveryService(createPlugin());
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await service.discoverModels(controller.signal);
+    if (result.kind !== 'completed') {
+      throw new Error('Expected completed Codex model discovery');
+    }
+
+    expect(result.diagnostics).toMatch(/cancelled/i);
+    expect(mockResolveLaunchSpec).not.toHaveBeenCalled();
+    expect(mockProcessStart).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/providers/codex/ui/CodexModelPicker.test.ts
+++ b/tests/unit/providers/codex/ui/CodexModelPicker.test.ts
@@ -321,4 +321,62 @@ describe('CodexModelPicker', () => {
     expect(plugin.saveSettings).not.toHaveBeenCalled();
     expect(context.refreshModelSelectors).toHaveBeenCalledTimes(1);
   });
+
+  it('checks cached catalog freshness on open and rerenders after background refresh', async () => {
+    const plugin = createPlugin();
+    const context = createContext(plugin);
+    const refreshedCatalog = [
+      ...TEST_CODEX_CATALOG,
+      {
+        ...TEST_CODEX_CATALOG[1],
+        model: 'gpt-5.6-new',
+        displayName: 'GPT-5.6 New',
+        description: 'Newly discovered model',
+      },
+    ];
+    let finishBackgroundRefresh!: (value: {
+      kind: 'completed';
+      models: typeof refreshedCatalog;
+      refreshed: true;
+    }) => void;
+    const backgroundRefresh = new Promise<{
+      kind: 'completed';
+      models: typeof refreshedCatalog;
+      refreshed: true;
+    }>((resolve) => {
+      finishBackgroundRefresh = resolve;
+    });
+    const ensureFresh = jest.fn().mockResolvedValue({
+      kind: 'completed',
+      models: TEST_CODEX_CATALOG,
+      refreshed: false,
+      backgroundRefresh,
+    });
+
+    renderCodexModelPicker(createElement() as any, context, {
+      modelCatalogCoordinator: { ensureFresh },
+    } as any);
+
+    const catalog = findElement(element =>
+      element.classes.has('claudian-provider-model-picker-catalog')
+    );
+    catalog.open = true;
+    catalog.trigger('toggle');
+    await flushPromises();
+
+    expect(ensureFresh).toHaveBeenCalledWith('model-picker', { force: false });
+
+    plugin.settings.providerConfigs.codex.discoveredModels = refreshedCatalog;
+    finishBackgroundRefresh({
+      kind: 'completed',
+      models: refreshedCatalog,
+      refreshed: true,
+    });
+    await flushPromises();
+
+    expect(elements.some(element => (
+      element.tag === 'label' && element.title === 'gpt-5.6-new'
+    ))).toBe(true);
+    expect(context.refreshModelSelectors).toHaveBeenCalledTimes(2);
+  });
 });

--- a/tests/unit/providers/codex/ui/CodexModelPicker.test.ts
+++ b/tests/unit/providers/codex/ui/CodexModelPicker.test.ts
@@ -284,17 +284,20 @@ describe('CodexModelPicker', () => {
   it('refreshes the app-server catalog through the provider-owned persistence boundary', async () => {
     const plugin = createPlugin();
     const context = createContext(plugin);
-    const refreshModelCatalog = jest.fn().mockResolvedValue({
-      changed: true,
-      persistedSettingsChanged: true,
+    const ensureFresh = jest.fn().mockResolvedValue({
+      kind: 'completed',
+      models: [],
+      refreshed: true,
     });
-    renderCodexModelPicker(createElement() as any, context, { refreshModelCatalog } as any);
+    renderCodexModelPicker(createElement() as any, context, {
+      modelCatalogCoordinator: { ensureFresh },
+    } as any);
 
     findElement(element => element.classes.has('claudian-provider-model-picker-action'))
       .trigger('click');
     await flushPromises();
 
-    expect(refreshModelCatalog).toHaveBeenCalledTimes(1);
+    expect(ensureFresh).toHaveBeenCalledWith('model-picker', { force: true });
     expect(plugin.saveSettings).not.toHaveBeenCalled();
     expect(context.refreshModelSelectors).toHaveBeenCalledTimes(1);
   });
@@ -302,11 +305,14 @@ describe('CodexModelPicker', () => {
   it('does not save when refresh only changes the runtime catalog', async () => {
     const plugin = createPlugin();
     const context = createContext(plugin);
-    const refreshModelCatalog = jest.fn().mockResolvedValue({
-      changed: true,
-      persistedSettingsChanged: false,
+    const ensureFresh = jest.fn().mockResolvedValue({
+      kind: 'completed',
+      models: [],
+      refreshed: false,
     });
-    renderCodexModelPicker(createElement() as any, context, { refreshModelCatalog } as any);
+    renderCodexModelPicker(createElement() as any, context, {
+      modelCatalogCoordinator: { ensureFresh },
+    } as any);
 
     findElement(element => element.classes.has('claudian-provider-model-picker-action'))
       .trigger('click');

--- a/tests/unit/scripts/rendererSafeUnref.test.ts
+++ b/tests/unit/scripts/rendererSafeUnref.test.ts
@@ -98,4 +98,20 @@ describe('rendererSafeUnref helpers', () => {
       { line: 5, snippet: 'setInterval(run, 1000).unref()' },
     ]);
   });
+
+  it('guards minified direct timer unref calls that do not match SDK source shapes', () => {
+    const input = [
+      'setTimeout((i,o)=>{i.exitCode===null&&i.kill("SIGKILL"),o()},5e3,n,e).unref();',
+      'new Promise(i=>setTimeout(i,2e3).unref())',
+    ].join('');
+
+    const result = patchRendererUnsafeUnrefSites(input);
+
+    expect(result.appliedPatches).toContainEqual({
+      name: 'direct-timer-unref-guard',
+      count: 2,
+    });
+    expect(result.contents).toContain('.unref?.()');
+    expect(findUnsafeTimerUnrefSites(result.contents)).toEqual([]);
+  });
 });

--- a/tests/unit/shared/mention/MentionDropdownController.test.ts
+++ b/tests/unit/shared/mention/MentionDropdownController.test.ts
@@ -330,6 +330,56 @@ describe('MentionDropdownController', () => {
     it('cleans up resources', () => {
       expect(() => controller.destroy()).not.toThrow();
     });
+
+    it('does not rerender after a lazy agent load completes', async () => {
+      let finishLoad!: () => void;
+      const load = new Promise<void>((resolve) => {
+        finishLoad = resolve;
+      });
+      const agentService = {
+        ensureLoaded: jest.fn().mockReturnValue(load),
+        isLoaded: jest.fn().mockReturnValue(false),
+        searchAgents: jest.fn().mockReturnValue([]),
+      } as any;
+      controller.setAgentService(agentService);
+      inputEl.value = '@agent';
+      inputEl.selectionStart = inputEl.value.length;
+      controller.handleInputChange();
+      jest.advanceTimersByTime(200);
+      const callsBeforeDestroy = agentService.searchAgents.mock.calls.length;
+
+      controller.destroy();
+      finishLoad();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(agentService.searchAgents).toHaveBeenCalledTimes(callsBeforeDestroy);
+    });
+  });
+
+  describe('lazy MCP loading', () => {
+    it('refreshes mention results after the MCP configuration loads', async () => {
+      let loaded = false;
+      const manager = {
+        ensureLoaded: jest.fn(async () => {
+          loaded = true;
+        }),
+        getContextSavingServers: jest.fn(() => loaded ? [{ name: 'lazy-server' }] : []),
+        isLoaded: jest.fn(() => loaded),
+      } as any;
+      controller.setMcpManager(manager);
+      inputEl.value = '@lazy';
+      inputEl.selectionStart = inputEl.value.length;
+      controller.handleInputChange();
+      jest.advanceTimersByTime(200);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(manager.ensureLoaded).toHaveBeenCalledTimes(1);
+      expect(getLatestDropdownRenderOptions().items).toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: 'lazy-server', type: 'mcp-server' }),
+      ]));
+    });
   });
 
   describe('handleInputChange', () => {


### PR DESCRIPTION
This PR completes the branch-wide startup performance implementation: in-memory diagnostics, lazy provider workspace initialization, Codex stale-while-revalidate discovery, deferred Claude SDK and locale loading, and asynchronous bounded filesystem work.

Conversation startup now restores metadata shells, hydrates only the active tab, defers history and hidden UI work, and consolidates tab persistence and unload cleanup.

The build stays self-contained for Obsidian distribution while strictly enforcing syntax, release integrity, and a 2.8 MB artifact budget, with the 50 ms cold-evaluation measurement reported as a platform-sensitive regression indicator.

Verification passed with typecheck, lint, build, 272 suites and 6,182 tests, and a 46.2 ms local median cold evaluation.