### PR TITLE
Fix Pi skill command display on replay

### DIFF
--- a/src/providers/pi/history/PiHistoryStore.ts
+++ b/src/providers/pi/history/PiHistoryStore.ts
@@ -6,6 +6,7 @@ import * as path from 'node:path';
 
 import { isWriteEditTool } from '../../../core/tools/toolNames';
 import type { ChatMessage, ContentBlock, ImageAttachment, ToolCallInfo } from '../../../core/types';
+import { extractUserQuery } from '../../../utils/context';
 import { extractDiffData } from '../../../utils/diff';
 import { buildImageAttachmentFromBase64 } from '../../../utils/imageAttachment';
 import {
@@ -442,9 +443,12 @@ function mapPiSessionEntry(
   const timestamp = getTimestamp(message.timestamp ?? entry.raw.timestamp);
 
   if (role === 'user') {
+    const content = extractTextContent(message.content ?? message.text ?? message.message);
+    const displayContent = extractPiSkillDisplayContent(content);
     const images = extractUserImages(message.content ?? message.parts ?? message.blocks, entry.id ?? `pi-user-${messages.length}`);
     return {
-      content: extractTextContent(message.content ?? message.text ?? message.message),
+      content,
+      ...(displayContent ? { displayContent } : {}),
       id: entry.id ?? `pi-user-${messages.length}`,
       ...(images.length > 0 ? { images } : {}),
       role: 'user',
@@ -505,6 +509,16 @@ function mapPiSessionEntry(
   }
 
   return null;
+}
+
+function extractPiSkillDisplayContent(content: string): string | undefined {
+  const match = content.match(
+    /^<skill name="([^"]+)" location="[^"]+">\n[\s\S]*?\n<\/skill>(?:\n\n([\s\S]+))?$/,
+  );
+  if (!match) return undefined;
+
+  const visibleArguments = match[2] ? extractUserQuery(match[2]) : '';
+  return `/skill:${match[1]}${visibleArguments ? ` ${visibleArguments}` : ''}`;
 }
 
 function extractAssistantContentBlocks(value: unknown): ContentBlock[] {

--- a/tests/unit/providers/pi/history/PiHistoryStore.test.ts
+++ b/tests/unit/providers/pi/history/PiHistoryStore.test.ts
@@ -70,6 +70,50 @@ describe('PiHistoryStore', () => {
     expect(messages[0].displayContent).toBeUndefined();
   });
 
+  it.each([
+    {
+      displayContent: '/skill:commit-push',
+      suffix: '',
+    },
+    {
+      displayContent: '/skill:commit-push include untracked files',
+      suffix: [
+        '',
+        '',
+        'include untracked files',
+        '',
+        '<linked_note path="notes/release.md" />',
+      ].join('\n'),
+    },
+  ])('restores $displayContent from Pi-expanded skill prompts', ({
+    displayContent,
+    suffix,
+  }) => {
+    const expandedPrompt = [
+      '<skill name="commit-push" location="/Users/test/.agents/skills/commit-push/SKILL.md">',
+      'References are relative to /Users/test/.agents/skills/commit-push.',
+      '',
+      'Commit all uncommitted changes, then push to remote.',
+      '</skill>',
+    ].join('\n') + suffix;
+    const content = JSON.stringify({
+      id: 'u1',
+      type: 'message',
+      message: {
+        role: 'user',
+        content: [{ type: 'text', text: expandedPrompt }],
+      },
+    });
+
+    const messages = parsePiSessionContent(content);
+
+    expect(messages[0]).toMatchObject({
+      content: expandedPrompt,
+      displayContent,
+      role: 'user',
+    });
+  });
+
   it('rehydrates user image content parts', () => {
     const content = [
       JSON.stringify({


### PR DESCRIPTION
## Summary

- reconstruct `/skill:<name>` display text from Pi-expanded skill prompts during history replay
- preserve Pi native transcript content while hiding expanded skill and context metadata in the chat UI
- cover skill replay with and without arguments and appended note context

## Testing

- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run build`