### PR TITLE
docs: add OrcaRouter to compatible API provider list

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Open the chat sidebar from the ribbon icon or command palette. Select text and u
   - [Grok Build](https://github.com/xai-org/grok-build)
   - [OpenCode](https://github.com/anomalyco/opencode)
   - [Pi](https://github.com/earendil-works/pi)
-- A compatible subscription or API provider, such as [OpenRouter](https://openrouter.ai/docs/guides/guides/claude-code-integration), [Kimi](https://platform.kimi.ai/docs/guide/claude-code-kimi), [GLM](https://docs.z.ai/devpack/tool/claude), or [DeepSeek](https://api-docs.deepseek.com/quick_start/agent_integrations/claude_code).
+- A compatible subscription or API provider, such as [OpenRouter](https://openrouter.ai/docs/guides/guides/claude-code-integration), [Kimi](https://platform.kimi.ai/docs/guide/claude-code-kimi), [GLM](https://docs.z.ai/devpack/tool/claude), [DeepSeek](https://api-docs.deepseek.com/quick_start/agent_integrations/claude_code), or [OrcaRouter](https://docs.orcarouter.ai/integrations/claude-code).
 - Obsidian v1.7.2+
 - Desktop only (macOS, Linux, Windows)
 


### PR DESCRIPTION
## What

Adds **OrcaRouter** to the list of compatible subscription/API providers in the README Requirements section.

OrcaRouter is an OpenAI- and Anthropic-compatible model gateway that works as a drop-in endpoint for the Claude Code CLI (the same `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN` configuration the list already documents for OpenRouter, Kimi, GLM, and DeepSeek). It also provides gateway-level security controls for AI agents.

## Change

- `README.md` — extend the "A compatible subscription or API provider, such as …" list with `[OrcaRouter](https://docs.orcarouter.ai/integrations/claude-code)`, mirroring the existing entries (each points at that provider's Claude Code integration guide).

This is a one-line documentation addition to an existing open-ended example list. It does not add a new provider implementation — consistent with the CONTRIBUTING.md policy, which scopes new-provider rejections to CLI harness integrations; Claude Code uses alternative model endpoints purely through configuration.

## Verification

- The linked integration guide resolves: `https://docs.orcarouter.ai/integrations/claude-code` returns `200`.
- L3 live check of the gateway endpoint with an `sk-orca-` key passed: `GET https://api.orcarouter.ai/v1/models` → `200` (model list includes namespaced slugs like `openai/gpt-5.5`, `anthropic/claude-sonnet-5`, `orcarouter/free`, `orcarouter/fusion`).

I'm an engineer on the [OrcaRouter](https://www.orcarouter.ai) team.
