### PR TITLE
fix: keep ordered-list markers visible in user messages

### DIFF
--- a/src/style/components/messages.css
+++ b/src/style/components/messages.css
@@ -57,6 +57,10 @@
   border-end-end-radius: 4px;
 }
 
+.claudian-message-user ol > li::marker {
+  color: inherit;
+}
+
 /* Text selection in user messages - visible highlight */
 .claudian-message-user ::selection {
   background: rgba(255, 255, 255, 0.35);


### PR DESCRIPTION
## Why

Fixes #1082, where Obsidian's default light theme rendered ordered-list markers with almost no contrast against user-message bubbles.

## What Changed

- Made ordered-list markers inside user messages inherit the surrounding message text color.

## Why This Approach

The override is scoped to user-message ordered lists, preserving assistant content and Obsidian's custom unordered-list rendering while remaining theme-aware.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run test` — 363 suites and 6,885 tests passed
- `npm run build`
- `git diff --check`
- Confirmed the generated stylesheet includes the marker override and that its selector outranks Obsidian's default `ol > li::marker` rule

## Impact and Follow-ups

No compatibility or data risks; no automated regression test was added because the repository has no computed-style browser harness for CSS-only behavior.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
