### PR TITLE
Add native actions to the vault file tree

### DIFF
--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -1188,7 +1188,6 @@ export class ClaudianView extends ItemView {
     return new VaultFileTree({
       app: this.plugin.app,
       hostEl,
-      sourceLeaf: this.leaf,
     });
   }
 

--- a/src/features/chat/ui/vault-file-tree/VaultFileCreateModal.ts
+++ b/src/features/chat/ui/vault-file-tree/VaultFileCreateModal.ts
@@ -1,0 +1,74 @@
+import type { App } from 'obsidian';
+import { Notice, type TFolder } from 'obsidian';
+
+import {
+  hasVaultPathConflict,
+  joinVaultPath,
+  showVaultFileNameModal,
+} from './VaultFileNameModal';
+
+export type VaultFileCreationKind = 'folder' | 'note';
+
+function getParentPath(parent: TFolder): string {
+  return parent.isRoot() ? '' : parent.path;
+}
+
+function getCreationName(kind: VaultFileCreationKind, name: string): string {
+  return kind === 'note' && !name.toLowerCase().endsWith('.md')
+    ? `${name}.md`
+    : name;
+}
+
+function getAvailableInitialName(
+  app: App,
+  parent: TFolder,
+  kind: VaultFileCreationKind,
+): string {
+  const parentPath = getParentPath(parent);
+  let suffix = 0;
+  while (true) {
+    const name = suffix === 0 ? 'Untitled' : `Untitled ${suffix}`;
+    const targetPath = joinVaultPath(parentPath, getCreationName(kind, name));
+    if (!hasVaultPathConflict(app, targetPath)) return name;
+    suffix += 1;
+  }
+}
+
+export function showVaultFileCreateModal(
+  app: App,
+  parent: TFolder,
+  kind: VaultFileCreationKind,
+): void {
+  const itemLabel = kind === 'note' ? 'note' : 'folder';
+
+  showVaultFileNameModal(app, {
+    failureMessage: `Failed to create ${itemLabel}`,
+    initialName: getAvailableInitialName(app, parent, kind),
+    submitLabel: 'Create',
+    title: kind === 'note' ? 'New note' : 'New folder',
+    onSubmit: async (name) => {
+      if (!parent.isRoot() && app.vault.getAbstractFileByPath(parent.path) !== parent) {
+        return 'Destination folder is no longer available';
+      }
+
+      const creationName = getCreationName(kind, name);
+      const targetPath = joinVaultPath(getParentPath(parent), creationName);
+      if (hasVaultPathConflict(app, targetPath)) {
+        return `A file or folder named "${creationName}" already exists`;
+      }
+
+      if (kind === 'folder') {
+        await app.vault.createFolder(targetPath);
+        return null;
+      }
+
+      const file = await app.vault.create(targetPath, '');
+      try {
+        await app.workspace.getLeaf(false).openFile(file);
+      } catch {
+        new Notice(`Created "${creationName}" but failed to open it`);
+      }
+      return null;
+    },
+  });
+}

--- a/src/features/chat/ui/vault-file-tree/VaultFileNameModal.ts
+++ b/src/features/chat/ui/vault-file-tree/VaultFileNameModal.ts
@@ -1,0 +1,132 @@
+import type { App, ButtonComponent, TAbstractFile, TextComponent } from 'obsidian';
+import { Modal, Notice, Setting } from 'obsidian';
+
+export type VaultFileNameSubmitResult = string | null;
+
+export type VaultFileNameModalOptions = {
+  failureMessage: string;
+  initialName: string;
+  onSubmit: (name: string) => Promise<VaultFileNameSubmitResult>;
+  submitLabel: string;
+  title: string;
+};
+
+type ValidatedVaultFileName =
+  | { name: string }
+  | { error: string };
+
+function validateVaultFileName(rawName: string): ValidatedVaultFileName {
+  const name = rawName.trim();
+  if (!name) return { error: 'Name cannot be empty' };
+  if (name === '.' || name === '..') return { error: 'Name cannot be "." or ".."' };
+  if (name.startsWith('.')) return { error: 'Name cannot start with "."' };
+  if (/[/\\\0]/.test(name)) {
+    return { error: 'Name cannot contain path separators' };
+  }
+  return { name };
+}
+
+export function joinVaultPath(parentPath: string, name: string): string {
+  const normalizedParent = parentPath.replace(/\/+$/, '');
+  return normalizedParent ? `${normalizedParent}/${name}` : name;
+}
+
+export function hasVaultPathConflict(
+  app: App,
+  targetPath: string,
+  currentFile?: TAbstractFile,
+): boolean {
+  const targetKey = targetPath.toLowerCase();
+  return app.vault.getAllLoadedFiles().some(file => (
+    file !== currentFile && file.path.toLowerCase() === targetKey
+  ));
+}
+
+class VaultFileNameModal extends Modal {
+  private nameInput: TextComponent | null = null;
+  private submitButton: ButtonComponent | null = null;
+  private submitting = false;
+
+  constructor(
+    app: App,
+    private readonly options: VaultFileNameModalOptions,
+  ) {
+    super(app);
+  }
+
+  onOpen(): void {
+    this.setTitle(this.options.title);
+    this.modalEl.addClass('claudian-vault-file-name-modal');
+
+    new Setting(this.contentEl)
+      .setName('Name')
+      .addText((input) => {
+        this.nameInput = input.setValue(this.options.initialName);
+        input.inputEl.setAttribute('aria-label', 'Name');
+        input.inputEl.addEventListener('keydown', (event) => {
+          if (event.key !== 'Enter' || event.isComposing) return;
+          event.preventDefault();
+          void this.submit();
+        });
+
+        input.inputEl.ownerDocument.defaultView?.requestAnimationFrame(() => {
+          input.inputEl.focus();
+          input.inputEl.select();
+        });
+      });
+
+    new Setting(this.contentEl)
+      .addButton(button => button
+        .setButtonText('Cancel')
+        .onClick(() => this.close()))
+      .addButton((button) => {
+        this.submitButton = button
+          .setButtonText(this.options.submitLabel)
+          .setCta()
+          .onClick(() => {
+            void this.submit();
+          });
+      });
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+    this.nameInput = null;
+    this.submitButton = null;
+  }
+
+  private async submit(): Promise<void> {
+    if (this.submitting || !this.nameInput) return;
+
+    const validatedName = validateVaultFileName(this.nameInput.getValue());
+    if ('error' in validatedName) {
+      new Notice(validatedName.error);
+      return;
+    }
+
+    const nameInput = this.nameInput;
+    const submitButton = this.submitButton;
+    this.submitting = true;
+    nameInput.setDisabled(true);
+    submitButton?.setDisabled(true);
+
+    try {
+      const validationError = await this.options.onSubmit(validatedName.name);
+      if (validationError) {
+        new Notice(validationError);
+        return;
+      }
+      this.close();
+    } catch {
+      new Notice(this.options.failureMessage);
+    } finally {
+      this.submitting = false;
+      nameInput.setDisabled(false);
+      submitButton?.setDisabled(false);
+    }
+  }
+}
+
+export function showVaultFileNameModal(app: App, options: VaultFileNameModalOptions): void {
+  new VaultFileNameModal(app, options).open();
+}

--- a/src/features/chat/ui/vault-file-tree/VaultFileRenameModal.ts
+++ b/src/features/chat/ui/vault-file-tree/VaultFileRenameModal.ts
@@ -1,0 +1,44 @@
+import type { App, TAbstractFile } from 'obsidian';
+import { TFile, TFolder } from 'obsidian';
+
+import {
+  hasVaultPathConflict,
+  joinVaultPath,
+  showVaultFileNameModal,
+} from './VaultFileNameModal';
+
+export function showVaultFileRenameModal(app: App, file: TAbstractFile): void {
+  const initiallyMarkdown = file instanceof TFile
+    && file.extension.toLowerCase() === 'md';
+
+  showVaultFileNameModal(app, {
+    failureMessage: `Failed to rename "${file.name}"`,
+    initialName: initiallyMarkdown ? file.basename : file.name,
+    submitLabel: 'Rename',
+    title: file instanceof TFolder ? 'Rename folder' : 'Rename file',
+    onSubmit: async (name) => {
+      if (app.vault.getAbstractFileByPath(file.path) !== file) {
+        return file instanceof TFolder
+          ? 'Folder is no longer available'
+          : 'File is no longer available';
+      }
+
+      const preserveMarkdownExtension = file instanceof TFile
+        && file.extension.toLowerCase() === 'md';
+      const targetName = preserveMarkdownExtension && !name.toLowerCase().endsWith('.md')
+        ? `${name}.md`
+        : name;
+      const separatorIndex = file.path.lastIndexOf('/');
+      const parentPath = separatorIndex >= 0 ? file.path.slice(0, separatorIndex) : '';
+      const targetPath = joinVaultPath(parentPath, targetName);
+      if (targetPath === file.path) return null;
+
+      if (hasVaultPathConflict(app, targetPath, file)) {
+        return `A file or folder named "${targetName}" already exists`;
+      }
+
+      await app.fileManager.renameFile(file, targetPath);
+      return null;
+    },
+  });
+}

--- a/src/features/chat/ui/vault-file-tree/VaultFileTree.ts
+++ b/src/features/chat/ui/vault-file-tree/VaultFileTree.ts
@@ -5,7 +5,7 @@ import type {
   FileTreeBatchOperation,
   FileTreeRowDecoration,
 } from '@pierre/trees';
-import type { App, EventRef, TAbstractFile, WorkspaceLeaf } from 'obsidian';
+import type { App, EventRef, TAbstractFile } from 'obsidian';
 import { Notice, setIcon, TFile, TFolder } from 'obsidian';
 
 import {
@@ -14,6 +14,7 @@ import {
   scheduleDelayedFrame,
 } from '@/utils/animationFrame';
 
+import { showVaultFileCreateModal } from './VaultFileCreateModal';
 import { showVaultFileTreeMenu } from './VaultFileTreeMenu';
 import { toVaultFileTreePath, toVaultPath } from './vaultFileTreePaths';
 
@@ -68,7 +69,6 @@ export type VaultFileTreeOptions = {
   app: App;
   hostEl: HTMLElement;
   loadTreeModule?: () => Promise<PierreTreeModule>;
-  sourceLeaf?: WorkspaceLeaf;
 };
 
 export class VaultFileTree {
@@ -210,6 +210,14 @@ export class VaultFileTree {
     ));
 
     const headerActions = this.createElement('div', 'claudian-vault-file-tree-header-actions');
+    const newNoteButton = this.createHeaderButton('New note', 'file-plus', () => {
+      const activeFilePath = this.options.app.workspace.getActiveFile()?.path ?? '';
+      const parent = this.options.app.fileManager.getNewFileParent(activeFilePath);
+      showVaultFileCreateModal(this.options.app, parent, 'note');
+    });
+    const newFolderButton = this.createHeaderButton('New folder', 'folder-plus', () => {
+      showVaultFileCreateModal(this.options.app, this.options.app.vault.getRoot(), 'folder');
+    });
     this.searchButtonEl = this.createElement(
       'button',
       'claudian-vault-file-tree-header-button',
@@ -226,7 +234,7 @@ export class VaultFileTree {
       }
     });
 
-    headerActions.append(this.searchButtonEl);
+    headerActions.append(newNoteButton, newFolderButton, this.searchButtonEl);
     this.defaultHeaderEl.append(headerActions);
 
     this.searchFieldEl = this.createElement(
@@ -503,6 +511,24 @@ export class VaultFileTree {
     return element;
   }
 
+  private createHeaderButton(
+    ariaLabel: string,
+    icon: string,
+    onClick: () => void,
+  ): HTMLButtonElement {
+    const button = this.createElement(
+      'button',
+      'claudian-vault-file-tree-header-button',
+    );
+    button.type = 'button';
+    button.setAttribute('aria-label', ariaLabel);
+    setIcon(button, icon);
+    button.addEventListener('click', () => {
+      if (!this.destroyed) onClick();
+    });
+    return button;
+  }
+
   private registerVaultEvents(): void {
     if (this.destroyed || this.eventRefs.length > 0) return;
     this.eventRefs.push(
@@ -722,7 +748,6 @@ export class VaultFileTree {
       isDestroyed: () => this.destroyed,
       item,
       selectedPaths: displayedTree?.getSelectedPaths() ?? [],
-      sourceLeaf: this.options.sourceLeaf,
     });
   }
 

--- a/src/features/chat/ui/vault-file-tree/VaultFileTreeMenu.ts
+++ b/src/features/chat/ui/vault-file-tree/VaultFileTreeMenu.ts
@@ -2,9 +2,11 @@ import type {
   ContextMenuItem,
   ContextMenuOpenContext,
 } from '@pierre/trees';
-import type { App, PaneType, WorkspaceLeaf } from 'obsidian';
-import { Menu, Notice, TFile } from 'obsidian';
+import type { App, PaneType, TAbstractFile } from 'obsidian';
+import { Menu, Notice, TFile, TFolder } from 'obsidian';
 
+import { showVaultFileCreateModal } from './VaultFileCreateModal';
+import { showVaultFileRenameModal } from './VaultFileRenameModal';
 import { toVaultPath } from './vaultFileTreePaths';
 
 export type VaultFileTreeMenuOptions = {
@@ -14,9 +16,10 @@ export type VaultFileTreeMenuOptions = {
   isDestroyed: () => boolean;
   item: ContextMenuItem;
   selectedPaths: readonly string[];
-  sourceLeaf?: WorkspaceLeaf;
   writeClipboard?: (text: string) => Promise<void>;
 };
+
+const FILE_EXPLORER_CONTEXT_MENU_SOURCE = 'file-explorer-context-menu';
 
 function getMenuPaths(itemPath: string, selectedPaths: readonly string[]): readonly string[] {
   return selectedPaths.length > 1 && selectedPaths.includes(itemPath)
@@ -51,6 +54,19 @@ function copyPaths(options: VaultFileTreeMenuOptions, paths: readonly string[]):
     .catch(() => new Notice(paths.length === 1 ? 'Failed to copy path' : 'Failed to copy paths'));
 }
 
+async function deleteFiles(app: App, files: readonly TAbstractFile[]): Promise<void> {
+  for (const file of files) {
+    const currentFile = app.vault.getAbstractFileByPath(file.path);
+    if (currentFile !== file) continue;
+
+    try {
+      await app.fileManager.promptForDeletion(currentFile);
+    } catch {
+      new Notice(`Failed to delete "${file.name}"`);
+    }
+  }
+}
+
 export function showVaultFileTreeMenu(options: VaultFileTreeMenuOptions): Menu | null {
   const paths = getMenuPaths(options.item.path, options.selectedPaths);
   const targets = paths.flatMap((path) => {
@@ -66,6 +82,19 @@ export function showVaultFileTreeMenu(options: VaultFileTreeMenuOptions): Menu |
 
   const menu = new Menu().setUseNativeMenu(false);
   const singleFile = files.length === 1 && files[0] instanceof TFile ? files[0] : null;
+  const singleFolder = files.length === 1 && files[0] instanceof TFolder ? files[0] : null;
+
+  if (singleFolder) {
+    menu.addItem(item => item
+      .setTitle('New note')
+      .setIcon('file-plus')
+      .onClick(() => showVaultFileCreateModal(options.app, singleFolder, 'note')));
+    menu.addItem(item => item
+      .setTitle('New folder')
+      .setIcon('folder-plus')
+      .onClick(() => showVaultFileCreateModal(options.app, singleFolder, 'folder')));
+    menu.addSeparator();
+  }
 
   if (singleFile) {
     menu.addItem(item => item
@@ -80,11 +109,14 @@ export function showVaultFileTreeMenu(options: VaultFileTreeMenuOptions): Menu |
       .setTitle('Open in split')
       .setIcon('columns-2')
       .onClick(() => openFile(options.app, singleFile, 'split')));
-    menu.addItem(item => item
-      .setTitle('Open in new window')
-      .setIcon('picture-in-picture-2')
-      .onClick(() => openFile(options.app, singleFile, 'window')));
     menu.addSeparator();
+  }
+
+  if (files.length === 1) {
+    menu.addItem(item => item
+      .setTitle('Rename')
+      .setIcon('pencil')
+      .onClick(() => showVaultFileRenameModal(options.app, files[0])));
   }
 
   menu.addItem(item => item
@@ -92,21 +124,29 @@ export function showVaultFileTreeMenu(options: VaultFileTreeMenuOptions): Menu |
     .setIcon('copy')
     .onClick(() => copyPaths(options, resolvedPaths)));
 
+  menu.addItem(item => item
+    .setTitle('Delete')
+    .setIcon('trash-2')
+    .setWarning(true)
+    .onClick(() => {
+      void deleteFiles(options.app, files);
+    }));
+
   if (files.length === 1) {
     options.app.workspace.trigger(
       'file-menu',
       menu,
       files[0],
-      'file-explorer',
-      options.sourceLeaf,
+      FILE_EXPLORER_CONTEXT_MENU_SOURCE,
+      null,
     );
   } else {
     options.app.workspace.trigger(
       'files-menu',
       menu,
       files,
-      'file-explorer',
-      options.sourceLeaf,
+      FILE_EXPLORER_CONTEXT_MENU_SOURCE,
+      null,
     );
   }
 

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -241,6 +241,8 @@ class MockMenuItem {
     return this;
   });
 
+  setWarning = jest.fn((_isWarning: boolean) => this);
+
   onClick = jest.fn((handler: () => void) => {
     this.clickHandler = handler;
     return this;

--- a/tests/unit/features/chat/ui/vault-file-tree/VaultFileCreateModal.test.ts
+++ b/tests/unit/features/chat/ui/vault-file-tree/VaultFileCreateModal.test.ts
@@ -1,0 +1,300 @@
+/** @jest-environment jsdom */
+
+import { createMockEl } from '@test/helpers/MockElement';
+import type { TAbstractFile } from 'obsidian';
+
+let lastModalInstance: any;
+let createdButtons: any[] = [];
+let createdTextComponents: any[] = [];
+const mockNotice = jest.fn();
+
+jest.mock('obsidian', () => {
+  const actual = jest.requireActual('obsidian');
+
+  class MockModal {
+    app: any;
+    modalEl = createMockEl();
+    contentEl = createMockEl();
+    setTitle = jest.fn();
+    close = jest.fn(() => this.onClose());
+
+    constructor(app: any) {
+      this.app = app;
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      lastModalInstance = this;
+    }
+
+    open(): void {
+      this.onOpen();
+    }
+
+    onOpen(): void {
+      // Overridden by subclass
+    }
+
+    onClose(): void {
+      // Overridden by subclass
+    }
+  }
+
+  class MockTextComponent {
+    inputEl = document.createElement('input');
+
+    constructor() {
+      createdTextComponents.push(this);
+    }
+
+    getValue(): string {
+      return this.inputEl.value;
+    }
+
+    setDisabled(disabled: boolean): this {
+      this.inputEl.disabled = disabled;
+      return this;
+    }
+
+    setValue(value: string): this {
+      this.inputEl.value = value;
+      return this;
+    }
+  }
+
+  class MockButtonComponent {
+    buttonEl = document.createElement('button');
+    clickHandler: (() => void) | null = null;
+    text = '';
+
+    constructor() {
+      createdButtons.push(this);
+    }
+
+    onClick(handler: () => void): this {
+      this.clickHandler = handler;
+      return this;
+    }
+
+    setButtonText(text: string): this {
+      this.text = text;
+      return this;
+    }
+
+    setCta(): this {
+      return this;
+    }
+
+    setDisabled(disabled: boolean): this {
+      this.buttonEl.disabled = disabled;
+      return this;
+    }
+  }
+
+  class MockSetting {
+    constructor(_containerEl: unknown) {}
+
+    setName(_name: string): this {
+      return this;
+    }
+
+    addText(callback: (component: MockTextComponent) => void): this {
+      callback(new MockTextComponent());
+      return this;
+    }
+
+    addButton(callback: (component: MockButtonComponent) => void): this {
+      callback(new MockButtonComponent());
+      return this;
+    }
+  }
+
+  return {
+    ...actual,
+    Modal: MockModal,
+    Notice: mockNotice,
+    Setting: MockSetting,
+  };
+});
+
+import { TFile, TFolder } from 'obsidian';
+
+import { showVaultFileCreateModal } from '@/features/chat/ui/vault-file-tree/VaultFileCreateModal';
+
+function createFile(path: string): TFile {
+  const file = new TFile();
+  file.path = path;
+  file.name = path.split('/').pop() ?? '';
+  file.basename = file.name.replace(/\.[^.]+$/, '');
+  file.extension = file.name.includes('.') ? file.name.split('.').pop() ?? '' : '';
+  return file;
+}
+
+function createFolder(path: string, isRoot = false): TFolder {
+  const folder = new TFolder();
+  folder.path = path;
+  folder.name = path.split('/').pop() ?? '';
+  folder.isRoot = jest.fn(() => isRoot);
+  return folder;
+}
+
+function createApp(existingFiles: readonly TAbstractFile[] = []) {
+  const files = new Map(existingFiles.map(file => [file.path, file]));
+  const openFile = jest.fn().mockResolvedValue(undefined);
+  const createdNote = createFile('created.md');
+  return {
+    app: {
+      vault: {
+        create: jest.fn().mockResolvedValue(createdNote),
+        createFolder: jest.fn().mockResolvedValue(createFolder('created')),
+        getAbstractFileByPath: jest.fn((path: string) => files.get(path) ?? null),
+        getAllLoadedFiles: jest.fn(() => [...files.values()]),
+      },
+      workspace: {
+        getLeaf: jest.fn(() => ({ openFile })),
+      },
+    },
+    createdNote,
+    files,
+    openFile,
+  };
+}
+
+function getButton(text: string): any {
+  const button = createdButtons.find(candidate => candidate.text === text);
+  if (!button) throw new Error(`Missing button: ${text}`);
+  return button;
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('VaultFileCreateModal', () => {
+  beforeEach(() => {
+    lastModalInstance = null;
+    createdButtons = [];
+    createdTextComponents = [];
+    mockNotice.mockReset();
+  });
+
+  it('creates and opens a Markdown note in the vault root', async () => {
+    const root = createFolder('/', true);
+    const { app, createdNote, openFile } = createApp();
+
+    showVaultFileCreateModal(app as never, root, 'note');
+    expect(createdTextComponents[0].getValue()).toBe('Untitled');
+    createdTextComponents[0].setValue('Roadmap');
+    getButton('Create').clickHandler();
+    await flushPromises();
+
+    expect(app.vault.create).toHaveBeenCalledWith('Roadmap.md', '');
+    expect(app.workspace.getLeaf).toHaveBeenCalledWith(false);
+    expect(openFile).toHaveBeenCalledWith(createdNote);
+    expect(lastModalInstance.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('chooses an available default note name and avoids duplicating the extension', async () => {
+    const root = createFolder('/', true);
+    const existing = createFile('untitled.md');
+    const { app } = createApp([existing]);
+
+    showVaultFileCreateModal(app as never, root, 'note');
+    expect(createdTextComponents[0].getValue()).toBe('Untitled 1');
+    createdTextComponents[0].setValue('README.md');
+    getButton('Create').clickHandler();
+    await flushPromises();
+
+    expect(app.vault.create).toHaveBeenCalledWith('README.md', '');
+  });
+
+  it('creates a folder inside the selected parent folder', async () => {
+    const parent = createFolder('Projects');
+    const { app } = createApp([parent]);
+
+    showVaultFileCreateModal(app as never, parent, 'folder');
+    createdTextComponents[0].setValue('Archive');
+    getButton('Create').clickHandler();
+    await flushPromises();
+
+    expect(app.vault.createFolder).toHaveBeenCalledWith('Projects/Archive');
+    expect(app.workspace.getLeaf).not.toHaveBeenCalled();
+    expect(lastModalInstance.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the current parent path when the folder moves while the modal is open', async () => {
+    const parent = createFolder('Projects');
+    const { app, files } = createApp([parent]);
+
+    showVaultFileCreateModal(app as never, parent, 'folder');
+    files.delete('Projects');
+    parent.path = 'Archive';
+    parent.name = 'Archive';
+    files.set(parent.path, parent);
+    createdTextComponents[0].setValue('Drafts');
+    getButton('Create').clickHandler();
+    await flushPromises();
+
+    expect(app.vault.createFolder).toHaveBeenCalledWith('Archive/Drafts');
+  });
+
+  it('rejects a replacement folder that reuses the original parent path', async () => {
+    const parent = createFolder('Projects');
+    const { app, files } = createApp([parent]);
+
+    showVaultFileCreateModal(app as never, parent, 'folder');
+    files.set(parent.path, createFolder('Projects'));
+    createdTextComponents[0].setValue('Archive');
+    getButton('Create').clickHandler();
+    await flushPromises();
+
+    expect(app.vault.createFolder).not.toHaveBeenCalled();
+    expect(lastModalInstance.close).not.toHaveBeenCalled();
+    expect(mockNotice).toHaveBeenCalledWith('Destination folder is no longer available');
+  });
+
+  it('keeps the modal open when the destination already exists', async () => {
+    const parent = createFolder('Projects');
+    const existing = createFolder('Projects/archive');
+    const { app } = createApp([parent, existing]);
+
+    showVaultFileCreateModal(app as never, parent, 'folder');
+    createdTextComponents[0].setValue('Archive');
+    getButton('Create').clickHandler();
+    await flushPromises();
+
+    expect(app.vault.createFolder).not.toHaveBeenCalled();
+    expect(lastModalInstance.close).not.toHaveBeenCalled();
+    expect(mockNotice).toHaveBeenCalledWith('A file or folder named "Archive" already exists');
+  });
+
+  it('rejects a dot-prefixed folder name before creating a hidden vault item', async () => {
+    const parent = createFolder('Projects');
+    const { app } = createApp([parent]);
+
+    showVaultFileCreateModal(app as never, parent, 'folder');
+    createdTextComponents[0].setValue('.archive');
+    getButton('Create').clickHandler();
+    await flushPromises();
+
+    expect(app.vault.createFolder).not.toHaveBeenCalled();
+    expect(lastModalInstance.close).not.toHaveBeenCalled();
+    expect(mockNotice).toHaveBeenCalledWith('Name cannot start with "."');
+  });
+
+  it('reports create failures and restores the controls for retry', async () => {
+    const parent = createFolder('Projects');
+    const { app } = createApp([parent]);
+    app.vault.create.mockRejectedValueOnce(new Error('disk failure'));
+
+    showVaultFileCreateModal(app as never, parent, 'note');
+    createdTextComponents[0].setValue('Roadmap');
+    const createButton = getButton('Create');
+    createButton.clickHandler();
+    await flushPromises();
+
+    expect(lastModalInstance.close).not.toHaveBeenCalled();
+    expect(createdTextComponents[0].inputEl.disabled).toBe(false);
+    expect(createButton.buttonEl.disabled).toBe(false);
+    expect(mockNotice).toHaveBeenCalledWith('Failed to create note');
+  });
+});

--- a/tests/unit/features/chat/ui/vault-file-tree/VaultFileRenameModal.test.ts
+++ b/tests/unit/features/chat/ui/vault-file-tree/VaultFileRenameModal.test.ts
@@ -1,0 +1,287 @@
+/** @jest-environment jsdom */
+
+import { createMockEl } from '@test/helpers/MockElement';
+import type { TAbstractFile } from 'obsidian';
+
+let lastModalInstance: any;
+let createdButtons: any[] = [];
+let createdTextComponents: any[] = [];
+const mockNotice = jest.fn();
+
+jest.mock('obsidian', () => {
+  const actual = jest.requireActual('obsidian');
+
+  class MockModal {
+    app: any;
+    modalEl = createMockEl();
+    contentEl = createMockEl();
+    setTitle = jest.fn();
+    close = jest.fn(() => this.onClose());
+
+    constructor(app: any) {
+      this.app = app;
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      lastModalInstance = this;
+    }
+
+    open(): void {
+      this.onOpen();
+    }
+
+    onOpen(): void {
+      // Overridden by subclass
+    }
+
+    onClose(): void {
+      // Overridden by subclass
+    }
+  }
+
+  class MockTextComponent {
+    inputEl = document.createElement('input');
+
+    constructor() {
+      createdTextComponents.push(this);
+    }
+
+    getValue(): string {
+      return this.inputEl.value;
+    }
+
+    setDisabled(disabled: boolean): this {
+      this.inputEl.disabled = disabled;
+      return this;
+    }
+
+    setValue(value: string): this {
+      this.inputEl.value = value;
+      return this;
+    }
+  }
+
+  class MockButtonComponent {
+    buttonEl = document.createElement('button');
+    clickHandler: (() => void) | null = null;
+    text = '';
+
+    constructor() {
+      createdButtons.push(this);
+    }
+
+    onClick(handler: () => void): this {
+      this.clickHandler = handler;
+      return this;
+    }
+
+    setButtonText(text: string): this {
+      this.text = text;
+      return this;
+    }
+
+    setCta(): this {
+      return this;
+    }
+
+    setDisabled(disabled: boolean): this {
+      this.buttonEl.disabled = disabled;
+      return this;
+    }
+  }
+
+  class MockSetting {
+    constructor(_containerEl: unknown) {}
+
+    setName(_name: string): this {
+      return this;
+    }
+
+    addText(callback: (component: MockTextComponent) => void): this {
+      callback(new MockTextComponent());
+      return this;
+    }
+
+    addButton(callback: (component: MockButtonComponent) => void): this {
+      callback(new MockButtonComponent());
+      return this;
+    }
+  }
+
+  return {
+    ...actual,
+    Modal: MockModal,
+    Notice: mockNotice,
+    Setting: MockSetting,
+  };
+});
+
+import { TFile, TFolder } from 'obsidian';
+
+import { showVaultFileRenameModal } from '@/features/chat/ui/vault-file-tree/VaultFileRenameModal';
+
+function createFile(path: string): TFile {
+  const file = new TFile();
+  file.path = path;
+  file.name = path.split('/').pop() ?? '';
+  file.basename = file.name.replace(/\.[^.]+$/, '');
+  file.extension = file.name.includes('.') ? file.name.split('.').pop() ?? '' : '';
+  return file;
+}
+
+function createFolder(path: string): TFolder {
+  const folder = new TFolder();
+  folder.path = path;
+  folder.name = path.split('/').pop() ?? '';
+  return folder;
+}
+
+function createApp(existingFiles: readonly TAbstractFile[] = []) {
+  const files = new Map(existingFiles.map(file => [file.path, file]));
+  return {
+    fileManager: {
+      renameFile: jest.fn().mockResolvedValue(undefined),
+    },
+    files,
+    vault: {
+      getAbstractFileByPath: jest.fn((path: string) => files.get(path) ?? null),
+      getAllLoadedFiles: jest.fn(() => [...files.values()]),
+    },
+  };
+}
+
+function getButton(text: string): any {
+  const button = createdButtons.find(candidate => candidate.text === text);
+  if (!button) throw new Error(`Missing button: ${text}`);
+  return button;
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('VaultFileRenameModal', () => {
+  beforeEach(() => {
+    lastModalInstance = null;
+    createdButtons = [];
+    createdTextComponents = [];
+    mockNotice.mockReset();
+  });
+
+  it('renames a file within its current folder through Obsidian FileManager', async () => {
+    const file = createFile('Projects/Plan.md');
+    const app = createApp([file]);
+
+    showVaultFileRenameModal(app as never, file);
+
+    expect(createdTextComponents[0].getValue()).toBe('Plan');
+    createdTextComponents[0].setValue('Roadmap');
+    getButton('Rename').clickHandler();
+    await flushPromises();
+
+    expect(app.fileManager.renameFile).toHaveBeenCalledWith(file, 'Projects/Roadmap.md');
+    expect(lastModalInstance.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('renames a folder without treating the operation as a move', async () => {
+    const folder = createFolder('Projects/Drafts');
+    const app = createApp([folder]);
+
+    showVaultFileRenameModal(app as never, folder);
+    createdTextComponents[0].setValue('Archive');
+    getButton('Rename').clickHandler();
+    await flushPromises();
+
+    expect(app.fileManager.renameFile).toHaveBeenCalledWith(folder, 'Projects/Archive');
+  });
+
+  it('preserves the Markdown extension during a case-only rename', async () => {
+    const file = createFile('Projects/Plan.md');
+    const app = createApp([file]);
+
+    showVaultFileRenameModal(app as never, file);
+    createdTextComponents[0].setValue('plan');
+    getButton('Rename').clickHandler();
+    await flushPromises();
+
+    expect(app.fileManager.renameFile).toHaveBeenCalledWith(file, 'Projects/plan.md');
+  });
+
+  it('uses the current parent path when the file moves while the modal is open', async () => {
+    const file = createFile('Projects/Plan.md');
+    const app = createApp([file]);
+
+    showVaultFileRenameModal(app as never, file);
+    app.files.delete('Projects/Plan.md');
+    file.path = 'Archive/Plan.md';
+    app.files.set(file.path, file);
+    createdTextComponents[0].setValue('Roadmap');
+    getButton('Rename').clickHandler();
+    await flushPromises();
+
+    expect(app.fileManager.renameFile).toHaveBeenCalledWith(file, 'Archive/Roadmap.md');
+  });
+
+  it('rejects a replacement file that reuses the original target path', async () => {
+    const file = createFile('Projects/Plan.md');
+    const app = createApp([file]);
+
+    showVaultFileRenameModal(app as never, file);
+    app.files.set(file.path, createFile('Projects/Plan.md'));
+    createdTextComponents[0].setValue('Roadmap');
+    getButton('Rename').clickHandler();
+    await flushPromises();
+
+    expect(app.fileManager.renameFile).not.toHaveBeenCalled();
+    expect(lastModalInstance.close).not.toHaveBeenCalled();
+    expect(mockNotice).toHaveBeenCalledWith('File is no longer available');
+  });
+
+  it.each(['', '   ', '.', '..', '.archive', '../Archive', 'Nested/Archive', 'Nested\\Archive'])(
+    'rejects an invalid new name: %p',
+    async (newName) => {
+      const file = createFile('Projects/Plan.md');
+      const app = createApp([file]);
+
+      showVaultFileRenameModal(app as never, file);
+      createdTextComponents[0].setValue(newName);
+      getButton('Rename').clickHandler();
+      await flushPromises();
+
+      expect(app.fileManager.renameFile).not.toHaveBeenCalled();
+      expect(lastModalInstance.close).not.toHaveBeenCalled();
+      expect(mockNotice).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('keeps the modal open when the destination already exists', async () => {
+    const file = createFile('Projects/Plan.md');
+    const existing = createFile('Projects/roadmap.md');
+    const app = createApp([file, existing]);
+
+    showVaultFileRenameModal(app as never, file);
+    createdTextComponents[0].setValue('Roadmap');
+    getButton('Rename').clickHandler();
+    await flushPromises();
+
+    expect(app.fileManager.renameFile).not.toHaveBeenCalled();
+    expect(lastModalInstance.close).not.toHaveBeenCalled();
+    expect(mockNotice).toHaveBeenCalledWith('A file or folder named "Roadmap.md" already exists');
+  });
+
+  it('reports rename failures and restores the controls for retry', async () => {
+    const file = createFile('Projects/Plan.md');
+    const app = createApp([file]);
+    app.fileManager.renameFile.mockRejectedValueOnce(new Error('disk failure'));
+
+    showVaultFileRenameModal(app as never, file);
+    createdTextComponents[0].setValue('Roadmap.md');
+    const renameButton = getButton('Rename');
+    renameButton.clickHandler();
+    await flushPromises();
+
+    expect(lastModalInstance.close).not.toHaveBeenCalled();
+    expect(createdTextComponents[0].inputEl.disabled).toBe(false);
+    expect(renameButton.buttonEl.disabled).toBe(false);
+    expect(mockNotice).toHaveBeenCalledWith('Failed to rename "Plan.md"');
+  });
+});

--- a/tests/unit/features/chat/ui/vault-file-tree/VaultFileTree.test.ts
+++ b/tests/unit/features/chat/ui/vault-file-tree/VaultFileTree.test.ts
@@ -5,8 +5,12 @@ import { TFile, TFolder } from 'obsidian';
 import { VaultFileTree } from '@/features/chat/ui/vault-file-tree/VaultFileTree';
 
 const mockShowVaultFileTreeMenu = jest.fn();
+const mockShowVaultFileCreateModal = jest.fn();
 jest.mock('@/features/chat/ui/vault-file-tree/VaultFileTreeMenu', () => ({
   showVaultFileTreeMenu: (...args: unknown[]) => mockShowVaultFileTreeMenu(...args),
+}));
+jest.mock('@/features/chat/ui/vault-file-tree/VaultFileCreateModal', () => ({
+  showVaultFileCreateModal: (...args: unknown[]) => mockShowVaultFileCreateModal(...args),
 }));
 
 type TreeOptions = {
@@ -98,11 +102,15 @@ function createHarness(ownerDocument: Document = document) {
   const openFile = jest.fn().mockResolvedValue(undefined);
   const getLeaf = jest.fn().mockReturnValue({ openFile });
   const app = {
+    fileManager: {
+      getNewFileParent: jest.fn(() => project),
+    },
     vault: {
       getAllLoadedFiles: jest.fn(() => files),
       getAbstractFileByPath: jest.fn((path: string) => (
         files.find(file => file.path === path) ?? null
       )),
+      getRoot: jest.fn(() => root),
       getName: jest.fn(() => 'Knowledge Vault'),
       offref: jest.fn(),
       on: jest.fn((event: string, handler: (...args: unknown[]) => void) => {
@@ -112,18 +120,19 @@ function createHarness(ownerDocument: Document = document) {
         return ref;
       }),
     },
-    workspace: { getLeaf },
+    workspace: {
+      getActiveFile: jest.fn(() => plan),
+      getLeaf,
+    },
   };
   const hostEl = ownerDocument.createElement('div');
   Object.assign(hostEl, {
     createEl: <K extends keyof HTMLElementTagNameMap>(tag: K) => ownerDocument.createElement(tag),
   });
-  const sourceLeaf = { id: 'claudian-leaf' };
   const tree = new VaultFileTree({
     app: app as never,
     hostEl,
     loadTreeModule: async () => ({ FileTree: FakePierreTree }) as never,
-    sourceLeaf: sourceLeaf as never,
   });
 
   return {
@@ -133,9 +142,9 @@ function createHarness(ownerDocument: Document = document) {
     handlers,
     hostEl,
     openFile,
+    project,
     refs,
     root,
-    sourceLeaf,
     tree,
   };
 }
@@ -143,7 +152,22 @@ function createHarness(ownerDocument: Document = document) {
 describe('VaultFileTree', () => {
   beforeEach(() => {
     FakePierreTree.instances = [];
+    mockShowVaultFileCreateModal.mockReset();
     mockShowVaultFileTreeMenu.mockReset();
+  });
+
+  it('offers root note and folder creation from the tree header', async () => {
+    const { app, hostEl, project, root, tree } = createHarness();
+
+    await tree.mount();
+    hostEl.querySelector<HTMLButtonElement>('[aria-label="New note"]')?.click();
+    hostEl.querySelector<HTMLButtonElement>('[aria-label="New folder"]')?.click();
+
+    expect(mockShowVaultFileCreateModal.mock.calls).toEqual([
+      [app, project, 'note'],
+      [app, root, 'folder'],
+    ]);
+    expect(app.fileManager.getNewFileParent).toHaveBeenCalledWith('Projects/Plan.md');
   });
 
   it('renders the visible vault through the vanilla Pierre tree', async () => {
@@ -298,7 +322,7 @@ describe('VaultFileTree', () => {
   });
 
   it('forwards right-click context to the native vault menu boundary', async () => {
-    const { app, sourceLeaf, tree } = createHarness();
+    const { app, tree } = createHarness();
     await tree.mount();
     const model = FakePierreTree.instances[0];
     const item = { kind: 'file', name: 'Plan.md', path: 'Projects/Plan.md' };
@@ -315,7 +339,6 @@ describe('VaultFileTree', () => {
       context,
       item,
       selectedPaths: ['Projects/Plan.md', 'Notes.md'],
-      sourceLeaf,
     }));
 
     const options = mockShowVaultFileTreeMenu.mock.calls[0][0];

--- a/tests/unit/features/chat/ui/vault-file-tree/VaultFileTreeMenu.test.ts
+++ b/tests/unit/features/chat/ui/vault-file-tree/VaultFileTreeMenu.test.ts
@@ -4,6 +4,16 @@ import { Menu, type TAbstractFile, TFile, TFolder } from 'obsidian';
 
 import { showVaultFileTreeMenu } from '@/features/chat/ui/vault-file-tree/VaultFileTreeMenu';
 
+const mockShowVaultFileRenameModal = jest.fn();
+const mockShowVaultFileCreateModal = jest.fn();
+
+jest.mock('@/features/chat/ui/vault-file-tree/VaultFileRenameModal', () => ({
+  showVaultFileRenameModal: (...args: unknown[]) => mockShowVaultFileRenameModal(...args),
+}));
+jest.mock('@/features/chat/ui/vault-file-tree/VaultFileCreateModal', () => ({
+  showVaultFileCreateModal: (...args: unknown[]) => mockShowVaultFileCreateModal(...args),
+}));
+
 type TestMenu = Menu & {
   hideCallback?: () => void;
   items: Array<{
@@ -52,6 +62,9 @@ function createHarness() {
     menu.addItem(item => item.setTitle('Plugin action'));
   });
   const app = {
+    fileManager: {
+      promptForDeletion: jest.fn().mockResolvedValue(true),
+    },
     vault: {
       getAbstractFileByPath: jest.fn((path: string) => files.get(path) ?? null),
     },
@@ -75,7 +88,6 @@ function createHarness() {
   };
   const focusPath = jest.fn();
   const writeClipboard = jest.fn().mockResolvedValue(undefined);
-  const sourceLeaf = { id: 'claudian-leaf' };
 
   return {
     app,
@@ -84,7 +96,6 @@ function createHarness() {
     focusPath,
     getLeaf,
     openedLeaves,
-    sourceLeaf,
     trigger,
     writeClipboard,
   };
@@ -98,6 +109,8 @@ function clickMenuItem(menu: TestMenu, title: string): void {
 
 describe('VaultFileTreeMenu', () => {
   beforeEach(() => {
+    mockShowVaultFileCreateModal.mockReset();
+    mockShowVaultFileRenameModal.mockReset();
     MockMenu.instances = [];
     MockMenu.prototype.onHide = function (callback: () => void): void {
       this.hideCallback = callback;
@@ -117,7 +130,6 @@ describe('VaultFileTreeMenu', () => {
       isDestroyed: () => false,
       item: { kind: 'file', name: 'Plan.md', path: 'Projects/Plan.md' },
       selectedPaths: ['Notes.md'],
-      sourceLeaf: harness.sourceLeaf as never,
       writeClipboard: harness.writeClipboard,
     }) as TestMenu;
 
@@ -125,8 +137,9 @@ describe('VaultFileTreeMenu', () => {
       'Open',
       'Open in new tab',
       'Open in split',
-      'Open in new window',
+      'Rename',
       'Copy path',
+      'Delete',
       'Plugin action',
     ]);
     expect(harness.context.close).toHaveBeenCalledWith({ restoreFocus: false });
@@ -134,14 +147,34 @@ describe('VaultFileTreeMenu', () => {
       'file-menu',
       menu,
       harness.files.get('Projects/Plan.md'),
-      'file-explorer',
-      harness.sourceLeaf,
+      'file-explorer-context-menu',
+      null,
     );
     expect(harness.trigger.mock.invocationCallOrder[0])
       .toBeLessThan((menu.showAtPosition as jest.Mock).mock.invocationCallOrder[0]);
     expect(menu.showAtPosition).toHaveBeenCalledWith(
       { x: 24, y: 46 },
       harness.context.anchorElement.ownerDocument,
+    );
+  });
+
+  it('offers rename for a single file and opens the rename modal', () => {
+    const harness = createHarness();
+    const menu = showVaultFileTreeMenu({
+      app: harness.app as never,
+      context: harness.context,
+      focusPath: harness.focusPath,
+      isDestroyed: () => false,
+      item: { kind: 'file', name: 'Plan.md', path: 'Projects/Plan.md' },
+      selectedPaths: [],
+      writeClipboard: harness.writeClipboard,
+    }) as TestMenu;
+
+    clickMenuItem(menu, 'Rename');
+
+    expect(mockShowVaultFileRenameModal).toHaveBeenCalledWith(
+      harness.app,
+      harness.files.get('Projects/Plan.md'),
     );
   });
 
@@ -154,14 +187,12 @@ describe('VaultFileTreeMenu', () => {
       isDestroyed: () => false,
       item: { kind: 'file', name: 'Plan.md', path: 'Projects/Plan.md' },
       selectedPaths: [],
-      sourceLeaf: harness.sourceLeaf as never,
       writeClipboard: harness.writeClipboard,
     }) as TestMenu;
 
     clickMenuItem(menu, 'Open');
     clickMenuItem(menu, 'Open in new tab');
     clickMenuItem(menu, 'Open in split');
-    clickMenuItem(menu, 'Open in new window');
     clickMenuItem(menu, 'Copy path');
     await Promise.resolve();
 
@@ -169,7 +200,6 @@ describe('VaultFileTreeMenu', () => {
       false,
       'tab',
       'split',
-      'window',
     ]);
     for (const leaf of harness.openedLeaves) {
       expect(leaf.openFile).toHaveBeenCalledWith(harness.files.get('Projects/Plan.md'));
@@ -187,17 +217,20 @@ describe('VaultFileTreeMenu', () => {
       isDestroyed: () => destroyed,
       item: { kind: 'file', name: 'Plan.md', path: 'Projects/Plan.md' },
       selectedPaths: ['Projects/Plan.md', 'Notes.md'],
-      sourceLeaf: harness.sourceLeaf as never,
       writeClipboard: harness.writeClipboard,
     }) as TestMenu;
 
-    expect(menu.items.map(item => item.title)).toEqual(['Copy paths', 'Plugin action']);
+    expect(menu.items.map(item => item.title)).toEqual([
+      'Copy paths',
+      'Delete',
+      'Plugin action',
+    ]);
     expect(harness.trigger).toHaveBeenCalledWith(
       'files-menu',
       menu,
       [harness.files.get('Projects/Plan.md'), harness.files.get('Notes.md')],
-      'file-explorer',
-      harness.sourceLeaf,
+      'file-explorer-context-menu',
+      null,
     );
 
     clickMenuItem(menu, 'Copy paths');
@@ -220,17 +253,107 @@ describe('VaultFileTreeMenu', () => {
       isDestroyed: () => false,
       item: { kind: 'directory', name: 'Projects', path: 'Projects/' },
       selectedPaths: [],
-      sourceLeaf: harness.sourceLeaf as never,
       writeClipboard: harness.writeClipboard,
     }) as TestMenu;
 
-    expect(menu.items.map(item => item.title)).toEqual(['Copy path', 'Plugin action']);
+    expect(menu.items.map(item => item.title)).toEqual([
+      'New note',
+      'New folder',
+      'Rename',
+      'Copy path',
+      'Delete',
+      'Plugin action',
+    ]);
     expect(harness.trigger).toHaveBeenCalledWith(
       'file-menu',
       menu,
       harness.files.get('Projects'),
-      'file-explorer',
-      harness.sourceLeaf,
+      'file-explorer-context-menu',
+      null,
     );
+
+    clickMenuItem(menu, 'Rename');
+    expect(mockShowVaultFileRenameModal).toHaveBeenCalledWith(
+      harness.app,
+      harness.files.get('Projects'),
+    );
+
+    clickMenuItem(menu, 'New note');
+    expect(mockShowVaultFileCreateModal).toHaveBeenCalledWith(
+      harness.app,
+      harness.files.get('Projects'),
+      'note',
+    );
+
+    clickMenuItem(menu, 'New folder');
+    expect(mockShowVaultFileCreateModal).toHaveBeenCalledWith(
+      harness.app,
+      harness.files.get('Projects'),
+      'folder',
+    );
+  });
+
+  it('deletes a single item through Obsidian confirmation', async () => {
+    const harness = createHarness();
+    const menu = showVaultFileTreeMenu({
+      app: harness.app as never,
+      context: harness.context,
+      focusPath: harness.focusPath,
+      isDestroyed: () => false,
+      item: { kind: 'file', name: 'Plan.md', path: 'Projects/Plan.md' },
+      selectedPaths: [],
+      writeClipboard: harness.writeClipboard,
+    }) as TestMenu;
+
+    clickMenuItem(menu, 'Delete');
+    await Promise.resolve();
+
+    expect(harness.app.fileManager.promptForDeletion).toHaveBeenCalledWith(
+      harness.files.get('Projects/Plan.md'),
+    );
+  });
+
+  it('deletes each still-existing item in a multi-selection', async () => {
+    const harness = createHarness();
+    const menu = showVaultFileTreeMenu({
+      app: harness.app as never,
+      context: harness.context,
+      focusPath: harness.focusPath,
+      isDestroyed: () => false,
+      item: { kind: 'file', name: 'Plan.md', path: 'Projects/Plan.md' },
+      selectedPaths: ['Projects/Plan.md', 'Notes.md'],
+      writeClipboard: harness.writeClipboard,
+    }) as TestMenu;
+
+    clickMenuItem(menu, 'Delete');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(harness.app.fileManager.promptForDeletion.mock.calls).toEqual([
+      [harness.files.get('Projects/Plan.md')],
+      [harness.files.get('Notes.md')],
+    ]);
+  });
+
+  it('does not delete a replacement that reuses a stale menu path', async () => {
+    const harness = createHarness();
+    const original = harness.files.get('Projects/Plan.md');
+    const menu = showVaultFileTreeMenu({
+      app: harness.app as never,
+      context: harness.context,
+      focusPath: harness.focusPath,
+      isDestroyed: () => false,
+      item: { kind: 'file', name: 'Plan.md', path: 'Projects/Plan.md' },
+      selectedPaths: [],
+      writeClipboard: harness.writeClipboard,
+    }) as TestMenu;
+    const replacement = createFile('Projects/Plan.md');
+    harness.files.set(replacement.path, replacement);
+
+    clickMenuItem(menu, 'Delete');
+    await Promise.resolve();
+
+    expect(original).not.toBe(replacement);
+    expect(harness.app.fileManager.promptForDeletion).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Why

The custom vault tree lacked core file management actions available in Obsidian's native explorer, and this focused UX gap does not require a separate issue.

## What Changed

Added header and context-menu creation, single-item rename, safe single/multi-item deletion, native menu-event integration, shared name validation, collision handling, and stale-object protection.

## Why This Approach

The implementation delegates mutations to Obsidian's public Vault and FileManager APIs and centralizes name entry so link updates, trash preferences, hidden-name safety, and popout-window behavior stay consistent.

## Validation

Passed `npm run typecheck`, `npm run lint`, `npm run test` (363 suites and 6,881 tests), `npm run build`, and `git diff --check`; no manual UI recording was captured.

## Impact and Follow-ups

No migration is required, while live popout placement and third-party menu ordering remain residual manual-testing risks.

## Checklist

- [x] kept the change focused on one problem
- [x] added or updated tests for changed behavior
- [x] ran the relevant tests or checks locally
- [x] updated user-facing documentation when needed
- [x] linked the issue or explained why no issue is required
- [x] called out any fallback or hard-to-reproduce limitation that remains
