### PR TITLE
Fix Codex memory citation rendering

### DIFF
--- a/src/core/execution/ProviderExecutionEvent.ts
+++ b/src/core/execution/ProviderExecutionEvent.ts
@@ -1,4 +1,5 @@
 import type {
+  CitationGroup,
   SDKToolUseResult,
   ToolProviderPayload,
   UsageInfo,
@@ -107,6 +108,13 @@ export type ProviderThinkingDeltaEvent = ProviderEventBase<
   ProviderOpaqueEventPayload & {
     readonly text: string;
   };
+
+export type ProviderCitationsEvent = ProviderEventBase<
+  'citations',
+  ProviderTurnEventScope
+> & {
+  readonly citations: CitationGroup;
+};
 
 interface ProviderToolIdentity {
   readonly toolCallId: string;
@@ -237,6 +245,7 @@ export type ProviderRequestedExecutionEvent =
   | (ProviderAssistantMessageStartedEvent & { readonly scope: ProviderRequestedEventScope })
   | (ProviderTextDeltaEvent & { readonly scope: ProviderRequestedEventScope })
   | (ProviderThinkingDeltaEvent & { readonly scope: ProviderRequestedEventScope })
+  | (ProviderCitationsEvent & { readonly scope: ProviderRequestedEventScope })
   | (ProviderToolStartedEvent & { readonly scope: ProviderRequestedEventScope })
   | (ProviderToolOutputEvent & { readonly scope: ProviderRequestedEventScope })
   | (ProviderToolCompletedEvent & { readonly scope: ProviderRequestedEventScope })
@@ -299,6 +308,7 @@ export type ProviderBackgroundOutputEvent =
   | (ProviderAssistantMessageStartedEvent & { readonly scope: ProviderBackgroundEventScope })
   | (ProviderTextDeltaEvent & { readonly scope: ProviderBackgroundEventScope })
   | (ProviderThinkingDeltaEvent & { readonly scope: ProviderBackgroundEventScope })
+  | (ProviderCitationsEvent & { readonly scope: ProviderBackgroundEventScope })
   | (ProviderToolStartedEvent & { readonly scope: ProviderBackgroundEventScope })
   | (ProviderToolOutputEvent & { readonly scope: ProviderBackgroundEventScope })
   | (ProviderToolCompletedEvent & { readonly scope: ProviderBackgroundEventScope })

--- a/src/core/execution/index.ts
+++ b/src/core/execution/index.ts
@@ -13,6 +13,7 @@ export {
   type ProviderBackgroundTurnCompletedEvent,
   type ProviderBackgroundTurnStartedEvent,
   type ProviderCancelledEvent,
+  type ProviderCitationsEvent,
   type ProviderContextCompactedEvent,
   type ProviderExecutionErrorCategory,
   type ProviderExecutionErrorEvent,

--- a/src/core/types/chat.ts
+++ b/src/core/types/chat.ts
@@ -75,12 +75,25 @@ export interface ExecutionInputSnapshot {
   context?: ExecutionInputContextSnapshot;
 }
 
+export interface CitationEntry {
+  path: string;
+  lineStart: number;
+  lineEnd: number;
+  note: string;
+}
+
+export interface CitationGroup {
+  kind: 'memory';
+  entries: CitationEntry[];
+}
+
 /** Content block for preserving streaming order in messages. */
 export type ContentBlock =
   | { type: 'text'; content: string }
   | { type: 'tool_use'; toolId: string }
   | { type: 'thinking'; content: string; durationSeconds?: number }
   | { type: 'subagent'; subagentId: string; mode?: SubagentMode }
+  | { type: 'citations'; citations: CitationGroup }
   | { type: 'context_compacted' };
 
 /** Chat message with content, tool calls, and attachments. */
@@ -199,6 +212,7 @@ export type StreamChunk =
   | { type: 'assistant_message_start'; itemId?: string }
   | { type: 'text'; content: string }
   | { type: 'thinking'; content: string }
+  | { type: 'citations'; citations: CitationGroup }
   | {
       type: 'tool_use';
       id: string;

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -1,6 +1,8 @@
 // Chat types
 export {
   type ChatMessage,
+  type CitationEntry,
+  type CitationGroup,
   type ContentBlock,
   type Conversation,
   type ConversationMeta,

--- a/src/features/chat/controllers/StreamController.ts
+++ b/src/features/chat/controllers/StreamController.ts
@@ -209,6 +209,20 @@ export class StreamController {
         await this.appendText(chunk.content);
         break;
 
+      case 'citations': {
+        this.flushPendingTools();
+        if (state.currentThinkingState) {
+          await this.finalizeCurrentThinkingBlock(msg);
+        }
+        await this.finalizeCurrentTextBlock(msg);
+        msg.contentBlocks = msg.contentBlocks || [];
+        msg.contentBlocks.push({ type: 'citations', citations: chunk.citations });
+        if (state.currentContentEl) {
+          this.deps.renderer.renderCitationGroup(state.currentContentEl, chunk.citations);
+        }
+        break;
+      }
+
       case 'tool_use': {
         if (state.currentThinkingState) {
           await this.finalizeCurrentThinkingBlock(msg);
@@ -1969,6 +1983,8 @@ export function providerOutputEventToStreamChunk(
       return { content: event.text, type: 'text' };
     case 'thinking_delta':
       return { content: event.text, type: 'thinking' };
+    case 'citations':
+      return { citations: event.citations, type: 'citations' };
     case 'tool_started':
       return event.toolScope.kind === 'subagent'
         ? {

--- a/src/features/chat/rendering/CitationRenderer.ts
+++ b/src/features/chat/rendering/CitationRenderer.ts
@@ -1,0 +1,46 @@
+import type { CitationGroup } from '../../../core/types';
+import { setupCollapsible } from './collapsible';
+
+function formatCitationLocation(
+  entry: CitationGroup['entries'][number],
+): string {
+  const lineRange = entry.lineStart === entry.lineEnd
+    ? `${entry.lineStart}`
+    : `${entry.lineStart}\u2013${entry.lineEnd}`;
+  return `${entry.path}:${lineRange}`;
+}
+
+export function renderCitationGroup(
+  parentEl: HTMLElement,
+  citations: CitationGroup,
+): HTMLElement {
+  const wrapperEl = parentEl.createDiv({ cls: 'claudian-citations' });
+  const headerEl = wrapperEl.createDiv({ cls: 'claudian-citations-header' });
+  headerEl.setAttribute('tabindex', '0');
+  headerEl.setAttribute('role', 'button');
+
+  headerEl.createSpan({ cls: 'claudian-citations-chevron', text: '\u203a' });
+  headerEl.createSpan({ cls: 'claudian-citations-label', text: 'Memory used' });
+  headerEl.createSpan({
+    cls: 'claudian-citations-count',
+    text: `${citations.entries.length} ${citations.entries.length === 1 ? 'source' : 'sources'}`,
+  });
+
+  const contentEl = wrapperEl.createDiv({ cls: 'claudian-citations-content' });
+  for (const entry of citations.entries) {
+    const entryEl = contentEl.createDiv({ cls: 'claudian-citation-entry' });
+    entryEl.createDiv({
+      cls: 'claudian-citation-location',
+      text: formatCitationLocation(entry),
+    });
+    if (entry.note) {
+      entryEl.createDiv({ cls: 'claudian-citation-note', text: entry.note });
+    }
+  }
+
+  setupCollapsible(wrapperEl, headerEl, contentEl, { isExpanded: false }, {
+    baseAriaLabel: `Memory used, ${citations.entries.length} ${citations.entries.length === 1 ? 'source' : 'sources'}`,
+  });
+
+  return wrapperEl;
+}

--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -13,7 +13,13 @@ import {
   TOOL_WRITE_STDIN,
 } from '../../../core/tools/toolNames';
 import { extractToolResultContent } from '../../../core/tools/toolResultContent';
-import type { ChatMessage, ImageAttachment, SubagentInfo, ToolCallInfo } from '../../../core/types';
+import type {
+  ChatMessage,
+  CitationGroup,
+  ImageAttachment,
+  SubagentInfo,
+  ToolCallInfo,
+} from '../../../core/types';
 import { t } from '../../../i18n/i18n';
 import { extractUserDisplayContent } from '../../../utils/context';
 import { formatDurationMmSs } from '../../../utils/date';
@@ -28,6 +34,7 @@ import {
 import type { FeatureHost } from '../../FeatureHost';
 import { findRewindContext } from '../rewind';
 import { formatConversationDirectoryTitle } from '../utils/conversationDirectoryTitle';
+import { renderCitationGroup as renderCitationBlock } from './CitationRenderer';
 import { resolveSubagentAdapter } from './subagentAdapterResolution';
 import {
   renderStoredAsyncSubagent,
@@ -320,6 +327,7 @@ export class MessageRenderer {
       for (const block of msg.contentBlocks) {
         if (block.type === 'thinking' && block.content.trim().length > 0) return true;
         if (block.type === 'text' && block.content.trim().length > 0) return true;
+        if (block.type === 'citations' && block.citations.entries.length > 0) return true;
         if (block.type === 'context_compacted') return true;
         if (block.type === 'subagent') return true;
         if (block.type === 'tool_use') {
@@ -386,6 +394,8 @@ export class MessageRenderer {
           const textEl = contentEl.createDiv({ cls: 'claudian-text-block' });
           void this.renderContent(textEl, normalized.content);
           this.addTextCopyButton(textEl, normalized.content);
+        } else if (block.type === 'citations') {
+          this.renderCitationGroup(contentEl, block.citations);
         } else if (block.type === 'tool_use') {
           const toolCall = msg.toolCalls?.find(tc => tc.id === block.toolId);
           if (toolCall) {
@@ -447,6 +457,10 @@ export class MessageRenderer {
     }
 
     return hadLegacyInterruptIndicator;
+  }
+
+  renderCitationGroup(parentEl: HTMLElement, citations: CitationGroup): HTMLElement {
+    return renderCitationBlock(parentEl, citations);
   }
 
   /**

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -2247,6 +2247,7 @@ function isVisibleAutoTurnChunk(chunk: StreamChunk, hiddenToolIds: Set<string>):
     case 'text':
       return chunk.content.trim().length > 0;
     case 'thinking':
+    case 'citations':
     case 'notice':
     case 'error':
     case 'tool_output':

--- a/src/providers/claude/execution/ClaudeExecutionEventNormalizer.ts
+++ b/src/providers/claude/execution/ClaudeExecutionEventNormalizer.ts
@@ -2,6 +2,7 @@ import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 
 import type {
   ProviderAssistantMessageStartedEvent,
+  ProviderCitationsEvent,
   ProviderContextCompactedEvent,
   ProviderNoticeEvent,
   ProviderTextDeltaEvent,
@@ -38,6 +39,7 @@ export type ClaudeNormalizedOutputEvent = WithoutScope<
   | ProviderAssistantMessageStartedEvent
   | ProviderTextDeltaEvent
   | ProviderThinkingDeltaEvent
+  | ProviderCitationsEvent
   | ProviderToolStartedEvent
   | ProviderToolOutputEvent
   | ProviderToolCompletedEvent
@@ -319,6 +321,11 @@ function toOutputEvent(
         type: 'thinking_delta',
         text: chunk.content,
       };
+    case 'citations':
+      return {
+        type: 'citations',
+        citations: chunk.citations,
+      };
     case 'tool_use':
     case 'subagent_tool_use':
       return normalizeToolStarted(chunk, state);
@@ -414,6 +421,7 @@ function isAssistantOutputChunk(chunk: StreamChunk): boolean {
   return (
     chunk.type === 'text'
     || chunk.type === 'thinking'
+    || chunk.type === 'citations'
     || chunk.type === 'tool_use'
     || chunk.type === 'subagent_tool_use'
   );

--- a/src/providers/codex/execution/CodexExecutionEventAdapter.ts
+++ b/src/providers/codex/execution/CodexExecutionEventAdapter.ts
@@ -26,6 +26,8 @@ export function adaptCodexStreamChunk(
       return { type: 'text_delta', scope, text: chunk.content };
     case 'thinking':
       return { type: 'thinking_delta', scope, text: chunk.content };
+    case 'citations':
+      return { type: 'citations', scope, citations: chunk.citations };
     case 'tool_use':
       return {
         type: 'tool_started',

--- a/src/providers/codex/history/CodexHistoryStore.ts
+++ b/src/providers/codex/history/CodexHistoryStore.ts
@@ -4,7 +4,13 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-import type { ChatMessage, ContentBlock, ImageAttachment, ToolCallInfo } from '../../../core/types';
+import type {
+  ChatMessage,
+  CitationGroup,
+  ContentBlock,
+  ImageAttachment,
+  ToolCallInfo,
+} from '../../../core/types';
 import { extractUserDisplayContent } from '../../../utils/context';
 import {
   buildImageAttachmentFromBase64,
@@ -14,6 +20,10 @@ import {
   extractCodexUserVisibleText,
   joinCodexUserTextParts,
 } from '../codexUserText';
+import {
+  normalizeCodexMemoryCitation,
+  stripCodexMemoryCitationMarkup,
+} from '../normalization/CodexMemoryCitation';
 import {
   appendCodexCommandOutput,
   decodeCodexExecEnvelope,
@@ -117,6 +127,8 @@ interface PersistedEventPayload {
   type?: string;
   text?: string;
   message?: string;
+  memory_citation?: unknown;
+  memoryCitation?: unknown;
 }
 
 interface PersistedCompactionPayload {
@@ -296,6 +308,51 @@ function appendOrderedTextChunk(
 
   chunks.push(trimmed);
   bubble.contentBlocks.push({ type, content: trimmed });
+}
+
+function appendCitationBlock(bubble: CodexAssistantBubble, value: unknown): void {
+  const citations = normalizeCodexMemoryCitation(value);
+  if (!citations) return;
+
+  const lastBlock = bubble.contentBlocks[bubble.contentBlocks.length - 1];
+  if (
+    lastBlock?.type === 'citations'
+    && areCitationGroupsEqual(lastBlock.citations, citations)
+  ) {
+    return;
+  }
+  bubble.contentBlocks.push({ type: 'citations', citations });
+}
+
+function areCitationGroupsEqual(left: CitationGroup, right: CitationGroup): boolean {
+  return left.kind === right.kind
+    && left.entries.length === right.entries.length
+    && left.entries.every((entry, index) => {
+      const other = right.entries[index];
+      return entry.path === other.path
+        && entry.lineStart === other.lineStart
+        && entry.lineEnd === other.lineEnd
+        && entry.note === other.note;
+    });
+}
+
+function appendPersistedAssistantText(
+  bubble: CodexAssistantBubble,
+  value: string,
+): void {
+  const trimmed = value.trim();
+  if (!trimmed) return;
+
+  const lastBlock = bubble.contentBlocks[bubble.contentBlocks.length - 1];
+  const previousBlock = bubble.contentBlocks[bubble.contentBlocks.length - 2];
+  if (
+    lastBlock?.type === 'citations'
+    && previousBlock?.type === 'text'
+    && previousBlock.content.trim() === trimmed
+  ) {
+    return;
+  }
+  appendOrderedTextChunk(bubble, 'text', trimmed);
 }
 
 function replaceLatestOrderedTextChunk(
@@ -568,8 +625,9 @@ function processLegacyItem(
     case 'agent_message':
       if (eventType === 'item.completed' || eventType === 'item.updated') {
         if (item.text) {
-          turn.assistantText = item.text;
-          setTextBlock(turn, item.text);
+          const visibleText = stripCodexMemoryCitationMarkup(item.text);
+          turn.assistantText = visibleText;
+          setTextBlock(turn, visibleText);
         }
       }
       break;
@@ -1119,11 +1177,13 @@ function processPersistedPayload(
         }
         appendUserImages(turn, messagePayload.content, timestamp);
       } else if (messagePayload.role === 'assistant') {
-        const text = extractMessageText(messagePayload.content);
+        const text = stripCodexMemoryCitationMarkup(
+          extractMessageText(messagePayload.content),
+        );
         const turn = ensureTurn(ctx.turns, ctx.turnOrder, nextTurnId(ctx), ctx.currentTurnId, timestamp);
         const bubble = ensureAssistantBubble(turn, timestamp);
         if (text) {
-          appendOrderedTextChunk(bubble, 'text', text);
+          appendPersistedAssistantText(bubble, text);
         }
       }
       break;
@@ -1239,8 +1299,15 @@ function processEventMsg(
       const bubble = ensureAssistantBubble(turn, timestamp);
       const msg = payload.message;
       if (typeof msg === 'string') {
-        appendOrderedTextChunk(bubble, 'text', msg);
+        appendPersistedAssistantText(
+          bubble,
+          stripCodexMemoryCitationMarkup(msg),
+        );
       }
+      appendCitationBlock(
+        bubble,
+        payload.memory_citation ?? payload.memoryCitation,
+      );
       break;
     }
 
@@ -1316,9 +1383,10 @@ function flushBubbleTurnMessages(
     const hasContent = contentText.trim().length > 0;
     const hasThinking = thinkingText.trim().length > 0;
     const hasToolCalls = bubble.toolCalls.length > 0;
+    const hasCitations = bubble.contentBlocks.some(block => block.type === 'citations');
     const hasCompactBoundary = bubble.contentBlocks.some(b => b.type === 'context_compacted');
 
-    if (!hasContent && !hasThinking && !hasToolCalls && !hasCompactBoundary) {
+    if (!hasContent && !hasThinking && !hasToolCalls && !hasCitations && !hasCompactBoundary) {
       if (bubble.interrupted) {
         messages.push({
           id: `codex-msg-${msgIndex}`,
@@ -1781,7 +1849,11 @@ function processLegacyItemInModernContext(
       if ((eventType === 'item.updated' || eventType === 'item.completed') && item.text) {
         const turn = ensureTurn(ctx.turns, ctx.turnOrder, nextTurnId(ctx), ctx.currentTurnId, timestamp);
         const bubble = ensureAssistantBubble(turn, timestamp);
-        replaceLatestOrderedTextChunk(bubble, 'text', item.text);
+        replaceLatestOrderedTextChunk(
+          bubble,
+          'text',
+          stripCodexMemoryCitationMarkup(item.text),
+        );
       }
       break;
     }

--- a/src/providers/codex/normalization/CodexMemoryCitation.ts
+++ b/src/providers/codex/normalization/CodexMemoryCitation.ts
@@ -1,0 +1,75 @@
+import type { CitationEntry, CitationGroup } from '../../../core/types';
+
+const MEMORY_CITATION_OPEN = '<oai-mem-citation>';
+const MEMORY_CITATION_CLOSE = '</oai-mem-citation>';
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function readLineNumber(...values: unknown[]): number | null {
+  for (const value of values) {
+    if (typeof value === 'number' && Number.isInteger(value) && value >= 0) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function normalizeEntry(value: unknown): CitationEntry | null {
+  const entry = asRecord(value);
+  if (!entry || typeof entry.path !== 'string' || typeof entry.note !== 'string') {
+    return null;
+  }
+
+  const path = entry.path.trim();
+  const lineStart = readLineNumber(entry.lineStart, entry.line_start);
+  const lineEnd = readLineNumber(entry.lineEnd, entry.line_end);
+  if (!path || lineStart === null || lineEnd === null || lineEnd < lineStart) {
+    return null;
+  }
+
+  return {
+    path,
+    lineStart,
+    lineEnd,
+    note: entry.note.trim(),
+  };
+}
+
+export function normalizeCodexMemoryCitation(value: unknown): CitationGroup | null {
+  const citation = asRecord(value);
+  if (!citation || !Array.isArray(citation.entries)) {
+    return null;
+  }
+
+  const entries = citation.entries
+    .map(normalizeEntry)
+    .filter((entry): entry is CitationEntry => entry !== null);
+  return entries.length > 0 ? { kind: 'memory', entries } : null;
+}
+
+export function stripCodexMemoryCitationMarkup(text: string): string {
+  let cursor = 0;
+  let visibleText = '';
+
+  while (cursor < text.length) {
+    const openIndex = text.indexOf(MEMORY_CITATION_OPEN, cursor);
+    if (openIndex < 0) {
+      visibleText += text.slice(cursor);
+      break;
+    }
+
+    visibleText += text.slice(cursor, openIndex);
+    const bodyStart = openIndex + MEMORY_CITATION_OPEN.length;
+    const closeIndex = text.indexOf(MEMORY_CITATION_CLOSE, bodyStart);
+    if (closeIndex < 0) {
+      break;
+    }
+    cursor = closeIndex + MEMORY_CITATION_CLOSE.length;
+  }
+
+  return visibleText;
+}

--- a/src/providers/codex/runtime/CodexNotificationRouter.ts
+++ b/src/providers/codex/runtime/CodexNotificationRouter.ts
@@ -1,5 +1,9 @@
-import type { StreamChunk, UsageInfo } from '../../../core/types';
+import type { CitationGroup, StreamChunk, UsageInfo } from '../../../core/types';
 import { extractCodexUserVisibleText, joinCodexUserTextParts } from '../codexUserText';
+import {
+  normalizeCodexMemoryCitation,
+  stripCodexMemoryCitationMarkup,
+} from '../normalization/CodexMemoryCitation';
 import {
   appendCodexCommandOutput,
   extractCodexExecCellId,
@@ -69,6 +73,8 @@ export class CodexNotificationRouter {
   private startedUserMessageIds = new Set<string>();
   private startedAgentMessageIds = new Set<string>();
   private agentMessageDeltaIds = new Set<string>();
+  private emittedMemoryCitationIds = new Set<string>();
+  private emittedMemoryCitationKeys = new Set<string>();
   private streamedAssistantTurnText = '';
   private currentAssistantSegmentId: string | undefined;
   private currentAssistantSegmentText = '';
@@ -140,6 +146,8 @@ export class CodexNotificationRouter {
     this.startedUserMessageIds.clear();
     this.startedAgentMessageIds.clear();
     this.agentMessageDeltaIds.clear();
+    this.emittedMemoryCitationIds.clear();
+    this.emittedMemoryCitationKeys.clear();
     this.resetAssistantTextTracking();
     this.rawStartedCallIds.clear();
     this.rawToolNamesByCallId.clear();
@@ -160,6 +168,8 @@ export class CodexNotificationRouter {
     this.startedUserMessageIds.clear();
     this.startedAgentMessageIds.clear();
     this.agentMessageDeltaIds.clear();
+    this.emittedMemoryCitationIds.clear();
+    this.emittedMemoryCitationKeys.clear();
     this.resetAssistantTextTracking();
     this.rawStartedCallIds.clear();
     this.rawToolNamesByCallId.clear();
@@ -396,8 +406,13 @@ export class CodexNotificationRouter {
       return;
     }
 
-    const text = firstString(payload.text, payload.message);
+    const text = stripCodexMemoryCitationMarkup(
+      firstString(payload.text, payload.message),
+    );
     this.emitMissingAssistantTurnText(text);
+    this.emitMemoryCitation(
+      payload.memory_citation ?? payload.memoryCitation,
+    );
   }
 
   private handleRawFunctionCall(item: Record<string, unknown>): void {
@@ -572,9 +587,10 @@ export class CodexNotificationRouter {
   }
 
   private emitMissingRawAgentMessageText(item: Record<string, unknown>): void {
-    const text = item.type === 'message'
+    const rawText = item.type === 'message'
       ? readAssistantMessageText(item)
       : firstString(item.text, item.message);
+    const text = stripCodexMemoryCitationMarkup(rawText);
     this.emitMissingAssistantSegmentText(text);
   }
 
@@ -883,11 +899,33 @@ export class CodexNotificationRouter {
       this.emitAgentMessageBoundary(item);
     }
 
-    if (this.agentMessageDeltaIds.has(item.id) || !item.text) {
+    const visibleText = stripCodexMemoryCitationMarkup(item.text);
+    if (!this.agentMessageDeltaIds.has(item.id) && visibleText) {
+      this.emitMissingAssistantSegmentText(visibleText, item.id);
+    }
+
+    this.emitMemoryCitation(item.memoryCitation, item.id);
+  }
+
+  private emitMemoryCitation(value: unknown, itemId?: string): void {
+    if (itemId && this.emittedMemoryCitationIds.has(itemId)) {
+      return;
+    }
+    const citations = normalizeCodexMemoryCitation(value);
+    if (!citations) {
       return;
     }
 
-    this.emitMissingAssistantSegmentText(item.text, item.id);
+    if (itemId) {
+      this.emittedMemoryCitationIds.add(itemId);
+    }
+    const citationKey = buildMemoryCitationKey(citations);
+    if (this.emittedMemoryCitationKeys.has(citationKey)) {
+      return;
+    }
+
+    this.emittedMemoryCitationKeys.add(citationKey);
+    this.emit({ type: 'citations', citations });
   }
 
   private extractUserMessageText(content: UserInput[]): string {
@@ -982,6 +1020,12 @@ function firstString(...values: unknown[]): string {
     }
   }
   return '';
+}
+
+function buildMemoryCitationKey(citations: CitationGroup): string {
+  return citations.entries
+    .map(entry => [entry.path, entry.lineStart, entry.lineEnd, entry.note].join('\0'))
+    .join('\u0001');
 }
 
 function getItemId(item: { id?: string } | Record<string, unknown>): string | undefined {

--- a/src/providers/codex/runtime/codexAppServerTypes.ts
+++ b/src/providers/codex/runtime/codexAppServerTypes.ts
@@ -124,7 +124,19 @@ export interface AgentMessageItem {
   id: string;
   text: string;
   phase: string;
-  memoryCitation: unknown;
+  memoryCitation: CodexMemoryCitation | null;
+}
+
+export interface CodexMemoryCitation {
+  entries: CodexMemoryCitationEntry[];
+  threadIds: string[];
+}
+
+export interface CodexMemoryCitationEntry {
+  path: string;
+  lineStart: number;
+  lineEnd: number;
+  note: string;
 }
 
 export interface PlanItem {

--- a/src/providers/pi/execution/PiExecutionSession.ts
+++ b/src/providers/pi/execution/PiExecutionSession.ts
@@ -758,6 +758,12 @@ implements ProviderExecutionSession, SteerableExecutionSession {
           type: 'thinking_delta',
         });
         break;
+      case 'citations':
+        this.emitRequested(active, {
+          citations: chunk.citations,
+          type: 'citations',
+        });
+        break;
       case 'tool_use':
       case 'subagent_tool_use':
         this.emitRequested(active, {
@@ -1512,6 +1518,7 @@ function getCompactInstructions(prompt: string): string | null {
 function isAssistantChunk(chunk: StreamChunk): boolean {
   return chunk.type === 'text'
     || chunk.type === 'thinking'
+    || chunk.type === 'citations'
     || chunk.type === 'tool_use'
     || chunk.type === 'subagent_tool_use';
 }

--- a/src/style/accessibility.css
+++ b/src/style/accessibility.css
@@ -3,6 +3,7 @@
 /* outline + offset + border-radius */
 .claudian-tool-header:focus-visible,
 .claudian-thinking-header:focus-visible,
+.claudian-citations-header:focus-visible,
 .claudian-subagent-header:focus-visible,
 .claudian-input-nav-btn:focus-visible,
 .claudian-model-btn:focus-visible,

--- a/src/style/components/citations.css
+++ b/src/style/components/citations.css
@@ -1,0 +1,59 @@
+.claudian-citations {
+  margin: 8px 0;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.claudian-citations-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+  padding: 3px 0;
+  cursor: pointer;
+}
+
+.claudian-citations-chevron {
+  color: var(--text-faint);
+  transition: transform 0.15s ease;
+}
+
+.claudian-citations.expanded .claudian-citations-chevron {
+  transform: rotate(90deg);
+}
+
+.claudian-citations-label {
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.claudian-citations-count {
+  color: var(--text-faint);
+}
+
+.claudian-citations-content {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 4px 0 0 7px;
+  padding: 4px 0 4px 17px;
+  border-inline-start: 2px solid var(--background-modifier-border);
+}
+
+.claudian-citation-location {
+  color: var(--text-muted);
+  font-family: var(--font-monospace);
+  overflow-wrap: anywhere;
+}
+
+.claudian-citation-note {
+  margin-top: 2px;
+  color: var(--text-faint);
+  line-height: 1.4;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .claudian-citations-chevron {
+    transition: none;
+  }
+}

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -13,6 +13,7 @@
 @import "./components/nav-sidebar.css";
 @import "./components/code.css";
 @import "./components/thinking.css";
+@import "./components/citations.css";
 @import "./components/toolcalls.css";
 @import "./components/status-panel.css";
 @import "./components/subagent.css";

--- a/tests/unit/features/chat/controllers/StreamController.test.ts
+++ b/tests/unit/features/chat/controllers/StreamController.test.ts
@@ -13,7 +13,11 @@ import {
   TOOL_WAIT_AGENT,
 } from '@/core/tools/toolNames';
 import type { ChatMessage, ToolCallInfo } from '@/core/types';
-import { StreamController, type StreamControllerDeps } from '@/features/chat/controllers/StreamController';
+import {
+  providerOutputEventToStreamChunk,
+  StreamController,
+  type StreamControllerDeps,
+} from '@/features/chat/controllers/StreamController';
 import { ChatState } from '@/features/chat/state/ChatState';
 
 jest.mock('@/core/tools/todo', () => ({
@@ -140,6 +144,7 @@ function createMockDeps(): MockStreamControllerDeps {
     renderer: {
       renderContent: jest.fn(),
       addTextCopyButton: jest.fn(),
+      renderCitationGroup: jest.fn(),
     } as any,
     subagentManager: {
       isAsyncTask: jest.fn().mockReturnValue(false),
@@ -513,6 +518,79 @@ describe('StreamController - Text Content', () => {
       await controller.handleStreamChunk({ type: 'context_compacted' }, msg);
 
       expect(msg.contentBlocks).toContainEqual({ type: 'context_compacted' });
+    });
+  });
+
+  describe('citation handling', () => {
+    it('maps provider citation events back to stream chunks', () => {
+      const citations = {
+        kind: 'memory' as const,
+        entries: [{
+          path: 'MEMORY.md',
+          lineStart: 10,
+          lineEnd: 12,
+          note: 'Used project conventions',
+        }],
+      };
+
+      expect(providerOutputEventToStreamChunk({
+        type: 'citations',
+        scope: {
+          kind: 'requested',
+          sessionInstanceId: 'session-1',
+          executionId: 'execution-1',
+          turnId: 'turn-1',
+          sequence: 1,
+        },
+        citations,
+      })).toEqual({ type: 'citations', citations });
+    });
+
+    it('finalizes text and records a rendered citation block', async () => {
+      const msg = createTestMessage();
+      deps.state.currentContentEl = createMockEl();
+
+      await controller.handleStreamChunk({ type: 'text', content: 'Answer' }, msg);
+      await controller.handleStreamChunk({
+        type: 'citations',
+        citations: {
+          kind: 'memory',
+          entries: [{
+            path: 'MEMORY.md',
+            lineStart: 10,
+            lineEnd: 12,
+            note: 'Used project conventions',
+          }],
+        },
+      }, msg);
+
+      expect(msg.contentBlocks).toEqual([
+        { type: 'text', content: 'Answer' },
+        {
+          type: 'citations',
+          citations: {
+            kind: 'memory',
+            entries: [{
+              path: 'MEMORY.md',
+              lineStart: 10,
+              lineEnd: 12,
+              note: 'Used project conventions',
+            }],
+          },
+        },
+      ]);
+      expect(deps.renderer.renderCitationGroup).toHaveBeenCalledWith(
+        deps.state.currentContentEl,
+        {
+          kind: 'memory',
+          entries: [{
+            path: 'MEMORY.md',
+            lineStart: 10,
+            lineEnd: 12,
+            note: 'Used project conventions',
+          }],
+        },
+      );
     });
   });
 

--- a/tests/unit/features/chat/rendering/CitationRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/CitationRenderer.test.ts
@@ -1,0 +1,67 @@
+import { createMockEl } from '@test/helpers/MockElement';
+
+import { renderCitationGroup } from '@/features/chat/rendering/CitationRenderer';
+
+describe('CitationRenderer', () => {
+  it('renders memory citations as a collapsed accessible disclosure', () => {
+    const parentEl = createMockEl();
+
+    const wrapperEl = renderCitationGroup(parentEl, {
+      kind: 'memory',
+      entries: [
+        {
+          path: 'MEMORY.md',
+          lineStart: 10,
+          lineEnd: 12,
+          note: 'Used project conventions',
+        },
+        {
+          path: 'rollout_summaries/session.md',
+          lineStart: 4,
+          lineEnd: 4,
+          note: 'Confirmed the command',
+        },
+      ],
+    });
+
+    const headerEl = wrapperEl.querySelector('.claudian-citations-header');
+    const contentEl = wrapperEl.querySelector('.claudian-citations-content');
+
+    expect(headerEl?.getAttribute('role')).toBe('button');
+    expect(headerEl?.getAttribute('tabindex')).toBe('0');
+    expect(headerEl?.getAttribute('aria-expanded')).toBe('false');
+    expect(headerEl?.children[1].textContent).toBe('Memory used');
+    expect(headerEl?.children[2].textContent).toBe('2 sources');
+    expect(contentEl?.hasClass('claudian-hidden')).toBe(true);
+
+    (headerEl as HTMLElement | null)?.click();
+
+    expect(headerEl?.getAttribute('aria-expanded')).toBe('true');
+    expect(contentEl?.hasClass('claudian-hidden')).toBe(false);
+    expect(contentEl?.children[0].children[0].textContent).toBe('MEMORY.md:10–12');
+    expect(contentEl?.children[0].children[1].textContent).toBe('Used project conventions');
+  });
+
+  it('escapes citation values by rendering them as text', () => {
+    const parentEl = createMockEl();
+
+    const wrapperEl = renderCitationGroup(parentEl, {
+      kind: 'memory',
+      entries: [{
+        path: '<img src=x onerror=alert(1)>',
+        lineStart: 1,
+        lineEnd: 1,
+        note: '<script>alert(1)</script>',
+      }],
+    });
+    const contentEl = wrapperEl.querySelector('.claudian-citations-content');
+
+    expect(contentEl?.children[0].children[0].textContent).toBe(
+      '<img src=x onerror=alert(1)>:1',
+    );
+    expect(contentEl?.children[0].children[1].textContent).toBe(
+      '<script>alert(1)</script>',
+    );
+    expect(contentEl?.children[0].children).toHaveLength(2);
+  });
+});

--- a/tests/unit/features/chat/rendering/MessageRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/MessageRenderer.test.ts
@@ -12,6 +12,7 @@ import {
   TOOL_WRITE_STDIN,
 } from '@/core/tools/toolNames';
 import type { ChatMessage, ImageAttachment } from '@/core/types';
+import { renderCitationGroup } from '@/features/chat/rendering/CitationRenderer';
 import { MessageRenderer } from '@/features/chat/rendering/MessageRenderer';
 import { renderStoredAsyncSubagent, renderStoredSubagent } from '@/features/chat/rendering/SubagentRenderer';
 import { renderStoredThinkingBlock } from '@/features/chat/rendering/ThinkingBlockRenderer';
@@ -24,6 +25,9 @@ jest.mock('@/features/chat/rendering/SubagentRenderer', () => ({
 }));
 jest.mock('@/features/chat/rendering/ThinkingBlockRenderer', () => ({
   renderStoredThinkingBlock: jest.fn(),
+}));
+jest.mock('@/features/chat/rendering/CitationRenderer', () => ({
+  renderCitationGroup: jest.fn(),
 }));
 jest.mock('@/features/chat/rendering/ToolCallRenderer', () => ({
   renderStoredToolCall: jest.fn(),
@@ -186,6 +190,33 @@ describe('MessageRenderer', () => {
     const interruptedEl = lastChild.children[0];
     expect(interruptedEl.hasClass('claudian-interrupted')).toBe(true);
     expect(interruptedEl.textContent).toBe('Interrupted');
+  });
+
+  it('renders persisted citation content blocks', () => {
+    const messagesEl = createMockEl();
+    const { renderer } = createRenderer(messagesEl, 'codex');
+    const citations = {
+      kind: 'memory' as const,
+      entries: [{
+        path: 'MEMORY.md',
+        lineStart: 10,
+        lineEnd: 12,
+        note: 'Used project conventions',
+      }],
+    };
+
+    renderer.renderStoredMessage({
+      id: 'assistant-citations',
+      role: 'assistant',
+      content: 'Answer',
+      timestamp: Date.now(),
+      contentBlocks: [
+        { type: 'text', content: 'Answer' },
+        { type: 'citations', citations },
+      ],
+    });
+
+    expect(renderCitationGroup).toHaveBeenCalledWith(expect.anything(), citations);
   });
 
   it('upgrades a persisted legacy interruption marker to the typed indicator', async () => {

--- a/tests/unit/providers/codex/execution/CodexExecutionEventAdapter.test.ts
+++ b/tests/unit/providers/codex/execution/CodexExecutionEventAdapter.test.ts
@@ -1,0 +1,29 @@
+import type { ProviderRequestedEventScope } from '@/core/execution';
+import { adaptCodexStreamChunk } from '@/providers/codex/execution/CodexExecutionEventAdapter';
+
+describe('CodexExecutionEventAdapter', () => {
+  it('adapts citation chunks without provider-owned tracking IDs', () => {
+    const scope: ProviderRequestedEventScope = {
+      kind: 'requested',
+      sessionInstanceId: 'session-1',
+      executionId: 'execution-1',
+      turnId: 'turn-1',
+      sequence: 1,
+    };
+    const citations = {
+      kind: 'memory' as const,
+      entries: [{
+        path: 'MEMORY.md',
+        lineStart: 10,
+        lineEnd: 12,
+        note: 'Used project conventions',
+      }],
+    };
+
+    expect(adaptCodexStreamChunk({ type: 'citations', citations }, scope)).toEqual({
+      type: 'citations',
+      scope,
+      citations,
+    });
+  });
+});

--- a/tests/unit/providers/codex/history/CodexHistoryStore.test.ts
+++ b/tests/unit/providers/codex/history/CodexHistoryStore.test.ts
@@ -219,6 +219,78 @@ describe('CodexHistoryStore', () => {
       ]);
     });
 
+    it('replays memory citations without exposing raw markup or duplicating assistant text', () => {
+      const citationMarkup = [
+        '<oai-mem-citation>',
+        '<citation_entries>',
+        'MEMORY.md:10-12|note=[Used project conventions]',
+        '</citation_entries>',
+        '<rollout_ids>',
+        'thread-1',
+        '</rollout_ids>',
+        '</oai-mem-citation>',
+      ].join('\n');
+      const content = [
+        JSON.stringify({
+          timestamp: '2026-07-29T00:00:00.000Z',
+          type: 'event_msg',
+          payload: { type: 'task_started' },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-29T00:00:01.000Z',
+          type: 'event_msg',
+          payload: {
+            type: 'agent_message',
+            message: 'Answer',
+            memory_citation: {
+              entries: [{
+                path: 'MEMORY.md',
+                lineStart: 10,
+                lineEnd: 12,
+                note: 'Used project conventions',
+              }],
+              rolloutIds: ['thread-1'],
+            },
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-29T00:00:01.001Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: `Answer\n${citationMarkup}` }],
+          },
+        }),
+        JSON.stringify({
+          timestamp: '2026-07-29T00:00:02.000Z',
+          type: 'event_msg',
+          payload: { type: 'task_complete' },
+        }),
+      ].join('\n');
+
+      const messages = parseCodexSessionContent(content);
+      const assistantMessage = messages.find(message => message.role === 'assistant');
+
+      expect(assistantMessage?.content).toBe('Answer');
+      expect(assistantMessage?.content).not.toContain('oai-mem-citation');
+      expect(assistantMessage?.contentBlocks).toEqual([
+        { type: 'text', content: 'Answer' },
+        {
+          type: 'citations',
+          citations: {
+            kind: 'memory',
+            entries: [{
+              path: 'MEMORY.md',
+              lineStart: 10,
+              lineEnd: 12,
+              note: 'Used project conventions',
+            }],
+          },
+        },
+      ]);
+    });
+
     it('rehydrates user images from persisted input_image parts', () => {
       const content = [
         JSON.stringify({

--- a/tests/unit/providers/codex/normalization/CodexMemoryCitation.test.ts
+++ b/tests/unit/providers/codex/normalization/CodexMemoryCitation.test.ts
@@ -1,0 +1,71 @@
+import {
+  normalizeCodexMemoryCitation,
+  stripCodexMemoryCitationMarkup,
+} from '@/providers/codex/normalization/CodexMemoryCitation';
+
+describe('CodexMemoryCitation', () => {
+  describe('stripCodexMemoryCitationMarkup', () => {
+    it('strips complete and unterminated citation blocks while preserving visible text', () => {
+      expect(stripCodexMemoryCitationMarkup(
+        'Before<oai-mem-citation>first</oai-mem-citation>After',
+      )).toBe('BeforeAfter');
+      expect(stripCodexMemoryCitationMarkup(
+        'Before<oai-mem-citation>unfinished',
+      )).toBe('Before');
+    });
+
+    it('preserves partial opening-tag prefixes that are not complete tags', () => {
+      expect(stripCodexMemoryCitationMarkup('Before<oai-mem-')).toBe('Before<oai-mem-');
+    });
+  });
+
+  describe('normalizeCodexMemoryCitation', () => {
+    it('normalizes valid entries and ignores provider tracking IDs', () => {
+      expect(normalizeCodexMemoryCitation({
+        entries: [{
+          path: ' MEMORY.md ',
+          lineStart: 10,
+          lineEnd: 12,
+          note: ' Used project conventions ',
+        }],
+        threadIds: ['thread-1'],
+      })).toEqual({
+        kind: 'memory',
+        entries: [{
+          path: 'MEMORY.md',
+          lineStart: 10,
+          lineEnd: 12,
+          note: 'Used project conventions',
+        }],
+      });
+    });
+
+    it('supports persisted snake_case line fields and drops malformed entries', () => {
+      expect(normalizeCodexMemoryCitation({
+        entries: [
+          {
+            path: 'rollout.md',
+            line_start: 3,
+            line_end: 4,
+            note: 'Prior result',
+          },
+          {
+            path: '../invalid.md',
+            lineStart: 8,
+            lineEnd: 2,
+            note: 'Invalid range',
+          },
+        ],
+      })).toEqual({
+        kind: 'memory',
+        entries: [{
+          path: 'rollout.md',
+          lineStart: 3,
+          lineEnd: 4,
+          note: 'Prior result',
+        }],
+      });
+      expect(normalizeCodexMemoryCitation({ entries: [] })).toBeNull();
+    });
+  });
+});

--- a/tests/unit/providers/codex/runtime/CodexNotificationRouter.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexNotificationRouter.test.ts
@@ -64,6 +64,177 @@ describe('CodexNotificationRouter', () => {
       ]);
     });
 
+    it('does not append raw memory citation markup after streamed text', () => {
+      router.handleNotification('item/agentMessage/delta', {
+        threadId: 't1',
+        turnId: 'turn1',
+        itemId: 'msg1',
+        delta: 'Answer\n',
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'message',
+          role: 'assistant',
+          content: [{
+            type: 'output_text',
+            text: [
+              'Answer',
+              '<oai-mem-citation>',
+              '<citation_entries>',
+              'MEMORY.md:10-12|note=[Used project conventions]',
+              '</citation_entries>',
+              '<rollout_ids>',
+              '</rollout_ids>',
+              '</oai-mem-citation>',
+            ].join('\n'),
+          }],
+        },
+      });
+
+      expect(chunks).toEqual([{ type: 'text', content: 'Answer\n' }]);
+    });
+
+    it('hides an unterminated raw memory citation block', () => {
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'message',
+          role: 'assistant',
+          content: [{
+            type: 'output_text',
+            text: 'Answer<oai-mem-citation>unfinished citation',
+          }],
+        },
+      });
+
+      expect(chunks).toEqual([{ type: 'text', content: 'Answer' }]);
+    });
+
+    it('emits structured memory citations from a completed agent message', () => {
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'agentMessage',
+          id: 'msg1',
+          text: '',
+          phase: 'streaming',
+          memoryCitation: null,
+        },
+      });
+      router.handleNotification('item/agentMessage/delta', {
+        threadId: 't1',
+        turnId: 'turn1',
+        itemId: 'msg1',
+        delta: 'Answer',
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'agentMessage',
+          id: 'msg1',
+          text: 'Answer',
+          phase: 'final_answer',
+          memoryCitation: {
+            entries: [{
+              path: 'MEMORY.md',
+              lineStart: 10,
+              lineEnd: 12,
+              note: 'Used project conventions',
+            }],
+            threadIds: ['thread-1'],
+          },
+        },
+      });
+
+      expect(chunks).toEqual([
+        { type: 'assistant_message_start', itemId: 'msg1' },
+        { type: 'text', content: 'Answer' },
+        {
+          type: 'citations',
+          citations: {
+            kind: 'memory',
+            entries: [{
+              path: 'MEMORY.md',
+              lineStart: 10,
+              lineEnd: 12,
+              note: 'Used project conventions',
+            }],
+          },
+        },
+      ]);
+    });
+
+    it('normalizes memory citations from event_msg fallback notifications without duplication', () => {
+      const memoryCitation = {
+        entries: [{
+          path: 'MEMORY.md',
+          lineStart: 10,
+          lineEnd: 12,
+          note: 'Used project conventions',
+        }],
+        rolloutIds: ['thread-1'],
+      };
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'agentMessage',
+          id: 'msg1',
+          text: '',
+          phase: 'streaming',
+          memoryCitation: null,
+        },
+      });
+      router.handleNotification('event_msg', {
+        type: 'agent_message',
+        message: [
+          'Answer',
+          '<oai-mem-citation>',
+          '<citation_entries>',
+          'MEMORY.md:10-12|note=[Used project conventions]',
+          '</citation_entries>',
+          '<rollout_ids>',
+          'thread-1',
+          '</rollout_ids>',
+          '</oai-mem-citation>',
+        ].join('\n'),
+        memory_citation: memoryCitation,
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'agentMessage',
+          id: 'msg1',
+          text: 'Answer\n',
+          phase: 'final_answer',
+          memoryCitation,
+        },
+      });
+
+      expect(chunks).toEqual([
+        { type: 'assistant_message_start', itemId: 'msg1' },
+        { type: 'text', content: 'Answer\n' },
+        {
+          type: 'citations',
+          citations: {
+            kind: 'memory',
+            entries: [{
+              path: 'MEMORY.md',
+              lineStart: 10,
+              lineEnd: 12,
+              note: 'Used project conventions',
+            }],
+          },
+        },
+      ]);
+    });
+
     it('deduplicates raw completed text against the current post-tool assistant segment', () => {
       router.handleNotification('item/agentMessage/delta', {
         threadId: 't1',


### PR DESCRIPTION
## Why

Codex memory citation tags could leak into live messages or replay as raw markup and duplicate the assistant answer, degrading affected conversations; closes #1028.

## What Changed

This adds provider-neutral citation events and content blocks, normalizes and deduplicates Codex citations at live and history boundaries, and renders them as a collapsed accessible “Memory used” disclosure.

## Why This Approach

Keeping provider-specific parsing inside Codex preserves core and feature ownership while structured entries—excluding provider tracking IDs—flow through shared contracts.

## Validation

Validated with `npm run typecheck && npm run lint && npm run test && npm run build` (343 suites, 6,306 tests), focused DOM, runtime, and history tests, architecture checks, and a clean adversarial review; no manual screenshot was captured.

## Impact and Follow-ups

Existing conversations remain compatible; citation locations are intentionally display-only, with no persistence migration or follow-up required.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
