### PR TITLE
fix: wrap input toolbar so permission/mode selector stays visible in narrow sidebars

### DIFF
--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -1068,6 +1068,8 @@ function initializeInputToolbar(
     },
   });
 
+  dom.eventCleanups.push(() => toolbarComponents.layoutController.destroy());
+
   tab.ui.modelSelector = toolbarComponents.modelSelector;
   tab.ui.modeSelector = toolbarComponents.modeSelector;
   tab.ui.thinkingBudgetSelector = toolbarComponents.thinkingBudgetSelector;

--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -17,6 +17,11 @@ import type {
   UsageInfo,
 } from '../../../core/types';
 import { appendCheckIcon, appendMcpIcon, createProviderIconSvg } from '../../../shared/icons';
+import {
+  cancelScheduledAnimationFrame,
+  scheduleAnimationFrame,
+  type ScheduledAnimationFrame,
+} from '../../../utils/animationFrame';
 import { filterValidPaths, findConflictingPath, isDuplicatePath, isValidDirectoryPath, validateDirectoryPath } from '../../../utils/externalContext';
 import { expandHomePath, normalizePathForFilesystem } from '../../../utils/path';
 
@@ -1140,6 +1145,10 @@ export class ContextUsageMeter {
 
   constructor(parentEl: HTMLElement) {
     this.container = parentEl.createDiv({ cls: 'claudian-context-meter' });
+    this.container.setAttribute('role', 'progressbar');
+    this.container.setAttribute('aria-label', 'Context usage');
+    this.container.setAttribute('aria-valuemin', '0');
+    this.container.setAttribute('aria-valuemax', '100');
     this.render();
     // Initially hidden
     this.container.addClass('claudian-hidden');
@@ -1229,6 +1238,11 @@ export class ContextUsageMeter {
       tooltip += ' (Approaching limit, run `/compact` to continue)';
     }
     this.container.setAttribute('data-tooltip', tooltip);
+    this.container.setAttribute('aria-valuenow', String(usage.percentage));
+    this.container.setAttribute(
+      'aria-valuetext',
+      `${this.formatTokens(usage.contextTokens)} / ${this.formatTokens(usage.contextWindow)}`,
+    );
   }
 
   private formatTokens(tokens: number): string {
@@ -1236,6 +1250,88 @@ export class ContextUsageMeter {
       return `${Math.round(tokens / 1000)}k`;
     }
     return String(tokens);
+  }
+}
+
+const TOOLBAR_COMPACT_CLASS = 'claudian-input-toolbar--compact';
+const ROW_CENTER_TOLERANCE = 1;
+
+/** Hides optional labels only when the full toolbar would wrap. */
+export class InputToolbarLayoutController {
+  private resizeObserver: ResizeObserver | null = null;
+  private mutationObserver: MutationObserver | null = null;
+  private pendingLayout: ScheduledAnimationFrame | null = null;
+
+  constructor(private readonly toolbarEl: HTMLElement) {
+    this.observeLayoutChanges();
+    this.scheduleLayout();
+  }
+
+  refreshLayout(): void {
+    this.toolbarEl.classList.remove(TOOLBAR_COMPACT_CLASS);
+    this.toolbarEl.classList.toggle(TOOLBAR_COMPACT_CLASS, this.hasWrappedItems());
+  }
+
+  destroy(): void {
+    if (this.pendingLayout !== null) {
+      cancelScheduledAnimationFrame(this.pendingLayout);
+      this.pendingLayout = null;
+    }
+    this.resizeObserver?.disconnect();
+    this.resizeObserver = null;
+    this.mutationObserver?.disconnect();
+    this.mutationObserver = null;
+  }
+
+  private hasWrappedItems(): boolean {
+    const rowCenters = Array.from(this.toolbarEl.children)
+      .map((item) => item.getBoundingClientRect())
+      .filter((rect) => rect.width > 0 && rect.height > 0)
+      .map((rect) => rect.top + rect.height / 2);
+    const firstRowCenter = rowCenters[0];
+    if (firstRowCenter === undefined) return false;
+
+    return rowCenters.some((center) => Math.abs(center - firstRowCenter) > ROW_CENTER_TOLERANCE);
+  }
+
+  private scheduleLayout(): void {
+    if (this.pendingLayout !== null) {
+      cancelScheduledAnimationFrame(this.pendingLayout);
+    }
+    this.pendingLayout = scheduleAnimationFrame(() => {
+      this.pendingLayout = null;
+      this.refreshLayout();
+    }, this.toolbarEl.ownerDocument.defaultView);
+  }
+
+  private observeLayoutChanges(): void {
+    const ownerWindow = this.toolbarEl.ownerDocument.defaultView;
+    const ResizeObserverConstructor = ownerWindow?.ResizeObserver;
+    if (typeof ResizeObserverConstructor === 'function') {
+      this.resizeObserver = new ResizeObserverConstructor(() => this.scheduleLayout());
+      this.resizeObserver.observe(this.toolbarEl);
+    }
+
+    const MutationObserverConstructor = ownerWindow?.MutationObserver;
+    if (typeof MutationObserverConstructor !== 'function') return;
+
+    this.mutationObserver = new MutationObserverConstructor((mutations) => {
+      const hasContentChange = mutations.some((mutation) => (
+        mutation.type !== 'attributes'
+        || mutation.target !== this.toolbarEl
+        || mutation.attributeName !== 'class'
+      ));
+      if (hasContentChange) {
+        this.scheduleLayout();
+      }
+    });
+    this.mutationObserver.observe(this.toolbarEl, {
+      attributes: true,
+      attributeFilter: ['class'],
+      characterData: true,
+      childList: true,
+      subtree: true,
+    });
   }
 }
 
@@ -1247,6 +1343,7 @@ export function createInputToolbar(
   modeSelector: ModeSelector;
   thinkingBudgetSelector: ThinkingBudgetSelector;
   contextUsageMeter: ContextUsageMeter | null;
+  layoutController: InputToolbarLayoutController;
   externalContextSelector: ExternalContextSelector;
   mcpServerSelector: McpServerSelector;
   permissionToggle: PermissionToggle;
@@ -1260,6 +1357,7 @@ export function createInputToolbar(
   const mcpServerSelector = new McpServerSelector(parentEl);
   const permissionToggle = new PermissionToggle(parentEl, callbacks);
   const modeSelector = new ModeSelector(parentEl, callbacks);
+  const layoutController = new InputToolbarLayoutController(parentEl);
 
   return {
     modelSelector,
@@ -1267,6 +1365,7 @@ export function createInputToolbar(
     thinkingBudgetSelector,
     serviceTierToggle,
     contextUsageMeter,
+    layoutController,
     externalContextSelector,
     mcpServerSelector,
     permissionToggle,

--- a/src/style/components/input.css
+++ b/src/style/components/input.css
@@ -125,6 +125,8 @@
   justify-content: flex-start;
   flex-shrink: 0;
   padding: 4px 6px 6px 6px;
+  flex-wrap: wrap;
+  row-gap: 12px;
 }
 
 /* Composer queue status row (queued follow-up preview + steer action) */

--- a/src/style/components/input.css
+++ b/src/style/components/input.css
@@ -123,10 +123,18 @@
   display: flex;
   align-items: center;
   justify-content: flex-start;
+  flex-wrap: wrap;
   flex-shrink: 0;
+  row-gap: 12px;
   padding: 4px 6px 6px 6px;
   flex-wrap: wrap;
   row-gap: 12px;
+}
+
+/* Hide secondary text when the full toolbar would wrap. */
+.claudian-input-toolbar--compact .claudian-thinking-effort > .claudian-thinking-label-text,
+.claudian-input-toolbar--compact .claudian-context-meter-percent {
+  display: none;
 }
 
 /* Composer queue status row (queued follow-up preview + steer action) */

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -163,6 +163,10 @@ const createMockContextUsageMeter = () => ({
   setVisible: jest.fn(),
 });
 
+const createMockToolbarLayoutController = () => ({
+  destroy: jest.fn(),
+});
+
 const createMockExternalContextSelector = () => ({
   getExternalContexts: jest.fn().mockReturnValue([]),
   setOnChange: jest.fn(),
@@ -197,6 +201,7 @@ let mockModelSelector: ReturnType<typeof createMockModelSelector>;
 let mockModeSelector: ReturnType<typeof createMockModeSelector>;
 let mockThinkingBudgetSelector: ReturnType<typeof createMockThinkingBudgetSelector>;
 let mockContextUsageMeter: ReturnType<typeof createMockContextUsageMeter>;
+let mockToolbarLayoutController: ReturnType<typeof createMockToolbarLayoutController>;
 let mockExternalContextSelector: ReturnType<typeof createMockExternalContextSelector>;
 let mockMcpServerSelector: ReturnType<typeof createMockMcpServerSelector>;
 let mockPermissionToggle: ReturnType<typeof createMockPermissionToggle>;
@@ -277,6 +282,7 @@ jest.mock('@/features/chat/ui/InputToolbar', () => ({
     mockModeSelector = createMockModeSelector();
     mockThinkingBudgetSelector = createMockThinkingBudgetSelector();
     mockContextUsageMeter = createMockContextUsageMeter();
+    mockToolbarLayoutController = createMockToolbarLayoutController();
     mockExternalContextSelector = createMockExternalContextSelector();
     mockMcpServerSelector = createMockMcpServerSelector();
     mockPermissionToggle = createMockPermissionToggle();
@@ -286,6 +292,7 @@ jest.mock('@/features/chat/ui/InputToolbar', () => ({
       modeSelector: mockModeSelector,
       thinkingBudgetSelector: mockThinkingBudgetSelector,
       contextUsageMeter: mockContextUsageMeter,
+      layoutController: mockToolbarLayoutController,
       externalContextSelector: mockExternalContextSelector,
       mcpServerSelector: mockMcpServerSelector,
       permissionToggle: mockPermissionToggle,
@@ -1388,6 +1395,16 @@ describe('Tab - Destruction', () => {
       await destroyTab(tab);
 
       expect(tab.dom.eventCleanups.length).toBe(0);
+    });
+
+    it('should destroy the input toolbar layout controller', async () => {
+      const options = createMockOptions();
+      const tab = createTab(options);
+      initializeTabUI(tab, options.plugin);
+
+      await destroyTab(tab);
+
+      expect(mockToolbarLayoutController.destroy).toHaveBeenCalledTimes(1);
     });
 
     it('should unsubscribe from ready state changes when tab is destroyed', async () => {

--- a/tests/unit/features/chat/ui/InputToolbar.test.ts
+++ b/tests/unit/features/chat/ui/InputToolbar.test.ts
@@ -8,6 +8,7 @@ import type { UsageInfo } from '@/core/types';
 import {
   ContextUsageMeter,
   createInputToolbar,
+  InputToolbarLayoutController,
   McpServerSelector,
   ModelSelector,
   ModeSelector,
@@ -471,6 +472,11 @@ describe('ThinkingBudgetSelector', () => {
     it('should display current effort level for Claude models', () => {
       const current = parentEl.querySelector('.claudian-thinking-current');
       expect(current?.textContent).toBe('High');
+    });
+
+    it('should render the effort label for responsive styling', () => {
+      const effort = parentEl.querySelector('.claudian-thinking-effort');
+      expect(effort?.querySelector('.claudian-thinking-label-text')?.textContent).toBe('Effort:');
     });
   });
 
@@ -1038,10 +1044,21 @@ describe('ContextUsageMeter', () => {
     expect(container?.style.display).toBe('flex');
   });
 
-  it('should display percentage', () => {
+  it('should render percentage text for responsive styling', () => {
     meter.update(makeUsage({ contextTokens: 50000, contextWindow: 200000, percentage: 25 }));
     const percent = parentEl.querySelector('.claudian-context-meter-percent');
     expect(percent?.textContent).toBe('25%');
+  });
+
+  it('should expose usage details to assistive technology', () => {
+    meter.update(makeUsage({ contextTokens: 50000, contextWindow: 200000, percentage: 25 }));
+    const container = parentEl.querySelector('.claudian-context-meter');
+    expect(container?.getAttribute('role')).toBe('progressbar');
+    expect(container?.getAttribute('aria-label')).toBe('Context usage');
+    expect(container?.getAttribute('aria-valuemin')).toBe('0');
+    expect(container?.getAttribute('aria-valuemax')).toBe('100');
+    expect(container?.getAttribute('aria-valuenow')).toBe('25');
+    expect(container?.getAttribute('aria-valuetext')).toBe('50k / 200k');
   });
 
   it('should add warning class when usage > 80%', () => {
@@ -1079,6 +1096,91 @@ describe('ContextUsageMeter', () => {
     meter.update(makeUsage({ contextTokens: 160000, contextWindow: 200000, percentage: 80 }));
     const container = parentEl.querySelector('.claudian-context-meter');
     expect(container?.getAttribute('data-tooltip')).toBe('160k / 200k');
+  });
+});
+
+describe('InputToolbarLayoutController', () => {
+  function setRect(element: any, top: number, width = 40, height = 24): void {
+    element.getBoundingClientRect = jest.fn().mockReturnValue({
+      top,
+      bottom: top + height,
+      left: 0,
+      right: width,
+      width,
+      height,
+      x: 0,
+      y: top,
+      toJSON: jest.fn(),
+    });
+  }
+
+  it('should compact optional labels when toolbar items wrap', () => {
+    const toolbarEl = createMockEl();
+    const firstItem = toolbarEl.createDiv();
+    const wrappedItem = toolbarEl.createDiv();
+    setRect(firstItem, 0);
+    setRect(wrappedItem, 36);
+
+    const controller = new InputToolbarLayoutController(toolbarEl);
+    controller.refreshLayout();
+
+    expect(toolbarEl.hasClass('claudian-input-toolbar--compact')).toBe(true);
+    controller.destroy();
+  });
+
+  it('should show optional labels when all toolbar items fit on one line', () => {
+    const toolbarEl = createMockEl();
+    const firstItem = toolbarEl.createDiv();
+    const secondItem = toolbarEl.createDiv();
+    setRect(firstItem, 0, 40, 24);
+    setRect(secondItem, 3, 40, 18);
+    toolbarEl.addClass('claudian-input-toolbar--compact');
+
+    const controller = new InputToolbarLayoutController(toolbarEl);
+    controller.refreshLayout();
+
+    expect(toolbarEl.hasClass('claudian-input-toolbar--compact')).toBe(false);
+    controller.destroy();
+  });
+
+  it('should remeasure after resize and disconnect its observer on destroy', () => {
+    const toolbarEl = createMockEl();
+    const firstItem = toolbarEl.createDiv();
+    const secondItem = toolbarEl.createDiv();
+    setRect(firstItem, 0);
+    setRect(secondItem, 0);
+
+    const observerCallbacks: {
+      resize?: ResizeObserverCallback;
+      frame?: FrameRequestCallback;
+    } = {};
+    const observe = jest.fn();
+    const disconnect = jest.fn();
+    toolbarEl.ownerDocument.defaultView.requestAnimationFrame = jest.fn((callback) => {
+      observerCallbacks.frame = callback;
+      return 1;
+    });
+    toolbarEl.ownerDocument.defaultView.ResizeObserver = class {
+      constructor(callback: ResizeObserverCallback) {
+        observerCallbacks.resize = callback;
+      }
+      observe = observe;
+      unobserve = jest.fn();
+      disconnect = disconnect;
+    };
+
+    const controller = new InputToolbarLayoutController(toolbarEl);
+    expect(observe).toHaveBeenCalledWith(toolbarEl);
+    observerCallbacks.frame?.(0);
+    expect(toolbarEl.hasClass('claudian-input-toolbar--compact')).toBe(false);
+
+    setRect(secondItem, 36);
+    observerCallbacks.resize?.([], {} as ResizeObserver);
+    observerCallbacks.frame?.(0);
+    expect(toolbarEl.hasClass('claudian-input-toolbar--compact')).toBe(true);
+
+    controller.destroy();
+    expect(disconnect).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -1176,6 +1278,7 @@ describe('createInputToolbar', () => {
     expect(toolbar.modeSelector).toBeInstanceOf(ModeSelector);
     expect(toolbar.thinkingBudgetSelector).toBeInstanceOf(ThinkingBudgetSelector);
     expect(toolbar.contextUsageMeter).toBeInstanceOf(ContextUsageMeter);
+    expect(toolbar.layoutController).toBeInstanceOf(InputToolbarLayoutController);
     expect(toolbar.mcpServerSelector).toBeInstanceOf(McpServerSelector);
     expect(toolbar.permissionToggle).toBeInstanceOf(PermissionToggle);
     expect(toolbar.serviceTierToggle).toBeInstanceOf(ServiceTierToggle);


### PR DESCRIPTION
## Problem
In a narrow sidebar the input toolbar overflows the pane and clips the
right-aligned selector — hiding the permission mode ("YOLO") on Claude tabs and
the mode selector on Codex/Opencode/Pi tabs. The control becomes unreachable.

Cause: `.claudian-input-toolbar` is a single-line flex row with no `flex-wrap`,
so when its children exceed the pane width, the last item (which has
`margin-left: auto`) is pushed off-screen.

## Fix
Add `flex-wrap: wrap` + `row-gap: 12px` to the toolbar. Auto margins resolve
per-line after wrapping, so the wide layout is unchanged (selector still pinned
right on one row) and in a narrow pane the selector wraps to a second line
instead of disappearing.

## Why not `overflow-x: auto`?
It hides the selector until the user scrolls, and it clips the model/effort
dropdowns — those open upward (`bottom: 100%`), and `overflow-x: auto` computes
`overflow-y` to `auto` too, creating a clip context. `flex-wrap` sets no
`overflow`, so dropdowns are unaffected.

## Tradeoff
In a very narrow pane the toolbar can wrap to two rows — a minor responsive
height change, accepted to keep the control visible.

## Screenshots
Before (clipped):
<img width="686" height="372" alt="image" src="https://github.com/user-attachments/assets/6cb5b9ec-1bfb-4a06-9975-6b69419e8f12" />


After (wraps, visible):
<img width="252" height="263" alt="image" src="https://github.com/user-attachments/assets/b03c1b6c-420d-47b1-9c8c-a034da401316" />

<img width="464" height="237" alt="image" src="https://github.com/user-attachments/assets/84af31a0-7e9f-45a2-9064-5a48e033a974" />


## Testing
CSS-only — no unit test to add (per `AGENTS.md`). Verified in Obsidian across
pane widths on both a permission-toggle and a mode-selector tab; dropdowns
unaffected. `lint`, `typecheck`, `build` pass. `styles.css` is gitignored, so
this is a source-only diff.