### PR TITLE
Refactor shared provider metadata command lifecycles

### DIFF
--- a/src/core/providers/commands/RuntimeCommandCatalog.ts
+++ b/src/core/providers/commands/RuntimeCommandCatalog.ts
@@ -1,0 +1,80 @@
+import type { SlashCommand } from '../../types';
+import type {
+  ProviderCommandCatalog,
+  ProviderCommandDropdownConfig,
+  ProviderCommandListContext,
+} from './ProviderCommandCatalog';
+import type { ProviderCommandEntry } from './ProviderCommandEntry';
+
+export interface RuntimeCommandCatalogOptions {
+  readonly dropdownConfig: ProviderCommandDropdownConfig;
+  readonly projectEntry: (command: SlashCommand) => ProviderCommandEntry;
+}
+
+export class RuntimeCommandCatalog implements ProviderCommandCatalog {
+  private readonly dropdownConfig: ProviderCommandDropdownConfig;
+  private commandSnapshot: SlashCommand[] = [];
+
+  constructor(private readonly options: RuntimeCommandCatalogOptions) {
+    this.dropdownConfig = cloneDropdownConfig(options.dropdownConfig);
+  }
+
+  setCommandSnapshot(commands: SlashCommand[]): void {
+    this.commandSnapshot = commands.map(cloneSlashCommand);
+  }
+
+  async listDropdownEntries(
+    context: ProviderCommandListContext,
+  ): Promise<ProviderCommandEntry[]> {
+    const commands = context.commandSnapshot
+      ?? (context.allowCachedCommandSnapshot === false ? [] : this.commandSnapshot);
+    return commands.map((command) => cloneProviderCommandEntry(
+      this.options.projectEntry(cloneSlashCommand(command)),
+    ));
+  }
+
+  getDropdownConfig(): ProviderCommandDropdownConfig {
+    return cloneDropdownConfig(this.dropdownConfig);
+  }
+
+  async refresh(): Promise<void> {}
+}
+
+function cloneDropdownConfig(
+  config: ProviderCommandDropdownConfig,
+): ProviderCommandDropdownConfig {
+  return {
+    ...config,
+    triggerChars: [...config.triggerChars],
+  };
+}
+
+function cloneSlashCommand(command: SlashCommand): SlashCommand {
+  return {
+    ...command,
+    ...(command.allowedTools ? { allowedTools: [...command.allowedTools] } : {}),
+    ...(command.hooks ? { hooks: cloneRecord(command.hooks) } : {}),
+  };
+}
+
+function cloneProviderCommandEntry(entry: ProviderCommandEntry): ProviderCommandEntry {
+  return {
+    ...entry,
+    ...(entry.allowedTools ? { allowedTools: [...entry.allowedTools] } : {}),
+    ...(entry.hooks ? { hooks: cloneRecord(entry.hooks) } : {}),
+  };
+}
+
+function cloneRecord(record: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(record).map(([key, value]) => [key, cloneValue(value)]),
+  );
+}
+
+function cloneValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(cloneValue);
+  if (!value || typeof value !== 'object') return value;
+  const prototype: unknown = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) return value;
+  return cloneRecord(value as Record<string, unknown>);
+}

--- a/src/core/providers/commands/RuntimeCommandLoader.ts
+++ b/src/core/providers/commands/RuntimeCommandLoader.ts
@@ -1,0 +1,62 @@
+import type { SlashCommand } from '../../types';
+import {
+  normalizeProviderCommandDiscoveryItems,
+  type ProviderCommandDiscoveryResult,
+} from './ProviderCommandDiscoveryResult';
+
+export interface RuntimeCommandLoaderOptions<TDiscovery> {
+  readonly allowIsolatedMetadataCreation: boolean;
+  readonly cleanup?: () => Promise<void> | void;
+  readonly discover: (signal?: AbortSignal) => Promise<TDiscovery>;
+  readonly errorMessage: string;
+  readonly projectItems: (
+    discovery: TDiscovery,
+  ) => readonly SlashCommand[] | null;
+  readonly readyCommandSnapshot?: readonly SlashCommand[];
+  readonly requiresSessionMessage: string;
+  readonly signal?: AbortSignal;
+}
+
+export async function loadRuntimeCommands<TDiscovery>(
+  options: RuntimeCommandLoaderOptions<TDiscovery>,
+): Promise<ProviderCommandDiscoveryResult<SlashCommand>> {
+  options.signal?.throwIfAborted();
+  if (options.readyCommandSnapshot) {
+    return normalizeProviderCommandDiscoveryItems(options.readyCommandSnapshot);
+  }
+  if (!options.allowIsolatedMetadataCreation) {
+    return {
+      message: options.requiresSessionMessage,
+      status: 'requires-session',
+    };
+  }
+
+  try {
+    const discovery = await options.discover(options.signal);
+    options.signal?.throwIfAborted();
+    const items = options.projectItems(discovery);
+    if (!items) return createErrorResult(options.errorMessage);
+    return normalizeProviderCommandDiscoveryItems(items);
+  } catch {
+    options.signal?.throwIfAborted();
+    return createErrorResult(options.errorMessage);
+  } finally {
+    if (options.cleanup) {
+      try {
+        await options.cleanup();
+      } catch {
+        // Cleanup failure must not replace provider discovery semantics.
+      }
+    }
+  }
+}
+
+function createErrorResult(
+  message: string,
+): ProviderCommandDiscoveryResult<SlashCommand> {
+  return {
+    message,
+    retryable: true,
+    status: 'error',
+  };
+}

--- a/src/core/providers/metadata/OwnedProbeRegistry.ts
+++ b/src/core/providers/metadata/OwnedProbeRegistry.ts
@@ -1,0 +1,125 @@
+import { throwIfAborted, toAbortError } from '../../../utils/abort';
+
+export interface OwnedProbeRegistryOptions<TResource> {
+  readonly abortMessage?: string;
+  readonly dispose: (resource: TResource) => Promise<void> | void;
+  readonly unavailableError?: () => Error;
+}
+
+export interface OwnedProbeOperation<TResource, TResult> {
+  readonly create: (signal: AbortSignal) => Promise<TResource> | TResource;
+  readonly initialize?: (
+    resource: TResource,
+    signal: AbortSignal,
+  ) => Promise<void> | void;
+  readonly query: (
+    resource: TResource,
+    signal: AbortSignal,
+  ) => Promise<TResult>;
+}
+
+interface ActiveProbe<TResource> {
+  cleanupFlight: Promise<void> | null;
+  readonly completion: Promise<void>;
+  readonly controller: AbortController;
+  hasResource: boolean;
+  resolveCompletion(): void;
+  resource?: TResource;
+}
+
+const DEFAULT_ABORT_MESSAGE = 'Provider metadata probe aborted';
+
+export class OwnedProbeRegistry<TResource> {
+  private readonly abortMessage: string;
+  private readonly activeProbes = new Set<ActiveProbe<TResource>>();
+  private disposed = false;
+  private disposeFlight: Promise<void> | null = null;
+
+  constructor(private readonly options: OwnedProbeRegistryOptions<TResource>) {
+    this.abortMessage = options.abortMessage ?? DEFAULT_ABORT_MESSAGE;
+  }
+
+  async run<TResult>(
+    operation: OwnedProbeOperation<TResource, TResult>,
+    callerSignal?: AbortSignal,
+  ): Promise<TResult> {
+    if (this.disposed) throw this.createUnavailableError();
+    throwIfAborted(callerSignal, this.abortMessage);
+
+    let resolveCompletion!: () => void;
+    const entry: ActiveProbe<TResource> = {
+      cleanupFlight: null,
+      completion: new Promise(resolve => { resolveCompletion = resolve; }),
+      controller: new AbortController(),
+      hasResource: false,
+      resolveCompletion: () => resolveCompletion(),
+    };
+    const onAbort = (): void => {
+      entry.controller.abort(toAbortError(callerSignal!, this.abortMessage));
+      void this.cleanupProbe(entry);
+    };
+    callerSignal?.addEventListener('abort', onAbort, { once: true });
+    this.activeProbes.add(entry);
+    if (callerSignal?.aborted) onAbort();
+
+    try {
+      entry.controller.signal.throwIfAborted();
+      const created = operation.create(entry.controller.signal);
+      entry.resource = isPromiseLike<TResource>(created)
+        ? await created
+        : created;
+      entry.hasResource = true;
+      entry.controller.signal.throwIfAborted();
+      const initialization = operation.initialize?.(
+        entry.resource,
+        entry.controller.signal,
+      );
+      if (initialization) await initialization;
+      entry.controller.signal.throwIfAborted();
+      const query = operation.query(entry.resource, entry.controller.signal);
+      const result = await query;
+      entry.controller.signal.throwIfAborted();
+      return result;
+    } finally {
+      callerSignal?.removeEventListener('abort', onAbort);
+      await this.cleanupProbe(entry);
+      this.activeProbes.delete(entry);
+      entry.resolveCompletion();
+    }
+  }
+
+  async quiesce(): Promise<void> {
+    const active = [...this.activeProbes];
+    for (const entry of active) entry.controller.abort();
+    await Promise.all(active.map(entry => this.cleanupProbe(entry)));
+    await Promise.all(active.map(entry => entry.completion));
+  }
+
+  dispose(): Promise<void> {
+    if (this.disposeFlight) return this.disposeFlight;
+    this.disposed = true;
+    this.disposeFlight = this.quiesce();
+    return this.disposeFlight;
+  }
+
+  private cleanupProbe(entry: ActiveProbe<TResource>): Promise<void> {
+    if (entry.cleanupFlight) return entry.cleanupFlight;
+    if (!entry.hasResource) return Promise.resolve();
+    const resource = entry.resource as TResource;
+    entry.hasResource = false;
+    entry.resource = undefined;
+    entry.cleanupFlight = Promise.resolve()
+      .then(() => this.options.dispose(resource))
+      .catch(() => undefined);
+    return entry.cleanupFlight;
+  }
+
+  private createUnavailableError(): Error {
+    return this.options.unavailableError?.()
+      ?? new Error('Provider metadata probe registry is disposed.');
+  }
+}
+
+function isPromiseLike<T>(value: T | Promise<T>): value is Promise<T> {
+  return typeof (value as Promise<T>)?.then === 'function';
+}

--- a/src/core/providers/metadata/ProviderTransitionFence.ts
+++ b/src/core/providers/metadata/ProviderTransitionFence.ts
@@ -1,0 +1,84 @@
+import { throwIfAborted, toAbortError } from '../../../utils/abort';
+
+export interface ProviderTransitionFenceOptions {
+  readonly abortMessage?: string;
+}
+
+interface TransitionWaiter {
+  readonly onAbort?: () => void;
+  readonly reject: (error: unknown) => void;
+  readonly resolve: (available: boolean) => void;
+  readonly signal?: AbortSignal;
+}
+
+const DEFAULT_ABORT_MESSAGE = 'Provider transition wait aborted';
+
+export class ProviderTransitionFence {
+  private readonly abortMessage: string;
+  private disposed = false;
+  private transitionDepth = 0;
+  private readonly waiters = new Set<TransitionWaiter>();
+
+  constructor(options: ProviderTransitionFenceOptions = {}) {
+    this.abortMessage = options.abortMessage ?? DEFAULT_ABORT_MESSAGE;
+  }
+
+  beginTransition(): void {
+    if (this.disposed) return;
+    this.transitionDepth += 1;
+  }
+
+  endTransition(): void {
+    if (this.disposed || this.transitionDepth === 0) return;
+    this.transitionDepth -= 1;
+    if (this.transitionDepth === 0) this.releaseWaiters(true);
+  }
+
+  isUnavailable(): boolean {
+    return this.disposed || this.transitionDepth > 0;
+  }
+
+  async waitUntilAvailable(signal?: AbortSignal): Promise<boolean> {
+    throwIfAborted(signal, this.abortMessage);
+    if (this.disposed) return false;
+    if (this.transitionDepth === 0) return true;
+
+    return await new Promise<boolean>((resolve, reject) => {
+      const onAbort = (): void => {
+        if (!this.waiters.delete(waiter)) return;
+        this.removeAbortListener(waiter);
+        reject(toAbortError(signal!, this.abortMessage));
+      };
+      const waiter: TransitionWaiter = {
+        reject,
+        resolve,
+        ...(signal ? { onAbort, signal } : {}),
+      };
+      this.waiters.add(waiter);
+      signal?.addEventListener('abort', onAbort, { once: true });
+      if (signal?.aborted) onAbort();
+    });
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.transitionDepth = 0;
+    this.releaseWaiters(false);
+  }
+
+  private releaseWaiters(available: boolean): void {
+    const waiters = [...this.waiters];
+    this.waiters.clear();
+    for (const waiter of waiters) {
+      this.removeAbortListener(waiter);
+      waiter.resolve(available);
+    }
+  }
+
+  private removeAbortListener(waiter: TransitionWaiter): void {
+    if (waiter.signal && waiter.onAbort) {
+      waiter.signal.removeEventListener('abort', waiter.onAbort);
+    }
+  }
+}

--- a/src/core/providers/metadata/ProviderTransitionFence.ts
+++ b/src/core/providers/metadata/ProviderTransitionFence.ts
@@ -7,7 +7,7 @@ export interface ProviderTransitionFenceOptions {
 interface TransitionWaiter {
   readonly onAbort?: () => void;
   readonly reject: (error: unknown) => void;
-  readonly resolve: (available: boolean) => void;
+  readonly resolve: () => void;
   readonly signal?: AbortSignal;
 }
 
@@ -31,7 +31,7 @@ export class ProviderTransitionFence {
   endTransition(): void {
     if (this.disposed || this.transitionDepth === 0) return;
     this.transitionDepth -= 1;
-    if (this.transitionDepth === 0) this.releaseWaiters(true);
+    if (this.transitionDepth === 0) this.releaseWaiters();
   }
 
   isUnavailable(): boolean {
@@ -40,10 +40,22 @@ export class ProviderTransitionFence {
 
   async waitUntilAvailable(signal?: AbortSignal): Promise<boolean> {
     throwIfAborted(signal, this.abortMessage);
-    if (this.disposed) return false;
-    if (this.transitionDepth === 0) return true;
+    while (!this.disposed && this.transitionDepth > 0) {
+      await this.waitForTransition(signal);
+    }
+    return !this.disposed;
+  }
 
-    return await new Promise<boolean>((resolve, reject) => {
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.transitionDepth = 0;
+    this.releaseWaiters();
+  }
+
+  private waitForTransition(signal?: AbortSignal): Promise<void> {
+    throwIfAborted(signal, this.abortMessage);
+    return new Promise<void>((resolve, reject) => {
       const onAbort = (): void => {
         if (!this.waiters.delete(waiter)) return;
         this.removeAbortListener(waiter);
@@ -60,19 +72,12 @@ export class ProviderTransitionFence {
     });
   }
 
-  dispose(): void {
-    if (this.disposed) return;
-    this.disposed = true;
-    this.transitionDepth = 0;
-    this.releaseWaiters(false);
-  }
-
-  private releaseWaiters(available: boolean): void {
+  private releaseWaiters(): void {
     const waiters = [...this.waiters];
     this.waiters.clear();
     for (const waiter of waiters) {
       this.removeAbortListener(waiter);
-      waiter.resolve(available);
+      waiter.resolve();
     }
   }
 

--- a/src/providers/codex/metadata/CodexMetadataTransitionGate.ts
+++ b/src/providers/codex/metadata/CodexMetadataTransitionGate.ts
@@ -1,71 +1,7 @@
-import { throwIfAborted, toAbortError } from '../../../utils/abort';
+import { ProviderTransitionFence } from '@/core/providers/metadata/ProviderTransitionFence';
 
-export class CodexMetadataTransitionGate {
-  private transitionDepth = 0;
-  private transitionPromise: Promise<void> | null = null;
-  private releaseTransition: (() => void) | null = null;
-  private disposed = false;
-
-  beginTransition(): void {
-    if (this.disposed) return;
-    this.transitionDepth += 1;
-    if (this.transitionDepth > 1) return;
-
-    this.transitionPromise = new Promise<void>((resolve) => {
-      this.releaseTransition = resolve;
-    });
-  }
-
-  endTransition(): void {
-    if (this.disposed || this.transitionDepth === 0) return;
-    this.transitionDepth -= 1;
-    if (this.transitionDepth === 0) this.releaseWaiters();
-  }
-
-  isUnavailable(): boolean {
-    return this.disposed || this.transitionPromise !== null;
-  }
-
-  async waitUntilAvailable(signal?: AbortSignal): Promise<boolean> {
-    throwIfAborted(signal, 'Codex metadata transition wait aborted');
-    while (!this.disposed && this.transitionPromise) {
-      await this.waitForTransition(this.transitionPromise, signal);
-    }
-    return !this.disposed;
-  }
-
-  dispose(): void {
-    if (this.disposed) return;
-    this.disposed = true;
-    this.transitionDepth = 0;
-    this.releaseWaiters();
-  }
-
-  private async waitForTransition(
-    transition: Promise<void>,
-    signal?: AbortSignal,
-  ): Promise<void> {
-    if (!signal) {
-      await transition;
-      return;
-    }
-
-    await new Promise<void>((resolve, reject) => {
-      const onAbort = (): void => reject(toAbortError(
-        signal,
-        'Codex metadata transition wait aborted',
-      ));
-      signal.addEventListener('abort', onAbort, { once: true });
-      void transition.then(resolve).finally(() => {
-        signal.removeEventListener('abort', onAbort);
-      });
-    });
-  }
-
-  private releaseWaiters(): void {
-    const release = this.releaseTransition;
-    this.releaseTransition = null;
-    this.transitionPromise = null;
-    release?.();
+export class CodexMetadataTransitionGate extends ProviderTransitionFence {
+  constructor() {
+    super({ abortMessage: 'Codex metadata transition wait aborted' });
   }
 }

--- a/src/providers/grok/app/GrokCommandLoader.ts
+++ b/src/providers/grok/app/GrokCommandLoader.ts
@@ -1,12 +1,11 @@
-import {
-  normalizeProviderCommandDiscoveryItems,
-  type ProviderCommandDiscoveryResult,
-} from '../../../core/providers/commands/ProviderCommandDiscoveryResult';
+import type { ProviderCommandDiscoveryResult } from '@/core/providers/commands/ProviderCommandDiscoveryResult';
+import { loadRuntimeCommands } from '@/core/providers/commands/RuntimeCommandLoader';
 import type {
   ProviderCommandLoader as ProviderCommandLoaderContract,
   ProviderCommandLoaderContext,
-} from '../../../core/providers/types';
-import type { SlashCommand } from '../../../core/types';
+} from '@/core/providers/types';
+import type { SlashCommand } from '@/core/types';
+
 import { getGrokProviderSettings } from '../settings';
 import type { GrokCommandMetadataProbe } from './GrokCommandMetadataProbe';
 
@@ -31,27 +30,14 @@ export class GrokCommandLoader implements ProviderCommandLoaderContract {
   async loadCommands(
     context: ProviderCommandLoaderContext,
   ): Promise<ProviderCommandDiscoveryResult<SlashCommand>> {
-    context.signal?.throwIfAborted();
-    if (context.readyCommandSnapshot) {
-      return normalizeProviderCommandDiscoveryItems(context.readyCommandSnapshot);
-    }
-    if (!context.allowIsolatedMetadataCreation) {
-      return {
-        message: 'Grok command metadata has not been loaded for this tab.',
-        status: 'requires-session',
-      };
-    }
-
-    try {
-      return normalizeProviderCommandDiscoveryItems(
-        await this.metadataProbe.load(context.signal),
-      );
-    } catch {
-      return {
-        message: 'Could not load Grok skills and commands.',
-        retryable: true,
-        status: 'error',
-      };
-    }
+    return loadRuntimeCommands({
+      allowIsolatedMetadataCreation: context.allowIsolatedMetadataCreation,
+      discover: signal => this.metadataProbe.load(signal),
+      errorMessage: 'Could not load Grok skills and commands.',
+      projectItems: commands => commands,
+      readyCommandSnapshot: context.readyCommandSnapshot,
+      requiresSessionMessage: 'Grok command metadata has not been loaded for this tab.',
+      signal: context.signal,
+    });
   }
 }

--- a/src/providers/grok/app/GrokCommandMetadataProbe.ts
+++ b/src/providers/grok/app/GrokCommandMetadataProbe.ts
@@ -1,7 +1,9 @@
-import type { ProviderHost } from '../../../core/providers/ProviderHost';
-import type { SlashCommand } from '../../../core/types';
-import { toAbortError } from '../../../utils/abort';
-import { getVaultPath } from '../../../utils/path';
+import { OwnedProbeRegistry } from '@/core/providers/metadata/OwnedProbeRegistry';
+import { ProviderTransitionFence } from '@/core/providers/metadata/ProviderTransitionFence';
+import type { ProviderHost } from '@/core/providers/ProviderHost';
+import type { SlashCommand } from '@/core/types';
+import { getVaultPath } from '@/utils/path';
+
 import type {
   GrokExecutionNativeConnection,
   GrokExecutionNativeFactory,
@@ -13,169 +15,80 @@ const DEFAULT_NATIVE_FACTORY: GrokExecutionNativeFactory = {
   create: options => new GrokExecutionNativeConnectionImpl(options),
 };
 
-interface ActiveCommandProbe {
-  readonly completion: Promise<void>;
-  readonly controller: AbortController;
-  native: GrokExecutionNativeConnection | null;
-  resolveCompletion(): void;
-  shutdownFlight: Promise<void> | null;
+interface GrokCommandProbeResource {
+  readonly cwd: string;
+  readonly native: GrokExecutionNativeConnection;
 }
 
-interface TransitionWaiter {
-  readonly onAbort?: () => void;
-  readonly reject: (error: unknown) => void;
-  readonly resolve: () => void;
-  readonly signal?: AbortSignal;
-}
+const ABORT_MESSAGE = 'Grok command metadata probe aborted';
+const DISPOSED_MESSAGE = 'Grok command metadata probe is disposed.';
 
 export class GrokCommandMetadataProbe {
-  private readonly activeProbes = new Set<ActiveCommandProbe>();
-  private readonly transitionWaiters = new Set<TransitionWaiter>();
-  private disposed = false;
-  private transitionActive = false;
+  private disposeFlight: Promise<void> | null = null;
+  private readonly probes: OwnedProbeRegistry<GrokCommandProbeResource>;
+  private readonly transitionFence = new ProviderTransitionFence({
+    abortMessage: ABORT_MESSAGE,
+  });
 
   constructor(
     private readonly plugin: ProviderHost,
     private readonly nativeFactory: GrokExecutionNativeFactory = DEFAULT_NATIVE_FACTORY,
-  ) {}
-
-  load(signal?: AbortSignal): Promise<SlashCommand[]> {
-    if (this.disposed) {
-      return Promise.reject(new Error('Grok command metadata probe is disposed.'));
-    }
-    if (signal?.aborted) {
-      return Promise.reject(toAbortError(
-        signal,
-        'Grok command metadata probe aborted',
-      ));
-    }
-    if (this.transitionActive) {
-      return this.waitForTransition(signal).then(() => this.load(signal));
-    }
-    return this.loadUnfenced(signal);
-  }
-
-  beginEnvironmentTransition(): void {
-    if (!this.disposed) this.transitionActive = true;
-  }
-
-  endEnvironmentTransition(): void {
-    if (this.disposed) return;
-    this.transitionActive = false;
-    this.releaseTransitionWaiters();
-  }
-
-  private async loadUnfenced(signal?: AbortSignal): Promise<SlashCommand[]> {
-    let resolveCompletion!: () => void;
-    const entry: ActiveCommandProbe = {
-      completion: new Promise(resolve => { resolveCompletion = resolve; }),
-      controller: new AbortController(),
-      native: null,
-      resolveCompletion: () => resolveCompletion(),
-      shutdownFlight: null,
-    };
-    const onAbort = (): void => {
-      entry.controller.abort();
-      void this.shutdownProbe(entry);
-    };
-    signal?.addEventListener('abort', onAbort, { once: true });
-    this.activeProbes.add(entry);
-    try {
-      entry.controller.signal.throwIfAborted();
-      const command = await this.plugin.getResolvedProviderCliPath('grok') ?? 'grok';
-      entry.controller.signal.throwIfAborted();
-      const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
-      entry.native = this.nativeFactory.create({
-        command,
-        cwd,
-        env: buildGrokRuntimeEnv(this.plugin.settings, command),
-        requestExtension: async () => null,
-        requestPermission: async () => ({ outcome: { outcome: 'cancelled' } }),
-        version: this.plugin.manifest?.version ?? '0.0.0',
-      });
-      await entry.native.initialize();
-      entry.controller.signal.throwIfAborted();
-      return await entry.native.listCommands(cwd, entry.controller.signal);
-    } finally {
-      signal?.removeEventListener('abort', onAbort);
-      await this.shutdownProbe(entry);
-      this.activeProbes.delete(entry);
-      entry.resolveCompletion();
-    }
-  }
-
-  async quiesceForEnvironmentChange(): Promise<void> {
-    const active = [...this.activeProbes];
-    for (const entry of active) entry.controller.abort();
-    await Promise.all(active.map(entry => this.shutdownProbe(entry)));
-    await Promise.all(active.map(entry => entry.completion));
-  }
-
-  async dispose(): Promise<void> {
-    if (this.disposed) return;
-    this.disposed = true;
-    this.rejectTransitionWaiters(new Error('Grok command metadata probe is disposed.'));
-    await this.quiesceForEnvironmentChange();
-  }
-
-  private waitForTransition(signal?: AbortSignal): Promise<void> {
-    if (this.disposed) {
-      return Promise.reject(new Error('Grok command metadata probe is disposed.'));
-    }
-    if (!this.transitionActive) return Promise.resolve();
-    if (signal?.aborted) {
-      return Promise.reject(toAbortError(
-        signal,
-        'Grok command metadata probe aborted',
-      ));
-    }
-
-    return new Promise<void>((resolve, reject) => {
-      const onAbort = (): void => {
-        if (!this.transitionWaiters.delete(waiter)) return;
-        reject(toAbortError(signal!, 'Grok command metadata probe aborted'));
-      };
-      const waiter: TransitionWaiter = {
-        reject,
-        resolve,
-        ...(signal ? { onAbort, signal } : {}),
-      };
-      this.transitionWaiters.add(waiter);
-      signal?.addEventListener('abort', onAbort, { once: true });
-      if (signal?.aborted) onAbort();
+  ) {
+    this.probes = new OwnedProbeRegistry({
+      abortMessage: ABORT_MESSAGE,
+      dispose: resource => resource.native.shutdown(),
+      unavailableError: () => new Error(DISPOSED_MESSAGE),
     });
   }
 
-  private releaseTransitionWaiters(): void {
-    const waiters = [...this.transitionWaiters];
-    this.transitionWaiters.clear();
-    for (const waiter of waiters) {
-      this.removeWaiterAbortListener(waiter);
-      waiter.resolve();
-    }
+  async load(signal?: AbortSignal): Promise<SlashCommand[]> {
+    const available = await this.transitionFence.waitUntilAvailable(signal);
+    if (!available) throw new Error(DISPOSED_MESSAGE);
+
+    return await this.probes.run({
+      create: async (ownedSignal) => {
+        const command = await this.plugin.getResolvedProviderCliPath('grok') ?? 'grok';
+        ownedSignal.throwIfAborted();
+        const cwd = getVaultPath(this.plugin.app) ?? process.cwd();
+        return {
+          cwd,
+          native: this.nativeFactory.create({
+            command,
+            cwd,
+            env: buildGrokRuntimeEnv(this.plugin.settings, command),
+            requestExtension: async () => null,
+            requestPermission: async () => ({ outcome: { outcome: 'cancelled' } }),
+            version: this.plugin.manifest?.version ?? '0.0.0',
+          }),
+        };
+      },
+      initialize: resource => resource.native.initialize(),
+      query: (resource, ownedSignal) => resource.native.listCommands(
+        resource.cwd,
+        ownedSignal,
+      ),
+    }, signal);
   }
 
-  private rejectTransitionWaiters(error: unknown): void {
-    const waiters = [...this.transitionWaiters];
-    this.transitionWaiters.clear();
-    for (const waiter of waiters) {
-      this.removeWaiterAbortListener(waiter);
-      waiter.reject(error);
-    }
+  beginEnvironmentTransition(): void {
+    this.transitionFence.beginTransition();
   }
 
-  private removeWaiterAbortListener(waiter: TransitionWaiter): void {
-    if (waiter.signal && waiter.onAbort) {
-      waiter.signal.removeEventListener('abort', waiter.onAbort);
-    }
+  endEnvironmentTransition(): void {
+    this.transitionFence.endTransition();
   }
 
-  private shutdownProbe(entry: ActiveCommandProbe): Promise<void> {
-    if (entry.shutdownFlight) return entry.shutdownFlight;
-    const native = entry.native;
-    if (!native) return Promise.resolve();
-    entry.native = null;
-    entry.shutdownFlight = native.shutdown().catch(() => undefined);
-    return entry.shutdownFlight;
+  quiesceForEnvironmentChange(): Promise<void> {
+    return this.probes.quiesce();
+  }
+
+  dispose(): Promise<void> {
+    if (this.disposeFlight) return this.disposeFlight;
+    this.transitionFence.dispose();
+    this.disposeFlight = (async () => {
+      await this.quiesceForEnvironmentChange();
+      await this.probes.dispose();
+    })();
+    return this.disposeFlight;
   }
 }

--- a/src/providers/grok/app/GrokCommandMetadataProbe.ts
+++ b/src/providers/grok/app/GrokCommandMetadataProbe.ts
@@ -42,8 +42,10 @@ export class GrokCommandMetadataProbe {
   }
 
   async load(signal?: AbortSignal): Promise<SlashCommand[]> {
-    const available = await this.transitionFence.waitUntilAvailable(signal);
-    if (!available) throw new Error(DISPOSED_MESSAGE);
+    if (this.transitionFence.isUnavailable()) {
+      const available = await this.transitionFence.waitUntilAvailable(signal);
+      if (!available) throw new Error(DISPOSED_MESSAGE);
+    }
 
     return await this.probes.run({
       create: async (ownedSignal) => {

--- a/src/providers/grok/commands/GrokCommandCatalog.ts
+++ b/src/providers/grok/commands/GrokCommandCatalog.ts
@@ -1,10 +1,6 @@
-import type {
-  ProviderCommandCatalog,
-  ProviderCommandDropdownConfig,
-  ProviderCommandListContext,
-} from '../../../core/providers/commands/ProviderCommandCatalog';
-import type { ProviderCommandEntry } from '../../../core/providers/commands/ProviderCommandEntry';
-import type { SlashCommand } from '../../../core/types';
+import type { ProviderCommandEntry } from '@/core/providers/commands/ProviderCommandEntry';
+import { RuntimeCommandCatalog } from '@/core/providers/commands/RuntimeCommandCatalog';
+import type { SlashCommand } from '@/core/types';
 
 function slashCommandToEntry(command: SlashCommand): ProviderCommandEntry {
   return {
@@ -31,30 +27,17 @@ function slashCommandToEntry(command: SlashCommand): ProviderCommandEntry {
   };
 }
 
-export class GrokCommandCatalog implements ProviderCommandCatalog {
-  private commandSnapshot: SlashCommand[] = [];
-
-  setCommandSnapshot(commands: SlashCommand[]): void {
-    this.commandSnapshot = commands.map(command => ({ ...command }));
+export class GrokCommandCatalog extends RuntimeCommandCatalog {
+  constructor() {
+    super({
+      dropdownConfig: {
+        builtInPrefix: '/',
+        commandPrefix: '/',
+        providerId: 'grok',
+        skillPrefix: '/',
+        triggerChars: ['/'],
+      },
+      projectEntry: slashCommandToEntry,
+    });
   }
-
-  async listDropdownEntries(
-    context: ProviderCommandListContext,
-  ): Promise<ProviderCommandEntry[]> {
-    const commands = context.commandSnapshot
-      ?? (context.allowCachedCommandSnapshot === false ? [] : this.commandSnapshot);
-    return commands.map(slashCommandToEntry);
-  }
-
-  getDropdownConfig(): ProviderCommandDropdownConfig {
-    return {
-      providerId: 'grok',
-      triggerChars: ['/'],
-      builtInPrefix: '/',
-      skillPrefix: '/',
-      commandPrefix: '/',
-    };
-  }
-
-  async refresh(): Promise<void> {}
 }

--- a/src/providers/opencode/app/OpencodeCommandLoader.ts
+++ b/src/providers/opencode/app/OpencodeCommandLoader.ts
@@ -1,17 +1,28 @@
-import {
-  normalizeProviderCommandDiscoveryItems,
-  type ProviderCommandDiscoveryResult,
-} from '../../../core/providers/commands/ProviderCommandDiscoveryResult';
+import type { ProviderCommandDiscoveryResult } from '@/core/providers/commands/ProviderCommandDiscoveryResult';
+import { loadRuntimeCommands } from '@/core/providers/commands/RuntimeCommandLoader';
+import type { ProviderHost } from '@/core/providers/ProviderHost';
 import type {
   ProviderCommandLoader as ProviderCommandLoaderContract,
   ProviderCommandLoaderContext,
-} from '../../../core/providers/types';
-import type { SlashCommand } from '../../../core/types';
+} from '@/core/providers/types';
+import type { SlashCommand } from '@/core/types';
+
 import { OpencodeMetadataService } from '../metadata/OpencodeMetadataService';
 import { getOpencodeProviderSettings } from '../settings';
 
+type OpencodeMetadataServiceFactory = (
+  plugin: ProviderHost,
+) => OpencodeMetadataService;
+
+const DEFAULT_METADATA_SERVICE_FACTORY: OpencodeMetadataServiceFactory =
+  plugin => new OpencodeMetadataService(plugin);
+
 export class OpencodeCommandLoader implements ProviderCommandLoaderContract {
-  constructor(private readonly metadataService?: OpencodeMetadataService) {}
+  constructor(
+    private readonly metadataService?: OpencodeMetadataService,
+    private readonly createMetadataService: OpencodeMetadataServiceFactory =
+      DEFAULT_METADATA_SERVICE_FACTORY,
+  ) {}
 
   getCacheFingerprint(settings: Record<string, unknown>): string {
     return `opencode:commands:v1:${getOpencodeProviderSettings(settings).enabled ? 'enabled' : 'disabled'}`;
@@ -24,40 +35,20 @@ export class OpencodeCommandLoader implements ProviderCommandLoaderContract {
   async loadCommands(
     context: ProviderCommandLoaderContext,
   ): Promise<ProviderCommandDiscoveryResult<SlashCommand>> {
-    context.signal?.throwIfAborted();
-    if (context.readyCommandSnapshot) {
-      return normalizeProviderCommandDiscoveryItems(context.readyCommandSnapshot);
-    }
-    if (!context.allowIsolatedMetadataCreation) {
-      return {
-        message: 'OpenCode command metadata has not been loaded for this tab.',
-        status: 'requires-session',
-      };
-    }
-
-    const metadataService = this.metadataService
-      ?? new OpencodeMetadataService(context.plugin);
-
-    try {
-      const result = await metadataService.discoverCommands(context.signal);
-      context.signal?.throwIfAborted();
-      if (!result.loaded) {
-        return {
-          message: 'Could not load OpenCode commands.',
-          retryable: true,
-          status: 'error' as const,
-        };
-      }
-
-      return normalizeProviderCommandDiscoveryItems(result.commands);
-    } catch {
-      return {
-        message: 'Could not load OpenCode commands.',
-        retryable: true,
-        status: 'error' as const,
-      };
-    } finally {
-      if (!this.metadataService) await metadataService.dispose();
-    }
+    let ownedService: OpencodeMetadataService | null = null;
+    return loadRuntimeCommands({
+      allowIsolatedMetadataCreation: context.allowIsolatedMetadataCreation,
+      cleanup: async () => ownedService?.dispose(),
+      discover: async (signal) => {
+        const metadataService = this.metadataService
+          ?? (ownedService = this.createMetadataService(context.plugin));
+        return await metadataService.discoverCommands(signal);
+      },
+      errorMessage: 'Could not load OpenCode commands.',
+      projectItems: result => result.loaded ? result.commands : null,
+      readyCommandSnapshot: context.readyCommandSnapshot,
+      requiresSessionMessage: 'OpenCode command metadata has not been loaded for this tab.',
+      signal: context.signal,
+    });
   }
 }

--- a/src/providers/opencode/commands/OpencodeCommandCatalog.ts
+++ b/src/providers/opencode/commands/OpencodeCommandCatalog.ts
@@ -1,10 +1,6 @@
-import type {
-  ProviderCommandCatalog,
-  ProviderCommandDropdownConfig,
-  ProviderCommandListContext,
-} from '../../../core/providers/commands/ProviderCommandCatalog';
-import type { ProviderCommandEntry } from '../../../core/providers/commands/ProviderCommandEntry';
-import type { SlashCommand } from '../../../core/types';
+import type { ProviderCommandEntry } from '@/core/providers/commands/ProviderCommandEntry';
+import { RuntimeCommandCatalog } from '@/core/providers/commands/RuntimeCommandCatalog';
+import type { SlashCommand } from '@/core/types';
 
 function slashCommandToEntry(command: SlashCommand): ProviderCommandEntry {
   return {
@@ -31,28 +27,17 @@ function slashCommandToEntry(command: SlashCommand): ProviderCommandEntry {
   };
 }
 
-export class OpencodeCommandCatalog implements ProviderCommandCatalog {
-  private commandSnapshot: SlashCommand[] = [];
-
-  setCommandSnapshot(commands: SlashCommand[]): void {
-    this.commandSnapshot = commands.map((command) => ({ ...command }));
+export class OpencodeCommandCatalog extends RuntimeCommandCatalog {
+  constructor() {
+    super({
+      dropdownConfig: {
+        builtInPrefix: '/',
+        commandPrefix: '/',
+        providerId: 'opencode',
+        skillPrefix: '/',
+        triggerChars: ['/'],
+      },
+      projectEntry: slashCommandToEntry,
+    });
   }
-
-  async listDropdownEntries(context: ProviderCommandListContext): Promise<ProviderCommandEntry[]> {
-    const commands = context.commandSnapshot
-      ?? (context.allowCachedCommandSnapshot === false ? [] : this.commandSnapshot);
-    return commands.map(slashCommandToEntry);
-  }
-
-  getDropdownConfig(): ProviderCommandDropdownConfig {
-    return {
-      providerId: 'opencode',
-      triggerChars: ['/'],
-      builtInPrefix: '/',
-      skillPrefix: '/',
-      commandPrefix: '/',
-    };
-  }
-
-  async refresh(): Promise<void> {}
 }

--- a/src/providers/opencode/metadata/OpencodeMetadataService.ts
+++ b/src/providers/opencode/metadata/OpencodeMetadataService.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'node:crypto';
 
 import type { ProviderInteractionPort } from '@/core/execution';
+import { OwnedProbeRegistry } from '@/core/providers/metadata/OwnedProbeRegistry';
+import { ProviderTransitionFence } from '@/core/providers/metadata/ProviderTransitionFence';
 import type { ProviderHost } from '@/core/providers/ProviderHost';
 import type { SlashCommand } from '@/core/types';
 import { AcpSessionUpdateNormalizer } from '@/providers/acp';
@@ -41,27 +43,15 @@ export interface OpencodeMetadataServiceOptions {
   readonly createProbe?: () => OpencodeMetadataProbe;
 }
 
-interface ActiveProbe {
-  readonly completion: Promise<void>;
-  readonly controller: AbortController;
-  disposed: boolean;
-  readonly probe: OpencodeMetadataProbe;
-  resolveCompletion(): void;
-}
-
-interface TransitionWaiter {
-  readonly resolve: (available: boolean) => void;
-  readonly signal?: AbortSignal;
-  readonly onAbort?: () => void;
-}
-
 export class OpencodeMetadataService {
-  private readonly activeProbes = new Set<ActiveProbe>();
   private readonly createProbe: () => OpencodeMetadataProbe;
-  private readonly transitionWaiters = new Set<TransitionWaiter>();
+  private readonly probes: OwnedProbeRegistry<OpencodeMetadataProbe>;
+  private readonly transitionFence = new ProviderTransitionFence({
+    abortMessage: 'OpenCode metadata probe aborted',
+  });
   private readonly unregisterTransitionHook: () => void;
   private disposed = false;
-  private transitionActive = false;
+  private disposeFlight: Promise<void> | null = null;
 
   constructor(
     private readonly plugin: ProviderHost,
@@ -69,6 +59,11 @@ export class OpencodeMetadataService {
   ) {
     this.createProbe = options.createProbe
       ?? (() => new DefaultOpencodeMetadataProbe(plugin));
+    this.probes = new OwnedProbeRegistry({
+      abortMessage: 'OpenCode metadata probe aborted',
+      dispose: probe => probe.dispose(),
+      unavailableError: () => new Error('OpenCode metadata service is disposed.'),
+    });
     this.unregisterTransitionHook = plugin.executionLifecycleRegistry
       .registerTransitionHook('opencode', {
         beforeTransition: () => {
@@ -144,115 +139,50 @@ export class OpencodeMetadataService {
 
   async invalidate(): Promise<void> {
     this.options.commandCatalog?.setCommandSnapshot([]);
-    const active = [...this.activeProbes];
-    for (const entry of active) entry.controller.abort();
-    await Promise.all(active.map((entry) => this.disposeProbe(entry)));
-    await Promise.all(active.map((entry) => entry.completion));
+    await this.probes.quiesce();
   }
 
-  async dispose(): Promise<void> {
-    if (this.disposed) return;
+  dispose(): Promise<void> {
+    if (this.disposeFlight) return this.disposeFlight;
     this.disposed = true;
-    this.releaseTransitionWaiters(false);
+    this.transitionFence.dispose();
     this.unregisterTransitionHook();
-    await this.invalidate();
+    this.disposeFlight = (async () => {
+      await this.invalidate();
+      await this.probes.dispose();
+    })();
+    return this.disposeFlight;
   }
 
-  private runProbe<T>(
+  private async runProbe<T>(
     operation: (probe: OpencodeMetadataProbe, signal: AbortSignal) => Promise<T>,
     signal?: AbortSignal,
   ): Promise<T | null> {
-    if (this.disposed || signal?.aborted) return Promise.resolve(null);
-    if (this.transitionActive) {
-      return this.waitForTransition(signal).then(available => (
-        available ? this.runProbe(operation, signal) : null
-      ));
-    }
-    return this.runProbeUnfenced(operation, signal);
-  }
-
-  private async runProbeUnfenced<T>(
-    operation: (probe: OpencodeMetadataProbe, signal: AbortSignal) => Promise<T>,
-    signal?: AbortSignal,
-  ): Promise<T | null> {
-    let resolveCompletion!: () => void;
-    const entry: ActiveProbe = {
-      completion: new Promise((resolve) => {
-        resolveCompletion = resolve;
-      }),
-      controller: new AbortController(),
-      disposed: false,
-      probe: this.createProbe(),
-      resolveCompletion: () => resolveCompletion(),
-    };
-    const onAbort = () => {
-      entry.controller.abort();
-      void this.disposeProbe(entry);
-    };
-    signal?.addEventListener('abort', onAbort, { once: true });
-    this.activeProbes.add(entry);
     try {
-      return await operation(entry.probe, entry.controller.signal);
+      if (this.disposed) return null;
+      if (this.transitionFence.isUnavailable()) {
+        const available = await this.transitionFence.waitUntilAvailable(signal);
+        if (!available) return null;
+      }
+      return await this.probes.run({
+        create: () => this.createProbe(),
+        query: operation,
+      }, signal);
     } catch {
       return null;
-    } finally {
-      signal?.removeEventListener('abort', onAbort);
-      this.activeProbes.delete(entry);
-      await this.disposeProbe(entry);
-      entry.resolveCompletion();
     }
   }
 
   private beginTransition(): void {
-    if (!this.disposed) this.transitionActive = true;
+    this.transitionFence.beginTransition();
   }
 
   private async completeTransition(): Promise<void> {
     try {
       await this.invalidate();
     } finally {
-      if (!this.disposed) {
-        this.transitionActive = false;
-        this.releaseTransitionWaiters(true);
-      }
+      this.transitionFence.endTransition();
     }
-  }
-
-  private waitForTransition(signal?: AbortSignal): Promise<boolean> {
-    if (this.disposed) return Promise.resolve(false);
-    if (!this.transitionActive) return Promise.resolve(true);
-    if (signal?.aborted) return Promise.resolve(false);
-
-    return new Promise<boolean>((resolve) => {
-      const onAbort = (): void => {
-        if (!this.transitionWaiters.delete(waiter)) return;
-        resolve(false);
-      };
-      const waiter: TransitionWaiter = {
-        resolve,
-        ...(signal ? { onAbort, signal } : {}),
-      };
-      this.transitionWaiters.add(waiter);
-      signal?.addEventListener('abort', onAbort, { once: true });
-      if (signal?.aborted) onAbort();
-    });
-  }
-
-  private releaseTransitionWaiters(available: boolean): void {
-    const waiters = [...this.transitionWaiters];
-    this.transitionWaiters.clear();
-    for (const waiter of waiters) {
-      if (waiter.signal && waiter.onAbort) {
-        waiter.signal.removeEventListener('abort', waiter.onAbort);
-      }
-      waiter.resolve(available);
-    }
-  }
-
-  private async disposeProbe(entry: ActiveProbe): Promise<void> {
-    if (entry.disposed) return;
-    entry.disposed = true;
-    await entry.probe.dispose().catch(() => undefined);
   }
 }
 

--- a/src/providers/pi/app/PiCommandLoader.ts
+++ b/src/providers/pi/app/PiCommandLoader.ts
@@ -1,13 +1,12 @@
-import {
-  normalizeProviderCommandDiscoveryItems,
-  type ProviderCommandDiscoveryResult,
-} from '../../../core/providers/commands/ProviderCommandDiscoveryResult';
+import type { ProviderCommandDiscoveryResult } from '@/core/providers/commands/ProviderCommandDiscoveryResult';
+import { loadRuntimeCommands } from '@/core/providers/commands/RuntimeCommandLoader';
 import type {
   ProviderCommandLoader as ProviderCommandLoaderContract,
   ProviderCommandLoaderContext,
-} from '../../../core/providers/types';
-import type { SlashCommand } from '../../../core/types';
-import { getVaultPath } from '../../../utils/path';
+} from '@/core/providers/types';
+import type { SlashCommand } from '@/core/types';
+import { getVaultPath } from '@/utils/path';
+
 import type { PiCommandMetadataProbe } from '../execution/PiCommandMetadataProbe';
 import { getPiProviderSettings } from '../settings';
 
@@ -25,30 +24,17 @@ export class PiCommandLoader implements ProviderCommandLoaderContract {
   async loadCommands(
     context: ProviderCommandLoaderContext,
   ): Promise<ProviderCommandDiscoveryResult<SlashCommand>> {
-    context.signal?.throwIfAborted();
-    if (context.readyCommandSnapshot) {
-      return normalizeProviderCommandDiscoveryItems(context.readyCommandSnapshot);
-    }
-    if (!context.allowIsolatedMetadataCreation) {
-      return {
-        message: 'Pi command metadata has not been loaded for this tab.',
-        status: 'requires-session',
-      };
-    }
-
-    try {
-      const commands = await this.metadataProbe.load(
+    return loadRuntimeCommands({
+      allowIsolatedMetadataCreation: context.allowIsolatedMetadataCreation,
+      discover: signal => this.metadataProbe.load(
         getVaultPath(context.plugin.app) ?? process.cwd(),
-        context.signal,
-      );
-      context.signal?.throwIfAborted();
-      return normalizeProviderCommandDiscoveryItems(commands);
-    } catch {
-      return {
-        message: 'Could not load Pi commands.',
-        retryable: true,
-        status: 'error' as const,
-      };
-    }
+        signal,
+      ),
+      errorMessage: 'Could not load Pi commands.',
+      projectItems: commands => commands,
+      readyCommandSnapshot: context.readyCommandSnapshot,
+      requiresSessionMessage: 'Pi command metadata has not been loaded for this tab.',
+      signal: context.signal,
+    });
   }
 }

--- a/src/providers/pi/commands/PiCommandCatalog.ts
+++ b/src/providers/pi/commands/PiCommandCatalog.ts
@@ -1,10 +1,6 @@
-import type {
-  ProviderCommandCatalog,
-  ProviderCommandDropdownConfig,
-  ProviderCommandListContext,
-} from '../../../core/providers/commands/ProviderCommandCatalog';
-import type { ProviderCommandEntry } from '../../../core/providers/commands/ProviderCommandEntry';
-import type { SlashCommand } from '../../../core/types';
+import type { ProviderCommandEntry } from '@/core/providers/commands/ProviderCommandEntry';
+import { RuntimeCommandCatalog } from '@/core/providers/commands/RuntimeCommandCatalog';
+import type { SlashCommand } from '@/core/types';
 
 function slashCommandToEntry(command: SlashCommand): ProviderCommandEntry {
   return {
@@ -31,28 +27,17 @@ function slashCommandToEntry(command: SlashCommand): ProviderCommandEntry {
   };
 }
 
-export class PiCommandCatalog implements ProviderCommandCatalog {
-  private commandSnapshot: SlashCommand[] = [];
-
-  setCommandSnapshot(commands: SlashCommand[]): void {
-    this.commandSnapshot = commands.map((command) => ({ ...command }));
+export class PiCommandCatalog extends RuntimeCommandCatalog {
+  constructor() {
+    super({
+      dropdownConfig: {
+        builtInPrefix: '/',
+        commandPrefix: '/',
+        providerId: 'pi',
+        skillPrefix: '/',
+        triggerChars: ['/'],
+      },
+      projectEntry: slashCommandToEntry,
+    });
   }
-
-  async listDropdownEntries(context: ProviderCommandListContext): Promise<ProviderCommandEntry[]> {
-    const commands = context.commandSnapshot
-      ?? (context.allowCachedCommandSnapshot === false ? [] : this.commandSnapshot);
-    return commands.map(slashCommandToEntry);
-  }
-
-  getDropdownConfig(): ProviderCommandDropdownConfig {
-    return {
-      builtInPrefix: '/',
-      commandPrefix: '/',
-      providerId: 'pi',
-      skillPrefix: '/',
-      triggerChars: ['/'],
-    };
-  }
-
-  async refresh(): Promise<void> {}
 }

--- a/src/providers/pi/execution/PiCommandMetadataProbe.ts
+++ b/src/providers/pi/execution/PiCommandMetadataProbe.ts
@@ -1,8 +1,10 @@
-import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
-import type { ProviderHost } from '../../../core/providers/ProviderHost';
-import type { SlashCommand } from '../../../core/types';
-import { toAbortError } from '../../../utils/abort';
-import { parseEnvironmentVariables } from '../../../utils/env';
+import { OwnedProbeRegistry } from '@/core/providers/metadata/OwnedProbeRegistry';
+import { ProviderTransitionFence } from '@/core/providers/metadata/ProviderTransitionFence';
+import { getRuntimeEnvironmentText } from '@/core/providers/providerEnvironment';
+import type { ProviderHost } from '@/core/providers/ProviderHost';
+import type { SlashCommand } from '@/core/types';
+import { parseEnvironmentVariables } from '@/utils/env';
+
 import { buildPiLaunchSpec } from '../runtime/PiLaunchSpec';
 import { getPiProviderSettings } from '../settings';
 import {
@@ -11,200 +13,95 @@ import {
   type PiExecutionKernelFactory,
 } from './PiExecutionKernel';
 
-interface ActiveCommandProbe {
-  readonly completion: Promise<void>;
-  readonly controller: AbortController;
-  kernel: PiExecutionKernel | null;
-  resolveCompletion(): void;
-  shutdownFlight: Promise<void> | null;
-}
-
-interface TransitionWaiter {
-  readonly onAbort?: () => void;
-  readonly reject: (error: unknown) => void;
-  readonly resolve: () => void;
-  readonly signal?: AbortSignal;
-}
+const ABORT_MESSAGE = 'Pi command metadata probe aborted';
+const DISPOSED_MESSAGE = 'Pi command metadata probe is disposed.';
 
 export class PiCommandMetadataProbe {
-  private readonly activeProbes = new Set<ActiveCommandProbe>();
-  private readonly transitionWaiters = new Set<TransitionWaiter>();
-  private disposed = false;
-  private transitionActive = false;
+  private disposeFlight: Promise<void> | null = null;
+  private readonly probes: OwnedProbeRegistry<PiExecutionKernel>;
+  private readonly transitionFence = new ProviderTransitionFence({
+    abortMessage: ABORT_MESSAGE,
+  });
 
   constructor(
     private readonly host: ProviderHost,
     private readonly createKernel: PiExecutionKernelFactory =
       createPiExecutionKernel,
-  ) {}
-
-  load(
-    vaultWorkingDirectory: string,
-    signal?: AbortSignal,
-  ): Promise<SlashCommand[]> {
-    if (this.disposed) {
-      return Promise.reject(new Error('Pi command metadata probe is disposed.'));
-    }
-    if (signal?.aborted) {
-      return Promise.reject(toAbortError(
-        signal,
-        'Pi command metadata probe aborted',
-      ));
-    }
-    if (this.transitionActive) {
-      return this.waitForTransition(signal).then(() =>
-        this.load(vaultWorkingDirectory, signal));
-    }
-    return this.loadUnfenced(vaultWorkingDirectory, signal);
-  }
-
-  beginEnvironmentTransition(): void {
-    if (!this.disposed) this.transitionActive = true;
-  }
-
-  endEnvironmentTransition(): void {
-    if (this.disposed) return;
-    this.transitionActive = false;
-    this.releaseTransitionWaiters();
-  }
-
-  private async loadUnfenced(
-    vaultWorkingDirectory: string,
-    signal?: AbortSignal,
-  ): Promise<SlashCommand[]> {
-    let resolveCompletion!: () => void;
-    const entry: ActiveCommandProbe = {
-      completion: new Promise(resolve => { resolveCompletion = resolve; }),
-      controller: new AbortController(),
-      kernel: null,
-      resolveCompletion: () => resolveCompletion(),
-      shutdownFlight: null,
-    };
-    const onAbort = (): void => {
-      entry.controller.abort();
-      void this.shutdownProbe(entry);
-    };
-    signal?.addEventListener('abort', onAbort, { once: true });
-    this.activeProbes.add(entry);
-    try {
-      entry.controller.signal.throwIfAborted();
-      const command = await this.host.getResolvedProviderCliPath('pi') ?? 'pi';
-      entry.controller.signal.throwIfAborted();
-      const envText = getRuntimeEnvironmentText(this.host.settings, 'pi');
-      const launchSpec = buildPiLaunchSpec({
-        command,
-        cwd: vaultWorkingDirectory,
-        env: {
-          ...process.env,
-          ...parseEnvironmentVariables(envText),
-        },
-        envText,
-        noSession: true,
-        settings: getPiProviderSettings(this.host.settings),
-      });
-      const kernel = this.createKernel(
-        launchSpec,
-        {
-          onClose: () => undefined,
-          onEvent: () => undefined,
-          onExtensionChunk: () => undefined,
-          onExtensionRequest: () => undefined,
-        },
-        null,
-      );
-      entry.kernel = kernel;
-      entry.controller.signal.throwIfAborted();
-      kernel.start();
-      entry.controller.signal.throwIfAborted();
-      const response = await kernel.request<unknown>(
-        'get_commands',
-        {},
-        10_000,
-        entry.controller.signal,
-      );
-      entry.controller.signal.throwIfAborted();
-      return normalizePiRuntimeCommands(response);
-    } finally {
-      signal?.removeEventListener('abort', onAbort);
-      await this.shutdownProbe(entry);
-      this.activeProbes.delete(entry);
-      entry.resolveCompletion();
-    }
-  }
-
-  async quiesceForEnvironmentChange(): Promise<void> {
-    const active = [...this.activeProbes];
-    for (const entry of active) entry.controller.abort();
-    await Promise.all(active.map(entry => this.shutdownProbe(entry)));
-    await Promise.all(active.map(entry => entry.completion));
-  }
-
-  async dispose(): Promise<void> {
-    if (this.disposed) return;
-    this.disposed = true;
-    this.rejectTransitionWaiters(new Error('Pi command metadata probe is disposed.'));
-    await this.quiesceForEnvironmentChange();
-  }
-
-  private waitForTransition(signal?: AbortSignal): Promise<void> {
-    if (this.disposed) {
-      return Promise.reject(new Error('Pi command metadata probe is disposed.'));
-    }
-    if (!this.transitionActive) return Promise.resolve();
-    if (signal?.aborted) {
-      return Promise.reject(toAbortError(
-        signal,
-        'Pi command metadata probe aborted',
-      ));
-    }
-
-    return new Promise<void>((resolve, reject) => {
-      const onAbort = (): void => {
-        if (!this.transitionWaiters.delete(waiter)) return;
-        reject(toAbortError(signal!, 'Pi command metadata probe aborted'));
-      };
-      const waiter: TransitionWaiter = {
-        reject,
-        resolve,
-        ...(signal ? { onAbort, signal } : {}),
-      };
-      this.transitionWaiters.add(waiter);
-      signal?.addEventListener('abort', onAbort, { once: true });
-      if (signal?.aborted) onAbort();
+  ) {
+    this.probes = new OwnedProbeRegistry({
+      abortMessage: ABORT_MESSAGE,
+      dispose: kernel => kernel.shutdown(),
+      unavailableError: () => new Error(DISPOSED_MESSAGE),
     });
   }
 
-  private releaseTransitionWaiters(): void {
-    const waiters = [...this.transitionWaiters];
-    this.transitionWaiters.clear();
-    for (const waiter of waiters) {
-      this.removeWaiterAbortListener(waiter);
-      waiter.resolve();
-    }
+  async load(
+    vaultWorkingDirectory: string,
+    signal?: AbortSignal,
+  ): Promise<SlashCommand[]> {
+    const available = await this.transitionFence.waitUntilAvailable(signal);
+    if (!available) throw new Error(DISPOSED_MESSAGE);
+
+    return await this.probes.run({
+      create: async (ownedSignal) => {
+        const command = await this.host.getResolvedProviderCliPath('pi') ?? 'pi';
+        ownedSignal.throwIfAborted();
+        const envText = getRuntimeEnvironmentText(this.host.settings, 'pi');
+        const launchSpec = buildPiLaunchSpec({
+          command,
+          cwd: vaultWorkingDirectory,
+          env: {
+            ...process.env,
+            ...parseEnvironmentVariables(envText),
+          },
+          envText,
+          noSession: true,
+          settings: getPiProviderSettings(this.host.settings),
+        });
+        return this.createKernel(
+          launchSpec,
+          {
+            onClose: () => undefined,
+            onEvent: () => undefined,
+            onExtensionChunk: () => undefined,
+            onExtensionRequest: () => undefined,
+          },
+          null,
+        );
+      },
+      initialize: kernel => kernel.start(),
+      query: async (kernel, ownedSignal) => {
+        const response = await kernel.request<unknown>(
+          'get_commands',
+          {},
+          10_000,
+          ownedSignal,
+        );
+        return normalizePiRuntimeCommands(response);
+      },
+    }, signal);
   }
 
-  private rejectTransitionWaiters(error: unknown): void {
-    const waiters = [...this.transitionWaiters];
-    this.transitionWaiters.clear();
-    for (const waiter of waiters) {
-      this.removeWaiterAbortListener(waiter);
-      waiter.reject(error);
-    }
+  beginEnvironmentTransition(): void {
+    this.transitionFence.beginTransition();
   }
 
-  private removeWaiterAbortListener(waiter: TransitionWaiter): void {
-    if (waiter.signal && waiter.onAbort) {
-      waiter.signal.removeEventListener('abort', waiter.onAbort);
-    }
+  endEnvironmentTransition(): void {
+    this.transitionFence.endTransition();
   }
 
-  private shutdownProbe(entry: ActiveCommandProbe): Promise<void> {
-    if (entry.shutdownFlight) return entry.shutdownFlight;
-    const kernel = entry.kernel;
-    if (!kernel) return Promise.resolve();
-    entry.kernel = null;
-    entry.shutdownFlight = kernel.shutdown().catch(() => undefined);
-    return entry.shutdownFlight;
+  quiesceForEnvironmentChange(): Promise<void> {
+    return this.probes.quiesce();
+  }
+
+  dispose(): Promise<void> {
+    if (this.disposeFlight) return this.disposeFlight;
+    this.transitionFence.dispose();
+    this.disposeFlight = (async () => {
+      await this.quiesceForEnvironmentChange();
+      await this.probes.dispose();
+    })();
+    return this.disposeFlight;
   }
 }
 

--- a/src/providers/pi/execution/PiCommandMetadataProbe.ts
+++ b/src/providers/pi/execution/PiCommandMetadataProbe.ts
@@ -39,8 +39,10 @@ export class PiCommandMetadataProbe {
     vaultWorkingDirectory: string,
     signal?: AbortSignal,
   ): Promise<SlashCommand[]> {
-    const available = await this.transitionFence.waitUntilAvailable(signal);
-    if (!available) throw new Error(DISPOSED_MESSAGE);
+    if (this.transitionFence.isUnavailable()) {
+      const available = await this.transitionFence.waitUntilAvailable(signal);
+      if (!available) throw new Error(DISPOSED_MESSAGE);
+    }
 
     return await this.probes.run({
       create: async (ownedSignal) => {

--- a/tests/unit/core/providers/commands/RuntimeCommandCatalog.test.ts
+++ b/tests/unit/core/providers/commands/RuntimeCommandCatalog.test.ts
@@ -1,0 +1,108 @@
+import { RuntimeCommandCatalog } from '@/core/providers/commands/RuntimeCommandCatalog';
+import type { SlashCommand } from '@/core/types';
+
+function createCatalog(): RuntimeCommandCatalog {
+  return new RuntimeCommandCatalog({
+    dropdownConfig: {
+      builtInPrefix: '/',
+      commandPrefix: '/',
+      providerId: 'pi',
+      skillPrefix: '/',
+      triggerChars: ['/'],
+    },
+    projectEntry: (command) => ({
+      content: command.content,
+      displayPrefix: '/',
+      hooks: command.hooks,
+      id: command.id,
+      insertPrefix: '/',
+      isDeletable: false,
+      isEditable: false,
+      kind: command.kind ?? 'command',
+      name: command.name,
+      providerId: 'pi',
+      scope: 'runtime',
+      source: command.source ?? 'sdk',
+    }),
+  });
+}
+
+describe('RuntimeCommandCatalog', () => {
+  it('defensively clones snapshots on input and output', async () => {
+    const catalog = createCatalog();
+    const command: SlashCommand = {
+      allowedTools: ['Read'],
+      content: '',
+      hooks: { nested: { value: 'original' } },
+      id: 'pi:skill:test',
+      kind: 'skill',
+      name: 'test',
+      source: 'sdk',
+    };
+    catalog.setCommandSnapshot([command]);
+    command.name = 'mutated input';
+    command.allowedTools?.push('Write');
+    (command.hooks?.nested as { value: string }).value = 'mutated input';
+
+    const first = await catalog.listDropdownEntries({ includeBuiltIns: false });
+    expect(first).toEqual([
+      expect.objectContaining({
+        hooks: { nested: { value: 'original' } },
+        kind: 'skill',
+        name: 'test',
+      }),
+    ]);
+    first[0].name = 'mutated output';
+    (first[0].hooks?.nested as { value: string }).value = 'mutated output';
+
+    await expect(catalog.listDropdownEntries({ includeBuiltIns: false })).resolves.toEqual([
+      expect.objectContaining({
+        hooks: { nested: { value: 'original' } },
+        name: 'test',
+      }),
+    ]);
+  });
+
+  it('handles empty, cached, request-scoped, and repeated snapshots stably', async () => {
+    const catalog = createCatalog();
+    const first = { content: '', id: 'first', name: 'first' };
+    const second = { content: '', id: 'second', name: 'second' };
+
+    await expect(catalog.listDropdownEntries({ includeBuiltIns: false })).resolves.toEqual([]);
+    catalog.setCommandSnapshot([first, second]);
+    catalog.setCommandSnapshot([first, second]);
+    await expect(catalog.listDropdownEntries({ includeBuiltIns: false })).resolves.toEqual([
+      expect.objectContaining({ id: 'first', name: 'first' }),
+      expect.objectContaining({ id: 'second', name: 'second' }),
+    ]);
+    await expect(catalog.listDropdownEntries({
+      allowCachedCommandSnapshot: false,
+      includeBuiltIns: false,
+    })).resolves.toEqual([]);
+    await expect(catalog.listDropdownEntries({
+      commandSnapshot: [second, first],
+      includeBuiltIns: false,
+    })).resolves.toEqual([
+      expect.objectContaining({ id: 'second' }),
+      expect.objectContaining({ id: 'first' }),
+    ]);
+
+    catalog.setCommandSnapshot([]);
+    await expect(catalog.listDropdownEntries({ includeBuiltIns: false })).resolves.toEqual([]);
+  });
+
+  it('returns a defensive dropdown configuration and keeps refresh a no-op', async () => {
+    const catalog = createCatalog();
+    const config = catalog.getDropdownConfig();
+    config.triggerChars.push('@');
+
+    expect(catalog.getDropdownConfig()).toEqual({
+      builtInPrefix: '/',
+      commandPrefix: '/',
+      providerId: 'pi',
+      skillPrefix: '/',
+      triggerChars: ['/'],
+    });
+    await expect(catalog.refresh()).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/core/providers/commands/RuntimeCommandLoader.test.ts
+++ b/tests/unit/core/providers/commands/RuntimeCommandLoader.test.ts
@@ -1,0 +1,120 @@
+import { loadRuntimeCommands } from '@/core/providers/commands/RuntimeCommandLoader';
+import type { SlashCommand } from '@/core/types';
+
+const COMMAND: SlashCommand = {
+  content: '',
+  id: 'runtime:test',
+  name: 'test',
+  source: 'sdk',
+};
+
+function load(
+  overrides: Partial<Parameters<typeof loadRuntimeCommands<SlashCommand[]>>[0]> = {},
+) {
+  return loadRuntimeCommands({
+    allowIsolatedMetadataCreation: true,
+    discover: async () => [COMMAND],
+    errorMessage: 'Could not load commands.',
+    projectItems: (commands) => commands,
+    requiresSessionMessage: 'Commands require a session.',
+    ...overrides,
+  });
+}
+
+describe('loadRuntimeCommands', () => {
+  it('checks cancellation before snapshots or isolated discovery', async () => {
+    const controller = new AbortController();
+    const failure = new Error('cancelled');
+    const discover = jest.fn(async () => [COMMAND]);
+    controller.abort(failure);
+
+    await expect(load({
+      discover,
+      readyCommandSnapshot: [COMMAND],
+      signal: controller.signal,
+    })).rejects.toBe(failure);
+    expect(discover).not.toHaveBeenCalled();
+  });
+
+  it('normalizes ready and empty snapshots without isolated discovery', async () => {
+    const discover = jest.fn(async () => [COMMAND]);
+
+    await expect(load({ discover, readyCommandSnapshot: [COMMAND] })).resolves.toEqual({
+      items: [COMMAND],
+      status: 'ready',
+    });
+    await expect(load({ discover, readyCommandSnapshot: [] })).resolves.toEqual({
+      status: 'empty',
+    });
+    expect(discover).not.toHaveBeenCalled();
+  });
+
+  it('returns requires-session without isolated discovery', async () => {
+    const discover = jest.fn(async () => [COMMAND]);
+
+    await expect(load({
+      allowIsolatedMetadataCreation: false,
+      discover,
+    })).resolves.toEqual({
+      message: 'Commands require a session.',
+      status: 'requires-session',
+    });
+    expect(discover).not.toHaveBeenCalled();
+  });
+
+  it('projects isolated discovery and maps failures to a retryable error', async () => {
+    await expect(load({
+      discover: async () => [{ ...COMMAND, name: 'native' }],
+      projectItems: commands => commands.map(command => ({
+        ...command,
+        name: `projected:${command.name}`,
+      })),
+    })).resolves.toEqual({
+      items: [expect.objectContaining({ name: 'projected:native' })],
+      status: 'ready',
+    });
+    await expect(load({
+      discover: async () => { throw new Error('native failure'); },
+    })).resolves.toEqual({
+      message: 'Could not load commands.',
+      retryable: true,
+      status: 'error',
+    });
+    await expect(load({
+      projectItems: () => null,
+    })).resolves.toEqual({
+      message: 'Could not load commands.',
+      retryable: true,
+      status: 'error',
+    });
+  });
+
+  it('rechecks cancellation after isolated discovery and still cleans up', async () => {
+    const controller = new AbortController();
+    const failure = new Error('cancelled after query');
+    const cleanup = jest.fn(async () => undefined);
+
+    await expect(load({
+      cleanup,
+      discover: async () => {
+        controller.abort(failure);
+        return [COMMAND];
+      },
+      signal: controller.signal,
+    })).rejects.toBe(failure);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans up only after isolated discovery and suppresses cleanup failures', async () => {
+    const cleanup = jest.fn(async () => { throw new Error('cleanup failed'); });
+
+    await expect(load({ cleanup })).resolves.toMatchObject({ status: 'ready' });
+    expect(cleanup).toHaveBeenCalledTimes(1);
+
+    cleanup.mockClear();
+    await expect(load({ cleanup, readyCommandSnapshot: [COMMAND] })).resolves.toMatchObject({
+      status: 'ready',
+    });
+    expect(cleanup).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/core/providers/metadata/OwnedProbeRegistry.test.ts
+++ b/tests/unit/core/providers/metadata/OwnedProbeRegistry.test.ts
@@ -1,0 +1,177 @@
+import { OwnedProbeRegistry } from '@/core/providers/metadata/OwnedProbeRegistry';
+
+class Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve!: (value: T | PromiseLike<T>) => void;
+  reject!: (reason?: unknown) => void;
+
+  constructor() {
+    this.promise = new Promise<T>((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+  }
+}
+
+interface TestResource {
+  readonly id: number;
+}
+
+function createRegistry(
+  dispose: (resource: TestResource) => Promise<void> | void = () => undefined,
+): OwnedProbeRegistry<TestResource> {
+  return new OwnedProbeRegistry({
+    dispose,
+    unavailableError: () => new Error('Registry unavailable'),
+  });
+}
+
+describe('OwnedProbeRegistry', () => {
+  it('tracks concurrent probes and disposes every resource exactly once', async () => {
+    const firstQuery = new Deferred<string>();
+    const secondQuery = new Deferred<string>();
+    const dispose = jest.fn();
+    const registry = createRegistry(dispose);
+
+    const first = registry.run({
+      create: () => ({ id: 1 }),
+      query: () => firstQuery.promise,
+    });
+    const second = registry.run({
+      create: () => ({ id: 2 }),
+      query: () => secondQuery.promise,
+    });
+    firstQuery.resolve('first');
+    secondQuery.resolve('second');
+
+    await expect(Promise.all([first, second])).resolves.toEqual(['first', 'second']);
+    expect(dispose).toHaveBeenCalledTimes(2);
+    expect(dispose.mock.calls.map(([resource]) => resource.id)).toEqual([1, 2]);
+    await registry.quiesce();
+  });
+
+  it('propagates caller cancellation and removes its abort listener', async () => {
+    const dispose = jest.fn();
+    const registry = createRegistry(dispose);
+    const controller = new AbortController();
+    const removeListener = jest.spyOn(controller.signal, 'removeEventListener');
+    let ownedSignal!: AbortSignal;
+    const queryStarted = new Deferred<void>();
+    const failure = new Error('caller cancelled');
+
+    const run = registry.run({
+      create: () => ({ id: 1 }),
+      query: (_resource, signal) => {
+        ownedSignal = signal;
+        queryStarted.resolve();
+        return new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+        });
+      },
+    }, controller.signal);
+    await queryStarted.promise;
+    controller.abort(failure);
+
+    await expect(run).rejects.toBe(failure);
+    expect(ownedSignal.aborted).toBe(true);
+    expect(ownedSignal.reason).toBe(failure);
+    expect(removeListener).toHaveBeenCalledWith('abort', expect.any(Function));
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans up initialization and query failures and remains usable after creation failure', async () => {
+    const dispose = jest.fn();
+    const registry = createRegistry(dispose);
+
+    await expect(registry.run({
+      create: () => { throw new Error('create failed'); },
+      query: async () => 'unused',
+    })).rejects.toThrow('create failed');
+    expect(dispose).not.toHaveBeenCalled();
+
+    await expect(registry.run({
+      create: () => ({ id: 1 }),
+      initialize: async () => { throw new Error('initialize failed'); },
+      query: async () => 'unused',
+    })).rejects.toThrow('initialize failed');
+    await expect(registry.run({
+      create: () => ({ id: 2 }),
+      query: async () => { throw new Error('query failed'); },
+    })).rejects.toThrow('query failed');
+
+    expect(dispose).toHaveBeenCalledTimes(2);
+    await registry.quiesce();
+  });
+
+  it('suppresses cleanup failure while preserving exactly-once disposal', async () => {
+    const dispose = jest.fn(async () => { throw new Error('cleanup failed'); });
+    const registry = createRegistry(dispose);
+
+    await expect(registry.run({
+      create: () => ({ id: 1 }),
+      query: async () => 'result',
+    })).resolves.toBe('result');
+    await registry.quiesce();
+
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts active operations and waits for cleanup and completion during quiescence', async () => {
+    const cleanup = new Deferred<void>();
+    const registry = createRegistry(() => cleanup.promise);
+    const queryStarted = new Deferred<void>();
+
+    const run = registry.run({
+      create: () => ({ id: 1 }),
+      query: (_resource, signal) => {
+        queryStarted.resolve();
+        return new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+        });
+      },
+    });
+    await queryStarted.promise;
+
+    let quiesced = false;
+    const quiescence = registry.quiesce().then(() => { quiesced = true; });
+    await Promise.resolve();
+    expect(quiesced).toBe(false);
+
+    cleanup.resolve();
+    await expect(run).rejects.toThrow('aborted');
+    await quiescence;
+    expect(quiesced).toBe(true);
+  });
+
+  it('safely disposes during an active probe and rejects future runs', async () => {
+    const cleanup = new Deferred<void>();
+    const disposeResource = jest.fn(() => cleanup.promise);
+    const registry = createRegistry(disposeResource);
+    const queryStarted = new Deferred<void>();
+    const run = registry.run({
+      create: () => ({ id: 1 }),
+      query: (_resource, signal) => {
+        queryStarted.resolve();
+        return new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(new Error('disposed')), { once: true });
+        });
+      },
+    });
+    await queryStarted.promise;
+
+    const firstDispose = registry.dispose();
+    const secondDispose = registry.dispose();
+    cleanup.resolve();
+
+    await expect(run).rejects.toThrow('disposed');
+    await expect(Promise.all([firstDispose, secondDispose])).resolves.toEqual([
+      undefined,
+      undefined,
+    ]);
+    expect(disposeResource).toHaveBeenCalledTimes(1);
+    await expect(registry.run({
+      create: () => ({ id: 2 }),
+      query: async () => 'unused',
+    })).rejects.toThrow('Registry unavailable');
+  });
+});

--- a/tests/unit/core/providers/metadata/ProviderTransitionFence.test.ts
+++ b/tests/unit/core/providers/metadata/ProviderTransitionFence.test.ts
@@ -24,6 +24,26 @@ describe('ProviderTransitionFence', () => {
     fence.endTransition();
   });
 
+  it('rechecks availability when another transition begins before a waiter resumes', async () => {
+    const fence = new ProviderTransitionFence();
+    fence.beginTransition();
+
+    let settled = false;
+    const availability = fence.waitUntilAvailable().then((value) => {
+      settled = true;
+      return value;
+    });
+    fence.endTransition();
+    fence.beginTransition();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(settled).toBe(false);
+    fence.endTransition();
+    await expect(availability).resolves.toBe(true);
+  });
+
   it('rejects an already-aborted waiter with the configured fallback', async () => {
     const fence = new ProviderTransitionFence({
       abortMessage: 'Metadata wait aborted',

--- a/tests/unit/core/providers/metadata/ProviderTransitionFence.test.ts
+++ b/tests/unit/core/providers/metadata/ProviderTransitionFence.test.ts
@@ -1,0 +1,76 @@
+import { ProviderTransitionFence } from '@/core/providers/metadata/ProviderTransitionFence';
+
+describe('ProviderTransitionFence', () => {
+  it('keeps nested transitions unavailable until the final end', async () => {
+    const fence = new ProviderTransitionFence();
+
+    fence.endTransition();
+    fence.beginTransition();
+    fence.beginTransition();
+    expect(fence.isUnavailable()).toBe(true);
+
+    let settled = false;
+    const availability = fence.waitUntilAvailable().then((value) => {
+      settled = true;
+      return value;
+    });
+    fence.endTransition();
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    fence.endTransition();
+    await expect(availability).resolves.toBe(true);
+    expect(fence.isUnavailable()).toBe(false);
+    fence.endTransition();
+  });
+
+  it('rejects an already-aborted waiter with the configured fallback', async () => {
+    const fence = new ProviderTransitionFence({
+      abortMessage: 'Metadata wait aborted',
+    });
+    const controller = new AbortController();
+    controller.abort('caller cancelled');
+
+    await expect(fence.waitUntilAvailable(controller.signal)).rejects.toMatchObject({
+      cause: 'caller cancelled',
+      message: 'Metadata wait aborted',
+    });
+  });
+
+  it('removes the abort listener when a transition or abort settles the waiter', async () => {
+    const fence = new ProviderTransitionFence({
+      abortMessage: 'Metadata wait aborted',
+    });
+    const releasedController = new AbortController();
+    const abortedController = new AbortController();
+    const releasedRemove = jest.spyOn(releasedController.signal, 'removeEventListener');
+    const abortedRemove = jest.spyOn(abortedController.signal, 'removeEventListener');
+    fence.beginTransition();
+
+    const released = fence.waitUntilAvailable(releasedController.signal);
+    const aborted = fence.waitUntilAvailable(abortedController.signal);
+    abortedController.abort(new Error('stop'));
+    fence.endTransition();
+
+    await expect(released).resolves.toBe(true);
+    await expect(aborted).rejects.toThrow('stop');
+    expect(releasedRemove).toHaveBeenCalledWith('abort', expect.any(Function));
+    expect(abortedRemove).toHaveBeenCalledWith('abort', expect.any(Function));
+  });
+
+  it('releases waiters as unavailable when disposed during a nested transition', async () => {
+    const fence = new ProviderTransitionFence();
+    fence.beginTransition();
+    fence.beginTransition();
+
+    const first = fence.waitUntilAvailable();
+    const second = fence.waitUntilAvailable();
+    fence.dispose();
+    fence.dispose();
+    fence.endTransition();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([false, false]);
+    await expect(fence.waitUntilAvailable()).resolves.toBe(false);
+    expect(fence.isUnavailable()).toBe(true);
+  });
+});

--- a/tests/unit/providers/grok/app/GrokCommandLoader.test.ts
+++ b/tests/unit/providers/grok/app/GrokCommandLoader.test.ts
@@ -63,4 +63,36 @@ describe('GrokCommandLoader', () => {
     });
     expect(metadataProbe.load).toHaveBeenCalledTimes(1);
   });
+
+  it('preserves caller cancellation after isolated discovery', async () => {
+    const controller = new AbortController();
+    const failure = new Error('caller cancelled');
+    const metadataProbe = {
+      load: jest.fn(async () => {
+        controller.abort(failure);
+        return [];
+      }),
+    };
+    const loader = new GrokCommandLoader(metadataProbe as any);
+
+    await expect(loader.loadCommands(createContext({
+      allowIsolatedMetadataCreation: true,
+      signal: controller.signal,
+    }))).rejects.toBe(failure);
+  });
+
+  it('maps native discovery failures to the Grok retryable error', async () => {
+    const metadataProbe = {
+      load: jest.fn(async () => { throw new Error('native failure'); }),
+    };
+    const loader = new GrokCommandLoader(metadataProbe as any);
+
+    await expect(loader.loadCommands(createContext({
+      allowIsolatedMetadataCreation: true,
+    }))).resolves.toEqual({
+      message: 'Could not load Grok skills and commands.',
+      retryable: true,
+      status: 'error',
+    });
+  });
 });

--- a/tests/unit/providers/grok/app/GrokCommandMetadataProbe.test.ts
+++ b/tests/unit/providers/grok/app/GrokCommandMetadataProbe.test.ts
@@ -63,6 +63,39 @@ class FakeMetadataNative implements GrokExecutionNativeConnection {
 }
 
 describe('GrokCommandMetadataProbe', () => {
+  it('registers a load before a synchronously started transition quiesces', async () => {
+    const cliResolution = new Deferred<string | null>();
+    const nativeFactory: GrokExecutionNativeFactory = {
+      create: jest.fn(() => new FakeMetadataNative('stale', false)),
+    };
+    const plugin = {
+      app: { vault: { adapter: { basePath: '/tmp/grok-vault' } } },
+      getResolvedProviderCliPath: jest.fn(() => cliResolution.promise),
+      manifest: { version: 'test' },
+      settings: {},
+    } as unknown as ProviderHost;
+    const probe = new GrokCommandMetadataProbe(plugin, nativeFactory);
+
+    const load = probe.load();
+    probe.beginEnvironmentTransition();
+    let quiesced = false;
+    const quiescence = probe.quiesceForEnvironmentChange().then(() => {
+      quiesced = true;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(quiesced).toBe(false);
+    cliResolution.resolve('/configured/grok');
+    await expect(load).rejects.toThrow();
+    await quiescence;
+    expect(nativeFactory.create).not.toHaveBeenCalled();
+
+    probe.endEnvironmentTransition();
+    await probe.dispose();
+  });
+
   it('quiesces an in-flight configured-CLI probe before resolving the next CLI', async () => {
     let configuredCli = '/configured/grok-a';
     const first = new FakeMetadataNative('from-a', true);

--- a/tests/unit/providers/opencode/OpencodeCommandLoader.test.ts
+++ b/tests/unit/providers/opencode/OpencodeCommandLoader.test.ts
@@ -45,6 +45,7 @@ describe('OpencodeCommandLoader', () => {
 
   it('loads commands through the metadata service when authorized', async () => {
     const metadataService = {
+      dispose: jest.fn(),
       discoverCommands: jest.fn().mockResolvedValue({
         commands: [{
           content: '',
@@ -65,5 +66,45 @@ describe('OpencodeCommandLoader', () => {
       status: 'ready',
     });
     expect(metadataService.discoverCommands).toHaveBeenCalledTimes(1);
+    expect(metadataService.dispose).not.toHaveBeenCalled();
+  });
+
+  it('disposes a loader-owned ephemeral service after discovery', async () => {
+    const metadataService = {
+      discoverCommands: jest.fn().mockResolvedValue({
+        commands: [],
+        loaded: true,
+      }),
+      dispose: jest.fn(async () => undefined),
+    };
+    const createMetadataService = jest.fn(() => metadataService as any);
+    const loader = new OpencodeCommandLoader(undefined, createMetadataService);
+    const context = createContext({ allowIsolatedMetadataCreation: true });
+
+    await expect(loader.loadCommands(context)).resolves.toEqual({ status: 'empty' });
+    expect(createMetadataService).toHaveBeenCalledWith(context.plugin);
+    expect(metadataService.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves caller cancellation while disposing an ephemeral service', async () => {
+    const controller = new AbortController();
+    const failure = new Error('caller cancelled');
+    const metadataService = {
+      discoverCommands: jest.fn(async () => {
+        controller.abort(failure);
+        return { commands: [], loaded: true };
+      }),
+      dispose: jest.fn(async () => undefined),
+    };
+    const loader = new OpencodeCommandLoader(
+      undefined,
+      () => metadataService as any,
+    );
+
+    await expect(loader.loadCommands(createContext({
+      allowIsolatedMetadataCreation: true,
+      signal: controller.signal,
+    }))).rejects.toBe(failure);
+    expect(metadataService.dispose).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/providers/pi/execution/PiCommandMetadataProbe.test.ts
+++ b/tests/unit/providers/pi/execution/PiCommandMetadataProbe.test.ts
@@ -1,7 +1,52 @@
 import type { ProviderHost } from '@/core/providers/ProviderHost';
 import { PiCommandMetadataProbe } from '@/providers/pi/execution/PiCommandMetadataProbe';
 
+class Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve!: (value: T) => void;
+
+  constructor() {
+    this.promise = new Promise<T>((resolve) => {
+      this.resolve = resolve;
+    });
+  }
+}
+
 describe('PiCommandMetadataProbe', () => {
+  it('registers a load before a synchronously started transition quiesces', async () => {
+    const cliResolution = new Deferred<string | null>();
+    const kernel = {
+      request: jest.fn(async () => ({ commands: [] })),
+      shutdown: jest.fn(async () => undefined),
+      start: jest.fn(),
+    };
+    const createKernel = jest.fn(() => kernel as any);
+    const host = {
+      getResolvedProviderCliPath: jest.fn(() => cliResolution.promise),
+      settings: {},
+    } as unknown as ProviderHost;
+    const probe = new PiCommandMetadataProbe(host, createKernel);
+
+    const load = probe.load('/vault');
+    probe.beginEnvironmentTransition();
+    let quiesced = false;
+    const quiescence = probe.quiesceForEnvironmentChange().then(() => {
+      quiesced = true;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(quiesced).toBe(false);
+    cliResolution.resolve('/configured/pi');
+    await expect(load).rejects.toThrow();
+    await quiescence;
+    expect(createKernel).not.toHaveBeenCalled();
+
+    probe.endEnvironmentTransition();
+    await probe.dispose();
+  });
+
   it('normalizes a non-Error abort reason while waiting behind a transition fence', async () => {
     const createKernel = jest.fn();
     const probe = new PiCommandMetadataProbe(

--- a/tests/unit/providers/pi/execution/PiExecutionBackend.test.ts
+++ b/tests/unit/providers/pi/execution/PiExecutionBackend.test.ts
@@ -429,7 +429,7 @@ describe('PiExecutionBackend', () => {
     expect(kernels).toHaveLength(0);
 
     controller.abort();
-    await expect(abortedLoad).resolves.toMatchObject({ status: 'error' });
+    await expect(abortedLoad).rejects.toMatchObject({ name: 'AbortError' });
     expect(kernels).toHaveLength(0);
 
     releaseMutation.resolve();


### PR DESCRIPTION
## Summary

- add provider-neutral transition fencing and owned probe lifecycle primitives
- migrate Grok, Pi, and OpenCode metadata probes while preserving native creation, initialization, querying, and cleanup
- add a configurable runtime command catalog and shared loader orchestration for Grok, OpenCode, and Pi
- keep the Codex metadata gate as a compatibility adapter and preserve provider-specific command projection and messages
- fence synchronous probe admission and recheck back-to-back transitions before releasing metadata work

## Testing

- npm run typecheck
- npm run lint
- npm run test
- npm run build

All 327 test suites and 6,183 tests pass, including architecture checks.