### PR TITLE
Fix plan mode activation in new chat sessions

### DIFF
--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -2382,7 +2382,7 @@ export async function updatePlanModeUI(
         snapshot,
       );
     });
-    if (options.syncExecution) {
+    if (options.syncExecution && tab.lifecycleState !== 'blank') {
       try {
         await tab.executionCoordinator?.setMode(getTabPermissionMode(tab, plugin));
       } catch (error) {

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -801,12 +801,27 @@ describe('Tab provider execution ownership', () => {
 
   it('synchronizes explicit mode changes through the coordinator', async () => {
     const plugin = createPlugin();
-    const tab = createTab({ plugin, containerEl: createMockEl() as any });
+    const tab = createTab({
+      plugin,
+      containerEl: createMockEl() as any,
+      conversation: createConversation(),
+    });
     const coordinator = coordinatorInstances[0];
 
     await updatePlanModeUI(tab, plugin, 'plan', { syncExecution: true });
 
     expect(plugin.settings.permissionMode).toBe('plan');
     expect(coordinator.setMode).toHaveBeenCalledWith('plan');
+  });
+
+  it('keeps plan mode as draft state when a blank tab has no execution conversation', async () => {
+    const plugin = createPlugin();
+    const tab = createTab({ plugin, containerEl: createMockEl() as any });
+    const coordinator = coordinatorInstances[0];
+
+    await updatePlanModeUI(tab, plugin, 'plan', { syncExecution: true });
+
+    expect(plugin.settings.permissionMode).toBe('plan');
+    expect(coordinator.setMode).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Why

New blank chat sessions could not enter plan mode because the UI attempted to synchronize with an execution coordinator before any conversation was bound, producing a warning and blocking the mode change.

## What Changed

Plan mode now remains draft configuration for blank tabs, while bound conversations continue synchronizing explicit mode changes with their execution coordinator; regression coverage verifies both paths.

## Why This Approach

Blank-tab configuration belongs to draft state until the first send binds a conversation, so skipping premature runtime synchronization preserves lazy session creation without changing established-session behavior.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test -- --runInBand` (6,122 tests passed)
- `npm run build`
- `git diff --check origin/main...HEAD`

## Impact and Follow-ups

None.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] No issue is needed for this focused regression fix.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] User-facing documentation is not needed for this behavior correction.
