### PR TITLE
feat: add Grok Build provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-Claudian is an Obsidian plugin that embeds provider-backed coding agents in a sidebar and inline-edit flow. Claude is the default provider. Codex, OpenCode, and Pi are optional providers that plug into the same conversation model through `Conversation.providerId` and opaque provider-owned `providerState`.
+Claudian is an Obsidian plugin that embeds provider-backed coding agents in a sidebar and inline-edit flow. Claude is the default provider. Codex, Grok Build, OpenCode, and Pi are optional providers that plug into the same conversation model through `Conversation.providerId` and opaque provider-owned `providerState`.
 
 Do not assume provider parity. Check each provider's `capabilities.ts`, `registration.ts`, and UI config before wiring shared behavior.
 
@@ -15,6 +15,7 @@ Do not assume provider parity. Check each provider's `capabilities.ts`, `registr
   - `src/features/chat/AGENTS.md`
   - `src/providers/claude/AGENTS.md`
   - `src/providers/codex/AGENTS.md`
+  - `src/providers/grok/AGENTS.md`
   - `src/providers/opencode/AGENTS.md`
   - `src/providers/pi/AGENTS.md`
   - `src/style/AGENTS.md`
@@ -81,6 +82,7 @@ The feature layer depends on `core/` contracts, not provider internals. Provider
 | `.pi/agent/sessions/` | Pi vault-local sessions |
 | `~/.claude/projects/{vault}/*.jsonl` | Claude-native transcripts |
 | `~/.codex/sessions/**/*.jsonl` | Codex-native transcripts |
+| `~/.grok/sessions/**/chat_history.jsonl` | Grok Build native transcripts |
 | `~/.pi/agent/sessions/` | Pi user-level sessions |
 
 ## Development Rules

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 ![Preview](assets/Preview.png)
 
-An Obsidian plugin that embeds AI coding agents (Claude Code, Codex, Opencode, Pi, and more to come) in your vault. Your vault becomes the agent's working directory — file read/write, search, bash, and multi-step workflows all work out of the box.
+An Obsidian plugin that embeds AI coding agents (Claude Code, Codex, Grok Build, Opencode, Pi, and more to come) in your vault. Your vault becomes the agent's working directory — file read/write, search, bash, and multi-step workflows all work out of the box.
 
 ## Features & Usage
 
-Open the chat sidebar from the ribbon icon or command palette. Select text and use the hotkey for inline edit. Everything works like your familiar coding agent, Claude Code, Codex, Opencode, and Pi — talk to the agent, and it reads, writes, edits, and searches files in your vault.
+Open the chat sidebar from the ribbon icon or command palette. Select text and use the hotkey for inline edit. Everything works like your familiar coding agent, Claude Code, Codex, Grok Build, Opencode, and Pi — talk to the agent, and it reads, writes, edits, and searches files in your vault.
 
 **Inline Edit** — Select text or start at the cursor position + hotkey to edit directly in notes with word-level diff preview.
 
@@ -29,7 +29,7 @@ Open the chat sidebar from the ribbon icon or command palette. Select text and u
 ## Requirements
 
 - **Claude provider**: [Claude Code CLI](https://code.claude.com/docs/en/overview) installed (native install recommended). Claude subscription/API or compatible provider ([Openrouter](https://openrouter.ai/docs/guides/guides/claude-code-integration), [Kimi](https://platform.kimi.ai/docs/guide/claude-code-kimi), [GLM](https://docs.z.ai/devpack/tool/claude) etc.).
-- **Optional providers**: [Codex CLI](https://github.com/openai/codex), [Opencode](https://opencode.ai/), [Pi](https://github.com/earendil-works/pi).
+- **Optional providers**: [Codex CLI](https://github.com/openai/codex), [Grok Build](https://x.ai/cli) (`grok` CLI; open source / local-first), [Opencode](https://opencode.ai/), [Pi](https://github.com/earendil-works/pi).
 - Obsidian v1.7.2+
 - Desktop only (macOS, Linux, Windows)
 
@@ -84,8 +84,8 @@ npm run build
 
 ## Privacy & Data Use
 
-- **Sent to API**: Your input, attached files, images, and tool call outputs. Default: Anthropic (Claude), OpenAI (Codex), or the provider configured in Opencode/Pi; configurable via provider settings and environment variables.
-- **Local storage**: Claudian settings and session metadata in `vault/.claudian/`; Claude provider files in `vault/.claude/`; transcripts in `~/.claude/projects/` (Claude), `~/.codex/sessions/` (Codex), and `.pi/agent/sessions/` or `~/.pi/agent/sessions/` (Pi).
+- **Sent to API**: Your input, attached files, images, and tool call outputs. Default: Anthropic (Claude), OpenAI (Codex), xAI (Grok Build), or the provider configured in Opencode/Pi; configurable via provider settings and environment variables.
+- **Local storage**: Claudian settings and session metadata in `vault/.claudian/`; Claude provider files in `vault/.claude/`; transcripts in `~/.claude/projects/` (Claude), `~/.codex/sessions/` (Codex), `~/.grok/sessions/` (Grok Build), and `.pi/agent/sessions/` or `~/.pi/agent/sessions/` (Pi).
 - **Environment variables**: Provider subprocesses inherit the Obsidian process environment plus any variables you configure in Claudian. This is needed for CLI authentication, proxies, certificates, and PATH resolution.
 - **Device-specific paths**: Per-device CLI paths use an opaque local key stored in browser local storage, not your system hostname.
 - **Background activity**: Claudian does not run telemetry beacons. UI polling timers read local Obsidian/editor selection state only. Network activity is limited to explicit provider runtime work, configured MCP endpoints, and provider SDK/CLI calls needed to answer your requests.
@@ -124,7 +124,7 @@ If different, GUI apps like Obsidian may not find Node.js.
 
 ### Other providers
 
-Codex, Opencode, and Pi support are live but features might be incomplete, and still need more testing across platforms and installation methods. If you have feature request or run into any bugs, please [submit a GitHub issue](https://github.com/YishenTu/claudian/issues).
+Codex, Grok Build, Opencode, and Pi support are live but features might be incomplete, and still need more testing across platforms and installation methods. Optional providers are disabled by default — enable them in Claudian settings. If you have feature request or run into any bugs, please [submit a GitHub issue](https://github.com/YishenTu/claudian/issues).
 
 ## Architecture
 
@@ -142,6 +142,7 @@ src/
 ├── providers/
 │   ├── claude/                  # Claude SDK adaptor, prompt encoding, storage, MCP, plugins
 │   ├── codex/                   # Codex app-server adaptor, JSON-RPC transport, JSONL history
+│   ├── grok/                    # Grok Build ACP adaptor, headless aux, JSONL history
 │   ├── opencode/                # Opencode adaptor
 │   ├── pi/                      # Pi RPC adaptor, model discovery, JSONL history
 │   └── acp/                     # Agent Client Protocol shared transport
@@ -186,5 +187,6 @@ improve through ongoing development and maintenance.
 - [Obsidian](https://obsidian.md) for the plugin API
 - [Anthropic](https://anthropic.com) for Claude and the [Claude Agent SDK](https://platform.claude.com/docs/en/agent-sdk/overview)
 - [OpenAI](https://openai.com) for [Codex](https://github.com/openai/codex)
+- [xAI](https://x.ai/) for [Grok Build](https://x.ai/cli)
 - [Opencode](https://opencode.ai/) 
 - [Pi](https://github.com/earendil-works/pi)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,10 +45,10 @@ const stagedObsidianRules = {
   'obsidianmd/ui/sentence-case': [
     obsidianRuleSeverity,
     {
-      ignoreWords: ['Claudian', 'Codex', 'OpenCode', 'Pi', 'WSL'],
-      brands: [...DEFAULT_BRANDS, 'Claudian', 'Codex', 'OpenCode', 'Pi'],
-      acronyms: [...DEFAULT_ACRONYMS, 'TOML', 'WSL'],
-      ignoreRegex: ['\\.(?:claude|codex|opencode)/'],
+      ignoreWords: ['Claudian', 'Codex', 'Grok', 'Grok Build', 'OpenCode', 'Pi', 'WSL', 'xAI'],
+      brands: [...DEFAULT_BRANDS, 'Claudian', 'Codex', 'Grok', 'Grok Build', 'OpenCode', 'Pi', 'xAI'],
+      acronyms: [...DEFAULT_ACRONYMS, 'ACP', 'CWD', 'TOML', 'WSL', 'YOLO'],
+      ignoreRegex: ['\\.(?:claude|codex|grok|opencode)(?:/|\\b)'],
       enforceCamelCaseLower: true,
     },
   ],

--- a/src/providers/defaultProviderConfigs.ts
+++ b/src/providers/defaultProviderConfigs.ts
@@ -1,6 +1,7 @@
 import type { ProviderConfigMap } from '../core/types/settings';
 import { DEFAULT_CLAUDE_PROVIDER_SETTINGS } from './claude/settings';
 import { DEFAULT_CODEX_PROVIDER_CONFIG } from './codex/settings';
+import { DEFAULT_GROK_PROVIDER_SETTINGS } from './grok/settings';
 import { DEFAULT_OPENCODE_PROVIDER_SETTINGS } from './opencode/settings';
 import { DEFAULT_PI_PROVIDER_SETTINGS } from './pi/settings';
 
@@ -8,6 +9,7 @@ export function getBuiltInProviderDefaultConfigs(): ProviderConfigMap {
   return {
     claude: { ...DEFAULT_CLAUDE_PROVIDER_SETTINGS },
     codex: { ...DEFAULT_CODEX_PROVIDER_CONFIG },
+    grok: { ...DEFAULT_GROK_PROVIDER_SETTINGS },
     opencode: { ...DEFAULT_OPENCODE_PROVIDER_SETTINGS },
     pi: { ...DEFAULT_PI_PROVIDER_SETTINGS },
   };

--- a/src/providers/grok/AGENTS.md
+++ b/src/providers/grok/AGENTS.md
@@ -1,0 +1,69 @@
+# Grok Provider
+
+`src/providers/grok/` adapts xAI Grok Build through Agent Client Protocol over a
+`grok agent … stdio` subprocess.
+
+## Ownership
+
+- Runtime process management, ACP transport, prompt encoding, stream
+  normalization, headless auxiliary queries, JSONL history hydration, CLI
+  resolution, settings UI, and Grok-specific settings reconciliation live here.
+- Shared code should consume Grok behavior through `ChatRuntime`, provider
+  capabilities, and workspace-service contracts.
+
+## Protocol Rules
+
+- Chat launches `grok agent [-m MODEL] [--reasoning-effort EFFORT] [--always-approve] stdio`.
+- Plan mode is applied via ACP `session/set_mode` with `modeId: "plan"` or
+  `"default"` (normal/yolo). Launch key tracks `yolo` only for process restart;
+  plan↔normal uses `setMode` without restarting. YOLO still uses launch
+  `--always-approve`.
+- Safe sandbox maps to `GROK_SANDBOX` in the process environment when the user
+  did not set it; `grok agent` has no `--sandbox` flag. Changing sandbox restarts
+  the ACP process (launch key includes `safeMode`). It constrains Grok agent
+  tools only — not Claudian ACP client filesystem access.
+- Live output comes from ACP session notifications and is normalized through
+  `AcpSessionUpdateNormalizer`.
+- Headless auxiliary work (title generation, instruction refine, inline edit)
+  uses the main CLI with `--output-format streaming-json` and
+  `--prompt-file`. Do not use `grok agent headless` (WebSocket relay) for those
+  calls.
+- History hydration reads Grok-native
+  `<grokHome>/sessions/<encoded-cwd>/<session-id>/chat_history.jsonl`. Persist
+  resolved `providerState.grokHome` so Claudian-configured `GROK_HOME` matches
+  the runtime. Never mutate native history from Claudian.
+
+## Session State
+
+- Persist `Conversation.sessionId`, `providerState.sessionId`, and
+  `providerState.grokHome` for resume/hydration.
+- `GROK_HOME` overrides the session root (`~/.grok` by default); resolve from
+  providerState first, then settings/process env.
+- Environment keys that affect Grok data or model selection should invalidate
+  sessions via `GrokSettingsReconciler` (`GROK_HOME`, model keys, API keys).
+
+## Capabilities (conservative)
+
+- Supported: persistent ACP runtime, native history, plan mode, effort control,
+  instruction mode.
+- Not claimed: rewind, fork, image attachments, Claudian-managed MCP tools,
+  provider command catalogs, turn steer.
+
+## Settings
+
+- Grok is opt-in and disabled by default (`providerConfigs.grok.enabled`).
+- Safe-mode sandbox profiles are Grok-native: `workspace` and `read-only`
+  (legacy `workspace-write` normalizes to `workspace`).
+- CLI resolution order: host-scoped path → legacy `cliPath` → PATH /
+  `~/.grok/bin` / `~/.local/bin`.
+- Environment keys `/^GROK_/i` and `/^XAI_/i` are provider-owned. Trace upload is
+  disabled by default (`GROK_TELEMETRY_TRACE_UPLOAD=0`) unless explicitly set.
+
+## Gotchas
+
+- `GrokAuxQueryRunner` owns its own headless process and is independent from the
+  chat runtime.
+- Model/effort defaults follow Grok Build 0.2.99 (`grok-4.5`, efforts
+  low/medium/high). Prefer runtime discovery over hardcoding new models later.
+- File read/write ACP delegates resolve relative paths against the session cwd
+  (vault path).

--- a/src/providers/grok/app/GrokWorkspaceServices.ts
+++ b/src/providers/grok/app/GrokWorkspaceServices.ts
@@ -1,0 +1,26 @@
+import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
+import type {
+  ProviderWorkspaceRegistration,
+  ProviderWorkspaceServices,
+} from '../../../core/providers/types';
+import { GrokCliResolver } from '../runtime/GrokCliResolver';
+import { grokSettingsTabRenderer } from '../ui/GrokSettingsTab';
+
+export interface GrokWorkspaceServices extends ProviderWorkspaceServices {
+  cliResolver: GrokCliResolver;
+}
+
+export async function createGrokWorkspaceServices(): Promise<GrokWorkspaceServices> {
+  return {
+    cliResolver: new GrokCliResolver(),
+    settingsTabRenderer: grokSettingsTabRenderer,
+  };
+}
+
+export const grokWorkspaceRegistration: ProviderWorkspaceRegistration<GrokWorkspaceServices> = {
+  initialize: async () => createGrokWorkspaceServices(),
+};
+
+export function maybeGetGrokWorkspaceServices(): GrokWorkspaceServices | null {
+  return ProviderWorkspaceRegistry.getServices('grok') as GrokWorkspaceServices | null;
+}

--- a/src/providers/grok/auxiliary/GrokInlineEditService.ts
+++ b/src/providers/grok/auxiliary/GrokInlineEditService.ts
@@ -1,0 +1,9 @@
+import { QueryBackedInlineEditService } from '../../../core/auxiliary/QueryBackedInlineEditService';
+import type { ProviderHost } from '../../../core/providers/ProviderHost';
+import { GrokAuxQueryRunner } from '../runtime/GrokAuxQueryRunner';
+
+export class GrokInlineEditService extends QueryBackedInlineEditService {
+  constructor(plugin: ProviderHost) {
+    super(new GrokAuxQueryRunner(plugin));
+  }
+}

--- a/src/providers/grok/auxiliary/GrokInstructionRefineService.ts
+++ b/src/providers/grok/auxiliary/GrokInstructionRefineService.ts
@@ -1,0 +1,9 @@
+import { QueryBackedInstructionRefineService } from '../../../core/auxiliary/QueryBackedInstructionRefineService';
+import type { ProviderHost } from '../../../core/providers/ProviderHost';
+import { GrokAuxQueryRunner } from '../runtime/GrokAuxQueryRunner';
+
+export class GrokInstructionRefineService extends QueryBackedInstructionRefineService {
+  constructor(plugin: ProviderHost) {
+    super(new GrokAuxQueryRunner(plugin));
+  }
+}

--- a/src/providers/grok/auxiliary/GrokTaskResultInterpreter.ts
+++ b/src/providers/grok/auxiliary/GrokTaskResultInterpreter.ts
@@ -1,0 +1,30 @@
+import type {
+  ProviderTaskResultInterpreter,
+  ProviderTaskTerminalStatus,
+} from '../../../core/providers/types';
+
+/** Grok does not use Claudian's Claude async-agent task system. */
+export class GrokTaskResultInterpreter implements ProviderTaskResultInterpreter {
+  hasAsyncLaunchMarker(_toolUseResult: unknown): boolean {
+    return false;
+  }
+
+  extractAgentId(_toolUseResult: unknown): string | null {
+    return null;
+  }
+
+  extractStructuredResult(_toolUseResult: unknown): string | null {
+    return null;
+  }
+
+  resolveTerminalStatus(
+    _toolUseResult: unknown,
+    fallbackStatus: ProviderTaskTerminalStatus,
+  ): ProviderTaskTerminalStatus {
+    return fallbackStatus;
+  }
+
+  extractTagValue(_payload: string, _tagName: string): string | null {
+    return null;
+  }
+}

--- a/src/providers/grok/auxiliary/GrokTitleGenerationService.ts
+++ b/src/providers/grok/auxiliary/GrokTitleGenerationService.ts
@@ -1,0 +1,19 @@
+import { QueryBackedTitleGenerationService } from '../../../core/auxiliary/QueryBackedTitleGenerationService';
+import type { ProviderHost } from '../../../core/providers/ProviderHost';
+import { GrokAuxQueryRunner } from '../runtime/GrokAuxQueryRunner';
+import { grokChatUIConfig } from '../ui/GrokChatUIConfig';
+
+export class GrokTitleGenerationService extends QueryBackedTitleGenerationService {
+  constructor(plugin: ProviderHost) {
+    super({
+      createRunner: () => new GrokAuxQueryRunner(plugin),
+      resolveModel: () => {
+        const settings = plugin.settings as unknown as Record<string, unknown>;
+        const titleModel = typeof settings.titleGenerationModel === 'string'
+          ? settings.titleGenerationModel
+          : '';
+        return grokChatUIConfig.ownsModel(titleModel, settings) ? titleModel : undefined;
+      },
+    });
+  }
+}

--- a/src/providers/grok/capabilities.ts
+++ b/src/providers/grok/capabilities.ts
@@ -1,0 +1,22 @@
+import type { ProviderCapabilities } from '../../core/providers/types';
+
+/**
+ * Conservative Grok Build capabilities for Claudian.
+ *
+ * Grok 0.2.99 ACP exposes loadSession and some agent commands, but Claudian does
+ * not yet claim rewind/fork/images/MCP management through shared contracts.
+ */
+export const GROK_PROVIDER_CAPABILITIES: Readonly<ProviderCapabilities> = Object.freeze({
+  providerId: 'grok',
+  supportsPersistentRuntime: true,
+  supportsNativeHistory: true,
+  supportsPlanMode: true,
+  supportsRewind: false,
+  supportsFork: false,
+  supportsProviderCommands: false,
+  supportsImageAttachments: false,
+  supportsInstructionMode: true,
+  supportsMcpTools: false,
+  supportsTurnSteer: false,
+  reasoningControl: 'effort',
+});

--- a/src/providers/grok/env/GrokSettingsReconciler.ts
+++ b/src/providers/grok/env/GrokSettingsReconciler.ts
@@ -1,0 +1,87 @@
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import type { ProviderSettingsReconciler } from '../../../core/providers/types';
+import type { Conversation } from '../../../core/types';
+import { parseEnvironmentVariables } from '../../../utils/env';
+import { getGrokProviderSettings, updateGrokProviderSettings } from '../settings';
+import { getGrokState } from '../types';
+import { grokChatUIConfig } from '../ui/GrokChatUIConfig';
+
+const GROK_ENV_HASH_KEYS = [
+  'GROK_HOME',
+  'GROK_MODEL',
+  'XAI_MODEL',
+  'XAI_API_KEY',
+  'GROK_DEPLOYMENT_KEY',
+] as const;
+
+function computeGrokEnvHash(envText: string): string {
+  const envVars = parseEnvironmentVariables(envText || '');
+  return GROK_ENV_HASH_KEYS
+    .filter((key) => envVars[key])
+    .map((key) => `${key}=${envVars[key]}`)
+    .sort()
+    .join('|');
+}
+
+function invalidateGrokConversationSessions(conversations: Conversation[]): Conversation[] {
+  const invalidatedConversations: Conversation[] = [];
+  for (const conversation of conversations) {
+    if (conversation.providerId !== 'grok') {
+      continue;
+    }
+
+    const state = getGrokState(conversation.providerState);
+    if (!conversation.sessionId && !state.sessionId) {
+      continue;
+    }
+
+    conversation.sessionId = null;
+    conversation.providerState = undefined;
+    invalidatedConversations.push(conversation);
+  }
+  return invalidatedConversations;
+}
+
+export const grokSettingsReconciler: ProviderSettingsReconciler = {
+  invalidateConversationSessions: invalidateGrokConversationSessions,
+
+  reconcileModelWithEnvironment(
+    settings: Record<string, unknown>,
+    conversations: Conversation[],
+  ): { changed: boolean; invalidatedConversations: Conversation[] } {
+    const envText = getRuntimeEnvironmentText(settings, 'grok');
+    const envVars = parseEnvironmentVariables(envText);
+    const envModel = (envVars.GROK_MODEL || envVars.XAI_MODEL || '').trim();
+    let changed = false;
+
+    if (envModel && settings.model !== envModel) {
+      settings.model = envModel;
+      changed = true;
+    }
+
+    const currentHash = computeGrokEnvHash(envText);
+    const savedHash = getGrokProviderSettings(settings).environmentHash;
+    if (currentHash !== savedHash) {
+      const invalidatedConversations = invalidateGrokConversationSessions(conversations);
+      updateGrokProviderSettings(settings, { environmentHash: currentHash });
+      return { changed: true, invalidatedConversations };
+    }
+
+    return { changed, invalidatedConversations: [] };
+  },
+
+  normalizeModelVariantSettings(settings: Record<string, unknown>): boolean {
+    const model = typeof settings.model === 'string' ? settings.model : '';
+    if (!model) {
+      return false;
+    }
+
+    const normalizedModel = grokChatUIConfig.normalizeModelVariant(model, settings);
+    if (normalizedModel === model) {
+      return false;
+    }
+
+    settings.model = normalizedModel;
+    return true;
+  },
+};

--- a/src/providers/grok/history/GrokConversationHistoryService.ts
+++ b/src/providers/grok/history/GrokConversationHistoryService.ts
@@ -1,0 +1,227 @@
+import * as fs from 'fs';
+
+import type {
+  ProviderConversationHistoryService,
+  ProviderHistoryPathContext,
+} from '../../../core/providers/types';
+import type { ChatMessage, Conversation } from '../../../core/types';
+import { getGrokState, type GrokProviderState, resolveGrokSessionId } from '../types';
+import { resolveGrokHistoryFile, resolveGrokHomeForHistory } from './GrokHistoryPaths';
+
+export function extractGrokHistoryText(content: unknown): string {
+  return readGrokString(content);
+}
+
+export function extractGrokUserQueryText(text: string): string {
+  const match = text.match(/<user_query>\s*([\s\S]*?)\s*<\/user_query>/);
+  return (match ? match[1] : text).trim();
+}
+
+export function shouldSkipGrokHistoryUser(
+  record: Record<string, unknown>,
+  text: string,
+): boolean {
+  const trimmed = text.trim();
+  return !!record.synthetic_reason
+    || !trimmed
+    || trimmed.startsWith('<user_info>')
+    || trimmed.startsWith('<system-reminder>');
+}
+
+function readGrokString(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(readGrokString).filter(Boolean).join('');
+  }
+  if (!value || typeof value !== 'object') {
+    return '';
+  }
+
+  const record = value as Record<string, unknown>;
+  if (typeof record.text === 'string') {
+    return record.text;
+  }
+  if (typeof record.delta === 'string') {
+    return record.delta;
+  }
+  if (typeof record.data === 'string') {
+    return record.data;
+  }
+  if (typeof record.content === 'string') {
+    return record.content;
+  }
+  if (Array.isArray(record.data)) {
+    return readGrokString(record.data);
+  }
+  if (record.data && typeof record.data === 'object') {
+    return readGrokString(record.data);
+  }
+  if (Array.isArray(record.content)) {
+    return readGrokString(record.content);
+  }
+  if (record.content && typeof record.content === 'object') {
+    return readGrokString(record.content);
+  }
+  if (record.message) {
+    return readGrokString(record.message);
+  }
+  return '';
+}
+
+export function loadGrokHistoryMessages(
+  historyPath: string,
+  sessionId: string,
+  baseTimestamp: number,
+): ChatMessage[] {
+  let content: string;
+  try {
+    content = fs.readFileSync(historyPath, 'utf-8');
+  } catch {
+    return [];
+  }
+
+  const messages: ChatMessage[] = [];
+  const lines = content.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) {
+      continue;
+    }
+
+    let record: Record<string, unknown>;
+    try {
+      record = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+
+    const role = typeof record.type === 'string' ? record.type : '';
+    const timestamp = baseTimestamp + messages.length;
+
+    if (role === 'user') {
+      const rawText = extractGrokHistoryText(record.content);
+      if (shouldSkipGrokHistoryUser(record, rawText)) {
+        continue;
+      }
+      const userText = extractGrokUserQueryText(rawText);
+      if (!userText) {
+        continue;
+      }
+      const id = `grok-${sessionId}-${i}-user`;
+      messages.push({
+        content: userText,
+        displayContent: userText,
+        id,
+        role: 'user',
+        timestamp,
+        userMessageId: id,
+      });
+      continue;
+    }
+
+    if (role === 'assistant') {
+      const assistantText = extractGrokHistoryText(record.content);
+      if (!assistantText.trim()) {
+        continue;
+      }
+      const id = `grok-${sessionId}-${i}-assistant`;
+      messages.push({
+        assistantMessageId: id,
+        content: assistantText,
+        contentBlocks: [{ type: 'text', content: assistantText }],
+        id,
+        role: 'assistant',
+        timestamp,
+      });
+    }
+  }
+
+  return messages;
+}
+
+export class GrokConversationHistoryService implements ProviderConversationHistoryService {
+  private hydratedKeys = new Map<string, string>();
+
+  async hydrateConversationHistory(
+    conversation: Conversation,
+    vaultPath: string | null,
+    pathContext?: ProviderHistoryPathContext,
+  ): Promise<void> {
+    const sessionId = this.resolveSessionIdForConversation(conversation);
+    const grokHome = resolveGrokHomeForHistory(conversation, pathContext);
+    const historyPath = resolveGrokHistoryFile(vaultPath, sessionId, { grokHome });
+    if (!sessionId || !historyPath) {
+      this.hydratedKeys.delete(conversation.id);
+      return;
+    }
+
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(historyPath);
+    } catch {
+      this.hydratedKeys.delete(conversation.id);
+      return;
+    }
+
+    const hydrationKey = `${sessionId}::${historyPath}::${stat.mtimeMs}::${stat.size}`;
+    if (conversation.messages.length > 0 && this.hydratedKeys.get(conversation.id) === hydrationKey) {
+      return;
+    }
+
+    const messages = loadGrokHistoryMessages(
+      historyPath,
+      sessionId,
+      typeof conversation.createdAt === 'number' ? conversation.createdAt : Date.now(),
+    );
+    if (messages.length === 0) {
+      this.hydratedKeys.delete(conversation.id);
+      return;
+    }
+
+    conversation.messages = messages;
+    this.hydratedKeys.set(conversation.id, hydrationKey);
+  }
+
+  async deleteConversationSession(
+    _conversation: Conversation,
+    _vaultPath: string | null,
+  ): Promise<void> {
+    // Never mutate Grok native history.
+  }
+
+  resolveSessionIdForConversation(conversation: Conversation | null): string | null {
+    return resolveGrokSessionId(conversation);
+  }
+
+  isPendingForkConversation(_conversation: Conversation): boolean {
+    return false;
+  }
+
+  buildForkProviderState(
+    sourceSessionId: string,
+    resumeAt: string,
+    sourceProviderState?: Record<string, unknown>,
+  ): Record<string, unknown> {
+    return {
+      ...(sourceProviderState ?? {}),
+      forkSource: { sessionId: sourceSessionId, resumeAt },
+    };
+  }
+
+  buildPersistedProviderState(
+    conversation: Conversation,
+  ): Record<string, unknown> | undefined {
+    const state = getGrokState(conversation.providerState);
+    const sessionId = resolveGrokSessionId(conversation) ?? state.sessionId;
+    const providerState: GrokProviderState = {
+      ...(sessionId ? { sessionId } : {}),
+      ...(state.grokHome ? { grokHome: state.grokHome } : {}),
+    };
+
+    return Object.keys(providerState).length > 0
+      ? providerState as Record<string, unknown>
+      : undefined;
+  }
+}

--- a/src/providers/grok/history/GrokHistoryPaths.ts
+++ b/src/providers/grok/history/GrokHistoryPaths.ts
@@ -1,0 +1,125 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import type { ProviderHistoryPathContext } from '../../../core/providers/types';
+import { parseEnvironmentVariables } from '../../../utils/env';
+import { getGrokState } from '../types';
+
+export function getGrokHome(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env.GROK_HOME?.trim();
+  if (override) {
+    return override;
+  }
+  return path.join(os.homedir(), '.grok');
+}
+
+export function encodeGrokSessionCwd(vaultPath: string): string {
+  return encodeURIComponent(vaultPath);
+}
+
+/**
+ * Resolve Grok home for history hydration.
+ *
+ * Order: persisted providerState.grokHome → pathContext env/settings → process.env → default.
+ */
+export function resolveGrokHomeForHistory(
+  conversation: {
+    providerState?: Record<string, unknown>;
+  } | null | undefined,
+  pathContext?: ProviderHistoryPathContext,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const stateHome = getGrokState(conversation?.providerState).grokHome;
+  if (stateHome) {
+    return stateHome;
+  }
+
+  const contextEnvHome = pathContext?.environment?.GROK_HOME?.trim();
+  if (contextEnvHome) {
+    return contextEnvHome;
+  }
+
+  if (pathContext?.settings) {
+    const envText = getRuntimeEnvironmentText(pathContext.settings, 'grok');
+    const vars = parseEnvironmentVariables(envText);
+    const settingsHome = vars.GROK_HOME?.trim();
+    if (settingsHome) {
+      return settingsHome;
+    }
+  }
+
+  return getGrokHome(env);
+}
+
+export function resolveGrokHistoryFile(
+  vaultPath: string | null | undefined,
+  sessionId: string | null | undefined,
+  options: {
+    env?: NodeJS.ProcessEnv;
+    grokHome?: string | null;
+  } = {},
+): string | null {
+  if (!vaultPath || !sessionId) {
+    return null;
+  }
+
+  const grokHome = options.grokHome?.trim() || getGrokHome(options.env ?? process.env);
+  const historyPath = path.join(
+    grokHome,
+    'sessions',
+    encodeGrokSessionCwd(vaultPath),
+    sessionId,
+    'chat_history.jsonl',
+  );
+
+  try {
+    return fs.statSync(historyPath).isFile() ? historyPath : null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveLatestGrokHistoryFile(
+  vaultPath: string | null | undefined,
+  afterMtimeMs = 0,
+  options: {
+    env?: NodeJS.ProcessEnv;
+    grokHome?: string | null;
+  } = {},
+): { historyPath: string; mtimeMs: number; sessionId: string } | null {
+  if (!vaultPath) {
+    return null;
+  }
+
+  const grokHome = options.grokHome?.trim() || getGrokHome(options.env ?? process.env);
+  const sessionsRoot = path.join(
+    grokHome,
+    'sessions',
+    encodeGrokSessionCwd(vaultPath),
+  );
+
+  let best: { historyPath: string; mtimeMs: number; sessionId: string } | null = null;
+  try {
+    for (const sessionId of fs.readdirSync(sessionsRoot)) {
+      const historyPath = path.join(sessionsRoot, sessionId, 'chat_history.jsonl');
+      let stat: fs.Stats;
+      try {
+        stat = fs.statSync(historyPath);
+      } catch {
+        continue;
+      }
+      if (!stat.isFile() || stat.mtimeMs < afterMtimeMs) {
+        continue;
+      }
+      if (!best || stat.mtimeMs > best.mtimeMs) {
+        best = { historyPath, mtimeMs: stat.mtimeMs, sessionId };
+      }
+    }
+  } catch {
+    return null;
+  }
+
+  return best;
+}

--- a/src/providers/grok/registration.ts
+++ b/src/providers/grok/registration.ts
@@ -1,0 +1,38 @@
+import type { ProviderModule } from '../../core/providers/types';
+import { grokWorkspaceRegistration } from './app/GrokWorkspaceServices';
+import { GrokInlineEditService } from './auxiliary/GrokInlineEditService';
+import { GrokInstructionRefineService } from './auxiliary/GrokInstructionRefineService';
+import { GrokTaskResultInterpreter } from './auxiliary/GrokTaskResultInterpreter';
+import { GrokTitleGenerationService } from './auxiliary/GrokTitleGenerationService';
+import { GROK_PROVIDER_CAPABILITIES } from './capabilities';
+import { grokSettingsReconciler } from './env/GrokSettingsReconciler';
+import { GrokConversationHistoryService } from './history/GrokConversationHistoryService';
+import { GrokChatRuntime } from './runtime/GrokChatRuntime';
+import { getGrokProviderSettings, updateGrokProviderSettings } from './settings';
+import { grokChatUIConfig } from './ui/GrokChatUIConfig';
+
+export const grokProviderRegistration: ProviderModule = {
+  id: 'grok',
+  displayName: 'Grok',
+  blankTabOrder: 12,
+  isEnabled: (settings) => getGrokProviderSettings(settings).enabled,
+  setEnabled: (settings, enabled) => updateGrokProviderSettings(settings, { enabled }),
+  capabilities: GROK_PROVIDER_CAPABILITIES,
+  environmentKeyPatterns: [/^GROK_/i, /^XAI_/i],
+  chatUIConfig: grokChatUIConfig,
+  settingsReconciler: grokSettingsReconciler,
+  settingsStorage: {
+    hostScopedFields: ['cliPathsByHost'],
+    normalizeStored(target, stored) {
+      updateGrokProviderSettings(target, getGrokProviderSettings(stored));
+      return false;
+    },
+  },
+  createRuntime: ({ plugin }) => new GrokChatRuntime(plugin),
+  createTitleGenerationService: (plugin) => new GrokTitleGenerationService(plugin),
+  createInstructionRefineService: (plugin) => new GrokInstructionRefineService(plugin),
+  createInlineEditService: (plugin) => new GrokInlineEditService(plugin),
+  historyService: new GrokConversationHistoryService(),
+  taskResultInterpreter: new GrokTaskResultInterpreter(),
+  workspace: grokWorkspaceRegistration,
+};

--- a/src/providers/grok/runtime/GrokAuxQueryRunner.ts
+++ b/src/providers/grok/runtime/GrokAuxQueryRunner.ts
@@ -1,0 +1,35 @@
+import type { AuxQueryConfig, AuxQueryRunner } from '../../../core/auxiliary/AuxQueryRunner';
+import type { ProviderHost } from '../../../core/providers/ProviderHost';
+import { getVaultPath } from '../../../utils/path';
+import { runGrokHeadless } from './GrokHeadlessRunner';
+
+export class GrokAuxQueryRunner implements AuxQueryRunner {
+  private abortController: AbortController | null = null;
+
+  constructor(private readonly plugin: ProviderHost) {}
+
+  async query(config: AuxQueryConfig, prompt: string): Promise<string> {
+    const cliPath = await this.plugin.getResolvedProviderCliPath('grok');
+    if (!cliPath) {
+      throw new Error(
+        'Grok CLI not found. Install Grok Build or set the Grok CLI path in Claudian settings.',
+      );
+    }
+
+    this.abortController = config.abortController || new AbortController();
+    return runGrokHeadless(this.plugin, cliPath, prompt, {
+      cwd: getVaultPath(this.plugin.app) || process.cwd(),
+      systemPrompt: config.systemPrompt,
+      model: config.model,
+      signal: this.abortController.signal,
+      onTextChunk: config.onTextChunk,
+    });
+  }
+
+  reset(): void {
+    if (this.abortController) {
+      this.abortController.abort();
+      this.abortController = null;
+    }
+  }
+}

--- a/src/providers/grok/runtime/GrokChatRuntime.ts
+++ b/src/providers/grok/runtime/GrokChatRuntime.ts
@@ -1,0 +1,1171 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import { buildSystemPrompt } from '../../../core/prompt/mainAgent';
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import type { ProviderHost } from '../../../core/providers/ProviderHost';
+import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
+import type { ProviderCapabilities } from '../../../core/providers/types';
+import type { ChatRuntime } from '../../../core/runtime/ChatRuntime';
+import type {
+  ApprovalCallback,
+  ApprovalDecisionOption,
+  AskUserQuestionCallback,
+  AutoTurnCallback,
+  ChatRewindMode,
+  ChatRewindResult,
+  ChatRuntimeConversationState,
+  ChatRuntimeEnsureReadyOptions,
+  ChatRuntimeQueryOptions,
+  ChatTurnMetadata,
+  ChatTurnRequest,
+  PreparedChatTurn,
+  SessionUpdateResult,
+} from '../../../core/runtime/types';
+import type {
+  ApprovalDecision,
+  ChatMessage,
+  Conversation,
+  ExitPlanModeCallback,
+  SlashCommand,
+  StreamChunk,
+  ToolCallInfo,
+} from '../../../core/types';
+import { getVaultPath } from '../../../utils/path';
+import {
+  AcpClientConnection,
+  AcpJsonRpcTransport,
+  type AcpReadTextFileRequest,
+  type AcpRequestPermissionRequest,
+  type AcpRequestPermissionResponse,
+  type AcpSessionNotification,
+  AcpSessionUpdateNormalizer,
+  AcpSubprocess,
+  buildAcpUsageInfo,
+} from '../../acp';
+import { GROK_PROVIDER_CAPABILITIES } from '../capabilities';
+import { getGrokProviderSettings } from '../settings';
+import { getGrokState, type GrokProviderState } from '../types';
+import { GROK_DEFAULT_MODEL } from '../ui/GrokChatUIConfig';
+import {
+  buildGrokAcpPromptBlocks,
+  buildGrokAcpPromptText,
+  buildGrokPromptWithHistory,
+  buildGrokTurnPromptText,
+} from './buildGrokPrompt';
+import {
+  buildGrokRuntimeEnv,
+  resolveGrokHomeFromSettings,
+} from './GrokRuntimeEnvironment';
+import { type GrokAcpModeId, resolveGrokAcpModeId } from './grokSessionMode';
+
+/**
+ * ACP process launch fingerprint.
+ *
+ * Includes safeMode (maps to GROK_SANDBOX at spawn) and yolo (needs
+ * --always-approve). Plan vs normal is applied via session/set_mode and must
+ * not force a process restart.
+ */
+export function buildGrokAcpLaunchKey(params: {
+  cliPath: string;
+  cwd: string;
+  effort: string;
+  envText: string;
+  model: string;
+  safeMode: string;
+  yolo: boolean;
+}): string {
+  return JSON.stringify({
+    cliPath: params.cliPath,
+    cwd: params.cwd,
+    effort: params.effort,
+    envText: params.envText,
+    model: params.model,
+    safeMode: params.safeMode,
+    yolo: params.yolo,
+  });
+}
+
+interface ActiveTurn {
+  cancelled: boolean;
+  queue: StreamChunkQueue;
+  sessionId: string;
+}
+
+class StreamChunkQueue {
+  private closed = false;
+  private readonly items: StreamChunk[] = [];
+  private readonly waiters: Array<(chunk: StreamChunk | null) => void> = [];
+
+  push(chunk: StreamChunk): void {
+    if (this.closed) {
+      return;
+    }
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter(chunk);
+      return;
+    }
+    this.items.push(chunk);
+  }
+
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    while (this.waiters.length > 0) {
+      this.waiters.shift()?.(null);
+    }
+  }
+
+  async next(): Promise<StreamChunk | null> {
+    if (this.items.length > 0) {
+      return this.items.shift() ?? null;
+    }
+    if (this.closed) {
+      return null;
+    }
+    return new Promise<StreamChunk | null>((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+}
+
+export class GrokChatRuntime implements ChatRuntime {
+  readonly providerId = 'grok' as const;
+
+  private activeTurn: ActiveTurn | null = null;
+  private approvalCallback: ApprovalCallback | null = null;
+  private connection: AcpClientConnection | null = null;
+  private connectionGeneration = 0;
+  private conversationId: string | null = null;
+  private conversationGeneration = 0;
+  private currentConversationModel: string | null = null;
+  private currentGrokHome: string | null = null;
+  private currentLaunchKey: string | null = null;
+  private currentSessionModeId: GrokAcpModeId | null = null;
+  private currentTurnMetadata: ChatTurnMetadata = {};
+  private disposed = false;
+  private lifecycleGeneration = 0;
+  private loadedSessionId: string | null = null;
+  private process: AcpSubprocess | null = null;
+  private readinessFlight: { key: string; promise: Promise<boolean> } | null = null;
+  private ready = false;
+  private readonly readyListeners: Array<(ready: boolean) => void> = [];
+  private sessionCwds = new Map<string, string>();
+  private sessionId: string | null = null;
+  private sessionInvalidated = false;
+  private readonly sessionUpdateNormalizer = new AcpSessionUpdateNormalizer();
+  private readonly supportedCommandWaiters: Array<(commands: SlashCommand[]) => void> = [];
+  private supportedCommands: SlashCommand[] = [];
+  private transport: AcpJsonRpcTransport | null = null;
+  private unregisterTransportClose: (() => void) | null = null;
+
+  constructor(private readonly plugin: ProviderHost) {}
+
+  getCapabilities(): Readonly<ProviderCapabilities> {
+    return GROK_PROVIDER_CAPABILITIES;
+  }
+
+  prepareTurn(request: ChatTurnRequest): PreparedChatTurn {
+    return {
+      isCompact: false,
+      mcpMentions: request.enabledMcpServers ?? new Set(),
+      persistedContent: '',
+      prompt: buildGrokTurnPromptText(request),
+      request,
+    };
+  }
+
+  onReadyStateChange(listener: (ready: boolean) => void): () => void {
+    this.readyListeners.push(listener);
+    try {
+      listener(this.ready);
+    } catch {
+      // ignore listener errors
+    }
+    return () => {
+      const index = this.readyListeners.indexOf(listener);
+      if (index >= 0) {
+        this.readyListeners.splice(index, 1);
+      }
+    };
+  }
+
+  setResumeCheckpoint(_checkpointId: string | undefined): void {}
+
+  syncConversationState(
+    conversation: ChatRuntimeConversationState | null,
+  ): void {
+    this.setCurrentConversationModel(conversation?.selectedModel);
+    const previousSessionId = this.sessionId;
+    const nextConversationId = conversation?.id ?? null;
+    const state = getGrokState(conversation?.providerState);
+    const nextSessionId = conversation?.sessionId
+      ?? state.sessionId
+      ?? null;
+
+    if (previousSessionId !== nextSessionId) {
+      this.loadedSessionId = null;
+      this.currentSessionModeId = null;
+      this.sessionInvalidated = false;
+      this.sessionUpdateNormalizer.reset();
+      this.setSupportedCommands([]);
+    }
+
+    const stateGrokHome = getGrokState(conversation?.providerState).grokHome;
+    if (stateGrokHome) {
+      this.currentGrokHome = stateGrokHome;
+    }
+
+    const targetChanged = nextConversationId !== this.conversationId
+      || nextSessionId !== this.sessionId;
+    this.conversationId = nextConversationId;
+    this.sessionId = nextSessionId;
+    if (targetChanged) {
+      this.conversationGeneration += 1;
+      if (this.readinessFlight) {
+        void this.shutdownProcess();
+      }
+    }
+  }
+
+  async reloadMcpServers(): Promise<void> {}
+
+  async ensureReady(options?: ChatRuntimeEnsureReadyOptions): Promise<boolean> {
+    if (this.disposed) {
+      return false;
+    }
+    const conversationGeneration = this.conversationGeneration;
+    const key = JSON.stringify({ conversationGeneration, options: options ?? {} });
+    if (this.readinessFlight) {
+      if (this.readinessFlight.key === key) {
+        return this.readinessFlight.promise;
+      }
+      await this.readinessFlight.promise.catch(() => undefined);
+      return this.ensureReady(options);
+    }
+
+    const lifecycleGeneration = this.lifecycleGeneration;
+    const promise = this.ensureReadyInternal(
+      options,
+      lifecycleGeneration,
+      conversationGeneration,
+    );
+    this.readinessFlight = { key, promise };
+    return promise.finally(() => {
+      if (this.readinessFlight?.promise === promise) {
+        this.readinessFlight = null;
+      }
+    });
+  }
+
+  private async ensureReadyInternal(
+    options: ChatRuntimeEnsureReadyOptions | undefined,
+    lifecycleGeneration: number,
+    conversationGeneration: number,
+  ): Promise<boolean> {
+    const settings = getGrokProviderSettings(this.plugin.settings);
+    if (!settings.enabled) {
+      this.setReady(false);
+      return false;
+    }
+
+    const cliPath = await this.plugin.getResolvedProviderCliPath('grok');
+    if (!cliPath) {
+      this.setReady(false);
+      return false;
+    }
+
+    if (!this.isReadinessCurrent(lifecycleGeneration, conversationGeneration)) {
+      return false;
+    }
+
+    const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
+    const providerSettings = ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+      this.plugin.settings,
+      'grok',
+    );
+    const model = this.resolveSelectedModel(providerSettings);
+    const effort = typeof providerSettings.effortLevel === 'string' && providerSettings.effortLevel.trim()
+      ? providerSettings.effortLevel.trim()
+      : 'high';
+    const permissionMode = typeof providerSettings.permissionMode === 'string'
+      ? providerSettings.permissionMode
+      : 'normal';
+    const yolo = permissionMode === 'yolo';
+    const safeMode = getGrokProviderSettings(this.plugin.settings).safeMode;
+    const envText = getRuntimeEnvironmentText(this.plugin.settings, 'grok');
+    const launchKey = buildGrokAcpLaunchKey({
+      cliPath,
+      cwd,
+      effort,
+      envText,
+      model,
+      safeMode,
+      yolo,
+    });
+
+    const shouldRestart = !this.process
+      || !this.transport
+      || !this.connection
+      || !this.process.isAlive()
+      || this.transport.isClosed
+      || options?.force === true
+      || this.currentLaunchKey !== launchKey;
+
+    if (shouldRestart) {
+      await this.shutdownProcess();
+      if (!this.isReadinessCurrent(lifecycleGeneration, conversationGeneration)) {
+        return false;
+      }
+      await this.startProcess({ cliPath, cwd, effort, model, yolo });
+      if (!this.isReadinessCurrent(lifecycleGeneration, conversationGeneration)) {
+        await this.shutdownProcess();
+        return false;
+      }
+      this.currentLaunchKey = launchKey;
+      this.loadedSessionId = null;
+      this.currentSessionModeId = null;
+      this.currentGrokHome = resolveGrokHomeFromSettings(this.plugin.settings, cliPath);
+    } else if (!this.currentGrokHome) {
+      this.currentGrokHome = resolveGrokHomeFromSettings(this.plugin.settings, cliPath);
+    }
+
+    const targetSessionId = this.sessionId;
+    if (targetSessionId) {
+      if (this.loadedSessionId !== targetSessionId) {
+        const loaded = await this.loadSession(targetSessionId, cwd);
+        if (!this.isReadinessCurrent(lifecycleGeneration, conversationGeneration)) {
+          await this.shutdownProcess();
+          return false;
+        }
+        if (!loaded) {
+          this.sessionInvalidated = true;
+          this.clearActiveSession();
+        }
+      } else {
+        await this.applySessionMode(targetSessionId);
+      }
+      return true;
+    }
+
+    if (!this.sessionId && !this.sessionInvalidated) {
+      if (options?.allowSessionCreation === false) {
+        return true;
+      }
+      const sessionId = await this.createSession(cwd);
+      if (!this.isReadinessCurrent(lifecycleGeneration, conversationGeneration)) {
+        await this.shutdownProcess();
+        return false;
+      }
+      return Boolean(sessionId);
+    }
+
+    return true;
+  }
+
+  async *query(
+    turn: PreparedChatTurn,
+    conversationHistory?: ChatMessage[],
+    queryOptions?: ChatRuntimeQueryOptions,
+  ): AsyncGenerator<StreamChunk> {
+    // Reject until the previous ACP prompt RPC fully settles (including cancel).
+    if (this.activeTurn) {
+      yield { type: 'error', content: 'Grok does not support overlapping turns.' };
+      yield { type: 'done' };
+      return;
+    }
+
+    if (queryOptions?.model) {
+      this.setCurrentConversationModel(queryOptions.model);
+    }
+
+    const conversationGeneration = this.conversationGeneration;
+    const previousMessages = conversationHistory ?? [];
+    const expectedSessionId = this.sessionId;
+    let shouldBootstrapHistory = previousMessages.length > 0
+      && (!expectedSessionId || this.sessionInvalidated);
+
+    if (!(await this.ensureReady())) {
+      yield {
+        type: 'error',
+        content: 'Failed to start Grok ACP runtime. Check the Grok CLI path and login state.',
+      };
+      yield { type: 'done' };
+      return;
+    }
+
+    if (!this.isConversationCurrent(conversationGeneration)) {
+      yield { type: 'error', content: 'Grok conversation changed before the turn started.' };
+      yield { type: 'done' };
+      return;
+    }
+
+    if (!this.connection) {
+      yield { type: 'error', content: 'Grok ACP runtime is not ready.' };
+      yield { type: 'done' };
+      return;
+    }
+
+    // Re-check after await: cancel/settle of a concurrent turn cannot open a race here
+    // because JS is single-threaded, but ensureReady may have yielded.
+    if (this.activeTurn) {
+      yield { type: 'error', content: 'Grok does not support overlapping turns.' };
+      yield { type: 'done' };
+      return;
+    }
+
+    const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
+    if (expectedSessionId && !this.sessionId) {
+      shouldBootstrapHistory = previousMessages.length > 0;
+    }
+
+    if (!this.sessionId) {
+      const sessionId = await this.createSession(cwd);
+      if (!sessionId) {
+        yield { type: 'error', content: 'Failed to create a Grok ACP session.' };
+        yield { type: 'done' };
+        return;
+      }
+    }
+
+    if (this.activeTurn) {
+      yield { type: 'error', content: 'Grok does not support overlapping turns.' };
+      yield { type: 'done' };
+      return;
+    }
+
+    const sessionId = this.sessionId!;
+    try {
+      await this.applySessionMode(sessionId);
+    } catch (error) {
+      yield {
+        type: 'error',
+        content: this.formatRuntimeError(error),
+      };
+      yield { type: 'done' };
+      return;
+    }
+
+    this.activeTurn = {
+      cancelled: false,
+      queue: new StreamChunkQueue(),
+      sessionId,
+    };
+    this.currentTurnMetadata = {};
+    this.sessionUpdateNormalizer.reset();
+
+    const activeTurn = this.activeTurn;
+    const systemPrompt = buildSystemPrompt({
+      mediaFolder: this.plugin.settings.mediaFolder,
+      customPrompt: this.plugin.settings.systemPrompt,
+      vaultPath: cwd,
+      userName: this.plugin.settings.userName,
+    });
+    const isFollowupTurn = Boolean(expectedSessionId) || previousMessages.length > 0;
+    const promptText = expectedSessionId && !shouldBootstrapHistory
+      ? turn.prompt
+      : buildGrokPromptWithHistory(turn.prompt, previousMessages);
+    const prompt = buildGrokAcpPromptBlocks(
+      buildGrokAcpPromptText(systemPrompt, promptText, isFollowupTurn),
+    );
+
+    const promptPromise = this.connection.prompt({
+      prompt,
+      sessionId,
+    }).then((response) => {
+      if (response.userMessageId) {
+        this.currentTurnMetadata.userMessageId = response.userMessageId;
+      }
+      const usage = buildAcpUsageInfo({
+        model: this.resolveSelectedModel(
+          ProviderSettingsCoordinator.getProviderSettingsSnapshot(this.plugin.settings, 'grok'),
+        ),
+        promptUsage: response.usage ?? null,
+      });
+      if (usage) {
+        activeTurn.queue.push({ sessionId, type: 'usage', usage });
+      }
+      if (!activeTurn.cancelled) {
+        activeTurn.queue.push({ type: 'done' });
+      }
+      activeTurn.queue.close();
+    }).catch((error) => {
+      if (!activeTurn.cancelled) {
+        activeTurn.queue.push({
+          type: 'error',
+          content: this.formatRuntimeError(error),
+        });
+        activeTurn.queue.push({ type: 'done' });
+      }
+      activeTurn.queue.close();
+    }).finally(() => {
+      if (this.activeTurn === activeTurn) {
+        this.activeTurn = null;
+      }
+    });
+
+    try {
+      while (true) {
+        const chunk = await activeTurn.queue.next();
+        if (!chunk) {
+          break;
+        }
+        yield chunk;
+      }
+    } finally {
+      // Always wait for the ACP prompt RPC so cancel keeps the busy barrier.
+      await promptPromise.catch(() => undefined);
+      if (this.activeTurn === activeTurn) {
+        this.activeTurn = null;
+      }
+    }
+  }
+
+  cancel(): void {
+    const activeTurn = this.activeTurn;
+    if (!activeTurn || activeTurn.cancelled) {
+      return;
+    }
+    activeTurn.cancelled = true;
+    if (this.connection && this.sessionId) {
+      this.connection.cancel({ sessionId: this.sessionId });
+    }
+    // Close the consumer queue immediately, but keep activeTurn until the
+    // ACP prompt promise settles so a second query cannot overlap.
+    activeTurn.queue.close();
+  }
+
+  resetSession(): void {
+    this.cancel();
+    this.clearActiveSession();
+    this.sessionInvalidated = false;
+  }
+
+  getSessionId(): string | null {
+    return this.sessionId;
+  }
+
+  consumeSessionInvalidation(): boolean {
+    const invalidated = this.sessionInvalidated;
+    this.sessionInvalidated = false;
+    return invalidated;
+  }
+
+  isReady(): boolean {
+    return this.ready;
+  }
+
+  async getSupportedCommands(): Promise<SlashCommand[]> {
+    if (this.supportedCommands.length > 0 && this.loadedSessionId === this.sessionId) {
+      return [...this.supportedCommands];
+    }
+    if (!this.sessionId) {
+      return [];
+    }
+    return this.waitForSupportedCommands();
+  }
+
+  cleanup(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    this.lifecycleGeneration += 1;
+    this.activeTurn?.queue.close();
+    this.activeTurn = null;
+    void this.shutdownProcess();
+    this.readyListeners.length = 0;
+    this.setReady(false);
+  }
+
+  async rewind(
+    _userMessageId: string,
+    _assistantMessageId: string | undefined,
+    _mode?: ChatRewindMode,
+  ): Promise<ChatRewindResult> {
+    return {
+      canRewind: false,
+      error: 'Grok does not support rewind from Claudian yet',
+    };
+  }
+
+  setApprovalCallback(callback: ApprovalCallback | null): void {
+    this.approvalCallback = callback;
+  }
+
+  setApprovalDismisser(_dismisser: (() => void) | null): void {}
+
+  setAskUserQuestionCallback(_callback: AskUserQuestionCallback | null): void {}
+
+  setExitPlanModeCallback(_callback: ExitPlanModeCallback | null): void {}
+
+  setPermissionModeSyncCallback(_callback: ((sdkMode: string) => void) | null): void {}
+
+  setAutoTurnCallback(_callback: AutoTurnCallback | null): void {}
+
+  consumeTurnMetadata(): ChatTurnMetadata {
+    const metadata = { ...this.currentTurnMetadata };
+    this.currentTurnMetadata = {};
+    return metadata;
+  }
+
+  buildSessionUpdates(params: {
+    conversation: Conversation | null;
+    sessionInvalidated: boolean;
+  }): SessionUpdateResult {
+    const existingState = params.conversation
+      ? getGrokState(params.conversation.providerState)
+      : null;
+    const sessionId = this.sessionId;
+    const grokHome = this.currentGrokHome ?? existingState?.grokHome;
+    const providerState: GrokProviderState = {
+      ...(sessionId
+        ? { sessionId }
+        : existingState?.sessionId
+        ? { sessionId: existingState.sessionId }
+        : {}),
+      ...(grokHome ? { grokHome } : {}),
+    };
+
+    const updates: Partial<Conversation> = {
+      providerState: Object.keys(providerState).length > 0
+        ? providerState as Record<string, unknown>
+        : undefined,
+      sessionId,
+    };
+
+    if (params.sessionInvalidated && !this.sessionId) {
+      updates.providerState = undefined;
+      updates.sessionId = null;
+    }
+
+    return { updates };
+  }
+
+  resolveSessionIdForFork(conversation: Conversation | null): string | null {
+    return this.sessionId
+      ?? conversation?.sessionId
+      ?? getGrokState(conversation?.providerState).sessionId
+      ?? null;
+  }
+
+  async loadSubagentToolCalls(_agentId: string): Promise<ToolCallInfo[]> {
+    return [];
+  }
+
+  async loadSubagentFinalResult(_agentId: string): Promise<string | null> {
+    return null;
+  }
+
+  private async startProcess(params: {
+    cliPath: string;
+    cwd: string;
+    effort: string;
+    model: string;
+    yolo: boolean;
+  }): Promise<void> {
+    const args = ['agent'];
+    if (params.model) {
+      args.push('-m', params.model);
+    }
+    if (params.effort) {
+      args.push('--reasoning-effort', params.effort);
+    }
+    if (params.yolo) {
+      args.push('--always-approve');
+    }
+    args.push('stdio');
+
+    const env = buildGrokRuntimeEnv(this.plugin.settings, params.cliPath);
+    this.currentGrokHome = resolveGrokHomeFromSettings(this.plugin.settings, params.cliPath);
+    this.process = new AcpSubprocess({
+      args,
+      command: params.cliPath,
+      cwd: params.cwd,
+      env,
+    });
+    this.process.start();
+
+    this.transport = new AcpJsonRpcTransport({
+      input: this.process.stdout,
+      onClose: (listener) => this.process!.onClose(listener),
+      output: this.process.stdin,
+    });
+    const transport = this.transport;
+    this.unregisterTransportClose = transport.onClose(() => {
+      if (this.transport === transport) {
+        this.setReady(false);
+        this.settleActiveTurn(new Error('Grok ACP runtime closed'));
+      }
+    });
+
+    const connectionGeneration = ++this.connectionGeneration;
+    this.connection = new AcpClientConnection({
+      clientInfo: {
+        name: 'claudian',
+        version: this.plugin.manifest?.version ?? '0.0.0',
+      },
+      delegate: {
+        fileSystem: {
+          readTextFile: (request) => this.readTextFile(request),
+          writeTextFile: (request) => this.writeTextFile(request),
+        },
+        onSessionNotification: (notification) => this.handleSessionNotification(
+          notification,
+          connectionGeneration,
+        ),
+        requestPermission: (request) => this.handlePermissionRequest(request),
+      },
+      transport: this.transport,
+    });
+
+    this.transport.start();
+    await this.connection.initialize({
+      clientCapabilities: {
+        fs: { readTextFile: true, writeTextFile: true },
+      },
+    });
+    this.setReady(true);
+  }
+
+  private async shutdownProcess(): Promise<void> {
+    this.connectionGeneration += 1;
+    this.setReady(false);
+    this.settleActiveTurn();
+    this.setSupportedCommands([]);
+
+    this.unregisterTransportClose?.();
+    this.unregisterTransportClose = null;
+
+    this.connection?.dispose();
+    this.connection = null;
+
+    this.transport?.dispose();
+    this.transport = null;
+
+    if (this.process) {
+      await this.process.shutdown().catch(() => {});
+      this.process = null;
+    }
+
+    this.currentLaunchKey = null;
+    this.loadedSessionId = null;
+    this.currentSessionModeId = null;
+    this.sessionUpdateNormalizer.reset();
+  }
+
+  private async createSession(cwd: string): Promise<string | null> {
+    if (!this.connection) {
+      return null;
+    }
+    try {
+      this.setSupportedCommands([]);
+      this.currentSessionModeId = null;
+      const response = await this.connection.newSession({
+        cwd,
+        mcpServers: [],
+      });
+      const sessionId = response.sessionId;
+      if (!sessionId) {
+        return null;
+      }
+      // Apply mode before committing local session state so setMode failures
+      // do not leave a half-initialized sessionId/loadedSessionId.
+      await this.applySessionMode(sessionId);
+      this.loadedSessionId = sessionId;
+      this.sessionId = sessionId;
+      this.sessionInvalidated = false;
+      this.sessionCwds.set(sessionId, cwd);
+      return sessionId;
+    } catch {
+      this.clearActiveSession();
+      return null;
+    }
+  }
+
+  private async loadSession(sessionId: string, cwd: string): Promise<boolean> {
+    if (!this.connection || !sessionId) {
+      return false;
+    }
+    try {
+      this.setSupportedCommands([]);
+      this.currentSessionModeId = null;
+      const response = await this.connection.loadSession({
+        cwd,
+        mcpServers: [],
+        sessionId,
+      });
+      const resolvedSessionId = response.sessionId || sessionId;
+      await this.applySessionMode(resolvedSessionId);
+      this.loadedSessionId = resolvedSessionId;
+      this.sessionId = resolvedSessionId;
+      this.sessionInvalidated = false;
+      this.sessionCwds.set(resolvedSessionId, cwd);
+      return true;
+    } catch {
+      this.clearActiveSession();
+      return false;
+    }
+  }
+
+  /**
+   * Apply Claudian permission mode to the live ACP session.
+   * Plan => modeId "plan"; normal/yolo => modeId "default".
+   */
+  private async applySessionMode(sessionId: string): Promise<void> {
+    if (!this.connection || !sessionId) {
+      return;
+    }
+
+    const modeId = resolveGrokAcpModeId(this.resolvePermissionMode());
+    if (modeId === this.currentSessionModeId) {
+      return;
+    }
+
+    await this.connection.setMode({
+      modeId,
+      sessionId,
+    });
+    this.currentSessionModeId = modeId;
+  }
+
+  private resolvePermissionMode(): string {
+    // Active toolbar permission mode is projected onto top-level settings.
+    const settings = this.plugin.settings as unknown as Record<string, unknown>;
+    const mode = typeof settings.permissionMode === 'string'
+      ? settings.permissionMode.trim()
+      : '';
+    return mode || 'normal';
+  }
+
+  private async handleSessionNotification(
+    notification: AcpSessionNotification,
+    connectionGeneration: number,
+  ): Promise<void> {
+    if (connectionGeneration !== this.connectionGeneration) {
+      return;
+    }
+    const sessionId = notification.sessionId ?? this.sessionId;
+    if (!sessionId || sessionId !== this.sessionId) {
+      return;
+    }
+
+    const normalized = this.sessionUpdateNormalizer.normalize(notification.update);
+    if (!normalized) {
+      return;
+    }
+
+    if (normalized.type === 'commands') {
+      this.setSupportedCommands(normalized.commands);
+      return;
+    }
+
+    if (!this.activeTurn || this.activeTurn.sessionId !== sessionId) {
+      return;
+    }
+
+    switch (normalized.type) {
+      case 'message_chunk': {
+        if (normalized.role === 'assistant' && normalized.messageId) {
+          this.currentTurnMetadata.assistantMessageId = normalized.messageId;
+        }
+        if (normalized.role === 'user' && normalized.messageId) {
+          this.currentTurnMetadata.userMessageId = normalized.messageId;
+        }
+        for (const chunk of normalized.streamChunks) {
+          this.activeTurn.queue.push(chunk);
+        }
+        return;
+      }
+      case 'tool_call':
+      case 'tool_call_update': {
+        for (const chunk of normalized.streamChunks) {
+          this.activeTurn.queue.push(chunk);
+        }
+        return;
+      }
+      case 'usage': {
+        const usage = buildAcpUsageInfo({
+          contextWindow: normalized.usage,
+          model: this.resolveSelectedModel(
+            ProviderSettingsCoordinator.getProviderSettingsSnapshot(this.plugin.settings, 'grok'),
+          ),
+        });
+        if (usage) {
+          this.activeTurn.queue.push({
+            sessionId,
+            type: 'usage',
+            usage,
+          });
+        }
+        return;
+      }
+      default:
+        return;
+    }
+  }
+
+  private async handlePermissionRequest(
+    request: AcpRequestPermissionRequest,
+  ): Promise<AcpRequestPermissionResponse> {
+    if (!this.approvalCallback) {
+      return { outcome: { outcome: 'cancelled' } };
+    }
+
+    const toolCall = request.toolCall ?? {};
+    const rawInput = (toolCall as { rawInput?: unknown; input?: unknown; arguments?: unknown }).rawInput
+      ?? (toolCall as { input?: unknown }).input
+      ?? (toolCall as { arguments?: unknown }).arguments;
+    const input = normalizeApprovalInput(rawInput);
+    const title = (
+      (toolCall as { title?: unknown }).title
+      ?? (toolCall as { kind?: unknown }).kind
+      ?? (toolCall as { name?: unknown }).name
+      ?? 'Grok tool'
+    ).toString();
+    const options = Array.isArray(request.options) ? request.options : [];
+    const decision = await this.approvalCallback(
+      title,
+      input,
+      `Grok wants to use ${title}.`,
+      options.length > 0
+        ? { decisionOptions: buildAcpApprovalDecisionOptions(options) }
+        : undefined,
+    );
+
+    if (options.length > 0) {
+      return mapApprovalDecision(decision, options);
+    }
+
+    if (decision === 'allow' || decision === 'allow-always') {
+      return {
+        outcome: {
+          optionId: decision === 'allow-always' ? 'allow_always' : 'allow_once',
+          outcome: 'selected',
+        },
+      };
+    }
+
+    return { outcome: { outcome: 'cancelled' } };
+  }
+
+  private setSupportedCommands(commands: SlashCommand[]): void {
+    this.supportedCommands = commands.map((command) => ({ ...command }));
+    const waiters = this.supportedCommandWaiters.splice(0);
+    for (const waiter of waiters) {
+      waiter(this.supportedCommands);
+    }
+  }
+
+  private waitForSupportedCommands(timeoutMs = 250): Promise<SlashCommand[]> {
+    if (this.supportedCommands.length > 0) {
+      return Promise.resolve([...this.supportedCommands]);
+    }
+    return new Promise((resolve) => {
+      const waiter = (commands: SlashCommand[]) => {
+        window.clearTimeout(timeoutId);
+        resolve([...commands]);
+      };
+      const timeoutId = window.setTimeout(() => {
+        const index = this.supportedCommandWaiters.indexOf(waiter);
+        if (index >= 0) {
+          this.supportedCommandWaiters.splice(index, 1);
+        }
+        resolve([...this.supportedCommands]);
+      }, timeoutMs);
+      this.supportedCommandWaiters.push(waiter);
+    });
+  }
+
+  private async readTextFile(
+    request: AcpReadTextFileRequest,
+  ): Promise<{ content: string }> {
+    const resolvedPath = this.resolveSessionPath(request.sessionId, request.path);
+    const content = await fs.readFile(resolvedPath, 'utf-8');
+    if (request.line === undefined && request.limit === undefined) {
+      return { content };
+    }
+    const lines = content.split(/\r?\n/);
+    const startIndex = Math.max(0, (request.line ?? 1) - 1);
+    const endIndex = request.limit
+      ? startIndex + Math.max(0, request.limit)
+      : lines.length;
+    return {
+      content: lines.slice(startIndex, endIndex).join('\n'),
+    };
+  }
+
+  private async writeTextFile(
+    request: { sessionId: string; path: string; content: string },
+  ): Promise<Record<string, never>> {
+    const resolvedPath = this.resolveSessionPath(request.sessionId, request.path);
+    await fs.mkdir(path.dirname(resolvedPath), { recursive: true });
+    await fs.writeFile(resolvedPath, request.content, 'utf-8');
+    return {};
+  }
+
+  private resolveSessionPath(sessionId: string, rawPath: string): string {
+    if (typeof rawPath !== 'string') {
+      return getVaultPath(this.plugin.app) ?? process.cwd();
+    }
+    if (path.isAbsolute(rawPath)) {
+      return rawPath;
+    }
+    const cwd = this.sessionCwds.get(sessionId)
+      ?? getVaultPath(this.plugin.app)
+      ?? process.cwd();
+    return path.resolve(cwd, rawPath);
+  }
+
+  private formatRuntimeError(error: unknown): string {
+    const baseMessage = error instanceof Error ? error.message : 'Grok ACP request failed';
+    const stderr = this.process?.getStderrSnapshot();
+    return stderr ? `${baseMessage}\n\n${stderr}` : baseMessage;
+  }
+
+  private clearActiveSession(): void {
+    this.sessionId = null;
+    this.loadedSessionId = null;
+    this.currentSessionModeId = null;
+    this.sessionUpdateNormalizer.reset();
+    this.setSupportedCommands([]);
+  }
+
+  private settleActiveTurn(error?: Error): void {
+    if (!this.activeTurn) {
+      return;
+    }
+    this.activeTurn.cancelled = true;
+    if (error) {
+      this.activeTurn.queue.push({ type: 'error', content: error.message });
+      this.activeTurn.queue.push({ type: 'done' });
+    }
+    // Close output for consumers; leave activeTurn until promptSettled so
+    // overlapping queries stay blocked for the remainder of the ACP RPC.
+    this.activeTurn.queue.close();
+  }
+
+  private setReady(ready: boolean): void {
+    if (this.ready === ready) {
+      return;
+    }
+    this.ready = ready;
+    for (const listener of this.readyListeners) {
+      try {
+        listener(ready);
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  private isLifecycleCurrent(generation: number): boolean {
+    return !this.disposed && generation === this.lifecycleGeneration;
+  }
+
+  private isConversationCurrent(generation: number): boolean {
+    return generation === this.conversationGeneration;
+  }
+
+  private isReadinessCurrent(
+    lifecycleGeneration: number,
+    conversationGeneration: number,
+  ): boolean {
+    return this.isLifecycleCurrent(lifecycleGeneration)
+      && this.isConversationCurrent(conversationGeneration);
+  }
+
+  private setCurrentConversationModel(model: unknown): void {
+    const selectedModel = typeof model === 'string' ? model.trim() : '';
+    this.currentConversationModel = selectedModel || null;
+  }
+
+  private resolveSelectedModel(settings: Record<string, unknown>): string {
+    if (this.currentConversationModel) {
+      return this.currentConversationModel;
+    }
+    if (typeof settings.model === 'string' && settings.model.trim()) {
+      return settings.model.trim();
+    }
+    return GROK_DEFAULT_MODEL;
+  }
+}
+
+function normalizeApprovalInput(rawInput: unknown): Record<string, unknown> {
+  if (rawInput && typeof rawInput === 'object' && !Array.isArray(rawInput)) {
+    return rawInput as Record<string, unknown>;
+  }
+  if (rawInput === undefined) {
+    return {};
+  }
+  return { value: rawInput };
+}
+
+function mapApprovalDecision(
+  decision: ApprovalDecision,
+  options: readonly {
+    kind: 'allow_once' | 'allow_always' | 'reject_once' | 'reject_always';
+    optionId: string;
+  }[],
+): AcpRequestPermissionResponse {
+  if (decision === 'allow') {
+    return selectPermissionOption(options, ['allow_once', 'allow_always']);
+  }
+  if (decision === 'allow-always') {
+    return selectPermissionOption(options, ['allow_always', 'allow_once']);
+  }
+  if (decision === 'deny') {
+    return selectPermissionOption(options, ['reject_once', 'reject_always']);
+  }
+  if (typeof decision === 'object' && decision.type === 'select-option') {
+    return {
+      outcome: {
+        optionId: decision.value,
+        outcome: 'selected',
+      },
+    };
+  }
+  return { outcome: { outcome: 'cancelled' } };
+}
+
+function selectPermissionOption(
+  options: readonly {
+    kind: 'allow_once' | 'allow_always' | 'reject_once' | 'reject_always';
+    optionId: string;
+  }[],
+  preferredKinds: Array<'allow_once' | 'allow_always' | 'reject_once' | 'reject_always'>,
+): AcpRequestPermissionResponse {
+  for (const kind of preferredKinds) {
+    const match = options.find((option) => option.kind === kind);
+    if (match) {
+      return {
+        outcome: {
+          optionId: match.optionId,
+          outcome: 'selected',
+        },
+      };
+    }
+  }
+  return { outcome: { outcome: 'cancelled' } };
+}
+
+function buildAcpApprovalDecisionOptions(
+  options: readonly {
+    kind: 'allow_once' | 'allow_always' | 'reject_once' | 'reject_always';
+    name: string;
+    optionId: string;
+  }[],
+): ApprovalDecisionOption[] {
+  return options.map((option) => ({
+    ...(option.kind === 'allow_once'
+      ? { decision: 'allow' as const }
+      : option.kind === 'allow_always'
+      ? { decision: 'allow-always' as const }
+      : {}),
+    label: option.name,
+    value: option.optionId,
+  }));
+}

--- a/src/providers/grok/runtime/GrokCliResolver.ts
+++ b/src/providers/grok/runtime/GrokCliResolver.ts
@@ -1,0 +1,95 @@
+import * as os from 'os';
+import * as path from 'path';
+
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import { findCliBinaryPath, isExistingFile, resolveConfiguredCliPath } from '../../../utils/cliBinaryLocator';
+import { getHostnameKey, parseEnvironmentVariables } from '../../../utils/env';
+import { getGrokProviderSettings } from '../settings';
+
+/**
+ * Resolve the Grok Build CLI path.
+ *
+ * Order: host-scoped path → legacy cliPath → PATH / common install dirs including
+ * `~/.grok/bin` and `~/.local/bin`.
+ */
+export class GrokCliResolver {
+  private readonly cachedHostname = getHostnameKey();
+  private lastCliPath = '';
+  private lastHostnamePath = '';
+  private lastEnvText = '';
+  private resolvedPath: string | null = null;
+
+  resolveFromSettings(settings: Record<string, unknown>): string | null {
+    const grokSettings = getGrokProviderSettings(settings);
+    const cliPath = grokSettings.cliPath.trim();
+    const hostnamePath = (grokSettings.cliPathsByHost[this.cachedHostname] ?? '').trim();
+    const envText = getRuntimeEnvironmentText(settings, 'grok');
+
+    if (
+      this.resolvedPath !== null
+      && cliPath === this.lastCliPath
+      && hostnamePath === this.lastHostnamePath
+      && envText === this.lastEnvText
+    ) {
+      return this.resolvedPath;
+    }
+
+    this.lastCliPath = cliPath;
+    this.lastHostnamePath = hostnamePath;
+    this.lastEnvText = envText;
+    this.resolvedPath = this.resolve(
+      grokSettings.cliPathsByHost,
+      cliPath,
+      envText,
+    );
+    return this.resolvedPath;
+  }
+
+  resolve(
+    hostnamePaths: Record<string, string> | undefined,
+    legacyPath: string,
+    envText: string,
+  ): string | null {
+    const hostnamePath = (hostnamePaths?.[this.cachedHostname] ?? '').trim();
+    const customEnv = parseEnvironmentVariables(envText || '');
+    return resolveConfiguredCliPath(hostnamePath)
+      ?? resolveConfiguredCliPath(legacyPath.trim())
+      ?? findGrokBinaryPath(customEnv.PATH);
+  }
+
+  reset(): void {
+    this.lastCliPath = '';
+    this.lastHostnamePath = '';
+    this.lastEnvText = '';
+    this.resolvedPath = null;
+  }
+}
+
+function findGrokBinaryPath(additionalPath?: string): string | null {
+  const fromShared = findCliBinaryPath('grok', additionalPath);
+  if (fromShared) {
+    return fromShared;
+  }
+
+  // Explicit Grok install roots (also mirrored in getEnhancedPath for PATH inheritance).
+  const home = os.homedir();
+  const candidates = [
+    path.join(home, '.grok', 'bin', 'grok'),
+    path.join(home, '.local', 'bin', 'grok'),
+    path.join(home, 'bin', 'grok'),
+  ];
+  if (process.platform === 'win32') {
+    candidates.push(
+      path.join(home, '.grok', 'bin', 'grok.exe'),
+      path.join(home, '.local', 'bin', 'grok.exe'),
+    );
+  }
+
+  for (const candidate of candidates) {
+    if (isExistingFile(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}

--- a/src/providers/grok/runtime/GrokHeadlessRunner.ts
+++ b/src/providers/grok/runtime/GrokHeadlessRunner.ts
@@ -1,0 +1,384 @@
+import { type ChildProcess,spawn } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import type { ProviderHost } from '../../../core/providers/ProviderHost';
+import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
+import { getVaultPath } from '../../../utils/path';
+import { getGrokProviderSettings, type GrokSafeMode } from '../settings';
+import { buildGrokRuntimeEnv } from './GrokRuntimeEnvironment';
+
+export interface GrokHeadlessRunOptions {
+  cwd?: string;
+  systemPrompt?: string;
+  model?: string;
+  effort?: string;
+  sessionId?: string;
+  signal?: AbortSignal;
+  onDelta?: (text: string) => void;
+  onTextChunk?: (accumulated: string) => void;
+  onSessionId?: (sessionId: string) => void;
+  onProcess?: (proc: ChildProcess) => void;
+}
+
+export interface GrokHeadlessArgOptions {
+  cwd: string;
+  promptFile: string;
+  model?: string;
+  effort?: string;
+  sessionId?: string;
+  permissionMode?: string;
+  safeMode?: GrokSafeMode;
+  systemRules?: string;
+}
+
+export function buildGrokHeadlessArgs(options: GrokHeadlessArgOptions): string[] {
+  const args = [
+    '--cwd',
+    options.cwd,
+    '--no-alt-screen',
+    '--output-format',
+    'streaming-json',
+  ];
+
+  if (options.model) {
+    args.push('-m', options.model);
+  }
+  if (options.effort) {
+    args.push('--effort', options.effort);
+  }
+  if (options.systemRules) {
+    args.push('--system-prompt-override', options.systemRules);
+  }
+  if (options.sessionId) {
+    args.push('--resume', options.sessionId);
+  }
+  if (options.permissionMode === 'yolo') {
+    args.push('--always-approve');
+  } else if (options.permissionMode === 'plan') {
+    args.push('--permission-mode', 'plan');
+  } else if (options.safeMode) {
+    args.push('--sandbox', options.safeMode);
+  }
+
+  args.push('--prompt-file', options.promptFile);
+  return args;
+}
+
+export function writeGrokPromptFile(prompt: string): string {
+  const filePath = path.join(
+    os.tmpdir(),
+    `claudian-grok-${Date.now()}-${Math.random().toString(36).slice(2)}.txt`,
+  );
+  fs.writeFileSync(filePath, prompt, 'utf-8');
+  return filePath;
+}
+
+function readGrokString(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(readGrokString).filter(Boolean).join('');
+  }
+  if (!value || typeof value !== 'object') {
+    return '';
+  }
+
+  const record = value as Record<string, unknown>;
+  if (typeof record.text === 'string') {
+    return record.text;
+  }
+  if (typeof record.delta === 'string') {
+    return record.delta;
+  }
+  if (typeof record.data === 'string') {
+    return record.data;
+  }
+  if (typeof record.content === 'string') {
+    return record.content;
+  }
+  if (Array.isArray(record.data)) {
+    return readGrokString(record.data);
+  }
+  if (record.data && typeof record.data === 'object') {
+    return readGrokString(record.data);
+  }
+  if (Array.isArray(record.content)) {
+    return readGrokString(record.content);
+  }
+  if (record.content && typeof record.content === 'object') {
+    return readGrokString(record.content);
+  }
+  if (record.message) {
+    return readGrokString(record.message);
+  }
+  if (record.update) {
+    return readGrokString(record.update);
+  }
+  if (record.params) {
+    return readGrokString(record.params);
+  }
+  if (record.result) {
+    return readGrokString(record.result);
+  }
+  if (Array.isArray(record.choices)) {
+    return readGrokString(record.choices);
+  }
+  if (typeof record.output_text === 'string') {
+    return record.output_text;
+  }
+  if (typeof record.response === 'string') {
+    return record.response;
+  }
+  return '';
+}
+
+export function extractGrokEventText(event: unknown): string {
+  if (!event || typeof event !== 'object') {
+    return '';
+  }
+
+  const record = event as Record<string, unknown>;
+  const type = typeof record.type === 'string' ? record.type.toLowerCase() : '';
+  if (type.includes('error')) {
+    return '';
+  }
+
+  const method = typeof record.method === 'string' ? record.method : '';
+  if (method === 'session/update' || method === '_x.ai/session/update') {
+    const params = record.params && typeof record.params === 'object'
+      ? record.params as Record<string, unknown>
+      : null;
+    const update = params?.update && typeof params.update === 'object'
+      ? params.update as Record<string, unknown>
+      : null;
+    const sessionUpdate = update && typeof update.sessionUpdate === 'string'
+      ? update.sessionUpdate
+      : '';
+    if (sessionUpdate === 'agent_message_chunk') {
+      return readGrokString(update?.content);
+    }
+    return '';
+  }
+
+  if (
+    record.data !== undefined
+    && (
+      !type
+      || type === 'text'
+      || type === 'delta'
+      || type.includes('message')
+      || type.includes('chunk')
+      || type.includes('output')
+      || type.includes('response')
+    )
+  ) {
+    return readGrokString(record.data);
+  }
+  if (record.delta !== undefined) {
+    return readGrokString(record.delta);
+  }
+  if (record.text !== undefined) {
+    return readGrokString(record.text);
+  }
+  if (record.content !== undefined) {
+    return readGrokString(record.content);
+  }
+  if (record.message !== undefined) {
+    return readGrokString(record.message);
+  }
+  if (record.update !== undefined) {
+    return readGrokString(record.update);
+  }
+  if (record.params !== undefined) {
+    return readGrokString(record.params);
+  }
+  if (record.result !== undefined) {
+    return readGrokString(record.result);
+  }
+  if (record.output_text !== undefined) {
+    return readGrokString(record.output_text);
+  }
+  if (record.response !== undefined) {
+    return readGrokString(record.response);
+  }
+  return '';
+}
+
+export function extractGrokEventError(event: unknown): string {
+  if (!event || typeof event !== 'object') {
+    return '';
+  }
+  const record = event as Record<string, unknown>;
+  const type = typeof record.type === 'string' ? record.type.toLowerCase() : '';
+  if (!type.includes('error') && record.error === undefined) {
+    return '';
+  }
+  return readGrokString(record.message)
+    || readGrokString(record.error)
+    || readGrokString(record.params)
+    || 'Grok returned an error';
+}
+
+export function extractGrokSessionId(event: unknown): string | null {
+  if (!event || typeof event !== 'object') {
+    return null;
+  }
+  const record = event as Record<string, unknown>;
+  const direct = record.session_id ?? record.sessionId ?? record.session ?? null;
+  if (typeof direct === 'string' && direct.trim()) {
+    return direct.trim();
+  }
+  return extractGrokSessionId(record.params)
+    || extractGrokSessionId(record.update)
+    || extractGrokSessionId(record.result);
+}
+
+export function runGrokHeadless(
+  plugin: ProviderHost,
+  cliPath: string,
+  prompt: string,
+  options: GrokHeadlessRunOptions = {},
+): Promise<string> {
+  const settings = ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+    plugin.settings,
+    'grok',
+  );
+  const grokSettings = getGrokProviderSettings(settings);
+  const cwd = options.cwd || getVaultPath(plugin.app) || process.cwd();
+  const promptFile = writeGrokPromptFile(prompt);
+  const args = buildGrokHeadlessArgs({
+    cwd,
+    promptFile,
+    model: options.model || (typeof settings.model === 'string' ? settings.model : undefined),
+    effort: options.effort || (typeof settings.effortLevel === 'string' ? settings.effortLevel : undefined),
+    sessionId: options.sessionId,
+    permissionMode: typeof settings.permissionMode === 'string' ? settings.permissionMode : undefined,
+    safeMode: grokSettings.safeMode,
+    systemRules: options.systemPrompt,
+  });
+  const env = buildGrokRuntimeEnv(settings, cliPath);
+  const proc = spawn(cliPath, args, {
+    cwd,
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  let stdoutBuffer = '';
+  let stderrText = '';
+  let accumulated = '';
+  let eventError = '';
+
+  const appendText = (text: string): void => {
+    if (!text) {
+      return;
+    }
+    accumulated += text;
+    options.onDelta?.(text);
+    options.onTextChunk?.(accumulated);
+  };
+
+  const handleLine = (line: string): void => {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      return;
+    }
+    try {
+      const event = JSON.parse(trimmed) as unknown;
+      const sessionId = extractGrokSessionId(event);
+      if (sessionId) {
+        options.onSessionId?.(sessionId);
+      }
+      const err = extractGrokEventError(event);
+      if (err) {
+        eventError = err;
+        return;
+      }
+      appendText(extractGrokEventText(event));
+    } catch {
+      appendText(line.endsWith('\n') ? line : `${line}\n`);
+    }
+  };
+
+  proc.stdout.on('data', (chunk: Buffer | string) => {
+    stdoutBuffer += chunk.toString('utf8');
+    let newlineIndex = stdoutBuffer.indexOf('\n');
+    while (newlineIndex >= 0) {
+      const line = stdoutBuffer.slice(0, newlineIndex);
+      stdoutBuffer = stdoutBuffer.slice(newlineIndex + 1);
+      handleLine(line);
+      newlineIndex = stdoutBuffer.indexOf('\n');
+    }
+  });
+
+  proc.stderr.on('data', (chunk: Buffer | string) => {
+    stderrText += chunk.toString('utf8');
+  });
+
+  const kill = (): void => {
+    if (!proc.killed) {
+      proc.kill('SIGTERM');
+      window.setTimeout(() => {
+        if (proc.exitCode === null && !proc.killed) {
+          try {
+            proc.kill('SIGKILL');
+          } catch {
+            // ignore
+          }
+        }
+      }, 1500);
+    }
+  };
+
+  if (options.signal) {
+    if (options.signal.aborted) {
+      kill();
+    } else {
+      options.signal.addEventListener('abort', kill, { once: true });
+    }
+  }
+
+  options.onProcess?.(proc);
+
+  return new Promise((resolve, reject) => {
+    proc.on('error', (err) => {
+      try {
+        fs.unlinkSync(promptFile);
+      } catch {
+        // ignore
+      }
+      reject(err);
+    });
+
+    proc.on('close', (code, signal) => {
+      if (stdoutBuffer.trim()) {
+        handleLine(stdoutBuffer);
+      }
+      try {
+        fs.unlinkSync(promptFile);
+      } catch {
+        // ignore
+      }
+      if (options.signal) {
+        options.signal.removeEventListener('abort', kill);
+      }
+      if (options.signal?.aborted) {
+        resolve(accumulated);
+        return;
+      }
+      if (eventError) {
+        reject(new Error(eventError));
+        return;
+      }
+      if (code && code !== 0) {
+        reject(new Error(
+          (stderrText.trim() || `Grok exited with code ${code}${signal ? ` (${signal})` : ''}`).trim(),
+        ));
+        return;
+      }
+      resolve(accumulated);
+    });
+  });
+}

--- a/src/providers/grok/runtime/GrokRuntimeEnvironment.ts
+++ b/src/providers/grok/runtime/GrokRuntimeEnvironment.ts
@@ -1,0 +1,54 @@
+import * as os from 'os';
+import * as path from 'path';
+
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import { getEnhancedPath, parseEnvironmentVariables } from '../../../utils/env';
+import { getGrokHome } from '../history/GrokHistoryPaths';
+import { getGrokProviderSettings } from '../settings';
+
+/**
+ * Build the environment for Grok Build subprocesses.
+ *
+ * - Disables telemetry trace upload by default unless the user explicitly sets
+ *   GROK_TELEMETRY_TRACE_UPLOAD.
+ * - Maps Claudian safeMode to GROK_SANDBOX when the user did not set GROK_SANDBOX.
+ *   `grok agent stdio` has no `--sandbox` flag; Grok reads this env (best-effort).
+ */
+export function buildGrokRuntimeEnv(
+  settings: Record<string, unknown>,
+  cliPath: string,
+): NodeJS.ProcessEnv {
+  const envText = getRuntimeEnvironmentText(settings, 'grok');
+  const customEnv = parseEnvironmentVariables(envText);
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...customEnv,
+  };
+
+  const pathEntries = [
+    path.dirname(cliPath),
+    path.join(os.homedir(), '.grok', 'bin'),
+    env.PATH,
+  ].filter(Boolean);
+  env.PATH = getEnhancedPath(pathEntries.join(path.delimiter), cliPath || undefined);
+  env.TERM = env.TERM || 'xterm-256color';
+  env.COLORTERM = env.COLORTERM || 'truecolor';
+
+  if (env.GROK_TELEMETRY_TRACE_UPLOAD === undefined) {
+    env.GROK_TELEMETRY_TRACE_UPLOAD = '0';
+  }
+
+  if (env.GROK_SANDBOX === undefined) {
+    env.GROK_SANDBOX = getGrokProviderSettings(settings).safeMode;
+  }
+
+  return env;
+}
+
+/** Resolve the Grok home directory effective for a Claudian settings bag. */
+export function resolveGrokHomeFromSettings(
+  settings: Record<string, unknown>,
+  cliPath = '',
+): string {
+  return getGrokHome(buildGrokRuntimeEnv(settings, cliPath));
+}

--- a/src/providers/grok/runtime/buildGrokPrompt.ts
+++ b/src/providers/grok/runtime/buildGrokPrompt.ts
@@ -1,0 +1,95 @@
+import type { ChatTurnRequest } from '../../../core/runtime/types';
+import type { ChatMessage } from '../../../core/types';
+import { appendBrowserContext } from '../../../utils/browser';
+import { appendCanvasContext } from '../../../utils/canvas';
+import { appendCurrentNote, stripCurrentNoteContext } from '../../../utils/context';
+import { appendEditorContext } from '../../../utils/editor';
+import { buildContextFromHistory, buildPromptWithHistoryContext } from '../../../utils/session';
+import type { AcpContentBlock } from '../../acp';
+
+export function buildGrokTurnPromptText(request: ChatTurnRequest): string {
+  let prompt = request.text;
+
+  if (request.currentNotePath) {
+    prompt = appendCurrentNote(prompt, request.currentNotePath);
+  }
+
+  if (request.editorSelection && request.editorSelection.mode !== 'none') {
+    prompt = appendEditorContext(prompt, request.editorSelection);
+  }
+
+  if (request.browserSelection) {
+    prompt = appendBrowserContext(prompt, request.browserSelection);
+  }
+
+  if (request.canvasSelection) {
+    prompt = appendCanvasContext(prompt, request.canvasSelection);
+  }
+
+  return prompt;
+}
+
+export function buildGrokPromptWithHistory(
+  prompt: string,
+  conversationHistory: ChatMessage[],
+): string {
+  if (conversationHistory.length === 0) {
+    return prompt;
+  }
+
+  const historyContext = buildContextFromHistory(conversationHistory);
+  if (!historyContext.trim()) {
+    return prompt;
+  }
+
+  const actualPrompt = stripCurrentNoteContext(prompt);
+  return buildPromptWithHistoryContext(
+    historyContext,
+    prompt,
+    actualPrompt,
+    conversationHistory,
+  );
+}
+
+export function buildGrokSystemIntegrationPrompt(
+  baseSystemPrompt: string,
+  isFollowupTurn: boolean,
+): string {
+  if (!isFollowupTurn) {
+    return baseSystemPrompt;
+  }
+
+  return `${baseSystemPrompt}
+
+## Grok Build Claudian Integration
+
+Startup greeting rules from vault instructions apply only to the first assistant reply in a new Claudian conversation. This is a resumed conversation, so do not repeat startup greetings. Answer the user's current message directly using the existing conversation context.`;
+}
+
+export function buildGrokFollowupTurnPrompt(
+  prompt: string,
+  isFollowupTurn: boolean,
+): string {
+  if (!isFollowupTurn) {
+    return prompt;
+  }
+
+  return `<claudian_followup_reminder>
+This is a follow-up turn in an existing Claudian conversation using Grok Build session resume. Continue the prior conversation and answer the user's current message directly. Do not run first-session startup rituals.
+</claudian_followup_reminder>
+
+${prompt}`;
+}
+
+export function buildGrokAcpPromptText(
+  systemPrompt: string,
+  promptText: string,
+  isFollowupTurn: boolean,
+): string {
+  const integrationPrompt = buildGrokSystemIntegrationPrompt(systemPrompt, isFollowupTurn);
+  return `<claudian_system_prompt>\n${integrationPrompt}\n</claudian_system_prompt>\n\n${buildGrokFollowupTurnPrompt(promptText, isFollowupTurn)}`;
+}
+
+export function buildGrokAcpPromptBlocks(text: string): AcpContentBlock[] {
+  return [{ type: 'text', text }];
+}

--- a/src/providers/grok/runtime/grokSessionMode.ts
+++ b/src/providers/grok/runtime/grokSessionMode.ts
@@ -1,0 +1,14 @@
+/**
+ * Map Claudian permission modes onto Grok Build ACP session modes.
+ *
+ * Verified against Grok Build 0.2.102:
+ * - `session/set_mode` accepts `modeId: "plan"` and `modeId: "default"`.
+ * YOLO remains a process launch flag (`--always-approve`), not an ACP mode.
+ */
+export type GrokAcpModeId = 'plan' | 'default';
+
+export function resolveGrokAcpModeId(
+  permissionMode: string | null | undefined,
+): GrokAcpModeId {
+  return permissionMode === 'plan' ? 'plan' : 'default';
+}

--- a/src/providers/grok/settings.ts
+++ b/src/providers/grok/settings.ts
@@ -1,0 +1,134 @@
+import { getProviderConfig, setProviderConfig } from '../../core/providers/providerConfig';
+import { getProviderEnvironmentVariables } from '../../core/providers/providerEnvironment';
+import type { HostnameCliPaths } from '../../core/types/settings';
+import {
+  getHostnameKey,
+  getLegacyHostnameKey,
+  migrateLegacyHostnameKeyedMap,
+} from '../../utils/env';
+
+/** Grok Build sandbox profiles (see Grok docs: workspace, read-only, strict, off). */
+export type GrokSafeMode = 'workspace' | 'read-only';
+
+export interface GrokProviderConfig {
+  enabled: boolean;
+  safeMode: GrokSafeMode;
+  cliPath: string;
+  cliPathsByHost: HostnameCliPaths;
+  environmentVariables: string;
+  environmentHash: string;
+}
+
+export type GrokProviderSettings = GrokProviderConfig;
+
+export const DEFAULT_GROK_PROVIDER_SETTINGS: Readonly<GrokProviderConfig> = Object.freeze({
+  enabled: false,
+  safeMode: 'workspace',
+  cliPath: '',
+  cliPathsByHost: {},
+  environmentVariables: '',
+  environmentHash: '',
+});
+
+function normalizeHostnameCliPaths(value: unknown): HostnameCliPaths {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  const result: HostnameCliPaths = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry === 'string' && entry.trim()) {
+      result[key] = entry.trim();
+    }
+  }
+  return result;
+}
+
+/** Map legacy Codex-style values and accept current Grok sandbox profile names. */
+export function normalizeGrokSafeMode(value: unknown): GrokSafeMode {
+  if (value === 'read-only' || value === 'read_only' || value === 'readonly') {
+    return 'read-only';
+  }
+  // Legacy extract used workspace-write (Codex naming).
+  if (value === 'workspace-write' || value === 'workspace_write' || value === 'workspace') {
+    return 'workspace';
+  }
+  return DEFAULT_GROK_PROVIDER_SETTINGS.safeMode;
+}
+
+export function getGrokProviderSettings(
+  settings: Record<string, unknown>,
+): GrokProviderSettings {
+  const config = getProviderConfig(settings, 'grok');
+  const normalizedCliPathsByHost = normalizeHostnameCliPaths(config.cliPathsByHost);
+  const cliPathsByHost = Object.keys(normalizedCliPathsByHost).length > 0
+    ? migrateLegacyHostnameKeyedMap(
+      normalizedCliPathsByHost,
+      getHostnameKey(),
+      getLegacyHostnameKey(),
+    )
+    : normalizedCliPathsByHost;
+
+  return {
+    enabled: (config.enabled as boolean | undefined)
+      ?? DEFAULT_GROK_PROVIDER_SETTINGS.enabled,
+    safeMode: normalizeGrokSafeMode(config.safeMode),
+    cliPath: (config.cliPath as string | undefined)
+      ?? DEFAULT_GROK_PROVIDER_SETTINGS.cliPath,
+    cliPathsByHost,
+    environmentVariables: (config.environmentVariables as string | undefined)
+      ?? getProviderEnvironmentVariables(settings, 'grok')
+      ?? DEFAULT_GROK_PROVIDER_SETTINGS.environmentVariables,
+    environmentHash: (config.environmentHash as string | undefined)
+      ?? DEFAULT_GROK_PROVIDER_SETTINGS.environmentHash,
+  };
+}
+
+export function updateGrokProviderSettings(
+  settings: Record<string, unknown>,
+  updates: Partial<GrokProviderSettings>,
+): GrokProviderSettings {
+  const current = getGrokProviderSettings(settings);
+  const hostnameKey = getHostnameKey();
+  const nextCliPathsByHost = 'cliPathsByHost' in updates
+    ? normalizeHostnameCliPaths(updates.cliPathsByHost)
+    : { ...current.cliPathsByHost };
+  let nextCliPath = 'cliPathsByHost' in updates
+    ? (
+      typeof updates.cliPath === 'string'
+        ? updates.cliPath.trim()
+        : DEFAULT_GROK_PROVIDER_SETTINGS.cliPath
+    )
+    : current.cliPath.trim();
+
+  if ('cliPath' in updates && !('cliPathsByHost' in updates)) {
+    const trimmedCliPath = typeof updates.cliPath === 'string' ? updates.cliPath.trim() : '';
+    if (trimmedCliPath) {
+      nextCliPathsByHost[hostnameKey] = trimmedCliPath;
+    } else {
+      delete nextCliPathsByHost[hostnameKey];
+    }
+    nextCliPath = DEFAULT_GROK_PROVIDER_SETTINGS.cliPath;
+  }
+
+  const next: GrokProviderSettings = {
+    ...current,
+    ...updates,
+    safeMode: 'safeMode' in updates
+      ? normalizeGrokSafeMode(updates.safeMode)
+      : current.safeMode,
+    cliPath: nextCliPath,
+    cliPathsByHost: nextCliPathsByHost,
+  };
+
+  setProviderConfig(settings, 'grok', {
+    enabled: next.enabled,
+    safeMode: next.safeMode,
+    cliPath: next.cliPath,
+    cliPathsByHost: next.cliPathsByHost,
+    environmentVariables: next.environmentVariables,
+    environmentHash: next.environmentHash,
+  });
+
+  return next;
+}

--- a/src/providers/grok/types.ts
+++ b/src/providers/grok/types.ts
@@ -1,0 +1,46 @@
+export interface GrokProviderState {
+  sessionId?: string;
+  /**
+   * Absolute Grok home used when the session was created/updated.
+   * Ensures history hydration matches the runtime even when GROK_HOME is only
+   * set in Claudian provider environment variables.
+   */
+  grokHome?: string;
+}
+
+export function getGrokState(
+  providerState?: Record<string, unknown>,
+): GrokProviderState {
+  if (!providerState || typeof providerState !== 'object') {
+    return {};
+  }
+
+  const sessionId = typeof providerState.sessionId === 'string' && providerState.sessionId.trim()
+    ? providerState.sessionId.trim()
+    : undefined;
+  const grokHome = typeof providerState.grokHome === 'string' && providerState.grokHome.trim()
+    ? providerState.grokHome.trim()
+    : undefined;
+
+  return {
+    ...(sessionId ? { sessionId } : {}),
+    ...(grokHome ? { grokHome } : {}),
+  };
+}
+
+export function resolveGrokSessionId(
+  conversation: {
+    sessionId?: string | null;
+    providerState?: Record<string, unknown>;
+  } | null | undefined,
+): string | null {
+  if (!conversation) {
+    return null;
+  }
+
+  if (typeof conversation.sessionId === 'string' && conversation.sessionId.trim()) {
+    return conversation.sessionId.trim();
+  }
+
+  return getGrokState(conversation.providerState).sessionId ?? null;
+}

--- a/src/providers/grok/ui/GrokChatUIConfig.ts
+++ b/src/providers/grok/ui/GrokChatUIConfig.ts
@@ -1,0 +1,117 @@
+import { getRuntimeEnvironmentVariables } from '../../../core/providers/providerEnvironment';
+import type {
+  ProviderChatUIConfig,
+  ProviderPermissionModeToggleConfig,
+  ProviderReasoningOption,
+  ProviderUIOption,
+} from '../../../core/providers/types';
+import { XAI_PROVIDER_ICON } from '../../../shared/icons';
+
+/** Default model id from Grok Build 0.2.99 ACP modelState. */
+export const GROK_DEFAULT_MODEL = 'grok-4.5';
+
+const GROK_MODELS: ProviderUIOption[] = [
+  {
+    value: GROK_DEFAULT_MODEL,
+    label: 'Grok 4.5',
+    description: 'xAI coding agent',
+  },
+];
+
+const GROK_MODEL_SET = new Set(GROK_MODELS.map((model) => model.value));
+
+/** Effort levels reported by Grok Build 0.2.99 for grok-4.5. */
+const GROK_EFFORT_LEVELS: ProviderReasoningOption[] = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+];
+
+const GROK_DEFAULT_EFFORT = 'high';
+const GROK_DEFAULT_CONTEXT_WINDOW = 500_000;
+
+const GROK_PERMISSION_MODE_TOGGLE: ProviderPermissionModeToggleConfig = {
+  inactiveValue: 'normal',
+  inactiveLabel: 'Safe',
+  activeValue: 'yolo',
+  activeLabel: 'YOLO',
+  planValue: 'plan',
+  planLabel: 'Plan',
+};
+
+function looksLikeGrokModel(model: string): boolean {
+  return /^grok[-_]/i.test(model);
+}
+
+function resolveCustomEnvModel(settings: Record<string, unknown>): string {
+  const envVars = getRuntimeEnvironmentVariables(settings, 'grok');
+  const customModel = envVars.GROK_MODEL || envVars.XAI_MODEL;
+  return typeof customModel === 'string' ? customModel.trim() : '';
+}
+
+export const grokChatUIConfig: ProviderChatUIConfig = {
+  getModelOptions(settings): ProviderUIOption[] {
+    const customModel = resolveCustomEnvModel(settings);
+    if (customModel && !GROK_MODEL_SET.has(customModel)) {
+      return [
+        { value: customModel, label: customModel, description: 'Custom (env)' },
+        ...GROK_MODELS,
+      ];
+    }
+    return [...GROK_MODELS];
+  },
+
+  getDefaultModel(): string {
+    return GROK_DEFAULT_MODEL;
+  },
+
+  ownsModel(model: string, settings: Record<string, unknown>): boolean {
+    if (this.getModelOptions(settings).some((option) => option.value === model)) {
+      return true;
+    }
+    return looksLikeGrokModel(model);
+  },
+
+  isAdaptiveReasoningModel(): boolean {
+    return true;
+  },
+
+  getReasoningOptions(): ProviderReasoningOption[] {
+    return [...GROK_EFFORT_LEVELS];
+  },
+
+  getDefaultReasoningValue(): string {
+    return GROK_DEFAULT_EFFORT;
+  },
+
+  getContextWindowSize(model: string, customLimits?: Record<string, number>): number {
+    return customLimits?.[model] ?? GROK_DEFAULT_CONTEXT_WINDOW;
+  },
+
+  isDefaultModel(model: string): boolean {
+    return GROK_MODEL_SET.has(model);
+  },
+
+  applyModelDefaults(): void {},
+
+  normalizeModelVariant(model: string, settings: Record<string, unknown>): string {
+    return this.ownsModel(model, settings) ? model : GROK_DEFAULT_MODEL;
+  },
+
+  getCustomModelIds(envVars: Record<string, string>): Set<string> {
+    const ids = new Set<string>();
+    const customModel = (envVars.GROK_MODEL || envVars.XAI_MODEL || '').trim();
+    if (customModel && !GROK_MODEL_SET.has(customModel)) {
+      ids.add(customModel);
+    }
+    return ids;
+  },
+
+  getPermissionModeToggle(): ProviderPermissionModeToggleConfig {
+    return GROK_PERMISSION_MODE_TOGGLE;
+  },
+
+  getProviderIcon() {
+    return XAI_PROVIDER_ICON;
+  },
+};

--- a/src/providers/grok/ui/GrokSettingsTab.ts
+++ b/src/providers/grok/ui/GrokSettingsTab.ts
@@ -1,0 +1,161 @@
+import * as fs from 'fs';
+import { Setting } from 'obsidian';
+
+import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
+import type {
+  ProviderSettingsTabRenderer,
+} from '../../../core/providers/types';
+import { renderEnvironmentSettingsSection } from '../../../shared/settings/EnvironmentSettingsSection';
+import { getHostnameKey } from '../../../utils/env';
+import { expandHomePath } from '../../../utils/path';
+import { maybeGetGrokWorkspaceServices } from '../app/GrokWorkspaceServices';
+import {
+  getGrokProviderSettings,
+  type GrokSafeMode,
+  updateGrokProviderSettings,
+} from '../settings';
+
+export const grokSettingsTabRenderer: ProviderSettingsTabRenderer = {
+  render(container, context) {
+    const settingsBag = context.plugin.settings as unknown as Record<string, unknown>;
+    const grokSettings = getGrokProviderSettings(settingsBag);
+    const hostnameKey = getHostnameKey();
+    const workspace = maybeGetGrokWorkspaceServices();
+
+    new Setting(container).setName('Setup').setHeading();
+
+    new Setting(container)
+      .setName('Enable Grok provider')
+      .setDesc(
+        'When enabled, Grok Build appears in the model selector for new conversations. Prompts, selected context, and tool outputs may be sent to xAI according to your Grok configuration. Existing Grok sessions are preserved.',
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(grokSettings.enabled)
+          .onChange(async (value) => {
+            await context.plugin.mutateSettings((settings) => {
+              ProviderSettingsCoordinator.applyProviderEnablement(settings, 'grok', value);
+            });
+            context.refreshModelSelectors();
+            context.refreshTitleGenerationModelOptions();
+          }),
+      );
+
+    const cliPathSetting = new Setting(container)
+      .setName(`Grok CLI path (${hostnameKey})`)
+      .setDesc(
+        'Custom path to the local Grok Build CLI. Leave empty for auto-detection from PATH, ~/.grok/bin, and ~/.local/bin.',
+      );
+
+    const validationEl = container.createDiv({
+      cls: 'claudian-cli-path-validation claudian-setting-validation claudian-setting-validation-error claudian-hidden',
+    });
+    const cliPathsByHost = { ...grokSettings.cliPathsByHost };
+    let cliPathInputEl: HTMLInputElement | null = null;
+
+    const updateCliPathValidation = (value: string, inputEl?: HTMLInputElement): boolean => {
+      const error = validateCliPath(value);
+      if (error) {
+        validationEl.setText(error);
+        validationEl.toggleClass('claudian-hidden', false);
+        inputEl?.toggleClass('claudian-input-error', true);
+        return false;
+      }
+      validationEl.toggleClass('claudian-hidden', true);
+      inputEl?.toggleClass('claudian-input-error', false);
+      return true;
+    };
+
+    const recycleGrokRuntime = async (): Promise<void> => {
+      await context.plugin.recycleProviderRuntimes?.('grok');
+    };
+
+    const persistCliPath = async (value: string): Promise<boolean> => {
+      if (!updateCliPathValidation(value, cliPathInputEl ?? undefined)) {
+        return false;
+      }
+
+      const trimmed = value.trim();
+      if (trimmed) {
+        cliPathsByHost[hostnameKey] = trimmed;
+      } else {
+        delete cliPathsByHost[hostnameKey];
+      }
+
+      await context.plugin.mutateSettings((settings) => {
+        updateGrokProviderSettings(settings, { cliPathsByHost: { ...cliPathsByHost } });
+      });
+      workspace?.cliResolver?.reset();
+      await recycleGrokRuntime();
+      return true;
+    };
+
+    const currentValue = grokSettings.cliPathsByHost[hostnameKey] || '';
+    cliPathSetting.addText((text) => {
+      text
+        .setPlaceholder(process.platform === 'win32'
+          ? 'C:\\Users\\you\\.grok\\bin\\grok.exe'
+          : '~/.grok/bin/grok')
+        .setValue(currentValue)
+        .onChange(async (value) => {
+          await persistCliPath(value);
+        });
+      text.inputEl.addClass('claudian-settings-cli-path-input');
+      cliPathInputEl = text.inputEl;
+      updateCliPathValidation(currentValue, text.inputEl);
+    });
+
+    new Setting(container).setName('Safety').setHeading();
+    new Setting(container)
+      .setName('Grok sandbox')
+      .setDesc(
+        'Sandbox profile for Grok agent tools (GROK_SANDBOX). Profiles: workspace (read everywhere, write CWD/temp/~/.grok) and read-only. This does not create a stronger Claudian or OS filesystem boundary for ACP client file access. YOLO mode uses Grok\'s always-approve flag instead.',
+      )
+      .addDropdown((dropdown) => {
+        dropdown
+          .addOption('workspace', 'Workspace')
+          .addOption('read-only', 'Read only')
+          .setValue(grokSettings.safeMode)
+          .onChange(async (value) => {
+            await context.plugin.mutateSettings((settings) => {
+              updateGrokProviderSettings(settings, {
+                safeMode: value as GrokSafeMode,
+              });
+            });
+            // GROK_SANDBOX is process launch env; recycle so the new profile applies.
+            await recycleGrokRuntime();
+          });
+      });
+
+    renderEnvironmentSettingsSection({
+      container,
+      plugin: context.plugin,
+      scope: 'provider:grok',
+      heading: 'Environment',
+      name: 'Grok environment',
+      desc: 'Grok-owned runtime variables only. Use this for GROK_* and XAI_* settings. If Grok auto-detection needs help, add its install directory to shared PATH instead of this provider section.',
+      placeholder: 'GROK_DEPLOYMENT_KEY=your-key\nXAI_API_KEY=your-key\nGROK_MODEL=grok-4.5',
+      renderCustomContextLimits: (target) => context.renderCustomContextLimits(target, 'grok'),
+    });
+  },
+};
+
+function validateCliPath(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const expandedPath = expandHomePath(trimmed);
+  if (!fs.existsSync(expandedPath)) {
+    return 'Path does not exist';
+  }
+  try {
+    const stat = fs.statSync(expandedPath);
+    if (!stat.isFile()) {
+      return 'Path is a directory, not a file';
+    }
+  } catch {
+    return 'Path does not exist';
+  }
+  return null;
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -2,6 +2,7 @@ import { ProviderRegistry } from '../core/providers/ProviderRegistry';
 import { ProviderWorkspaceRegistry } from '../core/providers/ProviderWorkspaceRegistry';
 import { claudeProviderRegistration } from './claude/registration';
 import { codexProviderRegistration } from './codex/registration';
+import { grokProviderRegistration } from './grok/registration';
 import { opencodeProviderRegistration } from './opencode/registration';
 import { piProviderRegistration } from './pi/registration';
 
@@ -10,6 +11,7 @@ let builtInProvidersRegistered = false;
 export const BUILT_IN_PROVIDER_MODULES = [
   claudeProviderRegistration,
   codexProviderRegistration,
+  grokProviderRegistration,
   opencodeProviderRegistration,
   piProviderRegistration,
 ] as const;

--- a/src/shared/icons.ts
+++ b/src/shared/icons.ts
@@ -110,6 +110,12 @@ export const PI_PROVIDER_ICON: ProviderIconSvg = {
   ],
 };
 
+/** xAI / Grok brand mark used in model selectors. */
+export const XAI_PROVIDER_ICON: ProviderIconSvg = {
+  viewBox: '0 0 24 24',
+  path: 'M3.787 9.362 12.039 21h3.668L7.454 9.362H3.787Zm3.664 6.464L3.782 21h3.671l1.833-2.586-1.835-2.588ZM16.547 3l-6.343 8.944 1.835 2.588L20.217 3h-3.67Zm.664 5.534V21h3.006V4.294l-3.006 4.24Z',
+};
+
 export interface CreateProviderIconSvgOptions {
   className?: string;
   dataProvider?: string;

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -121,6 +121,7 @@ function getExtraBinaryPaths(): string[] {
       paths.push(path.join(home, '.local', 'bin'));
       paths.push(path.join(home, '.bun', 'bin'));
       paths.push(path.join(home, '.opencode', 'bin'));
+      paths.push(path.join(home, '.grok', 'bin'));
     }
 
     paths.push(...getAppProvidedCliPaths());
@@ -160,6 +161,7 @@ function getExtraBinaryPaths(): string[] {
       paths.push(path.join(home, '.local', 'bin'));
       paths.push(path.join(home, '.bun', 'bin'));
       paths.push(path.join(home, '.opencode', 'bin'));
+      paths.push(path.join(home, '.grok', 'bin'));
       paths.push(path.join(home, '.docker', 'bin'));
       paths.push(path.join(home, '.volta', 'bin'));
       paths.push(path.join(home, '.asdf', 'shims'));

--- a/tests/unit/core/providers/ProviderRegistry.test.ts
+++ b/tests/unit/core/providers/ProviderRegistry.test.ts
@@ -104,6 +104,7 @@ describe('ProviderRegistry', () => {
     const ids = ProviderRegistry.getRegisteredProviderIds();
     expect(ids).toContain('claude');
     expect(ids).toContain('codex');
+    expect(ids).toContain('grok');
     expect(ids).toContain('pi');
   });
 
@@ -131,6 +132,14 @@ describe('ProviderRegistry', () => {
         pi: { enabled: true },
       },
     })).toEqual(['opencode', 'pi', 'codex', 'claude']);
+    expect(ProviderRegistry.getEnabledProviderIds({
+      providerConfigs: {
+        codex: { enabled: true },
+        grok: { enabled: true },
+        opencode: { enabled: true },
+        pi: { enabled: true },
+      },
+    })).toEqual(['opencode', 'pi', 'grok', 'codex', 'claude']);
   });
 
   it('exposes title generation models only from enabled providers', () => {

--- a/tests/unit/providers/ProviderModuleCatalog.test.ts
+++ b/tests/unit/providers/ProviderModuleCatalog.test.ts
@@ -5,6 +5,7 @@ describe('built-in ProviderModule catalog', () => {
     expect(BUILT_IN_PROVIDER_MODULES.map(module => module.id)).toEqual([
       'claude',
       'codex',
+      'grok',
       'opencode',
       'pi',
     ]);

--- a/tests/unit/providers/defaultProviderConfigs.test.ts
+++ b/tests/unit/providers/defaultProviderConfigs.test.ts
@@ -7,11 +7,13 @@ describe('getBuiltInProviderDefaultConfigs', () => {
 
     expect(first).toHaveProperty('claude');
     expect(first).toHaveProperty('codex');
+    expect(first).toHaveProperty('grok');
     expect(first).toHaveProperty('opencode');
     expect(first).toHaveProperty('pi');
     expect(first).not.toBe(second);
     expect(first.claude).not.toBe(second.claude);
     expect(first.codex).not.toBe(second.codex);
+    expect(first.grok).not.toBe(second.grok);
     expect(first.opencode).not.toBe(second.opencode);
     expect(first.pi).not.toBe(second.pi);
   });

--- a/tests/unit/providers/grok/GrokChatRuntime.test.ts
+++ b/tests/unit/providers/grok/GrokChatRuntime.test.ts
@@ -1,0 +1,552 @@
+import '@/providers';
+
+import {
+  AcpClientConnection,
+  AcpJsonRpcTransport,
+  AcpSubprocess,
+} from '@/providers/acp';
+import {
+  buildGrokAcpLaunchKey,
+  GrokChatRuntime,
+} from '@/providers/grok/runtime/GrokChatRuntime';
+
+jest.mock('@/providers/acp', () => {
+  const actual = jest.requireActual('@/providers/acp');
+  return {
+    ...actual,
+    AcpClientConnection: jest.fn(),
+    AcpJsonRpcTransport: jest.fn(),
+    AcpSubprocess: jest.fn(),
+  };
+});
+
+const MockAcpClientConnection = AcpClientConnection as jest.MockedClass<typeof AcpClientConnection>;
+const MockAcpJsonRpcTransport = AcpJsonRpcTransport as jest.MockedClass<typeof AcpJsonRpcTransport>;
+const MockAcpSubprocess = AcpSubprocess as jest.MockedClass<typeof AcpSubprocess>;
+
+function createMockPlugin(overrides: Record<string, unknown> = {}): any {
+  const settingsOverride = (overrides.settings as Record<string, unknown> | undefined) ?? {};
+  const { settings: _ignoredSettings, ...restOverrides } = overrides;
+  return {
+    settings: {
+      providerConfigs: {
+        grok: {
+          enabled: true,
+          safeMode: 'workspace',
+        },
+      },
+      permissionMode: 'normal',
+      model: 'grok-4.5',
+      effortLevel: 'high',
+      mediaFolder: '',
+      systemPrompt: '',
+      userName: '',
+      ...settingsOverride,
+    },
+    manifest: { version: '0.0.0-test' },
+    getResolvedProviderCliPath: jest.fn().mockResolvedValue('/usr/local/bin/grok'),
+    saveSettings: jest.fn().mockResolvedValue(undefined),
+    app: {
+      vault: {
+        adapter: {
+          basePath: '/tmp/claudian-grok-test-vault',
+        },
+      },
+    },
+    ...restOverrides,
+  };
+}
+
+function createDeferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('buildGrokAcpLaunchKey', () => {
+  it('includes safeMode and yolo but not full permissionMode', () => {
+    const base = {
+      cliPath: '/usr/local/bin/grok',
+      cwd: '/vault',
+      effort: 'high',
+      envText: '',
+      model: 'grok-4.5',
+    };
+
+    const workspaceNormal = buildGrokAcpLaunchKey({
+      ...base,
+      safeMode: 'workspace',
+      yolo: false,
+    });
+    const readOnlyNormal = buildGrokAcpLaunchKey({
+      ...base,
+      safeMode: 'read-only',
+      yolo: false,
+    });
+    const workspaceYolo = buildGrokAcpLaunchKey({
+      ...base,
+      safeMode: 'workspace',
+      yolo: true,
+    });
+
+    expect(workspaceNormal).not.toEqual(readOnlyNormal);
+    expect(workspaceNormal).not.toEqual(workspaceYolo);
+    expect(workspaceNormal).toContain('"safeMode":"workspace"');
+    expect(readOnlyNormal).toContain('"safeMode":"read-only"');
+    expect(workspaceYolo).toContain('"yolo":true');
+    expect(workspaceNormal).toContain('"yolo":false');
+    // Plan vs normal share the same launch fingerprint (yolo false).
+    expect(workspaceNormal).toEqual(buildGrokAcpLaunchKey({
+      ...base,
+      safeMode: 'workspace',
+      yolo: false,
+    }));
+  });
+});
+
+describe('GrokChatRuntime session mode application', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('applies ACP plan mode after creating a session', async () => {
+    const plugin = createMockPlugin({
+      settings: {
+        permissionMode: 'plan',
+      },
+    });
+    const runtime = new GrokChatRuntime(plugin);
+    const setMode = jest.fn().mockResolvedValue({});
+    const newSession = jest.fn().mockResolvedValue({ sessionId: 'sess-new' });
+
+    (runtime as any).connection = {
+      newSession,
+      setMode,
+      loadSession: jest.fn(),
+      dispose: jest.fn(),
+    };
+
+    const sessionId = await (runtime as any).createSession('/tmp/vault');
+
+    expect(sessionId).toBe('sess-new');
+    expect(newSession).toHaveBeenCalledWith({
+      cwd: '/tmp/vault',
+      mcpServers: [],
+    });
+    expect(setMode).toHaveBeenCalledWith({
+      sessionId: 'sess-new',
+      modeId: 'plan',
+    });
+    expect((runtime as any).currentSessionModeId).toBe('plan');
+  });
+
+  it('applies ACP default mode after loading a session for yolo', async () => {
+    const plugin = createMockPlugin({
+      settings: {
+        permissionMode: 'yolo',
+      },
+    });
+    const runtime = new GrokChatRuntime(plugin);
+    const setMode = jest.fn().mockResolvedValue({});
+    const loadSession = jest.fn().mockResolvedValue({ sessionId: 'sess-load' });
+
+    (runtime as any).connection = {
+      newSession: jest.fn(),
+      setMode,
+      loadSession,
+      dispose: jest.fn(),
+    };
+
+    await expect((runtime as any).loadSession('sess-load', '/tmp/vault')).resolves.toBe(true);
+    expect(loadSession).toHaveBeenCalledWith({
+      cwd: '/tmp/vault',
+      mcpServers: [],
+      sessionId: 'sess-load',
+    });
+    expect(setMode).toHaveBeenCalledWith({
+      sessionId: 'sess-load',
+      modeId: 'default',
+    });
+  });
+
+  it('does not commit session state when createSession setMode fails', async () => {
+    const plugin = createMockPlugin({
+      settings: {
+        permissionMode: 'plan',
+      },
+    });
+    const runtime = new GrokChatRuntime(plugin);
+    const setMode = jest.fn().mockRejectedValue(new Error('setMode failed'));
+    const newSession = jest.fn().mockResolvedValue({ sessionId: 'sess-new' });
+
+    (runtime as any).connection = {
+      newSession,
+      setMode,
+      loadSession: jest.fn(),
+      dispose: jest.fn(),
+    };
+
+    await expect((runtime as any).createSession('/tmp/vault')).resolves.toBeNull();
+    expect(setMode).toHaveBeenCalled();
+    expect((runtime as any).sessionId).toBeNull();
+    expect((runtime as any).loadedSessionId).toBeNull();
+    expect((runtime as any).currentSessionModeId).toBeNull();
+  });
+
+  it('does not commit session state when loadSession setMode fails', async () => {
+    const plugin = createMockPlugin({
+      settings: {
+        permissionMode: 'plan',
+      },
+    });
+    const runtime = new GrokChatRuntime(plugin);
+    const setMode = jest.fn().mockRejectedValue(new Error('setMode failed'));
+    const loadSession = jest.fn().mockResolvedValue({ sessionId: 'sess-load' });
+
+    (runtime as any).connection = {
+      newSession: jest.fn(),
+      setMode,
+      loadSession,
+      dispose: jest.fn(),
+    };
+
+    await expect((runtime as any).loadSession('sess-load', '/tmp/vault')).resolves.toBe(false);
+    expect(setMode).toHaveBeenCalled();
+    expect((runtime as any).sessionId).toBeNull();
+    expect((runtime as any).loadedSessionId).toBeNull();
+    expect((runtime as any).currentSessionModeId).toBeNull();
+  });
+
+  it('skips redundant setMode when the session already has the target mode', async () => {
+    const plugin = createMockPlugin({
+      settings: {
+        permissionMode: 'plan',
+      },
+    });
+    const runtime = new GrokChatRuntime(plugin);
+    const setMode = jest.fn().mockResolvedValue({});
+    (runtime as any).connection = { setMode };
+    (runtime as any).currentSessionModeId = 'plan';
+
+    await (runtime as any).applySessionMode('sess-1');
+    expect(setMode).not.toHaveBeenCalled();
+  });
+
+  it('applies session mode before each prompt turn', async () => {
+    const plugin = createMockPlugin({
+      settings: {
+        permissionMode: 'plan',
+      },
+    });
+    const runtime = new GrokChatRuntime(plugin);
+    runtime.syncConversationState({
+      id: 'conv-1',
+      sessionId: 'sess-turn',
+      providerState: { sessionId: 'sess-turn' },
+    });
+
+    const setMode = jest.fn().mockResolvedValue({});
+    const prompt = jest.fn().mockResolvedValue({});
+    (runtime as any).connection = {
+      setMode,
+      prompt,
+      cancel: jest.fn(),
+      dispose: jest.fn(),
+    };
+    (runtime as any).ready = true;
+    (runtime as any).loadedSessionId = 'sess-turn';
+    (runtime as any).sessionId = 'sess-turn';
+    (runtime as any).ensureReady = jest.fn().mockResolvedValue(true);
+
+    const turn = runtime.prepareTurn({
+      text: 'hello',
+    } as any);
+
+    const chunks: unknown[] = [];
+    for await (const chunk of runtime.query(turn, [])) {
+      chunks.push(chunk);
+    }
+
+    expect(setMode).toHaveBeenCalledWith({
+      sessionId: 'sess-turn',
+      modeId: 'plan',
+    });
+    expect(prompt).toHaveBeenCalled();
+    expect(chunks.some((chunk) => (chunk as { type?: string }).type === 'done')).toBe(true);
+  });
+
+  it('persists resolved grokHome in session updates', () => {
+    const plugin = createMockPlugin();
+    const runtime = new GrokChatRuntime(plugin);
+    (runtime as any).sessionId = 'sess-1';
+    (runtime as any).currentGrokHome = '/custom/grok-home';
+
+    const result = runtime.buildSessionUpdates({
+      conversation: null,
+      sessionInvalidated: false,
+    });
+
+    expect(result.updates).toEqual({
+      sessionId: 'sess-1',
+      providerState: {
+        sessionId: 'sess-1',
+        grokHome: '/custom/grok-home',
+      },
+    });
+  });
+
+  it('blocks overlapping query while a cancelled ACP prompt is still in flight', async () => {
+    const plugin = createMockPlugin();
+    const runtime = new GrokChatRuntime(plugin);
+    runtime.syncConversationState({
+      id: 'conv-1',
+      sessionId: 'sess-cancel',
+      providerState: { sessionId: 'sess-cancel' },
+    });
+
+    const deferred = createDeferred<Record<string, never>>();
+    const promptStarted = createDeferred();
+    const cancel = jest.fn();
+    const setMode = jest.fn().mockResolvedValue({});
+    const prompt = jest.fn().mockImplementation(() => {
+      promptStarted.resolve();
+      return deferred.promise;
+    });
+
+    (runtime as any).connection = {
+      setMode,
+      prompt,
+      cancel,
+      dispose: jest.fn(),
+    };
+    (runtime as any).ready = true;
+    (runtime as any).loadedSessionId = 'sess-cancel';
+    (runtime as any).sessionId = 'sess-cancel';
+    (runtime as any).ensureReady = jest.fn().mockResolvedValue(true);
+
+    const turn = runtime.prepareTurn({ text: 'first' } as any);
+    const firstQuery = (async () => {
+      const chunks: unknown[] = [];
+      for await (const chunk of runtime.query(turn, [])) {
+        chunks.push(chunk);
+      }
+      return chunks;
+    })();
+
+    await promptStarted.promise;
+    expect(prompt).toHaveBeenCalledTimes(1);
+    expect((runtime as any).activeTurn).not.toBeNull();
+
+    runtime.cancel();
+    expect(cancel).toHaveBeenCalledWith({ sessionId: 'sess-cancel' });
+    // Busy barrier remains until the ACP prompt RPC settles.
+    expect((runtime as any).activeTurn).not.toBeNull();
+    expect((runtime as any).activeTurn.cancelled).toBe(true);
+
+    const overlapChunks: unknown[] = [];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'second' } as any), [])) {
+      overlapChunks.push(chunk);
+    }
+    expect(overlapChunks).toEqual([
+      { type: 'error', content: 'Grok does not support overlapping turns.' },
+      { type: 'done' },
+    ]);
+    expect(prompt).toHaveBeenCalledTimes(1);
+
+    deferred.resolve({});
+    await firstQuery;
+
+    expect((runtime as any).activeTurn).toBeNull();
+
+    // After the cancelled turn settles, a new query can start.
+    const secondPrompt = jest.fn().mockResolvedValue({});
+    (runtime as any).connection.prompt = secondPrompt;
+    const postCancelChunks: unknown[] = [];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'third' } as any), [])) {
+      postCancelChunks.push(chunk);
+    }
+    expect(secondPrompt).toHaveBeenCalledTimes(1);
+    expect(postCancelChunks.some((chunk) => (chunk as { type?: string }).type === 'done')).toBe(true);
+  });
+});
+
+describe('GrokChatRuntime process launch', () => {
+  let mockConnection: {
+    cancel: jest.Mock;
+    dispose: jest.Mock;
+    initialize: jest.Mock;
+    loadSession: jest.Mock;
+    newSession: jest.Mock;
+    prompt: jest.Mock;
+    setMode: jest.Mock;
+  };
+  let mockProcess: {
+    getStderrSnapshot: jest.Mock;
+    isAlive: jest.Mock;
+    onClose: jest.Mock;
+    shutdown: jest.Mock;
+    start: jest.Mock;
+    stdin: Record<string, never>;
+    stdout: Record<string, never>;
+  };
+  let mockTransport: {
+    dispose: jest.Mock;
+    isClosed: boolean;
+    onClose: jest.Mock;
+    start: jest.Mock;
+  };
+  let lastSubprocessLaunch: { args: string[]; command: string; env: NodeJS.ProcessEnv } | null;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    lastSubprocessLaunch = null;
+
+    mockConnection = {
+      cancel: jest.fn(),
+      dispose: jest.fn(),
+      initialize: jest.fn().mockResolvedValue({}),
+      loadSession: jest.fn().mockResolvedValue({ sessionId: 'sess-load' }),
+      newSession: jest.fn().mockResolvedValue({ sessionId: 'sess-new' }),
+      prompt: jest.fn().mockResolvedValue({}),
+      setMode: jest.fn().mockResolvedValue({}),
+    };
+    mockProcess = {
+      getStderrSnapshot: jest.fn().mockReturnValue(''),
+      isAlive: jest.fn().mockReturnValue(true),
+      onClose: jest.fn().mockReturnValue(() => undefined),
+      shutdown: jest.fn().mockResolvedValue(undefined),
+      start: jest.fn(),
+      stdin: {},
+      stdout: {},
+    };
+    mockTransport = {
+      dispose: jest.fn(),
+      isClosed: false,
+      onClose: jest.fn().mockReturnValue(() => undefined),
+      start: jest.fn(),
+    };
+
+    MockAcpClientConnection.mockImplementation(() => mockConnection as any);
+    MockAcpJsonRpcTransport.mockImplementation(() => mockTransport as any);
+    MockAcpSubprocess.mockImplementation((spec: any) => {
+      lastSubprocessLaunch = {
+        args: spec.args,
+        command: spec.command,
+        env: spec.env,
+      };
+      return mockProcess as any;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('includes --always-approve in production YOLO launch args only', async () => {
+    const yoloPlugin = createMockPlugin({
+      settings: {
+        permissionMode: 'yolo',
+      },
+    });
+    const yoloRuntime = new GrokChatRuntime(yoloPlugin);
+    await (yoloRuntime as any).startProcess({
+      cliPath: '/usr/local/bin/grok',
+      cwd: '/tmp/vault',
+      effort: 'medium',
+      model: 'grok-4.5',
+      yolo: true,
+    });
+
+    expect(MockAcpSubprocess).toHaveBeenCalled();
+    expect(lastSubprocessLaunch).not.toBeNull();
+    expect(lastSubprocessLaunch!.args).toEqual([
+      'agent',
+      '-m',
+      'grok-4.5',
+      '--reasoning-effort',
+      'medium',
+      '--always-approve',
+      'stdio',
+    ]);
+    expect(mockProcess.start).toHaveBeenCalled();
+    expect(mockConnection.initialize).toHaveBeenCalled();
+
+    lastSubprocessLaunch = null;
+    const normalPlugin = createMockPlugin({
+      settings: {
+        permissionMode: 'normal',
+      },
+    });
+    const normalRuntime = new GrokChatRuntime(normalPlugin);
+    await (normalRuntime as any).startProcess({
+      cliPath: '/usr/local/bin/grok',
+      cwd: '/tmp/vault',
+      effort: 'medium',
+      model: 'grok-4.5',
+      yolo: false,
+    });
+
+    expect(lastSubprocessLaunch).not.toBeNull();
+    expect(lastSubprocessLaunch!.args).toEqual([
+      'agent',
+      '-m',
+      'grok-4.5',
+      '--reasoning-effort',
+      'medium',
+      'stdio',
+    ]);
+    expect(lastSubprocessLaunch!.args).not.toContain('--always-approve');
+  });
+
+  it('restarts ACP process when safeMode changes and keeps plan/normal on same process', async () => {
+    const plugin = createMockPlugin({
+      settings: {
+        permissionMode: 'normal',
+        providerConfigs: {
+          grok: {
+            enabled: true,
+            safeMode: 'workspace',
+          },
+        },
+      },
+    });
+    const runtime = new GrokChatRuntime(plugin);
+
+    await expect(runtime.ensureReady({ allowSessionCreation: false })).resolves.toBe(true);
+    expect(MockAcpSubprocess).toHaveBeenCalledTimes(1);
+    expect(lastSubprocessLaunch?.env.GROK_SANDBOX).toBe('workspace');
+    const firstLaunchKey = (runtime as any).currentLaunchKey as string;
+    expect(firstLaunchKey).toContain('"safeMode":"workspace"');
+    expect(firstLaunchKey).toContain('"yolo":false');
+
+    // plan vs normal: launch key stays yolo:false → no process restart.
+    plugin.settings.permissionMode = 'plan';
+    await expect(runtime.ensureReady({ allowSessionCreation: false })).resolves.toBe(true);
+    expect(MockAcpSubprocess).toHaveBeenCalledTimes(1);
+    expect((runtime as any).currentLaunchKey).toBe(firstLaunchKey);
+
+    // safeMode change: new launch key → restart with read-only sandbox env.
+    plugin.settings.providerConfigs.grok.safeMode = 'read-only';
+    await expect(runtime.ensureReady({ allowSessionCreation: false })).resolves.toBe(true);
+    expect(MockAcpSubprocess).toHaveBeenCalledTimes(2);
+    expect(mockProcess.shutdown).toHaveBeenCalled();
+    expect(lastSubprocessLaunch?.env.GROK_SANDBOX).toBe('read-only');
+    expect((runtime as any).currentLaunchKey).toContain('"safeMode":"read-only"');
+    expect((runtime as any).currentLaunchKey).not.toBe(firstLaunchKey);
+
+    // yolo requires restart for --always-approve.
+    plugin.settings.permissionMode = 'yolo';
+    await expect(runtime.ensureReady({ allowSessionCreation: false })).resolves.toBe(true);
+    expect(MockAcpSubprocess).toHaveBeenCalledTimes(3);
+    expect(lastSubprocessLaunch?.args).toContain('--always-approve');
+    expect((runtime as any).currentLaunchKey).toContain('"yolo":true');
+  });
+});

--- a/tests/unit/providers/grok/GrokChatUIConfig.test.ts
+++ b/tests/unit/providers/grok/GrokChatUIConfig.test.ts
@@ -1,0 +1,33 @@
+import { GROK_DEFAULT_MODEL, grokChatUIConfig } from '@/providers/grok/ui/GrokChatUIConfig';
+
+describe('grokChatUIConfig', () => {
+  it('exposes grok-4.5 and effort levels from Grok Build 0.2.99', () => {
+    expect(GROK_DEFAULT_MODEL).toBe('grok-4.5');
+    expect(grokChatUIConfig.getModelOptions({})).toEqual([
+      expect.objectContaining({ value: 'grok-4.5' }),
+    ]);
+    expect(grokChatUIConfig.getReasoningOptions('grok-4.5', {})).toEqual([
+      { value: 'low', label: 'Low' },
+      { value: 'medium', label: 'Medium' },
+      { value: 'high', label: 'High' },
+    ]);
+    expect(grokChatUIConfig.getDefaultReasoningValue('grok-4.5', {})).toBe('high');
+    expect(grokChatUIConfig.getContextWindowSize('grok-4.5')).toBe(500_000);
+    expect(grokChatUIConfig.ownsModel('grok-4.5', {})).toBe(true);
+    expect(grokChatUIConfig.ownsModel('claude-opus-4', {})).toBe(false);
+  });
+
+  it('includes custom env model when configured', () => {
+    const options = grokChatUIConfig.getModelOptions({
+      providerConfigs: {
+        grok: {
+          environmentVariables: 'GROK_MODEL=custom-grok',
+        },
+      },
+    });
+    expect(options[0]).toEqual(expect.objectContaining({
+      value: 'custom-grok',
+      description: 'Custom (env)',
+    }));
+  });
+});

--- a/tests/unit/providers/grok/GrokCliResolver.test.ts
+++ b/tests/unit/providers/grok/GrokCliResolver.test.ts
@@ -1,0 +1,93 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { GrokCliResolver } from '@/providers/grok/runtime/GrokCliResolver';
+
+jest.mock('fs');
+jest.mock('@/utils/env', () => ({
+  ...jest.requireActual('@/utils/env'),
+  getHostnameKey: () => 'current-host',
+}));
+
+const mockedStat = fs.statSync as jest.Mock;
+
+describe('GrokCliResolver', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (fs.existsSync as jest.Mock).mockReturnValue(false);
+  });
+
+  it('uses the current host path instead of another synced host path', () => {
+    mockedStat.mockImplementation((filePath: string) => {
+      if (filePath === '/current/grok') {
+        return { isFile: () => true };
+      }
+      throw new Error(`ENOENT: ${filePath}`);
+    });
+
+    const resolver = new GrokCliResolver();
+    const resolved = resolver.resolve(
+      {
+        'other-host': '/other/grok',
+        'current-host': '/current/grok',
+      },
+      '/legacy/grok',
+      '',
+    );
+
+    expect(resolved).toBe('/current/grok');
+  });
+
+  it('falls back to the legacy path when the current host has no custom path', () => {
+    mockedStat.mockImplementation((filePath: string) => {
+      if (filePath === '/legacy/grok') {
+        return { isFile: () => true };
+      }
+      throw new Error(`ENOENT: ${filePath}`);
+    });
+
+    const resolver = new GrokCliResolver();
+    const resolved = resolver.resolve(
+      {
+        'other-host': '/other/grok',
+      },
+      '/legacy/grok',
+      '',
+    );
+
+    expect(resolved).toBe('/legacy/grok');
+  });
+
+  it('falls back to PATH lookup when no Grok CLI path is configured', () => {
+    const pathDir = '/custom/bin';
+    const pathBinary = path.join(pathDir, 'grok');
+    mockedStat.mockImplementation((filePath: string) => {
+      if (filePath === pathBinary) {
+        return { isFile: () => true };
+      }
+      throw new Error(`ENOENT: ${filePath}`);
+    });
+
+    const resolver = new GrokCliResolver();
+    const resolved = resolver.resolve({}, '', `PATH=${pathDir}`);
+
+    expect(resolved).toBe(pathBinary);
+  });
+
+  it('returns null when no configured path or PATH binary exists', () => {
+    mockedStat.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+
+    const resolver = new GrokCliResolver();
+    const resolved = resolver.resolve(
+      {
+        'other-host': '/other/grok',
+      },
+      '/legacy/grok',
+      '',
+    );
+
+    expect(resolved).toBeNull();
+  });
+});

--- a/tests/unit/providers/grok/GrokConversationHistoryService.test.ts
+++ b/tests/unit/providers/grok/GrokConversationHistoryService.test.ts
@@ -1,0 +1,224 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import type { Conversation } from '../../../../src/core/types';
+import {
+  GrokConversationHistoryService,
+  loadGrokHistoryMessages,
+  shouldSkipGrokHistoryUser,
+} from '../../../../src/providers/grok/history/GrokConversationHistoryService';
+
+describe('GrokConversationHistoryService', () => {
+  let tmpRoot: string;
+  let vaultPath: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'claudian-grok-history-'));
+    vaultPath = path.join(tmpRoot, 'vault');
+    fs.mkdirSync(vaultPath, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { force: true, recursive: true });
+  });
+
+  it('skips synthetic system reminders and hydrates user/assistant turns', () => {
+    expect(shouldSkipGrokHistoryUser({ synthetic_reason: 'bootstrap' }, 'x')).toBe(true);
+    expect(shouldSkipGrokHistoryUser({}, '<user_info>\nos')).toBe(true);
+    expect(shouldSkipGrokHistoryUser({}, 'hello')).toBe(false);
+
+    const sessionId = 'session-1';
+    const historyPath = path.join(
+      tmpRoot,
+      'sessions',
+      encodeURIComponent(vaultPath),
+      sessionId,
+      'chat_history.jsonl',
+    );
+    fs.mkdirSync(path.dirname(historyPath), { recursive: true });
+    fs.writeFileSync(historyPath, [
+      JSON.stringify({ type: 'system', content: 'system prompt' }),
+      JSON.stringify({
+        type: 'user',
+        synthetic_reason: 'bootstrap',
+        content: [{ type: 'text', text: '<user_info>os</user_info>' }],
+      }),
+      JSON.stringify({
+        type: 'user',
+        content: [{ type: 'text', text: '<user_query>\nFix the bug\n</user_query>' }],
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        content: [{ type: 'text', text: 'Done.' }],
+      }),
+    ].join('\n'), 'utf-8');
+
+    const messages = loadGrokHistoryMessages(historyPath, sessionId, 1000);
+    expect(messages).toEqual([
+      expect.objectContaining({
+        role: 'user',
+        content: 'Fix the bug',
+      }),
+      expect.objectContaining({
+        role: 'assistant',
+        content: 'Done.',
+      }),
+    ]);
+  });
+
+  it('hydrates conversation from GROK_HOME session files without mutating them', async () => {
+    const sessionId = 'session-hydrate';
+    const historyPath = path.join(
+      tmpRoot,
+      'sessions',
+      encodeURIComponent(vaultPath),
+      sessionId,
+      'chat_history.jsonl',
+    );
+    fs.mkdirSync(path.dirname(historyPath), { recursive: true });
+    const original = JSON.stringify({
+      type: 'user',
+      content: 'Hello Grok',
+    }) + '\n' + JSON.stringify({
+      type: 'assistant',
+      content: 'Hi there',
+    }) + '\n';
+    fs.writeFileSync(historyPath, original, 'utf-8');
+
+    const conversation: Conversation = {
+      id: 'conv-1',
+      providerId: 'grok',
+      title: 'Test',
+      createdAt: 1_000,
+      updatedAt: 1_000,
+      messages: [],
+      sessionId,
+      providerState: { sessionId },
+    };
+
+    const previousHome = process.env.GROK_HOME;
+    process.env.GROK_HOME = tmpRoot;
+    try {
+      const service = new GrokConversationHistoryService();
+      await service.hydrateConversationHistory(conversation, vaultPath);
+
+      expect(conversation.messages.map((message) => message.content)).toEqual([
+        'Hello Grok',
+        'Hi there',
+      ]);
+      expect(fs.readFileSync(historyPath, 'utf-8')).toBe(original);
+
+      await service.deleteConversationSession(conversation, vaultPath);
+      expect(fs.existsSync(historyPath)).toBe(true);
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.GROK_HOME;
+      } else {
+        process.env.GROK_HOME = previousHome;
+      }
+    }
+  });
+
+  it('hydrates from providerState.grokHome even when process.env.GROK_HOME differs', async () => {
+    const sessionId = 'session-state-home';
+    const stateHome = path.join(tmpRoot, 'state-home');
+    const processHome = path.join(tmpRoot, 'process-home');
+    const historyPath = path.join(
+      stateHome,
+      'sessions',
+      encodeURIComponent(vaultPath),
+      sessionId,
+      'chat_history.jsonl',
+    );
+    const wrongHistoryPath = path.join(
+      processHome,
+      'sessions',
+      encodeURIComponent(vaultPath),
+      sessionId,
+      'chat_history.jsonl',
+    );
+    fs.mkdirSync(path.dirname(historyPath), { recursive: true });
+    fs.mkdirSync(path.dirname(wrongHistoryPath), { recursive: true });
+    fs.writeFileSync(historyPath, `${JSON.stringify({ type: 'user', content: 'From state home' })}\n`, 'utf-8');
+    fs.writeFileSync(wrongHistoryPath, `${JSON.stringify({ type: 'user', content: 'From process home' })}\n`, 'utf-8');
+
+    const conversation: Conversation = {
+      id: 'conv-state',
+      providerId: 'grok',
+      title: 'Test',
+      createdAt: 1_000,
+      updatedAt: 1_000,
+      messages: [],
+      sessionId,
+      providerState: { sessionId, grokHome: stateHome },
+    };
+
+    const previousHome = process.env.GROK_HOME;
+    process.env.GROK_HOME = processHome;
+    try {
+      const service = new GrokConversationHistoryService();
+      await service.hydrateConversationHistory(conversation, vaultPath);
+      expect(conversation.messages.map((message) => message.content)).toEqual([
+        'From state home',
+      ]);
+      expect(fs.readFileSync(historyPath, 'utf-8')).toContain('From state home');
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.GROK_HOME;
+      } else {
+        process.env.GROK_HOME = previousHome;
+      }
+    }
+  });
+
+  it('falls back to settings GROK_HOME via pathContext when providerState has no grokHome', async () => {
+    const sessionId = 'session-settings-home';
+    const settingsHome = path.join(tmpRoot, 'settings-home');
+    const historyPath = path.join(
+      settingsHome,
+      'sessions',
+      encodeURIComponent(vaultPath),
+      sessionId,
+      'chat_history.jsonl',
+    );
+    fs.mkdirSync(path.dirname(historyPath), { recursive: true });
+    fs.writeFileSync(historyPath, `${JSON.stringify({ type: 'user', content: 'From settings home' })}\n`, 'utf-8');
+
+    const conversation: Conversation = {
+      id: 'conv-settings',
+      providerId: 'grok',
+      title: 'Test',
+      createdAt: 1_000,
+      updatedAt: 1_000,
+      messages: [],
+      sessionId,
+      providerState: { sessionId },
+    };
+
+    const previousHome = process.env.GROK_HOME;
+    delete process.env.GROK_HOME;
+    try {
+      const service = new GrokConversationHistoryService();
+      await service.hydrateConversationHistory(conversation, vaultPath, {
+        environment: {},
+        settings: {
+          providerConfigs: {
+            grok: {
+              environmentVariables: `GROK_HOME=${settingsHome}`,
+            },
+          },
+        },
+      });
+      expect(conversation.messages.map((message) => message.content)).toEqual([
+        'From settings home',
+      ]);
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.GROK_HOME;
+      } else {
+        process.env.GROK_HOME = previousHome;
+      }
+    }
+  });
+});

--- a/tests/unit/providers/grok/GrokHeadlessRunner.test.ts
+++ b/tests/unit/providers/grok/GrokHeadlessRunner.test.ts
@@ -1,0 +1,74 @@
+import {
+  buildGrokHeadlessArgs,
+  extractGrokEventError,
+  extractGrokEventText,
+  extractGrokSessionId,
+} from '@/providers/grok/runtime/GrokHeadlessRunner';
+
+describe('GrokHeadlessRunner helpers', () => {
+  it('builds headless args with streaming JSON and sandbox profile', () => {
+    expect(buildGrokHeadlessArgs({
+      cwd: '/vault',
+      promptFile: '/tmp/prompt.txt',
+      model: 'grok-4.5',
+      effort: 'high',
+      sessionId: 'sess-1',
+      permissionMode: 'normal',
+      safeMode: 'workspace',
+      systemRules: 'Be concise',
+    })).toEqual([
+      '--cwd',
+      '/vault',
+      '--no-alt-screen',
+      '--output-format',
+      'streaming-json',
+      '-m',
+      'grok-4.5',
+      '--effort',
+      'high',
+      '--system-prompt-override',
+      'Be concise',
+      '--resume',
+      'sess-1',
+      '--sandbox',
+      'workspace',
+      '--prompt-file',
+      '/tmp/prompt.txt',
+    ]);
+  });
+
+  it('uses always-approve for yolo and plan permission mode when selected', () => {
+    expect(buildGrokHeadlessArgs({
+      cwd: '/vault',
+      promptFile: '/tmp/p.txt',
+      permissionMode: 'yolo',
+    })).toContain('--always-approve');
+
+    expect(buildGrokHeadlessArgs({
+      cwd: '/vault',
+      promptFile: '/tmp/p.txt',
+      permissionMode: 'plan',
+    })).toEqual(expect.arrayContaining(['--permission-mode', 'plan']));
+  });
+
+  it('extracts assistant text and session ids from streaming events', () => {
+    expect(extractGrokEventText({
+      method: 'session/update',
+      params: {
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'hello' },
+        },
+      },
+    })).toBe('hello');
+
+    expect(extractGrokSessionId({
+      params: { sessionId: 'abc-123' },
+    })).toBe('abc-123');
+
+    expect(extractGrokEventError({
+      type: 'error',
+      message: 'boom',
+    })).toBe('boom');
+  });
+});

--- a/tests/unit/providers/grok/GrokRuntimeEnvironment.test.ts
+++ b/tests/unit/providers/grok/GrokRuntimeEnvironment.test.ts
@@ -1,0 +1,53 @@
+import { buildGrokRuntimeEnv } from '@/providers/grok/runtime/GrokRuntimeEnvironment';
+
+describe('buildGrokRuntimeEnv', () => {
+  it('disables trace upload by default and preserves explicit overrides', () => {
+    const withDefault = buildGrokRuntimeEnv({
+      providerConfigs: {
+        grok: {
+          environmentVariables: 'GROK_MODEL=grok-4.5',
+        },
+      },
+    }, '/usr/local/bin/grok');
+
+    expect(withDefault.GROK_TELEMETRY_TRACE_UPLOAD).toBe('0');
+    expect(withDefault.GROK_MODEL).toBe('grok-4.5');
+    expect(withDefault.PATH).toContain('/usr/local/bin');
+
+    const withOverride = buildGrokRuntimeEnv({
+      providerConfigs: {
+        grok: {
+          environmentVariables: 'GROK_TELEMETRY_TRACE_UPLOAD=1',
+        },
+      },
+    }, '/usr/local/bin/grok');
+
+    expect(withOverride.GROK_TELEMETRY_TRACE_UPLOAD).toBe('1');
+  });
+
+  it('sets GROK_SANDBOX from safeMode when the user did not set it', () => {
+    const env = buildGrokRuntimeEnv({
+      providerConfigs: {
+        grok: {
+          safeMode: 'read-only',
+          environmentVariables: '',
+        },
+      },
+    }, '/usr/local/bin/grok');
+
+    expect(env.GROK_SANDBOX).toBe('read-only');
+  });
+
+  it('does not override an explicit GROK_SANDBOX from provider environment', () => {
+    const env = buildGrokRuntimeEnv({
+      providerConfigs: {
+        grok: {
+          safeMode: 'workspace',
+          environmentVariables: 'GROK_SANDBOX=strict',
+        },
+      },
+    }, '/usr/local/bin/grok');
+
+    expect(env.GROK_SANDBOX).toBe('strict');
+  });
+});

--- a/tests/unit/providers/grok/capabilities.test.ts
+++ b/tests/unit/providers/grok/capabilities.test.ts
@@ -1,0 +1,21 @@
+import { GROK_PROVIDER_CAPABILITIES } from '@/providers/grok/capabilities';
+
+describe('GROK_PROVIDER_CAPABILITIES', () => {
+  it('uses conservative Grok Build capabilities', () => {
+    expect(GROK_PROVIDER_CAPABILITIES).toEqual({
+      providerId: 'grok',
+      supportsPersistentRuntime: true,
+      supportsNativeHistory: true,
+      supportsPlanMode: true,
+      supportsRewind: false,
+      supportsFork: false,
+      supportsProviderCommands: false,
+      supportsImageAttachments: false,
+      supportsInstructionMode: true,
+      supportsMcpTools: false,
+      supportsTurnSteer: false,
+      reasoningControl: 'effort',
+    });
+    expect(Object.isFrozen(GROK_PROVIDER_CAPABILITIES)).toBe(true);
+  });
+});

--- a/tests/unit/providers/grok/grokSessionMode.test.ts
+++ b/tests/unit/providers/grok/grokSessionMode.test.ts
@@ -1,0 +1,14 @@
+import { resolveGrokAcpModeId } from '@/providers/grok/runtime/grokSessionMode';
+
+describe('resolveGrokAcpModeId', () => {
+  it('maps plan to ACP plan mode', () => {
+    expect(resolveGrokAcpModeId('plan')).toBe('plan');
+  });
+
+  it('maps normal and yolo to ACP default mode', () => {
+    expect(resolveGrokAcpModeId('normal')).toBe('default');
+    expect(resolveGrokAcpModeId('yolo')).toBe('default');
+    expect(resolveGrokAcpModeId(undefined)).toBe('default');
+    expect(resolveGrokAcpModeId('')).toBe('default');
+  });
+});

--- a/tests/unit/providers/grok/registration.test.ts
+++ b/tests/unit/providers/grok/registration.test.ts
@@ -1,0 +1,18 @@
+import { grokProviderRegistration } from '@/providers/grok/registration';
+
+describe('grokProviderRegistration', () => {
+  it('is opt-in and wires registry contracts', () => {
+    expect(grokProviderRegistration.id).toBe('grok');
+    expect(grokProviderRegistration.displayName).toBe('Grok');
+    expect(grokProviderRegistration.isEnabled({})).toBe(false);
+    expect(grokProviderRegistration.isEnabled({
+      providerConfigs: { grok: { enabled: true } },
+    })).toBe(true);
+    expect(grokProviderRegistration.environmentKeyPatterns?.some((pattern) => pattern.test('GROK_HOME'))).toBe(true);
+    expect(grokProviderRegistration.environmentKeyPatterns?.some((pattern) => pattern.test('XAI_API_KEY'))).toBe(true);
+    expect(grokProviderRegistration.capabilities.providerId).toBe('grok');
+    expect(grokProviderRegistration.historyService).toBeTruthy();
+    expect(grokProviderRegistration.workspace.initialize).toEqual(expect.any(Function));
+    expect(grokProviderRegistration.settingsStorage.normalizeStored).toEqual(expect.any(Function));
+  });
+});

--- a/tests/unit/providers/grok/settings.test.ts
+++ b/tests/unit/providers/grok/settings.test.ts
@@ -1,0 +1,113 @@
+const mockGetHostnameKey = jest.fn(() => 'host-a');
+const mockGetLegacyHostnameKey = jest.fn(() => 'legacy-host');
+
+jest.mock('../../../../src/utils/env', () => ({
+  ...jest.requireActual('../../../../src/utils/env'),
+  getHostnameKey: () => mockGetHostnameKey(),
+  getLegacyHostnameKey: () => mockGetLegacyHostnameKey(),
+}));
+
+import {
+  DEFAULT_GROK_PROVIDER_SETTINGS,
+  getGrokProviderSettings,
+  normalizeGrokSafeMode,
+  updateGrokProviderSettings,
+} from '../../../../src/providers/grok/settings';
+
+describe('Grok provider settings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetHostnameKey.mockReturnValue('host-a');
+    mockGetLegacyHostnameKey.mockReturnValue('legacy-host');
+  });
+
+  it('defaults to disabled with workspace sandbox', () => {
+    expect(DEFAULT_GROK_PROVIDER_SETTINGS).toEqual({
+      enabled: false,
+      safeMode: 'workspace',
+      cliPath: '',
+      cliPathsByHost: {},
+      environmentVariables: '',
+      environmentHash: '',
+    });
+    expect(getGrokProviderSettings({})).toMatchObject({
+      enabled: false,
+      safeMode: 'workspace',
+    });
+  });
+
+  it('normalizes legacy workspace-write sandbox to workspace', () => {
+    expect(normalizeGrokSafeMode('workspace-write')).toBe('workspace');
+    expect(normalizeGrokSafeMode('read-only')).toBe('read-only');
+    expect(normalizeGrokSafeMode('read_only')).toBe('read-only');
+  });
+
+  it('reads and updates providerConfigs.grok', () => {
+    const settings: Record<string, unknown> = {
+      providerConfigs: {
+        grok: {
+          enabled: true,
+          safeMode: 'workspace-write',
+          cliPathsByHost: {
+            'host-a': '/host-a/grok',
+          },
+          environmentVariables: 'GROK_MODEL=grok-4.5',
+        },
+      },
+    };
+
+    expect(getGrokProviderSettings(settings)).toMatchObject({
+      enabled: true,
+      safeMode: 'workspace',
+      cliPathsByHost: {
+        'host-a': '/host-a/grok',
+      },
+      environmentVariables: 'GROK_MODEL=grok-4.5',
+    });
+
+    updateGrokProviderSettings(settings, {
+      enabled: false,
+      safeMode: 'read-only',
+      cliPathsByHost: {
+        'host-a': '/custom/grok',
+      },
+    });
+
+    expect(getGrokProviderSettings(settings)).toMatchObject({
+      enabled: false,
+      safeMode: 'read-only',
+      cliPathsByHost: {
+        'host-a': '/custom/grok',
+      },
+    });
+  });
+
+  it('maps bare cliPath updates onto the current host', () => {
+    const settings: Record<string, unknown> = { providerConfigs: {} };
+    updateGrokProviderSettings(settings, { cliPath: '/usr/local/bin/grok' });
+
+    expect(getGrokProviderSettings(settings)).toMatchObject({
+      cliPath: '',
+      cliPathsByHost: {
+        'host-a': '/usr/local/bin/grok',
+      },
+    });
+  });
+
+  it('migrates legacy hostname-scoped CLI paths', () => {
+    mockGetHostnameKey.mockReturnValue('device:current');
+    mockGetLegacyHostnameKey.mockReturnValue('host-a');
+
+    expect(getGrokProviderSettings({
+      providerConfigs: {
+        grok: {
+          cliPathsByHost: {
+            'host-a': '/legacy/host/grok',
+          },
+        },
+      },
+    }).cliPathsByHost).toEqual({
+      'device:current': '/legacy/host/grok',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add Grok Build as an opt-in first-class provider backed by `grok agent stdio` and the shared ACP transport
- support persistent/new/resumed sessions, streamed assistant/tool/usage updates, approvals, Plan/Safe/YOLO modes, native history hydration, and provider-routed auxiliary generation
- add Grok CLI discovery, host-scoped paths, `GROK_*` / `XAI_*` environment settings, configurable `GROK_HOME`, conservative capabilities, privacy disclosure, and focused regression coverage

This builds on the implementation map and extracts shared by @kvarnelis in #709, adapted to the current provider registry/runtime architecture and the current Grok Build ACP behavior.

## Safety and lifecycle details

- disabled by default; users must explicitly enable the provider
- defaults `GROK_TELEMETRY_TRACE_UPLOAD=0` unless explicitly overridden
- maps Safe mode to Grok's `GROK_SANDBOX`; changing the profile recycles the ACP runtime
- maps Plan mode through ACP `session/set_mode`; YOLO alone launches with `--always-approve`
- keeps a cancelled turn busy until the ACP prompt settles, preventing overlapping prompts
- hydrates Grok's native `chat_history.jsonl` read-only and never deletes provider-native history
- documents that Grok's sandbox applies to Grok agent tools and is not a stronger Claudian/OS filesystem boundary

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅ (zero warnings/errors)
- `npm run build` ✅
- focused provider/registry tests: 13 suites, 56 tests ✅
- full suite: 281 suites / 6,231 tests pass; one unchanged Codex WSL test fails locally because the live WSL environment supplies a distro where that test expects none (`CodexLaunchSpecBuilder.test.ts`)
- live Grok Build ACP probes verified `initialize`, `session/new`, `session/set_mode` (`plan` / `default`), model metadata, and native session paths

## Notes

Grok Build is now open source and its ACP implementation is available at https://github.com/xai-org/grok-build. The integration remains intentionally conservative: rewind, fork, image attachments, Claudian-managed MCP tools, and turn steering are not advertised.

Closes #709
