### PR TITLE
Fix empty chat provider persistence across restarts

### DIFF
--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -22,7 +22,6 @@ import { MentionCacheCoordinator } from './services/MentionCacheCoordinator';
 import { TabStatePersistenceCoordinator } from './services/TabStatePersistenceCoordinator';
 import {
   getTabProviderId,
-  onProviderAvailabilityChanged,
   sendTabInputMessageFromExplicitEnterShortcut,
   updatePlanModeUI,
 } from './tabs/Tab';
@@ -111,8 +110,8 @@ export class ClaudianView extends ItemView {
 
   /** Refreshes model-dependent UI across all tabs (used after settings/env changes). */
   refreshModelSelector(changedProviderId?: ProviderId): void {
+    this.tabManager?.reconcileProviderAvailability();
     for (const tab of this.tabManager?.getAllTabs() ?? []) {
-      onProviderAvailabilityChanged(tab, this.plugin);
       const providerId = getTabProviderId(tab, this.plugin);
       if (
         changedProviderId
@@ -222,11 +221,13 @@ export class ClaudianView extends ItemView {
       this.tabContentEl,
       this,
       {
+        onPersistedStateChanged: () => {
+          this.persistTabState();
+        },
         onTabCreated: () => {
           this.updateTabBar();
           this.updateHistoryDropdown();
           this.updateInputLocation();
-          this.persistTabState();
           this.syncProviderBrandColor();
         },
         onActiveTabChanged: () => {
@@ -239,14 +240,12 @@ export class ClaudianView extends ItemView {
           this.updateTabBar();
           this.updateHistoryDropdown();
           this.updateInputLocation();
-          this.persistTabState();
           this.syncProviderBrandColor();
         },
         onTabClosed: () => {
           this.updateTabBar();
           this.updateHistoryDropdown();
           this.updateInputLocation();
-          this.persistTabState();
         },
         onTabStreamingChanged: () => {
           this.updateTabBar();
@@ -258,7 +257,6 @@ export class ClaudianView extends ItemView {
         onTabConversationChanged: () => {
           this.updateTabBar();
           this.updateHistoryDropdown();
-          this.persistTabState();
           this.syncProviderBrandColor();
         },
         onTabProviderChanged: () => {

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -139,6 +139,7 @@ export interface TabCreateOptions {
   onAttentionChanged?: (needsAttention: boolean) => void;
   onConversationIdChanged?: (conversationId: string | null) => void;
   onRuntimeInstalled?: (runtime: ChatRuntime) => void;
+  onPersistedStateChanged?: () => void;
 }
 
 export { getTabProviderId } from './providerResolution';
@@ -528,11 +529,13 @@ function resolveBlankTabFallback(
  * Reconciles blank drafts after provider or model availability changes.
  * Prefer the draft provider's advertised default before crossing providers.
  */
-export function onProviderAvailabilityChanged(tab: TabData, plugin: FeatureHost): void {
-  if (tab.lifecycleState !== 'blank') return;
+export function onProviderAvailabilityChanged(tab: TabData, plugin: FeatureHost): boolean {
+  if (tab.lifecycleState !== 'blank') return false;
 
   const settingsSnapshot = plugin.settings as unknown as Record<string, unknown>;
   const enabledProviderIds = ProviderRegistry.getEnabledProviderIds(settingsSnapshot);
+  const previousDraftModel = tab.draftModel;
+  const previousProviderId = tab.providerId;
   let nextProviderId = tab.providerId;
 
   if (tab.draftModel) {
@@ -577,6 +580,7 @@ export function onProviderAvailabilityChanged(tab: TabData, plugin: FeatureHost)
   invalidateTabProviderCommands(tab);
   refreshTabProviderUI(tab, plugin);
   applyProviderUIGating(tab, plugin);
+  return tab.draftModel !== previousDraftModel || tab.providerId !== previousProviderId;
 }
 
 /**
@@ -672,6 +676,7 @@ export function createTab(options: TabCreateOptions): TabData {
     },
     runtimeSupervisor,
     onRuntimeInstalled: options.onRuntimeInstalled,
+    onPersistedStateChanged: options.onPersistedStateChanged,
     providerCatalogResolver: null,
     serviceInitialized: false,
     state,
@@ -999,6 +1004,7 @@ function initializeInputToolbar(
   plugin: FeatureHost,
   getProviderCatalogConfig?: () => ProviderCatalogInfo,
   onProviderChanged?: (providerId: ProviderId) => void | Promise<void>,
+  onDraftModelChanged?: () => void,
   onCommandContextChanged?: () => void,
 ): void {
   const { dom } = tab;
@@ -1063,6 +1069,7 @@ function initializeInputToolbar(
         } else {
           syncSlashCommandDropdownForProvider(tab, plugin, getProviderCatalogConfig);
         }
+        onDraftModelChanged?.();
         await uiConfig.prepareModelMetadata?.(
           model,
           getProviderSettingsSnapshotWithModel(plugin.settings, newProvider, model),
@@ -1218,6 +1225,7 @@ function initializeInputToolbar(
 export interface InitializeTabUIOptions {
   getProviderCatalogConfig?: ProviderCatalogResolver;
   onProviderChanged?: (providerId: ProviderId) => void | Promise<void>;
+  onDraftModelChanged?: () => void;
   onCommandContextChanged?: () => void;
 }
 
@@ -1262,6 +1270,7 @@ export function initializeTabUI(
     plugin,
     options.getProviderCatalogConfig,
     options.onProviderChanged,
+    options.onDraftModelChanged,
     options.onCommandContextChanged,
   );
 
@@ -1665,6 +1674,7 @@ export function initializeTabControllers(
         refreshTabProviderUI(tab, plugin);
         applyProviderUIGating(tab, plugin);
         syncSlashCommandDropdownForProvider(tab, plugin, getProviderCatalogConfig);
+        tab.onPersistedStateChanged?.();
       },
       onConversationLoaded: () => invalidateTabProviderCommands(tab, getProviderCatalogConfig),
       onConversationSwitched: () => invalidateTabProviderCommands(tab, getProviderCatalogConfig),

--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -30,6 +30,7 @@ import {
   initializeTabControllers,
   initializeTabService,
   initializeTabUI,
+  onProviderAvailabilityChanged,
   recycleTabRuntime,
   refreshTabWorkspaceServices,
   setupServiceCallbacks,
@@ -231,8 +232,10 @@ export class TabManager implements TabManagerInterface {
           // Sync tab.conversationId when conversation is lazily created
           tab.conversationId = conversationId;
           this.callbacks.onTabConversationChanged?.(tab.id, conversationId);
+          this.notifyPersistedStateChanged();
         },
         onRuntimeInstalled: (runtime) => this.bindRuntimeCommandSubscription(tab, runtime),
+        onPersistedStateChanged: () => this.notifyPersistedStateChanged(),
       });
 
       this.tabCommandContextRevisions.set(tab.id, 0);
@@ -248,6 +251,9 @@ export class TabManager implements TabManagerInterface {
           this.bumpTabCommandContextRevision(tab.id);
           await this.ensureTabWorkspaceServices(tab, providerId, 'provider-selection');
           this.callbacks.onTabProviderChanged?.(tab.id, providerId);
+        },
+        onDraftModelChanged: () => {
+          this.notifyPersistedStateChanged();
         },
       });
 
@@ -267,6 +273,9 @@ export class TabManager implements TabManagerInterface {
       this.pendingTabCreations -= 1;
       reservationHeld = false;
       this.callbacks.onTabCreated?.(tab);
+      if (!this.isRestoringState) {
+        this.notifyPersistedStateChanged();
+      }
 
       if (!this.isRestoringState && (activate || !this.activeTabId)) {
         await this.switchToTab(tab.id);
@@ -312,6 +321,9 @@ export class TabManager implements TabManagerInterface {
       this.activeTabId = tabId;
       activateTab(tab);
       this.callbacks.onActiveTabChanged?.(previousTabId, tabId);
+      if (previousTabId !== tabId) {
+        this.notifyPersistedStateChanged();
+      }
 
       const providerId = tab.service?.providerId ?? tab.providerId;
       const needsHydration = !!tab.conversationId && tab.hydrationState !== 'ready';
@@ -437,12 +449,15 @@ export class TabManager implements TabManagerInterface {
     this.providerCommandDiscoveryStores.delete(tabId);
     this.tabCommandContextRevisions.delete(tabId);
     this.tabs.delete(tabId);
+    const wasActiveTab = this.activeTabId === tabId;
+    if (wasActiveTab) {
+      this.activeTabId = null;
+    }
     this.callbacks.onTabClosed?.(tabId);
+    this.notifyPersistedStateChanged();
 
     // If we closed the active tab, switch to another
-    if (this.activeTabId === tabId) {
-      this.activeTabId = null;
-
+    if (wasActiveTab) {
       if (this.tabs.size > 0) {
         // Fallback strategy: prefer previous tab, except for first tab (go to next)
         const fallbackTabId = closingIndex === 0
@@ -523,6 +538,18 @@ export class TabManager implements TabManagerInterface {
   /** Gets all tabs. */
   getAllTabs(): TabData[] {
     return Array.from(this.tabs.values());
+  }
+
+  /** Reconciles blank drafts after provider/model availability changes. */
+  reconcileProviderAvailability(): void {
+    let persistedStateChanged = false;
+    for (const tab of this.tabs.values()) {
+      persistedStateChanged = onProviderAvailabilityChanged(tab, this.plugin)
+        || persistedStateChanged;
+    }
+    if (persistedStateChanged) {
+      this.notifyPersistedStateChanged();
+    }
   }
 
   /** Gets the number of tabs. */
@@ -782,6 +809,10 @@ export class TabManager implements TabManagerInterface {
   // ============================================
   // Persistence
   // ============================================
+
+  private notifyPersistedStateChanged(): void {
+    this.callbacks.onPersistedStateChanged?.();
+  }
 
   /** Gets the state to persist. */
   getPersistedState(): PersistedTabManagerState {

--- a/src/features/chat/tabs/types.ts
+++ b/src/features/chat/tabs/types.ts
@@ -222,6 +222,9 @@ export interface TabData {
   /** Tab-manager hook for generation-guarded provider command subscriptions. */
   onRuntimeInstalled?: (runtime: ChatRuntime) => void;
 
+  /** Tab-manager hook for mutations that change the serialized tab state. */
+  onPersistedStateChanged?: () => void;
+
   /** Tab-manager-owned provider discovery callback retained across UI/runtime refreshes. */
   providerCatalogResolver: ProviderCatalogResolver | null;
 
@@ -271,6 +274,9 @@ export interface PersistedTabManagerState {
  * Callbacks for tab state changes.
  */
 export interface TabManagerCallbacks {
+  /** Called whenever the serialized tab-manager state may have changed. */
+  onPersistedStateChanged?: () => void;
+
   /** Called when a tab is created. */
   onTabCreated?: (tab: TabData) => void;
 

--- a/tests/unit/features/chat/ClaudianView.test.ts
+++ b/tests/unit/features/chat/ClaudianView.test.ts
@@ -5,6 +5,12 @@ import { ProviderRegistry } from '@/core/providers/ProviderRegistry';
 import { ProviderSettingsCoordinator } from '@/core/providers/ProviderSettingsCoordinator';
 import { ClaudianView } from '@/features/chat/ClaudianView';
 
+const mockTabManagerConstructor = jest.fn();
+jest.mock('@/features/chat/tabs/TabManager', () => ({
+  TabManager: jest.fn().mockImplementation((...args: unknown[]) =>
+    mockTabManagerConstructor(...args)),
+}));
+
 const MockScope = Scope as typeof Scope & { instances: Scope[] };
 
 function createModelRefreshTab(providerId: 'codex' | 'grok') {
@@ -97,6 +103,7 @@ describe('ClaudianView model refresh routing', () => {
     view.tabManager = {
       getAllTabs: jest.fn().mockReturnValue([codexTab, grokTab, blankGrokTab]),
       primeProviderRuntime,
+      reconcileProviderAvailability: jest.fn(),
     };
 
     view.refreshModelSelector('codex');
@@ -107,6 +114,7 @@ describe('ClaudianView model refresh routing', () => {
     expect(grokTab.ui.modelSelector.renderOptions).not.toHaveBeenCalled();
     expect(blankGrokTab.ui.modelSelector.updateDisplay).toHaveBeenCalled();
     expect(blankGrokTab.ui.modelSelector.renderOptions).toHaveBeenCalled();
+    expect(view.tabManager.reconcileProviderAvailability).toHaveBeenCalledTimes(1);
     expect(primeProviderRuntime).not.toHaveBeenCalled();
   });
 });
@@ -372,6 +380,43 @@ describe('ClaudianView tab controls', () => {
     expect(view.tabBar.setExpandedTitleTabIds).toHaveBeenCalledWith(['tab-1']);
     expect(view.updateTabBar).toHaveBeenCalledTimes(1);
     expect(view.tabManager.createTab).not.toHaveBeenCalled();
+  });
+});
+
+describe('ClaudianView tab persistence wiring', () => {
+  it('schedules persistence from the tab manager persisted-state signal', async () => {
+    let tabManagerCallbacks: any;
+    mockTabManagerConstructor.mockReset();
+    mockTabManagerConstructor.mockImplementation(
+      (_plugin, _containerEl, _view, callbacks) => {
+        tabManagerCallbacks = callbacks;
+        return {
+          getAllTabs: jest.fn().mockReturnValue([]),
+        };
+      },
+    );
+
+    const persistTabState = jest.fn();
+    const view = Object.create(ClaudianView.prototype) as any;
+    Object.assign(view, {
+      attachNavRowContentToInputFooter: jest.fn(),
+      buildInputFooter: jest.fn(),
+      buildNavRowContent: jest.fn().mockReturnValue(createMockEl()),
+      containerEl: createMockEl(),
+      contentEl: createMockEl(),
+      persistTabState,
+      plugin: {},
+      restoreOrCreateTabs: jest.fn().mockResolvedValue(undefined),
+      syncProviderBrandColor: jest.fn(),
+      updateInputLocation: jest.fn(),
+      updateTabBarVisibility: jest.fn(),
+      wireEventHandlers: jest.fn(),
+    });
+
+    await view.onOpenImpl();
+    tabManagerCallbacks.onPersistedStateChanged();
+
+    expect(persistTabState).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -1004,7 +1004,7 @@ describe('Tab - Service Initialization', () => {
       plugin.settings.providerConfigs.codex.enabled = false;
       mockSlashCommandDropdown.setProviderCatalog.mockClear();
 
-      onProviderAvailabilityChanged(tab, plugin);
+      expect(onProviderAvailabilityChanged(tab, plugin)).toBe(true);
 
       expect(staleService.cleanup).toHaveBeenCalled();
       expect(tab.providerId).toBe('claude');
@@ -1032,7 +1032,7 @@ describe('Tab - Service Initialization', () => {
       tab.providerId = 'codex';
       tab.lifecycleState = 'blank';
 
-      onProviderAvailabilityChanged(tab, plugin);
+      expect(onProviderAvailabilityChanged(tab, plugin)).toBe(true);
 
       expect(tab.providerId).toBe('codex');
       expect(tab.draftModel).toBe(TEST_CODEX_MODEL);
@@ -1051,7 +1051,7 @@ describe('Tab - Service Initialization', () => {
       tab.providerId = 'codex';
       tab.lifecycleState = 'blank';
 
-      onProviderAvailabilityChanged(tab, plugin);
+      expect(onProviderAvailabilityChanged(tab, plugin)).toBe(true);
 
       expect(tab.providerId).toBe('codex');
       expect(tab.draftModel).toBe(TEST_CODEX_MODEL);
@@ -1070,7 +1070,7 @@ describe('Tab - Service Initialization', () => {
       tab.providerId = 'codex';
       tab.lifecycleState = 'blank';
 
-      onProviderAvailabilityChanged(tab, plugin);
+      expect(onProviderAvailabilityChanged(tab, plugin)).toBe(false);
 
       expect(tab.providerId).toBe('codex');
       expect(tab.draftModel).toBe('gpt-5.4-mini');
@@ -2269,6 +2269,66 @@ describe('Tab - Controller Initialization', () => {
       initializeTabControllers(tab, options.plugin, mockComponent, options.mcpManager);
 
       expect(tab.controllers.conversationController).toBeDefined();
+    });
+
+    it('notifies persisted state after a direct conversation reset commits the blank draft', async () => {
+      const conversationControllerModule = jest.requireMock(
+        '@/features/chat/controllers/ConversationController',
+      ) as { ConversationController: jest.Mock };
+      conversationControllerModule.ConversationController.mockImplementationOnce(
+        (_deps: unknown, callbacks: { onNewConversation?: () => void }) => ({
+          createNew: jest.fn(async () => callbacks.onNewConversation?.()),
+          rewind: jest.fn().mockResolvedValue(undefined),
+          save: jest.fn().mockResolvedValue(undefined),
+        }),
+      );
+
+      const plugin = createMockPlugin({
+        settings: {
+          savedProviderModel: {
+            claude: 'claude-sonnet-4-5',
+            codex: TEST_CODEX_MODEL,
+          },
+        },
+      });
+      const snapshots: Array<{
+        conversationId: string | null;
+        draftModel: string | null;
+        lifecycleState: string;
+        providerId: string;
+      }> = [];
+      const options = createMockOptions({
+        plugin,
+        conversation: {
+          id: 'conv-codex',
+          providerId: 'codex',
+          title: 'Codex conversation',
+          messages: [],
+          sessionId: null,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+        onPersistedStateChanged: () => {
+          snapshots.push({
+            conversationId: tab.conversationId,
+            draftModel: tab.draftModel,
+            lifecycleState: tab.lifecycleState,
+            providerId: tab.providerId,
+          });
+        },
+      });
+      const tab = createTab(options);
+      initializeTabUI(tab, plugin);
+      initializeTabControllers(tab, plugin, {} as any, createMockMcpManager());
+
+      await tab.controllers.conversationController?.createNew();
+
+      expect(snapshots).toEqual([{
+        conversationId: null,
+        draftModel: TEST_CODEX_MODEL,
+        lifecycleState: 'blank',
+        providerId: 'codex',
+      }]);
     });
 
     it('should forward rewind mode from renderer to ConversationController', async () => {
@@ -4235,7 +4295,8 @@ describe('Tab - Blank Tab Draft Model Change', () => {
 
     const plugin = createMockPlugin();
     const tab = createTab(createMockOptions({ plugin }));
-    initializeTabUI(tab, plugin);
+    const onDraftModelChanged = jest.fn();
+    initializeTabUI(tab, plugin, { onDraftModelChanged });
 
     expect(tab.lifecycleState).toBe('blank');
     expect(tab.service).toBeNull();
@@ -4254,6 +4315,7 @@ describe('Tab - Blank Tab Draft Model Change', () => {
     expect(tab.service).toBeNull();
     expect(tab.serviceInitialized).toBe(false);
     expect(tab.lifecycleState).toBe('blank');
+    expect(onDraftModelChanged).toHaveBeenCalledTimes(1);
   });
 
   it('refreshes the service-tier toggle when the model changes on a blank tab', async () => {
@@ -4333,7 +4395,8 @@ describe('Tab - Blank Tab Draft Model Change', () => {
     const previousProvider = tab.providerId;
     const previousModel = tab.draftModel;
     const onProviderChanged = jest.fn().mockRejectedValue(new Error('workspace init failed'));
-    initializeTabUI(tab, plugin, { onProviderChanged });
+    const onDraftModelChanged = jest.fn();
+    initializeTabUI(tab, plugin, { onDraftModelChanged, onProviderChanged });
     const clearProviderCatalog = jest.spyOn(
       tab.ui.slashCommandDropdown!,
       'clearProviderCatalog',
@@ -4350,6 +4413,7 @@ describe('Tab - Blank Tab Draft Model Change', () => {
     expect(clearProviderCatalog).toHaveBeenCalled();
     expect(tab.providerId).toBe(previousProvider);
     expect(tab.draftModel).toBe(previousModel);
+    expect(onDraftModelChanged).not.toHaveBeenCalled();
   });
 
   it('does not trigger provider warmup when a blank-tab model switch stays on OpenCode', async () => {
@@ -4386,7 +4450,8 @@ describe('Tab - Blank Tab Draft Model Change', () => {
     const onProviderChanged = jest.fn().mockImplementation(() => new Promise<void>((resolve) => {
       releaseWarmup = resolve;
     }));
-    initializeTabUI(tab, plugin, { onProviderChanged });
+    const onDraftModelChanged = jest.fn();
+    initializeTabUI(tab, plugin, { onDraftModelChanged, onProviderChanged });
 
     const toolbarModule = jest.requireMock('@/features/chat/ui/InputToolbar') as {
       createInputToolbar: jest.Mock;
@@ -4403,6 +4468,7 @@ describe('Tab - Blank Tab Draft Model Change', () => {
     expect(tab.providerId).toBe('opencode');
     expect(tab.draftModel).toBe('opencode:anthropic/claude-sonnet-4');
     expect(onProviderChanged).not.toHaveBeenCalled();
+    expect(onDraftModelChanged).toHaveBeenCalledTimes(1);
 
     await changePromise;
     expect(settled).toBe(true);

--- a/tests/unit/features/chat/tabs/TabManager.test.ts
+++ b/tests/unit/features/chat/tabs/TabManager.test.ts
@@ -17,6 +17,7 @@ const mockDeactivateTab = jest.fn();
 const mockInitializeTabUI = jest.fn();
 const mockInitializeTabControllers = jest.fn();
 const mockInitializeTabService = jest.fn().mockResolvedValue(undefined);
+const mockOnProviderAvailabilityChanged = jest.fn().mockReturnValue(false);
 const mockRefreshTabWorkspaceServices = jest.fn();
 const mockSetupServiceCallbacks = jest.fn();
 const mockRecycleTabRuntime = jest.fn(async (tab: any) => {
@@ -41,6 +42,7 @@ jest.mock('@/features/chat/tabs/Tab', () => ({
   initializeTabUI: (...args: any[]) => mockInitializeTabUI(...args),
   initializeTabControllers: (...args: any[]) => mockInitializeTabControllers(...args),
   initializeTabService: (...args: any[]) => mockInitializeTabService(...args),
+  onProviderAvailabilityChanged: (...args: any[]) => mockOnProviderAvailabilityChanged(...args),
   refreshTabWorkspaceServices: (...args: any[]) => mockRefreshTabWorkspaceServices(...args),
   setupServiceCallbacks: (...args: any[]) => mockSetupServiceCallbacks(...args),
   recycleTabRuntime: (tab: any) => mockRecycleTabRuntime(tab),
@@ -269,6 +271,7 @@ describe('TabManager - Tab Lifecycle', () => {
       onTabCreated: jest.fn(),
       onTabSwitched: jest.fn(),
       onTabClosed: jest.fn(),
+      onPersistedStateChanged: jest.fn(),
       onTabStreamingChanged: jest.fn(),
       onTabTitleChanged: jest.fn(),
       onTabAttentionChanged: jest.fn(),
@@ -286,6 +289,7 @@ describe('TabManager - Tab Lifecycle', () => {
       expect(mockInitializeTabUI).toHaveBeenCalled();
       expect(mockInitializeTabControllers).toHaveBeenCalled();
       expect(mockWireTabInputEvents).toHaveBeenCalled();
+      expect(callbacks.onPersistedStateChanged).toHaveBeenCalled();
     });
 
     it('should call onTabCreated callback', async () => {
@@ -371,6 +375,7 @@ describe('TabManager - Tab Lifecycle', () => {
       expect(mockDeactivateTab).toHaveBeenCalled();
       expect(mockActivateTab).toHaveBeenCalled();
       expect(callbacks.onTabSwitched).toHaveBeenCalled();
+      expect(callbacks.onPersistedStateChanged).toHaveBeenCalled();
     });
 
     it('should not switch to non-existent tab', async () => {
@@ -540,12 +545,14 @@ describe('TabManager - Tab Lifecycle', () => {
 
       const tab1 = await manager.createTab();
       await manager.createTab(); // Need at least 2 tabs to close one
+      (callbacks.onPersistedStateChanged as jest.Mock).mockClear();
 
       const closed = await manager.closeTab(tab1!.id);
 
       expect(closed).toBe(true);
       expect(mockDestroyTab).toHaveBeenCalled();
       expect(callbacks.onTabClosed).toHaveBeenCalledWith(tab1!.id);
+      expect(callbacks.onPersistedStateChanged).toHaveBeenCalled();
     });
 
     it('should not close streaming tab unless forced', async () => {
@@ -592,6 +599,7 @@ describe('TabManager - Tab Lifecycle', () => {
       const manager = createManager({ callbacks });
       await manager.createTab();
       await manager.createTab();
+      (callbacks.onPersistedStateChanged as jest.Mock).mockClear();
 
       await expect(manager.closeTab('rewinding-tab')).resolves.toBe(false);
       await expect(manager.closeTab('rewinding-tab', true)).resolves.toBe(false);
@@ -600,6 +608,7 @@ describe('TabManager - Tab Lifecycle', () => {
       expect(mockDestroyTab).not.toHaveBeenCalled();
       expect(manager.getTab('rewinding-tab')).toBe(rewindingTab);
       expect(rewindingTab.lifecycleState).not.toBe('closing');
+      expect(callbacks.onPersistedStateChanged).not.toHaveBeenCalled();
     });
 
     it('allows close after rewind settles', async () => {
@@ -986,14 +995,24 @@ describe('TabManager - Conversation Management', () => {
   });
 
   describe('createNewConversation', () => {
-    it('should create new conversation in active tab', async () => {
-      const activeTab = manager.getActiveTab();
-      const createNew = jest.fn().mockResolvedValue(undefined);
+    it('relies on the tab reset commit for a single persisted-state notification', async () => {
+      const onPersistedStateChanged = jest.fn();
+      const notifyingManager = createManager({
+        callbacks: { onPersistedStateChanged },
+        plugin,
+      });
+      const activeTab = await notifyingManager.createTab();
+      const createOptions = mockCreateTab.mock.calls.at(-1)?.[0];
+      const createNew = jest.fn(async () => {
+        createOptions.onPersistedStateChanged();
+      });
       activeTab!.controllers.conversationController = { createNew } as any;
+      onPersistedStateChanged.mockClear();
 
-      await manager.createNewConversation();
+      await notifyingManager.createNewConversation();
 
       expect(createNew).toHaveBeenCalled();
+      expect(onPersistedStateChanged).toHaveBeenCalledTimes(1);
     });
   });
 });
@@ -2827,6 +2846,63 @@ describe('TabManager - Callback Wiring', () => {
     jest.clearAllMocks();
   });
 
+  it('marks persisted state dirty after successful blank-tab draft changes', async () => {
+    const onPersistedStateChanged = jest.fn();
+    const manager = createManager({
+      callbacks: { onPersistedStateChanged },
+      tabFactory: () => createMockTabData({ id: 'test-tab' }),
+    });
+
+    await manager.createTab();
+    onPersistedStateChanged.mockClear();
+
+    const initializeOptions = mockInitializeTabUI.mock.calls.at(-1)?.[2];
+    initializeOptions.onDraftModelChanged();
+
+    expect(onPersistedStateChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not mark persisted state dirty when availability reconciliation is unchanged', async () => {
+    const onPersistedStateChanged = jest.fn();
+    const manager = createManager({
+      callbacks: { onPersistedStateChanged },
+    });
+    await manager.createTab();
+    onPersistedStateChanged.mockClear();
+    mockOnProviderAvailabilityChanged.mockReturnValueOnce(false);
+
+    manager.reconcileProviderAvailability();
+
+    expect(onPersistedStateChanged).not.toHaveBeenCalled();
+  });
+
+  it('marks persisted state dirty when provider availability reconciles a blank draft', async () => {
+    const onPersistedStateChanged = jest.fn();
+    const tab = createMockTabData({
+      id: 'test-tab',
+      draftModel: 'removed-model',
+    });
+    const manager = createManager({
+      callbacks: { onPersistedStateChanged },
+      tabFactory: () => tab,
+    });
+    await manager.createTab();
+    onPersistedStateChanged.mockClear();
+    mockOnProviderAvailabilityChanged.mockImplementationOnce((targetTab) => {
+      targetTab.draftModel = TEST_CODEX_MODEL;
+      targetTab.providerId = 'codex';
+      return true;
+    });
+
+    manager.reconcileProviderAvailability();
+
+    expect(mockOnProviderAvailabilityChanged).toHaveBeenCalledWith(
+      tab,
+      expect.anything(),
+    );
+    expect(onPersistedStateChanged).toHaveBeenCalledTimes(1);
+  });
+
   describe('ChatState callbacks during tab creation', () => {
     it('should wire onStreamingChanged callback to TabManager callbacks', async () => {
       const onTabStreamingChanged = jest.fn();
@@ -2885,7 +2961,11 @@ describe('TabManager - Callback Wiring', () => {
 
     it('should wire onConversationIdChanged callback to sync tab conversationId', async () => {
       const onTabConversationChanged = jest.fn();
-      const callbacks: TabManagerCallbacks = { onTabConversationChanged };
+      const onPersistedStateChanged = jest.fn();
+      const callbacks: TabManagerCallbacks = {
+        onPersistedStateChanged,
+        onTabConversationChanged,
+      };
 
       let capturedCallbacks: any;
       const tabData = createMockTabData({
@@ -2900,6 +2980,7 @@ describe('TabManager - Callback Wiring', () => {
 
       const manager = new TabManager(createMockPlugin(), createMockMcpManager(), createMockEl(), createMockView(), callbacks);
       await manager.createTab();
+      onPersistedStateChanged.mockClear();
       const invalidateDiscovery = jest.spyOn(
         (manager as any).providerCommandDiscoveryStores.get('test-tab'),
         'invalidate'
@@ -2918,6 +2999,7 @@ describe('TabManager - Callback Wiring', () => {
       expect((manager as any).tabCommandContextRevisions.get('test-tab')).toBe(1);
       expect((manager as any).providerRuntimeCommandCache.has('test-tab')).toBe(false);
       expect(invalidateDiscovery).toHaveBeenCalledTimes(1);
+      expect(onPersistedStateChanged).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Centralizes serialized tab-state notifications in `TabManager` so blank-tab provider and model selections persist across restarts.
- Persists lifecycle changes from tab creation, switching, closing, availability reconciliation, draft-model changes, and direct `/clear` resets after the final blank state is committed.

## Testing

- Passed typecheck, lint, 6,876 tests, build, and `git diff --check`.