### PR TITLE
fix: focus the chat composer after creating a new tab

### DIFF
--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -464,6 +464,7 @@ export class ClaudianView extends ItemView {
       return;
     }
     this.updateTabBarVisibility();
+    tab.dom.inputEl.focus();
   }
 
   private updateTabBar(): void {
@@ -815,6 +816,11 @@ export class ClaudianView extends ItemView {
   /** Gets the currently active tab. */
   getActiveTab(): TabData | null {
     return this.tabManager?.getActiveTab() ?? null;
+  }
+
+  /** Focuses the active tab's composer. */
+  focusActiveInput(): void {
+    this.tabManager?.getActiveTab()?.dom.inputEl.focus();
   }
 
   /** Appends text to the active composer without sending it. */

--- a/src/main.ts
+++ b/src/main.ts
@@ -367,6 +367,7 @@ export default class ClaudianPlugin extends Plugin {
     // A cold-open view creates its initial tab during restore. Avoid stacking
     // an extra blank tab on top when there was no prior layout to restore.
     if (restoredTabCount === 0) {
+      view.focusActiveInput();
       return;
     }
 

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -2211,8 +2211,10 @@ describe('ClaudianPlugin', () => {
       await plugin.onload();
 
       const createNewTab = jest.fn().mockResolvedValue(undefined);
+      const focusActiveInput = jest.fn();
       const mockView = {
         createNewTab,
+        focusActiveInput,
       };
 
       let viewOpened = false;
@@ -2232,6 +2234,7 @@ describe('ClaudianPlugin', () => {
 
       expect(plugin.activateView).toHaveBeenCalledTimes(1);
       expect(createNewTab).not.toHaveBeenCalled();
+      expect(focusActiveInput).toHaveBeenCalledTimes(1);
     });
 
     it('creates a new tab after reopening a persisted tab layout', async () => {

--- a/tests/unit/features/chat/ClaudianView.test.ts
+++ b/tests/unit/features/chat/ClaudianView.test.ts
@@ -143,6 +143,23 @@ function createViewHarness(options: {
 }
 
 describe('ClaudianView tab controls', () => {
+  it('focuses the composer after creating a new tab', async () => {
+    const inputEl = createMockEl('textarea') as unknown as HTMLTextAreaElement;
+    inputEl.focus = jest.fn();
+    const tab = { dom: { inputEl } };
+    const view = Object.create(ClaudianView.prototype) as any;
+
+    view.plugin = { settings: {} };
+    view.tabManager = {
+      createTab: jest.fn().mockResolvedValue(tab),
+    };
+    view.updateTabBarVisibility = jest.fn();
+
+    await view.createNewTab();
+
+    expect(inputEl.focus).toHaveBeenCalledTimes(1);
+  });
+
   it('hides the new-tab button when the tab manager is at capacity', () => {
     const { newTabButtonEl, view } = createViewHarness({ canCreateTab: false });
 
@@ -441,6 +458,14 @@ describe('ClaudianView composer input', () => {
 
     return { inputEl, inputHandler, view };
   }
+
+  it('focuses the active composer', () => {
+    const { inputEl, view } = createComposerHarness('');
+
+    view.focusActiveInput();
+
+    expect(inputEl.focus).toHaveBeenCalledTimes(1);
+  });
 
   it('appends text after existing composer content', () => {
     const { inputEl, inputHandler, view } = createComposerHarness('Review this note');


### PR DESCRIPTION
## Why

Creating a chat tab left the composer unfocused, breaking the keyboard workflow behind the New Tab shortcut. Closes #997.

## What Changed

Newly created tabs now focus their composer, and cold-opening Claudian through the shortcut focuses the initial tab without creating a duplicate.

## Why This Approach

Focus stays at the view-level user-action boundary, so restoring tabs, opening conversations in the background, and ordinary tab switches do not steal focus.

## Validation

- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run test` (6,908 tests passed)
- `npm run build`
- Added unit and integration regression coverage for warm and cold view paths.

## Impact and Follow-ups

None.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
