### PR TITLE
fix(codex): reconcile duplicate streaming tool events

### DIFF
--- a/src/providers/codex/execution/CodexExecutionSession.ts
+++ b/src/providers/codex/execution/CodexExecutionSession.ts
@@ -524,6 +524,8 @@ export class CodexExecutionSession
 
       this.notificationRouter = new CodexNotificationRouter(
         chunk => this.handleStreamChunk(run, chunk),
+        undefined,
+        this.resolveTargetWorkingDirectory(),
       );
       const isPlanTurn = request.configuration.mode === 'plan'
         || request.configuration.permissionMode === 'plan'

--- a/src/providers/codex/normalization/codexToolNormalization.ts
+++ b/src/providers/codex/normalization/codexToolNormalization.ts
@@ -45,6 +45,11 @@ export interface NormalizedCodexToolCall {
   input: Record<string, unknown>;
 }
 
+export interface DecodedCodexExecEnvelopeCall extends NormalizedCodexToolCall {
+  rawName: string;
+  rawInput: Record<string, unknown>;
+}
+
 export function normalizeCodexToolCall(
   rawName: string | undefined,
   rawInput: Record<string, unknown>,
@@ -63,6 +68,15 @@ export function normalizeCodexToolCall(
 export function decodeCodexExecEnvelope(
   input: Record<string, unknown>,
 ): NormalizedCodexToolCall[] | null {
+  return decodeCodexExecEnvelopeCalls(input)?.map(({ name, input: normalizedInput }) => ({
+    name,
+    input: normalizedInput,
+  })) ?? null;
+}
+
+export function decodeCodexExecEnvelopeCalls(
+  input: Record<string, unknown>,
+): DecodedCodexExecEnvelopeCall[] | null {
   const source = firstNonEmptyString(input.raw, input.value);
   if (!source) return null;
 
@@ -72,11 +86,13 @@ export function decodeCodexExecEnvelope(
   const calls = findExecEnvelopeToolCalls(tokens);
   if (!calls || calls.length === 0) return null;
 
-  const decodedCalls: NormalizedCodexToolCall[] = [];
+  const decodedCalls: DecodedCodexExecEnvelopeCall[] = [];
   for (const call of calls) {
     const rawInput = decodeExecEnvelopeToolInput(tokens, call);
     if (!rawInput) return null;
     decodedCalls.push({
+      rawName: call.name,
+      rawInput,
       name: normalizeCodexToolName(call.name),
       input: normalizeCodexToolInput(call.name, rawInput),
     });

--- a/src/providers/codex/runtime/CodexNotificationRouter.ts
+++ b/src/providers/codex/runtime/CodexNotificationRouter.ts
@@ -1,3 +1,5 @@
+import * as path from 'path';
+
 import type { CitationGroup, StreamChunk, UsageInfo } from '../../../core/types';
 import { extractCodexUserVisibleText, joinCodexUserTextParts } from '../codexUserText';
 import {
@@ -6,6 +8,7 @@ import {
 } from '../normalization/CodexMemoryCitation';
 import {
   appendCodexCommandOutput,
+  decodeCodexExecEnvelopeCalls,
   extractCodexExecCellId,
   isCodexToolOutputError,
   normalizeCodexToolCall,
@@ -57,6 +60,43 @@ interface WrappedWaitCall {
   cellId: string;
 }
 
+interface PendingWrappedWaitCall {
+  callId: string;
+  cellId: string;
+  item: Record<string, unknown>;
+  rawArguments: Record<string, unknown>;
+}
+
+interface RawCommandProjection {
+  callId: string;
+  visibleId: string;
+  command: string;
+  workingDirectory?: string;
+  rawOwnsCompletion: boolean;
+}
+
+interface CanonicalCommandProjection {
+  itemId: string;
+  commands: string[];
+  workingDirectory?: string;
+}
+
+interface DeferredRawExecCall {
+  callId: string;
+  item: Record<string, unknown>;
+  rawArguments: Record<string, unknown>;
+  expectedCalls: Array<{
+    name: string;
+    input: Record<string, unknown>;
+    comparisonInput?: Record<string, unknown>;
+    claimed: boolean;
+    canonicalItemId?: string;
+    canonicalCompleted?: boolean;
+  }>;
+  hasRawOutput?: boolean;
+  rawOutput?: unknown;
+}
+
 const COLLAB_AGENT_TOOL_MAP: Record<string, string> = {
   spawnAgent: 'spawn_agent',
   wait: 'wait',
@@ -78,21 +118,44 @@ export class CodexNotificationRouter {
   private streamedAssistantTurnText = '';
   private currentAssistantSegmentId: string | undefined;
   private currentAssistantSegmentText = '';
+  private seenRawCallIds = new Set<string>();
+  private pendingRawOutputItemsByCallId = new Map<string, Record<string, unknown>>();
   private rawStartedCallIds = new Set<string>();
+  private startedCanonicalToolItemIds = new Set<string>();
+  private completedCanonicalToolItemIds = new Set<string>();
   private rawToolNamesByCallId = new Map<string, string>();
   private rawToolInputsByCallId = new Map<string, Record<string, unknown>>();
   private rawToolOutputsByCallId = new Map<string, RawToolResult>();
+  private handledRawOutputCallIds = new Set<string>();
+  private inFlightRawFunctionCallIds = new Set<string>();
   private immediateRawOutputCallIds = new Set<string>();
   private emittedImmediateToolResultIds = new Set<string>();
   private wrappedCommandCallIdsByCellId = new Map<string, string>();
   private wrappedCommandOutputByCallId = new Map<string, string>();
   private wrappedWaitCallsByCallId = new Map<string, WrappedWaitCall>();
+  private pendingWrappedWaitCallsByCallId = new Map<string, PendingWrappedWaitCall>();
+  private canonicalCommandOutputByItemId = new Map<string, string>();
+  private pendingCanonicalToolOutputByItemId = new Map<string, string[]>();
+  private canonicalPrefilledRawCommandCallIds = new Set<string>();
+  // Raw tool calls and canonical command items describe the same work with unrelated IDs.
+  // A uniquely correlated command keeps whichever projection started first as the visible row.
+  private unmatchedRawCommands: RawCommandProjection[] = [];
+  private unmatchedCanonicalCommands: CanonicalCommandProjection[] = [];
+  private rawCommandByCanonicalId = new Map<string, RawCommandProjection>();
+  // Non-Bash Code Mode exec calls are transport envelopes. Canonical items own their
+  // semantic lifecycles; the envelope remains available as a lossless raw-only fallback.
+  private deferredRawExecCalls = new Map<string, DeferredRawExecCall>();
+  private projectedCanonicalItemIds = new Set<string>();
+  private activeCanonicalToolProjections = new Map<string, CanonicalToolProjection>();
+  private deferredOwnedCanonicalItemIds = new Set<string>();
+  private ignoredLateRawOutputCallIds = new Set<string>();
   private suppressedRawCallIds = new Set<string>();
   private fileChangeInputsById = new Map<string, Record<string, unknown>>();
 
   constructor(
     private readonly emit: ChunkEmitter,
     private readonly onTurnMetadata?: TurnMetadataListener,
+    private readonly workingDirectory?: string,
   ) {}
 
   private resetAssistantTextTracking(): void {
@@ -149,15 +212,33 @@ export class CodexNotificationRouter {
     this.emittedMemoryCitationIds.clear();
     this.emittedMemoryCitationKeys.clear();
     this.resetAssistantTextTracking();
+    this.seenRawCallIds.clear();
+    this.pendingRawOutputItemsByCallId.clear();
     this.rawStartedCallIds.clear();
+    this.startedCanonicalToolItemIds.clear();
+    this.completedCanonicalToolItemIds.clear();
     this.rawToolNamesByCallId.clear();
     this.rawToolInputsByCallId.clear();
     this.rawToolOutputsByCallId.clear();
+    this.handledRawOutputCallIds.clear();
+    this.inFlightRawFunctionCallIds.clear();
     this.immediateRawOutputCallIds.clear();
     this.emittedImmediateToolResultIds.clear();
     this.wrappedCommandCallIdsByCellId.clear();
     this.wrappedCommandOutputByCallId.clear();
     this.wrappedWaitCallsByCallId.clear();
+    this.pendingWrappedWaitCallsByCallId.clear();
+    this.canonicalCommandOutputByItemId.clear();
+    this.pendingCanonicalToolOutputByItemId.clear();
+    this.canonicalPrefilledRawCommandCallIds.clear();
+    this.unmatchedRawCommands.length = 0;
+    this.unmatchedCanonicalCommands.length = 0;
+    this.rawCommandByCanonicalId.clear();
+    this.deferredRawExecCalls.clear();
+    this.projectedCanonicalItemIds.clear();
+    this.activeCanonicalToolProjections.clear();
+    this.deferredOwnedCanonicalItemIds.clear();
+    this.ignoredLateRawOutputCallIds.clear();
     this.suppressedRawCallIds.clear();
     this.fileChangeInputsById.clear();
   }
@@ -171,15 +252,33 @@ export class CodexNotificationRouter {
     this.emittedMemoryCitationIds.clear();
     this.emittedMemoryCitationKeys.clear();
     this.resetAssistantTextTracking();
+    this.seenRawCallIds.clear();
+    this.pendingRawOutputItemsByCallId.clear();
     this.rawStartedCallIds.clear();
+    this.startedCanonicalToolItemIds.clear();
+    this.completedCanonicalToolItemIds.clear();
     this.rawToolNamesByCallId.clear();
     this.rawToolInputsByCallId.clear();
     this.rawToolOutputsByCallId.clear();
+    this.handledRawOutputCallIds.clear();
+    this.inFlightRawFunctionCallIds.clear();
     this.immediateRawOutputCallIds.clear();
     this.emittedImmediateToolResultIds.clear();
     this.wrappedCommandCallIdsByCellId.clear();
     this.wrappedCommandOutputByCallId.clear();
     this.wrappedWaitCallsByCallId.clear();
+    this.pendingWrappedWaitCallsByCallId.clear();
+    this.canonicalCommandOutputByItemId.clear();
+    this.pendingCanonicalToolOutputByItemId.clear();
+    this.canonicalPrefilledRawCommandCallIds.clear();
+    this.unmatchedRawCommands.length = 0;
+    this.unmatchedCanonicalCommands.length = 0;
+    this.rawCommandByCanonicalId.clear();
+    this.deferredRawExecCalls.clear();
+    this.projectedCanonicalItemIds.clear();
+    this.activeCanonicalToolProjections.clear();
+    this.deferredOwnedCanonicalItemIds.clear();
+    this.ignoredLateRawOutputCallIds.clear();
     this.suppressedRawCallIds.clear();
     this.fileChangeInputsById.clear();
   }
@@ -207,8 +306,10 @@ export class CodexNotificationRouter {
         this.onPlanDelta(params as PlanDeltaNotification);
         break;
       case 'item/commandExecution/outputDelta':
+        this.onOutputDelta(params as { itemId: string; delta: string }, true);
+        break;
       case 'item/fileChange/outputDelta':
-        this.onOutputDelta(params as { itemId: string; delta: string });
+        this.onOutputDelta(params as { itemId: string; delta: string }, false);
         break;
       case 'item/fileChange/patchUpdated':
         this.onFileChangePatchUpdated(params as FileChangePatchUpdatedNotification);
@@ -258,8 +359,23 @@ export class CodexNotificationRouter {
   private onItemStarted(params: ItemStartedNotification): void {
     const item = params.item;
     const itemId = getItemId(item);
+    const deferredOwned = this.claimDeferredRawExecFromItem(item, false);
+    if (item.type === 'commandExecution' && !deferredOwned) {
+      if (this.claimPendingRawCommand(item)) {
+        this.activeCanonicalToolProjections.delete(item.id);
+        this.flushPendingCanonicalToolOutput(item.id);
+        return;
+      }
+    }
     if (itemId && this.rawStartedCallIds.has(itemId)) {
+      this.flushPendingCanonicalToolOutput(itemId);
       return;
+    }
+    if (itemId && isCanonicalToolItem(item)) {
+      if (this.startedCanonicalToolItemIds.has(itemId)) {
+        return;
+      }
+      this.startedCanonicalToolItemIds.add(itemId);
     }
 
     switch (item.type) {
@@ -276,6 +392,13 @@ export class CodexNotificationRouter {
 
       case 'commandExecution':
         this.emitToolUseFromCommand(item);
+        if (!deferredOwned) {
+          this.unmatchedCanonicalCommands.push({
+            itemId: item.id,
+            commands: readCanonicalCommandCandidates(item),
+            workingDirectory: normalizeWorkingDirectory(item.cwd, this.workingDirectory),
+          });
+        }
         break;
 
       case 'fileChange':
@@ -305,12 +428,47 @@ export class CodexNotificationRouter {
       default:
         break;
     }
+    if (itemId && isCanonicalToolItem(item)) {
+      this.flushPendingCanonicalToolOutput(itemId);
+    }
   }
 
   private onItemCompleted(params: ItemCompletedNotification): void {
     const item = params.item;
     const itemId = getItemId(item);
-    const rawResult = itemId ? this.consumeRawToolOutput(itemId) : undefined;
+    if (itemId && isCanonicalToolItem(item)) {
+      if (this.completedCanonicalToolItemIds.has(itemId)) {
+        return;
+      }
+      this.completedCanonicalToolItemIds.add(itemId);
+      this.inFlightRawFunctionCallIds.delete(itemId);
+    }
+    const deferredOwned = this.claimDeferredRawExecFromItem(item, true);
+    if (itemId && deferredOwned) {
+      this.markDeferredCanonicalCompleted(itemId);
+    }
+    const rawResult = item.type !== 'commandExecution' && itemId
+      ? this.consumeRawToolOutput(itemId)
+      : undefined;
+    const hadCanonicalToolUse = itemId
+      ? this.startedCanonicalToolItemIds.has(itemId)
+      : false;
+    const completedCommandRawProjection = item.type === 'commandExecution' && !deferredOwned
+      ? this.rawCommandByCanonicalId.get(item.id) ?? this.claimPendingRawCommand(item)
+      : undefined;
+    if (item.type === 'commandExecution') {
+      if (!this.startedCanonicalToolItemIds.has(item.id) && !completedCommandRawProjection) {
+        this.startedCanonicalToolItemIds.add(item.id);
+        this.emitToolUseFromCommand(item);
+      } else if (completedCommandRawProjection) {
+        this.startedCanonicalToolItemIds.add(item.id);
+      }
+    } else {
+      this.ensureCanonicalToolUseFromCompletion(item);
+    }
+    if (itemId && isCanonicalToolItem(item)) {
+      this.flushPendingCanonicalToolOutput(itemId);
+    }
 
     switch (item.type) {
       case 'userMessage':
@@ -324,11 +482,13 @@ export class CodexNotificationRouter {
         break;
 
       case 'commandExecution':
-        this.emitToolResultFromCommand(item, rawResult);
+        this.completeCommand(item, false, completedCommandRawProjection);
         break;
 
       case 'fileChange':
-        this.emitToolUseFromFileChange(item);
+        if (hadCanonicalToolUse) {
+          this.emitToolUseFromFileChange(item);
+        }
         this.emitToolResultFromFileChange(item);
         break;
 
@@ -362,6 +522,15 @@ export class CodexNotificationRouter {
         }
         break;
     }
+
+    if (
+      itemId
+      && item.type !== 'commandExecution'
+      && this.rawStartedCallIds.has(itemId)
+      && !rawResult
+    ) {
+      this.ignoredLateRawOutputCallIds.add(itemId);
+    }
   }
 
   private onRawResponseItemCompleted(params: unknown): void {
@@ -374,10 +543,12 @@ export class CodexNotificationRouter {
     switch (itemType) {
       case 'function_call':
         this.handleRawFunctionCall(item);
+        this.replayPendingRawToolOutput(item);
         break;
 
       case 'custom_tool_call':
         this.handleRawCustomToolCall(item);
+        this.replayPendingRawToolOutput(item);
         break;
 
       case 'function_call_output':
@@ -421,7 +592,14 @@ export class CodexNotificationRouter {
     if (!callId) {
       return;
     }
-
+    if (this.seenRawCallIds.has(callId)) {
+      return;
+    }
+    this.seenRawCallIds.add(callId);
+    if (this.completedCanonicalToolItemIds.has(callId)) {
+      this.ignoredLateRawOutputCallIds.add(callId);
+      return;
+    }
     const rawArguments = parseRawArguments(item);
     if (rawName === 'wait') {
       const cellId = readCodexExecCellIdArgument(rawArguments);
@@ -432,6 +610,15 @@ export class CodexNotificationRouter {
         this.wrappedWaitCallsByCallId.set(callId, { commandCallId, cellId });
         return;
       }
+      if (cellId) {
+        this.pendingWrappedWaitCallsByCallId.set(callId, {
+          callId,
+          cellId,
+          item,
+          rawArguments,
+        });
+        return;
+      }
     }
 
     if (rawName === 'write_stdin' && isSilentWriteStdinInput(rawArguments)) {
@@ -439,6 +626,7 @@ export class CodexNotificationRouter {
       return;
     }
 
+    this.inFlightRawFunctionCallIds.add(callId);
     this.emitRawToolUse(callId, rawName, item, rawArguments);
   }
 
@@ -448,18 +636,57 @@ export class CodexNotificationRouter {
     if (!callId) {
       return;
     }
-
-    if (rawName === 'apply_patch') {
-      const input = normalizeCodexToolInput(rawName, parseRawArguments(item));
-      this.rememberFileChangeInput(callId, input);
-      this.suppressedRawCallIds.add(callId);
-      this.resetAssistantSegmentText();
+    if (this.seenRawCallIds.has(callId)) {
       return;
+    }
+    this.seenRawCallIds.add(callId);
+    if (this.completedCanonicalToolItemIds.has(callId)) {
+      this.ignoredLateRawOutputCallIds.add(callId);
+      return;
+    }
+
+    const rawArguments = parseRawArguments(item);
+    if (rawName === 'apply_patch') {
+      const input = normalizeCodexToolInput(rawName, rawArguments);
+      this.rememberFileChangeInput(callId, input);
+      this.deferredRawExecCalls.set(callId, {
+        callId,
+        item,
+        rawArguments,
+        expectedCalls: [{ name: 'apply_patch', input, claimed: false }],
+      });
+      this.claimActiveCanonicalProjections();
+      return;
+    }
+
+    if (rawName === 'exec') {
+      const expectedCalls = decodeCodexExecEnvelopeCalls(rawArguments);
+      const isSingleCommand = expectedCalls?.length === 1
+        && expectedCalls[0]?.name === 'Bash';
+      if (!isSingleCommand) {
+        this.deferredRawExecCalls.set(callId, {
+          callId,
+          item,
+          rawArguments,
+          expectedCalls: (expectedCalls ?? []).map((call) => {
+            const semanticCall = projectRawSemanticToolCall(
+              call.name,
+              call.input,
+              call.rawName,
+              call.rawInput,
+              this.workingDirectory,
+            );
+            return { ...semanticCall, claimed: false };
+          }),
+        });
+        this.claimActiveCanonicalProjections();
+        return;
+      }
     }
 
     // Raw custom output is terminal unless a canonical dynamic-tool completion also arrives.
     this.immediateRawOutputCallIds.add(callId);
-    this.emitRawToolUse(callId, rawName, item);
+    this.emitRawToolUse(callId, rawName, item, rawArguments);
   }
 
   private emitRawToolUse(
@@ -467,10 +694,12 @@ export class CodexNotificationRouter {
     rawName: string,
     item: Record<string, unknown>,
     rawArguments?: Record<string, unknown>,
+    fromCanonicalProjection = false,
   ): void {
+    const toolArguments = rawArguments ?? parseRawArguments(item);
     const normalized = normalizeCodexToolCall(
       rawName,
-      rawArguments ?? parseRawArguments(item),
+      toolArguments,
     );
 
     if (this.rawStartedCallIds.has(callId)) {
@@ -482,6 +711,43 @@ export class CodexNotificationRouter {
     this.rawStartedCallIds.add(callId);
     this.rawToolNamesByCallId.set(callId, normalized.name);
     this.rawToolInputsByCallId.set(callId, normalized.input);
+    if (
+      normalized.name !== 'Bash'
+      && !fromCanonicalProjection
+      && this.startedCanonicalToolItemIds.has(callId)
+    ) {
+      return;
+    }
+    const command = normalized.name === 'Bash'
+      ? firstString(normalized.input.command)
+      : '';
+    if (command) {
+      const workingDirectory = this.readRawCommandWorkingDirectory(rawName, toolArguments);
+      const canonicalCommand = this.takeUniqueCanonicalCommand(command, workingDirectory);
+      const projection: RawCommandProjection = {
+        callId,
+        visibleId: canonicalCommand?.itemId ?? callId,
+        command,
+        workingDirectory,
+        rawOwnsCompletion: this.immediateRawOutputCallIds.has(callId),
+      };
+      if (canonicalCommand) {
+        this.rawCommandByCanonicalId.set(canonicalCommand.itemId, projection);
+        this.activeCanonicalToolProjections.delete(canonicalCommand.itemId);
+        const streamedOutput = this.canonicalCommandOutputByItemId.get(canonicalCommand.itemId);
+        this.canonicalCommandOutputByItemId.delete(canonicalCommand.itemId);
+        if (streamedOutput && projection.rawOwnsCompletion) {
+          this.wrappedCommandOutputByCallId.set(callId, streamedOutput);
+          this.canonicalPrefilledRawCommandCallIds.add(callId);
+        }
+      } else {
+        this.unmatchedRawCommands.push(projection);
+      }
+
+      if (canonicalCommand) {
+        return;
+      }
+    }
 
     this.resetAssistantSegmentText();
     this.emit({
@@ -497,6 +763,23 @@ export class CodexNotificationRouter {
     if (!callId) {
       return;
     }
+    if (
+      !this.seenRawCallIds.has(callId)
+      && !this.rawStartedCallIds.has(callId)
+      && !this.deferredRawExecCalls.has(callId)
+    ) {
+      this.pendingRawOutputItemsByCallId.set(callId, item);
+      return;
+    }
+    if (this.pendingWrappedWaitCallsByCallId.has(callId)) {
+      this.pendingRawOutputItemsByCallId.set(callId, item);
+      return;
+    }
+    if (this.handledRawOutputCallIds.has(callId)) {
+      return;
+    }
+    this.handledRawOutputCallIds.add(callId);
+    this.inFlightRawFunctionCallIds.delete(callId);
 
     const wrappedWaitCall = this.wrappedWaitCallsByCallId.get(callId);
     if (wrappedWaitCall) {
@@ -507,6 +790,38 @@ export class CodexNotificationRouter {
 
     if (this.suppressedRawCallIds.delete(callId)) {
       return;
+    }
+
+    if (this.ignoredLateRawOutputCallIds.has(callId)) {
+      return;
+    }
+
+    if (this.emittedImmediateToolResultIds.has(callId)) {
+      return;
+    }
+
+    const deferredExec = this.deferredRawExecCalls.get(callId);
+    if (deferredExec) {
+      if (deferredExec.expectedCalls.length > 0) {
+        deferredExec.hasRawOutput = true;
+        deferredExec.rawOutput = item.output;
+        if (deferredExec.expectedCalls.every(call => (
+          call.claimed && call.canonicalCompleted
+        ))) {
+          this.deferredRawExecCalls.delete(callId);
+        }
+        return;
+      }
+
+      this.deferredRawExecCalls.delete(callId);
+
+      this.immediateRawOutputCallIds.add(callId);
+      this.emitRawToolUse(
+        callId,
+        'exec',
+        deferredExec.item,
+        deferredExec.rawArguments,
+      );
     }
 
     const normalizedName = this.rawToolNamesByCallId.get(callId);
@@ -533,17 +848,37 @@ export class CodexNotificationRouter {
       if (execCellId) {
         this.wrappedCommandCallIdsByCellId.set(execCellId, callId);
         this.appendWrappedCommandOutput(callId, content);
+        this.bindPendingWrappedWaitCalls(execCellId, callId);
         return;
       }
 
+      this.wrappedCommandOutputByCallId.delete(callId);
+      this.canonicalPrefilledRawCommandCallIds.delete(callId);
       if (!this.emittedImmediateToolResultIds.has(callId)) {
         this.emittedImmediateToolResultIds.add(callId);
-        this.emit({ type: 'tool_result', id: callId, ...result });
+        this.emit({
+          type: 'tool_result',
+          id: this.visibleRawCallId(callId),
+          ...result,
+        });
       }
       return;
     }
 
     this.rawToolOutputsByCallId.set(callId, result);
+  }
+
+  private replayPendingRawToolOutput(item: Record<string, unknown>): void {
+    const callId = readRawCallId(item);
+    if (!callId) {
+      return;
+    }
+    const pendingOutput = this.pendingRawOutputItemsByCallId.get(callId);
+    if (!pendingOutput) {
+      return;
+    }
+    this.pendingRawOutputItemsByCallId.delete(callId);
+    this.handleRawToolOutput(pendingOutput);
   }
 
   private handleWrappedWaitOutput(waitCall: WrappedWaitCall, rawOutput: unknown): void {
@@ -565,24 +900,43 @@ export class CodexNotificationRouter {
     const previousOutput = this.wrappedCommandOutputByCallId.get(waitCall.commandCallId);
     const completeOutput = appendCodexCommandOutput(previousOutput, content);
     this.wrappedCommandOutputByCallId.delete(waitCall.commandCallId);
+    this.canonicalPrefilledRawCommandCallIds.delete(waitCall.commandCallId);
     this.wrappedCommandCallIdsByCellId.delete(waitCall.cellId);
+    this.emittedImmediateToolResultIds.add(waitCall.commandCallId);
     this.emit({
       type: 'tool_result',
-      id: waitCall.commandCallId,
+      id: this.visibleRawCallId(waitCall.commandCallId),
       content: completeOutput,
       isError: isCodexToolOutputError(rawOutputText),
     });
+  }
+
+  private bindPendingWrappedWaitCalls(cellId: string, commandCallId: string): void {
+    for (const [waitCallId, waitCall] of this.pendingWrappedWaitCallsByCallId) {
+      if (waitCall.cellId !== cellId) {
+        continue;
+      }
+      this.pendingWrappedWaitCallsByCallId.delete(waitCallId);
+      this.wrappedWaitCallsByCallId.set(waitCallId, { commandCallId, cellId });
+      const pendingOutput = this.pendingRawOutputItemsByCallId.get(waitCallId);
+      if (pendingOutput) {
+        this.pendingRawOutputItemsByCallId.delete(waitCallId);
+        this.handleRawToolOutput(pendingOutput);
+      }
+    }
   }
 
   private appendWrappedCommandOutput(callId: string, content: string): void {
     if (!content) return;
 
     const previousOutput = this.wrappedCommandOutputByCallId.get(callId);
-    const completeOutput = appendCodexCommandOutput(previousOutput, content);
+    const completeOutput = this.canonicalPrefilledRawCommandCallIds.delete(callId)
+      ? mergeOverlappingCommandOutput(previousOutput, content)
+      : appendCodexCommandOutput(previousOutput, content);
     const delta = completeOutput.slice(previousOutput?.length ?? 0);
     this.wrappedCommandOutputByCallId.set(callId, completeOutput);
     if (delta) {
-      this.emit({ type: 'tool_output', id: callId, content: delta });
+      this.emit({ type: 'tool_output', id: this.visibleRawCallId(callId), content: delta });
     }
   }
 
@@ -633,12 +987,419 @@ export class CodexNotificationRouter {
 
   private flushPendingRawToolOutputs(): void {
     for (const [callId, result] of this.rawToolOutputsByCallId) {
-      this.emit({ type: 'tool_result', id: callId, ...result });
+      this.emit({ type: 'tool_result', id: this.visibleRawCallId(callId), ...result });
     }
     this.rawToolOutputsByCallId.clear();
   }
 
+  private flushDeferredRawExecCalls(terminalError = false): void {
+    for (const deferredExec of this.deferredRawExecCalls.values()) {
+      if (this.emitDeferredRawExecFallback(
+        deferredExec,
+        deferredExec.rawOutput,
+        true,
+        terminalError,
+      )) {
+        continue;
+      }
+      this.emitRawToolUse(
+        deferredExec.callId,
+        'exec',
+        deferredExec.item,
+        deferredExec.rawArguments,
+      );
+      this.emit({
+        type: 'tool_result',
+        id: deferredExec.callId,
+        content: '',
+        isError: terminalError,
+      });
+    }
+    this.deferredRawExecCalls.clear();
+  }
+
+  private flushPendingWrappedWaitCalls(terminalError: boolean): void {
+    for (const [callId, waitCall] of this.pendingWrappedWaitCallsByCallId) {
+      this.pendingWrappedWaitCallsByCallId.delete(callId);
+      this.emitRawToolUse(callId, 'wait', waitCall.item, waitCall.rawArguments);
+      const pendingOutput = this.pendingRawOutputItemsByCallId.get(callId);
+      if (pendingOutput) {
+        this.pendingRawOutputItemsByCallId.delete(callId);
+        this.handleRawToolOutput(pendingOutput);
+      } else {
+        this.emittedImmediateToolResultIds.add(callId);
+        this.emit({ type: 'tool_result', id: callId, content: '', isError: terminalError });
+      }
+    }
+  }
+
+  private flushInFlightRawTools(isError: boolean): void {
+    const yieldedCommandCallIds = new Set(this.wrappedCommandCallIdsByCellId.values());
+    for (const callId of yieldedCommandCallIds) {
+      if (this.emittedImmediateToolResultIds.has(callId)) {
+        continue;
+      }
+      this.emittedImmediateToolResultIds.add(callId);
+      this.emit({
+        type: 'tool_result',
+        id: this.visibleRawCallId(callId),
+        content: this.wrappedCommandOutputByCallId.get(callId) ?? '',
+        isError,
+      });
+    }
+    for (const callId of this.immediateRawOutputCallIds) {
+      if (this.emittedImmediateToolResultIds.has(callId)) {
+        continue;
+      }
+      this.emittedImmediateToolResultIds.add(callId);
+      this.emit({
+        type: 'tool_result',
+        id: this.visibleRawCallId(callId),
+        content: '',
+        isError,
+      });
+    }
+    for (const callId of this.inFlightRawFunctionCallIds) {
+      if (this.emittedImmediateToolResultIds.has(callId)) {
+        continue;
+      }
+      this.emittedImmediateToolResultIds.add(callId);
+      this.emit({
+        type: 'tool_result',
+        id: this.visibleRawCallId(callId),
+        content: '',
+        isError,
+      });
+    }
+    this.wrappedCommandCallIdsByCellId.clear();
+    this.wrappedCommandOutputByCallId.clear();
+    this.wrappedWaitCallsByCallId.clear();
+    this.pendingWrappedWaitCallsByCallId.clear();
+    this.inFlightRawFunctionCallIds.clear();
+    this.immediateRawOutputCallIds.clear();
+  }
+
+  private emitDeferredRawExecFallback(
+    deferredExec: DeferredRawExecCall,
+    rawOutput?: unknown,
+    emitResult = false,
+    terminalError = false,
+  ): boolean {
+    if (deferredExec.expectedCalls.length === 0) {
+      return false;
+    }
+
+    const rawOutputText = stringifyCodexToolOutput(rawOutput);
+    deferredExec.expectedCalls.forEach((call, index) => {
+      if (call.claimed) {
+        if (!call.canonicalCompleted && call.canonicalItemId) {
+          this.completedCanonicalToolItemIds.add(call.canonicalItemId);
+          this.emit({
+            type: 'tool_result',
+            id: call.canonicalItemId,
+            content: normalizeRawToolOutput(call.name, rawOutput, call.input),
+            isError: isCodexToolOutputError(rawOutputText)
+              || (terminalError && !deferredExec.hasRawOutput),
+          });
+          call.canonicalCompleted = true;
+        }
+        return;
+      }
+      const fallbackId = deferredExec.expectedCalls.length === 1
+        ? deferredExec.callId
+        : `${deferredExec.callId}:${index + 1}`;
+      this.resetAssistantSegmentText();
+      this.emit({
+        type: 'tool_use',
+        id: fallbackId,
+        name: call.name,
+        input: call.input,
+      });
+      if (emitResult) {
+        this.emit({
+          type: 'tool_result',
+          id: fallbackId,
+          content: normalizeRawToolOutput(call.name, rawOutput, call.input),
+          isError: isCodexToolOutputError(rawOutputText)
+            || (terminalError && !deferredExec.hasRawOutput),
+        });
+      }
+    });
+    return true;
+  }
+
+  private claimDeferredRawExecFromItem(
+    item: ItemStartedNotification['item'],
+    completed: boolean,
+  ): boolean {
+    const projection = item.type === 'fileChange'
+      ? {
+          itemId: item.id,
+          name: 'apply_patch',
+          input: this.rememberFileChangeInput(
+            item.id,
+            buildFileChangeInput(item.changes ?? []),
+          ),
+        }
+      : buildCanonicalToolProjection(item, this.workingDirectory);
+    if (!projection) {
+      return false;
+    }
+    const claimed = this.registerCanonicalToolProjection(projection, completed);
+    if (claimed) {
+      this.deferredOwnedCanonicalItemIds.add(projection.itemId);
+    }
+    return claimed || this.deferredOwnedCanonicalItemIds.has(projection.itemId);
+  }
+
+  private registerCanonicalToolProjection(
+    projection: CanonicalToolProjection,
+    completed = false,
+  ): boolean {
+    if (this.projectedCanonicalItemIds.has(projection.itemId)) {
+      if (!this.activeCanonicalToolProjections.has(projection.itemId)) {
+        return false;
+      }
+      if (this.claimDeferredRawExec(
+        projection.name,
+        projection.input,
+        projection.comparisonInput,
+        projection.itemId,
+        completed,
+      )) {
+        this.activeCanonicalToolProjections.delete(projection.itemId);
+        return true;
+      } else {
+        this.activeCanonicalToolProjections.set(projection.itemId, projection);
+      }
+      return false;
+    }
+    this.projectedCanonicalItemIds.add(projection.itemId);
+    const claimed = this.claimDeferredRawExec(
+      projection.name,
+      projection.input,
+      projection.comparisonInput,
+      projection.itemId,
+      completed,
+    );
+    if (!claimed) {
+      this.activeCanonicalToolProjections.set(projection.itemId, projection);
+    }
+    return claimed;
+  }
+
+  private claimActiveCanonicalProjections(): void {
+    for (const [itemId, projection] of this.activeCanonicalToolProjections) {
+      if (this.claimDeferredRawExec(
+        projection.name,
+        projection.input,
+        projection.comparisonInput,
+        itemId,
+        this.completedCanonicalToolItemIds.has(itemId),
+        this.completedCanonicalToolItemIds.has(itemId),
+      )) {
+        this.activeCanonicalToolProjections.delete(itemId);
+        this.deferredOwnedCanonicalItemIds.add(itemId);
+        const unmatchedCommandIndex = this.unmatchedCanonicalCommands
+          .findIndex(command => command.itemId === itemId);
+        if (unmatchedCommandIndex !== -1) {
+          this.unmatchedCanonicalCommands.splice(unmatchedCommandIndex, 1);
+        }
+      }
+    }
+  }
+
+  private claimDeferredRawExec(
+    name: string,
+    input: Record<string, unknown>,
+    comparisonInput = input,
+    canonicalItemId?: string,
+    canonicalCompleted = false,
+    requireSameId = false,
+  ): boolean {
+    const projectedName = semanticToolName(name);
+    const availableCalls = [...this.deferredRawExecCalls.values()].flatMap(deferredExec => (
+      deferredExec.expectedCalls
+        .filter(call => !call.claimed && call.name === projectedName)
+        .map(expectedCall => ({ deferredExec, expectedCall }))
+    ));
+    const sameIdCalls = canonicalItemId
+      ? availableCalls.filter(({ deferredExec }) => deferredExec.callId === canonicalItemId)
+      : [];
+    const compatibleCalls = (
+      sameIdCalls.length > 0
+        ? sameIdCalls
+        : requireSameId
+          ? []
+          : availableCalls
+    )
+      .filter(({ expectedCall }) => toolInputsCompatible(
+        projectedName,
+        expectedCall.comparisonInput ?? expectedCall.input,
+        comparisonInput,
+        this.workingDirectory,
+      ));
+    const match = sameIdCalls.length === 1
+      ? sameIdCalls[0]
+      : compatibleCalls.length === 1
+        ? compatibleCalls[0]
+        : undefined;
+    if (!match) {
+      return false;
+    }
+
+    const { deferredExec, expectedCall } = match;
+    expectedCall.claimed = true;
+    expectedCall.canonicalItemId = canonicalItemId;
+    expectedCall.canonicalCompleted = canonicalCompleted;
+    if (
+      deferredExec.hasRawOutput
+      && deferredExec.expectedCalls.every(call => (
+        call.claimed && call.canonicalCompleted
+      ))
+    ) {
+      this.deferredRawExecCalls.delete(deferredExec.callId);
+    }
+    return true;
+  }
+
+  private markDeferredCanonicalCompleted(itemId: string): void {
+    for (const deferredExec of this.deferredRawExecCalls.values()) {
+      const claimedCall = deferredExec.expectedCalls.find(call => (
+        call.canonicalItemId === itemId
+      ));
+      if (claimedCall) {
+        claimedCall.canonicalCompleted = true;
+        if (
+          deferredExec.hasRawOutput
+          && deferredExec.expectedCalls.every(call => (
+            call.claimed && call.canonicalCompleted
+          ))
+        ) {
+          this.deferredRawExecCalls.delete(deferredExec.callId);
+        }
+        return;
+      }
+    }
+  }
+
   // -- commandExecution -------------------------------------------------------
+
+  private claimPendingRawCommand(item: CommandExecutionItem): RawCommandProjection | undefined {
+    const rawAction = readCanonicalCommand(item);
+    const workingDirectory = normalizeWorkingDirectory(item.cwd, this.workingDirectory);
+    let index = this.unmatchedRawCommands.findIndex(command => command.callId === item.id);
+    if (index === -1) {
+      const matchingIndexes = this.unmatchedRawCommands
+        .map((command, candidateIndex) => ({ command, candidateIndex }))
+        .filter(({ command }) => (
+          (command.command === rawAction || command.command === item.command)
+          && command.workingDirectory === workingDirectory
+        ));
+      if (matchingIndexes.length === 1) {
+        index = matchingIndexes[0]?.candidateIndex ?? -1;
+      }
+    }
+    if (index === -1) {
+      return undefined;
+    }
+
+    const [command] = this.unmatchedRawCommands.splice(index, 1);
+    if (!command) {
+      return undefined;
+    }
+    this.rawCommandByCanonicalId.set(item.id, command);
+    return command;
+  }
+
+  private takeUniqueCanonicalCommand(
+    command: string,
+    workingDirectory?: string,
+  ): CanonicalCommandProjection | undefined {
+    const matches = this.unmatchedCanonicalCommands
+      .map((candidate, index) => ({ candidate, index }))
+      .filter(({ candidate }) => (
+        candidate.commands.includes(command)
+        && candidate.workingDirectory === workingDirectory
+      ));
+    if (matches.length !== 1) {
+      return undefined;
+    }
+
+    const match = matches[0];
+    if (!match) {
+      return undefined;
+    }
+    this.unmatchedCanonicalCommands.splice(match.index, 1);
+    return match.candidate;
+  }
+
+  private readRawCommandWorkingDirectory(
+    rawName: string,
+    rawArguments: Record<string, unknown>,
+  ): string | undefined {
+    let commandInput = rawArguments;
+    if (rawName === 'exec') {
+      const calls = decodeCodexExecEnvelopeCalls(rawArguments);
+      const commandCall = calls?.length === 1 && calls[0]?.name === 'Bash'
+        ? calls[0]
+        : undefined;
+      commandInput = commandCall?.rawInput ?? {};
+    }
+
+    const rawWorkingDirectory = firstString(
+      commandInput.workdir,
+      commandInput.cwd,
+      commandInput.workingDirectory,
+    );
+    if (rawWorkingDirectory) {
+      return this.workingDirectory
+        ? path.resolve(this.workingDirectory, rawWorkingDirectory)
+        : normalizeWorkingDirectory(rawWorkingDirectory);
+    }
+    return normalizeWorkingDirectory(this.workingDirectory);
+  }
+
+  private visibleRawCallId(callId: string): string {
+    for (const projection of this.rawCommandByCanonicalId.values()) {
+      if (projection.callId === callId) {
+        return projection.visibleId;
+      }
+    }
+    return callId;
+  }
+
+  private completeCommand(
+    item: CommandExecutionItem,
+    allowRawCorrelation = true,
+    resolvedRawCommand?: RawCommandProjection,
+  ): void {
+    const rawCommand = resolvedRawCommand
+      ?? this.rawCommandByCanonicalId.get(item.id)
+      ?? (allowRawCorrelation ? this.claimPendingRawCommand(item) : undefined);
+    const unmatchedCanonicalIndex = this.unmatchedCanonicalCommands
+      .findIndex(command => command.itemId === item.id);
+    if (unmatchedCanonicalIndex !== -1) {
+      this.unmatchedCanonicalCommands.splice(unmatchedCanonicalIndex, 1);
+    }
+    if (rawCommand?.rawOwnsCompletion) {
+      return;
+    }
+
+    const resultId = rawCommand?.visibleId ?? item.id;
+    const rawResult = rawCommand
+      ? this.consumeRawToolOutput(rawCommand.callId)
+      : this.consumeRawToolOutput(item.id);
+    this.emitToolResultFromCommand(item, rawResult, resultId);
+    this.canonicalCommandOutputByItemId.delete(item.id);
+    if (rawCommand) {
+      this.wrappedCommandOutputByCallId.delete(rawCommand.callId);
+      this.canonicalPrefilledRawCommandCallIds.delete(rawCommand.callId);
+    }
+    if (rawCommand) {
+      this.ignoredLateRawOutputCallIds.add(rawCommand.callId);
+    }
+  }
 
   private emitToolUseFromCommand(item: CommandExecutionItem): void {
     const rawAction = item.commandActions?.[0]?.command ?? item.command;
@@ -649,7 +1410,11 @@ export class CodexNotificationRouter {
     this.emit({ type: 'tool_use', id: item.id, name: normalizedName, input });
   }
 
-  private emitToolResultFromCommand(item: CommandExecutionItem, rawResult?: RawToolResult): void {
+  private emitToolResultFromCommand(
+    item: CommandExecutionItem,
+    rawResult?: RawToolResult,
+    resultId = item.id,
+  ): void {
     const normalizedName = normalizeCodexToolName('command_execution');
     const output = item.aggregatedOutput ?? '';
     const content = rawResult?.content ?? normalizeCodexToolResult(normalizedName, output);
@@ -657,7 +1422,7 @@ export class CodexNotificationRouter {
       ? item.exitCode !== 0
       : rawResult?.isError ?? isCodexToolOutputError(output);
 
-    this.emit({ type: 'tool_result', id: item.id, content, isError });
+    this.emit({ type: 'tool_result', id: resultId, content, isError });
   }
 
   // -- fileChange -------------------------------------------------------------
@@ -705,6 +1470,14 @@ export class CodexNotificationRouter {
       itemId,
       buildFileChangeInput(params.changes ?? []),
     );
+    const claimed = this.registerCanonicalToolProjection(
+      { itemId, name: 'apply_patch', input },
+      false,
+    );
+    if (claimed) {
+      this.deferredOwnedCanonicalItemIds.add(itemId);
+    }
+    this.startedCanonicalToolItemIds.add(itemId);
 
     this.resetAssistantSegmentText();
     this.emit({
@@ -713,6 +1486,7 @@ export class CodexNotificationRouter {
       name: normalizeCodexToolName('file_change'),
       input,
     });
+    this.flushPendingCanonicalToolOutput(itemId);
   }
 
   private rememberFileChangeInput(
@@ -839,7 +1613,48 @@ export class CodexNotificationRouter {
       item.tool,
       {},
       asRecord(item.arguments) ?? {},
+      true,
     );
+  }
+
+  private ensureCanonicalToolUseFromCompletion(
+    item: ItemCompletedNotification['item'],
+  ): void {
+    const itemId = getItemId(item);
+    if (
+      !itemId
+      || !isCanonicalToolItem(item)
+      || this.startedCanonicalToolItemIds.has(itemId)
+    ) {
+      return;
+    }
+    this.startedCanonicalToolItemIds.add(itemId);
+    if (this.rawStartedCallIds.has(itemId)) {
+      return;
+    }
+
+    switch (item.type) {
+      case 'fileChange':
+        this.emitToolUseFromFileChange(item);
+        break;
+      case 'imageView':
+        this.emitToolUseFromImageView(item);
+        break;
+      case 'webSearch':
+        this.emitToolUseFromWebSearch(item);
+        break;
+      case 'collabAgentToolCall':
+        this.emitToolUseFromCollabAgent(item);
+        break;
+      case 'mcpToolCall':
+        this.emitToolUseFromMcp(item);
+        break;
+      case 'dynamicToolCall':
+        this.emitToolUseFromDynamic(item);
+        break;
+      default:
+        break;
+    }
   }
 
   private emitToolResultFromDynamic(item: DynamicToolCallItem): void {
@@ -939,7 +1754,7 @@ export class CodexNotificationRouter {
 
   private onPlanUpdated(params: TurnPlanUpdatedNotification): void {
     this.planUpdateCounter += 1;
-    const syntheticId = `plan-update-${params.turnId ?? this.planUpdateCounter}`;
+    const syntheticId = `plan-update-${params.turnId ?? 'turn'}-${this.planUpdateCounter}`;
     const PLAN_STATUS_MAP: Record<string, string> = {
       inProgress: 'in_progress',
       in_progress: 'in_progress',
@@ -952,6 +1767,18 @@ export class CodexNotificationRouter {
       status: PLAN_STATUS_MAP[item.status] ?? item.status,
     }));
 
+    const projectionInput = {
+      todos,
+      ...(params.explanation ? { explanation: params.explanation } : {}),
+    };
+    this.claimDeferredRawExec(
+      'TodoWrite',
+      projectionInput,
+      projectionInput,
+      syntheticId,
+      true,
+    );
+
     this.resetAssistantSegmentText();
     this.emit({ type: 'tool_use', id: syntheticId, name: 'TodoWrite', input: { todos } });
     this.emit({ type: 'tool_result', id: syntheticId, content: 'Plan updated', isError: false });
@@ -959,8 +1786,51 @@ export class CodexNotificationRouter {
 
   // -- outputDelta (commandExecution + fileChange) ----------------------------
 
-  private onOutputDelta(params: { itemId: string; delta: string }): void {
-    this.emit({ type: 'tool_output', id: params.itemId, content: params.delta });
+  private onOutputDelta(
+    params: { itemId: string; delta: string },
+    isCommandOutput: boolean,
+  ): void {
+    const rawCommand = this.rawCommandByCanonicalId.get(params.itemId);
+    if (rawCommand?.rawOwnsCompletion) {
+      return;
+    }
+    if (isCommandOutput) {
+      const previousOutput = this.canonicalCommandOutputByItemId.get(params.itemId) ?? '';
+      this.canonicalCommandOutputByItemId.set(params.itemId, previousOutput + params.delta);
+    }
+    const lifecycleStarted = this.startedCanonicalToolItemIds.has(params.itemId)
+      || this.rawStartedCallIds.has(params.itemId)
+      || rawCommand !== undefined;
+    if (!lifecycleStarted) {
+      const pendingOutput = this.pendingCanonicalToolOutputByItemId.get(params.itemId) ?? [];
+      pendingOutput.push(params.delta);
+      this.pendingCanonicalToolOutputByItemId.set(params.itemId, pendingOutput);
+      return;
+    }
+    this.emit({
+      type: 'tool_output',
+      id: rawCommand?.visibleId ?? params.itemId,
+      content: params.delta,
+    });
+  }
+
+  private flushPendingCanonicalToolOutput(itemId: string): void {
+    const pendingOutput = this.pendingCanonicalToolOutputByItemId.get(itemId);
+    if (!pendingOutput) {
+      return;
+    }
+    this.pendingCanonicalToolOutputByItemId.delete(itemId);
+    const rawCommand = this.rawCommandByCanonicalId.get(itemId);
+    if (rawCommand?.rawOwnsCompletion) {
+      return;
+    }
+    for (const content of pendingOutput) {
+      this.emit({
+        type: 'tool_output',
+        id: rawCommand?.visibleId ?? itemId,
+        content,
+      });
+    }
   }
 
   // -- tokenUsage / turnCompleted / error -------------------------------------
@@ -986,10 +1856,6 @@ export class CodexNotificationRouter {
   private onTurnCompleted(params: TurnCompletedNotification): void {
     const turn = params.turn;
 
-    if (turn.status === 'failed' && turn.error) {
-      this.emit({ type: 'error', content: turn.error.message });
-    }
-
     if (turn.status === 'completed') {
       this.onTurnMetadata?.({
         assistantMessageId: turn.id,
@@ -997,14 +1863,471 @@ export class CodexNotificationRouter {
       });
     }
 
+    const terminalError = turn.status === 'failed';
+    this.flushDeferredRawExecCalls(terminalError);
+    this.flushPendingWrappedWaitCalls(terminalError);
     this.flushPendingRawToolOutputs();
-    this.emit({ type: 'done' });
+    this.flushInFlightRawTools(terminalError);
+    if (turn.status === 'failed' && turn.error) {
+      this.emit({ type: 'error', content: turn.error.message });
+    } else {
+      this.emit({ type: 'done' });
+    }
   }
 
   private onError(params: ErrorNotification): void {
     if (params.willRetry) return;
+    this.flushDeferredRawExecCalls(true);
+    this.flushPendingWrappedWaitCalls(true);
+    this.flushPendingRawToolOutputs();
+    this.flushInFlightRawTools(true);
     this.emit({ type: 'error', content: params.error.message });
   }
+}
+
+interface CanonicalToolProjection {
+  itemId: string;
+  name: string;
+  input: Record<string, unknown>;
+  comparisonInput?: Record<string, unknown>;
+}
+
+function buildCanonicalToolProjection(
+  item: ItemStartedNotification['item'],
+  workingDirectory?: string,
+): CanonicalToolProjection | null {
+  switch (item.type) {
+    case 'commandExecution': {
+      const input = normalizeCodexToolInput('command_execution', {
+        command: readCanonicalCommand(item),
+      });
+      return {
+        itemId: item.id,
+        name: 'Bash',
+        input,
+        comparisonInput: {
+          ...input,
+          workingDirectory: resolveToolWorkingDirectory(item.cwd, workingDirectory),
+        },
+      };
+    }
+
+    case 'fileChange':
+      return {
+        itemId: item.id,
+        name: 'apply_patch',
+        input: buildFileChangeInput(item.changes ?? []),
+      };
+
+    case 'imageView':
+      return {
+        itemId: item.id,
+        name: 'Read',
+        input: normalizeCodexToolInput('view_image', { path: item.path }),
+      };
+
+    case 'webSearch':
+      return {
+        itemId: item.id,
+        name: 'WebSearch',
+        input: normalizeCodexToolInput('web_search', {
+          query: item.query ?? '',
+          queries: item.queries ?? [],
+          url: item.url ?? '',
+          pattern: item.pattern ?? '',
+          action: item.action ?? {},
+        }),
+      };
+
+    case 'collabAgentToolCall':
+      return {
+        itemId: item.id,
+        name: COLLAB_AGENT_TOOL_MAP[item.tool] ?? item.tool,
+        input: item.arguments ?? {},
+      };
+
+    case 'mcpToolCall':
+      return {
+        itemId: item.id,
+        name: `mcp__${item.server}__${item.tool}`,
+        input: item.arguments ?? {},
+      };
+
+    case 'dynamicToolCall': {
+      const normalized = normalizeCodexToolCall(
+        item.tool,
+        asRecord(item.arguments) ?? {},
+      );
+      return { itemId: item.id, ...normalized };
+    }
+
+    default:
+      return null;
+  }
+}
+
+function readCanonicalCommand(item: CommandExecutionItem): string {
+  return item.commandActions?.[0]?.command ?? item.command;
+}
+
+function readCanonicalCommandCandidates(item: CommandExecutionItem): string[] {
+  return [...new Set([
+    readCanonicalCommand(item),
+    item.command,
+  ].filter(Boolean))];
+}
+
+function normalizeWorkingDirectory(
+  workingDirectory: string | undefined,
+  baseDirectory?: string,
+): string | undefined {
+  return workingDirectory
+    ? path.resolve(baseDirectory ?? '', workingDirectory)
+    : undefined;
+}
+
+function resolveToolWorkingDirectory(
+  workingDirectory: string | undefined,
+  baseDirectory?: string,
+): string | undefined {
+  return workingDirectory
+    ? normalizeWorkingDirectory(workingDirectory, baseDirectory)
+    : normalizeWorkingDirectory(baseDirectory);
+}
+
+function semanticToolName(name: string): string {
+  switch (name) {
+    case 'web__run':
+      return 'WebSearch';
+    case 'wait_agent':
+      return 'wait';
+    default:
+      return name;
+  }
+}
+
+function projectRawSemanticToolCall(
+  name: string,
+  input: Record<string, unknown>,
+  rawName?: string,
+  rawInput?: Record<string, unknown>,
+  workingDirectory?: string,
+): {
+  name: string;
+  input: Record<string, unknown>;
+  comparisonInput?: Record<string, unknown>;
+} {
+  if (name === 'web__run') {
+    return {
+      name: 'WebSearch',
+      input: normalizeWebRunInput(input),
+    };
+  }
+  if (rawName === 'update_plan') {
+    const explanation = firstString(rawInput?.explanation);
+    return {
+      name: 'TodoWrite',
+      input: {
+        ...input,
+        ...(explanation ? { explanation } : {}),
+      },
+    };
+  }
+  if (name === 'Bash') {
+    return {
+      name,
+      input,
+      comparisonInput: {
+        ...input,
+        workingDirectory: resolveToolWorkingDirectory(
+          firstString(
+            rawInput?.workdir,
+            rawInput?.cwd,
+            rawInput?.workingDirectory,
+          ),
+          workingDirectory,
+        ),
+      },
+    };
+  }
+  return { name: semanticToolName(name), input };
+}
+
+function normalizeWebRunInput(input: Record<string, unknown>): Record<string, unknown> {
+  const regularQueries: unknown[] = Array.isArray(input.search_query)
+    ? input.search_query as unknown[]
+    : [];
+  const imageQueries: unknown[] = Array.isArray(input.image_query)
+    ? input.image_query as unknown[]
+    : [];
+  const searchQueries = [...regularQueries, ...imageQueries];
+  const queries = searchQueries
+    .map(query => firstString(asRecord(query)?.q))
+    .filter(Boolean);
+  if (queries.length > 0) {
+    return {
+      actionType: 'search',
+      query: queries[0],
+      ...(queries.length > 1 ? { queries } : {}),
+    };
+  }
+
+  const openRequest = asRecord(Array.isArray(input.open) ? input.open[0] : undefined);
+  const openUrl = firstString(openRequest?.ref_id, openRequest?.url);
+  if (openUrl) {
+    return { actionType: 'open_page', url: openUrl };
+  }
+
+  const findRequest = asRecord(Array.isArray(input.find) ? input.find[0] : undefined);
+  const findUrl = firstString(findRequest?.ref_id, findRequest?.url);
+  const pattern = firstString(findRequest?.pattern);
+  if (findUrl && pattern) {
+    return { actionType: 'find_in_page', url: findUrl, pattern };
+  }
+  return input;
+}
+
+function toolInputsCompatible(
+  name: string,
+  expected: Record<string, unknown>,
+  actual: Record<string, unknown>,
+  workingDirectory?: string,
+): boolean {
+  if (name === 'apply_patch') {
+    const expectedChanges = extractRawPatchChanges(expected.patch, workingDirectory);
+    const actualChanges = extractCanonicalFileChanges(actual.changes, workingDirectory);
+    if (expectedChanges.length > 0 || actualChanges.length > 0) {
+      if (expectedChanges.some(change => change.kind === 'update' && !change.hasContext)) {
+        return false;
+      }
+      return stableValueKey(expectedChanges) === stableValueKey(actualChanges);
+    }
+  }
+
+  if (name === 'WebSearch') {
+    return stableValueKey(normalizeComparedWebInput(expected))
+      === stableValueKey(normalizeComparedWebInput(actual));
+  }
+
+  return stableValueKey(expected) === stableValueKey(actual);
+}
+
+function normalizeComparedWebInput(input: Record<string, unknown>): Record<string, unknown> {
+  const actionType = firstString(input.actionType);
+  const normalizedActionType = actionType === 'openPage'
+    ? 'open_page'
+    : actionType === 'findInPage'
+      ? 'find_in_page'
+      : actionType;
+  const normalized: Record<string, unknown> = {
+    ...input,
+    ...(normalizedActionType ? { actionType: normalizedActionType } : {}),
+  };
+  if (normalizedActionType === 'open_page' || normalizedActionType === 'find_in_page') {
+    delete normalized.query;
+    delete normalized.queries;
+  } else if (
+    Array.isArray(normalized.queries)
+    && normalized.queries.length === 1
+    && normalized.queries[0] === normalized.query
+  ) {
+    delete normalized.queries;
+  }
+  return normalized;
+}
+
+interface ComparedFileChange {
+  path: string;
+  kind: string;
+  movePath?: string;
+  lines: string[];
+  hasContext: boolean;
+}
+
+function extractRawPatchChanges(
+  value: unknown,
+  workingDirectory?: string,
+): ComparedFileChange[] {
+  if (typeof value !== 'string') {
+    return [];
+  }
+  const changes: ComparedFileChange[] = [];
+  let current: ComparedFileChange | undefined;
+  for (const line of value.split('\n')) {
+    const match = line.match(/^\*\*\* (Add|Update|Delete) File: (.+)$/);
+    if (match?.[1] && match[2]) {
+      if (current) {
+        changes.push(current);
+      }
+      current = {
+        path: normalizeComparedFilePath(match[2], workingDirectory),
+        kind: normalizeComparedChangeKind(match[1]),
+        lines: [],
+        hasContext: false,
+      };
+      continue;
+    }
+    const moveMatch = line.match(/^\*\*\* Move to: (.+)$/);
+    if (current && moveMatch?.[1]) {
+      current.movePath = normalizeComparedFilePath(moveMatch[1], workingDirectory);
+      continue;
+    }
+    if (!current || line.startsWith('+++ ') || line.startsWith('--- ')) {
+      continue;
+    }
+    if (line.startsWith('@@')) {
+      const anchor = extractRawPatchHunkAnchor(line);
+      if (anchor) {
+        current.lines.push(`@${anchor}`);
+        current.hasContext = true;
+      }
+    } else if (line.startsWith('+') || line.startsWith('-')) {
+      current.lines.push(line);
+    } else if (line.startsWith(' ')) {
+      current.lines.push(line);
+      current.hasContext = true;
+    }
+  }
+  if (current) {
+    changes.push(current);
+  }
+  return changes.sort(compareFileChanges);
+}
+
+function extractCanonicalFileChanges(
+  value: unknown,
+  workingDirectory?: string,
+): ComparedFileChange[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((change): ComparedFileChange | null => {
+      const record = asRecord(change);
+      const changePath = normalizeComparedFilePath(
+        firstString(record?.path),
+        workingDirectory,
+      );
+      if (!record || !changePath) {
+        return null;
+      }
+      const lines: string[] = [];
+      let hasContext = false;
+      for (const line of firstString(record.diff).split('\n')) {
+        if (line.startsWith('@@')) {
+          const anchor = extractCanonicalDiffHunkAnchor(line);
+          if (anchor) {
+            lines.push(`@${anchor}`);
+            hasContext = true;
+          }
+          continue;
+        }
+        if (
+          line.startsWith('+++ ')
+          || line.startsWith('--- ')
+        ) {
+          continue;
+        }
+        if (line.startsWith('+') || line.startsWith('-')) {
+          lines.push(line);
+        } else if (line.startsWith(' ')) {
+          lines.push(line);
+          hasContext = true;
+        }
+      }
+      const movePath = firstString(record.movePath);
+      return {
+        path: changePath,
+        kind: movePath
+          ? 'update'
+          : normalizeComparedChangeKind(firstString(record.kind, record.type)),
+        ...(movePath
+          ? {
+              movePath: normalizeComparedFilePath(
+                movePath,
+                workingDirectory,
+              ),
+            }
+          : {}),
+        lines,
+        hasContext,
+      };
+    })
+    .filter((change): change is ComparedFileChange => change !== null)
+    .sort(compareFileChanges);
+}
+
+function extractRawPatchHunkAnchor(line: string): string {
+  return line.slice(2).trim().replace(/\s*@@$/, '').trim();
+}
+
+function extractCanonicalDiffHunkAnchor(line: string): string {
+  const closingMarker = line.indexOf('@@', 2);
+  return closingMarker === -1 ? '' : line.slice(closingMarker + 2).trim();
+}
+
+function normalizeComparedChangeKind(kind: string): string {
+  switch (kind.toLowerCase()) {
+    case 'add':
+    case 'create':
+      return 'add';
+    case 'delete':
+    case 'remove':
+      return 'delete';
+    case 'modify':
+    case 'change':
+    case 'update':
+      return 'update';
+    default:
+      return kind.toLowerCase();
+  }
+}
+
+function compareFileChanges(first: ComparedFileChange, second: ComparedFileChange): number {
+  return first.path.localeCompare(second.path) || first.kind.localeCompare(second.kind);
+}
+
+function normalizeComparedFilePath(filePath: string, workingDirectory?: string): string {
+  const trimmedPath = filePath.trim();
+  if (!trimmedPath) {
+    return '';
+  }
+  return workingDirectory
+    ? path.resolve(workingDirectory, trimmedPath)
+    : path.normalize(trimmedPath);
+}
+
+function stableValueKey(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableValueKey).join(',')}]`;
+  }
+  const record = asRecord(value);
+  if (record) {
+    return `{${Object.keys(record)
+      .sort()
+      .map(key => `${JSON.stringify(key)}:${stableValueKey(record[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value) ?? String(value);
+}
+
+function mergeOverlappingCommandOutput(previous: string | undefined, next: string): string {
+  if (!previous || !next) {
+    return previous || next;
+  }
+  if (next.startsWith(previous)) {
+    return next;
+  }
+  if (previous.endsWith(next)) {
+    return previous;
+  }
+  const maxOverlap = Math.min(previous.length, next.length);
+  for (let overlap = maxOverlap; overlap > 0; overlap -= 1) {
+    if (previous.endsWith(next.slice(0, overlap))) {
+      return previous + next.slice(overlap);
+    }
+  }
+  return appendCodexCommandOutput(previous, next);
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -1030,6 +2353,16 @@ function buildMemoryCitationKey(citations: CitationGroup): string {
 
 function getItemId(item: { id?: string } | Record<string, unknown>): string | undefined {
   return typeof item.id === 'string' ? item.id : undefined;
+}
+
+function isCanonicalToolItem(item: ItemStartedNotification['item']): boolean {
+  return item.type === 'commandExecution'
+    || item.type === 'fileChange'
+    || item.type === 'imageView'
+    || item.type === 'webSearch'
+    || item.type === 'collabAgentToolCall'
+    || item.type === 'mcpToolCall'
+    || item.type === 'dynamicToolCall';
 }
 
 function readRawCallId(item: Record<string, unknown>): string {

--- a/tests/unit/providers/codex/runtime/CodexNotificationRouter.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexNotificationRouter.test.ts
@@ -12,6 +12,7 @@ describe('CodexNotificationRouter', () => {
     router = new CodexNotificationRouter(
       (chunk) => chunks.push(chunk),
       (update) => turnMetadata.push(update),
+      '/workspace',
     );
   });
 
@@ -438,13 +439,56 @@ describe('CodexNotificationRouter', () => {
         turnId: 'turn1',
       });
 
-      expect(chunks).toHaveLength(1);
-      expect(chunks[0]).toMatchObject({
+      expect(chunks).toHaveLength(2);
+      expect(chunks[1]).toMatchObject({
         type: 'tool_result',
         id: 'call_abc',
         content: 'test\n',
         isError: false,
       });
+    });
+
+    it('ignores a late same-ID raw Bash call after canonical command completion', () => {
+      router.beginTurn({ isPlanTurn: false });
+      router.handleNotification('item/completed', {
+        item: {
+          type: 'commandExecution',
+          id: 'call_abc',
+          command: 'echo test',
+          cwd: '/workspace',
+          processId: '123',
+          source: 'unifiedExecStartup',
+          status: 'completed',
+          commandActions: [{ type: 'unknown', command: 'echo test' }],
+          aggregatedOutput: 'test\n',
+          exitCode: 0,
+          durationMs: 100,
+        },
+        threadId: 't1',
+        turnId: 'turn1',
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_abc',
+          input: 'const r = await tools.exec_command({cmd:"echo test"}); text(r.output);',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_abc',
+          output: 'Script completed\nOutput:\ntest\n',
+        },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_use')).toHaveLength(1);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(1);
     });
 
     it('marks tool_result as error when exitCode is non-zero', () => {
@@ -466,7 +510,8 @@ describe('CodexNotificationRouter', () => {
         turnId: 'turn1',
       });
 
-      expect(chunks[0]).toMatchObject({
+      expect(chunks).toHaveLength(2);
+      expect(chunks[1]).toMatchObject({
         type: 'tool_result',
         isError: true,
       });
@@ -577,6 +622,23 @@ describe('CodexNotificationRouter', () => {
           input: 'const r = await tools.exec_command({cmd:"npm test"}); text(r.output);',
         },
       });
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'commandExecution',
+          id: 'exec_canonical',
+          command: 'npm test',
+          cwd: '/workspace',
+          processId: '123',
+          source: 'unifiedExecStartup',
+          status: 'inProgress',
+          commandActions: [{ type: 'unknown', command: 'npm test' }],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      });
       router.handleNotification('rawResponseItem/completed', {
         threadId: 't1',
         turnId: 'turn1',
@@ -587,6 +649,41 @@ describe('CodexNotificationRouter', () => {
             { type: 'input_text', text: 'Script running with cell ID 42\nWall time 10.0 seconds\nOutput:\n' },
             { type: 'input_text', text: 'tests started\n' },
           ],
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_exec_wrapper',
+          output: [
+            { type: 'input_text', text: 'Script running with cell ID 42\nWall time 10.0 seconds\nOutput:\n' },
+            { type: 'input_text', text: 'tests started\n' },
+          ],
+        },
+      });
+      router.handleNotification('item/commandExecution/outputDelta', {
+        threadId: 't1',
+        turnId: 'turn1',
+        itemId: 'exec_canonical',
+        delta: 'tests started\n',
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'commandExecution',
+          id: 'exec_canonical',
+          command: 'npm test',
+          cwd: '/workspace',
+          processId: '123',
+          source: 'unifiedExecStartup',
+          status: 'completed',
+          commandActions: [{ type: 'unknown', command: 'npm test' }],
+          aggregatedOutput: 'tests started\n',
+          exitCode: 0,
+          durationMs: 10_000,
         },
       });
       router.handleNotification('rawResponseItem/completed', {
@@ -660,7 +757,70 @@ describe('CodexNotificationRouter', () => {
       ]);
     });
 
-    it('unwraps apply_patch inside exec envelopes', () => {
+    it('binds a wait call and output that arrive before the yielded exec output', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_exec_wrapper',
+          input: 'const r = await tools.exec_command({cmd:"npm test"}); text(r.output);',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'function_call',
+          name: 'wait',
+          call_id: 'call_wait',
+          arguments: '{"cell_id":"42","yield_time_ms":30000}',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'function_call_output',
+          call_id: 'call_wait',
+          output: 'Script completed\nOutput:\ntests passed\n',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_exec_wrapper',
+          output: 'Script running with cell ID 42\nOutput:\ntests started\n',
+        },
+      });
+
+      expect(chunks).toEqual([
+        {
+          type: 'tool_use',
+          id: 'call_exec_wrapper',
+          name: 'Bash',
+          input: { command: 'npm test' },
+        },
+        {
+          type: 'tool_output',
+          id: 'call_exec_wrapper',
+          content: 'tests started\n',
+        },
+        {
+          type: 'tool_result',
+          id: 'call_exec_wrapper',
+          content: 'tests started\ntests passed\n',
+          isError: false,
+        },
+      ]);
+    });
+
+    it('unwraps a raw-only apply_patch exec envelope when its output arrives', () => {
       router.beginTurn({ isPlanTurn: false });
       const patch = '*** Begin Patch\n*** Update File: note.md\n*** End Patch';
 
@@ -675,12 +835,39 @@ describe('CodexNotificationRouter', () => {
         },
       });
 
-      expect(chunks).toEqual([{
-        type: 'tool_use',
-        id: 'call_patch_wrapper',
-        name: 'apply_patch',
-        input: { patch },
-      }]);
+      expect(chunks).toEqual([]);
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_patch_wrapper',
+          output: 'Success. Updated files.',
+        },
+      });
+
+      expect(chunks).toEqual([]);
+      router.handleNotification('turn/completed', {
+        threadId: 't1',
+        turn: { id: 'turn1', items: [], status: 'completed', error: null },
+      });
+
+      expect(chunks).toEqual([
+        {
+          type: 'tool_use',
+          id: 'call_patch_wrapper',
+          name: 'apply_patch',
+          input: { patch },
+        },
+        {
+          type: 'tool_result',
+          id: 'call_patch_wrapper',
+          content: 'Success. Updated files.',
+          isError: false,
+        },
+        { type: 'done' },
+      ]);
     });
 
     it('does not normalize raw command output a second time when item/completed arrives', () => {
@@ -811,7 +998,2183 @@ describe('CodexNotificationRouter', () => {
       expect(chunks.filter(chunk => chunk.type === 'tool_use')).toHaveLength(1);
     });
 
-    it('suppresses raw apply_patch transport rows so fileChange remains the owner', () => {
+    it('coalesces raw exec envelopes with canonical commands that use a different id', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          id: 'ctc_raw',
+          name: 'exec',
+          call_id: 'call_raw',
+          input: 'const r = await tools.exec_command({cmd:"pwd",workdir:"/workspace"}); text(r.output);',
+        },
+      });
+      router.handleNotification('item/started', {
+        item: {
+          type: 'commandExecution',
+          id: 'exec_canonical',
+          command: 'pwd',
+          cwd: '/workspace',
+          processId: '123',
+          source: 'unifiedExecStartup',
+          status: 'inProgress',
+          commandActions: [{ type: 'unknown', command: 'pwd' }],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+        threadId: 't1',
+        turnId: 'turn1',
+      });
+      router.handleNotification('item/completed', {
+        item: {
+          type: 'commandExecution',
+          id: 'exec_canonical',
+          command: 'pwd',
+          cwd: '/workspace',
+          processId: '123',
+          source: 'unifiedExecStartup',
+          status: 'completed',
+          commandActions: [{ type: 'unknown', command: 'pwd' }],
+          aggregatedOutput: '/workspace\n',
+          exitCode: 0,
+          durationMs: 10,
+        },
+        threadId: 't1',
+        turnId: 'turn1',
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          id: 'ctco_raw',
+          call_id: 'call_raw',
+          output: [
+            { type: 'input_text', text: 'Script completed\nWall time 0.1 seconds\nOutput:\n' },
+            { type: 'input_text', text: '/workspace\n' },
+          ],
+        },
+      });
+
+      expect(chunks).toEqual([
+        {
+          type: 'tool_use',
+          id: 'call_raw',
+          name: 'Bash',
+          input: { command: 'pwd' },
+        },
+        {
+          type: 'tool_result',
+          id: 'call_raw',
+          content: '/workspace\n',
+          isError: false,
+        },
+      ]);
+    });
+
+    it('ignores repeated terminal output for a raw-owned Bash call', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_raw',
+          input: 'const r = await tools.exec_command({cmd:"pwd"}); text(r.output);',
+        },
+      });
+      for (let index = 0; index < 2; index += 1) {
+        router.handleNotification('rawResponseItem/completed', {
+          threadId: 't1',
+          turnId: 'turn1',
+          item: {
+            type: 'custom_tool_call_output',
+            call_id: 'call_raw',
+            output: 'Script completed\nOutput:\n/workspace\n',
+          },
+        });
+      }
+      router.handleNotification('turn/completed', {
+        threadId: 't1',
+        turn: { id: 'turn1', items: [], status: 'completed', error: null },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(1);
+    });
+
+    it('defers raw non-command exec envelopes to the canonical semantic item', () => {
+      router.beginTurn({ isPlanTurn: false });
+      const patch = '*** Begin Patch\n*** Add File: note.md\n+hello\n*** End Patch';
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          id: 'ctc_patch',
+          name: 'exec',
+          call_id: 'call_patch',
+          input: `const patch = ${JSON.stringify(patch)}; text(await tools.apply_patch(patch));`,
+        },
+      });
+
+      expect(chunks).toEqual([]);
+
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'fileChange',
+          id: 'exec_patch',
+          changes: [{
+            path: '/workspace/note.md',
+            type: 'add',
+            diff: '@@ -0,0 +1 @@\n+hello',
+          }],
+          status: 'inProgress',
+        },
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'fileChange',
+          id: 'exec_patch',
+          changes: [{
+            path: '/workspace/note.md',
+            type: 'add',
+            diff: '@@ -0,0 +1 @@\n+hello',
+          }],
+          status: 'completed',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          id: 'ctco_patch',
+          call_id: 'call_patch',
+          output: 'Success. Updated files.',
+        },
+      });
+
+      expect(chunks.filter(chunk => (
+        chunk.type === 'tool_use' || chunk.type === 'tool_result'
+      )).every(chunk => chunk.id === 'exec_patch')).toBe(true);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(1);
+    });
+
+    it('does not recreate a claimed exec envelope from a repeated raw call', () => {
+      router.beginTurn({ isPlanTurn: false });
+      const rawCall = {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_image',
+          input: 'const r = await tools.view_image({path:"/workspace/image.png"}); image(r.image_url);',
+        },
+      };
+
+      router.handleNotification('rawResponseItem/completed', rawCall);
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: { type: 'imageView', id: 'image_canonical', path: '/workspace/image.png' },
+      });
+      router.handleNotification('rawResponseItem/completed', rawCall);
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: { type: 'imageView', id: 'image_canonical', path: '/workspace/image.png' },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_image',
+          output: 'Image viewed.',
+        },
+      });
+      router.handleNotification('turn/completed', {
+        threadId: 't1',
+        turn: { id: 'turn1', items: [], status: 'completed', error: null },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_use')).toHaveLength(1);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(1);
+      expect(chunks.filter(chunk => (
+        chunk.type === 'tool_use' || chunk.type === 'tool_result'
+      )).every(chunk => chunk.id === 'image_canonical')).toBe(true);
+    });
+
+    it('replays Bash output that arrives before its raw call', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_bash',
+          output: 'Script completed\nOutput:\nready\n',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_bash',
+          input: 'const r = await tools.exec_command({cmd:"printf ready"}); text(r.output);',
+        },
+      });
+
+      expect(chunks).toEqual([
+        {
+          type: 'tool_use',
+          id: 'call_bash',
+          name: 'Bash',
+          input: { command: 'printf ready' },
+        },
+        {
+          type: 'tool_result',
+          id: 'call_bash',
+          content: 'ready\n',
+          isError: false,
+        },
+      ]);
+    });
+
+    it('replays deferred non-Bash output that arrives before its raw call', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_image',
+          output: 'Image viewed.',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_image',
+          input: 'const r = await tools.view_image({path:"/workspace/image.png"}); image(r.image_url);',
+        },
+      });
+      router.handleNotification('turn/completed', {
+        threadId: 't1',
+        turn: { id: 'turn1', items: [], status: 'completed', error: null },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_use')).toHaveLength(1);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(1);
+      expect(chunks.filter(chunk => (
+        chunk.type === 'tool_use' || chunk.type === 'tool_result'
+      )).every(chunk => chunk.id === 'call_image')).toBe(true);
+    });
+
+    it('does not correlate raw and canonical patches that affect different paths', () => {
+      router.beginTurn({ isPlanTurn: false });
+      const patch = '*** Begin Patch\n*** Add File: raw-only.md\n+raw\n*** End Patch';
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_raw_patch',
+          input: `const patch = ${JSON.stringify(patch)}; text(await tools.apply_patch(patch));`,
+        },
+      });
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'fileChange',
+          id: 'canonical_other_patch',
+          changes: [{ path: '/workspace/canonical-only.md', type: 'add' }],
+          status: 'inProgress',
+        },
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'fileChange',
+          id: 'canonical_other_patch',
+          changes: [{ path: '/workspace/canonical-only.md', type: 'add' }],
+          status: 'completed',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_raw_patch',
+          output: 'Success. Updated files.',
+        },
+      });
+      router.handleNotification('turn/completed', {
+        threadId: 't1',
+        turn: { id: 'turn1', items: [], status: 'completed', error: null },
+      });
+
+      const lifecycleIds = new Set(chunks
+        .filter(chunk => chunk.type === 'tool_use' || chunk.type === 'tool_result')
+        .map(chunk => chunk.id));
+      expect(lifecycleIds).toEqual(new Set(['call_raw_patch', 'canonical_other_patch']));
+    });
+
+    it('does not correlate different patch content for the same path', () => {
+      router.beginTurn({ isPlanTurn: false });
+      const patch = '*** Begin Patch\n*** Add File: same.md\n+raw\n*** End Patch';
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_raw_patch',
+          input: `const patch = ${JSON.stringify(patch)}; text(await tools.apply_patch(patch));`,
+        },
+      });
+      for (const method of ['item/started', 'item/completed']) {
+        router.handleNotification(method, {
+          threadId: 't1',
+          turnId: 'turn1',
+          item: {
+            type: 'fileChange',
+            id: 'canonical_other_patch',
+            changes: [{
+              path: '/workspace/same.md',
+              type: 'add',
+              diff: '@@ -0,0 +1 @@\n+canonical',
+            }],
+            status: method === 'item/started' ? 'inProgress' : 'completed',
+          },
+        });
+      }
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_raw_patch',
+          output: 'Success. Updated files.',
+        },
+      });
+      router.handleNotification('turn/completed', {
+        threadId: 't1',
+        turn: { id: 'turn1', items: [], status: 'completed', error: null },
+      });
+
+      const lifecycleIds = new Set(chunks
+        .filter(chunk => chunk.type === 'tool_use' || chunk.type === 'tool_result')
+        .map(chunk => chunk.id));
+      expect(lifecycleIds).toEqual(new Set(['call_raw_patch', 'canonical_other_patch']));
+    });
+
+    it('does not correlate identical edits in different patch contexts', () => {
+      router.beginTurn({ isPlanTurn: false });
+      const patch = [
+        '*** Begin Patch',
+        '*** Update File: same.md',
+        '@@',
+        ' section-a',
+        '-old',
+        '+new',
+        '*** End Patch',
+      ].join('\n');
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_raw_patch',
+          input: `const patch = ${JSON.stringify(patch)}; text(await tools.apply_patch(patch));`,
+        },
+      });
+      for (const method of ['item/started', 'item/completed']) {
+        router.handleNotification(method, {
+          threadId: 't1',
+          turnId: 'turn1',
+          item: {
+            type: 'fileChange',
+            id: 'canonical_other_patch',
+            changes: [{
+              path: '/workspace/same.md',
+              type: 'update',
+              diff: '@@ -1,2 +1,2 @@\n section-b\n-old\n+new',
+            }],
+            status: method === 'item/started' ? 'inProgress' : 'completed',
+          },
+        });
+      }
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_raw_patch',
+          output: 'Success. Updated files.',
+        },
+      });
+      router.handleNotification('turn/completed', {
+        threadId: 't1',
+        turn: { id: 'turn1', items: [], status: 'completed', error: null },
+      });
+
+      const lifecycleIds = new Set(chunks
+        .filter(chunk => chunk.type === 'tool_use' || chunk.type === 'tool_result')
+        .map(chunk => chunk.id));
+      expect(lifecycleIds).toEqual(new Set(['call_raw_patch', 'canonical_other_patch']));
+    });
+
+    it('correlates matching patch hunks with named anchors', () => {
+      router.beginTurn({ isPlanTurn: false });
+      const patch = [
+        '*** Begin Patch',
+        '*** Update File: note.md',
+        '@@ function target',
+        ' context',
+        '-old',
+        '+new',
+        '*** End Patch',
+      ].join('\n');
+      const change = {
+        path: '/workspace/note.md',
+        type: 'update',
+        diff: '@@ -1,2 +1,2 @@ function target\n context\n-old\n+new',
+      };
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_raw_patch',
+          input: `const patch = ${JSON.stringify(patch)}; text(await tools.apply_patch(patch));`,
+        },
+      });
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'fileChange',
+          id: 'canonical_patch',
+          changes: [change],
+          status: 'inProgress',
+        },
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'fileChange',
+          id: 'canonical_patch',
+          changes: [change],
+          status: 'completed',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_raw_patch',
+          output: 'Success. Updated files.',
+        },
+      });
+
+      const lifecycleIds = chunks
+        .filter(chunk => chunk.type === 'tool_use' || chunk.type === 'tool_result')
+        .map(chunk => chunk.id);
+      expect(lifecycleIds.every(id => id === 'canonical_patch')).toBe(true);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(1);
+    });
+
+    it('correlates matching move patches across raw and canonical kind shapes', () => {
+      router.beginTurn({ isPlanTurn: false });
+      const patch = [
+        '*** Begin Patch',
+        '*** Update File: old.md',
+        '*** Move to: new.md',
+        '@@',
+        ' context',
+        '-old',
+        '+new',
+        '*** End Patch',
+      ].join('\n');
+      const change = {
+        path: '/workspace/old.md',
+        kind: { type: 'move', move_path: '/workspace/new.md' },
+        diff: '@@ -1,2 +1,2 @@\n context\n-old\n+new',
+      };
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_raw_patch',
+          input: `const patch = ${JSON.stringify(patch)}; text(await tools.apply_patch(patch));`,
+        },
+      });
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'fileChange',
+          id: 'canonical_move',
+          changes: [change],
+          status: 'inProgress',
+        },
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'fileChange',
+          id: 'canonical_move',
+          changes: [change],
+          status: 'completed',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_raw_patch',
+          output: 'Success. Updated files.',
+        },
+      });
+
+      expect(chunks.filter(chunk => (
+        chunk.type === 'tool_use' || chunk.type === 'tool_result'
+      )).every(chunk => chunk.id === 'canonical_move')).toBe(true);
+    });
+
+    it('falls back to a raw non-command exec when no canonical item arrives', () => {
+      router.beginTurn({ isPlanTurn: false });
+      const imagePath = '/workspace/image.png';
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          id: 'ctc_image',
+          name: 'exec',
+          call_id: 'call_image',
+          input: `const result = await tools.view_image({path:${JSON.stringify(imagePath)}}); image(result.image_url);`,
+        },
+      });
+
+      expect(chunks).toEqual([]);
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          id: 'ctco_image',
+          call_id: 'call_image',
+          output: [{ type: 'input_text', text: 'Image Size: 100x100.' }],
+        },
+      });
+
+      expect(chunks).toEqual([]);
+      router.handleNotification('turn/completed', {
+        threadId: 't1',
+        turn: { id: 'turn1', items: [], status: 'completed', error: null },
+      });
+
+      expect(chunks).toEqual([
+        {
+          type: 'tool_use',
+          id: 'call_image',
+          name: 'Read',
+          input: { path: imagePath, file_path: imagePath },
+        },
+        {
+          type: 'tool_result',
+          id: 'call_image',
+          content: imagePath,
+          isError: false,
+        },
+        { type: 'done' },
+      ]);
+    });
+
+    it('waits for a canonical item when raw non-command output arrives first', () => {
+      router.beginTurn({ isPlanTurn: false });
+      const imagePath = '/workspace/image.png';
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_image',
+          input: `const r = await tools.view_image({path:${JSON.stringify(imagePath)}}); image(r.image_url);`,
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_image',
+          output: 'Image viewed.',
+        },
+      });
+      expect(chunks).toEqual([]);
+
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: { type: 'imageView', id: 'image_canonical', path: imagePath },
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: { type: 'imageView', id: 'image_canonical', path: imagePath },
+      });
+
+      expect(chunks).toEqual([
+        {
+          type: 'tool_use',
+          id: 'image_canonical',
+          name: 'Read',
+          input: { path: imagePath, file_path: imagePath },
+        },
+        {
+          type: 'tool_result',
+          id: 'image_canonical',
+          content: imagePath,
+          isError: false,
+        },
+      ]);
+    });
+
+    it('projects every call in a multi-tool exec through its canonical lifecycle', () => {
+      router.beginTurn({ isPlanTurn: false });
+      const imagePath = '/workspace/image.png';
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_multi',
+          input: [
+            'const results = await Promise.all([',
+            `tools.view_image({path:${JSON.stringify(imagePath)}}),`,
+            `tools.view_image({path:${JSON.stringify(imagePath)}})`,
+            ']); results.forEach(image);',
+          ].join(''),
+        },
+      });
+
+      for (const id of ['image_one', 'image_two']) {
+        router.handleNotification('item/started', {
+          threadId: 't1',
+          turnId: 'turn1',
+          item: { type: 'imageView', id, path: imagePath },
+        });
+        router.handleNotification('item/completed', {
+          threadId: 't1',
+          turnId: 'turn1',
+          item: { type: 'imageView', id, path: imagePath },
+        });
+      }
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_multi',
+          output: 'Images viewed.',
+        },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_use')).toHaveLength(2);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(2);
+      expect(chunks.some(chunk => (
+        (chunk.type === 'tool_use' || chunk.type === 'tool_result')
+        && chunk.id === 'call_multi'
+      ))).toBe(false);
+    });
+
+    it('projects mixed Bash and non-Bash exec calls through canonical lifecycles', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_multi',
+          input: [
+            'const results = await Promise.all([',
+            'tools.exec_command({cmd:"pwd"}),',
+            'tools.view_image({path:"/workspace/image.png"})',
+            ']); results.forEach(text);',
+          ].join(''),
+        },
+      });
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'commandExecution',
+          id: 'command_canonical',
+          command: 'pwd',
+          cwd: '/workspace',
+          processId: '123',
+          source: 'unifiedExecStartup',
+          status: 'inProgress',
+          commandActions: [{ type: 'unknown', command: 'pwd' }],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      });
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: { type: 'imageView', id: 'image_canonical', path: '/workspace/image.png' },
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'commandExecution',
+          id: 'command_canonical',
+          command: 'pwd',
+          cwd: '/workspace',
+          processId: '123',
+          source: 'unifiedExecStartup',
+          status: 'completed',
+          commandActions: [{ type: 'unknown', command: 'pwd' }],
+          aggregatedOutput: '/workspace\n',
+          exitCode: 0,
+          durationMs: 10,
+        },
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: { type: 'imageView', id: 'image_canonical', path: '/workspace/image.png' },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_multi',
+          output: 'Completed.',
+        },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_use').map(chunk => chunk.id)).toEqual([
+        'command_canonical',
+        'image_canonical',
+      ]);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(2);
+      expect(chunks.some(chunk => (
+        (chunk.type === 'tool_use' || chunk.type === 'tool_result')
+        && chunk.id.startsWith('call_multi')
+      ))).toBe(false);
+    });
+
+    it('does not correlate mixed-envelope Bash calls across working directories', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_multi',
+          input: [
+            'const results = await Promise.all([',
+            'tools.exec_command({cmd:"pwd",workdir:"/workspace/a"}),',
+            'tools.view_image({path:"/workspace/image.png"})',
+            ']); results.forEach(text);',
+          ].join(''),
+        },
+      });
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'commandExecution',
+          id: 'command_other_directory',
+          command: 'pwd',
+          cwd: '/workspace/b',
+          processId: '123',
+          source: 'unifiedExecStartup',
+          status: 'inProgress',
+          commandActions: [{ type: 'unknown', command: 'pwd' }],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'commandExecution',
+          id: 'command_other_directory',
+          command: 'pwd',
+          cwd: '/workspace/b',
+          processId: '123',
+          source: 'unifiedExecStartup',
+          status: 'completed',
+          commandActions: [{ type: 'unknown', command: 'pwd' }],
+          aggregatedOutput: '/workspace/b\n',
+          exitCode: 0,
+          durationMs: 10,
+        },
+      });
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: { type: 'imageView', id: 'image_canonical', path: '/workspace/image.png' },
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: { type: 'imageView', id: 'image_canonical', path: '/workspace/image.png' },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_multi',
+          output: 'Completed.',
+        },
+      });
+      router.handleNotification('turn/completed', {
+        threadId: 't1',
+        turn: { id: 'turn1', items: [], status: 'completed', error: null },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_use').map(chunk => chunk.id)).toEqual([
+        'command_other_directory',
+        'image_canonical',
+        'call_multi:1',
+      ]);
+    });
+
+    it('assigns a canonical Bash item to only one raw correlation path', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_multi',
+          input: [
+            'const results = await Promise.all([',
+            'tools.exec_command({cmd:"pwd"}),',
+            'tools.view_image({path:"/workspace/image.png"})',
+            ']); results.forEach(text);',
+          ].join(''),
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_single',
+          input: 'const r = await tools.exec_command({cmd:"pwd"}); text(r.output);',
+        },
+      });
+      const commandItem = {
+        type: 'commandExecution',
+        id: 'command_canonical',
+        command: 'pwd',
+        cwd: '/workspace',
+        processId: '123',
+        source: 'unifiedExecStartup',
+        commandActions: [{ type: 'unknown', command: 'pwd' }],
+      };
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          ...commandItem,
+          status: 'inProgress',
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      });
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: { type: 'imageView', id: 'image_canonical', path: '/workspace/image.png' },
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          ...commandItem,
+          status: 'completed',
+          aggregatedOutput: '/workspace\n',
+          exitCode: 0,
+          durationMs: 10,
+        },
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: { type: 'imageView', id: 'image_canonical', path: '/workspace/image.png' },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_single',
+          output: 'Script completed\nOutput:\n/workspace\n',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_multi',
+          output: 'Completed.',
+        },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_use').map(chunk => chunk.id)).toEqual([
+        'call_single',
+        'command_canonical',
+        'image_canonical',
+      ]);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(3);
+    });
+
+    it('falls back only the unclaimed operation from a partial multi-tool exec', () => {
+      router.beginTurn({ isPlanTurn: false });
+      const imagePath = '/workspace/image.png';
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_partial',
+          input: [
+            'const results = await Promise.all([',
+            `tools.view_image({path:${JSON.stringify(imagePath)}}),`,
+            'tools.probe_tool({})',
+            ']); results.forEach(text);',
+          ].join(''),
+        },
+      });
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: { type: 'imageView', id: 'image_canonical', path: imagePath },
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: { type: 'imageView', id: 'image_canonical', path: imagePath },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_partial',
+          output: 'probe complete',
+        },
+      });
+      router.handleNotification('turn/completed', {
+        threadId: 't1',
+        turn: { id: 'turn1', items: [], status: 'completed', error: null },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_use')).toEqual([
+        {
+          type: 'tool_use',
+          id: 'image_canonical',
+          name: 'Read',
+          input: { path: imagePath, file_path: imagePath },
+        },
+        {
+          type: 'tool_use',
+          id: 'call_partial:2',
+          name: 'probe_tool',
+          input: {},
+        },
+      ]);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(2);
+      expect(chunks).not.toContainEqual(expect.objectContaining({ name: 'exec' }));
+    });
+
+    it('keeps identical operations in one exec envelope visible when correlation is ambiguous', () => {
+      router.beginTurn({ isPlanTurn: false });
+      const imagePath = '/workspace/image.png';
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_multi',
+          input: [
+            'const results = await Promise.all([',
+            `tools.view_image({path:${JSON.stringify(imagePath)}}),`,
+            `tools.view_image({path:${JSON.stringify(imagePath)}})`,
+            ']); results.forEach(image);',
+          ].join(''),
+        },
+      });
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: { type: 'imageView', id: 'image_canonical', path: imagePath },
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: { type: 'imageView', id: 'image_canonical', path: imagePath },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_multi',
+          output: 'Images viewed.',
+        },
+      });
+      router.handleNotification('turn/completed', {
+        threadId: 't1',
+        turn: { id: 'turn1', items: [], status: 'completed', error: null },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_use').map(chunk => chunk.id)).toEqual([
+        'image_canonical',
+        'call_multi:1',
+        'call_multi:2',
+      ]);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(3);
+    });
+
+    it('coalesces a canonical-first non-command item with its later raw exec envelope', () => {
+      router.beginTurn({ isPlanTurn: false });
+      const imagePath = '/workspace/image.png';
+
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: { type: 'imageView', id: 'image_canonical', path: imagePath },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_image',
+          input: `const r = await tools.view_image({path:${JSON.stringify(imagePath)}}); image(r.image_url);`,
+        },
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: { type: 'imageView', id: 'image_canonical', path: imagePath },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_image',
+          output: 'Image viewed.',
+        },
+      });
+
+      expect(chunks).toEqual([
+        {
+          type: 'tool_use',
+          id: 'image_canonical',
+          name: 'Read',
+          input: { path: imagePath, file_path: imagePath },
+        },
+        {
+          type: 'tool_result',
+          id: 'image_canonical',
+          content: imagePath,
+          isError: false,
+        },
+      ]);
+    });
+
+    it('emits an ordered lifecycle when canonical completion precedes its start', () => {
+      router.beginTurn({ isPlanTurn: false });
+      const item = { type: 'imageView', id: 'image_canonical', path: '/workspace/image.png' };
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_image',
+          input: 'const r = await tools.view_image({path:"/workspace/image.png"}); image(r.image_url);',
+        },
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item,
+      });
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item,
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_image',
+          output: 'Image viewed.',
+        },
+      });
+
+      expect(chunks).toEqual([
+        {
+          type: 'tool_use',
+          id: 'image_canonical',
+          name: 'Read',
+          input: { path: '/workspace/image.png', file_path: '/workspace/image.png' },
+        },
+        {
+          type: 'tool_result',
+          id: 'image_canonical',
+          content: '/workspace/image.png',
+          isError: false,
+        },
+      ]);
+    });
+
+    it('ignores a repeated canonical tool completion', () => {
+      router.beginTurn({ isPlanTurn: false });
+      const item = { type: 'imageView', id: 'image_canonical', path: '/workspace/image.png' };
+
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item,
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item,
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item,
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_use')).toHaveLength(1);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(1);
+    });
+
+    it('keeps a later identical raw-only call visible after a canonical item completed', () => {
+      router.beginTurn({ isPlanTurn: false });
+      const imagePath = '/workspace/image.png';
+
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: { type: 'imageView', id: 'image_canonical', path: imagePath },
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: { type: 'imageView', id: 'image_canonical', path: imagePath },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_image',
+          input: `const r = await tools.view_image({path:${JSON.stringify(imagePath)}}); image(r.image_url);`,
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_image',
+          output: 'Image viewed.',
+        },
+      });
+      router.handleNotification('turn/completed', {
+        threadId: 't1',
+        turn: { id: 'turn1', items: [], status: 'completed', error: null },
+      });
+
+      const lifecycleIds = chunks
+        .filter(chunk => chunk.type === 'tool_use' || chunk.type === 'tool_result')
+        .map(chunk => chunk.id);
+      expect(new Set(lifecycleIds)).toEqual(new Set(['image_canonical', 'call_image']));
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(2);
+    });
+
+    it.each([
+      {
+        label: 'web search',
+        nestedCall: 'web__run',
+        nestedInput: { search_query: [{ q: 'Codex app server' }] },
+        canonicalId: 'web_canonical',
+        startedItem: {
+          type: 'webSearch',
+          id: 'web_canonical',
+          query: 'Codex app server',
+          status: 'inProgress',
+        },
+        completedItem: {
+          type: 'webSearch',
+          id: 'web_canonical',
+          query: 'Codex app server',
+          status: 'completed',
+        },
+      },
+      {
+        label: 'web open page',
+        nestedCall: 'web__run',
+        nestedInput: { open: [{ ref_id: 'https://example.com/docs' }] },
+        canonicalId: 'web_open_canonical',
+        startedItem: {
+          type: 'webSearch',
+          id: 'web_open_canonical',
+          action: { type: 'openPage', url: 'https://example.com/docs' },
+          status: 'inProgress',
+        },
+        completedItem: {
+          type: 'webSearch',
+          id: 'web_open_canonical',
+          query: 'https://example.com/docs',
+          action: { type: 'openPage', url: 'https://example.com/docs' },
+          status: 'completed',
+        },
+      },
+      {
+        label: 'web find in page',
+        nestedCall: 'web__run',
+        nestedInput: {
+          find: [{ ref_id: 'https://example.com/docs', pattern: 'Codex' }],
+        },
+        canonicalId: 'web_find_canonical',
+        startedItem: {
+          type: 'webSearch',
+          id: 'web_find_canonical',
+          status: 'inProgress',
+        },
+        completedItem: {
+          type: 'webSearch',
+          id: 'web_find_canonical',
+          query: 'https://example.com/docs',
+          action: {
+            type: 'findInPage',
+            url: 'https://example.com/docs',
+            pattern: 'Codex',
+          },
+          status: 'completed',
+        },
+      },
+      {
+        label: 'MCP tool',
+        nestedCall: 'mcp__docs__search',
+        nestedInput: { query: 'Codex app server' },
+        canonicalId: 'mcp_canonical',
+        startedItem: {
+          type: 'mcpToolCall',
+          id: 'mcp_canonical',
+          server: 'docs',
+          tool: 'search',
+          arguments: { query: 'Codex app server' },
+          status: 'inProgress',
+        },
+        completedItem: {
+          type: 'mcpToolCall',
+          id: 'mcp_canonical',
+          server: 'docs',
+          tool: 'search',
+          arguments: { query: 'Codex app server' },
+          status: 'completed',
+          result: { content: [{ type: 'text', text: 'Found.' }] },
+          error: null,
+        },
+      },
+      {
+        label: 'dynamic tool',
+        nestedCall: 'probe_tool',
+        nestedInput: {},
+        canonicalId: 'dynamic_canonical',
+        startedItem: {
+          type: 'dynamicToolCall',
+          id: 'dynamic_canonical',
+          tool: 'probe_tool',
+          arguments: {},
+          status: 'inProgress',
+        },
+        completedItem: {
+          type: 'dynamicToolCall',
+          id: 'dynamic_canonical',
+          tool: 'probe_tool',
+          arguments: {},
+          status: 'completed',
+          contentItems: [{ type: 'inputText', text: 'probe complete' }],
+          success: true,
+        },
+      },
+    ])('defers a raw exec envelope to the canonical $label item', ({
+      nestedCall,
+      nestedInput,
+      canonicalId,
+      startedItem,
+      completedItem,
+    }) => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_raw_exec',
+          input: `const r = await tools.${nestedCall}(${JSON.stringify(nestedInput)}); text(r);`,
+        },
+      });
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: startedItem,
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: completedItem,
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_raw_exec',
+          output: 'raw aggregate output',
+        },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_use')).toHaveLength(1);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(1);
+      expect(chunks.filter(chunk => (
+        chunk.type === 'tool_use' || chunk.type === 'tool_result'
+      )).every(chunk => chunk.id === canonicalId)).toBe(true);
+    });
+
+    it('does not correlate MCP calls when canonical arguments are a strict superset', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_raw_mcp',
+          input: [
+            'const r = await tools.mcp__docs__search(',
+            '{query:"Codex app server"}',
+            '); text(r);',
+          ].join(''),
+        },
+      });
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'mcpToolCall',
+          id: 'canonical_other_mcp',
+          server: 'docs',
+          tool: 'search',
+          arguments: { query: 'Codex app server', limit: 10 },
+          status: 'inProgress',
+        },
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'mcpToolCall',
+          id: 'canonical_other_mcp',
+          server: 'docs',
+          tool: 'search',
+          arguments: { query: 'Codex app server', limit: 10 },
+          status: 'completed',
+          result: { content: [{ type: 'text', text: 'Canonical result.' }] },
+          error: null,
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_raw_mcp',
+          output: 'Raw result.',
+        },
+      });
+      router.handleNotification('turn/completed', {
+        threadId: 't1',
+        turn: { id: 'turn1', items: [], status: 'completed', error: null },
+      });
+
+      const lifecycleIds = new Set(chunks
+        .filter(chunk => chunk.type === 'tool_use' || chunk.type === 'tool_result')
+        .map(chunk => chunk.id));
+      expect(lifecycleIds).toEqual(new Set(['call_raw_mcp', 'canonical_other_mcp']));
+    });
+
+    it('defers an update_plan exec envelope to turn/plan/updated', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_plan',
+          input: [
+            'const r = await tools.update_plan({',
+            'plan:[{step:"Confirm stream events",status:"in_progress"}]',
+            '}); text(r);',
+          ].join(''),
+        },
+      });
+      router.handleNotification('turn/plan/updated', {
+        threadId: 't1',
+        turnId: 'turn1',
+        explanation: null,
+        plan: [{ step: 'Confirm stream events', status: 'inProgress' }],
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_plan',
+          output: 'Plan updated.',
+        },
+      });
+
+      expect(chunks).toEqual([
+        {
+          type: 'tool_use',
+          id: 'plan-update-turn1-1',
+          name: 'TodoWrite',
+          input: {
+            todos: [{
+              id: '',
+              content: 'Confirm stream events',
+              activeForm: 'Confirm stream events',
+              status: 'in_progress',
+            }],
+          },
+        },
+        {
+          type: 'tool_result',
+          id: 'plan-update-turn1-1',
+          content: 'Plan updated',
+          isError: false,
+        },
+      ]);
+    });
+
+    it('correlates repeated update_plan calls within the same turn', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      for (const [index, step] of ['First plan', 'Second plan'].entries()) {
+        const callId = `call_plan_${index}`;
+        router.handleNotification('rawResponseItem/completed', {
+          threadId: 't1',
+          turnId: 'turn1',
+          item: {
+            type: 'custom_tool_call',
+            name: 'exec',
+            call_id: callId,
+            input: [
+              'const r = await tools.update_plan({',
+              `plan:[{step:${JSON.stringify(step)},status:"in_progress"}]`,
+              '}); text(r);',
+            ].join(''),
+          },
+        });
+        router.handleNotification('turn/plan/updated', {
+          threadId: 't1',
+          turnId: 'turn1',
+          explanation: null,
+          plan: [{ step, status: 'inProgress' }],
+        });
+        router.handleNotification('rawResponseItem/completed', {
+          threadId: 't1',
+          turnId: 'turn1',
+          item: {
+            type: 'custom_tool_call_output',
+            call_id: callId,
+            output: 'Plan updated.',
+          },
+        });
+      }
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_use')).toHaveLength(2);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(2);
+      expect(chunks.filter(chunk => chunk.type === 'tool_use').map(chunk => chunk.id)).toEqual([
+        'plan-update-turn1-1',
+        'plan-update-turn1-2',
+      ]);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result').map(chunk => chunk.id)).toEqual([
+        'plan-update-turn1-1',
+        'plan-update-turn1-2',
+      ]);
+    });
+
+    it('keeps a later identical raw-only call visible after a plan update completed', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('turn/plan/updated', {
+        threadId: 't1',
+        turnId: 'turn1',
+        explanation: null,
+        plan: [{ step: 'Canonical first', status: 'inProgress' }],
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_plan',
+          input: [
+            'const r = await tools.update_plan({',
+            'plan:[{step:"Canonical first",status:"in_progress"}]',
+            '}); text(r);',
+          ].join(''),
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_plan',
+          output: 'Plan updated.',
+        },
+      });
+      router.handleNotification('turn/completed', {
+        threadId: 't1',
+        turn: { id: 'turn1', items: [], status: 'completed', error: null },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_use').map(chunk => chunk.id)).toEqual([
+        'plan-update-turn1-1',
+        'call_plan',
+      ]);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(2);
+    });
+
+    it('routes canonical command progress through a correlated raw function call', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'function_call',
+          id: 'fc_raw',
+          name: 'exec_command',
+          call_id: 'call_raw',
+          arguments: '{"command":"pwd"}',
+        },
+      });
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'commandExecution',
+          id: 'exec_canonical',
+          command: 'pwd',
+          cwd: '/workspace',
+          processId: '123',
+          source: 'unifiedExecStartup',
+          status: 'inProgress',
+          commandActions: [{ type: 'unknown', command: 'pwd' }],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      });
+      router.handleNotification('item/commandExecution/outputDelta', {
+        threadId: 't1',
+        turnId: 'turn1',
+        itemId: 'exec_canonical',
+        delta: '/work',
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'commandExecution',
+          id: 'exec_canonical',
+          command: 'pwd',
+          cwd: '/workspace',
+          processId: '123',
+          source: 'unifiedExecStartup',
+          status: 'completed',
+          commandActions: [{ type: 'unknown', command: 'pwd' }],
+          aggregatedOutput: '/workspace\n',
+          exitCode: 0,
+          durationMs: 10,
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'function_call_output',
+          id: 'fco_raw',
+          call_id: 'call_raw',
+          output: 'Exit code: 0\nOutput:\n/workspace\n',
+        },
+      });
+
+      expect(chunks).toEqual([
+        { type: 'tool_use', id: 'call_raw', name: 'Bash', input: { command: 'pwd' } },
+        { type: 'tool_output', id: 'call_raw', content: '/work' },
+        { type: 'tool_result', id: 'call_raw', content: '/workspace\n', isError: false },
+      ]);
+    });
+
+    it('keeps repeated commands as separate calls while coalescing each canonical event', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      for (const suffix of ['one', 'two']) {
+        router.handleNotification('rawResponseItem/completed', {
+          threadId: 't1',
+          turnId: 'turn1',
+          item: {
+            type: 'custom_tool_call',
+            id: `ctc_${suffix}`,
+            name: 'exec',
+            call_id: `call_${suffix}`,
+            input: 'const r = await tools.exec_command({cmd:"pwd"}); text(r.output);',
+          },
+        });
+        router.handleNotification('item/started', {
+          threadId: 't1',
+          turnId: 'turn1',
+          item: {
+            type: 'commandExecution',
+            id: `exec_${suffix}`,
+            command: 'pwd',
+            cwd: '/workspace',
+            processId: suffix,
+            source: 'unifiedExecStartup',
+            status: 'inProgress',
+            commandActions: [{ type: 'unknown', command: 'pwd' }],
+            aggregatedOutput: null,
+            exitCode: null,
+            durationMs: null,
+          },
+        });
+      }
+
+      expect(chunks).toEqual([
+        { type: 'tool_use', id: 'call_one', name: 'Bash', input: { command: 'pwd' } },
+        { type: 'tool_use', id: 'call_two', name: 'Bash', input: { command: 'pwd' } },
+      ]);
+    });
+
+    it('coalesces a canonical-first command with its later raw exec envelope', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'commandExecution',
+          id: 'exec_canonical',
+          command: 'pwd',
+          cwd: '/workspace',
+          processId: '123',
+          source: 'unifiedExecStartup',
+          status: 'inProgress',
+          commandActions: [{ type: 'unknown', command: 'pwd' }],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_raw',
+          input: 'const r = await tools.exec_command({cmd:"pwd"}); text(r.output);',
+        },
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'commandExecution',
+          id: 'exec_canonical',
+          command: 'pwd',
+          cwd: '/workspace',
+          processId: '123',
+          source: 'unifiedExecStartup',
+          status: 'completed',
+          commandActions: [{ type: 'unknown', command: 'pwd' }],
+          aggregatedOutput: '/workspace\n',
+          exitCode: 0,
+          durationMs: 10,
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_raw',
+          output: 'Script completed\nOutput:\n/workspace\n',
+        },
+      });
+
+      expect(chunks).toEqual([
+        { type: 'tool_use', id: 'exec_canonical', name: 'Bash', input: { command: 'pwd' } },
+        { type: 'tool_result', id: 'exec_canonical', content: '/workspace\n', isError: false },
+      ]);
+    });
+
+    it('does not replay canonical output when a later raw Bash call yields', () => {
+      router.beginTurn({ isPlanTurn: false });
+      const canonicalItem = {
+        type: 'commandExecution',
+        id: 'exec_canonical',
+        command: 'npm test',
+        cwd: '/workspace',
+        processId: '123',
+        source: 'unifiedExecStartup',
+        commandActions: [{ type: 'unknown', command: 'npm test' }],
+      };
+
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          ...canonicalItem,
+          status: 'inProgress',
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      });
+      router.handleNotification('item/commandExecution/outputDelta', {
+        threadId: 't1',
+        turnId: 'turn1',
+        itemId: 'exec_canonical',
+        delta: 'tests started\n',
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_raw',
+          input: 'const r = await tools.exec_command({cmd:"npm test"}); text(r.output);',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_raw',
+          output: [
+            { type: 'input_text', text: 'Script running with cell ID 42\nOutput:\n' },
+            { type: 'input_text', text: 'tests started\n' },
+          ],
+        },
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          ...canonicalItem,
+          status: 'completed',
+          aggregatedOutput: 'tests started\n',
+          exitCode: 0,
+          durationMs: 10,
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'function_call',
+          name: 'wait',
+          call_id: 'call_wait',
+          arguments: '{"cell_id":"42","yield_time_ms":30000}',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'function_call_output',
+          call_id: 'call_wait',
+          output: 'Script completed\nOutput:\ntests passed\n',
+        },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_output')).toEqual([{
+        type: 'tool_output',
+        id: 'exec_canonical',
+        content: 'tests started\n',
+      }]);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toEqual([{
+        type: 'tool_result',
+        id: 'exec_canonical',
+        content: 'tests started\ntests passed\n',
+        isError: false,
+      }]);
+    });
+
+    it('keeps a later identical raw-only command visible after a canonical command completed', () => {
+      router.beginTurn({ isPlanTurn: false });
+      const canonicalItem = {
+        type: 'commandExecution',
+        id: 'exec_canonical',
+        command: 'pwd',
+        cwd: '/workspace',
+        processId: '123',
+        source: 'unifiedExecStartup',
+        commandActions: [{ type: 'unknown', command: 'pwd' }],
+        aggregatedOutput: '/workspace\n',
+        exitCode: 0,
+        durationMs: 10,
+      };
+
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          ...canonicalItem,
+          status: 'inProgress',
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: { ...canonicalItem, status: 'completed' },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_raw',
+          input: 'const r = await tools.exec_command({cmd:"pwd"}); text(r.output);',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_raw',
+          output: 'Script completed\nOutput:\n/workspace\n',
+        },
+      });
+
+      expect(chunks).toEqual([
+        { type: 'tool_use', id: 'exec_canonical', name: 'Bash', input: { command: 'pwd' } },
+        { type: 'tool_result', id: 'exec_canonical', content: '/workspace\n', isError: false },
+        { type: 'tool_use', id: 'call_raw', name: 'Bash', input: { command: 'pwd' } },
+        { type: 'tool_result', id: 'call_raw', content: '/workspace\n', isError: false },
+      ]);
+    });
+
+    it('coalesces a canonical command delivered after the raw terminal output', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_raw_only',
+          input: 'const r = await tools.exec_command({cmd:"pwd"}); text(r.output);',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_raw_only',
+          output: 'Script completed\nOutput:\n/workspace\n',
+        },
+      });
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'commandExecution',
+          id: 'exec_later',
+          command: 'pwd',
+          cwd: '/workspace',
+          processId: '456',
+          source: 'unifiedExecStartup',
+          status: 'inProgress',
+          commandActions: [{ type: 'unknown', command: 'pwd' }],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'commandExecution',
+          id: 'exec_later',
+          command: 'pwd',
+          cwd: '/workspace',
+          processId: '456',
+          source: 'unifiedExecStartup',
+          status: 'completed',
+          commandActions: [{ type: 'unknown', command: 'pwd' }],
+          aggregatedOutput: '/workspace\n',
+          exitCode: 0,
+          durationMs: 10,
+        },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_use')).toEqual([
+        { type: 'tool_use', id: 'call_raw_only', name: 'Bash', input: { command: 'pwd' } },
+      ]);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(1);
+    });
+
+    it('matches canonical-first commands by their full command alias', () => {
+      router.beginTurn({ isPlanTurn: false });
+      const canonicalItem = {
+        type: 'commandExecution',
+        id: 'exec_canonical',
+        command: '/bin/zsh -lc "echo test"',
+        cwd: '/workspace',
+        processId: '123',
+        source: 'unifiedExecStartup',
+        commandActions: [{ type: 'unknown', command: 'echo test' }],
+      };
+
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          ...canonicalItem,
+          status: 'inProgress',
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_raw',
+          input: 'const r = await tools.exec_command({cmd:"/bin/zsh -lc \\"echo test\\""}); text(r.output);',
+        },
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          ...canonicalItem,
+          status: 'completed',
+          aggregatedOutput: 'test\n',
+          exitCode: 0,
+          durationMs: 10,
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_raw',
+          output: 'Script completed\nOutput:\ntest\n',
+        },
+      });
+
+      expect(chunks).toEqual([
+        { type: 'tool_use', id: 'exec_canonical', name: 'Bash', input: { command: 'echo test' } },
+        { type: 'tool_result', id: 'exec_canonical', content: 'test\n', isError: false },
+      ]);
+    });
+
+    it('keeps ambiguous concurrent identical commands visible instead of guessing a correlation', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      for (const callId of ['call_one', 'call_two']) {
+        router.handleNotification('rawResponseItem/completed', {
+          threadId: 't1',
+          turnId: 'turn1',
+          item: {
+            type: 'custom_tool_call',
+            name: 'exec',
+            call_id: callId,
+            input: 'const r = await tools.exec_command({cmd:"pwd"}); text(r.output);',
+          },
+        });
+      }
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'commandExecution',
+          id: 'exec_ambiguous',
+          command: 'pwd',
+          cwd: '/workspace',
+          processId: '123',
+          source: 'unifiedExecStartup',
+          status: 'inProgress',
+          commandActions: [{ type: 'unknown', command: 'pwd' }],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_use').map(chunk => chunk.id)).toEqual([
+        'call_one',
+        'call_two',
+        'exec_ambiguous',
+      ]);
+    });
+
+    it('does not correlate identical commands from different working directories', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_raw_a',
+          input: [
+            'const r = await tools.exec_command({',
+            'cmd:"pwd",workdir:"/workspace/a"',
+            '}); text(r.output);',
+          ].join(''),
+        },
+      });
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'commandExecution',
+          id: 'exec_b',
+          command: 'pwd',
+          cwd: '/workspace/b',
+          processId: '123',
+          source: 'unifiedExecStartup',
+          status: 'inProgress',
+          commandActions: [{ type: 'unknown', command: 'pwd' }],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_use').map(chunk => chunk.id)).toEqual([
+        'call_raw_a',
+        'exec_b',
+      ]);
+    });
+
+    it('falls back to a direct raw-only apply_patch call at turn completion', () => {
       router.beginTurn({ isPlanTurn: false });
 
       router.handleNotification('rawResponseItem/completed', {
@@ -838,7 +3201,21 @@ describe('CodexNotificationRouter', () => {
         turn: { id: 'turn1', items: [], status: 'completed', error: null },
       });
 
-      expect(chunks).toEqual([{ type: 'done' }]);
+      expect(chunks).toEqual([
+        {
+          type: 'tool_use',
+          id: 'patch_raw',
+          name: 'apply_patch',
+          input: { patch: '*** Begin Patch\n*** End Patch' },
+        },
+        {
+          type: 'tool_result',
+          id: 'patch_raw',
+          content: 'Success. Updated files.',
+          isError: false,
+        },
+        { type: 'done' },
+      ]);
     });
 
     it('maps fileChange item/started to tool_use chunk', () => {
@@ -936,7 +3313,63 @@ describe('CodexNotificationRouter', () => {
       ]);
     });
 
+    it('retains raw ownership claimed by patchUpdated through completion', () => {
+      router.beginTurn({ isPlanTurn: false });
+      const patch = '*** Begin Patch\n*** Add File: note.md\n+hello\n*** End Patch';
+      const changes = [{
+        path: '/workspace/note.md',
+        type: 'add',
+        diff: '@@ -0,0 +1 @@\n+hello',
+      }];
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_patch',
+          input: `const patch = ${JSON.stringify(patch)}; text(await tools.apply_patch(patch));`,
+        },
+      });
+      router.handleNotification('item/fileChange/patchUpdated', {
+        threadId: 't1',
+        turnId: 'turn1',
+        itemId: 'patch_canonical',
+        changes,
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'fileChange',
+          id: 'patch_canonical',
+          changes,
+          status: 'completed',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_patch',
+          output: 'Success. Updated files.',
+        },
+      });
+      router.handleNotification('turn/completed', {
+        threadId: 't1',
+        turn: { id: 'turn1', items: [], status: 'completed', error: null },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(1);
+      expect(chunks.filter(chunk => (
+        chunk.type === 'tool_use' || chunk.type === 'tool_result'
+      )).every(chunk => chunk.id === 'patch_canonical')).toBe(true);
+    });
+
     it('merges raw apply_patch input into the fileChange-owned tool call', () => {
+      router.beginTurn({ isPlanTurn: false });
       router.handleNotification('rawResponseItem/completed', {
         threadId: 't1',
         turnId: 'turn1',
@@ -968,6 +3401,124 @@ describe('CodexNotificationRouter', () => {
           },
         },
       ]);
+    });
+
+    it('keeps a same-ID sparse direct patch owned by its canonical fileChange', () => {
+      router.beginTurn({ isPlanTurn: false });
+      const patch = [
+        '*** Begin Patch',
+        '*** Update File: /workspace/foo.ts',
+        '@@',
+        '-old',
+        '+new',
+        '*** End Patch',
+      ].join('\n');
+      const changes = [{ path: '/workspace/foo.ts', type: 'update' }];
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'apply_patch',
+          call_id: 'call_patch',
+          input: patch,
+        },
+      });
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'fileChange',
+          id: 'call_patch',
+          changes,
+          status: 'inProgress',
+        },
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'fileChange',
+          id: 'call_patch',
+          changes,
+          status: 'completed',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_patch',
+          output: 'Success',
+        },
+      });
+      router.handleNotification('turn/completed', {
+        threadId: 't1',
+        turn: { id: 'turn1', items: [], status: 'completed', error: null },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(1);
+      expect(chunks.filter(chunk => chunk.type === 'tool_use')).toHaveLength(2);
+      expect(chunks.every(chunk => (
+        chunk.type === 'done' || ('id' in chunk && chunk.id === 'call_patch')
+      ))).toBe(true);
+    });
+
+    it('keeps a canonical-completed-first direct patch owned when its raw call arrives later', () => {
+      router.beginTurn({ isPlanTurn: false });
+      const patch = [
+        '*** Begin Patch',
+        '*** Update File: /workspace/foo.ts',
+        '@@',
+        '-old',
+        '+new',
+        '*** End Patch',
+      ].join('\n');
+      const completedItem = {
+        type: 'fileChange' as const,
+        id: 'call_patch',
+        changes: [{ path: '/workspace/foo.ts', type: 'update' }],
+        status: 'completed' as const,
+      };
+
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: completedItem,
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'apply_patch',
+          call_id: 'call_patch',
+          input: patch,
+        },
+      });
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: { ...completedItem, status: 'inProgress' },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_patch',
+          output: 'Success',
+        },
+      });
+      router.handleNotification('turn/completed', {
+        threadId: 't1',
+        turn: { id: 'turn1', items: [], status: 'completed', error: null },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_use')).toHaveLength(1);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(1);
     });
   });
 
@@ -1036,8 +3587,8 @@ describe('CodexNotificationRouter', () => {
         turnId: 'turn1',
       });
 
-      expect(chunks).toHaveLength(1);
-      expect(chunks[0]).toMatchObject({
+      expect(chunks).toHaveLength(2);
+      expect(chunks[1]).toMatchObject({
         type: 'tool_result',
         id: 'call_img1',
         isError: false,
@@ -1101,8 +3652,8 @@ describe('CodexNotificationRouter', () => {
         turnId: 'turn1',
       });
 
-      expect(chunks).toHaveLength(1);
-      expect(chunks[0]).toMatchObject({
+      expect(chunks).toHaveLength(2);
+      expect(chunks[1]).toMatchObject({
         type: 'tool_result',
         id: 'ws_abc',
         isError: false,
@@ -1159,12 +3710,345 @@ describe('CodexNotificationRouter', () => {
         turnId: 'turn1',
       });
 
-      expect(chunks).toHaveLength(1);
-      expect(chunks[0]).toMatchObject({
+      expect(chunks).toHaveLength(2);
+      expect(chunks[1]).toMatchObject({
         type: 'tool_result',
         id: 'call_agent1',
         isError: false,
       });
+    });
+
+    it('ignores a late same-ID raw function call after canonical collab completion', () => {
+      router.beginTurn({ isPlanTurn: false });
+      router.handleNotification('item/completed', {
+        item: {
+          type: 'collabAgentToolCall',
+          id: 'call_wait',
+          tool: 'wait',
+          status: 'completed',
+          arguments: { timeout_ms: 30000 },
+          result: { status: 'done' },
+        },
+        threadId: 't1',
+        turnId: 'turn1',
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'function_call',
+          name: 'wait_agent',
+          call_id: 'call_wait',
+          arguments: '{"timeout_ms":30000}',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'function_call_output',
+          call_id: 'call_wait',
+          output: 'Agent finished.',
+        },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_use')).toHaveLength(1);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(1);
+    });
+
+    it('closes a raw-only function call without output at turn completion', () => {
+      router.beginTurn({ isPlanTurn: false });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'function_call',
+          name: 'wait_agent',
+          call_id: 'call_wait',
+          arguments: '{"timeout_ms":30000}',
+        },
+      });
+      router.handleNotification('turn/completed', {
+        threadId: 't1',
+        turn: { id: 'turn1', items: [], status: 'completed', error: null },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toEqual([{
+        type: 'tool_result',
+        id: 'call_wait',
+        content: '',
+        isError: false,
+      }]);
+    });
+
+    it('ignores a late raw output after a same-id canonical collab completion', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'function_call',
+          name: 'wait_agent',
+          call_id: 'call_wait',
+          arguments: '{"timeout_ms":30000}',
+        },
+      });
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'collabAgentToolCall',
+          id: 'call_wait',
+          tool: 'wait',
+          status: 'inProgress',
+          arguments: { timeout_ms: 30000 },
+        },
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'collabAgentToolCall',
+          id: 'call_wait',
+          tool: 'wait',
+          status: 'completed',
+          arguments: { timeout_ms: 30000 },
+          result: { status: 'done' },
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'function_call_output',
+          call_id: 'call_wait',
+          output: 'Agent finished.',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'function_call_output',
+          call_id: 'call_wait',
+          output: 'Agent finished.',
+        },
+      });
+      router.handleNotification('turn/completed', {
+        threadId: 't1',
+        turn: { id: 'turn1', items: [], status: 'completed', error: null },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_use')).toHaveLength(1);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(1);
+    });
+
+    it('flushes a deferred raw-only operation before a terminal error', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_image',
+          input: 'const r = await tools.view_image({path:"/workspace/image.png"}); image(r.image_url);',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_image',
+          output: 'Image viewed.',
+        },
+      });
+      router.handleNotification('error', {
+        error: { message: 'Transport failed' },
+        willRetry: false,
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_use')).toEqual([{
+        type: 'tool_use',
+        id: 'call_image',
+        name: 'Read',
+        input: { path: '/workspace/image.png', file_path: '/workspace/image.png' },
+      }]);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(1);
+      expect(chunks[chunks.length - 1]).toEqual({ type: 'error', content: 'Transport failed' });
+    });
+
+    it('marks an unfinished deferred raw-only operation failed at a terminal error', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_image',
+          input: 'const r = await tools.view_image({path:"/workspace/image.png"}); image(r.image_url);',
+        },
+      });
+      router.handleNotification('error', {
+        error: { message: 'Transport failed' },
+        willRetry: false,
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toEqual([{
+        type: 'tool_result',
+        id: 'call_image',
+        content: '',
+        isError: true,
+      }]);
+      expect(chunks[chunks.length - 1]).toEqual({ type: 'error', content: 'Transport failed' });
+    });
+
+    it('closes a claimed canonical operation before a terminal error', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_image',
+          input: 'const r = await tools.view_image({path:"/workspace/image.png"}); image(r.image_url);',
+        },
+      });
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: { type: 'imageView', id: 'image_canonical', path: '/workspace/image.png' },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_image',
+          output: 'Image viewed.',
+        },
+      });
+      router.handleNotification('error', {
+        error: { message: 'Transport failed' },
+        willRetry: false,
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: { type: 'imageView', id: 'image_canonical', path: '/workspace/image.png' },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_use')).toHaveLength(1);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toEqual([{
+        type: 'tool_result',
+        id: 'image_canonical',
+        content: 'Image viewed.',
+        isError: false,
+      }]);
+      expect(chunks[chunks.length - 1]).toEqual({ type: 'error', content: 'Transport failed' });
+    });
+
+    it('flushes deferred operations before a failed-turn error', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_image',
+          input: 'const r = await tools.view_image({path:"/workspace/image.png"}); image(r.image_url);',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_image',
+          output: 'Image viewed.',
+        },
+      });
+      router.handleNotification('turn/completed', {
+        threadId: 't1',
+        turn: {
+          id: 'turn1',
+          items: [],
+          status: 'failed',
+          error: { message: 'Turn failed' },
+        },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_use')).toHaveLength(1);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(1);
+      expect(chunks[chunks.length - 1]).toEqual({ type: 'error', content: 'Turn failed' });
+    });
+
+    it('closes a deferred raw-only operation without output at turn completion', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_image',
+          input: 'const r = await tools.view_image({path:"/workspace/image.png"}); image(r.image_url);',
+        },
+      });
+      router.handleNotification('turn/completed', {
+        threadId: 't1',
+        turn: { id: 'turn1', items: [], status: 'completed', error: null },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_use')).toHaveLength(1);
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toHaveLength(1);
+      expect(chunks[chunks.length - 1]).toEqual({ type: 'done' });
+    });
+
+    it('closes a yielded Bash operation at turn completion', () => {
+      router.beginTurn({ isPlanTurn: false });
+
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          call_id: 'call_bash',
+          input: 'const r = await tools.exec_command({cmd:"npm test"}); text(r.output);',
+        },
+      });
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_bash',
+          output: 'Script running with cell ID 42\nOutput:\ntests started\n',
+        },
+      });
+      router.handleNotification('turn/completed', {
+        threadId: 't1',
+        turn: { id: 'turn1', items: [], status: 'completed', error: null },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_result')).toEqual([{
+        type: 'tool_result',
+        id: 'call_bash',
+        content: 'tests started\n',
+        isError: false,
+      }]);
+      expect(chunks[chunks.length - 1]).toEqual({ type: 'done' });
     });
   });
 
@@ -1219,7 +4103,7 @@ describe('CodexNotificationRouter', () => {
       expect(chunks).toEqual([{ type: 'done' }]);
     });
 
-    it('emits error then done on turn/completed with status failed', () => {
+    it('emits a terminal error on turn/completed with status failed', () => {
       router.handleNotification('turn/completed', {
         threadId: 't1',
         turn: {
@@ -1230,10 +4114,7 @@ describe('CodexNotificationRouter', () => {
         },
       });
 
-      expect(chunks).toEqual([
-        { type: 'error', content: 'Model error' },
-        { type: 'done' },
-      ]);
+      expect(chunks).toEqual([{ type: 'error', content: 'Model error' }]);
     });
 
     it('emits done on turn/completed with status interrupted', () => {
@@ -1324,8 +4205,8 @@ describe('CodexNotificationRouter', () => {
         turnId: 'turn1',
       });
 
-      expect(chunks).toHaveLength(1);
-      expect(chunks[0]).toMatchObject({
+      expect(chunks).toHaveLength(2);
+      expect(chunks[1]).toMatchObject({
         type: 'tool_result',
         id: 'call_mcp1',
         content: '{"resources":[]}',
@@ -1350,8 +4231,8 @@ describe('CodexNotificationRouter', () => {
         turnId: 'turn1',
       });
 
-      expect(chunks).toHaveLength(1);
-      expect(chunks[0]).toMatchObject({
+      expect(chunks).toHaveLength(2);
+      expect(chunks[1]).toMatchObject({
         type: 'tool_result',
         id: 'call_mcp2',
         content: 'Connection refused',
@@ -1575,7 +4456,28 @@ describe('CodexNotificationRouter', () => {
   });
 
   describe('command execution output delta', () => {
-    it('emits tool_output chunk for incremental command output', () => {
+    const startCommand = (): void => {
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'commandExecution',
+          id: 'call_1',
+          command: 'echo line 1',
+          cwd: '/workspace',
+          processId: '123',
+          source: 'unifiedExecStartup',
+          status: 'inProgress',
+          commandActions: [{ type: 'unknown', command: 'echo line 1' }],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      });
+    };
+
+    it('buffers a command output delta until its tool use starts', () => {
+      router.beginTurn({ isPlanTurn: false });
       router.handleNotification('item/commandExecution/outputDelta', {
         threadId: 't1',
         turnId: 'turn1',
@@ -1583,12 +4485,45 @@ describe('CodexNotificationRouter', () => {
         delta: 'line 1\n',
       });
 
-      expect(chunks).toEqual([
+      expect(chunks).toEqual([]);
+
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'commandExecution',
+          id: 'call_1',
+          command: 'echo line 1',
+          cwd: '/workspace',
+          processId: '123',
+          source: 'unifiedExecStartup',
+          status: 'inProgress',
+          commandActions: [{ type: 'unknown', command: 'echo line 1' }],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      });
+
+      expect(chunks.map(chunk => chunk.type)).toEqual(['tool_use', 'tool_output']);
+    });
+
+    it('emits tool_output chunk for incremental command output', () => {
+      startCommand();
+      router.handleNotification('item/commandExecution/outputDelta', {
+        threadId: 't1',
+        turnId: 'turn1',
+        itemId: 'call_1',
+        delta: 'line 1\n',
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_output')).toEqual([
         { type: 'tool_output', id: 'call_1', content: 'line 1\n' },
       ]);
     });
 
     it('accumulates multiple output deltas', () => {
+      startCommand();
       router.handleNotification('item/commandExecution/outputDelta', {
         threadId: 't1', turnId: 'turn1', itemId: 'call_1', delta: 'line 1\n',
       });
@@ -1596,14 +4531,29 @@ describe('CodexNotificationRouter', () => {
         threadId: 't1', turnId: 'turn1', itemId: 'call_1', delta: 'line 2\n',
       });
 
-      expect(chunks).toHaveLength(2);
-      expect(chunks[0]).toEqual({ type: 'tool_output', id: 'call_1', content: 'line 1\n' });
-      expect(chunks[1]).toEqual({ type: 'tool_output', id: 'call_1', content: 'line 2\n' });
+      expect(chunks.filter(chunk => chunk.type === 'tool_output')).toEqual([
+        { type: 'tool_output', id: 'call_1', content: 'line 1\n' },
+        { type: 'tool_output', id: 'call_1', content: 'line 2\n' },
+      ]);
     });
   });
 
   describe('file change output delta', () => {
-    it('emits tool_output chunk for incremental file change output', () => {
+    const startFileChange = (): void => {
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'fileChange',
+          id: 'fc_1',
+          changes: [{ path: '/workspace/foo.ts', type: 'update' }],
+          status: 'inProgress',
+        },
+      });
+    };
+
+    it('buffers a file change output delta until its tool use starts', () => {
+      router.beginTurn({ isPlanTurn: false });
       router.handleNotification('item/fileChange/outputDelta', {
         threadId: 't1',
         turnId: 'turn1',
@@ -1611,7 +4561,32 @@ describe('CodexNotificationRouter', () => {
         delta: 'Applied patch to foo.ts',
       });
 
-      expect(chunks).toEqual([
+      expect(chunks).toEqual([]);
+
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'fileChange',
+          id: 'fc_1',
+          changes: [{ path: '/workspace/foo.ts', type: 'update' }],
+          status: 'inProgress',
+        },
+      });
+
+      expect(chunks.map(chunk => chunk.type)).toEqual(['tool_use', 'tool_output']);
+    });
+
+    it('emits tool_output chunk for incremental file change output', () => {
+      startFileChange();
+      router.handleNotification('item/fileChange/outputDelta', {
+        threadId: 't1',
+        turnId: 'turn1',
+        itemId: 'fc_1',
+        delta: 'Applied patch to foo.ts',
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'tool_output')).toEqual([
         { type: 'tool_output', id: 'fc_1', content: 'Applied patch to foo.ts' },
       ]);
     });


### PR DESCRIPTION
## Summary

- reconcile Codex raw response items with canonical semantic tool items so one model invocation renders one live lifecycle
- keep single Bash Code Mode executions raw-owned for yielded process output, while canonical items own non-Bash, mixed, and multi-tool operations
- make correlation exact and fail-visible across reordered, repeated, terminal, raw-only, and ambiguous event sequences
- leave native transcript history and rehydration unchanged

## Root cause

With experimental raw events enabled, Codex app-server emits both a raw tool call and a canonical semantic item for the same logical operation. These projections often use unrelated IDs, so the previous ID-based routing displayed both. This is a live presentation duplication; the model invokes the tool only once.

## Live verification

A disposable app-server probe confirmed the dual projection and event ordering for Bash, patch, image, plan, web open/find, MCP, dynamic, collaboration, multi-call, and mixed-call scenarios.

## Tests

- `npm run typecheck`
- `npm run lint`
- `npm run test` — 352 suites, 6,653 tests
- `npm run build`
- `git diff --check`
