### PR TITLE
fix: keep allow-once approvals invocation-scoped

### DIFF
--- a/src/providers/claude/execution/ClaudeInteractionHandler.ts
+++ b/src/providers/claude/execution/ClaudeInteractionHandler.ts
@@ -14,7 +14,7 @@ import {
   TOOL_EXIT_PLAN_MODE,
 } from '../../../core/tools/toolNames';
 import type { PermissionMode } from '../../../core/types/settings';
-import { buildPermissionUpdates } from '../security/ClaudePermissionUpdates';
+import { buildPersistentPermissionUpdates } from '../security/ClaudePermissionUpdates';
 
 export interface ClaudeExecutionInteractionDeps {
   readonly interactionPort: ProviderInteractionPort;
@@ -166,16 +166,23 @@ export class ClaudeInteractionHandler {
           interrupt: true,
         };
       }
-      if (decision === 'allow' || decision === 'allow-always') {
+      if (decision === 'allow') {
         return {
           behavior: 'allow',
           updatedInput: input,
-          updatedPermissions: buildPermissionUpdates(
+          decisionClassification: 'user_temporary',
+        };
+      }
+      if (decision === 'allow-always') {
+        return {
+          behavior: 'allow',
+          updatedInput: input,
+          updatedPermissions: buildPersistentPermissionUpdates(
             toolName,
             input,
-            decision,
             options.suggestions,
           ),
+          decisionClassification: 'user_permanent',
         };
       }
       this.deps.onToolBlocked(options.toolUseID);

--- a/src/providers/claude/security/ClaudePermissionUpdates.ts
+++ b/src/providers/claude/security/ClaudePermissionUpdates.ts
@@ -1,38 +1,29 @@
-import type { PermissionUpdate, PermissionUpdateDestination } from '@anthropic-ai/claude-agent-sdk';
+import type { PermissionUpdate } from '@anthropic-ai/claude-agent-sdk';
 
 import { getActionPattern } from '../../../core/security/approvalRules';
 
-export function buildPermissionUpdates(
+export function buildPersistentPermissionUpdates(
   toolName: string,
   input: Record<string, unknown>,
-  decision: 'allow' | 'allow-always',
   suggestions?: PermissionUpdate[]
 ): PermissionUpdate[] {
-  const destination: PermissionUpdateDestination =
-    decision === 'allow-always' ? 'projectSettings' : 'session';
-
   const processed: PermissionUpdate[] = [];
   let hasRuleUpdate = false;
 
   if (suggestions) {
     for (const suggestion of suggestions) {
       if (suggestion.type === 'addRules' || suggestion.type === 'replaceRules') {
-        if (decision === 'allow-always') {
-          const scopedRules = suggestion.rules.filter(hasNonEmptyRuleScope);
-          if (scopedRules.length === 0) {
-            continue;
-          }
-          hasRuleUpdate = true;
-          processed.push({
-            ...suggestion,
-            rules: scopedRules,
-            behavior: 'allow',
-            destination,
-          });
-        } else {
-          hasRuleUpdate = true;
-          processed.push({ ...suggestion, behavior: 'allow', destination });
+        const scopedRules = suggestion.rules.filter(hasNonEmptyRuleScope);
+        if (scopedRules.length === 0) {
+          continue;
         }
+        hasRuleUpdate = true;
+        processed.push({
+          ...suggestion,
+          rules: scopedRules,
+          behavior: 'allow',
+          destination: 'projectSettings',
+        });
       } else {
         processed.push(suggestion);
       }
@@ -41,7 +32,7 @@ export function buildPermissionUpdates(
 
   if (!hasRuleUpdate) {
     const pattern = getActionPattern(toolName, input);
-    if (decision === 'allow-always' && !isNonEmptyDerivedScope(pattern)) {
+    if (!isNonEmptyDerivedScope(pattern)) {
       return [];
     }
     const ruleValue: { toolName: string; ruleContent?: string } = { toolName };
@@ -53,7 +44,7 @@ export function buildPermissionUpdates(
       type: 'addRules',
       behavior: 'allow',
       rules: [ruleValue],
-      destination,
+      destination: 'projectSettings',
     });
   }
 

--- a/tests/unit/providers/claude/execution/ClaudeInteractionHandler.test.ts
+++ b/tests/unit/providers/claude/execution/ClaudeInteractionHandler.test.ts
@@ -43,6 +43,62 @@ const nativeOptions = {
 };
 
 describe('createClaudeExecutionCanUseTool', () => {
+  it('allows only the current invocation for an allow-once decision', async () => {
+    const port = createPort();
+    port.requestApproval.mockImplementation(async (request) => ({
+      interactionId: request.interactionId,
+      decision: 'allow',
+    }));
+    const handler = createHandler(port);
+    const input = { command: 'ls /external/path' };
+    const suggestions = [{
+      type: 'addRules' as const,
+      behavior: 'allow' as const,
+      rules: [{ toolName: 'Bash', ruleContent: 'ls *' }],
+      destination: 'session' as const,
+    }];
+
+    const result = await handler('Bash', input, {
+      ...nativeOptions,
+      suggestions,
+    });
+
+    expect(result).toEqual({
+      behavior: 'allow',
+      updatedInput: input,
+      decisionClassification: 'user_temporary',
+    });
+  });
+
+  it('applies provider suggestions only for an always-allow decision', async () => {
+    const port = createPort();
+    const handler = createHandler(port);
+    const input = { command: 'git status' };
+    const suggestions = [{
+      type: 'addRules' as const,
+      behavior: 'allow' as const,
+      rules: [{ toolName: 'Bash', ruleContent: 'git *' }],
+      destination: 'session' as const,
+    }];
+
+    const result = await handler('Bash', input, {
+      ...nativeOptions,
+      suggestions,
+    });
+
+    expect(result).toEqual({
+      behavior: 'allow',
+      updatedInput: input,
+      updatedPermissions: [{
+        type: 'addRules',
+        behavior: 'allow',
+        rules: [{ toolName: 'Bash', ruleContent: 'git *' }],
+        destination: 'projectSettings',
+      }],
+      decisionClassification: 'user_permanent',
+    });
+  });
+
   it('routes approvals with stable native/local identity and dismisses the exact interaction', async () => {
     const port = createPort();
     const handler = createHandler(port);

--- a/tests/unit/providers/claude/security/ClaudePermissionUpdates.test.ts
+++ b/tests/unit/providers/claude/security/ClaudePermissionUpdates.test.ts
@@ -1,19 +1,14 @@
-import { buildPermissionUpdates } from '@/providers/claude/security/ClaudePermissionUpdates';
+import { buildPersistentPermissionUpdates } from '@/providers/claude/security/ClaudePermissionUpdates';
 
-describe('buildPermissionUpdates', () => {
-  it('constructs allow rule for allow decision', () => {
-    const updates = buildPermissionUpdates('Bash', { command: 'git status' }, 'allow');
+describe('buildPersistentPermissionUpdates', () => {
+  it('constructs a project allow rule from the action', () => {
+    const updates = buildPersistentPermissionUpdates('Bash', { command: 'git status' });
     expect(updates).toEqual([{
       type: 'addRules',
       behavior: 'allow',
       rules: [{ toolName: 'Bash', ruleContent: 'git status' }],
-      destination: 'session',
+      destination: 'projectSettings',
     }]);
-  });
-
-  it('uses projectSettings destination for always decisions', () => {
-    const updates = buildPermissionUpdates('Bash', { command: 'git status' }, 'allow-always');
-    expect(updates[0].destination).toBe('projectSettings');
   });
 
   it('uses SDK suggestions when available', () => {
@@ -23,7 +18,7 @@ describe('buildPermissionUpdates', () => {
       rules: [{ toolName: 'Bash', ruleContent: 'git *' }],
       destination: 'session' as const,
     }];
-    const updates = buildPermissionUpdates('Bash', { command: 'git status' }, 'allow-always', suggestions);
+    const updates = buildPersistentPermissionUpdates('Bash', { command: 'git status' }, suggestions);
     expect(updates).toEqual([{
       type: 'addRules',
       behavior: 'allow',
@@ -33,23 +28,17 @@ describe('buildPermissionUpdates', () => {
   });
 
   it('falls back to constructed rule when no addRules suggestions', () => {
-    const updates = buildPermissionUpdates('Bash', { command: 'ls' }, 'allow', []);
+    const updates = buildPersistentPermissionUpdates('Bash', { command: 'ls' }, []);
     expect(updates).toEqual([{
       type: 'addRules',
       behavior: 'allow',
       rules: [{ toolName: 'Bash', ruleContent: 'ls' }],
-      destination: 'session',
+      destination: 'projectSettings',
     }]);
   });
 
-  it('omits ruleContent when pattern is null (missing file_path)', () => {
-    const updates = buildPermissionUpdates('Read', {}, 'allow');
-    expect(updates).toEqual([{
-      type: 'addRules',
-      behavior: 'allow',
-      rules: [{ toolName: 'Read' }],
-      destination: 'session',
-    }]);
+  it('does not persist an unscoped fallback rule', () => {
+    expect(buildPersistentPermissionUpdates('Read', {})).toEqual([]);
   });
 
   it('includes addDirectories suggestions without overriding destination', () => {
@@ -66,7 +55,7 @@ describe('buildPermissionUpdates', () => {
         destination: 'session' as const,
       },
     ];
-    const updates = buildPermissionUpdates('Read', { file_path: '/external/path/file.md' }, 'allow-always', suggestions);
+    const updates = buildPersistentPermissionUpdates('Read', { file_path: '/external/path/file.md' }, suggestions);
     expect(updates).toHaveLength(2);
     expect(updates[0]).toEqual({
       type: 'addRules',
@@ -89,7 +78,7 @@ describe('buildPermissionUpdates', () => {
         destination: 'session' as const,
       },
     ];
-    const updates = buildPermissionUpdates('Bash', { command: 'ls' }, 'allow-always', suggestions);
+    const updates = buildPersistentPermissionUpdates('Bash', { command: 'ls' }, suggestions);
     expect(updates).toHaveLength(2);
     expect(updates[0]).toEqual({
       type: 'addRules',
@@ -112,7 +101,7 @@ describe('buildPermissionUpdates', () => {
         destination: 'session' as const,
       },
     ];
-    const updates = buildPermissionUpdates('Bash', { command: 'echo hi' }, 'allow-always', suggestions);
+    const updates = buildPersistentPermissionUpdates('Bash', { command: 'echo hi' }, suggestions);
     expect(updates).toHaveLength(2);
     expect(updates[0]).toEqual({
       type: 'addRules',
@@ -135,7 +124,7 @@ describe('buildPermissionUpdates', () => {
         destination: 'session' as const,
       },
     ];
-    const updates = buildPermissionUpdates('Read', { file_path: '/new/dir/file.md' }, 'allow', suggestions);
+    const updates = buildPersistentPermissionUpdates('Read', { file_path: '/new/dir/file.md' }, suggestions);
     expect(updates).toHaveLength(2);
     expect(updates[0].type).toBe('addRules');
     expect(updates[1].type).toBe('addDirectories');
@@ -150,7 +139,7 @@ describe('buildPermissionUpdates', () => {
         destination: 'session' as const,
       },
     ];
-    const updates = buildPermissionUpdates('Bash', { command: 'git status' }, 'allow-always', suggestions);
+    const updates = buildPersistentPermissionUpdates('Bash', { command: 'git status' }, suggestions);
     expect(updates).toHaveLength(1);
     expect(updates[0]).toEqual({
       type: 'replaceRules',
@@ -169,13 +158,13 @@ describe('buildPermissionUpdates', () => {
         destination: 'session' as const,
       },
     ];
-    const updates = buildPermissionUpdates('Bash', { command: 'git status' }, 'allow', suggestions);
+    const updates = buildPersistentPermissionUpdates('Bash', { command: 'git status' }, suggestions);
     expect(updates).toHaveLength(2);
     expect(updates[0].type).toBe('addRules');
     expect(updates[0]).toMatchObject({
       behavior: 'allow',
       rules: [{ toolName: 'Bash', ruleContent: 'git status' }],
-      destination: 'session',
+      destination: 'projectSettings',
     });
     expect(updates[1].type).toBe('removeRules');
   });
@@ -189,7 +178,7 @@ describe('buildPermissionUpdates', () => {
         destination: 'session' as const,
       },
     ];
-    const updates = buildPermissionUpdates('Bash', { command: 'git status' }, 'allow-always', suggestions);
+    const updates = buildPersistentPermissionUpdates('Bash', { command: 'git status' }, suggestions);
     const removeEntry = updates.find(u => u.type === 'removeRules');
     expect(removeEntry).toBeDefined();
     expect(removeEntry!.behavior).toBe('deny');
@@ -197,9 +186,9 @@ describe('buildPermissionUpdates', () => {
   });
 
   it('returns no persistent update when neither suggestions nor fallback have a non-empty scope', () => {
-    expect(buildPermissionUpdates('Read', {}, 'allow-always')).toEqual([]);
-    expect(buildPermissionUpdates('Bash', { command: '   ' }, 'allow-always')).toEqual([]);
-    expect(buildPermissionUpdates('UnknownTool', {}, 'allow-always')).toEqual([]);
+    expect(buildPersistentPermissionUpdates('Read', {})).toEqual([]);
+    expect(buildPersistentPermissionUpdates('Bash', { command: '   ' })).toEqual([]);
+    expect(buildPersistentPermissionUpdates('UnknownTool', {})).toEqual([]);
   });
 
   it('ignores whitespace-only suggested scopes for persistent approval', () => {
@@ -210,7 +199,7 @@ describe('buildPermissionUpdates', () => {
       destination: 'session' as const,
     }];
 
-    expect(buildPermissionUpdates('Read', {}, 'allow-always', suggestions)).toEqual([]);
+    expect(buildPersistentPermissionUpdates('Read', {}, suggestions)).toEqual([]);
   });
 
   it('preserves the exact non-empty provider suggestion for persistent approval', () => {
@@ -221,7 +210,7 @@ describe('buildPermissionUpdates', () => {
       destination: 'session' as const,
     }];
 
-    expect(buildPermissionUpdates('Bash', {}, 'allow-always', suggestions)).toEqual([{
+    expect(buildPersistentPermissionUpdates('Bash', {}, suggestions)).toEqual([{
       type: 'addRules',
       behavior: 'allow',
       rules: [{ toolName: 'Bash', ruleContent: 'git *' }],


### PR DESCRIPTION
## Why

Fixes #1098. Claude “Allow once” approvals incorrectly installed session permission rules, allowing later matching or broadly suggested tool calls to bypass a new prompt.

## What Changed

- Return invocation-only approval results without SDK permission updates for temporary decisions.
- Restrict permission-update construction to persistent “Always allow” decisions and classify both approval scopes for the Claude SDK.
- Add regression coverage for broad Bash suggestions and persistent rule construction.

## Why This Approach

Keeping the distinction at the Claude interaction boundary matches the SDK contract and makes the persistent helper incapable of recreating temporary session grants.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run test` — 351 suites, 6,556 tests
- `npm run build`
- `git diff --check origin/main...`

## Impact and Follow-ups

Claude provider only; no persisted-data migration or user-facing documentation change is required.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
