### PR TITLE
Fix Claude task replay after compaction

### DIFF
--- a/src/providers/claude/history/ClaudeHistoryStore.ts
+++ b/src/providers/claude/history/ClaudeHistoryStore.ts
@@ -145,11 +145,7 @@ export async function loadSDKSessionMessages(
 
   // Merge consecutive assistant messages until an actual user message appears
   for (const sdkMsg of filteredEntries) {
-    const systemInjected = isSystemInjectedMessage(sdkMsg);
-    if (sdkMsg.type === 'user' && !systemInjected) {
-      taskToolNormalizer.reset();
-    }
-    if (systemInjected) continue;
+    if (isSystemInjectedMessage(sdkMsg)) continue;
 
     // Skip synthetic assistant messages (e.g., "No response requested." after /compact)
     if (sdkMsg.type === 'assistant' && sdkMsg.message?.model === '<synthetic>') continue;

--- a/tests/unit/utils/sdkSession.test.ts
+++ b/tests/unit/utils/sdkSession.test.ts
@@ -1147,6 +1147,34 @@ describe('sdkSession', () => {
       });
     });
 
+    it('preserves Claude task state across compacted history', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockFsPromises.readFile.mockResolvedValue([
+        '{"type":"user","uuid":"u1","timestamp":"2024-01-15T10:00:00Z","message":{"content":"Fix the issue"}}',
+        '{"type":"assistant","uuid":"a1","timestamp":"2024-01-15T10:01:00Z","message":{"content":[{"type":"tool_use","id":"create-1","name":"TaskCreate","input":{"subject":"Inspect issue","activeForm":"Inspecting issue"}}]}}',
+        '{"type":"user","uuid":"r1","timestamp":"2024-01-15T10:02:00Z","toolUseResult":{"task":{"id":"1","subject":"Inspect issue"}},"message":{"content":[{"type":"tool_result","tool_use_id":"create-1","content":"Task #1 created successfully: Inspect issue"}]}}',
+        '{"type":"system","subtype":"compact_boundary","uuid":"c1","timestamp":"2024-01-15T10:03:00Z"}',
+        '{"type":"user","uuid":"summary","timestamp":"2024-01-15T10:03:01Z","isMeta":true,"message":{"content":"This session is being continued from a previous conversation"}}',
+        '{"type":"user","uuid":"u2","timestamp":"2024-01-15T10:04:00Z","message":{"content":"Continue"}}',
+        '{"type":"assistant","uuid":"a2","timestamp":"2024-01-15T10:05:00Z","message":{"content":[{"type":"tool_use","id":"update-1","name":"TaskUpdate","input":{"taskId":"1","status":"completed"}}]}}',
+        '{"type":"user","uuid":"r2","timestamp":"2024-01-15T10:06:00Z","toolUseResult":{"success":true,"taskId":"1","updatedFields":["status"],"statusChange":{"from":"pending","to":"completed"}},"message":{"content":[{"type":"tool_result","tool_use_id":"update-1","content":"Updated task #1 status"}]}}',
+      ].join('\n'));
+
+      const result = await loadSDKSessionMessages('/Users/test/vault', 'session-task-compact');
+      const taskCalls = result.messages
+        .flatMap(message => message.toolCalls ?? [])
+        .filter(toolCall => toolCall.name === 'TodoWrite');
+
+      expect(taskCalls.at(-1)?.input).toEqual({
+        todos: [{
+          id: '1',
+          content: 'Inspect issue',
+          activeForm: 'Inspecting issue',
+          status: 'completed',
+        }],
+      });
+    });
+
     it('hydrates AskUserQuestion answers from result text when toolUseResult has no answers', async () => {
       mockExistsSync.mockReturnValue(true);
       mockFsPromises.readFile.mockResolvedValue([


### PR DESCRIPTION
## Summary

- preserve Claude task normalizer state throughout a filtered native session replay
- keep pre-compaction tasks available to post-compaction updates
- add regression coverage for compacted history followed by a real user continuation

## Testing

- `npm run test:unit -- --runInBand tests/unit/providers/claude/normalization/ClaudeTaskToolNormalizer.test.ts tests/unit/providers/claude/execution/ClaudeExecutionEventNormalizer.test.ts tests/unit/utils/sdkSession.test.ts`
- `npm run typecheck && npm run lint && npm run test && npm run build`

Closes #1032