### PR TITLE
Upgrade MCP tester to the v2 client

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,10 +5,11 @@
     "": {
       "name": "claudian",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.209",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.220",
         "@codemirror/state": "^6.5.0",
         "@codemirror/view": "^6.38.6",
-        "@modelcontextprotocol/sdk": "~1.29.0",
+        "@modelcontextprotocol/client": "^2.0.0",
+        "@modelcontextprotocol/sdk": "~1.30.0",
         "smol-toml": "^1.6.1",
         "tslib": "^2.8.1",
       },
@@ -41,23 +42,23 @@
     "js-yaml": "4.3.0",
   },
   "packages": {
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.212", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.212", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.212", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.212", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.212", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.212", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.212", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.212", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.212" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-BSowuUv7+EoeBo36oZbSox8uyY3dqyMLFolAoMyKW3uqAfZLDV8MpvjDsv+WDE+OGCkuWK60JIqfhyPhctGTgg=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.220", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.220", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.220", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.220", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.220", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.220", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.220", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.220", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.220" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-glc7SdwPkOkLw8oxwLo9PKTdLJGqW/PIR4urWXFoRtX9YllwozsEVc5Tc1+EvLSkfrsxPJqQWqOgpjUOQXf1oA=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.212", "", { "os": "darwin", "cpu": "arm64" }, "sha512-t9t5fP94XNslh5hIWlmwE0F7hrhEpnbzM6ddF9qjqyO3zT6XZQ3U/fT2wuM8WYdSpyAsOO+3WiABe1buzNVQbA=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.220", "", { "os": "darwin", "cpu": "arm64" }, "sha512-7VxlbEosK7DODiOnsjoVd0DSJzbnaPrM2jelMHI0y8zx1UnLS3WC6EFUXbvy74F2sXqEznh2tzn7EKWInaRN6Q=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.212", "", { "os": "darwin", "cpu": "x64" }, "sha512-0dgxPaf0+9lpOOpKYRXPtcXridq27QjhLFz/7UjVANy7roqcojdnwX4Wpjf8hII/URPkjLH+9PlAgZT3Ml1YIg=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.220", "", { "os": "darwin", "cpu": "x64" }, "sha512-X9RwDsSmbF6ultKZroaip+DL8WRgC64gHbrAwrRlAFSPNZV7zmJyP2ur8rW7KrxqmtuehdMMkw8+SAC/6hD2PA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.212", "", { "os": "linux", "cpu": "arm64" }, "sha512-laU4i0eN5yq/H/utAfHKDjyugjvSnFuAfMhHYv8idF7PQxl+6YDahDd4gqVPdIifcZvrAsi1HXfpdKayYv6dJg=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.220", "", { "os": "linux", "cpu": "arm64" }, "sha512-WkROPwWskqhKR9XgnmseHQ6rLi9zM9qt57IWoToIjL/eXOqDWipp7JXZ1L5ud+LrA42dunHPZfBwD/vXZ+A7LA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.212", "", { "os": "linux", "cpu": "arm64" }, "sha512-oeQr+cQk65eost/O+ZAROQkME0o3affxfLiRWpJjb/focycvA3Z/Z1vI3z6QL+bswMcEGsHp88cXBLoDYC0nNQ=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.220", "", { "os": "linux", "cpu": "arm64" }, "sha512-OHoZOZ8Cf2TBr6oXIXPwyvUxj9jrq2w8E4poA8dMpacXszcPSPiCQCMuuOh4aWJzfeJE1+TtWxhKMVb2csXyZQ=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.212", "", { "os": "linux", "cpu": "x64" }, "sha512-sUELD4LP2JLQeFZdven/7NPWS6/TIlE8aNwQJBj8+8RNF4XketoKUbmRdIBO6q8YpXFGn+4DVzirb+Cz6DIbuA=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.220", "", { "os": "linux", "cpu": "x64" }, "sha512-tkTJFnpR9VifvWX2fmkCAPkT6+8Wk/gVu8B5jsVekKZPiZoWRHmMXO30BnZn+f0TZhgYP+82PSX3S8crH1kn+w=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.212", "", { "os": "linux", "cpu": "x64" }, "sha512-MYs7C9UOqhwWv4GgEbGdD37BUp8C8ff6WPDupFHW6/html2wK0DAei72sWjTghoEiUJUlRcxay1nxPCiwB9w1A=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.220", "", { "os": "linux", "cpu": "x64" }, "sha512-K+FWj+LcGhC1Z7wqeWoLxm1iemcba5xKpLLFVwYm4V6HyMx3ruYd/2r2TiQtjT+JWeNFWIys0ScHiItR6vWAiA=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.212", "", { "os": "win32", "cpu": "arm64" }, "sha512-fCtzLDJHy8jO4oaK/GC971f3npRWSdVhzDbh2uOQeqsWnHpGnHkxpUVBa7fVeEW5oTvXlRATgjDODjO+3CVLIg=="],
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.220", "", { "os": "win32", "cpu": "arm64" }, "sha512-rIwgq0UwQExWl6KrHUyC4w5KwpL9l6nd95aUTx6RitexaAuEw//xtfTVLnuE4hDDQZFkzEwpdKc3nxDWoGcUbA=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.212", "", { "os": "win32", "cpu": "x64" }, "sha512-2DCQL7ZfzpoGo4kCzu+jqOifPOKUe+Zc6OgTiSDvatz/JGWxs0kV3jOTTjtxGCCUKpdKnflRjHzOHFjIKjODxA=="],
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.220", "", { "os": "win32", "cpu": "x64" }, "sha512-MuOuXhbr66HlGaWXD2f3w0k2PsvmnbkwcUZ0dAe2poFLdl72GC2dapwwOBefxm9QmoNqk9+jmv/dSKGOVWyvLw=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.93.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-q9vaSZQVFx6B/gPxetGYfLXSJD5v0sOmh0OpZDq7yCrTSA+Rscvrtyol7JJTW40wEpQB4U1B4JXzxQitbQ3CAA=="],
 
@@ -297,7 +298,11 @@
 
     "@microsoft/eslint-plugin-sdl": ["@microsoft/eslint-plugin-sdl@1.1.0", "", { "dependencies": { "eslint-plugin-n": "17.10.3", "eslint-plugin-react": "7.37.3", "eslint-plugin-security": "1.4.0" }, "peerDependencies": { "eslint": "^9" } }, "sha512-dxdNHOemLnBhfY3eByrujX9KyLigcNtW8sU+axzWv5nLGcsSBeKW2YYyTpfPo1hV8YPOmIGnfA4fZHyKVtWqBQ=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+    "@modelcontextprotocol/client": ["@modelcontextprotocol/client@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "jose": "^6.1.3", "pkce-challenge": "^5.0.0", "zod": "^4.2.0" } }, "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw=="],
+
+    "@modelcontextprotocol/core": ["@modelcontextprotocol/core@2.0.0", "", { "dependencies": { "zod": "^4.2.0" } }, "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@anthropic-ai/claude-agent-sdk": "^0.3.220",
         "@codemirror/state": "^6.5.0",
         "@codemirror/view": "^6.38.6",
-        "@modelcontextprotocol/sdk": "~1.29.0",
+        "@modelcontextprotocol/client": "^2.0.0",
+        "@modelcontextprotocol/sdk": "~1.30.0",
         "smol-toml": "^1.6.1",
         "tslib": "^2.8.1"
       },
@@ -2248,14 +2249,44 @@
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
     },
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "jose": "^6.1.3",
+        "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "@anthropic-ai/claude-agent-sdk": "^0.3.220",
     "@codemirror/state": "^6.5.0",
     "@codemirror/view": "^6.38.6",
-    "@modelcontextprotocol/sdk": "~1.29.0",
+    "@modelcontextprotocol/client": "^2.0.0",
+    "@modelcontextprotocol/sdk": "~1.30.0",
     "smol-toml": "^1.6.1",
     "tslib": "^2.8.1"
   },

--- a/src/core/mcp/McpTester.ts
+++ b/src/core/mcp/McpTester.ts
@@ -1,7 +1,10 @@
-import { Client } from '@modelcontextprotocol/sdk/client';
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp';
-import type { Transport } from '@modelcontextprotocol/sdk/shared/transport';
+import {
+  Client,
+  SSEClientTransport,
+  StreamableHTTPClientTransport,
+  type Transport,
+} from '@modelcontextprotocol/client';
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
 import * as http from 'http';
 import * as https from 'https';
 
@@ -9,6 +12,8 @@ import { getEnhancedPath } from '../../utils/env';
 import { parseCommand } from '../../utils/mcp';
 import type { ManagedMcpServer } from '../types';
 import { getMcpServerType } from '../types';
+
+const MCP_TEST_TIMEOUT_MS = 10_000;
 
 export interface McpTool {
   name: string;
@@ -27,20 +32,6 @@ export interface McpTestResult {
 interface UrlServerConfig {
   url: string;
   headers?: Record<string, string>;
-}
-
-type StreamableHttpTransportOptions = ConstructorParameters<typeof StreamableHTTPClientTransport>[1];
-type LegacySseTransportConstructor = new (
-  url: URL,
-  options?: StreamableHttpTransportOptions,
-) => Transport;
-
-function createLegacySseTransport(url: URL, options: StreamableHttpTransportOptions): Transport {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports -- Legacy SSE MCP servers still need the SDK's deprecated compatibility transport.
-  const module = require('@modelcontextprotocol/sdk/client/sse') as {
-    SSEClientTransport: LegacySseTransportConstructor;
-  };
-  return new module.SSEClientTransport(url, options);
 }
 
 /**
@@ -253,7 +244,7 @@ export async function testMcpServer(server: ManagedMcpServer): Promise<McpTestRe
         requestInit: config.headers ? { headers: config.headers } : undefined,
       };
       transport = type === 'sse'
-        ? createLegacySseTransport(url, options)
+        ? new SSEClientTransport(url, options)
         : new StreamableHTTPClientTransport(url, options);
     }
   } catch (error) {
@@ -264,12 +255,18 @@ export async function testMcpServer(server: ManagedMcpServer): Promise<McpTestRe
     };
   }
 
-  const client = new Client({ name: 'claudian-tester', version: '1.0.0' });
+  const clientInfo = { name: 'claudian-tester', version: '1.0.0' };
+  const client = type === 'http'
+    ? new Client(clientInfo, { versionNegotiation: { mode: 'auto' } })
+    : new Client(clientInfo);
   const controller = new AbortController();
-  const timeout = window.setTimeout(() => controller.abort(), 10000);
+  const timeout = window.setTimeout(() => controller.abort(), MCP_TEST_TIMEOUT_MS);
 
   try {
-    await client.connect(transport, { signal: controller.signal });
+    await client.connect(transport, {
+      signal: controller.signal,
+      timeout: MCP_TEST_TIMEOUT_MS,
+    });
 
     const serverVersion = client.getServerVersion();
     let tools: McpTool[] = [];
@@ -292,7 +289,11 @@ export async function testMcpServer(server: ManagedMcpServer): Promise<McpTestRe
     };
   } catch (error) {
     if (controller.signal.aborted) {
-      return { success: false, tools: [], error: 'Connection timeout (10s)' };
+      return {
+        success: false,
+        tools: [],
+        error: `Connection timeout (${MCP_TEST_TIMEOUT_MS / 1000}s)`,
+      };
     }
     return {
       success: false,

--- a/tests/integration/core/mcp/mcp.test.ts
+++ b/tests/integration/core/mcp/mcp.test.ts
@@ -1,7 +1,9 @@
-import { Client } from '@modelcontextprotocol/sdk/client';
-import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse';
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp';
+import {
+  Client,
+  SSEClientTransport,
+  StreamableHTTPClientTransport,
+} from '@modelcontextprotocol/client';
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
 
 import { parseClipboardConfig, tryParseClipboardConfig } from '@/core/mcp/McpConfigParser';
 import { McpServerManager } from '@/core/mcp/McpServerManager';
@@ -25,20 +27,14 @@ import {
   splitCommandString,
 } from '@/utils/mcp';
 
-jest.mock('@modelcontextprotocol/sdk/client', () => ({
+jest.mock('@modelcontextprotocol/client', () => ({
   Client: jest.fn(),
-}));
-
-jest.mock('@modelcontextprotocol/sdk/client/stdio', () => ({
-  StdioClientTransport: jest.fn(),
-}));
-
-jest.mock('@modelcontextprotocol/sdk/client/sse', () => ({
   SSEClientTransport: jest.fn(),
+  StreamableHTTPClientTransport: jest.fn(),
 }));
 
-jest.mock('@modelcontextprotocol/sdk/client/streamableHttp', () => ({
-  StreamableHTTPClientTransport: jest.fn(),
+jest.mock('@modelcontextprotocol/client/stdio', () => ({
+  StdioClientTransport: jest.fn(),
 }));
 
 function createMemoryStorage(initialFile?: Record<string, unknown>): {

--- a/tests/unit/core/mcp/McpTester.test.ts
+++ b/tests/unit/core/mcp/McpTester.test.ts
@@ -2,7 +2,7 @@ import { testMcpServer } from '@/core/mcp/McpTester';
 import type { ManagedMcpServer } from '@/core/types';
 
 // Mock the MCP SDK transports and client
-jest.mock('@modelcontextprotocol/sdk/client', () => ({
+jest.mock('@modelcontextprotocol/client', () => ({
   Client: jest.fn().mockImplementation(() => ({
     connect: jest.fn(),
     getServerVersion: jest.fn().mockReturnValue({ name: 'test-server', version: '1.0.0' }),
@@ -14,18 +14,12 @@ jest.mock('@modelcontextprotocol/sdk/client', () => ({
     }),
     close: jest.fn(),
   })),
-}));
-
-jest.mock('@modelcontextprotocol/sdk/client/sse', () => ({
   SSEClientTransport: jest.fn(),
-}));
-
-jest.mock('@modelcontextprotocol/sdk/client/stdio', () => ({
-  StdioClientTransport: jest.fn(),
-}));
-
-jest.mock('@modelcontextprotocol/sdk/client/streamableHttp', () => ({
   StreamableHTTPClientTransport: jest.fn(),
+}));
+
+jest.mock('@modelcontextprotocol/client/stdio', () => ({
+  StdioClientTransport: jest.fn(),
 }));
 
 jest.mock('@/utils/env', () => ({
@@ -47,6 +41,7 @@ describe('testMcpServer', () => {
 
   describe('stdio server', () => {
     it('should connect and return tools for a valid stdio server', async () => {
+      const { Client } = jest.requireMock('@modelcontextprotocol/client');
       const server: ManagedMcpServer = {
         name: 'test',
         config: { command: 'node server.js', args: ['--port', '3000'] },
@@ -63,6 +58,7 @@ describe('testMcpServer', () => {
       expect(result.tools[0].name).toBe('tool1');
       expect(result.tools[0].description).toBe('A test tool');
       expect(result.tools[1].name).toBe('tool2');
+      expect(Client).toHaveBeenCalledWith({ name: 'claudian-tester', version: '1.0.0' });
     });
 
     it('should return error for missing command', async () => {
@@ -86,7 +82,7 @@ describe('testMcpServer', () => {
 
   describe('sse server', () => {
     it('should connect to an SSE server', async () => {
-      const { SSEClientTransport } = jest.requireMock('@modelcontextprotocol/sdk/client/sse');
+      const { Client, SSEClientTransport } = jest.requireMock('@modelcontextprotocol/client');
       const server: ManagedMcpServer = {
         name: 'sse-test',
         config: { type: 'sse' as const, url: 'https://example.com/sse' },
@@ -104,12 +100,13 @@ describe('testMcpServer', () => {
           fetch: expect.any(Function),
         }),
       );
+      expect(Client).toHaveBeenCalledWith({ name: 'claudian-tester', version: '1.0.0' });
     });
   });
 
   describe('http server', () => {
     it('should connect to an HTTP server', async () => {
-      const { StreamableHTTPClientTransport } = jest.requireMock('@modelcontextprotocol/sdk/client/streamableHttp');
+      const { Client, StreamableHTTPClientTransport } = jest.requireMock('@modelcontextprotocol/client');
       const server: ManagedMcpServer = {
         name: 'http-test',
         config: { type: 'http' as const, url: 'https://example.com/api' },
@@ -126,10 +123,21 @@ describe('testMcpServer', () => {
           fetch: expect.any(Function),
         }),
       );
+      expect(Client).toHaveBeenCalledWith(
+        { name: 'claudian-tester', version: '1.0.0' },
+        { versionNegotiation: { mode: 'auto' } },
+      );
+      expect(Client.mock.results[0].value.connect).toHaveBeenCalledWith(
+        expect.anything(),
+        {
+          signal: expect.any(AbortSignal),
+          timeout: 10000,
+        },
+      );
     });
 
     it('should pass headers when configured', async () => {
-      const { StreamableHTTPClientTransport } = jest.requireMock('@modelcontextprotocol/sdk/client/streamableHttp');
+      const { StreamableHTTPClientTransport } = jest.requireMock('@modelcontextprotocol/client');
       const server: ManagedMcpServer = {
         name: 'http-auth',
         config: {
@@ -156,7 +164,7 @@ describe('testMcpServer', () => {
 
   describe('error handling', () => {
     it('should return error when transport creation fails', async () => {
-      const { SSEClientTransport } = jest.requireMock('@modelcontextprotocol/sdk/client/sse');
+      const { SSEClientTransport } = jest.requireMock('@modelcontextprotocol/client');
       SSEClientTransport.mockImplementationOnce(() => {
         throw new Error('Transport init failed');
       });
@@ -176,7 +184,7 @@ describe('testMcpServer', () => {
     });
 
     it('should return generic error for non-Error transport failures', async () => {
-      const { StreamableHTTPClientTransport } = jest.requireMock('@modelcontextprotocol/sdk/client/streamableHttp');
+      const { StreamableHTTPClientTransport } = jest.requireMock('@modelcontextprotocol/client');
       StreamableHTTPClientTransport.mockImplementationOnce(() => {
         throw 'string error';
       });
@@ -195,7 +203,7 @@ describe('testMcpServer', () => {
     });
 
     it('should return error when connection fails', async () => {
-      const { Client } = jest.requireMock('@modelcontextprotocol/sdk/client');
+      const { Client } = jest.requireMock('@modelcontextprotocol/client');
       Client.mockImplementationOnce(() => ({
         connect: jest.fn().mockRejectedValue(new Error('Connection refused')),
         close: jest.fn(),
@@ -215,7 +223,7 @@ describe('testMcpServer', () => {
     });
 
     it('should return unknown error for non-Error connection failures', async () => {
-      const { Client } = jest.requireMock('@modelcontextprotocol/sdk/client');
+      const { Client } = jest.requireMock('@modelcontextprotocol/client');
       Client.mockImplementationOnce(() => ({
         connect: jest.fn().mockRejectedValue(42),
         close: jest.fn(),
@@ -235,7 +243,7 @@ describe('testMcpServer', () => {
     });
 
     it('should handle listTools failure gracefully (partial success)', async () => {
-      const { Client } = jest.requireMock('@modelcontextprotocol/sdk/client');
+      const { Client } = jest.requireMock('@modelcontextprotocol/client');
       Client.mockImplementationOnce(() => ({
         connect: jest.fn(),
         getServerVersion: jest.fn().mockReturnValue({ name: 'partial', version: '0.1' }),
@@ -258,7 +266,7 @@ describe('testMcpServer', () => {
     });
 
     it('should handle close errors silently', async () => {
-      const { Client } = jest.requireMock('@modelcontextprotocol/sdk/client');
+      const { Client } = jest.requireMock('@modelcontextprotocol/client');
       Client.mockImplementationOnce(() => ({
         connect: jest.fn(),
         getServerVersion: jest.fn().mockReturnValue(null),

--- a/tests/unit/core/mcp/createNodeFetch.test.ts
+++ b/tests/unit/core/mcp/createNodeFetch.test.ts
@@ -1,3 +1,7 @@
+import {
+  Client,
+  StreamableHTTPClientTransport,
+} from '@modelcontextprotocol/client';
 import * as http from 'http';
 import type { AddressInfo } from 'net';
 
@@ -159,6 +163,33 @@ describe('createNodeFetch', () => {
     await expect(
       nodeFetch(getUrl(), { method: 'GET', signal: controller.signal }),
     ).rejects.toThrow();
+  });
+
+  it('should stop a hanging MCP HTTP discovery probe at the SDK request timeout', async () => {
+    const { server: hangingServer, getUrl: hangingUrl, received: hangingReceived } = createTestServer(
+      () => {
+        // Accept the discovery request without ever sending a response.
+      },
+    );
+    serversToClose.push(hangingServer);
+
+    const client = new Client(
+      { name: 'claudian-timeout-test', version: '1.0.0' },
+      { versionNegotiation: { mode: 'auto' } },
+    );
+    const transport = new StreamableHTTPClientTransport(
+      new URL(hangingUrl()),
+      { fetch: nodeFetch },
+    );
+    const startedAt = Date.now();
+
+    try {
+      await expect(client.connect(transport, { timeout: 100 })).rejects.toThrow();
+      expect(Date.now() - startedAt).toBeLessThan(2_000);
+      expect(hangingReceived).toHaveLength(1);
+    } finally {
+      await client.close();
+    }
   });
 
   it('should accept URL object as input', async () => {


### PR DESCRIPTION
## Why

No linked issue; Claudian's MCP tester needs compatibility with MCP 2026-07-28 while preserving current provider integrations.

## What Changed

Migrates the tester to `@modelcontextprotocol/client` v2, retains SDK v1.30 for the Claude Agent SDK peer, enables HTTP protocol auto-negotiation, and enforces the existing 10-second connection deadline.

## Why This Approach

Limits v2 adoption to Claudian-owned tester behavior while leaving provider-owned MCP runtimes and legacy stdio/SSE negotiation unchanged.

## Validation

`npm run typecheck && npm run lint && npm run test && npm run build` (6,903 tests), plus npm/Bun lockfile validation and a real hanging-HTTP discovery timeout regression.

## Impact and Follow-ups

No data migration or new provider; provider runtimes can adopt MCP 2026 independently.

## Checklist

- [x] This pull request addresses one focused problem.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
- [x] This pull request does not add a new provider.
- [x] I removed secrets, private vault content, and other sensitive information from the changes and evidence.
