### PR TITLE
Add native MCP setup guidance for OpenCode and Grok

### DIFF
--- a/src/providers/codex/ui/CodexSettingsTab.ts
+++ b/src/providers/codex/ui/CodexSettingsTab.ts
@@ -5,6 +5,7 @@ import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSet
 import type { ProviderSettingsTabRenderer } from '../../../core/providers/types';
 import { t } from '../../../i18n/i18n';
 import { renderEnvironmentSettingsSection } from '../../../shared/settings/EnvironmentSettingsSection';
+import { renderNativeMcpSettingsSection } from '../../../shared/settings/NativeMcpSettingsSection';
 import {
   renderLastEnabledProviderWarning,
   renderProviderModelEnablementWarning,
@@ -350,15 +351,13 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
 
     // --- MCP Servers ---
 
-    new Setting(container).setName(t('settings.mcpServers.name')).setHeading();
-    const mcpNotice = container.createDiv({ cls: 'claudian-mcp-settings-desc' });
-    const mcpDesc = mcpNotice.createEl('p', { cls: 'setting-item-description' });
-    mcpDesc.appendText(t('settings.codex.mcp.descBeforeCommand'));
-    mcpDesc.createEl('code').appendText('codex mcp');
-    mcpDesc.appendText(t('settings.codex.mcp.descAfterCommand'));
-    mcpDesc.createEl('a', {
-      text: t('settings.codex.mcp.learnMore'),
-      href: 'https://developers.openai.com/codex/mcp',
+    renderNativeMcpSettingsSection(container, {
+      descriptionAfterCommand: t('settings.codex.mcp.descAfterCommand'),
+      descriptionBeforeCommand: t('settings.codex.mcp.descBeforeCommand'),
+      documentationLabel: t('settings.codex.mcp.learnMore'),
+      documentationUrl: 'https://developers.openai.com/codex/mcp',
+      heading: t('settings.mcpServers.name'),
+      setupCommand: 'codex mcp',
     });
 
     // --- Environment ---

--- a/src/providers/grok/ui/GrokSettingsTab.ts
+++ b/src/providers/grok/ui/GrokSettingsTab.ts
@@ -12,6 +12,7 @@ import type {
 import type { ClaudianSettings } from '../../../core/types';
 import { t } from '../../../i18n/i18n';
 import { renderEnvironmentSettingsSection } from '../../../shared/settings/EnvironmentSettingsSection';
+import { renderNativeMcpSettingsSection } from '../../../shared/settings/NativeMcpSettingsSection';
 import {
   renderLastEnabledProviderWarning,
   renderProviderModelEnablementWarning,
@@ -208,6 +209,15 @@ export const grokSettingsTabRenderer: ProviderSettingsTabRenderer = {
       name: 'Hidden Grok commands',
       desc: 'Hide runtime commands advertised by Grok from the command dropdown. Enter names without the leading slash, one per line.',
       placeholder: 'compact\nreview',
+    });
+
+    renderNativeMcpSettingsSection(container, {
+      descriptionAfterCommand: ' and they will be available in Claudian. ',
+      descriptionBeforeCommand: 'Grok Build manages MCP servers through its own CLI. Configure them with ',
+      documentationLabel: 'Learn more',
+      documentationUrl: 'https://docs.x.ai/build/features/mcp-servers',
+      heading: t('settings.mcpServers.name'),
+      setupCommand: 'grok mcp add',
     });
 
     renderEnvironmentSettingsSection({

--- a/src/providers/opencode/ui/OpencodeSettingsTab.ts
+++ b/src/providers/opencode/ui/OpencodeSettingsTab.ts
@@ -8,6 +8,7 @@ import type {
 } from '../../../core/providers/types';
 import { t } from '../../../i18n/i18n';
 import { renderEnvironmentSettingsSection } from '../../../shared/settings/EnvironmentSettingsSection';
+import { renderNativeMcpSettingsSection } from '../../../shared/settings/NativeMcpSettingsSection';
 import {
   renderLastEnabledProviderWarning,
   renderProviderModelEnablementWarning,
@@ -190,6 +191,15 @@ export const opencodeSettingsTabRenderer: ProviderSettingsTabRenderer = {
         },
       );
     }
+
+    renderNativeMcpSettingsSection(container, {
+      descriptionAfterCommand: ' and they will be available in Claudian. ',
+      descriptionBeforeCommand: 'OpenCode manages MCP servers through its own CLI. Configure them with ',
+      documentationLabel: 'Learn more',
+      documentationUrl: 'https://opencode.ai/docs/mcp-servers/',
+      heading: t('settings.mcpServers.name'),
+      setupCommand: 'opencode mcp add',
+    });
 
     renderEnvironmentSettingsSection({
       container,

--- a/src/shared/settings/NativeMcpSettingsSection.ts
+++ b/src/shared/settings/NativeMcpSettingsSection.ts
@@ -1,0 +1,27 @@
+import { Setting } from 'obsidian';
+
+export interface NativeMcpSettingsSectionOptions {
+  descriptionAfterCommand: string;
+  descriptionBeforeCommand: string;
+  documentationLabel: string;
+  documentationUrl: string;
+  heading: string;
+  setupCommand: string;
+}
+
+export function renderNativeMcpSettingsSection(
+  container: HTMLElement,
+  options: NativeMcpSettingsSectionOptions,
+): void {
+  new Setting(container).setName(options.heading).setHeading();
+
+  const notice = container.createDiv({ cls: 'claudian-mcp-settings-desc' });
+  const description = notice.createEl('p', { cls: 'setting-item-description' });
+  description.appendText(options.descriptionBeforeCommand);
+  description.createEl('code').appendText(options.setupCommand);
+  description.appendText(options.descriptionAfterCommand);
+  description.createEl('a', {
+    href: options.documentationUrl,
+    text: options.documentationLabel,
+  });
+}

--- a/tests/unit/providers/grok/ui/GrokSettingsTab.test.ts
+++ b/tests/unit/providers/grok/ui/GrokSettingsTab.test.ts
@@ -125,11 +125,12 @@ interface MockSetting {
 interface MockElement {
   children: MockElement[];
   cls?: string;
+  href?: string;
   tag?: string;
   text?: string;
   appendText(value: string): void;
   createDiv(options?: { cls?: string; text?: string }): MockElement;
-  createEl(tag: string, options?: { cls?: string; text?: string }): MockElement;
+  createEl(tag: string, options?: { cls?: string; href?: string; text?: string }): MockElement;
   setText(value: string): void;
   toggleClass(cls: string, force: boolean): void;
 }
@@ -181,10 +182,14 @@ function createToggleComponent(): MockToggleComponent {
   return component;
 }
 
-function createElement(tag?: string, options?: { cls?: string; text?: string }): MockElement {
+function createElement(
+  tag?: string,
+  options?: { cls?: string; href?: string; text?: string },
+): MockElement {
   const element: MockElement = {
     children: [],
     cls: options?.cls,
+    href: options?.href,
     tag,
     text: options?.text,
     appendText(value) {
@@ -569,7 +574,27 @@ describe('GrokSettingsTab', () => {
       .not.toHaveProperty('reasoningMetadataResolved');
   });
 
-  it('renders only hidden runtime commands and the Grok environment scope', () => {
+  it('directs MCP setup to the native Grok CLI', () => {
+    const plugin = createPlugin();
+    grokSettingsTabRenderer.render(createContainer(), createContext(plugin));
+
+    expect(findSetting('MCP Servers').heading).toBe(true);
+    const notice = createdElements.find(element => element.cls === 'claudian-mcp-settings-desc');
+    const description = notice?.children[0];
+    expect(description?.text).toBe(
+      'Grok Build manages MCP servers through its own CLI. Configure them with  and they will be available in Claudian. ',
+    );
+    expect(description?.children).toEqual(expect.arrayContaining([
+      expect.objectContaining({ tag: 'code', text: 'grok mcp add' }),
+      expect.objectContaining({
+        href: 'https://docs.x.ai/build/features/mcp-servers',
+        tag: 'a',
+        text: 'Learn more',
+      }),
+    ]));
+  });
+
+  it('renders only native skills, hidden runtime commands, MCP guidance, and the Grok environment scope', () => {
     const plugin = createPlugin();
     const context = createContext(plugin);
     const container = createContainer();
@@ -590,7 +615,6 @@ describe('GrokSettingsTab', () => {
     }));
     expect(createdSettings.map(setting => setting.name)).not.toEqual(expect.arrayContaining([
       'Agents',
-      'MCP servers',
       'Skills',
       'Subagents',
     ]));

--- a/tests/unit/providers/opencode/OpencodeSettingsTab.test.ts
+++ b/tests/unit/providers/opencode/OpencodeSettingsTab.test.ts
@@ -603,6 +603,30 @@ describe('OpencodeSettingsTab', () => {
     );
   });
 
+  it('directs MCP setup to the native OpenCode CLI', () => {
+    const plugin = createPlugin();
+
+    opencodeSettingsTabRenderer.render(createContainer(), createContext(plugin));
+
+    expect(findSetting('MCP Servers').heading).toBe(true);
+    const notice = findElement('div', 'claudian-mcp-settings-desc');
+    const description = notice.createEl.mock.results[0].value;
+    expect(description.appendText).toHaveBeenNthCalledWith(
+      1,
+      'OpenCode manages MCP servers through its own CLI. Configure them with ',
+    );
+    expect(description.createEl.mock.results[0].value.appendText)
+      .toHaveBeenCalledWith('opencode mcp add');
+    expect(description.appendText).toHaveBeenNthCalledWith(
+      2,
+      ' and they will be available in Claudian. ',
+    );
+    expect(description.createEl).toHaveBeenCalledWith('a', {
+      href: 'https://opencode.ai/docs/mcp-servers/',
+      text: 'Learn more',
+    });
+  });
+
   it('refreshes vault subagent state inside an execution transition', async () => {
     const plugin = createPlugin();
 

--- a/tests/unit/shared/settings/NativeMcpSettingsSection.test.ts
+++ b/tests/unit/shared/settings/NativeMcpSettingsSection.test.ts
@@ -1,0 +1,78 @@
+import { renderNativeMcpSettingsSection } from '@/shared/settings/NativeMcpSettingsSection';
+
+const createdSettings: Array<{ heading: boolean; name: string }> = [];
+
+jest.mock('obsidian', () => ({
+  Setting: class MockSetting {
+    public heading = false;
+    public name = '';
+
+    constructor(_container: unknown) {
+      createdSettings.push(this);
+    }
+
+    setHeading() {
+      this.heading = true;
+      return this;
+    }
+
+    setName(name: string) {
+      this.name = name;
+      return this;
+    }
+  },
+}));
+
+function createElement(): any {
+  return {
+    appendText: jest.fn(),
+    createEl: jest.fn(() => createElement()),
+  };
+}
+
+describe('renderNativeMcpSettingsSection', () => {
+  beforeEach(() => {
+    createdSettings.length = 0;
+  });
+
+  it('renders the shared heading, native CLI command, and documentation link', () => {
+    const notice = createElement();
+    const container = {
+      createDiv: jest.fn(() => notice),
+    } as unknown as HTMLElement;
+
+    renderNativeMcpSettingsSection(container, {
+      descriptionAfterCommand: ' and they will be available in Claudian. ',
+      descriptionBeforeCommand: 'Grok Build manages MCP servers through its own CLI. Configure them with ',
+      documentationLabel: 'Learn more',
+      documentationUrl: 'https://docs.x.ai/build/features/mcp-servers',
+      heading: 'MCP Servers',
+      setupCommand: 'grok mcp add',
+    });
+
+    expect(createdSettings).toEqual([{ heading: true, name: 'MCP Servers' }]);
+    expect((container as any).createDiv).toHaveBeenCalledWith({
+      cls: 'claudian-mcp-settings-desc',
+    });
+    expect(notice.createEl).toHaveBeenCalledWith('p', {
+      cls: 'setting-item-description',
+    });
+
+    const description = notice.createEl.mock.results[0].value;
+    expect(description.appendText).toHaveBeenNthCalledWith(
+      1,
+      'Grok Build manages MCP servers through its own CLI. Configure them with ',
+    );
+    expect(description.appendText).toHaveBeenNthCalledWith(
+      2,
+      ' and they will be available in Claudian. ',
+    );
+    expect(description.createEl).toHaveBeenCalledWith('code');
+    expect(description.createEl.mock.results[0].value.appendText)
+      .toHaveBeenCalledWith('grok mcp add');
+    expect(description.createEl).toHaveBeenCalledWith('a', {
+      href: 'https://docs.x.ai/build/features/mcp-servers',
+      text: 'Learn more',
+    });
+  });
+});


### PR DESCRIPTION
## Why

OpenCode and Grok Build own their MCP configuration, but their Claudian settings tabs did not explain how native MCP servers become available. No issue is needed because this is a focused provider-settings clarification.

## What Changed

- Added native MCP setup guidance and official documentation links for OpenCode and Grok Build.
- Extracted the existing Codex-style notice into a shared renderer without changing its copy or behavior.
- Added focused tests for the shared renderer and both provider tabs.

## Why This Approach

Keeping configuration provider-owned avoids duplicating MCP persistence, authentication, permissions, and lifecycle behavior in Claudian while the shared renderer keeps the three notices structurally consistent.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run test` — 318 suites and 6,107 tests passed, plus 10 architecture and release checks.
- `npm run build`
- No screenshot was captured; the change reuses the existing Codex MCP notice styling.

## Impact and Follow-ups

No persisted settings or provider runtime behavior changes; no follow-up is required.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
