### PR TITLE
Add provider-aware Codex fast mode slash command

### DIFF
--- a/src/core/commands/builtInCommands.ts
+++ b/src/core/commands/builtInCommands.ts
@@ -8,9 +8,12 @@
 import { ProviderRegistry } from '../providers/ProviderRegistry';
 import type { ProviderCapabilities, ProviderId } from '../providers/types';
 
-export type BuiltInCommandAction = 'clear' | 'add-dir' | 'resume' | 'fork';
+export type BuiltInCommandAction = 'clear' | 'add-dir' | 'resume' | 'fork' | 'fast';
 type BuiltInCommandCapability = 'supportsNativeHistory' | 'supportsFork';
-type BuiltInCommandSupportContext = ProviderId | Pick<ProviderCapabilities, BuiltInCommandCapability>;
+type BuiltInCommandCapabilityContext =
+  Pick<ProviderCapabilities, BuiltInCommandCapability>
+  & Partial<Pick<ProviderCapabilities, 'providerId'>>;
+type BuiltInCommandSupportContext = ProviderId | BuiltInCommandCapabilityContext;
 
 export interface BuiltInCommand {
   name: string;
@@ -23,6 +26,8 @@ export interface BuiltInCommand {
   argumentHint?: string;
   /** When set, provider capabilities must expose this feature. */
   requiredCapability?: BuiltInCommandCapability;
+  /** When set, only these providers expose and execute the command. */
+  supportedProviderIds?: ProviderId[];
 }
 
 export interface BuiltInCommandResult {
@@ -57,6 +62,12 @@ export const BUILT_IN_COMMANDS: BuiltInCommand[] = [
     action: 'fork',
     requiredCapability: 'supportsFork',
   },
+  {
+    name: 'fast',
+    description: 'Toggle fast mode',
+    action: 'fast',
+    supportedProviderIds: ['codex'],
+  },
 ];
 
 /** Map of command names/aliases to their definitions. */
@@ -73,7 +84,7 @@ for (const cmd of BUILT_IN_COMMANDS) {
 
 function resolveCapabilities(
   context: BuiltInCommandSupportContext,
-): Pick<ProviderCapabilities, BuiltInCommandCapability> | null {
+): BuiltInCommandCapabilityContext | null {
   if (typeof context !== 'string') {
     return context;
   }
@@ -85,11 +96,31 @@ function resolveCapabilities(
   }
 }
 
+function isBuiltInCommandProviderSupported(
+  command: BuiltInCommand,
+  context?: BuiltInCommandSupportContext,
+): boolean {
+  if (!command.supportedProviderIds || !context) {
+    return true;
+  }
+
+  const providerId = typeof context === 'string' ? context : context.providerId;
+  return Boolean(providerId && command.supportedProviderIds.includes(providerId));
+}
+
 export function isBuiltInCommandSupported(
   command: BuiltInCommand,
   context?: BuiltInCommandSupportContext,
 ): boolean {
-  if (!command.requiredCapability || !context) {
+  if (!context) {
+    return true;
+  }
+
+  if (!isBuiltInCommandProviderSupported(command, context)) {
+    return false;
+  }
+
+  if (!command.requiredCapability) {
     return true;
   }
 
@@ -99,9 +130,13 @@ export function isBuiltInCommandSupported(
 
 /**
  * Checks if input is a built-in command.
+ * Provider-scoped commands are left to other providers' command handling.
  * Returns the command and arguments if found, null otherwise.
  */
-export function detectBuiltInCommand(input: string): BuiltInCommandResult | null {
+export function detectBuiltInCommand(
+  input: string,
+  context?: BuiltInCommandSupportContext,
+): BuiltInCommandResult | null {
   const trimmed = input.trim();
   if (!trimmed.startsWith('/')) return null;
 
@@ -112,6 +147,7 @@ export function detectBuiltInCommand(input: string): BuiltInCommandResult | null
   const cmdName = match[1].toLowerCase();
   const command = commandMap.get(cmdName);
   if (!command) return null;
+  if (!isBuiltInCommandProviderSupported(command, context)) return null;
 
   const args = (match[2] || '').trim();
 

--- a/src/core/providers/commands/ProviderCommandCatalog.ts
+++ b/src/core/providers/commands/ProviderCommandCatalog.ts
@@ -12,6 +12,8 @@ export interface ProviderCommandDropdownConfig {
 
 export interface ProviderCommandListContext {
   includeBuiltIns: boolean;
+  /** Cancels provider-owned work when the requesting discovery is abandoned. */
+  signal?: AbortSignal;
   /** Request-scoped runtime snapshot. Undefined falls back to catalog-owned state. */
   runtimeCommands?: readonly SlashCommand[];
   /** Whether provider-global runtime state may satisfy a request without a snapshot. */

--- a/src/core/providers/commands/ProviderCommandDiscoveryStore.ts
+++ b/src/core/providers/commands/ProviderCommandDiscoveryStore.ts
@@ -42,13 +42,16 @@ export class ProviderCommandDiscoveryStore<T>
 implements ProviderCommandDiscoveryController<T> {
   private snapshot: ProviderCommandDiscoverySnapshot<T> = { status: 'idle' };
   private inFlight: Promise<ProviderCommandDiscoveryResult<T>> | null = null;
+  private loadAbortController: AbortController | null = null;
   private generation = 0;
   private readonly listeners = new Set<() => void>();
   private readonly onBeforeRetry: (() => void) | undefined;
   private readonly timeoutMs: number;
 
   constructor(
-    private readonly loader: () => Promise<ProviderCommandDiscoveryResult<T>>,
+    private readonly loader: (
+      signal: AbortSignal,
+    ) => Promise<ProviderCommandDiscoveryResult<T>>,
     options: ProviderCommandDiscoveryStoreOptions = {},
   ) {
     this.onBeforeRetry = options.onBeforeRetry;
@@ -75,7 +78,9 @@ implements ProviderCommandDiscoveryController<T> {
     }
 
     const generation = this.generation;
-    const load = this.loadWithTimeout()
+    const abortController = new AbortController();
+    this.loadAbortController = abortController;
+    const load = this.loadWithTimeout(abortController)
       .catch((): ProviderCommandDiscoveryResult<T> => ({
         status: 'error',
         message: 'Could not load provider commands',
@@ -91,6 +96,9 @@ implements ProviderCommandDiscoveryController<T> {
       .finally(() => {
         if (this.inFlight === load) {
           this.inFlight = null;
+        }
+        if (this.loadAbortController === abortController) {
+          this.loadAbortController = null;
         }
       });
 
@@ -108,6 +116,8 @@ implements ProviderCommandDiscoveryController<T> {
 
   invalidate(): void {
     this.generation++;
+    this.loadAbortController?.abort();
+    this.loadAbortController = null;
     this.inFlight = null;
     this.snapshot = { status: 'idle' };
     this.notify();
@@ -120,18 +130,23 @@ implements ProviderCommandDiscoveryController<T> {
     };
   }
 
-  private async loadWithTimeout(): Promise<ProviderCommandDiscoveryResult<T>> {
+  private async loadWithTimeout(
+    abortController: AbortController,
+  ): Promise<ProviderCommandDiscoveryResult<T>> {
     let timeoutId: number | null = null;
     const timeout = new Promise<ProviderCommandDiscoveryResult<T>>(resolve => {
-      timeoutId = window.setTimeout(() => resolve({
-        status: 'error',
-        message: 'Provider command discovery timed out',
-        retryable: true,
-      }), this.timeoutMs);
+      timeoutId = window.setTimeout(() => {
+        resolve({
+          status: 'error',
+          message: 'Provider command discovery timed out',
+          retryable: true,
+        });
+        abortController.abort();
+      }, this.timeoutMs);
     });
 
     try {
-      return await Promise.race([this.loader(), timeout]);
+      return await Promise.race([this.loader(abortController.signal), timeout]);
     } finally {
       if (timeoutId !== null) {
         window.clearTimeout(timeoutId);

--- a/src/core/providers/commands/ProviderCommandDiscoveryStore.ts
+++ b/src/core/providers/commands/ProviderCommandDiscoveryStore.ts
@@ -1,0 +1,151 @@
+import type { ProviderCommandDiscoveryResult } from './ProviderCommandDiscoveryResult';
+
+export type ProviderCommandDiscoverySnapshot<T> =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | ProviderCommandDiscoveryResult<T>;
+
+export interface ProviderCommandDiscoverySource<T> {
+  getSnapshot(): ProviderCommandDiscoverySnapshot<T>;
+  load(): Promise<ProviderCommandDiscoveryResult<T>>;
+  retry(): Promise<ProviderCommandDiscoveryResult<T>>;
+  subscribe(listener: () => void): () => void;
+}
+
+export interface ProviderCommandDiscoveryController<T>
+  extends ProviderCommandDiscoverySource<T> {
+  invalidate(): void;
+}
+
+export interface ProviderCommandDiscoveryStoreOptions {
+  /** Evicts upstream discovery state before retry observers can start a new load. */
+  onBeforeRetry?: () => void;
+  timeoutMs?: number;
+}
+
+const DEFAULT_DISCOVERY_TIMEOUT_MS = 8_000;
+
+function cloneResult<T>(
+  result: ProviderCommandDiscoveryResult<T>,
+): ProviderCommandDiscoveryResult<T> {
+  if (result.status !== 'ready') {
+    return result;
+  }
+
+  return {
+    status: 'ready',
+    items: [...result.items] as [T, ...T[]],
+  };
+}
+
+export class ProviderCommandDiscoveryStore<T>
+implements ProviderCommandDiscoveryController<T> {
+  private snapshot: ProviderCommandDiscoverySnapshot<T> = { status: 'idle' };
+  private inFlight: Promise<ProviderCommandDiscoveryResult<T>> | null = null;
+  private generation = 0;
+  private readonly listeners = new Set<() => void>();
+  private readonly onBeforeRetry: (() => void) | undefined;
+  private readonly timeoutMs: number;
+
+  constructor(
+    private readonly loader: () => Promise<ProviderCommandDiscoveryResult<T>>,
+    options: ProviderCommandDiscoveryStoreOptions = {},
+  ) {
+    this.onBeforeRetry = options.onBeforeRetry;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_DISCOVERY_TIMEOUT_MS;
+  }
+
+  getSnapshot(): ProviderCommandDiscoverySnapshot<T> {
+    if (this.snapshot.status !== 'ready') {
+      return this.snapshot;
+    }
+
+    return {
+      status: 'ready',
+      items: [...this.snapshot.items] as [T, ...T[]],
+    };
+  }
+
+  load(): Promise<ProviderCommandDiscoveryResult<T>> {
+    if (this.inFlight) {
+      return this.inFlight;
+    }
+    if (this.snapshot.status !== 'idle' && this.snapshot.status !== 'loading') {
+      return Promise.resolve(cloneResult(this.snapshot));
+    }
+
+    const generation = this.generation;
+    const load = this.loadWithTimeout()
+      .catch((): ProviderCommandDiscoveryResult<T> => ({
+        status: 'error',
+        message: 'Could not load provider commands',
+        retryable: true,
+      }))
+      .then((result) => {
+        if (this.generation === generation) {
+          this.snapshot = cloneResult(result);
+          this.notify();
+        }
+        return cloneResult(result);
+      })
+      .finally(() => {
+        if (this.inFlight === load) {
+          this.inFlight = null;
+        }
+      });
+
+    this.inFlight = load;
+    this.snapshot = { status: 'loading' };
+    this.notify();
+    return load;
+  }
+
+  retry(): Promise<ProviderCommandDiscoveryResult<T>> {
+    this.onBeforeRetry?.();
+    this.invalidate();
+    return this.load();
+  }
+
+  invalidate(): void {
+    this.generation++;
+    this.inFlight = null;
+    this.snapshot = { status: 'idle' };
+    this.notify();
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private async loadWithTimeout(): Promise<ProviderCommandDiscoveryResult<T>> {
+    let timeoutId: number | null = null;
+    const timeout = new Promise<ProviderCommandDiscoveryResult<T>>(resolve => {
+      timeoutId = window.setTimeout(() => resolve({
+        status: 'error',
+        message: 'Provider command discovery timed out',
+        retryable: true,
+      }), this.timeoutMs);
+    });
+
+    try {
+      return await Promise.race([this.loader(), timeout]);
+    } finally {
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
+      }
+    }
+  }
+
+  private notify(): void {
+    for (const listener of this.listeners) {
+      try {
+        listener();
+      } catch {
+        // One consumer must not prevent other discovery observers from updating.
+      }
+    }
+  }
+}

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -389,6 +389,8 @@ export interface ProviderRuntimeCommandLoaderContext {
   externalContextPaths: string[];
   plugin: ProviderHost;
   runtime: ChatRuntime | null;
+  /** Cancels provider-owned discovery work when its consumer is invalidated. */
+  signal?: AbortSignal;
 }
 
 export interface ProviderRuntimeCommandLoader {

--- a/src/core/runtime/ChatRuntime.ts
+++ b/src/core/runtime/ChatRuntime.ts
@@ -45,6 +45,8 @@ export interface ChatRuntime {
   consumeSessionInvalidation(): boolean;
   isReady(): boolean;
   getSupportedCommands(signal?: AbortSignal): Promise<SlashCommand[]>;
+  /** Returns provider command metadata only when an authoritative snapshot is available. */
+  getSupportedCommandsSnapshot?(): SlashCommand[] | null;
   /** Publishes provider-native command snapshots without committing them to a shared catalog. */
   onSupportedCommandsChange?(
     listener: (commands: readonly SlashCommand[]) => void,

--- a/src/core/runtime/ChatRuntime.ts
+++ b/src/core/runtime/ChatRuntime.ts
@@ -44,7 +44,7 @@ export interface ChatRuntime {
   getSessionId(): string | null;
   consumeSessionInvalidation(): boolean;
   isReady(): boolean;
-  getSupportedCommands(): Promise<SlashCommand[]>;
+  getSupportedCommands(signal?: AbortSignal): Promise<SlashCommand[]>;
   /** Publishes provider-native command snapshots without committing them to a shared catalog. */
   onSupportedCommandsChange?(
     listener: (commands: readonly SlashCommand[]) => void,

--- a/src/features/chat/actions/toggleServiceTier.ts
+++ b/src/features/chat/actions/toggleServiceTier.ts
@@ -1,0 +1,27 @@
+import type { ProviderChatUIConfig } from '../../../core/providers/types';
+
+export interface ServiceTierActionSettings extends Record<string, unknown> {
+  serviceTier: string;
+}
+
+export interface ServiceTierActionContext {
+  getSettings(): ServiceTierActionSettings;
+  getUIConfig(): Pick<ProviderChatUIConfig, 'getServiceTierToggle'>;
+  onServiceTierChange(serviceTier: string): Promise<void>;
+}
+
+export async function toggleServiceTier(
+  context: ServiceTierActionContext,
+): Promise<boolean> {
+  const settings = context.getSettings();
+  const toggleConfig = context.getUIConfig().getServiceTierToggle?.(settings) ?? null;
+  if (!toggleConfig) {
+    return false;
+  }
+
+  const next = settings.serviceTier === toggleConfig.activeValue
+    ? toggleConfig.inactiveValue
+    : toggleConfig.activeValue;
+  await context.onServiceTierChange(next);
+  return true;
+}

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -111,12 +111,14 @@ export interface InputControllerDeps {
   getAuxiliaryModel?: () => string | null;
   getAgentService?: () => ChatRuntime | null;
   getSubagentManager: () => SubagentManager;
-  /** Tab-level provider fallback for blank tabs (derived from draft model). */
+  /** Authoritative tab/conversation provider, independent of runtime lifecycle. */
   getTabProviderId?: () => ProviderId;
   /** Returns true if ready. */
   ensureServiceInitialized?: () => Promise<boolean>;
   openConversation?: (conversationId: string) => Promise<void>;
   onForkAll?: () => Promise<void>;
+  /** Toggles the active provider's fast service tier when available. */
+  toggleFastMode?: () => Promise<boolean>;
   restorePrePlanPermissionModeIfNeeded?: () => void | Promise<void>;
   turnOwner?: ActiveTurnOwner;
 }
@@ -179,10 +181,15 @@ export class InputController {
   }
 
   private getActiveProviderId(): ProviderId {
+    const tabProviderId = this.deps.getTabProviderId?.();
+    if (tabProviderId) {
+      return tabProviderId;
+    }
+
     const agentService = this.getAgentService();
     const conversationId = this.deps.state.currentConversationId;
     if (!conversationId) {
-      return this.deps.getTabProviderId?.() ?? agentService?.providerId ?? DEFAULT_CHAT_PROVIDER_ID;
+      return agentService?.providerId ?? DEFAULT_CHAT_PROVIDER_ID;
     }
 
     if (agentService?.providerId) {
@@ -254,7 +261,7 @@ export class InputController {
     }
 
     // Check for built-in commands first (e.g., /clear, /new, /add-dir)
-    const builtInCmd = detectBuiltInCommand(content);
+    const builtInCmd = detectBuiltInCommand(content, this.getActiveProviderId());
     if (builtInCmd) {
       if (shouldUseInput) {
         inputEl.value = '';
@@ -1805,6 +1812,17 @@ export class InputController {
           return;
         }
         await this.deps.onForkAll();
+        break;
+      }
+      case 'fast': {
+        try {
+          const toggled = await this.deps.toggleFastMode?.() ?? false;
+          if (!toggled) {
+            new Notice('Fast mode is not available for this model.');
+          }
+        } catch {
+          new Notice('Failed to toggle fast mode.');
+        }
         break;
       }
       default: {

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -3,6 +3,7 @@ import { Notice, Platform } from 'obsidian';
 
 import { getHiddenProviderCommandSet } from '../../../core/providers/commands/hiddenCommands';
 import { normalizeProviderCommandDiscoveryItems } from '../../../core/providers/commands/ProviderCommandDiscoveryResult';
+import { ProviderCommandDiscoveryStore } from '../../../core/providers/commands/ProviderCommandDiscoveryStore';
 import {
   findProviderModelOption,
   getProviderSettingsSnapshotWithModel,
@@ -31,6 +32,7 @@ import { SlashCommandDropdown } from '../../../shared/components/SlashCommandDro
 import { getEnhancedPath } from '../../../utils/env';
 import { getVaultPath } from '../../../utils/path';
 import type { FeatureHost } from '../../FeatureHost';
+import { toggleServiceTier } from '../actions/toggleServiceTier';
 import { BrowserSelectionController } from '../controllers/BrowserSelectionController';
 import { CanvasSelectionController } from '../controllers/CanvasSelectionController';
 import { ConversationController } from '../controllers/ConversationController';
@@ -324,8 +326,10 @@ function getRegistryProviderCatalogInfo(providerId: ProviderId): ProviderCatalog
 
   return {
     config: catalog.getDropdownConfig(),
-    getEntries: async () => normalizeProviderCommandDiscoveryItems(
-      await catalog.listDropdownEntries({ includeBuiltIns: false }),
+    discovery: new ProviderCommandDiscoveryStore(async () =>
+      normalizeProviderCommandDiscoveryItems(
+        await catalog.listDropdownEntries({ includeBuiltIns: false }),
+      ),
     ),
   };
 }
@@ -345,16 +349,27 @@ function syncSlashCommandDropdownForProvider(
     return;
   }
 
+  const providerId = getTabProviderId(tab, plugin, conversation);
   const catalogInfo = (getProviderCatalogConfig ?? tab.providerCatalogResolver)?.()
-    ?? getRegistryProviderCatalogInfo(getTabProviderId(tab, plugin, conversation));
+    ?? getRegistryProviderCatalogInfo(providerId);
+
+  dropdown.setProviderId(providerId);
 
   if (catalogInfo) {
-    dropdown.setProviderCatalog?.(catalogInfo.config, catalogInfo.getEntries);
+    dropdown.setProviderCatalog?.(catalogInfo.config, catalogInfo.discovery);
   } else {
     dropdown.clearProviderCatalog?.();
   }
 
   dropdown.setHiddenCommands(getTabHiddenCommands(tab, plugin, conversation));
+}
+
+function invalidateTabProviderCommands(
+  tab: TabData,
+  getProviderCatalogConfig?: ProviderCatalogResolver,
+): void {
+  const catalogInfo = (getProviderCatalogConfig ?? tab.providerCatalogResolver)?.() ?? null;
+  catalogInfo?.discovery.invalidate();
 }
 
 async function updateTabProviderSettings(
@@ -374,6 +389,28 @@ async function updateTabProviderSettings(
     );
   });
   return snapshot;
+}
+
+async function updateTabServiceTier(
+  tab: TabData,
+  plugin: FeatureHost,
+  serviceTier: string,
+): Promise<void> {
+  await updateTabProviderSettings(tab, plugin, (settings) => {
+    settings.serviceTier = serviceTier;
+  });
+  tab.ui.serviceTierToggle?.updateDisplay();
+}
+
+async function toggleTabServiceTier(
+  tab: TabData,
+  plugin: FeatureHost,
+): Promise<boolean> {
+  return await toggleServiceTier({
+    getUIConfig: () => getTabChatUIConfig(tab, plugin),
+    getSettings: () => getTabSettingsSnapshot(tab, plugin),
+    onServiceTierChange: serviceTier => updateTabServiceTier(tab, plugin, serviceTier),
+  });
 }
 
 function refreshTabProviderUI(tab: TabData, plugin: FeatureHost): void {
@@ -536,8 +573,8 @@ export function onProviderAvailabilityChanged(tab: TabData, plugin: FeatureHost)
   }
 
   syncTabProviderServices(tab, plugin);
-  tab.ui.slashCommandDropdown?.setHiddenCommands(getTabHiddenCommands(tab, plugin));
-  tab.ui.slashCommandDropdown?.resetSdkSkillsCache();
+  syncSlashCommandDropdownForProvider(tab, plugin);
+  invalidateTabProviderCommands(tab);
   refreshTabProviderUI(tab, plugin);
   applyProviderUIGating(tab, plugin);
 }
@@ -876,6 +913,7 @@ function initializeContextManagers(tab: TabData, plugin: FeatureHost): void {
 
 function initializeSlashCommands(
   tab: TabData,
+  providerId: ProviderId,
   getHiddenCommands?: () => Set<string>,
   catalogInfo?: ProviderCatalogInfo,
 ): void {
@@ -889,9 +927,10 @@ function initializeSlashCommands(
       onHide: () => {},
     },
     {
+      providerId,
       hiddenCommands: getHiddenCommands?.() ?? new Set(),
       providerConfig: catalogInfo?.config,
-      discoverProviderEntries: catalogInfo?.getEntries,
+      providerDiscovery: catalogInfo?.discovery,
     }
   );
 }
@@ -1115,10 +1154,7 @@ function initializeInputToolbar(
       });
     },
     onServiceTierChange: async (serviceTier: string) => {
-      await updateTabProviderSettings(tab, plugin, (settings) => {
-        settings.serviceTier = serviceTier;
-      });
-      tab.ui.serviceTierToggle?.updateDisplay();
+      await updateTabServiceTier(tab, plugin, serviceTier);
     },
     onPermissionModeChange: async (mode: string) => {
       await updateTabProviderSettings(tab, plugin, (settings) => {
@@ -1208,6 +1244,7 @@ export function initializeTabUI(
   const catalogInfo = options.getProviderCatalogConfig?.() ?? null;
   initializeSlashCommands(
     tab,
+    getTabProviderId(tab, plugin),
     () => getTabHiddenCommands(tab, plugin),
     catalogInfo,
   );
@@ -1629,8 +1666,8 @@ export function initializeTabControllers(
         applyProviderUIGating(tab, plugin);
         syncSlashCommandDropdownForProvider(tab, plugin, getProviderCatalogConfig);
       },
-      onConversationLoaded: () => ui.slashCommandDropdown?.resetSdkSkillsCache(),
-      onConversationSwitched: () => ui.slashCommandDropdown?.resetSdkSkillsCache(),
+      onConversationLoaded: () => invalidateTabProviderCommands(tab, getProviderCatalogConfig),
+      onConversationSwitched: () => invalidateTabProviderCommands(tab, getProviderCatalogConfig),
     }
   );
 
@@ -1669,6 +1706,7 @@ export function initializeTabControllers(
     onForkAll: forkRequestCallback
       ? () => handleForkAll(tab, plugin, forkRequestCallback)
       : undefined,
+    toggleFastMode: () => toggleTabServiceTier(tab, plugin),
     restorePrePlanPermissionModeIfNeeded: async () => {
       if (getTabPermissionMode(tab, plugin) === 'plan') {
         const restoreMode = tab.state.prePlanPermissionMode ?? 'normal';

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -326,9 +326,9 @@ function getRegistryProviderCatalogInfo(providerId: ProviderId): ProviderCatalog
 
   return {
     config: catalog.getDropdownConfig(),
-    discovery: new ProviderCommandDiscoveryStore(async () =>
+    discovery: new ProviderCommandDiscoveryStore(async signal =>
       normalizeProviderCommandDiscoveryItems(
-        await catalog.listDropdownEntries({ includeBuiltIns: false }),
+        await catalog.listDropdownEntries({ includeBuiltIns: false, signal }),
       ),
     ),
   };

--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -932,13 +932,21 @@ export class TabManager implements TabManagerInterface {
       && targetService.isReady()
       && !targetTab.runtimeSupervisor.isInvalidated
     ) {
-      hasRuntimeSnapshot = true;
-      result = normalizeProviderCommandDiscoveryItems(
-        await (signal
-          ? targetService.getSupportedCommands(signal)
-          : targetService.getSupportedCommands()),
-      );
-      signal?.throwIfAborted();
+      if (targetService.getSupportedCommandsSnapshot) {
+        const snapshot = targetService.getSupportedCommandsSnapshot();
+        if (snapshot !== null) {
+          hasRuntimeSnapshot = true;
+          result = normalizeProviderCommandDiscoveryItems(snapshot);
+        }
+      } else {
+        hasRuntimeSnapshot = true;
+        result = normalizeProviderCommandDiscoveryItems(
+          await (signal
+            ? targetService.getSupportedCommands(signal)
+            : targetService.getSupportedCommands()),
+        );
+        signal?.throwIfAborted();
+      }
     }
 
     if (

--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -85,6 +85,7 @@ type ProviderCommandContext = ProviderWarmupContext & {
 };
 
 type ProviderCommandWarmupEntry = {
+  abortController: AbortController;
   key: string;
   promise: Promise<ProviderCommandDiscoveryResult<SlashCommand>>;
 };
@@ -412,6 +413,8 @@ export class TabManager implements TabManagerInterface {
 
     // Prevent in-flight hydration from mutating this tab while close awaits persistence.
     tab.lifecycleState = 'closing';
+    this.providerCommandDiscoveryStores.get(tabId)?.invalidate();
+    this.cancelProviderRuntimeCommandWarmup(tabId);
 
     // Save conversation before closing. Cleanup remains mandatory if save fails.
     let saveError: unknown;
@@ -430,7 +433,6 @@ export class TabManager implements TabManagerInterface {
     // Destroy tab resources (async for proper cleanup)
     await destroyTab(tab);
     this.unbindRuntimeCommandSubscription(tabId);
-    this.providerRuntimeCommandWarmups.delete(tabId);
     this.providerRuntimeCommandCache.delete(tabId);
     this.providerCommandDiscoveryStores.delete(tabId);
     this.tabCommandContextRevisions.delete(tabId);
@@ -858,12 +860,15 @@ export class TabManager implements TabManagerInterface {
 
   async getProviderCommandDiscovery(
     tabId?: TabId,
+    signal?: AbortSignal,
   ): Promise<ProviderCommandDiscoveryResult<ProviderCommandEntry>> {
+    signal?.throwIfAborted();
     const targetTab = (tabId ? this.tabs.get(tabId) : this.getActiveTab()) ?? null;
     if (!targetTab) return { status: 'empty' };
 
     const providerId = getTabProviderId(targetTab, this.plugin);
-    const discovery = await this.getSdkCommandDiscovery(targetTab.id);
+    const discovery = await this.getSdkCommandDiscovery(targetTab.id, signal);
+    signal?.throwIfAborted();
     const { result } = discovery;
     if (result.status === 'error' || result.status === 'requires-session') {
       return result;
@@ -873,6 +878,7 @@ export class TabManager implements TabManagerInterface {
     if (!catalog) return { status: 'empty' };
     const entries = await catalog.listDropdownEntries({
       includeBuiltIns: false,
+      ...(signal ? { signal } : {}),
       allowCachedRuntimeCommands: discovery.runtimeCommands !== undefined,
       ...(discovery.runtimeCommands !== undefined
         ? { runtimeCommands: discovery.runtimeCommands }
@@ -883,7 +889,9 @@ export class TabManager implements TabManagerInterface {
 
   private async getSdkCommandDiscovery(
     tabId?: TabId,
+    signal?: AbortSignal,
   ): Promise<SdkCommandDiscovery> {
+    signal?.throwIfAborted();
     const targetTab = (tabId ? this.tabs.get(tabId) : this.getActiveTab()) ?? null;
     if (!targetTab) {
       return { result: { status: 'empty' } };
@@ -892,6 +900,7 @@ export class TabManager implements TabManagerInterface {
     const providerId = getTabProviderId(targetTab, this.plugin);
     if (!ProviderWorkspaceRegistry.getIfInitialized(providerId)) {
       await ProviderWorkspaceRegistry.ensureInitialized(this.plugin.providerHost, providerId, 'command-picker');
+      signal?.throwIfAborted();
     }
 
     const staticCapabilities = ProviderRegistry.getCapabilities(providerId);
@@ -902,6 +911,7 @@ export class TabManager implements TabManagerInterface {
     const catalog = ProviderWorkspaceRegistry.getCommandCatalog(providerId);
     const runtimeCommandLoader = ProviderWorkspaceRegistry.getRuntimeCommandLoader(providerId);
     const context = await this.buildProviderWarmupContext(targetTab, providerId);
+    signal?.throwIfAborted();
     const commandContext = this.buildProviderCommandContext(targetTab, providerId, context);
     if (
       targetTab.lifecycleState === 'blank'
@@ -916,7 +926,7 @@ export class TabManager implements TabManagerInterface {
     const targetService = targetTab.service;
     if (runtimeCommandLoader) {
       hasRuntimeSnapshot = true;
-      result = await this.ensureProviderCommandRuntime(targetTab, providerId, context);
+      result = await this.ensureProviderCommandRuntime(targetTab, providerId, context, signal);
     } else if (
       targetService?.providerId === providerId
       && targetService.isReady()
@@ -926,6 +936,7 @@ export class TabManager implements TabManagerInterface {
       result = normalizeProviderCommandDiscoveryItems(
         await targetService.getSupportedCommands(),
       );
+      signal?.throwIfAborted();
     }
 
     if (
@@ -948,7 +959,9 @@ export class TabManager implements TabManagerInterface {
     tab: TabData,
     providerId: ProviderId,
     warmupContext?: ProviderWarmupContext,
+    signal?: AbortSignal,
   ): Promise<ProviderCommandDiscoveryResult<SlashCommand>> {
+    signal?.throwIfAborted();
     if (!this.isProviderCommandLoaderAvailable(providerId)) {
       return { status: 'empty' };
     }
@@ -973,20 +986,28 @@ export class TabManager implements TabManagerInterface {
 
     const existing = this.providerRuntimeCommandWarmups.get(tab.id);
     if (existing?.key === context.cacheKey) {
-      return await existing.promise;
+      return await this.awaitProviderCommandWarmup(existing, signal);
     }
-    this.providerRuntimeCommandWarmups.delete(tab.id);
+    this.cancelProviderRuntimeCommandWarmup(tab.id);
 
-    const warmup = this.warmProviderCommandRuntime(tab, providerId, context).finally(() => {
+    const abortController = new AbortController();
+    const warmup = this.warmProviderCommandRuntime(
+      tab,
+      providerId,
+      context,
+      abortController.signal,
+    ).finally(() => {
       if (this.providerRuntimeCommandWarmups.get(tab.id)?.promise === warmup) {
         this.providerRuntimeCommandWarmups.delete(tab.id);
       }
     });
-    this.providerRuntimeCommandWarmups.set(tab.id, {
+    const entry: ProviderCommandWarmupEntry = {
+      abortController,
       key: context.cacheKey,
       promise: warmup,
-    });
-    return await warmup;
+    };
+    this.providerRuntimeCommandWarmups.set(tab.id, entry);
+    return await this.awaitProviderCommandWarmup(entry, signal);
   }
 
   private maybePrimeProviderRuntime(tab: TabData): void {
@@ -1130,8 +1151,47 @@ export class TabManager implements TabManagerInterface {
       tabId,
       (this.tabCommandContextRevisions.get(tabId) ?? 0) + 1,
     );
-    this.providerRuntimeCommandWarmups.delete(tabId);
+    this.cancelProviderRuntimeCommandWarmup(tabId);
     this.providerRuntimeCommandCache.delete(tabId);
+  }
+
+  private cancelProviderRuntimeCommandWarmup(tabId: TabId): void {
+    const warmup = this.providerRuntimeCommandWarmups.get(tabId);
+    if (!warmup) {
+      return;
+    }
+    warmup.abortController.abort();
+    this.providerRuntimeCommandWarmups.delete(tabId);
+  }
+
+  private async awaitProviderCommandWarmup(
+    warmup: ProviderCommandWarmupEntry,
+    signal?: AbortSignal,
+  ): Promise<ProviderCommandDiscoveryResult<SlashCommand>> {
+    if (!signal) {
+      return await warmup.promise;
+    }
+    if (signal.aborted) {
+      warmup.abortController.abort();
+      signal.throwIfAborted();
+    }
+
+    let onAbort: (() => void) | null = null;
+    const aborted = new Promise<never>((_resolve, reject) => {
+      onAbort = () => {
+        warmup.abortController.abort();
+        reject(signal.reason ?? new Error('Provider command discovery aborted'));
+      };
+      signal.addEventListener('abort', onAbort, { once: true });
+    });
+
+    try {
+      return await Promise.race([warmup.promise, aborted]);
+    } finally {
+      if (onAbort) {
+        signal.removeEventListener('abort', onAbort);
+      }
+    }
   }
 
   private isCommandContextCurrent(
@@ -1170,6 +1230,7 @@ export class TabManager implements TabManagerInterface {
     tab: TabData,
     providerId: ProviderId,
     context: ProviderCommandContext,
+    signal: AbortSignal,
   ): Promise<ProviderCommandDiscoveryResult<SlashCommand>> {
     const loader = ProviderWorkspaceRegistry.getRuntimeCommandLoader(providerId);
     if (!loader) {
@@ -1183,6 +1244,7 @@ export class TabManager implements TabManagerInterface {
       externalContextPaths: context.externalContextPaths,
       plugin: this.plugin.providerHost,
       runtime: context.runtime,
+      signal,
     });
 
     if (
@@ -1215,7 +1277,7 @@ export class TabManager implements TabManagerInterface {
     }
 
     const discovery = new ProviderCommandDiscoveryStore(
-      () => this.getProviderCommandDiscovery(tabId),
+      signal => this.getProviderCommandDiscovery(tabId, signal),
       {
         onBeforeRetry: () => this.advanceTabCommandContextRevision(tabId),
       },
@@ -1324,13 +1386,19 @@ export class TabManager implements TabManagerInterface {
 
   /** Destroys all tabs and cleans up resources. */
   async destroy(): Promise<void> {
+    for (const discovery of this.providerCommandDiscoveryStores.values()) {
+      discovery.invalidate();
+    }
+    for (const warmup of this.providerRuntimeCommandWarmups.values()) {
+      warmup.abortController.abort();
+    }
+
     // Each tab drains background work and persists its final state during teardown.
     await Promise.all(Array.from(this.tabs.values()).map(tab => destroyTab(tab)));
 
     for (const tabId of this.runtimeCommandSubscriptions.keys()) {
       this.unbindRuntimeCommandSubscription(tabId);
     }
-
     this.tabs.clear();
     this.providerRuntimeCommandWarmups.clear();
     this.providerRuntimeCommandCache.clear();

--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -3,6 +3,7 @@ import { Notice } from 'obsidian';
 import { StartupProfiler } from '../../../core/performance/StartupProfiler';
 import type { ProviderCommandDiscoveryResult } from '../../../core/providers/commands/ProviderCommandDiscoveryResult';
 import { normalizeProviderCommandDiscoveryItems } from '../../../core/providers/commands/ProviderCommandDiscoveryResult';
+import { ProviderCommandDiscoveryStore } from '../../../core/providers/commands/ProviderCommandDiscoveryStore';
 import type { ProviderCommandEntry } from '../../../core/providers/commands/ProviderCommandEntry';
 import { ProviderRegistry } from '../../../core/providers/ProviderRegistry';
 import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
@@ -64,7 +65,7 @@ type OpenConversationOptions = {
   activate?: boolean;
 };
 
-type ProviderCommandCacheEntry = {
+type ProviderRuntimeCommandCacheEntry = {
   result: ProviderCommandDiscoveryResult<SlashCommand>;
   key: string;
 };
@@ -109,8 +110,12 @@ export class TabManager implements TabManagerInterface {
   private tabs: Map<TabId, TabData> = new Map();
   private activeTabId: TabId | null = null;
   private callbacks: TabManagerCallbacks;
-  private providerCommandWarmups = new Map<TabId, ProviderCommandWarmupEntry>();
-  private providerCommandCache = new Map<TabId, ProviderCommandCacheEntry>();
+  private providerRuntimeCommandWarmups = new Map<TabId, ProviderCommandWarmupEntry>();
+  private providerRuntimeCommandCache = new Map<TabId, ProviderRuntimeCommandCacheEntry>();
+  private providerCommandDiscoveryStores = new Map<
+    TabId,
+    ProviderCommandDiscoveryStore<ProviderCommandEntry>
+  >();
   private providerResourceGenerations = new Map<ProviderId, number>();
   private tabCommandContextRevisions = new Map<TabId, number>();
   private runtimeCommandSubscriptions = new Map<TabId, RuntimeCommandSubscription>();
@@ -222,7 +227,6 @@ export class TabManager implements TabManagerInterface {
         },
         onConversationIdChanged: (conversationId) => {
           this.bumpTabCommandContextRevision(tab.id);
-          tab.ui.slashCommandDropdown?.resetSdkSkillsCache();
           // Sync tab.conversationId when conversation is lazily created
           tab.conversationId = conversationId;
           this.callbacks.onTabConversationChanged?.(tab.id, conversationId);
@@ -231,13 +235,13 @@ export class TabManager implements TabManagerInterface {
       });
 
       this.tabCommandContextRevisions.set(tab.id, 0);
+      this.ensureProviderCommandDiscoveryStore(tab.id);
 
       // Initialize UI components with provider catalog
       initializeTabUI(tab, this.plugin, {
         getProviderCatalogConfig: () => this.getProviderCatalogConfig(tab),
         onCommandContextChanged: () => {
           this.bumpTabCommandContextRevision(tab.id);
-          tab.ui.slashCommandDropdown?.resetSdkSkillsCache();
         },
         onProviderChanged: async (providerId) => {
           this.bumpTabCommandContextRevision(tab.id);
@@ -426,8 +430,9 @@ export class TabManager implements TabManagerInterface {
     // Destroy tab resources (async for proper cleanup)
     await destroyTab(tab);
     this.unbindRuntimeCommandSubscription(tabId);
-    this.providerCommandWarmups.delete(tabId);
-    this.providerCommandCache.delete(tabId);
+    this.providerRuntimeCommandWarmups.delete(tabId);
+    this.providerRuntimeCommandCache.delete(tabId);
+    this.providerCommandDiscoveryStores.delete(tabId);
     this.tabCommandContextRevisions.delete(tabId);
     this.tabs.delete(tabId);
     this.callbacks.onTabClosed?.(tabId);
@@ -622,7 +627,6 @@ export class TabManager implements TabManagerInterface {
   invalidateProviderCommandCaches(providerIds?: ProviderId | ProviderId[]): void {
     for (const tab of this.filterTabsByProvider(providerIds, (tab) => getTabProviderId(tab, this.plugin))) {
       this.bumpTabCommandContextRevision(tab.id);
-      tab.ui?.slashCommandDropdown?.resetSdkSkillsCache();
     }
   }
 
@@ -643,9 +647,8 @@ export class TabManager implements TabManagerInterface {
     for (const tab of this.tabs.values()) {
       const providerId = tab.service?.providerId ?? getTabProviderId(tab, this.plugin);
       if (!filter.has(providerId)) continue;
-      this.bumpTabCommandContextRevision(tab.id);
       tab.runtimeSupervisor.invalidate(generation);
-      tab.ui.slashCommandDropdown?.resetSdkSkillsCache();
+      this.bumpTabCommandContextRevision(tab.id);
     }
   }
 
@@ -957,7 +960,7 @@ export class TabManager implements TabManagerInterface {
       providerId,
       resolvedWarmupContext,
     );
-    const cached = this.providerCommandCache.get(tab.id);
+    const cached = this.providerRuntimeCommandCache.get(tab.id);
     if (
       (!context.runtime || !context.runtime.isReady())
       && cached
@@ -968,18 +971,18 @@ export class TabManager implements TabManagerInterface {
         : cached.result;
     }
 
-    const existing = this.providerCommandWarmups.get(tab.id);
+    const existing = this.providerRuntimeCommandWarmups.get(tab.id);
     if (existing?.key === context.cacheKey) {
       return await existing.promise;
     }
-    this.providerCommandWarmups.delete(tab.id);
+    this.providerRuntimeCommandWarmups.delete(tab.id);
 
     const warmup = this.warmProviderCommandRuntime(tab, providerId, context).finally(() => {
-      if (this.providerCommandWarmups.get(tab.id)?.promise === warmup) {
-        this.providerCommandWarmups.delete(tab.id);
+      if (this.providerRuntimeCommandWarmups.get(tab.id)?.promise === warmup) {
+        this.providerRuntimeCommandWarmups.delete(tab.id);
       }
     });
-    this.providerCommandWarmups.set(tab.id, {
+    this.providerRuntimeCommandWarmups.set(tab.id, {
       key: context.cacheKey,
       promise: warmup,
     });
@@ -1118,12 +1121,17 @@ export class TabManager implements TabManagerInterface {
   }
 
   private bumpTabCommandContextRevision(tabId: TabId): void {
+    this.advanceTabCommandContextRevision(tabId);
+    this.providerCommandDiscoveryStores.get(tabId)?.invalidate();
+  }
+
+  private advanceTabCommandContextRevision(tabId: TabId): void {
     this.tabCommandContextRevisions.set(
       tabId,
       (this.tabCommandContextRevisions.get(tabId) ?? 0) + 1,
     );
-    this.providerCommandWarmups.delete(tabId);
-    this.providerCommandCache.delete(tabId);
+    this.providerRuntimeCommandWarmups.delete(tabId);
+    this.providerRuntimeCommandCache.delete(tabId);
   }
 
   private isCommandContextCurrent(
@@ -1182,14 +1190,14 @@ export class TabManager implements TabManagerInterface {
       && (!context.runtime || !context.runtime.isReady())
       && (result.status === 'ready' || result.status === 'empty')
     ) {
-      this.providerCommandCache.set(tab.id, {
+      this.providerRuntimeCommandCache.set(tab.id, {
         key: context.cacheKey,
         result: result.status === 'ready'
           ? { status: 'ready', items: result.items.map(command => ({ ...command })) as [SlashCommand, ...SlashCommand[]] }
           : result,
       });
     } else if (this.isCommandContextCurrent(tab, providerId, context)) {
-      this.providerCommandCache.delete(tab.id);
+      this.providerRuntimeCommandCache.delete(tab.id);
     }
     return result;
   }
@@ -1198,6 +1206,24 @@ export class TabManager implements TabManagerInterface {
   // Provider Command Catalog
   // ============================================
 
+  private ensureProviderCommandDiscoveryStore(
+    tabId: TabId,
+  ): ProviderCommandDiscoveryStore<ProviderCommandEntry> {
+    const existing = this.providerCommandDiscoveryStores.get(tabId);
+    if (existing) {
+      return existing;
+    }
+
+    const discovery = new ProviderCommandDiscoveryStore(
+      () => this.getProviderCommandDiscovery(tabId),
+      {
+        onBeforeRetry: () => this.advanceTabCommandContextRevision(tabId),
+      },
+    );
+    this.providerCommandDiscoveryStores.set(tabId, discovery);
+    return discovery;
+  }
+
   private getProviderCatalogConfig(tab: TabData) {
     const providerId = getTabProviderId(tab, this.plugin);
     const catalog = ProviderWorkspaceRegistry.getCommandCatalog(providerId);
@@ -1205,7 +1231,7 @@ export class TabManager implements TabManagerInterface {
 
     return {
       config: catalog.getDropdownConfig(),
-      getEntries: () => this.getProviderCommandDiscovery(tab.id),
+      discovery: this.ensureProviderCommandDiscoveryStore(tab.id),
     };
   }
 
@@ -1229,8 +1255,7 @@ export class TabManager implements TabManagerInterface {
           commands.map(command => ({ ...command })),
         );
       }
-      this.providerCommandCache.delete(tab.id);
-      tab.ui.slashCommandDropdown?.resetSdkSkillsCache();
+      this.bumpTabCommandContextRevision(tab.id);
     });
     this.runtimeCommandSubscriptions.set(tab.id, { runtime, unsubscribe });
   }
@@ -1307,8 +1332,9 @@ export class TabManager implements TabManagerInterface {
     }
 
     this.tabs.clear();
-    this.providerCommandWarmups.clear();
-    this.providerCommandCache.clear();
+    this.providerRuntimeCommandWarmups.clear();
+    this.providerRuntimeCommandCache.clear();
+    this.providerCommandDiscoveryStores.clear();
     this.tabCommandContextRevisions.clear();
     this.activeTabId = null;
   }

--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -934,7 +934,9 @@ export class TabManager implements TabManagerInterface {
     ) {
       hasRuntimeSnapshot = true;
       result = normalizeProviderCommandDiscoveryItems(
-        await targetService.getSupportedCommands(),
+        await (signal
+          ? targetService.getSupportedCommands(signal)
+          : targetService.getSupportedCommands()),
       );
       signal?.throwIfAborted();
     }

--- a/src/features/chat/tabs/types.ts
+++ b/src/features/chat/tabs/types.ts
@@ -1,7 +1,7 @@
 import type { Component, WorkspaceLeaf } from 'obsidian';
 
 import type { ProviderCommandDropdownConfig } from '../../../core/providers/commands/ProviderCommandCatalog';
-import type { ProviderCommandDiscoveryResult } from '../../../core/providers/commands/ProviderCommandDiscoveryResult';
+import type { ProviderCommandDiscoveryController } from '../../../core/providers/commands/ProviderCommandDiscoveryStore';
 import type { ProviderCommandEntry } from '../../../core/providers/commands/ProviderCommandEntry';
 import type { InstructionRefineService, ProviderId, TitleGenerationService } from '../../../core/providers/types';
 import type { ChatRuntime } from '../../../core/runtime/ChatRuntime';
@@ -90,7 +90,7 @@ export type TabId = string;
 
 export type ProviderCatalogInfo = {
   config: ProviderCommandDropdownConfig;
-  getEntries: () => Promise<ProviderCommandDiscoveryResult<ProviderCommandEntry>>;
+  discovery: ProviderCommandDiscoveryController<ProviderCommandEntry>;
 } | null;
 
 export type ProviderCatalogResolver = () => ProviderCatalogInfo;

--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -24,6 +24,7 @@ import {
 } from '../../../utils/animationFrame';
 import { filterValidPaths, findConflictingPath, isDuplicatePath, isValidDirectoryPath, validateDirectoryPath } from '../../../utils/externalContext';
 import { expandHomePath, normalizePathForFilesystem } from '../../../utils/path';
+import { toggleServiceTier } from '../actions/toggleServiceTier';
 
 interface ElectronOpenDialogResult {
   canceled: boolean;
@@ -507,7 +508,9 @@ export class ServiceTierToggle {
     this.updateDisplay();
 
     this.buttonEl.addEventListener('click', () => {
-      runToolbarAction(() => this.toggle(), 'Failed to change service tier');
+      runToolbarAction(async () => {
+        await this.toggle();
+      }, 'Failed to change service tier');
     });
   }
 
@@ -537,16 +540,12 @@ export class ServiceTierToggle {
     this.container.setAttribute('title', 'Toggle on/off fast mode');
   }
 
-  private async toggle() {
-    const toggleConfig = this.getToggleConfig();
-    if (!toggleConfig) return;
-
-    const current = this.callbacks.getSettings().serviceTier;
-    const next = current === toggleConfig.activeValue
-      ? toggleConfig.inactiveValue
-      : toggleConfig.activeValue;
-    await this.callbacks.onServiceTierChange(next);
-    this.updateDisplay();
+  async toggle(): Promise<boolean> {
+    const toggled = await toggleServiceTier(this.callbacks);
+    if (toggled) {
+      this.updateDisplay();
+    }
+    return toggled;
   }
 }
 

--- a/src/features/inline-edit/ui/InlineEditModal.ts
+++ b/src/features/inline-edit/ui/InlineEditModal.ts
@@ -5,6 +5,8 @@ import type { App, Component, Editor, MarkdownView } from 'obsidian';
 import { Notice } from 'obsidian';
 
 import { getHiddenProviderCommandSet } from '../../../core/providers/commands/hiddenCommands';
+import { normalizeProviderCommandDiscoveryItems } from '../../../core/providers/commands/ProviderCommandDiscoveryResult';
+import { ProviderCommandDiscoveryStore } from '../../../core/providers/commands/ProviderCommandDiscoveryStore';
 import { resolveConversationModel } from '../../../core/providers/conversationModel';
 import { ProviderRegistry } from '../../../core/providers/ProviderRegistry';
 import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
@@ -550,10 +552,16 @@ export class InlineEditSession {
       },
       {
         fixed: true,
+        includeBuiltIns: false,
+        providerId: this.resolvedProviderId,
         hiddenCommands: getHiddenProviderCommandSet(this.plugin.settings, this.resolvedProviderId),
         ...(inlineCatalog ? {
           providerConfig: inlineCatalog.getDropdownConfig(),
-          getProviderEntries: () => inlineCatalog.listDropdownEntries({ includeBuiltIns: false }),
+          providerDiscovery: new ProviderCommandDiscoveryStore(async () =>
+            normalizeProviderCommandDiscoveryItems(
+              await inlineCatalog.listDropdownEntries({ includeBuiltIns: false }),
+            ),
+          ),
         } : {}),
       }
     );

--- a/src/features/inline-edit/ui/InlineEditModal.ts
+++ b/src/features/inline-edit/ui/InlineEditModal.ts
@@ -557,9 +557,12 @@ export class InlineEditSession {
         hiddenCommands: getHiddenProviderCommandSet(this.plugin.settings, this.resolvedProviderId),
         ...(inlineCatalog ? {
           providerConfig: inlineCatalog.getDropdownConfig(),
-          providerDiscovery: new ProviderCommandDiscoveryStore(async () =>
+          providerDiscovery: new ProviderCommandDiscoveryStore(async signal =>
             normalizeProviderCommandDiscoveryItems(
-              await inlineCatalog.listDropdownEntries({ includeBuiltIns: false }),
+              await inlineCatalog.listDropdownEntries({
+                includeBuiltIns: false,
+                signal,
+              }),
             ),
           ),
         } : {}),

--- a/src/providers/claude/app/ClaudeWorkspaceServices.ts
+++ b/src/providers/claude/app/ClaudeWorkspaceServices.ts
@@ -68,7 +68,7 @@ export async function createClaudeWorkspaceServices(
   const commandCatalog = new ClaudeCommandCatalog(
     claudeStorage.commands,
     claudeStorage.skills,
-    () => probeRuntimeCommands(plugin),
+    signal => probeRuntimeCommands(plugin, signal),
   );
 
   return {

--- a/src/providers/claude/commands/ClaudeCommandCatalog.ts
+++ b/src/providers/claude/commands/ClaudeCommandCatalog.ts
@@ -61,7 +61,7 @@ const BUILTIN_HIDDEN_COMMANDS = new Set([
   'insights', 'loop', 'schedule', 'security-review', 'simplify', 'update-config',
 ]);
 
-export type CommandProbe = () => Promise<SlashCommand[]>;
+export type CommandProbe = (signal?: AbortSignal) => Promise<SlashCommand[]>;
 
 export class ClaudeCommandCatalog implements ProviderCommandCatalog, ProviderVaultEntryRepository {
   private runtimeCommands: SlashCommand[] = [];
@@ -82,6 +82,7 @@ export class ClaudeCommandCatalog implements ProviderCommandCatalog, ProviderVau
   }
 
   async listDropdownEntries(context: ProviderCommandListContext): Promise<ProviderCommandEntry[]> {
+    context.signal?.throwIfAborted();
     // SDK commands already include vault commands/skills (the SDK scans
     // .claude/commands/ and .claude/skills/ internally). No file scan needed.
     let commands = context.runtimeCommands;
@@ -90,7 +91,7 @@ export class ClaudeCommandCatalog implements ProviderCommandCatalog, ProviderVau
       if (allowCachedRuntimeCommands && this.runtimeCommands.length > 0) {
         commands = this.runtimeCommands;
       } else {
-        const probedCommands = await this.ensureProbed();
+        const probedCommands = await this.ensureProbed(context.signal);
         commands = allowCachedRuntimeCommands && this.runtimeCommands.length > 0
           ? this.runtimeCommands
           : probedCommands;
@@ -102,13 +103,25 @@ export class ClaudeCommandCatalog implements ProviderCommandCatalog, ProviderVau
     if (runtimeEntries.length > 0) {
       return runtimeEntries;
     }
-    return this.listVaultEntries();
+    return this.listVaultEntries(context.signal);
   }
 
   /** Probe the SDK for commands. Deduplicates concurrent calls. */
-  private async ensureProbed(): Promise<SlashCommand[]> {
+  private async ensureProbed(signal?: AbortSignal): Promise<SlashCommand[]> {
+    signal?.throwIfAborted();
     if (this.probedCommands) return this.probedCommands;
     if (!this.probe) return [];
+    if (signal) {
+      try {
+        const commands = await this.probe(signal);
+        signal.throwIfAborted();
+        this.probedCommands = commands.map(command => ({ ...command }));
+      } catch {
+        signal.throwIfAborted();
+        this.probedCommands = [];
+      }
+      return this.probedCommands;
+    }
     if (!this.probePromise) {
       this.probePromise = this.probe().then((commands) => {
         this.probedCommands = commands.map(command => ({ ...command }));
@@ -124,9 +137,12 @@ export class ClaudeCommandCatalog implements ProviderCommandCatalog, ProviderVau
     return await this.probePromise;
   }
 
-  async listVaultEntries(): Promise<ProviderCommandEntry[]> {
+  async listVaultEntries(signal?: AbortSignal): Promise<ProviderCommandEntry[]> {
+    signal?.throwIfAborted();
     const commands = await this.commandStorage.loadAll();
+    signal?.throwIfAborted();
     const skills = await this.skillStorage.loadAll();
+    signal?.throwIfAborted();
     return [...commands, ...skills].map(slashCommandToEntry);
   }
 

--- a/src/providers/claude/commands/probeRuntimeCommands.ts
+++ b/src/providers/claude/commands/probeRuntimeCommands.ts
@@ -22,6 +22,31 @@ function mapSdkCommands(sdkCommands: SDKSlashCommand[]): SlashCommand[] {
   }));
 }
 
+async function awaitWithAbort<T>(
+  promise: Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  if (!signal) {
+    return await promise;
+  }
+  signal.throwIfAborted();
+
+  let onAbort: (() => void) | null = null;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    onAbort = () => reject(
+      signal.reason ?? new Error('Claude command discovery aborted'),
+    );
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+  try {
+    return await Promise.race([promise, aborted]);
+  } finally {
+    if (onAbort) {
+      signal.removeEventListener('abort', onAbort);
+    }
+  }
+}
+
 /**
  * Probes the Claude SDK locally to discover available commands and skills.
  *
@@ -29,30 +54,38 @@ function mapSdkCommands(sdkCommands: SDKSlashCommand[]): SlashCommand[] {
  * event from local config parsing alone (no API call, no cost). The probe
  * captures that event, calls supportedCommands() for full metadata, then aborts.
  */
-export async function probeRuntimeCommands(plugin: ProviderHost): Promise<SlashCommand[]> {
-  const vaultPath = getVaultPath(plugin.app);
-  if (!vaultPath) return [];
-
-  const cliPath = await plugin.getResolvedProviderCliPath('claude');
-  if (!cliPath) return [];
-
-  const customEnv = parseEnvironmentVariables(
-    plugin.getActiveEnvironmentVariables('claude')
-  );
-  const enhancedPath = getEnhancedPath(customEnv.PATH, cliPath);
-  const claudeSettings = getClaudeProviderSettings(
-    plugin.settings,
-  );
-
+export async function probeRuntimeCommands(
+  plugin: ProviderHost,
+  signal?: AbortSignal,
+): Promise<SlashCommand[]> {
+  signal?.throwIfAborted();
   const abortController = new AbortController();
+  const onAbort = (): void => abortController.abort();
+  signal?.addEventListener('abort', onAbort, { once: true });
   let commands: SlashCommand[] = [];
-  const extraArgs = {
-    ...(claudeSettings.safeMode === 'auto' ? { 'enable-auto-mode': null } : {}),
-    ...(claudeSettings.enableChrome ? { chrome: null } : {}),
-  };
 
   try {
-    const agentQuery = await loadClaudeAgentQuery();
+    const vaultPath = getVaultPath(plugin.app);
+    if (!vaultPath) return [];
+
+    const cliPath = await awaitWithAbort(
+      Promise.resolve(plugin.getResolvedProviderCliPath('claude')),
+      signal,
+    );
+    if (!cliPath) return [];
+
+    const customEnv = parseEnvironmentVariables(
+      plugin.getActiveEnvironmentVariables('claude')
+    );
+    const enhancedPath = getEnhancedPath(customEnv.PATH, cliPath);
+    const claudeSettings = getClaudeProviderSettings(
+      plugin.settings,
+    );
+    const extraArgs = {
+      ...(claudeSettings.safeMode === 'auto' ? { 'enable-auto-mode': null } : {}),
+      ...(claudeSettings.enableChrome ? { chrome: null } : {}),
+    };
+    const agentQuery = await awaitWithAbort(loadClaudeAgentQuery(), signal);
     const conversation = agentQuery({
       prompt: '',
       options: {
@@ -69,18 +102,31 @@ export async function probeRuntimeCommands(plugin: ProviderHost): Promise<SlashC
       },
     });
 
-    for await (const event of conversation) {
+    while (true) {
+      const next = await awaitWithAbort(conversation.next(), signal);
+      if (next.done) {
+        break;
+      }
+      const event = next.value;
       if (event.type === 'system' && event.subtype === 'init') {
         try {
-          const sdkCommands: SDKSlashCommand[] = await conversation.supportedCommands();
+          const sdkCommands: SDKSlashCommand[] = await awaitWithAbort(
+            conversation.supportedCommands(),
+            signal,
+          );
           commands = mapSdkCommands(sdkCommands);
-        } catch { /* best-effort */ }
-        abortController.abort();
+        } catch {
+          signal?.throwIfAborted();
+        }
         break;
       }
     }
   } catch {
-    // Probe is best-effort; swallow abort errors.
+    signal?.throwIfAborted();
+    // Probe failures are best-effort; caller cancellation remains observable.
+  } finally {
+    signal?.removeEventListener('abort', onAbort);
+    abortController.abort();
   }
 
   return commands;

--- a/src/providers/claude/runtime/ClaudeChatRuntime.ts
+++ b/src/providers/claude/runtime/ClaudeChatRuntime.ts
@@ -1859,24 +1859,45 @@ export class ClaudianService implements ChatRuntime {
    * supportedCommands() call if the cache is empty (e.g., dropdown opened
    * before the first init event).
    */
-  async getSupportedCommands(): Promise<SlashCommand[]> {
+  async getSupportedCommands(signal?: AbortSignal): Promise<SlashCommand[]> {
+    signal?.throwIfAborted();
     if (this.cachedSdkCommands.length > 0) {
       return this.cachedSdkCommands;
     }
     if (!this.persistentQuery) {
       return [];
     }
-    return this.fetchAndCacheCommands(this.persistentQuery);
+    return this.fetchAndCacheCommands(this.persistentQuery, signal);
   }
 
   /**
    * Fetches commands from the SDK and caches them. Called on system/init
    * (fire-and-forget) and as a fallback from getSupportedCommands().
    */
-  private async fetchAndCacheCommands(query: Query | null): Promise<SlashCommand[]> {
+  private async fetchAndCacheCommands(
+    query: Query | null,
+    signal?: AbortSignal,
+  ): Promise<SlashCommand[]> {
     if (!query) return [];
+    signal?.throwIfAborted();
+    let onAbort: (() => void) | null = null;
+    const aborted = signal
+      ? new Promise<never>((_resolve, reject) => {
+        onAbort = () => {
+          if (this.persistentQuery === query) {
+            this.closePersistentQuery('command discovery aborted');
+          }
+          reject(signal.reason ?? new Error('Claude command discovery aborted'));
+        };
+        signal.addEventListener('abort', onAbort, { once: true });
+      })
+      : null;
     try {
-      const sdkCommands: SDKSlashCommand[] = await query.supportedCommands();
+      const commandRequest = query.supportedCommands();
+      const sdkCommands: SDKSlashCommand[] = aborted
+        ? await Promise.race([commandRequest, aborted])
+        : await commandRequest;
+      signal?.throwIfAborted();
       const mappedCommands = sdkCommands.map((cmd) => ({
         id: `sdk:${cmd.name}`,
         name: cmd.name,
@@ -1891,7 +1912,12 @@ export class ClaudianService implements ChatRuntime {
       this.cachedSdkCommands = mappedCommands;
       return this.cachedSdkCommands;
     } catch {
+      signal?.throwIfAborted();
       return [];
+    } finally {
+      if (onAbort && signal) {
+        signal.removeEventListener('abort', onAbort);
+      }
     }
   }
 

--- a/src/providers/claude/runtime/ClaudeChatRuntime.ts
+++ b/src/providers/claude/runtime/ClaudeChatRuntime.ts
@@ -196,6 +196,7 @@ export class ClaudianService implements ChatRuntime {
 
   // SDK command cache — populated on system/init, cleared on persistent query close
   private cachedSdkCommands: SlashCommand[] = [];
+  private hasCachedSdkCommandSnapshot = false;
 
   private _asyncSubagentCompletionCallback: AsyncSubagentCompletionCallback | null = null;
 
@@ -748,6 +749,7 @@ export class ClaudianService implements ChatRuntime {
     this.authoritativeContextWindow = null;
     this.contextWindowDiscovery = null;
     this.cachedSdkCommands = [];
+    this.hasCachedSdkCommandSnapshot = false;
     this.streamTransformState.clearAll();
     this.usageTransformState.clear();
     this._autoTurnBuffer = [];
@@ -1855,19 +1857,18 @@ export class ClaudianService implements ChatRuntime {
 
   /**
    * Get supported commands (SDK skills).
-   * Returns cached commands populated on system/init. Falls back to a fresh
-   * supportedCommands() call if the cache is empty (e.g., dropdown opened
-   * before the first init event).
+   * Live query control requests are deliberately excluded: dropdown discovery
+   * must not interrupt or otherwise own the active Claude session.
    */
   async getSupportedCommands(signal?: AbortSignal): Promise<SlashCommand[]> {
     signal?.throwIfAborted();
-    if (this.cachedSdkCommands.length > 0) {
-      return this.cachedSdkCommands;
-    }
-    if (!this.persistentQuery) {
-      return [];
-    }
-    return this.fetchAndCacheCommands(this.persistentQuery, signal);
+    return this.getSupportedCommandsSnapshot() ?? [];
+  }
+
+  getSupportedCommandsSnapshot(): SlashCommand[] | null {
+    return this.hasCachedSdkCommandSnapshot
+      ? this.cachedSdkCommands.map(command => ({ ...command }))
+      : null;
   }
 
   /**
@@ -1876,28 +1877,10 @@ export class ClaudianService implements ChatRuntime {
    */
   private async fetchAndCacheCommands(
     query: Query | null,
-    signal?: AbortSignal,
   ): Promise<SlashCommand[]> {
     if (!query) return [];
-    signal?.throwIfAborted();
-    let onAbort: (() => void) | null = null;
-    const aborted = signal
-      ? new Promise<never>((_resolve, reject) => {
-        onAbort = () => {
-          if (this.persistentQuery === query) {
-            this.closePersistentQuery('command discovery aborted');
-          }
-          reject(signal.reason ?? new Error('Claude command discovery aborted'));
-        };
-        signal.addEventListener('abort', onAbort, { once: true });
-      })
-      : null;
     try {
-      const commandRequest = query.supportedCommands();
-      const sdkCommands: SDKSlashCommand[] = aborted
-        ? await Promise.race([commandRequest, aborted])
-        : await commandRequest;
-      signal?.throwIfAborted();
+      const sdkCommands: SDKSlashCommand[] = await query.supportedCommands();
       const mappedCommands = sdkCommands.map((cmd) => ({
         id: `sdk:${cmd.name}`,
         name: cmd.name,
@@ -1910,14 +1893,10 @@ export class ClaudianService implements ChatRuntime {
         return this.cachedSdkCommands;
       }
       this.cachedSdkCommands = mappedCommands;
+      this.hasCachedSdkCommandSnapshot = true;
       return this.cachedSdkCommands;
     } catch {
-      signal?.throwIfAborted();
       return [];
-    } finally {
-      if (onAbort && signal) {
-        signal.removeEventListener('abort', onAbort);
-      }
     }
   }
 

--- a/src/providers/codex/commands/CodexSkillCatalog.ts
+++ b/src/providers/codex/commands/CodexSkillCatalog.ts
@@ -1,6 +1,7 @@
 import type {
   ProviderCommandCatalog,
   ProviderCommandDropdownConfig,
+  ProviderCommandListContext,
 } from '../../../core/providers/commands/ProviderCommandCatalog';
 import type { ProviderCommandEntry } from '../../../core/providers/commands/ProviderCommandEntry';
 import type { SlashCommand } from '../../../core/types';
@@ -57,8 +58,10 @@ export class CodexSkillCatalog implements ProviderCommandCatalog {
     // Codex dropdown entries come from app-server metadata; runtime commands are ignored.
   }
 
-  async listDropdownEntries(context: { includeBuiltIns: boolean }): Promise<ProviderCommandEntry[]> {
-    const skills = (await this.listProvider.listSkills())
+  async listDropdownEntries(context: ProviderCommandListContext): Promise<ProviderCommandEntry[]> {
+    const skills = (await this.listProvider.listSkills(
+      context.signal ? { signal: context.signal } : undefined,
+    ))
       .filter(skill => skill.enabled)
       .sort(compareCodexSkillPriority);
     const entries = skills.map(listedSkillToProviderEntry);

--- a/src/providers/codex/skills/CodexSkillListingService.ts
+++ b/src/providers/codex/skills/CodexSkillListingService.ts
@@ -13,7 +13,10 @@ import { CodexRpcTransport } from '../runtime/CodexRpcTransport';
 import { createCodexRuntimeContext } from '../runtime/CodexRuntimeContext';
 
 export interface CodexSkillListProvider {
-  listSkills(options?: { forceReload?: boolean }): Promise<SkillMetadata[]>;
+  listSkills(options?: {
+    forceReload?: boolean;
+    signal?: AbortSignal;
+  }): Promise<SkillMetadata[]>;
   invalidate(): void;
 }
 
@@ -108,10 +111,23 @@ export class CodexSkillListingService implements CodexSkillListProvider {
     this.now = options.now ?? (() => Date.now());
   }
 
-  async listSkills(options?: { forceReload?: boolean }): Promise<SkillMetadata[]> {
+  async listSkills(options?: {
+    forceReload?: boolean;
+    signal?: AbortSignal;
+  }): Promise<SkillMetadata[]> {
+    options?.signal?.throwIfAborted();
     if (options?.forceReload) {
       const generation = ++this.generation;
-      return this.startFetch(true, generation);
+      return this.startFetch(true, generation, options.signal);
+    }
+
+    if (options?.signal) {
+      if (this.cache && this.now() < this.cacheExpiresAt) {
+        return this.cache;
+      }
+      // A request-scoped signal owns its process lifetime. Do not coalesce it
+      // behind work that another consumer may invalidate independently.
+      return this.startFetch(false, this.generation, options.signal);
     }
 
     if (this.pending?.generation === this.generation) {
@@ -125,8 +141,15 @@ export class CodexSkillListingService implements CodexSkillListProvider {
     return this.startFetch(false, this.generation);
   }
 
-  private startFetch(forceReload: boolean, generation: number): Promise<SkillMetadata[]> {
-    const promise = this.fetchSkills(forceReload)
+  private startFetch(
+    forceReload: boolean,
+    generation: number,
+    signal?: AbortSignal,
+  ): Promise<SkillMetadata[]> {
+    const fetch = signal
+      ? this.fetchSkills(forceReload, signal)
+      : this.fetchSkills(forceReload);
+    const promise = fetch
       .then((skills) => {
         if (generation === this.generation) {
           this.storeCache(skills);
@@ -138,7 +161,9 @@ export class CodexSkillListingService implements CodexSkillListProvider {
           this.pending = null;
         }
       });
-    this.pending = { generation, promise };
+    if (!signal) {
+      this.pending = { generation, promise };
+    }
     return promise;
   }
 
@@ -149,16 +174,24 @@ export class CodexSkillListingService implements CodexSkillListProvider {
     this.pending = null;
   }
 
-  private async fetchSkills(forceReload: boolean): Promise<SkillMetadata[]> {
+  private async fetchSkills(
+    forceReload: boolean,
+    signal?: AbortSignal,
+  ): Promise<SkillMetadata[]> {
+    signal?.throwIfAborted();
     const launchSpec = await resolveCodexAppServerLaunchSpec(this.plugin, 'codex');
+    signal?.throwIfAborted();
     const process = new CodexAppServerProcess(launchSpec);
     process.start();
 
     const transport = new CodexRpcTransport(process);
     transport.start();
+    const onAbort = (): void => transport.dispose();
+    signal?.addEventListener('abort', onAbort, { once: true });
 
     try {
       const initializeResult = await initializeCodexAppServerTransport(transport);
+      signal?.throwIfAborted();
       createCodexRuntimeContext(launchSpec, initializeResult);
       const result = await transport.request<SkillsListResult>('skills/list', {
         cwds: [launchSpec.targetCwd],
@@ -171,6 +204,7 @@ export class CodexSkillListingService implements CodexSkillListProvider {
         path: launchSpec.pathMapper.toHostPath(skill.path) ?? skill.path,
       }));
     } finally {
+      signal?.removeEventListener('abort', onAbort);
       transport.dispose();
       await process.shutdown();
     }

--- a/src/providers/grok/app/GrokRuntimeCommandLoader.ts
+++ b/src/providers/grok/app/GrokRuntimeCommandLoader.ts
@@ -12,7 +12,7 @@ import { GrokChatRuntime } from '../runtime/GrokChatRuntime';
 import { getGrokProviderSettings } from '../settings';
 
 interface GrokRuntimeCommandSource {
-  discoverSupportedCommands(timeoutMs?: number): Promise<SlashCommand[]>;
+  discoverSupportedCommands(timeoutMs?: number, signal?: AbortSignal): Promise<SlashCommand[]>;
   getReadySupportedCommandsSnapshot(): SlashCommand[] | null;
   providerId: 'grok';
 }
@@ -59,6 +59,7 @@ export class GrokRuntimeCommandLoader implements ProviderRuntimeCommandLoader {
   async loadCommands(
     context: ProviderRuntimeCommandLoaderContext,
   ): Promise<ProviderCommandDiscoveryResult<SlashCommand>> {
+    context.signal?.throwIfAborted();
     const activeSource = resolveCommandSource(context.runtime);
     try {
       const commands = activeSource?.getReadySupportedCommandsSnapshot();
@@ -74,9 +75,19 @@ export class GrokRuntimeCommandLoader implements ProviderRuntimeCommandLoader {
     }
 
     const runtime = activeSource ?? this.createRuntime(context.plugin);
+    let cleanedUp = false;
+    const cleanup = (): void => {
+      if (activeSource || cleanedUp) {
+        return;
+      }
+      cleanedUp = true;
+      runtime.cleanup();
+    };
+    const onAbort = (): void => cleanup();
+    context.signal?.addEventListener('abort', onAbort, { once: true });
     try {
       return normalizeProviderCommandDiscoveryItems(
-        await runtime.discoverSupportedCommands(5_000),
+        await runtime.discoverSupportedCommands(5_000, context.signal),
       );
     } catch {
       return {
@@ -85,9 +96,8 @@ export class GrokRuntimeCommandLoader implements ProviderRuntimeCommandLoader {
         status: 'error',
       };
     } finally {
-      if (!activeSource) {
-        runtime.cleanup();
-      }
+      context.signal?.removeEventListener('abort', onAbort);
+      cleanup();
     }
   }
 }

--- a/src/providers/grok/runtime/GrokChatRuntime.ts
+++ b/src/providers/grok/runtime/GrokChatRuntime.ts
@@ -804,8 +804,13 @@ export class GrokChatRuntime implements ChatRuntime {
     return this.supportedCommands.map(cloneSlashCommand);
   }
 
-  async discoverSupportedCommands(timeoutMs = 5_000): Promise<SlashCommand[]> {
+  async discoverSupportedCommands(
+    timeoutMs = 5_000,
+    signal?: AbortSignal,
+  ): Promise<SlashCommand[]> {
+    signal?.throwIfAborted();
     const ready = await this.ensureReady({ allowSessionCreation: false });
+    signal?.throwIfAborted();
     const transport = this.transport;
     if (!ready || !transport || transport.isClosed) {
       throw new Error('Grok command transport is unavailable.');
@@ -814,7 +819,7 @@ export class GrokChatRuntime implements ChatRuntime {
     const response = await transport.request<GrokListCommandsResponse>(
       '_x.ai/commands/list',
       { cwd },
-      { timeoutMs },
+      { signal, timeoutMs },
     );
     if (!Array.isArray(response.commands)) {
       throw new Error('Grok returned malformed command metadata.');

--- a/src/providers/opencode/app/OpencodeRuntimeCommandLoader.ts
+++ b/src/providers/opencode/app/OpencodeRuntimeCommandLoader.ts
@@ -24,6 +24,7 @@ export class OpencodeRuntimeCommandLoader implements ProviderRuntimeCommandLoade
   async loadCommands(
     context: ProviderRuntimeCommandLoaderContext,
   ): Promise<ProviderCommandDiscoveryResult<SlashCommand>> {
+    context.signal?.throwIfAborted();
     const shouldWarmBlankSession = context.allowSessionCreation === true
       && !context.conversation?.sessionId;
     const shouldWarmPreSessionConversation = !!context.conversation
@@ -52,6 +53,16 @@ export class OpencodeRuntimeCommandLoader implements ProviderRuntimeCommandLoade
     const runtime = canReuseRuntime
       ? context.runtime!
       : new OpencodeChatRuntime(context.plugin);
+    let cleanedUp = false;
+    const cleanup = (): void => {
+      if (runtime === context.runtime || cleanedUp) {
+        return;
+      }
+      cleanedUp = true;
+      runtime.cleanup();
+    };
+    const onAbort = (): void => cleanup();
+    context.signal?.addEventListener('abort', onAbort, { once: true });
 
     try {
       if (shouldWarmPreSessionConversation) {
@@ -72,11 +83,14 @@ export class OpencodeRuntimeCommandLoader implements ProviderRuntimeCommandLoade
         });
       }
 
-      const commandSnapshot = (runtime as OpencodeChatRuntime).discoverSupportedCommands(5_000);
+      const commandSnapshot = context.signal
+        ? (runtime as OpencodeChatRuntime).discoverSupportedCommands(5_000, context.signal)
+        : (runtime as OpencodeChatRuntime).discoverSupportedCommands(5_000);
       void commandSnapshot.catch(() => {});
       const ready = await runtime.ensureReady({
         allowSessionCreation: shouldWarmBlankSession || shouldWarmPreSessionConversation,
       });
+      context.signal?.throwIfAborted();
       if (!ready) {
         return {
           message: 'Could not load OpenCode commands.',
@@ -93,9 +107,8 @@ export class OpencodeRuntimeCommandLoader implements ProviderRuntimeCommandLoade
         status: 'error' as const,
       };
     } finally {
-      if (runtime !== context.runtime) {
-        runtime.cleanup();
-      }
+      context.signal?.removeEventListener('abort', onAbort);
+      cleanup();
     }
   }
 }

--- a/src/providers/opencode/runtime/OpencodeChatRuntime.ts
+++ b/src/providers/opencode/runtime/OpencodeChatRuntime.ts
@@ -102,9 +102,9 @@ interface ActiveTurn {
 }
 
 interface SupportedCommandWaiter {
+  cleanup: () => void;
   reject: (error: Error) => void;
   resolve: (commands: SlashCommand[]) => void;
-  timeoutId: number;
 }
 
 class StreamChunkQueue {
@@ -635,23 +635,47 @@ export class OpencodeChatRuntime implements ChatRuntime {
     }
   }
 
-  discoverSupportedCommands(timeoutMs = 5_000): Promise<SlashCommand[]> {
+  discoverSupportedCommands(
+    timeoutMs = 5_000,
+    signal?: AbortSignal,
+  ): Promise<SlashCommand[]> {
+    signal?.throwIfAborted();
     if (this.supportedCommandsAdvertised && this.loadedSessionId === this.sessionId) {
       return Promise.resolve(this.cloneSupportedCommands());
     }
 
     return new Promise<SlashCommand[]>((resolve, reject) => {
-      const waiter: SupportedCommandWaiter = {
-        reject,
-        resolve,
-        timeoutId: window.setTimeout(() => {
+      let timeoutId: number | null = null;
+      let onAbort: (() => void) | null = null;
+      const cleanup = (): void => {
+        if (timeoutId !== null) {
+          window.clearTimeout(timeoutId);
+        }
+        if (onAbort && signal) {
+          signal.removeEventListener('abort', onAbort);
+        }
+      };
+      const waiter: SupportedCommandWaiter = { cleanup, reject, resolve };
+      timeoutId = window.setTimeout(() => {
+        const index = this.supportedCommandWaiters.indexOf(waiter);
+        if (index >= 0) {
+          this.supportedCommandWaiters.splice(index, 1);
+        }
+        cleanup();
+        reject(new Error('Timed out waiting for OpenCode commands.'));
+      }, timeoutMs);
+
+      if (signal) {
+        onAbort = () => {
           const index = this.supportedCommandWaiters.indexOf(waiter);
           if (index >= 0) {
             this.supportedCommandWaiters.splice(index, 1);
           }
-          reject(new Error('Timed out waiting for OpenCode commands.'));
-        }, timeoutMs),
-      };
+          cleanup();
+          reject(new Error('OpenCode command discovery aborted.'));
+        };
+        signal.addEventListener('abort', onAbort, { once: true });
+      }
       this.supportedCommandWaiters.push(waiter);
     });
   }
@@ -1587,7 +1611,7 @@ export class OpencodeChatRuntime implements ChatRuntime {
 
     const waiters = this.supportedCommandWaiters.splice(0);
     for (const waiter of waiters) {
-      window.clearTimeout(waiter.timeoutId);
+      waiter.cleanup();
       waiter.resolve(this.cloneSupportedCommands());
     }
 
@@ -1623,7 +1647,7 @@ export class OpencodeChatRuntime implements ChatRuntime {
   private rejectSupportedCommandWaiters(error: Error): void {
     const waiters = this.supportedCommandWaiters.splice(0);
     for (const waiter of waiters) {
-      window.clearTimeout(waiter.timeoutId);
+      waiter.cleanup();
       waiter.reject(error);
     }
   }

--- a/src/providers/pi/app/PiRuntimeCommandLoader.ts
+++ b/src/providers/pi/app/PiRuntimeCommandLoader.ts
@@ -23,6 +23,7 @@ export class PiRuntimeCommandLoader implements ProviderRuntimeCommandLoader {
   async loadCommands(
     context: ProviderRuntimeCommandLoaderContext,
   ): Promise<ProviderCommandDiscoveryResult<SlashCommand>> {
+    context.signal?.throwIfAborted();
     const persistedState = getPiState(context.conversation?.providerState);
     const hasPersistedSession = Boolean(
       context.conversation?.sessionId
@@ -49,6 +50,16 @@ export class PiRuntimeCommandLoader implements ProviderRuntimeCommandLoader {
     const runtime = canReuseRuntime
       ? context.runtime!
       : new PiChatRuntime(context.plugin);
+    let cleanedUp = false;
+    const cleanup = (): void => {
+      if (runtime === context.runtime || cleanedUp) {
+        return;
+      }
+      cleanedUp = true;
+      runtime.cleanup();
+    };
+    const onAbort = (): void => cleanup();
+    context.signal?.addEventListener('abort', onAbort, { once: true });
 
     try {
       if (canReuseRuntime && context.conversation) {
@@ -58,6 +69,7 @@ export class PiRuntimeCommandLoader implements ProviderRuntimeCommandLoader {
       const ready = await runtime.ensureReady({
         allowSessionCreation: false,
       });
+      context.signal?.throwIfAborted();
       if (!ready) {
         return {
           message: 'Could not load Pi commands.',
@@ -67,7 +79,7 @@ export class PiRuntimeCommandLoader implements ProviderRuntimeCommandLoader {
       }
 
       return normalizeProviderCommandDiscoveryItems(
-        await (runtime as PiChatRuntime).discoverSupportedCommands(),
+        await (runtime as PiChatRuntime).discoverSupportedCommands(context.signal),
       );
     } catch {
       return {
@@ -76,9 +88,8 @@ export class PiRuntimeCommandLoader implements ProviderRuntimeCommandLoader {
         status: 'error' as const,
       };
     } finally {
-      if (runtime !== context.runtime) {
-        runtime.cleanup();
-      }
+      context.signal?.removeEventListener('abort', onAbort);
+      cleanup();
     }
   }
 }

--- a/src/providers/pi/runtime/PiChatRuntime.ts
+++ b/src/providers/pi/runtime/PiChatRuntime.ts
@@ -555,7 +555,8 @@ export class PiChatRuntime implements ChatRuntime {
     }
   }
 
-  async discoverSupportedCommands(): Promise<SlashCommand[]> {
+  async discoverSupportedCommands(signal?: AbortSignal): Promise<SlashCommand[]> {
+    signal?.throwIfAborted();
     if (this.supportedCommandsLoaded) {
       return [...this.supportedCommands];
     }
@@ -563,7 +564,7 @@ export class PiChatRuntime implements ChatRuntime {
       throw new Error('Pi command transport is unavailable.');
     }
 
-    const response = await this.transport.request('get_commands', {}, 10_000);
+    const response = await this.transport.request('get_commands', {}, 10_000, signal);
     this.supportedCommands = normalizePiRuntimeCommands(response);
     this.supportedCommandsLoaded = true;
     return [...this.supportedCommands];

--- a/src/providers/pi/runtime/PiRpcTransport.ts
+++ b/src/providers/pi/runtime/PiRpcTransport.ts
@@ -100,6 +100,7 @@ export class PiRpcTransport {
     commandType: string,
     payload: Record<string, unknown> = {},
     timeoutMs = this.defaultTimeoutMs,
+    signal?: AbortSignal,
   ): Promise<T> {
     this.start();
     if (this.disposed) {
@@ -109,9 +110,13 @@ export class PiRpcTransport {
     const id = `req_${this.nextId++}`;
     return new Promise<T>((resolve, reject) => {
       let timer: number | undefined;
+      let onAbort: (() => void) | undefined;
       const cleanup = (): void => {
         if (timer !== undefined) {
           window.clearTimeout(timer);
+        }
+        if (onAbort && signal) {
+          signal.removeEventListener('abort', onAbort);
         }
       };
 
@@ -121,6 +126,20 @@ export class PiRpcTransport {
           cleanup();
           reject(new Error(`Request timeout: ${commandType} (${timeoutMs}ms)`));
         }, timeoutMs);
+      }
+
+      if (signal?.aborted) {
+        cleanup();
+        reject(new Error(`Request aborted: ${commandType}`));
+        return;
+      }
+      if (signal) {
+        onAbort = () => {
+          this.pending.delete(id);
+          cleanup();
+          reject(new Error(`Request aborted: ${commandType}`));
+        };
+        signal.addEventListener('abort', onAbort, { once: true });
       }
 
       this.pending.set(id, {

--- a/src/shared/components/SlashCommandDropdown.ts
+++ b/src/shared/components/SlashCommandDropdown.ts
@@ -1,7 +1,11 @@
 import { getBuiltInCommandsForDropdown } from '../../core/commands/builtInCommands';
 import type { ProviderCommandDropdownConfig } from '../../core/providers/commands/ProviderCommandCatalog';
-import type { ProviderCommandDiscoveryResult } from '../../core/providers/commands/ProviderCommandDiscoveryResult';
+import type {
+  ProviderCommandDiscoverySnapshot,
+  ProviderCommandDiscoverySource,
+} from '../../core/providers/commands/ProviderCommandDiscoveryStore';
 import type { ProviderCommandEntry } from '../../core/providers/commands/ProviderCommandEntry';
+import type { ProviderId } from '../../core/providers/types';
 import type { SlashCommand } from '../../core/types';
 import { normalizeArgumentHint } from '../../utils/slashCommand';
 
@@ -25,18 +29,19 @@ export interface SlashCommandDropdownCallbacks {
 export interface SlashCommandDropdownOptions {
   fixed?: boolean;
   hiddenCommands?: Set<string>;
+  /** Whether to include Claudian chat-action built-ins such as /clear and /fast. */
+  includeBuiltIns?: boolean;
+  /** Active provider identity, independent of optional catalog availability. */
+  providerId?: ProviderId;
   providerConfig?: ProviderCommandDropdownConfig;
-  /** Catalog-only compatibility path used by auxiliary consumers such as inline edit. */
-  getProviderEntries?: () => Promise<ProviderCommandEntry[]>;
-  /** Typed provider-protocol discovery used by the active chat composer. */
-  discoverProviderEntries?: () => Promise<ProviderCommandDiscoveryResult<ProviderCommandEntry>>;
+  /** Provider-protocol discovery state owned by the active chat tab. */
+  providerDiscovery?: ProviderCommandDiscoverySource<ProviderCommandEntry>;
 }
 
-type ProviderDiscoveryViewState =
-  | { status: 'loading' }
-  | ProviderCommandDiscoveryResult<ProviderCommandEntry>;
-
-const PROVIDER_DISCOVERY_TIMEOUT_MS = 8_000;
+type ProviderDiscoveryViewState = Exclude<
+  ProviderCommandDiscoverySnapshot<ProviderCommandEntry>,
+  { status: 'idle' }
+>;
 
 export class SlashCommandDropdown {
   private containerEl: HTMLElement;
@@ -50,19 +55,15 @@ export class SlashCommandDropdown {
   private selectedIndex = 0;
   private filteredItems: DropdownItem[] = [];
   private isFixed: boolean;
+  private includeBuiltIns: boolean;
   private hiddenCommands: Set<string>;
 
+  private providerId: ProviderId | null;
   private providerConfig: ProviderCommandDropdownConfig | null;
-  private getProviderEntries: (() => Promise<ProviderCommandEntry[]>) | null;
-  private discoverProviderEntries: (
-    () => Promise<ProviderCommandDiscoveryResult<ProviderCommandEntry>>
-  ) | null;
+  private providerDiscovery: ProviderCommandDiscoverySource<ProviderCommandEntry> | null = null;
+  private providerDiscoveryUnsubscribe: (() => void) | null = null;
   private cachedProviderEntries: ProviderCommandEntry[] = [];
-  private providerEntriesFetched = false;
   private providerDiscoveryState: ProviderDiscoveryViewState | null = null;
-
-  private requestId = 0;
-  private catalogGeneration = 0;
 
   constructor(
     containerEl: HTMLElement,
@@ -74,12 +75,11 @@ export class SlashCommandDropdown {
     this.inputEl = inputEl;
     this.callbacks = callbacks;
     this.isFixed = options.fixed ?? false;
+    this.includeBuiltIns = options.includeBuiltIns ?? true;
     this.hiddenCommands = options.hiddenCommands ?? new Set();
+    this.providerId = options.providerId ?? options.providerConfig?.providerId ?? null;
     this.providerConfig = options.providerConfig ?? null;
-    this.getProviderEntries = options.getProviderEntries ?? null;
-    this.discoverProviderEntries = options.getProviderEntries
-      ? null
-      : options.discoverProviderEntries ?? null;
+    this.bindProviderDiscovery(options.providerDiscovery ?? null);
 
     this.onInput = () => this.handleInputChange();
     this.inputEl.addEventListener('input', this.onInput);
@@ -98,29 +98,24 @@ export class SlashCommandDropdown {
 
   setProviderCatalog(
     config: ProviderCommandDropdownConfig,
-    discoverEntries: () => Promise<ProviderCommandDiscoveryResult<ProviderCommandEntry>>,
+    providerDiscovery: ProviderCommandDiscoverySource<ProviderCommandEntry>,
   ): void {
     this.clearProviderView();
-    this.catalogGeneration++;
-    this.requestId++;
+    this.providerId = config.providerId;
     this.providerConfig = config;
-    this.discoverProviderEntries = discoverEntries;
-    this.getProviderEntries = null;
-    this.cachedProviderEntries = [];
-    this.providerEntriesFetched = false;
-    this.providerDiscoveryState = null;
+    this.resetProviderViewState();
+    this.bindProviderDiscovery(providerDiscovery);
+  }
+
+  setProviderId(providerId: ProviderId): void {
+    this.providerId = providerId;
   }
 
   clearProviderCatalog(): void {
     this.clearProviderView();
-    this.catalogGeneration++;
-    this.requestId++;
     this.providerConfig = null;
-    this.discoverProviderEntries = null;
-    this.getProviderEntries = null;
-    this.cachedProviderEntries = [];
-    this.providerEntriesFetched = false;
-    this.providerDiscoveryState = null;
+    this.resetProviderViewState();
+    this.bindProviderDiscovery(null);
   }
 
   handleInputChange(): void {
@@ -199,7 +194,6 @@ export class SlashCommandDropdown {
   }
 
   hide(): void {
-    this.requestId++;
     if (this.dropdownEl) {
       this.dropdownEl.removeClass('visible');
     }
@@ -208,8 +202,9 @@ export class SlashCommandDropdown {
   }
 
   destroy(): void {
-    this.catalogGeneration++;
-    this.requestId++;
+    this.providerDiscoveryUnsubscribe?.();
+    this.providerDiscoveryUnsubscribe = null;
+    this.providerDiscovery = null;
     this.inputEl.removeEventListener('input', this.onInput);
     if (this.dropdownEl) {
       this.dropdownEl.remove();
@@ -217,11 +212,21 @@ export class SlashCommandDropdown {
     }
   }
 
-  resetSdkSkillsCache(): void {
-    this.requestId++;
+  private resetProviderViewState(): void {
     this.cachedProviderEntries = [];
-    this.providerEntriesFetched = false;
     this.providerDiscoveryState = null;
+  }
+
+  private bindProviderDiscovery(
+    providerDiscovery: ProviderCommandDiscoverySource<ProviderCommandEntry> | null,
+  ): void {
+    this.providerDiscoveryUnsubscribe?.();
+    this.providerDiscovery = providerDiscovery;
+    this.providerDiscoveryUnsubscribe = providerDiscovery?.subscribe(() => {
+      if (this.isVisible()) {
+        this.handleInputChange();
+      }
+    }) ?? null;
   }
 
   private clearProviderView(): void {
@@ -247,76 +252,32 @@ export class SlashCommandDropdown {
     this.inputEl.selectionEnd = pos;
   }
 
-  private async showDropdown(searchText: string, isAtPosition0 = true): Promise<void> {
-    const currentRequest = ++this.requestId;
-    const currentGeneration = this.catalogGeneration;
+  private showDropdown(searchText: string, isAtPosition0 = true): void {
     const searchLower = searchText.toLowerCase();
-    const includeBuiltIns = isAtPosition0 && this.activeTriggerChar === '/';
+    const includeBuiltIns = this.includeBuiltIns
+      && isAtPosition0
+      && this.activeTriggerChar === '/';
 
-    if (this.discoverProviderEntries) {
-      this.providerDiscoveryState = { status: 'loading' };
-      this.cachedProviderEntries = [];
-      this.updateFilteredItems(searchLower, includeBuiltIns);
-      this.render();
-
-      let result: ProviderCommandDiscoveryResult<ProviderCommandEntry>;
-      try {
-        result = await this.discoverProviderEntriesWithTimeout();
-      } catch {
-        result = {
-          status: 'error',
-          message: 'Could not load provider commands',
-          retryable: true,
-        };
-      }
-
-      if (
-        currentRequest !== this.requestId
-        || currentGeneration !== this.catalogGeneration
-      ) {
+    if (this.providerDiscovery) {
+      const snapshot = this.providerDiscovery.getSnapshot();
+      if (snapshot.status === 'idle') {
+        this.providerDiscoveryState = { status: 'loading' };
+        this.cachedProviderEntries = [];
+        this.updateFilteredItems(searchLower, includeBuiltIns);
+        this.render();
+        void this.providerDiscovery.load().catch(() => {});
         return;
       }
 
-      this.providerDiscoveryState = result;
-      this.cachedProviderEntries = result.status === 'ready' ? [...result.items] : [];
+      this.providerDiscoveryState = snapshot;
+      this.cachedProviderEntries = snapshot.status === 'ready' ? [...snapshot.items] : [];
       this.updateFilteredItems(searchLower, includeBuiltIns);
       this.finishRender(searchText);
       return;
     }
 
-    await this.fetchProviderEntries(currentRequest);
-
-    if (currentRequest !== this.requestId) return;
-
     this.updateFilteredItems(searchLower, includeBuiltIns);
     this.finishRender(searchText);
-  }
-
-  private async discoverProviderEntriesWithTimeout(): Promise<
-    ProviderCommandDiscoveryResult<ProviderCommandEntry>
-  > {
-    if (!this.discoverProviderEntries) {
-      return { status: 'empty' };
-    }
-
-    let timeoutId: number | null = null;
-    const timeout = new Promise<ProviderCommandDiscoveryResult<ProviderCommandEntry>>(
-      resolve => {
-        timeoutId = window.setTimeout(() => resolve({
-          status: 'error',
-          message: 'Provider command discovery timed out',
-          retryable: true,
-        }), PROVIDER_DISCOVERY_TIMEOUT_MS);
-      },
-    );
-
-    try {
-      return await Promise.race([this.discoverProviderEntries(), timeout]);
-    } finally {
-      if (timeoutId !== null) {
-        window.clearTimeout(timeoutId);
-      }
-    }
   }
 
   private updateFilteredItems(searchLower: string, includeBuiltIns: boolean): void {
@@ -340,27 +301,12 @@ export class SlashCommandDropdown {
     this.render();
   }
 
-  private async fetchProviderEntries(currentRequest: number): Promise<void> {
-    if (this.providerEntriesFetched || !this.getProviderEntries) return;
-
-    try {
-      const entries = await this.getProviderEntries();
-      if (currentRequest !== this.requestId) return;
-      if (entries.length > 0) {
-        this.cachedProviderEntries = entries;
-        this.providerEntriesFetched = true;
-      }
-    } catch {
-      if (currentRequest !== this.requestId) return;
-    }
-  }
-
   private buildItemList(includeBuiltIns: boolean): DropdownItem[] {
     const seenNames = new Set<string>();
     const items: DropdownItem[] = [];
 
     if (includeBuiltIns) {
-      const builtIns = getBuiltInCommandsForDropdown(this.providerConfig?.providerId);
+      const builtIns = getBuiltInCommandsForDropdown(this.providerId ?? undefined);
       for (const cmd of builtIns) {
         const nameLower = cmd.name.toLowerCase();
         if (!seenNames.has(nameLower)) {
@@ -497,7 +443,9 @@ export class SlashCommandDropdown {
           text: 'Retry',
           attr: { type: 'button' },
         });
-        retryEl.addEventListener('click', () => this.handleInputChange());
+        retryEl.addEventListener('click', () => {
+          void this.providerDiscovery?.retry().catch(() => {});
+        });
         break;
       }
     }

--- a/src/style/toolbar/service-tier-toggle.css
+++ b/src/style/toolbar/service-tier-toggle.css
@@ -37,3 +37,7 @@
 .claudian-service-tier-button.active {
   color: var(--claudian-brand);
 }
+
+.claudian-service-tier-button.active .claudian-service-tier-icon svg {
+  stroke-width: 2.5;
+}

--- a/tests/__mocks__/claude-agent-sdk.ts
+++ b/tests/__mocks__/claude-agent-sdk.ts
@@ -119,6 +119,11 @@ let customMockMessages: any[] | null = null;
 let appendResultMessage = true;
 let lastOptions: Options | undefined;
 let mockSupportedCommands: Array<{ name: string; description: string; argumentHint?: string }> = [];
+let mockSupportedCommandsImplementation: (() => Promise<Array<{
+  name: string;
+  description: string;
+  argumentHint?: string;
+}>>) | null = null;
 let lastResponse: (AsyncGenerator<any> & {
   interrupt: jest.Mock;
   setModel: jest.Mock;
@@ -145,6 +150,7 @@ export function resetMockMessages() {
   appendResultMessage = true;
   lastOptions = undefined;
   mockSupportedCommands = [];
+  mockSupportedCommandsImplementation = null;
   lastResponse = null;
   shouldThrowOnIteration = false;
   throwAfterChunks = 0;
@@ -155,6 +161,16 @@ export function setMockSupportedCommands(
   commands: Array<{ name: string; description: string; argumentHint?: string }>
 ) {
   mockSupportedCommands = commands;
+}
+
+export function setMockSupportedCommandsImplementation(
+  implementation: () => Promise<Array<{
+    name: string;
+    description: string;
+    argumentHint?: string;
+  }>>,
+) {
+  mockSupportedCommandsImplementation = implementation;
 }
 
 /**
@@ -310,7 +326,11 @@ export function query({ prompt, options }: { prompt: any; options: Options }): A
   gen.setPermissionMode = jest.fn().mockResolvedValue(undefined);
   gen.applyFlagSettings = jest.fn().mockResolvedValue(undefined);
   gen.setMcpServers = jest.fn().mockResolvedValue({ added: [], removed: [], errors: {} });
-  gen.supportedCommands = jest.fn().mockResolvedValue(mockSupportedCommands);
+  gen.supportedCommands = jest.fn().mockImplementation(() => (
+    mockSupportedCommandsImplementation
+      ? mockSupportedCommandsImplementation()
+      : Promise.resolve(mockSupportedCommands)
+  ));
   lastResponse = gen;
 
   return gen;

--- a/tests/unit/core/commands/builtInCommands.test.ts
+++ b/tests/unit/core/commands/builtInCommands.test.ts
@@ -98,6 +98,19 @@ describe('builtInCommands', () => {
       expect(detectBuiltInCommand('/FORK')).not.toBeNull();
       expect(detectBuiltInCommand('/Fork')).not.toBeNull();
     });
+
+    it('detects /fast command', () => {
+      const result = detectBuiltInCommand('/fast');
+      expect(result).not.toBeNull();
+      expect(result?.command.name).toBe('fast');
+      expect(result?.command.action).toBe('fast');
+      expect(result?.args).toBe('');
+    });
+
+    it('leaves provider-restricted commands to other providers', () => {
+      expect(detectBuiltInCommand('/fast', 'claude')).toBeNull();
+      expect(detectBuiltInCommand('/fast', 'codex')?.command.action).toBe('fast');
+    });
   });
 
   describe('getBuiltInCommandsForDropdown', () => {
@@ -155,6 +168,13 @@ describe('builtInCommands', () => {
       expect(forkCmd?.hasArgs).toBeUndefined();
     });
 
+    it('has a Codex-only fast command', () => {
+      const fastCmd = BUILT_IN_COMMANDS.find((c) => c.name === 'fast');
+      expect(fastCmd).toBeDefined();
+      expect(fastCmd?.action).toBe('fast');
+      expect(fastCmd?.supportedProviderIds).toEqual(['codex']);
+    });
+
     it('clear has no provider restriction', () => {
       const clearCmd = BUILT_IN_COMMANDS.find((c) => c.name === 'clear');
       expect(clearCmd?.requiredCapability).toBeUndefined();
@@ -182,13 +202,14 @@ describe('builtInCommands', () => {
       expect(commands.length).toBe(BUILT_IN_COMMANDS.length);
     });
 
-    it('returns all commands for claude provider', () => {
+    it('excludes Codex-only commands for the Claude provider', () => {
       const commands = getBuiltInCommandsForDropdown('claude');
-      expect(commands.length).toBe(BUILT_IN_COMMANDS.length);
+      expect(commands.length).toBe(BUILT_IN_COMMANDS.length - 1);
       expect(commands.map(c => c.name)).toContain('clear');
       expect(commands.map(c => c.name)).toContain('add-dir');
       expect(commands.map(c => c.name)).toContain('resume');
       expect(commands.map(c => c.name)).toContain('fork');
+      expect(commands.map(c => c.name)).not.toContain('fast');
     });
 
     it('returns all capability-supported commands for codex provider', () => {
@@ -198,12 +219,13 @@ describe('builtInCommands', () => {
       expect(names).toContain('add-dir');
       expect(names).toContain('resume');
       expect(names).toContain('fork');
+      expect(names).toContain('fast');
     });
 
     it('returns only commands supported by codex capabilities', () => {
       const commands = getBuiltInCommandsForDropdown('codex');
-      expect(commands.length).toBe(4);
-      expect(commands.map(c => c.name)).toEqual(['clear', 'add-dir', 'resume', 'fork']);
+      expect(commands.length).toBe(5);
+      expect(commands.map(c => c.name)).toEqual(['clear', 'add-dir', 'resume', 'fork', 'fast']);
     });
   });
 
@@ -233,6 +255,17 @@ describe('builtInCommands', () => {
         forkCmd,
         { supportsNativeHistory: true, supportsFork: false },
       )).toBe(false);
+    });
+
+    it('enforces explicit provider restrictions', () => {
+      const fastCmd = BUILT_IN_COMMANDS.find((c) => c.name === 'fast')!;
+      expect(isBuiltInCommandSupported(fastCmd, 'codex')).toBe(true);
+      expect(isBuiltInCommandSupported(fastCmd, 'claude')).toBe(false);
+      expect(isBuiltInCommandSupported(fastCmd, {
+        providerId: 'codex',
+        supportsNativeHistory: true,
+        supportsFork: true,
+      })).toBe(true);
     });
   });
 

--- a/tests/unit/core/providers/commands/ProviderCommandDiscoveryStore.test.ts
+++ b/tests/unit/core/providers/commands/ProviderCommandDiscoveryStore.test.ts
@@ -1,0 +1,139 @@
+import type { ProviderCommandDiscoveryResult } from '@/core/providers/commands/ProviderCommandDiscoveryResult';
+import { ProviderCommandDiscoveryStore } from '@/core/providers/commands/ProviderCommandDiscoveryStore';
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(finish => {
+    resolve = finish;
+  });
+  return { promise, resolve };
+}
+
+describe('ProviderCommandDiscoveryStore', () => {
+  it('shares an in-flight load and caches its terminal result', async () => {
+    const response = deferred<ProviderCommandDiscoveryResult<string>>();
+    const loader = jest.fn().mockReturnValue(response.promise);
+    const store = new ProviderCommandDiscoveryStore(loader);
+
+    const first = store.load();
+    const second = store.load();
+
+    expect(first).toBe(second);
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(store.getSnapshot()).toEqual({ status: 'loading' });
+
+    response.resolve({ status: 'ready', items: ['review'] });
+    await first;
+
+    expect(store.getSnapshot()).toEqual({ status: 'ready', items: ['review'] });
+    await store.load();
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it('notifies subscribers when loading and terminal state change', async () => {
+    const loader = jest.fn().mockResolvedValue({ status: 'empty' });
+    const store = new ProviderCommandDiscoveryStore<string>(loader);
+    const statuses: string[] = [];
+    const unsubscribe = store.subscribe(() => {
+      statuses.push(store.getSnapshot().status);
+    });
+
+    await store.load();
+
+    expect(statuses).toEqual(['loading', 'empty']);
+    unsubscribe();
+  });
+
+  it('invalidates a cached result and ignores stale completion', async () => {
+    const stale = deferred<ProviderCommandDiscoveryResult<string>>();
+    const loader = jest.fn()
+      .mockReturnValueOnce(stale.promise)
+      .mockResolvedValueOnce({ status: 'ready', items: ['fresh'] });
+    const store = new ProviderCommandDiscoveryStore(loader);
+
+    const staleLoad = store.load();
+    store.invalidate();
+    const freshLoad = store.load();
+    await freshLoad;
+
+    stale.resolve({ status: 'ready', items: ['stale'] });
+    await staleLoad;
+
+    expect(store.getSnapshot()).toEqual({ status: 'ready', items: ['fresh'] });
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps errors cached until retry is requested', async () => {
+    const loader = jest.fn()
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce({ status: 'ready', items: ['review'] });
+    const store = new ProviderCommandDiscoveryStore<string>(loader);
+
+    await store.load();
+    expect(store.getSnapshot()).toEqual({
+      status: 'error',
+      message: 'Could not load provider commands',
+      retryable: true,
+    });
+
+    await store.load();
+    expect(loader).toHaveBeenCalledTimes(1);
+
+    await store.retry();
+    expect(loader).toHaveBeenCalledTimes(2);
+    expect(store.getSnapshot()).toEqual({ status: 'ready', items: ['review'] });
+  });
+
+  it('prepares external cache state before notifying subscribers of a retry', async () => {
+    let retryPrepared = false;
+    const loader = jest.fn()
+      .mockResolvedValueOnce({
+        status: 'error',
+        message: 'Offline',
+        retryable: true,
+      })
+      .mockResolvedValueOnce({ status: 'empty' });
+    const store = new ProviderCommandDiscoveryStore<string>(loader, {
+      onBeforeRetry: () => {
+        retryPrepared = true;
+      },
+    });
+    const preparationStates: boolean[] = [];
+    store.subscribe(() => {
+      if (store.getSnapshot().status === 'idle') {
+        preparationStates.push(retryPrepared);
+      }
+    });
+
+    await store.load();
+    await store.retry();
+
+    expect(preparationStates).toEqual([true]);
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it('turns an unresponsive load into a retryable timeout', async () => {
+    jest.useFakeTimers();
+    try {
+      const store = new ProviderCommandDiscoveryStore<string>(
+        () => new Promise(() => undefined),
+        { timeoutMs: 100 },
+      );
+
+      const load = store.load();
+      await jest.advanceTimersByTimeAsync(100);
+      await load;
+
+      expect(store.getSnapshot()).toEqual({
+        status: 'error',
+        message: 'Provider command discovery timed out',
+        retryable: true,
+      });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/tests/unit/core/providers/commands/ProviderCommandDiscoveryStore.test.ts
+++ b/tests/unit/core/providers/commands/ProviderCommandDiscoveryStore.test.ts
@@ -49,14 +49,24 @@ describe('ProviderCommandDiscoveryStore', () => {
 
   it('invalidates a cached result and ignores stale completion', async () => {
     const stale = deferred<ProviderCommandDiscoveryResult<string>>();
-    const loader = jest.fn()
-      .mockReturnValueOnce(stale.promise)
-      .mockResolvedValueOnce({ status: 'ready', items: ['fresh'] });
+    const signals: AbortSignal[] = [];
+    const loader = jest.fn((signal: AbortSignal) => {
+      signals.push(signal);
+      return signals.length === 1
+        ? stale.promise
+        : Promise.resolve({
+          status: 'ready',
+          items: ['fresh'],
+        } as ProviderCommandDiscoveryResult<string>);
+    });
     const store = new ProviderCommandDiscoveryStore(loader);
 
     const staleLoad = store.load();
     store.invalidate();
+    expect(signals[0]?.aborted).toBe(true);
+
     const freshLoad = store.load();
+    expect(signals[1]?.aborted).toBe(false);
     await freshLoad;
 
     stale.resolve({ status: 'ready', items: ['stale'] });
@@ -118,8 +128,12 @@ describe('ProviderCommandDiscoveryStore', () => {
   it('turns an unresponsive load into a retryable timeout', async () => {
     jest.useFakeTimers();
     try {
+      let loaderSignal: AbortSignal | null = null;
       const store = new ProviderCommandDiscoveryStore<string>(
-        () => new Promise(() => undefined),
+        (signal) => {
+          loaderSignal = signal;
+          return new Promise(() => undefined);
+        },
         { timeoutMs: 100 },
       );
 
@@ -127,6 +141,7 @@ describe('ProviderCommandDiscoveryStore', () => {
       await jest.advanceTimersByTimeAsync(100);
       await load;
 
+      expect((loaderSignal as AbortSignal | null)?.aborted).toBe(true);
       expect(store.getSnapshot()).toEqual({
         status: 'error',
         message: 'Provider command discovery timed out',

--- a/tests/unit/features/chat/actions/toggleServiceTier.test.ts
+++ b/tests/unit/features/chat/actions/toggleServiceTier.test.ts
@@ -1,0 +1,51 @@
+import { toggleServiceTier } from '@/features/chat/actions/toggleServiceTier';
+
+describe('toggleServiceTier', () => {
+  it('persists the active tier when the current tier is inactive', async () => {
+    const onServiceTierChange = jest.fn().mockResolvedValue(undefined);
+
+    await expect(toggleServiceTier({
+      getSettings: () => ({ serviceTier: 'default' }),
+      getUIConfig: () => ({
+        getServiceTierToggle: () => ({
+          inactiveValue: 'default',
+          inactiveLabel: 'Standard',
+          activeValue: 'priority',
+          activeLabel: 'Fast',
+        }),
+      }),
+      onServiceTierChange,
+    })).resolves.toBe(true);
+
+    expect(onServiceTierChange).toHaveBeenCalledWith('priority');
+  });
+
+  it('returns false without persisting when the provider has no service-tier toggle', async () => {
+    const onServiceTierChange = jest.fn().mockResolvedValue(undefined);
+
+    await expect(toggleServiceTier({
+      getSettings: () => ({ serviceTier: 'default' }),
+      getUIConfig: () => ({}),
+      onServiceTierChange,
+    })).resolves.toBe(false);
+
+    expect(onServiceTierChange).not.toHaveBeenCalled();
+  });
+
+  it('propagates persistence failures to the invoking surface', async () => {
+    const failure = new Error('save failed');
+
+    await expect(toggleServiceTier({
+      getSettings: () => ({ serviceTier: 'priority' }),
+      getUIConfig: () => ({
+        getServiceTierToggle: () => ({
+          inactiveValue: 'default',
+          inactiveLabel: 'Standard',
+          activeValue: 'priority',
+          activeLabel: 'Fast',
+        }),
+      }),
+      onServiceTierChange: jest.fn().mockRejectedValue(failure),
+    })).rejects.toBe(failure);
+  });
+});

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -1,6 +1,7 @@
 import { createMockEl } from '@test/helpers/mockElement';
 import { Notice } from 'obsidian';
 
+import { ProviderRegistry } from '@/core/providers/ProviderRegistry';
 import { InputController, type InputControllerDeps } from '@/features/chat/controllers/InputController';
 import { ChatState } from '@/features/chat/state/ChatState';
 import { encodeClaudeTurn } from '@/providers/claude/prompt/ClaudeTurnEncoder';
@@ -2210,6 +2211,131 @@ describe('InputController - Message Queue', () => {
       await controller.sendMessage();
 
       expect(mockNotice).toHaveBeenCalledWith('Fork not available.');
+      expect(inputEl.value).toBe('');
+    });
+  });
+
+  describe('Built-in commands - /fast', () => {
+    beforeEach(() => {
+      mockNotice.mockClear();
+    });
+
+    it('toggles fast mode on Codex tabs', async () => {
+      const toggleFastMode = jest.fn().mockResolvedValue(true);
+      const runtime = (deps as any).mockAgentService;
+      deps.getAgentService = () => ({
+        ...runtime,
+        providerId: 'codex',
+        getCapabilities: jest.fn().mockReturnValue({
+          ...runtime.getCapabilities(),
+          providerId: 'codex',
+        }),
+      } as any);
+      deps.toggleFastMode = toggleFastMode;
+      inputEl.value = '/fast';
+      controller = new InputController(deps);
+
+      await controller.sendMessage();
+
+      expect(toggleFastMode).toHaveBeenCalledTimes(1);
+      expect(inputEl.value).toBe('');
+      expect((deps as any).mockAgentService.query).not.toHaveBeenCalled();
+    });
+
+    it('passes /fast through to non-Codex providers', async () => {
+      const toggleFastMode = jest.fn().mockResolvedValue(true);
+      deps.getTabProviderId = () => 'claude';
+      deps.toggleFastMode = toggleFastMode;
+      ((deps as any).mockAgentService.query as jest.Mock).mockReturnValue(
+        createMockStream([{ type: 'done' }]),
+      );
+      inputEl.value = '/fast';
+      controller = new InputController(deps);
+
+      await controller.sendMessage();
+
+      expect(toggleFastMode).not.toHaveBeenCalled();
+      expect((deps as any).mockAgentService.query).toHaveBeenCalledTimes(1);
+      expect(deps.state.messages[0]?.content).toBe('/fast');
+      expect(mockNotice).not.toHaveBeenCalledWith('/fast is not supported by this provider.');
+    });
+
+    it('toggles /fast after switching from a stale Claude runtime to Codex history', async () => {
+      const toggleFastMode = jest.fn().mockResolvedValue(true);
+      const capabilitiesSpy = jest.spyOn(ProviderRegistry, 'getCapabilities').mockReturnValue({
+        ...(deps as any).mockAgentService.getCapabilities(),
+        providerId: 'codex',
+      });
+      deps.state.currentConversationId = 'conv-codex';
+      deps.getTabProviderId = () => 'codex';
+      deps.toggleFastMode = toggleFastMode;
+      inputEl.value = '/fast';
+      controller = new InputController(deps);
+
+      await controller.sendMessage();
+
+      expect(toggleFastMode).toHaveBeenCalledTimes(1);
+      expect((deps as any).mockAgentService.query).not.toHaveBeenCalled();
+      capabilitiesSpy.mockRestore();
+    });
+
+    it('passes /fast through after switching from a stale Codex runtime to Claude history', async () => {
+      const staleRuntime = (deps as any).mockAgentService;
+      staleRuntime.providerId = 'codex';
+      staleRuntime.getCapabilities.mockReturnValue({
+        ...staleRuntime.getCapabilities(),
+        providerId: 'codex',
+      });
+      deps.state.currentConversationId = 'conv-claude';
+      deps.getTabProviderId = () => 'claude';
+      deps.toggleFastMode = jest.fn().mockResolvedValue(true);
+      staleRuntime.query.mockReturnValue(createMockStream([{ type: 'done' }]));
+      inputEl.value = '/fast';
+      controller = new InputController(deps);
+
+      await controller.sendMessage();
+
+      expect(deps.toggleFastMode).not.toHaveBeenCalled();
+      expect(staleRuntime.query).toHaveBeenCalledTimes(1);
+      expect(deps.state.messages[0]?.content).toBe('/fast');
+    });
+
+    it('reports when the selected Codex model has no fast tier', async () => {
+      const runtime = (deps as any).mockAgentService;
+      deps.getAgentService = () => ({
+        ...runtime,
+        providerId: 'codex',
+        getCapabilities: jest.fn().mockReturnValue({
+          ...runtime.getCapabilities(),
+          providerId: 'codex',
+        }),
+      } as any);
+      deps.toggleFastMode = jest.fn().mockResolvedValue(false);
+      inputEl.value = '/fast';
+      controller = new InputController(deps);
+
+      await controller.sendMessage();
+
+      expect(mockNotice).toHaveBeenCalledWith('Fast mode is not available for this model.');
+    });
+
+    it('reports settings persistence failures without rejecting the detached send', async () => {
+      const runtime = (deps as any).mockAgentService;
+      deps.getAgentService = () => ({
+        ...runtime,
+        providerId: 'codex',
+        getCapabilities: jest.fn().mockReturnValue({
+          ...runtime.getCapabilities(),
+          providerId: 'codex',
+        }),
+      } as any);
+      deps.toggleFastMode = jest.fn().mockRejectedValue(new Error('save failed'));
+      inputEl.value = '/fast';
+      controller = new InputController(deps);
+
+      await expect(controller.sendMessage()).resolves.toBeUndefined();
+
+      expect(mockNotice).toHaveBeenCalledWith('Failed to toggle fast mode.');
       expect(inputEl.value).toBe('');
     });
   });

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -8,6 +8,8 @@ import {
 import { createMockEl } from '@test/helpers/mockElement';
 import { Notice, Platform } from 'obsidian';
 
+import { ProviderCommandDiscoveryStore } from '@/core/providers/commands/ProviderCommandDiscoveryStore';
+import type { ProviderCommandEntry } from '@/core/providers/commands/ProviderCommandEntry';
 import { ProviderRegistry } from '@/core/providers/ProviderRegistry';
 import { ProviderWorkspaceRegistry } from '@/core/providers/ProviderWorkspaceRegistry';
 import { SelectionController } from '@/features/chat/controllers/SelectionController';
@@ -86,8 +88,8 @@ const createMockSlashCommandDropdown = () => ({
   handleKeydown: jest.fn().mockReturnValue(false),
   isVisible: jest.fn().mockReturnValue(false),
   hide: jest.fn(),
-  resetSdkSkillsCache: jest.fn(),
   setProviderCatalog: jest.fn(),
+  setProviderId: jest.fn(),
   setHiddenCommands: jest.fn(),
   setEnabled: jest.fn(),
   destroy: jest.fn(),
@@ -190,6 +192,7 @@ const createMockPermissionToggle = () => ({
 });
 
 const createMockServiceTierToggle = () => ({
+  toggle: jest.fn().mockResolvedValue(true),
   updateDisplay: jest.fn(),
 });
 
@@ -981,10 +984,25 @@ describe('Tab - Service Initialization', () => {
       const staleService = createMockClaudianService({ providerId: 'codex' });
       tab.service = staleService as any;
       tab.serviceInitialized = true;
+      const discovery = new ProviderCommandDiscoveryStore<ProviderCommandEntry>(
+        async () => ({ status: 'empty' }),
+      );
+      const invalidateDiscovery = jest.spyOn(discovery, 'invalidate');
+      tab.providerCatalogResolver = () => ({
+        config: {
+          providerId: 'claude',
+          triggerChars: ['/'],
+          builtInPrefix: '/',
+          skillPrefix: '/',
+          commandPrefix: '/',
+        },
+        discovery,
+      });
 
       // Disable Codex
       plugin.settings.codexEnabled = false;
       plugin.settings.providerConfigs.codex.enabled = false;
+      mockSlashCommandDropdown.setProviderCatalog.mockClear();
 
       onProviderAvailabilityChanged(tab, plugin);
 
@@ -992,7 +1010,13 @@ describe('Tab - Service Initialization', () => {
       expect(tab.providerId).toBe('claude');
       expect(tab.service).toBeNull();
       expect(tab.serviceInitialized).toBe(false);
-      expect(mockSlashCommandDropdown.resetSdkSkillsCache).toHaveBeenCalled();
+      expect(mockSlashCommandDropdown.setProviderCatalog).toHaveBeenCalledWith(
+        expect.objectContaining({ providerId: 'claude' }),
+        discovery,
+      );
+      expect(invalidateDiscovery).toHaveBeenCalledTimes(1);
+      expect(mockSlashCommandDropdown.setProviderCatalog.mock.invocationCallOrder[0])
+        .toBeLessThan(invalidateDiscovery.mock.invocationCallOrder[0]);
     });
 
     it('falls back a removed blank Codex draft to the refreshed Codex default', () => {
@@ -3038,6 +3062,9 @@ describe('Tab - UI Callback Wiring', () => {
         status: 'ready',
         items: mockEntries,
       });
+      const managerDiscovery = new ProviderCommandDiscoveryStore<ProviderCommandEntry>(
+        managerGetEntries,
+      );
       const plugin = createMockPlugin();
       const options = createMockOptions({ plugin });
       const tab = createTab(options);
@@ -3045,7 +3072,7 @@ describe('Tab - UI Callback Wiring', () => {
       initializeTabUI(tab, plugin, {
         getProviderCatalogConfig: () => ({
           config: mockConfig,
-          getEntries: managerGetEntries,
+          discovery: managerDiscovery,
         }),
       });
 
@@ -3053,16 +3080,17 @@ describe('Tab - UI Callback Wiring', () => {
       const constructorCall = SlashCommandDropdown.mock.calls[0];
       const opts = constructorCall[3]; // 4th argument is options
 
+      expect(opts.providerId).toBe('claude');
       expect(opts.providerConfig).toEqual(mockConfig);
-      expect(typeof opts.discoverProviderEntries).toBe('function');
+      expect(opts.providerDiscovery).toBe(managerDiscovery);
 
       const setProviderCatalogSpy = jest.fn();
       tab.ui.slashCommandDropdown!.setProviderCatalog = setProviderCatalogSpy;
       refreshTabWorkspaceServices(tab, plugin);
 
       expect(setProviderCatalogSpy).toHaveBeenCalledTimes(1);
-      const [, reboundGetEntries] = setProviderCatalogSpy.mock.calls[0];
-      await reboundGetEntries();
+      const [, reboundDiscovery] = setProviderCatalogSpy.mock.calls[0];
+      await reboundDiscovery.load();
       expect(managerGetEntries).toHaveBeenCalledTimes(1);
     });
 
@@ -3476,13 +3504,27 @@ describe('Tab - Controller Configuration', () => {
       expect(tab.dom.welcomeEl).toBe(newWelcomeEl);
     });
 
-    it('should reset slash-command cache across conversation lifecycle events', () => {
+    it('should invalidate provider commands across conversation lifecycle events', () => {
       const { ConversationController } = jest.requireMock('@/features/chat/controllers/ConversationController');
       const options = createMockOptions();
       const tab = createTab(options);
       const mockComponent = {} as any;
+      const discovery = new ProviderCommandDiscoveryStore<ProviderCommandEntry>(
+        async () => ({ status: 'empty' }),
+      );
+      const invalidateDiscovery = jest.spyOn(discovery, 'invalidate');
+      const getProviderCatalogConfig = () => ({
+        config: {
+          providerId: 'claude' as const,
+          triggerChars: ['/'],
+          builtInPrefix: '/',
+          skillPrefix: '/',
+          commandPrefix: '/',
+        },
+        discovery,
+      });
 
-      initializeTabUI(tab, options.plugin);
+      initializeTabUI(tab, options.plugin, { getProviderCatalogConfig });
       initializeTabControllers(tab, options.plugin, mockComponent, options.mcpManager);
 
       const constructorCall = ConversationController.mock.calls[0];
@@ -3492,8 +3534,7 @@ describe('Tab - Controller Configuration', () => {
       callbacks.onConversationLoaded();
       callbacks.onConversationSwitched();
 
-      expect(mockSlashCommandDropdown.clearProviderCatalog).toHaveBeenCalledTimes(1);
-      expect(mockSlashCommandDropdown.resetSdkSkillsCache).toHaveBeenCalledTimes(2);
+      expect(invalidateDiscovery).toHaveBeenCalledTimes(2);
     });
   });
 });
@@ -4463,6 +4504,9 @@ describe('Tab - Blank Tab Draft Model Change', () => {
       status: 'ready',
       items: managerEntries,
     });
+    const managerDiscovery = new ProviderCommandDiscoveryStore<ProviderCommandEntry>(
+      managerGetEntries,
+    );
 
     ProviderWorkspaceRegistry.setServices('codex', { commandCatalog: codexCatalog as any });
 
@@ -4473,14 +4517,14 @@ describe('Tab - Blank Tab Draft Model Change', () => {
         tab.providerId === 'codex'
           ? {
             config: codexCatalog.getDropdownConfig(),
-            getEntries: managerGetEntries,
+            discovery: managerDiscovery,
           }
           : null
       ),
       onProviderChanged: async () => {
         tab.ui.slashCommandDropdown?.setProviderCatalog(
           codexCatalog.getDropdownConfig(),
-          managerGetEntries,
+          managerDiscovery,
         );
       },
     });
@@ -4498,11 +4542,11 @@ describe('Tab - Blank Tab Draft Model Change', () => {
     await toolbarCallbacks.onModelChange(TEST_CODEX_MODEL);
 
     expect(setProviderCatalogSpy).toHaveBeenCalledTimes(1);
-    const [config, getEntries] = setProviderCatalogSpy.mock.calls[0];
+    const [config, discovery] = setProviderCatalogSpy.mock.calls[0];
     expect(config.triggerChars).toEqual(['/', '$']);
     expect(config.skillPrefix).toBe('$');
-    expect(typeof getEntries).toBe('function');
-    await getEntries();
+    expect(discovery).toBe(managerDiscovery);
+    await discovery.load();
     expect(managerGetEntries).toHaveBeenCalledTimes(1);
     expect(codexCatalog.listDropdownEntries).not.toHaveBeenCalled();
   });
@@ -4737,8 +4781,9 @@ describe('Tab - History Bind Without Runtime', () => {
       }),
       refresh: jest.fn(),
     };
-    const managerGetEntries = jest.fn().mockResolvedValue([
-      {
+    const managerGetEntries = jest.fn().mockResolvedValue({
+      status: 'ready',
+      items: [{
         id: 'codex-skill-analyze',
         providerId: 'codex',
         kind: 'skill',
@@ -4751,8 +4796,11 @@ describe('Tab - History Bind Without Runtime', () => {
         isDeletable: true,
         displayPrefix: '$',
         insertPrefix: '$',
-      },
-    ]);
+      }],
+    });
+    const managerDiscovery = new ProviderCommandDiscoveryStore<ProviderCommandEntry>(
+      managerGetEntries,
+    );
     ProviderWorkspaceRegistry.setServices('codex', { commandCatalog: codexCatalog as any });
 
     const plugin = createMockPlugin({
@@ -4794,7 +4842,7 @@ describe('Tab - History Bind Without Runtime', () => {
         tab.providerId === 'codex'
           ? {
             config: codexCatalog.getDropdownConfig(),
-            getEntries: managerGetEntries,
+            discovery: managerDiscovery,
           }
           : null
       ),
@@ -4810,7 +4858,7 @@ describe('Tab - History Bind Without Runtime', () => {
         tab.providerId === 'codex'
           ? {
             config: codexCatalog.getDropdownConfig(),
-            getEntries: managerGetEntries,
+            discovery: managerDiscovery,
           }
           : null
       ),
@@ -4835,8 +4883,8 @@ describe('Tab - History Bind Without Runtime', () => {
 
     expect(setProviderCatalogSpy).toHaveBeenCalledTimes(1);
     expect(setHiddenCommandsSpy).toHaveBeenCalledWith(new Set(['analyze']));
-    const [, getEntries] = setProviderCatalogSpy.mock.calls[0];
-    await getEntries();
+    const [, discovery] = setProviderCatalogSpy.mock.calls[0];
+    await discovery.load();
     expect(managerGetEntries).toHaveBeenCalledTimes(1);
     expect(codexCatalog.listDropdownEntries).not.toHaveBeenCalled();
   });
@@ -4895,6 +4943,10 @@ describe('Tab - Destroy Lifecycle Transition', () => {
 });
 
 describe('Tab - InputController getTabProviderId wiring', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('wires getTabProviderId to InputController deps', () => {
     jest.spyOn(ProviderRegistry, 'createInstructionRefineService').mockReturnValue({ cancel: jest.fn(), resetConversation: jest.fn() } as any);
     jest.spyOn(ProviderRegistry, 'createTitleGenerationService').mockReturnValue({ cancel: jest.fn() } as any);
@@ -4914,5 +4966,48 @@ describe('Tab - InputController getTabProviderId wiring', () => {
     // For a blank tab with default model, should resolve to claude
     const result = config.getTabProviderId();
     expect(result).toBe('claude');
+  });
+
+  it('wires the fast command to a tab-level action independent of the toolbar widget', async () => {
+    const plugin = createMockPlugin({
+      settings: {
+        settingsProvider: 'codex',
+        model: TEST_CODEX_MODEL,
+        serviceTier: 'default',
+        savedProviderModel: {
+          claude: 'claude-sonnet-4-5',
+          codex: TEST_CODEX_MODEL,
+        },
+        savedProviderEffort: {
+          claude: 'high',
+          codex: 'medium',
+        },
+        savedProviderServiceTier: {
+          claude: 'default',
+          codex: 'default',
+        },
+        savedProviderThinkingBudget: {
+          claude: 'low',
+          codex: 'off',
+        },
+      },
+    });
+    const tab = createTab(createMockOptions({
+      plugin,
+      draftModel: TEST_CODEX_MODEL,
+    }));
+    initializeTabUI(tab, plugin);
+    initializeTabControllers(tab, plugin, {} as any, createMockMcpManager());
+
+    const { InputController } = jest.requireMock('@/features/chat/controllers/InputController') as { InputController: jest.Mock };
+    const lastCall = InputController.mock.calls[InputController.mock.calls.length - 1];
+    const config = lastCall[0];
+
+    expect(config.getTabProviderId()).toBe('codex');
+    await expect(config.toggleFastMode()).resolves.toBe(true);
+    expect(plugin.settings.serviceTier).toBe('priority');
+    expect(plugin.settings.savedProviderServiceTier.codex).toBe('priority');
+    expect(plugin.saveSettings).toHaveBeenCalledTimes(1);
+    expect(mockServiceTierToggle.toggle).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/features/chat/tabs/TabManager.test.ts
+++ b/tests/unit/features/chat/tabs/TabManager.test.ts
@@ -2085,6 +2085,7 @@ describe('TabManager - Provider Resource Generations', () => {
   it('starts a fresh runtime warmup when discovery is retried after its outer timeout', async () => {
     jest.useFakeTimers();
     let resolveFirst!: (result: any) => void;
+    let firstSignal: AbortSignal | undefined;
     try {
       const firstWarmup = new Promise(resolve => {
         resolveFirst = resolve;
@@ -2093,7 +2094,10 @@ describe('TabManager - Provider Resource Generations', () => {
         getCacheFingerprint: jest.fn().mockReturnValue('opencode:retry'),
         isAvailable: jest.fn().mockReturnValue(true),
         loadCommands: jest.fn()
-          .mockReturnValueOnce(firstWarmup)
+          .mockImplementationOnce((context: { signal?: AbortSignal }) => {
+            firstSignal = context.signal;
+            return firstWarmup;
+          })
           .mockResolvedValueOnce({ status: 'empty' }),
       };
       const catalog = {
@@ -2127,15 +2131,22 @@ describe('TabManager - Provider Resource Generations', () => {
         message: 'Provider command discovery timed out',
         retryable: true,
       });
+      expect(firstSignal?.aborted).toBe(true);
 
       const retry = discovery.retry();
       await flushMicrotasks(8);
       const loadCountAfterRetry = loader.loadCommands.mock.calls.length;
+      const secondSignal = loader.loadCommands.mock.calls[1]?.[0]?.signal as
+        | AbortSignal
+        | undefined;
 
       resolveFirst({ status: 'error', message: 'Old request timed out', retryable: true });
       await retry;
 
       expect(loadCountAfterRetry).toBe(2);
+      expect(secondSignal).toBeDefined();
+      expect(secondSignal).not.toBe(firstSignal);
+      expect(secondSignal?.aborted).toBe(false);
       expect(discovery.getSnapshot()).toEqual({ status: 'empty' });
     } finally {
       jest.useRealTimers();
@@ -2480,6 +2491,7 @@ describe('TabManager - Provider Command Catalog', () => {
     expect(mockCatalog.listDropdownEntries).toHaveBeenCalledWith({
       includeBuiltIns: false,
       allowCachedRuntimeCommands: false,
+      signal: expect.any(AbortSignal),
     });
     expect(claudeCatalog.listDropdownEntries).not.toHaveBeenCalled();
   });

--- a/tests/unit/features/chat/tabs/TabManager.test.ts
+++ b/tests/unit/features/chat/tabs/TabManager.test.ts
@@ -2496,12 +2496,13 @@ describe('TabManager - Provider Command Catalog', () => {
     expect(claudeCatalog.listDropdownEntries).not.toHaveBeenCalled();
   });
 
-  it('should refresh Claude runtime commands before listing catalog entries', async () => {
+  it('should use the Claude runtime command snapshot before listing catalog entries', async () => {
     const supportedCommands = [{ id: 'sdk:commit', name: 'commit', content: '', source: 'sdk' }];
     const readyService = {
       providerId: 'claude',
       isReady: jest.fn().mockReturnValue(true),
-      getSupportedCommands: jest.fn().mockResolvedValue(supportedCommands),
+      getSupportedCommands: jest.fn(),
+      getSupportedCommandsSnapshot: jest.fn().mockReturnValue(supportedCommands),
     };
     const claudeCatalog = {
       listDropdownEntries: jest.fn().mockResolvedValue([]),
@@ -2533,9 +2534,8 @@ describe('TabManager - Provider Command Catalog', () => {
     const catalogConfig = options.getProviderCatalogConfig();
     await catalogConfig.discovery.load();
 
-    expect(readyService.getSupportedCommands).toHaveBeenCalledWith(
-      expect.any(AbortSignal),
-    );
+    expect(readyService.getSupportedCommandsSnapshot).toHaveBeenCalledTimes(1);
+    expect(readyService.getSupportedCommands).not.toHaveBeenCalled();
     expect(claudeCatalog.setRuntimeCommands).toHaveBeenCalledWith(supportedCommands);
     expect(claudeCatalog.listDropdownEntries).toHaveBeenCalledWith(expect.objectContaining({
       includeBuiltIns: false,
@@ -2543,11 +2543,76 @@ describe('TabManager - Provider Command Catalog', () => {
     }));
   });
 
+  it('uses the Claude catalog probe when a ready runtime has no command snapshot', async () => {
+    const probedEntry = {
+      id: 'sdk:probe',
+      providerId: 'claude',
+      kind: 'command',
+      name: 'probe',
+      description: 'Probed command',
+      content: '',
+      scope: 'runtime',
+      source: 'sdk',
+      isEditable: false,
+      isDeletable: false,
+      displayPrefix: '/',
+      insertPrefix: '/',
+    };
+    const readyService = {
+      providerId: 'claude',
+      isReady: jest.fn().mockReturnValue(true),
+      getSupportedCommands: jest.fn(),
+      getSupportedCommandsSnapshot: jest.fn().mockReturnValue(null),
+    };
+    const claudeCatalog = {
+      listDropdownEntries: jest.fn(async (context: {
+        runtimeCommands?: readonly unknown[];
+      }) => context.runtimeCommands === undefined ? [probedEntry] : []),
+      setRuntimeCommands: jest.fn(),
+      getDropdownConfig: jest.fn().mockReturnValue({
+        providerId: 'claude',
+        triggerChars: ['/'],
+        builtInPrefix: '/',
+        skillPrefix: '/',
+        commandPrefix: '/',
+      }),
+    };
+    ProviderWorkspaceRegistry.setServices('claude', {
+      commandCatalog: claudeCatalog as any,
+    });
+    const manager = createManager({
+      tabFactory: () => createMockTabData({
+        id: 'tab-claude',
+        providerId: 'claude',
+        service: readyService,
+      }),
+    });
+    const tab = await manager.createTab();
+    const discovery = (manager as any).providerCommandDiscoveryStores.get(tab!.id);
+
+    await expect(discovery.load()).resolves.toEqual({
+      items: [probedEntry],
+      status: 'ready',
+    });
+
+    expect(readyService.getSupportedCommandsSnapshot).toHaveBeenCalledTimes(1);
+    expect(readyService.getSupportedCommands).not.toHaveBeenCalled();
+    expect(claudeCatalog.listDropdownEntries).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowCachedRuntimeCommands: false,
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(claudeCatalog.listDropdownEntries.mock.calls[0]?.[0])
+      .not.toHaveProperty('runtimeCommands');
+  });
+
   it('should clear Claude runtime commands when revalidation returns no commands', async () => {
     const readyService = {
       providerId: 'claude',
       isReady: jest.fn().mockReturnValue(true),
-      getSupportedCommands: jest.fn().mockResolvedValue([]),
+      getSupportedCommands: jest.fn(),
+      getSupportedCommandsSnapshot: jest.fn().mockReturnValue([]),
     };
     const claudeCatalog = {
       listDropdownEntries: jest.fn().mockResolvedValue([]),
@@ -2576,6 +2641,8 @@ describe('TabManager - Provider Command Catalog', () => {
     const tab = await manager.createTab();
 
     await expect(manager.getSdkCommands(tab!.id)).resolves.toEqual([]);
+    expect(readyService.getSupportedCommandsSnapshot).toHaveBeenCalledTimes(1);
+    expect(readyService.getSupportedCommands).not.toHaveBeenCalled();
     expect(claudeCatalog.setRuntimeCommands).toHaveBeenCalledWith([]);
   });
 

--- a/tests/unit/features/chat/tabs/TabManager.test.ts
+++ b/tests/unit/features/chat/tabs/TabManager.test.ts
@@ -2533,7 +2533,9 @@ describe('TabManager - Provider Command Catalog', () => {
     const catalogConfig = options.getProviderCatalogConfig();
     await catalogConfig.discovery.load();
 
-    expect(readyService.getSupportedCommands).toHaveBeenCalledTimes(1);
+    expect(readyService.getSupportedCommands).toHaveBeenCalledWith(
+      expect.any(AbortSignal),
+    );
     expect(claudeCatalog.setRuntimeCommands).toHaveBeenCalledWith(supportedCommands);
     expect(claudeCatalog.listDropdownEntries).toHaveBeenCalledWith(expect.objectContaining({
       includeBuiltIns: false,

--- a/tests/unit/features/chat/tabs/TabManager.test.ts
+++ b/tests/unit/features/chat/tabs/TabManager.test.ts
@@ -1572,7 +1572,6 @@ describe('TabManager - SDK Commands', () => {
       supportsProviderCommands: providerId === 'opencode' || providerId === 'claude',
       reasoningControl: providerId === 'opencode' ? 'effort' : 'none',
     }));
-    const resetSdkSkillsCache = jest.fn();
     const plugin = createMockPlugin({
       getConversationById: jest.fn()
         .mockResolvedValueOnce({
@@ -1611,9 +1610,6 @@ describe('TabManager - SDK Commands', () => {
               externalContextSelector: {
                 getExternalContexts: jest.fn().mockReturnValue([]),
               },
-              slashCommandDropdown: {
-                resetSdkSkillsCache,
-              },
             },
           }
       ),
@@ -1621,6 +1617,10 @@ describe('TabManager - SDK Commands', () => {
 
     await manager.createTab();
     const tab = await manager.createTab('conv-opencode', 'tab-opencode', { activate: false });
+    const invalidateDiscovery = jest.spyOn(
+      (manager as any).providerCommandDiscoveryStores.get(tab!.id),
+      'invalidate'
+    );
 
     await expect(manager.getSdkCommands(tab!.id)).resolves.toEqual(firstCommands);
     await expect(manager.getSdkCommands(tab!.id)).resolves.toEqual(firstCommands);
@@ -1628,7 +1628,7 @@ describe('TabManager - SDK Commands', () => {
     manager.invalidateProviderCommandCaches('opencode');
     await expect(manager.getSdkCommands(tab!.id)).resolves.toEqual(secondCommands);
     expect(runtimeCommandLoader.loadCommands).toHaveBeenCalledTimes(2);
-    expect(resetSdkSkillsCache).toHaveBeenCalledTimes(1);
+    expect(invalidateDiscovery).toHaveBeenCalledTimes(1);
   });
 
   it('should load commands on demand for an active blank OpenCode tab', async () => {
@@ -2012,7 +2012,6 @@ describe('TabManager - Provider Resource Generations', () => {
       cleanup: jest.fn(),
       isReady: jest.fn().mockReturnValue(true),
     };
-    const resetSdkSkillsCache = jest.fn();
     const catalog = { setRuntimeCommands: jest.fn() };
     ProviderWorkspaceRegistry.setServices('opencode', { commandCatalog: catalog as any });
     const manager = createManager({
@@ -2022,10 +2021,20 @@ describe('TabManager - Provider Resource Generations', () => {
         lifecycleState: 'bound_active',
         service: runtime,
         serviceInitialized: true,
-        ui: { slashCommandDropdown: { resetSdkSkillsCache } },
       }),
     });
     const tab = await manager.createTab();
+    const invalidateDiscovery = jest.spyOn(
+      (manager as any).providerCommandDiscoveryStores.get(tab!.id),
+      'invalidate'
+    );
+    const invalidatedRuntimeStates: boolean[] = [];
+    const discovery = (manager as any).providerCommandDiscoveryStores.get(tab!.id);
+    discovery.subscribe(() => {
+      if (discovery.getSnapshot().status === 'idle') {
+        invalidatedRuntimeStates.push(tab!.runtimeSupervisor.isInvalidated);
+      }
+    });
 
     manager.invalidateProviderResources(['opencode'], 7);
 
@@ -2033,7 +2042,8 @@ describe('TabManager - Provider Resource Generations', () => {
     expect(runtime.cancel).not.toHaveBeenCalled();
     expect(runtime.cleanup).not.toHaveBeenCalled();
     expect(catalog.setRuntimeCommands).toHaveBeenCalledWith([]);
-    expect(resetSdkSkillsCache).toHaveBeenCalledTimes(1);
+    expect(invalidateDiscovery).toHaveBeenCalledTimes(1);
+    expect(invalidatedRuntimeStates).toEqual([true]);
   });
 
   it('discards a warmup catalog write after a newer generation is published', async () => {
@@ -2069,7 +2079,67 @@ describe('TabManager - Provider Resource Generations', () => {
     await expect(pending).resolves.toEqual(commands);
 
     expect(catalog.setRuntimeCommands).not.toHaveBeenCalled();
-    expect((manager as any).providerCommandCache.has(tab!.id)).toBe(false);
+    expect((manager as any).providerRuntimeCommandCache.has(tab!.id)).toBe(false);
+  });
+
+  it('starts a fresh runtime warmup when discovery is retried after its outer timeout', async () => {
+    jest.useFakeTimers();
+    let resolveFirst!: (result: any) => void;
+    try {
+      const firstWarmup = new Promise(resolve => {
+        resolveFirst = resolve;
+      });
+      const loader = {
+        getCacheFingerprint: jest.fn().mockReturnValue('opencode:retry'),
+        isAvailable: jest.fn().mockReturnValue(true),
+        loadCommands: jest.fn()
+          .mockReturnValueOnce(firstWarmup)
+          .mockResolvedValueOnce({ status: 'empty' }),
+      };
+      const catalog = {
+        listDropdownEntries: jest.fn().mockResolvedValue([]),
+        setRuntimeCommands: jest.fn(),
+      };
+      ProviderWorkspaceRegistry.setServices('opencode', {
+        commandCatalog: catalog as any,
+        runtimeCommandLoader: loader as any,
+        tabWarmupPolicy: { resolveMode: jest.fn().mockReturnValue('none') } as any,
+      });
+      const manager = createManager({
+        tabFactory: () => createMockTabData({
+          id: 'tab-opencode',
+          providerId: 'opencode',
+          draftModel: 'opencode:test',
+          lifecycleState: 'blank',
+          ui: { externalContextSelector: { getExternalContexts: jest.fn().mockReturnValue([]) } },
+        }),
+      });
+      const tab = await manager.createTab();
+      const discovery = (manager as any).providerCommandDiscoveryStores.get(tab!.id);
+
+      const firstDiscovery = discovery.load();
+      await flushMicrotasks(8);
+      expect(loader.loadCommands).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(8_000);
+      await expect(firstDiscovery).resolves.toEqual({
+        status: 'error',
+        message: 'Provider command discovery timed out',
+        retryable: true,
+      });
+
+      const retry = discovery.retry();
+      await flushMicrotasks(8);
+      const loadCountAfterRetry = loader.loadCommands.mock.calls.length;
+
+      resolveFirst({ status: 'error', message: 'Old request timed out', retryable: true });
+      await retry;
+
+      expect(loadCountAfterRetry).toBe(2);
+      expect(discovery.getSnapshot()).toEqual({ status: 'empty' });
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('keeps secrets and conversation state out of command cache keys', async () => {
@@ -2110,7 +2180,7 @@ describe('TabManager - Provider Resource Generations', () => {
     const tab = await manager.createTab('private-conversation');
 
     await manager.getSdkCommands(tab!.id);
-    const cacheKey = (manager as any).providerCommandCache.get(tab!.id)?.key ?? '';
+    const cacheKey = (manager as any).providerRuntimeCommandCache.get(tab!.id)?.key ?? '';
 
     expect(cacheKey).toContain('opencode:safe');
     expect(cacheKey).not.toContain(secret);
@@ -2160,7 +2230,7 @@ describe('TabManager - Provider Resource Generations', () => {
     expect(loader.loadCommands).toHaveBeenLastCalledWith(expect.objectContaining({
       externalContextPaths: ['/context/b'],
     }));
-    const cacheKey = (manager as any).providerCommandCache.get(tab!.id)?.key ?? '';
+    const cacheKey = (manager as any).providerRuntimeCommandCache.get(tab!.id)?.key ?? '';
     expect(cacheKey).not.toContain('/context/a');
     expect(cacheKey).not.toContain('/context/b');
   });
@@ -2304,7 +2374,7 @@ describe('TabManager - Provider Command Catalog', () => {
 
     const options = mockInitializeTabUI.mock.calls[0][2];
     const catalogConfig = options.getProviderCatalogConfig();
-    const result = await catalogConfig.getEntries();
+    const result = await catalogConfig.discovery.load();
 
     expect(result.status).toBe('ready');
     expect(result.items).toHaveLength(1);
@@ -2400,7 +2470,7 @@ describe('TabManager - Provider Command Catalog', () => {
 
     const options = mockInitializeTabUI.mock.calls[0][2];
     const catalogConfig = options.getProviderCatalogConfig();
-    const result = await catalogConfig.getEntries();
+    const result = await catalogConfig.discovery.load();
 
     expect(catalogConfig).not.toBeNull();
     expect(catalogConfig.config.skillPrefix).toBe('$');
@@ -2449,7 +2519,7 @@ describe('TabManager - Provider Command Catalog', () => {
 
     const options = mockInitializeTabUI.mock.calls[0][2];
     const catalogConfig = options.getProviderCatalogConfig();
-    await catalogConfig.getEntries();
+    await catalogConfig.discovery.load();
 
     expect(readyService.getSupportedCommands).toHaveBeenCalledTimes(1);
     expect(claudeCatalog.setRuntimeCommands).toHaveBeenCalledWith(supportedCommands);
@@ -2737,11 +2807,10 @@ describe('TabManager - Callback Wiring', () => {
       const callbacks: TabManagerCallbacks = { onTabConversationChanged };
 
       let capturedCallbacks: any;
-      const resetSdkSkillsCache = jest.fn();
       const tabData = createMockTabData({
         id: 'test-tab',
         conversationId: null,
-        ui: { externalContextSelector: null, slashCommandDropdown: { resetSdkSkillsCache } },
+        ui: { externalContextSelector: null },
       });
       mockCreateTab.mockImplementation((opts: any) => {
         capturedCallbacks = opts;
@@ -2750,7 +2819,11 @@ describe('TabManager - Callback Wiring', () => {
 
       const manager = new TabManager(createMockPlugin(), createMockMcpManager(), createMockEl(), createMockView(), callbacks);
       await manager.createTab();
-      (manager as any).providerCommandCache.set('test-tab', {
+      const invalidateDiscovery = jest.spyOn(
+        (manager as any).providerCommandDiscoveryStores.get('test-tab'),
+        'invalidate'
+      );
+      (manager as any).providerRuntimeCommandCache.set('test-tab', {
         key: 'claude|0|0|catalog|0',
         result: { status: 'empty' },
       });
@@ -2762,8 +2835,8 @@ describe('TabManager - Callback Wiring', () => {
       expect(tabData.conversationId).toBe('new-conv-id');
       expect(onTabConversationChanged).toHaveBeenCalledWith('test-tab', 'new-conv-id');
       expect((manager as any).tabCommandContextRevisions.get('test-tab')).toBe(1);
-      expect((manager as any).providerCommandCache.has('test-tab')).toBe(false);
-      expect(resetSdkSkillsCache).toHaveBeenCalledTimes(1);
+      expect((manager as any).providerRuntimeCommandCache.has('test-tab')).toBe(false);
+      expect(invalidateDiscovery).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/tests/unit/features/chat/ui/InputToolbar.test.ts
+++ b/tests/unit/features/chat/ui/InputToolbar.test.ts
@@ -846,6 +846,18 @@ describe('ServiceTierToggle', () => {
     const container = parentEl2.querySelector('.claudian-service-tier-toggle');
     expect(container?.style.display).toBe('none');
   });
+
+  it('does not toggle when the provider exposes no fast service tier', async () => {
+    callbacks.getUIConfig.mockReturnValue({
+      ...createMockUIConfig(),
+      getServiceTierToggle: jest.fn().mockReturnValue(null),
+    });
+    const parentEl2 = createMockEl();
+    const toggle = new ServiceTierToggle(parentEl2, callbacks);
+
+    await expect(toggle.toggle()).resolves.toBe(false);
+    expect(callbacks.onServiceTierChange).not.toHaveBeenCalled();
+  });
 });
 
 describe('McpServerSelector', () => {

--- a/tests/unit/features/inline-edit/ui/InlineEditModal.openAndWait.test.ts
+++ b/tests/unit/features/inline-edit/ui/InlineEditModal.openAndWait.test.ts
@@ -230,6 +230,16 @@ describe('InlineEditModal - openAndWait', () => {
         }),
       } as any;
       plugin.providerHost = plugin;
+      jest.spyOn(ProviderWorkspaceRegistry, 'getCommandCatalog').mockReturnValue({
+        getDropdownConfig: jest.fn().mockReturnValue({
+          providerId: 'codex',
+          triggerChars: ['/', '$'],
+          builtInPrefix: '/',
+          skillPrefix: '$',
+          commandPrefix: '/',
+        }),
+        listDropdownEntries: jest.fn().mockResolvedValue([]),
+      } as any);
       const editor = {} as any;
       const view = { editor } as any;
 
@@ -288,6 +298,9 @@ describe('InlineEditModal - openAndWait', () => {
       );
       const constructorCall = SlashCommandDropdown.mock.calls[0];
       expect(Array.from(constructorCall[3].hiddenCommands)).toEqual(['analyze']);
+      expect(constructorCall[3].includeBuiltIns).toBe(false);
+      expect(constructorCall[3].providerDiscovery).toBeDefined();
+      expect(constructorCall[3].getProviderEntries).toBeUndefined();
 
       widgetRef?.reject();
       await expect(resultPromise).resolves.toEqual({ decision: 'reject' });

--- a/tests/unit/providers/claude/commands/ClaudeCommandCatalog.test.ts
+++ b/tests/unit/providers/claude/commands/ClaudeCommandCatalog.test.ts
@@ -200,6 +200,47 @@ Deploy the app`,
       expect(b).toHaveLength(1);
     });
 
+    it('cancels a request-scoped probe and starts fresh work on retry', async () => {
+      const adapter = createMockAdapter({});
+      const commands = new SlashCommandStorage(adapter);
+      const skills = new SkillStorage(adapter);
+      let resolveFirst!: (commands: SlashCommand[]) => void;
+      const firstProbe = new Promise<SlashCommand[]>((resolve) => {
+        resolveFirst = resolve;
+      });
+      const freshCommands: SlashCommand[] = [{
+        id: 'sdk:fresh',
+        name: 'fresh',
+        description: 'Fresh command',
+        content: '',
+        source: 'sdk',
+      }];
+      const probe = jest.fn()
+        .mockReturnValueOnce(firstProbe)
+        .mockResolvedValueOnce(freshCommands);
+      const catalog = new ClaudeCommandCatalog(commands, skills, probe);
+      const firstController = new AbortController();
+      const secondController = new AbortController();
+
+      const abandoned = catalog.listDropdownEntries({
+        includeBuiltIns: false,
+        signal: firstController.signal,
+      });
+      firstController.abort();
+      const retry = catalog.listDropdownEntries({
+        includeBuiltIns: false,
+        signal: secondController.signal,
+      });
+      resolveFirst([]);
+
+      await expect(abandoned).rejects.toMatchObject({ name: 'AbortError' });
+      await expect(retry).resolves.toEqual([
+        expect.objectContaining({ name: 'fresh' }),
+      ]);
+      expect(probe).toHaveBeenNthCalledWith(1, firstController.signal);
+      expect(probe).toHaveBeenNthCalledWith(2, secondController.signal);
+    });
+
     it('does not overwrite runtime commands with stale probe results', async () => {
       const adapter = createMockAdapter({});
       const commands = new SlashCommandStorage(adapter);

--- a/tests/unit/providers/claude/commands/probeRuntimeCommands.test.ts
+++ b/tests/unit/providers/claude/commands/probeRuntimeCommands.test.ts
@@ -4,8 +4,18 @@ import type { ProviderHost } from '@/core/providers/ProviderHost';
 import { probeRuntimeCommands } from '@/providers/claude/commands/probeRuntimeCommands';
 
 const sdkMock = sdkModule as unknown as {
+  getLastResponse: () => {
+    supportedCommands: jest.Mock;
+  } | null;
   setMockMessages: (messages: any[], options?: { appendResult?: boolean }) => void;
   setMockSupportedCommands: (commands: Array<{ name: string; description: string; argumentHint?: string }>) => void;
+  setMockSupportedCommandsImplementation: (
+    implementation: () => Promise<Array<{
+      name: string;
+      description: string;
+      argumentHint?: string;
+    }>>,
+  ) => void;
   resetMockMessages: () => void;
   getLastOptions: () => sdkModule.Options | undefined;
 };
@@ -88,5 +98,33 @@ describe('probeRuntimeCommands', () => {
     }));
 
     expect(sdkMock.getLastOptions()?.extraArgs).toEqual({ 'enable-auto-mode': null });
+  });
+
+  it('aborts an in-flight SDK probe when its caller is cancelled', async () => {
+    sdkMock.setMockMessages([
+      { type: 'system', subtype: 'init', session_id: 'probe-session' },
+    ], { appendResult: false });
+    sdkMock.setMockSupportedCommandsImplementation(
+      () => new Promise(() => undefined),
+    );
+    const abortController = new AbortController();
+
+    const probe = probeRuntimeCommands(
+      createMockPlugin(),
+      abortController.signal,
+    );
+    for (
+      let i = 0;
+      i < 10 && !sdkMock.getLastResponse()?.supportedCommands.mock.calls.length;
+      i++
+    ) {
+      await new Promise<void>(resolve => setImmediate(resolve));
+    }
+    expect(sdkMock.getLastResponse()?.supportedCommands).toHaveBeenCalledTimes(1);
+
+    abortController.abort();
+    expect(sdkMock.getLastOptions()?.abortController?.signal.aborted).toBe(true);
+
+    await expect(probe).rejects.toMatchObject({ name: 'AbortError' });
   });
 });

--- a/tests/unit/providers/claude/runtime/ClaudianService.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudianService.test.ts
@@ -933,6 +933,30 @@ describe('ClaudianService', () => {
       expect(commands).toEqual([]);
     });
 
+    it('should close a stuck persistent query when command discovery is cancelled', async () => {
+      const supportedCommands = new Promise<Array<{
+        name: string;
+        description: string;
+        argumentHint: string;
+      }>>(() => undefined);
+      const mockQuery = {
+        interrupt: jest.fn().mockResolvedValue(undefined),
+        supportedCommands: jest.fn().mockReturnValue(supportedCommands),
+      };
+      (service as any).persistentQuery = mockQuery;
+      (service as any).queryAbortController = new AbortController();
+      const closeSpy = jest.spyOn(service, 'closePersistentQuery');
+      const abortController = new AbortController();
+
+      const commands = service.getSupportedCommands(abortController.signal);
+      abortController.abort();
+
+      await expect(commands).rejects.toMatchObject({ name: 'AbortError' });
+      expect(closeSpy).toHaveBeenCalledWith('command discovery aborted');
+      expect(mockQuery.interrupt).toHaveBeenCalledTimes(1);
+      expect((service as any).persistentQuery).toBeNull();
+    });
+
     it('should ignore late supportedCommands results from a stale query', async () => {
       let resolveStaleCommands: (commands: Array<{ name: string; description: string; argumentHint: string }>) => void;
       const staleCommandsPromise = new Promise<Array<{ name: string; description: string; argumentHint: string }>>((resolve) => {

--- a/tests/unit/providers/claude/runtime/ClaudianService.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudianService.test.ts
@@ -900,6 +900,7 @@ describe('ClaudianService', () => {
       };
       (service as any).persistentQuery = mockQuery;
 
+      await (service as any).fetchAndCacheCommands(mockQuery);
       const commands = await service.getSupportedCommands();
 
       expect(mockQuery.supportedCommands).toHaveBeenCalled();
@@ -920,6 +921,7 @@ describe('ClaudianService', () => {
         content: '',
         source: 'sdk',
       });
+      expect(service.getSupportedCommandsSnapshot()).toEqual(commands);
     });
 
     it('should return empty array on SDK error', async () => {
@@ -928,12 +930,27 @@ describe('ClaudianService', () => {
       };
       (service as any).persistentQuery = mockQuery;
 
-      const commands = await service.getSupportedCommands();
+      const commands = await (service as any).fetchAndCacheCommands(mockQuery);
 
       expect(commands).toEqual([]);
+      expect(service.getSupportedCommandsSnapshot()).toBeNull();
     });
 
-    it('should close a stuck persistent query when command discovery is cancelled', async () => {
+    it('should distinguish an authoritative empty command snapshot', async () => {
+      const mockQuery = {
+        supportedCommands: jest.fn().mockResolvedValue([]),
+      };
+      (service as any).persistentQuery = mockQuery;
+
+      await expect((service as any).fetchAndCacheCommands(mockQuery))
+        .resolves.toEqual([]);
+
+      expect(service.getSupportedCommandsSnapshot()).toEqual([]);
+      await expect(service.getSupportedCommands()).resolves.toEqual([]);
+      expect(mockQuery.supportedCommands).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not query or close an active runtime when command metadata is unavailable', async () => {
       const supportedCommands = new Promise<Array<{
         name: string;
         description: string;
@@ -946,15 +963,14 @@ describe('ClaudianService', () => {
       (service as any).persistentQuery = mockQuery;
       (service as any).queryAbortController = new AbortController();
       const closeSpy = jest.spyOn(service, 'closePersistentQuery');
-      const abortController = new AbortController();
 
-      const commands = service.getSupportedCommands(abortController.signal);
-      abortController.abort();
+      await expect(service.getSupportedCommands()).resolves.toEqual([]);
 
-      await expect(commands).rejects.toMatchObject({ name: 'AbortError' });
-      expect(closeSpy).toHaveBeenCalledWith('command discovery aborted');
-      expect(mockQuery.interrupt).toHaveBeenCalledTimes(1);
-      expect((service as any).persistentQuery).toBeNull();
+      expect(service.getSupportedCommandsSnapshot()).toBeNull();
+      expect(mockQuery.supportedCommands).not.toHaveBeenCalled();
+      expect(closeSpy).not.toHaveBeenCalled();
+      expect(mockQuery.interrupt).not.toHaveBeenCalled();
+      expect((service as any).persistentQuery).toBe(mockQuery);
     });
 
     it('should ignore late supportedCommands results from a stale query', async () => {

--- a/tests/unit/providers/codex/commands/CodexSkillCatalog.test.ts
+++ b/tests/unit/providers/codex/commands/CodexSkillCatalog.test.ts
@@ -35,10 +35,14 @@ describe('CodexSkillCatalog', () => {
       },
     ]);
     const catalog = new CodexSkillCatalog(listProvider);
+    const signal = new AbortController().signal;
 
-    const entries = await catalog.listDropdownEntries({ includeBuiltIns: false });
+    const entries = await catalog.listDropdownEntries({
+      includeBuiltIns: false,
+      signal,
+    });
 
-    expect(listProvider.listSkills).toHaveBeenCalledTimes(1);
+    expect(listProvider.listSkills).toHaveBeenCalledWith({ signal });
     expect(entries.map(entry => entry.name)).toEqual([
       'legacy-skill',
       'shared-skill',

--- a/tests/unit/providers/codex/skills/CodexSkillListingService.test.ts
+++ b/tests/unit/providers/codex/skills/CodexSkillListingService.test.ts
@@ -226,4 +226,47 @@ describe('CodexSkillListingService', () => {
       forceReload: true,
     });
   });
+
+  it('stops an app-server skill listing when its caller aborts', async () => {
+    mockResolveLaunchSpec.mockReturnValue({
+      target: { method: 'host', platformFamily: 'unix', platformOs: 'linux' },
+      command: 'codex',
+      args: ['app-server', '--listen', 'stdio://'],
+      spawnCwd: '/workspace',
+      targetCwd: '/workspace',
+      env: {},
+      pathMapper: {
+        target: { method: 'host', platformFamily: 'unix', platformOs: 'linux' },
+        toTargetPath: jest.fn((value: string) => value),
+        toHostPath: jest.fn((value: string) => value),
+        mapTargetPathList: jest.fn(),
+        canRepresentHostPath: jest.fn(),
+      },
+    });
+    let rejectRequest!: (error: Error) => void;
+    mockTransportRequest.mockImplementation(() => new Promise((_resolve, reject) => {
+      rejectRequest = reject;
+    }));
+    mockTransportDispose.mockImplementation(() => rejectRequest?.(new Error('aborted')));
+    const service = new CodexSkillListingService({
+      settings: {},
+      getResolvedProviderCliPath: jest.fn(),
+      getActiveEnvironmentVariables: jest.fn(),
+      app: {
+        vault: {
+          adapter: { basePath: '/workspace' },
+        },
+      },
+    } as any);
+    const abortController = new AbortController();
+
+    const listing = service.listSkills({ signal: abortController.signal });
+    await Promise.resolve();
+    abortController.abort();
+
+    await expect(listing).rejects.toThrow('aborted');
+    expect(abortController.signal.aborted).toBe(true);
+    expect(mockTransportDispose).toHaveBeenCalled();
+    expect(mockProcessShutdown).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/unit/providers/grok/app/GrokRuntimeCommandLoader.test.ts
+++ b/tests/unit/providers/grok/app/GrokRuntimeCommandLoader.test.ts
@@ -3,7 +3,7 @@ import type { SlashCommand } from '@/core/types';
 import { GrokRuntimeCommandLoader } from '@/providers/grok/app/GrokRuntimeCommandLoader';
 
 type TestGrokRuntime = ChatRuntime & {
-  discoverSupportedCommands(timeoutMs?: number): Promise<SlashCommand[]>;
+  discoverSupportedCommands(timeoutMs?: number, signal?: AbortSignal): Promise<SlashCommand[]>;
   getReadySupportedCommandsSnapshot(): SlashCommand[] | null;
 };
 
@@ -92,6 +92,52 @@ describe('GrokRuntimeCommandLoader', () => {
       });
     expect((runtime as any).discoverSupportedCommands).toHaveBeenCalledTimes(1);
     expect(runtime.getSupportedCommands).not.toHaveBeenCalled();
+  });
+
+  it('forwards cancellation to a live runtime without cleaning it up', async () => {
+    const abortController = new AbortController();
+    const runtime = createRuntime({
+      getReadySupportedCommandsSnapshot: jest.fn().mockReturnValue(null),
+    } as Partial<ChatRuntime>);
+    const context = createContext(runtime);
+    context.signal = abortController.signal;
+
+    await new GrokRuntimeCommandLoader().loadCommands(context);
+
+    expect((runtime as any).discoverSupportedCommands).toHaveBeenCalledWith(
+      5_000,
+      abortController.signal,
+    );
+    expect(runtime.cleanup).not.toHaveBeenCalled();
+  });
+
+  it('cleans up an isolated runtime when discovery is aborted', async () => {
+    const abortController = new AbortController();
+    const isolatedRuntime = createRuntime({
+      discoverSupportedCommands: jest.fn((
+        _timeoutMs: number,
+        signal?: AbortSignal,
+      ) => new Promise<SlashCommand[]>((_resolve, reject) => {
+        signal?.addEventListener('abort', () => reject(new Error('aborted')), {
+          once: true,
+        });
+      })),
+    } as Partial<ChatRuntime>);
+    const context = createContext();
+    context.signal = abortController.signal;
+
+    const discovery = new GrokRuntimeCommandLoader(
+      jest.fn().mockReturnValue(isolatedRuntime),
+    )
+      .loadCommands(context);
+    abortController.abort();
+
+    await expect(discovery).resolves.toEqual({
+      message: 'Could not load Grok skills and commands.',
+      retryable: true,
+      status: 'error',
+    });
+    expect(isolatedRuntime.cleanup).toHaveBeenCalledTimes(1);
   });
 
   it('loads exact protocol commands for a restored session without reloading that session', async () => {

--- a/tests/unit/providers/opencode/OpencodeChatRuntime.test.ts
+++ b/tests/unit/providers/opencode/OpencodeChatRuntime.test.ts
@@ -183,6 +183,20 @@ describe('OpencodeChatRuntime', () => {
     expect((runtime as any).supportedCommandWaiters).toHaveLength(0);
   });
 
+  it('rejects cancelled command discovery and removes the waiter', async () => {
+    const runtime = new OpencodeChatRuntime(createMockPlugin());
+    const abortController = new AbortController();
+    const commandsPromise = runtime.discoverSupportedCommands(
+      5_000,
+      abortController.signal,
+    );
+
+    abortController.abort();
+
+    await expect(commandsPromise).rejects.toThrow('OpenCode command discovery aborted.');
+    expect((runtime as any).supportedCommandWaiters).toHaveLength(0);
+  });
+
   it('rejects command waiters on cleanup and malformed command notifications', async () => {
     const runtime = new OpencodeChatRuntime(createMockPlugin());
     runtime.syncConversationState({ providerState: {}, sessionId: 'session-malformed' });

--- a/tests/unit/providers/opencode/OpencodeRuntimeCommandLoader.test.ts
+++ b/tests/unit/providers/opencode/OpencodeRuntimeCommandLoader.test.ts
@@ -198,4 +198,37 @@ describe('OpencodeRuntimeCommandLoader', () => {
 
     expect(cleanupSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('cleans up the isolated process when discovery is aborted', async () => {
+    const abortController = new AbortController();
+    jest.spyOn(OpencodeChatRuntime.prototype, 'syncConversationState').mockImplementation(() => {});
+    jest.spyOn(OpencodeChatRuntime.prototype, 'ensureReady').mockResolvedValue(true);
+    jest.spyOn(OpencodeChatRuntime.prototype, 'discoverSupportedCommands')
+      .mockImplementation((_timeoutMs, signal) => (
+        new Promise((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(new Error('aborted')), {
+            once: true,
+          });
+        })
+      ));
+    const cleanupSpy = jest.spyOn(OpencodeChatRuntime.prototype, 'cleanup')
+      .mockImplementation(() => {});
+
+    const discovery = new OpencodeRuntimeCommandLoader().loadCommands({
+      allowSessionCreation: true,
+      conversation: null,
+      externalContextPaths: [],
+      plugin: createMockPlugin(),
+      runtime: null,
+      signal: abortController.signal,
+    });
+    abortController.abort();
+
+    await expect(discovery).resolves.toEqual({
+      message: 'Could not load OpenCode commands.',
+      retryable: true,
+      status: 'error',
+    });
+    expect(cleanupSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/unit/providers/pi/PiRuntimeCommandLoader.test.ts
+++ b/tests/unit/providers/pi/PiRuntimeCommandLoader.test.ts
@@ -221,4 +221,25 @@ describe('PiRuntimeCommandLoader', () => {
     });
     expect(JSON.stringify(failure)).not.toContain('SECRET_SENTINEL');
   });
+
+  it('cleans up the isolated process when discovery is aborted', async () => {
+    const abortController = new AbortController();
+    const conversation = createConversation({ sessionId: 'session-1' });
+
+    const discovery = new PiRuntimeCommandLoader().loadCommands({
+      conversation,
+      externalContextPaths: [],
+      plugin: {} as any,
+      runtime: null,
+      signal: abortController.signal,
+    });
+    abortController.abort();
+
+    await expect(discovery).resolves.toEqual({
+      message: 'Could not load Pi commands.',
+      retryable: true,
+      status: 'error',
+    });
+    expect(mockCreatedRuntimes[0].cleanup).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/unit/providers/pi/runtime/PiRpcTransport.test.ts
+++ b/tests/unit/providers/pi/runtime/PiRpcTransport.test.ts
@@ -113,4 +113,21 @@ describe('PiRpcTransport', () => {
     input.write('{"type":"response","id":"req_2","success":true,"result":{"ok":true}}\n');
     await expect(next).resolves.toEqual({ ok: true });
   });
+
+  it('rejects an aborted request and removes it from the pending set', async () => {
+    const { input, transport } = createTransport();
+    const abortController = new AbortController();
+    const request = transport.request(
+      'get_commands',
+      {},
+      1_000,
+      abortController.signal,
+    );
+
+    abortController.abort();
+
+    await expect(request).rejects.toThrow('Request aborted: get_commands');
+    input.write('{"type":"response","id":"req_1","success":true,"result":[]}\n');
+    expect((transport as any).pending).toHaveProperty('size', 0);
+  });
 });

--- a/tests/unit/shared/components/SlashCommandDropdown.provider.test.ts
+++ b/tests/unit/shared/components/SlashCommandDropdown.provider.test.ts
@@ -1,7 +1,11 @@
 import { createMockEl } from '@test/helpers/mockElement';
 
 import type { ProviderCommandDropdownConfig } from '@/core/providers/commands/ProviderCommandCatalog';
-import type { ProviderCommandDiscoveryResult } from '@/core/providers/commands/ProviderCommandDiscoveryResult';
+import {
+  normalizeProviderCommandDiscoveryItems,
+  type ProviderCommandDiscoveryResult,
+} from '@/core/providers/commands/ProviderCommandDiscoveryResult';
+import { ProviderCommandDiscoveryStore } from '@/core/providers/commands/ProviderCommandDiscoveryStore';
 import type { ProviderCommandEntry } from '@/core/providers/commands/ProviderCommandEntry';
 import {
   SlashCommandDropdown,
@@ -15,12 +19,13 @@ jest.mock('@/core/commands/builtInCommands', () => ({
       { id: 'builtin:add-dir', name: 'add-dir', description: 'Add external context directory', content: '', argumentHint: 'path/to/directory' },
       { id: 'builtin:resume', name: 'resume', description: 'Resume a previous conversation', content: '', supportsNativeHistory: true },
       { id: 'builtin:fork', name: 'fork', description: 'Fork entire conversation to new session', content: '', supportsFork: true },
+      { id: 'builtin:fast', name: 'fast', description: 'Toggle fast mode', content: '' },
     ];
     if (!providerId) return all;
     if (providerId === 'codex') {
       return all;
     }
-    return all;
+    return all.filter(command => command.name !== 'fast');
   }),
 }));
 
@@ -86,6 +91,14 @@ function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
   return { promise, resolve };
 }
 
+function createEntryDiscovery(
+  loader: () => Promise<readonly ProviderCommandEntry[]>,
+): ProviderCommandDiscoveryStore<ProviderCommandEntry> {
+  return new ProviderCommandDiscoveryStore(async () =>
+    normalizeProviderCommandDiscoveryItems(await loader()),
+  );
+}
+
 const CLAUDE_CONFIG: ProviderCommandDropdownConfig = {
   providerId: 'claude',
   triggerChars: ['/'],
@@ -102,7 +115,7 @@ const CODEX_CONFIG: ProviderCommandDropdownConfig = {
   commandPrefix: '/',
 };
 
-const CLAUDE_ENTRIES: ProviderCommandEntry[] = [
+const CLAUDE_ENTRIES: [ProviderCommandEntry, ProviderCommandEntry] = [
   {
     id: 'cmd-review', providerId: 'claude', kind: 'command', name: 'review',
     description: 'Review code', content: '', scope: 'vault', source: 'user',
@@ -135,10 +148,35 @@ describe('SlashCommandDropdown - provider catalog', () => {
   });
 
   describe('Claude provider (/ trigger)', () => {
+    it('filters provider-scoped built-ins without a command catalog', async () => {
+      const dropdown = new SlashCommandDropdown(
+        containerEl,
+        inputEl,
+        callbacks,
+        { providerId: 'claude' },
+      );
+
+      inputEl.value = '/';
+      inputEl.selectionStart = 1;
+      dropdown.handleInputChange();
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(getRenderedCommandNames(containerEl)).toContain('/clear');
+      expect(getRenderedCommandNames(containerEl)).not.toContain('/fast');
+
+      dropdown.destroy();
+    });
+
     it('shows provider entries on / trigger', async () => {
       const getProviderEntries = jest.fn().mockResolvedValue(CLAUDE_ENTRIES);
       const dropdown = new SlashCommandDropdown(
-        containerEl, inputEl, callbacks, { providerConfig: CLAUDE_CONFIG, getProviderEntries }
+        containerEl,
+        inputEl,
+        callbacks,
+        {
+          providerConfig: CLAUDE_CONFIG,
+          providerDiscovery: createEntryDiscovery(getProviderEntries),
+        },
       );
 
       inputEl.value = '/';
@@ -151,6 +189,38 @@ describe('SlashCommandDropdown - provider catalog', () => {
       expect(names).toContain('/clear');
       expect(names).toContain('/review');
       expect(names).toContain('/deploy');
+      expect(names).not.toContain('/fast');
+
+      dropdown.destroy();
+    });
+
+    it('shows /fast when the provider catalog advertises it', async () => {
+      const fastCommand: ProviderCommandEntry = {
+        ...CLAUDE_ENTRIES[0],
+        id: 'cmd-fast',
+        name: 'fast',
+        description: 'Provider fast command',
+      };
+      const getProviderEntries = jest.fn().mockResolvedValue([
+        ...CLAUDE_ENTRIES,
+        fastCommand,
+      ]);
+      const dropdown = new SlashCommandDropdown(
+        containerEl,
+        inputEl,
+        callbacks,
+        {
+          providerConfig: CLAUDE_CONFIG,
+          providerDiscovery: createEntryDiscovery(getProviderEntries),
+        },
+      );
+
+      inputEl.value = '/';
+      inputEl.selectionStart = 1;
+      dropdown.handleInputChange();
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(getRenderedCommandNames(containerEl)).toContain('/fast');
 
       dropdown.destroy();
     });
@@ -158,7 +228,13 @@ describe('SlashCommandDropdown - provider catalog', () => {
     it('displays Claude entries with / prefix', async () => {
       const getProviderEntries = jest.fn().mockResolvedValue(CLAUDE_ENTRIES);
       const dropdown = new SlashCommandDropdown(
-        containerEl, inputEl, callbacks, { providerConfig: CLAUDE_CONFIG, getProviderEntries }
+        containerEl,
+        inputEl,
+        callbacks,
+        {
+          providerConfig: CLAUDE_CONFIG,
+          providerDiscovery: createEntryDiscovery(getProviderEntries),
+        },
       );
 
       inputEl.value = '/rev';
@@ -177,7 +253,13 @@ describe('SlashCommandDropdown - provider catalog', () => {
     it('shows Codex skills on $ trigger', async () => {
       const getProviderEntries = jest.fn().mockResolvedValue(CODEX_ENTRIES);
       const dropdown = new SlashCommandDropdown(
-        containerEl, inputEl, callbacks, { providerConfig: CODEX_CONFIG, getProviderEntries }
+        containerEl,
+        inputEl,
+        callbacks,
+        {
+          providerConfig: CODEX_CONFIG,
+          providerDiscovery: createEntryDiscovery(getProviderEntries),
+        },
       );
 
       inputEl.value = '$';
@@ -196,7 +278,13 @@ describe('SlashCommandDropdown - provider catalog', () => {
     it('shows built-ins + skills on / trigger at position 0', async () => {
       const getProviderEntries = jest.fn().mockResolvedValue(CODEX_ENTRIES);
       const dropdown = new SlashCommandDropdown(
-        containerEl, inputEl, callbacks, { providerConfig: CODEX_CONFIG, getProviderEntries }
+        containerEl,
+        inputEl,
+        callbacks,
+        {
+          providerConfig: CODEX_CONFIG,
+          providerDiscovery: createEntryDiscovery(getProviderEntries),
+        },
       );
 
       inputEl.value = '/';
@@ -214,7 +302,13 @@ describe('SlashCommandDropdown - provider catalog', () => {
     it('includes Codex-compatible built-ins in the Codex dropdown', async () => {
       const getProviderEntries = jest.fn().mockResolvedValue(CODEX_ENTRIES);
       const dropdown = new SlashCommandDropdown(
-        containerEl, inputEl, callbacks, { providerConfig: CODEX_CONFIG, getProviderEntries }
+        containerEl,
+        inputEl,
+        callbacks,
+        {
+          providerConfig: CODEX_CONFIG,
+          providerDiscovery: createEntryDiscovery(getProviderEntries),
+        },
       );
 
       inputEl.value = '/';
@@ -234,7 +328,13 @@ describe('SlashCommandDropdown - provider catalog', () => {
     it('inserts $name for Codex skill selection', async () => {
       const getProviderEntries = jest.fn().mockResolvedValue(CODEX_ENTRIES);
       const dropdown = new SlashCommandDropdown(
-        containerEl, inputEl, callbacks, { providerConfig: CODEX_CONFIG, getProviderEntries }
+        containerEl,
+        inputEl,
+        callbacks,
+        {
+          providerConfig: CODEX_CONFIG,
+          providerDiscovery: createEntryDiscovery(getProviderEntries),
+        },
       );
 
       inputEl.value = '$';
@@ -257,7 +357,13 @@ describe('SlashCommandDropdown - provider catalog', () => {
     it('resets cached entries on provider switch', async () => {
       const claudeEntries = jest.fn().mockResolvedValue(CLAUDE_ENTRIES);
       const dropdown = new SlashCommandDropdown(
-        containerEl, inputEl, callbacks, { providerConfig: CLAUDE_CONFIG, getProviderEntries: claudeEntries }
+        containerEl,
+        inputEl,
+        callbacks,
+        {
+          providerConfig: CLAUDE_CONFIG,
+          providerDiscovery: createEntryDiscovery(claudeEntries),
+        },
       );
 
       // Fetch Claude entries
@@ -273,7 +379,10 @@ describe('SlashCommandDropdown - provider catalog', () => {
         status: 'ready',
         items: CODEX_ENTRIES,
       });
-      dropdown.setProviderCatalog(CODEX_CONFIG, codexEntries);
+      dropdown.setProviderCatalog(
+        CODEX_CONFIG,
+        new ProviderCommandDiscoveryStore(codexEntries),
+      );
 
       inputEl.value = '$';
       inputEl.selectionStart = 1;
@@ -290,7 +399,10 @@ describe('SlashCommandDropdown - provider catalog', () => {
         containerEl,
         inputEl,
         callbacks,
-        { providerConfig: CLAUDE_CONFIG, getProviderEntries: async () => CLAUDE_ENTRIES },
+        {
+          providerConfig: CLAUDE_CONFIG,
+          providerDiscovery: createEntryDiscovery(async () => CLAUDE_ENTRIES),
+        },
       );
 
       inputEl.value = '/';
@@ -301,7 +413,10 @@ describe('SlashCommandDropdown - provider catalog', () => {
 
       dropdown.setProviderCatalog(
         CODEX_CONFIG,
-        async () => ({ status: 'ready', items: [CODEX_ENTRIES[0]] }),
+        new ProviderCommandDiscoveryStore(async () => ({
+          status: 'ready',
+          items: [CODEX_ENTRIES[0]],
+        })),
       );
 
       expect(dropdown.isVisible()).toBe(false);
@@ -363,7 +478,9 @@ describe('SlashCommandDropdown - provider catalog', () => {
               skillPrefix: displayPrefix,
               commandPrefix: '/',
             },
-            discoverProviderEntries: async () => ({ status: 'ready', items: entries }),
+            providerDiscovery: new ProviderCommandDiscoveryStore(
+              async () => ({ status: 'ready', items: entries }),
+            ),
           },
         );
 
@@ -389,7 +506,10 @@ describe('SlashCommandDropdown - provider catalog', () => {
         containerEl,
         inputEl,
         callbacks,
-        { providerConfig: CLAUDE_CONFIG, discoverProviderEntries },
+        {
+          providerConfig: CLAUDE_CONFIG,
+          providerDiscovery: new ProviderCommandDiscoveryStore(discoverProviderEntries),
+        },
       );
 
       inputEl.value = '/';
@@ -409,6 +529,96 @@ describe('SlashCommandDropdown - provider catalog', () => {
       dropdown.destroy();
     });
 
+    it('reuses settled discovery while filtering subsequent keystrokes', async () => {
+      const discoverProviderEntries = jest.fn().mockResolvedValue({
+        status: 'ready',
+        items: CLAUDE_ENTRIES,
+      });
+      const dropdown = new SlashCommandDropdown(
+        containerEl,
+        inputEl,
+        callbacks,
+        {
+          providerConfig: CLAUDE_CONFIG,
+          providerDiscovery: new ProviderCommandDiscoveryStore(discoverProviderEntries),
+        },
+      );
+
+      inputEl.value = '/';
+      inputEl.selectionStart = 1;
+      dropdown.handleInputChange();
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      inputEl.value = '/rev';
+      inputEl.selectionStart = 4;
+      dropdown.handleInputChange();
+
+      expect(discoverProviderEntries).toHaveBeenCalledTimes(1);
+      expect(getDiscoveryState(containerEl)).toBeNull();
+      expect(getRenderedCommandNames(containerEl)).toContain('/review');
+
+      dropdown.destroy();
+    });
+
+    it('shares in-flight discovery across keystrokes', async () => {
+      const response = deferred<ProviderCommandDiscoveryResult<ProviderCommandEntry>>();
+      const discoverProviderEntries = jest.fn().mockReturnValue(response.promise);
+      const dropdown = new SlashCommandDropdown(
+        containerEl,
+        inputEl,
+        callbacks,
+        {
+          providerConfig: CLAUDE_CONFIG,
+          providerDiscovery: new ProviderCommandDiscoveryStore(discoverProviderEntries),
+        },
+      );
+
+      inputEl.value = '/';
+      inputEl.selectionStart = 1;
+      dropdown.handleInputChange();
+      inputEl.value = '/rev';
+      inputEl.selectionStart = 4;
+      dropdown.handleInputChange();
+
+      expect(discoverProviderEntries).toHaveBeenCalledTimes(1);
+
+      response.resolve({ status: 'ready', items: CLAUDE_ENTRIES });
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(getDiscoveryState(containerEl)).toBeNull();
+      expect(getRenderedCommandNames(containerEl)).toContain('/review');
+
+      dropdown.destroy();
+    });
+
+    it('discovers again after explicit cache invalidation', async () => {
+      const discoverProviderEntries = jest.fn().mockResolvedValue({
+        status: 'ready',
+        items: CLAUDE_ENTRIES,
+      });
+      const providerDiscovery = new ProviderCommandDiscoveryStore<ProviderCommandEntry>(
+        discoverProviderEntries,
+      );
+      const dropdown = new SlashCommandDropdown(
+        containerEl,
+        inputEl,
+        callbacks,
+        { providerConfig: CLAUDE_CONFIG, providerDiscovery },
+      );
+
+      inputEl.value = '/';
+      inputEl.selectionStart = 1;
+      dropdown.handleInputChange();
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      providerDiscovery.invalidate();
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(discoverProviderEntries).toHaveBeenCalledTimes(2);
+
+      dropdown.destroy();
+    });
+
     it('replaces an unresponsive provider discovery with a retryable error', async () => {
       jest.useFakeTimers();
       try {
@@ -418,7 +628,9 @@ describe('SlashCommandDropdown - provider catalog', () => {
           callbacks,
           {
             providerConfig: CLAUDE_CONFIG,
-            discoverProviderEntries: () => new Promise(() => undefined),
+            providerDiscovery: new ProviderCommandDiscoveryStore(
+              () => new Promise(() => undefined),
+            ),
           },
         );
 
@@ -450,7 +662,10 @@ describe('SlashCommandDropdown - provider catalog', () => {
         containerEl,
         inputEl,
         callbacks,
-        { providerConfig: CLAUDE_CONFIG, discoverProviderEntries: async () => result },
+        {
+          providerConfig: CLAUDE_CONFIG,
+          providerDiscovery: new ProviderCommandDiscoveryStore(async () => result),
+        },
       );
 
       inputEl.value = '/';
@@ -476,7 +691,10 @@ describe('SlashCommandDropdown - provider catalog', () => {
         containerEl,
         inputEl,
         callbacks,
-        { providerConfig: CLAUDE_CONFIG, discoverProviderEntries },
+        {
+          providerConfig: CLAUDE_CONFIG,
+          providerDiscovery: new ProviderCommandDiscoveryStore(discoverProviderEntries),
+        },
       );
 
       inputEl.value = '/';
@@ -498,7 +716,7 @@ describe('SlashCommandDropdown - provider catalog', () => {
       dropdown.destroy();
     });
 
-    it('retries a failed discovery when the trigger is reopened', async () => {
+    it('keeps a failed discovery stable when the trigger is reopened', async () => {
       const discoverProviderEntries = jest.fn()
         .mockResolvedValueOnce({
           status: 'error',
@@ -510,7 +728,10 @@ describe('SlashCommandDropdown - provider catalog', () => {
         containerEl,
         inputEl,
         callbacks,
-        { providerConfig: CLAUDE_CONFIG, discoverProviderEntries },
+        {
+          providerConfig: CLAUDE_CONFIG,
+          providerDiscovery: new ProviderCommandDiscoveryStore(discoverProviderEntries),
+        },
       );
 
       inputEl.value = '/';
@@ -522,8 +743,8 @@ describe('SlashCommandDropdown - provider catalog', () => {
       dropdown.handleInputChange();
       await new Promise(resolve => setTimeout(resolve, 0));
 
-      expect(discoverProviderEntries).toHaveBeenCalledTimes(2);
-      expect(getDiscoveryState(containerEl)?.text).toBe('No provider commands advertised');
+      expect(discoverProviderEntries).toHaveBeenCalledTimes(1);
+      expect(getDiscoveryState(containerEl)?.text).toBe('Could not load provider commands');
 
       dropdown.destroy();
     });
@@ -534,7 +755,10 @@ describe('SlashCommandDropdown - provider catalog', () => {
         containerEl,
         inputEl,
         callbacks,
-        { providerConfig: CLAUDE_CONFIG, discoverProviderEntries: () => oldResponse.promise },
+        {
+          providerConfig: CLAUDE_CONFIG,
+          providerDiscovery: new ProviderCommandDiscoveryStore(() => oldResponse.promise),
+        },
       );
 
       inputEl.value = '/';
@@ -543,7 +767,10 @@ describe('SlashCommandDropdown - provider catalog', () => {
 
       dropdown.setProviderCatalog(
         CODEX_CONFIG,
-        async () => ({ status: 'ready', items: [CODEX_ENTRIES[0]] }),
+        new ProviderCommandDiscoveryStore(async () => ({
+          status: 'ready',
+          items: [CODEX_ENTRIES[0]],
+        })),
       );
       inputEl.value = '$';
       inputEl.selectionStart = 1;
@@ -574,7 +801,10 @@ describe('SlashCommandDropdown - provider catalog', () => {
         callbacks,
         {
           providerConfig: { ...CLAUDE_CONFIG, providerId: 'grok' },
-          discoverProviderEntries: async () => ({ status: 'ready', items: [qualifiedEntry] }),
+          providerDiscovery: new ProviderCommandDiscoveryStore(async () => ({
+            status: 'ready',
+            items: [qualifiedEntry],
+          })),
         },
       );
 
@@ -589,37 +819,19 @@ describe('SlashCommandDropdown - provider catalog', () => {
       dropdown.destroy();
     });
 
-    it('never invokes typed discovery for the legacy catalog-only path', async () => {
-      const legacyEntries = jest.fn().mockResolvedValue(CLAUDE_ENTRIES);
-      const typedDiscovery = jest.fn();
-      const dropdown = new SlashCommandDropdown(
-        containerEl,
-        inputEl,
-        callbacks,
-        {
-          providerConfig: CLAUDE_CONFIG,
-          getProviderEntries: legacyEntries,
-          discoverProviderEntries: typedDiscovery,
-        },
-      );
-
-      inputEl.value = '/';
-      inputEl.selectionStart = 1;
-      dropdown.handleInputChange();
-      await new Promise(resolve => setTimeout(resolve, 0));
-
-      expect(legacyEntries).toHaveBeenCalledTimes(1);
-      expect(typedDiscovery).not.toHaveBeenCalled();
-
-      dropdown.destroy();
-    });
   });
 
   describe('mid-sentence trigger detection', () => {
     it('opens Codex $ trigger mid-sentence', async () => {
       const getProviderEntries = jest.fn().mockResolvedValue(CODEX_ENTRIES);
       const dropdown = new SlashCommandDropdown(
-        containerEl, inputEl, callbacks, { providerConfig: CODEX_CONFIG, getProviderEntries }
+        containerEl,
+        inputEl,
+        callbacks,
+        {
+          providerConfig: CODEX_CONFIG,
+          providerDiscovery: createEntryDiscovery(getProviderEntries),
+        },
       );
 
       inputEl.value = 'some text $';
@@ -636,7 +848,13 @@ describe('SlashCommandDropdown - provider catalog', () => {
     it('opens Claude / trigger mid-sentence', async () => {
       const getProviderEntries = jest.fn().mockResolvedValue(CLAUDE_ENTRIES);
       const dropdown = new SlashCommandDropdown(
-        containerEl, inputEl, callbacks, { providerConfig: CLAUDE_CONFIG, getProviderEntries }
+        containerEl,
+        inputEl,
+        callbacks,
+        {
+          providerConfig: CLAUDE_CONFIG,
+          providerDiscovery: createEntryDiscovery(getProviderEntries),
+        },
       );
 
       inputEl.value = 'check this /';
@@ -653,7 +871,13 @@ describe('SlashCommandDropdown - provider catalog', () => {
     it('does not show built-ins mid-sentence', async () => {
       const getProviderEntries = jest.fn().mockResolvedValue(CODEX_ENTRIES);
       const dropdown = new SlashCommandDropdown(
-        containerEl, inputEl, callbacks, { providerConfig: CODEX_CONFIG, getProviderEntries }
+        containerEl,
+        inputEl,
+        callbacks,
+        {
+          providerConfig: CODEX_CONFIG,
+          providerDiscovery: createEntryDiscovery(getProviderEntries),
+        },
       );
 
       inputEl.value = 'some text /';
@@ -672,7 +896,13 @@ describe('SlashCommandDropdown - provider catalog', () => {
     it('does not open trigger without preceding whitespace', async () => {
       const getProviderEntries = jest.fn().mockResolvedValue(CODEX_ENTRIES);
       const dropdown = new SlashCommandDropdown(
-        containerEl, inputEl, callbacks, { providerConfig: CODEX_CONFIG, getProviderEntries }
+        containerEl,
+        inputEl,
+        callbacks,
+        {
+          providerConfig: CODEX_CONFIG,
+          providerDiscovery: createEntryDiscovery(getProviderEntries),
+        },
       );
 
       inputEl.value = 'word$';
@@ -688,7 +918,13 @@ describe('SlashCommandDropdown - provider catalog', () => {
     it('inserts correctly at mid-sentence position', async () => {
       const getProviderEntries = jest.fn().mockResolvedValue(CODEX_ENTRIES);
       const dropdown = new SlashCommandDropdown(
-        containerEl, inputEl, callbacks, { providerConfig: CODEX_CONFIG, getProviderEntries }
+        containerEl,
+        inputEl,
+        callbacks,
+        {
+          providerConfig: CODEX_CONFIG,
+          providerDiscovery: createEntryDiscovery(getProviderEntries),
+        },
       );
 
       inputEl.value = 'prefix $';

--- a/tests/unit/shared/components/SlashCommandDropdown.test.ts
+++ b/tests/unit/shared/components/SlashCommandDropdown.test.ts
@@ -1,6 +1,8 @@
 import { createMockEl } from '@test/helpers/mockElement';
 
 import type { ProviderCommandDropdownConfig } from '@/core/providers/commands/ProviderCommandCatalog';
+import { normalizeProviderCommandDiscoveryItems } from '@/core/providers/commands/ProviderCommandDiscoveryResult';
+import { ProviderCommandDiscoveryStore } from '@/core/providers/commands/ProviderCommandDiscoveryStore';
 import type { ProviderCommandEntry } from '@/core/providers/commands/ProviderCommandEntry';
 import {
   SlashCommandDropdown,
@@ -77,6 +79,14 @@ const PROVIDER_ENTRIES: ProviderCommandEntry[] = [
   makeEntry('compact', 'Compact context'),
 ];
 
+function createEntryDiscovery(
+  loader: () => Promise<readonly ProviderCommandEntry[]>,
+): ProviderCommandDiscoveryStore<ProviderCommandEntry> {
+  return new ProviderCommandDiscoveryStore(async () =>
+    normalizeProviderCommandDiscoveryItems(await loader()),
+  );
+}
+
 describe('SlashCommandDropdown', () => {
   let containerEl: any;
   let inputEl: any;
@@ -113,6 +123,35 @@ describe('SlashCommandDropdown', () => {
     });
   });
 
+  it('can exclude chat-action built-ins while retaining provider entries', async () => {
+    const getProviderEntries = jest.fn().mockResolvedValue(PROVIDER_ENTRIES);
+    const dropdownWithoutBuiltIns = new SlashCommandDropdown(
+      containerEl,
+      inputEl,
+      callbacks,
+      {
+        providerConfig: CLAUDE_CONFIG,
+        providerDiscovery: createEntryDiscovery(getProviderEntries),
+        includeBuiltIns: false,
+      },
+    );
+
+    inputEl.value = '/';
+    inputEl.selectionStart = 1;
+    dropdownWithoutBuiltIns.handleInputChange();
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    const commandNames = getRenderedCommandNames(containerEl);
+    expect(commandNames).toEqual(expect.arrayContaining([
+      'commit',
+      'pr',
+    ]));
+    expect(commandNames).not.toContain('clear');
+    expect(commandNames).not.toContain('add-dir');
+
+    dropdownWithoutBuiltIns.destroy();
+  });
+
   describe('setEnabled', () => {
     it('should not show dropdown when disabled', async () => {
       dropdown.setEnabled(false);
@@ -147,7 +186,7 @@ describe('SlashCommandDropdown', () => {
 
       const dropdownWithHidden = new SlashCommandDropdown(
         containerEl, inputEl, callbacks,
-        { hiddenCommands, providerConfig: CLAUDE_CONFIG, getProviderEntries }
+        { hiddenCommands, providerConfig: CLAUDE_CONFIG, providerDiscovery: createEntryDiscovery(getProviderEntries) }
       );
 
       inputEl.value = '/';
@@ -170,7 +209,7 @@ describe('SlashCommandDropdown', () => {
 
       const dropdownWithHidden = new SlashCommandDropdown(
         containerEl, inputEl, callbacks,
-        { hiddenCommands, providerConfig: CLAUDE_CONFIG, getProviderEntries }
+        { hiddenCommands, providerConfig: CLAUDE_CONFIG, providerDiscovery: createEntryDiscovery(getProviderEntries) }
       );
 
       inputEl.value = '/';
@@ -196,7 +235,7 @@ describe('SlashCommandDropdown', () => {
 
       const dropdownWithEntries = new SlashCommandDropdown(
         containerEl, inputEl, callbacks,
-        { providerConfig: CLAUDE_CONFIG, getProviderEntries }
+        { providerConfig: CLAUDE_CONFIG, providerDiscovery: createEntryDiscovery(getProviderEntries) }
       );
 
       inputEl.value = '/cle';
@@ -219,7 +258,7 @@ describe('SlashCommandDropdown', () => {
 
       const d = new SlashCommandDropdown(
         containerEl, inputEl, callbacks,
-        { providerConfig: CLAUDE_CONFIG, getProviderEntries }
+        { providerConfig: CLAUDE_CONFIG, providerDiscovery: createEntryDiscovery(getProviderEntries) }
       );
 
       inputEl.value = '/';
@@ -236,92 +275,6 @@ describe('SlashCommandDropdown', () => {
       d.destroy();
     });
 
-    it('should retry fetch when previous result was empty', async () => {
-      const getProviderEntries = jest.fn()
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce(PROVIDER_ENTRIES);
-
-      const d = new SlashCommandDropdown(
-        containerEl, inputEl, callbacks,
-        { providerConfig: CLAUDE_CONFIG, getProviderEntries }
-      );
-
-      inputEl.value = '/';
-      inputEl.selectionStart = 1;
-      d.handleInputChange();
-      await new Promise(resolve => setTimeout(resolve, 10));
-
-      inputEl.value = '/c';
-      inputEl.selectionStart = 2;
-      d.handleInputChange();
-      await new Promise(resolve => setTimeout(resolve, 10));
-
-      expect(getProviderEntries).toHaveBeenCalledTimes(2);
-      d.destroy();
-    });
-
-    it('should retry fetch when previous call threw error', async () => {
-      const getProviderEntries = jest.fn()
-        .mockRejectedValueOnce(new Error('Not ready'))
-        .mockResolvedValueOnce(PROVIDER_ENTRIES);
-
-      const d = new SlashCommandDropdown(
-        containerEl, inputEl, callbacks,
-        { providerConfig: CLAUDE_CONFIG, getProviderEntries }
-      );
-
-      inputEl.value = '/';
-      inputEl.selectionStart = 1;
-      d.handleInputChange();
-      await new Promise(resolve => setTimeout(resolve, 10));
-
-      inputEl.value = '/c';
-      inputEl.selectionStart = 2;
-      d.handleInputChange();
-      await new Promise(resolve => setTimeout(resolve, 10));
-
-      expect(getProviderEntries).toHaveBeenCalledTimes(2);
-      d.destroy();
-    });
-  });
-
-  describe('race condition handling', () => {
-    it('should discard stale results when newer request is made', async () => {
-      let resolveFirst: (value: ProviderCommandEntry[]) => void;
-      const firstPromise = new Promise<ProviderCommandEntry[]>(resolve => { resolveFirst = resolve; });
-
-      const getProviderEntries = jest.fn()
-        .mockReturnValueOnce(firstPromise)
-        .mockResolvedValueOnce([makeEntry('new-command', 'New')]);
-
-      const d = new SlashCommandDropdown(
-        containerEl, inputEl, callbacks,
-        { providerConfig: CLAUDE_CONFIG, getProviderEntries }
-      );
-
-      inputEl.value = '/';
-      inputEl.selectionStart = 1;
-      d.handleInputChange();
-
-      inputEl.value = '/n';
-      inputEl.selectionStart = 2;
-      d.handleInputChange();
-      await new Promise(resolve => setTimeout(resolve, 10));
-
-      resolveFirst!(PROVIDER_ENTRIES);
-      await new Promise(resolve => setTimeout(resolve, 10));
-
-      inputEl.value = '/';
-      inputEl.selectionStart = 1;
-      d.handleInputChange();
-      await new Promise(resolve => setTimeout(resolve, 10));
-
-      const names = getRenderedCommandNames(containerEl);
-      expect(names).toContain('new-command');
-      expect(names).not.toContain('commit');
-
-      d.destroy();
-    });
   });
 
   describe('setHiddenCommands', () => {
@@ -330,7 +283,7 @@ describe('SlashCommandDropdown', () => {
 
       const d = new SlashCommandDropdown(
         containerEl, inputEl, callbacks,
-        { providerConfig: CLAUDE_CONFIG, getProviderEntries }
+        { providerConfig: CLAUDE_CONFIG, providerDiscovery: createEntryDiscovery(getProviderEntries) }
       );
 
       inputEl.value = '/';
@@ -348,33 +301,6 @@ describe('SlashCommandDropdown', () => {
       await new Promise(resolve => setTimeout(resolve, 10));
 
       expect(getRenderedCommandNames(containerEl)).not.toContain('commit');
-
-      d.destroy();
-    });
-  });
-
-  describe('resetSdkSkillsCache', () => {
-    it('should clear cached entries and allow refetch', async () => {
-      const getProviderEntries = jest.fn().mockResolvedValue(PROVIDER_ENTRIES);
-
-      const d = new SlashCommandDropdown(
-        containerEl, inputEl, callbacks,
-        { providerConfig: CLAUDE_CONFIG, getProviderEntries }
-      );
-
-      inputEl.value = '/';
-      inputEl.selectionStart = 1;
-      d.handleInputChange();
-      await new Promise(resolve => setTimeout(resolve, 10));
-      expect(getProviderEntries).toHaveBeenCalledTimes(1);
-
-      d.resetSdkSkillsCache();
-
-      inputEl.value = '/c';
-      inputEl.selectionStart = 2;
-      d.handleInputChange();
-      await new Promise(resolve => setTimeout(resolve, 10));
-      expect(getProviderEntries).toHaveBeenCalledTimes(2);
 
       d.destroy();
     });
@@ -443,7 +369,7 @@ describe('SlashCommandDropdown', () => {
 
       const d = new SlashCommandDropdown(
         containerEl, inputEl, callbacks,
-        { providerConfig: CLAUDE_CONFIG, getProviderEntries }
+        { providerConfig: CLAUDE_CONFIG, providerDiscovery: createEntryDiscovery(getProviderEntries) }
       );
 
       inputEl.value = '/com';
@@ -463,7 +389,7 @@ describe('SlashCommandDropdown', () => {
 
       const d = new SlashCommandDropdown(
         containerEl, inputEl, callbacks,
-        { providerConfig: CLAUDE_CONFIG, getProviderEntries }
+        { providerConfig: CLAUDE_CONFIG, providerDiscovery: createEntryDiscovery(getProviderEntries) }
       );
 
       inputEl.value = '/pull';
@@ -490,7 +416,7 @@ describe('SlashCommandDropdown', () => {
 
       const d = new SlashCommandDropdown(
         containerEl, inputEl, callbacks,
-        { providerConfig: CLAUDE_CONFIG, getProviderEntries }
+        { providerConfig: CLAUDE_CONFIG, providerDiscovery: createEntryDiscovery(getProviderEntries) }
       );
 
       inputEl.value = '/';


### PR DESCRIPTION
Adds a built-in `/fast` chat command for Codex that toggles its fast service tier, reports persistence failures, and strengthens the active icon border. Refactors slash-command discovery into an observable per-tab store with caching, timeout, retry, invalidation, and provider-safe routing across history or provider switches. Keeps chat-only built-ins out of inline edit and migrates all dropdown consumers to the typed discovery contract. Validation: `npm run typecheck`, `npm run lint`, `npm run test` (317 suites, 6,859 tests), and `npm run build`.