### PR TITLE
Preserve Codex history during fingerprint migration

### DIFF
--- a/src/providers/codex/env/CodexSettingsReconciler.ts
+++ b/src/providers/codex/env/CodexSettingsReconciler.ts
@@ -3,7 +3,10 @@ import {
   hasCliPathFingerprintInputs,
 } from '../../../core/providers/cli/CliPathFingerprintInputs';
 import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
-import { createRuntimeInputFingerprint } from '../../../core/providers/settings/RuntimeInputFingerprint';
+import {
+  createRuntimeInputFingerprint,
+  isVersionedRuntimeInputFingerprint,
+} from '../../../core/providers/settings/RuntimeInputFingerprint';
 import type { ProviderSettingsReconciler } from '../../../core/providers/types';
 import type { Conversation } from '../../../core/types';
 import { getHostnameKey, parseEnvironmentVariables } from '../../../utils/env';
@@ -12,7 +15,12 @@ import { getCodexProviderSettings, updateCodexProviderSettings } from '../settin
 import { getCodexState } from '../types';
 import { codexChatUIConfig } from '../ui/CodexChatUIConfig';
 
-const ENV_HASH_KEYS = ['OPENAI_MODEL', 'OPENAI_BASE_URL', 'OPENAI_API_KEY', 'PATH'];
+const LEGACY_CODEX_ENV_HASH_KEYS = [
+  'OPENAI_MODEL',
+  'OPENAI_BASE_URL',
+  'OPENAI_API_KEY',
+] as const;
+const ENV_HASH_KEYS = [...LEGACY_CODEX_ENV_HASH_KEYS, 'PATH'] as const;
 
 export function computeCodexEnvHash(
   environmentText: string,
@@ -23,6 +31,56 @@ export function computeCodexEnvHash(
     environmentKeys: ENV_HASH_KEYS,
     environmentText,
   });
+}
+
+function isCurrentLegacyCodexFingerprint(
+  environmentText: string,
+  savedFingerprint: string,
+): boolean {
+  if (isVersionedRuntimeInputFingerprint(savedFingerprint)) {
+    return false;
+  }
+
+  const environment = parseEnvironmentVariables(environmentText);
+  const legacyFingerprint = LEGACY_CODEX_ENV_HASH_KEYS
+    .filter(key => environment[key])
+    .map(key => `${key}=${environment[key]}`)
+    .sort()
+    .join('|');
+  return savedFingerprint === legacyFingerprint;
+}
+
+function getCodexRuntimeFingerprintState(settings: Record<string, unknown>): {
+  currentFingerprint: string;
+  environmentText: string;
+  hasFingerprintInputs: boolean;
+  providerEnabled: boolean;
+  savedFingerprint: string;
+} {
+  const environmentText = getRuntimeEnvironmentText(settings, 'codex');
+  const codexSettings = getCodexProviderSettings(settings);
+  const cliPathInputs = createCliPathFingerprintInputs(
+    codexSettings.cliPathsByHost[getHostnameKey()],
+    codexSettings.cliPath,
+  );
+  const additionalInputs = {
+    ...cliPathInputs,
+    installationMethod: codexSettings.installationMethod,
+    wslDistroOverride: codexSettings.wslDistroOverride,
+  };
+  const environment = parseEnvironmentVariables(environmentText);
+  return {
+    currentFingerprint: computeCodexEnvHash(environmentText, additionalInputs),
+    environmentText,
+    hasFingerprintInputs: Boolean(
+      hasCliPathFingerprintInputs(cliPathInputs)
+      || codexSettings.installationMethod === 'wsl'
+      || codexSettings.wslDistroOverride
+      || ENV_HASH_KEYS.some(key => Object.prototype.hasOwnProperty.call(environment, key))
+    ),
+    providerEnabled: codexSettings.enabled,
+    savedFingerprint: codexSettings.environmentHash,
+  };
 }
 
 function invalidateCodexConversationSessions(conversations: Conversation[]): Conversation[] {
@@ -45,30 +103,11 @@ export const codexSettingsReconciler: ProviderSettingsReconciler = {
     settings: Record<string, unknown>,
     conversations: Conversation[],
   ): { changed: boolean; invalidatedConversations: Conversation[] } {
-    const envText = getRuntimeEnvironmentText(settings, 'codex');
-    const codexSettings = getCodexProviderSettings(settings);
-    const cliPathInputs = createCliPathFingerprintInputs(
-      codexSettings.cliPathsByHost[getHostnameKey()],
-      codexSettings.cliPath,
-    );
-    const currentHash = computeCodexEnvHash(envText, {
-      ...cliPathInputs,
-      installationMethod: codexSettings.installationMethod,
-      wslDistroOverride: codexSettings.wslDistroOverride,
-    });
-    const savedHash = codexSettings.environmentHash;
-
-    const environment = parseEnvironmentVariables(envText);
-    const hasFingerprintInputs = Boolean(
-      hasCliPathFingerprintInputs(cliPathInputs)
-      || codexSettings.installationMethod === 'wsl'
-      || codexSettings.wslDistroOverride
-      || ENV_HASH_KEYS.some(key => Object.prototype.hasOwnProperty.call(environment, key))
-    );
-    if (!savedHash && !hasFingerprintInputs) {
+    const fingerprint = getCodexRuntimeFingerprintState(settings);
+    if (!fingerprint.savedFingerprint && !fingerprint.hasFingerprintInputs) {
       return { changed: false, invalidatedConversations: [] };
     }
-    if (currentHash === savedHash) {
+    if (fingerprint.currentFingerprint === fingerprint.savedFingerprint) {
       return { changed: false, invalidatedConversations: [] };
     }
 
@@ -80,19 +119,39 @@ export const codexSettingsReconciler: ProviderSettingsReconciler = {
       settings.model = nextModel;
     }
 
-    updateCodexProviderSettings(settings, { environmentHash: currentHash });
+    updateCodexProviderSettings(settings, {
+      environmentHash: fingerprint.currentFingerprint,
+    });
     return { changed: true, invalidatedConversations };
   },
 
   normalizeModelVariantSettings(settings: Record<string, unknown>): boolean {
+    let changed = false;
+    const fingerprint = getCodexRuntimeFingerprintState(settings);
+    // Startup normalizes before reconciling. Upgrade an equivalent legacy
+    // fingerprint here so the fingerprint schema change is not treated as a
+    // runtime change that invalidates Codex sessions.
+    if (
+      (fingerprint.providerEnabled || fingerprint.hasFingerprintInputs)
+      && isCurrentLegacyCodexFingerprint(
+        fingerprint.environmentText,
+        fingerprint.savedFingerprint,
+      )
+    ) {
+      updateCodexProviderSettings(settings, {
+        environmentHash: fingerprint.currentFingerprint,
+      });
+      changed = true;
+    }
+
     const model = settings.model as string;
     if (!model) {
-      return false;
+      return changed;
     }
 
     const normalizedModel = codexChatUIConfig.normalizeModelVariant(model, settings);
     if (normalizedModel === model) {
-      return false;
+      return changed;
     }
 
     settings.model = normalizedModel;

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -3111,6 +3111,67 @@ describe('ClaudianPlugin', () => {
   });
 
   describe('loadSettings with conversations', () => {
+    it('migrates a legacy Codex fingerprint before reconciling persisted sessions', async () => {
+      const timestamp = Date.now();
+      const metadataPath = '.claudian/sessions/conv-codex-legacy.meta.json';
+      const sessionMetadata = {
+        id: 'conv-codex-legacy',
+        providerId: 'codex',
+        title: 'Legacy Codex Chat',
+        createdAt: timestamp,
+        lastActivityAt: timestamp,
+        sessionId: 'codex-thread-123',
+        selectedModel: 'openai-codex/gpt-5',
+        providerState: {
+          threadId: 'codex-thread-123',
+          sessionFilePath: 'C:\\Users\\tester\\.codex\\sessions\\codex-thread-123.jsonl',
+        },
+      };
+
+      mockApp.vault.adapter.exists.mockImplementation(async (path: string) => (
+        path === '.claudian/claudian-settings.json'
+        || path === '.claudian/sessions'
+        || path === metadataPath
+      ));
+      mockApp.vault.adapter.list.mockImplementation(async (path: string) => (
+        path === '.claudian/sessions'
+          ? { files: [metadataPath], folders: [] }
+          : { files: [], folders: [] }
+      ));
+      mockApp.vault.adapter.read.mockImplementation(async (path: string) => {
+        if (path === '.claudian/claudian-settings.json') {
+          return JSON.stringify({
+            providerConfigs: {
+              codex: {
+                cliPath: 'C:\\Users\\tester\\codex.exe',
+                enabled: true,
+                environmentHash: '',
+                environmentVariables: '',
+              },
+            },
+          });
+        }
+        if (path === metadataPath) {
+          return JSON.stringify(sessionMetadata);
+        }
+        return '';
+      });
+
+      await plugin.loadSettings();
+
+      expect(plugin.getCachedConversation(sessionMetadata.id)).toMatchObject({
+        sessionId: sessionMetadata.sessionId,
+        providerState: sessionMetadata.providerState,
+      });
+      expect(isVersionedRuntimeInputFingerprint(
+        getCodexProviderSettings(plugin.settings).environmentHash,
+      )).toBe(true);
+      expect(mockApp.vault.adapter.write).not.toHaveBeenCalledWith(
+        metadataPath,
+        expect.any(String),
+      );
+    });
+
     it('should preserve Claude metadata during startup when local native history is missing', async () => {
       const timestamp = Date.now();
       const sessionMeta = JSON.stringify({

--- a/tests/unit/providers/codex/env/CodexSettingsReconciler.test.ts
+++ b/tests/unit/providers/codex/env/CodexSettingsReconciler.test.ts
@@ -8,6 +8,144 @@ import {
 } from '@/providers/codex/env/CodexSettingsReconciler';
 
 describe('codexSettingsReconciler', () => {
+  it('finalizes an empty legacy fingerprint before later runtime inputs change', () => {
+    const conversation = {
+      providerId: 'codex',
+      sessionId: 'thread-123',
+      providerState: {
+        threadId: 'thread-123',
+        sessionFilePath: '/tmp/thread-123.jsonl',
+      },
+      messages: [],
+    } as unknown as Conversation;
+    const settings: Record<string, unknown> = {
+      model: TEST_CODEX_MODEL,
+      providerConfigs: {
+        codex: {
+          enabled: true,
+          discoveredModels: TEST_CODEX_CATALOG,
+          environmentVariables: '',
+          environmentHash: '',
+        },
+      },
+    };
+
+    expect(codexSettingsReconciler.normalizeModelVariantSettings(settings)).toBe(true);
+    expect(isVersionedRuntimeInputFingerprint(
+      (settings.providerConfigs as any).codex.environmentHash,
+    )).toBe(true);
+    expect(codexSettingsReconciler.reconcileModelWithEnvironment(settings, [conversation]))
+      .toEqual({ changed: false, invalidatedConversations: [] });
+
+    (settings.providerConfigs as any).codex.cliPath = '/opt/codex/bin/codex';
+
+    expect(codexSettingsReconciler.normalizeModelVariantSettings(settings)).toBe(false);
+    expect(codexSettingsReconciler.reconcileModelWithEnvironment(settings, [conversation]))
+      .toMatchObject({ changed: true, invalidatedConversations: [conversation] });
+    expect(conversation.sessionId).toBeNull();
+    expect(conversation.providerState).toBeUndefined();
+  });
+
+  it('migrates a legacy fingerprint with an existing CLI path without invalidating history', () => {
+    const conversation = {
+      providerId: 'codex',
+      sessionId: 'thread-123',
+      providerState: {
+        threadId: 'thread-123',
+        sessionFilePath: 'C:\\Users\\tester\\.codex\\sessions\\thread-123.jsonl',
+      },
+      messages: [],
+    } as unknown as Conversation;
+    const settings: Record<string, unknown> = {
+      model: TEST_CODEX_MODEL,
+      providerConfigs: {
+        codex: {
+          enabled: true,
+          cliPath: 'C:\\Users\\tester\\codex.exe',
+          discoveredModels: TEST_CODEX_CATALOG,
+          environmentVariables: '',
+          environmentHash: '',
+        },
+      },
+    };
+
+    expect(codexSettingsReconciler.normalizeModelVariantSettings(settings)).toBe(true);
+    expect(codexSettingsReconciler.reconcileModelWithEnvironment(settings, [conversation]))
+      .toEqual({ changed: false, invalidatedConversations: [] });
+    expect(conversation.sessionId).toBe('thread-123');
+    expect(conversation.providerState).toMatchObject({
+      threadId: 'thread-123',
+      sessionFilePath: 'C:\\Users\\tester\\.codex\\sessions\\thread-123.jsonl',
+    });
+    expect(isVersionedRuntimeInputFingerprint(
+      (settings.providerConfigs as any).codex.environmentHash,
+    )).toBe(true);
+  });
+
+  it('migrates a matching legacy environment fingerprint without invalidating history', () => {
+    const conversation = {
+      providerId: 'codex',
+      sessionId: 'thread-123',
+      providerState: {
+        threadId: 'thread-123',
+        sessionFilePath: '/tmp/thread-123.jsonl',
+      },
+      messages: [],
+    } as unknown as Conversation;
+    const settings: Record<string, unknown> = {
+      model: TEST_CODEX_MODEL,
+      providerConfigs: {
+        codex: {
+          enabled: true,
+          discoveredModels: TEST_CODEX_CATALOG,
+          environmentVariables: 'OPENAI_BASE_URL=https://same.example.com/v1',
+          environmentHash: 'OPENAI_BASE_URL=https://same.example.com/v1',
+        },
+      },
+    };
+
+    expect(codexSettingsReconciler.normalizeModelVariantSettings(settings)).toBe(true);
+    expect(codexSettingsReconciler.reconcileModelWithEnvironment(settings, [conversation]))
+      .toEqual({ changed: false, invalidatedConversations: [] });
+    expect(conversation.sessionId).toBe('thread-123');
+    expect(conversation.providerState).toMatchObject({
+      threadId: 'thread-123',
+      sessionFilePath: '/tmp/thread-123.jsonl',
+    });
+    expect(isVersionedRuntimeInputFingerprint(
+      (settings.providerConfigs as any).codex.environmentHash,
+    )).toBe(true);
+  });
+
+  it('invalidates session state when legacy settings contain a real environment change', () => {
+    const conversation = {
+      providerId: 'codex',
+      sessionId: 'thread-123',
+      providerState: {
+        threadId: 'thread-123',
+        sessionFilePath: '/tmp/thread-123.jsonl',
+      },
+      messages: [],
+    } as unknown as Conversation;
+    const settings: Record<string, unknown> = {
+      model: TEST_CODEX_MODEL,
+      providerConfigs: {
+        codex: {
+          enabled: true,
+          discoveredModels: TEST_CODEX_CATALOG,
+          environmentVariables: 'OPENAI_BASE_URL=https://new.example.com/v1',
+          environmentHash: 'OPENAI_BASE_URL=https://old.example.com/v1',
+        },
+      },
+    };
+
+    expect(codexSettingsReconciler.normalizeModelVariantSettings(settings)).toBe(false);
+    expect(codexSettingsReconciler.reconcileModelWithEnvironment(settings, [conversation]))
+      .toMatchObject({ changed: true, invalidatedConversations: [conversation] });
+    expect(conversation.sessionId).toBeNull();
+    expect(conversation.providerState).toBeUndefined();
+  });
+
   it('invalidates both sessionId and providerState when the Codex env hash changes', () => {
     const conversation = {
       providerId: 'codex',


### PR DESCRIPTION
## Summary

- migrate equivalent legacy Codex runtime fingerprints without invalidating resumable sessions
- finalize empty legacy fingerprints for enabled Codex configurations while preserving disabled defaults
- retain invalidation when legacy environment inputs genuinely changed
- cover reconciliation directly and through the plugin startup lifecycle

## Testing

- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run build`

Closes #1049
