### PR TITLE
fix: restore runtime context windows for custom Claude models

### DIFF
--- a/src/providers/claude/execution/ClaudeExecutionEventNormalizer.ts
+++ b/src/providers/claude/execution/ClaudeExecutionEventNormalizer.ts
@@ -14,7 +14,7 @@ import type {
   ProviderUserMessageStartedEvent,
   ToolExecutionScope,
 } from '../../../core/execution';
-import type { StreamChunk } from '../../../core/types';
+import type { StreamChunk, UsageInfo } from '../../../core/types';
 import { ClaudeTaskToolNormalizer } from '../normalization/ClaudeTaskToolNormalizer';
 import {
   isAsyncSubagentCompletion,
@@ -29,6 +29,7 @@ import type {
 import {
   createTransformStreamState,
   createTransformUsageState,
+  recalculateClaudeUsageContextWindow,
   transformSDKMessage,
 } from '../stream/transformClaudeMessage';
 
@@ -79,6 +80,11 @@ export type ClaudeNormalizedExecutionEvent =
     readonly providerSessionId?: string;
   }
   | {
+    readonly type: 'context_window';
+    readonly model: string;
+    readonly contextWindow: number;
+  }
+  | {
     readonly type: 'result';
   };
 
@@ -95,6 +101,7 @@ interface NormalizationState {
   readonly usageState: ReturnType<typeof createTransformUsageState>;
   readonly toolScopes: Map<string, ToolIdentity>;
   readonly blockedToolIds: Set<string>;
+  lastUsage: UsageInfo | null;
   assistantStarted: boolean;
   sawStreamText: boolean;
   sawStreamThinking: boolean;
@@ -115,6 +122,7 @@ export class ClaudeExecutionEventNormalizer {
     options: {
       readonly intendedModel?: string;
       readonly customContextLimits?: Record<string, number>;
+      readonly authoritativeContextWindow?: number;
     } = {},
   ): ClaudeNormalizedExecutionEvent[] {
     const state = this.states[channel];
@@ -139,6 +147,34 @@ export class ClaudeExecutionEventNormalizer {
         continue;
       }
       if (isContextWindowEvent(event)) {
+        const model = options.intendedModel ?? state.lastUsage?.model ?? 'sonnet';
+        const authoritativeContextWindow = isFinitePositiveNumber(
+          options.authoritativeContextWindow,
+        )
+          ? options.authoritativeContextWindow
+          : undefined;
+        if (authoritativeContextWindow === undefined) {
+          normalized.push({
+            type: 'context_window',
+            model,
+            contextWindow: event.contextWindow,
+          });
+        }
+        const correctedUsage = this.updateContextWindow(
+          channel,
+          model,
+          options.customContextLimits,
+          authoritativeContextWindow ?? event.contextWindow,
+        );
+        if (correctedUsage) {
+          normalized.push({
+            type: 'output',
+            event: {
+              type: 'usage_updated',
+              usage: correctedUsage,
+            },
+          });
+        }
         continue;
       }
       if (isStreamChunk(event)) {
@@ -160,6 +196,28 @@ export class ClaudeExecutionEventNormalizer {
     return normalized;
   }
 
+  updateContextWindow(
+    channel: ClaudeExecutionEventChannel,
+    model: string,
+    customContextLimits: Record<string, number> | undefined,
+    runtimeContextWindow: number,
+  ): UsageInfo | null {
+    const state = this.states[channel];
+    if (!state.lastUsage || state.lastUsage.model !== model) {
+      return null;
+    }
+    const correctedUsage = recalculateClaudeUsageContextWindow(
+      state.lastUsage,
+      customContextLimits,
+      runtimeContextWindow,
+    );
+    if (sameUsageWindow(state.lastUsage, correctedUsage)) {
+      return null;
+    }
+    state.lastUsage = correctedUsage;
+    return correctedUsage;
+  }
+
   markToolBlocked(
     toolUseId: string,
     channel: ClaudeExecutionEventChannel,
@@ -174,6 +232,7 @@ export class ClaudeExecutionEventNormalizer {
     state.usageState.clear();
     state.toolScopes.clear();
     state.blockedToolIds.clear();
+    state.lastUsage = null;
     state.assistantStarted = false;
     state.sawStreamText = false;
     state.sawStreamThinking = false;
@@ -258,6 +317,7 @@ function createNormalizationState(): NormalizationState {
     usageState: createTransformUsageState(),
     toolScopes: new Map(),
     blockedToolIds: new Set(),
+    lastUsage: null,
     assistantStarted: false,
     sawStreamText: false,
     sawStreamThinking: false,
@@ -353,6 +413,7 @@ function toOutputEvent(
       };
     }
     case 'usage':
+      state.lastUsage = chunk.usage;
       return {
         type: 'usage_updated',
         usage: chunk.usage,
@@ -368,6 +429,16 @@ function toOutputEvent(
         level: chunk.level,
       };
   }
+}
+
+function sameUsageWindow(current: UsageInfo, next: UsageInfo): boolean {
+  return current.contextWindow === next.contextWindow
+    && current.contextWindowIsAuthoritative === next.contextWindowIsAuthoritative
+    && current.percentage === next.percentage;
+}
+
+function isFinitePositiveNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
 }
 
 function normalizeToolStarted(

--- a/src/providers/claude/execution/ClaudeExecutionSession.ts
+++ b/src/providers/claude/execution/ClaudeExecutionSession.ts
@@ -114,6 +114,11 @@ ClaudeExecutionStrategySink {
   private lastAllowedTools: ReadonlySet<string> | null = null;
   private currentPermissionMode: PermissionMode;
   private readonly eventNormalizer = new ClaudeExecutionEventNormalizer();
+  private nativeQuery: Query | null = null;
+  private authoritativeContextWindow: {
+    readonly model: string;
+    readonly contextWindow: number;
+  } | null = null;
 
   constructor(
     private readonly host: ProviderHost,
@@ -454,12 +459,18 @@ ClaudeExecutionStrategySink {
     }
 
     const active = this.activeRun;
+    const intendedModel = this.lastEncodedRequest?.model;
+    const authoritativeContextWindow = intendedModel
+      && this.authoritativeContextWindow?.model === intendedModel
+      ? this.authoritativeContextWindow.contextWindow
+      : undefined;
     const normalizedEvents = this.eventNormalizer.normalize(
       message,
       active ? 'requested' : 'background',
       {
         intendedModel: this.lastEncodedRequest?.model,
         customContextLimits: this.host.settings.customContextLimits,
+        authoritativeContextWindow,
       },
     );
     if (
@@ -555,6 +566,13 @@ ClaudeExecutionStrategySink {
           this.finishBackgroundTurn('provider-ended');
         }
         return;
+      }
+      if (normalized.type === 'context_window') {
+        this.authoritativeContextWindow = {
+          model: normalized.model,
+          contextWindow: normalized.contextWindow,
+        };
+        continue;
       }
       if (normalized.type === 'result') {
         if (this.activeRun) {
@@ -670,6 +688,52 @@ ClaudeExecutionStrategySink {
 
   releaseNativeTurnFence(queryToken: number): void {
     this.suppressedEphemeralQueryTokens.delete(queryToken);
+  }
+
+  handleNativeQueryOpened(query: Query): void {
+    if (this.nativeQuery === query) return;
+    this.nativeQuery = query;
+    this.authoritativeContextWindow = null;
+  }
+
+  handleNativeQueryClosed(query: Query): void {
+    if (this.nativeQuery !== query) return;
+    this.nativeQuery = null;
+    this.authoritativeContextWindow = null;
+  }
+
+  handleAuthoritativeContextWindow(
+    query: Query,
+    model: string,
+    contextWindow: number,
+  ): void {
+    if (
+      this.nativeQuery !== query
+      || !Number.isFinite(contextWindow)
+      || contextWindow <= 0
+    ) {
+      return;
+    }
+    this.authoritativeContextWindow = { model, contextWindow };
+    const channel = this.activeRun
+      ? 'requested'
+      : this.backgroundTurn
+        ? 'background'
+        : null;
+    if (!channel) return;
+    const correctedUsage = this.eventNormalizer.updateContextWindow(
+      channel,
+      model,
+      this.host.settings.customContextLimits,
+      contextWindow,
+    );
+    const target = this.activeRun ?? this.backgroundTurn;
+    if (correctedUsage && target) {
+      this.emitTurnOutput(target, {
+        type: 'usage_updated',
+        usage: correctedUsage,
+      });
+    }
   }
 
   private async startExecution(

--- a/src/providers/claude/execution/ClaudeExecutionStrategies.ts
+++ b/src/providers/claude/execution/ClaudeExecutionStrategies.ts
@@ -23,6 +23,13 @@ export interface ClaudeExecutionStrategySink {
   handleNativeFailure(error: unknown, queryToken: number): void;
   handleNativeEnd(queryToken: number): void;
   releaseNativeTurnFence(queryToken: number): void;
+  handleNativeQueryOpened(query: Query): void;
+  handleNativeQueryClosed(query: Query): void;
+  handleAuthoritativeContextWindow(
+    query: Query,
+    model: string,
+    contextWindow: number,
+  ): void;
   publishCommands(query: Query, queryToken: number): void;
 }
 
@@ -60,6 +67,16 @@ implements ClaudeExecutionStrategy {
   private consumerPromise: Promise<void> | null = null;
   private currentConfig: ClaudeEncodedExecutionRequest | null = null;
   private activeNativeTurn: PersistentNativeTurn | null = null;
+  private authoritativeContextWindow: {
+    readonly query: Query;
+    readonly model: string;
+    readonly contextWindow: number;
+  } | null = null;
+  private contextWindowDiscovery: {
+    readonly query: Query;
+    readonly model: string;
+    readonly promise: Promise<void>;
+  } | null = null;
   private preparingTurnToken: number | null = null;
   private disposed = false;
 
@@ -90,6 +107,7 @@ implements ClaudeExecutionStrategy {
 
       await this.applyDynamicUpdates(request);
       requestSignal?.throwIfAborted();
+      void this.refreshAuthoritativeContextWindow(request.model);
       const message = buildClaudeSDKUserMessage(
         request.prompt,
         this.sink.getProviderSessionId() ?? '',
@@ -162,7 +180,10 @@ implements ClaudeExecutionStrategy {
     this.query = null;
     this.messageChannel = null;
     this.abortController = null;
+    this.authoritativeContextWindow = null;
+    this.contextWindowDiscovery = null;
     if (query) {
+      this.sink.handleNativeQueryClosed(query);
       this.finishNativeTurn(query, {
         type: 'failed',
         error: new Error('Claude persistent query was disposed.'),
@@ -217,6 +238,9 @@ implements ClaudeExecutionStrategy {
     this.messageChannel = messageChannel;
     this.query = query;
     this.currentConfig = request;
+    this.authoritativeContextWindow = null;
+    this.contextWindowDiscovery = null;
+    this.sink.handleNativeQueryOpened(query);
     this.consumerPromise = this.consume(query, queryToken);
   }
 
@@ -240,6 +264,62 @@ implements ClaudeExecutionStrategy {
       if (this.query !== query || this.disposed) return;
     }
     this.currentConfig = request;
+  }
+
+  private refreshAuthoritativeContextWindow(model: string): Promise<void> {
+    const query = this.query;
+    if (!query || typeof query.getContextUsage !== 'function') {
+      return Promise.resolve();
+    }
+    if (
+      this.authoritativeContextWindow?.query === query
+      && this.authoritativeContextWindow.model === model
+    ) {
+      return Promise.resolve();
+    }
+    if (
+      this.contextWindowDiscovery?.query === query
+      && this.contextWindowDiscovery.model === model
+    ) {
+      return this.contextWindowDiscovery.promise;
+    }
+
+    let request: ReturnType<Query['getContextUsage']>;
+    try {
+      request = query.getContextUsage();
+    } catch {
+      return Promise.resolve();
+    }
+    const promise = request
+      .then((contextUsage) => {
+        if (
+          this.query !== query
+          || this.currentConfig?.model !== model
+          || this.disposed
+        ) {
+          return;
+        }
+        const contextWindow = contextUsage.rawMaxTokens;
+        if (!isFinitePositiveNumber(contextWindow)) {
+          return;
+        }
+        this.authoritativeContextWindow = { query, model, contextWindow };
+        this.sink.handleAuthoritativeContextWindow(
+          query,
+          model,
+          contextWindow,
+        );
+      })
+      .catch(() => {
+        // Result model metadata remains the fallback when control discovery fails.
+      })
+      .finally(() => {
+        if (this.contextWindowDiscovery?.promise === promise) {
+          this.contextWindowDiscovery = null;
+        }
+      });
+    this.contextWindowDiscovery = { query, model, promise };
+    return promise;
   }
 
   private async consume(query: Query, queryToken: number): Promise<void> {
@@ -325,6 +405,9 @@ implements ClaudeExecutionStrategy {
     this.messageChannel = null;
     this.abortController = null;
     this.currentConfig = null;
+    this.authoritativeContextWindow = null;
+    this.contextWindowDiscovery = null;
+    this.sink.handleNativeQueryClosed(query);
   }
 }
 
@@ -380,6 +463,7 @@ implements ClaudeExecutionStrategy {
         onQuery: (openedQuery) => {
           query = openedQuery;
           this.activeQuery = openedQuery;
+          this.sink.handleNativeQueryOpened(openedQuery);
           this.sink.markNativeTurnHandedOff(queryToken);
         },
         onMessage: async (message) => {
@@ -408,6 +492,9 @@ implements ClaudeExecutionStrategy {
       }
     } finally {
       if (!query || this.activeQuery === query) {
+        if (query) {
+          this.sink.handleNativeQueryClosed(query);
+        }
         this.activeQuery = null;
         this.activeAbortController = null;
       }
@@ -443,10 +530,15 @@ implements ClaudeExecutionStrategy {
     this.activeAbortController = null;
     this.activeQuery = null;
     if (query) {
+      this.sink.handleNativeQueryClosed(query);
       await query.interrupt().catch(() => undefined);
     }
     await this.turnBarrier.catch(() => undefined);
   }
+}
+
+function isFinitePositiveNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
 }
 
 async function* toSingleMessagePrompt(

--- a/src/providers/claude/stream/transformClaudeMessage.ts
+++ b/src/providers/claude/stream/transformClaudeMessage.ts
@@ -327,24 +327,39 @@ function samePromptUsage(a: PromptUsageSnapshot, b: PromptUsageSnapshot): boolea
 
 function buildUsageInfo(promptUsage: PromptUsageSnapshot, options?: TransformOptions): UsageInfo {
   const model = options?.intendedModel ?? 'sonnet';
-  const contextWindowResolution = resolveContextWindowSize(
-    model,
-    options?.customContextLimits,
-    options?.authoritativeContextWindow,
-  );
-  const { contextWindow } = contextWindowResolution;
-  const percentage = Math.min(100, Math.max(0, Math.round((promptUsage.contextTokens / contextWindow) * 100)));
-
-  return {
+  return recalculateClaudeUsageContextWindow({
     model,
     inputTokens: promptUsage.inputTokens,
     cacheCreationInputTokens: promptUsage.cacheCreationInputTokens,
     cacheReadInputTokens: promptUsage.cacheReadInputTokens,
-    contextWindow,
-    ...(contextWindowResolution.source === 'runtime' ? { contextWindowIsAuthoritative: true } : {}),
+    contextWindow: 0,
     contextTokens: promptUsage.contextTokens,
-    percentage,
+    percentage: 0,
+  }, options?.customContextLimits, options?.authoritativeContextWindow);
+}
+
+export function recalculateClaudeUsageContextWindow(
+  usage: UsageInfo,
+  customContextLimits?: Record<string, number>,
+  runtimeContextWindow?: number,
+): UsageInfo {
+  const contextWindowResolution = resolveContextWindowSize(
+    usage.model ?? 'sonnet',
+    customContextLimits,
+    runtimeContextWindow,
+  );
+  const { contextWindow } = contextWindowResolution;
+  const nextUsage: UsageInfo = {
+    ...usage,
+    contextWindow,
+    percentage: Math.min(100, Math.max(0, Math.round((usage.contextTokens / contextWindow) * 100))),
   };
+  if (contextWindowResolution.source === 'runtime') {
+    nextUsage.contextWindowIsAuthoritative = true;
+  } else {
+    delete nextUsage.contextWindowIsAuthoritative;
+  }
+  return nextUsage;
 }
 
 export function createTransformUsageState(): TransformUsageState {
@@ -597,14 +612,6 @@ export function* transformSDKMessage(
         }
         options.usageState.clear();
       }
-      if (isResultError(message)) {
-        const content = message.errors.filter((e) => e.trim().length > 0).join('\n');
-        yield {
-          type: 'error',
-          content: content || `Result error: ${message.subtype}`,
-        };
-      }
-
       // Usage is now extracted from assistant messages for accuracy (excludes subagent tokens)
       // Result message usage is aggregated across main + subagents, causing inaccurate spikes
 
@@ -614,6 +621,13 @@ export function* transformSDKMessage(
         if (selectedEntry) {
           yield { type: 'context_window', contextWindow: selectedEntry.contextWindow };
         }
+      }
+      if (isResultError(message)) {
+        const content = message.errors.filter((e) => e.trim().length > 0).join('\n');
+        yield {
+          type: 'error',
+          content: content || `Result error: ${message.subtype}`,
+        };
       }
       break;
 

--- a/tests/__mocks__/claude-agent-sdk.ts
+++ b/tests/__mocks__/claude-agent-sdk.ts
@@ -124,6 +124,8 @@ let mockSupportedCommandsImplementation: (() => Promise<Array<{
   description: string;
   argumentHint?: string;
 }>>) | null = null;
+let mockContextUsage: { rawMaxTokens: number } | null = null;
+let mockContextUsageImplementation: (() => Promise<{ rawMaxTokens: number }>) | null = null;
 let lastResponse: (AsyncGenerator<any> & {
   interrupt: jest.Mock;
   setModel: jest.Mock;
@@ -132,6 +134,7 @@ let lastResponse: (AsyncGenerator<any> & {
   applyFlagSettings: jest.Mock;
   setMcpServers: jest.Mock;
   supportedCommands: jest.Mock;
+  getContextUsage: jest.Mock;
 }) | null = null;
 
 // Crash simulation control
@@ -151,6 +154,8 @@ export function resetMockMessages() {
   lastOptions = undefined;
   mockSupportedCommands = [];
   mockSupportedCommandsImplementation = null;
+  mockContextUsage = null;
+  mockContextUsageImplementation = null;
   lastResponse = null;
   shouldThrowOnIteration = false;
   throwAfterChunks = 0;
@@ -171,6 +176,16 @@ export function setMockSupportedCommandsImplementation(
   }>>,
 ) {
   mockSupportedCommandsImplementation = implementation;
+}
+
+export function setMockContextUsage(contextUsage: { rawMaxTokens: number } | null) {
+  mockContextUsage = contextUsage;
+}
+
+export function setMockContextUsageImplementation(
+  implementation: (() => Promise<{ rawMaxTokens: number }>) | null,
+) {
+  mockContextUsageImplementation = implementation;
 }
 
 /**
@@ -243,7 +258,8 @@ function getMessagesForPrompt(): any[] {
 async function* emitMessages(messages: any[], options: Options) {
   let chunksEmitted = 0;
 
-  for (const msg of messages) {
+  for (const pendingMessage of messages) {
+    const msg = await pendingMessage;
     // Check if we should throw (crash simulation)
     if (shouldThrowOnIteration && chunksEmitted >= throwAfterChunks) {
       // Reset for next query (allows recovery to work)
@@ -318,6 +334,7 @@ export function query({ prompt, options }: { prompt: any; options: Options }): A
     applyFlagSettings: jest.Mock;
     setMcpServers: jest.Mock;
     supportedCommands: jest.Mock;
+    getContextUsage: jest.Mock;
   };
   gen.interrupt = jest.fn().mockResolvedValue(undefined);
   // Dynamic update methods for persistent queries
@@ -330,6 +347,13 @@ export function query({ prompt, options }: { prompt: any; options: Options }): A
     mockSupportedCommandsImplementation
       ? mockSupportedCommandsImplementation()
       : Promise.resolve(mockSupportedCommands)
+  ));
+  gen.getContextUsage = jest.fn().mockImplementation(() => (
+    mockContextUsageImplementation
+      ? mockContextUsageImplementation()
+      : mockContextUsage
+      ? Promise.resolve(mockContextUsage)
+      : Promise.reject(new Error('Context usage unavailable'))
   ));
   lastResponse = gen;
 

--- a/tests/unit/providers/claude/execution/ClaudeExecutionBackend.test.ts
+++ b/tests/unit/providers/claude/execution/ClaudeExecutionBackend.test.ts
@@ -39,6 +39,7 @@ const sdkMock = sdkModule as unknown as {
     setPermissionMode: jest.Mock;
     setMcpServers: jest.Mock;
     supportedCommands: jest.Mock;
+    getContextUsage: jest.Mock;
   } | null;
   getQueryCallCount: () => number;
   resetMockMessages: () => void;
@@ -52,6 +53,12 @@ const sdkMock = sdkModule as unknown as {
       description: string;
       argumentHint?: string;
     }>,
+  ) => void;
+  setMockContextUsage: (
+    contextUsage: { rawMaxTokens: number } | null,
+  ) => void;
+  setMockContextUsageImplementation: (
+    implementation: (() => Promise<{ rawMaxTokens: number }>) | null,
   ) => void;
 };
 
@@ -501,6 +508,379 @@ describe('ClaudeExecutionBackend', () => {
     }));
     expect(events).toContainEqual(expect.objectContaining({
       type: 'context_compacted',
+    }));
+  });
+
+  it('keeps the persistent runtime context window when result metadata disagrees', async () => {
+    sdkMock.setMockContextUsage({ rawMaxTokens: 1_000_000 });
+    sdkMock.setMockMessages([
+      { type: 'system', subtype: 'init', session_id: 'session-1' },
+      {
+        type: 'assistant',
+        parent_tool_use_id: null,
+        message: {
+          content: [{ type: 'text', text: 'Hello' }],
+          usage: { input_tokens: 250_000 },
+        },
+      },
+      {
+        type: 'result',
+        subtype: 'success',
+        modelUsage: {
+          'custom-model': { contextWindow: 200_000 },
+        },
+      },
+    ], { appendResult: false });
+    const { services } = createServices();
+    const session = new ClaudeExecutionBackend(createHost(), services)
+      .createSession(createConfig());
+
+    const events = await collectEvents(session.execute(createRequest({
+      configuration: {
+        systemInstructions: { kind: 'provider-default' },
+        model: 'custom-model',
+        reasoning: 'medium',
+        permissionMode: 'ask',
+      },
+    })).events);
+
+    expect(sdkMock.getLastResponse()?.getContextUsage).toHaveBeenCalledTimes(1);
+    const usageEvents = events.filter((event) => event.type === 'usage_updated');
+    expect(usageEvents.at(-1)).toEqual(expect.objectContaining({
+      type: 'usage_updated',
+      usage: expect.objectContaining({
+        model: 'custom-model',
+        contextTokens: 250_000,
+        contextWindow: 1_000_000,
+        contextWindowIsAuthoritative: true,
+        percentage: 25,
+      }),
+    }));
+  });
+
+  it('corrects live usage when runtime context discovery resolves after usage', async () => {
+    const contextUsage = createDeferred<{ rawMaxTokens: number }>();
+    const resultBarrier = createDeferred<null>();
+    sdkMock.setMockContextUsageImplementation(() => contextUsage.promise);
+    sdkMock.setMockMessages([
+      {
+        type: 'assistant',
+        parent_tool_use_id: null,
+        message: {
+          content: [{ type: 'text', text: 'Hello' }],
+          usage: { input_tokens: 250_000 },
+        },
+      },
+      resultBarrier.promise,
+      { type: 'result', subtype: 'success' },
+    ], { appendResult: false });
+    const { services } = createServices();
+    const session = new ClaudeExecutionBackend(createHost(), services)
+      .createSession(createConfig());
+    const collected: ProviderExecutionEvent[] = [];
+    const run = session.execute(createRequest({
+      configuration: {
+        systemInstructions: { kind: 'provider-default' },
+        model: 'custom-model',
+        reasoning: 'medium',
+        permissionMode: 'ask',
+      },
+    }));
+    const collection = (async () => {
+      for await (const event of run.events) {
+        collected.push(event);
+      }
+    })();
+
+    await waitFor(() => collected.some((event) => (
+      event.type === 'usage_updated'
+      && event.usage.contextWindow === 200_000
+    )));
+    contextUsage.resolve({ rawMaxTokens: 1_000_000 });
+    await waitFor(() => collected.some((event) => (
+      event.type === 'usage_updated'
+      && event.usage.contextWindow === 1_000_000
+      && event.usage.contextWindowIsAuthoritative === true
+    )));
+    resultBarrier.resolve(null);
+    await collection;
+
+    expect(collected.filter((event) => event.type === 'usage_updated').at(-1))
+      .toEqual(expect.objectContaining({
+        usage: expect.objectContaining({
+          contextWindow: 1_000_000,
+          percentage: 25,
+        }),
+      }));
+  });
+
+  it('ignores a delayed context window after the persistent model changes', async () => {
+    const staleContextUsage = createDeferred<{ rawMaxTokens: number }>();
+    const secondResultBarrier = createDeferred<null>();
+    const getContextUsage = jest.fn()
+      .mockReturnValueOnce(staleContextUsage.promise)
+      .mockResolvedValueOnce({ rawMaxTokens: 500_000 });
+    const queryFactory = jest.fn((request: {
+      prompt: AsyncIterable<sdkModule.SDKUserMessage>;
+    }) => {
+      const query = attachContextUsage(
+        createPromptDrivenPersistentQuery(request.prompt, (prompt) => (
+          prompt.includes('First model')
+            ? [
+              { type: 'system', subtype: 'init', session_id: 'session-1' },
+              {
+                type: 'assistant',
+                message: {
+                  content: [{ type: 'text', text: 'First response' }],
+                  usage: { input_tokens: 250_000 },
+                },
+              },
+              { type: 'result', subtype: 'success' },
+            ]
+            : [
+              {
+                type: 'assistant',
+                message: {
+                  content: [{ type: 'text', text: 'Second response' }],
+                  usage: { input_tokens: 250_000 },
+                },
+              },
+              secondResultBarrier.promise,
+              { type: 'result', subtype: 'success' },
+            ]
+        )),
+        getContextUsage,
+      );
+      return query;
+    });
+    jest.spyOn(
+      await import('@/providers/claude/loadClaudeAgentSdk'),
+      'loadClaudeAgentQuery',
+    ).mockResolvedValueOnce(queryFactory as never);
+    const { services } = createServices();
+    const session = new ClaudeExecutionBackend(createHost(), services)
+      .createSession(createConfig());
+
+    await collectEvents(session.execute(createRequest({
+      input: [{ type: 'text', text: 'First model' }],
+      configuration: {
+        systemInstructions: { kind: 'provider-default' },
+        model: 'custom-model-a',
+        reasoning: 'medium',
+        permissionMode: 'ask',
+      },
+    })).events);
+    const secondEvents: ProviderExecutionEvent[] = [];
+    const secondRun = session.execute(createRequest({
+      input: [{ type: 'text', text: 'Second model' }],
+      configuration: {
+        systemInstructions: { kind: 'provider-default' },
+        model: 'custom-model-b',
+        reasoning: 'medium',
+        permissionMode: 'ask',
+      },
+    }));
+    const secondCollection = (async () => {
+      for await (const event of secondRun.events) {
+        secondEvents.push(event);
+      }
+    })();
+
+    await waitFor(() => secondEvents.some((event) => (
+      event.type === 'usage_updated'
+      && event.usage.contextWindow === 500_000
+    )));
+    staleContextUsage.resolve({ rawMaxTokens: 1_000_000 });
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(secondEvents).not.toContainEqual(expect.objectContaining({
+      type: 'usage_updated',
+      usage: expect.objectContaining({ contextWindow: 1_000_000 }),
+    }));
+    secondResultBarrier.resolve(null);
+    await secondCollection;
+    expect(getContextUsage).toHaveBeenCalledTimes(2);
+    await session.dispose();
+  });
+
+  it('ignores context discovery from a replaced persistent query', async () => {
+    const staleContextUsage = createDeferred<{ rawMaxTokens: number }>();
+    const replacementResultBarrier = createDeferred<null>();
+    const getStaleContextUsage = jest.fn().mockReturnValue(staleContextUsage.promise);
+    const getReplacementContextUsage = jest.fn().mockResolvedValue({ rawMaxTokens: 500_000 });
+    const staleFactory = jest.fn((request: {
+      prompt: AsyncIterable<sdkModule.SDKUserMessage>;
+    }) => {
+      const staleQuery = attachContextUsage(
+        createPromptDrivenPersistentQuery(request.prompt, () => [
+          { type: 'system', subtype: 'init', session_id: 'session-1' },
+          { type: 'result', subtype: 'success' },
+        ]),
+        getStaleContextUsage,
+      );
+      return staleQuery;
+    });
+    const replacementFactory = jest.fn((request: {
+      prompt: AsyncIterable<sdkModule.SDKUserMessage>;
+    }) => {
+      const replacementQuery = attachContextUsage(
+        createPromptDrivenPersistentQuery(request.prompt, () => [
+          { type: 'system', subtype: 'init', session_id: 'session-2' },
+          {
+            type: 'assistant',
+            message: {
+              content: [{ type: 'text', text: 'Replacement response' }],
+              usage: { input_tokens: 250_000 },
+            },
+          },
+          replacementResultBarrier.promise,
+          { type: 'result', subtype: 'success' },
+        ]),
+        getReplacementContextUsage,
+      );
+      return replacementQuery;
+    });
+    jest.spyOn(
+      await import('@/providers/claude/loadClaudeAgentSdk'),
+      'loadClaudeAgentQuery',
+    )
+      .mockResolvedValueOnce(staleFactory as never)
+      .mockResolvedValueOnce(replacementFactory as never);
+    const { services } = createServices();
+    const session = new ClaudeExecutionBackend(createHost(), services)
+      .createSession(createConfig());
+
+    await collectEvents(session.execute(createRequest({
+      configuration: {
+        systemInstructions: { kind: 'provider-default' },
+        model: 'custom-model',
+        reasoning: 'medium',
+        permissionMode: 'ask',
+      },
+    })).events);
+    const replacementEvents: ProviderExecutionEvent[] = [];
+    const replacementRun = session.execute(createRequest({
+      configuration: {
+        systemInstructions: {
+          kind: 'explicit',
+          instructions: 'Use replacement instructions.',
+        },
+        model: 'custom-model',
+        reasoning: 'medium',
+        permissionMode: 'ask',
+      },
+    }));
+    const replacementCollection = (async () => {
+      for await (const event of replacementRun.events) {
+        replacementEvents.push(event);
+      }
+    })();
+
+    await waitFor(() => replacementEvents.some((event) => (
+      event.type === 'usage_updated'
+      && event.usage.contextWindow === 500_000
+    )));
+    staleContextUsage.resolve({ rawMaxTokens: 1_000_000 });
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(replacementEvents).not.toContainEqual(expect.objectContaining({
+      type: 'usage_updated',
+      usage: expect.objectContaining({ contextWindow: 1_000_000 }),
+    }));
+    replacementResultBarrier.resolve(null);
+    await replacementCollection;
+    expect(getStaleContextUsage).toHaveBeenCalledTimes(1);
+    expect(getReplacementContextUsage).toHaveBeenCalledTimes(1);
+    await session.dispose();
+  });
+
+  it('corrects custom-model usage from result model metadata', async () => {
+    sdkMock.setMockMessages([
+      {
+        type: 'assistant',
+        parent_tool_use_id: null,
+        message: {
+          content: [{ type: 'text', text: 'Hello' }],
+          usage: { input_tokens: 250_000 },
+        },
+      },
+      {
+        type: 'result',
+        subtype: 'success',
+        modelUsage: {
+          'custom-model': { contextWindow: 1_000_000 },
+        },
+      },
+    ], { appendResult: false });
+    const { services } = createServices();
+    const session = new ClaudeExecutionBackend(createHost(), services)
+      .createSession(createConfig());
+
+    const events = await collectEvents(session.execute(createRequest({
+      configuration: {
+        systemInstructions: { kind: 'provider-default' },
+        model: 'custom-model',
+        reasoning: 'medium',
+        permissionMode: 'ask',
+      },
+    })).events);
+    const usageEvents = events.filter((event) => event.type === 'usage_updated');
+
+    expect(usageEvents.at(-1)).toEqual(expect.objectContaining({
+      type: 'usage_updated',
+      usage: expect.objectContaining({
+        model: 'custom-model',
+        contextTokens: 250_000,
+        contextWindow: 1_000_000,
+        contextWindowIsAuthoritative: true,
+        percentage: 25,
+      }),
+    }));
+  });
+
+  it('applies result context metadata before terminating an errored turn', async () => {
+    sdkMock.setMockMessages([
+      {
+        type: 'assistant',
+        parent_tool_use_id: null,
+        message: {
+          content: [{ type: 'text', text: 'Partial output' }],
+          usage: { input_tokens: 250_000 },
+        },
+      },
+      {
+        type: 'result',
+        subtype: 'error_max_turns',
+        errors: ['Hit maximum turn limit'],
+        modelUsage: {
+          'custom-model': { contextWindow: 1_000_000 },
+        },
+      },
+    ], { appendResult: false });
+    const { services } = createServices();
+    const session = new ClaudeExecutionBackend(createHost(), services)
+      .createSession(createConfig());
+
+    const events = await collectEvents(session.execute(createRequest({
+      configuration: {
+        systemInstructions: { kind: 'provider-default' },
+        model: 'custom-model',
+        reasoning: 'medium',
+        permissionMode: 'ask',
+      },
+    })).events);
+
+    expect(events.filter((event) => event.type === 'usage_updated').at(-1))
+      .toEqual(expect.objectContaining({
+        usage: expect.objectContaining({
+          contextWindow: 1_000_000,
+          contextWindowIsAuthoritative: true,
+          percentage: 25,
+        }),
+      }));
+    expect(events.at(-1)).toEqual(expect.objectContaining({
+      type: 'execution_error',
+      message: 'Hit maximum turn limit',
     }));
   });
 
@@ -1916,6 +2296,17 @@ type ScriptedQuery = AsyncGenerator<unknown> & {
   rewindFiles: jest.Mock;
   finished: Promise<void>;
 };
+
+type ContextAwareScriptedQuery = ScriptedQuery & {
+  getContextUsage: jest.Mock;
+};
+
+function attachContextUsage(
+  query: ScriptedQuery,
+  getContextUsage: jest.Mock,
+): ContextAwareScriptedQuery {
+  return Object.assign(query, { getContextUsage });
+}
 
 function attachQueryMethods(
   query: AsyncGenerator<unknown>,

--- a/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
+++ b/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
@@ -1258,8 +1258,8 @@ describe('transformSDKMessage', () => {
       const results = [...transformSDKMessage(message)];
 
       expect(results).toEqual([
-        { type: 'error', content: 'Hit maximum turn limit' },
         { type: 'context_window', contextWindow: 200000 },
+        { type: 'error', content: 'Hit maximum turn limit' },
       ]);
     });
 


### PR DESCRIPTION
## Why

Fixes #1090: custom Claude models with context windows above 200K were displayed using the heuristic fallback after the execution refactor disconnected authoritative SDK metadata.

## What Changed

Restores fail-soft `getContextUsage().rawMaxTokens` discovery, propagates result `modelUsage.contextWindow` as fallback, recalculates live usage, and preserves explicit custom-limit precedence.

## Why This Approach

The Claude execution strategy owns query-scoped discovery while the session fences updates by query and model, preventing stale asynchronous responses from affecting active usage.

## Validation

Passed `npm run typecheck && npm run lint && npm run test && npm run build` with 351 suites and 6,548 tests.

## Impact and Follow-ups

No persistence or compatibility migration is required; real Claude CLI control-channel timing remains the only residual integration risk.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.