### PR TITLE
fix: wrap long lines in expanded tool call content

### DIFF
--- a/src/features/chat/rendering/ToolCallRenderer.ts
+++ b/src/features/chat/rendering/ToolCallRenderer.ts
@@ -473,7 +473,7 @@ function renderLinesExpanded(
   const linesEl = container.createDiv({ cls: 'claudian-tool-lines' });
   for (const line of displayLines) {
     const stripped = line.replace(/^\s*\d+→/, '');
-    const lineEl = linesEl.createDiv({ cls: 'claudian-tool-line' });
+    const lineEl = linesEl.createDiv({ cls: 'claudian-tool-line claudian-tool-line-wrap' });
     if (hoverable) lineEl.addClass('hoverable');
     lineEl.setText(stripped || ' ');
   }

--- a/tests/unit/features/chat/rendering/ToolCallRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/ToolCallRenderer.test.ts
@@ -167,6 +167,23 @@ describe('ToolCallRenderer', () => {
       expect(setIcon).toHaveBeenCalledWith(expect.anything(), 'check');
     });
 
+    it('renders Read result lines with the wrap class so long lines wrap instead of scrolling horizontally', () => {
+      const parentEl = createMockEl();
+      const toolCall = createToolCall({
+        name: 'Read',
+        status: 'completed',
+        result: 'short line\n' + 'x'.repeat(200) + '\nanother line',
+      });
+
+      const toolEl = renderStoredToolCall(parentEl, toolCall);
+      const lines = toolEl.querySelectorAll('.claudian-tool-line');
+
+      expect(lines).toHaveLength(3);
+      for (const line of lines) {
+        expect(line.hasClass('claudian-tool-line-wrap')).toBe(true);
+      }
+    });
+
     it('should show error status icon', () => {
       const parentEl = createMockEl();
       const toolCall = createToolCall({ status: 'error' });


### PR DESCRIPTION
## Why

When the agent reads a file or runs a command, the expanded tool call content (Read, Bash, Grep, LS, WebSearch results, etc.) renders each line as a `.claudian-tool-line` element with `white-space: pre`, and the container has `overflow-x: auto`. Long lines therefore force horizontal scrolling inside the sidebar chat, which is especially noticeable when reading files with long lines.

## What

`renderLinesExpanded()` now adds the existing `claudian-tool-line-wrap` class to every rendered line. That class (`white-space: pre-wrap; word-break: break-word`) already exists in `toolcalls.css` and is already used by `renderWebFetchExpanded()` — this change simply applies the same wrapping behavior to all expanded tool result lines.

## Why this approach

- Reuses the plugin's own wrap class and CSS instead of adding new styles, keeping the change minimal (one line in the renderer).
- Consistent with the existing WebFetch path, so wrapping behavior is uniform across tool result types.
- CSS-only alternatives were considered (e.g. changing `.claudian-tool-line` to `pre-wrap` globally), but the class-based approach keeps the wrap behavior explicit in the renderer and testable.

## Validation

- Added a unit test asserting Read result lines carry `claudian-tool-line-wrap` (TDD: test written first, failed before the change, passes after).
- `npm run typecheck`, `npm run build`, and the full ToolCallRenderer test suite (101 tests) pass.
- Full test suite: no new failures vs. clean baseline (remaining failures are pre-existing Windows path-resolution tests unrelated to this change).
- Manual check in Obsidian: Read a file with long lines — content now wraps instead of scrolling horizontally.

## Impact

No configuration or data changes. Wrapping only affects display; the underlying result text is unchanged. Line-height and copy behavior are unaffected.

## Context

Closes nothing; standalone bug-fix PR.