### PR TITLE
Keep the sidebar footer compact and always visible

### DIFF
--- a/src/style/components/history.css
+++ b/src/style/components/history.css
@@ -3,9 +3,6 @@
 }
 
 .claudian-session-sidebar {
-  --claudian-sidebar-surface-footer-height: 40px;
-
-  position: relative;
   display: none;
   flex: 0 0 var(--claudian-session-sidebar-width, 240px);
   flex-direction: column;
@@ -58,36 +55,14 @@
 }
 
 .claudian-sidebar-surface-switcher {
-  position: absolute;
-  inset-inline: 0;
-  bottom: 0;
-  z-index: 5;
   display: flex;
+  flex: 0 0 28px;
   align-items: center;
   justify-content: center;
   box-sizing: border-box;
-  height: var(--claudian-sidebar-surface-footer-height);
   gap: 14px;
-  padding: 8px 12px 12px;
+  padding: 4px 12px;
   background: transparent;
-  opacity: 0;
-  transition: opacity 0.12s ease;
-}
-
-.claudian-sidebar-surface-switcher:hover,
-.claudian-sidebar-surface-switcher:focus-within {
-  opacity: 1;
-}
-
-.claudian-session-sidebar:has(> .claudian-sidebar-surface-switcher:hover)
-  > .claudian-session-surface,
-.claudian-session-sidebar:has(> .claudian-sidebar-surface-switcher:hover)
-  > .claudian-files-surface,
-.claudian-session-sidebar:has(> .claudian-sidebar-surface-switcher:focus-within)
-  > .claudian-session-surface,
-.claudian-session-sidebar:has(> .claudian-sidebar-surface-switcher:focus-within)
-  > .claudian-files-surface {
-  clip-path: inset(0 0 var(--claudian-sidebar-surface-footer-height) 0);
 }
 
 .claudian-session-sidebar .claudian-sidebar-surface-button {
@@ -113,8 +88,8 @@
 }
 
 .claudian-session-sidebar .claudian-sidebar-surface-button::before {
-  width: 8px;
-  height: 8px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
   background: currentColor;
   content: "";

--- a/tests/unit/style/components/history.test.ts
+++ b/tests/unit/style/components/history.test.ts
@@ -2,17 +2,20 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
 describe('Persistent sidebar surface pager styles', () => {
-  it('reveals the native sidebar background by clipping content under the footer', () => {
+  it('keeps the sidebar footer visible without overlaying or clipping content', () => {
     const css = readFileSync(path.resolve('src/style/components/history.css'), 'utf8');
 
     expect(css).toMatch(
-      /\.claudian-session-sidebar\s*{[^}]*--claudian-sidebar-surface-footer-height:\s*40px;/,
+      /\.claudian-sidebar-surface-switcher\s*{[^}]*flex:\s*0 0 28px;/,
     );
     expect(css).toMatch(
-      /\.claudian-sidebar-surface-switcher\s*{[^}]*height:\s*var\(--claudian-sidebar-surface-footer-height\);[^}]*background:\s*transparent;/,
+      /\.claudian-session-sidebar \.claudian-sidebar-surface-button::before\s*{[^}]*width:\s*6px;[^}]*height:\s*6px;/,
     );
-    expect(css).toMatch(
-      /\.claudian-session-sidebar:has\(> \.claudian-sidebar-surface-switcher:(?:hover|focus-within)\)[^{]*> \.claudian-(?:session|files)-surface[^{]*{[^}]*clip-path:\s*inset\(0 0 var\(--claudian-sidebar-surface-footer-height\) 0\);/,
+    expect(css).not.toMatch(
+      /\.claudian-sidebar-surface-switcher\s*{[^}]*(?:position:\s*absolute|opacity:\s*0);/,
+    );
+    expect(css).not.toMatch(
+      /\.claudian-session-sidebar:has\([^}]*clip-path:/,
     );
   });
 });


### PR DESCRIPTION
## Why

The sidebar view switcher was hidden until hover and lifted or clipped content, making navigation less discoverable and visually unstable. No issue is needed for this focused UI refinement.

## What Changed

- Keep the switcher in normal flex layout with a compact 28px footer
- Show smaller 6px view indicators at all times
- Remove hover and focus overlay, fade, and content-clipping behavior
- Update the CSS regression test for the persistent layout

## Why This Approach

A fixed flex footer reserves a small, predictable footprint without JavaScript state or browser-specific `:has()` behavior.

## Validation

- `npm run typecheck && npm run lint && npm run test && npm run build`
- 363 test suites and 6,876 tests passed
- Production CSS and plugin bundle built successfully

## Impact and Follow-ups

None.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
