### PR TITLE
fix(codex): recover missed turn completion

### DIFF
--- a/src/providers/codex/execution/CodexExecutionSession.ts
+++ b/src/providers/codex/execution/CodexExecutionSession.ts
@@ -56,9 +56,11 @@ import type {
   ServerRequestResolvedNotification,
   ThreadCompactStartResult,
   ThreadForkResult,
+  ThreadReadResult,
   ThreadResumeResult,
   ThreadRollbackResult,
   ThreadStartResult,
+  ThreadStatusChangedNotification,
   TurnCompletedNotification,
   TurnStartedNotification,
   TurnStartResult,
@@ -99,6 +101,8 @@ const PASSIVE_INSTRUCTIONS =
 const LEGACY_WORKSPACE_DEPENDENCY_INSTRUCTIONS =
   'This thread predates Claudian client-hosted workspace dependency tools. Do not emulate load_workspace_dependencies or install replacement dependencies.';
 const CODEX_SUPPORTS_EXACT_BUILT_IN_TOOL_ALLOW_LIST = false;
+const MISSED_TURN_COMPLETION_GRACE_MS = 1_000;
+const THREAD_READ_RECOVERY_TIMEOUT_MS = 5_000;
 const CODEX_CONSUMED_FORK_STATE_KEYS = [
   'forkSource',
   'forkSourceSessionFilePath',
@@ -279,6 +283,7 @@ export class CodexExecutionSession
   private forkIdentityPromise: Promise<CodexPendingForkTarget> | null = null;
   private forkSetupPromise: Promise<CodexEnsuredThread> | null = null;
   private disposePromise: Promise<void> | null = null;
+  private completionRecoveryTimer: number | null = null;
   private disposed = false;
   private lifecycleGeneration = 0;
 
@@ -746,6 +751,16 @@ export class CodexExecutionSession
       this.observeNativeTurn(started.threadId, started.turn.id);
       return;
     }
+    if (method === 'thread/status/changed') {
+      const changed = params as ThreadStatusChangedNotification;
+      if (changed.threadId !== run.nativeThreadId) return;
+      if (changed.status.type === 'idle') {
+        this.scheduleMissedTurnCompletionRecovery(run);
+      } else {
+        this.cancelMissedTurnCompletionRecovery();
+      }
+      return;
+    }
 
     const scope = extractNotificationScope(method, params);
     if (scope) {
@@ -762,6 +777,7 @@ export class CodexExecutionSession
     }
 
     if (method === 'turn/completed') {
+      this.cancelMissedTurnCompletionRecovery();
       const completed = params as TurnCompletedNotification;
       run.completion = {
         status: completed.turn.status === 'inProgress'
@@ -774,6 +790,69 @@ export class CodexExecutionSession
       };
     }
     this.notificationRouter?.handleNotification(method, params);
+  }
+
+  private scheduleMissedTurnCompletionRecovery(run: CodexExecutionRun): void {
+    if (
+      this.completionRecoveryTimer
+      || !run.nativeThreadId
+      || !run.nativeTurnId
+    ) {
+      return;
+    }
+    const generation = this.lifecycleGeneration;
+    this.completionRecoveryTimer = window.setTimeout(() => {
+      this.completionRecoveryTimer = null;
+      void this.recoverMissedTurnCompletion(run, generation);
+    }, MISSED_TURN_COMPLETION_GRACE_MS);
+  }
+
+  private cancelMissedTurnCompletionRecovery(): void {
+    if (!this.completionRecoveryTimer) return;
+    window.clearTimeout(this.completionRecoveryTimer);
+    this.completionRecoveryTimer = null;
+  }
+
+  private async recoverMissedTurnCompletion(
+    run: CodexExecutionRun,
+    generation: number,
+  ): Promise<void> {
+    const transport = this.transport;
+    const threadId = run.nativeThreadId;
+    const turnId = run.nativeTurnId;
+    if (
+      !transport
+      || !threadId
+      || !turnId
+      || this.activeRun !== run
+      || run.isTerminal
+      || run.isCancellationRequested
+      || generation !== this.lifecycleGeneration
+    ) {
+      return;
+    }
+
+    let result: ThreadReadResult;
+    try {
+      result = await transport.request<ThreadReadResult>(
+        'thread/read',
+        { threadId, includeTurns: true },
+        THREAD_READ_RECOVERY_TIMEOUT_MS,
+      );
+    } catch {
+      return;
+    }
+    if (
+      this.activeRun !== run
+      || run.isTerminal
+      || run.isCancellationRequested
+      || generation !== this.lifecycleGeneration
+    ) {
+      return;
+    }
+    const turn = result.thread.turns.find(candidate => candidate.id === turnId);
+    if (!turn || turn.status === 'inProgress') return;
+    this.handleNotification('turn/completed', { threadId, turn });
   }
 
   private observeNativeTurn(threadId: string, nativeTurnId: string): boolean {
@@ -1199,6 +1278,7 @@ export class CodexExecutionSession
 
   private cancelRun(run: CodexExecutionRun): void {
     if (this.activeRun !== run || run.isTerminal) return;
+    this.cancelMissedTurnCompletionRecovery();
     this.lifecycleGeneration += 1;
     this.serverRequestRouter.abortAll('cancelled');
     const transport = this.transport;
@@ -1286,6 +1366,7 @@ export class CodexExecutionSession
   }
 
   private releaseRun(run: CodexExecutionRun): void {
+    this.cancelMissedTurnCompletionRecovery();
     this.notificationRouter?.endTurn();
     this.notificationRouter = null;
     this.pendingTurnNotifications = [];

--- a/src/providers/codex/runtime/codexAppServerTypes.ts
+++ b/src/providers/codex/runtime/codexAppServerTypes.ts
@@ -429,6 +429,10 @@ export interface ThreadStartResult {
   reasoningEffort: string;
 }
 
+export interface ThreadReadResult {
+  thread: Thread;
+}
+
 export type SandboxPolicy =
   | { type: 'dangerFullAccess' }
   | {

--- a/tests/unit/providers/codex/execution/CodexExecutionBackend.test.ts
+++ b/tests/unit/providers/codex/execution/CodexExecutionBackend.test.ts
@@ -493,6 +493,111 @@ describe('CodexExecutionBackend', () => {
     await session.dispose();
   });
 
+  it('recovers a completed turn when the terminal notification is missed', async () => {
+    jest.useFakeTimers();
+    const threadId = 'thread-missed-completion';
+    const turnId = 'turn-missed-completion';
+    mockTransportRequest.mockImplementation(async (method: string) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'test',
+          codexHome: '/tmp/.codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'thread/start') return createThreadResult(threadId);
+      if (method === 'turn/start') return createTurnResult(turnId);
+      if (method === 'thread/read') {
+        return createThreadResult(threadId, [{ id: turnId }]);
+      }
+      if (method === 'turn/interrupt') return {};
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    const session = new CodexExecutionBackend(createPlugin())
+      .createSession(createSessionConfig());
+    const run = session.execute(createRequest());
+    const eventsPromise = collectEvents(run.events);
+
+    try {
+      await waitForCondition(() => mockTransportRequest.mock.calls.some(
+        ([method]) => method === 'turn/start',
+      ));
+      emitNotification('thread/status/changed', {
+        threadId,
+        status: { type: 'idle' },
+      });
+      await jest.advanceTimersByTimeAsync(5_000);
+
+      expect(mockTransportRequest).toHaveBeenCalledWith(
+        'thread/read',
+        { threadId, includeTurns: true },
+        expect.any(Number),
+      );
+      expect((await eventsPromise).at(-1)).toMatchObject({
+        nativeCheckpointId: turnId,
+        type: 'turn_completed',
+      });
+    } finally {
+      run.cancel();
+      await eventsPromise;
+      await session.dispose();
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not recover when the terminal notification arrives during the grace period', async () => {
+    jest.useFakeTimers();
+    const threadId = 'thread-normal-completion';
+    const turnId = 'turn-normal-completion';
+    mockTransportRequest.mockImplementation(async (method: string) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'test',
+          codexHome: '/tmp/.codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'thread/start') return createThreadResult(threadId);
+      if (method === 'turn/start') return createTurnResult(turnId);
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    const session = new CodexExecutionBackend(createPlugin())
+      .createSession(createSessionConfig());
+    const run = session.execute(createRequest());
+    const eventsPromise = collectEvents(run.events);
+
+    try {
+      await waitForCondition(() => mockTransportRequest.mock.calls.some(
+        ([method]) => method === 'turn/start',
+      ));
+      emitNotification('thread/status/changed', {
+        threadId,
+        status: { type: 'idle' },
+      });
+      completeTurn(threadId, turnId);
+      await jest.advanceTimersByTimeAsync(5_000);
+
+      expect(mockTransportRequest).not.toHaveBeenCalledWith(
+        'thread/read',
+        expect.anything(),
+        expect.anything(),
+      );
+      expect((await eventsPromise).at(-1)).toMatchObject({
+        nativeCheckpointId: turnId,
+        type: 'turn_completed',
+      });
+    } finally {
+      run.cancel();
+      await eventsPromise;
+      await session.dispose();
+      jest.useRealTimers();
+    }
+  });
+
   it('sends all attached context using canonical escaped XML', async () => {
     mockTransportRequest.mockImplementation(async (method: string) => {
       if (method === 'initialize') {


### PR DESCRIPTION
## Summary\n\n- treat an idle Codex app-server thread as a narrow recovery signal for the active turn\n- allow the normal turn/completed notification a one-second grace period\n- reconcile only the matching native turn through thread/read when its persisted status is terminal\n- cancel recovery work across normal completion, cancellation, and session lifecycle changes\n\nThis keeps turn/completed as the canonical live path. It does not add a fixed execution timeout or poll JSONL transcripts.\n\n## Tests\n\n- reproduces a missing terminal notification and verifies the requested run completes\n- verifies a normal terminal notification during the grace period prevents the recovery request\n- npm run typecheck\n- npm run lint\n- npm run test: 6,339 tests passed\n- npm run build\n\nCloses #1052