### PR TITLE
fix: correct provider tool rendering and history replay

### DIFF
--- a/src/features/chat/controllers/StreamController.ts
+++ b/src/features/chat/controllers/StreamController.ts
@@ -763,12 +763,17 @@ export class StreamController {
 
     const adapter = this.getSubagentAdapter(existingToolCall.name);
     if (!adapter || adapter.protocol !== 'lifecycle') return false;
+    const resolvedToolCall: ToolCallInfo = {
+      ...existingToolCall,
+      result: normalizedContent,
+      status: chunk.isError ? 'error' : 'completed',
+    };
     const linkedSpawnIds = adapter.resolveSpawnToolIds(
-      existingToolCall,
+      resolvedToolCall,
       this.lifecycleAgentIdToSpawnId,
     );
     const isFullyOwned = adapter.isToolCallFullyOwned(
-      existingToolCall,
+      resolvedToolCall,
       this.lifecycleAgentIdToSpawnId,
     );
     if (adapter.isHiddenTool(existingToolCall.name) && isFullyOwned) {
@@ -828,7 +833,7 @@ export class StreamController {
           );
         }
       }
-      return isFullyOwned;
+      return adapter.isHiddenTool(existingToolCall.name) && isFullyOwned;
     }
 
     if (adapter.isCloseTool(existingToolCall.name)) {
@@ -986,7 +991,11 @@ export class StreamController {
       // blocked detection — their status is determined solely by isError
       if (chunk.isError) {
         existingToolCall.status = 'error';
-      } else if (!skipsBlockedDetection(existingToolCall.name) && isBlocked) {
+      } else if (
+        lifecycleAdapter?.protocol !== 'lifecycle'
+        && !skipsBlockedDetection(existingToolCall.name)
+        && isBlocked
+      ) {
         existingToolCall.status = 'blocked';
       } else {
         existingToolCall.status = 'completed';

--- a/src/providers/acp/AcpSessionUpdateNormalizer.ts
+++ b/src/providers/acp/AcpSessionUpdateNormalizer.ts
@@ -1,4 +1,6 @@
 import type { SlashCommand, StreamChunk } from '../../core/types';
+import type { SDKToolUseResult } from '../../core/types/diff';
+import { extractAcpDiffToolUseResult } from './AcpToolResultNormalization';
 import type {
   AcpAvailableCommand,
   AcpContentBlock,
@@ -70,6 +72,7 @@ export interface AcpToolCallSnapshot {
   rawInput?: unknown;
   rawOutput?: unknown;
   status?: AcpToolCallStatus | null;
+  toolUseResult?: SDKToolUseResult;
 }
 
 type MessageRole = 'assistant' | 'thinking' | 'user';
@@ -166,6 +169,7 @@ export class AcpSessionUpdateNormalizer {
   }
 
   private normalizeToolCall(toolCall: AcpToolCall): Extract<AcpNormalizedUpdate, { type: 'tool_call' }> {
+    const toolUseResult = extractAcpDiffToolUseResult(toolCall.content);
     const toolState: AcpToolCallSnapshot = {
       input: normalizeToolInput(toolCall.rawInput),
       name: normalizeToolName(toolCall.title, toolCall.kind),
@@ -173,6 +177,7 @@ export class AcpSessionUpdateNormalizer {
       rawInput: toolCall.rawInput,
       rawOutput: toolCall.rawOutput,
       status: toolCall.status,
+      ...(toolUseResult ? { toolUseResult } : {}),
     };
     this.toolCalls.set(toolCall.toolCallId, toolState);
 
@@ -188,6 +193,7 @@ export class AcpSessionUpdateNormalizer {
         content: toolState.output || defaultToolResultText(toolState.status),
         id: toolCall.toolCallId,
         isError: toolState.status === 'failed',
+        ...(toolState.toolUseResult ? { toolUseResult: toolState.toolUseResult } : {}),
         type: 'tool_result',
       });
     }
@@ -218,6 +224,13 @@ export class AcpSessionUpdateNormalizer {
     if (toolCallUpdate.rawOutput !== undefined) {
       current.rawOutput = toolCallUpdate.rawOutput;
     }
+    const toolUseResult = extractAcpDiffToolUseResult(toolCallUpdate.content);
+    if (toolUseResult) {
+      current.toolUseResult = {
+        ...current.toolUseResult,
+        ...toolUseResult,
+      };
+    }
 
     const nextOutput = renderToolPayload(toolCallUpdate.content ?? undefined, toolCallUpdate.rawOutput)
       || current.output;
@@ -242,6 +255,7 @@ export class AcpSessionUpdateNormalizer {
         content: current.output || defaultToolResultText(current.status),
         id: toolCallUpdate.toolCallId,
         isError: current.status === 'failed',
+        ...(current.toolUseResult ? { toolUseResult: current.toolUseResult } : {}),
         type: 'tool_result',
       });
     }

--- a/src/providers/acp/AcpToolResultNormalization.ts
+++ b/src/providers/acp/AcpToolResultNormalization.ts
@@ -1,0 +1,26 @@
+import type { SDKToolUseResult } from '../../core/types/diff';
+
+export function extractAcpDiffToolUseResult(content: unknown): SDKToolUseResult | undefined {
+  if (!Array.isArray(content)) return undefined;
+
+  for (const entry of content) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    const diff = entry as Record<string, unknown>;
+    if (
+      diff.type !== 'diff'
+      || typeof diff.path !== 'string'
+      || !diff.path.trim()
+      || typeof diff.newText !== 'string'
+    ) {
+      continue;
+    }
+
+    return {
+      filePath: diff.path,
+      newText: diff.newText,
+      ...(typeof diff.oldText === 'string' ? { oldText: diff.oldText } : {}),
+    };
+  }
+
+  return undefined;
+}

--- a/src/providers/acp/AcpToolStreamAdapter.ts
+++ b/src/providers/acp/AcpToolStreamAdapter.ts
@@ -159,12 +159,13 @@ export class AcpToolStreamAdapter {
           ...this.buildProviderPayloadFields(state),
         };
       case 'tool_result': {
-        const toolUseResult = this.adapter.normalizeToolUseResult(
+        const providerToolUseResult = this.adapter.normalizeToolUseResult(
           state.rawName,
           state.input,
           state.rawOutput,
           state.rawInput,
         );
+        const toolUseResult = mergeToolUseResults(chunk.toolUseResult, providerToolUseResult);
         return toolUseResult
           ? { ...chunk, toolUseResult }
           : chunk;
@@ -186,6 +187,15 @@ export class AcpToolStreamAdapter {
     const providerPayload = normalizeToolProviderPayload(result?.providerPayload);
     return providerPayload ? { providerPayload } : {};
   }
+}
+
+function mergeToolUseResults(
+  nativeResult: SDKToolUseResult | undefined,
+  providerResult: SDKToolUseResult | undefined,
+): SDKToolUseResult | undefined {
+  if (!nativeResult) return providerResult;
+  if (!providerResult) return nativeResult;
+  return { ...nativeResult, ...providerResult };
 }
 
 function normalizeRawToolInput(rawInput: unknown): Record<string, unknown> {

--- a/src/providers/acp/index.ts
+++ b/src/providers/acp/index.ts
@@ -6,6 +6,7 @@ export * from './AcpPermissionAdapter';
 export * from './AcpSessionConfig';
 export * from './AcpSessionUpdateNormalizer';
 export * from './AcpSubprocess';
+export * from './AcpToolResultNormalization';
 export * from './AcpToolStreamAdapter';
 export * from './buildAcpUsageInfo';
 export * from './methodNames';

--- a/src/providers/codex/normalization/codexSubagentNormalization.ts
+++ b/src/providers/codex/normalization/codexSubagentNormalization.ts
@@ -23,6 +23,15 @@ interface CodexWaitResult {
   timedOut: boolean;
 }
 
+interface CodexAgentSnapshot {
+  agentId: string;
+  result?: string;
+  status: SubagentInfo['status'];
+}
+
+const CODEX_LIST_AGENTS = 'list_agents';
+const CODEX_INTERRUPT_AGENT = 'interrupt_agent';
+
 function parseJsonObject(raw: string | undefined): Record<string, unknown> | null {
   if (!raw) return null;
 
@@ -38,13 +47,26 @@ function parseJsonObject(raw: string | undefined): Record<string, unknown> | nul
   return null;
 }
 
-export function extractCodexSpawnResult(raw: string | undefined): CodexSpawnResult {
+export function extractCodexSpawnResult(
+  raw: string | undefined,
+  toolCall?: ToolCallInfo,
+): CodexSpawnResult {
   const parsed = parseJsonObject(raw);
-  if (!parsed) return {};
+  const inputTaskName = typeof toolCall?.input.task_name === 'string'
+    ? toolCall.input.task_name.trim()
+    : '';
+  const agentId = parsed && typeof parsed.agent_id === 'string'
+    ? parsed.agent_id
+    : parsed && typeof parsed.task_name === 'string'
+      ? parsed.task_name
+      : inputTaskName || undefined;
+  const nickname = parsed && typeof parsed.nickname === 'string'
+    ? parsed.nickname
+    : undefined;
 
   return {
-    agentId: typeof parsed.agent_id === 'string' ? parsed.agent_id : undefined,
-    nickname: typeof parsed.nickname === 'string' ? parsed.nickname : undefined,
+    ...(agentId ? { agentId } : {}),
+    ...(nickname ? { nickname } : {}),
   };
 }
 
@@ -57,15 +79,24 @@ export function extractCodexWaitResult(raw: string | undefined): CodexWaitResult
   const rawStatuses = parsed.status;
   const statuses: Record<string, CodexWaitStatus> = {};
 
+  for (const snapshot of extractCodexAgentSnapshots(parsed)) {
+    if (snapshot.status === 'completed') {
+      statuses[snapshot.agentId] = { completed: snapshot.result || 'DONE' };
+    } else if (snapshot.status === 'error') {
+      statuses[snapshot.agentId] = { error: snapshot.result || 'Agent stopped' };
+    }
+  }
+
   if (rawStatuses && typeof rawStatuses === 'object' && !Array.isArray(rawStatuses)) {
     for (const [agentId, value] of Object.entries(rawStatuses as Record<string, unknown>)) {
       if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
       const status = value as Record<string, unknown>;
-      statuses[agentId] = {
-        completed: typeof status.completed === 'string' ? status.completed : undefined,
-        error: typeof status.error === 'string' ? status.error : undefined,
-        failed: typeof status.failed === 'string' ? status.failed : undefined,
-      };
+      const normalized = normalizeCodexAgentStatus(status);
+      if (normalized?.status === 'completed') {
+        statuses[agentId] = { completed: normalized.result || 'DONE' };
+      } else if (normalized?.status === 'error') {
+        statuses[agentId] = { error: normalized.result || 'Agent stopped' };
+      }
     }
   }
 
@@ -73,6 +104,62 @@ export function extractCodexWaitResult(raw: string | undefined): CodexWaitResult
     statuses,
     timedOut: parsed.timed_out === true,
   };
+}
+
+function extractCodexAgentSnapshots(parsed: Record<string, unknown>): CodexAgentSnapshot[] {
+  if (!Array.isArray(parsed.agents)) return [];
+
+  return parsed.agents.flatMap((value): CodexAgentSnapshot[] => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return [];
+    const agent = value as Record<string, unknown>;
+    const agentId = firstString(agent, ['agent_name', 'task_name', 'agent_id', 'name']);
+    const status = normalizeCodexAgentStatus(agent.agent_status ?? agent.status);
+    return agentId && status ? [{ agentId, ...status }] : [];
+  });
+}
+
+function normalizeCodexAgentStatus(
+  value: unknown,
+): Omit<CodexAgentSnapshot, 'agentId'> | null {
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) return null;
+    if (/interrupt|cancel|error|fail|kill/.test(normalized)) {
+      return { result: value.trim(), status: 'error' };
+    }
+    if (/complete|success|finish|done/.test(normalized)) {
+      return { result: 'DONE', status: 'completed' };
+    }
+    if (/pending|running|progress|start|waiting/.test(normalized)) {
+      return { status: 'running' };
+    }
+    return null;
+  }
+
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const status = value as Record<string, unknown>;
+  const completed = firstString(status, ['completed']);
+  if (completed) return { result: completed, status: 'completed' };
+  const failure = firstString(status, ['error', 'failed', 'interrupted']);
+  if (failure) return { result: failure, status: 'error' };
+
+  const state = firstString(status, ['state', 'status']);
+  const result = firstString(status, ['output', 'result', 'message']);
+  const normalizedState = state ? normalizeCodexAgentStatus(state) : null;
+  return normalizedState
+    ? { ...normalizedState, ...(result ? { result } : {}) }
+    : null;
+}
+
+function firstString(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return undefined;
 }
 
 function getCodexSubagentPrompt(input: Record<string, unknown>): string {
@@ -95,9 +182,44 @@ function getCodexSubagentDescription(
 
 function resolveCodexWaitCompletion(
   spawnResult: CodexSpawnResult,
+  spawnToolCall: ToolCallInfo,
   siblingToolCalls: ToolCallInfo[],
 ): { status: SubagentInfo['status']; result?: string } {
-  for (const toolCall of siblingToolCalls) {
+  let completion: { status: SubagentInfo['status']; result?: string } = { status: 'running' };
+  const spawnIndex = siblingToolCalls.indexOf(spawnToolCall);
+  const followingToolCalls = spawnIndex >= 0
+    ? siblingToolCalls.slice(spawnIndex + 1)
+    : siblingToolCalls;
+
+  for (const toolCall of followingToolCalls) {
+    if (toolCall.name === CODEX_LIST_AGENTS && spawnResult.agentId) {
+      const parsed = parseJsonObject(toolCall.result);
+      const snapshot = parsed
+        ? extractCodexAgentSnapshots(parsed).find(agent => agent.agentId === spawnResult.agentId)
+        : undefined;
+      if (snapshot) {
+        completion = {
+          status: snapshot.status,
+          ...(snapshot.result ? { result: snapshot.result } : {}),
+        };
+      }
+      continue;
+    }
+
+    if (isCodexCloseTool(toolCall.name)) {
+      if (
+        spawnResult.agentId
+        && getCodexLifecycleTargetIds(toolCall).includes(spawnResult.agentId)
+        && toolCall.status !== 'running'
+      ) {
+        completion = {
+          status: 'error',
+          result: toolCall.result || 'Agent interrupted',
+        };
+      }
+      continue;
+    }
+
     if (toolCall.name !== TOOL_WAIT && toolCall.name !== TOOL_WAIT_AGENT) {
       continue;
     }
@@ -116,20 +238,17 @@ function resolveCodexWaitCompletion(
     }
 
     if (agentStatus?.completed) {
-      return { status: 'completed', result: agentStatus.completed };
+      completion = { status: 'completed', result: agentStatus.completed };
+      continue;
     }
 
     const failure = agentStatus?.error ?? agentStatus?.failed;
     if (failure) {
-      return { status: 'error', result: failure };
-    }
-
-    if (waitResult.timedOut) {
-      return { status: 'error', result: 'Timed out' };
+      completion = { status: 'error', result: failure };
     }
   }
 
-  return { status: 'running' };
+  return completion;
 }
 
 export function buildCodexSubagentInfo(
@@ -138,8 +257,11 @@ export function buildCodexSubagentInfo(
 ): SubagentInfo {
   const prompt = getCodexSubagentPrompt(spawnToolCall.input);
   const model = getCodexSubagentModel(spawnToolCall.input);
-  const spawnResult = extractCodexSpawnResult(spawnToolCall.result);
-  const description = getCodexSubagentDescription(spawnResult.nickname, model);
+  const spawnResult = extractCodexSpawnResult(spawnToolCall.result, spawnToolCall);
+  const taskName = typeof spawnToolCall.input.task_name === 'string'
+    ? spawnToolCall.input.task_name
+    : undefined;
+  const description = getCodexSubagentDescription(spawnResult.nickname ?? taskName, model);
 
   if (spawnToolCall.status === 'error') {
     return {
@@ -154,7 +276,7 @@ export function buildCodexSubagentInfo(
     };
   }
 
-  const completion = resolveCodexWaitCompletion(spawnResult, siblingToolCalls);
+  const completion = resolveCodexWaitCompletion(spawnResult, spawnToolCall, siblingToolCalls);
 
   return {
     id: spawnToolCall.id,
@@ -175,6 +297,10 @@ export function isCodexSubagentSpawnToolCall(toolCall: ToolCallInfo): boolean {
 
 function getCodexLifecycleTargetIds(toolCall: ToolCallInfo): string[] {
   const targetIds = new Set(Object.keys(extractCodexWaitResult(toolCall.result).statuses));
+  for (const key of ['target', 'agent_id', 'task_name'] as const) {
+    const target = toolCall.input[key];
+    if (typeof target === 'string' && target) targetIds.add(target);
+  }
   const targets = Array.isArray(toolCall.input.targets)
     ? toolCall.input.targets
     : Array.isArray(toolCall.input.ids)
@@ -183,15 +309,33 @@ function getCodexLifecycleTargetIds(toolCall: ToolCallInfo): string[] {
   for (const target of targets) {
     if (typeof target === 'string') targetIds.add(target);
   }
+  const parsed = parseJsonObject(toolCall.result);
+  if (parsed) {
+    for (const snapshot of extractCodexAgentSnapshots(parsed)) {
+      targetIds.add(snapshot.agentId);
+    }
+  }
   return [...targetIds];
+}
+
+function isCodexGlobalWaitToolCall(toolCall: ToolCallInfo): boolean {
+  return toolCall.name === TOOL_WAIT_AGENT
+    && getCodexLifecycleTargetIds(toolCall).length === 0;
+}
+
+function isCodexCloseTool(name: string): boolean {
+  return name === TOOL_CLOSE_AGENT || name === CODEX_INTERRUPT_AGENT;
 }
 
 export const codexSubagentLifecycleAdapter: ProviderSubagentLifecycleAdapter = {
   protocol: 'lifecycle',
   isHiddenTool(name: string): boolean {
-    return name === TOOL_WAIT || name === TOOL_WAIT_AGENT || name === TOOL_CLOSE_AGENT;
+    return name === TOOL_WAIT || name === TOOL_WAIT_AGENT || isCodexCloseTool(name);
   },
   isToolCallFullyOwned(toolCall, agentIdToSpawnId): boolean {
+    if (isCodexGlobalWaitToolCall(toolCall)) {
+      return agentIdToSpawnId.size > 0;
+    }
     const targetIds = getCodexLifecycleTargetIds(toolCall);
     return targetIds.length > 0 && targetIds.every(targetId => agentIdToSpawnId.has(targetId));
   },
@@ -199,15 +343,18 @@ export const codexSubagentLifecycleAdapter: ProviderSubagentLifecycleAdapter = {
     return name === TOOL_SPAWN_AGENT;
   },
   isWaitTool(name: string): boolean {
-    return name === TOOL_WAIT || name === TOOL_WAIT_AGENT;
+    return name === TOOL_WAIT || name === TOOL_WAIT_AGENT || name === CODEX_LIST_AGENTS;
   },
   isCloseTool(name: string): boolean {
-    return name === TOOL_CLOSE_AGENT;
+    return isCodexCloseTool(name);
   },
   resolveSpawnToolIds(
     waitToolCall,
     agentIdToSpawnId,
   ): string[] {
+    if (isCodexGlobalWaitToolCall(waitToolCall)) {
+      return [...new Set(agentIdToSpawnId.values())];
+    }
     const spawnIds = new Set<string>();
     for (const targetId of getCodexLifecycleTargetIds(waitToolCall)) {
       const spawnId = agentIdToSpawnId.get(targetId);
@@ -221,8 +368,8 @@ export const codexSubagentLifecycleAdapter: ProviderSubagentLifecycleAdapter = {
   buildSubagentInfo(spawnToolCall, siblingToolCalls = []): SubagentInfo {
     return buildCodexSubagentInfo(spawnToolCall, siblingToolCalls);
   },
-  extractSpawnResult(raw: string | undefined) {
-    return extractCodexSpawnResult(raw);
+  extractSpawnResult(raw: string | undefined, toolCall?: ToolCallInfo) {
+    return extractCodexSpawnResult(raw, toolCall);
   },
   extractWaitResult(raw: string | undefined) {
     return extractCodexWaitResult(raw);

--- a/src/providers/grok/execution/GrokExecutionSession.ts
+++ b/src/providers/grok/execution/GrokExecutionSession.ts
@@ -52,9 +52,9 @@ import {
   normalizeGrokDiscoveredModels,
 } from '../models';
 import {
-  buildGrokToolProviderPayload,
   normalizeGrokToolCall,
   normalizeGrokToolName,
+  normalizeGrokToolUseResult,
   resolveGrokRawToolName,
 } from '../normalization/grokToolNormalization';
 import { waitForGrokCancelDelivery } from '../runtime/GrokCancelDelivery';
@@ -1205,13 +1205,12 @@ function createGrokToolStreamAdapter(): AcpToolStreamAdapter {
       return normalizeGrokToolName(rawName ?? 'tool');
     },
     normalizeToolUseResult(rawName, _input, rawOutput, rawInput) {
-      return {
-        providerPayload: buildGrokToolProviderPayload({
-          rawInput,
-          rawName: rawName ?? 'tool',
-          rawOutput,
-        }),
-      };
+      return normalizeGrokToolUseResult(
+        rawName ?? 'tool',
+        _input,
+        rawOutput,
+        rawInput,
+      );
     },
     resolveRawToolName(currentRawName, update) {
       return resolveGrokRawToolName(currentRawName, update);

--- a/src/providers/grok/history/GrokHistoryStore.ts
+++ b/src/providers/grok/history/GrokHistoryStore.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
+import { isWriteEditTool, TOOL_ASK_USER_QUESTION } from '../../../core/tools/toolNames';
 import type {
   ChatMessage,
   ContentBlock,
@@ -8,10 +9,13 @@ import type {
   ImageMediaType,
   ToolCallInfo,
 } from '../../../core/types';
+import type { SDKToolUseResult } from '../../../core/types/diff';
+import { extractDiffData } from '../../../utils/diff';
+import { extractAcpDiffToolUseResult } from '../../acp/AcpToolResultNormalization';
 import {
-  buildGrokToolProviderPayload,
   type GrokRawToolNameResolution,
   normalizeGrokToolCall,
+  normalizeGrokToolUseResult,
   resolveGrokRawToolName,
 } from '../normalization/grokToolNormalization';
 
@@ -50,6 +54,7 @@ interface StoredTool {
   rawNameProvenance: GrokRawToolNameResolution['provenance'];
   rawOutput: unknown;
   status: ToolCallInfo['status'];
+  toolUseResult?: SDKToolUseResult;
 }
 
 interface PendingTurn {
@@ -397,6 +402,8 @@ function reconcileToolUpdate(turn: PendingTurn, update: Record<string, unknown>)
     title: rawName,
   }, rawNameResolution);
   const status = normalizeToolStatus(readString(update.status), current?.status);
+  const nativeToolUseResult = extractAcpDiffToolUseResult(update.content)
+    ?? current?.toolUseResult;
   const output = renderedContent || (update.rawOutput === undefined
     ? current?.output || normalized.output
     : normalized.output || current?.output) || '';
@@ -415,6 +422,7 @@ function reconcileToolUpdate(turn: PendingTurn, update: Record<string, unknown>)
     rawNameProvenance: rawNameResolution.provenance,
     rawOutput,
     status,
+    ...(nativeToolUseResult ? { toolUseResult: nativeToolUseResult } : {}),
   });
 }
 
@@ -448,18 +456,32 @@ function finalizeTurn(
     if (!tool) {
       return [];
     }
-    return [{
+    const providerToolUseResult = normalizeGrokToolUseResult(
+      tool.rawName,
+      tool.input,
+      tool.rawOutput,
+      tool.rawInput,
+    );
+    const toolUseResult: SDKToolUseResult = {
+      ...tool.toolUseResult,
+      ...providerToolUseResult,
+    };
+    const toolCall: ToolCallInfo = {
       id: tool.id,
       input: tool.input,
       name: tool.name,
-      providerPayload: buildGrokToolProviderPayload({
-        rawInput: tool.rawInput,
-        rawName: tool.rawName,
-        rawOutput: tool.rawOutput,
-      }),
+      providerPayload: providerToolUseResult.providerPayload,
       ...(tool.output ? { result: tool.output } : {}),
       status: tool.status,
-    } satisfies ToolCallInfo];
+    };
+    if (toolCall.name === TOOL_ASK_USER_QUESTION && providerToolUseResult.answers) {
+      toolCall.resolvedAnswers = providerToolUseResult.answers;
+    }
+    if (toolCall.status === 'completed' && isWriteEditTool(toolCall.name)) {
+      const diffData = extractDiffData(toolUseResult, toolCall);
+      if (diffData) toolCall.diffData = diffData;
+    }
+    return [toolCall];
   });
   const assistant: ChatMessage = {
     assistantMessageId: assistantId,

--- a/src/providers/grok/normalization/grokSubagentNormalization.ts
+++ b/src/providers/grok/normalization/grokSubagentNormalization.ts
@@ -50,8 +50,24 @@ function getRawOutput(toolCall: ToolCallInfo | undefined, raw: string | undefine
 }
 
 function extractTaskId(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value.match(/\b(?:task|subagent|agent)_id\s*[:=]\s*["']?([a-zA-Z0-9._:-]+)/i)?.[1];
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const id = extractTaskId(item);
+      if (id) return id;
+    }
+    return undefined;
+  }
   if (!isRecord(value)) return undefined;
-  return firstString(value, ['task_id', 'subagent_id', 'agent_id', 'id']);
+  const direct = firstString(value, ['task_id', 'subagent_id', 'agent_id', 'id']);
+  if (direct) return direct;
+  for (const key of ['text', 'output', 'message', 'result', 'Result'] as const) {
+    const id = extractTaskId(value[key]);
+    if (id) return id;
+  }
+  return undefined;
 }
 
 function extractText(value: unknown): string | undefined {

--- a/src/providers/grok/normalization/grokToolNormalization.ts
+++ b/src/providers/grok/normalization/grokToolNormalization.ts
@@ -1,9 +1,12 @@
+import { extractResolvedAnswersFromResultText } from '../../../core/tools/toolInput';
 import {
   TOOL_APPLY_PATCH,
   TOOL_ASK_USER_QUESTION,
   TOOL_BASH,
   TOOL_BASH_OUTPUT,
   TOOL_EDIT,
+  TOOL_ENTER_PLAN_MODE,
+  TOOL_EXIT_PLAN_MODE,
   TOOL_GREP,
   TOOL_KILL_SHELL,
   TOOL_LS,
@@ -16,6 +19,8 @@ import {
   TOOL_WEB_SEARCH,
   TOOL_WRITE,
 } from '../../../core/tools/toolNames';
+import type { AskUserAnswers } from '../../../core/types';
+import type { SDKToolUseResult } from '../../../core/types/diff';
 import type { AcpToolRawNameProvenance } from '../../acp/AcpToolStreamAdapter';
 import { GROK_SUBAGENT_LIFECYCLE_TOOL_NAMES } from './grokLifecycleToolNames';
 
@@ -23,6 +28,8 @@ const GROK_TOOL_NAME_MAP: Readonly<Record<string, string>> = {
   apply_patch: TOOL_APPLY_PATCH,
   ask_user_question: TOOL_ASK_USER_QUESTION,
   edit_notebook: TOOL_NOTEBOOK_EDIT,
+  enter_plan_mode: TOOL_ENTER_PLAN_MODE,
+  exit_plan_mode: TOOL_EXIT_PLAN_MODE,
   get_terminal_command_output: TOOL_BASH_OUTPUT,
   grep: TOOL_GREP,
   hashline_edit: TOOL_EDIT,
@@ -57,6 +64,11 @@ export interface GrokToolProviderPayload {
   rawOutput?: unknown;
 }
 
+export interface GrokNormalizedToolUseResult extends SDKToolUseResult {
+  answers?: AskUserAnswers;
+  providerPayload: GrokToolProviderPayload;
+}
+
 export interface GrokRawToolNameResolution {
   provenance: AcpToolRawNameProvenance;
   rawName: string;
@@ -77,6 +89,9 @@ export function resolveGrokRawToolName(
 ): GrokRawToolNameResolution {
   const title = update.title?.trim();
   const normalizedTitle = title?.toLowerCase();
+  if (currentRawName?.provenance === 'title') {
+    return currentRawName;
+  }
   if (
     normalizedTitle
     && (
@@ -86,13 +101,7 @@ export function resolveGrokRawToolName(
   ) {
     return { provenance: 'title', rawName: normalizedTitle };
   }
-  if (
-    title
-    && (
-      currentRawName?.provenance !== 'title'
-      || !isKnownGrokRawToolName(currentRawName.rawName)
-    )
-  ) {
+  if (title) {
     return { provenance: 'title', rawName: title };
   }
   if (currentRawName) {
@@ -122,17 +131,6 @@ export function normalizeGrokToolCall(value: {
   };
 }
 
-function isKnownGrokRawToolName(rawName: string | undefined): boolean {
-  const normalized = rawName?.trim().toLowerCase();
-  return Boolean(
-    normalized
-    && (
-      normalized in GROK_TOOL_NAME_MAP
-      || GROK_SUBAGENT_LIFECYCLE_TOOL_NAMES.has(normalized)
-    )
-  );
-}
-
 export function buildGrokToolProviderPayload(value: {
   rawInput?: unknown;
   rawName: string;
@@ -143,6 +141,65 @@ export function buildGrokToolProviderPayload(value: {
     rawName: value.rawName,
     ...(value.rawOutput !== undefined ? { rawOutput: value.rawOutput } : {}),
   };
+}
+
+export function normalizeGrokToolUseResult(
+  rawName: string,
+  input: Record<string, unknown>,
+  rawOutput: unknown,
+  rawInput?: unknown,
+): GrokNormalizedToolUseResult {
+  const providerPayload = buildGrokToolProviderPayload({
+    rawInput,
+    rawName,
+    rawOutput,
+  });
+  const answers = normalizeGrokQuestionAnswers(rawName, input, rawOutput);
+  return {
+    ...(answers ? { answers } : {}),
+    providerPayload,
+  };
+}
+
+function normalizeGrokQuestionAnswers(
+  rawName: string,
+  input: Record<string, unknown>,
+  rawOutput: unknown,
+): AskUserAnswers | undefined {
+  if (normalizeGrokToolName(rawName) !== TOOL_ASK_USER_QUESTION || !isRecord(rawOutput)) {
+    return undefined;
+  }
+  const userAnswered = isRecord(rawOutput.UserAnswered)
+    ? rawOutput.UserAnswered
+    : isRecord(rawOutput.userAnswered)
+      ? rawOutput.userAnswered
+      : null;
+  const message = userAnswered && typeof userAnswered.message === 'string'
+    ? userAnswered.message.trim()
+    : '';
+  if (!message) return undefined;
+
+  const questions = Array.isArray(input.questions)
+    ? input.questions.filter(isRecord)
+    : [];
+  const parsed = extractResolvedAnswersFromResultText(message);
+  if (parsed && questions.length !== 1) return parsed;
+  if (questions.length !== 1) {
+    return undefined;
+  }
+
+  const question = questions[0];
+  const questionText = typeof question.question === 'string' ? question.question : '';
+  if (!questionText) return undefined;
+  const questionId = typeof question.id === 'string' ? question.id : '';
+  if (parsed && (parsed[questionText] !== undefined || (questionId && parsed[questionId] !== undefined))) {
+    return parsed;
+  }
+  const answers: AskUserAnswers = { [questionText]: message };
+  if (questionId) {
+    answers[questionId] = message;
+  }
+  return answers;
 }
 
 function normalizeToolInput(rawName: string, value: unknown): Record<string, unknown> {

--- a/src/providers/pi/normalizations/piToolNormalization.ts
+++ b/src/providers/pi/normalizations/piToolNormalization.ts
@@ -5,6 +5,8 @@ import {
   TOOL_GREP,
   TOOL_LS,
   TOOL_READ,
+  TOOL_WEB_FETCH,
+  TOOL_WEB_SEARCH,
   TOOL_WRITE,
 } from '../../../core/tools/toolNames';
 
@@ -15,6 +17,8 @@ const PI_BUILT_IN_TOOL_NAMES: Record<string, string> = {
   grep: TOOL_GREP,
   ls: TOOL_LS,
   read: TOOL_READ,
+  web_fetch: TOOL_WEB_FETCH,
+  web_search: TOOL_WEB_SEARCH,
   write: TOOL_WRITE,
 };
 

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -152,6 +152,15 @@ export function extractDiffData(toolUseResult: unknown, toolCall: ToolCallInfo):
         return { filePath: resultFilePath, diffLines, stats: countLineChanges(diffLines) };
       }
     }
+
+    const replacements = getEditPairs(result);
+    if (replacements.length > 0) {
+      const resultFilePath = (typeof result.filePath === 'string' ? result.filePath : null)
+        || (typeof result.path === 'string' ? result.path : null)
+        || filePath;
+      const diffLines = buildReplacementDiffLines(replacements);
+      return { filePath: resultFilePath, diffLines, stats: countLineChanges(diffLines) };
+    }
   }
 
   return diffFromToolInput(toolCall, filePath);
@@ -251,15 +260,19 @@ function buildReplacementDiffLines(pairs: ReplacementPair[]): DiffLine[] {
   let newLineNum = 1;
 
   for (const pair of pairs) {
-    for (const line of pair.oldText.split('\n')) {
+    for (const line of splitReplacementLines(pair.oldText)) {
       diffLines.push({ type: 'delete', text: line, oldLineNum: oldLineNum++ });
     }
-    for (const line of pair.newText.split('\n')) {
+    for (const line of splitReplacementLines(pair.newText)) {
       diffLines.push({ type: 'insert', text: line, newLineNum: newLineNum++ });
     }
   }
 
   return diffLines;
+}
+
+function splitReplacementLines(text: string): string[] {
+  return text === '' ? [] : text.split('\n');
 }
 
 function buildApplyPatchFileDiff(current: {

--- a/tests/unit/features/chat/controllers/StreamController.test.ts
+++ b/tests/unit/features/chat/controllers/StreamController.test.ts
@@ -2997,6 +2997,104 @@ describe('StreamController - Text Content', () => {
         false,
       );
     });
+
+    it('updates current task-name agents from list_agents after global wait timeouts', async () => {
+      const { createSubagentBlock, finalizeSubagentBlock } = jest.requireMock('@/features/chat/rendering/SubagentRenderer');
+      const { updateToolCallResult } = jest.requireMock('@/features/chat/rendering/ToolCallRenderer');
+      const msg = createTestMessage();
+      deps.state.currentContentEl = createMockEl();
+      deps.getProviderId = () => 'codex';
+
+      const subagentState = {
+        info: { id: 'spawn-current', description: 'provider_review', prompt: '', status: 'running', toolCalls: [] },
+        labelEl: { setText: jest.fn() },
+      };
+      createSubagentBlock.mockReturnValueOnce(subagentState);
+
+      await controller.handleStreamChunk({
+        type: 'tool_use',
+        id: 'spawn-current',
+        name: TOOL_SPAWN_AGENT,
+        input: { message: 'Review the provider integration.', task_name: 'provider_review' },
+      }, msg);
+      await controller.handleStreamChunk({
+        type: 'tool_result',
+        id: 'spawn-current',
+        content: '{"task_name":"provider_review"}',
+      }, msg);
+      await controller.handleStreamChunk({
+        type: 'tool_use',
+        id: 'wait-current',
+        name: TOOL_WAIT_AGENT,
+        input: { timeout_ms: 10_000 },
+      }, msg);
+      await controller.handleStreamChunk({
+        type: 'tool_result',
+        id: 'wait-current',
+        content: '{"message":"Agents are still running.","timed_out":true}',
+      }, msg);
+
+      expect(finalizeSubagentBlock).not.toHaveBeenCalled();
+
+      await controller.handleStreamChunk({
+        type: 'tool_use',
+        id: 'list-current',
+        name: 'list_agents',
+        input: {},
+      }, msg);
+      await controller.handleStreamChunk({
+        type: 'tool_result',
+        id: 'list-current',
+        content: JSON.stringify({
+          agents: [{
+            agent_name: 'provider_review',
+            agent_status: { completed: 'Provider integration is sound.' },
+          }],
+        }),
+      }, msg);
+
+      expect(finalizeSubagentBlock).toHaveBeenCalledWith(
+        subagentState,
+        'Provider integration is sound.',
+        false,
+      );
+      expect(updateToolCallResult).toHaveBeenCalledWith(
+        'list-current',
+        expect.objectContaining({
+          name: 'list_agents',
+          status: 'completed',
+        }),
+        deps.state.toolCallElements,
+      );
+    });
+
+    it('does not infer list_agents status from nested agent result prose', async () => {
+      const { isBlockedToolResult } = jest.requireMock('@/features/chat/rendering/ToolCallRenderer');
+      (isBlockedToolResult as jest.Mock).mockReturnValueOnce(true);
+      const msg = createTestMessage();
+      deps.getProviderId = () => 'codex';
+      msg.toolCalls = [{
+        id: 'list-current',
+        input: {},
+        name: 'list_agents',
+        status: 'running',
+      }];
+
+      await controller.handleStreamChunk({
+        type: 'tool_result',
+        id: 'list-current',
+        content: JSON.stringify({
+          agents: [{
+            agent_name: '/root/reviewer',
+            agent_status: {
+              completed: 'The approval-denied path is handled correctly.',
+            },
+          }],
+        }),
+      }, msg);
+
+      expect(msg.toolCalls[0].status).toBe('completed');
+    });
   });
 
   describe('Grok subagent lifecycle', () => {

--- a/tests/unit/providers/acp/AcpSessionUpdateNormalizer.test.ts
+++ b/tests/unit/providers/acp/AcpSessionUpdateNormalizer.test.ts
@@ -91,6 +91,51 @@ describe('AcpSessionUpdateNormalizer', () => {
     });
   });
 
+  it('preserves native diff content through a status-only completion', () => {
+    const normalizer = new AcpSessionUpdateNormalizer();
+
+    normalizer.normalize({
+      rawInput: { content: 'new text', file_path: 'src/write.ts' },
+      sessionUpdate: 'tool_call',
+      title: 'write',
+      toolCallId: 'tool-write',
+    });
+    normalizer.normalize({
+      content: [{
+        newText: 'new text',
+        oldText: 'old text',
+        path: 'src/write.ts',
+        type: 'diff',
+      }],
+      sessionUpdate: 'tool_call_update',
+      status: 'in_progress',
+      toolCallId: 'tool-write',
+    });
+    const completed = normalizer.normalize({
+      sessionUpdate: 'tool_call_update',
+      status: 'completed',
+      toolCallId: 'tool-write',
+    });
+
+    expect(completed).toMatchObject({
+      streamChunks: [{
+        toolUseResult: {
+          filePath: 'src/write.ts',
+          newText: 'new text',
+          oldText: 'old text',
+        },
+        type: 'tool_result',
+      }],
+      toolState: {
+        toolUseResult: {
+          filePath: 'src/write.ts',
+          newText: 'new text',
+          oldText: 'old text',
+        },
+      },
+    });
+  });
+
   it('retains raw tool payloads while preferring concise rendered content', () => {
     const normalizer = new AcpSessionUpdateNormalizer();
     const rawInput = ['opaque', { nested: true }];

--- a/tests/unit/providers/acp/AcpToolStreamAdapter.test.ts
+++ b/tests/unit/providers/acp/AcpToolStreamAdapter.test.ts
@@ -77,6 +77,42 @@ describe('AcpToolStreamAdapter', () => {
     }]);
   });
 
+  it('merges native ACP diff data with provider-owned result metadata', () => {
+    const adapter = createAdapter();
+    adapter.normalizeToolCall({
+      rawInput: { content: 'new text', file_path: 'src/write.ts' },
+      title: 'write',
+      toolCallId: 'tool-write',
+    }, [{ id: 'tool-write', input: {}, name: 'write', type: 'tool_use' }]);
+
+    expect(adapter.normalizeToolCallUpdate({
+      status: 'completed',
+      toolCallId: 'tool-write',
+    }, [{
+      content: 'Diff: src/write.ts',
+      id: 'tool-write',
+      toolUseResult: {
+        filePath: 'src/write.ts',
+        newText: 'new text',
+        oldText: 'old text',
+      },
+      type: 'tool_result',
+    }])).toEqual([{
+      content: 'Diff: src/write.ts',
+      id: 'tool-write',
+      toolUseResult: {
+        filePath: 'src/write.ts',
+        newText: 'new text',
+        oldText: 'old text',
+        providerPayload: {
+          rawInput: { content: 'new text', file_path: 'src/write.ts' },
+          rawName: 'write',
+        },
+      },
+      type: 'tool_result',
+    }]);
+  });
+
   it('emits a title-only normalized-name refinement and ignores a no-name update', () => {
     const adapter = createAdapter();
     expect(adapter.normalizeToolCall({ title: 'tool', toolCallId: 'tool-1' }, [

--- a/tests/unit/providers/codex/normalization/codexSubagentNormalization.test.ts
+++ b/tests/unit/providers/codex/normalization/codexSubagentNormalization.test.ts
@@ -1,7 +1,8 @@
-import { TOOL_SPAWN_AGENT, TOOL_WAIT_AGENT } from '@/core/tools/toolNames';
+import { TOOL_SPAWN_AGENT, TOOL_WAIT, TOOL_WAIT_AGENT } from '@/core/tools/toolNames';
 import type { ToolCallInfo } from '@/core/types';
 import {
   buildCodexSubagentInfo,
+  codexSubagentLifecycleAdapter,
   extractCodexSpawnResult,
   extractCodexWaitResult,
 } from '@/providers/codex/normalization/codexSubagentNormalization';
@@ -77,5 +78,98 @@ describe('codexSubagentNormalization', () => {
         result: undefined,
       })
     );
+  });
+
+  it('uses current task-name and list-agents results to resolve completion', () => {
+    const spawnTool: ToolCallInfo = {
+      id: 'spawn-current',
+      name: TOOL_SPAWN_AGENT,
+      input: {
+        message: 'Review the provider integration.',
+        task_name: 'provider_review',
+      },
+      status: 'completed',
+      result: '{"task_name":"provider_review"}',
+    };
+    const timedOutWait: ToolCallInfo = {
+      id: 'wait-current',
+      name: TOOL_WAIT_AGENT,
+      input: { timeout_ms: 10_000 },
+      status: 'completed',
+      result: '{"message":"No agent completed before the timeout.","timed_out":true}',
+    };
+    const listAgents: ToolCallInfo = {
+      id: 'list-current',
+      name: 'list_agents',
+      input: {},
+      status: 'completed',
+      result: JSON.stringify({
+        agents: [{
+          agent_name: 'provider_review',
+          agent_status: { completed: 'Provider integration is sound.' },
+        }],
+      }),
+    };
+
+    expect(extractCodexSpawnResult(spawnTool.result, spawnTool)).toEqual({
+      agentId: 'provider_review',
+    });
+    expect(buildCodexSubagentInfo(
+      spawnTool,
+      [spawnTool, timedOutWait, listAgents],
+    )).toEqual(expect.objectContaining({
+      agentId: 'provider_review',
+      result: 'Provider integration is sound.',
+      status: 'completed',
+    }));
+  });
+
+  it('treats a current global wait timeout as polling, not agent failure', () => {
+    const spawnTool: ToolCallInfo = {
+      id: 'spawn-current',
+      name: TOOL_SPAWN_AGENT,
+      input: { message: 'Keep working.', task_name: 'background_work' },
+      status: 'completed',
+      result: '{"task_name":"background_work"}',
+    };
+    const waitTool: ToolCallInfo = {
+      id: 'wait-current',
+      name: TOOL_WAIT_AGENT,
+      input: { timeout_ms: 10_000 },
+      status: 'completed',
+      result: '{"message":"Agents are still running.","timed_out":true}',
+    };
+
+    expect(buildCodexSubagentInfo(spawnTool, [spawnTool, waitTool])).toEqual(
+      expect.objectContaining({ status: 'running', result: undefined }),
+    );
+
+    const agentIdToSpawnId = new Map([['background_work', 'spawn-current']]);
+    expect(codexSubagentLifecycleAdapter.isWaitTool('list_agents')).toBe(true);
+    expect(codexSubagentLifecycleAdapter.isHiddenTool('list_agents')).toBe(false);
+    expect(codexSubagentLifecycleAdapter.resolveSpawnToolIds(
+      waitTool,
+      agentIdToSpawnId,
+    )).toEqual(['spawn-current']);
+    expect(codexSubagentLifecycleAdapter.isToolCallFullyOwned(
+      waitTool,
+      agentIdToSpawnId,
+    )).toBe(true);
+
+    const executionCellWait: ToolCallInfo = {
+      id: 'wait-execution-cell',
+      name: TOOL_WAIT,
+      input: { cell_id: 'cell-1', yield_time_ms: 10_000 },
+      status: 'completed',
+      result: 'Cell completed.',
+    };
+    expect(codexSubagentLifecycleAdapter.resolveSpawnToolIds(
+      executionCellWait,
+      agentIdToSpawnId,
+    )).toEqual([]);
+    expect(codexSubagentLifecycleAdapter.isToolCallFullyOwned(
+      executionCellWait,
+      agentIdToSpawnId,
+    )).toBe(false);
   });
 });

--- a/tests/unit/providers/grok/execution/GrokExecutionBackend.test.ts
+++ b/tests/unit/providers/grok/execution/GrokExecutionBackend.test.ts
@@ -1408,6 +1408,54 @@ describe('GrokExecutionBackend', () => {
     }));
   });
 
+  it('preserves native overwrite diffs in live Grok tool results', async () => {
+    const native = new FakeNativeConnection();
+    const rawInput = { content: 'new text', file_path: 'src/write.ts' };
+    const rawOutput = { type: 'WriteResult' };
+    native.promptImplementation = async () => {
+      native.emit({
+        rawInput,
+        sessionUpdate: 'tool_call',
+        title: 'write',
+        toolCallId: 'tool-write',
+      });
+      native.emit({
+        content: [{
+          newText: 'new text',
+          oldText: 'old text',
+          path: 'src/write.ts',
+          type: 'diff',
+        }],
+        rawOutput,
+        sessionUpdate: 'tool_call_update',
+        status: 'completed',
+        toolCallId: 'tool-write',
+      });
+      return { stopReason: 'end_turn' };
+    };
+    const session = new GrokExecutionBackend(
+      { settings: {} } as ProviderHost,
+      { nativeFactory: { create: () => native } },
+    ).createSession(sessionConfig);
+
+    const events = await collect(session.execute(executionRequest()).events);
+
+    expect(events).toContainEqual(expect.objectContaining({
+      toolCallId: 'tool-write',
+      toolUseResult: {
+        filePath: 'src/write.ts',
+        newText: 'new text',
+        oldText: 'old text',
+        providerPayload: {
+          rawInput,
+          rawName: 'write',
+          rawOutput,
+        },
+      },
+      type: 'tool_completed',
+    }));
+  });
+
   it('uses native interjection and rewind without creating an unrelated session', async () => {
     const native = new FakeNativeConnection();
     native.promptImplementation = () => new Promise(() => {});

--- a/tests/unit/providers/grok/history/GrokHistoryStore.test.ts
+++ b/tests/unit/providers/grok/history/GrokHistoryStore.test.ts
@@ -701,6 +701,103 @@ describe('GrokHistoryStore', () => {
     });
   });
 
+  it('rehydrates current tool names, answers, and file diffs for shared renderers', () => {
+    const sessionId = 'session-current-tools';
+    const question = 'How should the audit continue?';
+    const answer = 'Fix the provider-owned normalization.';
+    const updates = [
+      {
+        content: { text: 'Fix the audited tool displays.', type: 'text' },
+        sessionUpdate: 'user_message_chunk',
+      },
+      {
+        rawInput: { content: 'first line\nsecond line', file_path: 'notes/audit.md' },
+        status: 'in_progress',
+        title: 'write',
+        toolCallId: 'tool-write',
+        sessionUpdate: 'tool_call',
+      },
+      {
+        content: [
+          {
+            newText: 'first line\nsecond line',
+            oldText: 'previous first\nprevious second',
+            path: 'notes/audit.md',
+            type: 'diff',
+          },
+          { content: { text: 'Wrote notes/audit.md', type: 'text' }, type: 'content' },
+        ],
+        rawOutput: { type: 'WriteResult' },
+        status: 'completed',
+        toolCallId: 'tool-write',
+        sessionUpdate: 'tool_call_update',
+      },
+      {
+        rawInput: {
+          questions: [{
+            multiSelect: false,
+            options: [{ description: '', label: 'Fix it' }],
+            question,
+          }],
+        },
+        status: 'in_progress',
+        title: 'ask_user_question',
+        toolCallId: 'tool-question',
+        sessionUpdate: 'tool_call',
+      },
+      {
+        content: [{ content: { text: answer, type: 'text' }, type: 'content' }],
+        rawOutput: { UserAnswered: { message: answer }, type: 'UserAnswered' },
+        status: 'completed',
+        toolCallId: 'tool-question',
+        sessionUpdate: 'tool_call_update',
+      },
+      {
+        rawInput: { plan: 'Apply the audited fixes.' },
+        status: 'in_progress',
+        title: 'exit_plan_mode',
+        toolCallId: 'tool-plan',
+        sessionUpdate: 'tool_call',
+      },
+      {
+        status: 'completed',
+        title: 'Plan mode exited',
+        toolCallId: 'tool-plan',
+        sessionUpdate: 'tool_call_update',
+      },
+      { sessionUpdate: 'turn_completed' },
+    ];
+    const content = updates.map((update, index) => JSON.stringify({
+      method: '_x.ai/session/update',
+      params: { sessionId, update },
+      timestamp: 1_000 + index,
+    })).join('\n');
+
+    const toolCalls = parseGrokHistoryContent(content, sessionId).messages[1].toolCalls ?? [];
+    const write = toolCalls.find(toolCall => toolCall.id === 'tool-write');
+    const ask = toolCalls.find(toolCall => toolCall.id === 'tool-question');
+    const exitPlan = toolCalls.find(toolCall => toolCall.id === 'tool-plan');
+
+    expect(write).toMatchObject({
+      diffData: {
+        filePath: 'notes/audit.md',
+        stats: { added: 2, removed: 2 },
+      },
+      name: 'Write',
+      status: 'completed',
+    });
+    expect(ask).toMatchObject({
+      name: 'AskUserQuestion',
+      resolvedAnswers: { [question]: answer },
+      status: 'completed',
+    });
+    expect(exitPlan).toMatchObject({
+      name: 'ExitPlanMode',
+      providerPayload: { rawName: 'exit_plan_mode' },
+      status: 'completed',
+    });
+  });
+
   it('finalizes a stable prior turn when the next user message supplies the missing boundary', () => {
     const records = [
       {

--- a/tests/unit/providers/grok/normalization/grokSubagentNormalization.test.ts
+++ b/tests/unit/providers/grok/normalization/grokSubagentNormalization.test.ts
@@ -111,6 +111,54 @@ describe('grokSubagentNormalization', () => {
     }));
   });
 
+  it('extracts the current background task id from native spawn text', () => {
+    const taskId = '019f7eca-4926-7b60-8d02-81f5933a8834';
+    const spawn = toolCall({
+      id: 'spawn-current',
+      name: 'spawn_subagent',
+      input: {
+        description: 'Inspect current history',
+        prompt: 'Audit the provider records.',
+        run_in_background: true,
+        task_id: null,
+      },
+      providerPayload: {
+        rawName: 'spawn_subagent',
+        rawOutput: {
+          text: [
+            `subagent_id: ${taskId}`,
+            `Use get_command_or_subagent_output with task_ids=["${taskId}"] to wait.`,
+          ].join('\n'),
+          type: 'Text',
+        },
+      },
+      result: `subagent_id: ${taskId}`,
+      status: 'completed',
+    });
+    const output = toolCall({
+      id: 'output-current',
+      name: 'get_command_or_subagent_output',
+      input: { task_ids: [taskId], timeout_ms: 10_000 },
+      providerPayload: {
+        rawName: 'get_command_or_subagent_output',
+        rawOutput: { Result: 'Audit complete.', type: 'Text' },
+      },
+      result: 'Audit complete.',
+      status: 'completed',
+    });
+
+    expect(extractGrokSpawnResult(spawn.result, spawn)).toEqual({ agentId: taskId });
+    expect(buildGrokSubagentInfo(spawn, [spawn, output])).toEqual(expect.objectContaining({
+      agentId: taskId,
+      asyncStatus: 'completed',
+      result: 'Audit complete.',
+      status: 'completed',
+    }));
+
+    const taskIds = new Map([[taskId, 'spawn-current']]);
+    expect(grokSubagentLifecycleAdapter.isToolCallFullyOwned(output, taskIds)).toBe(true);
+  });
+
   it('completes a background spawn from a raw-output-only task id', () => {
     const spawn = toolCall({
       id: 'spawn-output-only',

--- a/tests/unit/providers/grok/normalization/grokToolNormalization.test.ts
+++ b/tests/unit/providers/grok/normalization/grokToolNormalization.test.ts
@@ -1,6 +1,7 @@
 import {
   normalizeGrokToolCall,
   normalizeGrokToolName,
+  normalizeGrokToolUseResult,
   resolveGrokRawToolName,
 } from '@/providers/grok/normalization/grokToolNormalization';
 
@@ -26,6 +27,8 @@ describe('grokToolNormalization', () => {
     ['ask_user_question', 'AskUserQuestion'],
     ['skill', 'Skill'],
     ['search_tool', 'ToolSearch'],
+    ['enter_plan_mode', 'EnterPlanMode'],
+    ['exit_plan_mode', 'ExitPlanMode'],
   ])('maps %s to the approved renderer %s', (rawName, expected) => {
     expect(normalizeGrokToolName(rawName)).toBe(expected);
   });
@@ -142,25 +145,61 @@ describe('grokToolNormalization', () => {
     })).toEqual(current);
   });
 
-  it('replaces a kind fallback with late unknown titles and retains their provenance', () => {
+  it('accepts the first title after a kind fallback and keeps it stable', () => {
     const kindFallback = resolveGrokRawToolName(undefined, { kind: 'execute' });
     expect(kindFallback).toEqual({ provenance: 'kind', rawName: 'execute' });
 
     const firstTitle = resolveGrokRawToolName(kindFallback, { title: 'future_tool' });
     expect(firstTitle).toEqual({ provenance: 'title', rawName: 'future_tool' });
     expect(resolveGrokRawToolName(firstTitle, {})).toEqual(firstTitle);
-    expect(resolveGrokRawToolName(firstTitle, { title: 'future_tool_v2' })).toEqual({
-      provenance: 'title',
-      rawName: 'future_tool_v2',
-    });
+    expect(resolveGrokRawToolName(firstTitle, { title: 'Future tool complete' }))
+      .toEqual(firstTitle);
   });
 
-  it('allows a recognized raw title update but rejects a later human presentation label', () => {
+  it('keeps the first recognized raw title when later updates change presentation text', () => {
     const initial = resolveGrokRawToolName(undefined, { title: 'read_file' });
     const updated = resolveGrokRawToolName(initial, { title: 'run_terminal_command' });
-    expect(updated).toEqual({ provenance: 'title', rawName: 'run_terminal_command' });
+    expect(updated).toEqual(initial);
     expect(resolveGrokRawToolName(updated, {
       title: 'Execute the verification command',
     })).toEqual(updated);
+  });
+
+  it('normalizes native free-form answers for the shared question renderer', () => {
+    const input = {
+      questions: [{
+        multiSelect: false,
+        options: [{ description: '', label: 'Proceed' }],
+        question: 'How should we continue?',
+      }],
+    };
+    const rawOutput = {
+      UserAnswered: { message: 'Use the durable implementation.' },
+      type: 'UserAnswered',
+    };
+
+    expect(normalizeGrokToolUseResult(
+      'ask_user_question',
+      input,
+      rawOutput,
+      input,
+    )).toEqual({
+      answers: { 'How should we continue?': 'Use the durable implementation.' },
+      providerPayload: {
+        rawInput: input,
+        rawName: 'ask_user_question',
+        rawOutput,
+      },
+    });
+
+    const jsonAnswer = '{"preference":"keep this as the answer"}';
+    expect(normalizeGrokToolUseResult(
+      'ask_user_question',
+      input,
+      { UserAnswered: { message: jsonAnswer } },
+      input,
+    ).answers).toEqual({
+      'How should we continue?': jsonAnswer,
+    });
   });
 });

--- a/tests/unit/providers/pi/history/PiHistoryStore.test.ts
+++ b/tests/unit/providers/pi/history/PiHistoryStore.test.ts
@@ -173,6 +173,67 @@ describe('PiHistoryStore', () => {
     expect(messages[0].contentBlocks).toEqual([{ toolId: 'tool-1', type: 'tool_use' }]);
   });
 
+  it('rehydrates Pi web extension tools with shared renderer names', () => {
+    const content = [
+      JSON.stringify({
+        id: 'assistant-web',
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              arguments: { count: 5, query: 'provider protocol' },
+              id: 'web-search-1',
+              name: 'web_search',
+              type: 'toolCall',
+            },
+            {
+              arguments: { url: 'https://example.com/reference' },
+              id: 'web-fetch-1',
+              name: 'web_fetch',
+              type: 'toolCall',
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: 'message',
+        message: {
+          content: [{ text: 'Search result', type: 'text' }],
+          isError: false,
+          role: 'toolResult',
+          toolCallId: 'web-search-1',
+          toolName: 'web_search',
+        },
+      }),
+      JSON.stringify({
+        type: 'message',
+        message: {
+          content: [{ text: 'Fetched page', type: 'text' }],
+          isError: false,
+          role: 'toolResult',
+          toolCallId: 'web-fetch-1',
+          toolName: 'web_fetch',
+        },
+      }),
+    ].join('\n');
+
+    const toolCalls = parsePiSessionContent(content)[0].toolCalls ?? [];
+
+    expect(toolCalls).toEqual([
+      expect.objectContaining({
+        input: { count: 5, query: 'provider protocol' },
+        name: 'WebSearch',
+        result: 'Search result',
+      }),
+      expect.objectContaining({
+        input: { url: 'https://example.com/reference' },
+        name: 'WebFetch',
+        result: 'Fetched page',
+      }),
+    ]);
+  });
+
   it('merges Pi assistant continuations split by tool results into one chat message', () => {
     const content = [
       JSON.stringify({ id: 'u1', type: 'message', message: { role: 'user', content: 'Hide scrollbars' } }),

--- a/tests/unit/providers/pi/runtime/PiEventNormalization.test.ts
+++ b/tests/unit/providers/pi/runtime/PiEventNormalization.test.ts
@@ -81,6 +81,34 @@ describe('Pi event normalization', () => {
     }]);
   });
 
+  it('maps Pi web extension tools to shared renderer names', () => {
+    const state = createPiEventNormalizationState();
+
+    expect(normalizePiRpcEvent({
+      args: { count: 5, query: 'provider protocol' },
+      toolCallId: 'web-search-1',
+      toolName: 'web_search',
+      type: 'tool_execution_start',
+    }, state)).toEqual([{
+      id: 'web-search-1',
+      input: { count: 5, query: 'provider protocol' },
+      name: 'WebSearch',
+      type: 'tool_use',
+    }]);
+
+    expect(normalizePiRpcEvent({
+      args: { url: 'https://example.com/reference' },
+      toolCallId: 'web-fetch-1',
+      toolName: 'web_fetch',
+      type: 'tool_execution_start',
+    }, state)).toEqual([{
+      id: 'web-fetch-1',
+      input: { url: 'https://example.com/reference' },
+      name: 'WebFetch',
+      type: 'tool_use',
+    }]);
+  });
+
   it('preserves Pi write/edit result payloads for diff extraction', () => {
     const state = createPiEventNormalizationState();
 

--- a/tests/unit/utils/diff.test.ts
+++ b/tests/unit/utils/diff.test.ts
@@ -53,6 +53,61 @@ describe('extractDiffData', () => {
     expect(result!.stats).toEqual({ added: 1, removed: 1 });
   });
 
+  it('returns replacement diff data from ACP old and new text', () => {
+    const toolCall = makeToolCall('Write', {
+      content: 'new first\nnew second',
+      file_path: 'src/acp.ts',
+    });
+
+    const result = extractDiffData({
+      filePath: 'src/acp.ts',
+      newText: 'new first\nnew second',
+      oldText: 'old first\nold second',
+    }, toolCall);
+
+    expect(result).toMatchObject({
+      filePath: 'src/acp.ts',
+      stats: { added: 2, removed: 2 },
+    });
+    expect(result?.diffLines.map(line => [line.type, line.text])).toEqual([
+      ['delete', 'old first'],
+      ['delete', 'old second'],
+      ['insert', 'new first'],
+      ['insert', 'new second'],
+    ]);
+  });
+
+  it('treats empty ACP replacement sides as zero lines', () => {
+    const createCall = makeToolCall('Write', {
+      content: 'created',
+      file_path: 'src/created.ts',
+    });
+    const deleteCall = makeToolCall('Write', {
+      content: '',
+      file_path: 'src/cleared.ts',
+    });
+
+    const created = extractDiffData({
+      filePath: 'src/created.ts',
+      newText: 'created',
+      oldText: '',
+    }, createCall);
+    const cleared = extractDiffData({
+      filePath: 'src/cleared.ts',
+      newText: '',
+      oldText: 'removed',
+    }, deleteCall);
+
+    expect(created?.stats).toEqual({ added: 1, removed: 0 });
+    expect(created?.diffLines).toEqual([
+      { newLineNum: 1, text: 'created', type: 'insert' },
+    ]);
+    expect(cleared?.stats).toEqual({ added: 0, removed: 1 });
+    expect(cleared?.diffLines).toEqual([
+      { oldLineNum: 1, text: 'removed', type: 'delete' },
+    ]);
+  });
+
   it('uses SDK filePath when present in toolUseResult', () => {
     const toolCall = makeToolCall('Write', { file_path: 'input/path.ts' });
     const toolUseResult = {


### PR DESCRIPTION
## Summary

- normalize current Codex lifecycle schemas so spawn, wait, list, and interrupt tools update the correct subagent cards without false timeout or blocked states
- preserve Grok native tool identity, plan-mode names, question answers, background-task IDs, and accurate ACP diffs across live streaming and history replay
- canonicalize Pi web tools and share ACP old/new diff metadata through the live and replay pipelines
- add regression coverage for lifecycle ownership, history rehydration, overwrite/create diffs, and provider payload preservation

## Scope

Provider-native histories remain read-only. Legacy OpenCode `patchText` replay is intentionally outside this change.

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run test` — 323 suites, 6,149 tests passed
- `npm run build`
