### PR TITLE
docs: clarify ownership in agent guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Do not assume provider parity. Check each provider's `capabilities.ts`, `registr
 - This file is the canonical cross-agent guide. Keep shared instructions here.
 - `CLAUDE.md` files should import the nearest `AGENTS.md`; do not duplicate shared guidance there.
 - Before editing a scoped area, read its nearest scoped guide:
+  - `src/app/AGENTS.md`
   - `src/core/AGENTS.md`
   - `src/features/chat/AGENTS.md`
   - `src/providers/claude/AGENTS.md`
@@ -43,10 +44,14 @@ Tests mirror `src/` under `tests/unit/` and `tests/integration/`.
 
 ## Architecture
 
-| Area | Ownership |
+This table is a location map. It describes responsibility, not exclusive mutation authority. Scoped guides name the source of truth and allowed mutators for state in their area.
+
+| Area | Responsibility |
 | --- | --- |
-| `src/app/` | Shared settings defaults and plugin-level storage helpers |
+| `src/main.ts` | Plugin lifecycle and concrete application composition |
+| `src/app/` | Application conversation, settings, provider-host, and storage services |
 | `src/core/` | Provider-neutral runtime, registry, storage, tool, and type contracts |
+| `src/providers/acp/` | Shared ACP transport, interaction, and session primitives without provider policy |
 | `src/providers/*/` | Provider adaptors, provider-owned runtime protocol, history, storage, settings, and UI |
 | `src/features/chat/` | Sidebar chat orchestration against provider-neutral contracts |
 | `src/features/inline-edit/` | Inline edit modal and provider-backed edit services |
@@ -54,7 +59,33 @@ Tests mirror `src/` under `tests/unit/` and `tests/integration/`.
 | `src/shared/` | Reusable UI components |
 | `src/style/` | Modular CSS built into `styles.css` |
 
-The feature layer depends on `core/` contracts, not provider internals. Provider-specific session fields belong behind typed helpers in the owning provider directory.
+### Dependency Direction
+
+In the rules below, `A -> B` means `A` may import or call `B`:
+
+```text
+composition root (`src/main.ts`) -> app services + features + provider registrations + core
+app services -> core contracts
+features -> FeatureHost + core contracts + shared UI
+providers -> ProviderHost + core contracts + shared provider primitives
+```
+
+- `core/` must not import feature code, app composition, or provider implementations.
+- Feature code must not import provider implementations. Resolve provider behavior through core registries and contracts.
+- Provider runtime and protocol code must not import chat views, feature controllers, or other feature orchestration.
+- Existing Claude compatibility re-exports that point into `src/app/` are migration seams, not an allowed general dependency direction. Do not add new provider-to-app imports; move shared contracts into `core/` when touching those seams materially.
+- `src/providers/acp/` may contain protocol primitives shared by ACP providers. Provider-specific launch policy, extensions, normalization, history, and state remain in the owning provider.
+- If a dependency does not fit these directions, introduce or extend an explicit contract at the owning boundary instead of reaching across layers.
+
+### Cross-Layer Ownership
+
+- `src/main.ts` owns plugin lifecycle and wiring; it does not become the home for feature or provider behavior.
+- `src/app/` owns application-scoped repositories, settings transactions, host adapters, and persistence coordination. See its scoped guide for exact state authority.
+- `src/features/*/` owns user-facing orchestration and presentation state, not provider-native processes or storage formats.
+- `src/providers/*/` owns native protocol, process, session, transcript, settings, and provider-state interpretation.
+- `src/core/` owns provider-neutral contracts and shared lifecycle mechanisms, not concrete provider behavior.
+
+Provider-specific session fields belong behind typed helpers in the owning provider directory. Provider-native transcripts are read-only inputs; Claudian state changes must never rewrite or delete them.
 
 ## Provider Rules
 
@@ -106,3 +137,4 @@ The feature layer depends on `core/` contracts, not provider internals. Provider
 - Findings first: correctness, regression risk, API or contract ambiguity, and missing tests.
 - Treat maintainability issues as real findings when they increase future change cost or failure risk.
 - Call out duplicated logic, unclear ownership, and tight coupling with a concrete refactoring direction.
+- For architecture changes, ask whether the change reverses an allowed dependency, mutates state outside its owner, leaks a provider detail, or persists state with the wrong lifetime.

--- a/src/app/AGENTS.md
+++ b/src/app/AGENTS.md
@@ -1,0 +1,41 @@
+# Application Services
+
+`src/app/` owns application-scoped state services and adapters used by the composition root. Features and providers access these capabilities through stable host and core contracts rather than importing the concrete plugin class.
+
+## Dependency Direction
+
+- `src/main.ts` is the concrete composition root. It constructs app services and wires core registries, providers, and features.
+- App repositories, storage, and settings services depend on core contracts. They must not import chat views, feature controllers, renderers, or provider-native protocol implementations.
+- `FeatureHost` is the feature-facing application boundary; user-facing features must not import `ClaudianPlugin` from `src/main.ts`.
+- `ProviderHost` is the provider-facing application boundary; provider runtime code must not reach through it to chat views or feature controllers.
+- Concrete provider imports are allowed only in composition and provider-default assembly. Do not introduce them into conversation, storage, or settings transaction logic.
+- Existing Claude compatibility imports of app settings or storage are migration seams. Do not use them as precedent; move a shared contract into `core/` before creating another provider-to-app dependency.
+
+## Ownership
+
+| Component | Authority |
+| --- | --- |
+| `ConversationRepository` | The canonical in-memory Claudian conversation collection, hydration status, deletion transactions, per-conversation persistence queues, input-ledger coordination, and execution-snapshot binding |
+| `SharedStorageService` | Plugin-data and vault persistence I/O plus construction of shared persistence adapters |
+| `SettingsCoordinator` | Serialization of settings mutations, rollback before failed persistence, and post-commit publication ordering |
+| `ClaudianProviderHost` | Typed delegation to application capabilities; it owns no duplicate settings, storage, view, or execution state |
+
+Storage adapters own I/O mechanics, not domain decisions. Callers decide what state is valid; adapters merge and persist it without inventing conversation, tab, provider, or settings semantics.
+
+## State and Persistence Boundaries
+
+- `ConversationRepository` is the source of truth for Claudian's current in-memory conversation projection. Feature code must request conversation mutations through `FeatureHost` instead of mutating cached conversations independently.
+- Claudian metadata and accepted-input ledgers are durable Claudian state. Provider-native transcripts and history databases are provider-owned, read-only replay sources.
+- Provider session IDs, resume checkpoints, and opaque `providerState` may be interpreted only by provider snapshots or typed provider history/state helpers. Generic app code may store those opaque values but must not infer or rewrite their fields.
+- `AppTabManagerState` is a separate tab-layout snapshot. It may reference conversation IDs but must not duplicate conversation messages, provider state, or runtime objects.
+- `SharedStorageService.setTabManagerState()` must preserve unrelated plugin data when updating the tab-layout snapshot.
+- Settings changes must go through `SettingsCoordinator` or the application mutation APIs so persistence, rollback, provider reconciliation, and publication remain ordered.
+
+## Invariants
+
+- Closing or removing a tab never deletes a conversation.
+- Deleting a Claudian conversation never mutates or deletes provider-native session data.
+- Failed settings persistence restores the pre-mutation in-memory settings snapshot.
+- A post-commit publication failure is reported as committed state; it must not roll back data that was already persisted.
+- Conversation persistence for one conversation remains ordered, and stale execution snapshots must not overwrite newer provider state.
+- Deletion, hydration, and execution-snapshot writes must preserve their existing generation and binding fences.

--- a/src/app/CLAUDE.md
+++ b/src/app/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/src/core/AGENTS.md
+++ b/src/core/AGENTS.md
@@ -6,28 +6,43 @@
 
 | Module | Owns |
 | --- | --- |
+| `auxiliary/` | Provider-neutral title generation, instruction refinement, inline edit, and auxiliary-session orchestration |
 | `bootstrap/` | Provider-neutral session metadata storage and shared app-storage contracts |
 | `commands/` | Built-in cross-provider commands |
+| `execution/` | Provider execution, lifecycle, interaction, request, event, and session contracts |
 | `mcp/` | Provider-neutral MCP coordination and config parsing |
+| `performance/` | Startup performance instrumentation |
+| `process/` | Managed subprocess lifecycle primitives |
 | `prompt/` | Shared prompt templates |
 | `providers/` | Registry, capability, environment, model-routing, and workspace-service contracts |
 | `providers/commands/` | Shared command catalog contracts |
-| `execution/` | Provider execution, lifecycle, interaction, request, event, and session contracts |
+| `rpc/` | Provider-neutral JSON-RPC transport primitives |
 | `security/` | Permission and approval helpers |
+| `skills/` | Shared skill model, codec, validation, and repository contracts |
 | `storage/` | Generic vault/home filesystem adapters |
 | `tools/` | Shared tool constants and formatting helpers |
 | `types/` | Shared type definitions |
 
 ## Dependency Rules
 
-```text
-types/ <- all modules
-storage/ <- bootstrap/, provider workspace services
-execution/ + providers/ <- provider implementations
-features/ -> core contracts only
-```
+In the rules below, `A -> B` means `A` may import or call `B`.
 
-Do not import provider implementation files from `core/`. If shared behavior needs provider data, add an explicit contract and have providers implement it.
+- Features and provider implementations may depend on public core contracts.
+- Core modules may depend on shared core types and lower-level adapters, but must not depend on app composition, features, or provider implementations.
+- `bootstrap/` defines provider-neutral persistence contracts and normalization. It must not interpret provider-native session formats.
+- `execution/` defines leases, sessions, requests, events, interactions, and lifecycle coordination. It must not construct concrete providers.
+- `providers/` defines registries, capabilities, routing, workspace-service contracts, and provider-state boundaries. Registrations supply the concrete implementations.
+- `process/` and `rpc/` provide mechanics only. Provider launch arguments, protocol extensions, retry policy, and message semantics stay provider-owned.
+- `auxiliary/` may orchestrate provider-neutral executions through core contracts but must not special-case a concrete provider.
+
+If shared behavior needs provider data, add an explicit contract and have providers implement it. Do not import a provider implementation into `core/`, use provider-ID conditionals where a capability can express the distinction, or move provider-native state into a shared type.
+
+## State Ownership
+
+- `ProviderExecutionLifecycleRegistry` is the source of truth for provider generations, transition fencing, and live session leases. It does not own per-tab turn state or impose a global execution-capacity policy.
+- Provider execution sessions own native runtime interaction behind the `ProviderExecutionSession` contract.
+- Bootstrap persistence stores Claudian metadata and input ledgers. Provider transcript files remain provider-owned and read-only.
+- Registries own registration and lookup; they do not absorb the lifecycle or storage responsibilities of the registered service.
 
 ## Key Contracts
 

--- a/src/features/chat/AGENTS.md
+++ b/src/features/chat/AGENTS.md
@@ -2,6 +2,15 @@
 
 `src/features/chat/` owns the main sidebar chat interface. It assembles tabs, controllers, renderers, and provider-backed services around provider-neutral execution contracts.
 
+## Dependency Direction
+
+- `ClaudianView` is the view-level composition root. It constructs view services, `TabManager`, `TabBar`, layout DOM, and callbacks.
+- `TabManager` and the lifecycle functions in `Tab.ts` construct and wire each tab's state, controllers, renderers, provider services, and UI components.
+- Controllers request conversation and execution changes through injected callbacks, `FeatureHost`, and `ChatExecutionCoordinator`; cross-tab operations remain `TabManager` authority.
+- Execution orchestration depends on core execution and provider contracts, never concrete provider implementations.
+- Renderers and UI components may render state and emit user intent. They must not mutate tab membership, conversation persistence, or provider-session lifecycle directly.
+- Provider behavior is resolved through `ProviderRegistry`, `ProviderWorkspaceRegistry`, capabilities, and provider UI config. Do not add provider-ID branches when one of those contracts can express the behavior.
+
 ## Provider Boundary
 
 - Feature code depends on execution sessions, `ProviderCapabilities`, provider-neutral `Conversation`, and provider-neutral execution events.
@@ -10,6 +19,55 @@
 - Resolve provider-owned services through registries:
   - `ProviderRegistry`: execution backends, title generation, instruction refinement, inline edit, task-result interpretation.
   - `ProviderWorkspaceRegistry`: command catalogs, agent mentions, MCP managers, CLI resolution, settings tabs.
+
+## Ownership
+
+Use `owns` here to mean the source of truth or exclusive coordinator for a mutation. Non-owners must request changes through the owner's public operations and must not maintain independently mutable copies.
+
+| Component | Owns |
+| --- | --- |
+| `TabManager` | Open-tab membership, active-tab selection, create/switch/close/restore operations, and the tab/session portion of the persisted layout snapshot |
+| `TabSession` | Authoritative per-tab identity, conversation binding, provider binding, lifecycle value, execution-coordinator attachment, active-turn reference, and background-work sequencing |
+| `ChatExecutionCoordinator` | One tab's provider-session binding, active execution, interaction fencing, cancellation, and disposal |
+| `ChatState` | Transient per-tab message projection, stream state, queued input, render state, and conversation-operation flags |
+| `TabStatePersistenceCoordinator` | Debouncing, snapshotting, ordering, retry retention, and flushing of tab-layout writes |
+| `TabBar` | Expanded-title presentation state for the current view |
+| `ClaudianView` | View assembly, rendered DOM placement, presentation coordination, and assembly of the complete persisted layout snapshot |
+
+`TabSession` stores lifecycle values, while lifecycle operations in `Tab.ts` and `TabManager` perform the transitions. Controllers, renderers, and UI components must request those operations instead of assigning lifecycle state themselves.
+
+`TabStatePersistenceCoordinator` owns write sequencing, not the semantic tab state. It receives complete snapshots assembled by `ClaudianView` from `TabManager` and `TabBar`; it must not infer, add, or remove tabs.
+
+## State Model
+
+Keep these layers independent:
+
+1. **Durable conversation state**
+   - Claudian's in-memory conversation projection, metadata, input ledger, and provider resume snapshot are coordinated by the application conversation repository.
+   - Provider-native transcripts remain provider-owned replay sources and are read-only.
+2. **Persisted tab shell**
+   - `AppTabManagerState` stores open tab IDs, conversation bindings, the active tab ID, blank-tab draft models, and supported presentation metadata.
+   - It survives plugin reload, but must not contain DOM, controllers, hydrated messages, pending turns, execution sessions, or provider-native state.
+3. **Runtime tab state**
+   - `TabSession`, `ChatState`, controllers, renderers, and DOM exist only for the current view runtime.
+   - Hydration state is independent from both active-tab selection and provider execution state.
+4. **Provider execution state**
+   - `ChatExecutionCoordinator` owns the live per-tab execution binding.
+   - Core lifecycle leases fence provider-wide transitions; they are not tab state and do not imply an LRU or global execution pool.
+
+## Tab Lifecycle
+
+Valid lifecycle values are:
+
+```text
+blank | bound_cold | bound_active | closing
+```
+
+- A new unbound tab starts `blank`; a restored or selected conversation without a runtime starts `bound_cold`.
+- Preparing a provider session for a bound conversation changes `bound_cold` to `bound_active`.
+- Rebinding or clearing the conversation releases the old binding and returns the tab to `bound_cold` or `blank`.
+- Closing changes any live tab to `closing`, prevents new hydration work, saves when required, disposes execution resources, and removes the tab from `TabManager`.
+- `TabHydrationState` (`idle | loading | ready | failed`) is orthogonal to this lifecycle. Do not infer execution state from hydration, visibility, or active selection.
 
 ## State Flow
 
@@ -20,26 +78,28 @@ User input
   -> build canonical execution request
   -> execute provider session
   -> StreamController
-  -> renderers + ChatState persistence
+  -> renderers + transient ChatState projection
+  -> application conversation persistence
 ```
 
-Tabs stay cold until the first send. Keep metadata warmup explicit and provider-owned so command discovery does not accidentally create real execution sessions for history-backed conversations.
+Tab activation and conversation hydration do not themselves authorize creation of a provider execution session. Warmup must be explicit and provider-owned through `ProviderTabWarmupPolicy`. Command-only discovery must stay isolated and must not create a real chat session for a history-backed conversation; execution warmup is allowed only when the registered policy explicitly returns `execution`.
 
-## Main Parts
+## Invariants
 
-| Area | Owns |
-| --- | --- |
-| `ClaudianView` | Lifecycle, assembly, active-tab orchestration |
-| `ChatState` | Per-tab state and persistence inputs |
-| Controllers | Conversation, stream, input, selection, browser/canvas selection, navigation |
-| Renderers | Messages, tools, thinking, diffs, todos, subagents, plan approval, ask-user UI |
-| Tabs | Tab manager, tab bar, tab state |
-| UI components | Input toolbar, context managers, status panel, navigation sidebar, mode managers |
+- Every create and fork path must enforce the configured tab limit and the `MIN_TABS`/`MAX_TABS` bounds.
+- Restoring tab layout must not create provider executions for every restored tab. Background restored tabs remain shells until targeted work requires more.
+- Switching the active tab must not cancel, dispose, or transfer another tab's active execution.
+- Closing a tab disposes its runtime resources but never deletes its conversation or provider-native transcript.
+- Deleting a conversation is a separate application operation and must not be inferred from tab closure or layout changes.
+- Persisted tab state must exclude hydrated messages, DOM, controllers, pending work, and execution-session objects.
+- Layout and presentation changes must not alter conversation binding or execution lifecycle.
+- A stale provider generation, session binding, or stream generation must not update the current tab.
+- Provider command and metadata warmup must respect provider resource generations and must not reuse stale results.
 
 ## Gotchas
 
 - `ClaudianView.onClose()` must abort active tabs and dispose execution coordinators.
-- `ChatState` is per-tab. `TabManager` coordinates tab-level operations such as forks and provider-aware command catalogs.
+- `ChatState` is a transient per-tab projection, not the durable conversation source of truth. `TabManager` coordinates tab-level operations such as forks and provider-aware command catalogs.
 - Title generation runs concurrently per conversation and routes by the global title-generation model, not the active chat tab provider.
 - `/compact` is provider-specific:
   - Claude skips context injection so the provider handles the built-in command.

--- a/src/providers/claude/AGENTS.md
+++ b/src/providers/claude/AGENTS.md
@@ -2,14 +2,29 @@
 
 `src/providers/claude/` implements provider-neutral execution contracts over `@anthropic-ai/claude-agent-sdk` and layers Claude Code CLI compatibility around it.
 
+## Dependency Boundary
+
+- Claude code may depend on core contracts, shared UI primitives, the Anthropic SDK, and provider-local modules. It must not import chat views or feature controllers.
+- Native SDK events, options, transcript records, and provider state must be normalized before crossing into core or feature contracts.
+- Existing imports from provider compatibility storage/types into `src/app/` are migration seams. Do not add new ones; move a shared contract into `core/` when changing those seams materially.
+
 ## Ownership
 
-- Runtime lifecycle, prompt encoding, stream transforms, history hydration, CLI resolution, plugin discovery, agent discovery, MCP storage, settings UI, and Claude-specific storage live here.
+| Area | Owns |
+| --- | --- |
+| `execution/` | Provider execution-session binding, snapshots, event adaptation, interactions, and recovery policy |
+| `runtime/` | Persistent SDK query, restart decisions, message-channel behavior, CLI spawning, and native prompt construction |
+| `history/` | Read-only native transcript discovery, branch projection, rewind, and subagent replay |
+| `app/`, `commands/`, `agents/`, `plugins/` | Workspace-scoped discovery and provider-native catalogs |
+| `storage/` | Only the documented Claudian-managed portions of Claude-compatible settings, MCP, command, skill, agent, and plugin files |
+| `types/` | Typed interpretation and sanitization of Claude-owned provider state |
+
+The execution session owns the live provider snapshot. History services reconstruct replay state but must not become a second live-session authority.
 
 ## Design Rules
 
 - Keep the persistent SDK query alive across turns when possible. Update model, permission mode, MCP servers, and effort through SDK calls.
-- Restart the persistent query when the effective system prompt, disabled-tool set, plugin set, settings source set, CLI path, Chrome enablement, or external context paths change.
+- Restart the persistent query when the effective system prompt, disabled-tool set, plugin set, settings source set, CLI path, Chrome enablement, auto-mode enablement, or external context paths change.
 - Do not duplicate assistant text. The SDK can emit text incrementally and again in the final assistant message; stream handling must preserve the existing dedupe behavior.
 - Token usage is intentionally merged from assistant and result messages. Assistant messages provide accurate input-side counts; result messages provide authoritative context-window data.
 - `createCustomSpawnFunction()` handles Obsidian/Electron process quirks. Preserve full-path `node` resolution and manual abort handling.
@@ -31,3 +46,10 @@
 - Claude session files are tree-structured. Branch filtering must preserve the canonical branch plus relevant sibling tool results.
 - `EnterPlanMode` does not hit `canUseTool`; `ExitPlanMode` does.
 - Context-window selection must handle multi-model runs by exact model match first, then family match, and null on ambiguity.
+
+## Invariants
+
+- Dynamic model, permission, MCP, and effort updates must not restart a compatible persistent query.
+- Restarting or recovering a query must preserve the intended conversation binding and must not duplicate visible output.
+- Provider snapshots are the only path from live SDK state into persisted Claudian resume state.
+- Reads of native transcripts and user-owned Claude configuration are non-destructive; writes merge only the fields explicitly owned above.

--- a/src/providers/codex/AGENTS.md
+++ b/src/providers/codex/AGENTS.md
@@ -2,6 +2,25 @@
 
 `src/providers/codex/` adapts OpenAI Codex through `codex app-server` over stdio JSON-RPC 2.0.
 
+## Dependency Boundary
+
+- Codex code may depend on core contracts, shared UI primitives, and provider-local app-server modules. It must not import chat views or feature controllers.
+- App-server JSON-RPC types, notifications, raw response items, and JSONL records remain provider-local until normalized into core execution events, snapshots, or history projections.
+- App-server process management, model discovery, skill listing, and chat execution may share transport primitives but must not share a live process or session implicitly.
+
+## Ownership
+
+| Component | Owns |
+| --- | --- |
+| `CodexExecutionSession` | One provider execution binding, thread/turn requests, pending notification fencing, interactions, cancellation, and provider snapshots |
+| `CodexAppServerProcess` and `CodexRpcTransport` | App-server subprocess and JSON-RPC transport mechanics |
+| `CodexNotificationRouter` | Projection of live notifications and raw response items into normalized stream chunks |
+| `history/CodexHistoryStore.ts` | Read-only JSONL replay projection and session-file lookup |
+| `CodexSkillListingService` | Independent short-lived skill-listing process and result lifecycle |
+| `CodexModelCatalogCoordinator` | Workspace model discovery snapshots and transition fencing |
+
+Live execution state and replay state are separate authorities. Do not fill gaps in one by mutating or polling the other.
+
 ## Protocol Rules
 
 - The startup handshake is mandatory: send `initialize`, then notify `initialized`.
@@ -21,7 +40,7 @@
 
 - Native transcripts live under `~/.codex/sessions/`; resolve roots via `CodexHistoryPathResolver` (WSL and home-dir aware).
 - `CodexSkillListingService` uses a separate short-lived app-server process for `skills/list`. Do not couple skill discovery to the active chat runtime.
-- Environment hash changes for `OPENAI_MODEL`, `OPENAI_BASE_URL`, and `OPENAI_API_KEY` invalidate existing Codex sessions.
+- Runtime fingerprint changes invalidate existing Codex sessions. The fingerprint includes `OPENAI_MODEL`, `OPENAI_BASE_URL`, `OPENAI_API_KEY`, `PATH`, explicit/host CLI-path inputs, installation method, and WSL distro override.
 - Existing threads require `thread/resume` before operations in a new app-server process.
 - For forks, resume the new fork thread before `thread/rollback`.
 - Notifications can arrive before `turn/start` returns; preserve pending-turn buffering.
@@ -39,3 +58,11 @@
 - `serverRequest/resolved` can auto-dismiss approval or ask-user UI without client input.
 - The shared no-op task-result interpreter is intentional because Claudian's Claude async-agent task system does not apply to Codex.
 - Codex is opt-in and must stay disabled by default.
+
+## Invariants
+
+- A thread must be started or resumed before a turn, rollback, or compact operation targets it in the current app-server process.
+- Only current binding, provider generation, and turn notifications may update the active execution.
+- Live UI output comes from app-server notifications; JSONL remains read-only replay input.
+- Auxiliary model, dependency, and skill queries own their own process lifecycle and must not reuse the chat session.
+- Provider state persists opaque Codex thread and fork metadata; feature code must not reconstruct it.

--- a/src/providers/grok/AGENTS.md
+++ b/src/providers/grok/AGENTS.md
@@ -2,9 +2,22 @@
 
 `src/providers/grok/` adapts Grok Build through Agent Client Protocol over a `grok agent --no-leader stdio` subprocess.
 
+## Dependency Boundary
+
+- Grok code may depend on core contracts, shared ACP primitives from `src/providers/acp/`, shared UI primitives, and provider-local modules. It must not import chat views or feature controllers.
+- Standard ACP transport and interaction mechanics may be shared. xAI extensions, launch policy, model semantics, tool normalization, session metadata, and history interpretation remain Grok-owned.
+- Do not add a generic ACP runtime superclass. Share protocol primitives while keeping provider policy and lifecycle explicit.
+
 ## Ownership
 
-- Grok process/session lifecycle, xAI protocol extensions, native-history hydration, model catalogs, tool normalization, settings reconciliation, UI, and auxiliary services live here.
+| Area | Owns |
+| --- | --- |
+| `execution/` | Grok process/session binding, native connection, execution state, interaction routing, snapshots, and recovery |
+| `runtime/` | CLI resolution, xAI extension calls, model-catalog discovery, environment construction, and notification normalization |
+| `history/` | Read-only native-history discovery and replay projection |
+| `app/` and `commands/` | Workspace command metadata and model-catalog coordination |
+| `types.ts` and provider settings | Typed Grok provider state and current-device discovery snapshots |
+
 - Provider-owned conversation data stays behind `GrokProviderState` helpers; feature code must not inspect it.
 
 ## Protocol and Session Rules
@@ -12,7 +25,7 @@
 - Account authentication is Grok-native. Never call ACP `authenticate` automatically or persist xAI credentials.
 - Preserve `Conversation.sessionId` and provider state across prompt, CLI-path, and environment changes. Recycle the process and load the same native session.
 - Use Grok's native history under `~/.grok/sessions/` read-only.
-- Send image attachments as ACP image content blocks and rehydrate their persisted native blocks. Use Grok's `x.ai/interject` and `x.ai/session/fork` extensions behind typed provider-owned boundaries for steering and forks.
+- Send image attachments as ACP image content blocks and rehydrate their persisted native blocks. Use Grok's `_x.ai/interject` and `_x.ai/session/fork` extensions behind typed provider-owned boundaries for steering and forks.
 - Keep Grok/xAI tools enabled and preserve unknown tool data losslessly. Adapt Grok task-family lifecycle calls into the shared subagent renderer while retaining their raw names and payloads.
 - Expose Safe, Plan, and YOLO. Plan is a native ACP session mode layered over the remembered Safe or YOLO base; native mode updates remain authoritative.
 
@@ -22,7 +35,7 @@
 - Catalog snapshots are current-device scoped and contain only normalized non-secret metadata.
 - Expose Low, Medium, and High as the initial fallback for enabled models. After a real ACP session, persist and prefer the chosen model's advertised reasoning metadata; never create a session solely for discovery, and prune reasoning state when a model is disabled.
 - Do not rewrite `~/.grok/config.toml`, own BYOK endpoints, or source shell startup files.
-- Do not add a generic ACP runtime superclass; share protocol primitives while keeping xAI behavior provider-owned.
+- Any change to Grok environment text or resolved CLI-path fingerprint clears device discovery state and reloads provider processes while preserving native conversation identifiers.
 
 ## Repository Instructions vs Runtime Instructions
 
@@ -34,3 +47,11 @@
 
 - Provider behavior that is not established by standard ACP must be backed by sanitized Grok protocol evidence.
 - Put raw captures and throwaway scripts in `.context/`. Never commit credentials, private prompts, absolute personal paths, or raw user configuration.
+
+## Invariants
+
+- Environment and CLI changes recycle processes and catalogs; they do not clear `Conversation.sessionId` or opaque Grok provider state.
+- Native session mode notifications are authoritative over remembered UI mode.
+- Steering and fork extensions stay behind typed Grok boundaries and preserve unknown xAI payloads losslessly.
+- Command/model discovery must not create a user conversation session solely for metadata.
+- Existing native history and user configuration are never rewritten or deleted.

--- a/src/providers/opencode/AGENTS.md
+++ b/src/providers/opencode/AGENTS.md
@@ -2,22 +2,35 @@
 
 `src/providers/opencode/` adapts OpenCode through Agent Client Protocol over an `opencode acp` subprocess.
 
+## Dependency Boundary
+
+- OpenCode code may depend on core contracts, shared ACP primitives from `src/providers/acp/`, shared UI primitives, and provider-local modules. It must not import chat views or feature controllers.
+- ACP transport, session, and interaction mechanics may be shared. OpenCode launch artifacts, config layering, database semantics, modes, tools, agents, and metadata policy remain provider-owned.
+- Managed launch files live under `.claudian/opencode/`; user OpenCode config and the native history database remain outside Claudian ownership.
+
 ## Ownership
 
-- Runtime process management, ACP transport, prompt encoding, stream normalization, SQLite history hydration, model/mode discovery, command discovery, agent storage, settings UI, and OpenCode-specific settings reconciliation live here.
+| Component or area | Owns |
+| --- | --- |
+| `OpencodeExecutionSession` | Provider execution binding, request lifecycle, normalized events, provider snapshots, and recovery |
+| `OpencodeAcpSessionKernel` | Managed ACP process, native session, config options, file requests, and working-directory enforcement |
+| `OpencodeMetadataService` | Detached model and command metadata probes plus current-device discovery snapshots |
+| `history/` | Read-only SQLite history discovery and replay projection |
+| `OpencodeAgentStorage` | Claudian-supported parsing and serialization of vault OpenCode agent definitions |
+| `runtime/` | Managed config/system-prompt artifacts, environment construction, and path resolution |
 
 ## Protocol Rules
 
 - Live output comes from ACP session notifications and is normalized through `AcpSessionUpdateNormalizer` plus OpenCode tool normalization.
 - History hydration reads OpenCode's native SQLite database.
 - `providerState.databasePath` preserves the database used for a conversation. Keep it when building session updates.
-- `sessionCwds` maps ACP session IDs to vault working directories for read/write request path resolution.
+- File requests are resolved and permission-checked against the kernel's configured vault working directory; do not recreate path policy in feature code.
 
 ## Launch and Settings
 
 - `prepareOpencodeLaunchArtifacts()` writes managed config and system prompt files under `.claudian/opencode/`.
 - Preserve user OpenCode config by loading `OPENCODE_CONFIG` and layering Claudian-managed agent config over it.
-- Environment keys that affect config or data location invalidate OpenCode sessions: `OPENCODE_CONFIG`, `OPENCODE_DB`, `OPENCODE_DISABLE_PROJECT_CONFIG`, and `XDG_DATA_HOME`.
+- Runtime fingerprint changes invalidate OpenCode sessions. The fingerprint includes `OPENCODE_CONFIG`, `OPENCODE_DB`, `OPENCODE_DISABLE_PROJECT_CONFIG`, `XDG_DATA_HOME`, `PATH`, and explicit/host CLI-path inputs.
 - OpenCode mode IDs map to shared permission modes. Keep this mapping in `modes.ts`, not feature code.
 
 ## Commands and Agents
@@ -32,3 +45,11 @@
 - File read/write permission requests may target paths outside the session working directory. Preserve the existing approval mapping and path checks.
 - SQLite reading uses `OpencodeSqliteReader` fallbacks because runtime environments may not expose the same SQLite API.
 - OpenCode metadata warmup intentionally uses an in-memory or metadata database to avoid binding tab state to discovery work.
+
+## Invariants
+
+- Live ACP notifications are the live-output source; SQLite is read-only replay input.
+- Managed configuration layers over user configuration and must not clobber the user-selected `OPENCODE_CONFIG` source.
+- Command and model metadata probes own isolated processes/databases and must not bind a history-backed conversation to a new native session.
+- Database-path provider state is preserved until a typed history or environment transition deliberately replaces it.
+- Provider mode and variant mappings remain provider-owned and cross into chat only through core capabilities and UI config.

--- a/src/providers/pi/AGENTS.md
+++ b/src/providers/pi/AGENTS.md
@@ -2,9 +2,22 @@
 
 `src/providers/pi/` adapts Pi through a `pi --mode rpc` subprocess.
 
+## Dependency Boundary
+
+- Pi code may depend on core contracts, shared UI primitives, and provider-local RPC modules. It must not import chat views or feature controllers.
+- Pi RPC payloads, extension UI, session files, model metadata, commands, and provider state remain provider-owned until normalized into core contracts.
+- Auxiliary command/model discovery processes are independent from chat execution and own their own process lifecycle.
+
 ## Ownership
 
-- RPC process management, prompt encoding, event normalization, JSONL history hydration, model discovery, command discovery, extension UI bridging, settings UI, and Pi-specific settings reconciliation live here.
+| Component or area | Owns |
+| --- | --- |
+| `PiExecutionSession` | Provider execution binding, request/event lifecycle, provider snapshots, cancellation, and recovery |
+| `PiRpcSessionKernel` behind `PiExecutionKernel` | RPC turn coordination and live Pi execution mechanics |
+| `PiLaunchSpec` and `PiSubprocess` | Command-line, environment, subprocess, and transport construction |
+| `PiExtensionUiBridge` | Typed routing of provider extension UI requests to the Obsidian renderer |
+| `history/` | Native JSONL discovery, read-only replay, and new fork-file materialization |
+| `PiModelDiscoveryService` and `PiCommandMetadataProbe` | Independent metadata subprocesses and their results |
 
 ## Protocol Rules
 
@@ -20,6 +33,7 @@
 - History hydration reads Pi JSONL sessions from vault-local (`.pi/agent/sessions/`) and user-level (`~/.pi/agent/sessions/`) roots.
 - Forking creates a new Pi session file by copying the source branch up to `resumeAt`. Keep fork materialization provider-owned.
 - Environment keys that affect Pi data or package locations invalidate existing Pi sessions.
+- The runtime fingerprint includes `PI_CODING_AGENT_DIR`, `PI_CODING_AGENT_SESSION_DIR`, `PI_PACKAGE_DIR`, `PI_OFFLINE`, `PI_SKIP_VERSION_CHECK`, `PI_TELEMETRY`, `PI_CACHE_RETENTION`, `PATH`, and explicit/host CLI-path inputs.
 
 ## Commands and Models
 
@@ -32,3 +46,11 @@
 - Images are passed as prompt image blocks only when attachment data is available.
 - `new_session` invalidates persisted session state until the provider reports a replacement session.
 - Tool mode can launch Pi with readonly tools or no tools. Keep that logic in launch-spec construction.
+
+## Invariants
+
+- Live RPC events are the live-output source; JSONL is read-only replay input except when materializing a new provider-owned fork file.
+- Forking may create a new session file but must never alter or truncate the source file.
+- `new_session` clears stale persisted binding state before any replacement state is accepted.
+- Extension UI requests cross through `PiExtensionUiBridge`; execution code must not manipulate Obsidian DOM directly.
+- Model and command discovery remain isolated from the active chat process and session.

--- a/src/style/AGENTS.md
+++ b/src/style/AGENTS.md
@@ -4,17 +4,25 @@
 
 ## Structure
 
-```text
-src/style/
-├── base/           # container, animations, variables
-├── components/     # header, history, messages, code, thinking, toolcalls, status-panel, input, tabs
-├── toolbar/        # model selector, thinking selector, permission toggles, external context, MCP selector
-├── features/       # file/image context, inline edit, diff, commands, plan mode, ask-user, resume session
-├── modals/         # instruction, MCP, fork target
-├── settings/       # shared settings panels and provider settings modules
-├── accessibility.css
-└── index.css       # build order
-```
+| Area | Owns |
+| --- | --- |
+| `base/` | Variables, container primitives, animations, and global visibility behavior |
+| `components/` | Reusable chat surfaces such as messages, input, tabs, navigation, status, context, citations, and tool output |
+| `toolbar/` | Composer and provider-option controls |
+| `features/` | Styles coupled to a named feature workflow such as context, diff, inline edit, plan mode, or commands |
+| `modals/` | Modal-specific layouts |
+| `settings/` | Shared settings shell and provider settings modules |
+| `accessibility.css` | Cross-feature accessibility adaptations |
+| `index.css` | Complete module inclusion and deterministic build order |
+
+Choose a folder by UI ownership, not by the screen where a selector happens to appear. Shared visual primitives belong in `components/`; behavior-specific selectors stay with their feature.
+
+## Boundaries
+
+- TypeScript owns semantic and lifecycle state. CSS may render classes and attributes but must not be treated as the source of truth for state transitions.
+- Feature-specific styling must not leak provider behavior into shared selectors. Provider variants should use explicit provider classes or data attributes supplied by UI config.
+- Keep Obsidian host-selector overrides narrow. Do not globally restyle host classes when a Claudian container can scope the rule.
+- Root `styles.css` is generated output. Never edit it directly.
 
 ## Build Rules
 


### PR DESCRIPTION
## Summary

- define explicit dependency direction, ownership, state lifetimes, and invariants across every AGENTS.md guide
- add an app-scoped guide for conversation, settings, host, and persistence authority
- align provider protocol, environment fingerprint, replay, and process-lifecycle rules with the current implementation
- clarify chat tab composition and persistence ownership and replace the stale CSS module inventory

## Verification

- npm run build:css
- git diff --check
- verified every scoped CLAUDE.md imports the nearest AGENTS.md
- verified each root-plus-scoped instruction chain remains below the 32 KiB default limit