### PR TITLE
fix: preserve Claude history across environment changes

### DIFF
--- a/src/providers/claude/history/ClaudeConversationHistoryService.ts
+++ b/src/providers/claude/history/ClaudeConversationHistoryService.ts
@@ -14,7 +14,11 @@ import type {
   ToolCallInfo,
 } from '../../../core/types';
 import { isClaudeSubagentToolName } from '../subagentToolNames';
-import { type ClaudeProviderState, getClaudeState } from '../types/providerState';
+import {
+  type ClaudeProviderState,
+  getClaudeConversationSessionIds,
+  getClaudeState,
+} from '../types/providerState';
 import {
   deleteSDKSession,
   encodeVaultPathForSDK,
@@ -23,6 +27,7 @@ import {
   loadSubagentToolCalls,
   locateSDKSession,
   locateSDKSessions,
+  readLegacyConversationSessionId,
 } from './ClaudeHistoryStore';
 import type { SDKSessionLocation } from './sdkSessionPaths';
 
@@ -397,15 +402,7 @@ export class ClaudeConversationHistoryService implements ProviderConversationHis
   private relocatedSessionPathsByConversation = new Map<string, Map<string, string>>();
 
   private getConversationSessionIds(conversation: Conversation): string[] {
-    const state = getClaudeState(conversation.providerState);
-    if (this.isPendingForkConversation(conversation)) {
-      return [state.forkSource!.sessionId];
-    }
-
-    return [...new Set([
-      ...(state.previousProviderSessionIds || []),
-      state.providerSessionId ?? conversation.sessionId,
-    ].filter((id): id is string => !!id))];
+    return getClaudeConversationSessionIds(conversation);
   }
 
   private synchronizeHistoryCache(
@@ -602,12 +599,27 @@ export class ClaudeConversationHistoryService implements ProviderConversationHis
     if (!vaultPath) {
       return;
     }
+
+    let allSessionIds = this.getConversationSessionIds(conversation);
+    if (allSessionIds.length === 0) {
+      const recoveredSessionId = await readLegacyConversationSessionId(
+        vaultPath,
+        conversation.id,
+      );
+      if (recoveredSessionId) {
+        conversation.providerState = sanitizeProviderState({
+          ...getClaudeState(conversation.providerState),
+          previousProviderSessionIds: [recoveredSessionId],
+        });
+        allSessionIds = [recoveredSessionId];
+      }
+    }
+
     this.synchronizeHistoryCache(conversation, vaultPath, pathContext);
     if (this.hydratedConversationIds.has(conversation.id)) return;
 
     const state = getClaudeState(conversation.providerState);
     const isPendingFork = this.isPendingForkConversation(conversation);
-    const allSessionIds = this.getConversationSessionIds(conversation);
 
     if (allSessionIds.length === 0) {
       return;

--- a/src/providers/claude/history/ClaudeHistoryStore.ts
+++ b/src/providers/claude/history/ClaudeHistoryStore.ts
@@ -1,3 +1,6 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
 import type { ProviderHistoryPathContext } from '../../../core/providers/types';
 import type { ChatMessage, SubagentInfo, ToolCallInfo } from '../../../core/types';
 import { isClaudeSubagentToolName } from '../subagentToolNames';
@@ -65,6 +68,54 @@ export {
   extractAgentIdFromToolUseResult,
   resolveToolUseResultStatus,
 } from './sdkAsyncSubagent';
+
+export function parseLegacyConversationSessionId(
+  content: string,
+  conversationId: string,
+): string | null {
+  const firstLine = content.split(/\r?\n/, 1)[0];
+  if (!firstLine) {
+    return null;
+  }
+
+  try {
+    const record = JSON.parse(firstLine) as {
+      type?: unknown;
+      id?: unknown;
+      sessionId?: unknown;
+    };
+    if (
+      record.type !== 'meta'
+      || record.id !== conversationId
+      || typeof record.sessionId !== 'string'
+      || !isValidSessionId(record.sessionId)
+    ) {
+      return null;
+    }
+    return record.sessionId;
+  } catch {
+    return null;
+  }
+}
+
+export async function readLegacyConversationSessionId(
+  vaultPath: string,
+  conversationId: string,
+): Promise<string | null> {
+  if (!isValidSessionId(conversationId)) {
+    return null;
+  }
+
+  try {
+    const content = await fs.readFile(
+      path.join(vaultPath, '.claude', 'sessions', `${conversationId}.jsonl`),
+      'utf8',
+    );
+    return parseLegacyConversationSessionId(content, conversationId);
+  } catch {
+    return null;
+  }
+}
 
 export async function loadSDKSessionMessages(
   vaultPath: string,

--- a/src/providers/claude/types/providerState.ts
+++ b/src/providers/claude/types/providerState.ts
@@ -16,21 +16,46 @@ export function getClaudeState(
   return (providerState ?? {});
 }
 
+export function getClaudeConversationSessionIds(conversation: Conversation): string[] {
+  const state = getClaudeState(conversation.providerState);
+  const isPendingFork = !!state.forkSource
+    && !state.providerSessionId
+    && !conversation.sessionId;
+  if (isPendingFork) {
+    return [state.forkSource!.sessionId];
+  }
+
+  return [...new Set([
+    ...(state.previousProviderSessionIds || []),
+    state.providerSessionId ?? conversation.sessionId,
+  ].filter((id): id is string => !!id))];
+}
+
 export function clearClaudeResumeState(conversation: Conversation): boolean {
-  const providerState = { ...(conversation.providerState ?? {}) };
+  const providerState = { ...getClaudeState(conversation.providerState) };
+  const isPendingFork = !!providerState.forkSource
+    && !providerState.providerSessionId
+    && !conversation.sessionId;
   const hadResumeState = conversation.sessionId != null
-    || conversation.resumeAtMessageId != null
     || typeof providerState.providerSessionId === 'string'
-    || Array.isArray(providerState.previousProviderSessionIds)
     || providerState.forkSource !== undefined;
   if (!hadResumeState) {
     return false;
   }
 
+  // Stop provider resume while retaining transcript segments for history replay.
+  const preservedSessionIds = getClaudeConversationSessionIds(conversation);
+  if (preservedSessionIds.length > 0) {
+    providerState.previousProviderSessionIds = preservedSessionIds;
+  } else {
+    delete providerState.previousProviderSessionIds;
+  }
+  if (isPendingFork) {
+    conversation.resumeAtMessageId = providerState.forkSource!.resumeAt;
+  }
+
   conversation.sessionId = null;
-  delete conversation.resumeAtMessageId;
   delete providerState.providerSessionId;
-  delete providerState.previousProviderSessionIds;
   delete providerState.forkSource;
   conversation.providerState = Object.keys(providerState).length > 0
     ? providerState

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -321,14 +321,18 @@ describe('ClaudianPlugin', () => {
 
       expect(restored).toEqual(expect.objectContaining({
         sessionId: null,
-        providerState: undefined,
+        providerState: {
+          previousProviderSessionIds: ['restored-provider-session-id'],
+        },
+        resumeAtMessageId: 'restored-message-id',
       }));
-      expect(restored).not.toHaveProperty('resumeAtMessageId');
       expect(deferred).toEqual(expect.objectContaining({
         sessionId: null,
-        providerState: undefined,
+        providerState: {
+          previousProviderSessionIds: ['deferred-provider-session-id'],
+        },
+        resumeAtMessageId: 'deferred-message-id',
       }));
-      expect(deferred).not.toHaveProperty('resumeAtMessageId');
     });
 
     it('preserves restored and deferred sessions for a reload-policy environment change', async () => {
@@ -450,9 +454,13 @@ describe('ClaudianPlugin', () => {
       listSpy.mockRestore();
 
       expect(first?.sessionId).toBeNull();
-      expect(first?.providerState).toBeUndefined();
+      expect(first?.providerState).toEqual({
+        previousProviderSessionIds: ['first-provider-session-id'],
+      });
       expect(later?.sessionId).toBeNull();
-      expect(later?.providerState).toBeUndefined();
+      expect(later?.providerState).toEqual({
+        previousProviderSessionIds: ['later-provider-session-id'],
+      });
       expect(pendingGeneration).toEqual(expect.any(Number));
       expect(plugin.settings.pendingProviderSessionInvalidations.claude)
         .toBeUndefined();
@@ -698,9 +706,13 @@ describe('ClaudianPlugin', () => {
       restartedSaveMetadataSpy.mockRestore();
 
       expect(restartedConversation?.sessionId).toBeNull();
-      expect(restartedConversation?.providerState).toBeUndefined();
+      expect(restartedConversation?.providerState).toEqual({
+        previousProviderSessionIds: ['restart-provider-session-id'],
+      });
       expect(persistedMetadata.sessionId).toBeNull();
-      expect(persistedMetadata).not.toHaveProperty('providerState');
+      expect(persistedMetadata.providerState).toEqual({
+        previousProviderSessionIds: ['restart-provider-session-id'],
+      });
       expect(restartedSettings.pendingProviderSessionInvalidations?.claude).toBeUndefined();
       expect(deferredInvalidationWrites).toHaveLength(1);
     });
@@ -1605,11 +1617,21 @@ describe('ClaudianPlugin', () => {
 
       expect(invalidateSpy).toHaveBeenCalledTimes(1);
       expect(live.sessionId).toBeNull();
-      expect(live.providerState).toBeUndefined();
-      expect(live.resumeAtMessageId).toBeUndefined();
+      expect(live.providerState).toEqual({
+        previousProviderSessionIds: [
+          'live-previous-session',
+          'live-provider-session',
+        ],
+      });
+      expect(live.resumeAtMessageId).toBe('live-resume-message');
       expect(deferred?.sessionId).toBeNull();
-      expect(deferred?.providerState).toBeUndefined();
-      expect(deferred?.resumeAtMessageId).toBeUndefined();
+      expect(deferred?.providerState).toEqual({
+        previousProviderSessionIds: [
+          'deferred-previous-session',
+          'deferred-provider-session',
+        ],
+      });
+      expect(deferred?.resumeAtMessageId).toBe('deferred-resume-message');
       expect(saveMetadataSpy.mock.calls.map(([metadata]) => metadata.id).sort()).toEqual([
         deferredMetadata.id,
         live.id,

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -533,7 +533,7 @@ describe('Tab - Creation', () => {
       const tab = createTab(createMockOptions());
 
       expect(tab.dom.inputEl.getAttribute('placeholder'))
-        .toBe('Ask to make changes, @mention files,  run /commands');
+        .toBe('Ask to make changes, @mention files, run /commands');
     });
 
     it('should use provided tab ID when specified', () => {

--- a/tests/unit/providers/claude/env/ClaudeSettingsReconciler.test.ts
+++ b/tests/unit/providers/claude/env/ClaudeSettingsReconciler.test.ts
@@ -28,6 +28,9 @@ describe('claudeSettingsReconciler', () => {
       expect(result.changed).toBe(true);
       expect(result.invalidatedConversations).toEqual([conversation]);
       expect(conversation.sessionId).toBeNull();
+      expect(conversation.providerState).toEqual({
+        previousProviderSessionIds: ['session-1'],
+      });
       expect(settings.model).toBe('claude-code/claude-opus-4-6');
       expect(getClaudeProviderSettings(settings).environmentHash).toBe(
         'ANTHROPIC_BASE_URL=https://api.example.com',
@@ -54,7 +57,7 @@ describe('claudeSettingsReconciler', () => {
       expect(settings.model).toBe('sonnet');
     });
 
-    it('invalidates only Claude conversations and clears every Claude-owned resume field', () => {
+    it('invalidates only Claude conversations and preserves Claude transcript references', () => {
       const claudeConversation = {
         id: 'claude-conversation',
         providerId: 'claude',
@@ -93,8 +96,9 @@ describe('claudeSettingsReconciler', () => {
 
       expect(result.invalidatedConversations).toEqual([claudeConversation]);
       expect(claudeConversation.sessionId).toBeNull();
-      expect(claudeConversation.resumeAtMessageId).toBeUndefined();
+      expect(claudeConversation.resumeAtMessageId).toBe('assistant-1');
       expect(claudeConversation.providerState).toEqual({
+        previousProviderSessionIds: ['previous-session', 'provider-session'],
         subagentData: { task: { id: 'task' } },
         uiMetadata: { keep: true },
       });
@@ -126,7 +130,81 @@ describe('claudeSettingsReconciler', () => {
       const result = claudeSettingsReconciler.reconcileModelWithEnvironment(settings, [conversation]);
 
       expect(result.invalidatedConversations).toEqual([conversation]);
-      expect(conversation.providerState).toBeUndefined();
+      expect(conversation.providerState).toEqual({
+        previousProviderSessionIds: ['provider-session'],
+      });
+    });
+
+    it('preserves transcript session ids when invalidating resumable Claude state', () => {
+      const conversation = {
+        id: 'claude-history-backed',
+        providerId: 'claude',
+        sessionId: 'legacy-session',
+        resumeAtMessageId: 'assistant-checkpoint',
+        providerState: {
+          providerSessionId: 'current-provider-session',
+          previousProviderSessionIds: ['previous-provider-session'],
+          subagentData: { task: { id: 'task' } },
+        },
+        messages: [],
+      } as unknown as Conversation;
+      const settings: Record<string, unknown> = {
+        model: 'sonnet',
+        providerConfigs: {
+          claude: {
+            environmentVariables: 'ANTHROPIC_BASE_URL=https://api.example.com',
+            environmentHash: '',
+          },
+        },
+      };
+
+      const first = claudeSettingsReconciler.reconcileModelWithEnvironment(
+        settings,
+        [conversation],
+      );
+      const second = claudeSettingsReconciler.invalidateConversationSessions([conversation]);
+
+      expect(first.invalidatedConversations).toEqual([conversation]);
+      expect(second).toEqual([]);
+      expect(conversation).toMatchObject({
+        sessionId: null,
+        resumeAtMessageId: 'assistant-checkpoint',
+        providerState: {
+          previousProviderSessionIds: [
+            'previous-provider-session',
+            'current-provider-session',
+          ],
+          subagentData: { task: { id: 'task' } },
+        },
+      });
+      expect(conversation.providerState).not.toHaveProperty('providerSessionId');
+    });
+
+    it('converts a pending fork into replayable history at the fork checkpoint', () => {
+      const conversation = {
+        id: 'pending-fork',
+        providerId: 'claude',
+        sessionId: null,
+        providerState: {
+          forkSource: {
+            sessionId: 'fork-source-session',
+            resumeAt: 'fork-source-checkpoint',
+          },
+        },
+        messages: [],
+      } as unknown as Conversation;
+
+      const invalidated = claudeSettingsReconciler.invalidateConversationSessions([conversation]);
+
+      expect(invalidated).toEqual([conversation]);
+      expect(conversation).toMatchObject({
+        sessionId: null,
+        resumeAtMessageId: 'fork-source-checkpoint',
+        providerState: {
+          previousProviderSessionIds: ['fork-source-session'],
+        },
+      });
+      expect(conversation.providerState).not.toHaveProperty('forkSource');
     });
 
     it('reconciles the Fable alias to its tier mapping when all tier mappings change', () => {

--- a/tests/unit/providers/claude/history/ClaudeConversationHistoryService.test.ts
+++ b/tests/unit/providers/claude/history/ClaudeConversationHistoryService.test.ts
@@ -17,6 +17,35 @@ function createConversation(overrides: Partial<Conversation> = {}): Conversation
 }
 
 describe('ClaudeConversationHistoryService', () => {
+  describe('legacy conversation backup recovery', () => {
+    it('reads a matching safe session id from the metadata header', () => {
+      const content = [
+        JSON.stringify({
+          type: 'meta',
+          id: 'conversation-1',
+          sessionId: 'recovered-session',
+        }),
+        JSON.stringify({ type: 'message', message: { content: 'History' } }),
+      ].join('\r\n');
+
+      expect(historyStore.parseLegacyConversationSessionId(
+        content,
+        'conversation-1',
+      )).toBe('recovered-session');
+    });
+
+    it.each([
+      ['mismatched conversation', { type: 'meta', id: 'other', sessionId: 'session-1' }],
+      ['cleared session', { type: 'meta', id: 'conversation-1', sessionId: null }],
+      ['unsafe session', { type: 'meta', id: 'conversation-1', sessionId: '../session' }],
+    ])('rejects a %s header', (_label, header) => {
+      expect(historyStore.parseLegacyConversationSessionId(
+        JSON.stringify(header),
+        'conversation-1',
+      )).toBeNull();
+    });
+  });
+
   describe('getConversationSessionAvailability', () => {
     it('reports a missing native session', async () => {
       const availabilitySpy = jest.spyOn(historyStore, 'locateSDKSession')
@@ -227,6 +256,43 @@ describe('ClaudeConversationHistoryService', () => {
   });
 
   describe('hydrateConversationHistory', () => {
+    it('recovers a cleared session pointer from the legacy conversation backup', async () => {
+      const service = new ClaudeConversationHistoryService();
+      const conversation = createConversation({
+        sessionId: null,
+        providerState: undefined,
+      });
+      const legacySpy = jest.spyOn(historyStore, 'readLegacyConversationSessionId')
+        .mockResolvedValue('recovered-session');
+      const locationSpy = jest.spyOn(historyStore, 'locateSDKSessions')
+        .mockResolvedValue(new Map([['recovered-session', {
+          availability: 'available',
+          sessionPath: '/vault/recovered-session.jsonl',
+        }]]));
+      const loadSpy = jest.spyOn(historyStore, 'loadSDKSessionMessages')
+        .mockResolvedValue({
+          messages: [{
+            id: 'recovered-message',
+            role: 'user',
+            content: 'Recovered',
+            timestamp: 1,
+          }],
+          skippedLines: 0,
+        });
+
+      await service.hydrateConversationHistory(conversation, '/vault');
+
+      expect(legacySpy).toHaveBeenCalledWith('/vault', conversation.id);
+      expect(conversation.providerState).toEqual({
+        previousProviderSessionIds: ['recovered-session'],
+      });
+      expect(conversation.messages.map(message => message.content)).toEqual(['Recovered']);
+
+      legacySpy.mockRestore();
+      locationSpy.mockRestore();
+      loadSpy.mockRestore();
+    });
+
     it('re-resolves history when the effective Claude config directory changes', async () => {
       const service = new ClaudeConversationHistoryService();
       const conversation = createConversation();


### PR DESCRIPTION
Prevents Claude environment reconciliation from deleting transcript references across all conversations by moving active session IDs into replayable history while still forcing a cold start on the next send.
Preserves rewind and fork checkpoints and makes invalidation retries idempotent across deferred metadata scans and restarts.
Adds guarded recovery for already-affected v2.0.40 conversations using validated legacy `.claude/sessions/*.jsonl` metadata.
Verified with `npm run typecheck && npm run lint && npm run test && npm run build` (6,887 tests); closes #980.