### PR TITLE
Fix Codex first-response live rendering

### DIFF
--- a/src/providers/codex/execution/CodexExecutionSession.ts
+++ b/src/providers/codex/execution/CodexExecutionSession.ts
@@ -102,6 +102,8 @@ const LEGACY_WORKSPACE_DEPENDENCY_INSTRUCTIONS =
   'This thread predates Claudian client-hosted workspace dependency tools. Do not emulate load_workspace_dependencies or install replacement dependencies.';
 const CODEX_SUPPORTS_EXACT_BUILT_IN_TOOL_ALLOW_LIST = false;
 const MISSED_TURN_COMPLETION_GRACE_MS = 1_000;
+const MISSED_TURN_COMPLETION_MAX_ATTEMPTS = 3;
+const MISSED_TURN_COMPLETION_RETRY_BASE_MS = 500;
 const THREAD_READ_RECOVERY_TIMEOUT_MS = 5_000;
 const CODEX_CONSUMED_FORK_STATE_KEYS = [
   'forkSource',
@@ -130,6 +132,14 @@ interface TurnCompletion {
   readonly status: 'completed' | 'failed' | 'interrupted';
   readonly nativeTurnId: string;
   readonly errorMessage?: string;
+}
+
+interface CompletionRecovery {
+  readonly run: CodexExecutionRun;
+  readonly generation: number;
+  attempt: number;
+  inFlight: boolean;
+  timer: number | null;
 }
 
 interface CodexEnsuredThread {
@@ -283,7 +293,7 @@ export class CodexExecutionSession
   private forkIdentityPromise: Promise<CodexPendingForkTarget> | null = null;
   private forkSetupPromise: Promise<CodexEnsuredThread> | null = null;
   private disposePromise: Promise<void> | null = null;
-  private completionRecoveryTimer: number | null = null;
+  private completionRecovery: CompletionRecovery | null = null;
   private disposed = false;
   private lifecycleGeneration = 0;
 
@@ -758,7 +768,7 @@ export class CodexExecutionSession
       const changed = params as ThreadStatusChangedNotification;
       if (changed.threadId !== run.nativeThreadId) return;
       if (changed.status.type === 'idle') {
-        this.scheduleMissedTurnCompletionRecovery(run);
+        this.observeThreadIdle(run);
       } else {
         this.cancelMissedTurnCompletionRecovery();
       }
@@ -799,31 +809,60 @@ export class CodexExecutionSession
     this.notificationRouter?.handleNotification(method, params);
   }
 
-  private scheduleMissedTurnCompletionRecovery(run: CodexExecutionRun): void {
+  private observeThreadIdle(run: CodexExecutionRun): void {
+    let recovery = this.completionRecovery;
     if (
-      this.completionRecoveryTimer
-      || !run.nativeThreadId
-      || !run.nativeTurnId
+      !recovery
+      || recovery.run !== run
+      || recovery.generation !== this.lifecycleGeneration
+    ) {
+      this.cancelMissedTurnCompletionRecovery();
+      recovery = {
+        run,
+        generation: this.lifecycleGeneration,
+        attempt: 0,
+        inFlight: false,
+        timer: null,
+      };
+      this.completionRecovery = recovery;
+    }
+    this.scheduleMissedTurnCompletionRecovery(
+      recovery,
+      MISSED_TURN_COMPLETION_GRACE_MS,
+    );
+  }
+
+  private scheduleMissedTurnCompletionRecovery(
+    recovery: CompletionRecovery,
+    delayMs: number,
+  ): void {
+    if (
+      this.completionRecovery !== recovery
+      || recovery.timer !== null
+      || recovery.inFlight
+      || !this.isCompletionRecoveryCurrent(recovery)
+      || !recovery.run.nativeTurnId
     ) {
       return;
     }
-    const generation = this.lifecycleGeneration;
-    this.completionRecoveryTimer = window.setTimeout(() => {
-      this.completionRecoveryTimer = null;
-      void this.recoverMissedTurnCompletion(run, generation);
-    }, MISSED_TURN_COMPLETION_GRACE_MS);
+    recovery.timer = window.setTimeout(() => {
+      recovery.timer = null;
+      void this.recoverMissedTurnCompletion(recovery);
+    }, delayMs);
   }
 
   private cancelMissedTurnCompletionRecovery(): void {
-    if (!this.completionRecoveryTimer) return;
-    window.clearTimeout(this.completionRecoveryTimer);
-    this.completionRecoveryTimer = null;
+    const recovery = this.completionRecovery;
+    if (recovery && recovery.timer !== null) {
+      window.clearTimeout(recovery.timer);
+    }
+    this.completionRecovery = null;
   }
 
   private async recoverMissedTurnCompletion(
-    run: CodexExecutionRun,
-    generation: number,
+    recovery: CompletionRecovery,
   ): Promise<void> {
+    const { run } = recovery;
     const transport = this.transport;
     const threadId = run.nativeThreadId;
     const turnId = run.nativeTurnId;
@@ -831,13 +870,12 @@ export class CodexExecutionSession
       !transport
       || !threadId
       || !turnId
-      || this.activeRun !== run
-      || run.isTerminal
-      || run.isCancellationRequested
-      || generation !== this.lifecycleGeneration
+      || !this.isCompletionRecoveryCurrent(recovery)
     ) {
       return;
     }
+    recovery.attempt += 1;
+    recovery.inFlight = true;
 
     let result: ThreadReadResult;
     try {
@@ -847,20 +885,56 @@ export class CodexExecutionSession
         THREAD_READ_RECOVERY_TIMEOUT_MS,
       );
     } catch {
+      recovery.inFlight = false;
+      this.retryOrFailMissedTurnCompletion(recovery);
       return;
     }
-    if (
-      this.activeRun !== run
-      || run.isTerminal
-      || run.isCancellationRequested
-      || generation !== this.lifecycleGeneration
-    ) {
-      return;
-    }
+    if (!this.isCompletionRecoveryCurrent(recovery)) return;
+    recovery.inFlight = false;
     const turn = result.thread.turns.find(candidate => candidate.id === turnId);
-    if (!turn || turn.status === 'inProgress') return;
+    if (
+      result.thread.id !== threadId
+      || !turn
+      || turn.status === 'inProgress'
+    ) {
+      this.retryOrFailMissedTurnCompletion(recovery);
+      return;
+    }
     this.replayRecoveredTurnItems(threadId, turn);
     this.handleNotification('turn/completed', { threadId, turn });
+  }
+
+  private retryOrFailMissedTurnCompletion(
+    recovery: CompletionRecovery,
+  ): void {
+    if (!this.isCompletionRecoveryCurrent(recovery)) return;
+    if (recovery.attempt < MISSED_TURN_COMPLETION_MAX_ATTEMPTS) {
+      const retryDelay = MISSED_TURN_COMPLETION_RETRY_BASE_MS
+        * (2 ** (recovery.attempt - 1));
+      this.scheduleMissedTurnCompletionRecovery(recovery, retryDelay);
+      return;
+    }
+
+    this.cancelMissedTurnCompletionRecovery();
+    this.finishError(
+      recovery.run,
+      'provider',
+      'Codex became idle, but its completed turn could not be recovered.',
+      true,
+    );
+  }
+
+  private isCompletionRecoveryCurrent(
+    recovery: CompletionRecovery,
+  ): boolean {
+    const { run, generation } = recovery;
+    return (
+      this.completionRecovery === recovery
+      && this.activeRun === run
+      && !run.isTerminal
+      && !run.isCancellationRequested
+      && generation === this.lifecycleGeneration
+    );
   }
 
   private replayRecoveredTurnItems(
@@ -905,6 +979,13 @@ export class CodexExecutionSession
         nativeTurnId,
       });
       this.flushPendingTurnNotifications(run);
+      const recovery = this.completionRecovery;
+      if (recovery?.run === run) {
+        this.scheduleMissedTurnCompletionRecovery(
+          recovery,
+          MISSED_TURN_COMPLETION_GRACE_MS,
+        );
+      }
     }
     return true;
   }

--- a/src/providers/codex/execution/CodexExecutionSession.ts
+++ b/src/providers/codex/execution/CodexExecutionSession.ts
@@ -56,9 +56,11 @@ import type {
   ServerRequestResolvedNotification,
   ThreadCompactStartResult,
   ThreadForkResult,
+  ThreadReadResult,
   ThreadResumeResult,
   ThreadRollbackResult,
   ThreadStartResult,
+  ThreadStatusChangedNotification,
   TurnCompletedNotification,
   TurnStartedNotification,
   TurnStartResult,
@@ -99,6 +101,8 @@ const PASSIVE_INSTRUCTIONS =
 const LEGACY_WORKSPACE_DEPENDENCY_INSTRUCTIONS =
   'This thread predates Claudian client-hosted workspace dependency tools. Do not emulate load_workspace_dependencies or install replacement dependencies.';
 const CODEX_SUPPORTS_EXACT_BUILT_IN_TOOL_ALLOW_LIST = false;
+const MISSED_TURN_COMPLETION_GRACE_MS = 1_000;
+const THREAD_READ_RECOVERY_TIMEOUT_MS = 5_000;
 const CODEX_CONSUMED_FORK_STATE_KEYS = [
   'forkSource',
   'forkSourceSessionFilePath',
@@ -279,6 +283,7 @@ export class CodexExecutionSession
   private forkIdentityPromise: Promise<CodexPendingForkTarget> | null = null;
   private forkSetupPromise: Promise<CodexEnsuredThread> | null = null;
   private disposePromise: Promise<void> | null = null;
+  private completionRecoveryTimer: number | null = null;
   private disposed = false;
   private lifecycleGeneration = 0;
 
@@ -749,6 +754,17 @@ export class CodexExecutionSession
       return;
     }
 
+    if (method === 'thread/status/changed') {
+      const changed = params as ThreadStatusChangedNotification;
+      if (changed.threadId !== run.nativeThreadId) return;
+      if (changed.status.type === 'idle') {
+        this.scheduleMissedTurnCompletionRecovery(run);
+      } else {
+        this.cancelMissedTurnCompletionRecovery();
+      }
+      return;
+    }
+
     const scope = extractNotificationScope(method, params);
     if (scope) {
       if (!this.observeNativeTurn(scope.threadId, scope.turnId)) return;
@@ -764,6 +780,7 @@ export class CodexExecutionSession
     }
 
     if (method === 'turn/completed') {
+      this.cancelMissedTurnCompletionRecovery();
       const completed = params as TurnCompletedNotification;
       run.completion = {
         status: completed.turn.status === 'inProgress'
@@ -776,6 +793,83 @@ export class CodexExecutionSession
       };
     }
     this.notificationRouter?.handleNotification(method, params);
+  }
+
+  private scheduleMissedTurnCompletionRecovery(run: CodexExecutionRun): void {
+    if (
+      this.completionRecoveryTimer
+      || !run.nativeThreadId
+      || !run.nativeTurnId
+    ) {
+      return;
+    }
+    const generation = this.lifecycleGeneration;
+    this.completionRecoveryTimer = window.setTimeout(() => {
+      this.completionRecoveryTimer = null;
+      void this.recoverMissedTurnCompletion(run, generation);
+    }, MISSED_TURN_COMPLETION_GRACE_MS);
+  }
+
+  private cancelMissedTurnCompletionRecovery(): void {
+    if (!this.completionRecoveryTimer) return;
+    window.clearTimeout(this.completionRecoveryTimer);
+    this.completionRecoveryTimer = null;
+  }
+
+  private async recoverMissedTurnCompletion(
+    run: CodexExecutionRun,
+    generation: number,
+  ): Promise<void> {
+    const transport = this.transport;
+    const threadId = run.nativeThreadId;
+    const turnId = run.nativeTurnId;
+    if (
+      !transport
+      || !threadId
+      || !turnId
+      || this.activeRun !== run
+      || run.isTerminal
+      || run.isCancellationRequested
+      || generation !== this.lifecycleGeneration
+    ) {
+      return;
+    }
+
+    let result: ThreadReadResult;
+    try {
+      result = await transport.request<ThreadReadResult>(
+        'thread/read',
+        { threadId, includeTurns: true },
+        THREAD_READ_RECOVERY_TIMEOUT_MS,
+      );
+    } catch {
+      return;
+    }
+    if (
+      this.activeRun !== run
+      || run.isTerminal
+      || run.isCancellationRequested
+      || generation !== this.lifecycleGeneration
+    ) {
+      return;
+    }
+    const turn = result.thread.turns.find(candidate => candidate.id === turnId);
+    if (!turn || turn.status === 'inProgress') return;
+    this.replayRecoveredTurnItems(threadId, turn);
+    this.handleNotification('turn/completed', { threadId, turn });
+  }
+
+  private replayRecoveredTurnItems(
+    threadId: string,
+    turn: ThreadReadResult['thread']['turns'][number],
+  ): void {
+    for (const item of turn.items) {
+      this.handleNotification('item/completed', {
+        threadId,
+        turnId: turn.id,
+        item,
+      });
+    }
   }
 
   private observeNativeTurn(threadId: string, nativeTurnId: string): boolean {
@@ -1201,6 +1295,7 @@ export class CodexExecutionSession
 
   private cancelRun(run: CodexExecutionRun): void {
     if (this.activeRun !== run || run.isTerminal) return;
+    this.cancelMissedTurnCompletionRecovery();
     this.lifecycleGeneration += 1;
     this.serverRequestRouter.abortAll('cancelled');
     const transport = this.transport;
@@ -1288,6 +1383,7 @@ export class CodexExecutionSession
   }
 
   private releaseRun(run: CodexExecutionRun): void {
+    this.cancelMissedTurnCompletionRecovery();
     this.notificationRouter?.endTurn();
     this.notificationRouter = null;
     this.pendingTurnNotifications = [];

--- a/src/providers/codex/execution/CodexExecutionSession.ts
+++ b/src/providers/codex/execution/CodexExecutionSession.ts
@@ -767,6 +767,10 @@ export class CodexExecutionSession
 
     const scope = extractNotificationScope(method, params);
     if (scope) {
+      if (!run.nativeTurnId) {
+        this.pendingTurnNotifications.push({ method, params });
+        return;
+      }
       if (!this.observeNativeTurn(scope.threadId, scope.turnId)) return;
       if (
         scope.threadId !== run.nativeThreadId

--- a/src/providers/codex/runtime/CodexNotificationRouter.ts
+++ b/src/providers/codex/runtime/CodexNotificationRouter.ts
@@ -112,7 +112,7 @@ export class CodexNotificationRouter {
   private sawPlanDelta = false;
   private startedUserMessageIds = new Set<string>();
   private startedAgentMessageIds = new Set<string>();
-  private agentMessageDeltaIds = new Set<string>();
+  private streamedAgentMessageTextById = new Map<string, string>();
   private emittedMemoryCitationIds = new Set<string>();
   private emittedMemoryCitationKeys = new Set<string>();
   private streamedAssistantTurnText = '';
@@ -208,7 +208,7 @@ export class CodexNotificationRouter {
     this.sawPlanDelta = false;
     this.startedUserMessageIds.clear();
     this.startedAgentMessageIds.clear();
-    this.agentMessageDeltaIds.clear();
+    this.streamedAgentMessageTextById.clear();
     this.emittedMemoryCitationIds.clear();
     this.emittedMemoryCitationKeys.clear();
     this.resetAssistantTextTracking();
@@ -248,7 +248,7 @@ export class CodexNotificationRouter {
     this.sawPlanDelta = false;
     this.startedUserMessageIds.clear();
     this.startedAgentMessageIds.clear();
-    this.agentMessageDeltaIds.clear();
+    this.streamedAgentMessageTextById.clear();
     this.emittedMemoryCitationIds.clear();
     this.emittedMemoryCitationKeys.clear();
     this.resetAssistantTextTracking();
@@ -338,7 +338,8 @@ export class CodexNotificationRouter {
   }
 
   private onAgentMessageDelta(params: AgentMessageDeltaNotification): void {
-    this.agentMessageDeltaIds.add(params.itemId);
+    const previousText = this.streamedAgentMessageTextById.get(params.itemId) ?? '';
+    this.streamedAgentMessageTextById.set(params.itemId, previousText + params.delta);
     this.appendAssistantText(params.delta, params.itemId);
     this.emit({ type: 'text', content: params.delta });
   }
@@ -950,17 +951,37 @@ export class CodexNotificationRouter {
 
   private emitMissingAssistantSegmentText(text: string, itemId?: string): void {
     this.claimAssistantSegment(itemId);
+    const segmentId = itemId ?? this.currentAssistantSegmentId;
     const missingText = normalizeAgentMessageCompletionText(
       text,
       this.currentAssistantSegmentText,
     );
     if (text) {
       this.currentAssistantSegmentText = text;
+      if (segmentId) {
+        this.streamedAgentMessageTextById.set(segmentId, text);
+      }
     }
     if (!missingText) {
       return;
     }
 
+    this.streamedAssistantTurnText += missingText;
+    this.emit({ type: 'text', content: missingText });
+  }
+
+  private emitMissingAgentMessageText(text: string, itemId: string): void {
+    const streamedText = this.streamedAgentMessageTextById.get(itemId) ?? '';
+    const missingText = normalizeAgentMessageCompletionText(text, streamedText);
+    if (text) {
+      this.streamedAgentMessageTextById.set(itemId, text);
+    }
+    if (!missingText) {
+      return;
+    }
+
+    this.claimAssistantSegment(itemId);
+    this.currentAssistantSegmentText = text;
     this.streamedAssistantTurnText += missingText;
     this.emit({ type: 'text', content: missingText });
   }
@@ -976,6 +997,12 @@ export class CodexNotificationRouter {
 
     this.streamedAssistantTurnText += missingText;
     this.currentAssistantSegmentText += missingText;
+    if (this.currentAssistantSegmentId) {
+      this.streamedAgentMessageTextById.set(
+        this.currentAssistantSegmentId,
+        this.currentAssistantSegmentText,
+      );
+    }
     this.emit({ type: 'text', content: missingText });
   }
 
@@ -1715,8 +1742,8 @@ export class CodexNotificationRouter {
     }
 
     const visibleText = stripCodexMemoryCitationMarkup(item.text);
-    if (!this.agentMessageDeltaIds.has(item.id) && visibleText) {
-      this.emitMissingAssistantSegmentText(visibleText, item.id);
+    if (visibleText) {
+      this.emitMissingAgentMessageText(visibleText, item.id);
     }
 
     this.emitMemoryCitation(item.memoryCitation, item.id);

--- a/src/providers/codex/runtime/codexAppServerTypes.ts
+++ b/src/providers/codex/runtime/codexAppServerTypes.ts
@@ -429,6 +429,10 @@ export interface ThreadStartResult {
   reasoningEffort: string;
 }
 
+export interface ThreadReadResult {
+  thread: Thread;
+}
+
 export type SandboxPolicy =
   | { type: 'dangerFullAccess' }
   | {

--- a/tests/unit/providers/codex/execution/CodexExecutionBackend.test.ts
+++ b/tests/unit/providers/codex/execution/CodexExecutionBackend.test.ts
@@ -587,6 +587,275 @@ describe('CodexExecutionBackend', () => {
     }
   });
 
+  it('recovers when the idle status arrives before turn acknowledgement', async () => {
+    jest.useFakeTimers();
+    const threadId = 'thread-idle-before-ack';
+    const turnId = 'turn-idle-before-ack';
+    const turnStart = createDeferred<ReturnType<typeof createTurnResult>>();
+    mockTransportRequest.mockImplementation(async (method: string) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'test',
+          codexHome: '/tmp/.codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'thread/start') return createThreadResult(threadId);
+      if (method === 'turn/start') return turnStart.promise;
+      if (method === 'thread/read') {
+        return createThreadResult(threadId, [{
+          id: turnId,
+          items: [{
+            type: 'agentMessage',
+            id: 'assistant-idle-before-ack',
+            text: 'Recovered after acknowledgement.',
+            phase: 'final',
+            memoryCitation: null,
+          }],
+        }]);
+      }
+      if (method === 'turn/interrupt') return {};
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    const session = new CodexExecutionBackend(createPlugin())
+      .createSession(createSessionConfig());
+    const run = session.execute(createRequest());
+    const eventsPromise = collectEvents(run.events);
+
+    try {
+      await waitForCondition(() => mockTransportRequest.mock.calls.some(
+        ([method]) => method === 'turn/start',
+      ));
+      emitNotification('thread/status/changed', {
+        threadId,
+        status: { type: 'idle' },
+      });
+      turnStart.resolve(createTurnResult(turnId));
+      await flushMicrotasks();
+      await jest.advanceTimersByTimeAsync(5_000);
+
+      expect(mockTransportRequest).toHaveBeenCalledWith(
+        'thread/read',
+        { threadId, includeTurns: true },
+        expect.any(Number),
+      );
+      expect((await eventsPromise).at(-1)).toMatchObject({
+        nativeCheckpointId: turnId,
+        type: 'turn_completed',
+      });
+    } finally {
+      run.cancel();
+      await eventsPromise;
+      await session.dispose();
+      jest.useRealTimers();
+    }
+  });
+
+  it('retries stale recovery reads and reconciles partial assistant text once', async () => {
+    jest.useFakeTimers();
+    const threadId = 'thread-recovery-retry';
+    const turnId = 'turn-recovery-retry';
+    let readAttempt = 0;
+    const assistantItem = {
+      type: 'agentMessage',
+      id: 'assistant-recovery-retry',
+      text: 'Recovered response.',
+      phase: 'final',
+      memoryCitation: null,
+    };
+    mockTransportRequest.mockImplementation(async (method: string) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'test',
+          codexHome: '/tmp/.codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'thread/start') return createThreadResult(threadId);
+      if (method === 'turn/start') return createTurnResult(turnId);
+      if (method === 'thread/read') {
+        readAttempt += 1;
+        if (readAttempt === 1) return createThreadResult(threadId);
+        if (readAttempt === 2) {
+          return createThreadResult(threadId, [{
+            id: turnId,
+            items: [assistantItem],
+            status: 'inProgress',
+          }]);
+        }
+        return createThreadResult(threadId, [{
+          id: turnId,
+          items: [assistantItem],
+        }]);
+      }
+      if (method === 'turn/interrupt') return {};
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    const session = new CodexExecutionBackend(createPlugin())
+      .createSession(createSessionConfig());
+    const run = session.execute(createRequest());
+    const eventsPromise = collectEvents(run.events);
+
+    try {
+      await waitForCondition(() => mockTransportRequest.mock.calls.some(
+        ([method]) => method === 'turn/start',
+      ));
+      emitNotification('item/started', {
+        threadId,
+        turnId,
+        item: assistantItem,
+      });
+      emitNotification('item/agentMessage/delta', {
+        threadId,
+        turnId,
+        itemId: assistantItem.id,
+        delta: 'Recovered ',
+      });
+      emitNotification('thread/status/changed', {
+        threadId,
+        status: { type: 'idle' },
+      });
+      await jest.advanceTimersByTimeAsync(10_000);
+
+      const events = await eventsPromise;
+      expect(readAttempt).toBe(3);
+      expect(events
+        .filter((event): event is Extract<ProviderExecutionEvent, { type: 'text_delta' }> => (
+          event.type === 'text_delta'
+        ))
+        .map(event => event.text)
+        .join('')).toBe('Recovered response.');
+      expect(events.at(-1)).toMatchObject({
+        nativeCheckpointId: turnId,
+        type: 'turn_completed',
+      });
+    } finally {
+      run.cancel();
+      await eventsPromise;
+      await session.dispose();
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not overlap recovery reads when idle is reported repeatedly', async () => {
+    jest.useFakeTimers();
+    const threadId = 'thread-repeated-idle';
+    const turnId = 'turn-repeated-idle';
+    const threadRead = createDeferred<ReturnType<typeof createThreadResult>>();
+    let readAttempt = 0;
+    mockTransportRequest.mockImplementation(async (method: string) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'test',
+          codexHome: '/tmp/.codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'thread/start') return createThreadResult(threadId);
+      if (method === 'turn/start') return createTurnResult(turnId);
+      if (method === 'thread/read') {
+        readAttempt += 1;
+        return threadRead.promise;
+      }
+      if (method === 'turn/interrupt') return {};
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    const session = new CodexExecutionBackend(createPlugin())
+      .createSession(createSessionConfig());
+    const run = session.execute(createRequest());
+    const eventsPromise = collectEvents(run.events);
+
+    try {
+      await waitForCondition(() => mockTransportRequest.mock.calls.some(
+        ([method]) => method === 'turn/start',
+      ));
+      emitNotification('thread/status/changed', {
+        threadId,
+        status: { type: 'idle' },
+      });
+      await jest.advanceTimersByTimeAsync(1_000);
+      emitNotification('thread/status/changed', {
+        threadId,
+        status: { type: 'idle' },
+      });
+      await jest.advanceTimersByTimeAsync(1_000);
+
+      expect(readAttempt).toBe(1);
+      threadRead.resolve(createThreadResult(threadId, [{ id: turnId }]));
+      await flushMicrotasks();
+      expect((await eventsPromise).at(-1)).toMatchObject({
+        nativeCheckpointId: turnId,
+        type: 'turn_completed',
+      });
+    } finally {
+      run.cancel();
+      threadRead.resolve(createThreadResult(threadId, [{ id: turnId }]));
+      await eventsPromise;
+      await session.dispose();
+      jest.useRealTimers();
+    }
+  });
+
+  it('fails recoverably after bounded completion recovery failures', async () => {
+    jest.useFakeTimers();
+    const threadId = 'thread-recovery-failure';
+    const turnId = 'turn-recovery-failure';
+    let readAttempt = 0;
+    mockTransportRequest.mockImplementation(async (method: string) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'test',
+          codexHome: '/tmp/.codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'thread/start') return createThreadResult(threadId);
+      if (method === 'turn/start') return createTurnResult(turnId);
+      if (method === 'thread/read') {
+        readAttempt += 1;
+        throw new Error('thread/read unavailable');
+      }
+      if (method === 'turn/interrupt') return {};
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    const session = new CodexExecutionBackend(createPlugin())
+      .createSession(createSessionConfig());
+    const run = session.execute(createRequest());
+    const eventsPromise = collectEvents(run.events);
+
+    try {
+      await waitForCondition(() => mockTransportRequest.mock.calls.some(
+        ([method]) => method === 'turn/start',
+      ));
+      emitNotification('thread/status/changed', {
+        threadId,
+        status: { type: 'idle' },
+      });
+      await jest.advanceTimersByTimeAsync(10_000);
+
+      expect(session.getStatus()).toBe('idle');
+      expect(readAttempt).toBe(3);
+      expect((await eventsPromise).at(-1)).toMatchObject({
+        category: 'provider',
+        recoverable: true,
+        type: 'execution_error',
+      });
+    } finally {
+      run.cancel();
+      await eventsPromise;
+      await session.dispose();
+      jest.useRealTimers();
+    }
+  });
+
   it('does not recover when the terminal notification arrives during the grace period', async () => {
     jest.useFakeTimers();
     const threadId = 'thread-normal-completion';

--- a/tests/unit/providers/codex/execution/CodexExecutionBackend.test.ts
+++ b/tests/unit/providers/codex/execution/CodexExecutionBackend.test.ts
@@ -116,7 +116,15 @@ function emitNotification(method: string, params: unknown): void {
   notificationHandlers.get(method)?.(params);
 }
 
-function createThreadResult(threadId: string, turns: Array<{ id: string }> = []) {
+function createThreadResult(
+  threadId: string,
+  turns: Array<{
+    id: string;
+    error?: unknown;
+    items?: unknown[];
+    status?: 'completed' | 'failed' | 'inProgress' | 'interrupted';
+  }> = [],
+) {
   return {
     thread: {
       id: threadId,
@@ -126,9 +134,9 @@ function createThreadResult(threadId: string, turns: Array<{ id: string }> = [])
       status: { type: 'idle' },
       turns: turns.map(turn => ({
         ...turn,
-        items: [],
-        status: 'completed',
-        error: null,
+        items: turn.items ?? [],
+        status: turn.status ?? 'completed',
+        error: turn.error ?? null,
       })),
       cwd: '/vault',
       cliVersion: '0.146.0',
@@ -491,6 +499,131 @@ describe('CodexExecutionBackend', () => {
     }));
 
     await session.dispose();
+  });
+
+
+  it('recovers a completed turn when the terminal notification is missed', async () => {
+    jest.useFakeTimers();
+    const threadId = 'thread-missed-completion';
+    const turnId = 'turn-missed-completion';
+    mockTransportRequest.mockImplementation(async (method: string) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'test',
+          codexHome: '/tmp/.codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'thread/start') return createThreadResult(threadId);
+      if (method === 'turn/start') return createTurnResult(turnId);
+      if (method === 'thread/read') {
+        return createThreadResult(threadId, [{
+          id: turnId,
+          items: [
+            {
+              type: 'agentMessage',
+              id: 'assistant-recovered',
+              text: 'Recovered response.',
+              phase: 'final',
+              memoryCitation: null,
+            },
+          ],
+        }]);
+      }
+      if (method === 'turn/interrupt') return {};
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    const session = new CodexExecutionBackend(createPlugin())
+      .createSession(createSessionConfig());
+    const run = session.execute(createRequest());
+    const eventsPromise = collectEvents(run.events);
+
+    try {
+      await waitForCondition(() => mockTransportRequest.mock.calls.some(
+        ([method]) => method === 'turn/start',
+      ));
+      emitNotification('thread/status/changed', {
+        threadId,
+        status: { type: 'idle' },
+      });
+      await jest.advanceTimersByTimeAsync(5_000);
+
+      expect(mockTransportRequest).toHaveBeenCalledWith(
+        'thread/read',
+        { threadId, includeTurns: true },
+        expect.any(Number),
+      );
+      const events = await eventsPromise;
+      expect(events).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          nativeAssistantId: 'assistant-recovered',
+          type: 'assistant_message_started',
+        }),
+        expect.objectContaining({ text: 'Recovered response.', type: 'text_delta' }),
+      ]));
+      expect(events.at(-1)).toMatchObject({
+        nativeCheckpointId: turnId,
+        type: 'turn_completed',
+      });
+    } finally {
+      run.cancel();
+      await eventsPromise;
+      await session.dispose();
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not recover when the terminal notification arrives during the grace period', async () => {
+    jest.useFakeTimers();
+    const threadId = 'thread-normal-completion';
+    const turnId = 'turn-normal-completion';
+    mockTransportRequest.mockImplementation(async (method: string) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'test',
+          codexHome: '/tmp/.codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'thread/start') return createThreadResult(threadId);
+      if (method === 'turn/start') return createTurnResult(turnId);
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    const session = new CodexExecutionBackend(createPlugin())
+      .createSession(createSessionConfig());
+    const run = session.execute(createRequest());
+    const eventsPromise = collectEvents(run.events);
+
+    try {
+      await waitForCondition(() => mockTransportRequest.mock.calls.some(
+        ([method]) => method === 'turn/start',
+      ));
+      emitNotification('thread/status/changed', {
+        threadId,
+        status: { type: 'idle' },
+      });
+      completeTurn(threadId, turnId);
+      await jest.advanceTimersByTimeAsync(5_000);
+
+      expect(mockTransportRequest).not.toHaveBeenCalledWith(
+        'thread/read',
+        expect.anything(),
+        expect.anything(),
+      );
+      expect((await eventsPromise).at(-1)).toMatchObject({
+        nativeCheckpointId: turnId,
+        type: 'turn_completed',
+      });
+    } finally {
+      run.cancel();
+      await eventsPromise;
+      await session.dispose();
+      jest.useRealTimers();
+    }
   });
 
   it('sends all attached context using canonical escaped XML', async () => {

--- a/tests/unit/providers/codex/execution/CodexExecutionBackend.test.ts
+++ b/tests/unit/providers/codex/execution/CodexExecutionBackend.test.ts
@@ -339,6 +339,18 @@ async function collectEvents(
   return result;
 }
 
+async function collectUntil(
+  events: AsyncIterable<ProviderExecutionEvent>,
+  predicate: (event: ProviderExecutionEvent) => boolean,
+): Promise<ProviderExecutionEvent[]> {
+  const result: ProviderExecutionEvent[] = [];
+  for await (const event of events) {
+    result.push(event);
+    if (predicate(event)) break;
+  }
+  return result;
+}
+
 function completeTurn(threadId: string, turnId: string): void {
   emitNotification('turn/completed', {
     threadId,
@@ -967,6 +979,67 @@ describe('CodexExecutionBackend', () => {
     await session.dispose();
   });
 
+  it('does not bind a new run to a late scoped notification from the previous turn', async () => {
+    const threadId = 'thread-late-previous-scope';
+    const firstTurnId = 'turn-previous';
+    const secondTurnId = 'turn-current';
+    let turnAttempt = 0;
+    const secondTurnStart = createDeferred<ReturnType<typeof createTurnResult>>();
+    mockTransportRequest.mockImplementation(async (method: string) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'test',
+          codexHome: '/tmp/.codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'thread/start') return createThreadResult(threadId);
+      if (method === 'turn/start') {
+        turnAttempt += 1;
+        if (turnAttempt === 1) {
+          queueMicrotask(() => completeTurn(threadId, firstTurnId));
+          return createTurnResult(firstTurnId);
+        }
+
+        emitNotification('thread/tokenUsage/updated', {
+          threadId,
+          turnId: firstTurnId,
+          tokenUsage: {
+            last: { inputTokens: 1, cachedInputTokens: 0 },
+            modelContextWindow: 100,
+          },
+        });
+        return secondTurnStart.promise;
+      }
+      if (method === 'turn/interrupt') return {};
+      throw new Error(`Unexpected method: ${method}`);
+    });
+
+    const session = new CodexExecutionBackend(createPlugin())
+      .createSession(createSessionConfig());
+    try {
+      await collectEvents(session.execute(createRequest()).events);
+
+      const secondRun = session.execute(createRequest());
+      const secondTurnStartedPromise = collectUntil(
+        secondRun.events,
+        event => event.type === 'turn_started',
+      );
+      await waitForCondition(() => turnAttempt === 2);
+      secondTurnStart.resolve(createTurnResult(secondTurnId));
+
+      await expect(secondTurnStartedPromise).resolves.toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          accepted: true,
+          nativeTurnId: secondTurnId,
+          type: 'turn_started',
+        }),
+      ]));
+    } finally {
+      await session.dispose();
+    }
+  });
   it('persists native context when cancellation races a turn-start acknowledgement', async () => {
     const controller = new AbortController();
     let turnAttempt = 0;

--- a/tests/unit/providers/codex/runtime/CodexNotificationRouter.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexNotificationRouter.test.ts
@@ -65,6 +65,89 @@ describe('CodexNotificationRouter', () => {
       ]);
     });
 
+    it('emits only the missing suffix from a completed agent message', () => {
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'agentMessage',
+          id: 'msg1',
+          text: '',
+          phase: 'streaming',
+          memoryCitation: null,
+        },
+      });
+      router.handleNotification('item/agentMessage/delta', {
+        threadId: 't1',
+        turnId: 'turn1',
+        itemId: 'msg1',
+        delta: 'Hel',
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'agentMessage',
+          id: 'msg1',
+          text: 'Hello',
+          phase: 'final',
+          memoryCitation: null,
+        },
+      });
+
+      expect(chunks).toEqual([
+        { type: 'assistant_message_start', itemId: 'msg1' },
+        { type: 'text', content: 'Hel' },
+        { type: 'text', content: 'lo' },
+      ]);
+    });
+
+    it('does not repeat an earlier completed agent message after segment changes', () => {
+      const startAgentMessage = (itemId: string) => {
+        router.handleNotification('item/started', {
+          threadId: 't1',
+          turnId: 'turn1',
+          item: {
+            type: 'agentMessage',
+            id: itemId,
+            text: '',
+            phase: 'streaming',
+            memoryCitation: null,
+          },
+        });
+      };
+      startAgentMessage('msg1');
+      router.handleNotification('item/agentMessage/delta', {
+        threadId: 't1',
+        turnId: 'turn1',
+        itemId: 'msg1',
+        delta: 'First',
+      });
+      startAgentMessage('msg2');
+      router.handleNotification('item/agentMessage/delta', {
+        threadId: 't1',
+        turnId: 'turn1',
+        itemId: 'msg2',
+        delta: 'Second',
+      });
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'agentMessage',
+          id: 'msg1',
+          text: 'First',
+          phase: 'final',
+          memoryCitation: null,
+        },
+      });
+
+      expect(chunks.filter(chunk => chunk.type === 'text')).toEqual([
+        { type: 'text', content: 'First' },
+        { type: 'text', content: 'Second' },
+      ]);
+    });
+
     it('does not append raw memory citation markup after streamed text', () => {
       router.handleNotification('item/agentMessage/delta', {
         threadId: 't1',


### PR DESCRIPTION
## Why

Codex live responses can get stuck or display stale content in Obsidian after startup.

This affects Codex CLI users when app-server notifications arrive out of order: the model has already produced a response, but Claudian may either not render the recovered assistant text or may bind the active run to a previous native turn. In practice, the first prompt after startup could appear blank or show the previous prompt's response, and users had to send a throwaway message or reload Obsidian to recover.

No separate issue is linked; this was found while testing Codex CLI live rendering.

Note: this builds on the missed turn-completion recovery direction from #1053, with additional handling for recovered assistant items and stale scoped notifications.

## What Changed

- Added `ThreadReadResult` typing for Codex `thread/read`.
- When Codex reports a thread as idle but the terminal `turn/completed` notification was missed, Claudian now reads the thread and recovers the completed turn.
- Recovered turn items are replayed through the normal live notification path before synthesizing `turn/completed`, so assistant text is rendered instead of ending an empty response.
- Scoped notifications are buffered until the current native turn is confirmed by `turn/started` or `turn/start`, preventing late notifications from a previous turn from binding the active run to stale output.
- Added regression tests for missed completion recovery and stale scoped notification ordering.

## Why This Approach

This keeps live rendering driven by Codex app-server notifications and uses `thread/read` only as a targeted recovery mechanism when the server indicates the thread has gone idle without a terminal turn notification.

Replaying recovered items through the existing notification router avoids creating a separate history-rendering path and preserves the current projection behavior for assistant messages, tools, citations, and turn metadata.

Buffering scoped notifications before turn acknowledgement is a narrow fence against stale native turn IDs. The alternative would be to trust any scoped notification as proof of the active turn, but Codex can emit late usage/item notifications from a previous turn during startup or resume, which caused stale responses to render.

## Validation

- `npm run test:unit -- --runTestsByPath tests/unit/providers/codex/execution/CodexExecutionBackend.test.ts --runInBand`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

Manual check:
- Built the plugin and copied the generated files into the Obsidian plugin folder.
- Verified Codex no longer needs a throwaway first prompt after startup in the tested local setup.

## Impact and Follow-ups

Compatibility risk is low. The change is scoped to the Codex provider's app-server execution path.

`thread/read` is only used after an idle status when a terminal completion notification may have been missed. Provider-native transcript files remain read-only and are not used for live polling.

Known limitation: this does not change Codex CLI behavior itself; it only makes Claudian resilient to notification ordering and missed terminal events.

Follow-ups: None.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.