### PR TITLE
fix: restore conversation rename menu flow

### DIFF
--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -933,6 +933,31 @@ export class ClaudianView extends ItemView {
       showOpenStateLabels: navigationMode === 'history',
       showOpenStateActions: navigationMode === 'history' && !isArchiveView,
       preserveListState: true,
+      showInlinePinAction: navigationMode === 'sessions',
+      onRequestInlineRename: ({ beginRename, conversationId }) => {
+        if (navigationMode === 'sessions' && this.isSessionSearchActive) {
+          this.closeSessionSearch();
+        }
+        const restoreAndRename = () => {
+          if (
+            navigationMode === 'history'
+            && (signal.aborted || this.historyDropdown !== container)
+          ) return;
+          const targetItem = Array.from(
+            container.querySelectorAll<HTMLElement>('.claudian-history-item'),
+          ).find(item => item.getAttribute('data-conversation-id') === conversationId);
+          if (!targetItem) return;
+
+          if (navigationMode === 'history') {
+            container.addClass('visible');
+          }
+          beginRename(targetItem);
+        };
+        scheduleAnimationFrame(
+          restoreAndRename,
+          container.ownerDocument.defaultView,
+        );
+      },
       sessionScope: isArchiveView ? 'archived' : 'active',
       sessionActionMode: isArchiveView ? 'archived' : 'active',
       historyHeaderLabel: isArchiveView ? 'Archived' : 'Sessions',
@@ -1995,6 +2020,7 @@ export class ClaudianView extends ItemView {
   private cancelHistoryRendering(): void {
     this.historyRenderAbortController?.abort();
     this.historyRenderAbortController = null;
+    this.historyDropdownDirty = true;
   }
 
   private cancelSessionSidebarRendering(): void {
@@ -2118,13 +2144,14 @@ export class ClaudianView extends ItemView {
         || this.isSessionSearchComposing
         || this.vaultFileTree?.isComposingSearch()
       ) return;
+      const activeTab = this.tabManager?.getActiveTab();
+      if (activeTab?.controllers.conversationController.cancelInlineRename()) return false;
       if (this.vaultFileTree?.handleEscape(e)) return false;
       if (this.isSessionSearchActive) {
         this.closeSessionSearch();
         return false;
       }
       if (!e.defaultPrevented) {
-        const activeTab = this.tabManager?.getActiveTab();
         if (activeTab?.state.isStreaming) {
           activeTab.controllers.inputController.cancelStreaming();
         }

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -144,6 +144,11 @@ type HistoryRenderOptions = {
   onSetConversationPinned?: (id: string, isPinned: boolean) => Promise<void>;
   onSetConversationArchived?: (id: string, isArchived: boolean) => Promise<void>;
   onBeforeRestoreListState?: (container: HTMLElement) => void;
+  onRequestInlineRename?: (request: {
+    beginRename: (item: HTMLElement) => void;
+    conversationId: string;
+  }) => void;
+  showInlinePinAction?: boolean;
 };
 
 type HistorySurfaceRenderOptions = Omit<HistoryRenderOptions, 'onRerender'> & {
@@ -156,6 +161,10 @@ type HistoryScrollAnchor = {
 };
 
 export class ConversationController {
+  private activeInlineRename: {
+    cancel: () => void;
+    input: HTMLInputElement;
+  } | null = null;
   private deps: ConversationControllerDeps;
   private callbacks: ConversationCallbacks;
   private metadataPopoverCleanup: (() => void) | null = null;
@@ -728,6 +737,19 @@ export class ConversationController {
     }
   }
 
+  cancelInlineRename(): boolean {
+    const activeInlineRename = this.activeInlineRename;
+    if (!activeInlineRename) return false;
+    if (activeInlineRename.input.isConnected === false) {
+      this.activeInlineRename = null;
+      return false;
+    }
+
+    this.activeInlineRename = null;
+    activeInlineRename.cancel();
+    return true;
+  }
+
   updateHistoryDropdown(): void {
     const dropdown = this.deps.getHistoryDropdown();
     if (!dropdown) return;
@@ -776,6 +798,12 @@ export class ConversationController {
       : [];
     const organization = options.organization ?? 'list';
 
+    if (
+      this.activeInlineRename
+      && container.contains(this.activeInlineRename.input)
+    ) {
+      this.activeInlineRename = null;
+    }
     container.empty();
 
     const allConversations = plugin.getConversationList();
@@ -1478,21 +1506,23 @@ export class ConversationController {
     if (options.sessionActionMode === 'active') {
       if (!showAttentionState) {
         const isPinned = conversation.isPinned === true;
-        const pinBtn = actions.createEl('button', {
-          cls: 'claudian-action-btn claudian-pin-btn',
-        });
-        setIcon(pinBtn, isPinned ? 'pin-off' : 'pin');
-        pinBtn.setAttribute('aria-label', isPinned ? 'Unpin' : 'Pin');
-        pinBtn.addEventListener('click', (event) => {
-          event.stopPropagation();
-          runConversationAction(
-            () => this.runHistoryAction(
-              () => options.onSetConversationPinned?.(conversation.id, !isPinned),
+        if (options.showInlinePinAction !== false) {
+          const pinBtn = actions.createEl('button', {
+            cls: 'claudian-action-btn claudian-pin-btn',
+          });
+          setIcon(pinBtn, isPinned ? 'pin-off' : 'pin');
+          pinBtn.setAttribute('aria-label', isPinned ? 'Unpin' : 'Pin');
+          pinBtn.addEventListener('click', (event) => {
+            event.stopPropagation();
+            runConversationAction(
+              () => this.runHistoryAction(
+                () => options.onSetConversationPinned?.(conversation.id, !isPinned),
+                isPinned ? 'Failed to unpin session' : 'Failed to pin session',
+              ),
               isPinned ? 'Failed to unpin session' : 'Failed to pin session',
-            ),
-            isPinned ? 'Failed to unpin session' : 'Failed to pin session',
-          );
-        });
+            );
+          });
+        }
 
         const archiveBtn = actions.createEl('button', {
           cls: 'claudian-action-btn claudian-archive-btn',
@@ -1540,7 +1570,7 @@ export class ConversationController {
       renameBtn.setAttribute('aria-label', 'Rename');
       renameBtn.addEventListener('click', (event) => {
         event.stopPropagation();
-        this.showRenameInput(item, conversation.id, conversation.title, options);
+        this.showRenameEditor(item, conversation.id, conversation.title, options);
       });
       createDeleteButton();
     }
@@ -1980,6 +2010,11 @@ export class ConversationController {
     }
 
     if (options.sessionActionMode === 'active') {
+      menu.addItem((menuItem) => menuItem
+        .setTitle('Rename')
+        .onClick(() => {
+          this.showRenameEditor(item, conversationId, title, options);
+        }));
       menu.addItem((menuItem) => {
         menuItem
           .setTitle('Archive')
@@ -1993,11 +2028,6 @@ export class ConversationController {
           });
         }
       });
-      menu.addItem((menuItem) => menuItem
-        .setTitle('Rename')
-        .onClick(() => {
-          this.showRenameInput(item, conversationId, title, options);
-        }));
       menu.showAtMouseEvent(event);
       return;
     }
@@ -2005,7 +2035,7 @@ export class ConversationController {
     menu.addItem((menuItem) => menuItem
       .setTitle('Rename')
       .onClick(() => {
-        this.showRenameInput(item, conversationId, title, options);
+        this.showRenameEditor(item, conversationId, title, options);
       }));
     menu.addItem((menuItem) => menuItem
       .setTitle('Delete')
@@ -2034,6 +2064,26 @@ export class ConversationController {
     }
   }
 
+  private showRenameEditor(
+    item: HTMLElement,
+    convId: string,
+    currentTitle: string,
+    options: HistoryRenderOptions,
+  ): void {
+    const beginRename = (targetItem: HTMLElement) => {
+      this.showRenameInput(targetItem, convId, currentTitle, options);
+    };
+    if (options.onRequestInlineRename) {
+      options.onRequestInlineRename({
+        beginRename,
+        conversationId: convId,
+      });
+      return;
+    }
+
+    beginRename(item);
+  }
+
   /** Shows inline rename input for a conversation. */
   private showRenameInput(
     item: HTMLElement,
@@ -2053,17 +2103,36 @@ export class ConversationController {
     input.focus();
     input.select();
 
+    let isFinishing = false;
+    const cancelRename = () => {
+      input.value = currentTitle;
+      input.blur();
+    };
+    this.activeInlineRename = { cancel: cancelRename, input };
     const finishRename = async () => {
+      if (isFinishing) return;
+      isFinishing = true;
+      const newTitle = input.value.trim();
+      if (!newTitle || newTitle === currentTitle) {
+        isFinishing = false;
+        options.onRerender();
+        return;
+      }
+
       try {
-        const newTitle = input.value.trim() || currentTitle;
         await this.deps.plugin.renameConversation(convId, newTitle);
         options.onRerender();
       } catch {
         new Notice('Failed to rename conversation');
+      } finally {
+        isFinishing = false;
       }
     };
 
     input.addEventListener('blur', () => {
+      if (this.activeInlineRename?.input === input) {
+        this.activeInlineRename = null;
+      }
       runConversationAction(finishRename, 'Failed to rename conversation');
     });
     input.addEventListener('keydown', (e) => {
@@ -2071,8 +2140,9 @@ export class ConversationController {
       if (e.key === 'Enter' && !e.isComposing) {
         input.blur();
       } else if (e.key === 'Escape' && !e.isComposing) {
-        input.value = currentTitle;
-        input.blur();
+        e.preventDefault();
+        e.stopPropagation();
+        cancelRename();
       }
     });
   }

--- a/src/style/AGENTS.md
+++ b/src/style/AGENTS.md
@@ -38,6 +38,27 @@ Choose a folder by UI ownership, not by the screen where a selector happens to a
 - Use Obsidian CSS variables such as `--background-*`, `--text-*`, and `--interactive-*`.
 - Use `var(--font-monospace)` for code blocks.
 
+## Specific Element Rules
+
+Every Claudian-owned instance of an element listed below must use its required base pattern. A departure is allowed only through an explicit semantic or surface modifier; selector order, nesting, and inherited Obsidian styles are not exceptions.
+
+### Buttons
+
+- All buttons use `border: 0`, `background: transparent`, `box-shadow: none`, and `color: var(--text-muted)` at rest.
+- Hover and `focus-visible` use `color: var(--text-normal)` while retaining no border, transparent background, and no box shadow. Filled hover or focus surfaces require an explicit modifier.
+- Disabled buttons use `color: var(--text-faint)` and `cursor: default`, and must not retain hover, focus, or active emphasis.
+- Button SVGs inherit `currentColor`; their width and height are declared by the button's base selector. Different icon sizing requires an explicit modifier.
+- Apply the complete base pattern to the Claudian button class and its hover, focus, active, and disabled selectors so Obsidian cannot restore native button chrome in any state.
+
+### Inputs and Textareas
+
+- All standalone inputs and textareas use `min-width: 0`, `border: 1px solid var(--background-modifier-border)`, `background: var(--background-modifier-form-field)`, `box-shadow: none`, `color: var(--text-normal)`, and the inherited UI font.
+- Hover retains the base border, background, and box shadow. Focus uses `outline: none` and `border-color: var(--interactive-accent)` without introducing a browser or Obsidian box shadow.
+- Placeholders use `color: var(--text-muted)`. Disabled controls use `color: var(--text-faint)` and `cursor: default`.
+- An input or textarea embedded in a wrapper uses `border: 0`, `background: transparent`, and `box-shadow: none` in every interaction state; the wrapper alone owns the border, background, radius, and focus treatment.
+- Textareas use `resize: none` and `overflow-y: auto` by default. A resizable textarea requires an explicit modifier and bounded sizing.
+- Error, warning, read-only, and semantic-mode treatments require explicit modifiers or scoped custom properties; they must override every affected interaction state.
+
 ## Gotchas
 
 - Obsidian uses `body.theme-dark` and `body.theme-light` for theme detection.

--- a/src/style/components/history.css
+++ b/src/style/components/history.css
@@ -800,6 +800,22 @@ body.theme-dark .claudian-session-metadata-popover {
   color: var(--interactive-accent);
 }
 
+.claudian-history-menu .claudian-history-item-actions .claudian-action-btn {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  color: var(--text-muted);
+  transition: color 0.15s ease;
+}
+
+.claudian-history-menu .claudian-history-item-actions .claudian-action-btn:hover,
+.claudian-history-menu .claudian-history-item-actions .claudian-action-btn:focus-visible {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  color: var(--text-normal);
+}
+
 .claudian-rename-input {
   width: 100%;
   padding: 2px 4px;

--- a/tests/unit/features/chat/ClaudianView.test.ts
+++ b/tests/unit/features/chat/ClaudianView.test.ts
@@ -675,10 +675,17 @@ describe('ClaudianView tab controls', () => {
 
   it('keeps tab-aware navigation on the single-mode history surface', () => {
     const container = createMockEl();
+    const ownerRequestAnimationFrame = jest.fn((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    container.ownerDocument.defaultView.requestAnimationFrame = ownerRequestAnimationFrame;
+    const globalRequestAnimationFrame = jest.spyOn(window, 'requestAnimationFrame');
     const renderHistoryDropdown = jest.fn();
     const view = Object.create(ClaudianView.prototype) as any;
     Object.assign(view, {
       isArchiveSessionView: false,
+      historyDropdown: container,
       openHistoryConversation: jest.fn(),
       openHistoryConversationInNewTab: jest.fn(),
       getHistoryConversationStatus: jest.fn(),
@@ -698,10 +705,25 @@ describe('ClaudianView tab controls', () => {
     const options = renderHistoryDropdown.mock.calls[0]?.[1];
     expect(options.showOpenStateLabels).toBe(true);
     expect(options.showOpenStateActions).toBe(true);
+    expect(options.showInlinePinAction).toBe(false);
+    expect(options.onRequestInlineRename).toEqual(expect.any(Function));
     expect(options.onOpenConversationInNewTab).toEqual(expect.any(Function));
     expect(options.onBeforeRestoreListState).toEqual(expect.any(Function));
     expect(options).not.toHaveProperty('organization');
     expect(options).not.toHaveProperty('showMetadataPopover');
+
+    const beginRename = jest.fn();
+    const targetItem = container.createDiv({ cls: 'claudian-history-item' });
+    targetItem.setAttribute('data-conversation-id', 'conversation-1');
+    options.onRequestInlineRename({
+      beginRename,
+      conversationId: 'conversation-1',
+    });
+    expect(container.hasClass('visible')).toBe(true);
+    expect(beginRename).toHaveBeenCalledWith(targetItem);
+    expect(ownerRequestAnimationFrame).toHaveBeenCalledTimes(1);
+    expect(globalRequestAnimationFrame).not.toHaveBeenCalled();
+    globalRequestAnimationFrame.mockRestore();
   });
 
   it('collapses and expands every linked-note group from the session header', () => {
@@ -1152,12 +1174,20 @@ describe('ClaudianView tab controls', () => {
     view.updateHistoryDropdown();
 
     expect(renderHistoryDropdown).toHaveBeenCalledTimes(2);
+    const secondRenderSignal = renderHistoryDropdown.mock.calls[1][1].signal as AbortSignal;
 
     view.toggleHistoryDropdown();
     expect(firstRenderSignal.aborted).toBe(true);
+    expect(secondRenderSignal.aborted).toBe(true);
     view.updateHistoryDropdown();
 
     expect(renderHistoryDropdown).toHaveBeenCalledTimes(2);
+
+    view.toggleHistoryDropdown();
+
+    expect(renderHistoryDropdown).toHaveBeenCalledTimes(3);
+    const reopenedSignal = renderHistoryDropdown.mock.calls[2][1].signal as AbortSignal;
+    expect(reopenedSignal.aborted).toBe(false);
   });
 
   it('builds the persistent session column to the right of the chat panel', () => {
@@ -1897,10 +1927,12 @@ describe('ClaudianView tab controls', () => {
         getProviderIcon: expect.any(Function),
         getModelLabel: expect.any(Function),
         onRerender: expect.any(Function),
+        onRequestInlineRename: expect.any(Function),
         onSelectConversation: expect.any(Function),
         preserveListState: true,
         searchQuery: 'roadmap',
         showAttentionState: true,
+        showInlinePinAction: true,
         showOpenStateActions: false,
         showOpenStateLabels: false,
         showMetadataPopover: true,
@@ -1952,6 +1984,31 @@ describe('ClaudianView tab controls', () => {
         collapsedGroupKeys: expect.any(Set),
       }),
     );
+
+    const ownerRequestAnimationFrame = jest.fn((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    sessionSidebarEl.ownerDocument.defaultView.requestAnimationFrame = ownerRequestAnimationFrame;
+    let replacementItem: ReturnType<typeof createMockEl> | null = null;
+    view.isArchiveSessionView = false;
+    view.isSessionSearchActive = true;
+    view.closeSessionSearch = jest.fn(() => {
+      view.isSessionSearchActive = false;
+      sessionSidebarEl.empty();
+      replacementItem = sessionSidebarEl.createDiv({ cls: 'claudian-history-item' });
+      replacementItem.setAttribute('data-conversation-id', 'conversation-1');
+    });
+    const beginRename = jest.fn();
+
+    sessionOptions.onRequestInlineRename({
+      beginRename,
+      conversationId: 'conversation-1',
+    });
+
+    expect(view.closeSessionSearch).toHaveBeenCalledTimes(1);
+    expect(ownerRequestAnimationFrame).toHaveBeenCalledTimes(1);
+    expect(beginRename).toHaveBeenCalledWith(replacementItem);
   });
 
   it('projects local and cross-view runtime attention into session status', () => {
@@ -2990,10 +3047,12 @@ describe('ClaudianView Escape handling', () => {
   function createEscapeHarness(options: {
     isStreaming: boolean;
   }): {
+    cancelInlineRename: jest.Mock;
     cancelStreaming: jest.Mock;
     eventRefs: unknown[];
     view: any;
   } {
+    const cancelInlineRename = jest.fn().mockReturnValue(false);
     const cancelStreaming = jest.fn();
     const eventRefs: unknown[] = [];
     const parentScope = new Scope();
@@ -3027,6 +3086,7 @@ describe('ClaudianView Escape handling', () => {
       getActiveTab: jest.fn().mockReturnValue({
         state: { isStreaming: options.isStreaming },
         controllers: {
+          conversationController: { cancelInlineRename },
           inputController: { cancelStreaming },
         },
         ui: {
@@ -3040,7 +3100,7 @@ describe('ClaudianView Escape handling', () => {
       }),
     };
 
-    return { cancelStreaming, eventRefs, view };
+    return { cancelInlineRename, cancelStreaming, eventRefs, view };
   }
 
   function createScopedSendHarness(options: {
@@ -3139,6 +3199,24 @@ describe('ClaudianView Escape handling', () => {
     const escapeHandler = view.scope.handlers.find((handler: any) => handler.key === 'Escape');
     const result = escapeHandler.func({ key: 'Escape', isComposing: false } as KeyboardEvent);
 
+    expect(cancelStreaming).not.toHaveBeenCalled();
+    expect(result).toBe(false);
+  });
+
+  it('exits inline rename before handling other scoped Escape actions', () => {
+    const { cancelInlineRename, cancelStreaming, view } = createEscapeHarness({
+      isStreaming: true,
+    });
+    cancelInlineRename.mockReturnValue(true);
+    view.closeSessionSearch = jest.fn();
+    view.isSessionSearchActive = true;
+
+    view.wireEventHandlers();
+    const escapeHandler = view.scope.handlers.find((handler: any) => handler.key === 'Escape');
+    const result = escapeHandler.func({ key: 'Escape', isComposing: false } as KeyboardEvent);
+
+    expect(cancelInlineRename).toHaveBeenCalledTimes(1);
+    expect(view.closeSessionSearch).not.toHaveBeenCalled();
     expect(cancelStreaming).not.toHaveBeenCalled();
     expect(result).toBe(false);
   });

--- a/tests/unit/features/chat/controllers/ConversationController.test.ts
+++ b/tests/unit/features/chat/controllers/ConversationController.test.ts
@@ -2593,6 +2593,40 @@ describe('ConversationController', () => {
         expect(onSetConversationPinned).toHaveBeenCalledWith('pinned', false);
       });
 
+      it('hides the inline pin action without removing the context-menu action', () => {
+        const container = createMockEl();
+        (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
+          { id: 'active', title: 'Active', createdAt: 2 },
+        ]);
+
+        controller.renderHistoryDropdown(container, {
+          onSelectConversation: jest.fn(),
+          onSetConversationArchived: jest.fn().mockResolvedValue(undefined),
+          onSetConversationPinned: jest.fn().mockResolvedValue(undefined),
+          sessionActionMode: 'active',
+          showInlinePinAction: false,
+          showOpenStateActions: false,
+        });
+
+        const item = container.querySelector('.claudian-history-item')!;
+        expect(item.querySelector('.claudian-pin-btn')).toBeNull();
+        expect(item.querySelector('.claudian-archive-btn')).not.toBeNull();
+
+        item.dispatchEvent({
+          type: 'contextmenu',
+          stopPropagation: jest.fn(),
+          preventDefault: jest.fn(),
+        });
+        const menu = (Menu as typeof Menu & {
+          instances: Array<{ items: Array<{ title: string }> }>;
+        }).instances.at(-1)!;
+        expect(menu.items.map(menuItem => menuItem.title)).toEqual([
+          'Pin',
+          'Rename',
+          'Archive',
+        ]);
+      });
+
       it('keeps rename in the active context menu and delete in Archived only', () => {
         const activeContainer = createMockEl();
         (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
@@ -2619,7 +2653,7 @@ describe('ConversationController', () => {
           }>;
         }).instances.at(-1)!;
         expect(menu.useNativeMenu).toBe(false);
-        expect(menu.items.map(item => item.title)).toEqual(['Pin', 'Archive', 'Rename']);
+        expect(menu.items.map(item => item.title)).toEqual(['Pin', 'Rename', 'Archive']);
 
         const archivedContainer = createMockEl();
         (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
@@ -2646,6 +2680,60 @@ describe('ConversationController', () => {
         }).instances.at(-1)!;
         expect(menu.useNativeMenu).toBe(false);
         expect(menu.items.map(item => item.title)).toEqual(['Restore', 'Delete']);
+      });
+
+      it('defers inline rename until the transient history surface is restored', async () => {
+        const container = createMockEl();
+        const onRerender = jest.fn();
+        const onRequestInlineRename = jest.fn();
+        (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
+          { id: 'active', title: 'Original title', createdAt: 2 },
+        ]);
+
+        controller.renderHistoryDropdown(container, {
+          onSelectConversation: jest.fn(),
+          onRerender,
+          onRequestInlineRename,
+          sessionActionMode: 'active',
+          showOpenStateActions: true,
+        });
+
+        const item = container.querySelector('.claudian-history-item')!;
+        const title = item.querySelector('.claudian-history-item-title')!;
+        title.replaceWith = jest.fn();
+        item.dispatchEvent({
+          type: 'contextmenu',
+          stopPropagation: jest.fn(),
+          preventDefault: jest.fn(),
+        });
+
+        const menu = (Menu as typeof Menu & {
+          instances: Array<{
+            items: Array<{ title: string; clickHandler: (() => void) | null }>;
+          }>;
+        }).instances.at(-1)!;
+        menu.items.find(menuItem => menuItem.title === 'Rename')?.clickHandler?.();
+
+        expect(title.replaceWith).not.toHaveBeenCalled();
+        expect(item.querySelector('.claudian-rename-input')).toBeNull();
+        expect(onRequestInlineRename).toHaveBeenCalledWith({
+          beginRename: expect.any(Function),
+          conversationId: 'active',
+        });
+
+        onRequestInlineRename.mock.calls[0][0].beginRename(item);
+        const input = item.querySelector('.claudian-rename-input')!;
+        expect(title.replaceWith).toHaveBeenCalledWith(input);
+        input.value = 'Renamed title';
+        input.blur();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(deps.plugin.renameConversation).toHaveBeenCalledWith(
+          'active',
+          'Renamed title',
+        );
+        expect(onRerender).toHaveBeenCalledTimes(1);
       });
     });
   });
@@ -2789,6 +2877,83 @@ describe('ConversationController', () => {
 
       expect(deps.plugin.renameConversation).toHaveBeenCalledWith('conv-1', 'New title');
       expect(onRerender).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not persist an unchanged inline rename', async () => {
+      const container = createMockEl();
+      const onRerender = jest.fn();
+      (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
+        { id: 'conv-1', title: 'Original title', createdAt: 1000 },
+      ]);
+
+      controller.renderHistoryDropdown(container, {
+        onSelectConversation: jest.fn(),
+        onRerender,
+      });
+
+      const item = container.querySelector('.claudian-history-item')!;
+      const title = item.querySelector('.claudian-history-item-title')!;
+      title.replaceWith = jest.fn();
+      item.querySelector('.claudian-history-item-actions')!.children[0].click();
+      const input = item.querySelector('.claudian-rename-input')!;
+      input.value = '  Original title  ';
+      input.blur();
+      await Promise.resolve();
+
+      expect(deps.plugin.renameConversation).not.toHaveBeenCalled();
+      expect(onRerender).toHaveBeenCalledTimes(1);
+    });
+
+    it('cancels the active inline rename without persisting the draft', async () => {
+      const container = createMockEl();
+      const onRerender = jest.fn();
+      (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
+        { id: 'conv-1', title: 'Original title', createdAt: 1000 },
+      ]);
+
+      controller.renderHistoryDropdown(container, {
+        onSelectConversation: jest.fn(),
+        onRerender,
+      });
+
+      const item = container.querySelector('.claudian-history-item')!;
+      const title = item.querySelector('.claudian-history-item-title')!;
+      title.replaceWith = jest.fn();
+      item.querySelector('.claudian-history-item-actions')!.children[0].click();
+      const input = item.querySelector('.claudian-rename-input')!;
+      input.value = 'Unsaved title';
+
+      expect(controller.cancelInlineRename()).toBe(true);
+      await Promise.resolve();
+
+      expect(input.value).toBe('Original title');
+      expect(deps.plugin.renameConversation).not.toHaveBeenCalled();
+      expect(onRerender).toHaveBeenCalledTimes(1);
+      expect(controller.cancelInlineRename()).toBe(false);
+    });
+
+    it('releases inline rename ownership when its surface rerenders without blur', () => {
+      const container = createMockEl();
+      const options = {
+        onSelectConversation: jest.fn(),
+        onRerender: jest.fn(),
+      };
+      (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
+        { id: 'conv-1', title: 'Original title', createdAt: 1000 },
+      ]);
+
+      controller.renderHistoryDropdown(container, options);
+      const item = container.querySelector('.claudian-history-item')!;
+      const title = item.querySelector('.claudian-history-item-title')!;
+      title.replaceWith = jest.fn();
+      item.querySelector('.claudian-history-item-actions')!.children[0].click();
+      const input = item.querySelector('.claudian-rename-input')!;
+      input.value = 'Detached draft';
+
+      controller.renderHistoryDropdown(container, options);
+
+      expect(controller.cancelInlineRename()).toBe(false);
+      expect(deps.plugin.renameConversation).not.toHaveBeenCalled();
     });
 
     it('should delete conversation and reload active when deleting current conversation', async () => {

--- a/tests/unit/style/components/history.test.ts
+++ b/tests/unit/style/components/history.test.ts
@@ -19,3 +19,16 @@ describe('Persistent sidebar surface pager styles', () => {
     );
   });
 });
+
+describe('Single-pane history action styles', () => {
+  it('keeps row actions borderless and transparent while using color for interaction', () => {
+    const css = readFileSync(path.resolve('src/style/components/history.css'), 'utf8');
+
+    expect(css).toMatch(
+      /\.claudian-history-menu \.claudian-history-item-actions \.claudian-action-btn\s*{[^}]*background:\s*transparent;[^}]*border:\s*none;[^}]*box-shadow:\s*none;[^}]*color:\s*var\(--text-muted\);/,
+    );
+    expect(css).toMatch(
+      /\.claudian-history-menu \.claudian-history-item-actions \.claudian-action-btn:hover,[\s\S]*?\.claudian-history-menu \.claudian-history-item-actions \.claudian-action-btn:focus-visible\s*{[^}]*background:\s*transparent;[^}]*box-shadow:\s*none;[^}]*color:\s*var\(--text-normal\);/,
+    );
+  });
+});


### PR DESCRIPTION
## Why

The conversation context menu could dismiss its surface before the inline rename editor mounted, making Rename unreliable in single-pane history and filtered session views; no issue is linked because this is a contained UI regression fix.

## What Changed

Deferred rename until the owning history surface is restored, resolved the current row by conversation ID, made Escape and rerender cleanup safe, removed the duplicate single-pane pin affordance, normalized history action styling, and documented mandatory button and text-control style patterns.

## Why This Approach

The view coordinates surface lifecycle and owner-window scheduling while `ConversationController` retains ownership of rename behavior, preserving the existing feature boundary and avoiding stale DOM references.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run test` — 6,555 tests passed
- `npm run build`
- `git diff --check`

## Impact and Follow-ups

None; this changes no persisted format or provider contract.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
