### PR TITLE
fix: harden provider settings and architecture boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,7 @@ Provider-specific session fields belong behind typed helpers in the owning provi
 - Keep live streaming and history replay responsibilities separate. Live output should come from the provider runtime protocol when available; provider transcript files are the replay source.
 - New provider behavior must be expressed through registries and capabilities: `ProviderRegistry`, `ProviderWorkspaceRegistry`, `ProviderChatUIConfig`, provider capabilities, and provider-owned settings reconciliation.
 - Model, permission, plan-mode, command, MCP, skill, and subagent behavior is provider-specific unless the core contract explicitly makes it shared.
+- Treat persisted provider configuration as untrusted runtime input. Provider settings readers and storage normalization must decode every field; invalid permission, tool, and sandbox modes must fail closed.
 - When provider behavior is uncertain, inspect real runtime output first. Put throwaway scripts, traces, and handoff notes in `.context/`.
 - Treat provider-native history and transcripts as read-only. Never mutate or delete provider session data when a Claudian conversation changes.
 - Only explicitly enabled models belong in the chat selector: no synthetic provider entries, no hidden session models, and no provider-default fallback when none are enabled.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -180,35 +180,6 @@ export default defineConfig([
     },
   },
   {
-    files: [
-      'src/ClaudianService.ts',
-      'src/InlineEditService.ts',
-      'src/InstructionRefineService.ts',
-      'src/images/**/*.ts',
-      'src/prompt/**/*.ts',
-      'src/sdk/**/*.ts',
-      'src/security/**/*.ts',
-      'src/tools/**/*.ts',
-    ],
-    rules: {
-      'no-restricted-imports': [
-        'error',
-        {
-          patterns: [
-            {
-              group: ['./ui', './ui/*', '../ui', '../ui/*'],
-              message: 'Service and shared modules must not import UI modules.',
-            },
-            {
-              group: ['./ClaudianView', '../ClaudianView'],
-              message: 'Service and shared modules must not import the view.',
-            },
-          ],
-        },
-      ],
-    },
-  },
-  {
     files: ['tests/**/*.ts'],
     ...jestRecommended,
     rules: {

--- a/scripts/check-architecture-boundaries.test.mjs
+++ b/scripts/check-architecture-boundaries.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import test from 'node:test';
+import ts from 'typescript';
 
 function listTypeScriptFiles(root) {
   const files = [];
@@ -25,16 +26,189 @@ function findMatches(roots, pattern) {
   return matches;
 }
 
+function listSourceImports(file) {
+  const sourceText = fs.readFileSync(file, 'utf8');
+  const sourceFile = ts.createSourceFile(
+    file,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const imports = [];
+
+  function addImport(moduleSpecifier) {
+    if (!moduleSpecifier || !ts.isStringLiteralLike(moduleSpecifier)) return;
+    const { line } = sourceFile.getLineAndCharacterOfPosition(moduleSpecifier.getStart(sourceFile));
+    imports.push({
+      line: line + 1,
+      specifier: moduleSpecifier.text,
+    });
+  }
+
+  function visit(node) {
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+      addImport(node.moduleSpecifier);
+    } else if (
+      ts.isImportEqualsDeclaration(node)
+      && ts.isExternalModuleReference(node.moduleReference)
+    ) {
+      addImport(node.moduleReference.expression);
+    } else if (ts.isCallExpression(node)) {
+      const isDynamicImport = node.expression.kind === ts.SyntaxKind.ImportKeyword;
+      const isRequire = ts.isIdentifier(node.expression) && node.expression.text === 'require';
+      if (isDynamicImport || isRequire) addImport(node.arguments[0]);
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return imports;
+}
+
+function resolveSourceImport(importer, specifier) {
+  if (specifier.startsWith('@/')) {
+    return path.resolve(sourceRoot, specifier.slice(2));
+  }
+  if (specifier.startsWith('.')) {
+    return path.resolve(path.dirname(importer), specifier);
+  }
+  return null;
+}
+
+function isPathWithin(target, root) {
+  const relative = path.relative(root, target);
+  return relative === ''
+    || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative));
+}
+
+function normalizeModuleTarget(target) {
+  return target.replace(/\.(?:[cm]?[jt]sx?)$/, '');
+}
+
+function resolvedImportKey(importer, target) {
+  return `${path.normalize(importer)}::${normalizeModuleTarget(path.normalize(target))}`;
+}
+
+function findResolvedImportViolations(roots, isForbidden, allowedImports = new Set()) {
+  const violations = [];
+  for (const root of roots) {
+    for (const file of listTypeScriptFiles(root)) {
+      for (const sourceImport of listSourceImports(file)) {
+        const target = resolveSourceImport(file, sourceImport.specifier);
+        if (
+          !target
+          || !isForbidden(target)
+          || allowedImports.has(resolvedImportKey(file, target))
+        ) {
+          continue;
+        }
+        violations.push(
+          `${path.relative(process.cwd(), file)}:${sourceImport.line}`
+          + ` imports ${sourceImport.specifier} -> ${path.relative(process.cwd(), target)}`,
+        );
+      }
+    }
+  }
+  return violations;
+}
+
 const sourceRoot = path.join(process.cwd(), 'src');
+const appRoot = path.join(sourceRoot, 'app');
+const featuresRoot = path.join(sourceRoot, 'features');
+const providersRoot = path.join(sourceRoot, 'providers');
+
+function listConcreteProviderNames() {
+  return fs.readdirSync(providersRoot, { withFileTypes: true })
+    .filter(entry => (
+      entry.isDirectory()
+      && fs.existsSync(path.join(providersRoot, entry.name, 'registration.ts'))
+    ))
+    .map(entry => entry.name)
+    .sort();
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+const concreteProviderNames = listConcreteProviderNames();
+const concreteProviderPathPattern = new RegExp(
+  `providers/(?:${concreteProviderNames.map(escapeRegExp).join('|')})(?:/|['"])`,
+);
+const allowedAppProviderImports = new Set([
+  resolvedImportKey(
+    path.join(appRoot, 'settings', 'defaultSettings.ts'),
+    path.join(providersRoot, 'defaultProviderConfigs'),
+  ),
+]);
+const allowedProviderAppImports = new Set([
+  resolvedImportKey(
+    path.join(providersRoot, 'claude', 'types', 'settings.ts'),
+    path.join(appRoot, 'settings', 'defaultSettings'),
+  ),
+  resolvedImportKey(
+    path.join(providersRoot, 'claude', 'storage', 'StorageService.ts'),
+    path.join(appRoot, 'settings', 'ClaudianSettingsStorage'),
+  ),
+  resolvedImportKey(
+    path.join(providersRoot, 'claude', 'storage', 'ClaudianSettingsStorage.ts'),
+    path.join(appRoot, 'settings', 'ClaudianSettingsStorage'),
+  ),
+]);
+
+test('concrete provider pattern covers every registered provider directory', () => {
+  assert.notEqual(concreteProviderNames.length, 0);
+  for (const providerName of concreteProviderNames) {
+    assert.match(`providers/${providerName}/registration`, concreteProviderPathPattern);
+  }
+});
+
+test('source import resolution distinguishes provider-local app from root app', () => {
+  const importer = path.join(providersRoot, 'example', 'ui', 'SettingsTab.ts');
+  const providerLocalApp = resolveSourceImport(importer, '../app/WorkspaceServices');
+  const rootApp = resolveSourceImport(importer, '../../../app/settings/defaultSettings');
+
+  assert.equal(providerLocalApp, path.join(providersRoot, 'example', 'app', 'WorkspaceServices'));
+  assert.equal(isPathWithin(providerLocalApp, appRoot), false);
+  assert.equal(rootApp, path.join(appRoot, 'settings', 'defaultSettings'));
+  assert.equal(isPathWithin(rootApp, appRoot), true);
+  assert.equal(resolveSourceImport(importer, '@/app/settings/defaultSettings'), rootApp);
+});
 
 test('core is independent from main, features, and concrete providers', () => {
-  const pattern = /from\s+['"][^'"]*(?:main['"]|features\/|providers\/(?:claude|codex|opencode|pi))/;
+  const pattern = new RegExp(
+    `from\\s+['"][^'"]*(?:main['"]|features/|${concreteProviderPathPattern.source})`,
+  );
   assert.deepEqual(findMatches([path.join(sourceRoot, 'core')], pattern), []);
+});
+
+test('core is independent from root application adapters', () => {
+  assert.deepEqual(findResolvedImportViolations(
+    [path.join(sourceRoot, 'core')],
+    target => isPathWithin(target, appRoot),
+  ), []);
 });
 
 test('providers are independent from main and features', () => {
   const pattern = /from\s+['"][^'"]*(?:main['"]|features\/)/;
   assert.deepEqual(findMatches([path.join(sourceRoot, 'providers')], pattern), []);
+});
+
+test('providers avoid root app imports outside Claude compatibility seams', () => {
+  assert.deepEqual(findResolvedImportViolations(
+    [providersRoot],
+    target => isPathWithin(target, appRoot),
+    allowedProviderAppImports,
+  ), []);
+});
+
+test('app avoids features and provider implementations outside default assembly', () => {
+  assert.deepEqual(findResolvedImportViolations(
+    [appRoot],
+    target => isPathWithin(target, featuresRoot) || isPathWithin(target, providersRoot),
+    allowedAppProviderImports,
+  ), []);
 });
 
 test('features are independent from the composition root and app adapters', () => {
@@ -43,7 +217,9 @@ test('features are independent from the composition root and app adapters', () =
 });
 
 test('features and shared UI are independent from concrete providers', () => {
-  const pattern = /from\s+['"][^'"]*providers\/(?:claude|codex|opencode|pi)/;
+  const pattern = new RegExp(
+    `from\\s+['"][^'"]*${concreteProviderPathPattern.source}`,
+  );
   assert.deepEqual(findMatches([
     path.join(sourceRoot, 'features'),
     path.join(sourceRoot, 'shared'),
@@ -62,7 +238,7 @@ test('runtime command discovery cannot import shared skill management', () => {
   const roots = [
     path.join(sourceRoot, 'features', 'chat'),
     path.join(sourceRoot, 'shared', 'components'),
-    ...['claude', 'codex', 'grok', 'opencode', 'pi'].flatMap(provider => [
+    ...concreteProviderNames.flatMap(provider => [
       path.join(sourceRoot, 'providers', provider, 'app'),
       path.join(sourceRoot, 'providers', provider, 'commands'),
     ]).filter(fs.existsSync),

--- a/src/core/providers/settings/storedSettings.ts
+++ b/src/core/providers/settings/storedSettings.ts
@@ -1,0 +1,17 @@
+export function readStoredBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+export function readStoredString(value: unknown, fallback: string): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+export function hasStoredConfigNormalization(
+  storedConfig: Record<string, unknown>,
+  normalizedConfig: Record<string, unknown>,
+): boolean {
+  return Object.keys(normalizedConfig).some(key => (
+    Object.prototype.hasOwnProperty.call(storedConfig, key)
+    && JSON.stringify(storedConfig[key]) !== JSON.stringify(normalizedConfig[key])
+  ));
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,7 +69,6 @@ import { type InlineEditContext, InlineEditModal } from './features/inline-edit/
 import { ClaudianSettingTab } from './features/settings/ClaudianSettings';
 import { setLocale } from './i18n/i18n';
 import type { Locale } from './i18n/types';
-import { OPENCODE_PLAN_MODE_ID, OPENCODE_SAFE_MODE_ID } from './providers/opencode/modes';
 import { buildCursorContext } from './utils/editor';
 import { revealWorkspaceLeaf } from './utils/obsidianCompat';
 import { getVaultPath } from './utils/path';
@@ -454,16 +453,6 @@ export default class ClaudianPlugin extends Plugin {
         }
       }
     }
-    const opencodeConfig = this.settings.providerConfigs?.opencode;
-    if (
-      opencodeConfig
-      && typeof opencodeConfig === 'object'
-      && !Array.isArray(opencodeConfig)
-      && opencodeConfig.selectedMode === OPENCODE_PLAN_MODE_ID
-    ) {
-      opencodeConfig.selectedMode = OPENCODE_SAFE_MODE_ID;
-    }
-
     const didNormalizeProviderSelection = ProviderSettingsCoordinator.normalizeProviderSelection(
       this.settings,
     );

--- a/src/providers/claude/registration.ts
+++ b/src/providers/claude/registration.ts
@@ -1,4 +1,5 @@
 import { getProviderConfig } from '../../core/providers/providerConfig';
+import { hasStoredConfigNormalization } from '../../core/providers/settings/storedSettings';
 import type { ProviderModule } from '../../core/providers/types';
 import { parseEnvironmentVariables } from '../../utils/env';
 import {
@@ -46,7 +47,10 @@ export const claudeProviderRegistration: ProviderModule = {
       const storedConfig = getProviderConfig(stored, 'claude');
       const removedLegacy1MSettings = LEGACY_CLAUDE_1M_SETTINGS.some(key => key in storedConfig);
       updateClaudeProviderSettings(target, getClaudeProviderSettings(stored));
-      return removedLegacy1MSettings;
+      return removedLegacy1MSettings || hasStoredConfigNormalization(
+        storedConfig,
+        getProviderConfig(target, 'claude'),
+      );
     },
   },
   createExecutionBackend: (plugin) => {

--- a/src/providers/claude/settings.ts
+++ b/src/providers/claude/settings.ts
@@ -1,6 +1,10 @@
 import { getProviderConfig, setProviderConfig } from '../../core/providers/providerConfig';
 import { getProviderEnvironmentVariables } from '../../core/providers/providerEnvironment';
 import { normalizeHostnameStringMap } from '../../core/providers/settings/HostnameStringMap';
+import {
+  readStoredBoolean,
+  readStoredString,
+} from '../../core/providers/settings/storedSettings';
 import type { HostnameCliPaths } from '../../core/types/settings';
 import {
   type ClaudeModelEnvironmentType,
@@ -51,6 +55,16 @@ function normalizeClaudeSafeMode(value: unknown): ClaudeSafeMode | undefined {
     : undefined;
 }
 
+function readStoredClaudeSafeMode(
+  value: unknown,
+  fallback: ClaudeSafeMode,
+): ClaudeSafeMode {
+  if (value === undefined) {
+    return fallback;
+  }
+  return normalizeClaudeSafeMode(value) ?? 'default';
+}
+
 function normalizeClaudeModelEnvironmentType(
   value: unknown,
 ): ClaudeModelEnvironmentType | '' {
@@ -68,41 +82,62 @@ export function getClaudeProviderSettings(
   );
 
   return {
-    enabled: (config.enabled as boolean | undefined)
-      ?? DEFAULT_CLAUDE_PROVIDER_SETTINGS.enabled,
-    safeMode: normalizeClaudeSafeMode(config.safeMode)
-      ?? normalizeClaudeSafeMode(settings.claudeSafeMode)
-      ?? DEFAULT_CLAUDE_PROVIDER_SETTINGS.safeMode,
-    cliPath: (config.cliPath as string | undefined)
-      ?? (settings.claudeCliPath as string | undefined)
-      ?? DEFAULT_CLAUDE_PROVIDER_SETTINGS.cliPath,
+    enabled: readStoredBoolean(
+      config.enabled,
+      DEFAULT_CLAUDE_PROVIDER_SETTINGS.enabled,
+    ),
+    safeMode: readStoredClaudeSafeMode(
+      config.safeMode,
+      readStoredClaudeSafeMode(
+        settings.claudeSafeMode,
+        DEFAULT_CLAUDE_PROVIDER_SETTINGS.safeMode,
+      ),
+    ),
+    cliPath: readStoredString(
+      config.cliPath,
+      readStoredString(settings.claudeCliPath, DEFAULT_CLAUDE_PROVIDER_SETTINGS.cliPath),
+    ),
     cliPathsByHost,
-    loadUserSettings: (config.loadUserSettings as boolean | undefined)
-      ?? (settings.loadUserClaudeSettings as boolean | undefined)
-      ?? DEFAULT_CLAUDE_PROVIDER_SETTINGS.loadUserSettings,
-    enableChrome: (config.enableChrome as boolean | undefined)
-      ?? (settings.enableChrome as boolean | undefined)
-      ?? DEFAULT_CLAUDE_PROVIDER_SETTINGS.enableChrome,
-    enableBangBash: (config.enableBangBash as boolean | undefined)
-      ?? (settings.enableBangBash as boolean | undefined)
-      ?? DEFAULT_CLAUDE_PROVIDER_SETTINGS.enableBangBash,
-    customModels: (config.customModels as string | undefined)
-      ?? DEFAULT_CLAUDE_PROVIDER_SETTINGS.customModels,
-    defaultModel: (config.defaultModel as string | undefined)
-      ?? DEFAULT_CLAUDE_PROVIDER_SETTINGS.defaultModel,
-    lastModel: (config.lastModel as string | undefined)
-      ?? (settings.lastClaudeModel as string | undefined)
-      ?? DEFAULT_CLAUDE_PROVIDER_SETTINGS.lastModel,
+    loadUserSettings: readStoredBoolean(
+      config.loadUserSettings,
+      readStoredBoolean(
+        settings.loadUserClaudeSettings,
+        DEFAULT_CLAUDE_PROVIDER_SETTINGS.loadUserSettings,
+      ),
+    ),
+    enableChrome: readStoredBoolean(
+      config.enableChrome,
+      readStoredBoolean(settings.enableChrome, DEFAULT_CLAUDE_PROVIDER_SETTINGS.enableChrome),
+    ),
+    enableBangBash: readStoredBoolean(
+      config.enableBangBash,
+      readStoredBoolean(settings.enableBangBash, DEFAULT_CLAUDE_PROVIDER_SETTINGS.enableBangBash),
+    ),
+    customModels: readStoredString(
+      config.customModels,
+      DEFAULT_CLAUDE_PROVIDER_SETTINGS.customModels,
+    ),
+    defaultModel: readStoredString(
+      config.defaultModel,
+      DEFAULT_CLAUDE_PROVIDER_SETTINGS.defaultModel,
+    ),
+    lastModel: readStoredString(
+      config.lastModel,
+      readStoredString(settings.lastClaudeModel, DEFAULT_CLAUDE_PROVIDER_SETTINGS.lastModel),
+    ),
     modelEnvironmentType: normalizeClaudeModelEnvironmentType(config.modelEnvironmentType),
     titleModelEnvironmentType: normalizeClaudeModelEnvironmentType(
       config.titleModelEnvironmentType,
     ),
-    environmentVariables: (config.environmentVariables as string | undefined)
-      ?? getProviderEnvironmentVariables(settings, 'claude')
-      ?? DEFAULT_CLAUDE_PROVIDER_SETTINGS.environmentVariables,
-    environmentHash: (config.environmentHash as string | undefined)
-      ?? (settings.lastEnvHash as string | undefined)
-      ?? DEFAULT_CLAUDE_PROVIDER_SETTINGS.environmentHash,
+    environmentVariables: readStoredString(
+      config.environmentVariables,
+      getProviderEnvironmentVariables(settings, 'claude')
+        ?? DEFAULT_CLAUDE_PROVIDER_SETTINGS.environmentVariables,
+    ),
+    environmentHash: readStoredString(
+      config.environmentHash,
+      readStoredString(settings.lastEnvHash, DEFAULT_CLAUDE_PROVIDER_SETTINGS.environmentHash),
+    ),
   };
 }
 

--- a/src/providers/codex/settings.ts
+++ b/src/providers/codex/settings.ts
@@ -2,6 +2,10 @@ import { getProviderConfig, setProviderConfig } from '../../core/providers/provi
 import { getProviderEnvironmentVariables } from '../../core/providers/providerEnvironment';
 import { DEFAULT_REASONING_VALUE } from '../../core/providers/reasoning';
 import { normalizeHostnameStringMap } from '../../core/providers/settings/HostnameStringMap';
+import {
+  readStoredBoolean,
+  readStoredString,
+} from '../../core/providers/settings/storedSettings';
 import type { HostnameCliPaths } from '../../core/types/settings';
 import { getHostnameKey } from '../../utils/env';
 import {
@@ -19,6 +23,9 @@ export type CodexSafeMode = 'workspace-write' | 'read-only';
 export type CodexReasoningSummary = 'auto' | 'concise' | 'detailed' | 'none';
 export type CodexInstallationMethod = 'native-windows' | 'wsl';
 export type HostnameInstallationMethods = Record<string, CodexInstallationMethod>;
+
+const CODEX_SAFE_MODES = ['workspace-write', 'read-only'] as const;
+const CODEX_REASONING_SUMMARIES = ['auto', 'concise', 'detailed', 'none'] as const;
 
 export interface CodexProviderConfig {
   enabled: boolean;
@@ -55,6 +62,27 @@ function normalizeCodexInstallationMethod(value: unknown): CodexInstallationMeth
 
 function normalizeOptionalString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
+}
+
+function readStoredCodexSafeMode(
+  value: unknown,
+  fallback: CodexSafeMode,
+): CodexSafeMode {
+  if (value === undefined) {
+    return fallback;
+  }
+  return (CODEX_SAFE_MODES as readonly unknown[]).includes(value)
+    ? value as CodexSafeMode
+    : 'read-only';
+}
+
+function readStoredCodexReasoningSummary(
+  value: unknown,
+  fallback: CodexReasoningSummary,
+): CodexReasoningSummary {
+  return (CODEX_REASONING_SUMMARIES as readonly unknown[]).includes(value)
+    ? value as CodexReasoningSummary
+    : fallback;
 }
 
 function shouldPersistCodexInstallationSettings(): boolean {
@@ -374,18 +402,20 @@ function getCodexStoredConfig(
   const visibleModels = normalizeCodexVisibleModels(config.visibleModels, discoveredModels);
 
   return {
-    enabled: (config.enabled as boolean | undefined)
-      ?? (settings.codexEnabled as boolean | undefined)
-      ?? DEFAULT_CODEX_PROVIDER_CONFIG.enabled,
-    safeMode: (config.safeMode as CodexSafeMode | undefined)
-      ?? (settings.codexSafeMode as CodexSafeMode | undefined)
-      ?? DEFAULT_CODEX_PROVIDER_CONFIG.safeMode,
-    cliPath: (config.cliPath as string | undefined)
-      ?? (settings.codexCliPath as string | undefined)
-      ?? DEFAULT_CODEX_PROVIDER_CONFIG.cliPath,
+    enabled: readStoredBoolean(
+      config.enabled,
+      readStoredBoolean(settings.codexEnabled, DEFAULT_CODEX_PROVIDER_CONFIG.enabled),
+    ),
+    safeMode: readStoredCodexSafeMode(
+      config.safeMode,
+      readStoredCodexSafeMode(settings.codexSafeMode, DEFAULT_CODEX_PROVIDER_CONFIG.safeMode),
+    ),
+    cliPath: readStoredString(
+      config.cliPath,
+      readStoredString(settings.codexCliPath, DEFAULT_CODEX_PROVIDER_CONFIG.cliPath),
+    ),
     cliPathsByHost,
-    customModels: (config.customModels as string | undefined)
-      ?? DEFAULT_CODEX_PROVIDER_CONFIG.customModels,
+    customModels: readStoredString(config.customModels, DEFAULT_CODEX_PROVIDER_CONFIG.customModels),
     discoveredModels,
     modelAliases: pruneCodexModelAliases(
       normalizeCodexModelAliases(config.modelAliases, discoveredModels),
@@ -393,21 +423,31 @@ function getCodexStoredConfig(
     ),
     visibleModels,
     enableUltraEffort: config.enableUltraEffort === true,
-    reasoningSummary: (config.reasoningSummary as CodexReasoningSummary | undefined)
-      ?? (settings.codexReasoningSummary as CodexReasoningSummary | undefined)
-      ?? DEFAULT_CODEX_PROVIDER_CONFIG.reasoningSummary,
-    environmentVariables: (config.environmentVariables as string | undefined)
-      ?? getProviderEnvironmentVariables(settings, 'codex')
-      ?? DEFAULT_CODEX_PROVIDER_CONFIG.environmentVariables,
-    environmentHash: (config.environmentHash as string | undefined)
-      ?? (settings.lastCodexEnvHash as string | undefined)
-      ?? DEFAULT_CODEX_PROVIDER_CONFIG.environmentHash,
+    reasoningSummary: readStoredCodexReasoningSummary(
+      config.reasoningSummary,
+      readStoredCodexReasoningSummary(
+        settings.codexReasoningSummary,
+        DEFAULT_CODEX_PROVIDER_CONFIG.reasoningSummary,
+      ),
+    ),
+    environmentVariables: readStoredString(
+      config.environmentVariables,
+      getProviderEnvironmentVariables(settings, 'codex')
+        ?? DEFAULT_CODEX_PROVIDER_CONFIG.environmentVariables,
+    ),
+    environmentHash: readStoredString(
+      config.environmentHash,
+      readStoredString(settings.lastCodexEnvHash, DEFAULT_CODEX_PROVIDER_CONFIG.environmentHash),
+    ),
     catalogTimestamp: typeof config.catalogTimestamp === 'number'
+      && Number.isFinite(config.catalogTimestamp)
+      && config.catalogTimestamp >= 0
       ? config.catalogTimestamp
       : DEFAULT_CODEX_PROVIDER_CONFIG.catalogTimestamp,
-    catalogFingerprint: typeof config.catalogFingerprint === 'string'
-      ? config.catalogFingerprint
-      : DEFAULT_CODEX_PROVIDER_CONFIG.catalogFingerprint,
+    catalogFingerprint: readStoredString(
+      config.catalogFingerprint,
+      DEFAULT_CODEX_PROVIDER_CONFIG.catalogFingerprint,
+    ),
     installationMethodsByHost,
     wslDistroOverridesByHost,
   };

--- a/src/providers/grok/registration.ts
+++ b/src/providers/grok/registration.ts
@@ -1,4 +1,6 @@
 import { NOOP_TASK_RESULT_INTERPRETER } from '../../core/providers/NoopTaskResultInterpreter';
+import { getProviderConfig } from '../../core/providers/providerConfig';
+import { hasStoredConfigNormalization } from '../../core/providers/settings/storedSettings';
 import type { ProviderModule } from '../../core/providers/types';
 import {
   getGrokWorkspaceServices,
@@ -40,8 +42,12 @@ export const grokProviderRegistration: ProviderModule = {
   settingsStorage: {
     hostScopedFields: ['cliPathsByHost', 'catalogsByHost'],
     normalizeStored(target, stored) {
+      const storedConfig = getProviderConfig(stored, 'grok');
       updateGrokProviderSettings(target, getGrokProviderSettings(stored));
-      return false;
+      return hasStoredConfigNormalization(
+        storedConfig,
+        getProviderConfig(target, 'grok'),
+      );
     },
   },
   subagentAdapter: grokSubagentLifecycleAdapter,

--- a/src/providers/opencode/modes.ts
+++ b/src/providers/opencode/modes.ts
@@ -100,9 +100,13 @@ export function normalizeManagedOpencodeSelectedMode(
   value: unknown,
   modes: OpencodeMode[] = [],
 ): string {
+  if (value === undefined || (typeof value === 'string' && !value.trim())) {
+    return '';
+  }
+
   const normalized = normalizeOpencodeSelectedMode(value);
   if (!normalized) {
-    return '';
+    return OPENCODE_SAFE_MODE_ID;
   }
 
   const canonicalModeId = normalized === OPENCODE_BUILD_MODE_ID
@@ -111,7 +115,7 @@ export function normalizeManagedOpencodeSelectedMode(
   const managedModes = getManagedOpencodeModes(modes);
   return managedModes.some((mode) => mode.id === canonicalModeId)
     ? canonicalModeId
-    : (managedModes[0]?.id ?? '');
+    : managedModes.find((mode) => mode.id === OPENCODE_SAFE_MODE_ID)?.id ?? '';
 }
 
 export function resolveOpencodeModeForPermissionMode(
@@ -127,8 +131,11 @@ export function resolveOpencodeModeForPermissionMode(
   if (permissionMode === 'normal' && managedModeIds.has(OPENCODE_SAFE_MODE_ID)) {
     return OPENCODE_SAFE_MODE_ID;
   }
-  if (managedModeIds.has(OPENCODE_YOLO_MODE_ID)) {
+  if (permissionMode === 'yolo' && managedModeIds.has(OPENCODE_YOLO_MODE_ID)) {
     return OPENCODE_YOLO_MODE_ID;
+  }
+  if (managedModeIds.has(OPENCODE_SAFE_MODE_ID)) {
+    return OPENCODE_SAFE_MODE_ID;
   }
 
   return managedModes[0]?.id ?? '';

--- a/src/providers/opencode/registration.ts
+++ b/src/providers/opencode/registration.ts
@@ -1,4 +1,6 @@
 import { NOOP_TASK_RESULT_INTERPRETER } from '../../core/providers/NoopTaskResultInterpreter';
+import { getProviderConfig } from '../../core/providers/providerConfig';
+import { hasStoredConfigNormalization } from '../../core/providers/settings/storedSettings';
 import type { ProviderModule } from '../../core/providers/types';
 import {
   getOpencodeWorkspaceServices,
@@ -9,6 +11,7 @@ import { opencodeSettingsReconciler } from './env/OpencodeSettingsReconciler';
 import { OpencodeExecutionBackend } from './execution/OpencodeExecutionBackend';
 import { OpencodeConversationHistoryService } from './history/OpencodeConversationHistoryService';
 import { decodeOpencodeModelId } from './models';
+import { OPENCODE_PLAN_MODE_ID, OPENCODE_SAFE_MODE_ID } from './modes';
 import { getOpencodeProviderSettings, updateOpencodeProviderSettings } from './settings';
 import { opencodeSubagentAdapter } from './subagentAdapter';
 import { opencodeChatUIConfig } from './ui/OpencodeChatUIConfig';
@@ -42,8 +45,18 @@ export const opencodeProviderRegistration: ProviderModule = {
   settingsStorage: {
     hostScopedFields: ['cliPathsByHost'],
     normalizeStored(target, stored) {
-      updateOpencodeProviderSettings(target, getOpencodeProviderSettings(stored));
-      return false;
+      const storedConfig = getProviderConfig(stored, 'opencode');
+      const normalized = getOpencodeProviderSettings(stored);
+      updateOpencodeProviderSettings(target, {
+        ...normalized,
+        selectedMode: normalized.selectedMode === OPENCODE_PLAN_MODE_ID
+          ? OPENCODE_SAFE_MODE_ID
+          : normalized.selectedMode,
+      });
+      return hasStoredConfigNormalization(
+        storedConfig,
+        getProviderConfig(target, 'opencode'),
+      );
     },
   },
   taskResultInterpreter: NOOP_TASK_RESULT_INTERPRETER,

--- a/src/providers/opencode/settings.ts
+++ b/src/providers/opencode/settings.ts
@@ -1,6 +1,10 @@
 import { getProviderConfig, setProviderConfig } from '../../core/providers/providerConfig';
 import { getProviderEnvironmentVariables } from '../../core/providers/providerEnvironment';
 import { normalizeHostnameStringMap } from '../../core/providers/settings/HostnameStringMap';
+import {
+  readStoredBoolean,
+  readStoredString,
+} from '../../core/providers/settings/storedSettings';
 import type { HostnameCliPaths } from '../../core/types/settings';
 import { getHostnameKey } from '../../utils/env';
 import {
@@ -156,17 +160,19 @@ export function getOpencodeProviderSettings(
 
   return {
     availableModes,
-    cliPath: (config.cliPath as string | undefined)
-      ?? DEFAULT_OPENCODE_PROVIDER_SETTINGS.cliPath,
+    cliPath: readStoredString(config.cliPath, DEFAULT_OPENCODE_PROVIDER_SETTINGS.cliPath),
     cliPathsByHost,
     discoveredModels,
-    enabled: (config.enabled as boolean | undefined)
-      ?? DEFAULT_OPENCODE_PROVIDER_SETTINGS.enabled,
-    environmentHash: (config.environmentHash as string | undefined)
-      ?? DEFAULT_OPENCODE_PROVIDER_SETTINGS.environmentHash,
-    environmentVariables: (config.environmentVariables as string | undefined)
-      ?? getProviderEnvironmentVariables(settings, 'opencode')
-      ?? DEFAULT_OPENCODE_PROVIDER_SETTINGS.environmentVariables,
+    enabled: readStoredBoolean(config.enabled, DEFAULT_OPENCODE_PROVIDER_SETTINGS.enabled),
+    environmentHash: readStoredString(
+      config.environmentHash,
+      DEFAULT_OPENCODE_PROVIDER_SETTINGS.environmentHash,
+    ),
+    environmentVariables: readStoredString(
+      config.environmentVariables,
+      getProviderEnvironmentVariables(settings, 'opencode')
+        ?? DEFAULT_OPENCODE_PROVIDER_SETTINGS.environmentVariables,
+    ),
     modelAliases: normalizeOpencodeModelAliases(config.modelAliases, discoveredModels),
     preferredThinkingByModel: normalizeOpencodePreferredThinkingByModel(
       config.preferredThinkingByModel,

--- a/src/providers/pi/registration.ts
+++ b/src/providers/pi/registration.ts
@@ -1,4 +1,6 @@
 import { NOOP_TASK_RESULT_INTERPRETER } from '../../core/providers/NoopTaskResultInterpreter';
+import { getProviderConfig } from '../../core/providers/providerConfig';
+import { hasStoredConfigNormalization } from '../../core/providers/settings/storedSettings';
 import type { ProviderModule } from '../../core/providers/types';
 import {
   getPiWorkspaceServices,
@@ -38,8 +40,12 @@ export const piProviderRegistration: ProviderModule = {
   settingsStorage: {
     hostScopedFields: ['cliPathsByHost'],
     normalizeStored(target, stored) {
+      const storedConfig = getProviderConfig(stored, 'pi');
       updatePiProviderSettings(target, getPiProviderSettings(stored));
-      return false;
+      return hasStoredConfigNormalization(
+        storedConfig,
+        getProviderConfig(target, 'pi'),
+      );
     },
   },
   taskResultInterpreter: NOOP_TASK_RESULT_INTERPRETER,

--- a/src/providers/pi/settings.ts
+++ b/src/providers/pi/settings.ts
@@ -1,6 +1,10 @@
 import { getProviderConfig, setProviderConfig } from '../../core/providers/providerConfig';
 import { getProviderEnvironmentVariables } from '../../core/providers/providerEnvironment';
 import { normalizeHostnameStringMap } from '../../core/providers/settings/HostnameStringMap';
+import {
+  readStoredBoolean,
+  readStoredString,
+} from '../../core/providers/settings/storedSettings';
 import type { HostnameCliPaths } from '../../core/types/settings';
 import { getHostnameKey } from '../../utils/env';
 import { ensureProviderProjectionMap } from './internal/providerProjection';
@@ -125,17 +129,19 @@ export function getPiProviderSettings(settings: Record<string, unknown>): PiProv
   const persistableIds = getPersistablePiModelIds(settings, visibleModels);
 
   return {
-    cliPath: (config.cliPath as string | undefined)
-      ?? DEFAULT_PI_PROVIDER_SETTINGS.cliPath,
+    cliPath: readStoredString(config.cliPath, DEFAULT_PI_PROVIDER_SETTINGS.cliPath),
     cliPathsByHost,
     discoveredModels,
-    enabled: (config.enabled as boolean | undefined)
-      ?? DEFAULT_PI_PROVIDER_SETTINGS.enabled,
-    environmentHash: (config.environmentHash as string | undefined)
-      ?? DEFAULT_PI_PROVIDER_SETTINGS.environmentHash,
-    environmentVariables: (config.environmentVariables as string | undefined)
-      ?? getProviderEnvironmentVariables(settings, 'pi')
-      ?? DEFAULT_PI_PROVIDER_SETTINGS.environmentVariables,
+    enabled: readStoredBoolean(config.enabled, DEFAULT_PI_PROVIDER_SETTINGS.enabled),
+    environmentHash: readStoredString(
+      config.environmentHash,
+      DEFAULT_PI_PROVIDER_SETTINGS.environmentHash,
+    ),
+    environmentVariables: readStoredString(
+      config.environmentVariables,
+      getProviderEnvironmentVariables(settings, 'pi')
+        ?? DEFAULT_PI_PROVIDER_SETTINGS.environmentVariables,
+    ),
     modelAliases: normalizePiModelAliasesForPersistableIds(
       config.modelAliases,
       discoveredModels,
@@ -321,7 +327,10 @@ export function resolvePiModelAlias(
 }
 
 function normalizePiToolMode(value: unknown): PiToolMode {
-  return value === 'readonly' ? 'readonly' : 'all';
+  if (value === undefined) {
+    return 'all';
+  }
+  return value === 'all' || value === 'readonly' ? value : 'readonly';
 }
 
 function normalizePiEncodedId(

--- a/tests/unit/providers/ProviderModuleCatalog.test.ts
+++ b/tests/unit/providers/ProviderModuleCatalog.test.ts
@@ -1,4 +1,14 @@
 import { BUILT_IN_PROVIDER_MODULES } from '@/providers';
+import { getCodexProviderSettings } from '@/providers/codex/settings';
+import { getBuiltInProviderDefaultConfigs } from '@/providers/defaultProviderConfigs';
+
+function getProviderConfig(
+  settings: Record<string, unknown>,
+  providerId: string,
+): Record<string, unknown> {
+  const providerConfigs = settings.providerConfigs as Record<string, unknown>;
+  return providerConfigs[providerId] as Record<string, unknown>;
+}
 
 describe('built-in ProviderModule catalog', () => {
   it('is the single ordered source for chat, workspace, and settings composition', () => {
@@ -12,6 +22,119 @@ describe('built-in ProviderModule catalog', () => {
     for (const module of BUILT_IN_PROVIDER_MODULES) {
       expect(module.workspace.initialize).toEqual(expect.any(Function));
       expect(module.settingsStorage.normalizeStored).toEqual(expect.any(Function));
+    }
+  });
+
+  it('runtime-decodes malformed persisted scalar settings for every provider', () => {
+    const malformedSettings: Record<string, unknown> = {
+      providerConfigs: Object.fromEntries(BUILT_IN_PROVIDER_MODULES.map(module => [
+        module.id,
+        {
+          cliPath: 7,
+          enabled: 'false',
+          environmentHash: false,
+          environmentVariables: ['SECRET=not-a-string'],
+        },
+      ])),
+    };
+    Object.assign(getProviderConfig(malformedSettings, 'claude'), {
+      customModels: {},
+      defaultModel: {},
+      enableBangBash: 1,
+      enableChrome: 'true',
+      lastModel: [],
+      loadUserSettings: 'false',
+      safeMode: 'unknown',
+    });
+    Object.assign(getProviderConfig(malformedSettings, 'codex'), {
+      catalogFingerprint: [],
+      catalogTimestamp: 'now',
+      customModels: {},
+      reasoningSummary: 'verbose',
+      safeMode: 'danger-full-access',
+    });
+    Object.assign(getProviderConfig(malformedSettings, 'opencode'), {
+      selectedMode: 123,
+    });
+    Object.assign(getProviderConfig(malformedSettings, 'pi'), {
+      toolMode: 'danger-full-access',
+    });
+
+    const defaultEnabled: Record<string, boolean> = {
+      claude: true,
+      codex: false,
+      grok: false,
+      opencode: false,
+      pi: false,
+    };
+
+    for (const module of BUILT_IN_PROVIDER_MODULES) {
+      expect(module.isEnabled(malformedSettings)).toBe(defaultEnabled[module.id]);
+    }
+    expect(getCodexProviderSettings(malformedSettings).safeMode).toBe('read-only');
+
+    const normalizedSettings: Record<string, unknown> = {};
+    for (const module of BUILT_IN_PROVIDER_MODULES) {
+      expect(module.settingsStorage.normalizeStored(
+        normalizedSettings,
+        malformedSettings,
+      )).toBe(true);
+      const config = getProviderConfig(normalizedSettings, module.id);
+      expect(config.enabled).toBe(defaultEnabled[module.id]);
+      expect(config.cliPath).toEqual(expect.any(String));
+      expect(config.environmentHash).toEqual(expect.any(String));
+      expect(config.environmentVariables).toEqual(expect.any(String));
+    }
+
+    expect(getProviderConfig(normalizedSettings, 'claude')).toMatchObject({
+      customModels: expect.any(String),
+      defaultModel: expect.any(String),
+      enableBangBash: false,
+      enableChrome: false,
+      lastModel: expect.any(String),
+      loadUserSettings: true,
+      safeMode: 'default',
+    });
+    expect(getProviderConfig(normalizedSettings, 'codex')).toMatchObject({
+      catalogFingerprint: expect.any(String),
+      catalogTimestamp: 0,
+      customModels: expect.any(String),
+      reasoningSummary: 'detailed',
+      safeMode: 'read-only',
+    });
+    expect(getProviderConfig(normalizedSettings, 'opencode')).toMatchObject({
+      selectedMode: 'claudian-safe',
+    });
+    expect(getProviderConfig(normalizedSettings, 'pi')).toMatchObject({
+      toolMode: 'readonly',
+    });
+  });
+
+  it('keeps ephemeral OpenCode plan-mode normalization provider-owned', () => {
+    const opencodeModule = BUILT_IN_PROVIDER_MODULES.find(module => module.id === 'opencode');
+    const normalizedSettings: Record<string, unknown> = {};
+
+    expect(opencodeModule?.settingsStorage.normalizeStored(normalizedSettings, {
+      providerConfigs: {
+        opencode: {
+          selectedMode: 'plan',
+        },
+      },
+    })).toBe(true);
+    expect(getProviderConfig(normalizedSettings, 'opencode').selectedMode).toBe('claudian-safe');
+  });
+
+  it('does not report canonical provider defaults as changed', () => {
+    const storedSettings = {
+      providerConfigs: getBuiltInProviderDefaultConfigs(),
+    };
+    const normalizedSettings: Record<string, unknown> = {};
+
+    for (const module of BUILT_IN_PROVIDER_MODULES) {
+      expect(module.settingsStorage.normalizeStored(
+        normalizedSettings,
+        storedSettings,
+      )).toBe(false);
     }
   });
 });

--- a/tests/unit/providers/opencode/modes.test.ts
+++ b/tests/unit/providers/opencode/modes.test.ts
@@ -41,8 +41,15 @@ describe('OpenCode mode settings', () => {
     ])).toEqual(OPENCODE_FALLBACK_MODES);
   });
 
-  it('normalizes saved custom mode selections back to the managed YOLO mode', () => {
-    expect(normalizeManagedOpencodeSelectedMode('compaction')).toBe(OPENCODE_YOLO_MODE_ID);
+  it('normalizes unsupported saved mode selections to the managed safe mode', () => {
+    expect(normalizeManagedOpencodeSelectedMode('compaction')).toBe(OPENCODE_SAFE_MODE_ID);
+    expect(normalizeManagedOpencodeSelectedMode(123)).toBe(OPENCODE_SAFE_MODE_ID);
+    expect(normalizeManagedOpencodeSelectedMode(null)).toBe(OPENCODE_SAFE_MODE_ID);
+  });
+
+  it('preserves absent and blank saved mode selections as unset', () => {
+    expect(normalizeManagedOpencodeSelectedMode(undefined)).toBe('');
+    expect(normalizeManagedOpencodeSelectedMode('   ')).toBe('');
   });
 
   it('normalizes the legacy build id back to the managed YOLO mode', () => {
@@ -53,6 +60,7 @@ describe('OpenCode mode settings', () => {
     expect(resolveOpencodeModeForPermissionMode('yolo')).toBe(OPENCODE_YOLO_MODE_ID);
     expect(resolveOpencodeModeForPermissionMode('normal')).toBe(OPENCODE_SAFE_MODE_ID);
     expect(resolveOpencodeModeForPermissionMode('plan')).toBe('plan');
+    expect(resolveOpencodeModeForPermissionMode('danger-full-access')).toBe(OPENCODE_SAFE_MODE_ID);
   });
 
   it('maps managed OpenCode modes back to shared permission modes', () => {

--- a/tests/unit/providers/opencode/settings.test.ts
+++ b/tests/unit/providers/opencode/settings.test.ts
@@ -359,7 +359,7 @@ describe('OpenCode settings normalization', () => {
     });
   });
 
-  it('normalizes saved custom OpenCode modes back to the managed YOLO mode', () => {
+  it('normalizes saved custom OpenCode modes back to the managed safe mode', () => {
     expect(getOpencodeProviderSettings({
       providerConfigs: {
         opencode: {
@@ -367,7 +367,7 @@ describe('OpenCode settings normalization', () => {
           selectedMode: 'compaction',
         },
       },
-    }).selectedMode).toBe('claudian-yolo');
+    }).selectedMode).toBe('claudian-safe');
   });
 
   it('normalizes the legacy build alias back to the managed YOLO mode', () => {


### PR DESCRIPTION
## Why

Persisted provider configuration enters the runtime as unknown data, but several provider readers relied on TypeScript assertions. Malformed values could therefore stay truthy or, for Codex, select an unintended sandbox policy. The architecture checks also contained stale provider lists and obsolete lint targets, leaving documented dependency rules partially unenforced.

No issue is linked because this was identified during a focused local architecture and safety audit.

## What Changed

- Decode persisted scalar settings at runtime across all built-in providers.
- Fail closed for invalid Claude, Codex, OpenCode, and Pi permission-related values.
- Persist normalized provider settings and keep OpenCode restart normalization provider-owned.
- Discover concrete providers dynamically and resolve imports through the TypeScript AST for architecture checks.
- Enforce core, app, feature, and provider dependency directions while preserving exact compatibility seams.
- Remove an obsolete ESLint restriction that targeted files which no longer exist.
- Add cross-provider malformed-settings and architecture regression coverage.

## Why This Approach

Validation happens at provider-owned hydration and reader boundaries, where persisted input first becomes trusted application state. Small shared scalar readers avoid duplicated casts without introducing a schema dependency. Permission-related invalid values use explicit safe fallbacks. Architecture checks resolve actual imports, avoiding hard-coded provider lists and relative-path false positives.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run test` — 356 suites, 6,724 tests
- `npm run build`
- Architecture boundary checks — 12 passed
- Independent adversarial diff review — no remaining material findings

## Impact and Follow-ups

Valid persisted settings retain their existing behavior. Malformed permission-related values are repaired to safe modes; unsupported OpenCode modes now fall back to Safe instead of YOLO. Larger chat-tab decomposition remains intentionally out of scope for a separate discussion and change.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed. No user-facing documentation change is required; the contributor safety invariant is recorded in `AGENTS.md`.