### PR TITLE
Fix Claude task progress rendering

### DIFF
--- a/src/core/tools/todo.ts
+++ b/src/core/tools/todo.ts
@@ -32,6 +32,10 @@ export function parseTodoInput(input: Record<string, unknown>): TodoItem[] | nul
     return null;
   }
 
+  if (input.todos.length === 0) {
+    return [];
+  }
+
   const validTodos: TodoItem[] = [];
   for (const item of input.todos) {
     if (isValidTodoItem(item)) {

--- a/src/features/chat/rendering/ToolCallRenderer.ts
+++ b/src/features/chat/rendering/ToolCallRenderer.ts
@@ -735,7 +735,7 @@ function getCurrentTask(input: Record<string, unknown>): TodoItem | undefined {
 
 function areAllTodosCompleted(input: Record<string, unknown>): boolean {
   const todos = getTodos(input);
-  if (!todos || todos.length === 0) return false;
+  if (!todos) return false;
   return todos.every(t => t.status === 'completed');
 }
 

--- a/src/providers/claude/execution/ClaudeExecutionEventNormalizer.ts
+++ b/src/providers/claude/execution/ClaudeExecutionEventNormalizer.ts
@@ -14,6 +14,7 @@ import type {
   ToolExecutionScope,
 } from '../../../core/execution';
 import type { StreamChunk } from '../../../core/types';
+import { ClaudeTaskToolNormalizer } from '../normalization/ClaudeTaskToolNormalizer';
 import {
   isAsyncSubagentCompletion,
   isContextWindowEvent,
@@ -88,6 +89,7 @@ interface ToolIdentity {
 
 interface NormalizationState {
   readonly streamState: ReturnType<typeof createTransformStreamState>;
+  readonly taskToolNormalizer: ClaudeTaskToolNormalizer;
   readonly usageState: ReturnType<typeof createTransformUsageState>;
   readonly toolScopes: Map<string, ToolIdentity>;
   assistantStarted: boolean;
@@ -137,7 +139,9 @@ export class ClaudeExecutionEventNormalizer {
         continue;
       }
       if (isStreamChunk(event)) {
-        this.normalizeStreamChunk(message, event, state, normalized);
+        for (const chunk of normalizeTaskToolChunk(event, state.taskToolNormalizer)) {
+          this.normalizeStreamChunk(message, chunk, state, normalized);
+        }
       }
     }
 
@@ -156,6 +160,7 @@ export class ClaudeExecutionEventNormalizer {
   reset(channel: ClaudeExecutionEventChannel): void {
     const state = this.states[channel];
     state.streamState.clearAll();
+    state.taskToolNormalizer.reset();
     state.usageState.clear();
     state.toolScopes.clear();
     state.assistantStarted = false;
@@ -238,12 +243,53 @@ export class ClaudeExecutionEventNormalizer {
 function createNormalizationState(): NormalizationState {
   return {
     streamState: createTransformStreamState(),
+    taskToolNormalizer: new ClaudeTaskToolNormalizer(),
     usageState: createTransformUsageState(),
     toolScopes: new Map(),
     assistantStarted: false,
     sawStreamText: false,
     sawStreamThinking: false,
   };
+}
+
+function normalizeTaskToolChunk(
+  chunk: StreamChunk,
+  normalizer: ClaudeTaskToolNormalizer,
+): StreamChunk[] {
+  if (chunk.type === 'tool_use') {
+    const normalized = normalizer.normalizeToolUse(chunk.id, chunk.name, chunk.input);
+    if (!normalized) return [chunk];
+    return [{
+      ...chunk,
+      name: normalized.name,
+      input: normalized.input,
+      providerPayload: normalized.providerPayload,
+    }];
+  }
+
+  if (chunk.type === 'tool_result') {
+    const normalized = normalizer.normalizeToolResult(
+      chunk.id,
+      chunk.toolUseResult,
+      {
+        fallbackContent: chunk.content,
+        isError: chunk.isError,
+      },
+    );
+    if (!normalized) return [chunk];
+    return [
+      {
+        type: 'tool_use',
+        id: chunk.id,
+        name: normalized.name,
+        input: normalized.input,
+        providerPayload: normalized.providerPayload,
+      },
+      chunk,
+    ];
+  }
+
+  return [chunk];
 }
 
 function toOutputEvent(

--- a/src/providers/claude/history/ClaudeHistoryStore.ts
+++ b/src/providers/claude/history/ClaudeHistoryStore.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 
 import type { ProviderHistoryPathContext } from '../../../core/providers/types';
 import type { ChatMessage, SubagentInfo, ToolCallInfo } from '../../../core/types';
+import { ClaudeTaskToolNormalizer } from '../normalization/ClaudeTaskToolNormalizer';
 import { isClaudeSubagentToolName } from '../subagentToolNames';
 import { buildAsyncSubagentInfo } from './sdkAsyncSubagent';
 import { filterActiveBranch } from './sdkBranchFilter';
@@ -140,16 +141,22 @@ export async function loadSDKSessionMessages(
 
   const chatMessages: ChatMessage[] = [];
   let pendingAssistant: ChatMessage | null = null;
+  const taskToolNormalizer = new ClaudeTaskToolNormalizer();
 
   // Merge consecutive assistant messages until an actual user message appears
   for (const sdkMsg of filteredEntries) {
-    if (isSystemInjectedMessage(sdkMsg)) continue;
+    const systemInjected = isSystemInjectedMessage(sdkMsg);
+    if (sdkMsg.type === 'user' && !systemInjected) {
+      taskToolNormalizer.reset();
+    }
+    if (systemInjected) continue;
 
     // Skip synthetic assistant messages (e.g., "No response requested." after /compact)
     if (sdkMsg.type === 'assistant' && sdkMsg.message?.model === '<synthetic>') continue;
 
     const chatMsg = parseSDKMessageToChat(sdkMsg, toolResults);
     if (!chatMsg) continue;
+    normalizeTaskToolCalls(chatMsg, taskToolNormalizer, toolUseResults);
 
     if (chatMsg.role === 'assistant') {
       // context_compacted must not merge with previous assistant (it's a standalone separator)
@@ -237,4 +244,36 @@ export async function loadSDKSessionMessages(
   chatMessages.sort((a, b) => a.timestamp - b.timestamp);
 
   return { messages: chatMessages, skippedLines: result.skippedLines };
+}
+
+function normalizeTaskToolCalls(
+  message: ChatMessage,
+  normalizer: ClaudeTaskToolNormalizer,
+  toolUseResults: Map<string, unknown>,
+): void {
+  if (message.role !== 'assistant' || !message.toolCalls) return;
+
+  for (const toolCall of message.toolCalls) {
+    const normalizedUse = normalizer.normalizeToolUse(
+      toolCall.id,
+      toolCall.name,
+      toolCall.input,
+    );
+    if (!normalizedUse) continue;
+
+    const rawOutput = toolUseResults.get(toolCall.id);
+    const normalizedResult = toolCall.status === 'running'
+      ? null
+      : normalizer.normalizeToolResult(toolCall.id, rawOutput, {
+        fallbackContent: toolCall.result,
+        isError: toolCall.status === 'error' || toolCall.status === 'blocked',
+      });
+    const normalized = normalizedResult ?? normalizedUse;
+    toolCall.name = normalized.name;
+    toolCall.input = normalized.input;
+    toolCall.providerPayload = {
+      ...toolCall.providerPayload,
+      ...normalized.providerPayload,
+    };
+  }
 }

--- a/src/providers/claude/normalization/ClaudeTaskToolNormalizer.ts
+++ b/src/providers/claude/normalization/ClaudeTaskToolNormalizer.ts
@@ -1,0 +1,335 @@
+import type { TodoItem } from '../../../core/tools/todo';
+import { TOOL_TODO_WRITE } from '../../../core/tools/toolNames';
+import type { ToolProviderPayload } from '../../../core/types';
+
+const CLAUDE_TASK_TOOL_NAMES = [
+  'TaskCreate',
+  'TaskGet',
+  'TaskList',
+  'TaskUpdate',
+] as const;
+
+type ClaudeTaskToolName = typeof CLAUDE_TASK_TOOL_NAMES[number];
+type TaskStatus = TodoItem['status'];
+
+interface StoredTask extends TodoItem {
+  id?: string;
+}
+
+interface TaskCallState {
+  rawName: ClaudeTaskToolName;
+  rawInput: Record<string, unknown>;
+  taskKey?: string;
+  updateTaskId?: string;
+  updateTaskBefore?: StoredTask;
+}
+
+export interface NormalizedClaudeTaskToolCall {
+  name: typeof TOOL_TODO_WRITE;
+  input: {
+    todos: Array<TodoItem & { id?: string }>;
+  };
+  providerPayload: ToolProviderPayload;
+}
+
+export interface ClaudeTaskToolResultOptions {
+  fallbackContent?: string;
+  isError?: boolean;
+}
+
+/**
+ * Reduces Claude Code's incremental task tools into the full-list TodoWrite
+ * snapshots consumed by the provider-neutral chat UI.
+ */
+export class ClaudeTaskToolNormalizer {
+  private readonly calls = new Map<string, TaskCallState>();
+  private readonly tasks = new Map<string, StoredTask>();
+
+  normalizeToolUse(
+    toolCallId: string,
+    rawName: string,
+    rawInput: Record<string, unknown>,
+  ): NormalizedClaudeTaskToolCall | null {
+    if (!isClaudeTaskToolName(rawName)) return null;
+
+    const call = this.getOrCreateCall(toolCallId, rawName);
+    call.rawInput = { ...rawInput };
+
+    switch (rawName) {
+      case 'TaskCreate':
+        this.applyCreate(toolCallId, call, rawInput);
+        break;
+      case 'TaskUpdate':
+        this.applyUpdate(call, rawInput);
+        break;
+      case 'TaskGet':
+      case 'TaskList':
+        break;
+    }
+
+    return this.buildNormalizedCall(call);
+  }
+
+  normalizeToolResult(
+    toolCallId: string,
+    rawOutput: unknown,
+    options: ClaudeTaskToolResultOptions = {},
+  ): NormalizedClaudeTaskToolCall | null {
+    const call = this.calls.get(toolCallId);
+    if (!call) return null;
+
+    const effectiveOutput = rawOutput ?? options.fallbackContent;
+    const outputRecord = toRecord(effectiveOutput);
+    const failed = options.isError === true || outputRecord?.success === false;
+
+    switch (call.rawName) {
+      case 'TaskCreate':
+        if (failed) {
+          if (call.taskKey) this.tasks.delete(call.taskKey);
+        } else {
+          this.bindCreatedTask(call, effectiveOutput, options.fallbackContent);
+        }
+        break;
+      case 'TaskUpdate':
+        if (failed) {
+          this.restoreUpdate(call);
+        } else {
+          this.applyAuthoritativeUpdate(call, outputRecord);
+        }
+        break;
+      case 'TaskList':
+        if (!failed) this.applyTaskList(outputRecord);
+        break;
+      case 'TaskGet':
+        if (!failed) this.applyTaskGet(call, outputRecord);
+        break;
+    }
+
+    return this.buildNormalizedCall(call, effectiveOutput);
+  }
+
+  reset(): void {
+    this.calls.clear();
+    this.tasks.clear();
+  }
+
+  private getOrCreateCall(toolCallId: string, rawName: ClaudeTaskToolName): TaskCallState {
+    const existing = this.calls.get(toolCallId);
+    if (existing?.rawName === rawName) return existing;
+
+    const call: TaskCallState = {
+      rawName,
+      rawInput: {},
+    };
+    this.calls.set(toolCallId, call);
+    return call;
+  }
+
+  private applyCreate(
+    toolCallId: string,
+    call: TaskCallState,
+    input: Record<string, unknown>,
+  ): void {
+    const subject = readNonEmptyString(input.subject);
+    if (!subject) return;
+
+    const taskKey = call.taskKey ?? `pending:${toolCallId}`;
+    call.taskKey = taskKey;
+    const current = this.tasks.get(taskKey);
+    this.tasks.set(taskKey, {
+      ...(current?.id ? { id: current.id } : {}),
+      content: subject,
+      activeForm: readNonEmptyString(input.activeForm) ?? subject,
+      status: current?.status ?? 'pending',
+    });
+  }
+
+  private applyUpdate(call: TaskCallState, input: Record<string, unknown>): void {
+    const taskId = readNonEmptyString(input.taskId);
+    if (!taskId) return;
+
+    if (call.updateTaskId !== taskId) {
+      call.updateTaskId = taskId;
+      call.updateTaskBefore = cloneTask(this.tasks.get(taskId));
+    }
+
+    const before = call.updateTaskBefore;
+    if (!before) return;
+
+    const status = readTaskUpdateStatus(input.status);
+    if (status === 'deleted') {
+      this.tasks.delete(taskId);
+      return;
+    }
+
+    const subject = readNonEmptyString(input.subject);
+    const activeForm = readNonEmptyString(input.activeForm);
+    this.tasks.set(taskId, {
+      ...before,
+      ...(subject ? { content: subject } : {}),
+      ...(activeForm ? { activeForm } : {}),
+      ...(status ? { status } : {}),
+    });
+  }
+
+  private bindCreatedTask(
+    call: TaskCallState,
+    output: unknown,
+    fallbackContent?: string,
+  ): void {
+    if (!call.taskKey) return;
+
+    const taskRecord = toRecord(toRecord(output)?.task);
+    const taskId = readNonEmptyString(taskRecord?.id)
+      ?? extractCreatedTaskId(fallbackContent)
+      ?? extractCreatedTaskId(typeof output === 'string' ? output : undefined);
+    if (!taskId) return;
+
+    const pendingTask = this.tasks.get(call.taskKey);
+    if (!pendingTask) return;
+
+    const subject = readNonEmptyString(taskRecord?.subject);
+    const createdTask: StoredTask = {
+      ...pendingTask,
+      id: taskId,
+      ...(subject ? { content: subject } : {}),
+    };
+    this.replaceTaskKey(call.taskKey, taskId, createdTask);
+    call.taskKey = taskId;
+  }
+
+  private restoreUpdate(call: TaskCallState): void {
+    if (!call.updateTaskId) return;
+    if (call.updateTaskBefore) {
+      this.tasks.set(call.updateTaskId, cloneTask(call.updateTaskBefore)!);
+    } else {
+      this.tasks.delete(call.updateTaskId);
+    }
+  }
+
+  private applyAuthoritativeUpdate(
+    call: TaskCallState,
+    output: Record<string, unknown> | null,
+  ): void {
+    const taskId = readNonEmptyString(output?.taskId) ?? call.updateTaskId;
+    if (!taskId) return;
+
+    const statusChange = toRecord(output?.statusChange);
+    const status = readTaskUpdateStatus(statusChange?.to);
+    if (status === 'deleted') {
+      this.tasks.delete(taskId);
+    } else if (status) {
+      const task = this.tasks.get(taskId);
+      if (task) this.tasks.set(taskId, { ...task, status });
+    }
+  }
+
+  private applyTaskList(output: Record<string, unknown> | null): void {
+    if (!Array.isArray(output?.tasks)) return;
+
+    const nextTasks = new Map<string, StoredTask>();
+    for (const value of output.tasks) {
+      const record = toRecord(value);
+      const taskId = readNonEmptyString(record?.id);
+      const subject = readNonEmptyString(record?.subject);
+      const status = readTaskStatus(record?.status);
+      if (!taskId || !subject || !status) continue;
+
+      const current = this.tasks.get(taskId);
+      nextTasks.set(taskId, {
+        id: taskId,
+        content: subject,
+        activeForm: current?.activeForm ?? subject,
+        status,
+      });
+    }
+
+    this.tasks.clear();
+    for (const [taskId, task] of nextTasks) this.tasks.set(taskId, task);
+  }
+
+  private applyTaskGet(
+    call: TaskCallState,
+    output: Record<string, unknown> | null,
+  ): void {
+    if (!output || !Object.prototype.hasOwnProperty.call(output, 'task')) return;
+
+    const requestedTaskId = readNonEmptyString(call.rawInput.taskId);
+    if (output.task === null) {
+      if (requestedTaskId) this.tasks.delete(requestedTaskId);
+      return;
+    }
+
+    const taskRecord = toRecord(output.task);
+    const taskId = readNonEmptyString(taskRecord?.id) ?? requestedTaskId;
+    const subject = readNonEmptyString(taskRecord?.subject);
+    const status = readTaskStatus(taskRecord?.status);
+    if (!taskId || !subject || !status) return;
+
+    const current = this.tasks.get(taskId);
+    this.tasks.set(taskId, {
+      id: taskId,
+      content: subject,
+      activeForm: current?.activeForm ?? subject,
+      status,
+    });
+  }
+
+  private replaceTaskKey(oldKey: string, newKey: string, task: StoredTask): void {
+    const entries = [...this.tasks.entries()];
+    this.tasks.clear();
+    for (const [key, value] of entries) {
+      this.tasks.set(key === oldKey ? newKey : key, key === oldKey ? task : value);
+    }
+  }
+
+  private buildNormalizedCall(
+    call: TaskCallState,
+    rawOutput?: unknown,
+  ): NormalizedClaudeTaskToolCall {
+    const hasRawOutput = rawOutput !== undefined;
+    return {
+      name: TOOL_TODO_WRITE,
+      input: {
+        todos: [...this.tasks.values()].map(task => ({ ...task })),
+      },
+      providerPayload: {
+        rawName: call.rawName,
+        rawInput: { ...call.rawInput },
+        ...(hasRawOutput ? { rawOutput } : {}),
+      },
+    };
+  }
+}
+
+function isClaudeTaskToolName(name: string): name is ClaudeTaskToolName {
+  return (CLAUDE_TASK_TOOL_NAMES as readonly string[]).includes(name);
+}
+
+function readTaskStatus(value: unknown): TaskStatus | null {
+  return value === 'pending' || value === 'in_progress' || value === 'completed'
+    ? value
+    : null;
+}
+
+function readTaskUpdateStatus(value: unknown): TaskStatus | 'deleted' | null {
+  return value === 'deleted' ? value : readTaskStatus(value);
+}
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+function extractCreatedTaskId(content: string | undefined): string | null {
+  return content?.match(/Task #([^\s]+) created successfully/i)?.[1] ?? null;
+}
+
+function cloneTask(task: StoredTask | undefined): StoredTask | undefined {
+  return task ? { ...task } : undefined;
+}
+
+function toRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}

--- a/tests/unit/core/tools/todo.test.ts
+++ b/tests/unit/core/tools/todo.test.ts
@@ -60,8 +60,8 @@ describe('parseTodoInput', () => {
     expect(parseTodoInput(input)).toBeNull();
   });
 
-  it('should return null for empty todos array', () => {
-    expect(parseTodoInput({ todos: [] })).toBeNull();
+  it('should preserve an explicit empty todos array', () => {
+    expect(parseTodoInput({ todos: [] })).toEqual([]);
   });
 
   it('should reject items with missing activeForm', () => {

--- a/tests/unit/features/chat/rendering/TodoListRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/TodoListRenderer.test.ts
@@ -26,6 +26,10 @@ describe('TodoListRenderer', () => {
       expect(parseTodoInput({ todos: 'not an array' })).toBeNull();
     });
 
+    it('should preserve an explicit empty todo snapshot', () => {
+      expect(parseTodoInput({ todos: [] })).toEqual([]);
+    });
+
     it('should filter out invalid todo items', () => {
       const input = {
         todos: [

--- a/tests/unit/features/chat/rendering/ToolCallRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/ToolCallRenderer.test.ts
@@ -945,6 +945,23 @@ describe('ToolCallRenderer', () => {
       expect(statusEl?.hasClass('status-completed')).toBe(true);
     });
 
+    it('should mark an explicit empty todo snapshot as completed', () => {
+      const parentEl = createMockEl();
+      const toolCall = createToolCall({
+        id: 'todo-empty',
+        name: 'TodoWrite',
+        input: { todos: [] },
+        status: 'completed',
+      });
+      const toolCallElements = new Map<string, HTMLElement>();
+
+      renderToolCall(parentEl, toolCall, toolCallElements);
+      updateToolCallResult('todo-empty', toolCall, toolCallElements);
+
+      const statusEl = parentEl.querySelector('.claudian-tool-status');
+      expect(statusEl?.hasClass('status-completed')).toBe(true);
+    });
+
     it('should do nothing for non-existent tool id', () => {
       const toolCallElements = new Map<string, HTMLElement>();
       updateToolCallResult('nonexistent', createToolCall(), toolCallElements);

--- a/tests/unit/providers/claude/execution/ClaudeExecutionEventNormalizer.test.ts
+++ b/tests/unit/providers/claude/execution/ClaudeExecutionEventNormalizer.test.ts
@@ -1,0 +1,112 @@
+import { buildSDKMessage } from '@test/helpers/sdkMessages';
+
+import { TOOL_TODO_WRITE } from '@/core/tools/toolNames';
+import { ClaudeExecutionEventNormalizer } from '@/providers/claude/execution/ClaudeExecutionEventNormalizer';
+
+const msg = buildSDKMessage;
+
+describe('ClaudeExecutionEventNormalizer task tools', () => {
+  it('adapts main-thread task mutations and preserves native payloads', () => {
+    const normalizer = new ClaudeExecutionEventNormalizer();
+
+    const createEvents = normalizer.normalize(msg({
+      type: 'assistant',
+      message: {
+        content: [{
+          type: 'tool_use',
+          id: 'create-1',
+          name: 'TaskCreate',
+          input: { subject: 'Implement fix', activeForm: 'Implementing fix' },
+        }],
+      },
+    }), 'requested');
+    expect(createEvents).toContainEqual(expect.objectContaining({
+      type: 'output',
+      event: expect.objectContaining({
+        type: 'tool_started',
+        toolCallId: 'create-1',
+        name: TOOL_TODO_WRITE,
+        input: {
+          todos: [{
+            content: 'Implement fix',
+            activeForm: 'Implementing fix',
+            status: 'pending',
+          }],
+        },
+        providerPayload: {
+          rawName: 'TaskCreate',
+          rawInput: { subject: 'Implement fix', activeForm: 'Implementing fix' },
+        },
+      }),
+    }));
+
+    const resultEvents = normalizer.normalize(msg({
+      type: 'user',
+      tool_use_result: { task: { id: '1', subject: 'Implement fix' } },
+      message: {
+        content: [{
+          type: 'tool_result',
+          tool_use_id: 'create-1',
+          content: 'Task #1 created successfully: Implement fix',
+        }],
+      },
+    }), 'requested');
+    expect(resultEvents).toContainEqual(expect.objectContaining({
+      type: 'output',
+      event: expect.objectContaining({
+        type: 'tool_started',
+        toolCallId: 'create-1',
+        name: TOOL_TODO_WRITE,
+        input: {
+          todos: [{
+            id: '1',
+            content: 'Implement fix',
+            activeForm: 'Implementing fix',
+            status: 'pending',
+          }],
+        },
+        providerPayload: expect.objectContaining({
+          rawName: 'TaskCreate',
+          rawOutput: { task: { id: '1', subject: 'Implement fix' } },
+        }),
+      }),
+    }));
+    expect(resultEvents).toContainEqual(expect.objectContaining({
+      type: 'output',
+      event: expect.objectContaining({
+        type: 'tool_completed',
+        toolCallId: 'create-1',
+      }),
+    }));
+  });
+
+  it('does not add subagent task mutations to the main TodoWrite list', () => {
+    const normalizer = new ClaudeExecutionEventNormalizer();
+    const events = normalizer.normalize(msg({
+      type: 'assistant',
+      parent_tool_use_id: 'agent-1',
+      message: {
+        content: [{
+          type: 'tool_use',
+          id: 'create-1',
+          name: 'TaskCreate',
+          input: { subject: 'Subagent work' },
+        }],
+      },
+    }), 'requested');
+
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'output',
+      event: expect.objectContaining({
+        type: 'tool_started',
+        toolCallId: 'create-1',
+        name: 'TaskCreate',
+        toolScope: { kind: 'subagent', subagentId: 'agent-1' },
+      }),
+    }));
+    expect(events).not.toContainEqual(expect.objectContaining({
+      type: 'output',
+      event: expect.objectContaining({ name: TOOL_TODO_WRITE }),
+    }));
+  });
+});

--- a/tests/unit/providers/claude/normalization/ClaudeTaskToolNormalizer.test.ts
+++ b/tests/unit/providers/claude/normalization/ClaudeTaskToolNormalizer.test.ts
@@ -1,0 +1,206 @@
+import { TOOL_TODO_WRITE } from '@/core/tools/toolNames';
+import { ClaudeTaskToolNormalizer } from '@/providers/claude/normalization/ClaudeTaskToolNormalizer';
+
+function todosFrom(result: ReturnType<ClaudeTaskToolNormalizer['normalizeToolUse']>) {
+  return result?.input.todos;
+}
+
+describe('ClaudeTaskToolNormalizer', () => {
+  it('reduces create, update, and delete mutations into TodoWrite snapshots', () => {
+    const normalizer = new ClaudeTaskToolNormalizer();
+
+    const firstCreate = normalizer.normalizeToolUse('create-1', 'TaskCreate', {
+      subject: 'Inspect issue',
+      description: 'Read the issue and comments.',
+      activeForm: 'Inspecting issue',
+    });
+    expect(firstCreate).toMatchObject({
+      name: TOOL_TODO_WRITE,
+      providerPayload: {
+        rawName: 'TaskCreate',
+      },
+    });
+    expect(todosFrom(firstCreate)).toEqual([{
+      content: 'Inspect issue',
+      activeForm: 'Inspecting issue',
+      status: 'pending',
+    }]);
+
+    normalizer.normalizeToolResult('create-1', {
+      task: { id: '1', subject: 'Inspect issue' },
+    });
+    normalizer.normalizeToolUse('create-2', 'TaskCreate', {
+      subject: 'Implement fix',
+      description: 'Normalize Claude task tools.',
+    });
+    normalizer.normalizeToolResult('create-2', {
+      task: { id: '2', subject: 'Implement fix' },
+    });
+
+    const inProgress = normalizer.normalizeToolUse('update-1', 'TaskUpdate', {
+      taskId: '1',
+      status: 'in_progress',
+    });
+    expect(todosFrom(inProgress)).toEqual([
+      {
+        id: '1',
+        content: 'Inspect issue',
+        activeForm: 'Inspecting issue',
+        status: 'in_progress',
+      },
+      {
+        id: '2',
+        content: 'Implement fix',
+        activeForm: 'Implement fix',
+        status: 'pending',
+      },
+    ]);
+
+    normalizer.normalizeToolResult('update-1', {
+      success: true,
+      taskId: '1',
+      updatedFields: ['status'],
+      statusChange: { from: 'pending', to: 'in_progress' },
+    });
+    const deleted = normalizer.normalizeToolUse('delete-2', 'TaskUpdate', {
+      taskId: '2',
+      status: 'deleted',
+    });
+    expect(todosFrom(deleted)).toEqual([{
+      id: '1',
+      content: 'Inspect issue',
+      activeForm: 'Inspecting issue',
+      status: 'in_progress',
+    }]);
+  });
+
+  it('does not duplicate a TaskCreate when streamed input is refined', () => {
+    const normalizer = new ClaudeTaskToolNormalizer();
+
+    expect(todosFrom(normalizer.normalizeToolUse('create-1', 'TaskCreate', {}))).toEqual([]);
+    expect(todosFrom(normalizer.normalizeToolUse('create-1', 'TaskCreate', {
+      subject: 'Run tests',
+    }))).toEqual([{
+      content: 'Run tests',
+      activeForm: 'Run tests',
+      status: 'pending',
+    }]);
+    expect(todosFrom(normalizer.normalizeToolUse('create-1', 'TaskCreate', {
+      subject: 'Run tests',
+      activeForm: 'Running tests',
+    }))).toEqual([{
+      content: 'Run tests',
+      activeForm: 'Running tests',
+      status: 'pending',
+    }]);
+
+    const boundFromText = normalizer.normalizeToolResult('create-1', undefined, {
+      fallbackContent: 'Task #10 created successfully: Run tests',
+    });
+    expect(todosFrom(boundFromText)).toEqual([{
+      id: '10',
+      content: 'Run tests',
+      activeForm: 'Running tests',
+      status: 'pending',
+    }]);
+  });
+
+  it('rolls back optimistic mutations when the native tool fails', () => {
+    const normalizer = new ClaudeTaskToolNormalizer();
+    normalizer.normalizeToolUse('create-1', 'TaskCreate', { subject: 'Run tests' });
+    normalizer.normalizeToolResult('create-1', { task: { id: '1', subject: 'Run tests' } });
+
+    normalizer.normalizeToolUse('update-1', 'TaskUpdate', {
+      taskId: '1',
+      status: 'completed',
+    });
+    const rolledBackUpdate = normalizer.normalizeToolResult('update-1', {
+      success: false,
+      taskId: '1',
+      updatedFields: [],
+      error: 'Task update failed',
+    });
+    expect(todosFrom(rolledBackUpdate)).toEqual([{
+      id: '1',
+      content: 'Run tests',
+      activeForm: 'Run tests',
+      status: 'pending',
+    }]);
+
+    normalizer.normalizeToolUse('create-2', 'TaskCreate', { subject: 'Ship fix' });
+    const rolledBackCreate = normalizer.normalizeToolResult(
+      'create-2',
+      'Task creation failed',
+      { isError: true },
+    );
+    expect(todosFrom(rolledBackCreate)).toEqual([{
+      id: '1',
+      content: 'Run tests',
+      activeForm: 'Run tests',
+      status: 'pending',
+    }]);
+  });
+
+  it('uses TaskList as an authoritative snapshot and TaskGet as a targeted refresh', () => {
+    const normalizer = new ClaudeTaskToolNormalizer();
+    normalizer.normalizeToolUse('create-1', 'TaskCreate', {
+      subject: 'Old title',
+      activeForm: 'Doing old work',
+    });
+    normalizer.normalizeToolResult('create-1', { task: { id: '1', subject: 'Old title' } });
+
+    normalizer.normalizeToolUse('list-1', 'TaskList', {});
+    const listed = normalizer.normalizeToolResult('list-1', {
+      tasks: [{
+        id: '1',
+        subject: 'Listed title',
+        status: 'in_progress',
+        blockedBy: [],
+      }],
+    });
+    expect(todosFrom(listed)).toEqual([{
+      id: '1',
+      content: 'Listed title',
+      activeForm: 'Doing old work',
+      status: 'in_progress',
+    }]);
+
+    normalizer.normalizeToolUse('get-1', 'TaskGet', { taskId: '1' });
+    const refreshed = normalizer.normalizeToolResult('get-1', {
+      task: {
+        id: '1',
+        subject: 'Refreshed title',
+        description: 'Latest task details.',
+        status: 'completed',
+        blocks: [],
+        blockedBy: [],
+      },
+    });
+    expect(todosFrom(refreshed)).toEqual([{
+      id: '1',
+      content: 'Refreshed title',
+      activeForm: 'Doing old work',
+      status: 'completed',
+    }]);
+
+    normalizer.normalizeToolUse('list-2', 'TaskList', {});
+    expect(todosFrom(normalizer.normalizeToolResult('list-2', { tasks: [] }))).toEqual([]);
+  });
+
+  it('keeps state instance-local and clears it on reset', () => {
+    const first = new ClaudeTaskToolNormalizer();
+    const second = new ClaudeTaskToolNormalizer();
+
+    first.normalizeToolUse('create-1', 'TaskCreate', { subject: 'First window' });
+    expect(todosFrom(second.normalizeToolUse('list-2', 'TaskList', {}))).toEqual([]);
+
+    first.reset();
+    expect(todosFrom(first.normalizeToolUse('list-1', 'TaskList', {}))).toEqual([]);
+  });
+
+  it('ignores unrelated Claude tools', () => {
+    const normalizer = new ClaudeTaskToolNormalizer();
+    expect(normalizer.normalizeToolUse('read-1', 'Read', { file_path: 'a.md' })).toBeNull();
+    expect(normalizer.normalizeToolResult('read-1', 'contents')).toBeNull();
+  });
+});

--- a/tests/unit/utils/sdkSession.test.ts
+++ b/tests/unit/utils/sdkSession.test.ts
@@ -1114,6 +1114,39 @@ describe('sdkSession', () => {
       expect(result.messages[1].content).toContain('I found 10 results about cats.');
     });
 
+    it('hydrates Claude task mutations as TodoWrite snapshots', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockFsPromises.readFile.mockResolvedValue([
+        '{"type":"user","uuid":"u1","timestamp":"2024-01-15T10:00:00Z","message":{"content":"Fix the issue"}}',
+        '{"type":"assistant","uuid":"a1","timestamp":"2024-01-15T10:01:00Z","message":{"content":[{"type":"tool_use","id":"create-1","name":"TaskCreate","input":{"subject":"Inspect issue","activeForm":"Inspecting issue"}}]}}',
+        '{"type":"user","uuid":"r1","timestamp":"2024-01-15T10:02:00Z","toolUseResult":{"task":{"id":"1","subject":"Inspect issue"}},"message":{"content":[{"type":"tool_result","tool_use_id":"create-1","content":"Task #1 created successfully: Inspect issue"}]}}',
+        '{"type":"assistant","uuid":"a2","timestamp":"2024-01-15T10:03:00Z","message":{"content":[{"type":"tool_use","id":"create-2","name":"TaskCreate","input":{"subject":"Implement fix"}}]}}',
+        '{"type":"user","uuid":"r2","timestamp":"2024-01-15T10:04:00Z","toolUseResult":{"task":{"id":"2","subject":"Implement fix"}},"message":{"content":[{"type":"tool_result","tool_use_id":"create-2","content":"Task #2 created successfully: Implement fix"}]}}',
+        '{"type":"assistant","uuid":"a3","timestamp":"2024-01-15T10:05:00Z","message":{"content":[{"type":"tool_use","id":"update-1","name":"TaskUpdate","input":{"taskId":"1","status":"completed"}},{"type":"tool_use","id":"delete-2","name":"TaskUpdate","input":{"taskId":"2","status":"deleted"}}]}}',
+        '{"type":"user","uuid":"r3","timestamp":"2024-01-15T10:06:00Z","toolUseResult":{"success":true,"taskId":"1","updatedFields":["status"],"statusChange":{"from":"pending","to":"completed"}},"message":{"content":[{"type":"tool_result","tool_use_id":"update-1","content":"Updated task #1 status"}]}}',
+        '{"type":"user","uuid":"r4","timestamp":"2024-01-15T10:07:00Z","toolUseResult":{"success":true,"taskId":"2","updatedFields":["deleted"],"statusChange":{"from":"pending","to":"deleted"}},"message":{"content":[{"type":"tool_result","tool_use_id":"delete-2","content":"Updated task #2 deleted"}]}}',
+      ].join('\n'));
+
+      const result = await loadSDKSessionMessages('/Users/test/vault', 'session-task-tools');
+      const taskCalls = result.messages
+        .flatMap(message => message.toolCalls ?? [])
+        .filter(toolCall => toolCall.name === 'TodoWrite');
+
+      expect(taskCalls).toHaveLength(4);
+      expect(taskCalls[0].providerPayload).toMatchObject({
+        rawName: 'TaskCreate',
+        rawInput: { subject: 'Inspect issue', activeForm: 'Inspecting issue' },
+      });
+      expect(taskCalls.at(-1)?.input).toEqual({
+        todos: [{
+          id: '1',
+          content: 'Inspect issue',
+          activeForm: 'Inspecting issue',
+          status: 'completed',
+        }],
+      });
+    });
+
     it('hydrates AskUserQuestion answers from result text when toolUseResult has no answers', async () => {
       mockExistsSync.mockReturnValue(true);
       mockFsPromises.readFile.mockResolvedValue([


### PR DESCRIPTION
## Why

Fixes #934. Recent Claude Code releases replaced full-list `TodoWrite` calls with incremental `TaskCreate`, `TaskUpdate`, `TaskGet`, and `TaskList` mutations, leaving Claudian's task progress UI without the shape it renders.

## What Changed

- Added a Claude-owned task reducer that emits provider-neutral `TodoWrite` snapshots while preserving native payloads.
- Applied the same normalization to live execution and transcript replay, with per-execution isolation and subagent separation.
- Handled server-assigned IDs, deletions, failed-mutation rollback, text-result fallback, and explicit empty snapshots.
- Added focused reducer, execution, history, parser, and renderer coverage.

## Why This Approach

Normalizing at the Claude provider boundary keeps incremental provider state out of the shared feature layer while reusing the existing task UI and preserving native data for replay.

## Validation

- `npm run typecheck && npm run lint && npm run test && npm run build`
- 323 test suites and 6,132 tests passed.
- DeepSeek-backed Claude Agent SDK smoke test confirmed the native task result shapes.
- Manual Obsidian smoke test confirmed the task progress UI renders.

## Impact and Follow-ups

No settings or persisted-data migration is required; legacy `TodoWrite` behavior remains unchanged.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] User-facing documentation is not required for this internal compatibility fix.
