### PR TITLE
fix: resolve source-code warnings

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -103,8 +103,13 @@ export default defineConfig([
     },
     rules: {
       ...stagedObsidianRules,
+      '@typescript-eslint/no-duplicate-type-constituents': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+      '@typescript-eslint/only-throw-error': 'error',
       '@typescript-eslint/no-unsafe-argument': 'error',
+      '@typescript-eslint/no-unsafe-assignment': 'error',
       '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+      '@typescript-eslint/unbound-method': 'error',
     },
   },
   {

--- a/src/core/providers/ProviderInitializationBoundary.ts
+++ b/src/core/providers/ProviderInitializationBoundary.ts
@@ -76,9 +76,9 @@ export class ProviderInitializationBoundary {
     const promises: Promise<void>[] = [];
     for (const [providerId, services] of Object.entries(this.services)) {
       if (!services) continue;
-      const dispose = services.dispose;
-      if (typeof dispose === 'function') {
-        promises.push(Promise.resolve().then(() => dispose.call(services)));
+      const dispose = services.dispose?.bind(services);
+      if (dispose) {
+        promises.push(Promise.resolve(dispose()));
       }
       delete this.services[providerId];
     }

--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -322,12 +322,9 @@ export class ClaudianView extends ItemView {
    * The wrapper is moved to the active tab's nav row on tab switches.
    */
   private buildNavRowContent(): HTMLElement {
-    const activeDocument = this.containerEl.ownerDocument;
+    const wrapper = this.containerEl.createDiv({ cls: 'claudian-input-nav-content' });
 
-    const fragment = activeDocument.createDocumentFragment();
-
-    this.tabBarContainerEl = activeDocument.createElement('div');
-    this.tabBarContainerEl.className = 'claudian-tab-bar-container';
+    this.tabBarContainerEl = wrapper.createDiv({ cls: 'claudian-tab-bar-container' });
     this.tabBar = new TabBar(this.tabBarContainerEl, {
       onTabClick: (tabId) => this.handleTabClick(tabId),
       onTabClose: (tabId) => {
@@ -338,10 +335,8 @@ export class ClaudianView extends ItemView {
       },
       onTitleExpansionChanged: () => this.persistTabState(),
     });
-    fragment.appendChild(this.tabBarContainerEl);
 
-    const navActionsEl = activeDocument.createElement('div');
-    navActionsEl.className = 'claudian-input-nav-actions';
+    const navActionsEl = wrapper.createDiv({ cls: 'claudian-input-nav-actions' });
 
     this.newTabButtonEl = navActionsEl.createDiv({ cls: 'claudian-input-nav-btn claudian-new-tab-btn' });
     setIcon(this.newTabButtonEl, 'square-plus');
@@ -373,11 +368,6 @@ export class ClaudianView extends ItemView {
       this.toggleHistoryDropdown();
     });
 
-    fragment.appendChild(navActionsEl);
-
-    const wrapper = activeDocument.createElement('div');
-    wrapper.className = 'claudian-input-nav-content';
-    wrapper.appendChild(fragment);
     return wrapper;
   }
 
@@ -539,13 +529,12 @@ export class ClaudianView extends ItemView {
     const existing = this.logoEl.querySelector('svg');
     if (existing?.getAttribute('data-provider') === providerId) return;
     this.logoEl.empty();
-    const svg = createProviderIconSvg(icon, {
+    createProviderIconSvg(icon, {
       dataProvider: providerId,
       height: 18,
-      ownerDocument: this.logoEl.ownerDocument,
+      parent: this.logoEl,
       width: 18,
     });
-    this.logoEl.appendChild(svg);
   }
 
   // ============================================

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -930,10 +930,10 @@ export class ConversationController {
     const titleEl = item.querySelector('.claudian-history-item-title') as HTMLElement;
     if (!titleEl) return;
 
-    const input = (item.ownerDocument ?? window.document).createElement('input');
-    input.type = 'text';
-    input.className = 'claudian-rename-input';
-    input.value = currentTitle;
+    const input = item.createEl('input', {
+      cls: 'claudian-rename-input',
+      attr: { type: 'text', value: currentTitle },
+    });
 
     titleEl.replaceWith(input);
     input.focus();

--- a/src/features/chat/ui/ImageContext.ts
+++ b/src/features/chat/ui/ImageContext.ts
@@ -93,27 +93,22 @@ export class ImageContextManager {
 
     this.dropOverlay = inputWrapper.createDiv({ cls: 'claudian-drop-overlay' });
     const dropContent = this.dropOverlay.createDiv({ cls: 'claudian-drop-content' });
-    const ownerDocument = inputWrapper.ownerDocument ?? window.document;
-    const svg = ownerDocument.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    const svg = dropContent.createSvg('svg');
     svg.setAttribute('viewBox', '0 0 24 24');
     svg.setAttribute('width', '32');
     svg.setAttribute('height', '32');
     svg.setAttribute('fill', 'none');
     svg.setAttribute('stroke', 'currentColor');
     svg.setAttribute('stroke-width', '2');
-    const pathEl = ownerDocument.createElementNS('http://www.w3.org/2000/svg', 'path');
+    const pathEl = svg.createSvg('path');
     pathEl.setAttribute('d', 'M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4');
-    const polyline = ownerDocument.createElementNS('http://www.w3.org/2000/svg', 'polyline');
+    const polyline = svg.createSvg('polyline');
     polyline.setAttribute('points', '17 8 12 3 7 8');
-    const line = ownerDocument.createElementNS('http://www.w3.org/2000/svg', 'line');
+    const line = svg.createSvg('line');
     line.setAttribute('x1', '12');
     line.setAttribute('y1', '3');
     line.setAttribute('x2', '12');
     line.setAttribute('y2', '15');
-    svg.appendChild(pathEl);
-    svg.appendChild(polyline);
-    svg.appendChild(line);
-    dropContent.appendChild(svg);
     dropContent.createSpan({ text: 'Drop image here' });
 
     const dropZone = inputWrapper;

--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -126,12 +126,12 @@ export class ModelSelector {
 
       const icon = model.providerIcon ?? this.callbacks.getUIConfig().getProviderIcon?.();
       if (icon) {
-        option.appendChild(createProviderIconSvg(icon, {
+        createProviderIconSvg(icon, {
           className: 'claudian-model-provider-icon',
           height: 12,
-          ownerDocument: option.ownerDocument,
+          parent: option,
           width: 12,
-        }));
+        });
       }
       option.createSpan({ text: model.label });
       if (model.description) {
@@ -972,7 +972,7 @@ export class McpServerSelector {
     if (!manager || manager.isLoaded?.() !== false) return;
 
     const load = manager.ensureLoaded?.();
-    if (!load) return;
+    if (load === undefined) return;
 
     void load.then(() => {
       if (this.mcpManager !== manager) return;
@@ -1171,20 +1171,20 @@ export class ContextUsageMeter {
     const y2 = cy + radius * Math.sin(endRad);
 
     const gaugeEl = this.container.createDiv({ cls: 'claudian-context-meter-gauge' });
-    const svg = gaugeEl.ownerDocument.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    const svg = gaugeEl.createSvg('svg');
     svg.setAttribute('width', String(size));
     svg.setAttribute('height', String(size));
     svg.setAttribute('viewBox', `0 0 ${size} ${size}`);
 
     const pathData = `M ${x1} ${y1} A ${radius} ${radius} 0 1 1 ${x2} ${y2}`;
-    const backgroundPath = gaugeEl.ownerDocument.createElementNS('http://www.w3.org/2000/svg', 'path');
+    const backgroundPath = svg.createSvg('path');
     backgroundPath.classList.add('claudian-meter-bg');
     backgroundPath.setAttribute('d', pathData);
     backgroundPath.setAttribute('fill', 'none');
     backgroundPath.setAttribute('stroke-width', String(strokeWidth));
     backgroundPath.setAttribute('stroke-linecap', 'round');
 
-    const fillPath = gaugeEl.ownerDocument.createElementNS('http://www.w3.org/2000/svg', 'path');
+    const fillPath = svg.createSvg('path');
     fillPath.classList.add('claudian-meter-fill');
     fillPath.setAttribute('d', pathData);
     fillPath.setAttribute('fill', 'none');

--- a/src/features/chat/ui/StatusPanel.ts
+++ b/src/features/chat/ui/StatusPanel.ts
@@ -115,20 +115,16 @@ export class StatusPanel {
       return;
     }
 
-    const ownerDocument = this.containerEl.ownerDocument ?? window.document;
-
     // Create panel element (no border/background - seamless)
-    this.panelEl = ownerDocument.createElement('div');
-    this.panelEl.className = 'claudian-status-panel';
+    this.panelEl = this.containerEl.createDiv({ cls: 'claudian-status-panel' });
 
     // Bash output container - hidden by default
-    this.bashOutputContainerEl = ownerDocument.createElement('div');
-    this.bashOutputContainerEl.className = 'claudian-status-panel-bash claudian-hidden';
+    this.bashOutputContainerEl = this.panelEl.createDiv({ cls: 'claudian-status-panel-bash claudian-hidden' });
 
-    this.bashHeaderEl = ownerDocument.createElement('div');
-    this.bashHeaderEl.className = 'claudian-tool-header claudian-status-panel-bash-header';
-    this.bashHeaderEl.setAttribute('tabindex', '0');
-    this.bashHeaderEl.setAttribute('role', 'button');
+    this.bashHeaderEl = this.bashOutputContainerEl.createDiv({
+      cls: 'claudian-tool-header claudian-status-panel-bash-header',
+      attr: { tabindex: '0', role: 'button' },
+    });
 
     this.bashClickHandler = () => this.toggleBashSection();
     this.bashKeydownHandler = (e: KeyboardEvent) => {
@@ -140,23 +136,16 @@ export class StatusPanel {
     this.bashHeaderEl.addEventListener('click', this.bashClickHandler);
     this.bashHeaderEl.addEventListener('keydown', this.bashKeydownHandler);
 
-    this.bashContentEl = ownerDocument.createElement('div');
-    this.bashContentEl.className = 'claudian-status-panel-bash-content';
-
-    this.bashOutputContainerEl.appendChild(this.bashHeaderEl);
-    this.bashOutputContainerEl.appendChild(this.bashContentEl);
-    this.panelEl.appendChild(this.bashOutputContainerEl);
+    this.bashContentEl = this.bashOutputContainerEl.createDiv({ cls: 'claudian-status-panel-bash-content' });
 
     // Todo container
-    this.todoContainerEl = ownerDocument.createElement('div');
-    this.todoContainerEl.className = 'claudian-status-panel-todos claudian-hidden';
-    this.panelEl.appendChild(this.todoContainerEl);
+    this.todoContainerEl = this.panelEl.createDiv({ cls: 'claudian-status-panel-todos claudian-hidden' });
 
     // Todo header (collapsed view)
-    this.todoHeaderEl = ownerDocument.createElement('div');
-    this.todoHeaderEl.className = 'claudian-status-panel-header';
-    this.todoHeaderEl.setAttribute('tabindex', '0');
-    this.todoHeaderEl.setAttribute('role', 'button');
+    this.todoHeaderEl = this.todoContainerEl.createDiv({
+      cls: 'claudian-status-panel-header',
+      attr: { tabindex: '0', role: 'button' },
+    });
 
     // Store handler references for cleanup
     this.todoClickHandler = () => this.toggleTodos();
@@ -168,14 +157,11 @@ export class StatusPanel {
     };
     this.todoHeaderEl.addEventListener('click', this.todoClickHandler);
     this.todoHeaderEl.addEventListener('keydown', this.todoKeydownHandler);
-    this.todoContainerEl.appendChild(this.todoHeaderEl);
 
     // Todo content (expanded list)
-    this.todoContentEl = ownerDocument.createElement('div');
-    this.todoContentEl.className = 'claudian-status-panel-content claudian-todo-list-container claudian-hidden';
-    this.todoContainerEl.appendChild(this.todoContentEl);
-
-    this.containerEl.appendChild(this.panelEl);
+    this.todoContentEl = this.todoContainerEl.createDiv({
+      cls: 'claudian-status-panel-content claudian-todo-list-container claudian-hidden',
+    });
   }
 
   private syncPanelVisibility(): void {
@@ -235,36 +221,31 @@ export class StatusPanel {
     if (!this.todoHeaderEl) return;
 
     this.todoHeaderEl.empty();
-    const ownerDocument = this.todoHeaderEl.ownerDocument ?? window.document;
 
     // List icon
-    const icon = ownerDocument.createElement('span');
-    icon.className = 'claudian-status-panel-icon';
+    const icon = this.todoHeaderEl.createSpan({ cls: 'claudian-status-panel-icon' });
     setIcon(icon, getToolIcon(TOOL_TODO_WRITE));
-    this.todoHeaderEl.appendChild(icon);
 
     // Label
-    const label = ownerDocument.createElement('span');
-    label.className = 'claudian-status-panel-label';
-    label.textContent = `Tasks (${completedCount}/${totalCount})`;
-    this.todoHeaderEl.appendChild(label);
+    this.todoHeaderEl.createSpan({
+      cls: 'claudian-status-panel-label',
+      text: `Tasks (${completedCount}/${totalCount})`,
+    });
 
     // Collapsed-only elements: status indicator and current task preview
     if (!this.isTodoExpanded) {
       // Status indicator (tick only when all todos complete)
       if (completedCount === totalCount && totalCount > 0) {
-        const status = ownerDocument.createElement('span');
-        status.className = 'claudian-status-panel-status status-completed';
+        const status = this.todoHeaderEl.createSpan({ cls: 'claudian-status-panel-status status-completed' });
         setIcon(status, 'check');
-        this.todoHeaderEl.appendChild(status);
       }
 
       // Current task preview
       if (currentTask) {
-        const current = ownerDocument.createElement('span');
-        current.className = 'claudian-status-panel-current';
-        current.textContent = currentTask.activeForm;
-        this.todoHeaderEl.appendChild(current);
+        this.todoHeaderEl.createSpan({
+          cls: 'claudian-status-panel-current',
+          text: currentTask.activeForm,
+        });
       }
     }
   }
@@ -376,32 +357,26 @@ export class StatusPanel {
     this.syncPanelVisibility();
     this.bashHeaderEl.empty();
     this.bashContentEl.empty();
-    const ownerDocument = this.bashHeaderEl.ownerDocument ?? window.document;
 
-    const headerIconEl = ownerDocument.createElement('span');
-    headerIconEl.className = 'claudian-tool-icon';
-    headerIconEl.setAttribute('aria-hidden', 'true');
+    const headerIconEl = this.bashHeaderEl.createSpan({
+      cls: 'claudian-tool-icon',
+      attr: { 'aria-hidden': 'true' },
+    });
     setIcon(headerIconEl, 'terminal');
-    this.bashHeaderEl.appendChild(headerIconEl);
 
     const latest = Array.from(this.currentBashOutputs.values()).at(-1);
 
-    const headerLabelEl = ownerDocument.createElement('span');
-    headerLabelEl.className = 'claudian-tool-label';
+    const headerLabelEl = this.bashHeaderEl.createSpan({ cls: 'claudian-tool-label' });
     if (this.isBashExpanded) {
       headerLabelEl.textContent = t('chat.bangBash.commandPanel');
     } else {
       headerLabelEl.textContent = latest ? this.truncateDescription(latest.command, 60) : t('chat.bangBash.commandPanel');
     }
-    this.bashHeaderEl.appendChild(headerLabelEl);
 
-    const previewEl = ownerDocument.createElement('span');
-    previewEl.className = 'claudian-tool-current';
+    const previewEl = this.bashHeaderEl.createSpan({ cls: 'claudian-tool-current' });
     previewEl.classList.toggle('claudian-hidden', !this.isBashExpanded);
-    this.bashHeaderEl.appendChild(previewEl);
 
-    const summaryStatusEl = ownerDocument.createElement('span');
-    summaryStatusEl.className = 'claudian-tool-status';
+    const summaryStatusEl = this.bashHeaderEl.createSpan({ cls: 'claudian-tool-status' });
     if (!this.isBashExpanded && latest) {
       summaryStatusEl.classList.add(`status-${latest.status}`);
       summaryStatusEl.setAttribute('aria-label', t('chat.bangBash.statusLabel', { status: latest.status }));
@@ -410,19 +385,16 @@ export class StatusPanel {
     } else {
       summaryStatusEl.classList.add('claudian-hidden');
     }
-    this.bashHeaderEl.appendChild(summaryStatusEl);
 
     this.bashHeaderEl.setAttribute('aria-expanded', String(this.isBashExpanded));
 
-    const actionsEl = ownerDocument.createElement('span');
-    actionsEl.className = 'claudian-status-panel-bash-actions';
+    const actionsEl = this.bashHeaderEl.createSpan({ cls: 'claudian-status-panel-bash-actions' });
     this.appendActionButton(actionsEl, 'copy', t('chat.bangBash.copyAriaLabel'), 'copy', () => {
       void this.copyLatestBashOutput();
     });
     this.appendActionButton(actionsEl, 'clear', t('chat.bangBash.clearAriaLabel'), 'trash', () => {
       this.clearBashOutputs();
     });
-    this.bashHeaderEl.appendChild(actionsEl);
 
     this.bashContentEl.toggleClass('claudian-hidden', !this.isBashExpanded);
 
@@ -431,7 +403,7 @@ export class StatusPanel {
     }
 
     for (const info of this.currentBashOutputs.values()) {
-      this.bashContentEl.appendChild(this.renderBashEntry(info, ownerDocument));
+      this.bashContentEl.appendChild(this.renderBashEntry(info));
     }
 
     if (scroll) {
@@ -440,38 +412,32 @@ export class StatusPanel {
     }
   }
 
-  private renderBashEntry(info: PanelBashOutput, ownerDocument: Document): HTMLElement {
-    const entryEl = ownerDocument.createElement('div');
-    entryEl.className = 'claudian-tool-call claudian-status-panel-bash-entry';
+  private renderBashEntry(info: PanelBashOutput): HTMLElement {
+    const entryEl = createDiv({ cls: 'claudian-tool-call claudian-status-panel-bash-entry' });
 
-    const entryHeaderEl = ownerDocument.createElement('div');
-    entryHeaderEl.className = 'claudian-tool-header';
-    entryHeaderEl.setAttribute('tabindex', '0');
-    entryHeaderEl.setAttribute('role', 'button');
+    const entryHeaderEl = entryEl.createDiv({
+      cls: 'claudian-tool-header',
+      attr: { tabindex: '0', role: 'button' },
+    });
 
-    const entryIconEl = ownerDocument.createElement('span');
-    entryIconEl.className = 'claudian-tool-icon';
-    entryIconEl.setAttribute('aria-hidden', 'true');
+    const entryIconEl = entryHeaderEl.createSpan({
+      cls: 'claudian-tool-icon',
+      attr: { 'aria-hidden': 'true' },
+    });
     setIcon(entryIconEl, 'dollar-sign');
-    entryHeaderEl.appendChild(entryIconEl);
 
-    const entryLabelEl = ownerDocument.createElement('span');
-    entryLabelEl.className = 'claudian-tool-label';
-    entryLabelEl.textContent = t('chat.bangBash.commandLabel', { command: this.truncateDescription(info.command, 60) });
-    entryHeaderEl.appendChild(entryLabelEl);
+    entryHeaderEl.createSpan({
+      cls: 'claudian-tool-label',
+      text: t('chat.bangBash.commandLabel', { command: this.truncateDescription(info.command, 60) }),
+    });
 
-    const entryStatusEl = ownerDocument.createElement('span');
-    entryStatusEl.className = 'claudian-tool-status';
+    const entryStatusEl = entryHeaderEl.createSpan({ cls: 'claudian-tool-status' });
     entryStatusEl.classList.add(`status-${info.status}`);
     entryStatusEl.setAttribute('aria-label', t('chat.bangBash.statusLabel', { status: info.status }));
     if (info.status === 'completed') setIcon(entryStatusEl, 'check');
     if (info.status === 'error') setIcon(entryStatusEl, 'x');
-    entryHeaderEl.appendChild(entryStatusEl);
 
-    entryEl.appendChild(entryHeaderEl);
-
-    const contentEl = ownerDocument.createElement('div');
-    contentEl.className = 'claudian-tool-content';
+    const contentEl = entryEl.createDiv({ cls: 'claudian-tool-content' });
     const isEntryExpanded = this.bashEntryExpanded.get(info.id) ?? true;
     contentEl.classList.toggle('claudian-hidden', !isEntryExpanded);
     entryHeaderEl.setAttribute('aria-expanded', String(isEntryExpanded));
@@ -488,21 +454,15 @@ export class StatusPanel {
       }
     });
 
-    const rowEl = ownerDocument.createElement('div');
-    rowEl.className = 'claudian-tool-result-row';
+    const rowEl = contentEl.createDiv({ cls: 'claudian-tool-result-row' });
 
-    const textEl = ownerDocument.createElement('span');
-    textEl.className = 'claudian-tool-result-text';
+    const textEl = rowEl.createSpan({ cls: 'claudian-tool-result-text' });
     if (info.status === 'running' && !info.output) {
       textEl.textContent = t('chat.bangBash.running');
     } else if (info.output) {
       textEl.textContent = info.output;
     }
 
-    rowEl.appendChild(textEl);
-    contentEl.appendChild(rowEl);
-
-    entryEl.appendChild(contentEl);
     return entryEl;
   }
 
@@ -526,11 +486,14 @@ export class StatusPanel {
     icon: string,
     action: () => void
   ): void {
-    const el = (parent.ownerDocument ?? window.document).createElement('span');
-    el.className = `claudian-status-panel-bash-action claudian-status-panel-bash-action-${name}`;
-    el.setAttribute('role', 'button');
-    el.setAttribute('tabindex', '0');
-    el.setAttribute('aria-label', ariaLabel);
+    const el = parent.createSpan({
+      cls: `claudian-status-panel-bash-action claudian-status-panel-bash-action-${name}`,
+      attr: {
+        role: 'button',
+        tabindex: '0',
+        'aria-label': ariaLabel,
+      },
+    });
     setIcon(el, icon);
     el.addEventListener('click', (e) => {
       e.stopPropagation();

--- a/src/features/inline-edit/ui/InlineEditModal.ts
+++ b/src/features/inline-edit/ui/InlineEditModal.ts
@@ -521,33 +521,29 @@ export class InlineEditSession {
 
   createInputDOM(): HTMLElement {
     const ownerDocument = this.getOwnerDocument();
-    const container = ownerDocument.createElement('div');
-    container.className = 'claudian-inline-input-container';
+    const container = createDiv({ cls: 'claudian-inline-input-container' });
     this.containerEl = container;
 
-    this.agentReplyEl = ownerDocument.createElement('div');
-    this.agentReplyEl.className = 'claudian-inline-agent-reply claudian-hidden';
-    container.appendChild(this.agentReplyEl);
+    this.agentReplyEl = container.createDiv({ cls: 'claudian-inline-agent-reply claudian-hidden' });
 
-    const inputWrap = ownerDocument.createElement('div');
-    inputWrap.className = 'claudian-inline-input-wrap';
-    container.appendChild(inputWrap);
+    const inputWrap = container.createDiv({ cls: 'claudian-inline-input-wrap' });
 
-    this.inputEl = ownerDocument.createElement('input');
-    this.inputEl.type = 'text';
-    this.inputEl.className = 'claudian-inline-input';
-    this.inputEl.placeholder = this.mode === 'cursor' ? 'Insert instructions...' : 'Edit instructions...';
-    this.inputEl.spellcheck = false;
-    inputWrap.appendChild(this.inputEl);
+    const inputEl = inputWrap.createEl('input', {
+      cls: 'claudian-inline-input',
+      attr: {
+        type: 'text',
+        placeholder: this.mode === 'cursor' ? 'Insert instructions...' : 'Edit instructions...',
+        spellcheck: 'false',
+      },
+    });
+    this.inputEl = inputEl;
 
-    this.spinnerEl = ownerDocument.createElement('div');
-    this.spinnerEl.className = 'claudian-inline-spinner claudian-hidden';
-    inputWrap.appendChild(this.spinnerEl);
+    this.spinnerEl = inputWrap.createDiv({ cls: 'claudian-inline-spinner claudian-hidden' });
 
     const inlineCatalog = ProviderWorkspaceRegistry.getCommandCatalog(this.resolvedProviderId);
     this.slashCommandDropdown = new SlashCommandDropdown(
       ownerDocument.body,
-      this.inputEl,
+      inputEl,
       {
         onSelect: () => {},
         onHide: () => {},
@@ -564,7 +560,7 @@ export class InlineEditSession {
 
     this.mentionDropdown = new MentionDropdownController(
       ownerDocument.body,
-      this.inputEl,
+      inputEl,
       {
         // Inline-edit resolves @mentions at send time from input text.
         onAttachFile: () => {},
@@ -580,29 +576,23 @@ export class InlineEditSession {
       { fixed: true }
     );
 
-    this.inputEl.addEventListener('keydown', (e) => this.handleKeydown(e));
-    this.inputEl.addEventListener('input', () => this.mentionDropdown?.handleInputChange());
+    inputEl.addEventListener('keydown', (e) => this.handleKeydown(e));
+    inputEl.addEventListener('input', () => this.mentionDropdown?.handleInputChange());
 
-    window.setTimeout(() => this.inputEl?.focus(), 50);
+    window.setTimeout(() => inputEl.focus(), 50);
     return container;
   }
 
   createDiffPreviewDOM(diffOps: DiffOp[]): HTMLElement {
-    const ownerDocument = this.getOwnerDocument();
-    const previewEl = ownerDocument.createElement('div');
-    previewEl.className = 'claudian-inline-diff-preview';
+    const previewEl = createDiv({ cls: 'claudian-inline-diff-preview' });
 
-    const bodyEl = ownerDocument.createElement('div');
-    bodyEl.className = 'claudian-inline-diff-preview-body markdown-rendered';
-    previewEl.appendChild(bodyEl);
+    const bodyEl = previewEl.createDiv({ cls: 'claudian-inline-diff-preview-body markdown-rendered' });
 
-    const actionsEl = ownerDocument.createElement('div');
-    actionsEl.className = 'claudian-inline-preview-actions';
+    const actionsEl = previewEl.createDiv({ cls: 'claudian-inline-preview-actions' });
     actionsEl.setAttribute('role', 'toolbar');
     actionsEl.setAttribute('aria-label', 'Inline edit actions');
     actionsEl.appendChild(this.createPreviewActionButton('Reject', 'reject', () => this.reject()));
     actionsEl.appendChild(this.createPreviewActionButton('Accept', 'accept', () => this.accept()));
-    previewEl.appendChild(actionsEl);
 
     void this.renderMarkdownDiffPreview(bodyEl, diffOps);
     return previewEl;
@@ -613,14 +603,16 @@ export class InlineEditSession {
     variant: 'accept' | 'reject',
     onClick: () => void
   ): HTMLButtonElement {
-    const ownerDocument = this.getOwnerDocument();
-    const button = ownerDocument.createElement('button');
-    button.type = 'button';
-    button.className = `claudian-inline-preview-action ${variant}`;
-    button.textContent = label;
-    button.setAttribute('aria-label', `${label} inline edit`);
-    button.title = variant === 'accept' ? 'Accept (enter)' : 'Reject (esc)';
-    button.addEventListener('click', (event) => {
+    const button = createEl('button', {
+      cls: `claudian-inline-preview-action ${variant}`,
+      text: label,
+      attr: {
+        type: 'button',
+        'aria-label': `${label} inline edit`,
+        title: variant === 'accept' ? 'Accept (enter)' : 'Reject (esc)',
+      },
+    });
+    button.addEventListener('click', (event: MouseEvent) => {
       event.preventDefault?.();
       event.stopPropagation?.();
       onClick();
@@ -644,9 +636,7 @@ export class InlineEditSession {
     for (const document of buildMarkdownDiffDocuments(diffOps)) {
       if (!document.markdown) continue;
 
-      const opEl = this.getOwnerDocument().createElement('div');
-      opEl.className = `claudian-diff-block ${getDiffBlockClass(document.type)}`;
-      container.appendChild(opEl);
+      const opEl = container.createDiv({ cls: `claudian-diff-block ${getDiffBlockClass(document.type)}` });
       await this.renderMarkdownPreview(opEl, document.markdown);
     }
   }
@@ -760,7 +750,7 @@ export class InlineEditSession {
     if (!this.agentReplyEl || !this.containerEl) return;
     const replyEl = this.agentReplyEl;
     const renderVersion = ++this.agentReplyRenderVersion;
-    const renderedEl = this.getOwnerDocument().createElement('div');
+    const renderedEl = this.agentReplyEl.createDiv();
 
     replyEl.removeClass('claudian-hidden');
     replyEl.empty();

--- a/src/features/inline-edit/ui/inlineEditMarkdownPreview.ts
+++ b/src/features/inline-edit/ui/inlineEditMarkdownPreview.ts
@@ -23,10 +23,7 @@ function emptyElement(container: HTMLElement): void {
 }
 
 function appendFallback(container: HTMLElement, markdown: string): void {
-  const fallback = container.ownerDocument.createElement('div');
-  fallback.className = 'claudian-inline-markdown-fallback';
-  fallback.textContent = markdown;
-  container.appendChild(fallback);
+  container.createDiv({ cls: 'claudian-inline-markdown-fallback', text: markdown });
 }
 
 export async function renderInlineEditMarkdownPreview({

--- a/src/features/settings/ClaudianSettings.ts
+++ b/src/features/settings/ClaudianSettings.ts
@@ -116,6 +116,15 @@ export class ClaudianSettingTab extends PluginSettingTab {
     this.plugin = plugin;
   }
 
+  /**
+   * Declarative settings definitions for Obsidian 1.13.0+ settings search.
+   * Claudian still builds its settings imperatively in display(); this empty
+   * array satisfies the contract so the tab is registered in search.
+   */
+  getSettingDefinitions(): unknown[] {
+    return [];
+  }
+
   display(): void {
     const displayGeneration = ++this.displayGeneration;
     const { containerEl } = this;

--- a/src/main.ts
+++ b/src/main.ts
@@ -516,9 +516,8 @@ export default class ClaudianPlugin extends Plugin {
       }, 0);
     };
 
-    const onLayoutReady = this.app.workspace.onLayoutReady;
-    if (typeof onLayoutReady === 'function') {
-      onLayoutReady.call(this.app.workspace, schedule);
+    if (typeof this.app.workspace.onLayoutReady === 'function') {
+      this.app.workspace.onLayoutReady(schedule);
     } else {
       schedule();
     }

--- a/src/providers/codex/runtime/CodexModelCatalogCoordinator.ts
+++ b/src/providers/codex/runtime/CodexModelCatalogCoordinator.ts
@@ -226,7 +226,9 @@ export class CodexModelCatalogCoordinator {
       }
 
       if (!catalogFingerprint) {
-        throw catalogFingerprintError ?? new Error('Codex catalog fingerprint resolution failed');
+        throw catalogFingerprintError instanceof Error
+          ? catalogFingerprintError
+          : new Error('Codex catalog fingerprint resolution failed');
       }
       const persistedResult = await this.persistCatalog(
         discoveryResult.models,

--- a/src/providers/codex/runtime/CodexWorkspaceDependencyResolver.ts
+++ b/src/providers/codex/runtime/CodexWorkspaceDependencyResolver.ts
@@ -33,7 +33,7 @@ export interface CodexWorkspaceDependencies {
   fallbackBinaries: string;
 }
 
-function targetPathApi(context: CodexRuntimeContext): typeof path.posix | typeof path.win32 {
+function targetPathApi(context: CodexRuntimeContext): typeof path {
   return context.launchSpec.target.platformFamily === 'windows' ? path.win32 : path.posix;
 }
 

--- a/src/providers/codex/ui/CodexModelPicker.ts
+++ b/src/providers/codex/ui/CodexModelPicker.ts
@@ -132,5 +132,5 @@ export function renderCodexModelPicker(
     searchPlaceholder: 'Filter by model name, description, or ID...',
     settingDescription: 'Choose which app-server models appear in the Codex selector. Existing session models stay pinned even when hidden here.',
   });
-  refreshPicker = picker.refresh;
+  refreshPicker = picker.refresh.bind(picker);
 }

--- a/src/shared/icons.ts
+++ b/src/shared/icons.ts
@@ -4,34 +4,27 @@ export const MCP_ICON_SVG = `<svg fill="currentColor" fill-rule="evenodd" height
 
 export const CHECK_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>`;
 
-const SVG_NS = 'http://www.w3.org/2000/svg';
 const MCP_ICON_PATHS = [
   'M15.688 2.343a2.588 2.588 0 00-3.61 0l-9.626 9.44a.863.863 0 01-1.203 0 .823.823 0 010-1.18l9.626-9.44a4.313 4.313 0 016.016 0 4.116 4.116 0 011.204 3.54 4.3 4.3 0 013.609 1.18l.05.05a4.115 4.115 0 010 5.9l-8.706 8.537a.274.274 0 000 .393l1.788 1.754a.823.823 0 010 1.18.863.863 0 01-1.203 0l-1.788-1.753a1.92 1.92 0 010-2.754l8.706-8.538a2.47 2.47 0 000-3.54l-.05-.049a2.588 2.588 0 00-3.607-.003l-7.172 7.034-.002.002-.098.097a.863.863 0 01-1.204 0 .823.823 0 010-1.18l7.273-7.133a2.47 2.47 0 00-.003-3.537z',
   'M14.485 4.703a.823.823 0 000-1.18.863.863 0 00-1.204 0l-7.119 6.982a4.115 4.115 0 000 5.9 4.314 4.314 0 006.016 0l7.12-6.982a.823.823 0 000-1.18.863.863 0 00-1.204 0l-7.119 6.982a2.588 2.588 0 01-3.61 0 2.47 2.47 0 010-3.54l7.12-6.982z',
 ];
 
-function createSvgElement(ownerDocument: Document, tagName: string): SVGElement {
-  return ownerDocument.createElementNS(SVG_NS, tagName);
-}
-
 export function appendMcpIcon(container: HTMLElement): void {
   container.empty();
 
-  const svg = createSvgElement(container.ownerDocument, 'svg');
+  const svg = container.createSvg('svg');
   svg.setAttribute('fill', 'currentColor');
   svg.setAttribute('fill-rule', 'evenodd');
   svg.setAttribute('height', '1em');
   svg.setAttribute('viewBox', '0 0 24 24');
   svg.setAttribute('width', '1em');
 
-  const title = createSvgElement(container.ownerDocument, 'title');
+  const title = svg.createSvg('title');
   title.textContent = 'MCP';
-  svg.appendChild(title);
 
   for (const pathData of MCP_ICON_PATHS) {
-    const path = createSvgElement(container.ownerDocument, 'path');
+    const path = svg.createSvg('path');
     path.setAttribute('d', pathData);
-    svg.appendChild(path);
   }
 
   container.appendChild(svg);
@@ -40,7 +33,7 @@ export function appendMcpIcon(container: HTMLElement): void {
 export function appendCheckIcon(container: HTMLElement): void {
   container.empty();
 
-  const svg = createSvgElement(container.ownerDocument, 'svg');
+  const svg = container.createSvg('svg');
   svg.setAttribute('width', '12');
   svg.setAttribute('height', '12');
   svg.setAttribute('viewBox', '0 0 24 24');
@@ -50,9 +43,8 @@ export function appendCheckIcon(container: HTMLElement): void {
   svg.setAttribute('stroke-linecap', 'round');
   svg.setAttribute('stroke-linejoin', 'round');
 
-  const polyline = createSvgElement(container.ownerDocument, 'polyline');
+  const polyline = svg.createSvg('polyline');
   polyline.setAttribute('points', '20 6 9 17 4 12');
-  svg.appendChild(polyline);
 
   container.appendChild(svg);
 }
@@ -122,7 +114,7 @@ export interface CreateProviderIconSvgOptions {
   className?: string;
   dataProvider?: string;
   height?: number | string;
-  ownerDocument?: Document;
+  parent?: HTMLElement;
   width?: number | string;
 }
 
@@ -130,8 +122,8 @@ export function createProviderIconSvg(
   icon: ProviderIconSvg,
   options: CreateProviderIconSvgOptions = {},
 ): SVGElement {
-  const ownerDocument = options.ownerDocument ?? window.document;
-  const svg = ownerDocument.createElementNS(SVG_NS, 'svg');
+  const parent = options.parent ?? activeDocument.body;
+  const svg = parent.createSvg('svg');
   svg.setAttribute('viewBox', icon.viewBox);
   svg.setAttribute('fill', 'none');
   svg.setAttribute('aria-hidden', 'true');
@@ -152,27 +144,26 @@ export function createProviderIconSvg(
 
   if (icon.kind === 'composite') {
     for (const child of icon.children) {
-      svg.appendChild(createProviderSvgChild(child, ownerDocument));
+      svg.appendChild(createProviderSvgChild(child, svg));
     }
     return svg;
   }
 
-  const path = ownerDocument.createElementNS(SVG_NS, 'path');
+  const path = svg.createSvg('path');
   path.setAttribute('d', icon.path);
   path.setAttribute('fill', 'currentColor');
-  svg.appendChild(path);
   return svg;
 }
 
-function createProviderSvgChild(child: ProviderSvgChild, ownerDocument: Document): SVGElement {
-  const element = ownerDocument.createElementNS(SVG_NS, child.tag);
+function createProviderSvgChild(child: ProviderSvgChild, parent: SVGElement): SVGElement {
+  const element = parent.createSvg(child.tag);
   for (const [name, value] of Object.entries(child.attributes)) {
     element.setAttribute(name, value);
   }
 
   if (child.tag === 'g') {
     for (const nestedChild of child.children) {
-      element.appendChild(createProviderSvgChild(nestedChild, ownerDocument));
+      element.appendChild(createProviderSvgChild(nestedChild, element));
     }
   }
 

--- a/src/shared/settings/McpTestModal.ts
+++ b/src/shared/settings/McpTestModal.ts
@@ -20,23 +20,18 @@ function formatToggleError(error: unknown): string {
   return error.message || 'Failed to update tool setting';
 }
 
-const SVG_NS = 'http://www.w3.org/2000/svg';
-
 function appendSpinnerSvg(container: HTMLElement): void {
-  const svg = container.ownerDocument.createElementNS(SVG_NS, 'svg');
+  const svg = container.createSvg('svg');
   svg.setAttribute('viewBox', '0 0 24 24');
   svg.setAttribute('fill', 'none');
   svg.setAttribute('stroke', 'currentColor');
   svg.setAttribute('stroke-width', '2');
 
-  const path = container.ownerDocument.createElementNS(SVG_NS, 'path');
+  const path = svg.createSvg('path');
   path.setAttribute(
     'd',
     'M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83'
   );
-  svg.appendChild(path);
-
-  container.appendChild(svg);
 }
 
 export class McpTestModal extends Modal {

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -10,7 +10,7 @@ export async function mapWithConcurrency<T, U>(
     throw new Error('Concurrency must be at least 1');
   }
 
-  const results: U[] = new Array(items.length);
+  const results: U[] = new Array<U>(items.length);
   let index = 0;
 
   async function worker(): Promise<void> {

--- a/src/utils/fileLink.ts
+++ b/src/utils/fileLink.ts
@@ -110,16 +110,18 @@ function extractLinkPathFromTarget(linkTarget: string): string {
  * Click handling is done via event delegation in registerFileLinkHandler.
  */
 function createWikilink(
-  ownerDocument: Document,
+  parent: HTMLElement,
   linkTarget: string,
   displayText: string
 ): HTMLElement {
-  const link = ownerDocument.createElement('a');
-  link.className = 'claudian-file-link internal-link';
-  link.textContent = displayText;
-  link.setAttribute('data-href', linkTarget);
-  link.setAttribute('href', linkTarget);
-  return link;
+  return parent.createEl('a', {
+    cls: 'claudian-file-link internal-link',
+    text: displayText,
+    attr: {
+      'data-href': linkTarget,
+      href: linkTarget,
+    },
+  });
 }
 
 function repairEmptyInternalLink(app: App, link: HTMLAnchorElement): void {
@@ -163,7 +165,8 @@ export function registerFileLinkHandler(
   });
 }
 
-function buildFragmentWithLinks(ownerDocument: Document, text: string, matches: WikilinkMatch[]): DocumentFragment {
+function buildFragmentWithLinks(parent: HTMLElement, text: string, matches: WikilinkMatch[]): DocumentFragment {
+  const ownerDocument = parent.ownerDocument;
   const fragment = ownerDocument.createDocumentFragment();
   let currentIndex = text.length;
 
@@ -177,7 +180,7 @@ function buildFragmentWithLinks(ownerDocument: Document, text: string, matches: 
       );
     }
 
-    fragment.insertBefore(createWikilink(ownerDocument, linkTarget, displayText), fragment.firstChild);
+    fragment.insertBefore(createWikilink(parent, linkTarget, displayText), fragment.firstChild);
     currentIndex = index;
   }
 
@@ -198,7 +201,10 @@ function processTextNode(app: App, node: Text): boolean {
   const matches = findWikilinks(app, text);
   if (matches.length === 0) return false;
 
-  node.parentNode?.replaceChild(buildFragmentWithLinks(node.ownerDocument, text, matches), node);
+  const parent = node.parentElement;
+  if (!parent) return false;
+
+  node.parentNode?.replaceChild(buildFragmentWithLinks(parent, text, matches), node);
   return true;
 }
 
@@ -225,7 +231,7 @@ export function processFileLinks(app: App, container: HTMLElement): void {
     if (matches.length === 0) return;
 
     codeEl.textContent = '';
-    codeEl.appendChild(buildFragmentWithLinks(container.ownerDocument, text, matches));
+    codeEl.appendChild(buildFragmentWithLinks(codeEl, text, matches));
   });
 
   const walker = container.ownerDocument.createTreeWalker(

--- a/tests/helpers/mockElement.ts
+++ b/tests/helpers/mockElement.ts
@@ -21,6 +21,7 @@ export interface MockElement {
   createDiv: (opts?: { cls?: string; text?: string }) => MockElement;
   createSpan: (opts?: { cls?: string; text?: string }) => MockElement;
   createEl: (tag: string, opts?: { cls?: string; text?: string; attr?: Record<string, string> }) => MockElement;
+  createSvg: (tag: string, opts?: { cls?: string; attr?: Record<string, string> }) => MockElement;
   appendChild: (child: any) => any;
   insertBefore: (el: MockElement, ref: MockElement | null) => void;
   firstChild: MockElement | null;
@@ -258,6 +259,17 @@ export function createMockEl(tag = 'div'): any {
       const child = createMockEl(tagName);
       if (opts?.cls) child.addClass(opts.cls);
       if (opts?.text) child.textContent = opts.text;
+      if (opts?.attr) {
+        for (const [name, value] of Object.entries(opts.attr)) {
+          child.setAttribute(name, value);
+        }
+      }
+      children.push(child);
+      return child;
+    },
+    createSvg(tagName: string, opts?: { cls?: string; attr?: Record<string, string> }) {
+      const child = createMockEl(tagName);
+      if (opts?.cls) child.addClass(opts.cls);
       if (opts?.attr) {
         for (const [name, value] of Object.entries(opts.attr)) {
           child.setAttribute(name, value);

--- a/tests/setupWindow.ts
+++ b/tests/setupWindow.ts
@@ -24,3 +24,112 @@ if (!('window' in globalThis)) {
     writable: true,
   });
 }
+
+// Polyfill Obsidian DOM helpers for jsdom-based tests.
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+function applyDomElementInfo(el: Element, info: unknown): void {
+  if (!info) return;
+  if (typeof info === 'string') {
+    el.classList.add(...info.split(/\s+/).filter(Boolean));
+    return;
+  }
+  const opts = info as Record<string, unknown>;
+  if (opts.cls) {
+    const classes = Array.isArray(opts.cls) ? opts.cls : String(opts.cls).split(/\s+/);
+    el.classList.add(...classes.filter(Boolean) as string[]);
+  }
+  if (opts.text && 'textContent' in el) {
+    (el as HTMLElement).textContent = String(opts.text);
+  }
+  if (opts.attr) {
+    for (const [key, value] of Object.entries(opts.attr as Record<string, unknown>)) {
+      if (value === null || value === undefined) continue;
+      el.setAttribute(key, String(value));
+    }
+  }
+  if (opts.title && 'setAttribute' in el) {
+    el.setAttribute('title', String(opts.title));
+  }
+}
+
+(globalThis as typeof globalThis & { createDiv?: typeof createDiv }).createDiv = function createDiv(
+  info?: unknown,
+  callback?: (el: HTMLDivElement) => void,
+): HTMLDivElement {
+  const el = document.createElement('div');
+  applyDomElementInfo(el, info);
+  if (callback) callback(el);
+  return el;
+};
+
+(globalThis as typeof globalThis & { createEl?: typeof createEl }).createEl = function createEl<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  info?: unknown,
+  callback?: (el: HTMLElementTagNameMap[K]) => void,
+): HTMLElementTagNameMap[K] {
+  const el = document.createElement(tag);
+  applyDomElementInfo(el, info);
+  if (callback) callback(el);
+  return el;
+};
+
+(globalThis as typeof globalThis & { createSpan?: typeof createSpan }).createSpan = function createSpan(
+  info?: unknown,
+  callback?: (el: HTMLSpanElement) => void,
+): HTMLSpanElement {
+  const el = document.createElement('span');
+  applyDomElementInfo(el, info);
+  if (callback) callback(el);
+  return el;
+};
+
+(globalThis as typeof globalThis & { createSvg?: typeof createSvg }).createSvg = function createSvg<K extends keyof SVGElementTagNameMap>(
+  tag: K,
+  info?: unknown,
+  callback?: (el: SVGElementTagNameMap[K]) => void,
+): SVGElementTagNameMap[K] {
+  const el = document.createElementNS(SVG_NS, tag) as SVGElementTagNameMap[K];
+  applyDomElementInfo(el, info);
+  if (callback) callback(el);
+  return el;
+};
+
+(globalThis as typeof globalThis & { createFragment?: typeof createFragment }).createFragment = function createFragment(
+  callback?: (el: DocumentFragment) => void,
+): DocumentFragment {
+  const el = document.createDocumentFragment();
+  if (callback) callback(el);
+  return el;
+};
+
+if (globalThis.HTMLElement && !('createDiv' in globalThis.HTMLElement.prototype)) {
+  globalThis.HTMLElement.prototype.createDiv = function (this: HTMLElement, info?, callback?) {
+    const el = createDiv(info, callback);
+    this.appendChild(el);
+    return el;
+  };
+  globalThis.HTMLElement.prototype.createEl = function (this: HTMLElement, tag, info?, callback?) {
+    const el = createEl(tag, info, callback);
+    this.appendChild(el);
+    return el;
+  };
+  globalThis.HTMLElement.prototype.createSpan = function (this: HTMLElement, info?, callback?) {
+    const el = createSpan(info, callback);
+    this.appendChild(el);
+    return el;
+  };
+  globalThis.HTMLElement.prototype.createSvg = function (this: HTMLElement, tag, info?, callback?) {
+    const el = createSvg(tag, info, callback);
+    this.appendChild(el);
+    return el;
+  };
+}
+
+if (globalThis.SVGElement && !('createSvg' in globalThis.SVGElement.prototype)) {
+  globalThis.SVGElement.prototype.createSvg = function (this: SVGElement, tag, info?, callback?) {
+    const el = createSvg(tag, info, callback);
+    this.appendChild(el);
+    return el;
+  };
+}

--- a/tests/unit/features/chat/controllers/ConversationController.test.ts
+++ b/tests/unit/features/chat/controllers/ConversationController.test.ts
@@ -1293,17 +1293,19 @@ describe('ConversationController', () => {
         (titleEl as any).replaceWith = jest.fn();
       }
 
-      const origDocument = global.document;
-      global.document = { createElement: jest.fn().mockReturnValue(mockInput) } as any;
+      const origCreateEl = item.createEl;
+      item.createEl = jest.fn().mockReturnValue(mockInput) as any;
 
       try {
         clickHandlers![0]({ stopPropagation: jest.fn() });
 
-        expect(global.document.createElement).toHaveBeenCalledWith('input');
-        expect((mockInput as any).value).toBe('Test Title');
+        expect(item.createEl).toHaveBeenCalledWith('input', {
+          cls: 'claudian-rename-input',
+          attr: { type: 'text', value: 'Test Title' },
+        });
         expect(titleEl!.replaceWith).toHaveBeenCalledWith(mockInput);
       } finally {
-        global.document = origDocument;
+        item.createEl = origCreateEl;
       }
     });
 

--- a/tests/unit/features/chat/ui/StatusPanel.test.ts
+++ b/tests/unit/features/chat/ui/StatusPanel.test.ts
@@ -197,18 +197,53 @@ class MockElement {
   }
 
   // Obsidian-style helper methods
-  createDiv(options?: { cls?: string; text?: string }): MockElement {
+  createDiv(options?: { cls?: string; text?: string; attr?: Record<string, string> }): MockElement {
     const el = new MockElement('div');
     if (options?.cls) el.className = options.cls;
     if (options?.text) el.textContent = options.text;
+    if (options?.attr) {
+      for (const [key, value] of Object.entries(options.attr)) {
+        el.setAttribute(key, value);
+      }
+    }
     this.appendChild(el);
     return el;
   }
 
-  createSpan(options?: { cls?: string; text?: string }): MockElement {
+  createSpan(options?: { cls?: string; text?: string; attr?: Record<string, string> }): MockElement {
     const el = new MockElement('span');
     if (options?.cls) el.className = options.cls;
     if (options?.text) el.textContent = options.text;
+    if (options?.attr) {
+      for (const [key, value] of Object.entries(options.attr)) {
+        el.setAttribute(key, value);
+      }
+    }
+    this.appendChild(el);
+    return el;
+  }
+
+  createEl(tag: string, options?: { cls?: string; text?: string; attr?: Record<string, string> }): MockElement {
+    const el = new MockElement(tag);
+    if (options?.cls) el.className = options.cls;
+    if (options?.text) el.textContent = options.text;
+    if (options?.attr) {
+      for (const [key, value] of Object.entries(options.attr)) {
+        el.setAttribute(key, value);
+      }
+    }
+    this.appendChild(el);
+    return el;
+  }
+
+  createSvg(tag: string, options?: { cls?: string; attr?: Record<string, string> }): MockElement {
+    const el = new MockElement(tag);
+    if (options?.cls) el.className = options.cls;
+    if (options?.attr) {
+      for (const [key, value] of Object.entries(options.attr)) {
+        el.setAttribute(key, value);
+      }
+    }
     this.appendChild(el);
     return el;
   }

--- a/tests/unit/shared/icons.test.ts
+++ b/tests/unit/shared/icons.test.ts
@@ -12,7 +12,7 @@ describe('createProviderIconSvg', () => {
     const svg = createProviderIconSvg(OPENAI_PROVIDER_ICON, {
       className: 'test-icon',
       height: 12,
-      ownerDocument: document,
+      parent: document.body,
       width: 12,
     });
 
@@ -31,7 +31,7 @@ describe('createProviderIconSvg', () => {
     const svg = createProviderIconSvg(OPENCODE_PROVIDER_ICON, {
       dataProvider: 'opencode',
       height: 18,
-      ownerDocument: document,
+      parent: document.body,
       width: 18,
     });
 
@@ -44,7 +44,7 @@ describe('createProviderIconSvg', () => {
   it('renders the Pi provider icon as currentColor composite paths', () => {
     const svg = createProviderIconSvg(PI_PROVIDER_ICON, {
       dataProvider: 'pi',
-      ownerDocument: document,
+      parent: document.body,
     });
 
     expect(svg.getAttribute('viewBox')).toBe('0 0 800 800');


### PR DESCRIPTION
Fixes the full set of static-analysis warnings across src/: unbound method extractions, raw document.createElement/createElementNS calls, a Promise boolean check, a missing getSettingDefinitions implementation, a non-Error throw, a redundant path union, and an unsafe generic array allocation. Replaces DOM construction with Obsidian's createEl/createDiv/createSpan/createSvg helpers and adds the corresponding @typescript-eslint rules to eslint.config.mjs to prevent regressions. Updates unit-test mocks and jsdom polyfills to support the helper-based DOM construction. Verified with npm run typecheck, lint, test, and build.