### PR TITLE
feat: add file explorer action for Claudian mentions

### DIFF
--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -836,6 +836,25 @@ export class ClaudianView extends ItemView {
     return this.tabManager?.getActiveTab() ?? null;
   }
 
+  /** Appends text to the active composer without sending it. */
+  appendToActiveInput(text: string): boolean {
+    const inputEl = this.tabManager?.getActiveTab()?.dom.inputEl;
+    if (!inputEl || !text) return false;
+
+    const currentValue = inputEl.value;
+    const separator = currentValue && !/\s$/.test(currentValue) ? ' ' : '';
+    inputEl.value = `${currentValue}${separator}${text}`;
+
+    const cursorPosition = inputEl.value.length;
+    inputEl.selectionStart = cursorPosition;
+    inputEl.selectionEnd = cursorPosition;
+
+    const EventConstructor = inputEl.ownerDocument.defaultView?.Event ?? Event;
+    inputEl.dispatchEvent(new EventConstructor('input', { bubbles: true }));
+    inputEl.focus();
+    return true;
+  }
+
   notifyConversationListChanged(): void {
     this.updateHistoryDropdown();
   }

--- a/src/features/chat/fileMenu.ts
+++ b/src/features/chat/fileMenu.ts
@@ -1,0 +1,42 @@
+import type { App, EventRef } from 'obsidian';
+import { Notice, TFile } from 'obsidian';
+
+import { formatVaultFileMention } from '../../shared/mention/formatMention';
+
+interface FileMenuViewHost {
+  appendToActiveInput(text: string): boolean;
+}
+
+export interface FileMenuHost {
+  readonly app: App;
+  activateView(): Promise<void>;
+  getView(): FileMenuViewHost | null;
+  registerEvent(eventRef: EventRef): void;
+}
+
+export async function addFileToClaudian(host: FileMenuHost, file: TFile): Promise<boolean> {
+  try {
+    await host.activateView();
+    const appended = host.getView()?.appendToActiveInput(formatVaultFileMention(file.path)) ?? false;
+    if (!appended) {
+      new Notice('Claudian chat is not ready.');
+    }
+    return appended;
+  } catch {
+    new Notice('Failed to add file to Claudian.');
+    return false;
+  }
+}
+
+export function registerFileMenu(host: FileMenuHost): void {
+  host.registerEvent(
+    host.app.workspace.on('file-menu', (menu, file) => {
+      if (!(file instanceof TFile)) return;
+
+      menu.addItem((item) => item
+        .setTitle('Add to Claudian')
+        .setIcon('message-square-plus')
+        .onClick(() => addFileToClaudian(host, file)));
+    }),
+  );
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,7 @@ import {
 } from './core/types';
 import type { ChatViewPlacement, EnvironmentScope } from './core/types/settings';
 import { ClaudianView } from './features/chat/ClaudianView';
+import { registerFileMenu } from './features/chat/fileMenu';
 import { type InlineEditContext, InlineEditModal } from './features/inline-edit/ui/InlineEditModal';
 import { ClaudianSettingTab } from './features/settings/ClaudianSettings';
 import { setLocale } from './i18n/i18n';
@@ -133,6 +134,7 @@ export default class ClaudianPlugin extends Plugin {
         VIEW_TYPE_CLAUDIAN,
         (leaf) => new ClaudianView(leaf, this)
       );
+      registerFileMenu(this);
 
       this.addRibbonIcon('bot', 'Open Claudian', () => {
         void this.activateView();

--- a/src/shared/mention/MentionDropdownController.ts
+++ b/src/shared/mention/MentionDropdownController.ts
@@ -6,6 +6,7 @@ import { type ExternalContextFile, externalContextScanner } from '../../utils/ex
 import { extractMcpMentions } from '../../utils/mcp';
 import { SelectableDropdown } from '../components/SelectableDropdown';
 import { appendMcpIcon } from '../icons';
+import { formatVaultFileMention } from './formatMention';
 import {
   type AgentMentionProvider,
   type FolderMentionItem,
@@ -706,7 +707,11 @@ export class MentionDropdownController {
         if (normalizedPath) {
           this.callbacks.onAttachFile(normalizedPath);
         }
-        this.insertReplacement(beforeAt, `@${normalizedPath ?? selectedItem.name} `, afterCursor);
+        this.insertReplacement(
+          beforeAt,
+          formatVaultFileMention(normalizedPath ?? selectedItem.name),
+          afterCursor,
+        );
         break;
       }
     }

--- a/src/shared/mention/formatMention.ts
+++ b/src/shared/mention/formatMention.ts
@@ -1,0 +1,3 @@
+export function formatVaultFileMention(path: string): string {
+  return `@${path} `;
+}

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -13,6 +13,7 @@ export class Plugin {
   addCommand = jest.fn();
   addSettingTab = jest.fn();
   registerView = jest.fn();
+  registerEvent = jest.fn();
   loadData = jest.fn().mockResolvedValue({});
   saveData = jest.fn().mockResolvedValue(undefined);
 }

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -83,6 +83,7 @@ describe('ClaudianPlugin', () => {
         },
       },
       workspace: {
+        on: jest.fn().mockReturnValue({ id: 'workspace-event' }),
         onLayoutReady: jest.fn(),
         getLeavesOfType: jest.fn().mockReturnValue([]),
         getRightLeaf: jest.fn().mockReturnValue({
@@ -148,6 +149,16 @@ describe('ClaudianPlugin', () => {
         name: 'Open chat view',
         callback: expect.any(Function),
       });
+    });
+
+    it('registers the file explorer context menu', async () => {
+      await plugin.onload();
+
+      expect(mockApp.workspace.on).toHaveBeenCalledWith(
+        'file-menu',
+        expect.any(Function),
+      );
+      expect(plugin.registerEvent).toHaveBeenCalledWith({ id: 'workspace-event' });
     });
 
     it('loads restored-tab metadata without waiting for the full history scan', async () => {

--- a/tests/unit/features/chat/ClaudianView.test.ts
+++ b/tests/unit/features/chat/ClaudianView.test.ts
@@ -270,6 +270,59 @@ describe('ClaudianView tab controls', () => {
   });
 });
 
+describe('ClaudianView composer input', () => {
+  function createComposerHarness(existingContent: string): {
+    inputEl: HTMLTextAreaElement;
+    inputHandler: jest.Mock;
+    view: any;
+  } {
+    const inputEl = createMockEl('textarea') as unknown as HTMLTextAreaElement;
+    const inputHandler = jest.fn();
+    inputEl.value = existingContent;
+    inputEl.selectionStart = 0;
+    inputEl.selectionEnd = 0;
+    inputEl.focus = jest.fn();
+    inputEl.addEventListener('input', inputHandler);
+
+    const view = Object.create(ClaudianView.prototype) as any;
+    view.tabManager = {
+      getActiveTab: jest.fn().mockReturnValue({ dom: { inputEl } }),
+    };
+
+    return { inputEl, inputHandler, view };
+  }
+
+  it('appends text after existing composer content', () => {
+    const { inputEl, inputHandler, view } = createComposerHarness('Review this note');
+
+    const appended = view.appendToActiveInput('@projects/plan.md ');
+
+    expect(appended).toBe(true);
+    expect(inputEl.value).toBe('Review this note @projects/plan.md ');
+    expect(inputEl.selectionStart).toBe(inputEl.value.length);
+    expect(inputEl.selectionEnd).toBe(inputEl.value.length);
+    expect(inputHandler).toHaveBeenCalledTimes(1);
+    expect(inputEl.focus).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not add another separator when existing content ends in whitespace', () => {
+    const { inputEl, view } = createComposerHarness('Review this note\n');
+
+    view.appendToActiveInput('@projects/plan.md ');
+
+    expect(inputEl.value).toBe('Review this note\n@projects/plan.md ');
+  });
+
+  it('returns false when there is no active composer', () => {
+    const view = Object.create(ClaudianView.prototype) as any;
+    view.tabManager = {
+      getActiveTab: jest.fn().mockReturnValue(null),
+    };
+
+    expect(view.appendToActiveInput('@projects/plan.md ')).toBe(false);
+  });
+});
+
 describe('ClaudianView shutdown', () => {
   it('disposes view resources when the final tab-state flush fails', async () => {
     const error = new Error('disk full');

--- a/tests/unit/features/chat/fileMenu.test.ts
+++ b/tests/unit/features/chat/fileMenu.test.ts
@@ -1,0 +1,83 @@
+import { Menu, TFile, TFolder } from 'obsidian';
+
+import {
+  addFileToClaudian,
+  registerFileMenu,
+} from '@/features/chat/fileMenu';
+
+describe('Claudian file menu', () => {
+  function createFile(path: string): TFile {
+    const file = new TFile();
+    file.path = path;
+    file.name = path.split('/').pop() ?? path;
+    file.basename = file.name.replace(/\.[^.]+$/, '');
+    file.extension = file.name.split('.').pop() ?? '';
+    return file;
+  }
+
+  function createHost(options: { appendResult?: boolean } = {}) {
+    let fileMenuHandler: ((menu: Menu, file: TFile | TFolder) => void) | null = null;
+    const eventRef = { id: 'file-menu-ref' };
+    const appendToActiveInput = jest.fn().mockReturnValue(options.appendResult ?? true);
+    const view = { appendToActiveInput };
+    const host = {
+      app: {
+        workspace: {
+          on: jest.fn((event: string, handler: typeof fileMenuHandler) => {
+            if (event === 'file-menu') fileMenuHandler = handler;
+            return eventRef;
+          }),
+        },
+      },
+      registerEvent: jest.fn(),
+      activateView: jest.fn().mockResolvedValue(undefined),
+      getView: jest.fn().mockReturnValue(view),
+    };
+
+    return {
+      appendToActiveInput,
+      eventRef,
+      getFileMenuHandler: () => fileMenuHandler,
+      host,
+    };
+  }
+
+  beforeEach(() => {
+    (Menu as typeof Menu & { instances: Menu[] }).instances.length = 0;
+  });
+
+  it('registers an Add to Claudian item for files', () => {
+    const { eventRef, getFileMenuHandler, host } = createHost();
+
+    registerFileMenu(host as never);
+    const menu = new Menu();
+    getFileMenuHandler()?.(menu, createFile('projects/plan.md'));
+
+    expect(host.registerEvent).toHaveBeenCalledWith(eventRef);
+    expect((menu as any).items).toHaveLength(1);
+    expect((menu as any).items[0].title).toBe('Add to Claudian');
+  });
+
+  it('does not add the action for folders', () => {
+    const { getFileMenuHandler, host } = createHost();
+
+    registerFileMenu(host as never);
+    const menu = new Menu();
+    getFileMenuHandler()?.(menu, new TFolder());
+
+    expect((menu as any).items).toHaveLength(0);
+  });
+
+  it('reveals Claudian and appends the vault-relative mention', async () => {
+    const { appendToActiveInput, host } = createHost();
+    const file = createFile('projects/My Plan.md');
+
+    await addFileToClaudian(host as never, file);
+
+    expect(host.activateView).toHaveBeenCalledTimes(1);
+    expect(host.getView).toHaveBeenCalledTimes(1);
+    expect(appendToActiveInput).toHaveBeenCalledWith('@projects/My Plan.md ');
+    expect(host.activateView.mock.invocationCallOrder[0])
+      .toBeLessThan(appendToActiveInput.mock.invocationCallOrder[0]);
+  });
+});


### PR DESCRIPTION
Adds an **Add to Claudian** action to Obsidian's file explorer context menu.

The action reveals Claudian and appends the selected file as an `@path` mention to the active composer without sending, preserving existing input. Vault file mention formatting is shared with the picker to keep both paths aligned, with coverage for registration and composer behavior. Verified with typecheck, lint, 6,209 tests, architecture checks, and a production build. Partially addresses #959.