### PR TITLE
fix(claude): ignore runtime context window that under-reports a 1M model (#924)

### DIFF
--- a/src/providers/claude/types/models.ts
+++ b/src/providers/claude/types/models.ts
@@ -213,7 +213,14 @@ export function resolveContextWindowSize(
   }
 
   if (isValidContextLimit(runtimeContextWindow)) {
-    return { contextWindow: runtimeContextWindow, source: 'runtime' };
+    // The SDK can under-report a 1M-context model's window as the 200k standard
+    // window (issue #924), which pinned the context meter at "approaching limit"
+    // for context that plainly exceeds 200k. A runtime value must never shrink a
+    // known-larger model default; trust it only when it meets or exceeds it.
+    const modelDefault = getContextWindowSize(model);
+    if (runtimeContextWindow >= modelDefault) {
+      return { contextWindow: runtimeContextWindow, source: 'runtime' };
+    }
   }
 
   return {

--- a/tests/unit/providers/claude/types/types.test.ts
+++ b/tests/unit/providers/claude/types/types.test.ts
@@ -700,6 +700,75 @@ describe('types.ts', () => {
     });
   });
 
+  describe('resolveContextWindowSize', () => {
+    it('trusts a runtime window that meets or exceeds the model default', () => {
+      expect(resolveContextWindowSize('sonnet', undefined, CONTEXT_WINDOW_1M)).toEqual({
+        contextWindow: CONTEXT_WINDOW_1M,
+        source: 'runtime',
+      });
+      // A gateway advertising a larger-than-default window is still honored.
+      expect(resolveContextWindowSize('sonnet', undefined, 2_000_000)).toEqual({
+        contextWindow: 2_000_000,
+        source: 'runtime',
+      });
+    });
+
+    it('ignores a runtime window that under-reports a known 1M model as the standard window', () => {
+      // Regression for #924: the Claude SDK can report rawMaxTokens=200k for a
+      // 1M-context model. Trusting it made the footer meter read e.g. 358k/200k
+      // ("approaching limit") for context that plainly exceeds 200k. The runtime
+      // value must never shrink a known-larger model default.
+      expect(resolveContextWindowSize('sonnet', undefined, CONTEXT_WINDOW_STANDARD)).toEqual({
+        contextWindow: CONTEXT_WINDOW_1M,
+        source: 'model-default',
+      });
+      expect(resolveContextWindowSize('opus', undefined, CONTEXT_WINDOW_STANDARD)).toEqual({
+        contextWindow: CONTEXT_WINDOW_1M,
+        source: 'model-default',
+      });
+      expect(resolveContextWindowSize('fable', undefined, CONTEXT_WINDOW_STANDARD)).toEqual({
+        contextWindow: CONTEXT_WINDOW_1M,
+        source: 'model-default',
+      });
+    });
+
+    it('trusts the runtime window for a standard-window model', () => {
+      // haiku is a 200k model; a 200k runtime value is not an under-report.
+      expect(resolveContextWindowSize('haiku', undefined, CONTEXT_WINDOW_STANDARD)).toEqual({
+        contextWindow: CONTEXT_WINDOW_STANDARD,
+        source: 'runtime',
+      });
+    });
+
+    it('falls back to the model default when no runtime window is available', () => {
+      expect(resolveContextWindowSize('sonnet')).toEqual({
+        contextWindow: CONTEXT_WINDOW_1M,
+        source: 'model-default',
+      });
+      expect(resolveContextWindowSize('haiku', undefined, undefined)).toEqual({
+        contextWindow: CONTEXT_WINDOW_STANDARD,
+        source: 'model-default',
+      });
+    });
+
+    it('ignores an invalid runtime window and uses the model default', () => {
+      for (const bad of [0, -1, NaN, Infinity, -Infinity]) {
+        expect(resolveContextWindowSize('sonnet', undefined, bad)).toEqual({
+          contextWindow: CONTEXT_WINDOW_1M,
+          source: 'model-default',
+        });
+      }
+    });
+
+    it('prefers a custom limit over both runtime and model default', () => {
+      const customLimits = { 'custom-model': 256_000 };
+      expect(resolveContextWindowSize('custom-model', customLimits, CONTEXT_WINDOW_STANDARD)).toEqual({
+        contextWindow: 256_000,
+        source: 'custom',
+      });
+    });
+  });
+
   describe('supportsXHighEffort', () => {
     it('returns true for opaque custom model ids', () => {
       expect(supportsXHighEffort('custom-model')).toBe(true);


### PR DESCRIPTION
## Problem

`resolveContextWindowSize` (`src/providers/claude/types/models.ts`) trusts any positive, finite runtime value from the Claude SDK's `getContextUsage().rawMaxTokens`:

```ts
if (isValidContextLimit(runtimeContextWindow)) {
  return { contextWindow: runtimeContextWindow, source: 'runtime' };
}
```

But that value can come back as the **200k standard window for a 1M-context model**. When it does, the resolver returns `{ contextWindow: 200000, source: 'runtime' }` and never reaches the `model-default` branch that already knows the model is 1M (`getContextWindowSize` → `CONTEXT_WINDOW_1M`).

The result is the footer context meter reading e.g. **`358k / 200k (Approaching limit, run '/compact')`** on a 1M-model session. That reading is self-evidently wrong: 358k tokens cannot fit in a 200k window, so the true window is ~1M and the denominator is under-reported. The percentage and the "approaching limit" warning are both false.

This appears to be the remaining half of #924 — PR #928 added the `resolveContextWindowSize` precedence chain, but the runtime branch still trusts an under-reported window over the model's own known default.

## Fix

Guard the runtime branch so a runtime value can never *shrink* a known-larger model default:

```ts
if (isValidContextLimit(runtimeContextWindow)) {
  const modelDefault = getContextWindowSize(model);
  if (runtimeContextWindow >= modelDefault) {
    return { contextWindow: runtimeContextWindow, source: 'runtime' };
  }
}
return { contextWindow: getContextWindowSize(model), source: 'model-default' };
```

- **Under-report (the bug):** 1M model + runtime 200k → falls through to `model-default` (1M). ✅
- **Legitimate larger gateway window:** runtime ≥ default is still trusted (`source: 'runtime'`), so custom gateways advertising a bigger window keep working. ✅
- **Standard-window models:** haiku + runtime 200k is not an under-report, still trusted. ✅
- **Custom limits:** unchanged, still take precedence over everything. ✅

## Tests

Adds a `resolveContextWindowSize` describe block in `tests/unit/providers/claude/types/types.test.ts` covering: the #924 under-report regression (sonnet/opus/fable), standard-window models, runtime ≥ default, invalid runtime values, no-runtime fallback, and custom-limit precedence.

Verified locally with the full gate: `npm run typecheck && npm run lint && npm run test && npm run build` all pass (full jest suite: 315 suites / 6842 tests green).

## Notes

Display/accounting-only change — it does not alter what the SDK actually does, only which window the meter divides against. I couldn't add a test that reproduces the SDK's raw 200k report directly (that's provider-runtime behavior), so the coverage targets the resolver contract, which is where the decision is made.