### PR TITLE
feat: improve auto-title model selection

### DIFF
--- a/src/core/providers/ProviderRegistry.ts
+++ b/src/core/providers/ProviderRegistry.ts
@@ -126,7 +126,10 @@ export class ProviderRegistry {
           continue;
         }
         seenValues.add(option.value);
-        options.push(option);
+        options.push({
+          ...option,
+          label: `${this.getProviderDisplayName(providerId)}: ${option.label}`,
+        });
       }
     }
 

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -469,8 +469,8 @@ export interface ProviderSettingsTabRendererContext {
     providerId: ProviderId,
     copy: { name: string; desc: string; placeholder: string },
   ): void;
-  refreshModelSelectors(): void;
-  refreshTitleGenerationModelOptions(): void;
+  /** Publish provider model-option changes to every settings and chat consumer. */
+  notifyProviderModelOptionsChanged(providerId: ProviderId): void;
   renderCustomContextLimits(container: HTMLElement, providerId: ProviderId): void;
 }
 

--- a/src/features/settings/ClaudianSettings.ts
+++ b/src/features/settings/ClaudianSettings.ts
@@ -197,12 +197,9 @@ export class ClaudianSettingTab extends PluginSettingTab {
             targetProviderId,
             copy,
           ) => this.renderHiddenProviderCommandSetting(target, targetProviderId, copy),
-          refreshModelSelectors: () => {
-            for (const view of this.plugin.getAllViews()) {
-              view.refreshModelSelector();
-            }
+          notifyProviderModelOptionsChanged: (changedProviderId) => {
+            this.notifyProviderModelOptionsChanged(changedProviderId);
           },
-          refreshTitleGenerationModelOptions: () => this.refreshTitleModelOptions?.(),
           renderCustomContextLimits: (target, targetProviderId) => (
             this.renderCustomContextLimits(target, targetProviderId)
           ),
@@ -586,6 +583,13 @@ export class ClaudianSettingTab extends PluginSettingTab {
     });
   }
 
+  private notifyProviderModelOptionsChanged(providerId: ProviderId): void {
+    for (const view of this.plugin.getAllViews()) {
+      view.refreshModelSelector(providerId);
+    }
+    this.refreshTitleModelOptions?.();
+  }
+
   private renderHiddenProviderCommandSetting(
     container: HTMLElement,
     providerId: ProviderId,
@@ -682,9 +686,7 @@ export class ClaudianSettingTab extends PluginSettingTab {
             delete settings.customModelAliases[modelId];
           }
         });
-        for (const view of this.plugin.getAllViews()) {
-          view.refreshModelSelector();
-        }
+        this.notifyProviderModelOptionsChanged(providerId);
       };
 
       const saveContextLimit = async (): Promise<void> => {

--- a/src/providers/claude/ui/ClaudeSettingsTab.ts
+++ b/src/providers/claude/ui/ClaudeSettingsTab.ts
@@ -196,7 +196,7 @@ export const claudeSettingsTabRenderer: ProviderSettingsTabRenderer = {
             ProviderSettingsCoordinator.reconcileTitleGenerationModelSelection(settings);
           });
           savedCustomModels = nextCustomModels;
-          context.refreshModelSelectors();
+          context.notifyProviderModelOptionsChanged('claude');
         };
 
         text

--- a/src/providers/codex/ui/CodexModelPicker.ts
+++ b/src/providers/codex/ui/CodexModelPicker.ts
@@ -86,7 +86,7 @@ export function renderCodexModelPicker(
       updateCodexProviderSettings(settings, { visibleModels: nextVisibleModels });
       ProviderSettingsCoordinator.normalizeAllModelVariants(settings);
     });
-    context.refreshModelSelectors();
+    context.notifyProviderModelOptionsChanged('codex');
   };
 
   let refreshPicker = (): void => {};
@@ -105,13 +105,21 @@ export function renderCodexModelPicker(
       const result = await workspace.modelCatalogCoordinator.ensureFresh('model-picker', { force });
       if (result.backgroundRefresh) {
         void result.backgroundRefresh.then(
-          () => refreshPicker(),
+          (backgroundResult) => {
+            refreshPicker();
+            if (backgroundResult.refreshed) {
+              context.notifyProviderModelOptionsChanged('codex');
+            }
+          },
           () => refreshPicker(),
         );
       }
       if (result.diagnostics) {
         new Notice(`Codex model discovery failed: ${result.diagnostics}`);
         return 'failed';
+      }
+      if (result.refreshed) {
+        context.notifyProviderModelOptionsChanged('codex');
       }
       return getCodexProviderSettings(settingsBag).discoveredModels.length > 0 ? 'loaded' : 'empty';
     },
@@ -121,7 +129,7 @@ export function renderCodexModelPicker(
       await context.plugin.mutateSettings((settings) => {
         updateCodexProviderSettings(settings, { modelAliases });
       });
-      context.refreshModelSelectors();
+      context.notifyProviderModelOptionsChanged('codex');
     },
     onSelectedIdsChange: persistVisibleModels,
     providerName: 'Codex',

--- a/src/providers/codex/ui/CodexSettingsTab.ts
+++ b/src/providers/codex/ui/CodexSettingsTab.ts
@@ -49,8 +49,7 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
             if (value) {
               await refreshCodexModelCatalog();
             }
-            context.refreshModelSelectors();
-            context.refreshTitleGenerationModelOptions();
+            context.notifyProviderModelOptionsChanged('codex');
           })
       );
 

--- a/src/providers/grok/ui/GrokSettingsTab.ts
+++ b/src/providers/grok/ui/GrokSettingsTab.ts
@@ -47,7 +47,7 @@ export const grokSettingsTabRenderer: ProviderSettingsTabRenderer = {
         new Notice(`Grok model discovery failed: ${result.diagnostics}`);
         return 'failed';
       }
-      context.refreshTitleGenerationModelOptions();
+      context.notifyProviderModelOptionsChanged(GROK_PROVIDER_ID);
       return (getGrokProviderSettings(settingsBag).currentCatalog?.models.length ?? 0) > 0
         ? 'loaded'
         : 'empty';
@@ -71,8 +71,7 @@ export const grokSettingsTabRenderer: ProviderSettingsTabRenderer = {
           if (enabled) {
             await refreshModelCatalog();
           }
-          context.refreshModelSelectors();
-          context.refreshTitleGenerationModelOptions();
+          context.notifyProviderModelOptionsChanged(GROK_PROVIDER_ID);
         }));
 
     const cliPathSetting = new Setting(container)
@@ -153,8 +152,7 @@ export const grokSettingsTabRenderer: ProviderSettingsTabRenderer = {
         throw error;
       }
       currentCliPath = trimmed;
-      context.refreshModelSelectors();
-      context.refreshTitleGenerationModelOptions();
+      context.notifyProviderModelOptionsChanged(GROK_PROVIDER_ID);
     };
 
     cliPathSetting.addText(text => {
@@ -227,8 +225,7 @@ function renderGrokModelPicker(
       await context.plugin.mutateSettings((settings) => {
         updateGrokProviderSettings(settings, { modelAliases });
       });
-      context.refreshModelSelectors();
-      context.refreshTitleGenerationModelOptions();
+      context.notifyProviderModelOptionsChanged(GROK_PROVIDER_ID);
     },
     async onSelectedIdsChange(selectedIds) {
       const current = getGrokProviderSettings(settingsBag);
@@ -242,8 +239,7 @@ function renderGrokModelPicker(
       await context.plugin.mutateSettings((settings) => {
         updateGrokVisibleModels(settings, nextVisibleModels);
       });
-      context.refreshModelSelectors();
-      context.refreshTitleGenerationModelOptions();
+      context.notifyProviderModelOptionsChanged(GROK_PROVIDER_ID);
     },
     providerName: 'Grok',
     searchPlaceholder: 'Filter by model name, description, or alias ID...',

--- a/src/providers/opencode/ui/OpencodeSettingsTab.ts
+++ b/src/providers/opencode/ui/OpencodeSettingsTab.ts
@@ -54,8 +54,7 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
             await context.plugin.mutateSettings((settings) => {
               ProviderSettingsCoordinator.applyProviderEnablement(settings, 'opencode', value);
             });
-            context.refreshModelSelectors();
-            context.refreshTitleGenerationModelOptions();
+            context.notifyProviderModelOptionsChanged('opencode');
           })
       );
 
@@ -193,7 +192,7 @@ function renderOpencodeModelPicker(
         sessionId: null,
       });
       if (await runtime.warmModelMetadata(encodeOpencodeModelId(rawId))) {
-        context.refreshModelSelectors();
+        context.notifyProviderModelOptionsChanged('opencode');
       }
     } catch {
       // Metadata warmup is opportunistic; the first chat turn can still discover it.
@@ -220,7 +219,7 @@ function renderOpencodeModelPicker(
           return 'failed';
         }
         if (discoveredCount > 0) {
-          context.refreshModelSelectors();
+          context.notifyProviderModelOptionsChanged('opencode');
           return 'loaded';
         }
         return 'empty';
@@ -237,7 +236,7 @@ function renderOpencodeModelPicker(
       await context.plugin.mutateSettings((settings) => {
         updateOpencodeProviderSettings(settings, { modelAliases });
       });
-      context.refreshModelSelectors();
+      context.notifyProviderModelOptionsChanged('opencode');
     },
     onModelSelected: async (model) => warmModelMetadata(model.id),
     async onSelectedIdsChange(visibleModels) {
@@ -250,7 +249,7 @@ function renderOpencodeModelPicker(
       await context.plugin.mutateSettings((settings) => {
         updateOpencodeProviderSettings(settings, { visibleModels: normalized });
       });
-      context.refreshModelSelectors();
+      context.notifyProviderModelOptionsChanged('opencode');
     },
     providerName: 'OpenCode',
     settingDescription: 'Choose which OpenCode models are available in the chat selector. Filter by provider or type to search. OpenCode chat is unavailable when no models are selected.',

--- a/src/providers/pi/ui/PiSettingsTab.ts
+++ b/src/providers/pi/ui/PiSettingsTab.ts
@@ -45,8 +45,7 @@ export const piSettingsTabRenderer: ProviderSettingsTabRenderer = {
             await context.plugin.mutateSettings((settings) => {
               ProviderSettingsCoordinator.applyProviderEnablement(settings, 'pi', value);
             });
-            context.refreshModelSelectors();
-            context.refreshTitleGenerationModelOptions();
+            context.notifyProviderModelOptionsChanged('pi');
           })
       );
 
@@ -89,7 +88,7 @@ export const piSettingsTabRenderer: ProviderSettingsTabRenderer = {
         });
         workspace?.cliResolver?.reset();
       });
-      context.refreshModelSelectors();
+      context.notifyProviderModelOptionsChanged('pi');
     };
 
     new Setting(container)
@@ -175,7 +174,7 @@ function renderPiModelPicker(
             visibleModels: normalizedVisibleModels,
           });
         });
-        context.plugin.notifyProviderChatOptionsChanged('pi');
+        context.notifyProviderModelOptionsChanged('pi');
       }
       return result.models.length > 0 ? 'loaded' : 'empty';
     },
@@ -185,7 +184,7 @@ function renderPiModelPicker(
       await context.plugin.mutateSettings((settings) => {
         updatePiProviderSettings(settings, { modelAliases });
       });
-      context.refreshModelSelectors();
+      context.notifyProviderModelOptionsChanged('pi');
     },
     async onSelectedIdsChange(visibleModels) {
       const current = getPiProviderSettings(settingsBag);
@@ -197,7 +196,7 @@ function renderPiModelPicker(
       await context.plugin.mutateSettings((settings) => {
         updatePiProviderSettings(settings, { visibleModels: normalized });
       });
-      context.refreshModelSelectors();
+      context.notifyProviderModelOptionsChanged('pi');
     },
     providerName: 'Pi',
     settingDescription: 'Choose which Pi models are available in the chat selector. Filter by provider or type to search. Pi chat is unavailable when no models are selected.',

--- a/tests/unit/core/providers/ProviderRegistry.test.ts
+++ b/tests/unit/core/providers/ProviderRegistry.test.ts
@@ -1,6 +1,10 @@
 import '@/providers';
 
-import { TEST_CODEX_CATALOG, TEST_CODEX_MODEL } from '@test/helpers/codexModels';
+import {
+  TEST_CODEX_CATALOG,
+  TEST_CODEX_MODEL,
+  TEST_CODEX_MODEL_LABEL,
+} from '@test/helpers/codexModels';
 
 import { ProviderRegistry } from '@/core/providers/ProviderRegistry';
 import { ProviderWorkspaceRegistry } from '@/core/providers/ProviderWorkspaceRegistry';
@@ -190,6 +194,22 @@ describe('ProviderRegistry', () => {
       ProviderRegistry.getTitleGenerationModelOptions(enabledSettings)
         .some(option => option.value === TEST_CODEX_MODEL),
     ).toBe(true);
+  });
+
+  it('prefixes title generation model labels with their provider names', () => {
+    const options = ProviderRegistry.getTitleGenerationModelOptions({
+      providerConfigs: {
+        codex: {
+          discoveredModels: TEST_CODEX_CATALOG,
+          enabled: true,
+        },
+      },
+    });
+
+    expect(options.find(option => option.value === TEST_CODEX_MODEL)?.label)
+      .toBe(`Codex: ${TEST_CODEX_MODEL_LABEL}`);
+    expect(options.find(option => option.value === 'sonnet')?.label)
+      .toBe('Claude: Sonnet');
   });
 
   it('returns the display name from provider registration metadata', () => {

--- a/tests/unit/features/settings/ClaudianSettings.test.ts
+++ b/tests/unit/features/settings/ClaudianSettings.test.ts
@@ -1,0 +1,22 @@
+import { ClaudianSettingTab } from '@/features/settings/ClaudianSettings';
+
+describe('ClaudianSettingTab model option updates', () => {
+  it('refreshes provider-scoped chat selectors and the live title model menu together', () => {
+    const refreshModelSelector = jest.fn();
+    const plugin = {
+      getAllViews: jest.fn(() => [{ refreshModelSelector }]),
+      notifyAgentSkillsChanged: jest.fn(),
+      storage: {
+        getAdapter: jest.fn(() => ({})),
+      },
+    };
+    const tab = new ClaudianSettingTab({} as any, plugin as any);
+    const refreshTitleModelOptions = jest.fn();
+    (tab as any).refreshTitleModelOptions = refreshTitleModelOptions;
+
+    (tab as any).notifyProviderModelOptionsChanged('codex');
+
+    expect(refreshModelSelector).toHaveBeenCalledWith('codex');
+    expect(refreshTitleModelOptions).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/providers/claude/ui/ClaudeSettingsTab.test.ts
+++ b/tests/unit/providers/claude/ui/ClaudeSettingsTab.test.ts
@@ -380,8 +380,7 @@ function createPlugin(overrides: Record<string, unknown> = {}): any {
 function createContext(plugin: any) {
   return {
     plugin,
-    refreshModelSelectors: jest.fn(),
-    refreshTitleGenerationModelOptions: jest.fn(),
+    notifyProviderModelOptionsChanged: jest.fn(),
     renderAgentSkillSettings: jest.fn(),
     renderHiddenProviderCommandSetting: jest.fn(),
     renderCustomContextLimits: jest.fn(),
@@ -474,7 +473,7 @@ describe('ClaudeSettingsTab', () => {
     expect(plugin.settings.providerConfigs.claude.customModels).toBe('claude-opus-4-6');
     expect(plugin.settings.model).toBe('claude-opus-4-6');
     expect(mockSaveSettings).not.toHaveBeenCalled();
-    expect(context.refreshModelSelectors).not.toHaveBeenCalled();
+    expect(context.notifyProviderModelOptionsChanged).not.toHaveBeenCalled();
   });
 
   it('offers auto as a Claude safe mode and persists it', async () => {
@@ -516,6 +515,6 @@ describe('ClaudeSettingsTab', () => {
     expect(plugin.settings.model).toBe('sonnet');
     expect(plugin.settings.titleGenerationModel).toBe('');
     expect(mockSaveSettings).toHaveBeenCalledTimes(1);
-    expect(context.refreshModelSelectors).toHaveBeenCalledTimes(1);
+    expect(context.notifyProviderModelOptionsChanged).toHaveBeenCalledWith('claude');
   });
 });

--- a/tests/unit/providers/codex/ui/CodexModelPicker.test.ts
+++ b/tests/unit/providers/codex/ui/CodexModelPicker.test.ts
@@ -154,7 +154,7 @@ function createPlugin() {
 function createContext(plugin: ReturnType<typeof createPlugin>) {
   return {
     plugin,
-    refreshModelSelectors: jest.fn(),
+    notifyProviderModelOptionsChanged: jest.fn(),
   } as any;
 }
 
@@ -197,7 +197,7 @@ describe('CodexModelPicker', () => {
 
     expect(getCodexProviderSettings(plugin.settings).visibleModels).toEqual([]);
     expect(plugin.saveSettings).toHaveBeenCalledTimes(1);
-    expect(context.refreshModelSelectors).toHaveBeenCalledTimes(1);
+    expect(context.notifyProviderModelOptionsChanged).toHaveBeenCalledWith('codex');
   });
 
   it('registers void-returning DOM event callbacks for asynchronous actions', async () => {
@@ -278,7 +278,7 @@ describe('CodexModelPicker', () => {
       'gpt-5.5': 'Primary',
     });
     expect(plugin.saveSettings).toHaveBeenCalledTimes(1);
-    expect(context.refreshModelSelectors).toHaveBeenCalledTimes(1);
+    expect(context.notifyProviderModelOptionsChanged).toHaveBeenCalledWith('codex');
   });
 
   it('refreshes the app-server catalog through the provider-owned persistence boundary', async () => {
@@ -299,7 +299,7 @@ describe('CodexModelPicker', () => {
 
     expect(ensureFresh).toHaveBeenCalledWith('model-picker', { force: true });
     expect(plugin.saveSettings).not.toHaveBeenCalled();
-    expect(context.refreshModelSelectors).not.toHaveBeenCalled();
+    expect(context.notifyProviderModelOptionsChanged).toHaveBeenCalledWith('codex');
   });
 
   it('does not save when refresh only changes the runtime catalog', async () => {
@@ -319,7 +319,7 @@ describe('CodexModelPicker', () => {
     await flushPromises();
 
     expect(plugin.saveSettings).not.toHaveBeenCalled();
-    expect(context.refreshModelSelectors).not.toHaveBeenCalled();
+    expect(context.notifyProviderModelOptionsChanged).not.toHaveBeenCalled();
   });
 
   it('checks cached catalog freshness on open and rerenders after background refresh', async () => {
@@ -377,6 +377,6 @@ describe('CodexModelPicker', () => {
     expect(elements.some(element => (
       element.tag === 'label' && element.title === 'gpt-5.6-new'
     ))).toBe(true);
-    expect(context.refreshModelSelectors).not.toHaveBeenCalled();
+    expect(context.notifyProviderModelOptionsChanged).toHaveBeenCalledWith('codex');
   });
 });

--- a/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
+++ b/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
@@ -371,8 +371,7 @@ function createContext(plugin: any) {
     plugin,
     renderAgentSkillSettings: jest.fn(),
     renderHiddenProviderCommandSetting: jest.fn(),
-    refreshModelSelectors: jest.fn(),
-    refreshTitleGenerationModelOptions: jest.fn(),
+    notifyProviderModelOptionsChanged: jest.fn(),
     renderCustomContextLimits: jest.fn(),
   };
 }
@@ -437,7 +436,7 @@ describe('CodexSettingsTab', () => {
     );
     await enableSetting.toggleComponents[0].onChangeCallback?.(false);
 
-    expect(context.refreshTitleGenerationModelOptions).toHaveBeenCalledTimes(1);
+    expect(context.notifyProviderModelOptionsChanged).toHaveBeenCalledWith('codex');
   });
 
   it('renders the app-server model visibility picker', () => {

--- a/tests/unit/providers/grok/ui/GrokSettingsTab.test.ts
+++ b/tests/unit/providers/grok/ui/GrokSettingsTab.test.ts
@@ -284,8 +284,7 @@ function createPlugin(): any {
 function createContext(plugin: any): any {
   return {
     plugin,
-    refreshModelSelectors: jest.fn(),
-    refreshTitleGenerationModelOptions: jest.fn(),
+    notifyProviderModelOptionsChanged: jest.fn(),
     renderAgentSkillSettings: jest.fn(),
     renderCustomContextLimits: jest.fn(),
     renderHiddenProviderCommandSetting: jest.fn(),
@@ -341,8 +340,7 @@ describe('GrokSettingsTab', () => {
 
     expect(plugin.settings.providerConfigs.grok.enabled).toBe(true);
     expect(mockRefreshModelCatalog).toHaveBeenCalledTimes(1);
-    expect(context.refreshModelSelectors).toHaveBeenCalled();
-    expect(context.refreshTitleGenerationModelOptions).toHaveBeenCalled();
+    expect(context.notifyProviderModelOptionsChanged).toHaveBeenCalledWith('grok');
   });
 
   it('validates an executable CLI file before persisting it', async () => {
@@ -487,14 +485,13 @@ describe('GrokSettingsTab', () => {
     ]);
 
     await picker.onAliasesChange({ 'grok-4': 'Primary' });
-    expect(context.refreshTitleGenerationModelOptions).toHaveBeenCalledTimes(1);
-    context.refreshTitleGenerationModelOptions.mockClear();
+    expect(context.notifyProviderModelOptionsChanged).toHaveBeenCalledTimes(1);
+    context.notifyProviderModelOptionsChanged.mockClear();
     await picker.onSelectedIdsChange(['grok-4', 'kimi-coding']);
 
     expect(getGrokProviderSettings(plugin.settings).modelAliases).toEqual({ 'grok-4': 'Primary' });
     expect(getGrokProviderSettings(plugin.settings).visibleModels).toBeNull();
-    expect(context.refreshModelSelectors).toHaveBeenCalled();
-    expect(context.refreshTitleGenerationModelOptions).toHaveBeenCalledTimes(1);
+    expect(context.notifyProviderModelOptionsChanged).toHaveBeenCalledWith('grok');
   });
 
   it('prunes reasoning metadata and preferences when a model is disabled', async () => {

--- a/tests/unit/providers/opencode/OpencodeSettingsTab.test.ts
+++ b/tests/unit/providers/opencode/OpencodeSettingsTab.test.ts
@@ -424,8 +424,7 @@ function createContext(plugin: any) {
     plugin,
     renderAgentSkillSettings: jest.fn(),
     renderHiddenProviderCommandSetting: jest.fn(),
-    refreshModelSelectors: jest.fn(),
-    refreshTitleGenerationModelOptions: jest.fn(),
+    notifyProviderModelOptionsChanged: jest.fn(),
     renderCustomContextLimits: jest.fn(),
   };
 }
@@ -477,7 +476,7 @@ describe('OpencodeSettingsTab', () => {
     );
     await enableSetting.toggleComponents[0].onChangeCallback?.(false);
 
-    expect(context.refreshTitleGenerationModelOptions).toHaveBeenCalledTimes(1);
+    expect(context.notifyProviderModelOptionsChanged).toHaveBeenCalledWith('opencode');
   });
 
   it('stores the CLI path per host and resets active runtime state across all views', async () => {
@@ -604,7 +603,7 @@ describe('OpencodeSettingsTab', () => {
       { allowSessionCreation: true },
     );
     expect(mockRuntimeCleanup).toHaveBeenCalledTimes(1);
-    expect(context.refreshModelSelectors).toHaveBeenCalledTimes(1);
+    expect(context.notifyProviderModelOptionsChanged).toHaveBeenCalledTimes(1);
   });
 
   it('loads the OpenCode model catalog immediately when a fresh picker starts expanded', async () => {
@@ -645,7 +644,7 @@ describe('OpencodeSettingsTab', () => {
       { allowSessionCreation: true },
     );
     expect(mockRuntimeCleanup).toHaveBeenCalledTimes(1);
-    expect(context.refreshModelSelectors).toHaveBeenCalledTimes(1);
+    expect(context.notifyProviderModelOptionsChanged).toHaveBeenCalledTimes(1);
   });
 
   it('loads the OpenCode catalog when saved models start with the browser collapsed', async () => {
@@ -681,7 +680,7 @@ describe('OpencodeSettingsTab', () => {
       plugin,
       { allowSessionCreation: true },
     );
-    expect(context.refreshModelSelectors).toHaveBeenCalledTimes(1);
+    expect(context.notifyProviderModelOptionsChanged).toHaveBeenCalledTimes(1);
   });
 
   it('warms and persists thinking metadata when a model is added to the visible list', async () => {
@@ -724,7 +723,7 @@ describe('OpencodeSettingsTab', () => {
       plugin,
       'opencode:deepseek/deepseek-v4-pro',
     );
-    expect(context.refreshModelSelectors).toHaveBeenCalled();
+    expect(context.notifyProviderModelOptionsChanged).toHaveBeenCalledWith('opencode');
   });
 
   it('persists aliases through the shared model picker', async () => {
@@ -751,6 +750,6 @@ describe('OpencodeSettingsTab', () => {
     expect(getOpencodeProviderSettings(plugin.settings).modelAliases).toEqual({
       'deepseek/deepseek-v4-pro': 'V4 Pro',
     });
-    expect(context.refreshModelSelectors).toHaveBeenCalled();
+    expect(context.notifyProviderModelOptionsChanged).toHaveBeenCalledWith('opencode');
   });
 });

--- a/tests/unit/providers/pi/ui/PiSettingsTab.test.ts
+++ b/tests/unit/providers/pi/ui/PiSettingsTab.test.ts
@@ -343,8 +343,7 @@ function createContext(settings: Record<string, unknown>) {
       }),
     },
     renderAgentSkillSettings: jest.fn(),
-    refreshModelSelectors: jest.fn(),
-    refreshTitleGenerationModelOptions: jest.fn(),
+    notifyProviderModelOptionsChanged: jest.fn(),
     renderHiddenProviderCommandSetting: jest.fn(),
   };
 }
@@ -413,8 +412,7 @@ describe('PiSettingsTab', () => {
 
     expect(getPiProviderSettings(settings).enabled).toBe(true);
     expect(context.plugin.saveSettings).toHaveBeenCalled();
-    expect(context.refreshModelSelectors).toHaveBeenCalled();
-    expect(context.refreshTitleGenerationModelOptions).toHaveBeenCalled();
+    expect(context.notifyProviderModelOptionsChanged).toHaveBeenCalledWith('pi');
   });
 
   it('renders shared skills and keeps hidden provider commands separate', () => {
@@ -486,7 +484,7 @@ describe('PiSettingsTab', () => {
     expect(mockDiscoverModels).toHaveBeenCalledTimes(1);
     expect(getPiProviderSettings(settings).discoveredModels).toHaveLength(1);
     expect(getPiProviderSettings(settings).visibleModels).toEqual(['pi:anthropic/claude-sonnet-4']);
-    expect(context.plugin.notifyProviderChatOptionsChanged).toHaveBeenCalledWith('pi');
+    expect(context.notifyProviderModelOptionsChanged).toHaveBeenCalledWith('pi');
 
     mockDiscoverModels.mockResolvedValueOnce({
       diagnostics: 'not logged in',
@@ -558,7 +556,7 @@ describe('PiSettingsTab', () => {
     await flushPromises();
 
     expect(context.plugin.saveSettings).not.toHaveBeenCalled();
-    expect(context.plugin.notifyProviderChatOptionsChanged).not.toHaveBeenCalled();
+    expect(context.notifyProviderModelOptionsChanged).not.toHaveBeenCalled();
   });
 
   it('persists visible model choices and aliases', async () => {
@@ -594,6 +592,7 @@ describe('PiSettingsTab', () => {
     expect(getPiProviderSettings(settings).modelAliases).toEqual({
       'pi:anthropic/claude-sonnet-4': 'Sonnet',
     });
-    expect(context.refreshModelSelectors).toHaveBeenCalled();
+    expect(context.notifyProviderModelOptionsChanged).toHaveBeenCalledTimes(2);
+    expect(context.notifyProviderModelOptionsChanged).toHaveBeenCalledWith('pi');
   });
 });


### PR DESCRIPTION
Prefixes every auto-title generation model label with its provider display name so mixed-provider menus remain unambiguous.

Replaces separate settings refresh callbacks with one provider-scoped model-options notification that hot-reloads chat selectors and the auto-title dropdown after provider enablement, model visibility, alias, and catalog changes across Claude, Codex, Grok, OpenCode, and Pi. Adds coverage for provider-prefixed labels, settings fan-out, and provider model picker updates.

Validation: `npm run typecheck && npm run lint && npm run test && npm run build` (6,878 tests).