### PR TITLE
fix: preserve copy controls on language-tagged code blocks

### DIFF
--- a/src/features/chat/rendering/DisplayOnlyCodeFences.ts
+++ b/src/features/chat/rendering/DisplayOnlyCodeFences.ts
@@ -61,7 +61,7 @@ export async function restoreDisplayOnlyCodeFences(
 
   for (const fence of fences) {
     const placeholderClass = `language-${fence.placeholderLanguage}`;
-    const code = container.querySelector<HTMLElement>(`.${placeholderClass}`);
+    const code = container.querySelector<HTMLElement>(`code.${placeholderClass}`);
     if (!code) {
       continue;
     }

--- a/tests/helpers/MockElement.ts
+++ b/tests/helpers/MockElement.ts
@@ -361,9 +361,11 @@ export function createMockEl(tag = 'div'): any {
     },
 
     querySelector(selector: string) {
-      const cls = selector.replace('.', '');
+      const simpleClassSelector = selector.match(/^([a-z][\w-]*)?\.([\w-]+)$/i);
+      const tagName = simpleClassSelector?.[1]?.toUpperCase();
+      const cls = simpleClassSelector?.[2] ?? selector.replace('.', '');
       const find = (el: any): MockElement | null => {
-        if (el.hasClass?.(cls)) return el;
+        if ((!tagName || el.tagName === tagName) && el.hasClass?.(cls)) return el;
         for (const child of el.children || []) {
           const found = find(child);
           if (found) return found;
@@ -373,10 +375,12 @@ export function createMockEl(tag = 'div'): any {
       return find(element);
     },
     querySelectorAll(selector: string) {
-      const cls = selector.replace('.', '');
+      const simpleClassSelector = selector.match(/^([a-z][\w-]*)?\.([\w-]+)$/i);
+      const tagName = simpleClassSelector?.[1]?.toUpperCase();
+      const cls = simpleClassSelector?.[2] ?? selector.replace('.', '');
       const results: MockElement[] = [];
       const collect = (el: any) => {
-        if (el.hasClass?.(cls)) results.push(el);
+        if ((!tagName || el.tagName === tagName) && el.hasClass?.(cls)) results.push(el);
         for (const child of el.children || []) collect(child);
       };
       for (const child of children) collect(child);

--- a/tests/unit/features/chat/rendering/DisplayOnlyCodeFences.test.ts
+++ b/tests/unit/features/chat/rendering/DisplayOnlyCodeFences.test.ts
@@ -108,6 +108,33 @@ describe('DisplayOnlyCodeFences', () => {
     expect(highlightElement).toHaveBeenCalledWith(code);
   });
 
+  it('restores the nested code element when Prism copies the placeholder class to pre', async () => {
+    const highlightElement = jest.fn((element: { tagName: string; empty: () => void }) => {
+      if (element.tagName === 'PRE') {
+        element.empty();
+      }
+    });
+    (loadPrism as jest.Mock).mockResolvedValueOnce({ highlightElement });
+    const container = createMockEl();
+    const placeholderClass = 'language-claudian-display-only-fence-0';
+    const pre = container.createEl('pre', { cls: placeholderClass });
+    const code = pre.createEl('code', {
+      cls: placeholderClass,
+      text: 'const value = 1;',
+    });
+    const copyButton = pre.createEl('button', { cls: 'copy-code-button' });
+
+    await restoreDisplayOnlyCodeFences(container, [{
+      placeholderLanguage: 'claudian-display-only-fence-0',
+      originalLanguage: 'typescript',
+    }]);
+
+    expect(code.hasClass(placeholderClass)).toBe(false);
+    expect(code.hasClass('language-typescript')).toBe(true);
+    expect(highlightElement).toHaveBeenCalledWith(code);
+    expect(pre.querySelector('.copy-code-button')).toBe(copyButton);
+  });
+
   it('restores language classes even when Prism loading fails', async () => {
     (loadPrism as jest.Mock).mockRejectedValueOnce(new Error('Prism unavailable'));
     const container = createMockEl();


### PR DESCRIPTION
## Why

Fixes #1074, where Prism can select a language-tagged block's `<pre>` during fence restoration and destroy both the nested `<code>` element and its copy control.

## What Changed

- Restrict display-only fence restoration and highlighting to the nested `<code>` element.
- Add regression coverage for Prism copying the placeholder language class onto `<pre>` while preserving the copy button.
- Teach the lightweight DOM test helper to match `tag.class` selectors.

## Why This Approach

Targeting the element that owns the temporary class avoids the destructive parent rewrite while retaining Prism's native parent-language propagation.

## Validation

- `npm run typecheck && npm run lint && npm run test && npm run build`
- 6,873 Jest tests and 21 architecture/release checks passed.

## Impact and Follow-ups

None.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
