### PR TITLE
fix: don't resolve npm's POSIX sh shim as the Claude CLI on Windows

### DIFF
--- a/src/providers/claude/cli/findClaudeCLIPath.ts
+++ b/src/providers/claude/cli/findClaudeCLIPath.ts
@@ -99,7 +99,10 @@ function resolveClaudeFromPathEntries(
     return unixCandidate;
   }
 
-  const exeCandidate = findFirstExistingPath(entries, ['claude.exe', 'claude']);
+  // An extension-less `claude` on a Windows PATH entry is npm's POSIX sh shim, which
+  // cannot be spawned directly. Skip it like the .cmd shim and fall through to the
+  // Node-backed package entrypoint below.
+  const exeCandidate = findFirstExistingPath(entries, ['claude.exe']);
   if (exeCandidate) {
     return exeCandidate;
   }

--- a/tests/unit/utils/utils.test.ts
+++ b/tests/unit/utils/utils.test.ts
@@ -609,6 +609,25 @@ describe('utils.ts', () => {
         expect(findClaudeCLIPath(customPath)).toBe(cliWrapperPath);
       });
 
+      it('should prefer cli-wrapper.cjs over the extension-less npm sh shim', () => {
+        const npmBin = 'D:\\npm-global';
+        const shimPath = path.join(npmBin, 'claude');
+        const cliWrapperPath = path.join(npmBin, 'node_modules', '@anthropic-ai', 'claude-code', 'cli-wrapper.cjs');
+        mockExistingFile(shimPath, cliWrapperPath);
+
+        const customPath = `${npmBin};C:\\Windows\\System32`;
+        expect(findClaudeCLIPath(customPath)).toBe(cliWrapperPath);
+      });
+
+      it('should ignore the extension-less npm sh shim when no package entrypoint exists', () => {
+        jest.spyOn(os, 'homedir').mockReturnValue('C:\\Users\\test');
+        const npmBin = 'D:\\npm-global';
+        mockExistingFile(path.join(npmBin, 'claude'));
+
+        const customPath = `${npmBin};C:\\Windows\\System32`;
+        expect(findClaudeCLIPath(customPath)).toBeNull();
+      });
+
       it('should not return a directory path even if it exists', () => {
         jest.spyOn(os, 'homedir').mockReturnValue('C:\\Users\\test');
         const dirPath = path.join('C:\\Users\\test', '.claude', 'local', 'claude');


### PR DESCRIPTION
## Why

On Windows, `findClaudeCLIPath` falls back to scanning `PATH` when the npm global prefix is not one of the hard-coded guesses (`%APPDATA%\npm`, `%ProgramFiles%\nodejs\node_global`, ...). The scan accepts an extension-less `claude`. For npm/pnpm/yarn global installs that file is the POSIX `sh` shim npm generates alongside `claude.cmd`:

```sh
#!/bin/sh
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
...
exec "$basedir/node_modules/@anthropic-ai/claude-code/bin/claude.exe" "$@"
```

Windows cannot spawn that. The agent SDK treats any path not ending in `.js`/`.mjs`/`.ts*` as a native binary, so the failure surfaces as:

> Claude Code native binary at `D:\npm-global\claude` exists but failed to launch. This usually means the binary does not match this system's libc — e.g. spawning a musl-linked binary on a glibc Linux host fails because the musl dynamic loader (`/lib/ld-musl-*`) is missing.

What the user actually sees in Obsidian (Claudian 2.0.44, Windows 11, npm prefix `D:\npm-global`):
<img width="652" height="215" alt="image" src="https://github.com/user-attachments/assets/5cc6ebbd-5941-464a-b15d-e77ce21ecc4e" />


That text is Linux-specific and actively misleading on Windows — there is no way for a user to get from it to the real cause. This hits any Windows user whose npm prefix sits outside the guessed locations (e.g. after `npm config set prefix D:\npm-global`).

## What

`resolveClaudeFromPathEntries` no longer accepts a bare `claude` from a Windows `PATH` entry: `.exe` first, then the existing Node package-entrypoint probe, then `null`.

## Why this approach

- **The correct logic already exists and was simply unreachable.** `resolveClaudeCodeEntrypointFromPathEntries` resolves that very same directory to `<prefix>\node_modules\@anthropic-ai\claude-code\cli-wrapper.cjs` — precisely the value `cliPath.descWindows` recommends for package-manager installs. The bare `claude` short-circuited before it ran.
- **Consistent with how `.cmd` is already treated.** `should ignore .cmd fallback on Windows` asserts `null` rather than returning something unspawnable. A bare `sh` shim is strictly less runnable than `.cmd`, so ranking it *above* `cli-wrapper.cjs` was inconsistent.
- **Alternative considered:** keep bare `claude` as a last-resort fallback after the entrypoint probe. Rejected — it preserves the misleading error in the no-entrypoint case and contradicts the `.cmd` precedent above.

## Validation

- Two cases added to `findClaudeCLIPath > on Windows`. Both fail on the pre-fix code (`Expected: "...cli-wrapper.cjs"` / `Received: "D:\npm-global\claude"`) and pass with the fix.
- `npm run typecheck` clean. `npm run build` + `npm run check:performance` OK.
- `npm run test`: total 6307 → 6309, failure count unchanged. (My Windows machine has 57 pre-existing failures in unrelated suites from hard-coded POSIX separators; `findClaudeCLIPath > on Windows` is green before and after.)
- **Real machine:** Windows 11, npm prefix `D:\npm-global`, Claude Code 2.1.220 installed via npm. Calling the real `findClaudeCLIPath()` with `npm_config_prefix` unset (as a GUI app such as Obsidian sees it) returns:
  - before: `D:\npm-global\claude`
  - after: `D:\npm-global\node_modules\@anthropic-ai\claude-code\cli-wrapper.cjs`

## Impact

- win32 branch only; the Unix path is untouched; no new dependencies.
- Behavior change: on Windows a lone `sh` shim now yields "not found" instead of a broken spawn. Users can still point `cliPath` at any file explicitly.
