### PR TITLE
feat: support max thinking effort for Pi

### DIFF
--- a/src/providers/pi/models.ts
+++ b/src/providers/pi/models.ts
@@ -3,7 +3,17 @@ import {
   resolvePreferredReasoningDefault,
 } from '../../core/providers/reasoning';
 
-export type PiThinkingLevel = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+const PI_THINKING_LEVELS = [
+  'off',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+] as const;
+
+export type PiThinkingLevel = typeof PI_THINKING_LEVELS[number];
 
 export interface PiDiscoveredModel {
   api?: string;
@@ -26,22 +36,10 @@ export interface DecodedPiModelId {
 export const PI_MODEL_PREFIX = 'pi:';
 export const PI_DEFAULT_THINKING_LEVEL: PiThinkingLevel = DEFAULT_REASONING_VALUE;
 
-const VALID_THINKING_LEVELS = new Set<PiThinkingLevel>([
-  'off',
-  'minimal',
-  'low',
-  'medium',
-  'high',
-  'xhigh',
-]);
-
-const DEFAULT_REASONING_LEVELS: PiThinkingLevel[] = [
-  'off',
-  'minimal',
-  'low',
-  'medium',
-  'high',
-];
+const VALID_THINKING_LEVELS: ReadonlySet<string> = new Set(PI_THINKING_LEVELS);
+const DEFAULT_REASONING_LEVELS: PiThinkingLevel[] = PI_THINKING_LEVELS.filter(
+  level => level !== 'xhigh' && level !== 'max',
+);
 
 export function isPiModelSelectionId(model: string): boolean {
   return decodePiModelId(model) !== null;
@@ -79,7 +77,7 @@ export function normalizePiThinkingLevel(value: unknown): PiThinkingLevel | null
   }
 
   const normalized = value.trim().toLowerCase();
-  return VALID_THINKING_LEVELS.has(normalized as PiThinkingLevel)
+  return VALID_THINKING_LEVELS.has(normalized)
     ? normalized as PiThinkingLevel
     : null;
 }
@@ -201,6 +199,22 @@ export function clampPiThinkingLevel(
     return 'off';
   }
 
+  if (normalized) {
+    const requestedIndex = PI_THINKING_LEVELS.indexOf(normalized);
+    for (let index = requestedIndex + 1; index < PI_THINKING_LEVELS.length; index++) {
+      const candidate = PI_THINKING_LEVELS[index];
+      if (supportedLevels.includes(candidate)) {
+        return candidate;
+      }
+    }
+    for (let index = requestedIndex - 1; index >= 0; index--) {
+      const candidate = PI_THINKING_LEVELS[index];
+      if (supportedLevels.includes(candidate)) {
+        return candidate;
+      }
+    }
+  }
+
   return resolvePreferredReasoningDefault(supportedLevels, 'medium') as PiThinkingLevel;
 }
 
@@ -258,7 +272,7 @@ function collectThinkingLevelMapLevels(record: Record<string, unknown>): {
 }
 
 function sortThinkingLevels(levels: PiThinkingLevel[]): PiThinkingLevel[] {
-  const rank = new Map(DEFAULT_REASONING_LEVELS.concat('xhigh').map((level, index) => [level, index] as const));
+  const rank = new Map(PI_THINKING_LEVELS.map((level, index) => [level, index] as const));
   return [...levels].sort((left, right) => (rank.get(left) ?? 99) - (rank.get(right) ?? 99));
 }
 

--- a/src/providers/pi/settings.ts
+++ b/src/providers/pi/settings.ts
@@ -127,27 +127,11 @@ export function normalizePiPreferredThinkingByModel(
   value: unknown,
   discoveredModels: PiDiscoveredModel[] = [],
 ): Record<string, PiThinkingLevel> {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return {};
-  }
-
-  const normalized: Record<string, PiThinkingLevel> = {};
-  for (const [encodedId, thinkingLevel] of Object.entries(value as Record<string, unknown>)) {
-    const normalizedEncodedId = normalizePiEncodedId(encodedId, discoveredModels);
-    const normalizedThinkingLevel = normalizePiThinkingLevel(thinkingLevel);
-    if (!normalizedEncodedId || !normalizedThinkingLevel) {
-      continue;
-    }
-
-    const discoveredModel = discoveredModels.find(model => model.encodedId === normalizedEncodedId);
-    if (discoveredModel && !discoveredModel.thinkingLevels.includes(normalizedThinkingLevel)) {
-      continue;
-    }
-
-    normalized[normalizedEncodedId] = normalizedThinkingLevel;
-  }
-
-  return normalized;
+  return normalizePiPreferredThinkingEntries(
+    value,
+    discoveredModels,
+    encodedId => normalizePiEncodedId(encodedId, discoveredModels),
+  );
 }
 
 export function getPiProviderSettings(settings: Record<string, unknown>): PiProviderSettings {
@@ -316,28 +300,38 @@ function normalizePiPreferredThinkingForPersistableIds(
   discoveredModels: PiDiscoveredModel[],
   persistableIds: Set<string>,
 ): Record<string, PiThinkingLevel> {
+  return normalizePiPreferredThinkingEntries(
+    value,
+    discoveredModels,
+    encodedId => normalizePiPersistableEncodedId(
+      encodedId,
+      discoveredModels,
+      persistableIds,
+    ),
+  );
+}
+
+function normalizePiPreferredThinkingEntries(
+  value: unknown,
+  discoveredModels: PiDiscoveredModel[],
+  normalizeEncodedId: (encodedId: string) => string,
+): Record<string, PiThinkingLevel> {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return {};
   }
 
   const normalized: Record<string, PiThinkingLevel> = {};
   for (const [encodedId, thinkingLevel] of Object.entries(value as Record<string, unknown>)) {
-    const normalizedEncodedId = normalizePiPersistableEncodedId(
-      encodedId,
-      discoveredModels,
-      persistableIds,
-    );
+    const normalizedEncodedId = normalizeEncodedId(encodedId);
     const normalizedThinkingLevel = normalizePiThinkingLevel(thinkingLevel);
     if (!normalizedEncodedId || !normalizedThinkingLevel) {
       continue;
     }
 
     const discoveredModel = discoveredModels.find(model => model.encodedId === normalizedEncodedId);
-    if (discoveredModel && !discoveredModel.thinkingLevels.includes(normalizedThinkingLevel)) {
-      continue;
-    }
-
-    normalized[normalizedEncodedId] = normalizedThinkingLevel;
+    normalized[normalizedEncodedId] = discoveredModel
+      ? clampPiThinkingLevel(normalizedThinkingLevel, discoveredModel.thinkingLevels)
+      : normalizedThinkingLevel;
   }
 
   return normalized;

--- a/tests/unit/providers/pi/models.test.ts
+++ b/tests/unit/providers/pi/models.test.ts
@@ -1,8 +1,10 @@
 import {
+  clampPiThinkingLevel,
   decodePiModelId,
   encodePiModelId,
   getPiSupportedThinkingLevels,
   normalizePiDiscoveredModels,
+  normalizePiThinkingLevel,
 } from '@/providers/pi/models';
 
 describe('Pi model helpers', () => {
@@ -23,6 +25,7 @@ describe('Pi model helpers', () => {
   });
 
   it('normalizes thinking levels with Pi reasoning rules', () => {
+    expect(normalizePiThinkingLevel(' MAX ')).toBe('max');
     expect(getPiSupportedThinkingLevels({ reasoning: false })).toEqual(['off']);
     expect(getPiSupportedThinkingLevels({ reasoning: true })).toEqual([
       'off',
@@ -33,8 +36,8 @@ describe('Pi model helpers', () => {
     ]);
     expect(getPiSupportedThinkingLevels({
       reasoning: true,
-      thinkingLevels: ['low', null, 'xhigh', 'invalid', 'low'],
-    })).toEqual(['low', 'xhigh']);
+      thinkingLevels: ['max', 'low', null, 'xhigh', 'invalid', 'low'],
+    })).toEqual(['low', 'xhigh', 'max']);
     expect(getPiSupportedThinkingLevels({
       reasoning: {
         levels: ['minimal', 'high'],
@@ -44,10 +47,36 @@ describe('Pi model helpers', () => {
       reasoning: true,
       thinkingLevelMap: {
         high: null,
+        max: 'max',
         minimal: 'low',
         xhigh: 'xhigh',
       },
-    })).toEqual(['off', 'minimal', 'low', 'medium', 'xhigh']);
+    })).toEqual(['off', 'minimal', 'low', 'medium', 'xhigh', 'max']);
+    expect(getPiSupportedThinkingLevels({
+      reasoning: true,
+      thinkingLevelMap: {
+        off: null,
+        minimal: null,
+        low: 'low',
+        medium: null,
+        high: 'high',
+        xhigh: null,
+        max: 'max',
+      },
+    })).toEqual(['low', 'high', 'max']);
+  });
+
+  it('clamps supported thinking levels with Pi ladder semantics', () => {
+    expect(clampPiThinkingLevel(
+      'max',
+      ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'],
+    )).toBe('max');
+    expect(clampPiThinkingLevel(
+      'max',
+      ['off', 'minimal', 'low', 'medium', 'high', 'xhigh'],
+    )).toBe('xhigh');
+    expect(clampPiThinkingLevel('max', ['off', 'high'])).toBe('high');
+    expect(clampPiThinkingLevel('medium', ['low', 'high', 'max'])).toBe('high');
   });
 
   it('normalizes discovered model records', () => {

--- a/tests/unit/providers/pi/runtime/PiChatRuntime.test.ts
+++ b/tests/unit/providers/pi/runtime/PiChatRuntime.test.ts
@@ -694,6 +694,43 @@ describe('PiChatRuntime', () => {
     });
   });
 
+  it('passes max thinking through to the Pi RPC runtime', async () => {
+    const plugin = createPlugin();
+    plugin.settings.effortLevel = 'max';
+    plugin.settings.providerConfigs.pi = {
+      discoveredModels: [
+        {
+          encodedId: 'pi:anthropic/claude-opus-4-7',
+          id: 'claude-opus-4-7',
+          input: ['text'],
+          label: 'Claude Opus 4.7',
+          provider: 'anthropic',
+          reasoning: true,
+          thinkingLevels: ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'],
+        },
+      ],
+      enabled: true,
+      visibleModels: ['pi:anthropic/claude-opus-4-7'],
+    };
+    plugin.settings.model = 'pi:anthropic/claude-opus-4-7';
+    const runtime = new PiChatRuntime(plugin);
+    const chunks: unknown[] = [];
+    const promise = (async () => {
+      for await (const chunk of runtime.query(createTurn(runtime))) {
+        chunks.push(chunk);
+      }
+    })();
+
+    await flushPromises();
+    mockTransportInstances[0].eventHandlers[0]({ type: 'agent_end' });
+    await promise;
+
+    expect(chunks[chunks.length - 1]).toEqual({ type: 'done' });
+    expect(mockTransportInstances[0].request).toHaveBeenCalledWith('set_thinking_level', {
+      level: 'max',
+    });
+  });
+
   it('applies the conversation model thinking preference instead of the saved Pi model restriction', async () => {
     const deepSeekModel = 'pi:deepseek/deepseek-reasoner';
     const gptModel = 'pi:openai/gpt-5';

--- a/tests/unit/providers/pi/runtime/PiLaunchSpec.test.ts
+++ b/tests/unit/providers/pi/runtime/PiLaunchSpec.test.ts
@@ -58,6 +58,22 @@ describe('PiLaunchSpec', () => {
     ]);
   });
 
+  it('passes max thinking through to Pi', () => {
+    expect(buildPiLaunchSpec({
+      command: 'pi',
+      cwd: '/vault',
+      noSession: true,
+      settings: baseSettings,
+      thinkingLevel: 'max',
+    }).args).toEqual([
+      '--mode',
+      'rpc',
+      '--no-session',
+      '--thinking',
+      'max',
+    ]);
+  });
+
   it('uses no-tools for passive auxiliary launches', () => {
     expect(buildPiLaunchSpec({
       command: 'pi',

--- a/tests/unit/providers/pi/runtime/PiModelDiscoveryService.test.ts
+++ b/tests/unit/providers/pi/runtime/PiModelDiscoveryService.test.ts
@@ -89,6 +89,9 @@ describe('PiModelDiscoveryService', () => {
         name: 'GPT-5',
         provider: 'openai',
         reasoning: true,
+        thinkingLevelMap: {
+          max: 'max',
+        },
       }],
     });
 
@@ -108,7 +111,7 @@ describe('PiModelDiscoveryService', () => {
       maxTokens: 8192,
       provider: 'openai',
       reasoning: true,
-      thinkingLevels: ['off', 'minimal', 'low', 'medium', 'high'],
+      thinkingLevels: ['off', 'minimal', 'low', 'medium', 'high', 'max'],
     }]);
     expect(mockProcessStart).toHaveBeenCalled();
     expect(mockTransportStart).toHaveBeenCalled();

--- a/tests/unit/providers/pi/settings.test.ts
+++ b/tests/unit/providers/pi/settings.test.ts
@@ -81,7 +81,7 @@ describe('Pi settings normalization', () => {
     ], discoveredModels)).toEqual(['pi:anthropic/claude-sonnet-4']);
   });
 
-  it('normalizes aliases and preferred thinking', () => {
+  it('normalizes aliases and clamps preferred thinking to model capabilities', () => {
     expect(normalizePiModelAliases({
       'pi:anthropic/claude-sonnet-4': '  Sonnet  ',
       'pi:missing/model': 'Missing',
@@ -89,9 +89,31 @@ describe('Pi settings normalization', () => {
       'pi:anthropic/claude-sonnet-4': 'Sonnet',
     });
     expect(normalizePiPreferredThinkingByModel({
-      'pi:anthropic/claude-sonnet-4': 'high',
+      'pi:anthropic/claude-sonnet-4': 'max',
       'pi:openai/gpt-5': 'xhigh',
     }, discoveredModels)).toEqual({
+      'pi:anthropic/claude-sonnet-4': 'high',
+      'pi:openai/gpt-5': 'medium',
+    });
+  });
+
+  it('clamps max preferences to xhigh before high', () => {
+    expect(normalizePiPreferredThinkingByModel({
+      'pi:anthropic/claude-opus-4-7': 'max',
+      'pi:anthropic/claude-sonnet-4': 'max',
+    }, [
+      {
+        encodedId: 'pi:anthropic/claude-opus-4-7',
+        id: 'claude-opus-4-7',
+        input: ['text'],
+        label: 'Claude Opus 4.7',
+        provider: 'anthropic',
+        reasoning: true,
+        thinkingLevels: ['off', 'low', 'medium', 'high', 'xhigh'],
+      },
+      discoveredModels[0],
+    ])).toEqual({
+      'pi:anthropic/claude-opus-4-7': 'xhigh',
       'pi:anthropic/claude-sonnet-4': 'high',
     });
   });

--- a/tests/unit/providers/pi/ui/PiChatUIConfig.test.ts
+++ b/tests/unit/providers/pi/ui/PiChatUIConfig.test.ts
@@ -12,7 +12,7 @@ const settings: Record<string, unknown> = {
           label: 'Claude Sonnet 4',
           provider: 'anthropic',
           reasoning: true,
-          thinkingLevels: ['off', 'medium', 'high', 'xhigh'],
+          thinkingLevels: ['off', 'medium', 'high', 'xhigh', 'max'],
         },
         {
           encodedId: 'pi:openai/gpt-5',
@@ -98,6 +98,7 @@ describe('PiChatUIConfig', () => {
       { label: 'Medium', value: 'medium' },
       { label: 'High', value: 'high' },
       { label: 'xHigh', value: 'xhigh' },
+      { label: 'Max', value: 'max' },
     ]);
     expect(piChatUIConfig.getDefaultReasoningValue('pi:anthropic/claude-sonnet-4', settings)).toBe('high');
   });


### PR DESCRIPTION
## Why

Fixes #993 by exposing Pi's `max` thinking effort for models that advertise it while retaining safe fallbacks for other models.

## What Changed

- Added a canonical Pi thinking ladder through `max` and used it for validation, ordering, and model-capability discovery.
- Matched Pi's ordered clamping behavior, including `max → xhigh → high`, and clamp stale persisted preferences instead of discarding them.
- Covered discovery, sparse capability maps, settings, selector options, launch arguments, and RPC transport.

## Why This Approach

The capability and fallback rules remain provider-owned while the existing shared model/effort orchestration continues to consume Pi's discovered options generically.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run test` — 319 suites and 6,907 tests passed
- `npm run build`
- `git diff --check`
- Read-only Pi 0.82.1 RPC check confirmed both `max`-capable models and sparse thinking-level maps.

## Impact and Follow-ups

Existing unsupported Pi preferences now resolve to the nearest provider-supported level; no settings migration or follow-up work is required.

## Checklist

- [x] This pull request addresses one focused problem.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
- [x] This pull request does not add a new provider.
- [x] I removed secrets, private vault content, and other sensitive information from the changes and evidence.
