### PR TITLE
fix: prevent chat code blocks from running processors

### DIFF
--- a/src/features/chat/rendering/DisplayOnlyCodeFences.ts
+++ b/src/features/chat/rendering/DisplayOnlyCodeFences.ts
@@ -1,0 +1,82 @@
+import { loadPrism } from 'obsidian';
+
+import { transformMarkdownSegments } from '../../../utils/markdownSegments';
+
+const PLACEHOLDER_LANGUAGE_PREFIX = 'claudian-display-only-fence-';
+
+export interface DisplayOnlyCodeFence {
+  placeholderLanguage: string;
+  originalLanguage: string;
+}
+
+export interface PreparedDisplayOnlyCodeFences {
+  markdown: string;
+  fences: DisplayOnlyCodeFence[];
+}
+
+/** Replaces fence languages so Obsidian cannot dispatch registered code-block processors. */
+export function prepareDisplayOnlyCodeFences(
+  markdown: string,
+): PreparedDisplayOnlyCodeFences {
+  const fences: DisplayOnlyCodeFence[] = [];
+  const preparedMarkdown = transformMarkdownSegments(markdown, {
+    fence: (opener, fence) => {
+      const languageMatch = fence.info.match(/^([\t ]*)(\S+)(.*)$/);
+      if (!languageMatch) {
+        return opener;
+      }
+
+      const placeholderLanguage = `${PLACEHOLDER_LANGUAGE_PREFIX}${fences.length}`;
+      const originalLanguage = languageMatch[2];
+      fences.push({ placeholderLanguage, originalLanguage });
+
+      const transformedInfo = `${languageMatch[1]}${placeholderLanguage}${languageMatch[3]}`;
+      return opener.slice(0, fence.infoStart)
+        + transformedInfo
+        + opener.slice(fence.infoStart + fence.info.length);
+    },
+  });
+
+  return { markdown: preparedMarkdown, fences };
+}
+
+/** Restores display metadata after Markdown post-processors finish, then highlights the code. */
+export async function restoreDisplayOnlyCodeFences(
+  container: HTMLElement,
+  fences: readonly DisplayOnlyCodeFence[],
+): Promise<void> {
+  const codeBlocks: HTMLElement[] = [];
+
+  for (const fence of fences) {
+    const placeholderClass = `language-${fence.placeholderLanguage}`;
+    const code = container.querySelector<HTMLElement>(`.${placeholderClass}`);
+    if (!code) {
+      continue;
+    }
+
+    code.classList.remove(placeholderClass);
+    code.classList.add(`language-${fence.originalLanguage}`);
+    codeBlocks.push(code);
+  }
+
+  if (codeBlocks.length === 0) {
+    return;
+  }
+
+  try {
+    const prism: unknown = await loadPrism();
+    if (
+      typeof prism !== 'object'
+      || prism === null
+      || !('highlightElement' in prism)
+      || typeof prism.highlightElement !== 'function'
+    ) {
+      return;
+    }
+    for (const code of codeBlocks) {
+      prism.highlightElement(code);
+    }
+  } catch {
+    // Language restoration is authoritative; highlighting is best-effort.
+  }
+}

--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -35,6 +35,10 @@ import type { FeatureHost } from '../../FeatureHost';
 import { findRewindContext } from '../rewind';
 import { formatConversationDirectoryTitle } from '../utils/conversationDirectoryTitle';
 import { renderCitationGroup as renderCitationBlock } from './CitationRenderer';
+import {
+  prepareDisplayOnlyCodeFences,
+  restoreDisplayOnlyCodeFences,
+} from './DisplayOnlyCodeFences';
 import { resolveSubagentAdapter } from './subagentAdapterResolution';
 import {
   renderStoredAsyncSubagent,
@@ -741,8 +745,9 @@ export class MessageRenderer {
       // as plain text. Trusted plugin markup (image embeds) is injected only
       // after this step, otherwise it would be escaped too.
       const safeMarkdown = escapeRawHtmlTags(renderMarkdown);
+      const displayOnlyCodeFences = prepareDisplayOnlyCodeFences(safeMarkdown);
       const processedMarkdown = replaceImageEmbedsWithHtml(
-        safeMarkdown,
+        displayOnlyCodeFences.markdown,
         this.app,
         { mediaFolder: this.plugin.settings.mediaFolder }
       );
@@ -753,6 +758,7 @@ export class MessageRenderer {
         '',
         this.component
       );
+      await restoreDisplayOnlyCodeFences(el, displayOnlyCodeFences.fences);
 
       // Wrap pre elements and move buttons outside scroll area
       el.querySelectorAll('pre').forEach((pre) => {

--- a/src/utils/markdownSegments.ts
+++ b/src/utils/markdownSegments.ts
@@ -30,8 +30,14 @@ type ActiveListContext = Pick<ParagraphContext, 'blockquoteDepth' | 'listIndents
 interface MarkdownSegment {
   text: string;
   transformable: boolean;
+  fence?: MarkdownFenceOpening;
   rawHtml?: boolean;
   sealed?: boolean;
+}
+
+export interface MarkdownFenceOpening {
+  info: string;
+  infoStart: number;
 }
 
 interface InlineContinuation {
@@ -238,6 +244,25 @@ function appendSegment(
   } else {
     segments.push({ text, transformable, rawHtml });
   }
+}
+
+function appendFenceOpeningSegment(
+  segments: MarkdownSegment[],
+  line: string,
+  lineWithoutNewline: string,
+  fenceRun: FenceRun,
+): void {
+  const runStart = lineWithoutNewline.indexOf(fenceRun.run);
+  const infoStart = runStart + fenceRun.run.length;
+  segments.push({
+    text: line,
+    transformable: false,
+    fence: {
+      info: lineWithoutNewline.slice(infoStart),
+      infoStart,
+    },
+    sealed: true,
+  });
 }
 
 function sealLastSegment(segments: MarkdownSegment[]): void {
@@ -743,7 +768,7 @@ function splitMarkdown(markdown: string): MarkdownSegment[] {
     const fenceRun = contextualFenceRun ?? getFenceRun(lineWithoutNewline);
     if (fenceRun) {
       paragraphContext = null;
-      appendSegment(segments, line, false);
+      appendFenceOpeningSegment(segments, line, lineWithoutNewline, fenceRun);
       fence = {
         marker: fenceRun.run[0] as '`' | '~',
         length: fenceRun.run.length,
@@ -808,6 +833,7 @@ function splitMarkdown(markdown: string): MarkdownSegment[] {
 }
 
 interface MarkdownTransforms {
+  fence?: (opener: string, fence: MarkdownFenceOpening) => string;
   text?: (text: string) => string;
   rawHtml?: (text: string) => string;
 }
@@ -819,6 +845,9 @@ export function transformMarkdownSegments(
 ): string {
   return splitMarkdown(markdown)
     .map(segment => {
+      if (segment.fence) {
+        return transforms.fence?.(segment.text, segment.fence) ?? segment.text;
+      }
       if (segment.rawHtml) {
         return transforms.rawHtml?.(segment.text) ?? segment.text;
       }

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -262,6 +262,10 @@ export const MarkdownRenderer = {
   renderMarkdown: renderMarkdownMock,
 };
 
+export const loadPrism = jest.fn().mockResolvedValue({
+  highlightElement: jest.fn(),
+});
+
 export const setIcon = jest.fn();
 
 // Notice mock that tracks constructor calls

--- a/tests/unit/features/chat/rendering/DisplayOnlyCodeFences.test.ts
+++ b/tests/unit/features/chat/rendering/DisplayOnlyCodeFences.test.ts
@@ -1,0 +1,126 @@
+import { createMockEl } from '@test/helpers/MockElement';
+import { loadPrism } from 'obsidian';
+
+import {
+  prepareDisplayOnlyCodeFences,
+  restoreDisplayOnlyCodeFences,
+} from '@/features/chat/rendering/DisplayOnlyCodeFences';
+
+describe('DisplayOnlyCodeFences', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('replaces every fenced language while preserving fence structure and metadata', () => {
+    const markdown = [
+      '> ```dataview',
+      '> TABLE file.name',
+      '> ```',
+      '- ~~~typescript title="sample"',
+      '  const value = 1;',
+      '  ~~~',
+    ].join('\n');
+
+    const prepared = prepareDisplayOnlyCodeFences(markdown);
+
+    expect(prepared.markdown).toBe([
+      '> ```claudian-display-only-fence-0',
+      '> TABLE file.name',
+      '> ```',
+      '- ~~~claudian-display-only-fence-1 title="sample"',
+      '  const value = 1;',
+      '  ~~~',
+    ].join('\n'));
+    expect(prepared.fences).toEqual([
+      {
+        placeholderLanguage: 'claudian-display-only-fence-0',
+        originalLanguage: 'dataview',
+      },
+      {
+        placeholderLanguage: 'claudian-display-only-fence-1',
+        originalLanguage: 'typescript',
+      },
+    ]);
+  });
+
+  it('does not treat fence-like content inside an outer fence as a new block', () => {
+    const markdown = [
+      '````markdown',
+      '```dataview',
+      'TABLE file.name',
+      '```',
+      '````',
+    ].join('\n');
+
+    const prepared = prepareDisplayOnlyCodeFences(markdown);
+
+    expect(prepared.markdown).toBe([
+      '````claudian-display-only-fence-0',
+      '```dataview',
+      'TABLE file.name',
+      '```',
+      '````',
+    ].join('\n'));
+    expect(prepared.fences).toHaveLength(1);
+    expect(prepared.fences[0].originalLanguage).toBe('markdown');
+  });
+
+  it('protects unclosed streaming fences and leaves non-language syntax unchanged', () => {
+    const markdown = [
+      '` ```dataview`',
+      '```',
+      'plain code',
+      '```',
+      '```dataview',
+      'TABLE file.name',
+    ].join('\n');
+
+    const prepared = prepareDisplayOnlyCodeFences(markdown);
+
+    expect(prepared.markdown).toBe([
+      '` ```dataview`',
+      '```',
+      'plain code',
+      '```',
+      '```claudian-display-only-fence-0',
+      'TABLE file.name',
+    ].join('\n'));
+    expect(prepared.fences).toHaveLength(1);
+  });
+
+  it('restores original language classes and reapplies Prism highlighting', async () => {
+    const highlightElement = jest.fn();
+    (loadPrism as jest.Mock).mockResolvedValueOnce({ highlightElement });
+    const container = createMockEl();
+    const code = container.createEl('code', {
+      cls: 'language-claudian-display-only-fence-0 extra-class',
+      text: 'const value = 1;',
+    });
+
+    await restoreDisplayOnlyCodeFences(container, [{
+      placeholderLanguage: 'claudian-display-only-fence-0',
+      originalLanguage: 'typescript',
+    }]);
+
+    expect(code.hasClass('language-claudian-display-only-fence-0')).toBe(false);
+    expect(code.hasClass('language-typescript')).toBe(true);
+    expect(code.hasClass('extra-class')).toBe(true);
+    expect(highlightElement).toHaveBeenCalledWith(code);
+  });
+
+  it('restores language classes even when Prism loading fails', async () => {
+    (loadPrism as jest.Mock).mockRejectedValueOnce(new Error('Prism unavailable'));
+    const container = createMockEl();
+    const code = container.createEl('code', {
+      cls: 'language-claudian-display-only-fence-0',
+      text: 'TABLE file.name',
+    });
+
+    await expect(restoreDisplayOnlyCodeFences(container, [{
+      placeholderLanguage: 'claudian-display-only-fence-0',
+      originalLanguage: 'dataview',
+    }])).resolves.toBeUndefined();
+
+    expect(code.hasClass('language-dataview')).toBe(true);
+  });
+});

--- a/tests/unit/features/chat/rendering/MessageRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/MessageRenderer.test.ts
@@ -2205,6 +2205,35 @@ describe('MessageRenderer', () => {
   // ============================================
 
   describe('renderContent - language label and copy', () => {
+    it('renders fenced languages through inert placeholders and restores highlighting', async () => {
+      const { loadPrism, MarkdownRenderer } = await import('obsidian');
+      const { renderer } = createRenderer();
+      const el = createMockEl();
+      const highlightElement = jest.fn();
+      let code: ReturnType<typeof createMockEl> | null = null;
+      (loadPrism as jest.Mock).mockResolvedValueOnce({ highlightElement });
+
+      (MarkdownRenderer.renderMarkdown as jest.Mock).mockImplementationOnce(
+        async (renderedMarkdown: string, container: any) => {
+          const language = renderedMarkdown.match(/^```([^\n]+)/)?.[1];
+          const pre = container.createEl('pre');
+          code = pre.createEl('code', {
+            cls: `language-${language}`,
+            text: 'TABLE file.name',
+          });
+        }
+      );
+
+      await renderer.renderContent(el, '```dataview\nTABLE file.name\n```');
+
+      const renderedMarkdown = (MarkdownRenderer.renderMarkdown as jest.Mock).mock.calls[0][0];
+      expect(renderedMarkdown).toContain('```claudian-display-only-fence-0');
+      expect(renderedMarkdown).not.toContain('```dataview');
+      expect(code?.hasClass('language-dataview')).toBe(true);
+      expect(code?.hasClass('language-claudian-display-only-fence-0')).toBe(false);
+      expect(highlightElement).toHaveBeenCalledWith(code);
+    });
+
     it('should add language label when code block has language class', async () => {
       const { MarkdownRenderer } = await import('obsidian');
       const { renderer } = createRenderer();


### PR DESCRIPTION
## Why

Assistant and thinking messages can contain language-tagged code fences such as `dataview`. Obsidian's Markdown renderer dispatches registered code-block processors for those fences, causing Dataview queries to execute and error banners to appear and accumulate in the chat UI.

Closes #1040.

## What Changed

- Replace fenced-code language identifiers with inert per-render placeholders before calling Obsidian's Markdown renderer.
- Restore the original language classes after Markdown post-processing and reapply Prism highlighting.
- Extend the shared Markdown segmenter with a fence-opener transform so blockquoted, list-nested, tilde, outer, and unfinished streaming fences follow the same parser rules.
- Add regression coverage for processor neutralization, language restoration, highlighting, and fallback behavior.

## Why This Approach

The chat renderer is the shared boundary for stored and streaming assistant and thinking content, so enforcing display-only fences there covers every provider without provider-specific branches.

Using inert languages prevents processors from starting rather than hiding their output afterward. Reusing the existing Markdown segmenter preserves fence structure without introducing a competing regex parser. Restoring the language class and invoking Prism preserves normal code presentation and highlighting.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run test` — 344 suites, 6,317 tests
- `npm run build`
- Fresh-context adversarial review: no material in-scope findings

## Impact and Follow-ups

- Language-specific code-block processors, including Mermaid and Dataview, now render as source code in chat by design.
- If Prism is unavailable, the original language class and readable code remain, but highlighting is skipped.
- General Markdown post-processors that act on arbitrary DOM or inline syntax are outside this issue's scope.
- End-to-end verification with a live Dataview installation remains a manual coverage gap.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
