### PR TITLE
fix(grok): drop reasoning efforts the selected model does not advertise

### DIFF
--- a/src/providers/grok/runtime/GrokChatRuntime.ts
+++ b/src/providers/grok/runtime/GrokChatRuntime.ts
@@ -61,6 +61,8 @@ import {
 import {
   decodeGrokModelId,
   encodeGrokModelId,
+  findGrokModel,
+  getGrokAvailableReasoningEfforts,
   type GrokDiscoveredModel,
   normalizeGrokDiscoveredModels,
   normalizeGrokReasoningMetadata,
@@ -1964,9 +1966,21 @@ export class GrokChatRuntime implements ChatRuntime {
 
   private resolveSelectedEffort(rawModelId: string): string | null {
     const settings = this.getProviderSettings();
+    const grokSettings = getGrokProviderSettings(settings);
     const direct = typeof settings.effortLevel === 'string' ? settings.effortLevel.trim() : '';
-    const preferred = getGrokProviderSettings(settings).preferredReasoningByModel[rawModelId];
-    return direct || preferred || null;
+    const preferred = grokSettings.preferredReasoningByModel[rawModelId] ?? '';
+    // `effortLevel` is shared across providers, so it can still hold another
+    // provider's value when Grok has no saved projection yet. Grok rejects the
+    // whole turn when the advertised effort list does not contain it.
+    const advertised = getGrokAvailableReasoningEfforts(
+      findGrokModel(grokSettings.currentCatalog?.models ?? [], rawModelId),
+    ).map(effort => effort.value);
+    if (advertised.length === 0) {
+      return direct || preferred || null;
+    }
+    if (advertised.includes(direct)) return direct;
+    if (advertised.includes(preferred)) return preferred;
+    return null;
   }
 
   private setCurrentConversationModel(model: unknown): void {

--- a/tests/unit/providers/grok/runtime/GrokChatRuntime.test.ts
+++ b/tests/unit/providers/grok/runtime/GrokChatRuntime.test.ts
@@ -264,6 +264,43 @@ function createHost(overrides: Record<string, unknown> = {}): ProviderHost {
   } as unknown as ProviderHost;
 }
 
+function createCatalogHost(params: {
+  effortLevel: string;
+  preferredReasoningByModel?: Record<string, string>;
+}): ProviderHost {
+  return createHost({
+    settings: {
+      effortLevel: params.effortLevel,
+      providerConfigs: {
+        grok: {
+          catalogsByHost: {
+            [getHostnameKey()]: {
+              defaultModelId: 'grok-4.5',
+              fingerprint: 'catalog-fixture',
+              models: [{
+                displayName: 'Grok 4.5',
+                rawId: 'grok-4.5',
+                reasoningEfforts: [
+                  { label: 'High Effort', value: 'high' },
+                  { label: 'Medium Effort', value: 'medium' },
+                  { label: 'Low Effort', value: 'low' },
+                ],
+                reasoningMetadataResolved: true,
+                supportsReasoning: true,
+              }],
+              refreshedAt: 1,
+            },
+          },
+          enabled: true,
+          ...(params.preferredReasoningByModel
+            ? { preferredReasoningByModel: params.preferredReasoningByModel }
+            : {}),
+        },
+      },
+    },
+  });
+}
+
 function createHarness(params: {
   handlers?: ConstructorParameters<typeof FakeGrokProcess>[1];
   host?: ProviderHost;
@@ -734,6 +771,56 @@ describe('GrokChatRuntime', () => {
       sessionId: 'session-new',
       modelId: 'grok-4.5',
       _meta: { reasoningEffort: 'medium' },
+    });
+  });
+
+  it('drops a shared effort level the selected model does not advertise', async () => {
+    const harness = createHarness({
+      host: createCatalogHost({ effortLevel: 'max' }),
+    });
+
+    await collect(harness.runtime, 'First');
+
+    const setModel = harness.process.requests.filter(request => request.method === 'session/set_model');
+    expect(setModel).toHaveLength(1);
+    expect(setModel[0].params).toEqual({
+      sessionId: 'session-new',
+      modelId: 'grok-4.5',
+    });
+  });
+
+  it('falls back to the per-model reasoning preference when the shared level is unsupported', async () => {
+    const harness = createHarness({
+      host: createCatalogHost({
+        effortLevel: 'max',
+        preferredReasoningByModel: { 'grok-4.5': 'low' },
+      }),
+    });
+
+    await collect(harness.runtime, 'First');
+
+    const setModel = harness.process.requests.filter(request => request.method === 'session/set_model');
+    expect(setModel).toHaveLength(1);
+    expect(setModel[0].params).toEqual({
+      sessionId: 'session-new',
+      modelId: 'grok-4.5',
+      _meta: { reasoningEffort: 'low' },
+    });
+  });
+
+  it('keeps a shared effort level the selected model advertises', async () => {
+    const harness = createHarness({
+      host: createCatalogHost({ effortLevel: 'low' }),
+    });
+
+    await collect(harness.runtime, 'First');
+
+    const setModel = harness.process.requests.filter(request => request.method === 'session/set_model');
+    expect(setModel).toHaveLength(1);
+    expect(setModel[0].params).toEqual({
+      sessionId: 'session-new',
+      modelId: 'grok-4.5',
+      _meta: { reasoningEffort: 'low' },
     });
   });
 


### PR DESCRIPTION
## Why

Every Grok turn fails with a bare `❌ **Error:** Internal error` as soon as the shared effort level holds a value Grok 4.5 does not advertise.

Reproduced on Claudian 2.0.41, Obsidian 1.11.x, Windows 11, `grok` CLI 0.2.117, model `grok/grok-4.5`. Claudian only renders the generic JSON-RPC `-32603` fallback text, but the Grok CLI records the real cause in its own session log (`~/.grok/sessions/<cwd-key>/<session-id>/updates.jsonl`):

```json
{"sessionUpdate":"retry_state","type":"failed","error_type":"api",
 "message":"API error (status 400 Bad Request): invalid-argument: Invalid reasoning effort."}
```

and the matching `summary.json` shows what was applied to the session:

```json
{ "current_model_id": "grok-4.5", "reasoning_effort": "max" }
```

`max` is not a Grok effort. Both `~/.grok/models_cache.json` and the catalog snapshot Claudian persists in `providerConfigs.grok.catalogsByHost` advertise exactly `high` / `medium` / `low` for `grok-4.5`, with `high` as the default. `max` is a valid Codex and Pi effort (added for Pi in #995), and `effortLevel` is a single field shared by every provider.

The leak path: `GrokChatRuntime.getProviderSettings()` calls `projectSavedProviderValue(settings, 'savedProviderEffort', 'effortLevel')`, which is a no-op when `savedProviderEffort.grok` is absent — and `GrokChatUIConfig` deletes that key in `applyModelDefaults` / `applyModelProjectionDefaults` via `clearSavedGrokEffortProjection`. In my vault's settings the key really was missing while `effortLevel` was `"max"`, so `resolveSelectedEffort` returned `max` and forwarded it verbatim as `_meta.reasoningEffort` on `session/set_model`. Grok then fails the entire turn, not just the effort.

This is not a niche state: anyone who runs Codex or Pi at Max/xHigh and then switches to a Grok tab can land in it, and the surfaced message gives no hint about what to change.

## What Changed

`GrokChatRuntime.resolveSelectedEffort` now validates the effort it is about to send against the reasoning metadata the selected model actually advertises:

1. shared `effortLevel`, when the model advertises it;
2. otherwise the per-model `preferredReasoningByModel` entry, when the model advertises it;
3. otherwise `null`, so `_meta.reasoningEffort` is omitted and Grok applies its own default.

When no catalog metadata is known for the model, the previous pass-through behavior is kept unchanged.

No user-facing configuration changes, so no documentation update.

## Why This Approach

- It reuses `findGrokModel` + `getGrokAvailableReasoningEfforts`, the same pair `GrokChatUIConfig.getReasoningOptions` uses to build the selector. The runtime can no longer send something the picker would never have offered, and the low/medium/high fallback for unresolved models is inherited rather than re-derived.
- It matches the provider guidance in `src/providers/grok/AGENTS.md` ("after a real ACP session, persist and prefer the chosen model's advertised reasoning metadata") and mirrors `OpencodeChatRuntime.resolveSelectedEffortValue`, which already drops efforts outside `currentSessionEffortValues`. Grok was the odd one out.
- `mergeSessionModels` runs before `applySelectedModel` on both session create and session load, so the catalog consulted here has already absorbed the live session's advertised metadata.
- Alternatives considered:
  - *Clamp to the model default instead of omitting the field.* Rejected: inventing an effort the user never chose is a bigger behavior claim than letting Grok apply its own default, and the observable result here is the same (`high`).
  - *Fix the projection instead, e.g. make `projectSavedProviderValue` fall back to a Grok-valid default.* That is worth doing but is shared cross-provider settings code, a wider blast radius, and would still leave the runtime trusting an unvalidated value. The runtime guard is the narrow correctness boundary; I kept this PR to it.
  - *Have `getProviderSettings()` sanitize `effortLevel`.* Same validation, but it would also silently rewrite the value seen by unrelated call sites in that snapshot.

## Validation

Added three cases to `tests/unit/providers/grok/runtime/GrokChatRuntime.test.ts`, driven through the existing fake ACP process so they assert the real `session/set_model` payload:

- shared `max` against a catalog advertising high/medium/low → `_meta` omitted (this one fails on `main` with `_meta: { reasoningEffort: "max" }`, i.e. it reproduces the 400);
- shared `max` with `preferredReasoningByModel['grok-4.5'] = 'low'` → `_meta.reasoningEffort: "low"`;
- shared `low`, which the model does advertise → unchanged, still forwarded.

Ran `npm run typecheck`, `npm run lint`, `npm run build` (all clean) and `npm run test`.

On the full suite my Windows environment has 17 pre-existing suite failures (62 tests) from `spawn EFTYPE` and POSIX path assumptions — identical on `main` at `c89ddaf` and on this branch. Test counts: `6837 passed` before, `6840 passed` after, same 62 failures, i.e. exactly the three added cases and no regressions. Grok scope alone: `375 passed` vs `372 passed` baseline, same 11 pre-existing failures.

Manual: the failure itself was observed in a real vault and diagnosed from the Grok CLI session logs quoted above; the fix is verified by the reproduction test rather than by a second in-app run, since the failing payload (`_meta.reasoningEffort: "max"`) is asserted directly on the ACP wire. No screenshots — the change has no UI surface.

## Impact and Follow-ups

- No settings migration and no persisted-data change; only the value sent on `session/set_model`.
- Behavior change to be aware of: if the shared effort is unsupported and there is no per-model preference, the turn now runs at Grok's default effort instead of failing. That is the intent, but it is silent — there is no notice telling the user their Max selection did not apply to Grok.
- Follow-up worth considering separately: `savedProviderEffort.grok` being cleared by `clearSavedGrokEffortProjection` is what lets a foreign value reach the runtime at all. Repairing the projection would fix the cause as well as the symptom, and would also let the effort picker show the value that is actually in force.
- No linked issue; this is a small, self-contained bug fix with a concrete reproduction, so I went straight to a PR per the "one focused problem" guidance. Happy to open one if you prefer to track it.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
