### PR TITLE
fix: avoid renderer crash during provider initialization

### DIFF
--- a/scripts/check-architecture-boundaries.test.mjs
+++ b/scripts/check-architecture-boundaries.test.mjs
@@ -70,3 +70,8 @@ test('runtime command discovery cannot import shared skill management', () => {
   const pattern = /from\s+['"][^'"]*(?:core\/skills|AgentSkillSettings)/;
   assert.deepEqual(findMatches(roots, pattern), []);
 });
+
+test('renderer source does not import AsyncLocalStorage', () => {
+  const pattern = /import\s*\{[^}]*\bAsyncLocalStorage\b[^}]*\}\s*from\s*['"](?:node:)?async_hooks['"]/s;
+  assert.deepEqual(findMatches([sourceRoot], pattern), []);
+});

--- a/src/app/providers/ClaudianProviderHost.ts
+++ b/src/app/providers/ClaudianProviderHost.ts
@@ -1,3 +1,4 @@
+import type { ProviderExecutionTransitionScope } from '../../core/execution';
 import type { ProviderHost } from '../../core/providers/ProviderHost';
 import type { ProviderCliResolutionContext, ProviderId } from '../../core/providers/types';
 import type { EnvironmentScope } from '../../core/types/settings';
@@ -90,9 +91,17 @@ export class ClaudianProviderHost implements ProviderHost {
 
   runProviderExecutionTransition<T>(
     providerIds: ProviderId[],
-    mutation: () => Promise<T>,
+    mutation: (scope: ProviderExecutionTransitionScope) => Promise<T>,
+    parentScope?: ProviderExecutionTransitionScope,
   ): Promise<T> {
-    return this.plugin.runProviderExecutionTransition(providerIds, mutation);
+    if (!parentScope) {
+      return this.plugin.runProviderExecutionTransition(providerIds, mutation);
+    }
+    return this.plugin.runProviderExecutionTransition(
+      providerIds,
+      mutation,
+      parentScope,
+    );
   }
 
   notifyProviderChatOptionsChanged(providerId: ProviderId): void {

--- a/src/core/execution/ProviderExecutionLifecycleRegistry.ts
+++ b/src/core/execution/ProviderExecutionLifecycleRegistry.ts
@@ -1,5 +1,3 @@
-import { AsyncLocalStorage } from 'node:async_hooks';
-
 import { toError } from '../../utils/error';
 import type { ProviderId } from '../types/provider';
 import type {
@@ -7,6 +5,8 @@ import type {
   ProviderSessionConfig,
 } from './ProviderExecutionBackend';
 import type { ProviderExecutionSession } from './ProviderExecutionSession';
+
+declare const providerExecutionTransitionScopeBrand: unique symbol;
 
 export type ProviderExecutionOwnerKind =
   | 'chat'
@@ -40,6 +40,18 @@ export interface ProviderExecutionSessionLease {
 export interface ProviderExecutionTransitionContext {
   readonly providerId: ProviderId;
   readonly generation: number;
+  readonly scope: ProviderExecutionTransitionScope;
+}
+
+/**
+ * Explicit ownership marker for work running inside a provider transition.
+ *
+ * Renderer code must not use AsyncLocalStorage for this state because Node and
+ * Blink share the same continuation-preserved embedder slot in Electron.
+ */
+export interface ProviderExecutionTransitionScope {
+  readonly [providerExecutionTransitionScopeBrand]: true;
+  readonly providerIds: readonly ProviderId[];
 }
 
 type ProviderExecutionTransitionCallback = (
@@ -80,11 +92,6 @@ interface ProviderLifecycleState {
   readonly leases: Set<ProviderExecutionSessionLeaseImpl>;
   readonly hooks: Set<ProviderExecutionTransitionHook>;
   readonly lock: AsyncLock;
-}
-
-interface ActiveProviderTransition {
-  active: boolean;
-  readonly providerIds: ReadonlySet<ProviderId>;
 }
 
 class AsyncLock {
@@ -198,8 +205,8 @@ class ProviderExecutionSessionLeaseImpl
  */
 export class ProviderExecutionLifecycleRegistry {
   private readonly states = new Map<ProviderId, ProviderLifecycleState>();
-  private readonly activeTransition =
-    new AsyncLocalStorage<ActiveProviderTransition>();
+  private readonly activeTransitionScopes =
+    new WeakSet<ProviderExecutionTransitionScope>();
   private disposed = false;
   private disposePromise: Promise<void> | null = null;
 
@@ -229,40 +236,45 @@ export class ProviderExecutionLifecycleRegistry {
     return this.states.get(providerId)?.generation ?? 0;
   }
 
+  /**
+   * Runs a provider transition with explicit ownership across async boundaries.
+   * Work that can start another transition must forward the received scope as
+   * parentScope so re-entrancy fails before attempting to acquire nested locks.
+   */
   async runTransition<T>(
     providerIds: ProviderId[],
-    mutation: () => Promise<T>,
+    mutation: (scope: ProviderExecutionTransitionScope) => Promise<T>,
+    parentScope?: ProviderExecutionTransitionScope,
   ): Promise<T> {
     this.assertAvailable();
     const orderedProviderIds = [...new Set(providerIds)].sort();
-    const parentTransition = this.activeTransition.getStore();
-    if (parentTransition?.active) {
+    if (parentScope && this.activeTransitionScopes.has(parentScope)) {
       const rejectedProviderId =
         orderedProviderIds[0]
-        ?? [...parentTransition.providerIds].sort()[0];
+        ?? parentScope.providerIds[0];
       if (rejectedProviderId) {
         throw new ProviderExecutionTransitionError(rejectedProviderId);
       }
     }
 
-    const transition: ActiveProviderTransition = {
-      active: true,
-      providerIds: new Set([
-        ...(parentTransition?.active ? parentTransition.providerIds : []),
-        ...orderedProviderIds,
-      ]),
-    };
+    const scope = Object.freeze({
+      providerIds: Object.freeze([...orderedProviderIds]),
+    }) as ProviderExecutionTransitionScope;
+    this.activeTransitionScopes.add(scope);
     try {
-      return await this.activeTransition.run(transition, () =>
-        this.runTransitionWithLocks(orderedProviderIds, mutation),
+      return await this.runTransitionWithLocks(
+        orderedProviderIds,
+        scope,
+        () => mutation(scope),
       );
     } finally {
-      transition.active = false;
+      this.activeTransitionScopes.delete(scope);
     }
   }
 
   private async runTransitionWithLocks<T>(
     orderedProviderIds: ProviderId[],
+    scope: ProviderExecutionTransitionScope,
     mutation: () => Promise<T>,
   ): Promise<T> {
     const states = orderedProviderIds.map((providerId) => ({
@@ -286,6 +298,7 @@ export class ProviderExecutionLifecycleRegistry {
         return {
           providerId,
           generation: state.generation,
+          scope,
         } satisfies ProviderExecutionTransitionContext;
       });
 

--- a/src/core/execution/index.ts
+++ b/src/core/execution/index.ts
@@ -48,6 +48,7 @@ export {
   type ProviderExecutionTransitionContext,
   ProviderExecutionTransitionError,
   type ProviderExecutionTransitionHook,
+  type ProviderExecutionTransitionScope,
 } from './ProviderExecutionLifecycleRegistry';
 export {
   type ProviderCurrentNoteContext,

--- a/src/core/providers/ProviderHost.ts
+++ b/src/core/providers/ProviderHost.ts
@@ -1,7 +1,10 @@
 import type { App } from 'obsidian';
 
 import type { SharedAppStorage } from '../bootstrap/storage';
-import type { ProviderExecutionLifecycleRegistry } from '../execution';
+import type {
+  ProviderExecutionLifecycleRegistry,
+  ProviderExecutionTransitionScope,
+} from '../execution';
 import type { ClaudianSettings } from '../types';
 import type { EnvironmentScope } from '../types/settings';
 import type { ProviderCliResolutionContext, ProviderId } from './types';
@@ -52,7 +55,8 @@ export interface ProviderHost {
   ): Promise<string | null>;
   runProviderExecutionTransition<T>(
     providerIds: ProviderId[],
-    mutation: () => Promise<T>,
+    mutation: (scope: ProviderExecutionTransitionScope) => Promise<T>,
+    parentScope?: ProviderExecutionTransitionScope,
   ): Promise<T>;
 
   notifyProviderChatOptionsChanged(providerId: ProviderId): void;

--- a/src/core/providers/ProviderInitializationBoundary.ts
+++ b/src/core/providers/ProviderInitializationBoundary.ts
@@ -5,6 +5,7 @@
  * initialization promise so concurrent callers cannot repeat work.
  */
 
+import type { ProviderExecutionTransitionScope } from '../execution';
 import type { ProviderHost } from './ProviderHost';
 import type {
   ProviderId,
@@ -64,7 +65,12 @@ export class ProviderInitializationBoundary {
     const generation = this.generation;
     const promise = plugin.runProviderExecutionTransition(
       [providerId],
-      () => this.runInitialize(plugin, providerId, generation),
+      (transitionScope) => this.runInitialize(
+        plugin,
+        providerId,
+        generation,
+        transitionScope,
+      ),
     );
     const attempt: ProviderInitializationAttempt = {
       promise,
@@ -102,6 +108,7 @@ export class ProviderInitializationBoundary {
     plugin: ProviderHost,
     providerId: ProviderId,
     generation: number,
+    transitionScope: ProviderExecutionTransitionScope,
   ): Promise<void> {
     const registration = this.registrations[providerId];
     if (!registration) {
@@ -118,6 +125,7 @@ export class ProviderInitializationBoundary {
       storage,
       vaultAdapter,
       homeAdapter,
+      transitionScope,
     };
 
     const services = await registration.initialize(context);

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -1,6 +1,9 @@
 import type { CursorContext } from '../../utils/editor';
 import type { SharedAppStorage } from '../bootstrap/storage';
-import type { ProviderExecutionBackend } from '../execution';
+import type {
+  ProviderExecutionBackend,
+  ProviderExecutionTransitionScope,
+} from '../execution';
 import type { McpServerManager } from '../mcp/McpServerManager';
 import type { HomeFileAdapter } from '../storage/HomeFileAdapter';
 import type { VaultFileAdapter } from '../storage/VaultFileAdapter';
@@ -460,6 +463,7 @@ export interface ProviderWorkspaceInitContext {
   storage: SharedAppStorage;
   vaultAdapter: VaultFileAdapter;
   homeAdapter: HomeFileAdapter;
+  transitionScope: ProviderExecutionTransitionScope;
 }
 
 export interface ProviderWorkspaceRegistration<

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,10 @@ import {
 import { SharedStorageService } from './app/storage/SharedStorageService';
 import type { SessionMetadataReadResult } from './core/bootstrap/SessionStorage';
 import type { SharedAppStorage } from './core/bootstrap/storage';
-import { ProviderExecutionLifecycleRegistry } from './core/execution';
+import {
+  ProviderExecutionLifecycleRegistry,
+  type ProviderExecutionTransitionScope,
+} from './core/execution';
 import {
   getEnvironmentVariablesForScope as getScopedEnvironmentVariables,
   getRuntimeEnvironmentText,
@@ -1170,9 +1173,14 @@ export default class ClaudianPlugin extends Plugin {
 
   runProviderExecutionTransition<T>(
     providerIds: ProviderId[],
-    mutation: () => Promise<T>,
+    mutation: (scope: ProviderExecutionTransitionScope) => Promise<T>,
+    parentScope?: ProviderExecutionTransitionScope,
   ): Promise<T> {
-    return this.executionLifecycleRegistry.runTransition(providerIds, mutation);
+    return this.executionLifecycleRegistry.runTransition(
+      providerIds,
+      mutation,
+      parentScope,
+    );
   }
 
   private async resetDeletedConversationTabs(id: string): Promise<void> {

--- a/tests/unit/app/providers/ClaudianProviderHost.test.ts
+++ b/tests/unit/app/providers/ClaudianProviderHost.test.ts
@@ -1,4 +1,5 @@
 import { ClaudianProviderHost } from '@/app/providers/ClaudianProviderHost';
+import type { ProviderExecutionTransitionScope } from '@/core/execution';
 import type ClaudianPlugin from '@/main';
 
 function createPlugin(overrides: Record<string, unknown> = {}): ClaudianPlugin {
@@ -86,6 +87,20 @@ describe('ClaudianProviderHost', () => {
     expect(runProviderExecutionTransition).toHaveBeenCalledWith(
       ['opencode', 'claude'],
       mutation,
+    );
+
+    const parentScope = {
+      providerIds: ['claude'],
+    } as unknown as ProviderExecutionTransitionScope;
+    await host.runProviderExecutionTransition(
+      ['codex'],
+      mutation,
+      parentScope,
+    );
+    expect(runProviderExecutionTransition).toHaveBeenLastCalledWith(
+      ['codex'],
+      mutation,
+      parentScope,
     );
   });
 

--- a/tests/unit/core/execution/ProviderExecutionLifecycleRegistry.test.ts
+++ b/tests/unit/core/execution/ProviderExecutionLifecycleRegistry.test.ts
@@ -8,6 +8,7 @@ import {
   type ProviderExecutionSession,
   ProviderExecutionTransitionError,
   type ProviderExecutionTransitionHook,
+  type ProviderExecutionTransitionScope,
   type ProviderSessionConfig,
   type ProviderSessionEvent,
   type ProviderSessionSnapshot,
@@ -387,12 +388,72 @@ describe('ProviderExecutionLifecycleRegistry', () => {
     await registry.dispose();
   });
 
+  it('provides an explicit scope for rejecting nested transitions after async boundaries', async () => {
+    const registry = new ProviderExecutionLifecycleRegistry();
+    const nestedMutation = jest.fn(async () => undefined);
+
+    await registry.runTransition(['pi'], async (scope) => {
+      expect(scope.providerIds).toEqual(['pi']);
+      await Promise.resolve();
+
+      await expect(
+        registry.runTransition(['claude'], nestedMutation, scope),
+      ).rejects.toMatchObject({
+        providerId: 'claude',
+        retryable: true,
+      });
+    });
+
+    expect(nestedMutation).not.toHaveBeenCalled();
+    await registry.dispose();
+  });
+
+  it('provides transition hooks with the active scope', async () => {
+    const registry = new ProviderExecutionLifecycleRegistry();
+    const nestedMutation = jest.fn(async () => undefined);
+
+    registry.registerTransitionHook('claude', {
+      beforeTransition: async (context) => {
+        expect(context.scope.providerIds).toEqual(['claude']);
+        await expect(
+          registry.runTransition(['pi'], nestedMutation, context.scope),
+        ).rejects.toMatchObject({
+          providerId: 'pi',
+          retryable: true,
+        });
+      },
+    });
+
+    await registry.runTransition(['claude'], async () => undefined);
+
+    expect(nestedMutation).not.toHaveBeenCalled();
+    await registry.dispose();
+  });
+
+  it('does not treat a completed transition scope as active ownership', async () => {
+    const registry = new ProviderExecutionLifecycleRegistry();
+    let completedScope!: ProviderExecutionTransitionScope;
+
+    await registry.runTransition(['pi'], async (scope) => {
+      completedScope = scope;
+    });
+
+    await expect(
+      registry.runTransition(
+        ['claude'],
+        async () => 'completed',
+        completedScope,
+      ),
+    ).resolves.toBe('completed');
+    await registry.dispose();
+  });
+
   it('rejects a nested same-provider transition instead of deadlocking', async () => {
     const registry = new ProviderExecutionLifecycleRegistry();
     const nestedMutation = jest.fn(async () => undefined);
 
-    const transition = registry.runTransition(['claude'], async () => {
-      await registry.runTransition(['claude'], nestedMutation);
+    const transition = registry.runTransition(['claude'], async (scope) => {
+      await registry.runTransition(['claude'], nestedMutation, scope);
     });
     const outcome = await Promise.race([
       transition.then(
@@ -426,10 +487,10 @@ describe('ProviderExecutionLifecycleRegistry', () => {
     const nestedMutation = jest.fn(async () => undefined);
     const independentMutation = jest.fn(async () => undefined);
 
-    const outer = registry.runTransition(['pi'], async () => {
+    const outer = registry.runTransition(['pi'], async (scope) => {
       outerMutationStarted.resolve();
       await beginNestedTransition.promise;
-      await registry.runTransition(['claude'], nestedMutation);
+      await registry.runTransition(['claude'], nestedMutation, scope);
     });
     await outerMutationStarted.promise;
 

--- a/tests/unit/core/providers/ProviderWorkspaceRegistry.test.ts
+++ b/tests/unit/core/providers/ProviderWorkspaceRegistry.test.ts
@@ -1,6 +1,9 @@
 import '@/providers';
 
-import { ProviderExecutionLifecycleRegistry } from '@/core/execution';
+import {
+  ProviderExecutionLifecycleRegistry,
+  type ProviderExecutionTransitionScope,
+} from '@/core/execution';
 import type { ProviderHost } from '@/core/providers/ProviderHost';
 import { ProviderWorkspaceRegistry } from '@/core/providers/ProviderWorkspaceRegistry';
 import type { ProviderId } from '@/core/providers/types';
@@ -12,9 +15,14 @@ function createProviderHost(): ProviderHost {
     executionLifecycleRegistry,
     runProviderExecutionTransition: <T>(
       providerIds: ProviderId[],
-      mutation: () => Promise<T>,
+      mutation: (scope: ProviderExecutionTransitionScope) => Promise<T>,
+      parentScope?: ProviderExecutionTransitionScope,
     ) => (
-      executionLifecycleRegistry.runTransition(providerIds, mutation)
+      executionLifecycleRegistry.runTransition(
+        providerIds,
+        mutation,
+        parentScope,
+      )
     ),
     settings: {},
     storage: {
@@ -259,5 +267,45 @@ describe('ProviderWorkspaceRegistry', () => {
 
     expect(events).toEqual(['before', 'initialize', 'after']);
     expect(host.executionLifecycleRegistry.getProviderGeneration('grok')).toBe(1);
+  });
+
+  it('rejects a nested transition started by async provider initialization', async () => {
+    const host = createProviderHost();
+    const nestedMutation = jest.fn(async () => undefined);
+    ProviderWorkspaceRegistry.register('grok', {
+      initialize: jest.fn(async (context) => {
+        await Promise.resolve();
+        await context.plugin.runProviderExecutionTransition(
+          ['grok'],
+          nestedMutation,
+          context.transitionScope,
+        );
+        return { commandCatalog: {} as any };
+      }),
+    });
+
+    const initialization = ProviderWorkspaceRegistry.ensureInitialized(
+      host,
+      'grok',
+      'nested-transition',
+    );
+    const outcome = await Promise.race([
+      initialization.then(
+        () => ({ kind: 'resolved' as const }),
+        (error: unknown) => ({ kind: 'rejected' as const, error }),
+      ),
+      new Promise<{ kind: 'timeout' }>((resolve) => {
+        setTimeout(() => resolve({ kind: 'timeout' }), 100);
+      }),
+    ]);
+
+    expect(outcome).toMatchObject({
+      kind: 'rejected',
+      error: {
+        providerId: 'grok',
+        retryable: true,
+      },
+    });
+    expect(nestedMutation).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Why

Closes #1025 by removing Claudian's renderer activation dependency on `AsyncLocalStorage`, which crashes affected Electron 43/Node 24 installations during provider initialization.

## What Changed

Replaced ambient transition state with explicit immutable scopes, propagated scope ownership through lifecycle hooks, provider hosts, and workspace initialization, and added regression plus architecture coverage.

## Why This Approach

Explicit scopes avoid the conflicting renderer-native async-context slot while preserving top-level serialization, generation fencing, lease quiescence, and prompt rejection of nested transitions across async boundaries.

## Validation

Passed `npm run typecheck && npm run lint && npm run test && npm run build` with 340 suites and 6,295 tests, plus a clean second fresh-context adversarial review.

## Impact and Follow-ups

No data migration is required; an affected Electron 43 reporter should smoke-test tab activation and a Claude conversation after installation.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] User-facing documentation is not needed for this internal runtime fix.
