### PR TITLE
fix: preserve Pi transcript history on session reset

### DIFF
--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -508,7 +508,9 @@ export interface ProviderConversationHistoryService {
     sourceSessionId: string,
     resumeAt: string,
     sourceProviderState?: Record<string, unknown>,
-  ): Record<string, unknown>;
+    vaultPath?: string | null,
+    pathContext?: ProviderHistoryPathContext,
+  ): Record<string, unknown> | Promise<Record<string, unknown>>;
   /** Adds provider-owned persisted metadata to Conversation.providerState before session save. */
   buildPersistedProviderState?(conversation: Conversation): Record<string, unknown> | undefined;
 }

--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -5,6 +5,7 @@ import type { ProviderCommandDiscoveryResult } from '../../../core/providers/com
 import { normalizeProviderCommandDiscoveryItems } from '../../../core/providers/commands/ProviderCommandDiscoveryResult';
 import { ProviderCommandDiscoveryStore } from '../../../core/providers/commands/ProviderCommandDiscoveryStore';
 import type { ProviderCommandEntry } from '../../../core/providers/commands/ProviderCommandEntry';
+import { getRuntimeEnvironmentVariables } from '../../../core/providers/providerEnvironment';
 import { ProviderRegistry } from '../../../core/providers/ProviderRegistry';
 import { ProviderWorkspaceRegistry } from '../../../core/providers/ProviderWorkspaceRegistry';
 import type {
@@ -16,6 +17,7 @@ import { chooseForkTarget } from '../../../shared/modals/ForkTargetModal';
 import { throwIfAborted, toAbortError } from '../../../utils/abort';
 import { scheduleAnimationFrame } from '../../../utils/animationFrame';
 import { revealWorkspaceLeaf } from '../../../utils/obsidianCompat';
+import { getVaultPath } from '../../../utils/path';
 import type { FeatureHost } from '../../FeatureHost';
 import { getTabProviderId } from './providerResolution';
 import {
@@ -753,15 +755,25 @@ export class TabManager implements TabManagerInterface {
       ? this.buildForkTitle(context.sourceTitle, context.forkAtUserMessage)
       : undefined;
 
-    const forkProviderState = ProviderRegistry
-      .getConversationHistoryService(conversation.providerId)
-      .buildForkProviderState(
-        context.sourceSessionId,
-        context.resumeAt,
-        context.sourceProviderState,
-      );
-
     try {
+      const vaultPath = getVaultPath(this.plugin.app);
+      const forkProviderState = await ProviderRegistry
+        .getConversationHistoryService(conversation.providerId)
+        .buildForkProviderState(
+          context.sourceSessionId,
+          context.resumeAt,
+          context.sourceProviderState,
+          vaultPath,
+          {
+            environment: {
+              ...process.env,
+              ...getRuntimeEnvironmentVariables(this.plugin.settings, conversation.providerId),
+            },
+            hostPlatform: process.platform,
+            settings: this.plugin.settings,
+            vaultPath,
+          },
+        );
       await this.plugin.updateConversation(conversation.id, {
         messages: context.messages,
         providerState: forkProviderState,

--- a/src/providers/pi/env/PiSettingsReconciler.ts
+++ b/src/providers/pi/env/PiSettingsReconciler.ts
@@ -4,7 +4,10 @@ import {
   hasCliPathFingerprintInputs,
 } from '../../../core/providers/cli/CliPathFingerprintInputs';
 import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
-import { createRuntimeInputFingerprint } from '../../../core/providers/settings/RuntimeInputFingerprint';
+import {
+  createRuntimeInputFingerprint,
+  isVersionedRuntimeInputFingerprint,
+} from '../../../core/providers/settings/RuntimeInputFingerprint';
 import type { ProviderSettingsReconciler } from '../../../core/providers/types';
 import type { Conversation } from '../../../core/types';
 import { getHostnameKey, parseEnvironmentVariables } from '../../../utils/env';
@@ -22,9 +25,9 @@ import {
   normalizePiVisibleModels,
   updatePiProviderSettings,
 } from '../settings';
-import { getPiState } from '../types';
+import { clearPiResumeState } from '../types';
 
-const PI_ENV_HASH_KEYS = [
+const LEGACY_PI_ENV_HASH_KEYS = [
   'PI_CODING_AGENT_DIR',
   'PI_CODING_AGENT_SESSION_DIR',
   'PI_PACKAGE_DIR',
@@ -32,6 +35,10 @@ const PI_ENV_HASH_KEYS = [
   'PI_SKIP_VERSION_CHECK',
   'PI_TELEMETRY',
   'PI_CACHE_RETENTION',
+] as const;
+
+const PI_ENV_HASH_KEYS = [
+  ...LEGACY_PI_ENV_HASH_KEYS,
   'PATH',
 ] as const;
 
@@ -47,22 +54,31 @@ function computePiRuntimeFingerprint(
 }
 
 function invalidatePiConversationSessions(conversations: Conversation[]): Conversation[] {
-  const invalidatedConversations: Conversation[] = [];
-  for (const conversation of conversations) {
-    if (conversation.providerId !== 'pi') {
-      continue;
-    }
+  return conversations.filter(conversation => (
+    conversation.providerId === 'pi' && clearPiResumeState(conversation)
+  ));
+}
 
-    const state = getPiState(conversation.providerState);
-    if (!conversation.sessionId && !state.sessionId && !state.sessionFile) {
-      continue;
-    }
-
-    conversation.sessionId = null;
-    conversation.providerState = undefined;
-    invalidatedConversations.push(conversation);
+function isCurrentLegacyPiFingerprint(
+  environmentText: string,
+  savedFingerprint: string,
+  cliPathInputs: CliPathFingerprintInputs,
+): boolean {
+  if (
+    !savedFingerprint
+    || isVersionedRuntimeInputFingerprint(savedFingerprint)
+    || hasCliPathFingerprintInputs(cliPathInputs)
+  ) {
+    return false;
   }
-  return invalidatedConversations;
+
+  const environment = parseEnvironmentVariables(environmentText);
+  const legacyFingerprint = LEGACY_PI_ENV_HASH_KEYS
+    .filter(key => environment[key])
+    .map(key => `${key}=${environment[key]}`)
+    .sort()
+    .join('|');
+  return savedFingerprint === legacyFingerprint;
 }
 
 export const piSettingsReconciler: ProviderSettingsReconciler = {
@@ -113,6 +129,22 @@ export const piSettingsReconciler: ProviderSettingsReconciler = {
   normalizeModelVariantSettings(settings: Record<string, unknown>): boolean {
     const piSettings = getPiProviderSettings(settings);
     let changed = false;
+
+    const envText = getRuntimeEnvironmentText(settings, 'pi');
+    const cliPathInputs = createCliPathFingerprintInputs(
+      piSettings.cliPathsByHost[getHostnameKey()],
+      piSettings.cliPath,
+    );
+    if (isCurrentLegacyPiFingerprint(
+      envText,
+      piSettings.environmentHash,
+      cliPathInputs,
+    )) {
+      updatePiProviderSettings(settings, {
+        environmentHash: computePiRuntimeFingerprint(envText, cliPathInputs),
+      });
+      changed = true;
+    }
 
     const normalizeSelection = (value: unknown): string | null => {
       if (typeof value !== 'string') {

--- a/src/providers/pi/execution/PiExecutionSession.ts
+++ b/src/providers/pi/execution/PiExecutionSession.ts
@@ -53,6 +53,7 @@ import {
   resolvePiActivePath,
   type rollbackCreatedPiForkSessionFile,
 } from '../history/PiHistoryStore';
+import { encodePiRecoveryPrompt } from '../history/PiRecoveryPromptCodec';
 import {
   clampPiThinkingLevel,
   decodePiModelId,
@@ -1482,11 +1483,15 @@ function encodePrompt(
   if (replayConversationHistory && request.conversationHistory?.length) {
     const history = [...request.conversationHistory] as ChatMessage[];
     const historyContext = buildContextFromHistory(history);
-    text = buildPromptWithHistoryContext(
+    const recoveredPrompt = buildPromptWithHistoryContext(
       historyContext,
       text,
       text,
       history,
+    );
+    text = encodePiRecoveryPrompt(
+      historyContext,
+      recoveredPrompt === historyContext ? null : text,
     );
   }
   return {

--- a/src/providers/pi/history/PiConversationHistoryService.ts
+++ b/src/providers/pi/history/PiConversationHistoryService.ts
@@ -1,20 +1,35 @@
 import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 
 import { mergePersistedProviderState } from '../../../core/providers/providerState';
 import type {
   ProviderConversationHistoryService,
   ProviderHistoryPathContext,
 } from '../../../core/providers/types';
-import type { Conversation } from '../../../core/types';
-import { buildPersistedPiState, getPiState } from '../types';
-import { resolvePiSessionFileHint } from './PiHistoryPathResolver';
-import { parsePiSessionContent } from './PiHistoryStore';
+import type { ChatMessage, Conversation } from '../../../core/types';
+import {
+  addPiPreviousSession,
+  buildPersistedPiState,
+  clearPiResumeState,
+  getPiState,
+  type PiPreviousSession,
+} from '../types';
+import {
+  isPiSessionPathReference,
+  resolvePiSessionFileHint,
+} from './PiHistoryPathResolver';
+import {
+  parsePiSessionContent,
+  parsePiSessionEntries,
+  readPiSessionHeader,
+} from './PiHistoryStore';
 
 const PI_PROVIDER_STATE_KEYS = [
   'forkSource',
   'forkSourceSessionFile',
   'leafEntryId',
   'parentSession',
+  'previousSessions',
   'sessionFile',
   'sessionId',
 ] as const;
@@ -29,11 +44,15 @@ export class PiConversationHistoryService implements ProviderConversationHistory
   ): Promise<void> {
     const state = getPiState(conversation.providerState);
     if (this.isPendingForkConversation(conversation)) {
-      const sourceSessionFile = resolvePiSessionFileHint(
-        state.forkSourceSessionFile,
-        state.forkSource!.sessionId,
+      const sourceSessionFile = await this.resolvePreviousSessionFile(
+        {
+          leafEntryId: state.forkSource!.resumeAt,
+          sessionFile: state.forkSourceSessionFile,
+          sessionId: state.forkSource!.sessionId,
+        },
         vaultPath,
         pathContext,
+        true,
       );
       this.replaceResolvedPath(
         conversation,
@@ -54,6 +73,7 @@ export class PiConversationHistoryService implements ProviderConversationHistory
         const messages = parsePiSessionContent(content, {
           leafEntryId: state.forkSource!.resumeAt,
           requireLeafEntryId: true,
+          syntheticIdNamespace: sourceSessionFile,
         });
         if (messages.length === 0) {
           this.hydratedKeys.delete(conversation.id);
@@ -68,30 +88,72 @@ export class PiConversationHistoryService implements ProviderConversationHistory
       return;
     }
 
-    const sessionTarget = state.sessionId ?? conversation.sessionId;
-    if (!state.sessionFile && !sessionTarget) {
+    const currentSession: PiPreviousSession = {
+      ...(state.leafEntryId ? { leafEntryId: state.leafEntryId } : {}),
+      ...(state.sessionFile ? { sessionFile: state.sessionFile } : {}),
+      ...(state.sessionId ?? conversation.sessionId
+        ? { sessionId: (state.sessionId ?? conversation.sessionId)! }
+        : {}),
+    };
+    const sources = [
+      ...(state.previousSessions ?? []).map((source, index) => ({
+        index,
+        kind: 'previous' as const,
+        source,
+      })),
+      ...(currentSession.sessionFile || currentSession.sessionId
+        ? [{ kind: 'current' as const, source: currentSession }]
+        : []),
+    ];
+    if (sources.length === 0) {
       this.hydratedKeys.delete(conversation.id);
       return;
     }
 
-    const sessionFile = resolvePiSessionFileHint(
-      state.sessionFile,
-      sessionTarget,
-      vaultPath,
-      pathContext,
-    );
-    this.replaceResolvedPath(
-      conversation,
-      'sessionFile',
-      state.sessionFile,
-      sessionFile,
-    );
-    if (!sessionFile) {
+    const resolvedSources: Array<{
+      index?: number;
+      kind: 'current' | 'previous';
+      leafEntryId?: string;
+      persistedPath?: string;
+      sessionFile: string;
+    }> = [];
+    for (const item of sources) {
+      const sessionFile = item.kind === 'previous'
+        ? await this.resolvePreviousSessionFile(
+          item.source,
+          vaultPath,
+          pathContext,
+        )
+        : resolvePiSessionFileHint(
+          item.source.sessionFile,
+          item.source.sessionId,
+          vaultPath,
+          pathContext,
+        );
+      if (item.kind === 'current') {
+        this.replaceResolvedPath(
+          conversation,
+          'sessionFile',
+          item.source.sessionFile,
+          sessionFile,
+        );
+      }
+      if (sessionFile) {
+        resolvedSources.push({
+          ...(item.kind === 'previous' ? { index: item.index } : {}),
+          kind: item.kind,
+          ...(item.source.leafEntryId ? { leafEntryId: item.source.leafEntryId } : {}),
+          ...(item.source.sessionFile ? { persistedPath: item.source.sessionFile } : {}),
+          sessionFile,
+        });
+      }
+    }
+    if (resolvedSources.length === 0) {
       this.hydratedKeys.delete(conversation.id);
       return;
     }
 
-    const hydrationKey = `${sessionFile}::${state.leafEntryId ?? ''}`;
+    const hydrationKey = JSON.stringify(resolvedSources);
     if (
       conversation.messages.length > 0
       && this.hydratedKeys.get(conversation.id) === hydrationKey
@@ -99,21 +161,39 @@ export class PiConversationHistoryService implements ProviderConversationHistory
       return;
     }
 
-    try {
-      const content = await fs.readFile(sessionFile, 'utf-8');
-      const messages = parsePiSessionContent(content, {
-        leafEntryId: state.leafEntryId,
-      });
-      if (messages.length === 0) {
-        this.hydratedKeys.delete(conversation.id);
-        return;
+    const messages: ChatMessage[] = [];
+    for (const source of resolvedSources) {
+      try {
+        const content = await fs.readFile(source.sessionFile, 'utf-8');
+        const sourceMessages = parsePiSessionContent(content, {
+          leafEntryId: source.leafEntryId,
+          requireLeafEntryId: source.kind === 'previous' && !!source.leafEntryId,
+          syntheticIdNamespace: source.sessionFile,
+        });
+        messages.push(...sourceMessages);
+        if (
+          source.kind === 'previous'
+          && sourceMessages.length > 0
+          && source.index !== undefined
+          && source.sessionFile !== source.persistedPath
+        ) {
+          this.replacePreviousSessionPath(
+            conversation,
+            source.index,
+            source.sessionFile,
+          );
+        }
+      } catch {
+        // One unavailable segment must not hide the remaining replayable history.
       }
-
-      conversation.messages = messages;
-      this.hydratedKeys.set(conversation.id, hydrationKey);
-    } catch {
-      this.hydratedKeys.delete(conversation.id);
     }
+    if (messages.length === 0) {
+      this.hydratedKeys.delete(conversation.id);
+      return;
+    }
+
+    conversation.messages = dedupeMessages(messages);
+    this.hydratedKeys.set(conversation.id, hydrationKey);
   }
 
   resolveSessionIdForConversation(conversation: Conversation | null): string | null {
@@ -122,6 +202,7 @@ export class PiConversationHistoryService implements ProviderConversationHistory
       ?? state.sessionId
       ?? conversation?.sessionId
       ?? state.forkSource?.sessionId
+      ?? getLastPreviousSessionTarget(state.previousSessions)
       ?? null;
   }
 
@@ -143,23 +224,36 @@ export class PiConversationHistoryService implements ProviderConversationHistory
       return 'preserve';
     }
 
-    const providerState = { ...(conversation.providerState ?? {}) };
-    if (state.sessionFile === currentTarget) delete providerState.sessionFile;
-    if (state.sessionId === currentTarget) delete providerState.sessionId;
-    if (conversation.sessionId === currentTarget) conversation.sessionId = null;
-
-    const remainingState = getPiState(providerState);
-    if (
-      !remainingState.sessionFile
-      && !remainingState.sessionId
-      && !conversation.sessionId
-    ) {
-      delete providerState.leafEntryId;
-      delete providerState.parentSession;
+    const hasFallbackTarget = Boolean(
+      (state.sessionFile && state.sessionFile !== currentTarget)
+      || (state.sessionId && state.sessionId !== currentTarget)
+      || (conversation.sessionId && conversation.sessionId !== currentTarget),
+    );
+    if (!hasFallbackTarget) {
+      clearPiResumeState(conversation);
+    } else {
+      const providerState = { ...(conversation.providerState ?? {}) };
+      providerState.previousSessions = addPiPreviousSession(
+        state.previousSessions,
+        {
+          ...(state.leafEntryId ? { leafEntryId: state.leafEntryId } : {}),
+          ...(state.sessionFile === currentTarget
+            ? { sessionFile: state.sessionFile }
+            : {}),
+          ...(state.sessionId === currentTarget
+            ? { sessionId: state.sessionId }
+            : conversation.sessionId === currentTarget
+              ? { sessionId: conversation.sessionId }
+              : {}),
+        },
+      );
+      if (state.sessionFile === currentTarget) delete providerState.sessionFile;
+      if (state.sessionId === currentTarget) delete providerState.sessionId;
+      if (conversation.sessionId === currentTarget) conversation.sessionId = null;
+      conversation.providerState = Object.keys(providerState).length > 0
+        ? providerState
+        : undefined;
     }
-    conversation.providerState = Object.keys(providerState).length > 0
-      ? providerState
-      : undefined;
     this.hydratedKeys.delete(conversation.id);
     return 'reset';
   }
@@ -169,16 +263,66 @@ export class PiConversationHistoryService implements ProviderConversationHistory
     return !!state.forkSource && !state.sessionId && !state.sessionFile && !_conversation.sessionId;
   }
 
-  buildForkProviderState(
+  async buildForkProviderState(
     sourceSessionId: string,
     resumeAt: string,
     sourceProviderState?: Record<string, unknown>,
-  ): Record<string, unknown> {
+    vaultPath: string | null = null,
+    pathContext?: ProviderHistoryPathContext,
+  ): Promise<Record<string, unknown>> {
     const sourceState = getPiState(sourceProviderState);
-    const sourceSessionFile = sourceState.sessionFile ?? sourceState.forkSourceSessionFile;
+    const candidates: PiForkSourceCandidate[] = [];
+    const addCandidate = (source: PiPreviousSession, sessionFile: string | null): void => {
+      if (!sessionFile) return;
+      candidates.push({
+        sessionFile,
+        sessionId: source.sessionId ?? source.sessionFile ?? sourceSessionId,
+      });
+    };
+    const currentSource: PiPreviousSession = {
+      sessionFile: sourceState.sessionFile,
+      sessionId: sourceState.sessionId ?? sourceSessionId,
+    };
+    addCandidate(
+      currentSource,
+      resolvePiSessionFileHint(
+        currentSource.sessionFile,
+        currentSource.sessionId,
+        vaultPath,
+        pathContext,
+      ),
+    );
+    if (sourceState.forkSource) {
+      const pendingSource: PiPreviousSession = {
+        leafEntryId: sourceState.forkSource.resumeAt,
+        sessionFile: sourceState.forkSourceSessionFile,
+        sessionId: sourceState.forkSource.sessionId,
+      };
+      addCandidate(
+        pendingSource,
+        await this.resolvePreviousSessionFile(
+          pendingSource,
+          vaultPath,
+          pathContext,
+          true,
+        ),
+      );
+    }
+    for (const source of [...(sourceState.previousSessions ?? [])].reverse()) {
+      addCandidate(
+        source,
+        await this.resolvePreviousSessionFile(source, vaultPath, pathContext),
+      );
+    }
+    const dedupedCandidates = dedupeForkSources(candidates);
+    const matchingSource = await findForkSourceContainingCheckpoint(dedupedCandidates, resumeAt)
+      ?? dedupedCandidates[0]
+      ?? { sessionId: sourceSessionId };
     return buildPersistedPiState({
-      forkSource: { sessionId: sourceSessionId, resumeAt },
-      ...(sourceSessionFile ? { forkSourceSessionFile: sourceSessionFile } : {}),
+      forkSource: { sessionId: matchingSource.sessionId, resumeAt },
+      ...(matchingSource.sessionFile
+        ? { forkSourceSessionFile: matchingSource.sessionFile }
+        : {}),
     }) as Record<string, unknown>;
   }
 
@@ -215,5 +359,147 @@ export class PiConversationHistoryService implements ProviderConversationHistory
       PI_PROVIDER_STATE_KEYS,
       buildPersistedPiState(nextState) as Record<string, unknown> | undefined,
     );
+  }
+
+  private async resolvePreviousSessionFile(
+    source: PiPreviousSession,
+    vaultPath: string | null,
+    pathContext?: ProviderHistoryPathContext,
+    preferResolvedPath = false,
+  ): Promise<string | null> {
+    const resolved = resolvePiSessionFileHint(
+      source.sessionFile,
+      source.sessionId,
+      vaultPath,
+      pathContext,
+    );
+    if (resolved === source.sessionFile) {
+      return resolved;
+    }
+    if (
+      preferResolvedPath
+      && resolved
+      && await isMatchingArchivedPiSession(resolved, source, vaultPath)
+    ) {
+      return resolved;
+    }
+    if (
+      source.sessionFile
+      && await isMatchingArchivedPiSession(source.sessionFile, source, vaultPath)
+    ) {
+      return source.sessionFile;
+    }
+    if (resolved && await isMatchingArchivedPiSession(resolved, source, vaultPath)) {
+      return resolved;
+    }
+    return null;
+  }
+
+  private replacePreviousSessionPath(
+    conversation: Conversation,
+    index: number,
+    sessionFile: string,
+  ): void {
+    const state = getPiState(conversation.providerState);
+    if (!state.previousSessions?.[index]) {
+      return;
+    }
+    const previousSessions = state.previousSessions.map((source, sourceIndex) => (
+      sourceIndex === index ? { ...source, sessionFile } : source
+    ));
+    conversation.providerState = mergePersistedProviderState(
+      conversation.providerState,
+      PI_PROVIDER_STATE_KEYS,
+      buildPersistedPiState({ ...state, previousSessions }) as Record<string, unknown> | undefined,
+    );
+  }
+}
+
+interface PiForkSourceCandidate {
+  sessionFile?: string;
+  sessionId: string;
+}
+
+function dedupeForkSources(candidates: PiForkSourceCandidate[]): PiForkSourceCandidate[] {
+  const seen = new Set<string>();
+  return candidates.filter((candidate) => {
+    if (!candidate.sessionFile || seen.has(candidate.sessionFile)) {
+      return false;
+    }
+    seen.add(candidate.sessionFile);
+    return true;
+  });
+}
+
+async function findForkSourceContainingCheckpoint(
+  candidates: PiForkSourceCandidate[],
+  resumeAt: string,
+): Promise<PiForkSourceCandidate | null> {
+  for (const candidate of candidates) {
+    try {
+      const content = await fs.readFile(candidate.sessionFile!, 'utf-8');
+      if (parsePiSessionEntries(content).entries.some(entry => entry.id === resumeAt)) {
+        return candidate;
+      }
+    } catch {
+      // An unavailable segment cannot contain a usable fork checkpoint.
+    }
+  }
+  return null;
+}
+
+function getLastPreviousSessionTarget(
+  sessions: PiPreviousSession[] | undefined,
+): string | null {
+  const session = sessions?.at(-1);
+  return session?.sessionFile ?? session?.sessionId ?? null;
+}
+
+function dedupeMessages(messages: ChatMessage[]): ChatMessage[] {
+  const seen = new Set<string>();
+  return messages.filter((message) => {
+    if (seen.has(message.id)) {
+      return false;
+    }
+    seen.add(message.id);
+    return true;
+  });
+}
+
+async function isMatchingArchivedPiSession(
+  sessionFile: string,
+  source: PiPreviousSession,
+  vaultPath: string | null,
+): Promise<boolean> {
+  const header = await readPiSessionHeader(sessionFile);
+  if (!header) {
+    return false;
+  }
+
+  const expectedSessionId = source.sessionId
+    && !isPiSessionPathReference(source.sessionId)
+    ? source.sessionId
+    : null;
+  if (
+    expectedSessionId
+    && (typeof header.id !== 'string' || header.id.trim() !== expectedSessionId)
+  ) {
+    return false;
+  }
+  if (!vaultPath) {
+    return expectedSessionId !== null;
+  }
+  if (typeof header.cwd !== 'string' || !header.cwd.trim()) {
+    return false;
+  }
+
+  return await resolveRealPath(header.cwd) === await resolveRealPath(vaultPath);
+}
+
+async function resolveRealPath(value: string): Promise<string> {
+  try {
+    return path.resolve(await fs.realpath(value));
+  } catch {
+    return path.resolve(value);
   }
 }

--- a/src/providers/pi/history/PiHistoryStore.ts
+++ b/src/providers/pi/history/PiHistoryStore.ts
@@ -14,6 +14,7 @@ import {
   normalizePiToolInput,
   normalizePiToolName,
 } from '../normalizations/piToolNormalization';
+import { decodePiRecoveryPrompt } from './PiRecoveryPromptCodec';
 
 export interface PiSessionEntry {
   id?: string;
@@ -31,6 +32,7 @@ export interface ParsedPiSessionEntries {
 export interface ParsePiSessionContentOptions {
   leafEntryId?: string;
   requireLeafEntryId?: boolean;
+  syntheticIdNamespace?: string;
 }
 
 export interface CreatePiForkSessionFileOptions {
@@ -71,10 +73,10 @@ export function parsePiSessionContent(
     return [];
   }
 
-  return mapPiSessionEntries(resolvePiActivePath(
-    parsed.entries,
-    leafEntryId,
-  ));
+  return mapPiSessionEntries(
+    resolvePiActivePath(parsed.entries, leafEntryId),
+    options.syntheticIdNamespace,
+  );
 }
 
 export function parsePiSessionEntries(content: string): ParsedPiSessionEntries {
@@ -116,6 +118,33 @@ export function parsePiSessionEntries(content: string): ParsedPiSessionEntries {
   }
 
   return { entries, header };
+}
+
+export async function readPiSessionHeader(
+  sessionFile: string,
+): Promise<Record<string, unknown> | null> {
+  const maxHeaderBytes = 64 * 1024;
+  let handle: fsp.FileHandle | null = null;
+  try {
+    handle = await fsp.open(sessionFile, 'r');
+    const buffer = Buffer.alloc(maxHeaderBytes);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    const content = buffer.subarray(0, bytesRead).toString('utf8');
+    const newlineIndex = content.search(/\r?\n/);
+    if (newlineIndex === -1 && bytesRead === maxHeaderBytes) {
+      return null;
+    }
+    const firstLine = newlineIndex === -1 ? content : content.slice(0, newlineIndex);
+    const parsed = JSON.parse(firstLine) as unknown;
+    if (!isPlainObject(parsed) || getString(parsed.type) !== 'session') {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
 }
 
 export function resolvePiActivePath(entries: PiSessionEntry[], leafId?: string): PiSessionEntry[] {
@@ -374,11 +403,14 @@ export function derivePiSessionsRootFromSessionPath(sessionPath: string): string
   return path.dirname(normalized);
 }
 
-function mapPiSessionEntries(entries: PiSessionEntry[]): ChatMessage[] {
+function mapPiSessionEntries(
+  entries: PiSessionEntry[],
+  syntheticIdNamespace?: string,
+): ChatMessage[] {
   const messages: ChatMessage[] = [];
 
   for (const entry of entries) {
-    const mapped = mapPiSessionEntry(entry, messages);
+    const mapped = mapPiSessionEntry(entry, messages, syntheticIdNamespace);
     if (mapped) {
       const previous = messages[messages.length - 1];
       if (isAssistantMessageEntry(entry) && canMergeAssistantContinuation(previous, mapped)) {
@@ -437,19 +469,33 @@ function mergeAssistantContinuation(target: ChatMessage, source: ChatMessage): v
 function mapPiSessionEntry(
   entry: PiSessionEntry,
   messages: ChatMessage[],
+  syntheticIdNamespace?: string,
 ): ChatMessage | null {
   const message = entry.message ?? entry.raw;
   const role = getString(message.role) ?? inferRole(entry.type);
   const timestamp = getTimestamp(message.timestamp ?? entry.raw.timestamp);
 
   if (role === 'user') {
-    const content = extractTextContent(message.content ?? message.text ?? message.message);
+    const rawContent = extractTextContent(message.content ?? message.text ?? message.message);
+    const recoveryPrompt = decodePiRecoveryPrompt(rawContent);
+    const content = recoveryPrompt?.currentInput ?? (recoveryPrompt ? '' : rawContent);
     const displayContent = extractPiSkillDisplayContent(content);
-    const images = extractUserImages(message.content ?? message.parts ?? message.blocks, entry.id ?? `pi-user-${messages.length}`);
+    const messageId = entry.id ?? createSyntheticPiMessageId(
+      'user',
+      messages.length,
+      syntheticIdNamespace,
+    );
+    const images = extractUserImages(
+      message.content ?? message.parts ?? message.blocks,
+      messageId,
+    );
+    if (recoveryPrompt?.currentInput === null && images.length === 0) {
+      return null;
+    }
     return {
       content,
       ...(displayContent ? { displayContent } : {}),
-      id: entry.id ?? `pi-user-${messages.length}`,
+      id: messageId,
       ...(images.length > 0 ? { images } : {}),
       role: 'user',
       timestamp,
@@ -469,7 +515,11 @@ function mapPiSessionEntry(
       assistantMessageId: entry.id,
       content: text,
       ...(contentBlocks.length > 0 ? { contentBlocks } : {}),
-      id: entry.id ?? `pi-assistant-${messages.length}`,
+      id: entry.id ?? createSyntheticPiMessageId(
+        'assistant',
+        messages.length,
+        syntheticIdNamespace,
+      ),
       role: 'assistant',
       timestamp,
       ...(toolCalls.length > 0 ? { toolCalls } : {}),
@@ -485,7 +535,11 @@ function mapPiSessionEntry(
     return {
       content: '',
       contentBlocks: [{ type: 'context_compacted' }],
-      id: entry.id ?? `pi-compaction-${messages.length}`,
+      id: entry.id ?? createSyntheticPiMessageId(
+        'compaction',
+        messages.length,
+        syntheticIdNamespace,
+      ),
       role: 'assistant',
       timestamp,
     };
@@ -502,13 +556,26 @@ function mapPiSessionEntry(
     return {
       content,
       contentBlocks: [{ type: 'text', content }],
-      id: entry.id ?? `pi-notice-${messages.length}`,
+      id: entry.id ?? createSyntheticPiMessageId(
+        'notice',
+        messages.length,
+        syntheticIdNamespace,
+      ),
       role: 'assistant',
       timestamp,
     };
   }
 
   return null;
+}
+
+function createSyntheticPiMessageId(
+  kind: string,
+  index: number,
+  namespace?: string,
+): string {
+  const localId = `pi-${kind}-${index}`;
+  return namespace ? `${namespace}:${localId}` : localId;
 }
 
 function extractPiSkillDisplayContent(content: string): string | undefined {

--- a/src/providers/pi/history/PiRecoveryPromptCodec.ts
+++ b/src/providers/pi/history/PiRecoveryPromptCodec.ts
@@ -1,0 +1,50 @@
+const RECOVERY_HISTORY_PREFIX = '<claudian_recovery_history length="';
+const RECOVERY_HISTORY_HEADER_SUFFIX = '">\n';
+const RECOVERY_HISTORY_SUFFIX = '\n</claudian_recovery_history>';
+const RECOVERY_INPUT_PREFIX = '\n\nUser: ';
+
+export interface DecodedPiRecoveryPrompt {
+  currentInput: string | null;
+}
+
+export function encodePiRecoveryPrompt(
+  historyContext: string,
+  currentInput: string | null,
+): string {
+  const historyBlock = `${RECOVERY_HISTORY_PREFIX}${historyContext.length}`
+    + `${RECOVERY_HISTORY_HEADER_SUFFIX}${historyContext}${RECOVERY_HISTORY_SUFFIX}`;
+  return currentInput === null
+    ? historyBlock
+    : `${historyBlock}${RECOVERY_INPUT_PREFIX}${currentInput}`;
+}
+
+export function decodePiRecoveryPrompt(prompt: string): DecodedPiRecoveryPrompt | null {
+  if (!prompt.startsWith(RECOVERY_HISTORY_PREFIX)) {
+    return null;
+  }
+
+  const lengthEnd = prompt.indexOf(RECOVERY_HISTORY_HEADER_SUFFIX);
+  if (lengthEnd < RECOVERY_HISTORY_PREFIX.length) {
+    return null;
+  }
+  const historyLength = Number(prompt.slice(RECOVERY_HISTORY_PREFIX.length, lengthEnd));
+  if (!Number.isSafeInteger(historyLength) || historyLength < 0) {
+    return null;
+  }
+
+  const historyStart = lengthEnd + RECOVERY_HISTORY_HEADER_SUFFIX.length;
+  const historyEnd = historyStart + historyLength;
+  if (prompt.slice(historyEnd, historyEnd + RECOVERY_HISTORY_SUFFIX.length)
+    !== RECOVERY_HISTORY_SUFFIX) {
+    return null;
+  }
+
+  const remainder = prompt.slice(historyEnd + RECOVERY_HISTORY_SUFFIX.length);
+  if (!remainder) {
+    return { currentInput: null };
+  }
+  if (!remainder.startsWith(RECOVERY_INPUT_PREFIX)) {
+    return null;
+  }
+  return { currentInput: remainder.slice(RECOVERY_INPUT_PREFIX.length) };
+}

--- a/src/providers/pi/types.ts
+++ b/src/providers/pi/types.ts
@@ -1,6 +1,14 @@
+import type { Conversation } from '../../core/types';
+
 export interface PiForkSource {
   resumeAt: string;
   sessionId: string;
+}
+
+export interface PiPreviousSession {
+  leafEntryId?: string;
+  sessionFile?: string;
+  sessionId?: string;
 }
 
 export interface PiProviderState {
@@ -8,6 +16,7 @@ export interface PiProviderState {
   forkSourceSessionFile?: string;
   leafEntryId?: string;
   parentSession?: string;
+  previousSessions?: PiPreviousSession[];
   sessionFile?: string;
   sessionId?: string;
 }
@@ -19,6 +28,7 @@ export function getPiState(value: unknown): PiProviderState {
 
   const record = value as Record<string, unknown>;
   const forkSource = getPiForkSource(record.forkSource);
+  const previousSessions = getPiPreviousSessions(record.previousSessions);
   return {
     ...(forkSource ? { forkSource } : {}),
     ...(typeof record.forkSourceSessionFile === 'string' && record.forkSourceSessionFile.trim()
@@ -30,6 +40,7 @@ export function getPiState(value: unknown): PiProviderState {
     ...(typeof record.parentSession === 'string' && record.parentSession.trim()
       ? { parentSession: record.parentSession.trim() }
       : {}),
+    ...(previousSessions.length > 0 ? { previousSessions } : {}),
     ...(typeof record.sessionFile === 'string' && record.sessionFile.trim()
       ? { sessionFile: record.sessionFile.trim() }
       : {}),
@@ -45,11 +56,60 @@ export function buildPersistedPiState(state: PiProviderState): PiProviderState |
     ...(state.forkSourceSessionFile ? { forkSourceSessionFile: state.forkSourceSessionFile } : {}),
     ...(state.leafEntryId ? { leafEntryId: state.leafEntryId } : {}),
     ...(state.parentSession ? { parentSession: state.parentSession } : {}),
+    ...(state.previousSessions && state.previousSessions.length > 0
+      ? { previousSessions: state.previousSessions.map(session => ({ ...session })) }
+      : {}),
     ...(state.sessionFile ? { sessionFile: state.sessionFile } : {}),
     ...(state.sessionId ? { sessionId: state.sessionId } : {}),
   };
 
   return Object.keys(persisted).length > 0 ? persisted : undefined;
+}
+
+export function clearPiResumeState(conversation: Conversation): boolean {
+  const state = getPiState(conversation.providerState);
+  const hasResumeState = conversation.sessionId != null
+    || !!state.sessionId
+    || !!state.sessionFile
+    || !!state.forkSource;
+  if (!hasResumeState) {
+    return false;
+  }
+
+  const currentSession = state.forkSource && !state.sessionId && !state.sessionFile
+    ? {
+      leafEntryId: state.forkSource.resumeAt,
+      sessionFile: state.forkSourceSessionFile,
+      sessionId: state.forkSource.sessionId,
+    }
+    : {
+      leafEntryId: state.leafEntryId,
+      sessionFile: state.sessionFile,
+      sessionId: state.sessionId ?? conversation.sessionId ?? undefined,
+    };
+  const previousSessions = addPiPreviousSession(
+    state.previousSessions,
+    currentSession,
+  );
+
+  const providerState = { ...(conversation.providerState ?? {}) };
+  delete providerState.forkSource;
+  delete providerState.forkSourceSessionFile;
+  delete providerState.leafEntryId;
+  delete providerState.parentSession;
+  delete providerState.sessionFile;
+  delete providerState.sessionId;
+  if (previousSessions.length > 0) {
+    providerState.previousSessions = previousSessions;
+  } else {
+    delete providerState.previousSessions;
+  }
+
+  conversation.sessionId = null;
+  conversation.providerState = Object.keys(providerState).length > 0
+    ? providerState
+    : undefined;
+  return true;
 }
 
 function getPiForkSource(value: unknown): PiForkSource | undefined {
@@ -61,4 +121,57 @@ function getPiForkSource(value: unknown): PiForkSource | undefined {
   const sessionId = typeof record.sessionId === 'string' ? record.sessionId.trim() : '';
   const resumeAt = typeof record.resumeAt === 'string' ? record.resumeAt.trim() : '';
   return sessionId && resumeAt ? { resumeAt, sessionId } : undefined;
+}
+
+function getPiPreviousSessions(value: unknown): PiPreviousSession[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((item): PiPreviousSession[] => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      return [];
+    }
+    const record = item as Record<string, unknown>;
+    const sessionFile = getNonEmptyString(record.sessionFile);
+    const sessionId = getNonEmptyString(record.sessionId);
+    if (!sessionFile && !sessionId) {
+      return [];
+    }
+    const leafEntryId = getNonEmptyString(record.leafEntryId);
+    return [{
+      ...(leafEntryId ? { leafEntryId } : {}),
+      ...(sessionFile ? { sessionFile } : {}),
+      ...(sessionId ? { sessionId } : {}),
+    }];
+  });
+}
+
+export function addPiPreviousSession(
+  sessions: readonly PiPreviousSession[] | undefined,
+  candidate: PiPreviousSession,
+): PiPreviousSession[] {
+  const nextSessions = (sessions ?? []).map(session => ({ ...session }));
+  if (!candidate.sessionFile && !candidate.sessionId) {
+    return nextSessions;
+  }
+  if (nextSessions.some(session => (
+    session.leafEntryId === candidate.leafEntryId
+    && session.sessionFile === candidate.sessionFile
+    && session.sessionId === candidate.sessionId
+  ))) {
+    return nextSessions;
+  }
+  nextSessions.push({
+    ...(candidate.leafEntryId ? { leafEntryId: candidate.leafEntryId } : {}),
+    ...(candidate.sessionFile ? { sessionFile: candidate.sessionFile } : {}),
+    ...(candidate.sessionId ? { sessionId: candidate.sessionId } : {}),
+  });
+  return nextSessions;
+}
+
+function getNonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim()
+    ? value.trim()
+    : undefined;
 }

--- a/tests/unit/features/chat/tabs/TabManager.test.ts
+++ b/tests/unit/features/chat/tabs/TabManager.test.ts
@@ -1,6 +1,7 @@
 import { createMockEl } from '@test/helpers/MockElement';
 
 import { ProviderExecutionLifecycleRegistry } from '@/core/execution';
+import { ProviderRegistry } from '@/core/providers/ProviderRegistry';
 import { TabManager } from '@/features/chat/tabs/TabManager';
 
 const mockInitializeTabExecution = jest.fn().mockResolvedValue(undefined);
@@ -104,6 +105,7 @@ jest.mock('@/core/providers/ProviderRegistry', () => ({
 function createPlugin(overrides: Record<string, unknown> = {}) {
   return {
     app: {
+      vault: { adapter: { basePath: '/vault' } },
       workspace: {
         revealLeaf: jest.fn(),
         setActiveLeaf: jest.fn(),
@@ -301,6 +303,23 @@ describe('TabManager provider execution orchestration', () => {
       resumeAt: 'assistant-checkpoint',
       sourceSessionId: 'native-session',
     })).rejects.toThrow('ledger copy failed');
+
+    expect(plugin.deleteConversation).toHaveBeenCalledWith('forked');
+  });
+
+  it('deletes a partial fork if async provider-state construction fails', async () => {
+    const { manager, plugin } = createManager();
+    await manager.createTab();
+    (ProviderRegistry.getConversationHistoryService as jest.Mock).mockReturnValueOnce({
+      buildForkProviderState: jest.fn().mockRejectedValue(new Error('fork state failed')),
+    });
+
+    await expect(manager.forkToNewTab({
+      messages: [],
+      providerId: 'claude',
+      resumeAt: 'assistant-checkpoint',
+      sourceSessionId: 'native-session',
+    })).rejects.toThrow('fork state failed');
 
     expect(plugin.deleteConversation).toHaveBeenCalledWith('forked');
   });

--- a/tests/unit/providers/pi/env/PiSettingsReconciler.test.ts
+++ b/tests/unit/providers/pi/env/PiSettingsReconciler.test.ts
@@ -1,3 +1,6 @@
+import '@/providers';
+
+import { ProviderSettingsCoordinator } from '@/core/providers/ProviderSettingsCoordinator';
 import { isVersionedRuntimeInputFingerprint } from '@/core/providers/settings/RuntimeInputFingerprint';
 import type { Conversation } from '@/core/types';
 import { piSettingsReconciler } from '@/providers/pi/env/PiSettingsReconciler';
@@ -17,7 +20,11 @@ describe('piSettingsReconciler', () => {
       id: 'pi-conversation',
       messages: [],
       providerId: 'pi',
-      providerState: { sessionFile: '/old/session.jsonl' },
+      providerState: {
+        futureResumeCursor: { token: 'keep-me' },
+        leafEntryId: 'assistant-1',
+        sessionFile: '/old/session.jsonl',
+      },
       sessionId: 'session-1',
     } as unknown as Conversation;
     const claudeConversation = {
@@ -36,11 +43,94 @@ describe('piSettingsReconciler', () => {
     expect(result.changed).toBe(true);
     expect(result.invalidatedConversations).toEqual([piConversation]);
     expect(piConversation.sessionId).toBeNull();
-    expect(piConversation.providerState).toBeUndefined();
+    expect(piConversation.providerState).toEqual({
+      futureResumeCursor: { token: 'keep-me' },
+      previousSessions: [{
+        leafEntryId: 'assistant-1',
+        sessionFile: '/old/session.jsonl',
+        sessionId: 'session-1',
+      }],
+    });
     expect(claudeConversation.sessionId).toBe('claude-session');
     const fingerprint = (settings.providerConfigs as any).pi.environmentHash;
     expect(isVersionedRuntimeInputFingerprint(fingerprint)).toBe(true);
     expect(fingerprint).not.toContain('/new');
+  });
+
+  it('migrates a matching legacy environment fingerprint before coordinator invalidation', () => {
+    const settings: Record<string, unknown> = {
+      providerConfigs: {
+        pi: {
+          enabled: true,
+          environmentHash: 'PI_OFFLINE=1',
+          environmentVariables: 'PI_OFFLINE=1',
+        },
+      },
+    };
+    const conversation = {
+      id: 'pi-conversation',
+      messages: [],
+      providerId: 'pi',
+      providerState: {
+        leafEntryId: 'assistant-1',
+        sessionFile: '/sessions/current.jsonl',
+        sessionId: 'current-session',
+      },
+      sessionId: 'current-session',
+    } as unknown as Conversation;
+
+    expect(piSettingsReconciler.normalizeModelVariantSettings(settings)).toBe(true);
+    const result = ProviderSettingsCoordinator.reconcileProviders(
+      settings,
+      [conversation],
+      ['pi'],
+    );
+
+    expect(result).toMatchObject({
+      changed: false,
+      environmentChangedProviderIds: [],
+      invalidatedConversations: [],
+      sessionInvalidationProviderIds: [],
+    });
+    expect(conversation.sessionId).toBe('current-session');
+    expect(conversation.providerState).toMatchObject({
+      leafEntryId: 'assistant-1',
+      sessionFile: '/sessions/current.jsonl',
+      sessionId: 'current-session',
+    });
+    expect(isVersionedRuntimeInputFingerprint(
+      (settings.providerConfigs as any).pi.environmentHash,
+    )).toBe(true);
+  });
+
+  it('converts pending forks into replayable previous sessions idempotently', () => {
+    const conversation = {
+      id: 'pi-pending-fork',
+      messages: [],
+      providerId: 'pi',
+      providerState: {
+        forkSource: {
+          resumeAt: 'assistant-1',
+          sessionId: 'source-session',
+        },
+        forkSourceSessionFile: '/sessions/source.jsonl',
+        futureResumeCursor: { token: 'keep-me' },
+      },
+      sessionId: null,
+    } as unknown as Conversation;
+
+    expect(piSettingsReconciler.invalidateConversationSessions([conversation])).toEqual([
+      conversation,
+    ]);
+    expect(conversation.providerState).toEqual({
+      futureResumeCursor: { token: 'keep-me' },
+      previousSessions: [{
+        leafEntryId: 'assistant-1',
+        sessionFile: '/sessions/source.jsonl',
+        sessionId: 'source-session',
+      }],
+    });
+    expect(piSettingsReconciler.invalidateConversationSessions([conversation])).toEqual([]);
   });
 
   it('normalizes malformed Pi model selections instead of preserving invalid ids', () => {

--- a/tests/unit/providers/pi/execution/PiExecutionBackend.test.ts
+++ b/tests/unit/providers/pi/execution/PiExecutionBackend.test.ts
@@ -680,12 +680,136 @@ describe('PiExecutionBackend', () => {
     expect(conversation.sessionId).toBeNull();
     expect(conversation.providerState).toEqual({
       futureResumeCursor: { token: 'keep-me' },
+      previousSessions: [{
+        sessionFile: missingSessionFile,
+        sessionId: missingSessionFile,
+      }],
     });
 
     await recovery.coordinator.prepare();
     expect(recovery.createSessionSpy).toHaveBeenCalledTimes(2);
     expect(recovery.createSessionSpy.mock.calls[1]?.[0].resumeSeed).toBeUndefined();
     await recovery.coordinator.dispose();
+    await fs.rm(sessionDir, { force: true, recursive: true });
+  });
+
+  it('starts fresh while retaining detached Pi history state', async () => {
+    const harness = createHarness(createConfig({
+      resumeSeed: {
+        providerState: {
+          futureResumeCursor: { token: 'keep-me' },
+          previousSessions: [{
+            leafEntryId: 'assistant-1',
+            sessionFile: '/tmp/previous.jsonl',
+            sessionId: 'previous-session',
+          }],
+        },
+      },
+    }));
+    const run = harness.session.execute(createRequest({
+      conversationHistory: createConversationHistory('detached prior'),
+    }));
+    const eventsPromise = collect(run.events);
+    await waitFor(() => harness.kernels.length === 1);
+    await waitFor(() => getPromptMessages(harness.kernels[0]).length === 1);
+    completeTurn(harness.kernels[0]);
+    await eventsPromise;
+
+    expect(harness.kernels[0].launchSpec.args).not.toContain('--session');
+    expect(getPromptMessages(harness.kernels[0])[0]).toEqual(expect.stringContaining(
+      'detached prior question',
+    ));
+    expect(harness.session.getSnapshot().providerState).toMatchObject({
+      futureResumeCursor: { token: 'keep-me' },
+      previousSessions: [{
+        leafEntryId: 'assistant-1',
+        sessionFile: '/tmp/previous.jsonl',
+        sessionId: 'previous-session',
+      }],
+    });
+  });
+
+  it('does not duplicate recovered history after the fresh native session reloads', async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-recovery-reload-'));
+    const previousFile = path.join(sessionDir, 'previous.jsonl');
+    const activeFile = path.join(sessionDir, 'active.jsonl');
+    await fs.writeFile(previousFile, [
+      JSON.stringify({ type: 'session', id: 'previous-session', cwd: sessionDir }),
+      JSON.stringify({
+        id: 'recovered-user',
+        type: 'message',
+        message: { role: 'user', content: 'recovered question' },
+      }),
+      JSON.stringify({
+        id: 'recovered-assistant',
+        type: 'message',
+        message: { role: 'assistant', content: 'recovered answer' },
+      }),
+    ].join('\n'));
+    const previousSession = {
+      leafEntryId: 'recovered-assistant',
+      sessionFile: previousFile,
+      sessionId: 'previous-session',
+    };
+    const harness = createHarness(createConfig({
+      resumeSeed: { providerState: { previousSessions: [previousSession] } },
+      vaultWorkingDirectory: sessionDir,
+    }));
+    const run = harness.session.execute(createRequest({
+      conversationHistory: createConversationHistory('recovered'),
+      input: [{ text: 'Follow up', type: 'text' }],
+    }));
+    const eventsPromise = collect(run.events);
+    await waitFor(() => harness.kernels.length === 1);
+    await waitFor(() => getPromptMessages(harness.kernels[0]).length === 1);
+    completeTurn(harness.kernels[0]);
+    await eventsPromise;
+
+    await fs.writeFile(activeFile, [
+      JSON.stringify({ type: 'session', id: 'active-session', cwd: sessionDir }),
+      JSON.stringify({
+        id: 'fresh-user',
+        type: 'message',
+        message: { role: 'user', content: getPromptMessages(harness.kernels[0])[0] },
+      }),
+      JSON.stringify({
+        id: 'fresh-assistant',
+        type: 'message',
+        message: { role: 'assistant', content: 'Fresh answer' },
+      }),
+    ].join('\n'));
+    const conversation = {
+      id: 'recovered-conversation',
+      providerId: 'pi',
+      title: 'Recovered',
+      createdAt: 1,
+      updatedAt: 1,
+      sessionId: 'active-session',
+      messages: [],
+      providerState: {
+        previousSessions: [previousSession],
+        sessionFile: activeFile,
+        sessionId: 'active-session',
+      },
+    } as Conversation;
+
+    await new PiConversationHistoryService().hydrateConversationHistory(
+      conversation,
+      sessionDir,
+      {
+        environment: {
+          HOME: sessionDir,
+          PI_CODING_AGENT_SESSION_DIR: sessionDir,
+        },
+      },
+    );
+
+    expect(conversation.messages.map(message => message.content)).toEqual([
+      'recovered question',
+      'recovered answer',
+      'Follow up',
+      'Fresh answer',
+    ]);
     await fs.rm(sessionDir, { force: true, recursive: true });
   });
 

--- a/tests/unit/providers/pi/history/PiConversationHistoryService.test.ts
+++ b/tests/unit/providers/pi/history/PiConversationHistoryService.test.ts
@@ -97,6 +97,314 @@ describe('PiConversationHistoryService', () => {
     expect(conversation.providerState).toEqual({ sessionFile });
   });
 
+  it('hydrates detached previous sessions without making them active resume state', async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-history-detached-'));
+    const trustedDir = path.join(home, '.pi', 'agent', 'sessions');
+    await fs.mkdir(trustedDir, { recursive: true });
+    const sessionFile = path.join(trustedDir, 'detached.jsonl');
+    await fs.writeFile(sessionFile, [
+      JSON.stringify({ type: 'session', id: 'detached-session' }),
+      JSON.stringify({
+        id: 'u1',
+        message: { content: 'Detached history', role: 'user', timestamp: 1 },
+        type: 'message',
+      }),
+    ].join('\n'));
+    const conversation = createConversation(sessionFile);
+    conversation.providerState = {
+      previousSessions: [{
+        leafEntryId: 'u1',
+        sessionFile,
+        sessionId: 'detached-session',
+      }],
+    };
+    conversation.sessionId = null;
+    const service = new PiConversationHistoryService();
+
+    await service.hydrateConversationHistory(
+      conversation,
+      null,
+      { environment: { HOME: home } },
+    );
+
+    expect(conversation.messages.map(message => message.content)).toEqual(['Detached history']);
+    expect(service.resolveSessionIdForConversation(conversation)).toBe(sessionFile);
+    expect(conversation.providerState).toEqual({
+      previousSessions: [{
+        leafEntryId: 'u1',
+        sessionFile,
+        sessionId: 'detached-session',
+      }],
+    });
+  });
+
+  it('hydrates previous and active Pi session segments in chronological order', async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-history-segments-'));
+    const trustedDir = path.join(home, '.pi', 'agent', 'sessions');
+    await fs.mkdir(trustedDir, { recursive: true });
+    const previousFile = path.join(trustedDir, 'previous.jsonl');
+    const activeFile = path.join(trustedDir, 'active.jsonl');
+    await fs.writeFile(previousFile, [
+      JSON.stringify({ type: 'session', id: 'previous-session' }),
+      JSON.stringify({
+        id: 'previous-user',
+        message: { content: 'Previous', role: 'user', timestamp: 1 },
+        type: 'message',
+      }),
+    ].join('\n'));
+    await fs.writeFile(activeFile, [
+      JSON.stringify({ type: 'session', id: 'active-session' }),
+      JSON.stringify({
+        id: 'active-user',
+        message: { content: 'Active', role: 'user', timestamp: 2 },
+        type: 'message',
+      }),
+    ].join('\n'));
+    const conversation = createConversation(activeFile);
+    conversation.providerState = {
+      previousSessions: [{
+        leafEntryId: 'previous-user',
+        sessionFile: previousFile,
+        sessionId: 'previous-session',
+      }],
+      sessionFile: activeFile,
+      sessionId: 'active-session',
+    };
+    conversation.sessionId = 'active-session';
+
+    await new PiConversationHistoryService().hydrateConversationHistory(
+      conversation,
+      null,
+      { environment: { HOME: home } },
+    );
+
+    expect(conversation.messages.map(message => message.content)).toEqual(['Previous', 'Active']);
+  });
+
+  it('preserves unrelated id-less messages from different session segments', async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-history-idless-segments-'));
+    const trustedDir = path.join(home, '.pi', 'agent', 'sessions');
+    await fs.mkdir(trustedDir, { recursive: true });
+    const previousFile = path.join(trustedDir, 'previous.jsonl');
+    const activeFile = path.join(trustedDir, 'active.jsonl');
+    await fs.writeFile(previousFile, [
+      JSON.stringify({ type: 'session', id: 'previous-session' }),
+      JSON.stringify({ type: 'custom_message', content: 'Previous notice' }),
+    ].join('\n'));
+    await fs.writeFile(activeFile, [
+      JSON.stringify({ type: 'session', id: 'active-session' }),
+      JSON.stringify({ type: 'custom_message', content: 'Active notice' }),
+    ].join('\n'));
+    const conversation = createConversation(activeFile);
+    conversation.providerState = {
+      previousSessions: [{
+        sessionFile: previousFile,
+        sessionId: 'previous-session',
+      }],
+      sessionFile: activeFile,
+      sessionId: 'active-session',
+    };
+
+    await new PiConversationHistoryService().hydrateConversationHistory(
+      conversation,
+      null,
+      { environment: { HOME: home } },
+    );
+
+    expect(conversation.messages.map(message => message.content)).toEqual([
+      'Previous notice',
+      'Active notice',
+    ]);
+  });
+
+  it('builds a fork from the segment that contains the selected checkpoint', async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-history-fork-segment-'));
+    const trustedDir = path.join(home, '.pi', 'agent', 'sessions');
+    await fs.mkdir(trustedDir, { recursive: true });
+    const previousFile = path.join(trustedDir, 'previous.jsonl');
+    const activeFile = path.join(trustedDir, 'active.jsonl');
+    await fs.writeFile(previousFile, [
+      JSON.stringify({ type: 'session', id: 'previous-session' }),
+      JSON.stringify({
+        id: 'previous-assistant',
+        message: { content: 'Previous', role: 'assistant', timestamp: 1 },
+        type: 'message',
+      }),
+    ].join('\n'));
+    await fs.writeFile(activeFile, [
+      JSON.stringify({ type: 'session', id: 'active-session' }),
+      JSON.stringify({
+        id: 'active-assistant',
+        message: { content: 'Active', role: 'assistant', timestamp: 2 },
+        type: 'message',
+      }),
+    ].join('\n'));
+    const providerState = {
+      previousSessions: [{
+        leafEntryId: 'previous-assistant',
+        sessionFile: previousFile,
+        sessionId: 'previous-session',
+      }],
+      sessionFile: activeFile,
+      sessionId: 'active-session',
+    };
+    const conversation = createConversation(activeFile);
+    conversation.providerState = providerState;
+    conversation.sessionId = 'active-session';
+    const service = new PiConversationHistoryService();
+
+    await service.hydrateConversationHistory(
+      conversation,
+      null,
+      { environment: { HOME: home } },
+    );
+
+    await expect(service.buildForkProviderState(
+      'active-session',
+      'previous-assistant',
+      providerState,
+    )).resolves.toEqual({
+      forkSource: { sessionId: 'previous-session', resumeAt: 'previous-assistant' },
+      forkSourceSessionFile: previousFile,
+    });
+    await expect(service.buildForkProviderState(
+      'active-session',
+      'active-assistant',
+      providerState,
+    )).resolves.toEqual({
+      forkSource: { sessionId: 'active-session', resumeAt: 'active-assistant' },
+      forkSourceSessionFile: activeFile,
+    });
+  });
+
+  it('does not probe an archived fork source that fails path identity validation', async () => {
+    const vault = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-history-fork-vault-'));
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-history-fork-safe-home-'));
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-history-fork-unsafe-'));
+    const trustedDir = path.join(home, '.pi', 'agent', 'sessions');
+    await fs.mkdir(trustedDir, { recursive: true });
+    const activeFile = path.join(trustedDir, 'active.jsonl');
+    const outsideFile = path.join(outside, 'previous.jsonl');
+    await fs.writeFile(activeFile, [
+      JSON.stringify({ type: 'session', id: 'active-session', cwd: vault }),
+      JSON.stringify({ id: 'active-assistant', type: 'message', message: { role: 'assistant' } }),
+    ].join('\n'));
+    await fs.writeFile(outsideFile, [
+      JSON.stringify({ type: 'session', id: 'previous-session', cwd: outside }),
+      JSON.stringify({ id: 'target-assistant', type: 'message', message: { role: 'assistant' } }),
+    ].join('\n'));
+    const service = new PiConversationHistoryService();
+
+    await expect((service.buildForkProviderState as any)(
+      'active-session',
+      'target-assistant',
+      {
+        previousSessions: [{
+          sessionFile: outsideFile,
+          sessionId: 'previous-session',
+        }],
+        sessionFile: activeFile,
+        sessionId: 'active-session',
+      },
+      vault,
+      { environment: { HOME: home }, vaultPath: vault },
+    )).resolves.toEqual({
+      forkSource: { sessionId: 'active-session', resumeAt: 'target-assistant' },
+      forkSourceSessionFile: activeFile,
+    });
+  });
+
+  it('hydrates an archived transcript after the configured session root changes', async () => {
+    const vault = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-history-archive-vault-'));
+    const oldRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-history-archive-old-'));
+    const newRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-history-archive-new-'));
+    const safeHome = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-history-archive-home-'));
+    const sessionFile = path.join(oldRoot, 'archived.jsonl');
+    await fs.writeFile(sessionFile, [
+      JSON.stringify({ type: 'session', id: 'archived-session', cwd: vault }),
+      JSON.stringify({
+        id: 'archived-user',
+        message: { content: 'Archived history', role: 'user', timestamp: 1 },
+        type: 'message',
+      }),
+    ].join('\n'));
+    const conversation = createConversation(sessionFile);
+    conversation.providerState = {
+      previousSessions: [{
+        leafEntryId: 'archived-user',
+        sessionFile,
+        sessionId: 'archived-session',
+      }],
+    };
+    conversation.sessionId = null;
+
+    await new PiConversationHistoryService().hydrateConversationHistory(
+      conversation,
+      vault,
+      {
+        environment: {
+          HOME: safeHome,
+          PI_CODING_AGENT_SESSION_DIR: newRoot,
+        },
+      },
+    );
+
+    expect(conversation.messages.map(message => message.content)).toEqual(['Archived history']);
+    expect(conversation.providerState).toEqual({
+      previousSessions: [{
+        leafEntryId: 'archived-user',
+        sessionFile,
+        sessionId: 'archived-session',
+      }],
+    });
+  });
+
+  it('does not replace an archived path with a mismatched logical-id candidate', async () => {
+    const vault = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-history-identity-vault-'));
+    const oldRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-history-identity-old-'));
+    const newRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-history-identity-new-'));
+    const safeHome = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-history-identity-home-'));
+    const archivedPath = path.join(oldRoot, 'archived-session.jsonl');
+    const mismatchedPath = path.join(newRoot, 'archived-session.jsonl');
+    await fs.writeFile(mismatchedPath, [
+      JSON.stringify({ type: 'session', id: 'different-session', cwd: vault }),
+      JSON.stringify({
+        id: 'wrong-user',
+        message: { content: 'Wrong history', role: 'user', timestamp: 1 },
+        type: 'message',
+      }),
+    ].join('\n'));
+    const conversation = createConversation(archivedPath);
+    conversation.providerState = {
+      previousSessions: [{
+        leafEntryId: 'archived-user',
+        sessionFile: archivedPath,
+        sessionId: 'archived-session',
+      }],
+    };
+    conversation.sessionId = null;
+
+    await new PiConversationHistoryService().hydrateConversationHistory(
+      conversation,
+      vault,
+      {
+        environment: {
+          HOME: safeHome,
+          PI_CODING_AGENT_SESSION_DIR: newRoot,
+        },
+      },
+    );
+
+    expect(conversation.messages).toEqual([]);
+    expect(conversation.providerState).toEqual({
+      previousSessions: [{
+        leafEntryId: 'archived-user',
+        sessionFile: archivedPath,
+        sessionId: 'archived-session',
+      }],
+    });
+  });
+
   it('accepts a metadata path under the explicitly configured session directory', async () => {
     const configuredDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-history-configured-'));
     const sessionFile = path.join(configuredDir, 'session.jsonl');
@@ -142,44 +450,61 @@ describe('PiConversationHistoryService', () => {
     expect(conversation.messages).toEqual([]);
   });
 
-  it('builds pending fork state from source session metadata', () => {
+  it('builds pending fork state from source session metadata', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-history-fork-state-'));
+    const sessionFile = path.join(dir, 'session.jsonl');
+    const sourceFile = path.join(dir, 'source.jsonl');
+    await fs.writeFile(sessionFile, [
+      JSON.stringify({ type: 'session', id: 's1' }),
+      JSON.stringify({ id: 'checkpoint', type: 'message', message: { role: 'assistant' } }),
+    ].join('\n'));
+    await fs.writeFile(sourceFile, [
+      JSON.stringify({ type: 'session', id: 'source-session' }),
+      JSON.stringify({ id: 'checkpoint', type: 'message', message: { role: 'assistant' } }),
+    ].join('\n'));
     const service = new PiConversationHistoryService();
-    const conversation = createConversation('/tmp/session.jsonl');
+    const conversation = createConversation(sessionFile);
     conversation.providerState = {
       forkSource: { sessionId: 'source-session', resumeAt: 'assistant-1' },
-      forkSourceSessionFile: '/tmp/source.jsonl',
+      forkSourceSessionFile: sourceFile,
     };
     conversation.sessionId = null;
 
     expect(service.isPendingForkConversation(conversation)).toBe(true);
     expect(service.resolveSessionIdForConversation(conversation)).toBe('source-session');
-    expect(service.buildForkProviderState('s1', 'checkpoint', {
-      sessionFile: '/tmp/session.jsonl',
-    })).toEqual({
+    await expect(service.buildForkProviderState('s1', 'checkpoint', {
+      sessionFile,
+    })).resolves.toEqual({
       forkSource: { sessionId: 's1', resumeAt: 'checkpoint' },
-      forkSourceSessionFile: '/tmp/session.jsonl',
+      forkSourceSessionFile: sessionFile,
     });
-    expect(service.buildForkProviderState('source-session', 'checkpoint', {
+    await expect(service.buildForkProviderState('source-session', 'checkpoint', {
       forkSource: { sessionId: 'source-session', resumeAt: 'assistant-1' },
-      forkSourceSessionFile: '/tmp/source.jsonl',
-    })).toEqual({
+      forkSourceSessionFile: sourceFile,
+    })).resolves.toEqual({
       forkSource: { sessionId: 'source-session', resumeAt: 'checkpoint' },
-      forkSourceSessionFile: '/tmp/source.jsonl',
+      forkSourceSessionFile: sourceFile,
     });
   });
 
-  it('resolves file-only Pi sessions as fork sources', () => {
+  it('resolves file-only Pi sessions as fork sources', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-history-file-fork-'));
+    const sessionFile = path.join(dir, 'session.jsonl');
+    await fs.writeFile(sessionFile, [
+      JSON.stringify({ type: 'session', id: 'file-session' }),
+      JSON.stringify({ id: 'checkpoint', type: 'message', message: { role: 'assistant' } }),
+    ].join('\n'));
     const service = new PiConversationHistoryService();
-    const conversation = createConversation('/tmp/session.jsonl');
-    conversation.providerState = { sessionFile: '/tmp/session.jsonl' };
+    const conversation = createConversation(sessionFile);
+    conversation.providerState = { sessionFile };
     conversation.sessionId = null;
 
-    expect(service.resolveSessionIdForConversation(conversation)).toBe('/tmp/session.jsonl');
-    expect(service.buildForkProviderState('/tmp/session.jsonl', 'checkpoint', {
-      sessionFile: '/tmp/session.jsonl',
-    })).toEqual({
-      forkSource: { sessionId: '/tmp/session.jsonl', resumeAt: 'checkpoint' },
-      forkSourceSessionFile: '/tmp/session.jsonl',
+    expect(service.resolveSessionIdForConversation(conversation)).toBe(sessionFile);
+    await expect(service.buildForkProviderState(sessionFile, 'checkpoint', {
+      sessionFile,
+    })).resolves.toEqual({
+      forkSource: { sessionId: sessionFile, resumeAt: 'checkpoint' },
+      forkSourceSessionFile: sessionFile,
     });
   });
 
@@ -306,6 +631,15 @@ describe('PiConversationHistoryService', () => {
       futureResumeCursor: { token: 'cursor-1' },
       leafEntryId: 'leaf-1',
       parentSession: '/tmp/source.jsonl',
+      previousSessions: [
+        {
+          leafEntryId: 'previous-leaf',
+          sessionFile: '/tmp/previous.jsonl',
+          sessionId: 'previous-session',
+        },
+        { sessionId: ' ' },
+        { ignored: true },
+      ],
       sessionFile: '/tmp/session.jsonl',
       sessionId: 's1',
     };
@@ -315,6 +649,11 @@ describe('PiConversationHistoryService', () => {
       futureResumeCursor: { token: 'cursor-1' },
       leafEntryId: 'leaf-1',
       parentSession: '/tmp/source.jsonl',
+      previousSessions: [{
+        leafEntryId: 'previous-leaf',
+        sessionFile: '/tmp/previous.jsonl',
+        sessionId: 'previous-session',
+      }],
       sessionFile: '/tmp/session.jsonl',
       sessionId: 's1',
     });
@@ -344,6 +683,11 @@ describe('PiConversationHistoryService', () => {
         futureResumeCursor: { token: 'keep-me' },
         leafEntryId: 'assistant-1',
         parentSession: '/trusted/parent.jsonl',
+        previousSessions: [{
+          leafEntryId: 'assistant-1',
+          sessionFile: '/trusted/missing.jsonl',
+          sessionId: '/trusted/missing.jsonl',
+        }],
         sessionId: 's1',
       });
       expect(service.resolveSessionIdForConversation(conversation)).toBe('s1');
@@ -375,12 +719,17 @@ describe('PiConversationHistoryService', () => {
       expect(recreatedConversation.sessionId).toBeNull();
       expect(recreatedConversation.providerState).toEqual({
         futureResumeCursor: { token: 'keep-me' },
+        previousSessions: [{
+          leafEntryId: 'assistant-1',
+          sessionFile: missingPath,
+          sessionId: missingPath,
+        }],
       });
       expect(
         new PiConversationHistoryService().resolveSessionIdForConversation(
           recreatedConversation,
         ),
-      ).toBeNull();
+      ).toBe(missingPath);
     });
 
     it('clears an exact stale logical binding while preserving unknown state and native files', async () => {
@@ -406,6 +755,10 @@ describe('PiConversationHistoryService', () => {
       expect(conversation.sessionId).toBeNull();
       expect(conversation.providerState).toEqual({
         futureResumeCursor: { token: 'keep-me' },
+        previousSessions: [{
+          leafEntryId: 'assistant-1',
+          sessionId: 's1',
+        }],
       });
       await expect(fs.readFile(nativeFile, 'utf8')).resolves.toBe(nativeContent);
     });

--- a/tests/unit/providers/pi/runtime/PiLaunchSpec.test.ts
+++ b/tests/unit/providers/pi/runtime/PiLaunchSpec.test.ts
@@ -58,6 +58,21 @@ describe('PiLaunchSpec', () => {
     ]);
   });
 
+  it('does not resume from detached previous sessions', () => {
+    expect(buildPiLaunchSpec({
+      command: 'pi',
+      cwd: '/vault',
+      providerState: {
+        previousSessions: [{
+          leafEntryId: 'assistant-1',
+          sessionFile: '/tmp/previous.jsonl',
+          sessionId: 'previous-session',
+        }],
+      },
+      settings: baseSettings,
+    }).args).toEqual(['--mode', 'rpc']);
+  });
+
   it('passes max thinking through to Pi', () => {
     expect(buildPiLaunchSpec({
       command: 'pi',


### PR DESCRIPTION
## Why

Fixes #1043: Pi missing-session false alarms and environment invalidation could erase Claudian's transcript pointer even though the native JSONL remained intact.

## What Changed

- Detach stale active bindings into provider-owned `previousSessions`, preserve unknown state, and safely hydrate and deduplicate archived and active transcript segments.
- Make fork selection segment-aware with validated paths and safe asynchronous cleanup.
- Migrate legacy Pi environment fingerprints without invalidation and encode recovery replay so fresh sessions do not duplicate history after reload.

## Why This Approach

Separating active resume state from replay metadata fixes ownership at the Pi provider boundary; the tradeoff is new opaque `previousSessions` metadata instead of attempting to rebuild already-lost pointers or introducing a provider-neutral history framework.

## Validation

- `npm run typecheck && npm run lint && npm run test && npm run build`
- 344 suites and 6,332 tests passed; four fresh adversarial review passes completed, with the final pass clean.

## Impact and Follow-ups

Metadata pointers erased by older versions cannot be recovered automatically, while provider-native transcript files remain read-only and are never modified.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
