### PR TITLE
fix: Resolve OpenCode database path correctly on Windows

### DIFF
--- a/src/providers/opencode/runtime/OpencodePaths.ts
+++ b/src/providers/opencode/runtime/OpencodePaths.ts
@@ -15,11 +15,6 @@ export function resolveOpencodeDataDir(
   }
 
   const home = env.HOME || os.homedir();
-  if (process.platform === 'win32') {
-    const appData = env.APPDATA || env.LOCALAPPDATA || path.join(home, 'AppData', 'Roaming');
-    return path.join(appData, OPENCODE_APP_NAME);
-  }
-
   return path.join(home, '.local', 'share', OPENCODE_APP_NAME);
 }
 

--- a/tests/unit/providers/opencode/OpencodeConversationHistoryService.test.ts
+++ b/tests/unit/providers/opencode/OpencodeConversationHistoryService.test.ts
@@ -7,6 +7,7 @@ import type { Conversation } from '../../../../src/core/types';
 import { OpencodeConversationHistoryService } from '../../../../src/providers/opencode/history/OpencodeConversationHistoryService';
 
 describe('OpencodeConversationHistoryService', () => {
+  const originalPlatform = process.platform;
   let tmpRoot: string;
 
   beforeEach(() => {
@@ -14,6 +15,7 @@ describe('OpencodeConversationHistoryService', () => {
   });
 
   afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
     rmSync(tmpRoot, { force: true, recursive: true });
   });
 
@@ -146,6 +148,37 @@ describe('OpencodeConversationHistoryService', () => {
     expect(conversation.messages.map(message => message.content)).toEqual(['Trusted prompt']);
     expect(conversation.providerState).toEqual({
       databasePath: trustedPath,
+      futureResumeCursor: { token: 'cursor-1' },
+    });
+  });
+
+  it('replaces a legacy Windows AppData database hint with the home database', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const sessionId = 'session-windows-home';
+    const home = path.join(tmpRoot, 'home');
+    const appData = path.join(home, 'AppData', 'Roaming');
+    const legacyPath = path.join(appData, 'opencode', 'opencode.db');
+    const homePath = path.join(home, '.local', 'share', 'opencode', 'opencode.db');
+    seedDatabase(legacyPath, sessionId, 'Legacy AppData prompt');
+    seedDatabase(homePath, sessionId, 'Current home prompt');
+    const conversation = createConversation(sessionId, legacyPath);
+    conversation.providerState!.futureResumeCursor = { token: 'cursor-1' };
+
+    await new OpencodeConversationHistoryService().hydrateConversationHistory(
+      conversation,
+      null,
+      {
+        environment: {
+          APPDATA: appData,
+          HOME: home,
+          LOCALAPPDATA: path.join(home, 'AppData', 'Local'),
+        },
+      },
+    );
+
+    expect(conversation.messages.map(message => message.content)).toEqual(['Current home prompt']);
+    expect(conversation.providerState).toEqual({
+      databasePath: homePath,
       futureResumeCursor: { token: 'cursor-1' },
     });
   });

--- a/tests/unit/providers/opencode/OpencodePaths.test.ts
+++ b/tests/unit/providers/opencode/OpencodePaths.test.ts
@@ -9,11 +9,52 @@ import {
 } from '../../../../src/providers/opencode/runtime/OpencodePaths';
 
 describe('OpencodePaths', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
   it('prefers XDG data directories for OpenCode data', () => {
     expect(resolveOpencodeDataDir({
       HOME: '/home/tester',
       XDG_DATA_HOME: '/tmp/xdg-data',
     } as NodeJS.ProcessEnv)).toBe('/tmp/xdg-data/opencode');
+  });
+
+  it('uses the home data directory on Windows even when AppData paths are available', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const home = path.join(os.tmpdir(), 'claudian-opencode-home');
+    const env = {
+      APPDATA: path.join(home, 'AppData', 'Roaming'),
+      HOME: home,
+      LOCALAPPDATA: path.join(home, 'AppData', 'Local'),
+    } as NodeJS.ProcessEnv;
+    const expectedDataDir = path.join(home, '.local', 'share', 'opencode');
+
+    expect(resolveOpencodeDataDir(env)).toBe(expectedDataDir);
+    expect(resolveOpencodeDatabasePath(env)).toBe(path.join(expectedDataDir, 'opencode.db'));
+  });
+
+  it('preserves XDG_DATA_HOME and OPENCODE_DB precedence on Windows', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const xdgDataHome = path.join(os.tmpdir(), 'claudian-opencode-xdg');
+    const absoluteDatabasePath = path.join(os.tmpdir(), 'claudian-opencode-custom.db');
+    const env = {
+      APPDATA: path.join(os.tmpdir(), 'claudian-opencode-appdata'),
+      HOME: path.join(os.tmpdir(), 'claudian-opencode-home'),
+      XDG_DATA_HOME: xdgDataHome,
+    } as NodeJS.ProcessEnv;
+
+    expect(resolveOpencodeDataDir(env)).toBe(path.join(xdgDataHome, 'opencode'));
+    expect(resolveOpencodeDatabasePath({
+      ...env,
+      OPENCODE_DB: absoluteDatabasePath,
+    })).toBe(absoluteDatabasePath);
+    expect(resolveOpencodeDatabasePath({
+      ...env,
+      OPENCODE_DB: 'opencode-work.db',
+    })).toBe(path.join(xdgDataHome, 'opencode', 'opencode-work.db'));
   });
 
   it('falls back to the existing resolved database when persisted metadata points at a missing path', () => {


### PR DESCRIPTION
## Why

Update the provider-owned data-directory resolver in `OpencodePaths.ts` so the default Windows root matches OpenCode's `~/.local/share/opencode` convention instead of consulting `APPDATA` or `LOCALAPPDATA`, while preserving explicit environment overrides and existing macOS/Linux behavior. Because launch artifact preparation and history trust validation already consume this shared resolver, the corrected default will both launch new ACP processes against the real database and cause hydration to reject a previously persisted AppData hint, discover the real database, and rewrite provider state. Add focused Windows-platform coverage to the path tests and an end-to-end history-hydration regression that seeds both a stale AppData database and the real home database.

On Windows, Claudian resolves OpenCode's default data directory under `%APPDATA%`, while OpenCode 1.18.15 uses `XDG_DATA_HOME` or the user's `~/.local/share` directory on every platform. Claudian persists the resulting empty AppData database path in `providerState.databasePath`, then supplies it as `OPENCODE_DB` when an interrupted or restarted conversation resumes. The ACP process consequently loads the wrong database and reports `Internal error: OpenCode service failure` because the session is absent. Explicit `OPENCODE_DB` and `XDG_DATA_HOME` overrides must continue to take precedence.

Fixes #1073

## What Changed

Update the provider-owned data-directory resolver in `OpencodePaths.ts` so the default Windows root matches OpenCode's `~/.local/share/opencode` convention instead of consulting `APPDATA` or `LOCALAPPDATA`, while preserving explicit environment overrides and existing macOS/Linux behavior. Because launch artifact preparation and history trust validation already consume this shared resolver, the corrected default will both launch new ACP processes against the real database and cause hydration to reject a previously persisted AppData hint, discover the real database, and rewrite provider state. Add focused Windows-platform coverage to the path tests and an end-to-end history-hydration regression that seeds both a stale AppData database and the real home database.

## Why This Approach

Covered in the summary above.

## Validation

On mocked `win32` with no `XDG_DATA_HOME` or `OPENCODE_DB`, resolving the OpenCode data and database paths uses `<HOME>/.local/share/opencode/opencode.db` even when `APPDATA` and `LOCALAPPDATA` are populated.
On mocked `win32`, an explicit `XDG_DATA_HOME` remains the default data root and an explicit absolute or relative `OPENCODE_DB` retains its existing precedence and resolution behavior.
Hydrating a Windows conversation whose persisted database points to an existing `%APPDATA%/opencode/opencode.db` rejects that legacy hint, reads the matching session from `<HOME>/.local/share/opencode/opencode.db`, and rewrites `providerState.databasePath` without losing unknown provider-owned state.
When neither default database exists, resolution still selects the corrected home-based default so launch artifact preparation can create the database directory at the same location OpenCode expects.

## Impact and Follow-ups

Scoped to the files listed above; no other caller or consumer changes.

## Checklist

- [ ] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [ ] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [ ] I updated user-facing documentation when needed.

AI was used for assistance.
