### PR TITLE
Add opt-in Codex ultra reasoning effort

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -360,6 +360,10 @@
         "detailed": "Ausführlich",
         "off": "Aus"
       },
+      "ultraEffort": {
+        "name": "Ultra-Denktiefe aktivieren",
+        "desc": "Ultra in der Auswahl für Codex-Modelle anzeigen, die es unterstützen. Ultra nutzt maximale Denktiefe mit automatischer Aufgabendelegation."
+      },
       "skills": {
         "name": "Codex-Fähigkeiten",
         "desc": "Manage shared vault-level skills stored only in .agents/skills/.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -360,6 +360,10 @@
         "detailed": "Detailed",
         "off": "Off"
       },
+      "ultraEffort": {
+        "name": "Enable ultra effort",
+        "desc": "Allow Ultra in the effort selector for Codex models that advertise support. Ultra uses maximum reasoning with automatic task delegation."
+      },
       "skills": {
         "name": "Codex skills",
         "desc": "Manage shared vault-level skills stored only in .agents/skills/.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -360,6 +360,10 @@
         "detailed": "Detallado",
         "off": "Desactivado"
       },
+      "ultraEffort": {
+        "name": "Activar esfuerzo ultra",
+        "desc": "Muestra Ultra en el selector de esfuerzo para los modelos Codex compatibles. Ultra usa el razonamiento máximo con delegación automática de tareas."
+      },
       "skills": {
         "name": "Habilidades de Codex",
         "desc": "Manage shared vault-level skills stored only in .agents/skills/.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -360,6 +360,10 @@
         "detailed": "Détaillée",
         "off": "Désactivé"
       },
+      "ultraEffort": {
+        "name": "Activer l’effort ultra",
+        "desc": "Affiche Ultra dans le sélecteur d’effort pour les modèles Codex compatibles. Ultra utilise le raisonnement maximal avec délégation automatique des tâches."
+      },
       "skills": {
         "name": "Compétences Codex",
         "desc": "Manage shared vault-level skills stored only in .agents/skills/.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -360,6 +360,10 @@
         "detailed": "詳細",
         "off": "オフ"
       },
+      "ultraEffort": {
+        "name": "Ultra 推論レベルを有効化",
+        "desc": "Ultra をサポートする Codex モデルの推論レベル選択に表示します。Ultra は最大限の推論とタスクの自動委任を使用します。"
+      },
       "skills": {
         "name": "Codex スキル",
         "desc": "Manage shared vault-level skills stored only in .agents/skills/.",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -360,6 +360,10 @@
         "detailed": "상세",
         "off": "끄기"
       },
+      "ultraEffort": {
+        "name": "Ultra 추론 강도 활성화",
+        "desc": "Ultra를 지원하는 Codex 모델의 추론 강도 선택기에 표시합니다. Ultra는 최대 추론과 자동 작업 위임을 사용합니다."
+      },
       "skills": {
         "name": "Codex 스킬",
         "desc": "Manage shared vault-level skills stored only in .agents/skills/.",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -360,6 +360,10 @@
         "detailed": "Detalhado",
         "off": "Desativado"
       },
+      "ultraEffort": {
+        "name": "Ativar esforço ultra",
+        "desc": "Exibe Ultra no seletor de esforço para modelos Codex compatíveis. Ultra usa o raciocínio máximo com delegação automática de tarefas."
+      },
       "skills": {
         "name": "Habilidades Codex",
         "desc": "Manage shared vault-level skills stored only in .agents/skills/.",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -360,6 +360,10 @@
         "detailed": "Подробно",
         "off": "Выкл."
       },
+      "ultraEffort": {
+        "name": "Включить уровень Ultra",
+        "desc": "Показывать Ultra в выборе усилия для моделей Codex, которые его поддерживают. Ultra использует максимальное рассуждение с автоматическим делегированием задач."
+      },
       "skills": {
         "name": "Навыки Codex",
         "desc": "Manage shared vault-level skills stored only in .agents/skills/.",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -360,6 +360,10 @@
         "detailed": "详细",
         "off": "关闭"
       },
+      "ultraEffort": {
+        "name": "启用 Ultra 推理强度",
+        "desc": "在支持 Ultra 的 Codex 模型的推理强度选择器中显示此选项。Ultra 使用最高推理强度并自动委派任务。"
+      },
       "skills": {
         "name": "Codex 技能",
         "desc": "Manage shared vault-level skills stored only in .agents/skills/.",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -360,6 +360,10 @@
         "detailed": "詳細",
         "off": "關閉"
       },
+      "ultraEffort": {
+        "name": "啟用 Ultra 推理強度",
+        "desc": "在支援 Ultra 的 Codex 模型的推理強度選擇器中顯示此選項。Ultra 使用最高推理強度並自動委派工作。"
+      },
       "skills": {
         "name": "Codex 技能",
         "desc": "Manage shared vault-level skills stored only in .agents/skills/.",

--- a/src/providers/codex/execution/CodexExecutionSession.ts
+++ b/src/providers/codex/execution/CodexExecutionSession.ts
@@ -35,7 +35,10 @@ import {
   findCodexSessionFile,
 } from '../history/CodexHistoryStore';
 import { getCodexModelOptions } from '../modelOptions';
-import { findCodexModel } from '../models';
+import {
+  findCodexModel,
+  resolveCodexReasoningEffort,
+} from '../models';
 import { toCodexRuntimeModelId } from '../modelSelection';
 import { CodexAppServerProcess } from '../runtime/CodexAppServerProcess';
 import {
@@ -448,6 +451,7 @@ export class CodexExecutionSession
         );
         return;
       }
+      const effort = this.resolveReasoningEffort(request, settings, model);
 
       if (
         request.toolPolicy.kind === 'allow-list'
@@ -545,9 +549,6 @@ export class CodexExecutionSession
       );
       const bundle = this.buildInputBundle(request, turnInput);
       this.activeInputBundles.add(bundle);
-      const effort = normalizeString(request.configuration.reasoning)
-        ?? normalizeString(settings.effortLevel)
-        ?? 'medium';
       const serviceTier = resolveCodexServiceTier(
         request.configuration.serviceTier ?? settings.serviceTier,
         model,
@@ -1563,6 +1564,25 @@ export class CodexExecutionSession
       option => toCodexRuntimeModelId(option.value) === runtimeModel,
     );
     return enabled ? runtimeModel : null;
+  }
+
+  private resolveReasoningEffort(
+    request: ProviderExecutionRequest,
+    settings: Record<string, unknown>,
+    model: string,
+  ): string {
+    const codexSettings = getCodexProviderSettings(settings);
+    const modelMetadata = findCodexModel(codexSettings.discoveredModels, model);
+    const effort = resolveCodexReasoningEffort(
+      modelMetadata,
+      codexSettings.enableUltraEffort,
+      normalizeString(request.configuration.reasoning)
+        ?? normalizeString(settings.effortLevel),
+    );
+    if (!effort) {
+      throw new Error(`Codex model "${model}" has no enabled reasoning efforts.`);
+    }
+    return effort;
   }
 
   private resolveBaseInstructions(request: ProviderExecutionRequest): string {

--- a/src/providers/codex/modelOptions.ts
+++ b/src/providers/codex/modelOptions.ts
@@ -1,6 +1,10 @@
 import { getRuntimeEnvironmentVariables } from '../../core/providers/providerEnvironment';
 import type { ProviderUIOption } from '../../core/providers/types';
-import { getCodexModelsInPickerOrder, getDefaultCodexModel } from './models';
+import {
+  getCodexModelsInPickerOrder,
+  getDefaultCodexModel,
+  isCodexModelAvailable,
+} from './models';
 import {
   encodeCodexModelSelectionId,
   toCodexRuntimeModelId,
@@ -25,7 +29,12 @@ function getConfiguredEnvModel(settings: Record<string, unknown>): string | null
 export function getConfiguredEnvCustomModel(settings: Record<string, unknown>): string | null {
   const modelId = getConfiguredEnvModel(settings);
   const discoveredModels = getCodexProviderSettings(settings).discoveredModels;
-  return modelId && !discoveredModels.some(model => model.model === modelId) ? modelId : null;
+  const runtimeModelId = modelId ? toCodexRuntimeModelId(modelId) : null;
+  return modelId
+    && runtimeModelId
+    && !discoveredModels.some(model => model.model === runtimeModelId)
+    ? modelId
+    : null;
 }
 
 export function parseConfiguredCustomModelIds(value: string): string[] {
@@ -55,14 +64,18 @@ export function getCodexModelOptions(settings: Record<string, unknown>): Provide
     codexSettings.discoveredModels,
   ));
   const pickerOrderedModels = getCodexModelsInPickerOrder(codexSettings.discoveredModels);
+  const discoveredModelIds = new Set(codexSettings.discoveredModels.map(model => model.model));
   const visibleDiscoveredModels = pickerOrderedModels
-    .filter(model => visibleModelIds.has(model.model));
+    .filter(model =>
+      visibleModelIds.has(model.model)
+      && isCodexModelAvailable(model, codexSettings.enableUltraEffort)
+    );
   const models: ProviderUIOption[] = visibleDiscoveredModels.map(model => ({
     value: model.model,
     label: getModelLabel(model.model, model.displayName),
     description: model.description || undefined,
   }));
-  const seenModelIds = new Set(visibleDiscoveredModels.map(model => model.model));
+  const seenModelIds = new Set(discoveredModelIds);
 
   const persistedVisibleModels = codexSettings.visibleModels === null
     ? []
@@ -110,6 +123,7 @@ export function resolveCodexModelSelection(
   settings: Record<string, unknown>,
   currentModel: string,
 ): string | null {
+  const codexSettings = getCodexProviderSettings(settings);
   const modelOptions = getCodexModelOptions(settings);
   const envModel = getConfiguredEnvModel(settings);
   if (envModel) {
@@ -118,7 +132,15 @@ export function resolveCodexModelSelection(
       option.value === envModel
       || toCodexRuntimeModelId(option.value) === envRuntimeModel
     );
-    return envOption?.value ?? envModel;
+    if (envOption) {
+      return envOption.value;
+    }
+    const envDiscoveredModel = codexSettings.discoveredModels.find(model =>
+      toCodexRuntimeModelId(model.model) === envRuntimeModel
+    );
+    if (!envDiscoveredModel) {
+      return envModel;
+    }
   }
 
   if (currentModel) {
@@ -132,13 +154,15 @@ export function resolveCodexModelSelection(
     }
   }
 
-  const codexSettings = getCodexProviderSettings(settings);
   const visibleModelIds = new Set(getVisibleCodexModelIds(
     codexSettings.visibleModels,
     codexSettings.discoveredModels,
   ));
   const defaultModel = getDefaultCodexModel(
-    codexSettings.discoveredModels.filter(model => visibleModelIds.has(model.model)),
+    codexSettings.discoveredModels.filter(model =>
+      visibleModelIds.has(model.model)
+      && isCodexModelAvailable(model, codexSettings.enableUltraEffort)
+    ),
   );
   return defaultModel?.model ?? modelOptions[0]?.value ?? null;
 }

--- a/src/providers/codex/models.ts
+++ b/src/providers/codex/models.ts
@@ -29,7 +29,7 @@ export interface CodexDiscoveredModel {
 }
 
 const DEFAULT_INPUT_MODALITIES: Array<'text' | 'image'> = ['text', 'image'];
-const EXCLUDED_REASONING_EFFORTS = new Set(['ultra']);
+const ULTRA_REASONING_EFFORT = 'ultra';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
@@ -57,7 +57,7 @@ function normalizeReasoningEfforts(value: unknown): CodexReasoningEffortOption[]
     }
 
     const effort = normalizeNonEmptyString(entry.value ?? entry.reasoningEffort);
-    if (!effort || EXCLUDED_REASONING_EFFORTS.has(effort.toLowerCase()) || seen.has(effort)) {
+    if (!effort || seen.has(effort)) {
       continue;
     }
 
@@ -134,23 +134,12 @@ export function normalizeCodexDiscoveredModels(value: unknown): CodexDiscoveredM
     }
 
     const supportedReasoningEfforts = normalizeReasoningEfforts(entry.supportedReasoningEfforts);
-    let defaultReasoningEffort = normalizeNonEmptyString(entry.defaultReasoningEffort);
+    const defaultReasoningEffort = normalizeNonEmptyString(entry.defaultReasoningEffort);
     if (
       !defaultReasoningEffort
       || !supportedReasoningEfforts.some(option => option.value === defaultReasoningEffort)
     ) {
-      if (
-        defaultReasoningEffort
-        && EXCLUDED_REASONING_EFFORTS.has(defaultReasoningEffort.toLowerCase())
-        && supportedReasoningEfforts.length > 0
-      ) {
-        defaultReasoningEffort = resolvePreferredReasoningDefault(
-          supportedReasoningEfforts.map(option => option.value),
-          supportedReasoningEfforts[0].value,
-        );
-      } else {
-        continue;
-      }
+      continue;
     }
 
     const serviceTiers = normalizeServiceTiers(entry.serviceTiers);
@@ -199,11 +188,28 @@ export function getCodexModelsInPickerOrder(
 
 export function getCodexDefaultReasoningEffort(
   model: CodexDiscoveredModel,
+  enableUltraEffort: boolean,
 ): string {
+  const supportedReasoningEfforts = getCodexReasoningEffortOptions(model, enableUltraEffort);
+  const supportedValues = supportedReasoningEfforts.map(option => option.value);
+  const fallbackValue = supportedValues.includes(model.defaultReasoningEffort)
+    ? model.defaultReasoningEffort
+    : DEFAULT_REASONING_VALUE;
   return resolvePreferredReasoningDefault(
-    model.supportedReasoningEfforts.map(option => option.value),
-    model.defaultReasoningEffort || DEFAULT_REASONING_VALUE,
+    supportedValues,
+    fallbackValue,
   );
+}
+
+export function getCodexReasoningEffortOptions(
+  model: CodexDiscoveredModel,
+  enableUltraEffort: boolean,
+): CodexReasoningEffortOption[] {
+  return enableUltraEffort
+    ? model.supportedReasoningEfforts
+    : model.supportedReasoningEfforts.filter(
+      option => option.value.toLowerCase() !== ULTRA_REASONING_EFFORT,
+    );
 }
 
 export function getCodexFastServiceTier(

--- a/src/providers/codex/models.ts
+++ b/src/providers/codex/models.ts
@@ -28,6 +28,14 @@ export interface CodexDiscoveredModel {
   isDefault: boolean;
 }
 
+export const CODEX_FALLBACK_REASONING_EFFORT_VALUES = [
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+] as const;
+
 const DEFAULT_INPUT_MODALITIES: Array<'text' | 'image'> = ['text', 'image'];
 const ULTRA_REASONING_EFFORT = 'ultra';
 
@@ -189,9 +197,12 @@ export function getCodexModelsInPickerOrder(
 export function getCodexDefaultReasoningEffort(
   model: CodexDiscoveredModel,
   enableUltraEffort: boolean,
-): string {
+): string | null {
   const supportedReasoningEfforts = getCodexReasoningEffortOptions(model, enableUltraEffort);
   const supportedValues = supportedReasoningEfforts.map(option => option.value);
+  if (supportedValues.length === 0) {
+    return null;
+  }
   const fallbackValue = supportedValues.includes(model.defaultReasoningEffort)
     ? model.defaultReasoningEffort
     : DEFAULT_REASONING_VALUE;
@@ -210,6 +221,33 @@ export function getCodexReasoningEffortOptions(
     : model.supportedReasoningEfforts.filter(
       option => option.value.toLowerCase() !== ULTRA_REASONING_EFFORT,
     );
+}
+
+export function isCodexModelAvailable(
+  model: CodexDiscoveredModel,
+  enableUltraEffort: boolean,
+): boolean {
+  return getCodexReasoningEffortOptions(model, enableUltraEffort).length > 0;
+}
+
+export function resolveCodexReasoningEffort(
+  model: CodexDiscoveredModel | null,
+  enableUltraEffort: boolean,
+  requestedEffort: string | null,
+): string | null {
+  if (!model) {
+    const fallbackValues: readonly string[] = CODEX_FALLBACK_REASONING_EFFORT_VALUES;
+    return requestedEffort && fallbackValues.includes(requestedEffort)
+      ? requestedEffort
+      : resolvePreferredReasoningDefault(fallbackValues, DEFAULT_REASONING_VALUE);
+  }
+
+  const supportedValues = getCodexReasoningEffortOptions(model, enableUltraEffort)
+    .map(option => option.value);
+  if (requestedEffort && supportedValues.includes(requestedEffort)) {
+    return requestedEffort;
+  }
+  return getCodexDefaultReasoningEffort(model, enableUltraEffort);
 }
 
 export function getCodexFastServiceTier(

--- a/src/providers/codex/runtime/CodexModelCatalogFingerprint.ts
+++ b/src/providers/codex/runtime/CodexModelCatalogFingerprint.ts
@@ -16,7 +16,7 @@ import { computeCodexEnvHash } from '../env/CodexSettingsReconciler';
 import { getCodexProviderSettings } from '../settings';
 import { resolveCodexExecutionTargetAsync } from './CodexExecutionTargetResolver';
 
-const CATALOG_FINGERPRINT_VERSION = '1';
+const CATALOG_FINGERPRINT_VERSION = '2';
 
 export interface CodexCatalogFingerprintInputs {
   resolvedCliCommand: string | null;

--- a/src/providers/codex/settings.ts
+++ b/src/providers/codex/settings.ts
@@ -159,6 +159,7 @@ export function applyCodexModelDefaults(
   const modelMetadata = findCodexModel(codexSettings.discoveredModels, model);
   settings.effortLevel = modelMetadata
     ? getCodexDefaultReasoningEffort(modelMetadata, codexSettings.enableUltraEffort)
+      ?? DEFAULT_REASONING_VALUE
     : DEFAULT_REASONING_VALUE;
   if (shouldDisableCodexReasoningSummary(model)) {
     updateCodexProviderSettings(settings, { reasoningSummary: 'none' });
@@ -329,7 +330,7 @@ function retargetRemovedCodexSelections(
     ensureCodexProjectionMap(settings, 'savedProviderEffort').codex = getCodexDefaultReasoningEffort(
       fallbackModel,
       next.enableUltraEffort,
-    );
+    ) ?? DEFAULT_REASONING_VALUE;
     ensureCodexProjectionMap(settings, 'savedProviderServiceTier').codex = fallbackServiceTier;
   }
 
@@ -339,7 +340,7 @@ function retargetRemovedCodexSelections(
     settings.effortLevel = getCodexDefaultReasoningEffort(
       fallbackModel,
       next.enableUltraEffort,
-    );
+    ) ?? DEFAULT_REASONING_VALUE;
     settings.serviceTier = fallbackServiceTier;
   }
 

--- a/src/providers/codex/settings.ts
+++ b/src/providers/codex/settings.ts
@@ -31,6 +31,7 @@ export interface CodexProviderConfig {
   discoveredModels: CodexDiscoveredModel[];
   modelAliases: Record<string, string>;
   visibleModels: string[] | null;
+  enableUltraEffort: boolean;
   reasoningSummary: CodexReasoningSummary;
   environmentVariables: string;
   environmentHash: string;
@@ -98,6 +99,7 @@ export interface CodexProviderSettings {
   discoveredModels: CodexProviderConfig['discoveredModels'];
   modelAliases: CodexProviderConfig['modelAliases'];
   visibleModels: CodexProviderConfig['visibleModels'];
+  enableUltraEffort: CodexProviderConfig['enableUltraEffort'];
   reasoningSummary: CodexProviderConfig['reasoningSummary'];
   environmentVariables: CodexProviderConfig['environmentVariables'];
   environmentHash: CodexProviderConfig['environmentHash'];
@@ -118,6 +120,7 @@ export const DEFAULT_CODEX_PROVIDER_CONFIG: Readonly<CodexProviderConfig> = Obje
   discoveredModels: [],
   modelAliases: {},
   visibleModels: null,
+  enableUltraEffort: false,
   reasoningSummary: 'detailed',
   environmentVariables: '',
   environmentHash: '',
@@ -152,9 +155,10 @@ export function applyCodexModelDefaults(
   model: string,
   settings: Record<string, unknown>,
 ): void {
-  const modelMetadata = findCodexModel(getCodexProviderSettings(settings).discoveredModels, model);
+  const codexSettings = getCodexProviderSettings(settings);
+  const modelMetadata = findCodexModel(codexSettings.discoveredModels, model);
   settings.effortLevel = modelMetadata
-    ? getCodexDefaultReasoningEffort(modelMetadata)
+    ? getCodexDefaultReasoningEffort(modelMetadata, codexSettings.enableUltraEffort)
     : DEFAULT_REASONING_VALUE;
   if (shouldDisableCodexReasoningSummary(model)) {
     updateCodexProviderSettings(settings, { reasoningSummary: 'none' });
@@ -322,14 +326,20 @@ function retargetRemovedCodexSelections(
   const nextSavedModel = maybeRetarget(savedCodexModel);
   if (nextSavedModel) {
     ensureCodexProjectionMap(settings, 'savedProviderModel').codex = nextSavedModel;
-    ensureCodexProjectionMap(settings, 'savedProviderEffort').codex = getCodexDefaultReasoningEffort(fallbackModel);
+    ensureCodexProjectionMap(settings, 'savedProviderEffort').codex = getCodexDefaultReasoningEffort(
+      fallbackModel,
+      next.enableUltraEffort,
+    );
     ensureCodexProjectionMap(settings, 'savedProviderServiceTier').codex = fallbackServiceTier;
   }
 
   const nextTopLevelModel = maybeRetarget(settings.model);
   if (nextTopLevelModel) {
     settings.model = nextTopLevelModel;
-    settings.effortLevel = getCodexDefaultReasoningEffort(fallbackModel);
+    settings.effortLevel = getCodexDefaultReasoningEffort(
+      fallbackModel,
+      next.enableUltraEffort,
+    );
     settings.serviceTier = fallbackServiceTier;
   }
 
@@ -399,6 +409,7 @@ function getCodexStoredConfig(
       getCodexAliasModelIds(visibleModels, discoveredModels),
     ),
     visibleModels,
+    enableUltraEffort: config.enableUltraEffort === true,
     reasoningSummary: (config.reasoningSummary as CodexReasoningSummary | undefined)
       ?? (settings.codexReasoningSummary as CodexReasoningSummary | undefined)
       ?? DEFAULT_CODEX_PROVIDER_CONFIG.reasoningSummary,
@@ -606,6 +617,7 @@ export function updateCodexProviderSettings(
     discoveredModels: next.discoveredModels,
     modelAliases: next.modelAliases,
     visibleModels: next.visibleModels,
+    enableUltraEffort: next.enableUltraEffort,
     reasoningSummary: next.reasoningSummary,
     environmentVariables: next.environmentVariables,
     environmentHash: next.environmentHash,

--- a/src/providers/codex/ui/CodexChatUIConfig.ts
+++ b/src/providers/codex/ui/CodexChatUIConfig.ts
@@ -12,11 +12,13 @@ import type {
 import { OPENAI_PROVIDER_ICON } from '../../../shared/icons';
 import { getCodexModelOptions } from '../modelOptions';
 import {
+  CODEX_FALLBACK_REASONING_EFFORT_VALUES,
   findCodexModel,
   getCodexDefaultReasoningEffort,
   getCodexFastServiceTier,
   getCodexReasoningEffortOptions,
   getDefaultCodexModel,
+  isCodexModelAvailable,
 } from '../models';
 import {
   isCodexModelSelectionId,
@@ -30,11 +32,7 @@ import {
 } from '../settings';
 
 const EFFORT_LEVELS: ProviderReasoningOption[] = [
-  'low',
-  'medium',
-  'high',
-  'xhigh',
-  'max',
+  ...CODEX_FALLBACK_REASONING_EFFORT_VALUES,
 ].map(value => ({ value, label: formatReasoningValueLabel(value) }));
 
 const CODEX_PERMISSION_MODE_TOGGLE: ProviderPermissionModeToggleConfig = {
@@ -57,7 +55,10 @@ function getVisibleDiscoveredModels(settings: Record<string, unknown>) {
     codexSettings.visibleModels,
     codexSettings.discoveredModels,
   ));
-  return codexSettings.discoveredModels.filter(model => visibleModelIds.has(model.model));
+  return codexSettings.discoveredModels.filter(model =>
+    visibleModelIds.has(model.model)
+    && isCodexModelAvailable(model, codexSettings.enableUltraEffort)
+  );
 }
 
 export const codexChatUIConfig: ProviderChatUIConfig = {
@@ -115,6 +116,7 @@ export const codexChatUIConfig: ProviderChatUIConfig = {
     );
     return model
       ? getCodexDefaultReasoningEffort(model, codexSettings.enableUltraEffort)
+        ?? DEFAULT_REASONING_VALUE
       : DEFAULT_REASONING_VALUE;
   },
 

--- a/src/providers/codex/ui/CodexChatUIConfig.ts
+++ b/src/providers/codex/ui/CodexChatUIConfig.ts
@@ -15,6 +15,7 @@ import {
   findCodexModel,
   getCodexDefaultReasoningEffort,
   getCodexFastServiceTier,
+  getCodexReasoningEffortOptions,
   getDefaultCodexModel,
 } from '../models';
 import {
@@ -90,15 +91,16 @@ export const codexChatUIConfig: ProviderChatUIConfig = {
   },
 
   getReasoningOptions(modelId: string, settings: Record<string, unknown>): ProviderReasoningOption[] {
+    const codexSettings = getCodexProviderSettings(settings);
     const model = findCodexModel(
-      getCodexProviderSettings(settings).discoveredModels,
+      codexSettings.discoveredModels,
       modelId,
     );
     if (!model) {
       return [...EFFORT_LEVELS];
     }
 
-    return model.supportedReasoningEfforts.map(option => ({
+    return getCodexReasoningEffortOptions(model, codexSettings.enableUltraEffort).map(option => ({
       value: option.value,
       label: formatReasoningValueLabel(option.value),
       ...(option.description ? { description: option.description } : {}),
@@ -106,11 +108,14 @@ export const codexChatUIConfig: ProviderChatUIConfig = {
   },
 
   getDefaultReasoningValue(modelId: string, settings: Record<string, unknown>): string {
+    const codexSettings = getCodexProviderSettings(settings);
     const model = findCodexModel(
-      getCodexProviderSettings(settings).discoveredModels,
+      codexSettings.discoveredModels,
       modelId,
     );
-    return model ? getCodexDefaultReasoningEffort(model) : DEFAULT_REASONING_VALUE;
+    return model
+      ? getCodexDefaultReasoningEffort(model, codexSettings.enableUltraEffort)
+      : DEFAULT_REASONING_VALUE;
   },
 
   getContextWindowSize(): number {

--- a/src/providers/codex/ui/CodexModelPicker.ts
+++ b/src/providers/codex/ui/CodexModelPicker.ts
@@ -3,12 +3,16 @@ import { Notice } from 'obsidian';
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import type { ProviderSettingsTabRendererContext } from '../../../core/providers/types';
 import {
+  type ProviderModelPickerController,
   type ProviderModelPickerModel,
   type ProviderModelPickerState,
   renderProviderModelPicker,
 } from '../../../shared/settings/ProviderModelPicker';
 import type { CodexWorkspaceServices } from '../app/CodexWorkspaceServices';
-import { getCodexModelsInPickerOrder } from '../models';
+import {
+  getCodexModelsInPickerOrder,
+  isCodexModelAvailable,
+} from '../models';
 import {
   createCodexVisibleModelFilter,
   getCodexProviderSettings,
@@ -27,7 +31,7 @@ export function renderCodexModelPicker(
   container: HTMLElement,
   context: ProviderSettingsTabRendererContext,
   workspace: CodexWorkspaceServices,
-): void {
+): ProviderModelPickerController {
   const settingsBag = context.plugin.settings as unknown as Record<string, unknown>;
 
   const getState = (): ProviderModelPickerState => {
@@ -47,13 +51,22 @@ export function renderCodexModelPicker(
       }
     }
 
-    const models: ProviderModelPickerModel[] = pickerOrderedModels.map(model => ({
-      ...(model.isDefault ? { catalogBadge: 'Default' } : {}),
-      description: model.description,
-      id: model.model,
-      isAvailable: true,
-      name: model.displayName,
-    }));
+    const models: ProviderModelPickerModel[] = pickerOrderedModels.map((model) => {
+      const isAvailable = isCodexModelAvailable(model, current.enableUltraEffort);
+      return {
+        ...(model.isDefault ? { catalogBadge: 'Default' } : {}),
+        description: model.description,
+        id: model.model,
+        isAvailable,
+        name: model.displayName,
+        ...(!isAvailable
+          ? {
+            unavailableMessage: 'Requires Ultra effort to be enabled',
+            unavailableTitle: 'This model only supports Ultra effort',
+          }
+          : {}),
+      };
+    });
     const discoveredIds = new Set(models.map(model => model.id));
     for (const modelId of visibleModelIds) {
       if (!discoveredIds.has(modelId)) {
@@ -136,4 +149,5 @@ export function renderCodexModelPicker(
     searchPlaceholder: 'Filter by model name, description, or ID...',
   });
   refreshPicker = picker.refresh.bind(picker);
+  return picker;
 }

--- a/src/providers/codex/ui/CodexSettingsTab.ts
+++ b/src/providers/codex/ui/CodexSettingsTab.ts
@@ -274,7 +274,7 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
 
     new Setting(container).setName(t('settings.models')).setHeading();
 
-    renderCodexModelPicker(container, modelWarning.context, codexWorkspace);
+    const modelPicker = renderCodexModelPicker(container, modelWarning.context, codexWorkspace);
 
     new Setting(container)
       .setName(t('settings.codex.ultraEffort.name'))
@@ -284,7 +284,9 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
         .onChange(async (value) => {
           await context.plugin.mutateSettings((settings) => {
             updateCodexProviderSettings(settings, { enableUltraEffort: value });
+            ProviderSettingsCoordinator.normalizeAllModelVariants(settings);
           });
+          modelPicker.refresh();
           context.notifyProviderModelOptionsChanged('codex');
         }));
 

--- a/src/providers/codex/ui/CodexSettingsTab.ts
+++ b/src/providers/codex/ui/CodexSettingsTab.ts
@@ -276,6 +276,18 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
 
     renderCodexModelPicker(container, modelWarning.context, codexWorkspace);
 
+    new Setting(container)
+      .setName(t('settings.codex.ultraEffort.name'))
+      .setDesc(t('settings.codex.ultraEffort.desc'))
+      .addToggle(toggle => toggle
+        .setValue(codexSettings.enableUltraEffort)
+        .onChange(async (value) => {
+          await context.plugin.mutateSettings((settings) => {
+            updateCodexProviderSettings(settings, { enableUltraEffort: value });
+          });
+          context.notifyProviderModelOptionsChanged('codex');
+        }));
+
     const SUMMARY_OPTIONS: { value: string; label: string }[] = [
       { value: 'auto', label: t('settings.codex.reasoningSummary.auto') },
       { value: 'concise', label: t('settings.codex.reasoningSummary.concise') },

--- a/tests/unit/core/providers/ProviderSettingsCoordinator.test.ts
+++ b/tests/unit/core/providers/ProviderSettingsCoordinator.test.ts
@@ -37,6 +37,44 @@ describe('ProviderSettingsCoordinator', () => {
       expect(settings.effortLevel).toBe('low');
     });
 
+    it('preserves an opted-in ultra effort across Codex provider and conversation projections', () => {
+      const ultraModel = {
+        ...TEST_CODEX_CATALOG[0],
+        model: 'gpt-5.6-sol',
+        supportedReasoningEfforts: [
+          { value: 'max', description: 'Maximum reasoning' },
+          { value: 'ultra', description: 'Automatic task delegation' },
+        ],
+        defaultReasoningEffort: 'max',
+      };
+      const settings: Record<string, unknown> = {
+        settingsProvider: 'claude',
+        model: 'haiku',
+        effortLevel: 'high',
+        serviceTier: 'default',
+        savedProviderModel: { codex: ultraModel.model },
+        savedProviderEffort: { codex: 'ultra' },
+        savedProviderServiceTier: { codex: 'default' },
+        providerConfigs: {
+          codex: {
+            enabled: true,
+            enableUltraEffort: true,
+            discoveredModels: [ultraModel],
+          },
+        },
+      };
+
+      const conversationSnapshot = getProviderSettingsSnapshotWithModel(
+        settings,
+        'codex',
+        ultraModel.model,
+      );
+      ProviderSettingsCoordinator.projectProviderState(settings, 'codex');
+
+      expect(conversationSnapshot.effortLevel).toBe('ultra');
+      expect(settings.effortLevel).toBe('ultra');
+    });
+
     it('uses a Pi conversation model preference before normalizing against the saved provider model', () => {
       const deepSeekModel = 'pi:deepseek/deepseek-reasoner';
       const gptModel = 'pi:openai/gpt-5';

--- a/tests/unit/providers/codex/execution/CodexExecutionBackend.test.ts
+++ b/tests/unit/providers/codex/execution/CodexExecutionBackend.test.ts
@@ -2114,8 +2114,22 @@ describe('CodexExecutionBackend', () => {
       }
       throw new Error(`Unexpected method: ${method}`);
     });
-    const session = new CodexExecutionBackend(createPlugin())
-      .createSession(createSessionConfig());
+    const plugin = createPlugin();
+    const codexConfig = (
+      plugin.settings.providerConfigs as Record<string, Record<string, unknown>>
+    ).codex;
+    codexConfig.enableUltraEffort = true;
+    codexConfig.discoveredModels = [
+      {
+        ...(codexConfig.discoveredModels as Array<Record<string, unknown>>)[0],
+        supportedReasoningEfforts: [
+          { value: 'high', description: 'Deep reasoning' },
+          { value: 'ultra', description: 'Automatic task delegation' },
+        ],
+        defaultReasoningEffort: 'high',
+      },
+    ];
+    const session = new CodexExecutionBackend(plugin).createSession(createSessionConfig());
     await collectEvents(session.execute(createRequest()).events);
     await collectEvents(session.execute(createRequest(
       new AbortController().signal,
@@ -2140,6 +2154,94 @@ describe('CodexExecutionBackend', () => {
       serviceTier: 'priority',
       approvalPolicy: 'never',
       sandboxPolicy: { type: 'dangerFullAccess' },
+    }));
+
+    await session.dispose();
+  });
+
+  it('validates saved ultra effort against the setting and auxiliary request model', async () => {
+    let turnIndex = 0;
+    mockTransportRequest.mockImplementation(async (method: string) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'test',
+          codexHome: '/tmp/.codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'thread/start') return createThreadResult('thread-auxiliary-effort');
+      if (method === 'turn/start') {
+        turnIndex += 1;
+        const turnId = `turn-auxiliary-effort-${turnIndex}`;
+        queueMicrotask(() => completeTurn('thread-auxiliary-effort', turnId));
+        return createTurnResult(turnId);
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const plugin = createPlugin();
+    const settings = plugin.settings as Record<string, unknown>;
+    const providerConfigs = settings.providerConfigs as Record<string, Record<string, unknown>>;
+    const currentCodexConfig = providerConfigs.codex;
+    const currentModels = currentCodexConfig.discoveredModels as Array<Record<string, unknown>>;
+    settings.savedProviderEffort = { codex: 'ultra' };
+    providerConfigs.codex = {
+      ...currentCodexConfig,
+      enableUltraEffort: false,
+      discoveredModels: [
+        {
+          ...currentModels[0],
+          supportedReasoningEfforts: [
+            { value: 'high', description: 'Deep reasoning' },
+            { value: 'ultra', description: 'Automatic task delegation' },
+          ],
+          defaultReasoningEffort: 'high',
+        },
+        {
+          ...currentModels[0],
+          model: 'gpt-5.6-luna',
+          displayName: 'GPT-5.6-Luna',
+          supportedReasoningEfforts: [
+            { value: 'low', description: 'Fast responses' },
+            { value: 'medium', description: 'Balanced' },
+          ],
+          defaultReasoningEffort: 'medium',
+          isDefault: false,
+        },
+      ],
+    };
+    const session = new CodexExecutionBackend(plugin).createSession(createSessionConfig());
+    const createAuxiliaryRequest = (model: string): ProviderExecutionRequest => createRequest(
+      new AbortController().signal,
+      {
+        configuration: {
+          model,
+          permissionMode: 'normal',
+          systemInstructions: { kind: 'explicit', instructions: 'Be concise.' },
+        },
+      },
+    );
+
+    await collectEvents(session.execute(createAuxiliaryRequest(TEST_CODEX_MODEL)).events);
+    providerConfigs.codex.enableUltraEffort = true;
+    await collectEvents(session.execute(createAuxiliaryRequest('gpt-5.6-luna')).events);
+
+    const turnParams = mockTransportRequest.mock.calls
+      .filter(call => call[0] === 'turn/start')
+      .map(call => call[1]);
+    expect(turnParams[0]).toEqual(expect.objectContaining({
+      model: TEST_CODEX_MODEL,
+      effort: 'high',
+      collaborationMode: expect.objectContaining({
+        settings: expect.objectContaining({ reasoning_effort: 'high' }),
+      }),
+    }));
+    expect(turnParams[1]).toEqual(expect.objectContaining({
+      model: 'gpt-5.6-luna',
+      effort: 'medium',
+      collaborationMode: expect.objectContaining({
+        settings: expect.objectContaining({ reasoning_effort: 'medium' }),
+      }),
     }));
 
     await session.dispose();

--- a/tests/unit/providers/codex/execution/CodexExecutionBackend.test.ts
+++ b/tests/unit/providers/codex/execution/CodexExecutionBackend.test.ts
@@ -2094,7 +2094,7 @@ describe('CodexExecutionBackend', () => {
     await session.dispose();
   });
 
-  it('uses request-scoped mode and reasoning configuration on a later turn', async () => {
+  it('forwards request-scoped ultra effort and mode configuration on a later turn', async () => {
     let turnIndex = 0;
     mockTransportRequest.mockImplementation(async (method: string) => {
       if (method === 'initialize') {
@@ -2123,7 +2123,7 @@ describe('CodexExecutionBackend', () => {
         configuration: {
           systemInstructions: { kind: 'explicit', instructions: 'Plan.' },
           model: TEST_CODEX_MODEL,
-          reasoning: 'low',
+          reasoning: 'ultra',
           serviceTier: 'priority',
           permissionMode: 'yolo',
         },
@@ -2133,7 +2133,10 @@ describe('CodexExecutionBackend', () => {
     const secondTurnParams = mockTransportRequest.mock.calls
       .filter(call => call[0] === 'turn/start')[1][1];
     expect(secondTurnParams).toEqual(expect.objectContaining({
-      effort: 'low',
+      effort: 'ultra',
+      collaborationMode: expect.objectContaining({
+        settings: expect.objectContaining({ reasoning_effort: 'ultra' }),
+      }),
       serviceTier: 'priority',
       approvalPolicy: 'never',
       sandboxPolicy: { type: 'dangerFullAccess' },

--- a/tests/unit/providers/codex/models.test.ts
+++ b/tests/unit/providers/codex/models.test.ts
@@ -45,7 +45,7 @@ describe('Codex models', () => {
     },
   ];
 
-  it('normalizes app-server model metadata while excluding ultra', () => {
+  it('normalizes all app-server reasoning efforts without changing model capabilities', () => {
     expect(normalizeCodexDiscoveredModels(rawModels)).toEqual([
       {
         model: 'gpt-5.6-sol',
@@ -54,6 +54,7 @@ describe('Codex models', () => {
         supportedReasoningEfforts: [
           { value: 'low', description: 'Fast responses' },
           { value: 'max', description: 'Maximum reasoning' },
+          { value: 'ultra', description: 'Automatic task delegation' },
         ],
         defaultReasoningEffort: 'low',
         serviceTiers: [
@@ -80,7 +81,7 @@ describe('Codex models', () => {
     ]);
   });
 
-  it('keeps a model when its excluded app-server default is ultra', () => {
+  it('preserves an app-server default of ultra in the discovered catalog', () => {
     expect(normalizeCodexDiscoveredModels([{
       ...rawModels[0],
       defaultReasoningEffort: 'ultra',
@@ -92,10 +93,11 @@ describe('Codex models', () => {
     }])).toEqual([
       expect.objectContaining({
         model: 'gpt-5.6-sol',
-        defaultReasoningEffort: 'high',
+        defaultReasoningEffort: 'ultra',
         supportedReasoningEfforts: [
           { value: 'low', description: 'Fast responses' },
           { value: 'high', description: 'Deep reasoning' },
+          { value: 'ultra', description: 'Automatic task delegation' },
         ],
       }),
     ]);

--- a/tests/unit/providers/codex/runtime/CodexModelCatalogCoordinator.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexModelCatalogCoordinator.test.ts
@@ -183,7 +183,7 @@ describe('CodexModelCatalogCoordinator', () => {
 
   it('does not expose environment secrets in the catalog fingerprint', () => {
     expect(FAKE_FINGERPRINT).not.toContain('secret');
-    expect(FAKE_FINGERPRINT).toMatch(/^1:[a-f0-9]{64}$/);
+    expect(FAKE_FINGERPRINT).toMatch(/^2:[a-f0-9]{64}$/);
   });
 
   it('returns cached models immediately when cache is fresh', async () => {

--- a/tests/unit/providers/codex/settings.test.ts
+++ b/tests/unit/providers/codex/settings.test.ts
@@ -34,12 +34,13 @@ describe('codex settings', () => {
     Object.defineProperty(process, 'platform', { value: originalPlatform });
   });
 
-  it('defaults installationMethod to native-windows and leaves wslDistroOverride empty', () => {
+  it('defaults installationMethod to native-windows, ultra effort off, and leaves wslDistroOverride empty', () => {
     const settings = getCodexProviderSettings({});
 
     expect(settings.customModels).toBe('');
     expect(settings.modelAliases).toEqual({});
     expect(settings.visibleModels).toBeNull();
+    expect(settings.enableUltraEffort).toBe(false);
     expect(settings.installationMethod).toBe('native-windows');
     expect(settings.wslDistroOverride).toBe('');
     expect(settings.installationMethod).toBe(DEFAULT_CODEX_PROVIDER_SETTINGS.installationMethod);
@@ -139,6 +140,7 @@ describe('codex settings', () => {
       defaultReasoningEffort: 'low',
       supportedReasoningEfforts: [
         { value: 'low', description: 'Fast' },
+        { value: 'ultra', description: 'Automatic task delegation' },
       ],
     });
 
@@ -147,6 +149,21 @@ describe('codex settings', () => {
       providerConfigs: {
         codex: {
           discoveredModels,
+        },
+      },
+    });
+  });
+
+  it('persists ultra effort as an explicit Codex opt-in', () => {
+    const settingsBag: Record<string, unknown> = {};
+
+    updateCodexProviderSettings(settingsBag, { enableUltraEffort: true });
+
+    expect(getCodexProviderSettings(settingsBag).enableUltraEffort).toBe(true);
+    expect(settingsBag).toMatchObject({
+      providerConfigs: {
+        codex: {
+          enableUltraEffort: true,
         },
       },
     });

--- a/tests/unit/providers/codex/ui/CodexChatUIConfig.test.ts
+++ b/tests/unit/providers/codex/ui/CodexChatUIConfig.test.ts
@@ -372,6 +372,98 @@ describe('CodexChatUIConfig', () => {
       expect(codexChatUIConfig.getDefaultReasoningValue('gpt-5.6-sol', settings)).toBe('low');
     });
 
+    it('exposes ultra only when it is enabled and advertised by the selected model', () => {
+      const discoveredModels = [
+        {
+          model: 'gpt-5.6-sol',
+          displayName: 'GPT-5.6-Sol',
+          description: 'Latest',
+          supportedReasoningEfforts: [
+            { value: 'max', description: 'Maximum reasoning' },
+            { value: 'ultra', description: 'Automatic task delegation' },
+          ],
+          defaultReasoningEffort: 'max',
+          serviceTiers: [],
+          defaultServiceTier: null,
+          inputModalities: ['text', 'image'],
+          isDefault: true,
+        },
+        {
+          model: 'gpt-5.6-luna',
+          displayName: 'GPT-5.6-Luna',
+          description: 'Fast',
+          supportedReasoningEfforts: [
+            { value: 'max', description: 'Maximum reasoning' },
+          ],
+          defaultReasoningEffort: 'max',
+          serviceTiers: [],
+          defaultServiceTier: null,
+          inputModalities: ['text', 'image'],
+          isDefault: false,
+        },
+      ];
+      const disabledSettings = {
+        providerConfigs: { codex: { discoveredModels } },
+      };
+      const enabledSettings = {
+        providerConfigs: { codex: { discoveredModels, enableUltraEffort: true } },
+      };
+
+      expect(codexChatUIConfig.getReasoningOptions('gpt-5.6-sol', disabledSettings))
+        .toEqual([{ value: 'max', label: 'Max', description: 'Maximum reasoning' }]);
+      expect(codexChatUIConfig.getReasoningOptions('gpt-5.6-sol', enabledSettings))
+        .toEqual([
+          { value: 'max', label: 'Max', description: 'Maximum reasoning' },
+          { value: 'ultra', label: 'Ultra', description: 'Automatic task delegation' },
+        ]);
+      expect(codexChatUIConfig.getReasoningOptions('gpt-5.6-luna', enabledSettings))
+        .toEqual([{ value: 'max', label: 'Max', description: 'Maximum reasoning' }]);
+    });
+
+    it('uses an advertised ultra default only while ultra effort is enabled', () => {
+      const discoveredModels = [{
+        model: 'gpt-5.6-sol',
+        displayName: 'GPT-5.6-Sol',
+        description: 'Latest',
+        supportedReasoningEfforts: [
+          { value: 'max', description: 'Maximum reasoning' },
+          { value: 'ultra', description: 'Automatic task delegation' },
+        ],
+        defaultReasoningEffort: 'ultra',
+        serviceTiers: [],
+        defaultServiceTier: null,
+        inputModalities: ['text', 'image'],
+        isDefault: true,
+      }];
+
+      expect(codexChatUIConfig.getDefaultReasoningValue('gpt-5.6-sol', {
+        providerConfigs: { codex: { discoveredModels } },
+      })).toBe('max');
+      expect(codexChatUIConfig.getDefaultReasoningValue('gpt-5.6-sol', {
+        providerConfigs: { codex: { discoveredModels, enableUltraEffort: true } },
+      })).toBe('ultra');
+    });
+
+    it('does not retain an ultra default when ultra is the only advertised effort and is disabled', () => {
+      const discoveredModels = [{
+        model: 'gpt-ultra-only',
+        displayName: 'GPT Ultra Only',
+        description: 'Ultra only',
+        supportedReasoningEfforts: [
+          { value: 'ultra', description: 'Automatic task delegation' },
+        ],
+        defaultReasoningEffort: 'ultra',
+        serviceTiers: [],
+        defaultServiceTier: null,
+        inputModalities: ['text'],
+        isDefault: true,
+      }];
+      const settings = { providerConfigs: { codex: { discoveredModels } } };
+
+      expect(codexChatUIConfig.getReasoningOptions('gpt-ultra-only', settings)).toEqual([]);
+      expect(codexChatUIConfig.getDefaultReasoningValue('gpt-ultra-only', settings)).toBe('high');
+    });
+
     it('prefers high over the app-server default when the model supports it', () => {
       const settings = withDiscoveredModels({ model: TEST_CODEX_MODEL });
       const config = settings.providerConfigs as { codex: { discoveredModels: any[] } };

--- a/tests/unit/providers/codex/ui/CodexChatUIConfig.test.ts
+++ b/tests/unit/providers/codex/ui/CodexChatUIConfig.test.ts
@@ -444,7 +444,7 @@ describe('CodexChatUIConfig', () => {
       })).toBe('ultra');
     });
 
-    it('does not retain an ultra default when ultra is the only advertised effort and is disabled', () => {
+    it('makes an ultra-only model unavailable while ultra effort is disabled', () => {
       const discoveredModels = [{
         model: 'gpt-ultra-only',
         displayName: 'GPT Ultra Only',
@@ -458,10 +458,35 @@ describe('CodexChatUIConfig', () => {
         inputModalities: ['text'],
         isDefault: true,
       }];
-      const settings = { providerConfigs: { codex: { discoveredModels } } };
+      const settings = {
+        providerConfigs: {
+          codex: {
+            customModels: 'gpt-ultra-only',
+            discoveredModels,
+            environmentVariables: 'OPENAI_MODEL=openai-codex/gpt-ultra-only',
+            visibleModels: ['gpt-ultra-only'],
+          },
+        },
+      };
 
       expect(codexChatUIConfig.getReasoningOptions('gpt-ultra-only', settings)).toEqual([]);
-      expect(codexChatUIConfig.getDefaultReasoningValue('gpt-ultra-only', settings)).toBe('high');
+      expect(codexChatUIConfig.getModelOptions(settings)).toEqual([]);
+      expect(codexChatUIConfig.getDefaultModel?.(settings)).toBeNull();
+      expect(codexChatUIConfig.getModelOptions({
+        providerConfigs: {
+          codex: {
+            discoveredModels,
+            enableUltraEffort: true,
+            visibleModels: ['gpt-ultra-only'],
+          },
+        },
+      })).toEqual([
+        {
+          value: 'gpt-ultra-only',
+          label: 'GPT Ultra Only',
+          description: 'Ultra only',
+        },
+      ]);
     });
 
     it('prefers high over the app-server default when the model supports it', () => {

--- a/tests/unit/providers/codex/ui/CodexModelPicker.test.ts
+++ b/tests/unit/providers/codex/ui/CodexModelPicker.test.ts
@@ -224,6 +224,33 @@ describe('CodexModelPicker', () => {
     expect(context.notifyProviderModelOptionsChanged).toHaveBeenCalledWith('codex');
   });
 
+  it('marks an ultra-only model unavailable while ultra effort is disabled', () => {
+    const plugin = createPlugin();
+    plugin.settings.providerConfigs.codex = {
+      discoveredModels: [{
+        ...TEST_CODEX_CATALOG[0],
+        model: 'gpt-ultra-only',
+        displayName: 'GPT Ultra Only',
+        supportedReasoningEfforts: [
+          { value: 'ultra', description: 'Automatic task delegation' },
+        ],
+        defaultReasoningEffort: 'ultra',
+      }],
+      enableUltraEffort: false,
+      modelAliases: {},
+      visibleModels: null,
+    };
+
+    renderCodexModelPicker(createElement() as any, createContext(plugin), {} as any);
+
+    expect(findElement(element =>
+      element.classes.has('claudian-provider-model-picker-row-badge')
+    ).text).toBe('Unavailable');
+    expect(findElement(element =>
+      element.classes.has('claudian-provider-model-picker-selected-unavailable')
+    ).text).toBe('Requires Ultra effort to be enabled');
+  });
+
   it('registers void-returning DOM event callbacks for asynchronous actions', async () => {
     const plugin = createPlugin();
     const context = createContext(plugin);

--- a/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
+++ b/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
@@ -464,6 +464,23 @@ describe('CodexSettingsTab', () => {
     expect(headings.indexOf('Models')).toBeLessThan(headings.indexOf('Safety'));
   });
 
+  it('renders a default-off ultra effort toggle and publishes changes to chat consumers', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const plugin = createPlugin();
+    const context = createContext(plugin);
+
+    codexSettingsTabRenderer.render(createContainer(), context);
+
+    const setting = findSetting('Enable ultra effort');
+    const toggle = setting.toggleComponents[0];
+    expect(toggle.value).toBe(false);
+
+    await toggle.onChangeCallback?.(true);
+
+    expect(plugin.settings.providerConfigs.codex.enableUltraEffort).toBe(true);
+    expect(context.notifyProviderModelOptionsChanged).toHaveBeenCalledWith('codex');
+  });
+
   it('refreshes title model options after Codex enablement changes', async () => {
     Object.defineProperty(process, 'platform', { value: 'darwin' });
     const plugin = createPlugin();

--- a/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
+++ b/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 
 import { ProviderExecutionLifecycleRegistry } from '@/core/execution';
+import { ProviderSettingsCoordinator } from '@/core/providers/ProviderSettingsCoordinator';
 import { DEFAULT_CODEX_PROVIDER_SETTINGS } from '@/providers/codex/settings';
 import { codexSettingsTabRenderer } from '@/providers/codex/ui/CodexSettingsTab';
 
@@ -8,7 +9,12 @@ const mockGetHostnameKey = jest.fn(() => 'host-a');
 const mockRenderEnvironmentSettingsSection = jest.fn();
 const mockSaveSettings = jest.fn().mockResolvedValue(undefined);
 const mockCodexCliResolverReset = jest.fn();
-const mockRenderCodexModelPicker = jest.fn();
+const mockRefreshCodexModelPicker = jest.fn();
+const mockRenderCodexModelPicker = jest.fn((
+  _container: unknown,
+  _context: { notifyProviderModelOptionsChanged: (providerId: string) => void },
+  _workspace: unknown,
+) => ({ refresh: mockRefreshCodexModelPicker }));
 const mockRefreshModelCatalog = jest.fn().mockResolvedValue({ changed: false });
 
 jest.mock('fs');
@@ -31,6 +37,7 @@ jest.mock('@/core/providers/ProviderSettingsCoordinator', () => ({
       }
       return false;
     }),
+    normalizeAllModelVariants: jest.fn(),
   },
 }));
 jest.mock('obsidian', () => {
@@ -117,7 +124,11 @@ jest.mock('@/providers/codex/app/CodexWorkspaceServices', () => ({
 }));
 
 jest.mock('@/providers/codex/ui/CodexModelPicker', () => ({
-  renderCodexModelPicker: (...args: unknown[]) => mockRenderCodexModelPicker(...args),
+  renderCodexModelPicker: (
+    container: unknown,
+    context: { notifyProviderModelOptionsChanged: (providerId: string) => void },
+    workspace: unknown,
+  ) => mockRenderCodexModelPicker(container, context, workspace),
 }));
 
 jest.mock('@/providers/codex/ui/CodexSubagentSettings', () => ({
@@ -478,6 +489,10 @@ describe('CodexSettingsTab', () => {
     await toggle.onChangeCallback?.(true);
 
     expect(plugin.settings.providerConfigs.codex.enableUltraEffort).toBe(true);
+    expect(ProviderSettingsCoordinator.normalizeAllModelVariants).toHaveBeenCalledWith(
+      plugin.settings,
+    );
+    expect(mockRefreshCodexModelPicker).toHaveBeenCalledTimes(1);
     expect(context.notifyProviderModelOptionsChanged).toHaveBeenCalledWith('codex');
   });
 


### PR DESCRIPTION
## Why

Closes #893. Codex can advertise `ultra` reasoning for individual models, but Claudian removed it during catalog normalization so supported models could never expose it.

## What Changed

- Added a default-off **Enable ultra effort** setting for Codex
- Preserved provider-advertised effort metadata and gated Ultra by both the setting and selected-model capability
- Preserved Ultra across provider/conversation projections and forwarded it in Codex turn requests
- Versioned the model catalog fingerprint to refresh previously filtered caches
- Added localized setting copy and focused regression coverage

## Why This Approach

Keeping provider metadata intact while gating the user-facing selector preserves Codex capability ownership and avoids exposing Ultra on unsupported models.

## Validation

- `npm run typecheck && npm run lint && npm run test && npm run build`
- 6,127 tests passed, including settings UI, model capability, projection, forwarding, locale, and cache-version coverage

## Impact and Follow-ups

Existing users remain opted out by default, while enabling the setting refreshes supported catalog behavior without altering unsupported models; no follow-up work is required.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
