### PR TITLE
fix: unify Codex linked note context format

### DIFF
--- a/src/providers/codex/prompt/encodeCodexTurn.ts
+++ b/src/providers/codex/prompt/encodeCodexTurn.ts
@@ -1,4 +1,5 @@
 import type { ChatTurnRequest, PreparedChatTurn } from '../../../core/runtime/types';
+import { appendCurrentNote } from '../../../utils/context';
 
 function isCompactCommand(text: string): boolean {
   return /^\/compact(\s|$)/i.test(text);
@@ -17,12 +18,11 @@ export function encodeCodexTurn(request: ChatTurnRequest): PreparedChatTurn {
     };
   }
 
-  const sections: string[] = [];
-  sections.push(request.text);
-
-  if (request.currentNotePath) {
-    sections.push(`\n[Current note: ${request.currentNotePath}]`);
-  }
+  const sections: string[] = [
+    request.currentNotePath
+      ? appendCurrentNote(request.text, request.currentNotePath)
+      : request.text,
+  ];
 
   if (request.editorSelection?.selectedText) {
     sections.push(

--- a/tests/unit/providers/codex/prompt/encodeCodexTurn.test.ts
+++ b/tests/unit/providers/codex/prompt/encodeCodexTurn.test.ts
@@ -20,7 +20,9 @@ describe('encodeCodexTurn', () => {
     };
     const result = encodeCodexTurn(request);
 
-    expect(result.prompt).toContain('[Current note: notes/todo.md]');
+    expect(result.prompt).toBe(
+      'Fix this\n\n<linked_note>\nnotes/todo.md\n</linked_note>'
+    );
     expect(result.persistedContent).toBe('Fix this');
   });
 
@@ -93,7 +95,7 @@ describe('encodeCodexTurn', () => {
     const result = encodeCodexTurn(request);
 
     expect(result.prompt).toContain('Do something');
-    expect(result.prompt).toContain('[Current note: note.md]');
+    expect(result.prompt).toContain('<linked_note>\nnote.md\n</linked_note>');
     expect(result.prompt).toContain('[Editor selection');
     expect(result.prompt).toContain('[Browser selection');
     expect(result.prompt).toContain('[Canvas selection');
@@ -159,7 +161,7 @@ describe('encodeCodexTurn', () => {
 
       expect(result.isCompact).toBe(true);
       expect(result.prompt).toBe('/compact');
-      expect(result.prompt).not.toContain('[Current note');
+      expect(result.prompt).not.toContain('<linked_note>');
       expect(result.prompt).not.toContain('[Editor selection');
       expect(result.prompt).not.toContain('[Browser selection');
       expect(result.prompt).not.toContain('[Canvas selection');


### PR DESCRIPTION
## Summary

- encode Codex linked-note context with the shared `<linked_note>` format
- align Codex input with the documented provider-neutral message contract
- retain legacy bracket-format parsing for existing Codex history

## Verification

- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm test -- --runInBand` (6,887 tests)
- `npm run build`