### PR TITLE
fix(grok): restore provider effort metadata

### DIFF
--- a/src/providers/grok/execution/GrokExecutionBackend.ts
+++ b/src/providers/grok/execution/GrokExecutionBackend.ts
@@ -14,8 +14,10 @@ import type {
   AcpPromptResponse,
   AcpRequestPermissionRequest,
   AcpRequestPermissionResponse,
+  AcpSessionModelState,
   AcpSessionNotification,
   AcpSetSessionModelRequest,
+  AcpSetSessionModelResponse,
   AcpSetSessionModeRequest,
 } from '../../acp';
 import type { GrokCommandCatalog } from '../commands/GrokCommandCatalog';
@@ -56,6 +58,7 @@ export interface GrokExecutionNativeConnection {
     ) => void,
   ): () => void;
   onModeChanged?(listener: (mode: 'normal' | 'yolo') => void): () => void;
+  onModelsChanged?(listener: (models: AcpSessionModelState) => void): () => void;
   prompt(request: AcpPromptRequest): Promise<AcpPromptResponse>;
   rewind?(request: {
     force: boolean;
@@ -70,7 +73,7 @@ export interface GrokExecutionNativeConnection {
     success: boolean;
   }>;
   setMode(request: AcpSetSessionModeRequest): Promise<unknown>;
-  setModel(request: AcpSetSessionModelRequest): Promise<unknown>;
+  setModel(request: AcpSetSessionModelRequest): Promise<AcpSetSessionModelResponse>;
   shutdown(): Promise<void>;
 }
 

--- a/src/providers/grok/execution/GrokExecutionNativeConnection.ts
+++ b/src/providers/grok/execution/GrokExecutionNativeConnection.ts
@@ -18,6 +18,7 @@ import type {
   GrokExecutionNativeConnection,
   GrokExecutionNativeCreateOptions,
 } from './GrokExecutionBackend';
+import { parseGrokModelUpdateState } from './GrokSessionModelMetadata';
 
 const GROK_EXTENSION_REQUEST_METHODS = [
   'x.ai/ask_user_question',
@@ -31,11 +32,19 @@ const GROK_EXTENSION_NOTIFICATION_METHODS = [
   '_x.ai/yolo_mode_changed',
 ] as const;
 
+const GROK_MODEL_UPDATE_NOTIFICATION_METHODS = [
+  'x.ai/models/update',
+  '_x.ai/models/update',
+] as const;
+
 export class GrokExecutionNativeConnectionImpl
 implements GrokExecutionNativeConnection {
   private readonly connection: AcpClientConnection;
   private readonly listeners = new Set<Parameters<GrokExecutionNativeConnection['onNotification']>[0]>();
   private readonly modeListeners = new Set<(mode: 'normal' | 'yolo') => void>();
+  private readonly modelListeners = new Set<
+    Parameters<NonNullable<GrokExecutionNativeConnection['onModelsChanged']>>[0]
+  >();
   private readonly process: AcpSubprocess;
   private readonly transport: AcpJsonRpcTransport;
   private readonly unsubscribers: Array<() => void> = [];
@@ -82,6 +91,13 @@ implements GrokExecutionNativeConnection {
         if (!isRecord(params) || typeof params.yolo_mode !== 'boolean') return;
         const mode = params.yolo_mode ? 'yolo' : 'normal';
         for (const listener of this.modeListeners) listener(mode);
+      }));
+    }
+    for (const method of GROK_MODEL_UPDATE_NOTIFICATION_METHODS) {
+      this.unsubscribers.push(this.transport.onNotification(method, params => {
+        const models = parseGrokModelUpdateState(params);
+        if (!models) return;
+        for (const listener of this.modelListeners) listener(models);
       }));
     }
   }
@@ -148,6 +164,13 @@ implements GrokExecutionNativeConnection {
     return () => this.modeListeners.delete(listener);
   }
 
+  onModelsChanged(
+    listener: Parameters<NonNullable<GrokExecutionNativeConnection['onModelsChanged']>>[0],
+  ): () => void {
+    this.modelListeners.add(listener);
+    return () => this.modelListeners.delete(listener);
+  }
+
   prompt: GrokExecutionNativeConnection['prompt'] = request => (
     this.connection.prompt(request)
   );
@@ -168,6 +191,7 @@ implements GrokExecutionNativeConnection {
     while (this.unsubscribers.length > 0) this.unsubscribers.pop()?.();
     this.listeners.clear();
     this.modeListeners.clear();
+    this.modelListeners.clear();
     this.connection.dispose();
     this.transport.dispose();
     await this.process.shutdown();

--- a/src/providers/grok/execution/GrokExecutionSession.ts
+++ b/src/providers/grok/execution/GrokExecutionSession.ts
@@ -33,11 +33,13 @@ import {
   AcpInteractionController,
   type AcpPromptResponse,
   type AcpSessionConfigOption,
+  type AcpSessionModelState,
   type AcpSessionNotification,
   AcpToolStreamAdapter,
   buildAcpUsageInfo,
 } from '../../acp';
 import type { GrokCommandCatalog } from '../commands/GrokCommandCatalog';
+import { computeGrokEnvironmentHash } from '../env/GrokSettingsReconciler';
 import {
   resolveGrokSessionCwd,
   resolveGrokSessionDirectory,
@@ -65,6 +67,11 @@ import type {
   GrokExecutionNativeFactory,
 } from './GrokExecutionBackend';
 import { GrokExecutionInteractionRouter } from './GrokExecutionInteractionRouter';
+import {
+  normalizeGrokModelUpdateMetadata,
+  normalizeGrokSessionModelMetadata,
+  normalizeGrokSetModelMetadata,
+} from './GrokSessionModelMetadata';
 
 interface GrokExecutionSessionOptions {
   readonly commandCatalog?: Pick<GrokCommandCatalog, 'setCommandSnapshot'>;
@@ -167,6 +174,8 @@ interface GrokNativeOwner {
   loadedSessionConfigurationKey: string | null;
   loadedSessionId: string | null;
   modeUnsubscribe: () => void;
+  readonly modelContextKey: string;
+  modelsUnsubscribe: () => void;
   readonly native: GrokExecutionNativeConnection;
   notificationUnsubscribe: () => void;
   shutdownFlight: Promise<void> | null;
@@ -501,6 +510,8 @@ RewindableExecutionSession {
       loadedSessionConfigurationKey: null,
       loadedSessionId: null,
       modeUnsubscribe: () => {},
+      modelContextKey: computeGrokEnvironmentHash(this.plugin.settings),
+      modelsUnsubscribe: () => {},
       native,
       notificationUnsubscribe: () => {},
       shutdownFlight: null,
@@ -515,6 +526,12 @@ RewindableExecutionSession {
         if (!this.isCurrentNativeOwner(owner)) return;
         this.updateSnapshot(this.active ? 'executing' : 'idle');
         this.emitSessionMode(mode);
+      }) ?? (() => {});
+      owner.modelsUnsubscribe = native.onModelsChanged?.(models => {
+        if (!this.isCurrentNativeOwner(owner)) return;
+        void this.publishModelUpdate(owner, models).catch(() => {
+          // Catalog synchronization is best-effort and cannot disrupt the session.
+        });
       }) ?? (() => {});
       await native.initialize();
       if (
@@ -576,7 +593,7 @@ RewindableExecutionSession {
       owner.loadedSessionConfigurationKey = sessionConfigurationKey;
       this.updateSnapshot(this.active ? 'executing' : 'idle');
       this.emitCurrentSnapshot();
-      await this.publishModels(response.models);
+      await this.publishSessionModels(response, owner.modelContextKey);
       this.throwIfCancellationRequested(active);
       return this.providerSessionId;
     }
@@ -626,7 +643,7 @@ RewindableExecutionSession {
     owner.loadedSessionConfigurationKey = sessionConfigurationKey;
     this.updateSnapshot(this.active ? 'executing' : 'idle');
     this.emitCurrentSnapshot();
-    await this.publishModels(response.models);
+    await this.publishSessionModels(response, owner.modelContextKey);
     this.throwIfCancellationRequested(active);
     return response.sessionId;
   }
@@ -647,7 +664,7 @@ RewindableExecutionSession {
         rawModel,
         request.configuration.reasoning,
       );
-      await native.setModel({
+      const response = await native.setModel({
         ...(reasoningEffort
           ? { _meta: { reasoningEffort } }
           : {}),
@@ -655,6 +672,15 @@ RewindableExecutionSession {
         sessionId,
       });
       this.throwIfCancellationRequested(active);
+      const model = normalizeGrokSetModelMetadata(rawModel, response._meta);
+      if (model) {
+        await this.options.modelCatalogCoordinator?.mergeLiveModels(
+          [model],
+          undefined,
+          this.getNativeOwner(native).modelContextKey,
+        );
+        this.throwIfCancellationRequested(active);
+      }
     }
     const requestedMode = resolveGrokNativeMode(request);
     if (requestedMode) {
@@ -670,16 +696,13 @@ RewindableExecutionSession {
     rawModelId: string,
     requestedReasoning: string | undefined,
   ): string | null {
-    const requested = requestedReasoning?.trim() ?? '';
-    if (!requested) return null;
-
     const settings = getGrokProviderSettings(this.plugin.settings);
-    const advertisedValues = getGrokAvailableReasoningEfforts(
-      findGrokModel(settings.currentCatalog?.models ?? [], rawModelId),
-    ).map(effort => effort.value);
-    if (advertisedValues.length === 0 || advertisedValues.includes(requested)) {
-      return requested;
-    }
+    const model = findGrokModel(settings.currentCatalog?.models ?? [], rawModelId);
+    if (model?.reasoningMetadataResolved !== true) return null;
+    const advertisedValues = getGrokAvailableReasoningEfforts(model)
+      .map(effort => effort.value);
+    const requested = requestedReasoning?.trim() ?? '';
+    if (advertisedValues.includes(requested)) return requested;
 
     const preferred = settings.preferredReasoningByModel[rawModelId]?.trim() ?? '';
     return advertisedValues.includes(preferred) ? preferred : null;
@@ -704,7 +727,8 @@ RewindableExecutionSession {
       return;
     }
     if (result.metadata?.type === 'config_options') {
-      void this.publishModelsFromConfig(result.metadata.configOptions);
+      const owner = this.nativeOwner;
+      if (owner) void this.publishModelsFromConfig(result.metadata.configOptions, owner);
       return;
     }
     if (result.metadata?.type === 'current_mode') {
@@ -909,6 +933,11 @@ RewindableExecutionSession {
       } catch {
         // Listener cleanup cannot prevent process shutdown.
       }
+      try {
+        owner.modelsUnsubscribe();
+      } catch {
+        // Listener cleanup cannot prevent process shutdown.
+      }
     }
     if (!owner.shutdownFlight) {
       owner.shutdownFlight = Promise.resolve().then(() => owner.native.shutdown());
@@ -1001,28 +1030,42 @@ RewindableExecutionSession {
     };
   }
 
-  private async publishModels(
-    state: Awaited<ReturnType<GrokExecutionNativeConnection['newSession']>>['models'],
+  private async publishSessionModels(
+    response: Pick<
+      Awaited<ReturnType<GrokExecutionNativeConnection['newSession']>>,
+      '_meta' | 'configOptions' | 'models'
+    >,
+    sourceContextKey: string,
   ): Promise<void> {
-    if (!state) return;
-    const models = normalizeGrokDiscoveredModels(state.availableModels.map(model => ({
-      description: model.description ?? undefined,
-      displayName: model.name,
-      rawId: model.modelId ?? model.id,
-      reasoningEfforts: [],
-      supportsReasoning: false,
-    })));
+    const { currentModelId, models } = normalizeGrokSessionModelMetadata(response);
     if (models.length > 0) {
       await this.options.modelCatalogCoordinator?.mergeLiveModels(
         models,
-        state.currentModelId,
+        currentModelId ?? undefined,
+        sourceContextKey,
       );
     }
   }
 
+  private async publishModelUpdate(
+    owner: GrokNativeOwner,
+    state: AcpSessionModelState,
+  ): Promise<void> {
+    if (!this.isCurrentNativeOwner(owner)) return;
+    const update = normalizeGrokModelUpdateMetadata(state);
+    if (!update || !this.isCurrentNativeOwner(owner)) return;
+    await this.options.modelCatalogCoordinator?.mergeLiveModels(
+      update.models,
+      update.currentModelId ?? undefined,
+      owner.modelContextKey,
+    );
+  }
+
   private async publishModelsFromConfig(
     options: readonly AcpSessionConfigOption[],
+    owner: GrokNativeOwner,
   ): Promise<void> {
+    if (!this.isCurrentNativeOwner(owner)) return;
     const modelOption = options.find(option => option.id === 'model' && option.type === 'select');
     if (!modelOption || modelOption.type !== 'select') return;
     const flat = modelOption.options.flatMap(option => (
@@ -1038,6 +1081,7 @@ RewindableExecutionSession {
       await this.options.modelCatalogCoordinator?.mergeLiveModels(
         models,
         modelOption.currentValue,
+        owner.modelContextKey,
       );
     }
   }

--- a/src/providers/grok/execution/GrokExecutionSession.ts
+++ b/src/providers/grok/execution/GrokExecutionSession.ts
@@ -42,8 +42,10 @@ import {
   resolveGrokSessionCwd,
   resolveGrokSessionDirectory,
 } from '../history/GrokHistoryPathResolver';
-import { decodeGrokModelId } from '../models';
 import {
+  decodeGrokModelId,
+  findGrokModel,
+  getGrokAvailableReasoningEfforts,
   normalizeGrokDiscoveredModels,
 } from '../models';
 import {
@@ -56,6 +58,7 @@ import { waitForGrokCancelDelivery } from '../runtime/GrokCancelDelivery';
 import type { GrokModelCatalogCoordinator } from '../runtime/GrokModelCatalogCoordinator';
 import { buildGrokRuntimeEnv } from '../runtime/GrokRuntimeEnvironment';
 import { GrokSessionNotificationMirrorDeduplicator } from '../runtime/GrokSessionNotificationMirrorDeduplicator';
+import { getGrokProviderSettings } from '../settings';
 import { parseGrokProviderState } from '../types';
 import type {
   GrokExecutionNativeConnection,
@@ -638,9 +641,15 @@ RewindableExecutionSession {
       ? decodeGrokModelId(request.configuration.model)
       : null;
     if (rawModel) {
+      // The request can predate model discovery, so validate again after
+      // ensureSession has published the live model catalog.
+      const reasoningEffort = this.resolveReasoningEffort(
+        rawModel,
+        request.configuration.reasoning,
+      );
       await native.setModel({
-        ...(request.configuration.reasoning
-          ? { _meta: { reasoningEffort: request.configuration.reasoning } }
+        ...(reasoningEffort
+          ? { _meta: { reasoningEffort } }
           : {}),
         modelId: rawModel,
         sessionId,
@@ -655,6 +664,25 @@ RewindableExecutionSession {
       });
       this.throwIfCancellationRequested(active);
     }
+  }
+
+  private resolveReasoningEffort(
+    rawModelId: string,
+    requestedReasoning: string | undefined,
+  ): string | null {
+    const requested = requestedReasoning?.trim() ?? '';
+    if (!requested) return null;
+
+    const settings = getGrokProviderSettings(this.plugin.settings);
+    const advertisedValues = getGrokAvailableReasoningEfforts(
+      findGrokModel(settings.currentCatalog?.models ?? [], rawModelId),
+    ).map(effort => effort.value);
+    if (advertisedValues.length === 0 || advertisedValues.includes(requested)) {
+      return requested;
+    }
+
+    const preferred = settings.preferredReasoningByModel[rawModelId]?.trim() ?? '';
+    return advertisedValues.includes(preferred) ? preferred : null;
   }
 
   private handleNotification(

--- a/src/providers/grok/execution/GrokExecutionSession.ts
+++ b/src/providers/grok/execution/GrokExecutionSession.ts
@@ -48,6 +48,7 @@ import {
   decodeGrokModelId,
   findGrokModel,
   getGrokAvailableReasoningEfforts,
+  type GrokDiscoveredModel,
   normalizeGrokDiscoveredModels,
 } from '../models';
 import {
@@ -674,7 +675,7 @@ RewindableExecutionSession {
       this.throwIfCancellationRequested(active);
       const model = normalizeGrokSetModelMetadata(rawModel, response._meta);
       if (model) {
-        await this.options.modelCatalogCoordinator?.mergeLiveModels(
+        await this.mergeModelMetadataBestEffort(
           [model],
           undefined,
           this.getNativeOwner(native).modelContextKey,
@@ -702,6 +703,7 @@ RewindableExecutionSession {
     const advertisedValues = getGrokAvailableReasoningEfforts(model)
       .map(effort => effort.value);
     const requested = requestedReasoning?.trim() ?? '';
+    if (!requested) return null;
     if (advertisedValues.includes(requested)) return requested;
 
     const preferred = settings.preferredReasoningByModel[rawModelId]?.trim() ?? '';
@@ -1039,7 +1041,7 @@ RewindableExecutionSession {
   ): Promise<void> {
     const { currentModelId, models } = normalizeGrokSessionModelMetadata(response);
     if (models.length > 0) {
-      await this.options.modelCatalogCoordinator?.mergeLiveModels(
+      await this.mergeModelMetadataBestEffort(
         models,
         currentModelId ?? undefined,
         sourceContextKey,
@@ -1054,7 +1056,7 @@ RewindableExecutionSession {
     if (!this.isCurrentNativeOwner(owner)) return;
     const update = normalizeGrokModelUpdateMetadata(state);
     if (!update || !this.isCurrentNativeOwner(owner)) return;
-    await this.options.modelCatalogCoordinator?.mergeLiveModels(
+    await this.mergeModelMetadataBestEffort(
       update.models,
       update.currentModelId ?? undefined,
       owner.modelContextKey,
@@ -1078,11 +1080,27 @@ RewindableExecutionSession {
       supportsReasoning: false,
     })));
     if (models.length > 0) {
-      await this.options.modelCatalogCoordinator?.mergeLiveModels(
+      await this.mergeModelMetadataBestEffort(
         models,
         modelOption.currentValue,
         owner.modelContextKey,
       );
+    }
+  }
+
+  private async mergeModelMetadataBestEffort(
+    models: GrokDiscoveredModel[],
+    defaultModelId: string | undefined,
+    sourceContextKey: string,
+  ): Promise<void> {
+    try {
+      await this.options.modelCatalogCoordinator?.mergeLiveModels(
+        models,
+        defaultModelId,
+        sourceContextKey,
+      );
+    } catch {
+      // Catalog synchronization is best-effort and cannot disrupt execution.
     }
   }
 

--- a/src/providers/grok/execution/GrokSessionModelMetadata.ts
+++ b/src/providers/grok/execution/GrokSessionModelMetadata.ts
@@ -1,0 +1,111 @@
+import {
+  type AcpMetadata,
+  type AcpModelInfo,
+  type AcpSessionConfigOption,
+  type AcpSessionModelState,
+  extractAcpSessionModelState,
+} from '../../acp';
+import {
+  type GrokDiscoveredModel,
+  normalizeGrokDiscoveredModels,
+} from '../models';
+
+export interface NormalizedGrokSessionModels {
+  currentModelId: string | null;
+  models: GrokDiscoveredModel[];
+}
+
+export function normalizeGrokSessionModelMetadata(response: {
+  _meta?: AcpMetadata | null;
+  configOptions?: AcpSessionConfigOption[] | null;
+  models?: AcpSessionModelState | null;
+}): NormalizedGrokSessionModels {
+  const state = extractAcpSessionModelState(response);
+  const rawModelsById = new Map(
+    (response.models?.availableModels ?? []).flatMap(model => {
+      const id = resolveAcpModelId(model);
+      return id ? [[id, model] as const] : [];
+    }),
+  );
+  const models = state.availableModels.flatMap(model => {
+    const rawModel = rawModelsById.get(model.id);
+    const metadata = {
+      ...(model.id === state.currentModelId && isRecord(response._meta)
+        ? response._meta
+        : {}),
+      ...(isRecord(rawModel?._meta) ? rawModel._meta : {}),
+      ...(isRecord(model._meta) ? model._meta : {}),
+    };
+    return normalizeGrokDiscoveredModels([{
+      ...metadata,
+      description: model.description ?? rawModel?.description ?? undefined,
+      displayName: model.name,
+      rawId: model.id,
+      reasoningMetadataResolved: true,
+    }]);
+  });
+
+  return {
+    currentModelId: state.currentModelId,
+    models,
+  };
+}
+
+export function normalizeGrokSetModelMetadata(
+  rawModelId: string,
+  metadata: AcpMetadata | null | undefined,
+): GrokDiscoveredModel | null {
+  if (!isRecord(metadata?.model)) return null;
+  return normalizeGrokDiscoveredModels([{
+    ...metadata.model,
+    rawId: readModelId(metadata.model) ?? rawModelId,
+    reasoningMetadataResolved: true,
+  }])[0] ?? null;
+}
+
+export function normalizeGrokModelUpdateMetadata(
+  value: unknown,
+): NormalizedGrokSessionModels | null {
+  const state = parseGrokModelUpdateState(value);
+  return state ? normalizeGrokSessionModelMetadata({ models: state }) : null;
+}
+
+export function parseGrokModelUpdateState(
+  value: unknown,
+): AcpSessionModelState | null {
+  if (!isRecord(value)) return null;
+  const candidate = isRecord(value.models) ? value.models : value;
+  if (
+    !Array.isArray(candidate.availableModels)
+    || typeof candidate.currentModelId !== 'string'
+    || !candidate.currentModelId.trim()
+    || !candidate.availableModels.every(isAcpModelInfo)
+  ) {
+    return null;
+  }
+
+  return candidate as unknown as AcpSessionModelState;
+}
+
+function isAcpModelInfo(value: unknown): value is AcpModelInfo {
+  return isRecord(value)
+    && typeof value.name === 'string'
+    && readModelId(value) !== null;
+}
+
+function resolveAcpModelId(model: AcpModelInfo): string | null {
+  return readModelId(model);
+}
+
+function readModelId(value: Record<string, unknown>): string | null {
+  const id = typeof value.modelId === 'string'
+    ? value.modelId
+    : typeof value.id === 'string'
+      ? value.id
+      : '';
+  return id.trim() || null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/providers/grok/models.ts
+++ b/src/providers/grok/models.ts
@@ -113,10 +113,7 @@ export function getGrokAvailableReasoningEfforts(
   if (!model) {
     return [];
   }
-  if (
-    model.reasoningMetadataResolved === true
-    && model.reasoningEfforts.length > 0
-  ) {
+  if (model.reasoningMetadataResolved === true) {
     return model.reasoningEfforts;
   }
   return GROK_FALLBACK_REASONING_EFFORTS;

--- a/src/providers/grok/ui/GrokChatUIConfig.ts
+++ b/src/providers/grok/ui/GrokChatUIConfig.ts
@@ -1,8 +1,3 @@
-import {
-  DEFAULT_REASONING_VALUE,
-  formatReasoningValueLabel,
-  resolvePreferredReasoningDefault,
-} from '../../../core/providers/reasoning';
 import type {
   ProviderChatUIConfig,
   ProviderPermissionModeToggleConfig,
@@ -17,6 +12,7 @@ import {
   getGrokAvailableReasoningEfforts,
   isGrokModelSelectionId,
   resolveGrokContextWindow,
+  resolveGrokDefaultReasoningEffort,
 } from '../models';
 import { getGrokProviderSettings, updateGrokProviderSettings } from '../settings';
 
@@ -72,7 +68,7 @@ export const grokChatUIConfig: ProviderChatUIConfig = {
       getExplicitlySelectedGrokModel(model, settings),
     ).map(option => ({
       ...(option.description ? { description: option.description } : {}),
-      label: formatReasoningValueLabel(option.value),
+      label: option.label,
       value: option.value,
     }));
   },
@@ -83,18 +79,15 @@ export const grokChatUIConfig: ProviderChatUIConfig = {
     if (!rawId) {
       return '';
     }
-    const efforts = getGrokAvailableReasoningEfforts(
-      getExplicitlySelectedGrokModel(model, settings),
-    );
+    const selectedModel = getExplicitlySelectedGrokModel(model, settings);
+    const efforts = getGrokAvailableReasoningEfforts(selectedModel);
     if (efforts.length === 0) {
       return '';
     }
-    const availableValues = efforts.map(effort => effort.value);
-    const preferred = grokSettings.preferredReasoningByModel[rawId];
-    if (preferred && availableValues.includes(preferred)) {
-      return preferred;
-    }
-    return resolvePreferredReasoningDefault(availableValues, DEFAULT_REASONING_VALUE);
+    return resolveGrokDefaultReasoningEffort(
+      selectedModel ? { ...selectedModel, reasoningEfforts: [...efforts] } : null,
+      grokSettings.preferredReasoningByModel[rawId],
+    );
   },
 
   getContextWindowSize(model, customLimits = {}, settings = {}): number {

--- a/tests/unit/providers/grok/app/GrokCommandMetadataProbe.test.ts
+++ b/tests/unit/providers/grok/app/GrokCommandMetadataProbe.test.ts
@@ -35,7 +35,9 @@ class FakeMetadataNative implements GrokExecutionNativeConnection {
   onNotification(): () => void { return () => undefined; }
   async prompt(): Promise<never> { throw new Error('unused'); }
   async setMode(): Promise<void> {}
-  async setModel(): Promise<void> {}
+  async setModel(): Promise<Record<string, never>> {
+    return {};
+  }
 
   async listCommands(_cwd: string, signal?: AbortSignal): Promise<any[]> {
     this.listStarted.resolve();

--- a/tests/unit/providers/grok/execution/GrokExecutionBackend.test.ts
+++ b/tests/unit/providers/grok/execution/GrokExecutionBackend.test.ts
@@ -552,6 +552,64 @@ describe('GrokExecutionBackend', () => {
     ], undefined, expect.any(String));
   });
 
+  it('continues the turn when selected-model metadata persistence fails', async () => {
+    const native = new FakeNativeConnection();
+    native.modelImplementation = async () => ({
+      _meta: {
+        model: {
+          reasoningEffort: 'high',
+          supportsReasoningEffort: true,
+          'x.ai/sessionConfig': {
+            options: [
+              { category: 'mode', id: 'high', label: 'High', selected: true },
+            ],
+          },
+        },
+      },
+    });
+    const host = createGrok45Host();
+    persistGrok45Catalog(host);
+    const mergeLiveModels = jest.fn(async () => {
+      throw new Error('settings persistence failed');
+    });
+    const session = new GrokExecutionBackend(host, {
+      modelCatalogCoordinator: { mergeLiveModels },
+      nativeFactory: { create: () => native },
+    }).createSession(sessionConfig);
+
+    const events = await collect(session.execute(grok45Request('high')).events);
+
+    expect(mergeLiveModels).toHaveBeenCalledTimes(1);
+    expect(native.promptRequests).toHaveLength(1);
+    expect(events.at(-1)).toMatchObject({ type: 'turn_completed' });
+  });
+
+  it('continues the turn when session-model metadata persistence fails', async () => {
+    const native = new FakeNativeConnection();
+    native.loadResponse = {
+      models: {
+        availableModels: [{ modelId: 'grok-4.5', name: 'Grok 4.5' }],
+        currentModelId: 'grok-4.5',
+      },
+      sessionId: 'session-existing',
+    };
+    const host = createGrok45Host();
+    persistGrok45Catalog(host);
+    const mergeLiveModels = jest.fn(async () => {
+      throw new Error('settings persistence failed');
+    });
+    const session = new GrokExecutionBackend(host, {
+      modelCatalogCoordinator: { mergeLiveModels },
+      nativeFactory: { create: () => native },
+    }).createSession(sessionConfig);
+
+    const events = await collect(session.execute(grok45Request('high')).events);
+
+    expect(mergeLiveModels).toHaveBeenCalledTimes(1);
+    expect(native.promptRequests).toHaveLength(1);
+    expect(events.at(-1)).toMatchObject({ type: 'turn_completed' });
+  });
+
   it('persists live model updates and fences notifications from a quarantined native', async () => {
     const native = new FakeNativeConnection();
     native.promptImplementation = () => new Promise(() => {});
@@ -618,7 +676,7 @@ describe('GrokExecutionBackend', () => {
     }]);
   });
 
-  it('uses a valid per-model preference when the request has no projected effort', async () => {
+  it('omits a saved per-model preference when the request has no projected effort', async () => {
     const native = new FakeNativeConnection();
     const host = createGrok45Host();
     persistGrok45Catalog(host);
@@ -635,7 +693,6 @@ describe('GrokExecutionBackend', () => {
     await collect(session.execute({ ...request, configuration }).events);
 
     expect(native.modelRequests).toEqual([{
-      _meta: { reasoningEffort: 'low' },
       modelId: 'grok-4.5',
       sessionId: 'session-existing',
     }]);

--- a/tests/unit/providers/grok/execution/GrokExecutionBackend.test.ts
+++ b/tests/unit/providers/grok/execution/GrokExecutionBackend.test.ts
@@ -37,6 +37,11 @@ import {
   type GrokExecutionNativeCreateOptions,
   type GrokExecutionNativeFactory,
 } from '@/providers/grok/execution/GrokExecutionBackend';
+import type { GrokDiscoveredModel } from '@/providers/grok/models';
+import {
+  updateCurrentGrokCatalog,
+  updateGrokProviderSettings,
+} from '@/providers/grok/settings';
 
 const interactionPort: ProviderInteractionPort = {
   askUserQuestion: jest.fn(),
@@ -81,6 +86,55 @@ function executionRequest(text = 'hello'): ProviderExecutionRequest {
     signal: new AbortController().signal,
     toolPolicy: { kind: 'provider-default' },
   };
+}
+
+function grok45Request(reasoning: string): ProviderExecutionRequest {
+  const request = executionRequest();
+  return {
+    ...request,
+    configuration: {
+      ...request.configuration,
+      model: 'grok/grok-4.5',
+      reasoning,
+    },
+  };
+}
+
+function createGrok45Host(): ProviderHost {
+  return {
+    settings: {
+      model: 'grok/grok-4.5',
+      providerConfigs: {
+        grok: {
+          enabled: true,
+          preferredReasoningByModel: {},
+        },
+      },
+      savedProviderModel: { grok: 'grok/grok-4.5' },
+    },
+  } as unknown as ProviderHost;
+}
+
+function persistGrok45Catalog(
+  host: ProviderHost,
+  models: GrokDiscoveredModel[] = [{
+    displayName: 'Grok 4.5',
+    rawId: 'grok-4.5',
+    reasoningMetadataResolved: true,
+    reasoningEfforts: [
+      { label: 'High', value: 'high' },
+      { label: 'Medium', value: 'medium' },
+      { label: 'Low', value: 'low' },
+    ],
+    supportsReasoning: true,
+  }],
+): void {
+  updateCurrentGrokCatalog(host.settings, {
+    defaultModelId: 'grok-4.5',
+    fingerprint: 'catalog-fixture',
+    models,
+    refreshedAt: 1,
+  });
 }
 
 function featurePermissionRequest(
@@ -349,6 +403,89 @@ describe('GrokExecutionBackend', () => {
       providerSessionId: 'session-existing',
       status: 'idle',
     });
+  });
+
+  it('drops an unsupported reasoning effort after cold-session model discovery', async () => {
+    const native = new FakeNativeConnection();
+    native.loadResponse = {
+      models: {
+        availableModels: [{ modelId: 'grok-4.5', name: 'Grok 4.5' }],
+        currentModelId: 'grok-4.5',
+      },
+      sessionId: 'session-existing',
+    };
+    const host = createGrok45Host();
+    const mergeLiveModels = jest.fn(async (models: GrokDiscoveredModel[]) => {
+      persistGrok45Catalog(host, models);
+      return { changed: true };
+    });
+    const session = new GrokExecutionBackend(host, {
+      modelCatalogCoordinator: { mergeLiveModels },
+      nativeFactory: { create: () => native },
+    }).createSession(sessionConfig);
+
+    await collect(session.execute(grok45Request('max')).events);
+
+    expect(mergeLiveModels).toHaveBeenCalledTimes(1);
+    expect(native.modelRequests).toEqual([{
+      modelId: 'grok-4.5',
+      sessionId: 'session-existing',
+    }]);
+  });
+
+  it('keeps the requested reasoning effort when the selected model metadata is unknown', async () => {
+    const native = new FakeNativeConnection();
+    const session = new GrokExecutionBackend(
+      createGrok45Host(),
+      { nativeFactory: { create: () => native } },
+    ).createSession(sessionConfig);
+
+    await collect(session.execute(grok45Request('max')).events);
+
+    expect(native.modelRequests).toEqual([{
+      _meta: { reasoningEffort: 'max' },
+      modelId: 'grok-4.5',
+      sessionId: 'session-existing',
+    }]);
+  });
+
+  it('uses a valid per-model preference when the requested reasoning effort is unsupported', async () => {
+    const native = new FakeNativeConnection();
+    const host = createGrok45Host();
+    persistGrok45Catalog(host);
+    updateGrokProviderSettings(host.settings, {
+      preferredReasoningByModel: { 'grok-4.5': 'low' },
+    });
+    const session = new GrokExecutionBackend(
+      host,
+      { nativeFactory: { create: () => native } },
+    ).createSession(sessionConfig);
+
+    await collect(session.execute(grok45Request('max')).events);
+
+    expect(native.modelRequests).toEqual([{
+      _meta: { reasoningEffort: 'low' },
+      modelId: 'grok-4.5',
+      sessionId: 'session-existing',
+    }]);
+  });
+
+  it('keeps a requested reasoning effort the selected model advertises', async () => {
+    const native = new FakeNativeConnection();
+    const host = createGrok45Host();
+    persistGrok45Catalog(host);
+    const session = new GrokExecutionBackend(
+      host,
+      { nativeFactory: { create: () => native } },
+    ).createSession(sessionConfig);
+
+    await collect(session.execute(grok45Request('low')).events);
+
+    expect(native.modelRequests).toEqual([{
+      _meta: { reasoningEffort: 'low' },
+      modelId: 'grok-4.5',
+      sessionId: 'session-existing',
+    }]);
   });
 
   it('loads once per native connection and quarantines session replay from live output', async () => {

--- a/tests/unit/providers/grok/execution/GrokExecutionBackend.test.ts
+++ b/tests/unit/providers/grok/execution/GrokExecutionBackend.test.ts
@@ -27,8 +27,10 @@ import type {
   AcpLoadSessionRequest,
   AcpNewSessionRequest,
   AcpPromptRequest,
+  AcpSessionModelState,
   AcpSessionNotification,
   AcpSetSessionModelRequest,
+  AcpSetSessionModelResponse,
   AcpSetSessionModeRequest,
 } from '@/providers/acp';
 import {
@@ -204,6 +206,8 @@ class FakeNativeConnection implements GrokExecutionNativeConnection {
     value: AcpSessionNotification,
     source: 'extension' | 'standard',
   ) => void) | null = null;
+  private modelsChanged: ((models: AcpSessionModelState) => void) | null = null;
+  private retainedModelsChanged: ((models: AcpSessionModelState) => void) | null = null;
   initializeImplementation: () => Promise<void> = async () => {};
   forkImplementation: (request: {
     newCwd: string;
@@ -218,7 +222,9 @@ class FakeNativeConnection implements GrokExecutionNativeConnection {
     parentSessionId: request.sourceSessionId,
   });
   interjectImplementation: () => Promise<void> = async () => {};
-  modelImplementation: (request: AcpSetSessionModelRequest) => Promise<void> = async () => {};
+  modelImplementation: (
+    request: AcpSetSessionModelRequest,
+  ) => Promise<AcpSetSessionModelResponse> = async () => ({});
   promptImplementation: () => Promise<{ stopReason: string }> = async () => ({
     stopReason: 'end_turn',
   });
@@ -276,6 +282,12 @@ class FakeNativeConnection implements GrokExecutionNativeConnection {
     return () => { this.notification = null; };
   }
 
+  onModelsChanged(listener: (models: AcpSessionModelState) => void): () => void {
+    this.modelsChanged = listener;
+    this.retainedModelsChanged = listener;
+    return () => { this.modelsChanged = null; };
+  }
+
   async prompt(request: AcpPromptRequest): Promise<{ stopReason: string }> {
     this.promptRequests.push(request);
     return this.promptImplementation();
@@ -302,9 +314,9 @@ class FakeNativeConnection implements GrokExecutionNativeConnection {
     this.modeRequests.push(request);
   }
 
-  async setModel(request: AcpSetSessionModelRequest): Promise<void> {
+  async setModel(request: AcpSetSessionModelRequest): Promise<AcpSetSessionModelResponse> {
     this.modelRequests.push(request);
-    await this.modelImplementation(request);
+    return this.modelImplementation(request);
   }
 
   async shutdown(): Promise<void> {
@@ -327,6 +339,14 @@ class FakeNativeConnection implements GrokExecutionNativeConnection {
       sessionId: 'session-existing',
       update,
     } as unknown as AcpSessionNotification, source);
+  }
+
+  emitModelsChanged(models: AcpSessionModelState): void {
+    this.modelsChanged?.(models);
+  }
+
+  emitRetainedModelsChanged(models: AcpSessionModelState): void {
+    this.retainedModelsChanged?.(models);
   }
 }
 
@@ -358,8 +378,7 @@ describe('GrokExecutionBackend', () => {
     const events = await collect(run.events);
 
     expect(native.loadRequests).toHaveLength(1);
-    expect(native.modelRequests[0]).toMatchObject({
-      _meta: { reasoningEffort: 'high' },
+    expect(native.modelRequests[0]).toEqual({
       modelId: 'grok-4',
       sessionId: 'session-existing',
     });
@@ -433,7 +452,7 @@ describe('GrokExecutionBackend', () => {
     }]);
   });
 
-  it('keeps the requested reasoning effort when the selected model metadata is unknown', async () => {
+  it('omits the requested reasoning effort when the selected model metadata is unknown', async () => {
     const native = new FakeNativeConnection();
     const session = new GrokExecutionBackend(
       createGrok45Host(),
@@ -443,10 +462,139 @@ describe('GrokExecutionBackend', () => {
     await collect(session.execute(grok45Request('max')).events);
 
     expect(native.modelRequests).toEqual([{
+      modelId: 'grok-4.5',
+      sessionId: 'session-existing',
+    }]);
+  });
+
+  it('accepts a future effort value advertised by live session metadata', async () => {
+    const native = new FakeNativeConnection();
+    native.loadResponse = {
+      _meta: {
+        reasoningEffort: 'max',
+        'x.ai/sessionConfig': {
+          options: [
+            { category: 'mode', id: 'high', label: 'High', selected: false },
+            { category: 'mode', id: 'max', label: 'Maximum', selected: true },
+          ],
+        },
+      },
+      models: {
+        availableModels: [{
+          _meta: { supportsReasoningEffort: true },
+          modelId: 'grok-4.5',
+          name: 'Grok 4.5',
+        }],
+        currentModelId: 'grok-4.5',
+      },
+      sessionId: 'session-existing',
+    };
+    const host = createGrok45Host();
+    const mergeLiveModels = jest.fn(async (models: GrokDiscoveredModel[]) => {
+      persistGrok45Catalog(host, models);
+      return { changed: true };
+    });
+    const session = new GrokExecutionBackend(host, {
+      modelCatalogCoordinator: { mergeLiveModels },
+      nativeFactory: { create: () => native },
+    }).createSession(sessionConfig);
+
+    await collect(session.execute(grok45Request('max')).events);
+
+    expect(native.modelRequests).toEqual([{
       _meta: { reasoningEffort: 'max' },
       modelId: 'grok-4.5',
       sessionId: 'session-existing',
     }]);
+    expect(mergeLiveModels).toHaveBeenCalledWith([
+      expect.objectContaining({
+        defaultReasoningEffort: 'max',
+        reasoningEfforts: expect.arrayContaining([
+          expect.objectContaining({ value: 'max' }),
+        ]),
+        reasoningMetadataResolved: true,
+      }),
+    ], 'grok-4.5', expect.any(String));
+  });
+
+  it('persists authoritative metadata returned by model selection', async () => {
+    const native = new FakeNativeConnection();
+    native.modelImplementation = async () => ({
+      _meta: {
+        model: {
+          reasoningEffort: 'max',
+          supportsReasoningEffort: true,
+          'x.ai/sessionConfig': {
+            options: [
+              { category: 'mode', id: 'high', label: 'High', selected: false },
+              { category: 'mode', id: 'max', label: 'Maximum', selected: true },
+            ],
+          },
+        },
+      },
+    });
+    const host = createGrok45Host();
+    persistGrok45Catalog(host);
+    const mergeLiveModels = jest.fn();
+    const session = new GrokExecutionBackend(host, {
+      modelCatalogCoordinator: { mergeLiveModels },
+      nativeFactory: { create: () => native },
+    }).createSession(sessionConfig);
+
+    await collect(session.execute(grok45Request('low')).events);
+
+    expect(mergeLiveModels).toHaveBeenCalledWith([
+      expect.objectContaining({
+        defaultReasoningEffort: 'max',
+        rawId: 'grok-4.5',
+        reasoningMetadataResolved: true,
+      }),
+    ], undefined, expect.any(String));
+  });
+
+  it('persists live model updates and fences notifications from a quarantined native', async () => {
+    const native = new FakeNativeConnection();
+    native.promptImplementation = () => new Promise(() => {});
+    const mergeLiveModels = jest.fn(async () => ({ changed: true }));
+    const session = new GrokExecutionBackend(createGrok45Host(), {
+      modelCatalogCoordinator: { mergeLiveModels },
+      nativeFactory: { create: () => native },
+    }).createSession(sessionConfig);
+    const run = session.execute(grok45Request('max'));
+    while (native.promptRequests.length === 0) await Promise.resolve();
+    const models: AcpSessionModelState = {
+      availableModels: [{
+        _meta: {
+          reasoningEffort: 'max',
+          supportsReasoningEffort: true,
+          'x.ai/sessionConfig': {
+            options: [
+              { category: 'mode', id: 'high', label: 'High', selected: false },
+              { category: 'mode', id: 'max', label: 'Maximum', selected: true },
+            ],
+          },
+        },
+        modelId: 'grok-4.5',
+        name: 'Grok 4.5',
+      }],
+      currentModelId: 'grok-4.5',
+    };
+
+    native.emitModelsChanged(models);
+    await drainMicrotasks();
+    expect(mergeLiveModels).toHaveBeenCalledWith([
+      expect.objectContaining({
+        defaultReasoningEffort: 'max',
+        rawId: 'grok-4.5',
+        reasoningMetadataResolved: true,
+      }),
+    ], 'grok-4.5', expect.any(String));
+
+    run.cancel();
+    await collect(run.events);
+    native.emitRetainedModelsChanged(models);
+    await drainMicrotasks();
+    expect(mergeLiveModels).toHaveBeenCalledTimes(1);
   });
 
   it('uses a valid per-model preference when the requested reasoning effort is unsupported', async () => {
@@ -462,6 +610,29 @@ describe('GrokExecutionBackend', () => {
     ).createSession(sessionConfig);
 
     await collect(session.execute(grok45Request('max')).events);
+
+    expect(native.modelRequests).toEqual([{
+      _meta: { reasoningEffort: 'low' },
+      modelId: 'grok-4.5',
+      sessionId: 'session-existing',
+    }]);
+  });
+
+  it('uses a valid per-model preference when the request has no projected effort', async () => {
+    const native = new FakeNativeConnection();
+    const host = createGrok45Host();
+    persistGrok45Catalog(host);
+    updateGrokProviderSettings(host.settings, {
+      preferredReasoningByModel: { 'grok-4.5': 'low' },
+    });
+    const request = grok45Request('high');
+    const { reasoning: _reasoning, ...configuration } = request.configuration;
+    const session = new GrokExecutionBackend(
+      host,
+      { nativeFactory: { create: () => native } },
+    ).createSession(sessionConfig);
+
+    await collect(session.execute({ ...request, configuration }).events);
 
     expect(native.modelRequests).toEqual([{
       _meta: { reasoningEffort: 'low' },
@@ -1634,6 +1805,7 @@ describe('GrokExecutionBackend', () => {
     expect(mergeLiveModels).toHaveBeenCalledWith(
       [expect.objectContaining({ rawId: 'grok-4' })],
       'grok-4',
+      expect.any(String),
     );
     const systemPromptOverride = String(
       native.loadRequests[0]?._meta?.systemPromptOverride,

--- a/tests/unit/providers/grok/execution/GrokSessionModelMetadata.test.ts
+++ b/tests/unit/providers/grok/execution/GrokSessionModelMetadata.test.ts
@@ -1,0 +1,119 @@
+import {
+  normalizeGrokModelUpdateMetadata,
+  normalizeGrokSessionModelMetadata,
+  normalizeGrokSetModelMetadata,
+} from '@/providers/grok/execution/GrokSessionModelMetadata';
+
+const sessionReasoningMeta = {
+  reasoningEffort: 'max',
+  'x.ai/sessionConfig': {
+    options: [
+      { category: 'mode', id: 'low', label: 'Low', selected: false },
+      { category: 'mode', id: 'high', label: 'High', selected: false },
+      { category: 'mode', id: 'max', label: 'Maximum', selected: true },
+    ],
+  },
+};
+
+describe('GrokSessionModelMetadata', () => {
+  it('combines session and per-model metadata without leaking the current default', () => {
+    const result = normalizeGrokSessionModelMetadata({
+      _meta: sessionReasoningMeta,
+      configOptions: [{
+        category: 'model',
+        currentValue: 'grok-4.5',
+        id: 'model',
+        name: 'Model',
+        options: [
+          { name: 'Grok 4.5', value: 'grok-4.5' },
+          { name: 'Other', value: 'other-model' },
+        ],
+        type: 'select',
+      }],
+      models: {
+        availableModels: [{
+          _meta: {
+            agentType: 'grok-build-plan',
+            supportsReasoningEffort: true,
+            totalContextTokens: 200_000,
+          },
+          modelId: 'grok-4.5',
+          name: 'Grok 4.5',
+        }, {
+          _meta: {
+            agentType: 'grok-build',
+            supportsReasoningEffort: false,
+          },
+          modelId: 'other-model',
+          name: 'Other',
+        }],
+        currentModelId: 'grok-4.5',
+      },
+    });
+
+    expect(result.currentModelId).toBe('grok-4.5');
+    expect(result.models).toEqual([
+      expect.objectContaining({
+        agentType: 'grok-build-plan',
+        contextWindow: 200_000,
+        defaultReasoningEffort: 'max',
+        rawId: 'grok-4.5',
+        reasoningEfforts: [
+          { label: 'Low', value: 'low' },
+          { label: 'High', value: 'high' },
+          { label: 'Maximum', value: 'max' },
+        ],
+        reasoningMetadataResolved: true,
+        supportsReasoning: true,
+      }),
+      expect.objectContaining({
+        agentType: 'grok-build',
+        rawId: 'other-model',
+        reasoningEfforts: [],
+        reasoningMetadataResolved: true,
+        supportsReasoning: false,
+      }),
+    ]);
+    expect(result.models[1]).not.toHaveProperty('defaultReasoningEffort');
+  });
+
+  it('attaches the requested model id to set-model metadata', () => {
+    expect(normalizeGrokSetModelMetadata('grok-future', {
+      model: {
+        ...sessionReasoningMeta,
+        displayName: 'Grok Future',
+        supportsReasoningEffort: true,
+      },
+    })).toEqual(expect.objectContaining({
+      defaultReasoningEffort: 'max',
+      displayName: 'Grok Future',
+      rawId: 'grok-future',
+      reasoningMetadataResolved: true,
+      reasoningEfforts: expect.arrayContaining([
+        expect.objectContaining({ value: 'max' }),
+      ]),
+    }));
+  });
+
+  it('normalizes direct and wrapped xAI model update payloads', () => {
+    const state = {
+      availableModels: [{
+        _meta: sessionReasoningMeta,
+        modelId: 'grok-future',
+        name: 'Grok Future',
+      }],
+      currentModelId: 'grok-future',
+    };
+
+    expect(normalizeGrokModelUpdateMetadata(state)).toEqual(expect.objectContaining({
+      currentModelId: 'grok-future',
+      models: [expect.objectContaining({
+        rawId: 'grok-future',
+        reasoningMetadataResolved: true,
+      })],
+    }));
+    expect(normalizeGrokModelUpdateMetadata({ models: state }))
+      .toEqual(normalizeGrokModelUpdateMetadata(state));
+    expect(normalizeGrokModelUpdateMetadata({ invalid: true })).toBeNull();
+  });
+});

--- a/tests/unit/providers/grok/models.test.ts
+++ b/tests/unit/providers/grok/models.test.ts
@@ -2,6 +2,7 @@ import {
   decodeGrokModelId,
   encodeGrokModelId,
   findGrokModel,
+  getGrokAvailableReasoningEfforts,
   GROK_CONTEXT_WINDOW_FALLBACK,
   isGrokModelSelectionId,
   mergeGrokDiscoveredModels,
@@ -146,6 +147,25 @@ describe('Grok model metadata', () => {
       reasoningMetadataResolved: true,
       supportsReasoning: false,
     });
+  });
+
+  it('uses fallback efforts only until ACP reasoning metadata is resolved', () => {
+    const unresolved = {
+      displayName: 'Unresolved',
+      rawId: 'unresolved',
+      reasoningEfforts: [],
+      supportsReasoning: false,
+    };
+    const resolvedEmpty = {
+      ...unresolved,
+      displayName: 'Resolved',
+      rawId: 'resolved',
+      reasoningMetadataResolved: true,
+    };
+
+    expect(getGrokAvailableReasoningEfforts(unresolved).map(effort => effort.value))
+      .toEqual(['low', 'medium', 'high']);
+    expect(getGrokAvailableReasoningEfforts(resolvedEmpty)).toEqual([]);
   });
 
   it('resolves preferred, declared, high, and first reasoning defaults in order', () => {

--- a/tests/unit/providers/grok/settings.test.ts
+++ b/tests/unit/providers/grok/settings.test.ts
@@ -148,6 +148,45 @@ describe('Grok settings', () => {
     expect(JSON.stringify(snapshot)).not.toContain('secret');
   });
 
+  it('round-trips future provider-advertised effort metadata and preferences', () => {
+    const settings: Record<string, unknown> = {
+      providerConfigs: {
+        grok: {
+          catalogsByHost: {
+            'device:current': {
+              defaultModelId: 'grok-future',
+              fingerprint: 'future-catalog',
+              models: [{
+                defaultReasoningEffort: 'max',
+                displayName: 'Grok Future',
+                rawId: 'grok-future',
+                reasoningEfforts: [
+                  { label: 'High', value: 'high' },
+                  { label: 'Maximum', value: 'max' },
+                ],
+                reasoningMetadataResolved: true,
+                supportsReasoning: true,
+              }],
+              refreshedAt: 123,
+            },
+          },
+          preferredReasoningByModel: { 'grok-future': 'max' },
+          visibleModels: ['grok-future'],
+        },
+      },
+    };
+
+    const grok = getGrokProviderSettings(settings);
+    expect(grok.currentCatalog?.models[0]).toEqual(expect.objectContaining({
+      defaultReasoningEffort: 'max',
+      reasoningEfforts: expect.arrayContaining([
+        expect.objectContaining({ value: 'max' }),
+      ]),
+      reasoningMetadataResolved: true,
+    }));
+    expect(grok.preferredReasoningByModel).toEqual({ 'grok-future': 'max' });
+  });
+
   it('normalizes catalog-scoped preferences while retaining a selected stale model', () => {
     const settings = getGrokProviderSettings({
       model: 'grok/legacy-model',

--- a/tests/unit/providers/grok/ui/GrokChatUIConfig.test.ts
+++ b/tests/unit/providers/grok/ui/GrokChatUIConfig.test.ts
@@ -143,9 +143,9 @@ describe('GrokChatUIConfig', () => {
     expect(grokChatUIConfig.isAdaptiveReasoningModel('grok/grok-4', settings)).toBe(true);
     expect(grokChatUIConfig.isAdaptiveReasoningModel('grok/kimi-coding', settings)).toBe(false);
     expect(grokChatUIConfig.getReasoningOptions('grok/grok-4', settings)).toEqual([
-      { description: 'Fastest', label: 'Minimal', value: 'minimal' },
-      { label: 'High', value: 'high' },
-      { label: 'xHigh', value: 'xhigh' },
+      { description: 'Fastest', label: 'Minimal Effort', value: 'minimal' },
+      { label: 'High Effort', value: 'high' },
+      { label: 'Extra High Effort', value: 'xhigh' },
     ]);
     expect(grokChatUIConfig.getDefaultReasoningValue('grok/grok-4', settings)).toBe('high');
 
@@ -161,6 +161,67 @@ describe('GrokChatUIConfig', () => {
     settings.effortLevel = 'medium';
     grokChatUIConfig.applyModelProjectionDefaults?.('grok/grok-4', settings);
     expect(settings.effortLevel).toBe('xhigh');
+  });
+
+  it('uses the provider-advertised reasoning default without a saved preference', () => {
+    const catalogWithAdvertisedDefault = {
+      ...catalog,
+      models: catalog.models.map(model => model.rawId === 'grok-4'
+        ? {
+          ...model,
+          reasoningEfforts: [
+            ...model.reasoningEfforts,
+            { label: 'Medium Effort', value: 'medium' },
+          ],
+        }
+        : model),
+    };
+    const settings = makeSettings({
+      providerConfigs: {
+        grok: {
+          catalogsByHost: { 'device:current': catalogWithAdvertisedDefault },
+          preferredReasoningByModel: {},
+          visibleModels: ['grok-4'],
+        },
+      },
+    });
+
+    expect(grokChatUIConfig.getDefaultReasoningValue('grok/grok-4', settings)).toBe('medium');
+  });
+
+  it('adopts and persists a future provider-advertised effort value', () => {
+    const futureCatalog = {
+      ...catalog,
+      models: [{
+        defaultReasoningEffort: 'max',
+        displayName: 'Grok Future',
+        rawId: 'grok-future',
+        reasoningEfforts: [
+          { label: 'High', value: 'high' },
+          { label: 'Maximum', value: 'max' },
+        ],
+        reasoningMetadataResolved: true,
+        supportsReasoning: true,
+      }],
+    };
+    const settings = makeSettings({
+      providerConfigs: {
+        grok: {
+          catalogsByHost: { 'device:current': futureCatalog },
+          preferredReasoningByModel: {},
+          visibleModels: ['grok-future'],
+        },
+      },
+    });
+
+    expect(grokChatUIConfig.getReasoningOptions('grok/grok-future', settings))
+      .toEqual(expect.arrayContaining([
+        expect.objectContaining({ label: 'Maximum', value: 'max' }),
+      ]));
+    expect(grokChatUIConfig.getDefaultReasoningValue('grok/grok-future', settings)).toBe('max');
+    grokChatUIConfig.applyReasoningSelection?.('grok/grok-future', 'max', settings);
+    expect(getGrokProviderSettings(settings).preferredReasoningByModel)
+      .toEqual({ 'grok-future': 'max' });
   });
 
   it('uses and persists the standard fallback for models without reasoning metadata', () => {
@@ -209,7 +270,7 @@ describe('GrokChatUIConfig', () => {
     expect(grokChatUIConfig.getDefaultReasoningValue('grok/grok-4.5', settings)).toBe('high');
   });
 
-  it('keeps the standard fallback when ACP resolves no effort choices', () => {
+  it('removes reasoning choices when ACP resolves an empty effort list', () => {
     const resolvedCatalog = {
       ...catalog,
       models: catalog.models.map(model => model.rawId === 'kimi-coding'
@@ -225,13 +286,9 @@ describe('GrokChatUIConfig', () => {
       },
     });
 
-    expect(grokChatUIConfig.isAdaptiveReasoningModel('grok/kimi-coding', settings)).toBe(true);
-    expect(grokChatUIConfig.getReasoningOptions('grok/kimi-coding', settings)).toEqual([
-      { label: 'Low', value: 'low' },
-      { label: 'Medium', value: 'medium' },
-      { label: 'High', value: 'high' },
-    ]);
-    expect(grokChatUIConfig.getDefaultReasoningValue('grok/kimi-coding', settings)).toBe('high');
+    expect(grokChatUIConfig.isAdaptiveReasoningModel('grok/kimi-coding', settings)).toBe(false);
+    expect(grokChatUIConfig.getReasoningOptions('grok/kimi-coding', settings)).toEqual([]);
+    expect(grokChatUIConfig.getDefaultReasoningValue('grok/kimi-coding', settings)).toBe('');
   });
 
   it('preserves explicit model preferences across projection updates', () => {


### PR DESCRIPTION
## Why

PR #1003 identified that Grok rejects reasoning efforts that its selected model does not advertise. The chat runtime refactor removed the runtime targeted by that PR, but it also dropped Grok's ACP effort-metadata ingestion: session responses, model-selection responses, and live xAI model updates were reduced to model names only.

That left Claudian projecting shared fallback values such as `max` without an authoritative Grok capability record. This PR supersedes #1003 at the refactored provider boundary.

## What Changed

- Restore provider-owned effort metadata from ACP `session/new` and `session/load` responses, `session/set_model` responses, and `x.ai/models/update` notifications.
- Normalize session-level and per-model metadata into the Grok model catalog and persist it in the current host's `providerConfigs.grok.catalogsByHost` settings entry.
- Preserve arbitrary future provider-advertised effort values and labels, such as `max`, instead of maintaining a local Grok tier list.
- Treat resolved empty effort metadata as authoritative, so models without effort choices do not show a reasoning selector.
- For explicit chat effort projections, use an advertised request or saved per-model preference. Auxiliary requests without an effort projection omit reasoning so Grok applies its native default.
- Keep catalog synchronization best-effort so settings persistence failures cannot abort an otherwise valid native turn.
- Fence live metadata writes by native ownership and Grok environment hash so stale processes cannot update a new host catalog.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test` — 317 suites and 6,091 tests passed
- `npm run build`

This replaces the now-closed #1003 with the equivalent fix in the refactored execution architecture.
