### PR TITLE
fix: read the basename from either path separator in the file-naming lint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,7 +14,8 @@ const tsconfigRootDir = dirname(fileURLToPath(import.meta.url));
 const obsidianRuleSeverity = 'warn';
 
 // Enforces the file naming conventions from AGENTS.md without extra dependencies.
-const fileNamingRule = {
+// Exported so scripts/check-eslint-config.test.mjs can exercise it directly.
+export const fileNamingRule = {
   meta: {
     type: 'suggestion',
     docs: { description: 'Enforce the file naming conventions from AGENTS.md' },
@@ -27,7 +28,7 @@ const fileNamingRule = {
   },
   create(context) {
     const filename = context.physicalFilename ?? context.filename;
-    const base = filename.split('/').pop() ?? '';
+    const base = filename.split(/[\\/]/).pop() ?? '';
     if (!base.endsWith('.ts')) return {};
     const first = base.split('.')[0];
     if (first === 'index' || first === 'types') return {};

--- a/scripts/check-eslint-config.test.mjs
+++ b/scripts/check-eslint-config.test.mjs
@@ -3,9 +3,38 @@ import test from 'node:test';
 
 import { ESLint } from 'eslint';
 
+import { fileNamingRule } from '../eslint.config.mjs';
+
 test('Obsidian DOM creation helpers are enforced for source files', async () => {
   const eslint = new ESLint();
   const config = await eslint.calculateConfigForFile('src/utils/fileLink.ts');
 
   assert.deepEqual(config.rules['obsidianmd/prefer-create-el'], [2]);
+});
+
+// ESLint hands the rule an absolute path using the host platform's separator, so the
+// basename has to be taken from either separator. Windows paths are used here on every
+// platform on purpose: they are what regressed, and CI only runs Linux.
+function reportsFor(physicalFilename) {
+  const reported = [];
+  const visitor = fileNamingRule.create({
+    physicalFilename,
+    report: descriptor => reported.push(descriptor),
+  });
+  visitor.Program({ body: [] });
+
+  return reported;
+}
+
+test('file naming reads the basename from either path separator', () => {
+  assert.deepEqual(reportsFor('/repo/src/utils/fileLink.ts'), []);
+  assert.deepEqual(reportsFor('D:\\repo\\src\\utils\\fileLink.ts'), []);
+});
+
+test('file naming still rejects an invalid basename behind a Windows path', () => {
+  const reported = reportsFor('D:\\repo\\src\\utils\\some_snake_case.ts');
+
+  assert.equal(reported.length, 1);
+  assert.equal(reported[0].messageId, 'invalidCase');
+  assert.equal(reported[0].data.name, 'some_snake_case.ts');
 });


### PR DESCRIPTION
## Why

`local/file-naming` derives the basename with `filename.split('/')`, but ESLint hands the rule an absolute path built with the host platform's separator. On Windows there is no `/` to split on, so the entire path becomes the "filename":

```
D:\repo\tests\unit\utils\utils.test.ts
  .split('/').pop()  ->  'D:\repo\tests\unit\utils\utils.test.ts'
  .split('.')[0]     ->  'D:\repo\tests\unit\utils\utils'   // matches no case style
```

It also slips past the `if (!base.endsWith('.ts')) return {}` guard, since the full path ends in `.ts` as well. On a clean checkout of `main` (985838e8), Windows 11:

```
$ npm run lint
✖ 816 problems (816 errors, 0 warnings)
```

That is every `.ts` file in the repo, one error each. CONTRIBUTING requires `npm run lint` before opening a pull request, so a Windows contributor cannot satisfy the checklist. I ran into this preparing #1042 and had to fall back to comparing per-rule error counts against a baseline instead of getting a clean run.

The message is wrong on Windows too — it prints `Filename 'D:\repo\src\utils\fileLink.ts'` rather than `Filename 'fileLink.ts'`.

## What

Take the basename from either separator, and export the rule so it can be exercised directly by a test.

## Why this approach

- **`path.basename()` looks like the obvious fix but is worse here.** On Linux it does not treat `\` as a separator, so a test feeding a Windows-style path could never reproduce the regression on CI. Splitting on `[\\/]` is separator-agnostic, which lets a single test guard this on `ubuntu-latest`.
- **Linux behaviour is byte-for-byte unchanged.** A POSIX path contains no `\`, so the new character class matches exactly what `split('/')` matched.
- **Exporting `fileNamingRule` is the one debatable part.** It is what makes the rule unit-testable without leaning on ESLint's glob-matching semantics for a synthetic file path. Glad to switch to an `eslint.lintText()`-based test instead if you would rather keep the config's surface closed.

## Validation

Windows 11, Node 24.12.0:

- `npm run lint`: **816 errors → 0**, exit code 0.
- Rule still fires: a scratch `src/utils/some_snake_case.ts` is still reported, now as `Filename 'some_snake_case.ts'`.
- New tests fail on the old line and pass with the fix:
  ```
  # before
  actual:   'D:\repo\src\utils\some_snake_case.ts'
  expected: 'some_snake_case.ts'
  # after
  ℹ pass 3   ℹ fail 0
  ```
- `npm run typecheck`, `npm run build`, `npm run check:performance`: exit code 0.
- `npm run test`: jest totals identical to baseline (57 failed / 6309 total on this machine — pre-existing Windows failures in unrelated suites from hard-coded POSIX separators, untouched here).

One caveat worth stating: on Windows `npm run test` never reaches the `node --test` step, because `scripts/run-tests.js` exits as soon as jest returns non-zero. The new tests were therefore verified by running `node --test scripts/check-eslint-config.test.mjs` directly. On CI jest is green, so the step runs normally.

## Impact

- Build tooling only — no runtime, plugin, or user-visible change.
- CI results are unaffected; this only changes what Windows contributors see locally.
- No new dependencies.
