### PR TITLE
perf: coordinate streaming markdown renders

### DIFF
--- a/src/features/chat/controllers/StreamController.ts
+++ b/src/features/chat/controllers/StreamController.ts
@@ -59,6 +59,7 @@ import {
 import {
   createThinkingBlock,
   finalizeThinkingBlock,
+  type ThinkingBlockState,
 } from '../rendering/ThinkingBlockRenderer';
 import {
   getToolName,
@@ -75,6 +76,7 @@ import {
 import type { SubagentManager } from '../services/SubagentManager';
 import type { ChatState } from '../state/ChatState';
 import type { FileContextManager } from '../ui/FileContext';
+import { StreamingRenderCoordinator } from './StreamingRenderCoordinator';
 
 export interface StreamControllerDeps {
   plugin: FeatureHost;
@@ -90,18 +92,22 @@ export interface StreamControllerDeps {
   persistConversation?: () => Promise<void>;
 }
 
+interface StreamingContentSnapshot {
+  el: HTMLElement;
+  content: string;
+  options?: RenderContentOptions;
+}
+
+const STREAMING_RENDER_MIN_INTERVAL_MS = 150;
+
 export class StreamController {
   private static readonly ASYNC_SUBAGENT_RESULT_RETRY_DELAYS_MS = [200, 600, 1500] as const;
 
   private deps: StreamControllerDeps;
-  private pendingTextRenderFrame: ScheduledAnimationFrame | null = null;
-  private pendingTextRenderPromise: Promise<void> | null = null;
-  private resolvePendingTextRender: (() => void) | null = null;
-  private isTextRenderRunning = false;
-  private pendingThinkingRenderFrame: ScheduledAnimationFrame | null = null;
-  private pendingThinkingRenderPromise: Promise<void> | null = null;
-  private resolvePendingThinkingRender: (() => void) | null = null;
-  private isThinkingRenderRunning = false;
+  private readonly textRenderCoordinator: StreamingRenderCoordinator<StreamingContentSnapshot>;
+  private readonly thinkingRenderCoordinator: StreamingRenderCoordinator<StreamingContentSnapshot>;
+  private tabActive = true;
+  private viewportVisible = true;
   private pendingToolOutputFrames = new Map<string, ScheduledAnimationFrame>();
   private pendingScrollFrame: ScheduledAnimationFrame | null = null;
 
@@ -111,6 +117,37 @@ export class StreamController {
 
   constructor(deps: StreamControllerDeps) {
     this.deps = deps;
+    this.textRenderCoordinator = this.createRenderCoordinator(
+      () => this.getStreamingRenderWindow()
+    );
+    this.thinkingRenderCoordinator = this.createRenderCoordinator(
+      () => this.getThinkingRenderWindow()
+    );
+  }
+
+  private createRenderCoordinator(
+    getOwnerWindow: () => Window | null
+  ): StreamingRenderCoordinator<StreamingContentSnapshot> {
+    return new StreamingRenderCoordinator({
+      getOwnerWindow,
+      minIntervalMs: STREAMING_RENDER_MIN_INTERVAL_MS,
+      render: async ({ el, content, options }) => {
+        if (options) {
+          await this.deps.renderer.renderContent(el, content, options);
+        } else {
+          await this.deps.renderer.renderContent(el, content);
+        }
+        this.scrollToBottom();
+      },
+    });
+  }
+
+  private createStreamingSnapshot(
+    el: HTMLElement,
+    content: string
+  ): StreamingContentSnapshot {
+    const options = this.getStreamingRenderOptions(content);
+    return options ? { el, content, options } : { el, content };
   }
 
   private getActiveProviderId(): ProviderId {
@@ -991,115 +1028,42 @@ export class StreamController {
     this.hideThinkingIndicator();
 
     if (!state.currentTextEl) {
+      this.textRenderCoordinator.cancel();
       state.currentTextEl = state.currentContentEl.createDiv({ cls: 'claudian-text-block' });
       state.currentTextContent = '';
     }
 
     state.currentTextContent += text;
-    void this.scheduleCurrentTextRender();
+    this.textRenderCoordinator.request(
+      this.createStreamingSnapshot(state.currentTextEl, state.currentTextContent)
+    );
   }
 
   async finalizeCurrentTextBlock(msg?: ChatMessage): Promise<void> {
     const { state, renderer } = this.deps;
-    await this.flushPendingTextRender();
-
-    if (msg && state.currentTextContent) {
-      if (
-        state.currentTextEl
-        && this.shouldDeferMathRendering()
-        && hasStreamingMathDelimiters(state.currentTextContent)
-      ) {
-        await renderer.renderContent(state.currentTextEl, state.currentTextContent);
-      }
-      msg.contentBlocks = msg.contentBlocks || [];
-      msg.contentBlocks.push({ type: 'text', content: state.currentTextContent });
-      // Copy button added here (not during streaming) to match history-loaded messages
-      if (state.currentTextEl) {
-        renderer.addTextCopyButton(state.currentTextEl, state.currentTextContent);
-      }
-    }
-    state.currentTextEl = null;
-    state.currentTextContent = '';
-  }
-
-  private scheduleCurrentTextRender(): Promise<void> {
-    if (!this.pendingTextRenderPromise) {
-      this.pendingTextRenderPromise = new Promise(resolve => {
-        this.resolvePendingTextRender = resolve;
-      });
-    }
-
-    if (this.pendingTextRenderFrame === null && !this.isTextRenderRunning) {
-      this.pendingTextRenderFrame = scheduleAnimationFrame(() => {
-        this.pendingTextRenderFrame = null;
-        void this.renderPendingText();
-      }, this.getStreamingRenderWindow());
-    }
-
-    return this.pendingTextRenderPromise;
-  }
-
-  private async flushPendingTextRender(): Promise<void> {
-    const pendingRender = this.pendingTextRenderPromise;
-    if (!pendingRender) return;
-
-    if (this.pendingTextRenderFrame !== null) {
-      cancelScheduledAnimationFrame(this.pendingTextRenderFrame);
-      this.pendingTextRenderFrame = null;
-      void this.renderPendingText();
-    }
-
-    await pendingRender;
-  }
-
-  private async renderPendingText(): Promise<void> {
-    if (this.isTextRenderRunning) return;
-    this.isTextRenderRunning = true;
-
-    const { state, renderer } = this.deps;
     const textEl = state.currentTextEl;
     const content = state.currentTextContent;
 
-    try {
+    if (
+      textEl
+      && this.shouldDeferMathRendering()
+      && hasStreamingMathDelimiters(content)
+    ) {
+      this.textRenderCoordinator.request({ el: textEl, content });
+    }
+    await this.textRenderCoordinator.flush();
+
+    if (msg && content) {
+      msg.contentBlocks = msg.contentBlocks || [];
+      msg.contentBlocks.push({ type: 'text', content });
+      // Copy button added here (not during streaming) to match history-loaded messages
       if (textEl) {
-        const options = this.getStreamingRenderOptions(content);
-        if (options) {
-          await renderer.renderContent(textEl, content, options);
-        } else {
-          await renderer.renderContent(textEl, content);
-        }
-        this.scrollToBottom();
+        renderer.addTextCopyButton(textEl, content);
       }
-    } catch {
-      // MessageRenderer owns user-visible render fallback; keep stream state moving.
-    } finally {
-      this.isTextRenderRunning = false;
     }
-
-    if (state.currentTextEl === textEl && state.currentTextContent !== content) {
-      this.pendingTextRenderFrame = scheduleAnimationFrame(() => {
-        this.pendingTextRenderFrame = null;
-        void this.renderPendingText();
-      }, this.getStreamingRenderWindow());
-      return;
-    }
-
-    const resolve = this.resolvePendingTextRender;
-    this.pendingTextRenderPromise = null;
-    this.resolvePendingTextRender = null;
-    resolve?.();
-  }
-
-  private cancelPendingTextRender(): void {
-    if (this.pendingTextRenderFrame !== null) {
-      cancelScheduledAnimationFrame(this.pendingTextRenderFrame);
-      this.pendingTextRenderFrame = null;
-    }
-
-    const resolve = this.resolvePendingTextRender;
-    this.pendingTextRenderPromise = null;
-    this.resolvePendingTextRender = null;
-    resolve?.();
+    this.textRenderCoordinator.cancel();
+    state.currentTextEl = null;
+    state.currentTextContent = '';
   }
 
   private scheduleToolOutputRender(toolId: string, toolCall: ToolCallInfo): void {
@@ -1133,30 +1097,42 @@ export class StreamController {
   // ============================================
 
   async appendThinking(content: string): Promise<void> {
-    const { state, renderer } = this.deps;
+    const { state } = this.deps;
     if (!state.currentContentEl) return;
 
     this.hideThinkingIndicator();
     if (!state.currentThinkingState) {
-      state.currentThinkingState = createThinkingBlock(
-        state.currentContentEl,
-        (el, md) => renderer.renderContent(el, md)
-      );
+      this.thinkingRenderCoordinator.cancel();
+      const thinkingState = createThinkingBlock(state.currentContentEl, {
+        onToggle: (isExpanded) => {
+          this.handleThinkingToggle(thinkingState, isExpanded);
+        },
+      });
+      state.currentThinkingState = thinkingState;
+      this.syncThinkingRenderAvailability();
     }
 
     state.currentThinkingState.content += content;
-    void this.scheduleCurrentThinkingRender();
+    this.thinkingRenderCoordinator.request(
+      this.createStreamingSnapshot(
+        state.currentThinkingState.contentEl,
+        state.currentThinkingState.content
+      )
+    );
   }
 
   async finalizeCurrentThinkingBlock(msg?: ChatMessage): Promise<void> {
-    const { state, renderer } = this.deps;
+    const { state } = this.deps;
     if (!state.currentThinkingState) return;
-    await this.flushPendingThinkingRender();
 
     const thinkingState = state.currentThinkingState;
     if (this.getStreamingRenderOptions(thinkingState.content)) {
-      await renderer.renderContent(thinkingState.contentEl, thinkingState.content);
+      this.thinkingRenderCoordinator.request({
+        el: thinkingState.contentEl,
+        content: thinkingState.content,
+      });
     }
+    await this.thinkingRenderCoordinator.flush();
 
     const durationSeconds = finalizeThinkingBlock(thinkingState);
 
@@ -1170,86 +1146,17 @@ export class StreamController {
     }
 
     state.currentThinkingState = null;
+    this.thinkingRenderCoordinator.cancel();
   }
 
-  private scheduleCurrentThinkingRender(): Promise<void> {
-    if (!this.pendingThinkingRenderPromise) {
-      this.pendingThinkingRenderPromise = new Promise(resolve => {
-        this.resolvePendingThinkingRender = resolve;
-      });
-    }
+  private handleThinkingToggle(
+    thinkingState: ThinkingBlockState,
+    isExpanded: boolean
+  ): void {
+    if (this.deps.state.currentThinkingState !== thinkingState) return;
 
-    if (this.pendingThinkingRenderFrame === null && !this.isThinkingRenderRunning) {
-      this.pendingThinkingRenderFrame = scheduleAnimationFrame(() => {
-        this.pendingThinkingRenderFrame = null;
-        void this.renderPendingThinking();
-      }, this.getThinkingRenderWindow());
-    }
-
-    return this.pendingThinkingRenderPromise;
-  }
-
-  private async flushPendingThinkingRender(): Promise<void> {
-    const pendingRender = this.pendingThinkingRenderPromise;
-    if (!pendingRender) return;
-
-    if (this.pendingThinkingRenderFrame !== null) {
-      cancelScheduledAnimationFrame(this.pendingThinkingRenderFrame);
-      this.pendingThinkingRenderFrame = null;
-      void this.renderPendingThinking();
-    }
-
-    await pendingRender;
-  }
-
-  private async renderPendingThinking(): Promise<void> {
-    if (this.isThinkingRenderRunning) return;
-    this.isThinkingRenderRunning = true;
-
-    const { state, renderer } = this.deps;
-    const thinkingState = state.currentThinkingState;
-    const content = thinkingState?.content ?? '';
-
-    try {
-      if (thinkingState) {
-        const options = this.getStreamingRenderOptions(content);
-        if (options) {
-          await renderer.renderContent(thinkingState.contentEl, content, options);
-        } else {
-          await renderer.renderContent(thinkingState.contentEl, content);
-        }
-        this.scrollToBottom();
-      }
-    } catch {
-      // MessageRenderer owns user-visible render fallback; keep stream state moving.
-    } finally {
-      this.isThinkingRenderRunning = false;
-    }
-
-    if (state.currentThinkingState === thinkingState && thinkingState && thinkingState.content !== content) {
-      this.pendingThinkingRenderFrame = scheduleAnimationFrame(() => {
-        this.pendingThinkingRenderFrame = null;
-        void this.renderPendingThinking();
-      }, this.getThinkingRenderWindow());
-      return;
-    }
-
-    const resolve = this.resolvePendingThinkingRender;
-    this.pendingThinkingRenderPromise = null;
-    this.resolvePendingThinkingRender = null;
-    resolve?.();
-  }
-
-  private cancelPendingThinkingRender(): void {
-    if (this.pendingThinkingRenderFrame !== null) {
-      cancelScheduledAnimationFrame(this.pendingThinkingRenderFrame);
-      this.pendingThinkingRenderFrame = null;
-    }
-
-    const resolve = this.resolvePendingThinkingRender;
-    this.pendingThinkingRenderPromise = null;
-    this.resolvePendingThinkingRender = null;
-    resolve?.();
+    thinkingState.isExpanded = isExpanded;
+    this.syncThinkingRenderAvailability();
   }
 
   // ============================================
@@ -1914,6 +1821,29 @@ export class StreamController {
     this.pendingScrollFrame = null;
   }
 
+  setTabActive(active: boolean): void {
+    this.tabActive = active;
+    this.syncRenderAvailability();
+  }
+
+  setViewportVisible(visible: boolean): void {
+    this.viewportVisible = visible;
+    this.syncRenderAvailability();
+  }
+
+  private syncRenderAvailability(): void {
+    const visible = this.tabActive && this.viewportVisible;
+    this.textRenderCoordinator.setAvailable(visible);
+    this.syncThinkingRenderAvailability();
+  }
+
+  private syncThinkingRenderAvailability(): void {
+    const thinkingExpanded = this.deps.state.currentThinkingState?.isExpanded === true;
+    this.thinkingRenderCoordinator.setAvailable(
+      this.tabActive && this.viewportVisible && thinkingExpanded
+    );
+  }
+
   private getMessagesWindow(): Window | null {
     return this.deps.getMessagesEl().ownerDocument.defaultView ?? null;
   }
@@ -1934,8 +1864,8 @@ export class StreamController {
 
   resetStreamingState(): void {
     const { state } = this.deps;
-    this.cancelPendingTextRender();
-    this.cancelPendingThinkingRender();
+    this.textRenderCoordinator.cancel();
+    this.thinkingRenderCoordinator.cancel();
     this.cancelPendingToolOutputRenders();
     this.cancelPendingScroll();
     this.hideThinkingIndicator();
@@ -1949,6 +1879,13 @@ export class StreamController {
     state.pendingTools.clear();
     // Reset response timer (duration already captured at this point)
     state.responseStartTime = null;
+  }
+
+  dispose(): void {
+    this.textRenderCoordinator.dispose();
+    this.thinkingRenderCoordinator.dispose();
+    this.cancelPendingToolOutputRenders();
+    this.cancelPendingScroll();
   }
 }
 

--- a/src/features/chat/controllers/StreamingRenderCoordinator.ts
+++ b/src/features/chat/controllers/StreamingRenderCoordinator.ts
@@ -1,0 +1,213 @@
+import {
+  cancelScheduledAnimationFrame,
+  scheduleAnimationFrame,
+  type ScheduledAnimationFrame,
+  scheduleDelayedFrame,
+} from '../../../utils/animationFrame';
+
+export interface StreamingRenderCoordinatorOptions<TSnapshot> {
+  render: (snapshot: TSnapshot) => Promise<void>;
+  getOwnerWindow: () => Window | null;
+  minIntervalMs: number;
+}
+
+interface RenderWaiter {
+  version: number;
+  resolve: () => void;
+}
+
+export class StreamingRenderCoordinator<TSnapshot> {
+  private readonly render: (snapshot: TSnapshot) => Promise<void>;
+  private readonly getOwnerWindow: () => Window | null;
+  private readonly minIntervalMs: number;
+
+  private latestSnapshot: TSnapshot | null = null;
+  private requestedVersion = 0;
+  private renderedVersion = 0;
+  private forceThroughVersion = 0;
+  private lastRenderCompletedAt = Number.NEGATIVE_INFINITY;
+  private scheduledFrame: ScheduledAnimationFrame | null = null;
+  private renderRunning = false;
+  private available = true;
+  private bypassThrottle = false;
+  private generation = 0;
+  private disposed = false;
+  private waiters: RenderWaiter[] = [];
+
+  constructor(options: StreamingRenderCoordinatorOptions<TSnapshot>) {
+    this.render = options.render;
+    this.getOwnerWindow = options.getOwnerWindow;
+    this.minIntervalMs = options.minIntervalMs;
+  }
+
+  request(snapshot: TSnapshot): void {
+    if (this.disposed) return;
+
+    this.latestSnapshot = snapshot;
+    this.requestedVersion += 1;
+    this.schedule();
+  }
+
+  setAvailable(available: boolean): void {
+    if (this.disposed || this.available === available) return;
+
+    this.available = available;
+    if (!available) {
+      if (this.forceThroughVersion <= this.renderedVersion) {
+        this.cancelScheduledFrame();
+      }
+      return;
+    }
+
+    this.schedule(true);
+  }
+
+  async flush(): Promise<void> {
+    if (this.disposed || this.requestedVersion <= this.renderedVersion) return;
+
+    const targetVersion = this.requestedVersion;
+    this.forceThroughVersion = Math.max(this.forceThroughVersion, targetVersion);
+    this.bypassThrottle = true;
+    this.cancelScheduledFrame();
+
+    const completion = this.waitForVersion(targetVersion);
+    if (!this.renderRunning) {
+      void this.runRender();
+    }
+    await completion;
+  }
+
+  cancel(): void {
+    this.generation += 1;
+    this.cancelScheduledFrame();
+    this.latestSnapshot = null;
+    this.requestedVersion = 0;
+    this.renderedVersion = 0;
+    this.forceThroughVersion = 0;
+    this.lastRenderCompletedAt = Number.NEGATIVE_INFINITY;
+    this.bypassThrottle = false;
+    this.resolveAllWaiters();
+  }
+
+  dispose(): void {
+    this.cancel();
+    this.disposed = true;
+  }
+
+  private schedule(bypassThrottle = false): void {
+    if (this.disposed || this.renderRunning || this.scheduledFrame) return;
+    if (!this.latestSnapshot || this.requestedVersion <= this.renderedVersion) return;
+
+    const forcePending = this.forceThroughVersion > this.renderedVersion;
+    if (!this.available && !forcePending) return;
+
+    this.bypassThrottle ||= bypassThrottle;
+    const ownerWindow = this.getOwnerWindow();
+    if (!ownerWindow) {
+      void this.runRender();
+      return;
+    }
+
+    this.scheduledFrame = scheduleAnimationFrame(() => {
+      this.scheduledFrame = null;
+      void this.runRender();
+    }, ownerWindow);
+  }
+
+  private async runRender(): Promise<void> {
+    if (this.disposed || this.renderRunning) return;
+    if (!this.latestSnapshot || this.requestedVersion <= this.renderedVersion) {
+      this.resolveCompletedWaiters();
+      return;
+    }
+
+    const forcePending = this.forceThroughVersion > this.renderedVersion;
+    if (!this.available && !forcePending) return;
+
+    const throttleWait = this.minIntervalMs - (Date.now() - this.lastRenderCompletedAt);
+    if (!forcePending && !this.bypassThrottle && throttleWait > 0) {
+      const ownerWindow = this.getOwnerWindow();
+      if (!ownerWindow) {
+        this.bypassThrottle = true;
+        void this.runRender();
+        return;
+      }
+
+      this.scheduledFrame = scheduleDelayedFrame(() => {
+        this.scheduledFrame = null;
+        this.schedule();
+      }, throttleWait, ownerWindow);
+      return;
+    }
+
+    this.bypassThrottle = false;
+    const snapshot = this.latestSnapshot;
+    const version = this.requestedVersion;
+    const renderGeneration = this.generation;
+    this.renderRunning = true;
+
+    try {
+      await this.render(snapshot);
+    } catch {
+      // Rendering owns user-visible fallback. Treat the snapshot as consumed so
+      // a renderer failure cannot stall stream finalization.
+    } finally {
+      this.renderRunning = false;
+    }
+
+    if (renderGeneration !== this.generation) {
+      this.schedule(true);
+      return;
+    }
+
+    this.renderedVersion = Math.max(this.renderedVersion, version);
+    this.lastRenderCompletedAt = Date.now();
+    if (this.forceThroughVersion <= this.renderedVersion) {
+      this.forceThroughVersion = 0;
+    }
+    this.resolveCompletedWaiters();
+
+    if (this.requestedVersion > this.renderedVersion) {
+      if (this.forceThroughVersion > this.renderedVersion) {
+        void this.runRender();
+      } else {
+        this.schedule();
+      }
+    }
+  }
+
+  private waitForVersion(version: number): Promise<void> {
+    if (version <= this.renderedVersion) return Promise.resolve();
+
+    return new Promise(resolve => {
+      this.waiters.push({ version, resolve });
+    });
+  }
+
+  private resolveCompletedWaiters(): void {
+    const pending: RenderWaiter[] = [];
+    for (const waiter of this.waiters) {
+      if (waiter.version <= this.renderedVersion) {
+        waiter.resolve();
+      } else {
+        pending.push(waiter);
+      }
+    }
+    this.waiters = pending;
+  }
+
+  private resolveAllWaiters(): void {
+    const waiters = this.waiters;
+    this.waiters = [];
+    for (const waiter of waiters) {
+      waiter.resolve();
+    }
+  }
+
+  private cancelScheduledFrame(): void {
+    if (!this.scheduledFrame) return;
+
+    cancelScheduledAnimationFrame(this.scheduledFrame);
+    this.scheduledFrame = null;
+  }
+}

--- a/src/features/chat/rendering/ThinkingBlockRenderer.ts
+++ b/src/features/chat/rendering/ThinkingBlockRenderer.ts
@@ -12,9 +12,13 @@ export interface ThinkingBlockState {
   isExpanded: boolean;
 }
 
+export interface ThinkingBlockOptions {
+  onToggle?: (isExpanded: boolean) => void;
+}
+
 export function createThinkingBlock(
   parentEl: HTMLElement,
-  renderContent: RenderContentFn
+  options: ThinkingBlockOptions = {},
 ): ThinkingBlockState {
   const wrapperEl = parentEl.createDiv({ cls: 'claudian-thinking-block' });
 
@@ -50,8 +54,9 @@ export function createThinkingBlock(
     isExpanded: false,
   };
 
-  // Setup collapsible behavior (handles click, keyboard, ARIA, CSS)
-  setupCollapsible(wrapperEl, header, contentEl, state);
+  setupCollapsible(wrapperEl, header, contentEl, state, {
+    onToggle: options.onToggle,
+  });
 
   return state;
 }

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -1593,6 +1593,20 @@ export function initializeTabControllers(
       }
     },
   });
+  tab.controllers.streamController.setTabActive(
+    !dom.contentEl.hasClass('claudian-hidden')
+  );
+
+  const renderWindow = dom.messagesEl.ownerDocument.defaultView;
+  const IntersectionObserverConstructor = renderWindow?.IntersectionObserver;
+  if (IntersectionObserverConstructor) {
+    const renderVisibilityObserver = new IntersectionObserverConstructor((entries) => {
+      const entry = entries.find(candidate => candidate.target === dom.messagesEl) ?? entries[0];
+      tab.controllers.streamController?.setViewportVisible(entry?.isIntersecting ?? true);
+    });
+    renderVisibilityObserver.observe(dom.messagesEl);
+    dom.eventCleanups.push(() => renderVisibilityObserver.disconnect());
+  }
 
   // Wire subagent callback now that StreamController exists
   // DOM updates for async subagents are handled by SubagentManager directly;
@@ -1883,6 +1897,7 @@ export function wireTabInputEvents(tab: TabData, plugin: FeatureHost): void {
  */
 export function activateTab(tab: TabData): void {
   tab.dom.contentEl.removeClass('claudian-hidden');
+  tab.controllers.streamController?.setTabActive(true);
   tab.controllers.selectionController?.start();
   tab.controllers.browserSelectionController?.start();
   tab.controllers.canvasSelectionController?.start();
@@ -1894,6 +1909,7 @@ export function activateTab(tab: TabData): void {
  * Deactivates a tab (hides it and stops services).
  */
 export function deactivateTab(tab: TabData): void {
+  tab.controllers.streamController?.setTabActive(false);
   tab.dom.contentEl.addClass('claudian-hidden');
   tab.controllers.selectionController?.stop();
   tab.controllers.browserSelectionController?.stop();
@@ -1998,6 +2014,7 @@ export async function destroyTab(tab: TabData): Promise<void> {
   tab.ui.statusPanel = null;
   tab.ui.navigationSidebar?.destroy();
   tab.ui.navigationSidebar = null;
+  tab.controllers.streamController?.dispose();
 
   for (const cleanup of tab.dom.eventCleanups) {
     cleanup();

--- a/src/utils/animationFrame.ts
+++ b/src/utils/animationFrame.ts
@@ -33,6 +33,24 @@ export function scheduleAnimationFrame(
   };
 }
 
+export function scheduleDelayedFrame(
+  callback: () => void,
+  delayMs: number,
+  ownerWindow: Window | null = getRendererWindow(),
+): ScheduledAnimationFrame {
+  const targetWindow = ownerWindow ?? getRendererWindow();
+  if (!targetWindow) {
+    callback();
+    return { kind: 'timeout', id: 0, ownerWindow: null };
+  }
+
+  return {
+    kind: 'timeout',
+    id: targetWindow.setTimeout(callback, delayMs),
+    ownerWindow: targetWindow,
+  };
+}
+
 export function cancelScheduledAnimationFrame(frame: ScheduledAnimationFrame): void {
   const targetWindow = frame.ownerWindow ?? getRendererWindow();
   if (!targetWindow) return;

--- a/tests/unit/features/chat/controllers/StreamController.test.ts
+++ b/tests/unit/features/chat/controllers/StreamController.test.ts
@@ -41,11 +41,14 @@ jest.mock('@/features/chat/rendering/SubagentRenderer', () => ({
 
 jest.mock('@/features/chat/rendering/ThinkingBlockRenderer', () => ({
   appendThinkingContent: jest.fn(),
-  createThinkingBlock: jest.fn().mockImplementation(() => ({
-    container: {},
+  createThinkingBlock: jest.fn().mockImplementation((_parentEl, options) => ({
+    wrapperEl: {},
     contentEl: {},
+    labelEl: {},
     content: '',
     startTime: Date.now(),
+    isExpanded: false,
+    onToggle: options?.onToggle,
   })),
   finalizeThinkingBlock: jest.fn().mockReturnValue(0),
 }));
@@ -283,6 +286,65 @@ describe('StreamController - Text Content', () => {
       );
     });
 
+    it('should throttle successive streaming text renders', async () => {
+      deps.state.currentTextEl = createMockEl();
+
+      await controller.appendText('First');
+      jest.advanceTimersByTime(16);
+      await Promise.resolve();
+      expect(deps.renderer.renderContent).toHaveBeenCalledTimes(1);
+
+      await controller.appendText(' second');
+      jest.advanceTimersByTime(16);
+      await Promise.resolve();
+      expect(deps.renderer.renderContent).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(150);
+      await Promise.resolve();
+      expect(deps.renderer.renderContent).toHaveBeenCalledTimes(2);
+      expect(deps.renderer.renderContent).toHaveBeenLastCalledWith(
+        deps.state.currentTextEl,
+        'First second'
+      );
+    });
+
+    it('should catch up with the latest text when a hidden tab becomes active', async () => {
+      deps.state.currentTextEl = createMockEl();
+      controller.setTabActive(false);
+
+      await controller.appendText('Hidden ');
+      await controller.appendText('content');
+      jest.advanceTimersByTime(500);
+      await Promise.resolve();
+
+      expect(deps.renderer.renderContent).not.toHaveBeenCalled();
+
+      controller.setTabActive(true);
+      jest.advanceTimersByTime(16);
+      await Promise.resolve();
+
+      expect(deps.renderer.renderContent).toHaveBeenCalledTimes(1);
+      expect(deps.renderer.renderContent).toHaveBeenCalledWith(
+        deps.state.currentTextEl,
+        'Hidden content'
+      );
+    });
+
+    it('should force the final text render while its viewport is hidden', async () => {
+      const msg = createTestMessage();
+      deps.state.currentTextEl = createMockEl();
+      controller.setViewportVisible(false);
+
+      await controller.appendText('Final hidden content');
+      await controller.finalizeCurrentTextBlock(msg);
+
+      expect(deps.renderer.renderContent).toHaveBeenCalledTimes(1);
+      expect(deps.renderer.renderContent).toHaveBeenCalledWith(
+        expect.anything(),
+        'Final hidden content'
+      );
+    });
+
     it('should defer math rendering during live text renders', async () => {
       deps.state.currentTextEl = createMockEl();
 
@@ -348,7 +410,7 @@ describe('StreamController - Text Content', () => {
       });
     });
 
-    it('should render original math once when finalizing a deferred text block', async () => {
+    it('should coalesce a pending deferred render into the final math render', async () => {
       const msg = createTestMessage();
 
       await controller.appendText('Final $x^2$');
@@ -357,14 +419,9 @@ describe('StreamController - Text Content', () => {
       expect(deps.renderer.renderContent).toHaveBeenNthCalledWith(
         1,
         expect.anything(),
-        'Final $x^2$',
-        { deferMath: true }
-      );
-      expect(deps.renderer.renderContent).toHaveBeenNthCalledWith(
-        2,
-        expect.anything(),
         'Final $x^2$'
       );
+      expect(deps.renderer.renderContent).toHaveBeenCalledTimes(1);
       expect(deps.renderer.addTextCopyButton).toHaveBeenCalledWith(
         expect.anything(),
         'Final $x^2$'
@@ -1606,6 +1663,7 @@ describe('StreamController - Text Content', () => {
         labelEl: createMockEl(),
         content: '',
         startTime: Date.now(),
+        isExpanded: true,
       });
 
       await controller.handleStreamChunk({ type: 'thinking', content: 'Let ' }, msg);
@@ -1630,6 +1688,7 @@ describe('StreamController - Text Content', () => {
         labelEl: createMockEl(),
         content: '',
         startTime: Date.now(),
+        isExpanded: true,
       });
 
       await controller.handleStreamChunk({ type: 'thinking', content: 'Reasoning $x^2$' }, msg);
@@ -1644,7 +1703,7 @@ describe('StreamController - Text Content', () => {
       );
     });
 
-    it('should render original math once when finalizing a deferred thinking block', async () => {
+    it('should render original math once when finalizing a collapsed thinking block', async () => {
       const { createThinkingBlock } = jest.requireMock('@/features/chat/rendering/ThinkingBlockRenderer');
       const msg = createTestMessage();
       const contentEl = createMockEl();
@@ -1654,9 +1713,39 @@ describe('StreamController - Text Content', () => {
         labelEl: createMockEl(),
         content: '',
         startTime: Date.now(),
+        isExpanded: false,
       });
 
       await controller.handleStreamChunk({ type: 'thinking', content: 'Reasoning $x^2$' }, msg);
+      await controller.finalizeCurrentThinkingBlock(msg);
+
+      expect(deps.renderer.renderContent).toHaveBeenNthCalledWith(
+        1,
+        contentEl,
+        'Reasoning $x^2$'
+      );
+      expect(deps.renderer.renderContent).toHaveBeenCalledTimes(1);
+      expect(msg.contentBlocks).toContainEqual(
+        expect.objectContaining({ type: 'thinking', content: 'Reasoning $x^2$' })
+      );
+    });
+
+    it('should replace deferred math when finalizing an expanded thinking block', async () => {
+      const { createThinkingBlock } = jest.requireMock('@/features/chat/rendering/ThinkingBlockRenderer');
+      const msg = createTestMessage();
+      const contentEl = createMockEl();
+      createThinkingBlock.mockReturnValueOnce({
+        wrapperEl: createMockEl(),
+        contentEl,
+        labelEl: createMockEl(),
+        content: '',
+        startTime: Date.now(),
+        isExpanded: true,
+      });
+
+      await controller.handleStreamChunk({ type: 'thinking', content: 'Reasoning $x^2$' }, msg);
+      jest.advanceTimersByTime(16);
+      await Promise.resolve();
       await controller.finalizeCurrentThinkingBlock(msg);
 
       expect(deps.renderer.renderContent).toHaveBeenNthCalledWith(
@@ -1670,8 +1759,66 @@ describe('StreamController - Text Content', () => {
         contentEl,
         'Reasoning $x^2$'
       );
-      expect(msg.contentBlocks).toContainEqual(
-        expect.objectContaining({ type: 'thinking', content: 'Reasoning $x^2$' })
+    });
+
+    it('should skip live renders while thinking is collapsed', async () => {
+      const { createThinkingBlock } = jest.requireMock('@/features/chat/rendering/ThinkingBlockRenderer');
+      const msg = createTestMessage();
+      const contentEl = createMockEl();
+      createThinkingBlock.mockReturnValueOnce({
+        wrapperEl: createMockEl(),
+        contentEl,
+        labelEl: createMockEl(),
+        content: '',
+        startTime: Date.now(),
+        isExpanded: false,
+      });
+
+      await controller.handleStreamChunk({ type: 'thinking', content: 'Hidden ' }, msg);
+      await controller.handleStreamChunk({ type: 'thinking', content: 'reasoning' }, msg);
+      jest.advanceTimersByTime(500);
+      await Promise.resolve();
+
+      expect(deps.renderer.renderContent).not.toHaveBeenCalled();
+
+      await controller.finalizeCurrentThinkingBlock(msg);
+
+      expect(deps.renderer.renderContent).toHaveBeenCalledTimes(1);
+      expect(deps.renderer.renderContent).toHaveBeenCalledWith(contentEl, 'Hidden reasoning');
+    });
+
+    it('should render accumulated thinking through the coordinator when expanded', async () => {
+      const { createThinkingBlock } = jest.requireMock('@/features/chat/rendering/ThinkingBlockRenderer');
+      const msg = createTestMessage();
+      const contentEl = createMockEl();
+      const thinkingState: Record<string, any> = {
+        wrapperEl: createMockEl(),
+        contentEl,
+        labelEl: createMockEl(),
+        content: '',
+        startTime: Date.now(),
+        isExpanded: false,
+      };
+      let onToggle: ((isExpanded: boolean) => void) | undefined;
+      createThinkingBlock.mockImplementationOnce((_parentEl: HTMLElement, options: any) => {
+        onToggle = options.onToggle;
+        return thinkingState;
+      });
+
+      await controller.handleStreamChunk({ type: 'thinking', content: 'Deferred reasoning' }, msg);
+      jest.advanceTimersByTime(500);
+      await Promise.resolve();
+      expect(deps.renderer.renderContent).not.toHaveBeenCalled();
+
+      thinkingState.isExpanded = true;
+      onToggle?.(true);
+      jest.advanceTimersByTime(16);
+      await Promise.resolve();
+
+      expect(deps.renderer.renderContent).toHaveBeenCalledTimes(1);
+      expect(deps.renderer.renderContent).toHaveBeenCalledWith(
+        contentEl,
+        'Deferred reasoning'
       );
     });
 

--- a/tests/unit/features/chat/controllers/StreamingRenderCoordinator.test.ts
+++ b/tests/unit/features/chat/controllers/StreamingRenderCoordinator.test.ts
@@ -1,0 +1,194 @@
+import { StreamingRenderCoordinator } from '@/features/chat/controllers/StreamingRenderCoordinator';
+
+interface Deferred {
+  promise: Promise<void>;
+  resolve: () => void;
+}
+
+function createDeferred(): Deferred {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('StreamingRenderCoordinator', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('coalesces requests and never overlaps asynchronous renders', async () => {
+    const firstRender = createDeferred();
+    const secondRender = createDeferred();
+    let activeRenders = 0;
+    let maxActiveRenders = 0;
+    const render = jest.fn(async (content: string) => {
+      activeRenders += 1;
+      maxActiveRenders = Math.max(maxActiveRenders, activeRenders);
+      await (render.mock.calls.length === 1 ? firstRender.promise : secondRender.promise);
+      activeRenders -= 1;
+    });
+    const coordinator = new StreamingRenderCoordinator<string>({
+      render,
+      getOwnerWindow: () => window,
+      minIntervalMs: 0,
+    });
+
+    coordinator.request('first');
+    jest.advanceTimersByTime(16);
+    await flushMicrotasks();
+
+    coordinator.request('second');
+    coordinator.request('latest');
+    jest.advanceTimersByTime(100);
+    await flushMicrotasks();
+
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(render).toHaveBeenNthCalledWith(1, 'first');
+
+    firstRender.resolve();
+    await flushMicrotasks();
+    jest.advanceTimersByTime(16);
+    await flushMicrotasks();
+
+    expect(render).toHaveBeenCalledTimes(2);
+    expect(render).toHaveBeenNthCalledWith(2, 'latest');
+    expect(maxActiveRenders).toBe(1);
+
+    secondRender.resolve();
+    await flushMicrotasks();
+  });
+
+  it('throttles successive renders using the latest requested snapshot', async () => {
+    const render = jest.fn().mockResolvedValue(undefined);
+    const coordinator = new StreamingRenderCoordinator<string>({
+      render,
+      getOwnerWindow: () => window,
+      minIntervalMs: 150,
+    });
+
+    coordinator.request('first');
+    jest.advanceTimersByTime(16);
+    await flushMicrotasks();
+
+    coordinator.request('second');
+    coordinator.request('latest');
+    jest.advanceTimersByTime(149);
+    await flushMicrotasks();
+
+    expect(render).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(17);
+    await flushMicrotasks();
+
+    expect(render).toHaveBeenCalledTimes(2);
+    expect(render).toHaveBeenLastCalledWith('latest');
+  });
+
+  it('retains dirty content while unavailable and catches up when revealed', async () => {
+    const render = jest.fn().mockResolvedValue(undefined);
+    const coordinator = new StreamingRenderCoordinator<string>({
+      render,
+      getOwnerWindow: () => window,
+      minIntervalMs: 150,
+    });
+
+    coordinator.setAvailable(false);
+    coordinator.request('hidden');
+    coordinator.request('latest hidden');
+    jest.advanceTimersByTime(1000);
+    await flushMicrotasks();
+
+    expect(render).not.toHaveBeenCalled();
+
+    coordinator.setAvailable(true);
+    jest.advanceTimersByTime(16);
+    await flushMicrotasks();
+
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(render).toHaveBeenCalledWith('latest hidden');
+  });
+
+  it('flushes the latest snapshot immediately even while unavailable', async () => {
+    const render = jest.fn().mockResolvedValue(undefined);
+    const coordinator = new StreamingRenderCoordinator<string>({
+      render,
+      getOwnerWindow: () => window,
+      minIntervalMs: 150,
+    });
+
+    coordinator.setAvailable(false);
+    coordinator.request('final content');
+
+    await coordinator.flush();
+
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(render).toHaveBeenCalledWith('final content');
+  });
+
+  it('runs a forced trailing render without waiting for a hidden animation frame', async () => {
+    const firstRender = createDeferred();
+    const render = jest.fn((content: string) => (
+      content === 'streaming' ? firstRender.promise : Promise.resolve()
+    ));
+    const coordinator = new StreamingRenderCoordinator<string>({
+      render,
+      getOwnerWindow: () => window,
+      minIntervalMs: 150,
+    });
+
+    coordinator.request('streaming');
+    jest.advanceTimersByTime(16);
+    await flushMicrotasks();
+
+    coordinator.setAvailable(false);
+    coordinator.request('final');
+    const flush = coordinator.flush();
+    firstRender.resolve();
+
+    await flush;
+
+    expect(render).toHaveBeenNthCalledWith(1, 'streaming');
+    expect(render).toHaveBeenNthCalledWith(2, 'final');
+  });
+
+  it('cancels scheduled work without rendering stale content', async () => {
+    const render = jest.fn().mockResolvedValue(undefined);
+    const coordinator = new StreamingRenderCoordinator<string>({
+      render,
+      getOwnerWindow: () => window,
+      minIntervalMs: 150,
+    });
+
+    coordinator.request('stale');
+    coordinator.cancel();
+    jest.advanceTimersByTime(1000);
+    await flushMicrotasks();
+
+    expect(render).not.toHaveBeenCalled();
+  });
+
+  it('does not stall flush when the renderer rejects', async () => {
+    const render = jest.fn().mockRejectedValue(new Error('render failed'));
+    const coordinator = new StreamingRenderCoordinator<string>({
+      render,
+      getOwnerWindow: () => window,
+      minIntervalMs: 150,
+    });
+
+    coordinator.request('content');
+
+    await expect(coordinator.flush()).resolves.toBeUndefined();
+    expect(render).toHaveBeenCalledWith('content');
+  });
+});

--- a/tests/unit/features/chat/rendering/ThinkingBlockRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/ThinkingBlockRenderer.test.ts
@@ -23,7 +23,7 @@ describe('ThinkingBlockRenderer', () => {
     it('should show timer label', () => {
       const parentEl = createMockEl();
 
-      const state = createThinkingBlock(parentEl, mockRenderContent);
+      const state = createThinkingBlock(parentEl);
 
       expect(state.labelEl.textContent).toContain('Thinking');
     });
@@ -31,7 +31,7 @@ describe('ThinkingBlockRenderer', () => {
     it('should clean up timer on finalize', () => {
       const parentEl = createMockEl();
 
-      const state = createThinkingBlock(parentEl, mockRenderContent);
+      const state = createThinkingBlock(parentEl);
 
       expect(state.timerInterval).not.toBeNull();
 
@@ -39,13 +39,28 @@ describe('ThinkingBlockRenderer', () => {
 
       expect(state.timerInterval).toBeNull();
     });
+
+    it('reports expansion state without rendering content itself', () => {
+      const parentEl = createMockEl();
+      const onToggle = jest.fn();
+      const state = createThinkingBlock(parentEl, { onToggle });
+      const header = (state.wrapperEl as any)._children[0];
+      const clickHandlers = header._eventListeners.get('click') || [];
+
+      clickHandlers[0]();
+      clickHandlers[0]();
+
+      expect(onToggle).toHaveBeenNthCalledWith(1, true);
+      expect(onToggle).toHaveBeenNthCalledWith(2, false);
+      expect(mockRenderContent).not.toHaveBeenCalled();
+    });
   });
 
   describe('finalizeThinkingBlock', () => {
     it('should collapse the block when finalized', () => {
       const parentEl = createMockEl();
 
-      const state = createThinkingBlock(parentEl, mockRenderContent);
+      const state = createThinkingBlock(parentEl);
 
       // Manually expand first
       state.wrapperEl.addClass('expanded');
@@ -60,7 +75,7 @@ describe('ThinkingBlockRenderer', () => {
     it('should update label with final duration', () => {
       const parentEl = createMockEl();
 
-      const state = createThinkingBlock(parentEl, mockRenderContent);
+      const state = createThinkingBlock(parentEl);
 
       // Advance time by 5 seconds
       jest.advanceTimersByTime(5000);
@@ -74,7 +89,7 @@ describe('ThinkingBlockRenderer', () => {
     it('should sync isExpanded state so toggle works correctly after finalize', () => {
       const parentEl = createMockEl();
 
-      const state = createThinkingBlock(parentEl, mockRenderContent);
+      const state = createThinkingBlock(parentEl);
       const header = (state.wrapperEl as any)._children[0];
 
       // Expand the block
@@ -98,7 +113,7 @@ describe('ThinkingBlockRenderer', () => {
     it('should update aria-expanded on finalize', () => {
       const parentEl = createMockEl();
 
-      const state = createThinkingBlock(parentEl, mockRenderContent);
+      const state = createThinkingBlock(parentEl);
       const header = (state.wrapperEl as any)._children[0];
 
       // Expand first

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -216,7 +216,12 @@ let mockMessageRenderer: { scrollToBottomIfNeeded: jest.Mock; setAsyncSubagentCl
 let mockSelectionController: ReturnType<typeof createMockSelectionController>;
 let mockBrowserSelectionController: ReturnType<typeof createMockBrowserSelectionController>;
 let mockCanvasSelectionController: ReturnType<typeof createMockCanvasSelectionController>;
-let mockStreamController: { onAsyncSubagentStateChange: jest.Mock };
+let mockStreamController: {
+  onAsyncSubagentStateChange: jest.Mock;
+  setTabActive: jest.Mock;
+  setViewportVisible: jest.Mock;
+  dispose: jest.Mock;
+};
 let mockConversationController: { save: jest.Mock; rewind: jest.Mock };
 let mockInputController: ReturnType<typeof createMockInputController>;
 let mockNavigationController: { initialize: jest.Mock; dispose: jest.Mock };
@@ -353,7 +358,12 @@ jest.mock('@/features/chat/controllers/CanvasSelectionController', () => ({
 
 jest.mock('@/features/chat/controllers/StreamController', () => ({
   StreamController: jest.fn().mockImplementation(() => {
-    mockStreamController = { onAsyncSubagentStateChange: jest.fn() };
+    mockStreamController = {
+      onAsyncSubagentStateChange: jest.fn(),
+      setTabActive: jest.fn(),
+      setViewportVisible: jest.fn(),
+      dispose: jest.fn(),
+    };
     return mockStreamController;
   }),
 }));
@@ -1425,10 +1435,13 @@ describe('Tab - Activation/Deactivation', () => {
     it('should show tab content', () => {
       const options = createMockOptions();
       const tab = createTab(options);
+      const setTabActive = jest.fn();
+      tab.controllers.streamController = { setTabActive } as any;
 
       activateTab(tab);
 
       expect(tab.dom.contentEl.style.display).toBe('flex');
+      expect(setTabActive).toHaveBeenCalledWith(true);
     });
   });
 
@@ -1436,12 +1449,15 @@ describe('Tab - Activation/Deactivation', () => {
     it('should hide tab content', () => {
       const options = createMockOptions();
       const tab = createTab(options);
+      const setTabActive = jest.fn();
+      tab.controllers.streamController = { setTabActive } as any;
 
       // First activate, then deactivate
       activateTab(tab);
       deactivateTab(tab);
 
       expect(tab.dom.contentEl.style.display).toBe('none');
+      expect(setTabActive).toHaveBeenLastCalledWith(false);
     });
   });
 });
@@ -2258,6 +2274,38 @@ describe('Tab - Controller Initialization', () => {
       initializeTabControllers(tab, options.plugin, mockComponent, options.mcpManager);
 
       expect(tab.controllers.streamController).toBeDefined();
+    });
+
+    it('should forward viewport visibility changes from IntersectionObserver', () => {
+      const options = createMockOptions();
+      const tab = createTab(options);
+      const mockComponent = {} as any;
+      const observe = jest.fn();
+      const disconnect = jest.fn();
+      let visibilityCallback: IntersectionObserverCallback | undefined;
+      (tab.dom.messagesEl.ownerDocument.defaultView as any).IntersectionObserver = jest.fn(
+        (callback: IntersectionObserverCallback) => {
+          visibilityCallback = callback;
+          return { observe, disconnect };
+        },
+      );
+
+      initializeTabUI(tab, options.plugin);
+      initializeTabControllers(tab, options.plugin, mockComponent, options.mcpManager);
+      visibilityCallback?.([
+        {
+          target: tab.dom.messagesEl,
+          isIntersecting: false,
+        } as unknown as IntersectionObserverEntry,
+      ], {} as IntersectionObserver);
+
+      expect(observe).toHaveBeenCalledWith(tab.dom.messagesEl);
+      expect(mockStreamController.setViewportVisible).toHaveBeenCalledWith(false);
+
+      for (const cleanup of tab.dom.eventCleanups) {
+        cleanup();
+      }
+      expect(disconnect).toHaveBeenCalled();
     });
 
     it('should create ConversationController', () => {


### PR DESCRIPTION
## Summary

- serialize streaming Markdown renders through a latest-wins coordinator
- throttle live text and thinking updates to 150 ms while preserving immediate final renders
- skip live work for hidden tabs, offscreen chat panes, and collapsed thinking blocks
- resume with the latest content when rendering becomes relevant again
- add focused coverage for overlapping renders, visibility changes, finalization, thinking expansion, and math rendering

## Why

Streaming previously scheduled a full Markdown rerender on every animation frame. Long or concurrent conversations could accumulate expensive and overlapping async renders, including work the user could not see.

This keeps at most one render in flight per stream, coalesces intermediate updates, and makes visibility-driven catch-up event-based. Final content still bypasses throttling and visibility checks so persisted and displayed output remains exact.

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run test` (319 suites, 6902 tests)
- `npm run build`
- manual smoke test with concurrent tabs and the sidebar hidden/reopened

Supersedes #964 while retaining its performance analysis and motivation.
