### PR TITLE
Fix stale provider model options after catalog discovery

### DIFF
--- a/src/app/providers/ClaudianProviderHost.ts
+++ b/src/app/providers/ClaudianProviderHost.ts
@@ -77,9 +77,9 @@ export class ClaudianProviderHost implements ProviderHost {
     return this.plugin.getResolvedProviderCliPath(providerId, context);
   }
 
-  refreshModelSelectors(): void {
+  notifyProviderChatOptionsChanged(providerId: ProviderId): void {
     for (const view of this.plugin.getAllViews()) {
-      view.refreshModelSelector();
+      view.refreshModelSelector(providerId);
     }
   }
 

--- a/src/core/providers/ProviderHost.ts
+++ b/src/core/providers/ProviderHost.ts
@@ -41,7 +41,7 @@ export interface ProviderHost {
     context?: ProviderCliResolutionContext,
   ): Promise<string | null>;
 
-  refreshModelSelectors?(): void;
+  notifyProviderChatOptionsChanged(providerId: ProviderId): void;
   broadcastToActiveViewRuntimes?(
     action: (runtime: ChatRuntime) => Promise<void> | void,
   ): Promise<void>;

--- a/src/core/providers/conversationModel.ts
+++ b/src/core/providers/conversationModel.ts
@@ -16,7 +16,7 @@ function trimModel(model: unknown): string {
   return typeof model === 'string' ? model.trim() : '';
 }
 
-function findModelOption(
+export function findProviderModelOption(
   providerId: ProviderId,
   model: string,
   settings: Record<string, unknown>,
@@ -52,7 +52,7 @@ export function normalizeProviderModelSelection(
     model: rawModel,
   };
 
-  const rawOption = findModelOption(providerId, rawModel, rawSettings);
+  const rawOption = findProviderModelOption(providerId, rawModel, rawSettings);
   if (rawOption) {
     return rawOption;
   }
@@ -69,7 +69,7 @@ export function normalizeProviderModelSelection(
     ...baseSettings,
     model: normalizedModel,
   };
-  const normalizedOption = findModelOption(providerId, normalizedModel, normalizedSettings);
+  const normalizedOption = findProviderModelOption(providerId, normalizedModel, normalizedSettings);
   if (normalizedOption) {
     return normalizedOption;
   }

--- a/src/features/FeatureHost.ts
+++ b/src/features/FeatureHost.ts
@@ -19,7 +19,7 @@ export interface FeatureTabManagerHost {
 export interface FeatureViewHost extends TabManagerViewHost {
   getActiveTab(): TabData | null;
   getTabManager(): FeatureTabManagerHost | null;
-  refreshModelSelector(): void;
+  refreshModelSelector(providerId?: ProviderId): void;
   refreshTabControls(): void;
   updateHiddenProviderCommands(): void;
   invalidateProviderResources(providerIds: ProviderId[], generation: number): void;

--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -110,10 +110,17 @@ export class ClaudianView extends ItemView {
   }
 
   /** Refreshes model-dependent UI across all tabs (used after settings/env changes). */
-  refreshModelSelector(): void {
+  refreshModelSelector(changedProviderId?: ProviderId): void {
     for (const tab of this.tabManager?.getAllTabs() ?? []) {
       onProviderAvailabilityChanged(tab, this.plugin);
       const providerId = getTabProviderId(tab, this.plugin);
+      if (
+        changedProviderId
+        && tab.lifecycleState !== 'blank'
+        && providerId !== changedProviderId
+      ) {
+        continue;
+      }
       const conversation = tab.conversationId
         ? this.plugin.getConversationSync(tab.conversationId)
         : null;
@@ -153,7 +160,9 @@ export class ClaudianView extends ItemView {
       );
     }
 
-    this.tabManager?.primeProviderRuntime();
+    if (!changedProviderId) {
+      this.tabManager?.primeProviderRuntime();
+    }
   }
 
   invalidateProviderCommandCaches(providerIds?: ProviderId[]): void {

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -4,6 +4,7 @@ import { Notice, Platform } from 'obsidian';
 import { getHiddenProviderCommandSet } from '../../../core/providers/commands/hiddenCommands';
 import { normalizeProviderCommandDiscoveryItems } from '../../../core/providers/commands/ProviderCommandDiscoveryResult';
 import {
+  findProviderModelOption,
   getProviderSettingsSnapshotWithModel,
   normalizeProviderModelSelection,
   resolveConversationModel,
@@ -456,10 +457,39 @@ function cleanupTabRuntime(tab: TabData): void {
   tab.serviceInitialized = false;
 }
 
+function resolveBlankTabFallback(
+  settings: Record<string, unknown>,
+  enabledProviderIds: ProviderId[],
+  preferredProviderId: ProviderId,
+): { model: string; providerId: ProviderId } | null {
+  const providerIds = [
+    ...(enabledProviderIds.includes(preferredProviderId) ? [preferredProviderId] : []),
+    ...enabledProviderIds.filter(providerId => providerId !== preferredProviderId),
+  ];
+
+  for (const providerId of providerIds) {
+    const uiConfig = ProviderRegistry.getChatUIConfig(providerId);
+    const modelOptions = uiConfig.getModelOptions(settings);
+    if (modelOptions.length === 0) {
+      continue;
+    }
+
+    const defaultModel = uiConfig.getDefaultModel?.(settings);
+    const availableDefault = defaultModel
+      ? findProviderModelOption(providerId, defaultModel, settings)
+      : null;
+    return {
+      model: availableDefault ?? modelOptions[0].value,
+      providerId,
+    };
+  }
+
+  return null;
+}
+
 /**
- * Called when provider availability changes. If a blank tab targets a provider
- * that is now disabled, it falls back to the first enabled provider's default
- * blank-tab model. Refreshes model selector options for all blank tabs.
+ * Reconciles blank drafts after provider or model availability changes.
+ * Prefer the draft provider's advertised default before crossing providers.
  */
 export function onProviderAvailabilityChanged(tab: TabData, plugin: FeatureHost): void {
   if (tab.lifecycleState !== 'blank') return;
@@ -469,17 +499,26 @@ export function onProviderAvailabilityChanged(tab: TabData, plugin: FeatureHost)
   let nextProviderId = tab.providerId;
 
   if (tab.draftModel) {
-    const draftProvider = getEnabledProviderForModel(tab.draftModel, settingsSnapshot);
-    const draftProviderOwnsModel = ProviderRegistry
-      .getChatUIConfig(draftProvider)
-      .ownsModel(tab.draftModel, settingsSnapshot);
-    if (!enabledProviderIds.includes(draftProvider) || !draftProviderOwnsModel) {
-      const fallbackProviderId = enabledProviderIds[0] ?? DEFAULT_CHAT_PROVIDER_ID;
-      const fallbackModels = ProviderRegistry.getChatUIConfig(fallbackProviderId)
-        .getModelOptions(settingsSnapshot);
-      tab.draftModel = fallbackModels[0]?.value ?? tab.draftModel;
-      nextProviderId = fallbackProviderId;
+    const draftProvider = getEnabledProviderForModel(
+      tab.draftModel,
+      settingsSnapshot,
+      tab.providerId,
+    );
+    const availableDraftModel = enabledProviderIds.includes(draftProvider)
+      ? findProviderModelOption(draftProvider, tab.draftModel, settingsSnapshot)
+      : null;
+    if (!availableDraftModel) {
+      const fallback = resolveBlankTabFallback(
+        settingsSnapshot,
+        enabledProviderIds,
+        draftProvider,
+      );
+      if (fallback) {
+        tab.draftModel = fallback.model;
+        nextProviderId = fallback.providerId;
+      }
     } else {
+      tab.draftModel = availableDraftModel;
       nextProviderId = draftProvider;
     }
   }

--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -73,6 +73,10 @@ export class ModelSelector {
     this.callbacks = callbacks;
     this.container = parentEl.createDiv({ cls: 'claudian-model-selector' });
     this.render();
+    this.container.addEventListener('mouseenter', () => {
+      this.updateDisplay();
+      this.renderOptions();
+    });
   }
 
   private getAvailableModels() {

--- a/src/providers/codex/runtime/CodexModelCatalogCoordinator.ts
+++ b/src/providers/codex/runtime/CodexModelCatalogCoordinator.ts
@@ -282,6 +282,9 @@ export class CodexModelCatalogCoordinator {
         };
       }
       this.state = 'ready';
+      if (persistedResult.changed) {
+        this.plugin.notifyProviderChatOptionsChanged('codex');
+      }
       return {
         kind: 'completed',
         models: discoveryResult.models,

--- a/src/providers/codex/ui/CodexModelPicker.ts
+++ b/src/providers/codex/ui/CodexModelPicker.ts
@@ -105,10 +105,7 @@ export function renderCodexModelPicker(
       const result = await workspace.modelCatalogCoordinator.ensureFresh('model-picker', { force });
       if (result.backgroundRefresh) {
         void result.backgroundRefresh.then(
-          () => {
-            context.refreshModelSelectors();
-            refreshPicker();
-          },
+          () => refreshPicker(),
           () => refreshPicker(),
         );
       }
@@ -116,7 +113,6 @@ export function renderCodexModelPicker(
         new Notice(`Codex model discovery failed: ${result.diagnostics}`);
         return 'failed';
       }
-      context.refreshModelSelectors();
       return getCodexProviderSettings(settingsBag).discoveredModels.length > 0 ? 'loaded' : 'empty';
     },
     loadingCatalogText: 'Loading the Codex model catalog...',

--- a/src/providers/grok/runtime/GrokModelCatalogCoordinator.ts
+++ b/src/providers/grok/runtime/GrokModelCatalogCoordinator.ts
@@ -209,7 +209,7 @@ export class GrokModelCatalogCoordinator {
       this.pendingLiveRevisions.delete(revision);
     }
     if (persisted.changed) {
-      this.plugin.refreshModelSelectors?.();
+      this.plugin.notifyProviderChatOptionsChanged('grok');
     }
     return persisted;
   }
@@ -273,7 +273,7 @@ export class GrokModelCatalogCoordinator {
       }
       this.state = 'ready';
       if (persisted.changed) {
-        this.plugin.refreshModelSelectors?.();
+        this.plugin.notifyProviderChatOptionsChanged('grok');
       }
       return {
         catalog: this.getCachedCatalog(),

--- a/src/providers/grok/ui/GrokSettingsTab.ts
+++ b/src/providers/grok/ui/GrokSettingsTab.ts
@@ -47,7 +47,6 @@ export const grokSettingsTabRenderer: ProviderSettingsTabRenderer = {
         new Notice(`Grok model discovery failed: ${result.diagnostics}`);
         return 'failed';
       }
-      context.refreshModelSelectors();
       context.refreshTitleGenerationModelOptions();
       return (getGrokProviderSettings(settingsBag).currentCatalog?.models.length ?? 0) > 0
         ? 'loaded'

--- a/src/providers/opencode/runtime/OpencodeChatRuntime.ts
+++ b/src/providers/opencode/runtime/OpencodeChatRuntime.ts
@@ -1232,7 +1232,7 @@ export class OpencodeChatRuntime implements ChatRuntime {
     ) {
       return;
     }
-    this.refreshModelSelectors();
+    this.plugin.notifyProviderChatOptionsChanged('opencode');
   }
 
   private seedActiveModelSelection(
@@ -1337,11 +1337,7 @@ export class OpencodeChatRuntime implements ChatRuntime {
     ) {
       return;
     }
-    this.refreshModelSelectors();
-  }
-
-  private refreshModelSelectors(): void {
-    this.plugin.refreshModelSelectors?.();
+    this.plugin.notifyProviderChatOptionsChanged('opencode');
   }
 
   private emitPermissionModeSync(modeId: string): void {

--- a/src/providers/pi/internal/compareCollections.ts
+++ b/src/providers/pi/internal/compareCollections.ts
@@ -1,4 +1,26 @@
+import type { PiDiscoveredModel } from '../models';
+
 export function sameStringList(left: string[], right: string[]): boolean {
   return left.length === right.length
     && left.every((value, index) => value === right[index]);
+}
+
+export function sameDiscoveredModels(
+  left: PiDiscoveredModel[],
+  right: PiDiscoveredModel[],
+): boolean {
+  return left.length === right.length
+    && left.every((model, index) => {
+      const candidate = right[index];
+      return model.api === candidate?.api
+        && model.contextWindow === candidate?.contextWindow
+        && model.encodedId === candidate?.encodedId
+        && model.id === candidate?.id
+        && sameStringList(model.input, candidate?.input ?? [])
+        && model.label === candidate?.label
+        && model.maxTokens === candidate?.maxTokens
+        && model.provider === candidate?.provider
+        && model.reasoning === candidate?.reasoning
+        && sameStringList(model.thinkingLevels, candidate?.thinkingLevels ?? []);
+    });
 }

--- a/src/providers/pi/ui/PiSettingsTab.ts
+++ b/src/providers/pi/ui/PiSettingsTab.ts
@@ -17,7 +17,7 @@ import {
 import { getHostnameKey } from '../../../utils/env';
 import { expandHomePath } from '../../../utils/path';
 import { maybeGetPiWorkspaceServices } from '../app/PiWorkspaceServices';
-import { sameStringList } from '../internal/compareCollections';
+import { sameDiscoveredModels, sameStringList } from '../internal/compareCollections';
 import { decodePiModelId, type PiDiscoveredModel } from '../models';
 import { PiModelDiscoveryService } from '../runtime/PiModelDiscoveryService';
 import {
@@ -166,17 +166,16 @@ function renderPiModelPicker(
 
       const current = getPiProviderSettings(settingsBag);
       const normalizedVisibleModels = normalizePiVisibleModels(current.visibleModels, result.models);
-      const shouldPersist = result.models.length > 0
-        || current.discoveredModels.length > 0
-        || !sameStringList(current.visibleModels, normalizedVisibleModels);
-      if (shouldPersist) {
+      const catalogChanged = !sameDiscoveredModels(current.discoveredModels, result.models);
+      const visibilityChanged = !sameStringList(current.visibleModels, normalizedVisibleModels);
+      if (catalogChanged || visibilityChanged) {
         await context.plugin.mutateSettings((settings) => {
           updatePiProviderSettings(settings, {
             discoveredModels: result.models,
             visibleModels: normalizedVisibleModels,
           });
         });
-        context.refreshModelSelectors();
+        context.plugin.notifyProviderChatOptionsChanged('pi');
       }
       return result.models.length > 0 ? 'loaded' : 'empty';
     },

--- a/tests/unit/app/providers/ClaudianProviderHost.test.ts
+++ b/tests/unit/app/providers/ClaudianProviderHost.test.ts
@@ -44,6 +44,23 @@ describe('ClaudianProviderHost', () => {
     expect('addCommand' in host).toBe(false);
   });
 
+  it('routes provider chat-option changes to every view with provider scope', () => {
+    const firstRefresh = jest.fn();
+    const secondRefresh = jest.fn();
+    const plugin = createPlugin({
+      getAllViews: jest.fn(() => [
+        { refreshModelSelector: firstRefresh },
+        { refreshModelSelector: secondRefresh },
+      ]),
+    });
+    const host = new ClaudianProviderHost(plugin);
+
+    host.notifyProviderChatOptionsChanged('codex');
+
+    expect(firstRefresh).toHaveBeenCalledWith('codex');
+    expect(secondRefresh).toHaveBeenCalledWith('codex');
+  });
+
   it('delivers provider runtime recycling to views in their existing order', async () => {
     const trace: string[] = [];
     const createView = (id: string) => ({

--- a/tests/unit/features/chat/ClaudianView.test.ts
+++ b/tests/unit/features/chat/ClaudianView.test.ts
@@ -1,9 +1,115 @@
 import { createMockEl } from '@test/helpers/mockElement';
 import { Platform, Scope } from 'obsidian';
 
+import { ProviderRegistry } from '@/core/providers/ProviderRegistry';
+import { ProviderSettingsCoordinator } from '@/core/providers/ProviderSettingsCoordinator';
 import { ClaudianView } from '@/features/chat/ClaudianView';
 
 const MockScope = Scope as typeof Scope & { instances: Scope[] };
+
+function createModelRefreshTab(providerId: 'codex' | 'grok') {
+  return {
+    conversationId: null,
+    dom: {
+      inputWrapper: {
+        toggleClass: jest.fn(),
+      },
+    },
+    lifecycleState: 'bound_cold',
+    providerId,
+    service: null,
+    state: { usage: null },
+    ui: {
+      modeSelector: {
+        renderOptions: jest.fn(),
+        updateDisplay: jest.fn(),
+      },
+      modelSelector: {
+        renderOptions: jest.fn(),
+        updateDisplay: jest.fn(),
+      },
+      permissionToggle: { updateDisplay: jest.fn() },
+      serviceTierToggle: { updateDisplay: jest.fn() },
+      thinkingBudgetSelector: { updateDisplay: jest.fn() },
+    },
+  };
+}
+
+function createBlankModelRefreshTab(providerId: 'codex' | 'grok') {
+  return {
+    ...createModelRefreshTab(providerId),
+    draftModel: null,
+    lifecycleState: 'blank',
+    services: {
+      instructionRefineService: null,
+      subagentManager: {
+        setTaskResultInterpreter: jest.fn(),
+      },
+    },
+    ui: {
+      ...createModelRefreshTab(providerId).ui,
+      permissionToggle: {
+        setVisible: jest.fn(),
+        updateDisplay: jest.fn(),
+      },
+    },
+  };
+}
+
+describe('ClaudianView model refresh routing', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('refreshes matching bound tabs and all blank tabs without priming runtimes', () => {
+    jest.spyOn(ProviderSettingsCoordinator, 'getProviderSettingsSnapshot')
+      .mockImplementation((_settings, providerId) => ({
+        customContextLimits: {},
+        model: `${providerId}-model`,
+        permissionMode: 'normal',
+      }));
+    jest.spyOn(ProviderRegistry, 'getChatUIConfig').mockReturnValue({
+      getContextWindowSize: jest.fn().mockReturnValue(200_000),
+      getPermissionModeToggle: jest.fn().mockReturnValue(null),
+    } as any);
+    jest.spyOn(ProviderRegistry, 'getCapabilities').mockImplementation(providerId => ({
+      providerId,
+      supportsImageAttachments: false,
+      supportsMcpTools: false,
+      supportsPlanMode: false,
+    } as any));
+    jest.spyOn(ProviderRegistry, 'getEnabledProviderIds').mockReturnValue(['codex', 'grok']);
+    jest.spyOn(ProviderRegistry, 'createInstructionRefineService')
+      .mockReturnValue(null as any);
+    jest.spyOn(ProviderRegistry, 'getTaskResultInterpreter')
+      .mockReturnValue(null as any);
+
+    const codexTab = createModelRefreshTab('codex');
+    const grokTab = createModelRefreshTab('grok');
+    const blankGrokTab = createBlankModelRefreshTab('grok');
+    const primeProviderRuntime = jest.fn();
+    const view = Object.create(ClaudianView.prototype) as any;
+    view.plugin = {
+      getConversationSync: jest.fn().mockReturnValue(null),
+      providerHost: {},
+      settings: {},
+    };
+    view.tabManager = {
+      getAllTabs: jest.fn().mockReturnValue([codexTab, grokTab, blankGrokTab]),
+      primeProviderRuntime,
+    };
+
+    view.refreshModelSelector('codex');
+
+    expect(codexTab.ui.modelSelector.updateDisplay).toHaveBeenCalledTimes(1);
+    expect(codexTab.ui.modelSelector.renderOptions).toHaveBeenCalledTimes(1);
+    expect(grokTab.ui.modelSelector.updateDisplay).not.toHaveBeenCalled();
+    expect(grokTab.ui.modelSelector.renderOptions).not.toHaveBeenCalled();
+    expect(blankGrokTab.ui.modelSelector.updateDisplay).toHaveBeenCalled();
+    expect(blankGrokTab.ui.modelSelector.renderOptions).toHaveBeenCalled();
+    expect(primeProviderRuntime).not.toHaveBeenCalled();
+  });
+});
 
 function createViewHarness(options: {
   canCreateTab: boolean;

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -995,6 +995,63 @@ describe('Tab - Service Initialization', () => {
       expect(mockSlashCommandDropdown.resetSdkSkillsCache).toHaveBeenCalled();
     });
 
+    it('falls back a removed blank Codex draft to the refreshed Codex default', () => {
+      jest.spyOn(ProviderRegistry, 'createInstructionRefineService').mockReturnValue({ cancel: jest.fn(), resetConversation: jest.fn() } as any);
+      jest.spyOn(ProviderRegistry, 'createTitleGenerationService').mockReturnValue({ cancel: jest.fn() } as any);
+      jest.spyOn(ProviderRegistry, 'getTaskResultInterpreter').mockReturnValue({} as any);
+
+      const plugin = createMockPlugin();
+      const tab = createTab(createMockOptions({ plugin }));
+      initializeTabUI(tab, plugin);
+
+      tab.draftModel = 'gpt-5.3-removed';
+      tab.providerId = 'codex';
+      tab.lifecycleState = 'blank';
+
+      onProviderAvailabilityChanged(tab, plugin);
+
+      expect(tab.providerId).toBe('codex');
+      expect(tab.draftModel).toBe(TEST_CODEX_MODEL);
+    });
+
+    it('keeps the known draft provider when an unprefixed custom model disappears', () => {
+      jest.spyOn(ProviderRegistry, 'createInstructionRefineService').mockReturnValue({ cancel: jest.fn(), resetConversation: jest.fn() } as any);
+      jest.spyOn(ProviderRegistry, 'createTitleGenerationService').mockReturnValue({ cancel: jest.fn() } as any);
+      jest.spyOn(ProviderRegistry, 'getTaskResultInterpreter').mockReturnValue({} as any);
+
+      const plugin = createMockPlugin();
+      const tab = createTab(createMockOptions({ plugin }));
+      initializeTabUI(tab, plugin);
+
+      tab.draftModel = 'my-custom-model';
+      tab.providerId = 'codex';
+      tab.lifecycleState = 'blank';
+
+      onProviderAvailabilityChanged(tab, plugin);
+
+      expect(tab.providerId).toBe('codex');
+      expect(tab.draftModel).toBe(TEST_CODEX_MODEL);
+    });
+
+    it('preserves a blank Codex draft that remains in the refreshed catalog', () => {
+      jest.spyOn(ProviderRegistry, 'createInstructionRefineService').mockReturnValue({ cancel: jest.fn(), resetConversation: jest.fn() } as any);
+      jest.spyOn(ProviderRegistry, 'createTitleGenerationService').mockReturnValue({ cancel: jest.fn() } as any);
+      jest.spyOn(ProviderRegistry, 'getTaskResultInterpreter').mockReturnValue({} as any);
+
+      const plugin = createMockPlugin();
+      const tab = createTab(createMockOptions({ plugin }));
+      initializeTabUI(tab, plugin);
+
+      tab.draftModel = 'gpt-5.4-mini';
+      tab.providerId = 'codex';
+      tab.lifecycleState = 'blank';
+
+      onProviderAvailabilityChanged(tab, plugin);
+
+      expect(tab.providerId).toBe('codex');
+      expect(tab.draftModel).toBe('gpt-5.4-mini');
+    });
+
     it('rebinds provider-scoped helper services when a newly enabled provider takes over the draft model', () => {
       const createInstructionRefineServiceSpy = jest.spyOn(ProviderRegistry, 'createInstructionRefineService')
         .mockReturnValue({ cancel: jest.fn(), resetConversation: jest.fn() } as any);

--- a/tests/unit/features/chat/ui/InputToolbar.test.ts
+++ b/tests/unit/features/chat/ui/InputToolbar.test.ts
@@ -276,6 +276,30 @@ describe('ModelSelector', () => {
     expect(options[2]?.children[0]?.textContent).toBe('Haiku');
   });
 
+  it('should reread model options before the dropdown becomes visible', () => {
+    const uiConfig = callbacks.getUIConfig();
+    uiConfig.getModelOptions.mockReturnValue([
+      { value: 'gpt-new', label: 'GPT New' },
+      { value: 'gpt-fast', label: 'GPT Fast' },
+    ]);
+    callbacks.getSettings.mockReturnValue({
+      model: 'gpt-new',
+      thinkingBudget: 'low',
+      effortLevel: 'high',
+      serviceTier: 'default',
+      permissionMode: 'normal',
+    });
+
+    parentEl.querySelector('.claudian-model-selector')?.dispatchEvent('mouseenter');
+
+    expect(parentEl.querySelector('.claudian-model-label')?.textContent).toBe('GPT New');
+    const options = parentEl.querySelector('.claudian-model-dropdown')?.children ?? [];
+    expect(options.map((option: any) => option.children[0]?.textContent)).toEqual([
+      'GPT Fast',
+      'GPT New',
+    ]);
+  });
+
   it('should mark current model as selected', () => {
     const dropdown = parentEl.querySelector('.claudian-model-dropdown');
     const options = dropdown?.children || [];

--- a/tests/unit/providers/claude/commands/probeRuntimeCommands.test.ts
+++ b/tests/unit/providers/claude/commands/probeRuntimeCommands.test.ts
@@ -1,6 +1,6 @@
 import * as sdkModule from '@anthropic-ai/claude-agent-sdk';
 
-import type ClaudianPlugin from '@/main';
+import type { ProviderHost } from '@/core/providers/ProviderHost';
 import { probeRuntimeCommands } from '@/providers/claude/commands/probeRuntimeCommands';
 
 const sdkMock = sdkModule as unknown as {
@@ -20,13 +20,13 @@ jest.mock('@/utils/env', () => ({
   findNodeExecutable: jest.fn().mockReturnValue('/usr/bin/node'),
 }));
 
-function createMockPlugin(settings: Record<string, unknown> = {}): ClaudianPlugin {
+function createMockPlugin(settings: Record<string, unknown> = {}): ProviderHost {
   return {
     app: {},
     settings,
     getResolvedProviderCliPath: jest.fn().mockReturnValue('/mock/claude'),
     getActiveEnvironmentVariables: jest.fn().mockReturnValue(''),
-  } as unknown as ClaudianPlugin;
+  } as unknown as ProviderHost;
 }
 
 describe('probeRuntimeCommands', () => {

--- a/tests/unit/providers/claude/runtime/ClaudianService.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudianService.test.ts
@@ -4,7 +4,7 @@ import * as sdkModule from '@anthropic-ai/claude-agent-sdk';
 import { Notice } from 'obsidian';
 
 import type { McpServerManager } from '@/core/mcp/McpServerManager';
-import type ClaudianPlugin from '@/main';
+import type { ProviderHost } from '@/core/providers/ProviderHost';
 import * as historyStore from '@/providers/claude/history/ClaudeHistoryStore';
 import * as sdkLoader from '@/providers/claude/loadClaudeAgentSdk';
 import { ClaudianService } from '@/providers/claude/runtime/ClaudeChatRuntime';
@@ -24,7 +24,7 @@ const sdkMock = sdkModule as unknown as {
 type MockMcpServerManager = jest.Mocked<McpServerManager>;
 
 describe('ClaudianService', () => {
-  let mockPlugin: Partial<ClaudianPlugin>;
+  let mockPlugin: Partial<ProviderHost>;
   let mockMcpManager: MockMcpServerManager;
   let service: ClaudianService;
 
@@ -67,7 +67,7 @@ describe('ClaudianService', () => {
       pluginManager: {
         getPluginsKey: jest.fn().mockReturnValue(''),
       },
-    } as unknown as ClaudianPlugin;
+    } as unknown as ProviderHost;
 
     mockMcpManager = {
       loadServers: jest.fn().mockResolvedValue(undefined),
@@ -79,7 +79,7 @@ describe('ClaudianService', () => {
       transformMentions: jest.fn().mockImplementation((text: string) => text),
     } as unknown as MockMcpServerManager;
 
-    service = new ClaudianService(mockPlugin as ClaudianPlugin, mockMcpManager);
+    service = new ClaudianService(mockPlugin as ProviderHost, mockMcpManager);
   });
 
   describe('prepareTurn', () => {

--- a/tests/unit/providers/codex/app/CodexWorkspaceServices.test.ts
+++ b/tests/unit/providers/codex/app/CodexWorkspaceServices.test.ts
@@ -65,6 +65,7 @@ function createPlugin(
       },
     },
     saveSettings: jest.fn().mockResolvedValue(undefined),
+    notifyProviderChatOptionsChanged: jest.fn(),
     getResolvedProviderCliPath: jest.fn(),
     getActiveEnvironmentVariables: jest.fn().mockReturnValue(''),
     app: {
@@ -121,6 +122,20 @@ describe('CodexWorkspaceServices', () => {
     await services.refreshModelCatalog!();
 
     expect(plugin.saveSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('publishes a deferred layout-ready catalog to mounted model selectors', async () => {
+    const plugin = createPlugin(true);
+    const sol = makeDiscoveredModel('gpt-5.6-sol');
+    mockDiscoverModels.mockResolvedValue({ kind: 'completed', models: [sol] });
+    await createCodexWorkspaceServices(plugin, {} as any);
+    const layoutReadyCallback = plugin.app.workspace.onLayoutReady.mock.calls[0][0];
+
+    layoutReadyCallback();
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(getCodexProviderSettings(plugin.settings).discoveredModels).toEqual([sol]);
+    expect(plugin.notifyProviderChatOptionsChanged).toHaveBeenCalledWith('codex');
   });
 
   it('does not start app-server for a disabled provider', async () => {

--- a/tests/unit/providers/codex/runtime/CodexModelCatalogCoordinator.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexModelCatalogCoordinator.test.ts
@@ -83,6 +83,7 @@ function createFakeHost(overrides: {
     },
     getResolvedProviderCliPath: jest.fn(() => resolvedCliPath),
     getActiveEnvironmentVariables: jest.fn(() => envText),
+    notifyProviderChatOptionsChanged: jest.fn(),
     mutateSettingsConditionally: jest.fn(async (mutation) => {
       return mutation({
         ...DEFAULT_CODEX_PROVIDER_SETTINGS,
@@ -243,6 +244,53 @@ describe('CodexModelCatalogCoordinator', () => {
     expect(result.backgroundRefresh).toBeDefined();
     await result.backgroundRefresh;
     expect(discovery.discoverModels).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes mounted model selectors after a background catalog change commits', async () => {
+    const cachedModel = makeModel('gpt-4o');
+    const discoveredModel = makeModel('gpt-4o-mini');
+    const host = createFakeHost({
+      discoveredModels: [cachedModel],
+      catalogTimestamp: 1,
+    });
+    (host.mutateSettingsConditionally as jest.Mock).mockImplementation(async (mutation) => {
+      await mutation(host.settings);
+    });
+    const coordinator = new CodexModelCatalogCoordinator(host, createDiscovery({
+      kind: 'completed',
+      models: [discoveredModel],
+    }));
+
+    const result = await coordinator.ensureFresh('layout-ready');
+
+    expect(result.models).toEqual([cachedModel]);
+    expect(host.notifyProviderChatOptionsChanged).not.toHaveBeenCalled();
+
+    await result.backgroundRefresh;
+
+    expect(getCodexProviderSettings(host.settings).discoveredModels).toEqual([discoveredModel]);
+    expect(host.notifyProviderChatOptionsChanged).toHaveBeenCalledWith('codex');
+  });
+
+  it('does not refresh mounted model selectors when only catalog freshness changes', async () => {
+    const cachedModel = makeModel('gpt-4o');
+    const host = createFakeHost({
+      discoveredModels: [cachedModel],
+      catalogTimestamp: 1,
+    });
+    (host.mutateSettingsConditionally as jest.Mock).mockImplementation(async (mutation) => {
+      await mutation(host.settings);
+    });
+    const coordinator = new CodexModelCatalogCoordinator(host, createDiscovery({
+      kind: 'completed',
+      models: [cachedModel],
+    }));
+
+    const result = await coordinator.ensureFresh('layout-ready');
+    const backgroundResult = await result.backgroundRefresh;
+
+    expect(backgroundResult?.refreshed).toBe(false);
+    expect(host.notifyProviderChatOptionsChanged).not.toHaveBeenCalled();
   });
 
   it('preserves cached models when cache fingerprint resolution fails', async () => {

--- a/tests/unit/providers/codex/ui/CodexModelPicker.test.ts
+++ b/tests/unit/providers/codex/ui/CodexModelPicker.test.ts
@@ -299,7 +299,7 @@ describe('CodexModelPicker', () => {
 
     expect(ensureFresh).toHaveBeenCalledWith('model-picker', { force: true });
     expect(plugin.saveSettings).not.toHaveBeenCalled();
-    expect(context.refreshModelSelectors).toHaveBeenCalledTimes(1);
+    expect(context.refreshModelSelectors).not.toHaveBeenCalled();
   });
 
   it('does not save when refresh only changes the runtime catalog', async () => {
@@ -319,7 +319,7 @@ describe('CodexModelPicker', () => {
     await flushPromises();
 
     expect(plugin.saveSettings).not.toHaveBeenCalled();
-    expect(context.refreshModelSelectors).toHaveBeenCalledTimes(1);
+    expect(context.refreshModelSelectors).not.toHaveBeenCalled();
   });
 
   it('checks cached catalog freshness on open and rerenders after background refresh', async () => {
@@ -377,6 +377,6 @@ describe('CodexModelPicker', () => {
     expect(elements.some(element => (
       element.tag === 'label' && element.title === 'gpt-5.6-new'
     ))).toBe(true);
-    expect(context.refreshModelSelectors).toHaveBeenCalledTimes(2);
+    expect(context.refreshModelSelectors).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/providers/grok/app/GrokWorkspaceServices.test.ts
+++ b/tests/unit/providers/grok/app/GrokWorkspaceServices.test.ts
@@ -38,7 +38,7 @@ function createPlugin(cached = true): any {
     mutateSettingsConditionally: jest.fn(async (mutation: (value: any) => boolean) => {
       await mutation(settings);
     }),
-    refreshModelSelectors: jest.fn(),
+    notifyProviderChatOptionsChanged: jest.fn(),
     settings,
   };
 }

--- a/tests/unit/providers/grok/runtime/GrokChatRuntime.test.ts
+++ b/tests/unit/providers/grok/runtime/GrokChatRuntime.test.ts
@@ -258,7 +258,7 @@ function createHost(overrides: Record<string, unknown> = {}): ProviderHost {
     manifest: { version: '1.2.3' },
     mutateSettings: jest.fn(async mutation => mutation(settings as never)),
     mutateSettingsConditionally: jest.fn(async mutation => { await mutation(settings as never); }),
-    refreshModelSelectors: jest.fn(),
+    notifyProviderChatOptionsChanged: jest.fn(),
     ...overrides,
     settings,
   } as unknown as ProviderHost;

--- a/tests/unit/providers/grok/runtime/GrokModelCatalogCoordinator.test.ts
+++ b/tests/unit/providers/grok/runtime/GrokModelCatalogCoordinator.test.ts
@@ -77,7 +77,7 @@ function makeHost(options: {
     mutateSettingsConditionally: jest.fn(async (mutation) => {
       await mutation(settings as never);
     }),
-    refreshModelSelectors: jest.fn(),
+    notifyProviderChatOptionsChanged: jest.fn(),
     settings,
   } as unknown as ProviderHost;
 }
@@ -338,7 +338,7 @@ describe('GrokModelCatalogCoordinator', () => {
       fingerprint: 'owner-fingerprint',
       models: [expect.objectContaining({ rawId: 'owner-model' })],
     });
-    expect(host.refreshModelSelectors).toHaveBeenCalledTimes(1);
+    expect(host.notifyProviderChatOptionsChanged).toHaveBeenCalledWith('grok');
   });
 
   it('merges richer live ACP metadata by raw id and preserves CLI-only models', async () => {

--- a/tests/unit/providers/opencode/OpencodeChatRuntime.test.ts
+++ b/tests/unit/providers/opencode/OpencodeChatRuntime.test.ts
@@ -34,9 +34,9 @@ function createMockPlugin(overrides: Record<string, unknown> = {}): any {
     },
     ...overrides,
   };
-  plugin.refreshModelSelectors ??= jest.fn(() => {
+  plugin.notifyProviderChatOptionsChanged ??= jest.fn((providerId: string) => {
     for (const view of plugin.getAllViews()) {
-      view.refreshModelSelector();
+      view.refreshModelSelector(providerId);
     }
   });
   plugin.mutateSettings ??= jest.fn(async (mutation: (settings: any) => void | Promise<void>) => {

--- a/tests/unit/providers/pi/ui/PiSettingsTab.test.ts
+++ b/tests/unit/providers/pi/ui/PiSettingsTab.test.ts
@@ -334,6 +334,7 @@ function createContext(settings: Record<string, unknown>) {
   const saveSettings = jest.fn().mockResolvedValue(undefined);
   return {
     plugin: {
+      notifyProviderChatOptionsChanged: jest.fn(),
       saveSettings,
       settings,
       mutateSettings: jest.fn(async (mutation: (current: any) => void | Promise<void>) => {
@@ -485,7 +486,7 @@ describe('PiSettingsTab', () => {
     expect(mockDiscoverModels).toHaveBeenCalledTimes(1);
     expect(getPiProviderSettings(settings).discoveredModels).toHaveLength(1);
     expect(getPiProviderSettings(settings).visibleModels).toEqual(['pi:anthropic/claude-sonnet-4']);
-    expect(context.refreshModelSelectors).toHaveBeenCalled();
+    expect(context.plugin.notifyProviderChatOptionsChanged).toHaveBeenCalledWith('pi');
 
     mockDiscoverModels.mockResolvedValueOnce({
       diagnostics: 'not logged in',
@@ -527,6 +528,37 @@ describe('PiSettingsTab', () => {
 
     expect(getPiProviderSettings(settings).discoveredModels).toEqual([cachedModel]);
     expect(context.plugin.saveSettings).not.toHaveBeenCalled();
+  });
+
+  it('does not publish unchanged model discovery', async () => {
+    const cachedModel = {
+      encodedId: 'pi:anthropic/claude-sonnet-4',
+      id: 'claude-sonnet-4',
+      input: ['text'] as Array<'text'>,
+      label: 'Claude Sonnet 4',
+      provider: 'anthropic',
+      reasoning: true,
+      thinkingLevels: ['off', 'medium'] as Array<'off' | 'medium'>,
+    };
+    const settings: Record<string, unknown> = {
+      providerConfigs: {
+        pi: {
+          discoveredModels: [cachedModel],
+          visibleModels: [cachedModel.encodedId],
+        },
+      },
+    };
+    const context = render(settings);
+    mockDiscoverModels.mockResolvedValueOnce({
+      kind: 'completed',
+      models: [cachedModel],
+    });
+
+    await findElement('button', 'claudian-provider-model-picker-action').dispatchMockEvent('click');
+    await flushPromises();
+
+    expect(context.plugin.saveSettings).not.toHaveBeenCalled();
+    expect(context.plugin.notifyProviderChatOptionsChanged).not.toHaveBeenCalled();
   });
 
   it('persists visible model choices and aliases', async () => {


### PR DESCRIPTION
Fixes #958.

This adds a required provider-scoped chat-option notification and routes catalog changes from Codex, Grok, OpenCode, and Pi to mounted views without priming unrelated runtimes. It reconciles blank drafts against current provider options while preserving known provider ownership, and refreshes picker contents on hover as a fallback. Verification passed with typecheck, ESLint, 315 test suites / 6,836 tests, and the production build.