### PR TITLE
perf: throttle streaming renders, skip hidden/collapsed blocks

### DIFF
--- a/src/features/chat/controllers/StreamController.ts
+++ b/src/features/chat/controllers/StreamController.ts
@@ -30,6 +30,7 @@ import {
   cancelScheduledAnimationFrame,
   scheduleAnimationFrame,
   type ScheduledAnimationFrame,
+  scheduleDelayedFrame,
 } from '../../../utils/animationFrame';
 import { formatDurationMmSs } from '../../../utils/date';
 import { extractDiffData } from '../../../utils/diff';
@@ -78,6 +79,16 @@ export interface StreamControllerDeps {
   persistConversation?: () => Promise<void>;
 }
 
+/**
+ * Minimum wall-clock gap between successive streaming markdown re-renders of the
+ * same block. Each render redoes the whole block, so rendering every animation
+ * frame is O(block^2). ~150ms is imperceptible while cutting render work ~10x.
+ */
+const STREAMING_RENDER_MIN_INTERVAL_MS = 150;
+
+/** Poll interval for re-checking visibility while a render target is hidden. */
+const HIDDEN_RENDER_POLL_INTERVAL_MS = 250;
+
 export class StreamController {
   private static readonly ASYNC_SUBAGENT_RESULT_RETRY_DELAYS_MS = [200, 600, 1500] as const;
 
@@ -86,10 +97,14 @@ export class StreamController {
   private pendingTextRenderPromise: Promise<void> | null = null;
   private resolvePendingTextRender: (() => void) | null = null;
   private isTextRenderRunning = false;
+  private lastTextRenderTime = Number.NEGATIVE_INFINITY;
+  private forceTextRenderFlush = false;
   private pendingThinkingRenderFrame: ScheduledAnimationFrame | null = null;
   private pendingThinkingRenderPromise: Promise<void> | null = null;
   private resolvePendingThinkingRender: (() => void) | null = null;
   private isThinkingRenderRunning = false;
+  private lastThinkingRenderTime = Number.NEGATIVE_INFINITY;
+  private forceThinkingRenderFlush = false;
   private pendingToolOutputFrames = new Map<string, ScheduledAnimationFrame>();
   private pendingScrollFrame: ScheduledAnimationFrame | null = null;
 
@@ -741,17 +756,44 @@ export class StreamController {
     const pendingRender = this.pendingTextRenderPromise;
     if (!pendingRender) return;
 
+    // Force the final render through the throttle/visibility gates so the block
+    // is fully rendered even if the stream ends while it is throttled or hidden.
+    this.forceTextRenderFlush = true;
     if (this.pendingTextRenderFrame !== null) {
       cancelScheduledAnimationFrame(this.pendingTextRenderFrame);
       this.pendingTextRenderFrame = null;
+    }
+    if (!this.isTextRenderRunning) {
       void this.renderPendingText();
     }
 
     await pendingRender;
   }
 
+  private scheduleTextRenderRetry(delayMs: number): void {
+    this.pendingTextRenderFrame = scheduleDelayedFrame(() => {
+      this.pendingTextRenderFrame = null;
+      void this.renderPendingText();
+    }, delayMs, this.getStreamingRenderWindow());
+  }
+
   private async renderPendingText(): Promise<void> {
     if (this.isTextRenderRunning) return;
+
+    if (!this.forceTextRenderFlush) {
+      if (this.isRenderTargetHidden()) {
+        // Skip painting a hidden leaf/tab; keep polling so a mid-stream reveal
+        // catches up. finalize forces a render regardless (see flush).
+        this.scheduleTextRenderRetry(HIDDEN_RENDER_POLL_INTERVAL_MS);
+        return;
+      }
+      const wait = this.streamingRenderThrottleWait(this.lastTextRenderTime);
+      if (wait > 0) {
+        this.scheduleTextRenderRetry(wait);
+        return;
+      }
+    }
+
     this.isTextRenderRunning = true;
 
     const { state, renderer } = this.deps;
@@ -766,6 +808,7 @@ export class StreamController {
         } else {
           await renderer.renderContent(textEl, content);
         }
+        this.lastTextRenderTime = Date.now();
         this.scrollToBottom();
       }
     } catch {
@@ -782,6 +825,7 @@ export class StreamController {
       return;
     }
 
+    this.forceTextRenderFlush = false;
     const resolve = this.resolvePendingTextRender;
     this.pendingTextRenderPromise = null;
     this.resolvePendingTextRender = null;
@@ -794,6 +838,8 @@ export class StreamController {
       this.pendingTextRenderFrame = null;
     }
 
+    this.forceTextRenderFlush = false;
+    this.lastTextRenderTime = Number.NEGATIVE_INFINITY;
     const resolve = this.resolvePendingTextRender;
     this.pendingTextRenderPromise = null;
     this.resolvePendingTextRender = null;
@@ -852,7 +898,9 @@ export class StreamController {
     await this.flushPendingThinkingRender();
 
     const thinkingState = state.currentThinkingState;
-    if (this.getStreamingRenderOptions(thinkingState.content)) {
+    // A collapsed block is hidden and renders lazily on expand, so only the
+    // deferred-math re-render is needed here when the block is expanded.
+    if (thinkingState.isExpanded && this.getStreamingRenderOptions(thinkingState.content)) {
       await renderer.renderContent(thinkingState.contentEl, thinkingState.content);
     }
 
@@ -891,40 +939,70 @@ export class StreamController {
     const pendingRender = this.pendingThinkingRenderPromise;
     if (!pendingRender) return;
 
+    this.forceThinkingRenderFlush = true;
     if (this.pendingThinkingRenderFrame !== null) {
       cancelScheduledAnimationFrame(this.pendingThinkingRenderFrame);
       this.pendingThinkingRenderFrame = null;
+    }
+    if (!this.isThinkingRenderRunning) {
       void this.renderPendingThinking();
     }
 
     await pendingRender;
   }
 
+  private scheduleThinkingRenderRetry(delayMs: number): void {
+    this.pendingThinkingRenderFrame = scheduleDelayedFrame(() => {
+      this.pendingThinkingRenderFrame = null;
+      void this.renderPendingThinking();
+    }, delayMs, this.getThinkingRenderWindow());
+  }
+
   private async renderPendingThinking(): Promise<void> {
     if (this.isThinkingRenderRunning) return;
-    this.isThinkingRenderRunning = true;
 
     const { state, renderer } = this.deps;
     const thinkingState = state.currentThinkingState;
     const content = thinkingState?.content ?? '';
 
-    try {
-      if (thinkingState) {
-        const options = this.getStreamingRenderOptions(content);
-        if (options) {
-          await renderer.renderContent(thinkingState.contentEl, content, options);
-        } else {
-          await renderer.renderContent(thinkingState.contentEl, content);
-        }
-        this.scrollToBottom();
+    // Skip rendering into a collapsed (hidden) thinking block; it renders lazily
+    // on expand (ThinkingBlockRenderer wires an on-expand render). This is the
+    // biggest streaming win since thinking blocks are collapsed by default.
+    if (!thinkingState || !thinkingState.isExpanded) {
+      this.finishThinkingRender();
+      return;
+    }
+
+    if (!this.forceThinkingRenderFlush) {
+      if (this.isRenderTargetHidden()) {
+        this.scheduleThinkingRenderRetry(HIDDEN_RENDER_POLL_INTERVAL_MS);
+        return;
       }
+      const wait = this.streamingRenderThrottleWait(this.lastThinkingRenderTime);
+      if (wait > 0) {
+        this.scheduleThinkingRenderRetry(wait);
+        return;
+      }
+    }
+
+    this.isThinkingRenderRunning = true;
+
+    try {
+      const options = this.getStreamingRenderOptions(content);
+      if (options) {
+        await renderer.renderContent(thinkingState.contentEl, content, options);
+      } else {
+        await renderer.renderContent(thinkingState.contentEl, content);
+      }
+      this.lastThinkingRenderTime = Date.now();
+      this.scrollToBottom();
     } catch {
       // MessageRenderer owns user-visible render fallback; keep stream state moving.
     } finally {
       this.isThinkingRenderRunning = false;
     }
 
-    if (state.currentThinkingState === thinkingState && thinkingState && thinkingState.content !== content) {
+    if (state.currentThinkingState === thinkingState && thinkingState.content !== content) {
       this.pendingThinkingRenderFrame = scheduleAnimationFrame(() => {
         this.pendingThinkingRenderFrame = null;
         void this.renderPendingThinking();
@@ -932,6 +1010,11 @@ export class StreamController {
       return;
     }
 
+    this.finishThinkingRender();
+  }
+
+  private finishThinkingRender(): void {
+    this.forceThinkingRenderFlush = false;
     const resolve = this.resolvePendingThinkingRender;
     this.pendingThinkingRenderPromise = null;
     this.resolvePendingThinkingRender = null;
@@ -944,10 +1027,30 @@ export class StreamController {
       this.pendingThinkingRenderFrame = null;
     }
 
+    this.forceThinkingRenderFlush = false;
+    this.lastThinkingRenderTime = Number.NEGATIVE_INFINITY;
     const resolve = this.resolvePendingThinkingRender;
     this.pendingThinkingRenderPromise = null;
     this.resolvePendingThinkingRender = null;
     resolve?.();
+  }
+
+  /** Milliseconds still to wait before the next throttled streaming render. */
+  private streamingRenderThrottleWait(lastRenderTime: number): number {
+    return STREAMING_RENDER_MIN_INTERVAL_MS - (Date.now() - lastRenderTime);
+  }
+
+  /**
+   * True when the messages container is attached but not painted (inactive tab,
+   * background leaf, or collapsed sidebar). offsetParent is null for a
+   * display:none ancestor; the attachment check avoids treating an element torn
+   * down mid-stream as merely hidden.
+   */
+  private isRenderTargetHidden(): boolean {
+    const el = this.deps.getMessagesEl();
+    if (el.offsetParent !== null) return false;
+    const doc = el.ownerDocument;
+    return !!doc?.body?.contains(el);
   }
 
   // ============================================

--- a/src/features/chat/rendering/ThinkingBlockRenderer.ts
+++ b/src/features/chat/rendering/ThinkingBlockRenderer.ts
@@ -50,8 +50,18 @@ export function createThinkingBlock(
     isExpanded: false,
   };
 
-  // Setup collapsible behavior (handles click, keyboard, ARIA, CSS)
-  setupCollapsible(wrapperEl, header, contentEl, state);
+  // Setup collapsible behavior (handles click, keyboard, ARIA, CSS).
+  // Render the accumulated content on expand: while collapsed, the streaming
+  // loop skips rendering into this hidden block, so the DOM may be stale/empty
+  // when the user opens it (mid-stream or after finalize).
+  setupCollapsible(wrapperEl, header, contentEl, state, {
+    onToggle: (isExpanded) => {
+      if (!isExpanded) return;
+      void renderContent(contentEl, state.content).catch(() => {
+        contentEl.setText(state.content);
+      });
+    },
+  });
 
   return state;
 }

--- a/src/utils/animationFrame.ts
+++ b/src/utils/animationFrame.ts
@@ -33,6 +33,29 @@ export function scheduleAnimationFrame(
   };
 }
 
+/**
+ * Schedules a callback after a fixed delay in the given window, returning a
+ * handle cancellable by {@link cancelScheduledAnimationFrame}. Used to throttle
+ * or defer work that would otherwise run every animation frame.
+ */
+export function scheduleDelayedFrame(
+  callback: () => void,
+  delayMs: number,
+  ownerWindow: Window | null = getRendererWindow(),
+): ScheduledAnimationFrame {
+  const targetWindow = ownerWindow ?? getRendererWindow();
+  if (!targetWindow) {
+    callback();
+    return { kind: 'timeout', id: 0, ownerWindow: null };
+  }
+
+  return {
+    kind: 'timeout',
+    id: targetWindow.setTimeout(callback, delayMs),
+    ownerWindow: targetWindow,
+  };
+}
+
 export function cancelScheduledAnimationFrame(frame: ScheduledAnimationFrame): void {
   const targetWindow = frame.ownerWindow ?? getRendererWindow();
   if (!targetWindow) return;

--- a/tests/unit/features/chat/controllers/StreamController.test.ts
+++ b/tests/unit/features/chat/controllers/StreamController.test.ts
@@ -254,6 +254,51 @@ describe('StreamController - Text Content', () => {
       );
     });
 
+    it('should throttle successive streaming text renders', async () => {
+      deps.state.currentTextEl = createMockEl();
+
+      await controller.appendText('First');
+      jest.advanceTimersByTime(16);
+      await Promise.resolve();
+      expect(deps.renderer.renderContent).toHaveBeenCalledTimes(1);
+
+      // A second chunk shortly after must not re-render until the throttle window elapses.
+      await controller.appendText(' second');
+      jest.advanceTimersByTime(16);
+      await Promise.resolve();
+      expect(deps.renderer.renderContent).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(150);
+      await Promise.resolve();
+      expect(deps.renderer.renderContent).toHaveBeenCalledTimes(2);
+      expect(deps.renderer.renderContent).toHaveBeenLastCalledWith(
+        deps.state.currentTextEl,
+        'First second'
+      );
+    });
+
+    it('should skip live text renders while the leaf is hidden, then flush on finalize', async () => {
+      const msg = createTestMessage();
+      const hiddenEl = {
+        offsetParent: null,
+        ownerDocument: { body: { contains: () => true } },
+      };
+      deps.getMessagesEl = () => hiddenEl as any;
+      deps.state.currentTextEl = createMockEl();
+
+      await controller.appendText('While hidden');
+      jest.advanceTimersByTime(500);
+      await Promise.resolve();
+      expect(deps.renderer.renderContent).not.toHaveBeenCalled();
+
+      // finalize forces the render through regardless of visibility.
+      await controller.finalizeCurrentTextBlock(msg);
+      expect(deps.renderer.renderContent).toHaveBeenCalledWith(
+        expect.anything(),
+        'While hidden'
+      );
+    });
+
     it('should defer math rendering during live text renders', async () => {
       deps.state.currentTextEl = createMockEl();
 
@@ -1441,6 +1486,7 @@ describe('StreamController - Text Content', () => {
         labelEl: createMockEl(),
         content: '',
         startTime: Date.now(),
+        isExpanded: true,
       });
 
       await controller.handleStreamChunk({ type: 'thinking', content: 'Let ' }, msg);
@@ -1465,6 +1511,7 @@ describe('StreamController - Text Content', () => {
         labelEl: createMockEl(),
         content: '',
         startTime: Date.now(),
+        isExpanded: true,
       });
 
       await controller.handleStreamChunk({ type: 'thinking', content: 'Reasoning $x^2$' }, msg);
@@ -1489,6 +1536,7 @@ describe('StreamController - Text Content', () => {
         labelEl: createMockEl(),
         content: '',
         startTime: Date.now(),
+        isExpanded: true,
       });
 
       await controller.handleStreamChunk({ type: 'thinking', content: 'Reasoning $x^2$' }, msg);
@@ -1511,7 +1559,17 @@ describe('StreamController - Text Content', () => {
     });
 
     it('should flush a pending thinking render before finalizing', async () => {
+      const { createThinkingBlock } = jest.requireMock('@/features/chat/rendering/ThinkingBlockRenderer');
       const msg = createTestMessage();
+      const contentEl = createMockEl();
+      createThinkingBlock.mockReturnValueOnce({
+        wrapperEl: createMockEl(),
+        contentEl,
+        labelEl: createMockEl(),
+        content: '',
+        startTime: Date.now(),
+        isExpanded: true,
+      });
 
       await controller.handleStreamChunk({ type: 'thinking', content: 'Reasoning' }, msg);
       await controller.finalizeCurrentThinkingBlock(msg);
@@ -1522,6 +1580,38 @@ describe('StreamController - Text Content', () => {
       );
       expect(msg.contentBlocks).toContainEqual(
         expect.objectContaining({ type: 'thinking', content: 'Reasoning' })
+      );
+    });
+
+    it('should skip live renders while the thinking block is collapsed', async () => {
+      const { createThinkingBlock } = jest.requireMock('@/features/chat/rendering/ThinkingBlockRenderer');
+      const msg = createTestMessage();
+      const contentEl = createMockEl();
+      // Collapsed by default (isExpanded falsy): the streaming loop must not
+      // render into the hidden block.
+      createThinkingBlock.mockReturnValueOnce({
+        wrapperEl: createMockEl(),
+        contentEl,
+        labelEl: createMockEl(),
+        content: '',
+        startTime: Date.now(),
+        isExpanded: false,
+      });
+
+      await controller.handleStreamChunk({ type: 'thinking', content: 'Hidden ' }, msg);
+      await controller.handleStreamChunk({ type: 'thinking', content: 'reasoning' }, msg);
+
+      jest.advanceTimersByTime(500);
+      await Promise.resolve();
+
+      expect(deps.renderer.renderContent).not.toHaveBeenCalled();
+
+      // Finalizing a collapsed block still records the content without painting
+      // the hidden DOM (it renders lazily on expand).
+      await controller.finalizeCurrentThinkingBlock(msg);
+      expect(deps.renderer.renderContent).not.toHaveBeenCalled();
+      expect(msg.contentBlocks).toContainEqual(
+        expect.objectContaining({ type: 'thinking', content: 'Hidden reasoning' })
       );
     });
   });

--- a/tests/unit/features/chat/rendering/ThinkingBlockRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/ThinkingBlockRenderer.test.ts
@@ -39,6 +39,26 @@ describe('ThinkingBlockRenderer', () => {
 
       expect(state.timerInterval).toBeNull();
     });
+
+    it('should render accumulated content when expanded (streaming loop skips collapsed blocks)', () => {
+      const parentEl = createMockEl();
+
+      const state = createThinkingBlock(parentEl, mockRenderContent);
+      // Simulate content accumulated by the streaming loop while collapsed.
+      state.content = 'deferred reasoning';
+      expect(mockRenderContent).not.toHaveBeenCalled();
+
+      const header = (state.wrapperEl as any)._children[0];
+      const clickHandlers = header._eventListeners.get('click') || [];
+      clickHandlers[0]();
+
+      expect(mockRenderContent).toHaveBeenCalledWith(state.contentEl, 'deferred reasoning');
+
+      // Collapsing again must not trigger another render.
+      mockRenderContent.mockClear();
+      clickHandlers[0]();
+      expect(mockRenderContent).not.toHaveBeenCalled();
+    });
   });
 
   describe('finalizeThinkingBlock', () => {


### PR DESCRIPTION
## Problem

During streaming, every chunk schedules a `requestAnimationFrame` that re-renders the **entire current block from scratch** in `StreamController` → `MessageRenderer.renderContent`: `el.empty()`, a full `MarkdownRenderer.render`, and re-wrapping every `<pre>`. That runs up to ~60×/sec and is O(block²) over the stream, on the Obsidian render thread. With a few concurrent chat tabs it produces visible UI jank (observed with 3–4 concurrent sessions on a laptop).

Three things compound it:
1. Thinking blocks are collapsed by default, yet the full thinking text is re-rendered every frame into a hidden element.
2. There is no throttle — one full re-render per animation frame.
3. There is no visibility check — a tab/leaf that isn't shown still re-renders every frame.

## Changes

1. **Skip live rendering of collapsed thinking blocks.** The streaming loop no longer renders into a collapsed (hidden) thinking block. `createThinkingBlock` wires an on-expand render of the accumulated content, so expanding mid-stream or after finalize renders the current text once; while expanded it updates live. The deferred-math finalize path only re-renders when the block is expanded.
2. **Throttle streaming text/thinking re-renders** to a minimum interval (150ms) instead of once per frame (~10× less render work, imperceptible). `finalize` forces the final render through the throttle so a completed block is always fully rendered.
3. **Skip rendering while the messages container is hidden** (inactive tab, background leaf, or collapsed sidebar), detected via `offsetParent`. It polls for reveal so a mid-stream switch catches up, and `finalize` renders regardless of visibility.

A small `scheduleDelayedFrame` helper is added to `utils/animationFrame` for the throttle/poll (cancellable via the existing `cancelScheduledAnimationFrame`).

## Notes / scope

- I described the mechanism and the observed jank; I did not run before/after profiling, so the ~10× figure is the reduction in render invocations, not a measured frame-time delta.
- A minor known transient: if a user reveals a background tab during a streaming *pause* (no new chunk in flight), the block updates on the next chunk or at finalize (within the poll interval) rather than instantly.
- Incremental rendering (only re-rendering the trailing incomplete block to kill the O(n²) entirely) is a larger, separate change and is intentionally out of scope here.

## Testing

`npm run typecheck && npm run lint && npm run build` pass. Added/updated unit tests in `StreamController.test.ts` (throttle, hidden-skip + finalize flush, collapsed-thinking skip) and `ThinkingBlockRenderer.test.ts` (on-expand render); the rendering/controller suites pass.