### PR TITLE
fix: hide MCP selector when no servers are configured

### DIFF
--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -914,6 +914,7 @@ export class McpServerSelector {
     this.pruneEnabledServers();
     this.updateDisplay();
     this.renderDropdown();
+    this.ensureManagerLoaded(manager);
   }
 
   setOnChange(callback: (enabled: Set<string>) => void): void {
@@ -965,6 +966,21 @@ export class McpServerSelector {
     if (changed) {
       this.onChangeCallback?.(this.enabledServers);
     }
+  }
+
+  private ensureManagerLoaded(manager: McpServerManager | null): void {
+    if (!manager || manager.isLoaded?.() !== false) return;
+
+    const load = manager.ensureLoaded?.();
+    if (!load) return;
+
+    void load.then(() => {
+      if (this.mcpManager !== manager) return;
+      this.updateDisplay();
+      this.renderDropdown();
+    }).catch(() => {
+      // Keep the selector hidden when its configuration cannot be loaded.
+    });
   }
 
   private render() {
@@ -1088,8 +1104,7 @@ export class McpServerSelector {
     if (!this.iconEl || !this.badgeEl) return;
 
     const count = this.enabledServers.size;
-    const isPendingLazyLoad = this.mcpManager?.isLoaded?.() === false;
-    const hasServers = isPendingLazyLoad || (this.mcpManager?.getServers().length || 0) > 0;
+    const hasServers = (this.mcpManager?.getServers().length || 0) > 0;
 
     // Show/hide container based on whether there are servers and visibility
     if (!hasServers || !this.visible) {

--- a/tests/unit/features/chat/ui/InputToolbar.test.ts
+++ b/tests/unit/features/chat/ui/InputToolbar.test.ts
@@ -820,7 +820,7 @@ describe('McpServerSelector', () => {
     expect(container?.hasClass('claudian-hidden')).toBe(false);
   });
 
-  it('keeps a lazy selector reachable and loads servers on first hover', async () => {
+  it('keeps a lazy selector hidden until configured servers finish loading', async () => {
     let loaded = false;
     const manager = {
       ensureLoaded: jest.fn(async () => {
@@ -835,12 +835,34 @@ describe('McpServerSelector', () => {
     selector.setMcpManager(manager);
     const container = parentEl.querySelector('.claudian-mcp-selector');
 
-    expect(container?.hasClass('claudian-hidden')).toBe(false);
-    await container?.dispatchEvent('mouseenter');
+    expect(container?.hasClass('claudian-hidden')).toBe(true);
+    await Promise.resolve();
     await Promise.resolve();
 
     expect(manager.ensureLoaded).toHaveBeenCalledTimes(1);
+    expect(container?.hasClass('claudian-hidden')).toBe(false);
     expect(parentEl.querySelector('.claudian-mcp-selector-item')).not.toBeNull();
+  });
+
+  it('stays hidden when lazy loading finds no configured servers', async () => {
+    let loaded = false;
+    const manager = {
+      ensureLoaded: jest.fn(async () => {
+        loaded = true;
+      }),
+      getServers: jest.fn().mockReturnValue([]),
+      isLoaded: jest.fn(() => loaded),
+    } as any;
+
+    selector.setMcpManager(manager);
+    const container = parentEl.querySelector('.claudian-mcp-selector');
+
+    expect(container?.hasClass('claudian-hidden')).toBe(true);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(manager.ensureLoaded).toHaveBeenCalledTimes(1);
+    expect(container?.hasClass('claudian-hidden')).toBe(true);
   });
 
   it('should show empty message when all servers are disabled', () => {


### PR DESCRIPTION
## Summary
- Keep the MCP selector hidden while configuration is loading.
- Load MCP configuration when the manager is attached and reveal the selector only when servers exist.
- Add regression coverage for configured and empty lazy-loaded states.

## Testing
- `npm run typecheck && npm run lint && npm run test && npm run build`