### PR TITLE
fix: preserve auto-scroll after bottom navigation

### DIFF
--- a/src/features/chat/tabs/runtime/TabRuntimeInputBindings.ts
+++ b/src/features/chat/tabs/runtime/TabRuntimeInputBindings.ts
@@ -112,15 +112,114 @@ export function buildTabRuntimeInputBindings(
   const scrollThreshold = 20;
   const reEnableDelay = 150;
   let reEnableTimeout: number | null = null;
+  let bottomNavigationInProgress = false;
 
   const isAutoScrollAllowed = (): boolean => plugin.settings.enableAutoScroll ?? true;
+  const cancelReEnableTimeout = (): void => {
+    if (reEnableTimeout === null) return;
+    window.clearTimeout(reEnableTimeout);
+    reEnableTimeout = null;
+  };
+
+  ui.navigationSidebar.setOnScrollIntent((intent) => {
+    cancelReEnableTimeout();
+    const enabled = intent === 'bottom' && isAutoScrollAllowed();
+    bottomNavigationInProgress = enabled;
+    state.autoScrollEnabled = enabled;
+  });
+  options.registerCleanup('tab scroll navigation binding', () => {
+    ui.navigationSidebar.setOnScrollIntent(null);
+  });
+
+  const nativeBoundaryScrollKeys = new Set(['end', 'home']);
+  const nativePageScrollKeys = new Set(['pagedown', 'pageup']);
+  const nativeArrowScrollKeys = new Set(['arrowdown', 'arrowup']);
+  const userScrollIntentHandler = (event: Event) => {
+    if (event.type === 'keydown') {
+      const keyboardEvent = event as KeyboardEvent;
+      const settings = plugin.settings.keyboardNavigation;
+      const key = keyboardEvent.key.toLowerCase();
+      const hasControlModifier = keyboardEvent.ctrlKey || keyboardEvent.metaKey;
+      const isConfiguredScrollKey = !hasControlModifier
+        && !keyboardEvent.altKey
+        && !keyboardEvent.shiftKey && (
+        key === settings.scrollUpKey.toLowerCase()
+        || key === settings.scrollDownKey.toLowerCase()
+      );
+      const target = keyboardEvent.target as HTMLElement | null;
+      const targetTag = target?.tagName;
+      const isTextEntryTarget = targetTag === 'INPUT'
+        || targetTag === 'SELECT'
+        || targetTag === 'TEXTAREA'
+        || target?.isContentEditable === true;
+      const isActivatableTarget = targetTag === 'A'
+        || targetTag === 'BUTTON'
+        || targetTag === 'SUMMARY'
+        || target?.getAttribute?.('role') === 'button';
+      const isNativeBoundaryScrollKey = !keyboardEvent.altKey
+        && !keyboardEvent.shiftKey
+        && nativeBoundaryScrollKeys.has(key)
+        && !isTextEntryTarget;
+      const isNativePageScrollKey = !hasControlModifier
+        && !keyboardEvent.altKey
+        && !keyboardEvent.shiftKey
+        && nativePageScrollKeys.has(key)
+        && !isTextEntryTarget;
+      const isNativeArrowScrollKey = !keyboardEvent.altKey
+        && !keyboardEvent.shiftKey
+        && nativeArrowScrollKeys.has(key)
+        && !isTextEntryTarget
+        && !isActivatableTarget;
+      const isNativeSpaceScrollKey = key === ' '
+        && !hasControlModifier
+        && !keyboardEvent.altKey
+        && !isTextEntryTarget
+        && !isActivatableTarget;
+      const isNativeScrollKey = isNativeBoundaryScrollKey
+        || isNativePageScrollKey
+        || isNativeArrowScrollKey
+        || isNativeSpaceScrollKey;
+      if (!isConfiguredScrollKey && !isNativeScrollKey) {
+        return;
+      }
+    }
+    if (event.type === 'pointerdown') {
+      const pointerEvent = event as PointerEvent;
+      if (pointerEvent.target !== dom.messagesEl) return;
+      const scrollbarWidth = dom.messagesEl.offsetWidth - dom.messagesEl.clientWidth;
+      if (scrollbarWidth <= 0 || dom.messagesEl.scrollHeight <= dom.messagesEl.clientHeight) return;
+      const bounds = dom.messagesEl.getBoundingClientRect();
+      const pointerX = pointerEvent.clientX - bounds.left;
+      const direction = dom.messagesEl.ownerDocument.defaultView
+        ?.getComputedStyle?.(dom.messagesEl).direction;
+      const isInScrollbarGutter = direction === 'rtl'
+        ? pointerX <= scrollbarWidth
+        : pointerX >= bounds.width - scrollbarWidth;
+      if (!isInScrollbarGutter) return;
+    }
+    cancelReEnableTimeout();
+    bottomNavigationInProgress = false;
+    state.autoScrollEnabled = false;
+  };
+  const userScrollIntentEvents = [
+    'wheel',
+    'touchmove',
+    'pointerdown',
+    'keydown',
+  ] as const;
+  for (const eventName of userScrollIntentEvents) {
+    dom.messagesEl.addEventListener(eventName, userScrollIntentHandler, { passive: true });
+  }
+  options.registerCleanup('tab user scroll intent binding', () => {
+    for (const eventName of userScrollIntentEvents) {
+      dom.messagesEl.removeEventListener(eventName, userScrollIntentHandler);
+    }
+  });
 
   const scrollHandler = () => {
     if (!isAutoScrollAllowed()) {
-      if (reEnableTimeout) {
-        window.clearTimeout(reEnableTimeout);
-        reEnableTimeout = null;
-      }
+      bottomNavigationInProgress = false;
+      cancelReEnableTimeout();
       state.autoScrollEnabled = false;
       return;
     }
@@ -129,13 +228,12 @@ export function buildTabRuntimeInputBindings(
     const isAtBottom = scrollHeight - scrollTop - clientHeight <= scrollThreshold;
 
     if (!isAtBottom) {
-      if (reEnableTimeout) {
-        window.clearTimeout(reEnableTimeout);
-        reEnableTimeout = null;
-      }
+      if (bottomNavigationInProgress) return;
+      cancelReEnableTimeout();
       state.autoScrollEnabled = false;
-    } else if (!state.autoScrollEnabled) {
-      if (!reEnableTimeout) {
+    } else {
+      if (state.autoScrollEnabled) return;
+      if (reEnableTimeout === null) {
         reEnableTimeout = window.setTimeout(() => {
           reEnableTimeout = null;
           const { scrollTop, scrollHeight, clientHeight } = dom.messagesEl;
@@ -149,7 +247,7 @@ export function buildTabRuntimeInputBindings(
   dom.messagesEl.addEventListener('scroll', scrollHandler, { passive: true });
   options.registerCleanup('tab message scroll binding', () => {
     dom.messagesEl.removeEventListener('scroll', scrollHandler);
-    if (reEnableTimeout) window.clearTimeout(reEnableTimeout);
+    cancelReEnableTimeout();
   });
   return { installed: true };
 }

--- a/src/features/chat/ui/NavigationSidebar.ts
+++ b/src/features/chat/ui/NavigationSidebar.ts
@@ -7,6 +7,8 @@ import {
 } from '../../../utils/animationFrame';
 import { formatConversationDirectoryTitle } from '../utils/conversationDirectoryTitle';
 
+type NavigationScrollIntent = 'away' | 'bottom';
+
 /**
  * Floating sidebar for navigating chat history.
  * Provides quick access to top/bottom and previous/next user messages.
@@ -24,10 +26,11 @@ export class NavigationSidebar {
   private mutationObserver: MutationObserver | null = null;
   private pendingVisibilityFrame: ScheduledAnimationFrame | null = null;
   private isVisible: boolean | null = null;
+  private onScrollIntent: ((intent: NavigationScrollIntent) => void) | null = null;
 
   constructor(
     private parentEl: HTMLElement,
-    private messagesEl: HTMLElement
+    private messagesEl: HTMLElement,
   ) {
     this.container = this.parentEl.createDiv({ cls: 'claudian-nav-sidebar' });
 
@@ -61,15 +64,23 @@ export class NavigationSidebar {
 
     // Button clicks
     this.topBtn.addEventListener('click', () => {
+      this.onScrollIntent?.('away');
       this.messagesEl.scrollTo({ top: 0, behavior: 'smooth' });
     });
 
     this.bottomBtn.addEventListener('click', () => {
+      this.onScrollIntent?.('bottom');
       this.messagesEl.scrollTo({ top: this.messagesEl.scrollHeight, behavior: 'smooth' });
     });
 
-    this.prevBtn.addEventListener('click', () => this.scrollToMessage('prev'));
-    this.nextBtn.addEventListener('click', () => this.scrollToMessage('next'));
+    this.prevBtn.addEventListener('click', () => {
+      this.onScrollIntent?.('away');
+      this.scrollToMessage('prev');
+    });
+    this.nextBtn.addEventListener('click', () => {
+      this.onScrollIntent?.('away');
+      this.scrollToMessage('next');
+    });
     this.tocBtn.addEventListener('click', (event) => {
       event.stopPropagation();
       this.toggleDirectory();
@@ -208,6 +219,7 @@ export class NavigationSidebar {
       itemEl.setAttribute('title', entry.title);
 
       const selectEntry = () => {
+        this.onScrollIntent?.('away');
         this.scrollToElement(entry.el);
         this.closeDirectory();
       };
@@ -271,6 +283,10 @@ export class NavigationSidebar {
     }
   }
 
+  setOnScrollIntent(callback: ((intent: NavigationScrollIntent) => void) | null): void {
+    this.onScrollIntent = callback;
+  }
+
   destroy(): void {
     if (this.pendingVisibilityFrame !== null) {
       cancelScheduledAnimationFrame(this.pendingVisibilityFrame);
@@ -283,6 +299,7 @@ export class NavigationSidebar {
     }
     this.mutationObserver?.disconnect();
     this.mutationObserver = null;
+    this.onScrollIntent = null;
     this.messagesEl.removeEventListener('scroll', this.scrollHandler);
     this.container.remove();
   }

--- a/tests/unit/features/chat/tabs/TabRuntimeFactory.test.ts
+++ b/tests/unit/features/chat/tabs/TabRuntimeFactory.test.ts
@@ -400,6 +400,207 @@ describe('Tab provider execution ownership', () => {
     expect(coordinatorInstances).toHaveLength(1);
   });
 
+  it('lets later navigation override bottom auto-scroll intent', async () => {
+    const plugin = createPlugin();
+    plugin.settings.keyboardNavigation = {
+      focusInputKey: 'i',
+      scrollDownKey: 's',
+      scrollUpKey: 'w',
+    };
+    const tab = await createTestTab({
+      plugin,
+      containerEl: createMockEl() as any,
+    });
+    tab.dom.messagesEl.scrollHeight = 1_000;
+    tab.dom.messagesEl.clientHeight = 500;
+    tab.dom.messagesEl.scrollTop = 100;
+    tab.state.autoScrollEnabled = false;
+    tab.dom.messagesEl.scrollTo = jest.fn();
+
+    const bottomButton = tab.dom.messagesWrapperEl.querySelector(
+      '.claudian-nav-btn-bottom',
+    );
+    bottomButton?.click();
+
+    expect(bottomButton).not.toBeNull();
+    expect(tab.state.autoScrollEnabled).toBe(true);
+
+    tab.dom.messagesEl.dispatchEvent('scroll');
+
+    expect(tab.state.autoScrollEnabled).toBe(true);
+
+    tab.dom.messagesEl.scrollTop = 500;
+    tab.dom.messagesEl.dispatchEvent('scroll');
+    tab.dom.messagesEl.scrollHeight = 1_200;
+    tab.dom.messagesEl.dispatchEvent('scroll');
+
+    expect(tab.state.autoScrollEnabled).toBe(true);
+
+    const sidebar = tab.dom.messagesWrapperEl.querySelector('.claudian-nav-sidebar');
+    for (const buttonIndex of [0, 1, 3]) {
+      bottomButton?.click();
+      sidebar?.children[buttonIndex]?.click();
+      expect(tab.state.autoScrollEnabled).toBe(false);
+    }
+
+    const userMessage = tab.dom.messagesEl.createDiv({ cls: 'claudian-message-user' });
+    userMessage.setAttribute('data-toc-title', 'Prompt');
+    const queryMessages = tab.dom.messagesEl.querySelectorAll.bind(tab.dom.messagesEl);
+    tab.dom.messagesEl.querySelectorAll = jest.fn((selector: string) => (
+      selector === '.claudian-message-user, [data-role="user"]'
+        ? [userMessage]
+        : queryMessages(selector)
+    ));
+    const messageControl = userMessage.createEl('button');
+    bottomButton?.click();
+    sidebar?.children[2]?.click();
+    tab.dom.messagesWrapperEl.querySelector('.claudian-nav-toc-item')?.click();
+    expect(tab.state.autoScrollEnabled).toBe(false);
+
+    bottomButton?.click();
+    tab.dom.messagesEl.dispatchEvent({
+      type: 'keydown',
+      key: 'w',
+      target: messageControl,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      preventDefault: jest.fn(),
+    });
+    expect(tab.state.autoScrollEnabled).toBe(false);
+
+    bottomButton?.click();
+    tab.dom.messagesEl.dispatchEvent({
+      type: 'keydown',
+      key: 'PageUp',
+      target: messageControl,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      preventDefault: jest.fn(),
+    });
+    expect(tab.state.autoScrollEnabled).toBe(false);
+
+    bottomButton?.click();
+    tab.dom.messagesEl.dispatchEvent({
+      type: 'pointerdown',
+      target: tab.dom.messagesEl,
+      clientX: 250,
+    });
+    expect(tab.state.autoScrollEnabled).toBe(true);
+
+    tab.dom.messagesEl.dispatchEvent({
+      type: 'touchstart',
+      target: userMessage,
+    });
+    expect(tab.state.autoScrollEnabled).toBe(true);
+
+    tab.dom.messagesEl.dispatchEvent({
+      type: 'touchmove',
+      target: userMessage,
+    });
+    expect(tab.state.autoScrollEnabled).toBe(false);
+
+    bottomButton?.click();
+    tab.dom.messagesEl.dispatchEvent({
+      type: 'keydown',
+      key: ' ',
+      target: messageControl,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      preventDefault: jest.fn(),
+    });
+    expect(tab.state.autoScrollEnabled).toBe(true);
+
+    tab.dom.messagesEl.dispatchEvent({
+      type: 'pointermove',
+      target: tab.dom.messagesEl,
+      buttons: 1,
+    });
+    expect(tab.state.autoScrollEnabled).toBe(true);
+
+    bottomButton?.click();
+    tab.dom.messagesEl.offsetWidth = 506;
+    tab.dom.messagesEl.clientWidth = 500;
+    tab.dom.messagesEl.getBoundingClientRect = jest.fn().mockReturnValue({
+      bottom: 500,
+      height: 500,
+      left: 0,
+      right: 506,
+      top: 0,
+      width: 506,
+      x: 0,
+      y: 0,
+      toJSON: jest.fn(),
+    });
+    tab.dom.messagesEl.dispatchEvent({
+      type: 'pointerdown',
+      target: tab.dom.messagesEl,
+      clientX: 503,
+    });
+    expect(tab.state.autoScrollEnabled).toBe(false);
+
+    bottomButton?.click();
+    tab.dom.messagesEl.dispatchEvent({
+      type: 'keydown',
+      key: 'Home',
+      target: messageControl,
+      altKey: false,
+      ctrlKey: true,
+      metaKey: false,
+      shiftKey: false,
+      preventDefault: jest.fn(),
+    });
+    expect(tab.state.autoScrollEnabled).toBe(false);
+
+    bottomButton?.click();
+    tab.dom.messagesEl.dispatchEvent({ type: 'wheel' });
+
+    expect(tab.state.autoScrollEnabled).toBe(false);
+  });
+
+  it('keeps auto-scroll disabled when bottom navigation is used with the setting off', async () => {
+    const plugin = createPlugin();
+    plugin.settings.enableAutoScroll = false;
+    const tab = await createTestTab({
+      plugin,
+      containerEl: createMockEl() as any,
+    });
+    tab.state.autoScrollEnabled = false;
+    tab.dom.messagesEl.scrollTo = jest.fn();
+
+    tab.dom.messagesWrapperEl.querySelector('.claudian-nav-btn-bottom')?.click();
+
+    expect(tab.state.autoScrollEnabled).toBe(false);
+  });
+
+  it('does not let a pending bottom re-arm override newer navigation', async () => {
+    jest.useFakeTimers();
+    try {
+      const tab = await createTestTab({
+        plugin: createPlugin(),
+        containerEl: createMockEl() as any,
+      });
+      tab.dom.messagesEl.scrollHeight = 1_000;
+      tab.dom.messagesEl.clientHeight = 500;
+      tab.dom.messagesEl.scrollTop = 500;
+      tab.dom.messagesEl.scrollTo = jest.fn();
+      tab.state.autoScrollEnabled = false;
+
+      tab.dom.messagesEl.dispatchEvent('scroll');
+      tab.dom.messagesWrapperEl.querySelector('.claudian-nav-btn-top')?.click();
+      jest.advanceTimersByTime(150);
+
+      expect(tab.state.autoScrollEnabled).toBe(false);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('releases the renderer file-link listener during tab teardown', async () => {
     const tab = await createTestTab({
       plugin: createPlugin(),


### PR DESCRIPTION
## Why

Closes #1101 by ensuring an explicit Scroll to bottom action resumes auto-scroll for the rest of streaming.

## What Changed

- Emit explicit sidebar scroll intent for Bottom and competing navigation actions.
- Keep Bottom intent active through smooth-scroll events while allowing real wheel, touch, scrollbar, and keyboard navigation to override it.
- Cancel stale re-arm timers and add regression coverage for intent ordering, settings, and non-scroll interactions.

## Why This Approach

The sidebar reports user intent while tab runtime bindings retain ownership of auto-scroll policy, preserving the existing feature boundary and smooth-scroll behavior.

## Validation

- `npm run typecheck && npm run lint && npm run test && npm run build`
- 351 test suites and 6,559 tests passed.

## Impact and Follow-ups

No compatibility or data migration impact; asynchronous post-render layout growth remains unchanged and can be considered separately.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.