### PR TITLE
feat: add Kimi Code ACP provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-Claudian is an Obsidian plugin that embeds provider-backed coding agents in a sidebar and inline-edit flow. Claude is the default provider. Codex, OpenCode, and Pi are optional providers that plug into the same conversation model through `Conversation.providerId` and opaque provider-owned `providerState`.
+Claudian is an Obsidian plugin that embeds provider-backed coding agents in a sidebar and inline-edit flow. Claude is the default provider. Codex, OpenCode, Pi, and Kimi Code are optional providers that plug into the same conversation model through `Conversation.providerId` and opaque provider-owned `providerState`.
 
 Do not assume provider parity. Check each provider's `capabilities.ts`, `registration.ts`, and UI config before wiring shared behavior.
 
@@ -17,6 +17,7 @@ Do not assume provider parity. Check each provider's `capabilities.ts`, `registr
   - `src/providers/codex/AGENTS.md`
   - `src/providers/opencode/AGENTS.md`
   - `src/providers/pi/AGENTS.md`
+  - `src/providers/kimi/AGENTS.md`
   - `src/style/AGENTS.md`
 
 ## Commands
@@ -82,6 +83,7 @@ The feature layer depends on `core/` contracts, not provider internals. Provider
 | `~/.claude/projects/{vault}/*.jsonl` | Claude-native transcripts |
 | `~/.codex/sessions/**/*.jsonl` | Codex-native transcripts |
 | `~/.pi/agent/sessions/` | Pi user-level sessions |
+| `~/.kimi-code/` (or `$KIMI_CODE_HOME`) | Kimi Code config, sessions, credentials (provider never writes credentials) |
 
 ## Development Rules
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 ![Preview](assets/Preview.png)
 
-An Obsidian plugin that embeds AI coding agents (Claude Code, Codex, Opencode, Pi, and more to come) in your vault. Your vault becomes the agent's working directory — file read/write, search, bash, and multi-step workflows all work out of the box.
+An Obsidian plugin that embeds AI coding agents (Claude Code, Codex, Opencode, Pi, Kimi Code, and more to come) in your vault. Your vault becomes the agent's working directory — file read/write, search, bash, and multi-step workflows all work out of the box.
 
 ## Features & Usage
 
-Open the chat sidebar from the ribbon icon or command palette. Select text and use the hotkey for inline edit. Everything works like your familiar coding agent, Claude Code, Codex, Opencode, and Pi — talk to the agent, and it reads, writes, edits, and searches files in your vault.
+Open the chat sidebar from the ribbon icon or command palette. Select text and use the hotkey for inline edit. Everything works like your familiar coding agent, Claude Code, Codex, Opencode, Pi, and Kimi Code — talk to the agent, and it reads, writes, edits, and searches files in your vault.
 
 **Inline Edit** — Select text or start at the cursor position + hotkey to edit directly in notes with word-level diff preview.
 
@@ -29,7 +29,7 @@ Open the chat sidebar from the ribbon icon or command palette. Select text and u
 ## Requirements
 
 - **Claude provider**: [Claude Code CLI](https://code.claude.com/docs/en/overview) installed (native install recommended). Claude subscription/API or compatible provider ([Openrouter](https://openrouter.ai/docs/guides/guides/claude-code-integration), [Kimi](https://platform.kimi.ai/docs/guide/claude-code-kimi), [GLM](https://docs.z.ai/devpack/tool/claude) etc.).
-- **Optional providers**: [Codex CLI](https://github.com/openai/codex), [Opencode](https://opencode.ai/), [Pi](https://github.com/earendil-works/pi).
+- **Optional providers**: [Codex CLI](https://github.com/openai/codex), [Opencode](https://opencode.ai/), [Pi](https://github.com/earendil-works/pi), [Kimi Code](https://github.com/MoonshotAI/kimi-code) CLI (`kimi acp`, >= 0.27.0).
 - Obsidian v1.7.2+
 - Desktop only (macOS, Linux, Windows)
 
@@ -84,8 +84,8 @@ npm run build
 
 ## Privacy & Data Use
 
-- **Sent to API**: Your input, attached files, images, and tool call outputs. Default: Anthropic (Claude), OpenAI (Codex), or the provider configured in Opencode/Pi; configurable via provider settings and environment variables.
-- **Local storage**: Claudian settings and session metadata in `vault/.claudian/`; Claude provider files in `vault/.claude/`; transcripts in `~/.claude/projects/` (Claude), `~/.codex/sessions/` (Codex), and `.pi/agent/sessions/` or `~/.pi/agent/sessions/` (Pi).
+- **Sent to API**: Your input, attached files, images, and tool call outputs. Default: Anthropic (Claude), OpenAI (Codex), or the service configured in Kimi Code, Opencode, or Pi; configurable via provider settings and environment variables.
+- **Local storage**: Claudian settings and session metadata in `vault/.claudian/`; Claude provider files in `vault/.claude/`; transcripts in `~/.claude/projects/` (Claude), `~/.codex/sessions/` (Codex), `.pi/agent/sessions/` or `~/.pi/agent/sessions/` (Pi), and `~/.kimi-code/` or `$KIMI_CODE_HOME` (Kimi Code). Claudian never writes Kimi credentials.
 - **Environment variables**: Provider subprocesses inherit the Obsidian process environment plus any variables you configure in Claudian. This is needed for CLI authentication, proxies, certificates, and PATH resolution.
 - **Device-specific paths**: Per-device CLI paths use an opaque local key stored in browser local storage, not your system hostname.
 - **Background activity**: Claudian does not run telemetry beacons. UI polling timers read local Obsidian/editor selection state only. Network activity is limited to explicit provider runtime work, configured MCP endpoints, and provider SDK/CLI calls needed to answer your requests.
@@ -124,7 +124,7 @@ If different, GUI apps like Obsidian may not find Node.js.
 
 ### Other providers
 
-Codex, Opencode, and Pi support are live but features might be incomplete, and still need more testing across platforms and installation methods. If you have feature request or run into any bugs, please [submit a GitHub issue](https://github.com/YishenTu/claudian/issues).
+Codex, Opencode, Pi, and Kimi Code support are live but features might be incomplete, and still need more testing across platforms and installation methods. Kimi Code uses official `kimi acp` (authenticate with `kimi login` outside Claudian when required). If you have feature request or run into any bugs, please [submit a GitHub issue](https://github.com/YishenTu/claudian/issues).
 
 ## Architecture
 
@@ -144,6 +144,7 @@ src/
 │   ├── codex/                   # Codex app-server adaptor, JSON-RPC transport, JSONL history
 │   ├── opencode/                # Opencode adaptor
 │   ├── pi/                      # Pi RPC adaptor, model discovery, JSONL history
+│   ├── kimi/                    # Kimi Code ACP adaptor (`kimi acp`)
 │   └── acp/                     # Agent Client Protocol shared transport
 ├── features/
 │   ├── chat/                    # Sidebar chat: tabs, controllers, renderers
@@ -188,3 +189,4 @@ improve through ongoing development and maintenance.
 - [OpenAI](https://openai.com) for [Codex](https://github.com/openai/codex)
 - [Opencode](https://opencode.ai/) 
 - [Pi](https://github.com/earendil-works/pi)
+- [MoonshotAI](https://www.moonshot.cn/) for [Kimi Code](https://github.com/MoonshotAI/kimi-code)

--- a/src/providers/defaultProviderConfigs.ts
+++ b/src/providers/defaultProviderConfigs.ts
@@ -1,6 +1,7 @@
 import type { ProviderConfigMap } from '../core/types/settings';
 import { DEFAULT_CLAUDE_PROVIDER_SETTINGS } from './claude/settings';
 import { DEFAULT_CODEX_PROVIDER_CONFIG } from './codex/settings';
+import { DEFAULT_KIMI_PROVIDER_SETTINGS } from './kimi/settings';
 import { DEFAULT_OPENCODE_PROVIDER_SETTINGS } from './opencode/settings';
 import { DEFAULT_PI_PROVIDER_SETTINGS } from './pi/settings';
 
@@ -10,5 +11,6 @@ export function getBuiltInProviderDefaultConfigs(): ProviderConfigMap {
     codex: { ...DEFAULT_CODEX_PROVIDER_CONFIG },
     opencode: { ...DEFAULT_OPENCODE_PROVIDER_SETTINGS },
     pi: { ...DEFAULT_PI_PROVIDER_SETTINGS },
+    kimi: { ...DEFAULT_KIMI_PROVIDER_SETTINGS },
   };
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -2,6 +2,7 @@ import { ProviderRegistry } from '../core/providers/ProviderRegistry';
 import { ProviderWorkspaceRegistry } from '../core/providers/ProviderWorkspaceRegistry';
 import { claudeProviderRegistration } from './claude/registration';
 import { codexProviderRegistration } from './codex/registration';
+import { kimiProviderRegistration } from './kimi/registration';
 import { opencodeProviderRegistration } from './opencode/registration';
 import { piProviderRegistration } from './pi/registration';
 
@@ -12,6 +13,7 @@ export const BUILT_IN_PROVIDER_MODULES = [
   codexProviderRegistration,
   opencodeProviderRegistration,
   piProviderRegistration,
+  kimiProviderRegistration,
 ] as const;
 
 export function registerBuiltInProviders(): void {

--- a/src/providers/kimi/AGENTS.md
+++ b/src/providers/kimi/AGENTS.md
@@ -1,0 +1,55 @@
+# Kimi Code Provider
+
+`src/providers/kimi/` adapts Moonshot Kimi Code through Agent Client Protocol over a
+`kimi acp` subprocess (Kimi Code >= 0.27.0).
+
+## Ownership
+
+- Runtime process management, ACP transport, prompt encoding, stream
+  normalization, CLI resolution, settings UI, model/mode/thinking discovery,
+  auxiliary ACP queries, and Kimi-specific settings reconciliation live here.
+- Shared code should consume Kimi behavior through `ChatRuntime`, provider
+  capabilities, and workspace-service contracts.
+
+## Protocol Rules
+
+- Chat launches `[resolved kimi binary, "acp"]`.
+- Live output comes from ACP session notifications and is normalized through
+  `AcpSessionUpdateNormalizer`.
+- Model, mode, and thought-level options come from `configOptions` on
+  `session/new` / `session/load` and `config_option_update` notifications.
+- Model IDs are namespaced as `kimi:<rawId>` (`KIMI_SYNTHETIC_MODEL_ID` = `kimi`
+  before discovery).
+- Modes map to shared permission modes in `modes.ts` (default/plan/auto/yolo).
+- Claudian does not launch ACP terminal auth. JSON-RPC `-32000 Authentication
+  required` must surface guidance to run `kimi login`.
+- Phase 1 does not forward Claudian-managed MCP servers.
+- Never mutate native Kimi history or credentials under `~/.kimi-code/`.
+
+## Session State
+
+- Persist `Conversation.sessionId`, `providerState.sessionId`, and
+  `providerState.kimiCodeHome` for resume/hydration.
+- `KIMI_CODE_HOME` overrides the data root (`~/.kimi-code` by default).
+- Deleting a Claudian conversation must not delete native Kimi data.
+
+## Capabilities
+
+- Supported: persistent ACP runtime, native history, plan mode, provider
+  commands, image attachments, instruction mode, thinking on/off effort axis.
+- Not claimed: rewind, fork, managed MCP, turn steer.
+
+## Settings
+
+- Kimi is opt-in and disabled by default (`providerConfigs.kimi.enabled`).
+- CLI resolution: host-scoped path → legacy `cliPath` → PATH / common install
+  dirs (`kimi`, `kimi.exe`, `kimi.cmd`).
+- Environment keys `/^KIMI_/i` and `/^MOONSHOT_/i` are provider-owned.
+
+## Gotchas
+
+- `KimiAuxQueryRunner` owns its own ACP process and session; it never silently
+  approves tools.
+- Cancel marks the process for restart (`restartRequiredAfterCancel`) for
+  deterministic cleanup.
+- Auxiliary prompts should not approve tools.

--- a/src/providers/kimi/app/KimiWorkspaceServices.ts
+++ b/src/providers/kimi/app/KimiWorkspaceServices.ts
@@ -1,0 +1,26 @@
+import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
+import type {
+  ProviderWorkspaceRegistration,
+  ProviderWorkspaceServices,
+} from '../../../core/providers/types';
+import { KimiCliResolver } from '../runtime/KimiCliResolver';
+import { kimiSettingsTabRenderer } from '../ui/KimiSettingsTab';
+
+export interface KimiWorkspaceServices extends ProviderWorkspaceServices {
+  cliResolver: KimiCliResolver;
+}
+
+export async function createKimiWorkspaceServices(): Promise<KimiWorkspaceServices> {
+  return {
+    cliResolver: new KimiCliResolver(),
+    settingsTabRenderer: kimiSettingsTabRenderer,
+  };
+}
+
+export const kimiWorkspaceRegistration: ProviderWorkspaceRegistration<KimiWorkspaceServices> = {
+  initialize: async () => createKimiWorkspaceServices(),
+};
+
+export function maybeGetKimiWorkspaceServices(): KimiWorkspaceServices | null {
+  return ProviderWorkspaceRegistry.getServices('kimi') as KimiWorkspaceServices | null;
+}

--- a/src/providers/kimi/auxiliary/KimiInlineEditService.ts
+++ b/src/providers/kimi/auxiliary/KimiInlineEditService.ts
@@ -1,0 +1,9 @@
+import { QueryBackedInlineEditService } from '../../../core/auxiliary/QueryBackedInlineEditService';
+import type { ProviderHost } from '../../../core/providers/ProviderHost';
+import { KimiAuxQueryRunner } from '../runtime/KimiAuxQueryRunner';
+
+export class KimiInlineEditService extends QueryBackedInlineEditService {
+  constructor(plugin: ProviderHost) {
+    super(new KimiAuxQueryRunner(plugin, { allowReadTextFile: true }));
+  }
+}

--- a/src/providers/kimi/auxiliary/KimiInstructionRefineService.ts
+++ b/src/providers/kimi/auxiliary/KimiInstructionRefineService.ts
@@ -1,0 +1,9 @@
+import { QueryBackedInstructionRefineService } from '../../../core/auxiliary/QueryBackedInstructionRefineService';
+import type { ProviderHost } from '../../../core/providers/ProviderHost';
+import { KimiAuxQueryRunner } from '../runtime/KimiAuxQueryRunner';
+
+export class KimiInstructionRefineService extends QueryBackedInstructionRefineService {
+  constructor(plugin: ProviderHost) {
+    super(new KimiAuxQueryRunner(plugin));
+  }
+}

--- a/src/providers/kimi/auxiliary/KimiTaskResultInterpreter.ts
+++ b/src/providers/kimi/auxiliary/KimiTaskResultInterpreter.ts
@@ -1,0 +1,29 @@
+import type {
+  ProviderTaskResultInterpreter,
+  ProviderTaskTerminalStatus,
+} from '../../../core/providers/types';
+
+export class KimiTaskResultInterpreter implements ProviderTaskResultInterpreter {
+  hasAsyncLaunchMarker(_toolUseResult: unknown): boolean {
+    return false;
+  }
+
+  extractAgentId(_toolUseResult: unknown): string | null {
+    return null;
+  }
+
+  extractStructuredResult(_toolUseResult: unknown): string | null {
+    return null;
+  }
+
+  resolveTerminalStatus(
+    _toolUseResult: unknown,
+    fallbackStatus: ProviderTaskTerminalStatus,
+  ): ProviderTaskTerminalStatus {
+    return fallbackStatus;
+  }
+
+  extractTagValue(_payload: string, _tagName: string): string | null {
+    return null;
+  }
+}

--- a/src/providers/kimi/auxiliary/KimiTitleGenerationService.ts
+++ b/src/providers/kimi/auxiliary/KimiTitleGenerationService.ts
@@ -1,0 +1,24 @@
+import { QueryBackedTitleGenerationService } from '../../../core/auxiliary/QueryBackedTitleGenerationService';
+import type { ProviderHost } from '../../../core/providers/ProviderHost';
+import { decodeKimiModelId } from '../models';
+import { KimiAuxQueryRunner } from '../runtime/KimiAuxQueryRunner';
+import { kimiChatUIConfig } from '../ui/KimiChatUIConfig';
+
+export class KimiTitleGenerationService extends QueryBackedTitleGenerationService {
+  constructor(plugin: ProviderHost) {
+    super({
+      createRunner: () => new KimiAuxQueryRunner(plugin),
+      resolveModel: () => {
+        const settings = plugin.settings as unknown as Record<string, unknown>;
+        const titleModel = typeof settings.titleGenerationModel === 'string'
+          ? settings.titleGenerationModel
+          : '';
+        if (!kimiChatUIConfig.ownsModel(titleModel, settings)) {
+          return undefined;
+        }
+
+        return decodeKimiModelId(titleModel) ?? titleModel;
+      },
+    });
+  }
+}

--- a/src/providers/kimi/capabilities.ts
+++ b/src/providers/kimi/capabilities.ts
@@ -1,0 +1,26 @@
+import type { ProviderCapabilities } from '../../core/providers/types';
+
+/**
+ * Conservative Kimi Code ACP capabilities for Claudian.
+ *
+ * Verified against Kimi Code >= 0.27.0 ACP adapter:
+ * - loadSession, image prompts, configOptions (model/mode/thinking), commands
+ * - plan/default/auto/yolo modes when advertised
+ * - no Claudian-managed MCP forwarding in Phase 1
+ * - no rewind/fork/turn steering
+ */
+export const KIMI_PROVIDER_CAPABILITIES: Readonly<ProviderCapabilities> = Object.freeze({
+  providerId: 'kimi',
+  supportsPersistentRuntime: true,
+  supportsNativeHistory: true,
+  supportsPlanMode: true,
+  supportsRewind: false,
+  supportsFork: false,
+  supportsProviderCommands: true,
+  supportsImageAttachments: true,
+  supportsInstructionMode: true,
+  supportsMcpTools: false,
+  supportsTurnSteer: false,
+  // Kimi advertises thought_level as an on/off select (effort-like axis).
+  reasoningControl: 'effort',
+});

--- a/src/providers/kimi/discoveryState.ts
+++ b/src/providers/kimi/discoveryState.ts
@@ -1,0 +1,129 @@
+import { sameDiscoveredModels, sameModes, sameThinkingOptionsByModel } from './internal/compareCollections';
+import {
+  type KimiDiscoveredModel,
+  type KimiThinkingOptionsByModel,
+  normalizeKimiDiscoveredModels,
+  normalizeKimiThinkingOptionsByModel,
+} from './models';
+import {
+  type KimiMode,
+  normalizeKimiAvailableModes,
+} from './modes';
+
+const KIMI_DISCOVERY_STATE = Symbol('kimiDiscoveryState');
+
+interface KimiDiscoveryState {
+  availableModes: KimiMode[];
+  discoveredModels: KimiDiscoveredModel[];
+  thinkingOptionsByModel: KimiThinkingOptionsByModel;
+}
+
+type SettingsBag = Record<string | symbol, unknown>;
+
+function ensureDiscoveryState(settings: Record<string, unknown>): KimiDiscoveryState {
+  const bag = settings as SettingsBag;
+  const existing = bag[KIMI_DISCOVERY_STATE];
+  if (existing && typeof existing === 'object' && !Array.isArray(existing)) {
+    const state = existing as Partial<KimiDiscoveryState>;
+    state.availableModes ??= [];
+    state.discoveredModels ??= [];
+    state.thinkingOptionsByModel ??= {};
+    return state as KimiDiscoveryState;
+  }
+
+  const next: KimiDiscoveryState = {
+    availableModes: [],
+    discoveredModels: [],
+    thinkingOptionsByModel: {},
+  };
+  bag[KIMI_DISCOVERY_STATE] = next;
+  return next;
+}
+
+function cloneModes(modes: KimiMode[]): KimiMode[] {
+  return modes.map((mode) => ({ ...mode }));
+}
+
+function cloneDiscoveredModels(models: KimiDiscoveredModel[]): KimiDiscoveredModel[] {
+  return models.map((model) => ({ ...model }));
+}
+
+function cloneThinkingOptionsByModel(
+  optionsByModel: KimiThinkingOptionsByModel,
+): KimiThinkingOptionsByModel {
+  return Object.fromEntries(
+    Object.entries(optionsByModel).map(([rawId, options]) => [
+      rawId,
+      options.map((option) => ({ ...option })),
+    ]),
+  );
+}
+
+export function getKimiDiscoveryState(settings: Record<string, unknown>): KimiDiscoveryState {
+  const state = ensureDiscoveryState(settings);
+  return {
+    availableModes: cloneModes(state.availableModes),
+    discoveredModels: cloneDiscoveredModels(state.discoveredModels),
+    thinkingOptionsByModel: cloneThinkingOptionsByModel(state.thinkingOptionsByModel),
+  };
+}
+
+export function updateKimiDiscoveryState(
+  settings: Record<string, unknown>,
+  updates: Partial<KimiDiscoveryState>,
+): boolean {
+  const state = ensureDiscoveryState(settings);
+  const nextAvailableModes = 'availableModes' in updates
+    ? normalizeKimiAvailableModes(updates.availableModes)
+    : state.availableModes;
+  const nextDiscoveredModels = 'discoveredModels' in updates
+    ? normalizeKimiDiscoveredModels(updates.discoveredModels)
+    : state.discoveredModels;
+  const nextThinkingOptionsByModel = 'thinkingOptionsByModel' in updates
+    ? normalizeKimiThinkingOptionsByModel(updates.thinkingOptionsByModel, nextDiscoveredModels)
+    : state.thinkingOptionsByModel;
+
+  const changed = !sameModes(state.availableModes, nextAvailableModes)
+    || !sameDiscoveredModels(state.discoveredModels, nextDiscoveredModels)
+    || !sameThinkingOptionsByModel(state.thinkingOptionsByModel, nextThinkingOptionsByModel);
+
+  if (!changed) {
+    return false;
+  }
+
+  state.availableModes = cloneModes(nextAvailableModes);
+  state.discoveredModels = cloneDiscoveredModels(nextDiscoveredModels);
+  state.thinkingOptionsByModel = cloneThinkingOptionsByModel(nextThinkingOptionsByModel);
+  return true;
+}
+
+export function clearKimiDiscoveryState(settings: Record<string, unknown>): boolean {
+  const bag = settings as SettingsBag;
+  if (!(KIMI_DISCOVERY_STATE in bag)) {
+    return false;
+  }
+  delete bag[KIMI_DISCOVERY_STATE];
+  return true;
+}
+
+export function seedKimiDiscoveryStateFromLegacyConfig(
+  settings: Record<string, unknown>,
+  config: Record<string, unknown>,
+): void {
+  if (
+    !('availableModes' in config)
+    && !('discoveredModels' in config)
+    && !('thinkingOptionsByModel' in config)
+  ) {
+    return;
+  }
+
+  updateKimiDiscoveryState(settings, {
+    availableModes: normalizeKimiAvailableModes(config.availableModes),
+    discoveredModels: normalizeKimiDiscoveredModels(config.discoveredModels),
+    thinkingOptionsByModel: normalizeKimiThinkingOptionsByModel(
+      config.thinkingOptionsByModel,
+      normalizeKimiDiscoveredModels(config.discoveredModels),
+    ),
+  });
+}

--- a/src/providers/kimi/env/KimiSettingsReconciler.ts
+++ b/src/providers/kimi/env/KimiSettingsReconciler.ts
@@ -1,0 +1,172 @@
+import * as crypto from 'node:crypto';
+
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import type { ProviderSettingsReconciler } from '../../../core/providers/types';
+import type { Conversation } from '../../../core/types';
+import { parseEnvironmentVariables } from '../../../utils/env';
+import { clearKimiDiscoveryState } from '../discoveryState';
+import { sameStringList, sameStringMap } from '../internal/compareCollections';
+import { ensureProviderProjectionMap } from '../internal/providerProjection';
+import {
+  decodeKimiModelId,
+  encodeKimiModelId,
+  isKimiModelSelectionId,
+  KIMI_DEFAULT_THINKING_LEVEL,
+  resolveKimiBaseModelRawId,
+} from '../models';
+import {
+  getKimiProviderSettings,
+  normalizeKimiPreferredThinkingByModel,
+  normalizeKimiVisibleModels,
+  updateKimiProviderSettings,
+} from '../settings';
+import { getKimiState } from '../types';
+
+interface NormalizedSelection {
+  baseModelId: string | null;
+}
+
+const KIMI_ENV_HASH_KEYS = [
+  'KIMI_CODE_HOME',
+  'KIMI_API_KEY',
+  'MOONSHOT_API_KEY',
+] as const;
+
+function computeKimiEnvHash(envText: string): string {
+  const envVars = parseEnvironmentVariables(envText || '');
+  const canonical = KIMI_ENV_HASH_KEYS
+    .filter((key) => envVars[key])
+    .map((key) => `${key}=${envVars[key]}`)
+    .sort()
+    .join('|');
+  return canonical
+    ? `sha256:${crypto.createHash('sha256').update(canonical).digest('hex')}`
+    : '';
+}
+
+function invalidateKimiConversationSessions(conversations: Conversation[]): Conversation[] {
+  const invalidatedConversations: Conversation[] = [];
+  for (const conversation of conversations) {
+    if (conversation.providerId !== 'kimi') {
+      continue;
+    }
+
+    const state = getKimiState(conversation.providerState);
+    if (!conversation.sessionId && !state.sessionId) {
+      continue;
+    }
+
+    conversation.sessionId = null;
+    conversation.providerState = undefined;
+    invalidatedConversations.push(conversation);
+  }
+  return invalidatedConversations;
+}
+
+export const kimiSettingsReconciler: ProviderSettingsReconciler = {
+  handleEnvironmentChange(settings: Record<string, unknown>): boolean {
+    return clearKimiDiscoveryState(settings);
+  },
+
+  invalidateConversationSessions: invalidateKimiConversationSessions,
+
+  reconcileModelWithEnvironment(
+    settings: Record<string, unknown>,
+    conversations: Conversation[],
+  ): { changed: boolean; invalidatedConversations: Conversation[] } {
+    const envText = getRuntimeEnvironmentText(settings, 'kimi');
+    const currentHash = computeKimiEnvHash(envText);
+    const savedHash = getKimiProviderSettings(settings).environmentHash;
+
+    if (currentHash === savedHash) {
+      return { changed: false, invalidatedConversations: [] };
+    }
+
+    const invalidatedConversations = invalidateKimiConversationSessions(conversations);
+    updateKimiProviderSettings(settings, { environmentHash: currentHash });
+    return { changed: true, invalidatedConversations };
+  },
+
+  normalizeModelVariantSettings(settings: Record<string, unknown>): boolean {
+    const kimiSettings = getKimiProviderSettings(settings);
+    let changed = false;
+
+    const normalizeSelection = (value: unknown): NormalizedSelection => {
+      if (typeof value !== 'string' || !isKimiModelSelectionId(value)) {
+        return { baseModelId: null };
+      }
+
+      const rawModelId = decodeKimiModelId(value);
+      if (!rawModelId) {
+        return { baseModelId: value };
+      }
+
+      const baseRawId = resolveKimiBaseModelRawId(rawModelId, kimiSettings.discoveredModels);
+      return {
+        baseModelId: encodeKimiModelId(baseRawId),
+      };
+    };
+
+    const modelSelection = normalizeSelection(settings.model);
+    if (
+      typeof settings.model === 'string'
+      && modelSelection.baseModelId
+      && settings.model !== modelSelection.baseModelId
+    ) {
+      settings.model = modelSelection.baseModelId;
+      changed = true;
+    }
+
+    const titleModelSelection = normalizeSelection(settings.titleGenerationModel);
+    if (
+      typeof settings.titleGenerationModel === 'string'
+      && titleModelSelection.baseModelId
+      && settings.titleGenerationModel !== titleModelSelection.baseModelId
+    ) {
+      settings.titleGenerationModel = titleModelSelection.baseModelId;
+      changed = true;
+    }
+
+    const savedProviderModelRaw = settings.savedProviderModel;
+    if (savedProviderModelRaw && typeof savedProviderModelRaw === 'object' && !Array.isArray(savedProviderModelRaw)) {
+      const savedProviderModel = savedProviderModelRaw as Record<string, unknown>;
+      const savedSelection = normalizeSelection(savedProviderModel.kimi);
+      if (
+        typeof savedProviderModel.kimi === 'string'
+        && savedSelection.baseModelId
+        && savedProviderModel.kimi !== savedSelection.baseModelId
+      ) {
+        savedProviderModel.kimi = savedSelection.baseModelId;
+        changed = true;
+      }
+      if (savedSelection.baseModelId) {
+        ensureProviderProjectionMap(settings, 'savedProviderEffort');
+      }
+    }
+
+    const normalizedVisibleModels = normalizeKimiVisibleModels(
+      kimiSettings.visibleModels,
+      kimiSettings.discoveredModels,
+    );
+    const normalizedPreferredThinking = normalizeKimiPreferredThinkingByModel(
+      kimiSettings.preferredThinkingByModel,
+      kimiSettings.discoveredModels,
+    );
+    const shouldUpdateProviderSettings = !sameStringList(normalizedVisibleModels, kimiSettings.visibleModels)
+      || !sameStringMap(normalizedPreferredThinking, kimiSettings.preferredThinkingByModel);
+    if (shouldUpdateProviderSettings) {
+      updateKimiProviderSettings(settings, {
+        preferredThinkingByModel: normalizedPreferredThinking,
+        visibleModels: normalizedVisibleModels,
+      });
+      changed = true;
+    }
+
+    if (typeof settings.effortLevel === 'string' && !settings.effortLevel.trim()) {
+      settings.effortLevel = KIMI_DEFAULT_THINKING_LEVEL;
+      changed = true;
+    }
+
+    return changed;
+  },
+};

--- a/src/providers/kimi/history/KimiConversationHistoryService.ts
+++ b/src/providers/kimi/history/KimiConversationHistoryService.ts
@@ -1,0 +1,291 @@
+import * as fs from 'fs';
+
+import type {
+  ProviderConversationHistoryService,
+  ProviderHistoryPathContext,
+} from '../../../core/providers/types';
+import type { ChatMessage, Conversation } from '../../../core/types';
+import { getKimiState, type KimiProviderState, resolveKimiSessionId } from '../types';
+import {
+  resolveKimiCodeHomeForHistory,
+  resolveKimiHistoryFile,
+} from './KimiHistoryPaths';
+
+function readTextContent(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(readTextContent).filter(Boolean).join('');
+  }
+  if (!value || typeof value !== 'object') {
+    return '';
+  }
+
+  const record = value as Record<string, unknown>;
+  if (typeof record.text === 'string') {
+    return record.text;
+  }
+  if (typeof record.content === 'string') {
+    return record.content;
+  }
+  if (Array.isArray(record.content)) {
+    return readTextContent(record.content);
+  }
+  if (record.content && typeof record.content === 'object') {
+    return readTextContent(record.content);
+  }
+  if (record.message) {
+    return readTextContent(record.message);
+  }
+  if (record.delta) {
+    return readTextContent(record.delta);
+  }
+  return '';
+}
+
+function resolveRecordTime(record: Record<string, unknown>, fallback: number): number {
+  return typeof record.time === 'number' && Number.isFinite(record.time)
+    ? record.time
+    : fallback;
+}
+
+function appendHistoryMessage(
+  messages: ChatMessage[],
+  role: 'assistant' | 'user',
+  text: string,
+  sessionId: string,
+  recordIndex: number,
+  timestamp: number,
+): void {
+  const content = text.trim();
+  if (!content) {
+    return;
+  }
+
+  const id = `kimi-${sessionId}-${recordIndex}-${role}`;
+  if (role === 'user') {
+    messages.push({
+      content,
+      displayContent: content,
+      id,
+      role: 'user',
+      timestamp,
+      userMessageId: id,
+    });
+    return;
+  }
+
+  messages.push({
+    assistantMessageId: id,
+    content,
+    contentBlocks: [{ type: 'text', content }],
+    id,
+    role: 'assistant',
+    timestamp,
+  });
+}
+
+/** Rebuild user and assistant text from Kimi Code's AgentRecord wire log. */
+export function loadKimiHistoryMessages(
+  historyPath: string,
+  sessionId: string,
+  baseTimestamp: number,
+): ChatMessage[] {
+  let content: string;
+  try {
+    content = fs.readFileSync(historyPath, 'utf-8');
+  } catch {
+    return [];
+  }
+
+  const messages: ChatMessage[] = [];
+  const openAssistantSteps = new Map<string, {
+    recordIndex: number;
+    text: string;
+    timestamp: number;
+  }>();
+  const lines = content.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) {
+      continue;
+    }
+
+    let record: Record<string, unknown>;
+    try {
+      record = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+
+    const type = typeof record.type === 'string' ? record.type : '';
+    const timestamp = resolveRecordTime(record, baseTimestamp + i);
+
+    if (type === 'context.append_message') {
+      const message = record.message;
+      if (!message || typeof message !== 'object' || Array.isArray(message)) {
+        continue;
+      }
+      const messageRecord = message as Record<string, unknown>;
+      const origin = messageRecord.origin;
+      const originKind = origin && typeof origin === 'object' && !Array.isArray(origin)
+        ? (origin as Record<string, unknown>).kind
+        : undefined;
+      if (originKind === 'compaction_summary' || originKind === 'injection') {
+        continue;
+      }
+      const role = messageRecord.role;
+      if (role === 'user' || role === 'assistant') {
+        appendHistoryMessage(
+          messages,
+          role,
+          readTextContent(messageRecord.content),
+          sessionId,
+          i,
+          timestamp,
+        );
+      }
+      continue;
+    }
+
+    if (type !== 'context.append_loop_event') {
+      continue;
+    }
+    const event = record.event;
+    if (!event || typeof event !== 'object' || Array.isArray(event)) {
+      continue;
+    }
+    const eventRecord = event as Record<string, unknown>;
+    const eventType = eventRecord.type;
+    const stepUuid = typeof eventRecord.stepUuid === 'string'
+      ? eventRecord.stepUuid
+      : typeof eventRecord.uuid === 'string'
+      ? eventRecord.uuid
+      : '';
+
+    if (eventType === 'step.begin' && stepUuid) {
+      openAssistantSteps.set(stepUuid, { recordIndex: i, text: '', timestamp });
+      continue;
+    }
+    if (eventType === 'content.part' && stepUuid) {
+      const step = openAssistantSteps.get(stepUuid);
+      if (step) {
+        step.text += readTextContent(eventRecord.part);
+      }
+      continue;
+    }
+    if (eventType === 'step.end' && stepUuid) {
+      const step = openAssistantSteps.get(stepUuid);
+      if (step) {
+        appendHistoryMessage(
+          messages,
+          'assistant',
+          step.text,
+          sessionId,
+          step.recordIndex,
+          step.timestamp,
+        );
+        openAssistantSteps.delete(stepUuid);
+      }
+    }
+  }
+
+  for (const step of openAssistantSteps.values()) {
+    appendHistoryMessage(
+      messages,
+      'assistant',
+      step.text,
+      sessionId,
+      step.recordIndex,
+      step.timestamp,
+    );
+  }
+
+  return messages;
+}
+
+export class KimiConversationHistoryService implements ProviderConversationHistoryService {
+  private hydratedKeys = new Map<string, string>();
+
+  async hydrateConversationHistory(
+    conversation: Conversation,
+    vaultPath: string | null,
+    pathContext?: ProviderHistoryPathContext,
+  ): Promise<void> {
+    const sessionId = this.resolveSessionIdForConversation(conversation);
+    const kimiCodeHome = resolveKimiCodeHomeForHistory(conversation, pathContext);
+    const historyPath = resolveKimiHistoryFile(vaultPath, sessionId, { kimiCodeHome });
+    if (!sessionId || !historyPath) {
+      this.hydratedKeys.delete(conversation.id);
+      return;
+    }
+
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(historyPath);
+    } catch {
+      this.hydratedKeys.delete(conversation.id);
+      return;
+    }
+
+    const hydrationKey = `${sessionId}::${historyPath}::${stat.mtimeMs}::${stat.size}`;
+    if (conversation.messages.length > 0 && this.hydratedKeys.get(conversation.id) === hydrationKey) {
+      return;
+    }
+
+    const messages = loadKimiHistoryMessages(
+      historyPath,
+      sessionId,
+      typeof conversation.createdAt === 'number' ? conversation.createdAt : Date.now(),
+    );
+    if (messages.length === 0) {
+      this.hydratedKeys.delete(conversation.id);
+      return;
+    }
+
+    conversation.messages = messages;
+    this.hydratedKeys.set(conversation.id, hydrationKey);
+  }
+
+  async deleteConversationSession(
+    _conversation: Conversation,
+    _vaultPath: string | null,
+  ): Promise<void> {
+    // Never mutate Kimi native history.
+  }
+
+  resolveSessionIdForConversation(conversation: Conversation | null): string | null {
+    return resolveKimiSessionId(conversation);
+  }
+
+  isPendingForkConversation(_conversation: Conversation): boolean {
+    return false;
+  }
+
+  buildForkProviderState(
+    sourceSessionId: string,
+    resumeAt: string,
+    sourceProviderState?: Record<string, unknown>,
+  ): Record<string, unknown> {
+    return {
+      ...(sourceProviderState ?? {}),
+      forkSource: { sessionId: sourceSessionId, resumeAt },
+    };
+  }
+
+  buildPersistedProviderState(
+    conversation: Conversation,
+  ): Record<string, unknown> | undefined {
+    const state = getKimiState(conversation.providerState);
+    const sessionId = resolveKimiSessionId(conversation) ?? state.sessionId;
+    const providerState: KimiProviderState = {
+      ...(sessionId ? { sessionId } : {}),
+      ...(state.kimiCodeHome ? { kimiCodeHome: state.kimiCodeHome } : {}),
+    };
+
+    return Object.keys(providerState).length > 0
+      ? providerState as Record<string, unknown>
+      : undefined;
+  }
+}

--- a/src/providers/kimi/history/KimiHistoryPaths.ts
+++ b/src/providers/kimi/history/KimiHistoryPaths.ts
@@ -1,0 +1,170 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import type { ProviderHistoryPathContext } from '../../../core/providers/types';
+import { parseEnvironmentVariables } from '../../../utils/env';
+import { getKimiState } from '../types';
+
+export function getKimiCodeHome(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env.KIMI_CODE_HOME?.trim();
+  if (override) {
+    return override;
+  }
+  return path.join(os.homedir(), '.kimi-code');
+}
+
+/** Matches Kimi Code's agent-core workdir-key.ts. */
+export function encodeKimiWorkDirKey(vaultPath: string): string {
+  const normalized = /^[A-Za-z]:[\\/]/.test(vaultPath) || /^[\\/]{2}[^\\/]+[\\/][^\\/]+/.test(vaultPath)
+    ? path.win32.resolve(vaultPath).replaceAll('\\', '/')
+    : path.resolve(vaultPath);
+  const name = normalized.slice(normalized.lastIndexOf('/') + 1);
+  const slugValue = name
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40)
+    .replace(/^-+|-+$/g, '');
+  const slug = !slugValue || slugValue === '.' || slugValue === '..'
+    ? 'workspace'
+    : slugValue;
+  const hash = crypto.createHash('sha256').update(normalized).digest('hex').slice(0, 12);
+  return `wd_${slug}_${hash}`;
+}
+
+/**
+ * Resolve Kimi home for history hydration.
+ *
+ * Order: persisted providerState.kimiCodeHome → pathContext env/settings → process.env → default.
+ */
+export function resolveKimiCodeHomeForHistory(
+  conversation: {
+    providerState?: Record<string, unknown>;
+  } | null | undefined,
+  pathContext?: ProviderHistoryPathContext,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const stateHome = getKimiState(conversation?.providerState).kimiCodeHome;
+  if (stateHome) {
+    return stateHome;
+  }
+
+  const contextEnvHome = pathContext?.environment?.KIMI_CODE_HOME?.trim();
+  if (contextEnvHome) {
+    return contextEnvHome;
+  }
+
+  if (pathContext?.settings) {
+    const envText = getRuntimeEnvironmentText(pathContext.settings, 'kimi');
+    const vars = parseEnvironmentVariables(envText);
+    const settingsHome = vars.KIMI_CODE_HOME?.trim();
+    if (settingsHome) {
+      return settingsHome;
+    }
+  }
+
+  return getKimiCodeHome(env);
+}
+
+export function resolveKimiWireHistoryFile(
+  vaultPath: string | null | undefined,
+  sessionId: string | null | undefined,
+  options: {
+    env?: NodeJS.ProcessEnv;
+    kimiCodeHome?: string | null;
+  } = {},
+): string | null {
+  if (!vaultPath || !isSafeKimiSessionId(sessionId)) {
+    return null;
+  }
+
+  const kimiCodeHome = options.kimiCodeHome?.trim()
+    || getKimiCodeHome(options.env ?? process.env);
+  const workDirKey = encodeKimiWorkDirKey(vaultPath);
+  const wirePath = path.join(
+    kimiCodeHome,
+    'sessions',
+    workDirKey,
+    sessionId,
+    'agents',
+    'main',
+    'wire.jsonl',
+  );
+
+  try {
+    return fs.statSync(wirePath).isFile() ? wirePath : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Scan session_index.jsonl for a session and return its wire.jsonl when present.
+ * Falls back to workDirKey path resolution.
+ */
+export function resolveKimiHistoryFile(
+  vaultPath: string | null | undefined,
+  sessionId: string | null | undefined,
+  options: {
+    env?: NodeJS.ProcessEnv;
+    kimiCodeHome?: string | null;
+  } = {},
+): string | null {
+  if (!isSafeKimiSessionId(sessionId)) {
+    return null;
+  }
+
+  const direct = resolveKimiWireHistoryFile(vaultPath, sessionId, options);
+  if (direct) {
+    return direct;
+  }
+
+  const kimiCodeHome = options.kimiCodeHome?.trim()
+    || getKimiCodeHome(options.env ?? process.env);
+  const indexPath = path.join(kimiCodeHome, 'session_index.jsonl');
+  try {
+    const content = fs.readFileSync(indexPath, 'utf-8');
+    for (const line of content.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        continue;
+      }
+      let record: Record<string, unknown>;
+      try {
+        record = JSON.parse(trimmed) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      const id = typeof record.sessionId === 'string' ? record.sessionId : '';
+      const sessionDir = typeof record.sessionDir === 'string' ? record.sessionDir : '';
+      if (id !== sessionId || !sessionDir) {
+        continue;
+      }
+      const wirePath = path.join(sessionDir, 'agents', 'main', 'wire.jsonl');
+      try {
+        if (fs.statSync(wirePath).isFile()) {
+          return wirePath;
+        }
+      } catch {
+        // continue
+      }
+    }
+  } catch {
+    // index missing
+  }
+
+  return null;
+}
+
+function isSafeKimiSessionId(sessionId: string | null | undefined): sessionId is string {
+  if (!sessionId) {
+    return false;
+  }
+  return !sessionId.includes('/')
+    && !sessionId.includes('\\')
+    && sessionId !== '.'
+    && sessionId !== '..';
+}

--- a/src/providers/kimi/internal/compareCollections.ts
+++ b/src/providers/kimi/internal/compareCollections.ts
@@ -1,0 +1,94 @@
+import type { KimiDiscoveredModel, KimiThinkingOptionsByModel } from '../models';
+import type { KimiMode } from '../modes';
+
+export function sameStringList(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function sameStringMap(
+  a: Record<string, string>,
+  b: Record<string, string>,
+): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+  for (const key of aKeys) {
+    if (a[key] !== b[key]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function sameDiscoveredModels(
+  a: KimiDiscoveredModel[],
+  b: KimiDiscoveredModel[],
+): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (
+      a[i].rawId !== b[i].rawId
+      || a[i].label !== b[i].label
+      || (a[i].description ?? '') !== (b[i].description ?? '')
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function sameModes(a: KimiMode[], b: KimiMode[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (
+      a[i].id !== b[i].id
+      || a[i].name !== b[i].name
+      || (a[i].description ?? '') !== (b[i].description ?? '')
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function sameThinkingOptionsByModel(
+  a: KimiThinkingOptionsByModel,
+  b: KimiThinkingOptionsByModel,
+): boolean {
+  const aKeys = Object.keys(a).sort();
+  const bKeys = Object.keys(b).sort();
+  if (!sameStringList(aKeys, bKeys)) {
+    return false;
+  }
+  for (const key of aKeys) {
+    const aOptions = a[key] ?? [];
+    const bOptions = b[key] ?? [];
+    if (aOptions.length !== bOptions.length) {
+      return false;
+    }
+    for (let i = 0; i < aOptions.length; i++) {
+      if (
+        aOptions[i].value !== bOptions[i].value
+        || aOptions[i].label !== bOptions[i].label
+        || (aOptions[i].description ?? '') !== (bOptions[i].description ?? '')
+      ) {
+        return false;
+      }
+    }
+  }
+  return true;
+}

--- a/src/providers/kimi/internal/providerProjection.ts
+++ b/src/providers/kimi/internal/providerProjection.ts
@@ -1,0 +1,12 @@
+export function ensureProviderProjectionMap(
+  settings: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> {
+  const existing = settings[key];
+  if (existing && typeof existing === 'object' && !Array.isArray(existing)) {
+    return existing as Record<string, unknown>;
+  }
+  const next: Record<string, unknown> = {};
+  settings[key] = next;
+  return next;
+}

--- a/src/providers/kimi/models.ts
+++ b/src/providers/kimi/models.ts
@@ -1,0 +1,180 @@
+import {
+  DEFAULT_REASONING_VALUE,
+  formatReasoningValueLabel,
+  resolvePreferredReasoningDefault,
+} from '../../core/providers/reasoning';
+
+export interface KimiDiscoveredModel {
+  description?: string;
+  label: string;
+  rawId: string;
+}
+
+export interface KimiModelVariant {
+  description?: string;
+  label: string;
+  value: string;
+}
+
+export type KimiThinkingOptionsByModel = Record<string, KimiModelVariant[]>;
+
+export const KIMI_SYNTHETIC_MODEL_ID = 'kimi';
+export const KIMI_DEFAULT_THINKING_LEVEL = 'off';
+export const KIMI_MODEL_PREFIX = 'kimi:';
+
+export function resolveKimiDefaultThinkingLevel(
+  options: KimiModelVariant[],
+  preferredValue?: string,
+  fallbackValue: string = KIMI_DEFAULT_THINKING_LEVEL,
+): string {
+  const values = options.map((option) => option.value);
+  if (preferredValue && (values.length === 0 || values.includes(preferredValue))) {
+    return preferredValue;
+  }
+
+  return resolvePreferredReasoningDefault(values, fallbackValue);
+}
+
+export function isKimiModelSelectionId(model: string): boolean {
+  return model === KIMI_SYNTHETIC_MODEL_ID || model.startsWith(KIMI_MODEL_PREFIX);
+}
+
+export function encodeKimiModelId(rawModelId: string): string {
+  const normalized = rawModelId.trim();
+  return normalized ? `${KIMI_MODEL_PREFIX}${normalized}` : KIMI_SYNTHETIC_MODEL_ID;
+}
+
+export function decodeKimiModelId(model: string): string | null {
+  if (!model.startsWith(KIMI_MODEL_PREFIX)) {
+    return null;
+  }
+
+  const rawModelId = model.slice(KIMI_MODEL_PREFIX.length).trim();
+  return rawModelId || null;
+}
+
+export function normalizeKimiDiscoveredModels(value: unknown): KimiDiscoveredModel[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const normalized: KimiDiscoveredModel[] = [];
+  const seen = new Set<string>();
+  for (const entry of value as unknown[]) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      continue;
+    }
+    const record = entry as Record<string, unknown>;
+
+    const rawId = typeof record.rawId === 'string'
+      ? record.rawId.trim()
+      : typeof record.id === 'string'
+      ? record.id.trim()
+      : '';
+    const label = typeof record.label === 'string'
+      ? record.label.trim()
+      : typeof record.name === 'string'
+      ? record.name.trim()
+      : rawId;
+    const description = typeof record.description === 'string'
+      ? record.description.trim()
+      : '';
+
+    if (!rawId || seen.has(rawId)) {
+      continue;
+    }
+
+    seen.add(rawId);
+    normalized.push({
+      ...(description ? { description } : {}),
+      label: label || rawId,
+      rawId,
+    });
+  }
+
+  return normalized;
+}
+
+export function normalizeKimiModelVariants(value: unknown): KimiModelVariant[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const variants: KimiModelVariant[] = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      continue;
+    }
+
+    const record = entry as Record<string, unknown>;
+    const rawValue = typeof record.value === 'string'
+      ? record.value.trim()
+      : typeof record.id === 'string'
+      ? record.id.trim()
+      : '';
+    if (!rawValue || seen.has(rawValue)) {
+      continue;
+    }
+
+    let rawLabel = '';
+    if (typeof record.label === 'string') {
+      rawLabel = record.label.trim();
+    } else if (typeof record.name === 'string') {
+      rawLabel = record.name.trim();
+    }
+    const description = typeof record.description === 'string'
+      ? record.description.trim()
+      : '';
+
+    seen.add(rawValue);
+    variants.push({
+      ...(description ? { description } : {}),
+      label: rawLabel || formatReasoningValueLabel(rawValue),
+      value: rawValue,
+    });
+  }
+
+  return variants;
+}
+
+export function normalizeKimiThinkingOptionsByModel(
+  value: unknown,
+  discoveredModels: KimiDiscoveredModel[] = [],
+): KimiThinkingOptionsByModel {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  const knownIds = new Set(discoveredModels.map((model) => model.rawId));
+  const normalized: KimiThinkingOptionsByModel = {};
+  for (const [rawId, variants] of Object.entries(value as Record<string, unknown>)) {
+    const trimmed = rawId.trim();
+    if (!trimmed) {
+      continue;
+    }
+    if (knownIds.size > 0 && !knownIds.has(trimmed)) {
+      continue;
+    }
+    const options = normalizeKimiModelVariants(variants);
+    if (options.length > 0) {
+      normalized[trimmed] = options;
+    }
+  }
+  return normalized;
+}
+
+export function resolveKimiBaseModelRawId(
+  rawModelId: string,
+  _discoveredModels: KimiDiscoveredModel[] = [],
+): string {
+  return rawModelId.trim();
+}
+
+export function buildKimiBaseModels(
+  discoveredModels: KimiDiscoveredModel[],
+): KimiDiscoveredModel[] {
+  return normalizeKimiDiscoveredModels(discoveredModels);
+}
+
+export { DEFAULT_REASONING_VALUE };

--- a/src/providers/kimi/modes.ts
+++ b/src/providers/kimi/modes.ts
@@ -1,0 +1,117 @@
+export interface KimiMode {
+  description?: string;
+  id: string;
+  name: string;
+}
+
+/** Canonical Kimi ACP modes (adapter PLAN D9): default, plan, auto, yolo. */
+export const KIMI_DEFAULT_MODE_ID = 'default';
+export const KIMI_PLAN_MODE_ID = 'plan';
+export const KIMI_AUTO_MODE_ID = 'auto';
+export const KIMI_YOLO_MODE_ID = 'yolo';
+
+export const KIMI_FALLBACK_MODES: ReadonlyArray<KimiMode> = Object.freeze([
+  {
+    description: 'Manual approvals; tools execute normally.',
+    id: KIMI_DEFAULT_MODE_ID,
+    name: 'Default',
+  },
+  {
+    description: 'Read-only planning; no tool execution.',
+    id: KIMI_PLAN_MODE_ID,
+    name: 'Plan',
+  },
+  {
+    description: 'Fully autonomous — agent decides everything without asking.',
+    id: KIMI_AUTO_MODE_ID,
+    name: 'Auto',
+  },
+  {
+    description: 'Auto-approve tool actions; agent may still ask questions.',
+    id: KIMI_YOLO_MODE_ID,
+    name: 'YOLO',
+  },
+]);
+
+const KIMI_KNOWN_MODE_IDS = new Set(KIMI_FALLBACK_MODES.map((mode) => mode.id));
+
+export function isKimiModeId(value: unknown): value is string {
+  return typeof value === 'string' && KIMI_KNOWN_MODE_IDS.has(value);
+}
+
+export function normalizeKimiAvailableModes(value: unknown): KimiMode[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const normalized: KimiMode[] = [];
+  const seen = new Set<string>();
+  for (const entry of value as unknown[]) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      continue;
+    }
+    const record = entry as Record<string, unknown>;
+
+    const id = typeof record.id === 'string' ? record.id.trim() : '';
+    const name = typeof record.name === 'string' ? record.name.trim() : id;
+    const description = typeof record.description === 'string'
+      ? record.description.trim()
+      : '';
+
+    if (!id || seen.has(id)) {
+      continue;
+    }
+
+    seen.add(id);
+    normalized.push({
+      ...(description ? { description } : {}),
+      id,
+      name: name || id,
+    });
+  }
+
+  return normalized;
+}
+
+export function getEffectiveKimiModes(modes: KimiMode[]): KimiMode[] {
+  return modes.length > 0 ? modes : [...KIMI_FALLBACK_MODES];
+}
+
+/**
+ * Map Claudian shared permission modes onto Kimi ACP mode ids.
+ * Prefer advertised modes; fall back to canonical ids only when listed.
+ */
+export function resolveKimiModeForPermissionMode(
+  permissionMode: unknown,
+  modes: KimiMode[] = [],
+): string {
+  const effective = getEffectiveKimiModes(modes);
+  const modeIds = new Set(effective.map((mode) => mode.id));
+
+  if (permissionMode === 'plan' && modeIds.has(KIMI_PLAN_MODE_ID)) {
+    return KIMI_PLAN_MODE_ID;
+  }
+  if (permissionMode === 'yolo' && modeIds.has(KIMI_YOLO_MODE_ID)) {
+    return KIMI_YOLO_MODE_ID;
+  }
+  if (modeIds.has(KIMI_DEFAULT_MODE_ID)) {
+    return KIMI_DEFAULT_MODE_ID;
+  }
+
+  return effective[0]?.id ?? KIMI_DEFAULT_MODE_ID;
+}
+
+export function resolvePermissionModeForKimiMode(
+  modeId: unknown,
+): 'normal' | 'plan' | 'yolo' | null {
+  if (modeId === KIMI_PLAN_MODE_ID) {
+    return 'plan';
+  }
+  if (modeId === KIMI_YOLO_MODE_ID || modeId === KIMI_AUTO_MODE_ID) {
+    return 'yolo';
+  }
+  if (modeId === KIMI_DEFAULT_MODE_ID) {
+    return 'normal';
+  }
+  return null;
+}

--- a/src/providers/kimi/registration.ts
+++ b/src/providers/kimi/registration.ts
@@ -1,0 +1,39 @@
+import type { ProviderModule } from '../../core/providers/types';
+import { kimiWorkspaceRegistration } from './app/KimiWorkspaceServices';
+import { KimiInlineEditService } from './auxiliary/KimiInlineEditService';
+import { KimiInstructionRefineService } from './auxiliary/KimiInstructionRefineService';
+import { KimiTaskResultInterpreter } from './auxiliary/KimiTaskResultInterpreter';
+import { KimiTitleGenerationService } from './auxiliary/KimiTitleGenerationService';
+import { KIMI_PROVIDER_CAPABILITIES } from './capabilities';
+import { kimiSettingsReconciler } from './env/KimiSettingsReconciler';
+import { KimiConversationHistoryService } from './history/KimiConversationHistoryService';
+import { KimiChatRuntime } from './runtime/KimiChatRuntime';
+import { getKimiProviderSettings, updateKimiProviderSettings } from './settings';
+import { kimiChatUIConfig } from './ui/KimiChatUIConfig';
+
+export const kimiProviderRegistration: ProviderModule = {
+  id: 'kimi',
+  displayName: 'Kimi Code',
+  // After existing providers (opencode 10, pi 11, codex 15, claude 20).
+  blankTabOrder: 12,
+  isEnabled: (settings) => getKimiProviderSettings(settings).enabled,
+  setEnabled: (settings, enabled) => updateKimiProviderSettings(settings, { enabled }),
+  capabilities: KIMI_PROVIDER_CAPABILITIES,
+  environmentKeyPatterns: [/^KIMI_/i, /^MOONSHOT_/i],
+  chatUIConfig: kimiChatUIConfig,
+  settingsReconciler: kimiSettingsReconciler,
+  settingsStorage: {
+    hostScopedFields: ['cliPathsByHost'],
+    normalizeStored(target, stored) {
+      updateKimiProviderSettings(target, getKimiProviderSettings(stored));
+      return false;
+    },
+  },
+  createRuntime: ({ plugin }) => new KimiChatRuntime(plugin),
+  createTitleGenerationService: (plugin) => new KimiTitleGenerationService(plugin),
+  createInstructionRefineService: (plugin) => new KimiInstructionRefineService(plugin),
+  createInlineEditService: (plugin) => new KimiInlineEditService(plugin),
+  historyService: new KimiConversationHistoryService(),
+  taskResultInterpreter: new KimiTaskResultInterpreter(),
+  workspace: kimiWorkspaceRegistration,
+};

--- a/src/providers/kimi/runtime/KimiAuxQueryRunner.ts
+++ b/src/providers/kimi/runtime/KimiAuxQueryRunner.ts
@@ -1,0 +1,377 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import type { AuxQueryConfig, AuxQueryRunner } from '../../../core/auxiliary/AuxQueryRunner';
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import type { ProviderHost } from '../../../core/providers/ProviderHost';
+import { getVaultPath } from '../../../utils/path';
+import {
+  AcpClientConnection,
+  AcpJsonRpcTransport,
+  type AcpReadTextFileRequest,
+  type AcpRequestPermissionRequest,
+  type AcpRequestPermissionResponse,
+  AcpSessionUpdateNormalizer,
+  AcpSubprocess,
+  extractAcpSessionModelState,
+} from '../../acp';
+import { decodeKimiModelId } from '../models';
+import { formatKimiRuntimeError } from './KimiChatRuntime';
+import { buildKimiRuntimeEnv } from './KimiRuntimeEnvironment';
+
+/**
+ * Temporary ACP session runner for auxiliary prompts.
+ * Never silently approves tools — permission requests are cancelled.
+ */
+export class KimiAuxQueryRunner implements AuxQueryRunner {
+  private availableModelIds = new Set<string>();
+  private connection: AcpClientConnection | null = null;
+  private currentModelId: string | null = null;
+  private currentLaunchKey: string | null = null;
+  private process: AcpSubprocess | null = null;
+  private readonly sessionCwds = new Map<string, string>();
+  private sessionId: string | null = null;
+  private readonly sessionUpdateNormalizer = new AcpSessionUpdateNormalizer();
+  /** Serialized/deduplicated process shutdown so reset cannot race a later start. */
+  private shutdownBarrier: Promise<void> | null = null;
+  private transport: AcpJsonRpcTransport | null = null;
+  private allowReadTextFile: boolean;
+
+  constructor(
+    private readonly plugin: ProviderHost,
+    options: { allowReadTextFile?: boolean } = {},
+  ) {
+    this.allowReadTextFile = options.allowReadTextFile === true;
+  }
+
+  async query(config: AuxQueryConfig, prompt: string): Promise<string> {
+    const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
+    await this.ensureReady(cwd);
+
+    if (!this.connection) {
+      throw new Error('Kimi Code runtime is not ready.');
+    }
+
+    if (!this.sessionId) {
+      const sessionId = await this.createSession(cwd);
+      if (!sessionId) {
+        throw new Error(
+          'Failed to create a Kimi Code session. Run `kimi login` if authentication is required.',
+        );
+      }
+    }
+
+    const sessionId = this.sessionId!;
+    const selectedModel = this.resolveSelectedRawModel(config.model);
+    const nextModel = this.resolveApplicableModel(selectedModel);
+    if (nextModel) {
+      const response = await this.connection.setConfigOption({
+        configId: 'model',
+        sessionId,
+        type: 'select',
+        value: nextModel,
+      });
+      this.syncSessionModelState({
+        configOptions: response.configOptions,
+      });
+    }
+
+    this.sessionUpdateNormalizer.reset();
+    let accumulatedText = '';
+    const removeListener = this.connection.onSessionNotification((notification) => {
+      if (notification.sessionId !== sessionId) {
+        return;
+      }
+
+      const normalized = this.sessionUpdateNormalizer.normalize(notification.update);
+      if (normalized.type !== 'message_chunk' || normalized.role !== 'assistant') {
+        return;
+      }
+
+      for (const chunk of normalized.streamChunks) {
+        if (chunk.type !== 'text') {
+          continue;
+        }
+
+        accumulatedText += chunk.content;
+        config.onTextChunk?.(accumulatedText);
+      }
+    });
+
+    const abortHandler = () => {
+      if (this.connection && this.sessionId) {
+        this.connection.cancel({ sessionId: this.sessionId });
+      }
+    };
+    config.abortController?.signal.addEventListener('abort', abortHandler, { once: true });
+
+    try {
+      if (config.abortController?.signal.aborted) {
+        throw new Error('Cancelled');
+      }
+
+      const promptText = config.systemPrompt
+        ? `${config.systemPrompt.trim()}\n\n${prompt}`
+        : prompt;
+
+      await this.connection.prompt({
+        prompt: [{ type: 'text', text: promptText }],
+        sessionId,
+      });
+
+      if (config.abortController?.signal.aborted) {
+        throw new Error('Cancelled');
+      }
+
+      return accumulatedText;
+    } catch (error) {
+      throw new Error(
+        formatKimiRuntimeError(error, this.process?.getStderrSnapshot()),
+        error instanceof Error ? { cause: error } : undefined,
+      );
+    } finally {
+      config.abortController?.signal.removeEventListener('abort', abortHandler);
+      removeListener();
+    }
+  }
+
+  /**
+   * Synchronously clear session state and schedule process shutdown.
+   * Public interface stays void; callers that need deterministic cleanup
+   * (ensureReady) await the internal shutdown barrier.
+   */
+  reset(): void {
+    this.clearRuntimeState();
+    void this.beginShutdown();
+  }
+
+  private clearRuntimeState(): void {
+    this.availableModelIds.clear();
+    this.sessionId = null;
+    this.sessionCwds.clear();
+    this.currentModelId = null;
+    this.currentLaunchKey = null;
+    this.connection?.dispose();
+    this.connection = null;
+    this.transport?.dispose();
+    this.transport = null;
+    this.sessionUpdateNormalizer.reset();
+  }
+
+  /**
+   * Capture the current process (if any) and chain its shutdown onto the
+   * shared barrier. Concurrent reset/start callers share one in-flight
+   * promise so shutdown is deduplicated and ordered.
+   */
+  private beginShutdown(): Promise<void> {
+    const process = this.process;
+    this.process = null;
+
+    if (!process && !this.shutdownBarrier) {
+      return Promise.resolve();
+    }
+
+    const previous = this.shutdownBarrier;
+    const next = (async () => {
+      if (previous) {
+        await previous.catch(() => {});
+      }
+      if (process) {
+        await process.shutdown().catch(() => {});
+      }
+    })();
+
+    this.shutdownBarrier = next;
+    void next.finally(() => {
+      if (this.shutdownBarrier === next) {
+        this.shutdownBarrier = null;
+      }
+    });
+    return next;
+  }
+
+  private async awaitShutdownBarrier(): Promise<void> {
+    while (this.shutdownBarrier) {
+      const barrier = this.shutdownBarrier;
+      await barrier.catch(() => {});
+      if (this.shutdownBarrier === barrier) {
+        this.shutdownBarrier = null;
+      }
+    }
+  }
+
+  private async ensureReady(cwd: string): Promise<void> {
+    // Finish any in-flight shutdown before inspecting or spawning.
+    await this.awaitShutdownBarrier();
+
+    const resolvedCliPath = await this.plugin.getResolvedProviderCliPath('kimi');
+    if (!resolvedCliPath) {
+      throw new Error(
+        'Kimi Code CLI not found. Install Kimi Code (>= 0.27.0) or set the CLI path in Claudian settings.',
+      );
+    }
+
+    const settings = this.plugin.settings as unknown as Record<string, unknown>;
+    const nextLaunchKey = JSON.stringify({
+      command: resolvedCliPath,
+      envText: getRuntimeEnvironmentText(settings, 'kimi'),
+    });
+
+    const shouldRestart = !this.process
+      || !this.transport
+      || !this.connection
+      || !this.process.isAlive()
+      || this.transport.isClosed
+      || this.currentLaunchKey !== nextLaunchKey;
+
+    if (!shouldRestart) {
+      return;
+    }
+
+    // Tear down and wait for the old process to fully exit before spawning.
+    this.clearRuntimeState();
+    await this.beginShutdown();
+
+    const env = buildKimiRuntimeEnv(settings, resolvedCliPath);
+    this.process = new AcpSubprocess({
+      args: ['acp'],
+      command: resolvedCliPath,
+      cwd,
+      env,
+    });
+    this.process.start();
+
+    this.transport = new AcpJsonRpcTransport({
+      input: this.process.stdout,
+      onClose: (listener) => this.process!.onClose(listener),
+      output: this.process.stdin,
+    });
+
+    this.connection = new AcpClientConnection({
+      clientInfo: {
+        name: 'claudian-kimi-aux',
+        version: this.plugin.manifest?.version ?? '0.0.0',
+      },
+      delegate: {
+        fileSystem: {
+          readTextFile: (request) => this.readTextFile(request),
+          writeTextFile: async () => ({}),
+        },
+        requestPermission: (request) => this.handlePermissionRequest(request),
+      },
+      transport: this.transport,
+    });
+
+    this.transport.start();
+    await this.connection.initialize({
+      clientCapabilities: {
+        fs: {
+          readTextFile: this.allowReadTextFile,
+          writeTextFile: false,
+        },
+      },
+    });
+    this.currentLaunchKey = nextLaunchKey;
+  }
+
+  private async createSession(cwd: string): Promise<string | null> {
+    if (!this.connection) {
+      return null;
+    }
+
+    try {
+      const response = await this.connection.newSession({
+        cwd,
+        mcpServers: [],
+      });
+      const sessionId = response.sessionId;
+      if (!sessionId) {
+        return null;
+      }
+      this.sessionId = sessionId;
+      this.sessionCwds.set(sessionId, cwd);
+      this.syncSessionModelState({
+        configOptions: response.configOptions,
+        models: response.models,
+      });
+      return sessionId;
+    } catch (error) {
+      throw new Error(
+        formatKimiRuntimeError(error, this.process?.getStderrSnapshot()),
+        error instanceof Error ? { cause: error } : undefined,
+      );
+    }
+  }
+
+  private resolveSelectedRawModel(model: string | undefined): string | null {
+    if (!model) {
+      return null;
+    }
+    return decodeKimiModelId(model) ?? (model.includes(':') ? null : model.trim() || null);
+  }
+
+  private resolveApplicableModel(selected: string | null): string | null {
+    if (!selected) {
+      return null;
+    }
+    if (this.availableModelIds.size > 0 && !this.availableModelIds.has(selected)) {
+      return null;
+    }
+    if (selected === this.currentModelId) {
+      return null;
+    }
+    return selected;
+  }
+
+  private syncSessionModelState(params: {
+    configOptions?: unknown;
+    models?: unknown;
+  }): void {
+    const state = extractAcpSessionModelState(params as {
+      configOptions?: Parameters<typeof extractAcpSessionModelState>[0]['configOptions'];
+      models?: Parameters<typeof extractAcpSessionModelState>[0]['models'];
+    });
+    if (state.currentModelId) {
+      this.currentModelId = state.currentModelId;
+    }
+    this.availableModelIds = new Set(state.availableModels.map((model) => model.id));
+  }
+
+  private async handlePermissionRequest(
+    _request: AcpRequestPermissionRequest,
+  ): Promise<AcpRequestPermissionResponse> {
+    // Auxiliary prompts must not silently approve tools.
+    return { outcome: { outcome: 'cancelled' } };
+  }
+
+  private async readTextFile(
+    request: AcpReadTextFileRequest,
+  ): Promise<{ content: string }> {
+    if (!this.allowReadTextFile) {
+      throw new Error('Kimi auxiliary runner denied filesystem read.');
+    }
+    const resolvedPath = this.resolveSessionPath(request.sessionId, request.path);
+    const content = await fs.readFile(resolvedPath, 'utf-8');
+    if (request.line === undefined && request.limit === undefined) {
+      return { content };
+    }
+    const lines = content.split(/\r?\n/);
+    const startIndex = Math.max(0, (request.line ?? 1) - 1);
+    const endIndex = request.limit
+      ? startIndex + Math.max(0, request.limit)
+      : lines.length;
+    return {
+      content: lines.slice(startIndex, endIndex).join('\n'),
+    };
+  }
+
+  private resolveSessionPath(sessionId: string, rawPath: string): string {
+    if (path.isAbsolute(rawPath)) {
+      return rawPath;
+    }
+    const cwd = this.sessionCwds.get(sessionId)
+      ?? getVaultPath(this.plugin.app)
+      ?? process.cwd();
+    return path.resolve(cwd, rawPath);
+  }
+}

--- a/src/providers/kimi/runtime/KimiChatRuntime.ts
+++ b/src/providers/kimi/runtime/KimiChatRuntime.ts
@@ -1,0 +1,1768 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import type { ProviderHost } from '../../../core/providers/ProviderHost';
+import { ProviderRegistry } from '../../../core/providers/ProviderRegistry';
+import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
+import type { ProviderCapabilities } from '../../../core/providers/types';
+import type { ChatRuntime } from '../../../core/runtime/ChatRuntime';
+import type {
+  ApprovalCallback,
+  ApprovalDecisionOption,
+  AskUserQuestionCallback,
+  AutoTurnCallback,
+  ChatRewindMode,
+  ChatRewindResult,
+  ChatRuntimeConversationState,
+  ChatRuntimeEnsureReadyOptions,
+  ChatRuntimeQueryOptions,
+  ChatTurnMetadata,
+  ChatTurnRequest,
+  PreparedChatTurn,
+  SessionUpdateResult,
+} from '../../../core/runtime/types';
+import type {
+  ApprovalDecision,
+  ChatMessage,
+  Conversation,
+  ExitPlanModeCallback,
+  SlashCommand,
+  StreamChunk,
+  ToolCallInfo,
+} from '../../../core/types';
+import { getEnhancedPath } from '../../../utils/env';
+import { getVaultPath } from '../../../utils/path';
+import {
+  AcpClientConnection,
+  AcpJsonRpcTransport,
+  type AcpReadTextFileRequest,
+  type AcpRequestPermissionRequest,
+  type AcpRequestPermissionResponse,
+  type AcpSessionConfigOption,
+  type AcpSessionModelState,
+  type AcpSessionModeState,
+  type AcpSessionNotification,
+  AcpSessionUpdateNormalizer,
+  AcpSubprocess,
+  type AcpUsage,
+  type AcpUsageUpdate,
+  type AcpWriteTextFileRequest,
+  buildAcpUsageInfo,
+  extractAcpSessionModelState,
+  extractAcpSessionModeState,
+  extractAcpSessionThoughtLevelState,
+  JsonRpcErrorResponse,
+} from '../../acp';
+import { KIMI_PROVIDER_CAPABILITIES } from '../capabilities';
+import { updateKimiDiscoveryState } from '../discoveryState';
+import {
+  sameDiscoveredModels,
+  sameModes,
+  sameStringList,
+  sameStringMap,
+  sameThinkingOptionsByModel,
+} from '../internal/compareCollections';
+import { ensureProviderProjectionMap } from '../internal/providerProjection';
+import {
+  decodeKimiModelId,
+  encodeKimiModelId,
+  isKimiModelSelectionId,
+  KIMI_DEFAULT_THINKING_LEVEL,
+  KIMI_SYNTHETIC_MODEL_ID,
+  normalizeKimiDiscoveredModels,
+  normalizeKimiModelVariants,
+  resolveKimiBaseModelRawId,
+  resolveKimiDefaultThinkingLevel,
+} from '../models';
+import {
+  normalizeKimiAvailableModes,
+  resolveKimiModeForPermissionMode,
+  resolvePermissionModeForKimiMode,
+} from '../modes';
+import { getKimiProviderSettings, updateKimiProviderSettings } from '../settings';
+import { getKimiState, type KimiProviderState } from '../types';
+import { buildKimiPromptBlocks, buildKimiPromptText } from './buildKimiPrompt';
+import {
+  buildKimiRuntimeEnv,
+  resolveKimiCodeHomeFromSettings,
+} from './KimiRuntimeEnvironment';
+
+/** ACP auth required (Kimi Code >= 0.27.0 may return this from session/new). */
+export const KIMI_ACP_AUTH_REQUIRED_CODE = -32000;
+
+export const KIMI_AUTH_REQUIRED_MESSAGE =
+  'Kimi Code authentication required. Run `kimi login` in a terminal, then retry. '
+  + 'You can also open Claudian Settings → Kimi Code for setup guidance.';
+
+export function buildKimiAcpLaunchKey(params: {
+  cliPath: string;
+  cwd: string;
+  envText: string;
+}): string {
+  return JSON.stringify({
+    cliPath: params.cliPath,
+    cwd: params.cwd,
+    envText: params.envText,
+  });
+}
+
+export function isKimiAuthRequiredError(error: unknown): boolean {
+  if (error instanceof JsonRpcErrorResponse && error.code === KIMI_ACP_AUTH_REQUIRED_CODE) {
+    return true;
+  }
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase();
+    return message.includes('authentication required')
+      || message.includes('auth required')
+      || message.includes('-32000');
+  }
+  return false;
+}
+
+export function formatKimiRuntimeError(error: unknown, stderr?: string | null): string {
+  if (isKimiAuthRequiredError(error)) {
+    return stderr ? `${KIMI_AUTH_REQUIRED_MESSAGE}\n\n${stderr}` : KIMI_AUTH_REQUIRED_MESSAGE;
+  }
+  const baseMessage = error instanceof Error ? error.message : 'Kimi Code ACP request failed';
+  return stderr ? `${baseMessage}\n\n${stderr}` : baseMessage;
+}
+
+interface ActiveTurn {
+  cancelled: boolean;
+  queue: StreamChunkQueue;
+  sessionId: string;
+}
+
+class StreamChunkQueue {
+  private closed = false;
+  private readonly items: StreamChunk[] = [];
+  private readonly waiters: Array<(chunk: StreamChunk | null) => void> = [];
+
+  push(chunk: StreamChunk): void {
+    if (this.closed) {
+      return;
+    }
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter(chunk);
+      return;
+    }
+    this.items.push(chunk);
+  }
+
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    while (this.waiters.length > 0) {
+      this.waiters.shift()?.(null);
+    }
+  }
+
+  async next(): Promise<StreamChunk | null> {
+    if (this.items.length > 0) {
+      return this.items.shift() ?? null;
+    }
+    if (this.closed) {
+      return null;
+    }
+    return new Promise<StreamChunk | null>((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+}
+
+export class KimiChatRuntime implements ChatRuntime {
+  readonly providerId = 'kimi' as const;
+
+  private activeTurn: ActiveTurn | null = null;
+  private approvalCallback: ApprovalCallback | null = null;
+  private connection: AcpClientConnection | null = null;
+  private connectionGeneration = 0;
+  private conversationId: string | null = null;
+  private conversationGeneration = 0;
+  private contextUsage: AcpUsageUpdate | null = null;
+  private currentKimiCodeHome: string | null = null;
+  private currentLaunchKey: string | null = null;
+  private currentSessionEffortConfigId: string | null = null;
+  private currentSessionEffortValue: string | null = null;
+  private currentSessionEffortValues = new Set<string>();
+  private currentSessionModelId: string | null = null;
+  private currentConversationModel: string | null = null;
+  private currentSessionModeId: string | null = null;
+  private currentTurnMetadata: ChatTurnMetadata = {};
+  private loadedSessionId: string | null = null;
+  private permissionModeSyncCallback: ((mode: string) => void) | null = null;
+  private process: AcpSubprocess | null = null;
+  private promptUsage: AcpUsage | null = null;
+  private readonly readyListeners: Array<(ready: boolean) => void> = [];
+  private ready = false;
+  private readinessFlight: { key: string; promise: Promise<boolean> } | null = null;
+  private disposed = false;
+  private lifecycleGeneration = 0;
+  private restartRequiredAfterCancel = false;
+  private sessionInvalidated = false;
+  private readonly supportedCommandWaiters: Array<(commands: SlashCommand[]) => void> = [];
+  private supportedCommands: SlashCommand[] = [];
+  private sessionCwds = new Map<string, string>();
+  private sessionId: string | null = null;
+  private readonly sessionUpdateNormalizer = new AcpSessionUpdateNormalizer();
+  private transport: AcpJsonRpcTransport | null = null;
+  private unregisterTransportClose: (() => void) | null = null;
+
+  constructor(
+    private readonly plugin: ProviderHost,
+  ) {}
+
+  getCapabilities(): Readonly<ProviderCapabilities> {
+    return KIMI_PROVIDER_CAPABILITIES;
+  }
+
+  prepareTurn(request: ChatTurnRequest): PreparedChatTurn {
+    return {
+      isCompact: false,
+      mcpMentions: request.enabledMcpServers ?? new Set(),
+      persistedContent: '',
+      prompt: buildKimiPromptText(request),
+      request,
+    };
+  }
+
+  onReadyStateChange(listener: (ready: boolean) => void): () => void {
+    this.readyListeners.push(listener);
+    try {
+      listener(this.ready);
+    } catch {
+      // ignore
+    }
+    return () => {
+      const index = this.readyListeners.indexOf(listener);
+      if (index >= 0) {
+        this.readyListeners.splice(index, 1);
+      }
+    };
+  }
+
+  setResumeCheckpoint(_checkpointId: string | undefined): void {}
+
+  syncConversationState(
+    conversation: ChatRuntimeConversationState | null,
+  ): void {
+    this.setCurrentConversationModel(conversation?.selectedModel);
+    const previousSessionId = this.sessionId;
+    const nextConversationId = conversation?.id ?? null;
+    const state = getKimiState(conversation?.providerState);
+    const nextSessionId = conversation?.sessionId
+      ?? state.sessionId
+      ?? null;
+
+    if (previousSessionId !== nextSessionId) {
+      this.loadedSessionId = null;
+      this.currentSessionEffortConfigId = null;
+      this.currentSessionEffortValue = null;
+      this.currentSessionEffortValues = new Set<string>();
+      this.currentSessionModelId = null;
+      this.currentSessionModeId = null;
+      this.sessionInvalidated = false;
+      this.sessionUpdateNormalizer.reset();
+      this.setSupportedCommands([]);
+    }
+
+    if (state.kimiCodeHome) {
+      this.currentKimiCodeHome = state.kimiCodeHome;
+    }
+
+    const targetChanged = nextConversationId !== this.conversationId
+      || nextSessionId !== this.sessionId;
+    this.conversationId = nextConversationId;
+    this.sessionId = nextSessionId;
+    if (targetChanged) {
+      this.conversationGeneration += 1;
+      if (this.readinessFlight) {
+        void this.shutdownProcess();
+      }
+    }
+  }
+
+  async reloadMcpServers(): Promise<void> {}
+
+  async warmModelMetadata(model: string): Promise<boolean> {
+    const conversationGeneration = this.conversationGeneration;
+    const selectedRawModelId = decodeKimiModelId(model);
+    if (!selectedRawModelId) {
+      return false;
+    }
+
+    if (!(await this.ensureReady({ allowSessionCreation: true }))) {
+      return false;
+    }
+    if (
+      !this.connection
+      || !this.sessionId
+      || !this.isConversationCurrent(conversationGeneration)
+    ) {
+      return false;
+    }
+
+    const discoveredModels = getKimiProviderSettings(this.plugin.settings).discoveredModels;
+    const selectedBaseRawModelId = resolveKimiBaseModelRawId(selectedRawModelId, discoveredModels);
+    if (!selectedBaseRawModelId) {
+      return false;
+    }
+
+    const availableModelIds = new Set(discoveredModels.map((entry) => entry.rawId));
+    if (availableModelIds.size > 0 && !availableModelIds.has(selectedBaseRawModelId)) {
+      return false;
+    }
+
+    const response = await this.connection.setConfigOption({
+      configId: 'model',
+      sessionId: this.sessionId,
+      type: 'select',
+      value: selectedBaseRawModelId,
+    });
+    if (!this.isConversationCurrent(conversationGeneration)) {
+      return false;
+    }
+    this.currentSessionModelId = selectedBaseRawModelId;
+    await this.syncSessionModelState({
+      configOptions: response.configOptions,
+    }, conversationGeneration);
+    return this.isConversationCurrent(conversationGeneration);
+  }
+
+  async ensureReady(options?: ChatRuntimeEnsureReadyOptions): Promise<boolean> {
+    if (this.disposed) {
+      return false;
+    }
+    const conversationGeneration = this.conversationGeneration;
+    const key = JSON.stringify({ conversationGeneration, options: options ?? {} });
+    if (this.readinessFlight) {
+      if (this.readinessFlight.key === key) {
+        return this.readinessFlight.promise;
+      }
+      await this.readinessFlight.promise.catch(() => undefined);
+      return this.ensureReady(options);
+    }
+
+    const lifecycleGeneration = this.lifecycleGeneration;
+    const promise = this.ensureReadyInternal(
+      options,
+      lifecycleGeneration,
+      conversationGeneration,
+    );
+    this.readinessFlight = { key, promise };
+    return promise.finally(() => {
+      if (this.readinessFlight?.promise === promise) {
+        this.readinessFlight = null;
+      }
+    });
+  }
+
+  private async ensureReadyInternal(
+    options: ChatRuntimeEnsureReadyOptions | undefined,
+    lifecycleGeneration: number,
+    conversationGeneration: number,
+  ): Promise<boolean> {
+    const settings = getKimiProviderSettings(this.plugin.settings);
+    if (!settings.enabled) {
+      this.setReady(false);
+      return false;
+    }
+
+    const cliPath = await this.plugin.getResolvedProviderCliPath('kimi');
+    if (!cliPath) {
+      this.setReady(false);
+      return false;
+    }
+
+    if (!this.isReadinessCurrent(lifecycleGeneration, conversationGeneration)) {
+      return false;
+    }
+
+    const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
+    const envText = getRuntimeEnvironmentText(this.plugin.settings, 'kimi');
+    const launchKey = buildKimiAcpLaunchKey({ cliPath, cwd, envText });
+
+    const shouldRestart = !this.process
+      || !this.transport
+      || !this.connection
+      || !this.process.isAlive()
+      || this.transport.isClosed
+      || options?.force === true
+      || this.restartRequiredAfterCancel
+      || this.currentLaunchKey !== launchKey;
+
+    if (shouldRestart) {
+      await this.shutdownProcess();
+      if (!this.isReadinessCurrent(lifecycleGeneration, conversationGeneration)) {
+        return false;
+      }
+      await this.startProcess({ cliPath, cwd });
+      if (!this.isReadinessCurrent(lifecycleGeneration, conversationGeneration)) {
+        await this.shutdownProcess();
+        return false;
+      }
+      this.restartRequiredAfterCancel = false;
+      this.currentLaunchKey = launchKey;
+      this.loadedSessionId = null;
+      this.currentSessionModeId = null;
+      this.currentKimiCodeHome = resolveKimiCodeHomeFromSettings(this.plugin.settings, cliPath);
+      this.setReady(true);
+    } else if (!this.currentKimiCodeHome) {
+      this.currentKimiCodeHome = resolveKimiCodeHomeFromSettings(this.plugin.settings, cliPath);
+    }
+
+    const targetSessionId = this.sessionId;
+    if (targetSessionId) {
+      if (this.loadedSessionId !== targetSessionId) {
+        const loaded = await this.loadSession(targetSessionId, cwd, conversationGeneration);
+        if (!this.isReadinessCurrent(lifecycleGeneration, conversationGeneration)) {
+          await this.shutdownProcess();
+          return false;
+        }
+        if (!loaded) {
+          this.sessionInvalidated = true;
+          this.clearActiveSession();
+        }
+      }
+      return true;
+    }
+
+    if (!this.sessionId && !this.sessionInvalidated) {
+      if (options?.allowSessionCreation === false) {
+        return true;
+      }
+      const sessionId = await this.createSession(cwd, conversationGeneration);
+      if (!this.isReadinessCurrent(lifecycleGeneration, conversationGeneration)) {
+        await this.shutdownProcess();
+        return false;
+      }
+      return Boolean(sessionId);
+    }
+
+    return true;
+  }
+
+  async *query(
+    turn: PreparedChatTurn,
+    conversationHistory?: ChatMessage[],
+    queryOptions?: ChatRuntimeQueryOptions,
+  ): AsyncGenerator<StreamChunk> {
+    if (this.activeTurn) {
+      yield { type: 'error', content: 'Kimi Code does not support overlapping turns.' };
+      yield { type: 'done' };
+      return;
+    }
+    if (queryOptions?.model) {
+      this.setCurrentConversationModel(queryOptions.model);
+    }
+    const conversationGeneration = this.conversationGeneration;
+    const previousMessages = conversationHistory ?? [];
+    const expectedSessionId = this.sessionId;
+    let shouldBootstrapHistory = previousMessages.length > 0
+      && (!expectedSessionId || this.sessionInvalidated);
+
+    if (!(await this.ensureReady())) {
+      yield {
+        type: 'error',
+        content: 'Failed to start Kimi Code ACP runtime. Check the CLI path and run `kimi login` if needed.',
+      };
+      yield { type: 'done' };
+      return;
+    }
+
+    if (!this.isConversationCurrent(conversationGeneration)) {
+      yield { type: 'error', content: 'Kimi Code conversation changed before the turn started.' };
+      yield { type: 'done' };
+      return;
+    }
+
+    if (!this.connection) {
+      yield { type: 'error', content: 'Kimi Code ACP runtime is not ready.' };
+      yield { type: 'done' };
+      return;
+    }
+
+    if (this.activeTurn) {
+      yield { type: 'error', content: 'Kimi Code does not support overlapping turns.' };
+      yield { type: 'done' };
+      return;
+    }
+
+    const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
+    if (expectedSessionId && !this.sessionId) {
+      shouldBootstrapHistory = previousMessages.length > 0;
+    }
+
+    if (!this.sessionId) {
+      const sessionId = await this.createSession(cwd, conversationGeneration);
+      if (!sessionId) {
+        yield {
+          type: 'error',
+          content: this.lastSessionError
+            ?? 'Failed to create a Kimi Code ACP session. If authentication is required, run `kimi login`.',
+        };
+        yield { type: 'done' };
+        return;
+      }
+    }
+
+    const sessionId = this.sessionId!;
+    this.activeTurn = {
+      cancelled: false,
+      queue: new StreamChunkQueue(),
+      sessionId,
+    };
+    this.currentTurnMetadata = {};
+    this.contextUsage = null;
+    this.promptUsage = null;
+    this.sessionUpdateNormalizer.reset();
+
+    const activeTurn = this.activeTurn;
+    try {
+      await this.applySelectedMode(sessionId, conversationGeneration);
+      await this.applySelectedModel(sessionId, queryOptions, conversationGeneration);
+      await this.applySelectedEffort(sessionId, conversationGeneration);
+      if (!this.isConversationCurrent(conversationGeneration)) {
+        throw new Error('Kimi Code conversation changed before the turn started.');
+      }
+    } catch (error) {
+      yield {
+        type: 'error',
+        content: this.formatRuntimeError(error),
+      };
+      yield { type: 'done' };
+      activeTurn.queue.close();
+      this.activeTurn = null;
+      return;
+    }
+
+    const promptPromise = this.connection.prompt({
+      prompt: buildKimiPromptBlocks(
+        turn.request,
+        shouldBootstrapHistory ? previousMessages : [],
+      ),
+      sessionId,
+    }).then((response) => {
+      if (response.userMessageId) {
+        this.currentTurnMetadata.userMessageId = response.userMessageId;
+      }
+      this.promptUsage = response.usage ?? null;
+
+      const usage = buildAcpUsageInfo({
+        contextWindow: this.contextUsage,
+        model: this.getActiveDisplayModel(queryOptions),
+        promptUsage: this.promptUsage,
+      });
+      if (usage) {
+        activeTurn.queue.push({ sessionId, type: 'usage', usage });
+      }
+
+      if (!activeTurn.cancelled) {
+        activeTurn.queue.push({ type: 'done' });
+      }
+      activeTurn.queue.close();
+    }).catch((error) => {
+      if (!activeTurn.cancelled) {
+        activeTurn.queue.push({
+          type: 'error',
+          content: this.formatRuntimeError(error),
+        });
+        activeTurn.queue.push({ type: 'done' });
+      }
+      activeTurn.queue.close();
+    }).finally(() => {
+      if (this.activeTurn === activeTurn) {
+        this.activeTurn = null;
+      }
+    });
+
+    try {
+      while (true) {
+        const chunk = await activeTurn.queue.next();
+        if (!chunk) {
+          break;
+        }
+        yield chunk;
+      }
+    } finally {
+      await promptPromise.catch(() => undefined);
+      if (this.activeTurn === activeTurn) {
+        this.activeTurn = null;
+      }
+    }
+  }
+
+  cancel(): void {
+    const activeTurn = this.activeTurn;
+    if (!activeTurn || activeTurn.cancelled) {
+      return;
+    }
+    activeTurn.cancelled = true;
+    if (this.connection && this.sessionId) {
+      this.connection.cancel({ sessionId: this.sessionId });
+    }
+    this.restartRequiredAfterCancel = true;
+    activeTurn.queue.close();
+  }
+
+  resetSession(): void {
+    this.cancel();
+    this.clearActiveSession();
+    this.sessionInvalidated = false;
+  }
+
+  getSessionId(): string | null {
+    return this.sessionId;
+  }
+
+  consumeSessionInvalidation(): boolean {
+    const invalidated = this.sessionInvalidated;
+    this.sessionInvalidated = false;
+    return invalidated;
+  }
+
+  isReady(): boolean {
+    return this.ready;
+  }
+
+  async getSupportedCommands(): Promise<SlashCommand[]> {
+    if (this.supportedCommands.length > 0 && this.loadedSessionId === this.sessionId) {
+      return [...this.supportedCommands];
+    }
+
+    if (this.sessionId && this.loadedSessionId !== this.sessionId) {
+      const ready = await this.ensureReady({ allowSessionCreation: false });
+      if (!ready) {
+        return [];
+      }
+    }
+
+    if (!this.sessionId) {
+      return [];
+    }
+
+    if (this.supportedCommands.length > 0) {
+      return [...this.supportedCommands];
+    }
+
+    if (!this.sessionId || this.loadedSessionId !== this.sessionId) {
+      return [];
+    }
+
+    return this.waitForSupportedCommands();
+  }
+
+  cleanup(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    this.lifecycleGeneration += 1;
+    this.activeTurn?.queue.close();
+    this.activeTurn = null;
+    void this.shutdownProcess();
+    this.readyListeners.length = 0;
+    this.setReady(false);
+  }
+
+  async rewind(
+    _userMessageId: string,
+    _assistantMessageId: string | undefined,
+    _mode?: ChatRewindMode,
+  ): Promise<ChatRewindResult> {
+    return {
+      canRewind: false,
+      error: 'Kimi Code does not support rewind from Claudian yet',
+    };
+  }
+
+  setApprovalCallback(callback: ApprovalCallback | null): void {
+    this.approvalCallback = callback;
+  }
+
+  setApprovalDismisser(_dismisser: (() => void) | null): void {}
+
+  setAskUserQuestionCallback(_callback: AskUserQuestionCallback | null): void {}
+
+  setExitPlanModeCallback(_callback: ExitPlanModeCallback | null): void {}
+
+  setPermissionModeSyncCallback(callback: ((sdkMode: string) => void) | null): void {
+    this.permissionModeSyncCallback = callback;
+  }
+
+  setAutoTurnCallback(_callback: AutoTurnCallback | null): void {}
+
+  consumeTurnMetadata(): ChatTurnMetadata {
+    const metadata = { ...this.currentTurnMetadata };
+    this.currentTurnMetadata = {};
+    return metadata;
+  }
+
+  buildSessionUpdates(params: {
+    conversation: Conversation | null;
+    sessionInvalidated: boolean;
+  }): SessionUpdateResult {
+    const existingState = params.conversation
+      ? getKimiState(params.conversation.providerState)
+      : null;
+    const sessionId = this.sessionId;
+    const kimiCodeHome = this.currentKimiCodeHome ?? existingState?.kimiCodeHome;
+    const providerState: KimiProviderState = {
+      ...(sessionId
+        ? { sessionId }
+        : existingState?.sessionId
+        ? { sessionId: existingState.sessionId }
+        : {}),
+      ...(kimiCodeHome ? { kimiCodeHome } : {}),
+    };
+
+    const updates: Partial<Conversation> = {
+      providerState: Object.keys(providerState).length > 0
+        ? providerState as Record<string, unknown>
+        : undefined,
+      sessionId,
+    };
+
+    if (params.sessionInvalidated && !this.sessionId) {
+      updates.providerState = undefined;
+      updates.sessionId = null;
+    }
+
+    return { updates };
+  }
+
+  resolveSessionIdForFork(conversation: Conversation | null): string | null {
+    return this.sessionId
+      ?? conversation?.sessionId
+      ?? getKimiState(conversation?.providerState).sessionId
+      ?? null;
+  }
+
+  async loadSubagentToolCalls(_agentId: string): Promise<ToolCallInfo[]> {
+    return [];
+  }
+
+  async loadSubagentFinalResult(_agentId: string): Promise<string | null> {
+    return null;
+  }
+
+  getAuxiliaryModel(): string | null {
+    return this.currentConversationModel ?? this.getActiveDisplayModel() ?? null;
+  }
+
+  private lastSessionError: string | null = null;
+
+  private async startProcess(params: {
+    cliPath: string;
+    cwd: string;
+  }): Promise<void> {
+    const env = buildKimiRuntimeEnv(this.plugin.settings, params.cliPath);
+    env.PATH = getEnhancedPath(
+      env.PATH,
+      path.isAbsolute(params.cliPath) ? params.cliPath : undefined,
+    );
+    this.currentKimiCodeHome = resolveKimiCodeHomeFromSettings(this.plugin.settings, params.cliPath);
+
+    this.process = new AcpSubprocess({
+      args: ['acp'],
+      command: params.cliPath,
+      cwd: params.cwd,
+      env,
+    });
+    this.process.start();
+
+    this.transport = new AcpJsonRpcTransport({
+      input: this.process.stdout,
+      onClose: (listener) => this.process!.onClose(listener),
+      output: this.process.stdin,
+    });
+    const transport = this.transport;
+    this.unregisterTransportClose = transport.onClose((error) => {
+      if (this.transport === transport) {
+        this.setReady(false);
+        this.settleActiveTurn(error ?? new Error('Kimi Code ACP runtime closed'));
+      }
+    });
+
+    const connectionGeneration = ++this.connectionGeneration;
+    this.connection = new AcpClientConnection({
+      clientInfo: {
+        name: 'claudian',
+        version: this.plugin.manifest?.version ?? '0.0.0',
+      },
+      delegate: {
+        fileSystem: {
+          readTextFile: (request) => this.readTextFile(request),
+          writeTextFile: (request) => this.writeTextFile(request),
+        },
+        onSessionNotification: (notification) => this.handleSessionNotification(
+          notification,
+          connectionGeneration,
+        ),
+        requestPermission: (request) => this.handlePermissionRequest(request),
+      },
+      transport: this.transport,
+    });
+
+    this.transport.start();
+    const init = await this.connection.initialize({
+      clientCapabilities: {
+        fs: { readTextFile: true, writeTextFile: true },
+      },
+    });
+
+    // Prefer agent verification when agentInfo is present; do not hard-fail on missing name
+    // because some builds may omit it during early handshake.
+    const agentName = init.agentInfo?.name?.toLowerCase() ?? '';
+    if (agentName && !agentName.includes('kimi') && !agentName.includes('moonshot')) {
+      throw new Error(
+        `Unexpected ACP agent "${init.agentInfo?.name ?? 'unknown'}". Expected Kimi Code CLI.`,
+      );
+    }
+  }
+
+  private async shutdownProcess(): Promise<void> {
+    this.connectionGeneration += 1;
+    this.setReady(false);
+    this.settleActiveTurn();
+    this.currentSessionModelId = null;
+    this.currentSessionModeId = null;
+    this.setSupportedCommands([]);
+
+    this.unregisterTransportClose?.();
+    this.unregisterTransportClose = null;
+
+    this.connection?.dispose();
+    this.connection = null;
+
+    this.transport?.dispose();
+    this.transport = null;
+
+    if (this.process) {
+      await this.process.shutdown().catch(() => {});
+      this.process = null;
+    }
+
+    this.currentLaunchKey = null;
+    this.loadedSessionId = null;
+    this.sessionUpdateNormalizer.reset();
+  }
+
+  private async createSession(
+    cwd: string,
+    conversationGeneration = this.conversationGeneration,
+  ): Promise<string | null> {
+    if (!this.connection) {
+      return null;
+    }
+
+    this.lastSessionError = null;
+    try {
+      this.setSupportedCommands([]);
+      this.currentSessionModeId = null;
+      // Phase 1: no Claudian-managed MCP forwarding.
+      const response = await this.connection.newSession({
+        cwd,
+        mcpServers: [],
+      });
+      if (!this.isConversationCurrent(conversationGeneration)) {
+        return null;
+      }
+      const sessionId = response.sessionId;
+      if (!sessionId) {
+        return null;
+      }
+      this.loadedSessionId = sessionId;
+      this.sessionId = sessionId;
+      this.sessionInvalidated = false;
+      this.sessionCwds.set(sessionId, cwd);
+      await this.syncSessionModelState({
+        configOptions: response.configOptions ?? null,
+        models: response.models ?? null,
+      }, conversationGeneration);
+      if (!this.isConversationCurrent(conversationGeneration)) {
+        return null;
+      }
+      await this.syncSessionModeState({
+        configOptions: response.configOptions ?? null,
+        modes: response.modes ?? null,
+      }, conversationGeneration);
+      if (!this.isConversationCurrent(conversationGeneration)) {
+        return null;
+      }
+      return sessionId;
+    } catch (error) {
+      this.lastSessionError = this.formatRuntimeError(error);
+      this.clearActiveSession();
+      return null;
+    }
+  }
+
+  private async loadSession(
+    sessionId: string,
+    cwd: string,
+    conversationGeneration = this.conversationGeneration,
+  ): Promise<boolean> {
+    if (!this.connection || !sessionId) {
+      return false;
+    }
+
+    try {
+      this.setSupportedCommands([]);
+      this.currentSessionModeId = null;
+      const response = await this.connection.loadSession({
+        cwd,
+        mcpServers: [],
+        sessionId,
+      });
+      if (!this.isConversationCurrent(conversationGeneration)) {
+        return false;
+      }
+      const resolvedSessionId = response.sessionId || sessionId;
+      this.sessionInvalidated = false;
+      this.loadedSessionId = resolvedSessionId;
+      this.sessionId = resolvedSessionId;
+      this.sessionCwds.set(resolvedSessionId, cwd);
+      await this.syncSessionModelState({
+        configOptions: response.configOptions ?? null,
+        models: response.models ?? null,
+      }, conversationGeneration);
+      if (!this.isConversationCurrent(conversationGeneration)) {
+        return false;
+      }
+      await this.syncSessionModeState({
+        configOptions: response.configOptions ?? null,
+        modes: response.modes ?? null,
+      }, conversationGeneration);
+      if (!this.isConversationCurrent(conversationGeneration)) {
+        return false;
+      }
+      return true;
+    } catch {
+      this.clearActiveSession();
+      return false;
+    }
+  }
+
+  private getProviderSettings(): Record<string, unknown> {
+    const settings = ProviderSettingsCoordinator.getProviderSettingsSnapshot(
+      this.plugin.settings,
+      this.providerId,
+    );
+    if (this.currentConversationModel) {
+      settings.model = this.currentConversationModel;
+    }
+    return settings;
+  }
+
+  private resolveSelectedRawModelId(queryOptions?: ChatRuntimeQueryOptions): string | null {
+    const providerSettings = this.getProviderSettings();
+    const selectedModel = typeof queryOptions?.model === 'string'
+      ? queryOptions.model
+      : typeof providerSettings.model === 'string'
+      ? providerSettings.model
+      : '';
+
+    if (!isKimiModelSelectionId(selectedModel)) {
+      return null;
+    }
+
+    const selectedBaseRawModelId = decodeKimiModelId(selectedModel);
+    if (!selectedBaseRawModelId) {
+      return null;
+    }
+
+    const discoveredModels = getKimiProviderSettings(providerSettings).discoveredModels;
+    const normalizedBaseRawModelId = resolveKimiBaseModelRawId(selectedBaseRawModelId, discoveredModels);
+    if (!normalizedBaseRawModelId) {
+      return null;
+    }
+
+    const availableModelIds = new Set(discoveredModels.map((model) => model.rawId));
+    if (availableModelIds.size > 0 && !availableModelIds.has(normalizedBaseRawModelId)) {
+      return null;
+    }
+
+    return normalizedBaseRawModelId;
+  }
+
+  private setCurrentConversationModel(model: unknown): void {
+    const selectedModel = typeof model === 'string' ? model.trim() : '';
+    this.currentConversationModel = selectedModel || null;
+  }
+
+  private getActiveDisplayModel(queryOptions?: ChatRuntimeQueryOptions): string | undefined {
+    const providerSettings = this.getProviderSettings();
+    const selectedModel = typeof queryOptions?.model === 'string'
+      ? queryOptions.model
+      : typeof providerSettings.model === 'string'
+      ? providerSettings.model
+      : '';
+
+    if (
+      selectedModel
+      && selectedModel !== KIMI_SYNTHETIC_MODEL_ID
+      && isKimiModelSelectionId(selectedModel)
+    ) {
+      const selectedRawModelId = this.resolveSelectedRawModelId(queryOptions);
+      return selectedRawModelId
+        ? encodeKimiModelId(selectedRawModelId)
+        : selectedModel;
+    }
+
+    return this.currentSessionModelId
+      ? encodeKimiModelId(this.currentSessionModelId)
+      : (selectedModel && isKimiModelSelectionId(selectedModel) ? selectedModel : undefined);
+  }
+
+  private resolveSelectedModeId(): string | null {
+    const providerSettings = this.getProviderSettings();
+    const kimiSettings = getKimiProviderSettings(providerSettings);
+    return resolveKimiModeForPermissionMode(
+      providerSettings.permissionMode,
+      kimiSettings.availableModes,
+    );
+  }
+
+  private async applySelectedMode(
+    sessionId: string,
+    conversationGeneration = this.conversationGeneration,
+  ): Promise<void> {
+    if (!this.connection) {
+      return;
+    }
+
+    const selectedModeId = this.resolveSelectedModeId();
+    if (!selectedModeId || selectedModeId === this.currentSessionModeId) {
+      return;
+    }
+
+    const response = await this.connection.setConfigOption({
+      configId: 'mode',
+      sessionId,
+      type: 'select',
+      value: selectedModeId,
+    });
+    if (!this.isConversationCurrent(conversationGeneration)) {
+      return;
+    }
+    this.currentSessionModeId = selectedModeId;
+    await this.syncSessionModeState({
+      configOptions: response.configOptions,
+    }, conversationGeneration);
+  }
+
+  private async applySelectedModel(
+    sessionId: string,
+    queryOptions?: ChatRuntimeQueryOptions,
+    conversationGeneration = this.conversationGeneration,
+  ): Promise<void> {
+    if (!this.connection) {
+      return;
+    }
+
+    const selectedRawModelId = this.resolveSelectedRawModelId(queryOptions);
+    if (!selectedRawModelId || selectedRawModelId === this.currentSessionModelId) {
+      return;
+    }
+
+    const response = await this.connection.setConfigOption({
+      configId: 'model',
+      sessionId,
+      type: 'select',
+      value: selectedRawModelId,
+    });
+    if (!this.isConversationCurrent(conversationGeneration)) {
+      return;
+    }
+    this.currentSessionModelId = selectedRawModelId;
+    await this.syncSessionModelState({
+      configOptions: response.configOptions,
+    }, conversationGeneration);
+  }
+
+  private resolveSelectedEffortValue(): string | null {
+    const providerSettings = this.getProviderSettings();
+    const selectedEffort = typeof providerSettings.effortLevel === 'string'
+      ? providerSettings.effortLevel.trim()
+      : '';
+    if (!selectedEffort) {
+      return null;
+    }
+
+    return this.currentSessionEffortValues.has(selectedEffort)
+      ? selectedEffort
+      : null;
+  }
+
+  private async applySelectedEffort(
+    sessionId: string,
+    conversationGeneration = this.conversationGeneration,
+  ): Promise<void> {
+    if (!this.connection || !this.currentSessionEffortConfigId) {
+      return;
+    }
+
+    const selectedEffort = this.resolveSelectedEffortValue();
+    if (!selectedEffort || selectedEffort === this.currentSessionEffortValue) {
+      return;
+    }
+
+    const response = await this.connection.setConfigOption({
+      configId: this.currentSessionEffortConfigId,
+      sessionId,
+      type: 'select',
+      value: selectedEffort,
+    });
+    if (!this.isConversationCurrent(conversationGeneration)) {
+      return;
+    }
+    this.currentSessionEffortValue = selectedEffort;
+    await this.syncSessionModelState({
+      configOptions: response.configOptions,
+    }, conversationGeneration);
+  }
+
+  private async syncSessionModelState(params: {
+    configOptions?: AcpSessionConfigOption[] | null;
+    models?: AcpSessionModelState | null;
+  }, conversationGeneration?: number): Promise<void> {
+    if (
+      conversationGeneration !== undefined
+      && !this.isConversationCurrent(conversationGeneration)
+    ) {
+      return;
+    }
+    const acpState = extractAcpSessionModelState(params);
+    const currentRawModelId = acpState.currentModelId ?? this.currentSessionModelId;
+    const discoveredModels = normalizeKimiDiscoveredModels(
+      acpState.availableModels.map((model) => ({
+        ...(model.description ? { description: model.description } : {}),
+        label: model.name,
+        rawId: model.id,
+      })),
+    );
+    if (currentRawModelId) {
+      this.currentSessionModelId = currentRawModelId;
+    }
+
+    const settingsBag = this.plugin.settings as unknown as Record<string, unknown>;
+    const currentSettings = getKimiProviderSettings(settingsBag);
+    const currentBaseRawModelId = currentRawModelId
+      ? resolveKimiBaseModelRawId(currentRawModelId, discoveredModels)
+      : null;
+    const currentPreferredThinking = currentBaseRawModelId
+      ? currentSettings.preferredThinkingByModel[currentBaseRawModelId]
+      : '';
+    const thoughtLevelState = extractAcpSessionThoughtLevelState(params);
+    const currentThinkingOptions = normalizeKimiModelVariants(
+      thoughtLevelState.availableLevels.map((level) => ({
+        ...(level.description ? { description: level.description } : {}),
+        label: level.name,
+        value: level.id,
+      })),
+    );
+    const currentThinkingLevel = thoughtLevelState.currentLevel;
+    const defaultThinkingLevel = currentThinkingOptions.length > 0
+      ? resolveKimiDefaultThinkingLevel(
+        currentThinkingOptions,
+        currentPreferredThinking,
+        currentThinkingLevel ?? KIMI_DEFAULT_THINKING_LEVEL,
+      )
+      : currentThinkingLevel;
+    this.currentSessionEffortConfigId = currentThinkingOptions.length > 0
+      ? thoughtLevelState.configId
+      : null;
+    this.currentSessionEffortValue = currentThinkingOptions.length > 0
+      ? currentThinkingLevel
+      : null;
+    this.currentSessionEffortValues = new Set(currentThinkingOptions.map((option) => option.value));
+
+    const nextThinkingOptionsByModel = { ...currentSettings.thinkingOptionsByModel };
+    if (currentBaseRawModelId) {
+      if (currentThinkingOptions.length > 0) {
+        nextThinkingOptionsByModel[currentBaseRawModelId] = currentThinkingOptions;
+      } else {
+        delete nextThinkingOptionsByModel[currentBaseRawModelId];
+      }
+    }
+
+    const nextVisibleModels = currentSettings.visibleModels.length === 0 && currentBaseRawModelId
+      ? [currentBaseRawModelId]
+      : currentSettings.visibleModels;
+    const shouldSeedCurrentThinking = currentBaseRawModelId
+      && defaultThinkingLevel
+      && (
+        !currentPreferredThinking
+        || (
+          currentThinkingOptions.length > 0
+          && !this.currentSessionEffortValues.has(currentPreferredThinking)
+        )
+      );
+    const nextPreferredThinkingByModel = shouldSeedCurrentThinking && currentBaseRawModelId && defaultThinkingLevel
+      ? {
+        ...currentSettings.preferredThinkingByModel,
+        [currentBaseRawModelId]: defaultThinkingLevel,
+      }
+      : currentSettings.preferredThinkingByModel;
+    const shouldSeedVisibleModels = !sameStringList(currentSettings.visibleModels, nextVisibleModels);
+    const shouldSeedPreferredThinking = !sameStringMap(
+      currentSettings.preferredThinkingByModel,
+      nextPreferredThinkingByModel,
+    );
+    const shouldUpdateDiscoveredModels = discoveredModels.length > 0
+      && !sameDiscoveredModels(currentSettings.discoveredModels, discoveredModels);
+    const shouldUpdateThinkingOptions = !sameThinkingOptionsByModel(
+      currentSettings.thinkingOptionsByModel,
+      nextThinkingOptionsByModel,
+    );
+    const discoveryChanged = shouldUpdateDiscoveredModels
+      && updateKimiDiscoveryState(settingsBag, { discoveredModels });
+    let changed = shouldSeedVisibleModels || shouldSeedPreferredThinking;
+
+    if (currentBaseRawModelId) {
+      const probeSettings = {
+        ...settingsBag,
+        savedProviderEffort: {
+          ...(settingsBag.savedProviderEffort as Record<string, unknown> | undefined),
+        },
+        savedProviderModel: {
+          ...(settingsBag.savedProviderModel as Record<string, unknown> | undefined),
+        },
+      };
+      const seeded = this.seedActiveModelSelection(
+        probeSettings,
+        encodeKimiModelId(currentBaseRawModelId),
+        defaultThinkingLevel,
+      );
+      changed = changed || seeded;
+    }
+
+    if (!changed && !discoveryChanged && !shouldUpdateThinkingOptions) {
+      return;
+    }
+
+    if (changed || shouldUpdateThinkingOptions) {
+      await this.plugin.mutateSettings((settings) => {
+        if (
+          conversationGeneration !== undefined
+          && !this.isConversationCurrent(conversationGeneration)
+        ) {
+          return;
+        }
+        if (currentBaseRawModelId) {
+          this.seedActiveModelSelection(
+            settings,
+            encodeKimiModelId(currentBaseRawModelId),
+            defaultThinkingLevel,
+          );
+        }
+        if (shouldUpdateThinkingOptions || shouldSeedPreferredThinking || shouldSeedVisibleModels) {
+          updateKimiProviderSettings(settings, {
+            ...(shouldSeedPreferredThinking ? { preferredThinkingByModel: nextPreferredThinkingByModel } : {}),
+            ...(shouldUpdateThinkingOptions ? { thinkingOptionsByModel: nextThinkingOptionsByModel } : {}),
+            ...(shouldSeedVisibleModels ? { visibleModels: nextVisibleModels } : {}),
+          });
+        }
+      });
+    }
+    if (
+      conversationGeneration !== undefined
+      && !this.isConversationCurrent(conversationGeneration)
+    ) {
+      return;
+    }
+    this.refreshModelSelectors();
+  }
+
+  private seedActiveModelSelection(
+    settingsBag: Record<string, unknown>,
+    modelSelection: string,
+    thinkingLevel: string | null,
+  ): boolean {
+    let changed = false;
+    const savedProviderModel = ensureProviderProjectionMap(settingsBag, 'savedProviderModel');
+    const savedModel = typeof savedProviderModel.kimi === 'string'
+      ? savedProviderModel.kimi
+      : '';
+    if (!savedModel || savedModel === KIMI_SYNTHETIC_MODEL_ID) {
+      savedProviderModel.kimi = modelSelection;
+      changed = true;
+    }
+
+    if (thinkingLevel) {
+      const savedProviderEffort = ensureProviderProjectionMap(settingsBag, 'savedProviderEffort');
+      const savedEffort = typeof savedProviderEffort.kimi === 'string'
+        ? savedProviderEffort.kimi.trim()
+        : '';
+      if (
+        !savedEffort
+        || savedEffort === KIMI_DEFAULT_THINKING_LEVEL
+        || !this.currentSessionEffortValues.has(savedEffort)
+      ) {
+        savedProviderEffort.kimi = thinkingLevel;
+        changed = true;
+      }
+    }
+
+    if (ProviderRegistry.resolveSettingsProviderId(settingsBag) !== this.providerId) {
+      return changed;
+    }
+
+    const activeModel = typeof settingsBag.model === 'string' ? settingsBag.model : '';
+    if (!activeModel || activeModel === KIMI_SYNTHETIC_MODEL_ID) {
+      settingsBag.model = modelSelection;
+      changed = true;
+    }
+    if (thinkingLevel) {
+      const activeEffort = typeof settingsBag.effortLevel === 'string' ? settingsBag.effortLevel : '';
+      if (
+        !activeEffort
+        || activeEffort === KIMI_DEFAULT_THINKING_LEVEL
+        || !this.currentSessionEffortValues.has(activeEffort)
+      ) {
+        settingsBag.effortLevel = thinkingLevel;
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
+  private async syncSessionModeState(params: {
+    configOptions?: AcpSessionConfigOption[] | null;
+    currentModeId?: string | null;
+    modes?: AcpSessionModeState | null;
+  }, conversationGeneration?: number): Promise<void> {
+    if (
+      conversationGeneration !== undefined
+      && !this.isConversationCurrent(conversationGeneration)
+    ) {
+      return;
+    }
+    const acpState = extractAcpSessionModeState(params);
+    const availableModes = normalizeKimiAvailableModes(acpState.availableModes);
+    const currentModeId = params.currentModeId ?? acpState.currentModeId;
+    if (currentModeId) {
+      this.currentSessionModeId = currentModeId;
+      this.emitPermissionModeSync(currentModeId);
+    }
+
+    const settingsBag = this.plugin.settings as unknown as Record<string, unknown>;
+    const currentSettings = getKimiProviderSettings(settingsBag);
+    const discoveryChanged = availableModes.length > 0
+      && !sameModes(currentSettings.availableModes, availableModes)
+      && updateKimiDiscoveryState(settingsBag, { availableModes });
+
+    if (!discoveryChanged) {
+      return;
+    }
+    if (
+      conversationGeneration !== undefined
+      && !this.isConversationCurrent(conversationGeneration)
+    ) {
+      return;
+    }
+    this.refreshModelSelectors();
+  }
+
+  private refreshModelSelectors(): void {
+    this.plugin.refreshModelSelectors?.();
+  }
+
+  private emitPermissionModeSync(modeId: string): void {
+    const permissionMode = resolvePermissionModeForKimiMode(modeId);
+    if (!permissionMode || !this.permissionModeSyncCallback) {
+      return;
+    }
+
+    try {
+      this.permissionModeSyncCallback(permissionMode);
+    } catch {
+      // Non-critical UI sync callback.
+    }
+  }
+
+  private settleActiveTurn(error?: Error): void {
+    const activeTurn = this.activeTurn;
+    if (!activeTurn || activeTurn.cancelled) {
+      return;
+    }
+
+    activeTurn.cancelled = true;
+    if (error) {
+      activeTurn.queue.push({ type: 'error', content: this.formatRuntimeError(error) });
+    }
+    activeTurn.queue.push({ type: 'done' });
+    activeTurn.queue.close();
+    if (this.activeTurn === activeTurn) {
+      this.activeTurn = null;
+    }
+  }
+
+  private async handleSessionNotification(
+    notification: AcpSessionNotification,
+    connectionGeneration = this.connectionGeneration,
+  ): Promise<void> {
+    if (connectionGeneration !== this.connectionGeneration) {
+      return;
+    }
+    if (notification.sessionId !== this.sessionId) {
+      return;
+    }
+
+    const normalized = this.sessionUpdateNormalizer.normalize(notification.update);
+    if (normalized.type === 'config_options') {
+      await this.syncSessionModelState({
+        configOptions: normalized.configOptions,
+      });
+      await this.syncSessionModeState({
+        configOptions: normalized.configOptions,
+      });
+      return;
+    }
+
+    if (normalized.type === 'current_mode') {
+      await this.syncSessionModeState({
+        currentModeId: normalized.currentModeId,
+      });
+      return;
+    }
+
+    if (normalized.type === 'commands') {
+      this.setSupportedCommands(normalized.commands);
+      return;
+    }
+
+    if (!this.activeTurn || this.activeTurn.sessionId !== notification.sessionId) {
+      return;
+    }
+
+    switch (normalized.type) {
+      case 'message_chunk': {
+        if (normalized.role === 'assistant' && normalized.messageId) {
+          this.currentTurnMetadata.assistantMessageId = normalized.messageId;
+        }
+        if (normalized.role === 'user' && normalized.messageId) {
+          this.currentTurnMetadata.userMessageId = normalized.messageId;
+        }
+        for (const chunk of normalized.streamChunks) {
+          this.activeTurn.queue.push(chunk);
+        }
+        return;
+      }
+      case 'tool_call':
+      case 'tool_call_update': {
+        for (const chunk of normalized.streamChunks) {
+          this.activeTurn.queue.push(chunk);
+        }
+        return;
+      }
+      case 'usage': {
+        this.contextUsage = normalized.usage;
+        const usage = buildAcpUsageInfo({
+          contextWindow: normalized.usage,
+          model: this.getActiveDisplayModel(),
+          promptUsage: this.promptUsage,
+        });
+        if (usage) {
+          this.activeTurn.queue.push({
+            sessionId: notification.sessionId,
+            type: 'usage',
+            usage,
+          });
+        }
+        return;
+      }
+      default:
+        return;
+    }
+  }
+
+  private async handlePermissionRequest(
+    request: AcpRequestPermissionRequest,
+  ): Promise<AcpRequestPermissionResponse> {
+    if (!this.approvalCallback) {
+      return { outcome: { outcome: 'cancelled' } };
+    }
+
+    const toolCall = request.toolCall ?? {};
+    const rawInput = (toolCall as { rawInput?: unknown; input?: unknown; arguments?: unknown }).rawInput
+      ?? (toolCall as { input?: unknown }).input
+      ?? (toolCall as { arguments?: unknown }).arguments;
+    const input = normalizeApprovalInput(rawInput);
+    const title = (
+      (toolCall as { title?: unknown }).title
+      ?? (toolCall as { kind?: unknown }).kind
+      ?? (toolCall as { name?: unknown }).name
+      ?? 'Kimi tool'
+    ).toString();
+    const options = Array.isArray(request.options) ? request.options : [];
+    const decision = await this.approvalCallback(
+      title,
+      input,
+      `Kimi Code wants to use ${title}.`,
+      options.length > 0
+        ? { decisionOptions: buildAcpApprovalDecisionOptions(options) }
+        : undefined,
+    );
+
+    // Always map through the shared helper so deny / empty-options / optionId
+    // fallbacks use Kimi-canonical ids (`approve_once` / `approve_always` /
+    // `reject`) instead of silently cancelling when `decision` has no kind match.
+    return mapApprovalDecision(decision, options);
+  }
+
+  private setSupportedCommands(commands: SlashCommand[]): void {
+    this.supportedCommands = commands.map((command) => ({ ...command }));
+    const waiters = this.supportedCommandWaiters.splice(0);
+    for (const waiter of waiters) {
+      waiter(this.supportedCommands);
+    }
+  }
+
+  private waitForSupportedCommands(timeoutMs = 250): Promise<SlashCommand[]> {
+    if (this.supportedCommands.length > 0) {
+      return Promise.resolve([...this.supportedCommands]);
+    }
+    return new Promise((resolve) => {
+      const waiter = (commands: SlashCommand[]) => {
+        window.clearTimeout(timeoutId);
+        resolve([...commands]);
+      };
+      const timeoutId = window.setTimeout(() => {
+        const index = this.supportedCommandWaiters.indexOf(waiter);
+        if (index >= 0) {
+          this.supportedCommandWaiters.splice(index, 1);
+        }
+        resolve([...this.supportedCommands]);
+      }, timeoutMs);
+      this.supportedCommandWaiters.push(waiter);
+    });
+  }
+
+  private async readTextFile(
+    request: AcpReadTextFileRequest,
+  ): Promise<{ content: string }> {
+    const resolvedPath = this.resolveSessionPath(request.sessionId, request.path);
+    const content = await fs.readFile(resolvedPath, 'utf-8');
+    if (request.line === undefined && request.limit === undefined) {
+      return { content };
+    }
+    const lines = content.split(/\r?\n/);
+    const startIndex = Math.max(0, (request.line ?? 1) - 1);
+    const endIndex = request.limit
+      ? startIndex + Math.max(0, request.limit)
+      : lines.length;
+    return {
+      content: lines.slice(startIndex, endIndex).join('\n'),
+    };
+  }
+
+  private async writeTextFile(
+    request: AcpWriteTextFileRequest,
+  ): Promise<Record<string, never>> {
+    const resolvedPath = this.resolveSessionPath(request.sessionId, request.path);
+    await fs.mkdir(path.dirname(resolvedPath), { recursive: true });
+    await fs.writeFile(resolvedPath, request.content, 'utf-8');
+    return {};
+  }
+
+  private resolveSessionPath(sessionId: string, rawPath: string): string {
+    if (typeof rawPath !== 'string') {
+      return getVaultPath(this.plugin.app) ?? process.cwd();
+    }
+    if (path.isAbsolute(rawPath)) {
+      return rawPath;
+    }
+    const cwd = this.sessionCwds.get(sessionId)
+      ?? getVaultPath(this.plugin.app)
+      ?? process.cwd();
+    return path.resolve(cwd, rawPath);
+  }
+
+  private formatRuntimeError(error: unknown): string {
+    return formatKimiRuntimeError(error, this.process?.getStderrSnapshot());
+  }
+
+  private clearActiveSession(): void {
+    this.sessionId = null;
+    this.loadedSessionId = null;
+    this.currentSessionModelId = null;
+    this.currentSessionModeId = null;
+    this.sessionUpdateNormalizer.reset();
+    this.setSupportedCommands([]);
+  }
+
+  private setReady(ready: boolean): void {
+    if (this.ready === ready) {
+      return;
+    }
+    this.ready = ready;
+    for (const listener of this.readyListeners) {
+      try {
+        listener(ready);
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  private isLifecycleCurrent(generation: number): boolean {
+    return !this.disposed && generation === this.lifecycleGeneration;
+  }
+
+  private isConversationCurrent(generation: number): boolean {
+    return generation === this.conversationGeneration;
+  }
+
+  private isReadinessCurrent(
+    lifecycleGeneration: number,
+    conversationGeneration: number,
+  ): boolean {
+    return this.isLifecycleCurrent(lifecycleGeneration)
+      && this.isConversationCurrent(conversationGeneration);
+  }
+}
+
+function normalizeApprovalInput(rawInput: unknown): Record<string, unknown> {
+  if (rawInput && typeof rawInput === 'object' && !Array.isArray(rawInput)) {
+    return rawInput as Record<string, unknown>;
+  }
+  if (rawInput === undefined) {
+    return {};
+  }
+  return { value: rawInput };
+}
+
+/** Kimi 0.27 canonical + legacy optionIds accepted by the ACP adapter. */
+const KIMI_ALLOW_ONCE_OPTION_IDS = ['approve_once', 'approve', 'allow_once'] as const;
+const KIMI_ALLOW_ALWAYS_OPTION_IDS = [
+  'approve_always',
+  'approve_for_session',
+  'allow_always',
+] as const;
+/** Canonical is `reject`; also accept ACP-style reject_* ids if an agent advertises them. */
+const KIMI_REJECT_OPTION_IDS = ['reject', 'reject_once', 'reject_always'] as const;
+
+const KIMI_CANONICAL_ALLOW_ONCE_OPTION_ID = 'approve_once';
+const KIMI_CANONICAL_ALLOW_ALWAYS_OPTION_ID = 'approve_always';
+const KIMI_CANONICAL_REJECT_OPTION_ID = 'reject';
+
+function mapApprovalDecision(
+  decision: ApprovalDecision,
+  options: readonly {
+    kind: 'allow_once' | 'allow_always' | 'reject_once' | 'reject_always';
+    optionId: string;
+  }[],
+): AcpRequestPermissionResponse {
+  if (decision === 'allow') {
+    return selectPermissionOption(options, {
+      fallbackOptionId: KIMI_CANONICAL_ALLOW_ONCE_OPTION_ID,
+      preferredKinds: ['allow_once', 'allow_always'],
+      preferredOptionIds: KIMI_ALLOW_ONCE_OPTION_IDS,
+    });
+  }
+  if (decision === 'allow-always') {
+    return selectPermissionOption(options, {
+      fallbackOptionId: KIMI_CANONICAL_ALLOW_ALWAYS_OPTION_ID,
+      preferredKinds: ['allow_always', 'allow_once'],
+      preferredOptionIds: KIMI_ALLOW_ALWAYS_OPTION_IDS,
+    });
+  }
+  if (decision === 'deny') {
+    return selectPermissionOption(options, {
+      fallbackOptionId: KIMI_CANONICAL_REJECT_OPTION_ID,
+      preferredKinds: ['reject_once', 'reject_always'],
+      preferredOptionIds: KIMI_REJECT_OPTION_IDS,
+    });
+  }
+  // Arbitrary agent-advertised options (plan_opt_*, plan_revise, custom ids, …)
+  // round-trip as select-option so the exact optionId is preserved.
+  if (typeof decision === 'object' && decision.type === 'select-option') {
+    const optionId = typeof decision.value === 'string' ? decision.value.trim() : '';
+    if (optionId) {
+      return {
+        outcome: {
+          optionId,
+          outcome: 'selected',
+        },
+      };
+    }
+  }
+  return { outcome: { outcome: 'cancelled' } };
+}
+
+function selectPermissionOption(
+  options: readonly {
+    kind: 'allow_once' | 'allow_always' | 'reject_once' | 'reject_always';
+    optionId: string;
+  }[],
+  preference: {
+    fallbackOptionId: string;
+    preferredKinds: ReadonlyArray<'allow_once' | 'allow_always' | 'reject_once' | 'reject_always'>;
+    preferredOptionIds: readonly string[];
+  },
+): AcpRequestPermissionResponse {
+  for (const optionId of preference.preferredOptionIds) {
+    const match = options.find((option) => option.optionId === optionId);
+    if (match) {
+      return {
+        outcome: {
+          optionId: match.optionId,
+          outcome: 'selected',
+        },
+      };
+    }
+  }
+
+  for (const kind of preference.preferredKinds) {
+    const match = options.find((option) => (
+      option.kind === kind && !option.optionId.startsWith('plan_')
+    ));
+    if (match) {
+      return {
+        outcome: {
+          optionId: match.optionId,
+          outcome: 'selected',
+        },
+      };
+    }
+  }
+
+  // Agent omitted options (or only advertised semantically distinct plan
+  // choices): emit the canonical fail-safe selection rather than guessing.
+  return {
+    outcome: {
+      optionId: preference.fallbackOptionId,
+      outcome: 'selected',
+    },
+  };
+}
+
+function buildAcpApprovalDecisionOptions(
+  options: readonly {
+    kind: 'allow_once' | 'allow_always' | 'reject_once' | 'reject_always';
+    name: string;
+    optionId: string;
+  }[],
+): ApprovalDecisionOption[] {
+  return options.map((option) => {
+    // Only canonical/legacy tool approvals map to shared decisions. Plan-review
+    // choices reuse allow_once/reject_once kinds for styling, but every
+    // `plan_*` option is semantically distinct and must round-trip by optionId.
+    const decision = KIMI_ALLOW_ONCE_OPTION_IDS.some((id) => id === option.optionId)
+      ? ('allow' as const)
+      : KIMI_ALLOW_ALWAYS_OPTION_IDS.some((id) => id === option.optionId)
+      ? ('allow-always' as const)
+      : undefined;
+    return {
+      ...(decision ? { decision } : {}),
+      label: option.name,
+      value: option.optionId,
+    };
+  });
+}

--- a/src/providers/kimi/runtime/KimiCliResolver.ts
+++ b/src/providers/kimi/runtime/KimiCliResolver.ts
@@ -1,0 +1,96 @@
+import * as os from 'os';
+import * as path from 'path';
+
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import { findCliBinaryPath, isExistingFile, resolveConfiguredCliPath } from '../../../utils/cliBinaryLocator';
+import { getHostnameKey, parseEnvironmentVariables } from '../../../utils/env';
+import { getKimiProviderSettings } from '../settings';
+
+/**
+ * Resolve the Kimi Code CLI path.
+ *
+ * Order: host-scoped path → legacy cliPath → PATH / common install dirs.
+ * Finds `kimi`, `kimi.exe`, and `kimi.cmd` via shared binary helpers.
+ */
+export class KimiCliResolver {
+  private readonly cachedHostname = getHostnameKey();
+  private lastCliPath = '';
+  private lastHostnamePath = '';
+  private lastEnvText = '';
+  private resolvedPath: string | null = null;
+
+  resolveFromSettings(settings: Record<string, unknown>): string | null {
+    const kimiSettings = getKimiProviderSettings(settings);
+    const cliPath = kimiSettings.cliPath.trim();
+    const hostnamePath = (kimiSettings.cliPathsByHost[this.cachedHostname] ?? '').trim();
+    const envText = getRuntimeEnvironmentText(settings, 'kimi');
+
+    if (
+      this.resolvedPath !== null
+      && cliPath === this.lastCliPath
+      && hostnamePath === this.lastHostnamePath
+      && envText === this.lastEnvText
+    ) {
+      return this.resolvedPath;
+    }
+
+    this.lastCliPath = cliPath;
+    this.lastHostnamePath = hostnamePath;
+    this.lastEnvText = envText;
+    this.resolvedPath = this.resolve(
+      kimiSettings.cliPathsByHost,
+      cliPath,
+      envText,
+    );
+    return this.resolvedPath;
+  }
+
+  resolve(
+    hostnamePaths: Record<string, string> | undefined,
+    legacyPath: string,
+    envText: string,
+  ): string | null {
+    const hostnamePath = (hostnamePaths?.[this.cachedHostname] ?? '').trim();
+    const customEnv = parseEnvironmentVariables(envText || '');
+    return resolveConfiguredCliPath(hostnamePath)
+      ?? resolveConfiguredCliPath(legacyPath.trim())
+      ?? findKimiBinaryPath(customEnv.PATH);
+  }
+
+  reset(): void {
+    this.lastCliPath = '';
+    this.lastHostnamePath = '';
+    this.lastEnvText = '';
+    this.resolvedPath = null;
+  }
+}
+
+function findKimiBinaryPath(additionalPath?: string): string | null {
+  const fromShared = findCliBinaryPath('kimi', additionalPath);
+  if (fromShared) {
+    return fromShared;
+  }
+
+  const home = os.homedir();
+  const candidates = [
+    path.join(home, '.kimi-code', 'bin', 'kimi'),
+    path.join(home, '.local', 'bin', 'kimi'),
+    path.join(home, 'bin', 'kimi'),
+  ];
+  if (process.platform === 'win32') {
+    candidates.push(
+      path.join(home, '.kimi-code', 'bin', 'kimi.exe'),
+      path.join(home, '.kimi-code', 'bin', 'kimi.cmd'),
+      path.join(home, '.local', 'bin', 'kimi.exe'),
+      path.join(home, '.local', 'bin', 'kimi.cmd'),
+    );
+  }
+
+  for (const candidate of candidates) {
+    if (isExistingFile(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}

--- a/src/providers/kimi/runtime/KimiRuntimeEnvironment.ts
+++ b/src/providers/kimi/runtime/KimiRuntimeEnvironment.ts
@@ -1,0 +1,44 @@
+import * as os from 'os';
+import * as path from 'path';
+
+import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
+import { getEnhancedPath, parseEnvironmentVariables } from '../../../utils/env';
+import { getKimiCodeHome } from '../history/KimiHistoryPaths';
+
+/**
+ * Build the environment for Kimi Code ACP / auxiliary subprocesses.
+ *
+ * Supports KIMI_CODE_HOME and other Kimi-owned env vars from provider settings.
+ * Never reads or writes credentials files.
+ */
+export function buildKimiRuntimeEnv(
+  settings: Record<string, unknown>,
+  cliPath: string,
+): NodeJS.ProcessEnv {
+  const envText = getRuntimeEnvironmentText(settings, 'kimi');
+  const customEnv = parseEnvironmentVariables(envText);
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...customEnv,
+  };
+
+  const pathEntries = [
+    path.dirname(cliPath),
+    path.join(os.homedir(), '.kimi-code', 'bin'),
+    path.join(os.homedir(), '.local', 'bin'),
+    env.PATH,
+  ].filter(Boolean);
+  env.PATH = getEnhancedPath(pathEntries.join(path.delimiter), cliPath || undefined);
+  env.TERM = env.TERM || 'xterm-256color';
+  env.COLORTERM = env.COLORTERM || 'truecolor';
+
+  return env;
+}
+
+/** Resolve the Kimi home directory effective for a Claudian settings bag. */
+export function resolveKimiCodeHomeFromSettings(
+  settings: Record<string, unknown>,
+  cliPath = '',
+): string {
+  return getKimiCodeHome(buildKimiRuntimeEnv(settings, cliPath));
+}

--- a/src/providers/kimi/runtime/buildKimiPrompt.ts
+++ b/src/providers/kimi/runtime/buildKimiPrompt.ts
@@ -1,0 +1,82 @@
+import type { ChatTurnRequest } from '../../../core/runtime/types';
+import type { ChatMessage } from '../../../core/types';
+import { appendBrowserContext } from '../../../utils/browser';
+import { appendCanvasContext } from '../../../utils/canvas';
+import { appendCurrentNote } from '../../../utils/context';
+import { appendEditorContext } from '../../../utils/editor';
+import { buildContextFromHistory, buildPromptWithHistoryContext } from '../../../utils/session';
+import type { AcpContentBlock } from '../../acp';
+
+export function buildKimiPromptText(
+  request: ChatTurnRequest,
+  conversationHistory: ChatMessage[] = [],
+): string {
+  let prompt = request.text;
+
+  if (request.currentNotePath) {
+    prompt = appendCurrentNote(prompt, request.currentNotePath);
+  }
+
+  if (request.editorSelection && request.editorSelection.mode !== 'none') {
+    prompt = appendEditorContext(prompt, request.editorSelection);
+  }
+
+  if (request.browserSelection) {
+    prompt = appendBrowserContext(prompt, request.browserSelection);
+  }
+
+  if (request.canvasSelection) {
+    prompt = appendCanvasContext(prompt, request.canvasSelection);
+  }
+
+  if (conversationHistory.length > 0) {
+    const historyContext = buildContextFromHistory(conversationHistory);
+    prompt = buildPromptWithHistoryContext(
+      historyContext,
+      prompt,
+      prompt,
+      conversationHistory,
+    );
+  }
+
+  return prompt;
+}
+
+export function buildKimiPromptBlocks(
+  request: ChatTurnRequest,
+  conversationHistory: ChatMessage[] = [],
+): AcpContentBlock[] {
+  const blocks: AcpContentBlock[] = [
+    { type: 'text', text: buildKimiPromptText(request, conversationHistory) },
+  ];
+
+  for (const image of request.images ?? []) {
+    if (!image.data) {
+      continue;
+    }
+
+    blocks.push({
+      data: image.data,
+      mimeType: image.mediaType,
+      type: 'image',
+    });
+  }
+
+  // External context paths as embedded resource links (text bodies come via FS if needed).
+  for (const contextPath of request.externalContextPaths ?? []) {
+    const trimmed = typeof contextPath === 'string' ? contextPath.trim() : '';
+    if (!trimmed) {
+      continue;
+    }
+    const uri = trimmed.startsWith('file://') || trimmed.includes('://')
+      ? trimmed
+      : `file://${trimmed}`;
+    blocks.push({
+      name: trimmed.split(/[\\/]/).pop() || trimmed,
+      type: 'resource_link',
+      uri,
+    });
+  }
+
+  return blocks;
+}

--- a/src/providers/kimi/settings.ts
+++ b/src/providers/kimi/settings.ts
@@ -1,0 +1,413 @@
+import { getProviderConfig, setProviderConfig } from '../../core/providers/providerConfig';
+import { getProviderEnvironmentVariables } from '../../core/providers/providerEnvironment';
+import type { HostnameCliPaths } from '../../core/types/settings';
+import {
+  getHostnameKey,
+  getLegacyHostnameKey,
+  migrateLegacyHostnameKeyedMap,
+} from '../../utils/env';
+import {
+  getKimiDiscoveryState,
+  seedKimiDiscoveryStateFromLegacyConfig,
+  updateKimiDiscoveryState,
+} from './discoveryState';
+import { ensureProviderProjectionMap } from './internal/providerProjection';
+import {
+  decodeKimiModelId,
+  encodeKimiModelId,
+  isKimiModelSelectionId,
+  type KimiDiscoveredModel,
+  type KimiThinkingOptionsByModel,
+  normalizeKimiThinkingOptionsByModel,
+  resolveKimiBaseModelRawId,
+  resolveKimiDefaultThinkingLevel,
+} from './models';
+import {
+  type KimiMode,
+} from './modes';
+
+export interface PersistedKimiProviderSettings {
+  cliPath: string;
+  cliPathsByHost: HostnameCliPaths;
+  enabled: boolean;
+  environmentHash: string;
+  environmentVariables: string;
+  modelAliases: Record<string, string>;
+  preferredThinkingByModel: Record<string, string>;
+  thinkingOptionsByModel: KimiThinkingOptionsByModel;
+  visibleModels: string[];
+}
+
+export interface KimiProviderSettings extends PersistedKimiProviderSettings {
+  availableModes: KimiMode[];
+  discoveredModels: KimiDiscoveredModel[];
+}
+
+export const DEFAULT_KIMI_PROVIDER_SETTINGS: Readonly<PersistedKimiProviderSettings> = Object.freeze({
+  cliPath: '',
+  cliPathsByHost: {},
+  enabled: false,
+  environmentHash: '',
+  environmentVariables: '',
+  modelAliases: {},
+  preferredThinkingByModel: {},
+  thinkingOptionsByModel: {},
+  visibleModels: [],
+});
+
+function normalizeHostnameCliPaths(value: unknown): HostnameCliPaths {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  const result: HostnameCliPaths = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry === 'string' && entry.trim()) {
+      result[key] = entry.trim();
+    }
+  }
+  return result;
+}
+
+export function normalizeKimiVisibleModels(
+  value: unknown,
+  discoveredModels: KimiDiscoveredModel[] = [],
+): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (typeof entry !== 'string') {
+      continue;
+    }
+
+    const trimmed = resolveKimiBaseModelRawId(entry.trim(), discoveredModels);
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+
+  return normalized;
+}
+
+export function normalizeKimiModelAliases(
+  value: unknown,
+  discoveredModels: KimiDiscoveredModel[] = [],
+): Record<string, string> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  const normalized: Record<string, string> = {};
+  for (const [rawId, alias] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof alias !== 'string') {
+      continue;
+    }
+
+    const normalizedRawId = resolveKimiBaseModelRawId(rawId.trim(), discoveredModels);
+    const normalizedAlias = alias.trim();
+    if (!normalizedRawId || !normalizedAlias) {
+      continue;
+    }
+
+    normalized[normalizedRawId] = normalizedAlias;
+  }
+
+  return normalized;
+}
+
+export function normalizeKimiPreferredThinkingByModel(
+  value: unknown,
+  discoveredModels: KimiDiscoveredModel[] = [],
+): Record<string, string> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  const normalized: Record<string, string> = {};
+  for (const [rawId, thinkingLevel] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof thinkingLevel !== 'string') {
+      continue;
+    }
+
+    const normalizedRawId = resolveKimiBaseModelRawId(rawId.trim(), discoveredModels);
+    const normalizedThinkingLevel = thinkingLevel.trim();
+    if (!normalizedRawId || !normalizedThinkingLevel) {
+      continue;
+    }
+
+    normalized[normalizedRawId] = normalizedThinkingLevel;
+  }
+
+  return normalized;
+}
+
+export function getKimiProviderSettings(
+  settings: Record<string, unknown>,
+): KimiProviderSettings {
+  const config = getProviderConfig(settings, 'kimi');
+  const normalizedCliPathsByHost = normalizeHostnameCliPaths(config.cliPathsByHost);
+  const cliPathsByHost = Object.keys(normalizedCliPathsByHost).length > 0
+    ? migrateLegacyHostnameKeyedMap(
+      normalizedCliPathsByHost,
+      getHostnameKey(),
+      getLegacyHostnameKey(),
+    )
+    : normalizedCliPathsByHost;
+  seedKimiDiscoveryStateFromLegacyConfig(settings, config);
+  const discoveryState = getKimiDiscoveryState(settings);
+  const availableModes = discoveryState.availableModes;
+  const discoveredModels = discoveryState.discoveredModels;
+  const persistedThinkingOptionsByModel = normalizeKimiThinkingOptionsByModel(
+    config.thinkingOptionsByModel,
+    discoveredModels,
+  );
+  const thinkingOptionsByModel = normalizeKimiThinkingOptionsByModel({
+    ...persistedThinkingOptionsByModel,
+    ...discoveryState.thinkingOptionsByModel,
+  }, discoveredModels);
+
+  return {
+    availableModes,
+    cliPath: (config.cliPath as string | undefined)
+      ?? DEFAULT_KIMI_PROVIDER_SETTINGS.cliPath,
+    cliPathsByHost,
+    discoveredModels,
+    enabled: (config.enabled as boolean | undefined)
+      ?? DEFAULT_KIMI_PROVIDER_SETTINGS.enabled,
+    environmentHash: (config.environmentHash as string | undefined)
+      ?? DEFAULT_KIMI_PROVIDER_SETTINGS.environmentHash,
+    environmentVariables: (config.environmentVariables as string | undefined)
+      ?? getProviderEnvironmentVariables(settings, 'kimi')
+      ?? DEFAULT_KIMI_PROVIDER_SETTINGS.environmentVariables,
+    modelAliases: normalizeKimiModelAliases(config.modelAliases, discoveredModels),
+    preferredThinkingByModel: normalizeKimiPreferredThinkingByModel(
+      config.preferredThinkingByModel,
+      discoveredModels,
+    ),
+    thinkingOptionsByModel,
+    visibleModels: normalizeKimiVisibleModels(config.visibleModels, discoveredModels),
+  };
+}
+
+export function updateKimiProviderSettings(
+  settings: Record<string, unknown>,
+  updates: Partial<KimiProviderSettings>,
+): KimiProviderSettings {
+  const current = getKimiProviderSettings(settings);
+  const hostnameKey = getHostnameKey();
+  if ('availableModes' in updates || 'discoveredModels' in updates || 'thinkingOptionsByModel' in updates) {
+    updateKimiDiscoveryState(settings, {
+      ...(updates.availableModes !== undefined ? { availableModes: updates.availableModes } : {}),
+      ...(updates.discoveredModels !== undefined ? { discoveredModels: updates.discoveredModels } : {}),
+      ...(updates.thinkingOptionsByModel !== undefined
+        ? { thinkingOptionsByModel: updates.thinkingOptionsByModel }
+        : {}),
+    });
+  }
+  const discoveryState = getKimiDiscoveryState(settings);
+  const nextAvailableModes = discoveryState.availableModes;
+  const nextDiscoveredModels = discoveryState.discoveredModels;
+  const nextThinkingOptionsByModel = updates.thinkingOptionsByModel !== undefined
+    ? discoveryState.thinkingOptionsByModel
+    : normalizeKimiThinkingOptionsByModel(
+      current.thinkingOptionsByModel,
+      nextDiscoveredModels,
+    );
+  const nextVisibleModels = normalizeKimiVisibleModels(
+    updates.visibleModels ?? current.visibleModels,
+    nextDiscoveredModels,
+  );
+  const nextModelAliases = pruneModelAliasesToVisible(
+    normalizeKimiModelAliases(
+      updates.modelAliases ?? current.modelAliases,
+      nextDiscoveredModels,
+    ),
+    nextVisibleModels,
+  );
+  const nextCliPathsByHost = 'cliPathsByHost' in updates
+    ? normalizeHostnameCliPaths(updates.cliPathsByHost)
+    : { ...current.cliPathsByHost };
+  let nextCliPath = 'cliPathsByHost' in updates
+    ? (
+      typeof updates.cliPath === 'string'
+        ? updates.cliPath.trim()
+        : DEFAULT_KIMI_PROVIDER_SETTINGS.cliPath
+    )
+    : current.cliPath.trim();
+
+  if ('cliPath' in updates && !('cliPathsByHost' in updates)) {
+    const trimmedCliPath = typeof updates.cliPath === 'string' ? updates.cliPath.trim() : '';
+    if (trimmedCliPath) {
+      nextCliPathsByHost[hostnameKey] = trimmedCliPath;
+    } else {
+      delete nextCliPathsByHost[hostnameKey];
+    }
+    nextCliPath = DEFAULT_KIMI_PROVIDER_SETTINGS.cliPath;
+  }
+
+  const next: KimiProviderSettings = {
+    ...current,
+    ...updates,
+    availableModes: nextAvailableModes,
+    cliPath: nextCliPath,
+    cliPathsByHost: nextCliPathsByHost,
+    discoveredModels: nextDiscoveredModels,
+    modelAliases: nextModelAliases,
+    preferredThinkingByModel: normalizeKimiPreferredThinkingByModel(
+      updates.preferredThinkingByModel ?? current.preferredThinkingByModel,
+      nextDiscoveredModels,
+    ),
+    thinkingOptionsByModel: nextThinkingOptionsByModel,
+    visibleModels: nextVisibleModels,
+  };
+
+  if (updates.visibleModels !== undefined) {
+    retargetRemovedKimiSelections(settings, next);
+  }
+
+  const persistedThinkingOptionsByModel = pruneThinkingOptionsToPersistedSelections(
+    settings,
+    next,
+  );
+
+  setProviderConfig(settings, 'kimi', {
+    cliPath: next.cliPath,
+    cliPathsByHost: next.cliPathsByHost,
+    enabled: next.enabled,
+    environmentHash: next.environmentHash,
+    environmentVariables: next.environmentVariables,
+    modelAliases: next.modelAliases,
+    preferredThinkingByModel: next.preferredThinkingByModel,
+    thinkingOptionsByModel: persistedThinkingOptionsByModel,
+    visibleModels: next.visibleModels,
+  });
+
+  return next;
+}
+
+function pruneModelAliasesToVisible(
+  aliases: Record<string, string>,
+  visibleModels: string[],
+): Record<string, string> {
+  if (visibleModels.length === 0 || Object.keys(aliases).length === 0) {
+    return {};
+  }
+
+  const visibleSet = new Set(visibleModels);
+  const pruned: Record<string, string> = {};
+  for (const [rawId, alias] of Object.entries(aliases)) {
+    if (visibleSet.has(rawId)) {
+      pruned[rawId] = alias;
+    }
+  }
+  return pruned;
+}
+
+function pruneThinkingOptionsToPersistedSelections(
+  settings: Record<string, unknown>,
+  next: KimiProviderSettings,
+): KimiThinkingOptionsByModel {
+  const persistableRawIds = new Set(next.visibleModels);
+  addPersistableSelection(persistableRawIds, settings.model, next.discoveredModels);
+  addPersistableSelection(persistableRawIds, settings.titleGenerationModel, next.discoveredModels);
+
+  const savedProviderModel = settings.savedProviderModel;
+  if (savedProviderModel && typeof savedProviderModel === 'object' && !Array.isArray(savedProviderModel)) {
+    addPersistableSelection(
+      persistableRawIds,
+      (savedProviderModel as Record<string, unknown>).kimi,
+      next.discoveredModels,
+    );
+  }
+
+  const pruned: KimiThinkingOptionsByModel = {};
+  for (const rawId of persistableRawIds) {
+    const options = next.thinkingOptionsByModel[rawId];
+    if (options?.length) {
+      pruned[rawId] = options.map((option) => ({ ...option }));
+    }
+  }
+  return pruned;
+}
+
+function addPersistableSelection(
+  target: Set<string>,
+  value: unknown,
+  discoveredModels: KimiDiscoveredModel[],
+): void {
+  if (typeof value !== 'string' || !isKimiModelSelectionId(value)) {
+    return;
+  }
+
+  const rawModelId = decodeKimiModelId(value);
+  if (!rawModelId) {
+    return;
+  }
+
+  const baseRawId = resolveKimiBaseModelRawId(rawModelId, discoveredModels);
+  if (baseRawId) {
+    target.add(baseRawId);
+  }
+}
+
+function retargetRemovedKimiSelections(
+  settings: Record<string, unknown>,
+  next: KimiProviderSettings,
+): void {
+  if (next.visibleModels.length === 0) {
+    if (
+      typeof settings.titleGenerationModel === 'string'
+      && isKimiModelSelectionId(settings.titleGenerationModel)
+    ) {
+      settings.titleGenerationModel = '';
+    }
+    return;
+  }
+
+  const visibleSet = new Set(next.visibleModels);
+  const fallbackRawId = next.visibleModels[0];
+  const fallbackModelId = encodeKimiModelId(fallbackRawId);
+  const fallbackEffort = resolveKimiDefaultThinkingLevel(
+    next.thinkingOptionsByModel[fallbackRawId] ?? [],
+    next.preferredThinkingByModel[fallbackRawId],
+  );
+
+  const maybeRetargetModel = (value: unknown): string | null => {
+    if (typeof value !== 'string' || !isKimiModelSelectionId(value)) {
+      return null;
+    }
+
+    const rawModelId = decodeKimiModelId(value);
+    if (!rawModelId) {
+      return fallbackModelId;
+    }
+
+    const baseRawId = resolveKimiBaseModelRawId(rawModelId, next.discoveredModels);
+    return visibleSet.has(baseRawId) ? null : fallbackModelId;
+  };
+
+  const savedProviderModel = ensureProviderProjectionMap(settings, 'savedProviderModel');
+  const nextSavedModel = maybeRetargetModel(savedProviderModel.kimi);
+  if (nextSavedModel) {
+    savedProviderModel.kimi = nextSavedModel;
+    ensureProviderProjectionMap(settings, 'savedProviderEffort').kimi = fallbackEffort;
+  }
+
+  const nextTopLevelModel = maybeRetargetModel(settings.model);
+  if (nextTopLevelModel) {
+    settings.model = nextTopLevelModel;
+    settings.effortLevel = fallbackEffort;
+  }
+
+  const nextTitleGenerationModel = maybeRetargetModel(settings.titleGenerationModel);
+  if (nextTitleGenerationModel) {
+    settings.titleGenerationModel = nextTitleGenerationModel;
+  }
+}

--- a/src/providers/kimi/types.ts
+++ b/src/providers/kimi/types.ts
@@ -1,0 +1,47 @@
+export interface KimiProviderState {
+  sessionId?: string;
+  /**
+   * Absolute Kimi home used when the session was created/updated.
+   * Ensures history hydration matches the runtime even when KIMI_CODE_HOME is
+   * only set in Claudian provider environment variables.
+   */
+  kimiCodeHome?: string;
+}
+
+export function getKimiState(
+  providerState?: Record<string, unknown>,
+): KimiProviderState {
+  if (!providerState || typeof providerState !== 'object') {
+    return {};
+  }
+
+  const sessionId = typeof providerState.sessionId === 'string' && providerState.sessionId.trim()
+    ? providerState.sessionId.trim()
+    : undefined;
+  const kimiCodeHome = typeof providerState.kimiCodeHome === 'string'
+    && providerState.kimiCodeHome.trim()
+    ? providerState.kimiCodeHome.trim()
+    : undefined;
+
+  return {
+    ...(sessionId ? { sessionId } : {}),
+    ...(kimiCodeHome ? { kimiCodeHome } : {}),
+  };
+}
+
+export function resolveKimiSessionId(
+  conversation: {
+    sessionId?: string | null;
+    providerState?: Record<string, unknown>;
+  } | null | undefined,
+): string | null {
+  if (!conversation) {
+    return null;
+  }
+
+  if (typeof conversation.sessionId === 'string' && conversation.sessionId.trim()) {
+    return conversation.sessionId.trim();
+  }
+
+  return getKimiState(conversation.providerState).sessionId ?? null;
+}

--- a/src/providers/kimi/ui/KimiChatUIConfig.ts
+++ b/src/providers/kimi/ui/KimiChatUIConfig.ts
@@ -1,0 +1,220 @@
+import type {
+  ProviderChatUIConfig,
+  ProviderPermissionModeToggleConfig,
+  ProviderReasoningOption,
+  ProviderUIOption,
+} from '../../../core/providers/types';
+import { KIMI_PROVIDER_ICON } from '../../../shared/icons';
+import {
+  buildKimiBaseModels,
+  decodeKimiModelId,
+  encodeKimiModelId,
+  isKimiModelSelectionId,
+  KIMI_DEFAULT_THINKING_LEVEL,
+  KIMI_SYNTHETIC_MODEL_ID,
+  resolveKimiBaseModelRawId,
+  resolveKimiDefaultThinkingLevel,
+} from '../models';
+import { getKimiProviderSettings } from '../settings';
+
+const KIMI_MODELS: ProviderUIOption[] = [
+  { value: KIMI_SYNTHETIC_MODEL_ID, label: 'Kimi Code', description: 'ACP runtime' },
+];
+const DEFAULT_CONTEXT_WINDOW = 262_144;
+const KIMI_PERMISSION_MODE_TOGGLE: ProviderPermissionModeToggleConfig = {
+  inactiveValue: 'normal',
+  inactiveLabel: 'Safe',
+  activeValue: 'yolo',
+  activeLabel: 'YOLO',
+  planValue: 'plan',
+  planLabel: 'Plan',
+};
+
+export const kimiChatUIConfig: ProviderChatUIConfig = {
+  getModelOptions(settings): ProviderUIOption[] {
+    const kimiSettings = getKimiProviderSettings(settings);
+    const applyAlias = (rawId: string, option: ProviderUIOption): ProviderUIOption => {
+      const alias = kimiSettings.modelAliases[rawId];
+      return alias ? { ...option, label: alias } : option;
+    };
+    const discoveredModels = new Map(buildKimiBaseModels(kimiSettings.discoveredModels).map((model) => [
+      encodeKimiModelId(model.rawId),
+      applyAlias(model.rawId, {
+        description: model.description ?? 'ACP runtime',
+        label: model.label,
+        value: encodeKimiModelId(model.rawId),
+      }),
+    ]));
+    const savedProviderModel = (
+      settings.savedProviderModel
+      && typeof settings.savedProviderModel === 'object'
+      && !Array.isArray(settings.savedProviderModel)
+    )
+      ? settings.savedProviderModel as Record<string, unknown>
+      : null;
+
+    const seenValues = new Set<string>();
+    const options: ProviderUIOption[] = [];
+    for (const rawModelId of [...kimiSettings.visibleModels].reverse()) {
+      const encodedModelId = encodeKimiModelId(rawModelId);
+      pushOption(
+        options,
+        seenValues,
+        encodedModelId,
+        discoveredModels.get(encodedModelId)
+          ?? applyAlias(rawModelId, {
+            description: 'Configured model',
+            label: rawModelId,
+            value: encodedModelId,
+          }),
+      );
+    }
+
+    const selectedModelValues = [
+      typeof settings.model === 'string' ? settings.model : '',
+      typeof savedProviderModel?.kimi === 'string'
+        ? savedProviderModel.kimi
+        : '',
+    ];
+
+    for (const model of selectedModelValues) {
+      const rawModelId = decodeKimiModelId(model);
+      if (
+        !model
+        || !isKimiModelSelectionId(model)
+        || model === KIMI_SYNTHETIC_MODEL_ID
+        || !rawModelId
+      ) {
+        continue;
+      }
+
+      const baseRawId = resolveKimiBaseModelRawId(rawModelId, kimiSettings.discoveredModels);
+      const baseModelId = encodeKimiModelId(baseRawId);
+      pushOption(
+        options,
+        seenValues,
+        baseModelId,
+        discoveredModels.get(baseModelId)
+          ?? applyAlias(baseRawId, {
+            description: 'Selected in an existing session',
+            label: baseRawId,
+            value: baseModelId,
+          }),
+      );
+    }
+
+    return options.length > 0 ? options : [...KIMI_MODELS];
+  },
+
+  ownsModel(model: string): boolean {
+    return isKimiModelSelectionId(model);
+  },
+
+  isAdaptiveReasoningModel(model: string, settings: Record<string, unknown>): boolean {
+    return getKimiThinkingOptions(model, settings).length > 0;
+  },
+
+  getReasoningOptions(model: string, settings: Record<string, unknown>): ProviderReasoningOption[] {
+    return getKimiThinkingOptions(model, settings)
+      .map((variant) => ({
+        description: variant.description,
+        label: variant.label,
+        value: variant.value,
+      }));
+  },
+
+  getDefaultReasoningValue(model: string, settings: Record<string, unknown>): string {
+    const rawModelId = decodeKimiModelId(model);
+    if (!rawModelId) {
+      return KIMI_DEFAULT_THINKING_LEVEL;
+    }
+
+    const kimiSettings = getKimiProviderSettings(settings);
+    const baseRawId = resolveKimiBaseModelRawId(rawModelId, kimiSettings.discoveredModels);
+    return getDefaultThinkingLevelForModel(baseRawId, settings);
+  },
+
+  getContextWindowSize(model: string, customLimits?: Record<string, number>): number {
+    return customLimits?.[model] ?? DEFAULT_CONTEXT_WINDOW;
+  },
+
+  isDefaultModel(model: string): boolean {
+    return isKimiModelSelectionId(model);
+  },
+
+  applyModelDefaults(model: string, settings: unknown): void {
+    if (!settings || typeof settings !== 'object' || Array.isArray(settings)) {
+      return;
+    }
+
+    const settingsBag = settings as Record<string, unknown>;
+    const rawModelId = decodeKimiModelId(model);
+    if (!rawModelId) {
+      settingsBag.effortLevel = KIMI_DEFAULT_THINKING_LEVEL;
+      return;
+    }
+
+    const kimiSettings = getKimiProviderSettings(settingsBag);
+    const baseRawId = resolveKimiBaseModelRawId(rawModelId, kimiSettings.discoveredModels);
+    settingsBag.model = encodeKimiModelId(baseRawId);
+    settingsBag.effortLevel = getDefaultThinkingLevelForModel(baseRawId, settingsBag);
+  },
+
+  normalizeModelVariant(model: string, settings: Record<string, unknown>): string {
+    if (!isKimiModelSelectionId(model)) {
+      return KIMI_SYNTHETIC_MODEL_ID;
+    }
+    const rawModelId = decodeKimiModelId(model);
+    if (!rawModelId) {
+      return model;
+    }
+    const kimiSettings = getKimiProviderSettings(settings);
+    return encodeKimiModelId(resolveKimiBaseModelRawId(rawModelId, kimiSettings.discoveredModels));
+  },
+
+  getCustomModelIds(_envVars: Record<string, string>): Set<string> {
+    return new Set();
+  },
+
+  getPermissionModeToggle(): ProviderPermissionModeToggleConfig {
+    return KIMI_PERMISSION_MODE_TOGGLE;
+  },
+
+  getProviderIcon() {
+    return KIMI_PROVIDER_ICON;
+  },
+};
+
+function getKimiThinkingOptions(model: string, settings: Record<string, unknown>) {
+  const rawModelId = decodeKimiModelId(model);
+  if (!rawModelId) {
+    return [];
+  }
+  const kimiSettings = getKimiProviderSettings(settings);
+  const baseRawId = resolveKimiBaseModelRawId(rawModelId, kimiSettings.discoveredModels);
+  return kimiSettings.thinkingOptionsByModel[baseRawId] ?? [];
+}
+
+function getDefaultThinkingLevelForModel(
+  baseRawId: string,
+  settings: Record<string, unknown>,
+): string {
+  const kimiSettings = getKimiProviderSettings(settings);
+  return resolveKimiDefaultThinkingLevel(
+    kimiSettings.thinkingOptionsByModel[baseRawId] ?? [],
+    kimiSettings.preferredThinkingByModel[baseRawId],
+  );
+}
+
+function pushOption(
+  options: ProviderUIOption[],
+  seenValues: Set<string>,
+  value: string,
+  option: ProviderUIOption,
+): void {
+  if (seenValues.has(value)) {
+    return;
+  }
+  seenValues.add(value);
+  options.push(option);
+}

--- a/src/providers/kimi/ui/KimiSettingsTab.ts
+++ b/src/providers/kimi/ui/KimiSettingsTab.ts
@@ -1,0 +1,152 @@
+import * as fs from 'fs';
+import { Setting } from 'obsidian';
+
+import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
+import type {
+  ProviderSettingsTabRenderer,
+} from '../../../core/providers/types';
+import { renderEnvironmentSettingsSection } from '../../../shared/settings/EnvironmentSettingsSection';
+import { getHostnameKey } from '../../../utils/env';
+import { expandHomePath } from '../../../utils/path';
+import { maybeGetKimiWorkspaceServices } from '../app/KimiWorkspaceServices';
+import {
+  getKimiProviderSettings,
+  updateKimiProviderSettings,
+} from '../settings';
+
+export const kimiSettingsTabRenderer: ProviderSettingsTabRenderer = {
+  render(container, context) {
+    const settingsBag = context.plugin.settings as unknown as Record<string, unknown>;
+    const kimiSettings = getKimiProviderSettings(settingsBag);
+    const hostnameKey = getHostnameKey();
+    const workspace = maybeGetKimiWorkspaceServices();
+
+    new Setting(container).setName('Setup').setHeading();
+
+    new Setting(container)
+      // Product name casing matches other providers (e.g. OpenCode).
+      // eslint-disable-next-line obsidianmd/ui/sentence-case -- brand name
+      .setName('Enable Kimi Code')
+      .setDesc(
+        'When enabled, Kimi Code appears in the model selector for new conversations. '
+        + 'Prompts, selected context, and tool outputs may be sent according to your Kimi configuration. '
+        + 'Requires Kimi Code CLI >= 0.27.0 (`kimi acp`). Existing Kimi sessions are preserved.',
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(kimiSettings.enabled)
+          .onChange(async (value) => {
+            await context.plugin.mutateSettings((settings) => {
+              ProviderSettingsCoordinator.applyProviderEnablement(settings, 'kimi', value);
+            });
+            context.refreshModelSelectors();
+            context.refreshTitleGenerationModelOptions();
+          }),
+      );
+
+    new Setting(container)
+      .setName('Authentication')
+      .setDesc(
+        'Kimi Code uses terminal device-code login. Claudian does not store Kimi credentials. '
+        + 'Run `kimi login` in a terminal if session creation reports Authentication required (-32000). '
+        + 'Do not edit `~/.kimi-code/config.toml` or credential files from Claudian.',
+      );
+
+    const cliPathSetting = new Setting(container)
+      .setName(`Kimi CLI path (${hostnameKey})`)
+      .setDesc(
+        'Custom path to the local Kimi Code CLI (`kimi` / `kimi.exe` / `kimi.cmd`). '
+        + 'Leave empty for auto-detection from PATH and common install dirs.',
+      );
+
+    const validationEl = container.createDiv({
+      cls: 'claudian-cli-path-validation claudian-setting-validation claudian-setting-validation-error claudian-hidden',
+    });
+    const cliPathsByHost = { ...kimiSettings.cliPathsByHost };
+    let cliPathInputEl: HTMLInputElement | null = null;
+
+    const updateCliPathValidation = (value: string, inputEl?: HTMLInputElement): boolean => {
+      const error = validateCliPath(value);
+      if (error) {
+        validationEl.setText(error);
+        validationEl.toggleClass('claudian-hidden', false);
+        inputEl?.toggleClass('claudian-input-error', true);
+        return false;
+      }
+      validationEl.toggleClass('claudian-hidden', true);
+      inputEl?.toggleClass('claudian-input-error', false);
+      return true;
+    };
+
+    const recycleKimiRuntime = async (): Promise<void> => {
+      await context.plugin.recycleProviderRuntimes?.('kimi');
+    };
+
+    const persistCliPath = async (value: string): Promise<boolean> => {
+      if (!updateCliPathValidation(value, cliPathInputEl ?? undefined)) {
+        return false;
+      }
+
+      const trimmed = value.trim();
+      if (trimmed) {
+        cliPathsByHost[hostnameKey] = trimmed;
+      } else {
+        delete cliPathsByHost[hostnameKey];
+      }
+
+      await context.plugin.mutateSettings((settings) => {
+        updateKimiProviderSettings(settings, { cliPathsByHost: { ...cliPathsByHost } });
+      });
+      workspace?.cliResolver?.reset();
+      await recycleKimiRuntime();
+      return true;
+    };
+
+    const currentValue = kimiSettings.cliPathsByHost[hostnameKey] || '';
+    cliPathSetting.addText((text) => {
+      text
+        .setPlaceholder(process.platform === 'win32'
+          ? 'C:\\Users\\you\\AppData\\Local\\kimi\\kimi.cmd'
+          : '~/.local/bin/kimi')
+        .setValue(currentValue)
+        .onChange(async (value) => {
+          await persistCliPath(value);
+        });
+      text.inputEl.addClass('claudian-settings-cli-path-input');
+      cliPathInputEl = text.inputEl;
+      updateCliPathValidation(currentValue, text.inputEl);
+    });
+
+    renderEnvironmentSettingsSection({
+      container,
+      plugin: context.plugin,
+      scope: 'provider:kimi',
+      heading: 'Environment',
+      name: 'Kimi environment',
+      desc: 'Kimi-owned runtime variables only (for example KIMI_CODE_HOME). '
+        + 'Never put credentials here that you would not store in plain text. '
+        + 'If auto-detection needs help, add the install directory to shared PATH instead.',
+      placeholder: 'KIMI_CODE_HOME=/path/to/kimi-home',
+      renderCustomContextLimits: (target) => context.renderCustomContextLimits(target, 'kimi'),
+    });
+  },
+};
+
+function validateCliPath(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const expandedPath = expandHomePath(trimmed);
+  if (!fs.existsSync(expandedPath)) {
+    return 'Path does not exist';
+  }
+  try {
+    if (!fs.statSync(expandedPath).isFile()) {
+      return 'Path is not a file';
+    }
+  } catch {
+    return 'Path is not accessible';
+  }
+  return null;
+}

--- a/src/shared/icons.ts
+++ b/src/shared/icons.ts
@@ -110,6 +110,37 @@ export const PI_PROVIDER_ICON: ProviderIconSvg = {
   ],
 };
 
+/** Kimi Code monochrome robot-face mark (stroke + eyes), currentColor. */
+export const KIMI_PROVIDER_ICON: ProviderIconSvg = {
+  kind: 'composite',
+  viewBox: '0 0 24 24',
+  children: [
+    {
+      tag: 'path',
+      attributes: {
+        d: 'M5.2 4.5h13.6a2.2 2.2 0 0 1 2.2 2.2v8.6a2.2 2.2 0 0 1-2.2 2.2H5.2A2.2 2.2 0 0 1 3 15.3V6.7A2.2 2.2 0 0 1 5.2 4.5Z',
+        fill: 'none',
+        stroke: 'currentColor',
+        'stroke-width': '1.6',
+      },
+    },
+    {
+      tag: 'path',
+      attributes: {
+        d: 'M9.6 8h1.4a0.45 0.45 0 0 1 0.45 0.45v1.7A0.45 0.45 0 0 1 11 10.6H9.6A0.45 0.45 0 0 1 9.15 10.15v-1.7A0.45 0.45 0 0 1 9.6 8Z',
+        fill: 'currentColor',
+      },
+    },
+    {
+      tag: 'path',
+      attributes: {
+        d: 'M15.6 8h1.4a0.45 0.45 0 0 1 0.45 0.45v1.7a0.45 0.45 0 0 1-0.45 0.45h-1.4a0.45 0.45 0 0 1-0.45-0.45v-1.7A0.45 0.45 0 0 1 15.6 8Z',
+        fill: 'currentColor',
+      },
+    },
+  ],
+};
+
 export interface CreateProviderIconSvgOptions {
   className?: string;
   dataProvider?: string;

--- a/tests/fixtures/provider-protocol-child.mjs
+++ b/tests/fixtures/provider-protocol-child.mjs
@@ -3,11 +3,137 @@ import * as readline from 'node:readline';
 const mode = process.argv[2];
 const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
 
+function send(message) {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+const kimiConfigOptions = (model = 'kimi-code/k2') => [
+  {
+    type: 'select',
+    id: 'model',
+    name: 'Model',
+    category: 'model',
+    currentValue: model,
+    options: [
+      { value: 'kimi-code/k2', name: 'K2' },
+      { value: 'kimi-code/k3', name: 'K3' },
+    ],
+  },
+  {
+    type: 'select',
+    id: 'thinking',
+    name: 'Thinking',
+    category: 'thought_level',
+    currentValue: 'off',
+    options: [{ value: 'off', name: 'Off' }, { value: 'on', name: 'On' }],
+  },
+  {
+    type: 'select',
+    id: 'mode',
+    name: 'Mode',
+    category: 'mode',
+    currentValue: 'default',
+    options: [
+      { value: 'default', name: 'Default' },
+      { value: 'plan', name: 'Plan' },
+      { value: 'auto', name: 'Auto' },
+      { value: 'yolo', name: 'YOLO' },
+    ],
+  },
+];
+
+let pendingKimiPromptId = null;
+
 for await (const line of rl) {
   let message;
   try {
     message = JSON.parse(line);
   } catch {
+    continue;
+  }
+
+  if (mode === 'kimi-acp') {
+    if (message.id === 900 && message.method === undefined) {
+      if (pendingKimiPromptId === null) continue;
+      send({
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId: 'kimi-fixture-session',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'fixture reply' },
+          },
+        },
+      });
+      send({
+        jsonrpc: '2.0',
+        id: pendingKimiPromptId,
+        result: { stopReason: 'end_turn', usage: { inputTokens: 2, outputTokens: 3 } },
+      });
+      pendingKimiPromptId = null;
+      continue;
+    }
+
+    if (message.method === 'initialize') {
+      send({
+        jsonrpc: '2.0',
+        id: message.id,
+        result: {
+          protocolVersion: 1,
+          agentInfo: { name: 'Kimi Code CLI Fixture', version: '0.27.0' },
+          agentCapabilities: { loadSession: true },
+          authMethods: [{ id: 'login', name: 'Log in', description: 'Fixture login' }],
+        },
+      });
+      continue;
+    }
+    if (message.method === 'session/new' || message.method === 'session/load') {
+      send({
+        jsonrpc: '2.0',
+        id: message.id,
+        result: {
+          sessionId: 'kimi-fixture-session',
+          configOptions: kimiConfigOptions(),
+        },
+      });
+      continue;
+    }
+    if (message.method === 'session/set_config_option') {
+      send({
+        jsonrpc: '2.0',
+        id: message.id,
+        result: {
+          configOptions: kimiConfigOptions(
+            message.params?.configId === 'model' ? message.params.value : 'kimi-code/k2',
+          ),
+        },
+      });
+      continue;
+    }
+    if (message.method === 'session/prompt') {
+      pendingKimiPromptId = message.id;
+      send({
+        jsonrpc: '2.0',
+        id: 900,
+        method: 'session/request_permission',
+        params: {
+          sessionId: 'kimi-fixture-session',
+          toolCall: { toolCallId: 'tool-1', title: 'Read', rawInput: { path: 'README.md' } },
+          options: [
+            { optionId: 'approve_once', name: 'Approve once', kind: 'allow_once' },
+            { optionId: 'approve_always', name: 'Approve for this session', kind: 'allow_always' },
+            { optionId: 'reject', name: 'Reject', kind: 'reject_once' },
+          ],
+        },
+      });
+      continue;
+    }
+    send({
+      jsonrpc: '2.0',
+      id: message.id,
+      error: { code: -32601, message: `Unknown fixture method: ${message.method}` },
+    });
     continue;
   }
 
@@ -24,18 +150,18 @@ for await (const line of rl) {
   }
 
   if (mode === 'pi') {
-    process.stdout.write(`${JSON.stringify({
+    send({
       id: message.id,
       result: { command: message.type, payload: message.payload ?? null },
       success: true,
       type: 'response',
-    })}\n`);
+    });
     continue;
   }
 
-  process.stdout.write(`${JSON.stringify({
+  send({
     id: message.id,
     jsonrpc: '2.0',
     result: { method: message.method, params: message.params ?? null },
-  })}\n`);
+  });
 }

--- a/tests/integration/providers/ProviderLifecycleFixtures.test.ts
+++ b/tests/integration/providers/ProviderLifecycleFixtures.test.ts
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 
+import { AcpClientConnection } from '@/providers/acp/AcpClientConnection';
 import { AcpJsonRpcTransport } from '@/providers/acp/AcpJsonRpcTransport';
 import { AcpSubprocess } from '@/providers/acp/AcpSubprocess';
 import { CodexAppServerProcess } from '@/providers/codex/runtime/CodexAppServerProcess';
@@ -52,6 +53,89 @@ describe('provider lifecycle fixture subprocesses', () => {
 
     transport.dispose();
     await processOwner.shutdown();
+    expect(processOwner.isAlive()).toBe(false);
+  });
+
+  it('runs the Kimi initialize/session/config/permission/prompt flow through a real ACP child', async () => {
+    const processOwner = new AcpSubprocess({
+      args: [fixturePath, 'kimi-acp'],
+      command: process.execPath,
+      cwd: process.cwd(),
+      env: { ...process.env },
+    });
+    processOwner.start();
+    const transport = new AcpJsonRpcTransport({
+      input: processOwner.stdout,
+      onClose: listener => processOwner.onClose(listener),
+      output: processOwner.stdin,
+    }, 2_000);
+    const permissionRequests: unknown[] = [];
+    const notifications: unknown[] = [];
+    const connection = new AcpClientConnection({
+      clientInfo: { name: 'claudian-kimi-fixture', version: '0.0.0' },
+      delegate: {
+        onSessionNotification: notification => {
+          notifications.push(notification);
+        },
+        requestPermission: async request => {
+          permissionRequests.push(request);
+          return { outcome: { outcome: 'selected', optionId: 'approve_once' } };
+        },
+      },
+      transport,
+    });
+    transport.start();
+
+    try {
+      const initialized = await connection.initialize();
+      expect(initialized).toMatchObject({
+        protocolVersion: 1,
+        agentInfo: { name: 'Kimi Code CLI Fixture', version: '0.27.0' },
+        authMethods: [{ id: 'login' }],
+      });
+
+      const session = await connection.newSession({ cwd: process.cwd(), mcpServers: [] });
+      expect(session.sessionId).toBe('kimi-fixture-session');
+      expect(session.configOptions).toEqual(expect.arrayContaining([
+        expect.objectContaining({ id: 'model', currentValue: 'kimi-code/k2' }),
+        expect.objectContaining({ id: 'thinking', currentValue: 'off' }),
+        expect.objectContaining({ id: 'mode', currentValue: 'default' }),
+      ]));
+
+      const configured = await connection.setConfigOption({
+        configId: 'model',
+        sessionId: session.sessionId,
+        type: 'select',
+        value: 'kimi-code/k3',
+      });
+      expect(configured.configOptions).toEqual(expect.arrayContaining([
+        expect.objectContaining({ id: 'model', currentValue: 'kimi-code/k3' }),
+      ]));
+
+      await expect(connection.prompt({
+        prompt: [{ type: 'text', text: 'fixture prompt' }],
+        sessionId: session.sessionId,
+      })).resolves.toMatchObject({ stopReason: 'end_turn' });
+      expect(permissionRequests).toEqual([
+        expect.objectContaining({
+          sessionId: 'kimi-fixture-session',
+          options: expect.arrayContaining([
+            expect.objectContaining({ optionId: 'approve_once' }),
+            expect.objectContaining({ optionId: 'reject' }),
+          ]),
+        }),
+      ]);
+      expect(notifications).toEqual([
+        expect.objectContaining({
+          sessionId: 'kimi-fixture-session',
+          update: expect.objectContaining({ sessionUpdate: 'agent_message_chunk' }),
+        }),
+      ]);
+    } finally {
+      connection.dispose();
+      transport.dispose();
+      await processOwner.shutdown();
+    }
     expect(processOwner.isAlive()).toBe(false);
   });
 

--- a/tests/unit/providers/ProviderModuleCatalog.test.ts
+++ b/tests/unit/providers/ProviderModuleCatalog.test.ts
@@ -7,6 +7,7 @@ describe('built-in ProviderModule catalog', () => {
       'codex',
       'opencode',
       'pi',
+      'kimi',
     ]);
     for (const module of BUILT_IN_PROVIDER_MODULES) {
       expect(module.workspace.initialize).toEqual(expect.any(Function));

--- a/tests/unit/providers/defaultProviderConfigs.test.ts
+++ b/tests/unit/providers/defaultProviderConfigs.test.ts
@@ -9,10 +9,12 @@ describe('getBuiltInProviderDefaultConfigs', () => {
     expect(first).toHaveProperty('codex');
     expect(first).toHaveProperty('opencode');
     expect(first).toHaveProperty('pi');
+    expect(first).toHaveProperty('kimi');
     expect(first).not.toBe(second);
     expect(first.claude).not.toBe(second.claude);
     expect(first.codex).not.toBe(second.codex);
     expect(first.opencode).not.toBe(second.opencode);
     expect(first.pi).not.toBe(second.pi);
+    expect(first.kimi).not.toBe(second.kimi);
   });
 });

--- a/tests/unit/providers/kimi/KimiAuxQueryRunner.test.ts
+++ b/tests/unit/providers/kimi/KimiAuxQueryRunner.test.ts
@@ -1,0 +1,237 @@
+import '@/providers';
+
+import { AcpClientConnection, AcpJsonRpcTransport, AcpSubprocess } from '@/providers/acp';
+import { KimiAuxQueryRunner } from '@/providers/kimi/runtime/KimiAuxQueryRunner';
+
+jest.mock('@/providers/acp', () => {
+  const actual = jest.requireActual('@/providers/acp');
+  return {
+    ...actual,
+    AcpClientConnection: jest.fn(),
+    AcpJsonRpcTransport: jest.fn(),
+    AcpSubprocess: jest.fn(),
+  };
+});
+
+const MockAcpClientConnection = AcpClientConnection as jest.MockedClass<typeof AcpClientConnection>;
+const MockAcpJsonRpcTransport = AcpJsonRpcTransport as jest.MockedClass<typeof AcpJsonRpcTransport>;
+const MockAcpSubprocess = AcpSubprocess as jest.MockedClass<typeof AcpSubprocess>;
+
+function createMockPlugin(overrides: Record<string, unknown> = {}): any {
+  return {
+    settings: {
+      providerConfigs: {
+        kimi: {
+          enabled: true,
+        },
+      },
+      model: 'kimi',
+      ...((overrides.settings as Record<string, unknown> | undefined) ?? {}),
+    },
+    manifest: { version: '0.0.0-test' },
+    getResolvedProviderCliPath: jest.fn().mockResolvedValue('/usr/local/bin/kimi'),
+    app: {
+      vault: {
+        adapter: {
+          basePath: '/tmp/claudian-kimi-aux-vault',
+        },
+      },
+    },
+    ...overrides,
+  };
+}
+
+function createDeferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: () => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = () => res();
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('KimiAuxQueryRunner', () => {
+  let mockConnection: {
+    cancel: jest.Mock;
+    dispose: jest.Mock;
+    initialize: jest.Mock;
+    newSession: jest.Mock;
+    onSessionNotification: jest.Mock;
+    prompt: jest.Mock;
+    setConfigOption: jest.Mock;
+  };
+  let mockTransport: {
+    dispose: jest.Mock;
+    isClosed: boolean;
+    start: jest.Mock;
+  };
+  let sessionNotificationListener: ((notification: any) => void | Promise<void>) | null;
+  let processInstances: Array<{
+    getStderrSnapshot: jest.Mock;
+    isAlive: jest.Mock;
+    onClose: jest.Mock;
+    shutdown: jest.Mock;
+    start: jest.Mock;
+    stdin: Record<string, never>;
+    stdout: Record<string, never>;
+  }>;
+  let shutdownDeferreds: Array<ReturnType<typeof createDeferred>>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionNotificationListener = null;
+    processInstances = [];
+    shutdownDeferreds = [];
+
+    mockConnection = {
+      cancel: jest.fn(),
+      dispose: jest.fn(),
+      initialize: jest.fn().mockResolvedValue({}),
+      newSession: jest.fn().mockResolvedValue({ sessionId: 'aux-session-1', configOptions: [] }),
+      onSessionNotification: jest.fn((listener) => {
+        sessionNotificationListener = listener;
+        return jest.fn();
+      }),
+      prompt: jest.fn().mockImplementation(async () => {
+        await sessionNotificationListener?.({
+          sessionId: 'aux-session-1',
+          update: {
+            content: { text: 'aux reply', type: 'text' },
+            sessionUpdate: 'agent_message_chunk',
+          },
+        });
+        return { stopReason: 'end_turn' };
+      }),
+      setConfigOption: jest.fn().mockResolvedValue({ configOptions: [] }),
+    };
+    mockTransport = {
+      dispose: jest.fn(),
+      isClosed: false,
+      start: jest.fn(),
+    };
+
+    MockAcpClientConnection.mockImplementation(() => mockConnection as any);
+    MockAcpJsonRpcTransport.mockImplementation(() => mockTransport as any);
+    MockAcpSubprocess.mockImplementation(() => {
+      const shutdownDeferred = createDeferred();
+      shutdownDeferreds.push(shutdownDeferred);
+      const instance = {
+        getStderrSnapshot: jest.fn().mockReturnValue(''),
+        isAlive: jest.fn().mockReturnValue(true),
+        onClose: jest.fn().mockReturnValue(() => undefined),
+        shutdown: jest.fn().mockImplementation(() => shutdownDeferred.promise),
+        start: jest.fn(),
+        stdin: {},
+        stdout: {},
+      };
+      processInstances.push(instance);
+      return instance as any;
+    });
+  });
+
+  it('launches kimi acp and streams auxiliary text', async () => {
+    // First process must shut down instantly if ensureReady restarts; initial start has none.
+    const runner = new KimiAuxQueryRunner(createMockPlugin());
+
+    await expect(runner.query({
+      systemPrompt: 'Title helper',
+    }, 'Summarize')).resolves.toBe('aux reply');
+
+    expect(MockAcpSubprocess).toHaveBeenCalledWith(expect.objectContaining({
+      args: ['acp'],
+      command: '/usr/local/bin/kimi',
+    }));
+    expect(mockConnection.initialize).toHaveBeenCalled();
+    expect(mockConnection.newSession).toHaveBeenCalledWith({
+      cwd: expect.any(String),
+      mcpServers: [],
+    });
+    expect(mockConnection.prompt).toHaveBeenCalledWith({
+      prompt: [{ type: 'text', text: 'Title helper\n\nSummarize' }],
+      sessionId: 'aux-session-1',
+    });
+  });
+
+  it('awaits prior process shutdown before spawning after reset', async () => {
+    const runner = new KimiAuxQueryRunner(createMockPlugin());
+
+    // Start first process (no prior shutdown).
+    shutdownDeferreds[0]?.resolve(); // no-op safety
+    const firstQuery = runner.query({ systemPrompt: 'p' }, 'one');
+    // Resolve any accidental shutdown from first path and let query complete.
+    for (const deferred of shutdownDeferreds) {
+      deferred.resolve();
+    }
+    await firstQuery;
+    expect(MockAcpSubprocess).toHaveBeenCalledTimes(1);
+    const firstProcess = processInstances[0]!;
+
+    // Hold the first process shutdown so a subsequent start must wait.
+    const heldShutdown = createDeferred();
+    firstProcess.shutdown.mockImplementation(() => heldShutdown.promise);
+
+    runner.reset();
+    expect(firstProcess.shutdown).toHaveBeenCalledTimes(1);
+    expect(MockAcpSubprocess).toHaveBeenCalledTimes(1);
+
+    let secondQuerySettled = false;
+    const secondQuery = runner.query({ systemPrompt: 'p' }, 'two').then((result) => {
+      secondQuerySettled = true;
+      return result;
+    });
+
+    // Allow microtasks to run; second spawn must still be blocked on shutdown.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(secondQuerySettled).toBe(false);
+    expect(MockAcpSubprocess).toHaveBeenCalledTimes(1);
+
+    heldShutdown.resolve();
+    await expect(secondQuery).resolves.toBe('aux reply');
+    expect(MockAcpSubprocess).toHaveBeenCalledTimes(2);
+    expect(processInstances[1]!.start).toHaveBeenCalled();
+  });
+
+  it('deduplicates concurrent reset shutdown onto one barrier', async () => {
+    const runner = new KimiAuxQueryRunner(createMockPlugin());
+
+    for (const deferred of shutdownDeferreds) {
+      deferred.resolve();
+    }
+    await runner.query({ systemPrompt: 'p' }, 'warm');
+    const firstProcess = processInstances[0]!;
+
+    const heldShutdown = createDeferred();
+    firstProcess.shutdown.mockImplementation(() => heldShutdown.promise);
+
+    runner.reset();
+    runner.reset();
+    runner.reset();
+
+    expect(firstProcess.shutdown).toHaveBeenCalledTimes(1);
+
+    heldShutdown.resolve();
+    await (runner as any).awaitShutdownBarrier();
+    expect(firstProcess.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels permission requests without approving tools', async () => {
+    const runner = new KimiAuxQueryRunner(createMockPlugin());
+
+    await expect((runner as any).handlePermissionRequest({
+      options: [
+        { kind: 'allow_once', name: 'Allow', optionId: 'approve_once' },
+        { kind: 'reject_once', name: 'Reject', optionId: 'reject' },
+      ],
+      sessionId: 's1',
+      toolCall: { title: 'Bash', toolCallId: 't1' },
+    })).resolves.toEqual({
+      outcome: { outcome: 'cancelled' },
+    });
+  });
+});

--- a/tests/unit/providers/kimi/KimiChatRuntime.test.ts
+++ b/tests/unit/providers/kimi/KimiChatRuntime.test.ts
@@ -1,0 +1,731 @@
+import '@/providers';
+
+import {
+  AcpClientConnection,
+  AcpJsonRpcTransport,
+  AcpSubprocess,
+  JsonRpcErrorResponse,
+} from '@/providers/acp';
+import {
+  buildKimiAcpLaunchKey,
+  formatKimiRuntimeError,
+  isKimiAuthRequiredError,
+  KIMI_AUTH_REQUIRED_MESSAGE,
+  KimiChatRuntime,
+} from '@/providers/kimi/runtime/KimiChatRuntime';
+
+jest.mock('@/providers/acp', () => {
+  const actual = jest.requireActual('@/providers/acp');
+  return {
+    ...actual,
+    AcpClientConnection: jest.fn(),
+    AcpJsonRpcTransport: jest.fn(),
+    AcpSubprocess: jest.fn(),
+  };
+});
+
+const MockAcpClientConnection = AcpClientConnection as jest.MockedClass<typeof AcpClientConnection>;
+const MockAcpJsonRpcTransport = AcpJsonRpcTransport as jest.MockedClass<typeof AcpJsonRpcTransport>;
+const MockAcpSubprocess = AcpSubprocess as jest.MockedClass<typeof AcpSubprocess>;
+
+function createMockPlugin(overrides: Record<string, unknown> = {}): any {
+  const settingsOverride = (overrides.settings as Record<string, unknown> | undefined) ?? {};
+  const { settings: _ignoredSettings, ...restOverrides } = overrides;
+  return {
+    settings: {
+      providerConfigs: {
+        kimi: {
+          enabled: true,
+        },
+      },
+      permissionMode: 'normal',
+      model: 'kimi',
+      effortLevel: 'off',
+      mediaFolder: '',
+      systemPrompt: '',
+      userName: '',
+      ...settingsOverride,
+    },
+    manifest: { version: '0.0.0-test' },
+    getResolvedProviderCliPath: jest.fn().mockResolvedValue('/usr/local/bin/kimi'),
+    saveSettings: jest.fn().mockResolvedValue(undefined),
+    mutateSettings: jest.fn(async (mutation: (settings: any) => void | Promise<void>) => {
+      await mutation((overrides.settings as any) ?? {});
+    }),
+    refreshModelSelectors: jest.fn(),
+    app: {
+      vault: {
+        adapter: {
+          basePath: '/tmp/claudian-kimi-test-vault',
+        },
+      },
+    },
+    ...restOverrides,
+  };
+}
+
+function createDeferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('Kimi auth error helpers', () => {
+  it('detects JSON-RPC -32000 authentication required', () => {
+    const error = new JsonRpcErrorResponse('session/new', -32000, 'Authentication required');
+    expect(isKimiAuthRequiredError(error)).toBe(true);
+    expect(formatKimiRuntimeError(error)).toContain('kimi login');
+    expect(formatKimiRuntimeError(error)).toBe(KIMI_AUTH_REQUIRED_MESSAGE);
+  });
+});
+
+describe('Kimi permission fallback', () => {
+  it('uses Kimi canonical approval option ids when the agent omits options', async () => {
+    const runtime = new KimiChatRuntime(createMockPlugin());
+    runtime.setApprovalCallback(jest.fn().mockResolvedValue('allow-always'));
+
+    await expect((runtime as any).handlePermissionRequest({
+      sessionId: 's1',
+      toolCall: { title: 'Bash', rawInput: { command: 'pwd' } },
+      options: [],
+    })).resolves.toEqual({
+      outcome: { optionId: 'approve_always', outcome: 'selected' },
+    });
+  });
+
+  it('maps deny without options to the Kimi canonical reject optionId', async () => {
+    const runtime = new KimiChatRuntime(createMockPlugin());
+    runtime.setApprovalCallback(jest.fn().mockResolvedValue('deny'));
+
+    await expect((runtime as any).handlePermissionRequest({
+      sessionId: 's1',
+      toolCall: { title: 'Bash', rawInput: { command: 'rm -rf /' } },
+      options: [],
+    })).resolves.toEqual({
+      outcome: { optionId: 'reject', outcome: 'selected' },
+    });
+  });
+
+  it('maps deny to the Kimi canonical reject option when agent advertises reject', async () => {
+    const runtime = new KimiChatRuntime(createMockPlugin());
+    runtime.setApprovalCallback(jest.fn().mockResolvedValue('deny'));
+
+    await expect((runtime as any).handlePermissionRequest({
+      sessionId: 's1',
+      toolCall: { title: 'Bash', rawInput: { command: 'ls' } },
+      options: [
+        { optionId: 'approve_once', kind: 'allow_once', name: 'Approve once' },
+        { optionId: 'approve_always', kind: 'allow_always', name: 'Approve for this session' },
+        { optionId: 'reject', kind: 'reject_once', name: 'Reject' },
+      ],
+    })).resolves.toEqual({
+      outcome: { optionId: 'reject', outcome: 'selected' },
+    });
+  });
+
+  it('preserves every Plan Review choice as an exact select-option id', async () => {
+    const runtime = new KimiChatRuntime(createMockPlugin());
+    const approval = jest.fn().mockResolvedValue({
+      type: 'select-option',
+      value: 'plan_opt_1',
+    });
+    runtime.setApprovalCallback(approval);
+
+    await expect((runtime as any).handlePermissionRequest({
+      sessionId: 's1',
+      toolCall: { title: 'ExitPlanMode', rawInput: {} },
+      options: [
+        { optionId: 'plan_opt_0', kind: 'allow_once', name: 'Path A' },
+        { optionId: 'plan_opt_1', kind: 'allow_once', name: 'Path B' },
+        { optionId: 'plan_revise', kind: 'reject_once', name: 'Revise' },
+        { optionId: 'plan_reject_and_exit', kind: 'reject_once', name: 'Reject and Exit' },
+      ],
+    })).resolves.toEqual({
+      outcome: { optionId: 'plan_opt_1', outcome: 'selected' },
+    });
+    expect(approval).toHaveBeenCalledWith(
+      'ExitPlanMode',
+      {},
+      'Kimi Code wants to use ExitPlanMode.',
+      {
+        decisionOptions: [
+          { label: 'Path A', value: 'plan_opt_0' },
+          { label: 'Path B', value: 'plan_opt_1' },
+          { label: 'Revise', value: 'plan_revise' },
+          { label: 'Reject and Exit', value: 'plan_reject_and_exit' },
+        ],
+      },
+    );
+  });
+
+  it('selects the exact advertised reject option id via select-option', async () => {
+    const runtime = new KimiChatRuntime(createMockPlugin());
+    const approval = jest.fn().mockResolvedValue({
+      type: 'select-option',
+      value: 'reject',
+    });
+    runtime.setApprovalCallback(approval);
+
+    const response = await (runtime as any).handlePermissionRequest({
+      sessionId: 's1',
+      toolCall: { title: 'Bash', rawInput: { command: 'ls' } },
+      options: [
+        { optionId: 'approve_once', kind: 'allow_once', name: 'Approve once' },
+        { optionId: 'approve_always', kind: 'allow_always', name: 'Approve for this session' },
+        { optionId: 'reject', kind: 'reject_once', name: 'Reject' },
+      ],
+    });
+
+    expect(response).toEqual({
+      outcome: { optionId: 'reject', outcome: 'selected' },
+    });
+    expect(approval).toHaveBeenCalledWith(
+      'Bash',
+      { command: 'ls' },
+      'Kimi Code wants to use Bash.',
+      {
+        decisionOptions: [
+          { decision: 'allow', label: 'Approve once', value: 'approve_once' },
+          { decision: 'allow-always', label: 'Approve for this session', value: 'approve_always' },
+          // Reject intentionally omits `decision` so UI returns select-option.
+          { label: 'Reject', value: 'reject' },
+        ],
+      },
+    );
+  });
+
+  it('does not cancel when deny maps through reject_always kind', async () => {
+    const runtime = new KimiChatRuntime(createMockPlugin());
+    runtime.setApprovalCallback(jest.fn().mockResolvedValue('deny'));
+
+    await expect((runtime as any).handlePermissionRequest({
+      sessionId: 's1',
+      toolCall: { title: 'Write', rawInput: { path: 'a.md' } },
+      options: [
+        { optionId: 'allow_once', kind: 'allow_once', name: 'Allow' },
+        { optionId: 'reject_always', kind: 'reject_always', name: 'Reject always' },
+      ],
+    })).resolves.toEqual({
+      outcome: { optionId: 'reject_always', outcome: 'selected' },
+    });
+  });
+});
+
+describe('buildKimiAcpLaunchKey', () => {
+  it('tracks cli path, cwd, and env text', () => {
+    const key = buildKimiAcpLaunchKey({
+      cliPath: '/usr/local/bin/kimi',
+      cwd: '/vault',
+      envText: 'KIMI_CODE_HOME=/tmp/kimi',
+    });
+    expect(key).toContain('"/usr/local/bin/kimi"');
+    expect(key).toContain('"/vault"');
+    expect(key).toContain('KIMI_CODE_HOME');
+  });
+});
+
+describe('KimiChatRuntime session lifecycle', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('creates a session, applies mode/model from config options, and streams text/tool/usage', async () => {
+    const plugin = createMockPlugin({
+      settings: {
+        permissionMode: 'plan',
+        model: 'kimi:kimi-code/k3',
+      },
+    });
+    const runtime = new KimiChatRuntime(plugin);
+
+    const setConfigOption = jest.fn().mockResolvedValue({
+      configOptions: [
+        {
+          type: 'select',
+          id: 'model',
+          name: 'Model',
+          category: 'model',
+          currentValue: 'kimi-code/k3',
+          options: [{ value: 'kimi-code/k3', name: 'K3' }],
+        },
+        {
+          type: 'select',
+          id: 'thinking',
+          name: 'Thinking',
+          category: 'thought_level',
+          currentValue: 'off',
+          options: [
+            { value: 'off', name: 'Thinking Off' },
+            { value: 'on', name: 'Thinking On' },
+          ],
+        },
+        {
+          type: 'select',
+          id: 'mode',
+          name: 'Mode',
+          category: 'mode',
+          currentValue: 'plan',
+          options: [
+            { value: 'default', name: 'Default' },
+            { value: 'plan', name: 'Plan' },
+            { value: 'yolo', name: 'YOLO' },
+          ],
+        },
+      ],
+    });
+    const prompt = jest.fn().mockImplementation(async () => {
+      await (runtime as any).handleSessionNotification({
+        sessionId: 'sess-new',
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'hi' },
+        },
+      });
+      await (runtime as any).handleSessionNotification({
+        sessionId: 'sess-new',
+        update: {
+          sessionUpdate: 'agent_thought_chunk',
+          content: { type: 'text', text: 'thinking...' },
+        },
+      });
+      await (runtime as any).handleSessionNotification({
+        sessionId: 'sess-new',
+        update: {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'tc-1',
+          title: 'Read',
+          status: 'pending',
+        },
+      });
+      await (runtime as any).handleSessionNotification({
+        sessionId: 'sess-new',
+        update: {
+          sessionUpdate: 'plan',
+          entries: [{ content: 'step 1', status: 'pending', priority: 'medium' }],
+        },
+      });
+      await (runtime as any).handleSessionNotification({
+        sessionId: 'sess-new',
+        update: {
+          sessionUpdate: 'available_commands_update',
+          availableCommands: [{ name: 'compact', description: 'Compact' }],
+        },
+      });
+      return { usage: { inputTokens: 1, outputTokens: 2 } };
+    });
+    const newSession = jest.fn().mockResolvedValue({
+      sessionId: 'sess-new',
+      configOptions: [
+        {
+          type: 'select',
+          id: 'model',
+          name: 'Model',
+          category: 'model',
+          currentValue: 'kimi-code/k3',
+          options: [{ value: 'kimi-code/k3', name: 'K3' }],
+        },
+        {
+          type: 'select',
+          id: 'mode',
+          name: 'Mode',
+          category: 'mode',
+          currentValue: 'default',
+          options: [
+            { value: 'default', name: 'Default' },
+            { value: 'plan', name: 'Plan' },
+          ],
+        },
+      ],
+    });
+
+    (runtime as any).connection = {
+      newSession,
+      loadSession: jest.fn(),
+      setConfigOption,
+      prompt,
+      cancel: jest.fn(),
+      dispose: jest.fn(),
+    };
+    (runtime as any).ready = true;
+    (runtime as any).ensureReady = jest.fn().mockResolvedValue(true);
+
+    const chunks: any[] = [];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'hello' } as any), [])) {
+      chunks.push(chunk);
+    }
+
+    expect(newSession).toHaveBeenCalledWith({ cwd: expect.any(String), mcpServers: [] });
+    expect(setConfigOption).toHaveBeenCalledWith(expect.objectContaining({
+      configId: 'mode',
+      value: 'plan',
+    }));
+    expect(prompt).toHaveBeenCalled();
+    expect(chunks.some((chunk) => chunk.type === 'text' && chunk.content === 'hi')).toBe(true);
+    expect(chunks.some((chunk) => chunk.type === 'thinking')).toBe(true);
+    expect(chunks.some((chunk) => chunk.type === 'tool_call' || chunk.type === 'tool_use')).toBe(true);
+    expect(chunks.some((chunk) => chunk.type === 'done')).toBe(true);
+    expect(runtime.getSessionId()).toBe('sess-new');
+
+    const commands = await runtime.getSupportedCommands();
+    expect(commands.some((command) => command.name === 'compact')).toBe(true);
+  });
+
+  it('surfaces auth-required errors from session/new', async () => {
+    const plugin = createMockPlugin();
+    const runtime = new KimiChatRuntime(plugin);
+    const newSession = jest.fn().mockRejectedValue(
+      new JsonRpcErrorResponse('session/new', -32000, 'Authentication required'),
+    );
+    (runtime as any).connection = {
+      newSession,
+      dispose: jest.fn(),
+    };
+
+    await expect((runtime as any).createSession('/tmp/vault')).resolves.toBeNull();
+    expect((runtime as any).lastSessionError).toContain('kimi login');
+  });
+
+  it('maps permission allow/reject decisions', async () => {
+    const plugin = createMockPlugin();
+    const runtime = new KimiChatRuntime(plugin);
+    const approval = jest.fn().mockResolvedValue('allow');
+    runtime.setApprovalCallback(approval);
+
+    const allowResponse = await (runtime as any).handlePermissionRequest({
+      sessionId: 's1',
+      toolCall: { title: 'Bash', rawInput: { command: 'ls' } },
+      options: [
+        { optionId: 'allow_once', kind: 'allow_once', name: 'Allow' },
+        { optionId: 'reject_once', kind: 'reject_once', name: 'Reject' },
+      ],
+    });
+    expect(allowResponse).toEqual({
+      outcome: { optionId: 'allow_once', outcome: 'selected' },
+    });
+
+    approval.mockResolvedValueOnce('deny');
+    const denyResponse = await (runtime as any).handlePermissionRequest({
+      sessionId: 's1',
+      toolCall: { title: 'Bash', rawInput: { command: 'ls' } },
+      options: [
+        { optionId: 'allow_once', kind: 'allow_once', name: 'Allow' },
+        { optionId: 'reject_once', kind: 'reject_once', name: 'Reject' },
+      ],
+    });
+    expect(denyResponse).toEqual({
+      outcome: { optionId: 'reject_once', outcome: 'selected' },
+    });
+  });
+
+  it('skips setConfigOption when model/mode/thinking already match session state', async () => {
+    const plugin = createMockPlugin({
+      settings: {
+        permissionMode: 'plan',
+        model: 'kimi:kimi-code/k3',
+        effortLevel: 'on',
+      },
+    });
+    const runtime = new KimiChatRuntime(plugin);
+    const setConfigOption = jest.fn().mockResolvedValue({});
+    (runtime as any).connection = { setConfigOption };
+    (runtime as any).currentSessionModelId = 'kimi-code/k3';
+    (runtime as any).currentSessionModeId = 'plan';
+    (runtime as any).currentSessionEffortConfigId = 'thinking';
+    (runtime as any).currentSessionEffortValue = 'on';
+    (runtime as any).currentSessionEffortValues = new Set(['off', 'on']);
+    (runtime as any).resolveSelectedRawModelId = jest.fn().mockReturnValue('kimi-code/k3');
+    (runtime as any).resolveSelectedModeId = jest.fn().mockReturnValue('plan');
+
+    await (runtime as any).applySelectedModel('sess-1');
+    await (runtime as any).applySelectedMode('sess-1');
+    await (runtime as any).applySelectedEffort('sess-1');
+
+    expect(setConfigOption).not.toHaveBeenCalled();
+  });
+
+  it('calls setConfigOption with model/thinking/mode when values change', async () => {
+    const plugin = createMockPlugin({
+      settings: {
+        permissionMode: 'yolo',
+        model: 'kimi:kimi-code/k3',
+        effortLevel: 'on',
+      },
+    });
+    const runtime = new KimiChatRuntime(plugin);
+    const setConfigOption = jest.fn().mockResolvedValue({ configOptions: [] });
+    (runtime as any).connection = { setConfigOption };
+    (runtime as any).currentSessionModelId = 'kimi-code/old';
+    (runtime as any).currentSessionModeId = 'default';
+    (runtime as any).currentSessionEffortConfigId = 'thinking';
+    (runtime as any).currentSessionEffortValue = 'off';
+    (runtime as any).currentSessionEffortValues = new Set(['off', 'on']);
+    (runtime as any).resolveSelectedRawModelId = jest.fn().mockReturnValue('kimi-code/k3');
+    (runtime as any).resolveSelectedModeId = jest.fn().mockReturnValue('yolo');
+    (runtime as any).syncSessionModelState = jest.fn().mockResolvedValue(undefined);
+    (runtime as any).syncSessionModeState = jest.fn().mockResolvedValue(undefined);
+
+    await (runtime as any).applySelectedModel('sess-1');
+    await (runtime as any).applySelectedMode('sess-1');
+    await (runtime as any).applySelectedEffort('sess-1');
+
+    expect(setConfigOption).toHaveBeenCalledWith({
+      configId: 'model',
+      sessionId: 'sess-1',
+      type: 'select',
+      value: 'kimi-code/k3',
+    });
+    expect(setConfigOption).toHaveBeenCalledWith({
+      configId: 'mode',
+      sessionId: 'sess-1',
+      type: 'select',
+      value: 'yolo',
+    });
+    expect(setConfigOption).toHaveBeenCalledWith({
+      configId: 'thinking',
+      sessionId: 'sess-1',
+      type: 'select',
+      value: 'on',
+    });
+  });
+
+  it('cancels an active turn and blocks overlapping queries until settle', async () => {
+    const plugin = createMockPlugin();
+    const runtime = new KimiChatRuntime(plugin);
+    runtime.syncConversationState({
+      id: 'conv-1',
+      sessionId: 'sess-cancel',
+      providerState: { sessionId: 'sess-cancel' },
+    });
+
+    const deferred = createDeferred<Record<string, never>>();
+    const promptStarted = createDeferred();
+    const cancel = jest.fn();
+    const setConfigOption = jest.fn().mockResolvedValue({});
+    const prompt = jest.fn().mockImplementation(() => {
+      promptStarted.resolve();
+      return deferred.promise;
+    });
+
+    (runtime as any).connection = {
+      setConfigOption,
+      prompt,
+      cancel,
+      dispose: jest.fn(),
+    };
+    (runtime as any).ready = true;
+    (runtime as any).loadedSessionId = 'sess-cancel';
+    (runtime as any).sessionId = 'sess-cancel';
+    (runtime as any).ensureReady = jest.fn().mockResolvedValue(true);
+
+    const firstQuery = (async () => {
+      const chunks: unknown[] = [];
+      for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'first' } as any), [])) {
+        chunks.push(chunk);
+      }
+      return chunks;
+    })();
+
+    await promptStarted.promise;
+    runtime.cancel();
+    expect(cancel).toHaveBeenCalledWith({ sessionId: 'sess-cancel' });
+    expect((runtime as any).restartRequiredAfterCancel).toBe(true);
+    expect((runtime as any).activeTurn).not.toBeNull();
+
+    const overlap: unknown[] = [];
+    for await (const chunk of runtime.query(runtime.prepareTurn({ text: 'second' } as any), [])) {
+      overlap.push(chunk);
+    }
+    expect(overlap).toEqual([
+      { type: 'error', content: 'Kimi Code does not support overlapping turns.' },
+      { type: 'done' },
+    ]);
+
+    deferred.resolve({});
+    await firstQuery;
+    expect((runtime as any).activeTurn).toBeNull();
+  });
+
+  it('loads an existing session and cleans up deterministically', async () => {
+    const plugin = createMockPlugin();
+    const runtime = new KimiChatRuntime(plugin);
+    const loadSession = jest.fn().mockResolvedValue({
+      sessionId: 'sess-load',
+      configOptions: [],
+    });
+    (runtime as any).connection = {
+      loadSession,
+      dispose: jest.fn(),
+      newSession: jest.fn(),
+      setConfigOption: jest.fn().mockResolvedValue({}),
+    };
+
+    await expect((runtime as any).loadSession('sess-load', '/tmp/vault')).resolves.toBe(true);
+    expect(loadSession).toHaveBeenCalledWith({
+      cwd: '/tmp/vault',
+      mcpServers: [],
+      sessionId: 'sess-load',
+    });
+    expect(runtime.getSessionId()).toBe('sess-load');
+
+    runtime.cleanup();
+    expect(runtime.isReady()).toBe(false);
+  });
+
+  it('persists kimiCodeHome in session updates', () => {
+    const plugin = createMockPlugin();
+    const runtime = new KimiChatRuntime(plugin);
+    (runtime as any).sessionId = 'sess-1';
+    (runtime as any).currentKimiCodeHome = '/custom/kimi-home';
+
+    const result = runtime.buildSessionUpdates({
+      conversation: null,
+      sessionInvalidated: false,
+    });
+
+    expect(result.updates).toEqual({
+      sessionId: 'sess-1',
+      providerState: {
+        sessionId: 'sess-1',
+        kimiCodeHome: '/custom/kimi-home',
+      },
+    });
+  });
+});
+
+describe('KimiChatRuntime process launch', () => {
+  let mockConnection: {
+    cancel: jest.Mock;
+    dispose: jest.Mock;
+    initialize: jest.Mock;
+    loadSession: jest.Mock;
+    newSession: jest.Mock;
+    prompt: jest.Mock;
+    setConfigOption: jest.Mock;
+  };
+  let mockProcess: {
+    getStderrSnapshot: jest.Mock;
+    isAlive: jest.Mock;
+    onClose: jest.Mock;
+    shutdown: jest.Mock;
+    start: jest.Mock;
+    stdin: Record<string, never>;
+    stdout: Record<string, never>;
+  };
+  let mockTransport: {
+    dispose: jest.Mock;
+    isClosed: boolean;
+    onClose: jest.Mock;
+    start: jest.Mock;
+  };
+  let lastSubprocessLaunch: { args: string[]; command: string } | null;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    lastSubprocessLaunch = null;
+
+    mockConnection = {
+      cancel: jest.fn(),
+      dispose: jest.fn(),
+      initialize: jest.fn().mockResolvedValue({
+        agentInfo: { name: 'Kimi Code CLI', version: '0.27.0' },
+        agentCapabilities: { loadSession: true },
+      }),
+      loadSession: jest.fn().mockResolvedValue({ sessionId: 'sess-load' }),
+      newSession: jest.fn().mockResolvedValue({ sessionId: 'sess-new', configOptions: [] }),
+      prompt: jest.fn().mockResolvedValue({}),
+      setConfigOption: jest.fn().mockResolvedValue({}),
+    };
+    mockProcess = {
+      getStderrSnapshot: jest.fn().mockReturnValue(''),
+      isAlive: jest.fn().mockReturnValue(true),
+      onClose: jest.fn().mockReturnValue(() => undefined),
+      shutdown: jest.fn().mockResolvedValue(undefined),
+      start: jest.fn(),
+      stdin: {},
+      stdout: {},
+    };
+    mockTransport = {
+      dispose: jest.fn(),
+      isClosed: false,
+      onClose: jest.fn().mockReturnValue(() => undefined),
+      start: jest.fn(),
+    };
+
+    MockAcpClientConnection.mockImplementation(() => mockConnection as any);
+    MockAcpJsonRpcTransport.mockImplementation(() => mockTransport as any);
+    MockAcpSubprocess.mockImplementation((spec: any) => {
+      lastSubprocessLaunch = {
+        args: spec.args,
+        command: spec.command,
+      };
+      return mockProcess as any;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('spawns kimi acp and initializes the ACP connection', async () => {
+    const plugin = createMockPlugin();
+    const runtime = new KimiChatRuntime(plugin);
+    await (runtime as any).startProcess({
+      cliPath: '/usr/local/bin/kimi',
+      cwd: '/tmp/vault',
+    });
+
+    expect(lastSubprocessLaunch).toEqual({
+      args: ['acp'],
+      command: '/usr/local/bin/kimi',
+    });
+    expect(mockProcess.start).toHaveBeenCalled();
+    expect(mockConnection.initialize).toHaveBeenCalledWith({
+      clientCapabilities: {
+        fs: { readTextFile: true, writeTextFile: true },
+      },
+    });
+  });
+
+  it('includes image blocks in the prompt payload', async () => {
+    const plugin = createMockPlugin();
+    const runtime = new KimiChatRuntime(plugin);
+    runtime.syncConversationState({
+      id: 'c1',
+      sessionId: 'sess-img',
+      providerState: { sessionId: 'sess-img' },
+    });
+    const prompt = jest.fn().mockResolvedValue({});
+    (runtime as any).connection = {
+      prompt,
+      setConfigOption: jest.fn().mockResolvedValue({}),
+      cancel: jest.fn(),
+      dispose: jest.fn(),
+    };
+    (runtime as any).ready = true;
+    (runtime as any).loadedSessionId = 'sess-img';
+    (runtime as any).sessionId = 'sess-img';
+    (runtime as any).ensureReady = jest.fn().mockResolvedValue(true);
+
+    for await (const chunk of runtime.query(runtime.prepareTurn({
+      text: 'see image',
+      images: [{ data: 'abc', mediaType: 'image/png' }],
+    } as any), [])) {
+      void chunk;
+    }
+
+    expect(prompt).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: expect.arrayContaining([
+        { type: 'text', text: 'see image' },
+        { type: 'image', data: 'abc', mimeType: 'image/png' },
+      ]),
+    }));
+  });
+});

--- a/tests/unit/providers/kimi/KimiChatUIConfig.test.ts
+++ b/tests/unit/providers/kimi/KimiChatUIConfig.test.ts
@@ -1,0 +1,12 @@
+import { KIMI_SYNTHETIC_MODEL_ID } from '@/providers/kimi/models';
+import { kimiChatUIConfig } from '@/providers/kimi/ui/KimiChatUIConfig';
+
+describe('kimiChatUIConfig', () => {
+  it('exposes synthetic model before discovery and owns kimi ids', () => {
+    const options = kimiChatUIConfig.getModelOptions({});
+    expect(options.some((option) => option.value === KIMI_SYNTHETIC_MODEL_ID)).toBe(true);
+    expect(kimiChatUIConfig.ownsModel('kimi:kimi-code/k3', {})).toBe(true);
+    expect(kimiChatUIConfig.ownsModel('gpt-5', {})).toBe(false);
+    expect(kimiChatUIConfig.getProviderIcon?.()).toBeTruthy();
+  });
+});

--- a/tests/unit/providers/kimi/KimiCliResolver.test.ts
+++ b/tests/unit/providers/kimi/KimiCliResolver.test.ts
@@ -1,0 +1,94 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { KimiCliResolver } from '@/providers/kimi/runtime/KimiCliResolver';
+
+jest.mock('fs');
+jest.mock('@/utils/env', () => ({
+  ...jest.requireActual('@/utils/env'),
+  getHostnameKey: () => 'current-host',
+}));
+
+const mockedStat = fs.statSync as jest.Mock;
+
+describe('KimiCliResolver', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (fs.existsSync as jest.Mock).mockReturnValue(false);
+  });
+
+  it('uses the current host path instead of another synced host path', () => {
+    mockedStat.mockImplementation((filePath: string) => {
+      if (filePath === '/current/kimi') {
+        return { isFile: () => true };
+      }
+      throw new Error(`ENOENT: ${filePath}`);
+    });
+
+    const resolver = new KimiCliResolver();
+    const resolved = resolver.resolve(
+      {
+        'other-host': '/other/kimi',
+        'current-host': '/current/kimi',
+      },
+      '/legacy/kimi',
+      '',
+    );
+
+    expect(resolved).toBe('/current/kimi');
+  });
+
+  it('falls back to the legacy path when the current host has no custom path', () => {
+    mockedStat.mockImplementation((filePath: string) => {
+      if (filePath === '/legacy/kimi') {
+        return { isFile: () => true };
+      }
+      throw new Error(`ENOENT: ${filePath}`);
+    });
+
+    const resolver = new KimiCliResolver();
+    const resolved = resolver.resolve(
+      {
+        'other-host': '/other/kimi',
+      },
+      '/legacy/kimi',
+      '',
+    );
+
+    expect(resolved).toBe('/legacy/kimi');
+  });
+
+  it('falls back to PATH lookup when no Kimi CLI path is configured', () => {
+    const pathDir = '/custom/bin';
+    const pathBinary = path.join(pathDir, 'kimi');
+    mockedStat.mockImplementation((filePath: string) => {
+      if (filePath === pathBinary) {
+        return { isFile: () => true };
+      }
+      throw new Error(`ENOENT: ${filePath}`);
+    });
+
+    const resolver = new KimiCliResolver();
+    const resolved = resolver.resolve({}, '', `PATH=${pathDir}`);
+
+    expect(resolved).toBe(pathBinary);
+  });
+
+  it('resolves Windows cmd shim names via shared binary helpers', () => {
+    const pathDir = 'C:\\Users\\me\\AppData\\Local\\kimi';
+    const cmdShim = path.join(pathDir, 'kimi.cmd');
+    mockedStat.mockImplementation((filePath: string) => {
+      if (filePath === cmdShim) {
+        return { isFile: () => true };
+      }
+      throw new Error(`ENOENT: ${filePath}`);
+    });
+
+    const resolver = new KimiCliResolver();
+    // On non-Windows CI hosts, findCliBinaryPath still searches .cmd only when platform=win32.
+    // Assert host-scoped configured path resolves the Windows cmd shim.
+    expect(
+      resolver.resolve({ 'current-host': cmdShim }, '', ''),
+    ).toBe(cmdShim);
+  });
+});

--- a/tests/unit/providers/kimi/KimiConversationHistoryService.test.ts
+++ b/tests/unit/providers/kimi/KimiConversationHistoryService.test.ts
@@ -1,0 +1,110 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+  KimiConversationHistoryService,
+  loadKimiHistoryMessages,
+} from '@/providers/kimi/history/KimiConversationHistoryService';
+
+describe('KimiConversationHistoryService', () => {
+  it('preserves session state and never deletes native data', async () => {
+    const service = new KimiConversationHistoryService();
+    const conversation = {
+      id: 'c1',
+      providerId: 'kimi',
+      sessionId: 'sess-1',
+      providerState: { sessionId: 'sess-1', kimiCodeHome: '/tmp/kimi-home' },
+      messages: [],
+    } as any;
+
+    await service.deleteConversationSession(conversation, '/vault');
+    expect(conversation.sessionId).toBe('sess-1');
+
+    const persisted = service.buildPersistedProviderState(conversation);
+    expect(persisted).toEqual({
+      sessionId: 'sess-1',
+      kimiCodeHome: '/tmp/kimi-home',
+    });
+    expect(service.resolveSessionIdForConversation(conversation)).toBe('sess-1');
+  });
+
+  it('loads user and streamed assistant messages from Kimi AgentRecord wire lines', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kimi-hist-'));
+    const file = path.join(dir, 'wire.jsonl');
+    fs.writeFileSync(file, [
+      JSON.stringify({
+        type: 'context.append_message',
+        time: 1100,
+        message: { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+      }),
+      JSON.stringify({
+        type: 'context.append_loop_event',
+        time: 1200,
+        event: { type: 'step.begin', uuid: 'step-1' },
+      }),
+      JSON.stringify({
+        type: 'context.append_loop_event',
+        time: 1201,
+        event: {
+          type: 'content.part',
+          stepUuid: 'step-1',
+          part: { type: 'text', text: 'hel' },
+        },
+      }),
+      JSON.stringify({
+        type: 'context.append_loop_event',
+        time: 1202,
+        event: {
+          type: 'content.part',
+          stepUuid: 'step-1',
+          part: { type: 'text', text: 'lo' },
+        },
+      }),
+      JSON.stringify({
+        type: 'context.append_loop_event',
+        time: 1203,
+        event: { type: 'step.end', stepUuid: 'step-1' },
+      }),
+      JSON.stringify({ type: 'noise' }),
+    ].join('\n'), 'utf-8');
+
+    const messages = loadKimiHistoryMessages(file, 'sess-1', 1000);
+    expect(messages).toHaveLength(2);
+    expect(messages[0].role).toBe('user');
+    expect(messages[0].content).toBe('hi');
+    expect(messages[1].role).toBe('assistant');
+    expect(messages[1].content).toBe('hello');
+    expect(messages[0].timestamp).toBe(1100);
+    expect(messages[1].timestamp).toBe(1200);
+  });
+
+  it('ignores compaction summaries, injections, and tool messages', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kimi-hist-filter-'));
+    const file = path.join(dir, 'wire.jsonl');
+    fs.writeFileSync(file, [
+      JSON.stringify({
+        type: 'context.append_message',
+        message: {
+          role: 'user',
+          origin: { kind: 'compaction_summary' },
+          content: [{ type: 'text', text: 'summary' }],
+        },
+      }),
+      JSON.stringify({
+        type: 'context.append_message',
+        message: {
+          role: 'user',
+          origin: { kind: 'injection' },
+          content: [{ type: 'text', text: 'injected' }],
+        },
+      }),
+      JSON.stringify({
+        type: 'context.append_message',
+        message: { role: 'tool', content: [{ type: 'text', text: 'tool output' }] },
+      }),
+    ].join('\n'), 'utf-8');
+
+    expect(loadKimiHistoryMessages(file, 'sess-1', 1000)).toEqual([]);
+  });
+});

--- a/tests/unit/providers/kimi/KimiHistoryPaths.test.ts
+++ b/tests/unit/providers/kimi/KimiHistoryPaths.test.ts
@@ -1,0 +1,36 @@
+import * as crypto from 'node:crypto';
+import * as path from 'node:path';
+
+import {
+  encodeKimiWorkDirKey,
+  resolveKimiHistoryFile,
+} from '@/providers/kimi/history/KimiHistoryPaths';
+
+describe('encodeKimiWorkDirKey', () => {
+  it('matches Kimi agent-core basename slug and normalized-path hash', () => {
+    const vaultPath = path.resolve('/tmp/My Study Vault');
+    const hash = crypto.createHash('sha256').update(vaultPath).digest('hex').slice(0, 12);
+
+    expect(encodeKimiWorkDirKey(vaultPath)).toBe(`wd_my-study-vault_${hash}`);
+  });
+
+  it('normalizes Windows-shaped paths independent of the current host OS', () => {
+    const normalized = 'C:/Users/Eone/My Vault';
+    const hash = crypto.createHash('sha256').update(normalized).digest('hex').slice(0, 12);
+
+    expect(encodeKimiWorkDirKey('C:\\Users\\Eone\\My Vault')).toBe(
+      `wd_my-vault_${hash}`,
+    );
+  });
+});
+
+describe('resolveKimiHistoryFile', () => {
+  it('rejects path traversal in persisted session ids', () => {
+    expect(resolveKimiHistoryFile('/vault', '../../credentials', {
+      kimiCodeHome: '/tmp/kimi-home',
+    })).toBeNull();
+    expect(resolveKimiHistoryFile('/vault', '..\\..\\credentials', {
+      kimiCodeHome: '/tmp/kimi-home',
+    })).toBeNull();
+  });
+});

--- a/tests/unit/providers/kimi/KimiSettingsReconciler.test.ts
+++ b/tests/unit/providers/kimi/KimiSettingsReconciler.test.ts
@@ -1,0 +1,37 @@
+import { kimiSettingsReconciler } from '@/providers/kimi/env/KimiSettingsReconciler';
+
+describe('kimiSettingsReconciler.reconcileModelWithEnvironment', () => {
+  it('persists a digest instead of copying Kimi secrets into provider settings', () => {
+    const settings: Record<string, unknown> = {
+      providerConfigs: {
+        kimi: {
+          enabled: true,
+          environmentHash: '',
+          environmentVariables: [
+            'KIMI_CODE_HOME=/tmp/kimi-home',
+            'KIMI_API_KEY=super-secret-value',
+          ].join('\n'),
+        },
+      },
+    };
+    const conversations = [{
+      id: 'conv-kimi',
+      messages: [],
+      providerId: 'kimi',
+      providerState: { sessionId: 'session-1' },
+      sessionId: 'session-1',
+    }] as any;
+
+    const first = kimiSettingsReconciler.reconcileModelWithEnvironment(settings, conversations);
+    const persistedHash = (settings.providerConfigs as any).kimi.environmentHash as string;
+
+    expect(first.changed).toBe(true);
+    expect(first.invalidatedConversations).toHaveLength(1);
+    expect(conversations[0].sessionId).toBeNull();
+    expect(persistedHash).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(persistedHash).not.toContain('super-secret-value');
+
+    const second = kimiSettingsReconciler.reconcileModelWithEnvironment(settings, conversations);
+    expect(second).toEqual({ changed: false, invalidatedConversations: [] });
+  });
+});

--- a/tests/unit/providers/kimi/buildKimiPrompt.test.ts
+++ b/tests/unit/providers/kimi/buildKimiPrompt.test.ts
@@ -1,0 +1,27 @@
+import { buildKimiPromptBlocks } from '@/providers/kimi/runtime/buildKimiPrompt';
+
+describe('buildKimiPromptBlocks', () => {
+  it('includes image and external context resource_link blocks', () => {
+    const blocks = buildKimiPromptBlocks({
+      text: 'hello',
+      images: [
+        { data: 'base64data', mediaType: 'image/png' } as any,
+      ],
+      externalContextPaths: ['/vault/note.md'],
+    } as any);
+
+    expect(blocks[0]).toEqual({ type: 'text', text: 'hello' });
+    expect(blocks).toEqual(expect.arrayContaining([
+      {
+        type: 'image',
+        data: 'base64data',
+        mimeType: 'image/png',
+      },
+      {
+        type: 'resource_link',
+        name: 'note.md',
+        uri: 'file:///vault/note.md',
+      },
+    ]));
+  });
+});

--- a/tests/unit/providers/kimi/capabilities.test.ts
+++ b/tests/unit/providers/kimi/capabilities.test.ts
@@ -1,0 +1,20 @@
+import { KIMI_PROVIDER_CAPABILITIES } from '@/providers/kimi/capabilities';
+
+describe('KIMI_PROVIDER_CAPABILITIES', () => {
+  it('declares conservative but real ACP capabilities', () => {
+    expect(KIMI_PROVIDER_CAPABILITIES).toMatchObject({
+      providerId: 'kimi',
+      supportsPersistentRuntime: true,
+      supportsNativeHistory: true,
+      supportsPlanMode: true,
+      supportsRewind: false,
+      supportsFork: false,
+      supportsProviderCommands: true,
+      supportsImageAttachments: true,
+      supportsInstructionMode: true,
+      supportsMcpTools: false,
+      supportsTurnSteer: false,
+      reasoningControl: 'effort',
+    });
+  });
+});

--- a/tests/unit/providers/kimi/models.test.ts
+++ b/tests/unit/providers/kimi/models.test.ts
@@ -1,0 +1,36 @@
+import {
+  decodeKimiModelId,
+  encodeKimiModelId,
+  isKimiModelSelectionId,
+  KIMI_SYNTHETIC_MODEL_ID,
+  normalizeKimiDiscoveredModels,
+  normalizeKimiModelVariants,
+} from '@/providers/kimi/models';
+
+describe('kimi models', () => {
+  it('namespaces model ids as Kimi-owned', () => {
+    expect(encodeKimiModelId('kimi-code/k3')).toBe('kimi:kimi-code/k3');
+    expect(decodeKimiModelId('kimi:kimi-code/k3')).toBe('kimi-code/k3');
+    expect(isKimiModelSelectionId(KIMI_SYNTHETIC_MODEL_ID)).toBe(true);
+    expect(isKimiModelSelectionId('claude-sonnet')).toBe(false);
+  });
+
+  it('normalizes discovered models and thinking variants', () => {
+    expect(normalizeKimiDiscoveredModels([
+      { rawId: 'kimi-code/k3', label: 'K3', description: 'default' },
+      { id: 'kimi-plain', name: 'Plain' },
+      { rawId: 'kimi-code/k3', label: 'dup' },
+    ])).toEqual([
+      { rawId: 'kimi-code/k3', label: 'K3', description: 'default' },
+      { rawId: 'kimi-plain', label: 'Plain' },
+    ]);
+
+    expect(normalizeKimiModelVariants([
+      { value: 'off', name: 'Thinking Off' },
+      { id: 'on', label: 'Thinking On' },
+    ])).toEqual([
+      { value: 'off', label: 'Thinking Off' },
+      { value: 'on', label: 'Thinking On' },
+    ]);
+  });
+});

--- a/tests/unit/providers/kimi/modes.test.ts
+++ b/tests/unit/providers/kimi/modes.test.ts
@@ -1,0 +1,19 @@
+import {
+  resolveKimiModeForPermissionMode,
+  resolvePermissionModeForKimiMode,
+} from '@/providers/kimi/modes';
+
+describe('kimi modes', () => {
+  it('maps shared permission modes onto Kimi ACP modes', () => {
+    expect(resolveKimiModeForPermissionMode('normal')).toBe('default');
+    expect(resolveKimiModeForPermissionMode('plan')).toBe('plan');
+    expect(resolveKimiModeForPermissionMode('yolo')).toBe('yolo');
+  });
+
+  it('maps Kimi modes back to shared permission modes', () => {
+    expect(resolvePermissionModeForKimiMode('default')).toBe('normal');
+    expect(resolvePermissionModeForKimiMode('plan')).toBe('plan');
+    expect(resolvePermissionModeForKimiMode('yolo')).toBe('yolo');
+    expect(resolvePermissionModeForKimiMode('auto')).toBe('yolo');
+  });
+});

--- a/tests/unit/providers/kimi/registration.test.ts
+++ b/tests/unit/providers/kimi/registration.test.ts
@@ -1,0 +1,20 @@
+import '@/providers';
+
+import { kimiProviderRegistration } from '@/providers/kimi/registration';
+import { DEFAULT_KIMI_PROVIDER_SETTINGS } from '@/providers/kimi/settings';
+import { piProviderRegistration } from '@/providers/pi/registration';
+
+describe('kimiProviderRegistration', () => {
+  it('registers as disabled optional provider after current providers', () => {
+    expect(kimiProviderRegistration.id).toBe('kimi');
+    expect(kimiProviderRegistration.displayName).toBe('Kimi Code');
+    expect(DEFAULT_KIMI_PROVIDER_SETTINGS.enabled).toBe(false);
+    expect(kimiProviderRegistration.blankTabOrder).toBeGreaterThan(piProviderRegistration.blankTabOrder);
+    expect(kimiProviderRegistration.isEnabled({
+      providerConfigs: { kimi: { enabled: false } },
+    })).toBe(false);
+    expect(kimiProviderRegistration.capabilities.supportsPersistentRuntime).toBe(true);
+    expect(kimiProviderRegistration.capabilities.supportsMcpTools).toBe(false);
+    expect(kimiProviderRegistration.capabilities.supportsRewind).toBe(false);
+  });
+});

--- a/tests/unit/providers/kimi/settings.test.ts
+++ b/tests/unit/providers/kimi/settings.test.ts
@@ -1,0 +1,60 @@
+import {
+  DEFAULT_KIMI_PROVIDER_SETTINGS,
+  getKimiProviderSettings,
+  updateKimiProviderSettings,
+} from '@/providers/kimi/settings';
+
+jest.mock('@/utils/env', () => ({
+  ...jest.requireActual('@/utils/env'),
+  getHostnameKey: () => 'current-host',
+  getLegacyHostnameKey: () => 'legacy-host',
+}));
+
+describe('kimi settings', () => {
+  it('defaults to disabled with empty host paths', () => {
+    const settings = getKimiProviderSettings({});
+    expect(settings.enabled).toBe(false);
+    expect(settings.cliPath).toBe('');
+    expect(settings.cliPathsByHost).toEqual({});
+    expect(DEFAULT_KIMI_PROVIDER_SETTINGS.enabled).toBe(false);
+  });
+
+  it('normalizes host-scoped CLI paths and migrates legacy cliPath writes', () => {
+    const bag: Record<string, unknown> = {};
+    updateKimiProviderSettings(bag, {
+      cliPath: '/opt/kimi',
+      enabled: true,
+    });
+
+    const settings = getKimiProviderSettings(bag);
+    expect(settings.enabled).toBe(true);
+    expect(settings.cliPathsByHost['current-host']).toBe('/opt/kimi');
+    expect(settings.cliPath).toBe('');
+  });
+
+  it('updates host path map without clobbering other hosts', () => {
+    const bag: Record<string, unknown> = {
+      providerConfigs: {
+        kimi: {
+          enabled: true,
+          cliPathsByHost: {
+            'other-host': '/other/kimi',
+          },
+        },
+      },
+    };
+
+    updateKimiProviderSettings(bag, {
+      cliPathsByHost: {
+        'other-host': '/other/kimi',
+        'current-host': '/current/kimi',
+      },
+    });
+
+    const settings = getKimiProviderSettings(bag);
+    expect(settings.cliPathsByHost).toEqual({
+      'other-host': '/other/kimi',
+      'current-host': '/current/kimi',
+    });
+  });
+});

--- a/tests/unit/shared/icons.test.ts
+++ b/tests/unit/shared/icons.test.ts
@@ -2,6 +2,7 @@
 
 import {
   createProviderIconSvg,
+  KIMI_PROVIDER_ICON,
   OPENAI_PROVIDER_ICON,
   OPENCODE_PROVIDER_ICON,
   PI_PROVIDER_ICON,
@@ -52,5 +53,16 @@ describe('createProviderIconSvg', () => {
     expect(paths).toHaveLength(2);
     expect(paths[0].getAttribute('fill-rule')).toBe('evenodd');
     expect(paths.every(path => path.getAttribute('fill') === 'currentColor')).toBe(true);
+  });
+
+  it('renders the Kimi provider icon as a composite mark', () => {
+    const svg = createProviderIconSvg(KIMI_PROVIDER_ICON, {
+      dataProvider: 'kimi',
+      parent: document.body,
+    });
+
+    expect(svg.getAttribute('viewBox')).toBe('0 0 24 24');
+    expect(svg.getAttribute('data-provider')).toBe('kimi');
+    expect(svg.querySelectorAll('path').length).toBeGreaterThanOrEqual(2);
   });
 });


### PR DESCRIPTION
## Summary

Adds Kimi Code as a first-class, opt-in Claudian provider using the official `kimi acp` protocol.

- starts and supervises `kimi acp` through Claudian's shared ACP transport
- supports persistent sessions, `session/new` / `session/load`, cancellation, text/thinking/tool streams, usage, images, commands, and reverse filesystem RPC
- discovers models, thinking options, and `default` / `plan` / `auto` / `yolo` modes dynamically from ACP `configOptions`
- preserves Kimi permission option IDs, including Plan Review's distinct `plan_*` choices
- provides CLI discovery, provider settings/UI, native history hydration, title generation, inline edit, and instruction refinement
- keeps Kimi credentials and `config.toml` owned by the official CLI; authentication errors direct users to `kimi login`
- keeps the provider disabled by default

## Data safety

- Claudian does not read or write Kimi credential files.
- Native session history is read-only; deleting Claudian metadata does not delete Kimi sessions.
- `KIMI_API_KEY` / `MOONSHOT_API_KEY` values are never copied into provider settings; environment invalidation stores only a SHA-256 digest.
- Tests use a local fixture ACP child and do not make paid API requests.

## Verification

Passed on the final commit:

- `npm run typecheck`
- `npm run lint`
- `npm run test:architecture` — 5/5
- `npm run build`
- focused Kimi/provider/integration gate — 17 suites, 59 tests
- Kimi-only gate — 13 suites, 44 tests
- real isolated Kimi Code 0.27.0 ACP probe:
  - protocol version 1
  - agent `Kimi Code CLI 0.27.0`
  - auth method `login`
  - unauthenticated `session/new` returns `-32000 Authentication required`

Full Jest run: 284 suites / 6240 tests passed; one unrelated Codex WSL test fails on this WSL host (`CodexLaunchSpecBuilder` default-distro negative case). The exact same failure reproduces on the unmodified upstream `main` worktree.

## Requirements

Install Kimi Code >= 0.27.0 and authenticate with `kimi login` outside Claudian when required.
