### PR TITLE
fix: detect Claude Code installed under nvm-for-Windows

### DIFF
--- a/src/providers/claude/cli/findClaudeCLIPath.ts
+++ b/src/providers/claude/cli/findClaudeCLIPath.ts
@@ -152,6 +152,15 @@ function getNpmClaudeCodeEntrypointPaths(): string[] {
       addClaudeCodeEntrypointPaths(entrypointPaths, npmPrefix);
     }
 
+    // nvm-for-Windows keeps global packages under the active version directory that
+    // NVM_SYMLINK points at. Its layout shares nothing with nvm-sh, so
+    // resolveNvmDefaultBin() never matches it, and a GUI app does not necessarily
+    // inherit that directory on PATH.
+    const nvmWindowsCurrent = process.env.NVM_SYMLINK;
+    if (nvmWindowsCurrent) {
+      addClaudeCodeEntrypointPaths(entrypointPaths, nvmWindowsCurrent);
+    }
+
     const programFiles = process.env.ProgramFiles || 'C:\\Program Files';
     const programFilesX86 = process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)';
 

--- a/tests/unit/utils/utils.test.ts
+++ b/tests/unit/utils/utils.test.ts
@@ -577,6 +577,15 @@ describe('utils.ts', () => {
         expect(findClaudeCLIPath()).toBe(expectedPath);
       });
 
+      it('should find cli-wrapper.cjs under an nvm-for-Windows install', () => {
+        jest.spyOn(os, 'homedir').mockReturnValue('C:\\Users\\test');
+        process.env.NVM_SYMLINK = 'D:\\nvm\\v22.22.0';
+        const expectedPath = path.join('D:\\nvm\\v22.22.0', 'node_modules', '@anthropic-ai', 'claude-code', 'cli-wrapper.cjs');
+        mockExistingFile(expectedPath);
+
+        expect(findClaudeCLIPath()).toBe(expectedPath);
+      });
+
       it('should fall back to .exe if package entrypoint is not found', () => {
         jest.spyOn(os, 'homedir').mockReturnValue('C:\\Users\\test');
         const expectedPath = path.join('C:\\Users\\test', '.claude', 'local', 'claude.exe');


### PR DESCRIPTION
## Why

nvm-for-Windows keeps global npm packages under the **active version directory**, which `NVM_SYMLINK` points at:

```
NVM_HOME    = D:\nvm
NVM_SYMLINK = D:\nodejs        ->  D:\nvm\v24.12.0
package     = <NVM_SYMLINK>\node_modules\@anthropic-ai\claude-code\cli-wrapper.cjs
```

`resolveNvmDefaultBin()` cannot match that. It looks for `NVM_DIR` (or `~/.nvm`), an `alias/default` file, and a `versions/node/vX.Y.Z` tree — three assumptions from nvm-sh, none of which nvm-for-Windows satisfies. Checked on a real box:

| assumption | nvm-for-Windows reality |
| --- | --- |
| `NVM_DIR` / `~/.nvm` | unset; the variable is `NVM_HOME` |
| `<root>/alias/default` | no such file (uses `settings.txt` + a symlink) |
| `<root>/versions/node/vX` | flat `<root>\v24.12.0` |

None of the hard-coded Windows npm prefixes (`%APPDATA%\npm`, `%ProgramFiles%\nodejs\node_global`, …) cover it either.

When the directory happens to be on `PATH`, `resolveClaudeCodeEntrypointFromPathEntries` already finds the package, so many users are fine. But a GUI app does not necessarily inherit it, and then detection returns `null` even though `NVM_SYMLINK` is a system environment variable pointing straight at the install.

Reported in #533 by several users, each of whom worked around it differently:

- typed the full path by hand: `C:\Users\...\nvm\v22.22.0\node_modules\@anthropic-ai\claude-code\cli.js`
- typed the full path by hand: `D:\Program Files (x86)\nvm\v24.11.0\node_modules\@anthropic-ai\claude-code\cli-wrapper.cjs`
- added the nvm directory to Claudian's PATH override: `PATH=XXX\NVM\nodejs;%PATH%` — *"I guess you also use nvm to manage nodejs versions"*

## What

Probe the `NVM_SYMLINK` directory alongside the other Windows npm prefixes in `getNpmClaudeCodeEntrypointPaths()`.

## Why this approach

- **It mirrors what the codebase already does for nvm-sh.** The existing call site is commented `// NVM: resolve default version bin when NVM_BIN env var is not available (GUI apps)` — the exact same problem, solved for POSIX only. This is the Windows half.
- **`NVM_SYMLINK` is the right variable.** The installer writes it to the system environment, and it always points at the version that is currently active, which is where `npm -g` puts packages. No directory scanning, no guessing a version.
- **Alternative considered:** enumerate `<NVM_HOME>\v*` and probe each. Rejected — it needs a directory listing and an arbitrary rule for which version wins when several have Claude Code installed. `NVM_SYMLINK` answers that question authoritatively.
- Read defensively (`if (nvmWindowsCurrent)`), so nothing changes when the variable is absent.

## Validation

Windows 11, nvm-for-Windows 1.2.2, Node 24.12.0:

- Drove the real `findClaudeCLIPath()` against a synthetic nvm-for-Windows tree, in both `PATH` situations:

  | scenario | before | after |
  | --- | --- | --- |
  | nvm dir on `PATH` | resolves | resolves (unchanged) |
  | nvm dir **not** on `PATH` | `null` | resolves |

- New test in `findClaudeCLIPath > on Windows` fails on the old code (`Expected "D:\nvm\v22.22.0\...\cli-wrapper.cjs"`, `Received: null`) and passes with the fix.
- `npm run typecheck`, `npm run lint`, `npm run build`: exit 0.
- `npm run test`: 6327 → 6328 total, +1 passed, failure count unchanged (this machine has 57 pre-existing Windows failures in unrelated suites, from hard-coded POSIX separators and from `symlinkSync` needing elevation).

## Impact

- win32 branch only; no change when `NVM_SYMLINK` is unset, so nothing moves on Linux or macOS.
- Detection only — nothing about spawning or the `cliPath` override changes.
- No new dependencies.
