### PR TITLE
Fix Pi session continuity across turns and Obsidian restarts

### DIFF
--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -402,11 +402,10 @@ export class ClaudianView extends ItemView {
     this.eventRefs = [];
     this.restoreActiveInputToTabContent();
 
-    const shutdownSnapshotPromise = this.captureShutdownSnapshot(
+    const shutdownSnapshotPromise = this.ensureShutdownSnapshot(
       tabManager,
       tabStatePersistence,
     );
-    this.shutdownSnapshotPromise = shutdownSnapshotPromise;
     try {
       await shutdownSnapshotPromise;
       const ownsCloseLifecycle = this.viewShutdownStarted === true
@@ -433,6 +432,25 @@ export class ClaudianView extends ItemView {
         this.shutdownSnapshotPromise = null;
       }
     }
+  }
+
+  async prepareForPluginUnload(): Promise<void> {
+    const tabManager = this.tabManager;
+    tabManager?.beginShutdown();
+    await this.ensureShutdownSnapshot(tabManager, this.tabStatePersistence);
+  }
+
+  private ensureShutdownSnapshot(
+    tabManager: TabManager | null,
+    tabStatePersistence: TabStatePersistenceCoordinator | null,
+  ): Promise<void> {
+    if (this.shutdownSnapshotPromise) return this.shutdownSnapshotPromise;
+    const shutdownSnapshotPromise = this.captureShutdownSnapshot(
+      tabManager,
+      tabStatePersistence,
+    );
+    this.shutdownSnapshotPromise = shutdownSnapshotPromise;
+    return shutdownSnapshotPromise;
   }
 
   private async captureShutdownSnapshot(

--- a/src/main.ts
+++ b/src/main.ts
@@ -145,6 +145,7 @@ export default class ClaudianPlugin extends Plugin {
   private remainingSessionMetadataLoad: Promise<void> | null = null;
   private providerChatOptionsChangeTail: Promise<void> = Promise.resolve();
   private isUnloading = false;
+  private applicationShutdownPromise: Promise<void> | null = null;
 
   get executionPersistence(): ChatExecutionPersistence {
     return this.conversationRepository;
@@ -317,11 +318,24 @@ export default class ClaudianPlugin extends Plugin {
       this.sessionMetadataLoadTimer = null;
     }
     StartupProfiler.freeze();
-    void Promise.all(
-      this.getAllViews().map(view => view.flushCurrentTabState()),
-    ).catch(() => undefined);
-    void this.executionLifecycleRegistry.dispose();
-    void ProviderWorkspaceRegistry.disposeInitialized();
+    this.applicationShutdownPromise ??= this.shutdownApplication();
+    void this.applicationShutdownPromise.catch(() => undefined);
+  }
+
+  private async shutdownApplication(): Promise<void> {
+    await Promise.allSettled(
+      this.getAllViews().map(view => view.prepareForPluginUnload()),
+    );
+    try {
+      await this.executionLifecycleRegistry.dispose();
+    } catch {
+      // Continue releasing provider workspaces even if execution cleanup fails.
+    }
+    try {
+      await ProviderWorkspaceRegistry.disposeInitialized();
+    } catch {
+      // Obsidian teardown has no error channel; workspace cleanup is best effort.
+    }
   }
 
   async activateView() {

--- a/src/providers/pi/execution/PiExecutionSession.ts
+++ b/src/providers/pi/execution/PiExecutionSession.ts
@@ -154,7 +154,8 @@ implements ProviderExecutionSession, SteerableExecutionSession {
   private forkMaterializationFlight: Promise<void> | null = null;
   private kernel: PiExecutionKernel | null = null;
   private kernelGeneration = 0;
-  private launchKey: string | null = null;
+  private processKey: string | null = null;
+  private readonly kernelSessionTargets = new Set<string>();
   private lifecycleError: Error | null = null;
   private normalizationState: PiEventNormalizationState =
     createPiEventNormalizationState();
@@ -516,8 +517,7 @@ implements ProviderExecutionSession, SteerableExecutionSession {
     const hasAcceptedCompatibleLiveContext = Boolean(
       this.nativeConversationContextEstablished
       && !hasNativeSession
-      && this.kernel
-      && this.launchKey === launchSpec.launchKey,
+      && this.canReuseKernel(launchSpec),
     );
     const prompt = encodePrompt(
       request,
@@ -593,8 +593,7 @@ implements ProviderExecutionSession, SteerableExecutionSession {
       return;
     }
     if (
-      this.kernel
-      && this.launchKey === launchSpec.launchKey
+      this.canReuseKernel(launchSpec)
     ) {
       return;
     }
@@ -625,7 +624,8 @@ implements ProviderExecutionSession, SteerableExecutionSession {
       return;
     }
     this.kernel = kernel;
-    this.launchKey = launchSpec.launchKey;
+    this.processKey = launchSpec.processKey;
+    this.replaceKernelSessionTargets(launchSpec.sessionTarget);
     if (
       !this.isActive(active)
       || active.abortController.signal.aborted
@@ -825,7 +825,8 @@ implements ProviderExecutionSession, SteerableExecutionSession {
       kernel.getStderrSnapshot(),
     );
     this.kernel = null;
-    this.launchKey = null;
+    this.processKey = null;
+    this.kernelSessionTargets.clear();
     if (!this.hasNativeSessionState()) {
       this.nativeConversationContextEstablished = false;
     }
@@ -897,6 +898,7 @@ implements ProviderExecutionSession, SteerableExecutionSession {
     if (this.shouldDisableNativePersistence()) {
       this.providerSessionId = null;
       this.removeNativeProviderState();
+      this.kernelSessionTargets.clear();
       this.bumpRevision();
       return;
     }
@@ -922,6 +924,7 @@ implements ProviderExecutionSession, SteerableExecutionSession {
     this.setOptionalProviderStateValue('sessionFile', sessionFile);
     this.setOptionalProviderStateValue('leafEntryId', leafEntryId);
     this.setOptionalProviderStateValue('parentSession', parentSession);
+    this.replaceKernelSessionTargets(sessionFile, sessionId);
     this.deleteProviderStateValue('forkSource');
     this.deleteProviderStateValue('forkSourceSessionFile');
     this.bumpRevision();
@@ -1205,11 +1208,28 @@ implements ProviderExecutionSession, SteerableExecutionSession {
       && !this.disposed;
   }
 
+  private canReuseKernel(launchSpec: PiLaunchSpec): boolean {
+    if (!this.kernel || this.processKey !== launchSpec.processKey) return false;
+    return launchSpec.sessionTarget
+      ? this.kernelSessionTargets.has(launchSpec.sessionTarget)
+      : this.kernelSessionTargets.size === 0;
+  }
+
+  private replaceKernelSessionTargets(
+    ...targets: Array<string | null | undefined>
+  ): void {
+    this.kernelSessionTargets.clear();
+    for (const target of targets) {
+      if (target) this.kernelSessionTargets.add(target);
+    }
+  }
+
   private shutdownKernel(): Promise<void> {
     if (this.shutdownPromise) return this.shutdownPromise;
     const kernel = this.kernel;
     this.kernel = null;
-    this.launchKey = null;
+    this.processKey = null;
+    this.kernelSessionTargets.clear();
     this.kernelGeneration += 1;
     if (!this.hasNativeSessionState()) {
       this.nativeConversationContextEstablished = false;

--- a/src/providers/pi/runtime/PiLaunchSpec.ts
+++ b/src/providers/pi/runtime/PiLaunchSpec.ts
@@ -22,13 +22,18 @@ export interface PiLaunchSpec {
   command: string;
   cwd: string;
   env: NodeJS.ProcessEnv;
-  launchKey: string;
+  processKey: string;
+  sessionTarget: string | null;
 }
 
 const READONLY_TOOLS = 'read,grep,find,ls';
 
 export function buildPiLaunchSpec(params: BuildPiLaunchSpecParams): PiLaunchSpec {
   const args = ['--mode', 'rpc'];
+  let sessionFlagIndex: number | null = null;
+  const sessionTarget = params.providerState?.sessionFile
+    ?? params.providerState?.sessionId
+    ?? null;
   const systemPrompt = params.systemPrompt?.trim();
   if (systemPrompt) {
     args.push('--system-prompt', systemPrompt);
@@ -36,8 +41,9 @@ export function buildPiLaunchSpec(params: BuildPiLaunchSpecParams): PiLaunchSpec
 
   if (params.noSession) {
     args.push('--no-session');
-  } else if (params.providerState?.sessionFile || params.providerState?.sessionId) {
-    args.push('--session', params.providerState.sessionFile ?? params.providerState.sessionId!);
+  } else if (sessionTarget) {
+    sessionFlagIndex = args.length;
+    args.push('--session', sessionTarget);
   }
 
   if (params.noTools) {
@@ -63,11 +69,23 @@ export function buildPiLaunchSpec(params: BuildPiLaunchSpecParams): PiLaunchSpec
     command: params.command,
     cwd: params.cwd,
     env: params.env ?? process.env,
-    launchKey: JSON.stringify({
-      args,
+    processKey: JSON.stringify({
+      args: withoutSessionTarget(args, sessionFlagIndex),
       command: params.command,
       cwd: params.cwd,
       envText: params.envText ?? params.settings.environmentVariables,
     }),
+    sessionTarget: params.noSession ? null : sessionTarget,
   };
+}
+
+function withoutSessionTarget(
+  args: readonly string[],
+  sessionFlagIndex: number | null,
+): string[] {
+  if (sessionFlagIndex === null) return [...args];
+  return [
+    ...args.slice(0, sessionFlagIndex),
+    ...args.slice(sessionFlagIndex + 2),
+  ];
 }

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -1112,21 +1112,43 @@ describe('ClaudianPlugin', () => {
       expect(disposeSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('flushes the current tab identity when views are not closed first', async () => {
+    it('drains views before disposing execution and workspace resources', async () => {
       await plugin.onload();
-      const flushCurrentTabState = jest.fn().mockResolvedValue(undefined);
+      let resolveViewDrain!: () => void;
+      const viewDrain = new Promise<void>((resolve) => {
+        resolveViewDrain = resolve;
+      });
+      const prepareForPluginUnload = jest.fn(() => viewDrain);
       mockApp.workspace.getLeavesOfType.mockReturnValue([{
         view: {
-          flushCurrentTabState,
+          prepareForPluginUnload,
           getTabManager: jest.fn(),
         },
       }]);
+      const disposeExecution = jest.spyOn(
+        plugin.executionLifecycleRegistry,
+        'dispose',
+      ).mockResolvedValue(undefined);
+      const disposeWorkspaces = jest.spyOn(
+        ProviderWorkspaceRegistry,
+        'disposeInitialized',
+      ).mockResolvedValue(undefined);
 
       plugin.onunload();
       await Promise.resolve();
-      await Promise.resolve();
 
-      expect(flushCurrentTabState).toHaveBeenCalledTimes(1);
+      expect(prepareForPluginUnload).toHaveBeenCalledTimes(1);
+      expect(disposeExecution).not.toHaveBeenCalled();
+      expect(disposeWorkspaces).not.toHaveBeenCalled();
+
+      resolveViewDrain();
+      await (plugin as any).applicationShutdownPromise;
+
+      expect(disposeExecution).toHaveBeenCalledTimes(1);
+      expect(disposeWorkspaces).toHaveBeenCalledTimes(1);
+      expect(disposeExecution.mock.invocationCallOrder[0]).toBeLessThan(
+        disposeWorkspaces.mock.invocationCallOrder[0],
+      );
     });
   });
 

--- a/tests/unit/features/chat/ClaudianView.test.ts
+++ b/tests/unit/features/chat/ClaudianView.test.ts
@@ -2636,6 +2636,46 @@ describe('ClaudianView composer input', () => {
 });
 
 describe('ClaudianView shutdown', () => {
+  it('prepares plugin unload through one shared drained snapshot', async () => {
+    const drain = deferred<void>();
+    const flush = jest.fn().mockResolvedValue(undefined);
+    const manager = {
+      beginShutdown: jest.fn(),
+      drainForShutdownSnapshot: jest.fn(() => drain.promise),
+      getActiveTab: jest.fn().mockReturnValue({
+        conversationId: 'conversation-1',
+        id: 'tab-1',
+      }),
+      sealShutdownSnapshot: jest.fn(),
+    };
+    const persistence = {
+      flush,
+      update: jest.fn(),
+    };
+    const view = Object.create(ClaudianView.prototype) as any;
+    Object.assign(view, {
+      tabManager: manager,
+      tabStatePersistence: persistence,
+    });
+
+    const first = view.prepareForPluginUnload();
+    const second = view.prepareForPluginUnload();
+
+    expect(manager.beginShutdown).toHaveBeenCalledTimes(2);
+    expect(manager.drainForShutdownSnapshot).toHaveBeenCalledTimes(1);
+    expect(flush).not.toHaveBeenCalled();
+
+    drain.resolve(undefined);
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined]);
+
+    expect(persistence.update).toHaveBeenCalledWith({
+      activeTabId: 'tab-1',
+      openTabs: [{ conversationId: 'conversation-1', tabId: 'tab-1' }],
+    });
+    expect(flush).toHaveBeenCalledTimes(1);
+    expect(manager.sealShutdownSnapshot).toHaveBeenCalledTimes(1);
+  });
+
   it('drains active turns before flushing and sealing the final tab identity', async () => {
     const drain = deferred<void>();
     const activeTab = { conversationId: null as string | null, id: 'tab-1' };

--- a/tests/unit/providers/pi/execution/PiExecutionBackend.test.ts
+++ b/tests/unit/providers/pi/execution/PiExecutionBackend.test.ts
@@ -963,6 +963,7 @@ describe('PiExecutionBackend', () => {
     }
 
     const prompts = harness.kernels.flatMap(getPromptMessages);
+    expect(harness.kernels).toHaveLength(1);
     expect(prompts[0]).toContain('prior question');
     expect(prompts[0]).toContain('prior answer');
     expect(prompts[1]).toBe('Second follow up');
@@ -1910,12 +1911,18 @@ describe('PiExecutionBackend', () => {
     const run = harness.session.execute(createRequest());
     const eventsPromise = collect(run.events);
     await waitFor(() => harness.kernels.length === 1);
+    const sessionTargetIndex = harness.kernels[0].launchSpec.args.indexOf('--session') + 1;
+    const forkFile = harness.kernels[0].launchSpec.args[sessionTargetIndex];
+    harness.responses.set('get_state', {
+      leafEntryId: 'assistant-1',
+      parentSession: sourceFile,
+      sessionFile: forkFile,
+      sessionId: 'fork-session',
+    });
     harness.kernels[0].emit({ type: 'agent_start' });
     harness.kernels[0].emit({ type: 'agent_end' });
     await eventsPromise;
 
-    const sessionTargetIndex = harness.kernels[0].launchSpec.args.indexOf('--session') + 1;
-    const forkFile = harness.kernels[0].launchSpec.args[sessionTargetIndex];
     expect(forkFile).not.toBe(sourceFile);
     expect(path.dirname(forkFile)).toBe(tempDir);
     expect(await fs.readFile(forkFile, 'utf8')).toContain(
@@ -1924,7 +1931,7 @@ describe('PiExecutionBackend', () => {
     const snapshot = harness.session.getSnapshot();
     expect(snapshot.providerState).toMatchObject({
       futureState: { retained: true },
-      sessionFile: '/tmp/pi-session.jsonl',
+      sessionFile: forkFile,
     });
     expect(snapshot.providerState).not.toHaveProperty('forkSource');
     expect(snapshot.providerState).not.toHaveProperty('forkSourceSessionFile');
@@ -1937,10 +1944,11 @@ describe('PiExecutionBackend', () => {
       input: [{ text: 'Continue after fork', type: 'text' }],
     }));
     const continuedEventsPromise = collect(continuedRun.events);
-    await waitFor(() => harness.kernels.length === 2);
-    harness.kernels[1].emit({ type: 'agent_start' });
-    harness.kernels[1].emit({ type: 'agent_end' });
+    await waitFor(() => getPromptMessages(harness.kernels[0]).length === 2);
+    harness.kernels[0].emit({ type: 'agent_start' });
+    harness.kernels[0].emit({ type: 'agent_end' });
     await continuedEventsPromise;
+    expect(harness.kernels).toHaveLength(1);
     expect(harness.session.getSnapshot().providerStateDeletes).toEqual([
       'forkSource',
       'forkSourceSessionFile',

--- a/tests/unit/providers/pi/runtime/PiLaunchSpec.test.ts
+++ b/tests/unit/providers/pi/runtime/PiLaunchSpec.test.ts
@@ -104,7 +104,7 @@ describe('PiLaunchSpec', () => {
     ]);
   });
 
-  it('includes full runtime environment text in the launch key', () => {
+  it('includes full runtime environment text in the process key', () => {
     const first = buildPiLaunchSpec({
       command: 'pi',
       cwd: '/vault',
@@ -118,6 +118,33 @@ describe('PiLaunchSpec', () => {
       settings: baseSettings,
     });
 
-    expect(first.launchKey).not.toBe(second.launchKey);
+    expect(first.processKey).not.toBe(second.processKey);
+  });
+
+  it('keeps session identity separate from process compatibility', () => {
+    const first = buildPiLaunchSpec({
+      command: 'pi',
+      cwd: '/vault',
+      providerState: { sessionFile: '/tmp/first.jsonl' },
+      settings: baseSettings,
+      systemPrompt: '--session',
+    });
+    const second = buildPiLaunchSpec({
+      command: 'pi',
+      cwd: '/vault',
+      providerState: { sessionFile: '/tmp/second.jsonl' },
+      settings: baseSettings,
+      systemPrompt: '--session',
+    });
+
+    expect(first.processKey).toBe(second.processKey);
+    expect(JSON.parse(first.processKey).args).toEqual([
+      '--mode',
+      'rpc',
+      '--system-prompt',
+      '--session',
+    ]);
+    expect(first.sessionTarget).toBe('/tmp/first.jsonl');
+    expect(second.sessionTarget).toBe('/tmp/second.jsonl');
   });
 });

--- a/tests/unit/providers/pi/runtime/PiSubprocess.test.ts
+++ b/tests/unit/providers/pi/runtime/PiSubprocess.test.ts
@@ -83,6 +83,33 @@ describe('PiSubprocess', () => {
     );
   });
 
+  it('preserves Unicode Windows session paths when resuming through a .cmd shim', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const sessionFile = 'D:\\文档\\Documents\\Atlas\\Pi Sessions\\session.jsonl';
+    const subprocess = new PiSubprocess({
+      args: ['--mode', 'rpc', '--session', sessionFile],
+      command: 'C:\\Users\\dev\\AppData\\Roaming\\npm\\pi.cmd',
+      cwd: 'D:\\文档\\Documents\\Atlas',
+      env: { PATH: 'C:\\Windows\\System32' },
+    });
+
+    subprocess.start();
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      process.env.ComSpec || process.env.comspec || 'cmd.exe',
+      [
+        '/d',
+        '/s',
+        '/c',
+        '"C:\\Users\\dev\\AppData\\Roaming\\npm\\pi.cmd --mode rpc --session "D:\\文档\\Documents\\Atlas\\Pi Sessions\\session.jsonl""',
+      ],
+      expect.objectContaining({
+        cwd: 'D:\\文档\\Documents\\Atlas',
+        windowsVerbatimArguments: true,
+      }),
+    );
+  });
+
   it('kills the process tree when shutting down Windows .cmd shims', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
     const subprocess = new PiSubprocess({


### PR DESCRIPTION
## Why

Fixes #1061 and #1066: Pi could lose conversation context by restarting its native RPC session between messages or by failing to persist the final `sessionFile` before Obsidian shutdown.

## What Changed

- Separate Pi process compatibility from native session identity so a live compatible kernel is reused while forks and configuration changes still replace it.
- Drain and persist chat view state before disposing application execution and provider workspace resources.
- Add regression coverage for multi-turn continuity, unload ordering, fork continuity, and Windows `.cmd` resume paths containing Unicode and spaces.

## Why This Approach

Pi remains the owner of native conversation context, while Claudian explicitly coordinates process reuse and shutdown ordering at their existing lifecycle boundaries.

## Validation

- `npm run typecheck && npm run lint && npm run test && npm run build`
- 363 suites and 6,875 tests passed.

## Impact and Follow-ups

No migration or stored-data changes are required; an actual Windows smoke test remains recommended because Windows process launch was validated through automated construction tests from macOS.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
