### PR TITLE
fix: make Codex Fast mode reflect the next query

### DIFF
--- a/src/core/providers/ProviderSettingsCoordinator.ts
+++ b/src/core/providers/ProviderSettingsCoordinator.ts
@@ -90,6 +90,16 @@ function normalizeProviderModel(
   return uiConfig.normalizeModelVariant(model, settings);
 }
 
+function normalizeServiceTier(
+  uiConfig: ProviderChatUIConfig,
+  settings: Record<string, unknown>,
+): void {
+  const toggle = uiConfig.getServiceTierToggle?.(settings) ?? null;
+  settings.serviceTier = toggle
+    ? (toggle.isActive ? toggle.activeValue : toggle.inactiveValue)
+    : 'default';
+}
+
 function normalizeModelDependentSettings(
   uiConfig: ProviderChatUIConfig,
   settings: Record<string, unknown>,
@@ -111,25 +121,7 @@ function normalizeModelDependentSettings(
     );
   }
 
-  const serviceTierToggle = uiConfig.getServiceTierToggle?.(settings) ?? null;
-  if (!serviceTierToggle) {
-    settings.serviceTier = 'default';
-    return;
-  }
-
-  const currentServiceTier = typeof settings.serviceTier === 'string'
-    ? settings.serviceTier
-    : undefined;
-  if (currentServiceTier === 'fast') {
-    settings.serviceTier = serviceTierToggle.activeValue;
-    return;
-  }
-  if (
-    currentServiceTier !== serviceTierToggle.inactiveValue
-    && currentServiceTier !== serviceTierToggle.activeValue
-  ) {
-    settings.serviceTier = serviceTierToggle.inactiveValue;
-  }
+  normalizeServiceTier(uiConfig, settings);
 }
 
 export class ProviderSettingsCoordinator {

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -249,6 +249,8 @@ export interface ProviderServiceTierToggleConfig {
   inactiveLabel: string;
   activeValue: string;
   activeLabel: string;
+  /** Whether the provider will use the active tier for the next request. */
+  isActive: boolean;
   description?: string;
 }
 

--- a/src/features/chat/actions/toggleServiceTier.ts
+++ b/src/features/chat/actions/toggleServiceTier.ts
@@ -19,7 +19,7 @@ export async function toggleServiceTier(
     return false;
   }
 
-  const next = settings.serviceTier === toggleConfig.activeValue
+  const next = toggleConfig.isActive
     ? toggleConfig.inactiveValue
     : toggleConfig.activeValue;
   await context.onServiceTierChange(next);

--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -525,15 +525,16 @@ export class ServiceTierToggle {
     }
 
     this.container.removeClass('claudian-hidden');
-    const current = this.callbacks.getSettings().serviceTier;
-    const isActive = current === toggleConfig.activeValue;
-    if (isActive) {
+    if (toggleConfig.isActive) {
       this.buttonEl.addClass('active');
     } else {
       this.buttonEl.removeClass('active');
     }
 
-    this.container.setAttribute('title', 'Toggle on/off fast mode');
+    const currentLabel = toggleConfig.isActive
+      ? toggleConfig.activeLabel
+      : toggleConfig.inactiveLabel;
+    this.container.setAttribute('title', `Fast mode: ${currentLabel}`);
   }
 
   async toggle(): Promise<boolean> {

--- a/src/providers/codex/execution/CodexExecutionSession.ts
+++ b/src/providers/codex/execution/CodexExecutionSession.ts
@@ -43,6 +43,7 @@ import {
 import { getCodexModelOptions } from '../modelOptions';
 import {
   findCodexModel,
+  resolveCodexModelServiceTier,
   resolveCodexReasoningEffort,
 } from '../models';
 import { toCodexRuntimeModelId } from '../modelSelection';
@@ -2124,18 +2125,7 @@ function resolveCodexServiceTier(
     getCodexProviderSettings(settings).discoveredModels,
     modelId,
   );
-  if (!model) return null;
-  if (typeof serviceTier === 'string') {
-    if (model.serviceTiers.some(tier => tier.id === serviceTier)) {
-      return serviceTier;
-    }
-    if (serviceTier === 'fast') {
-      return model.serviceTiers.find(
-        tier => tier.name.toLowerCase() === 'fast',
-      )?.id ?? null;
-    }
-  }
-  return model.defaultServiceTier;
+  return resolveCodexModelServiceTier(model, serviceTier);
 }
 
 function shouldExposeDynamicTools(policy: ProviderToolPolicy): boolean {

--- a/src/providers/codex/models.ts
+++ b/src/providers/codex/models.ts
@@ -38,6 +38,7 @@ export const CODEX_FALLBACK_REASONING_EFFORT_VALUES = [
 
 const DEFAULT_INPUT_MODALITIES: Array<'text' | 'image'> = ['text', 'image'];
 const ULTRA_REASONING_EFFORT = 'ultra';
+export const CODEX_DEFAULT_SERVICE_TIER = 'default';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
@@ -254,4 +255,26 @@ export function getCodexFastServiceTier(
   model: CodexDiscoveredModel,
 ): CodexModelServiceTier | null {
   return model.serviceTiers.find(tier => tier.name.trim().toLowerCase() === 'fast') ?? null;
+}
+
+export function resolveCodexModelServiceTier(
+  model: CodexDiscoveredModel | null,
+  selectedServiceTier: unknown,
+): string | null {
+  if (!model) {
+    return null;
+  }
+  // "default" is an explicit Standard selection, distinct from the catalog default.
+  if (selectedServiceTier === CODEX_DEFAULT_SERVICE_TIER) {
+    return CODEX_DEFAULT_SERVICE_TIER;
+  }
+  if (typeof selectedServiceTier === 'string') {
+    if (model.serviceTiers.some(tier => tier.id === selectedServiceTier)) {
+      return selectedServiceTier;
+    }
+    if (selectedServiceTier === 'fast') {
+      return getCodexFastServiceTier(model)?.id ?? null;
+    }
+  }
+  return model.defaultServiceTier;
 }

--- a/src/providers/codex/ui/CodexChatUIConfig.ts
+++ b/src/providers/codex/ui/CodexChatUIConfig.ts
@@ -12,6 +12,7 @@ import type {
 import { OPENAI_PROVIDER_ICON } from '../../../shared/icons';
 import { getCodexModelOptions } from '../modelOptions';
 import {
+  CODEX_DEFAULT_SERVICE_TIER,
   CODEX_FALLBACK_REASONING_EFFORT_VALUES,
   findCodexModel,
   getCodexDefaultReasoningEffort,
@@ -19,6 +20,7 @@ import {
   getCodexReasoningEffortOptions,
   getDefaultCodexModel,
   isCodexModelAvailable,
+  resolveCodexModelServiceTier,
 } from '../models';
 import {
   isCodexModelSelectionId,
@@ -44,7 +46,6 @@ const CODEX_PERMISSION_MODE_TOGGLE: ProviderPermissionModeToggleConfig = {
   planLabel: 'Plan',
 };
 
-const DEFAULT_SERVICE_TIER_VALUE = 'default';
 const DEFAULT_SERVICE_TIER_LABEL = 'Standard';
 
 const DEFAULT_CONTEXT_WINDOW = 200_000;
@@ -184,10 +185,11 @@ export const codexChatUIConfig: ProviderChatUIConfig = {
     }
 
     return {
-      inactiveValue: model.defaultServiceTier ?? DEFAULT_SERVICE_TIER_VALUE,
+      inactiveValue: CODEX_DEFAULT_SERVICE_TIER,
       inactiveLabel: DEFAULT_SERVICE_TIER_LABEL,
       activeValue: tier.id,
       activeLabel: tier.name,
+      isActive: resolveCodexModelServiceTier(model, settings.serviceTier) === tier.id,
       description: tier.description || undefined,
     };
   },

--- a/tests/unit/core/providers/ProviderSettingsCoordinator.test.ts
+++ b/tests/unit/core/providers/ProviderSettingsCoordinator.test.ts
@@ -75,6 +75,49 @@ describe('ProviderSettingsCoordinator', () => {
       expect(settings.effortLevel).toBe('ultra');
     });
 
+    it.each([
+      {
+        caseName: 'legacy Fast with no catalog default',
+        storedServiceTier: 'fast',
+        defaultServiceTier: null,
+        expectedServiceTier: 'priority',
+      },
+      {
+        caseName: 'explicit Standard with a Fast catalog default',
+        storedServiceTier: 'default',
+        defaultServiceTier: 'priority',
+        expectedServiceTier: 'default',
+      },
+    ])('canonicalizes $caseName for a model snapshot', ({
+      storedServiceTier,
+      defaultServiceTier,
+      expectedServiceTier,
+    }) => {
+      const discoveredModels = TEST_CODEX_CATALOG.map(model => model.model === TEST_CODEX_MODEL
+        ? { ...model, defaultServiceTier }
+        : model);
+      const settings: Record<string, unknown> = {
+        settingsProvider: 'codex',
+        model: TEST_CODEX_MODEL,
+        effortLevel: 'medium',
+        serviceTier: storedServiceTier,
+        providerConfigs: {
+          codex: {
+            enabled: true,
+            discoveredModels,
+          },
+        },
+      };
+
+      const conversationSnapshot = getProviderSettingsSnapshotWithModel(
+        settings,
+        'codex',
+        TEST_CODEX_MODEL,
+      );
+
+      expect(conversationSnapshot.serviceTier).toBe(expectedServiceTier);
+    });
+
     it('uses a Pi conversation model preference before normalizing against the saved provider model', () => {
       const deepSeekModel = 'pi:deepseek/deepseek-reasoner';
       const gptModel = 'pi:openai/gpt-5';

--- a/tests/unit/features/chat/actions/toggleServiceTier.test.ts
+++ b/tests/unit/features/chat/actions/toggleServiceTier.test.ts
@@ -12,12 +12,33 @@ describe('toggleServiceTier', () => {
           inactiveLabel: 'Standard',
           activeValue: 'priority',
           activeLabel: 'Fast',
+          isActive: false,
         }),
       }),
       onServiceTierChange,
     })).resolves.toBe(true);
 
     expect(onServiceTierChange).toHaveBeenCalledWith('priority');
+  });
+
+  it('uses the provider-resolved active state instead of the raw setting', async () => {
+    const onServiceTierChange = jest.fn().mockResolvedValue(undefined);
+
+    await expect(toggleServiceTier({
+      getSettings: () => ({ serviceTier: 'fast' }),
+      getUIConfig: () => ({
+        getServiceTierToggle: () => ({
+          inactiveValue: 'default',
+          inactiveLabel: 'Standard',
+          activeValue: 'priority',
+          activeLabel: 'Fast',
+          isActive: true,
+        }),
+      }),
+      onServiceTierChange,
+    })).resolves.toBe(true);
+
+    expect(onServiceTierChange).toHaveBeenCalledWith('default');
   });
 
   it('returns false without persisting when the provider has no service-tier toggle', async () => {
@@ -43,6 +64,7 @@ describe('toggleServiceTier', () => {
           inactiveLabel: 'Standard',
           activeValue: 'priority',
           activeLabel: 'Fast',
+          isActive: true,
         }),
       }),
       onServiceTierChange: jest.fn().mockRejectedValue(failure),

--- a/tests/unit/features/chat/ui/InputToolbar.test.ts
+++ b/tests/unit/features/chat/ui/InputToolbar.test.ts
@@ -131,6 +131,7 @@ function createMockUIConfig() {
           inactiveLabel: 'Standard',
           activeValue: 'fast',
           activeLabel: 'Fast',
+          isActive: settings.serviceTier === 'fast',
           description: '1.5x speed, 2x credits',
         }
         : null
@@ -754,17 +755,19 @@ describe('PermissionToggle', () => {
 describe('ServiceTierToggle', () => {
   let parentEl: any;
   let callbacks: ReturnType<typeof createMockCallbacks>;
+  let uiConfig: ReturnType<typeof createMockUIConfig>;
 
   beforeEach(() => {
     jest.clearAllMocks();
     parentEl = createMockEl();
-    const uiConfig = createMockUIConfig();
+    uiConfig = createMockUIConfig();
     uiConfig.getServiceTierToggle.mockReturnValue({
       inactiveValue: 'default',
       inactiveLabel: 'Standard',
       activeValue: 'fast',
       activeLabel: 'Fast',
       description: '1.5x speed, 2x credits',
+      isActive: false,
     });
     callbacks = createMockCallbacks({
       getUIConfig: jest.fn().mockReturnValue(uiConfig),
@@ -791,16 +794,17 @@ describe('ServiceTierToggle', () => {
     const container = parentEl.querySelector('.claudian-service-tier-toggle');
     expect(button?.hasClass('active')).toBe(false);
     expect(icon).not.toBeNull();
-    expect(container?.getAttribute('title')).toBe('Toggle on/off fast mode');
+    expect(container?.getAttribute('title')).toBe('Fast mode: Standard');
   });
 
   it('renders the icon button in the active state when fast mode is on', () => {
-    callbacks.getSettings.mockReturnValue({
-      model: TEST_CODEX_MODEL,
-      thinkingBudget: 'off',
-      effortLevel: 'medium',
-      serviceTier: 'fast',
-      permissionMode: 'normal',
+    uiConfig.getServiceTierToggle.mockReturnValue({
+      inactiveValue: 'default',
+      inactiveLabel: 'Standard',
+      activeValue: 'fast',
+      activeLabel: 'Fast',
+      description: '1.5x speed, 2x credits',
+      isActive: true,
     });
     const parentEl2 = createMockEl();
     new ServiceTierToggle(parentEl2, callbacks);
@@ -808,7 +812,7 @@ describe('ServiceTierToggle', () => {
     const button = parentEl2.querySelector('.claudian-service-tier-button');
     const container = parentEl2.querySelector('.claudian-service-tier-toggle');
     expect(button?.hasClass('active')).toBe(true);
-    expect(container?.getAttribute('title')).toBe('Toggle on/off fast mode');
+    expect(container?.getAttribute('title')).toBe('Fast mode: Fast');
   });
 
   it('toggles from Standard to Fast on click', async () => {
@@ -824,6 +828,14 @@ describe('ServiceTierToggle', () => {
       effortLevel: 'medium',
       serviceTier: 'fast',
       permissionMode: 'normal',
+    });
+    uiConfig.getServiceTierToggle.mockReturnValue({
+      inactiveValue: 'default',
+      inactiveLabel: 'Standard',
+      activeValue: 'fast',
+      activeLabel: 'Fast',
+      description: '1.5x speed, 2x credits',
+      isActive: true,
     });
     const parentEl2 = createMockEl();
     new ServiceTierToggle(parentEl2, callbacks);

--- a/tests/unit/providers/codex/execution/CodexExecutionBackend.test.ts
+++ b/tests/unit/providers/codex/execution/CodexExecutionBackend.test.ts
@@ -513,6 +513,52 @@ describe('CodexExecutionBackend', () => {
     await session.dispose();
   });
 
+  it('keeps an explicit Standard selection off when the catalog defaults to Fast', async () => {
+    mockTransportRequest.mockImplementation(async (method: string) => {
+      if (method === 'initialize') {
+        return {
+          userAgent: 'test',
+          codexHome: '/tmp/.codex',
+          platformFamily: 'unix',
+          platformOs: 'macos',
+        };
+      }
+      if (method === 'thread/start') return createThreadResult('thread-standard-tier');
+      if (method === 'turn/start') {
+        queueMicrotask(() => completeTurn('thread-standard-tier', 'turn-standard-tier'));
+        return createTurnResult('turn-standard-tier');
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const plugin = createPlugin();
+    const codexConfig = (
+      plugin.settings.providerConfigs as Record<string, Record<string, unknown>>
+    ).codex;
+    codexConfig.discoveredModels = [{
+      ...(codexConfig.discoveredModels as Array<Record<string, unknown>>)[0],
+      defaultServiceTier: 'priority',
+    }];
+    const session = new CodexExecutionBackend(plugin).createSession(createSessionConfig());
+    await collectEvents(session.execute(createRequest(
+      new AbortController().signal,
+      {
+        configuration: {
+          systemInstructions: { kind: 'explicit', instructions: 'Be concise.' },
+          model: TEST_CODEX_MODEL,
+          reasoning: 'high',
+          serviceTier: 'default',
+          permissionMode: 'normal',
+        },
+      },
+    )).events);
+
+    expect(mockTransportRequest).toHaveBeenCalledWith(
+      'turn/start',
+      expect.objectContaining({ serviceTier: 'default' }),
+    );
+
+    await session.dispose();
+  });
 
   it('recovers a completed turn when the terminal notification is missed', async () => {
     jest.useFakeTimers();

--- a/tests/unit/providers/codex/models.test.ts
+++ b/tests/unit/providers/codex/models.test.ts
@@ -1,8 +1,24 @@
 import {
+  type CodexDiscoveredModel,
   findCodexModel,
   getDefaultCodexModel,
   normalizeCodexDiscoveredModels,
+  resolveCodexModelServiceTier,
 } from '@/providers/codex/models';
+
+function createFastModel(defaultServiceTier: string | null = null): CodexDiscoveredModel {
+  return {
+    model: 'gpt-5.6-sol',
+    displayName: 'GPT-5.6-Sol',
+    description: 'Latest frontier agentic coding model.',
+    supportedReasoningEfforts: [{ value: 'low', description: 'Fast responses' }],
+    defaultReasoningEffort: 'low',
+    serviceTiers: [{ id: 'priority', name: 'Fast', description: '1.5x speed' }],
+    defaultServiceTier,
+    inputModalities: ['text', 'image'],
+    isDefault: true,
+  };
+}
 
 describe('Codex models', () => {
   const rawModels = [
@@ -121,6 +137,41 @@ describe('Codex models', () => {
 
     expect(getDefaultCodexModel(models)?.model).toBe('gpt-5.6-sol');
     expect(findCodexModel(models, 'gpt-5.6-luna')?.displayName).toBe('GPT-5.6-Luna');
+  });
+
+  it.each([
+    {
+      caseName: 'returns no tier without a model',
+      model: null,
+      selectedServiceTier: 'priority',
+      expectedServiceTier: null,
+    },
+    {
+      caseName: 'preserves explicit Standard when the catalog defaults to Fast',
+      model: createFastModel('priority'),
+      selectedServiceTier: 'default',
+      expectedServiceTier: 'default',
+    },
+    {
+      caseName: 'preserves an advertised tier id',
+      model: createFastModel(),
+      selectedServiceTier: 'priority',
+      expectedServiceTier: 'priority',
+    },
+    {
+      caseName: 'maps the legacy Fast value to the advertised tier id',
+      model: createFastModel(),
+      selectedServiceTier: 'fast',
+      expectedServiceTier: 'priority',
+    },
+    {
+      caseName: 'uses the catalog default for an invalid selection',
+      model: createFastModel('priority'),
+      selectedServiceTier: 'unsupported',
+      expectedServiceTier: 'priority',
+    },
+  ])('$caseName', ({ model, selectedServiceTier, expectedServiceTier }) => {
+    expect(resolveCodexModelServiceTier(model, selectedServiceTier)).toBe(expectedServiceTier);
   });
 
   it('rejects malformed entries, hidden entries, duplicate models, and invalid defaults', () => {

--- a/tests/unit/providers/codex/ui/CodexChatUIConfig.test.ts
+++ b/tests/unit/providers/codex/ui/CodexChatUIConfig.test.ts
@@ -658,11 +658,15 @@ describe('CodexChatUIConfig', () => {
     });
 
     it('uses the selected model service tier metadata from app-server', () => {
-      const settings = withDiscoveredModels({ model: TEST_CODEX_MODEL });
+      const settings = withDiscoveredModels({
+        model: TEST_CODEX_MODEL,
+        serviceTier: 'default',
+      });
       const config = settings.providerConfigs as { codex: { discoveredModels: any[] } };
       config.codex.discoveredModels[1] = {
         ...config.codex.discoveredModels[1],
         serviceTiers: [{ id: 'priority', name: 'Fast', description: '1.5x speed' }],
+        defaultServiceTier: 'priority',
       };
 
       expect(codexChatUIConfig.getServiceTierToggle!(settings)).toEqual({
@@ -671,6 +675,25 @@ describe('CodexChatUIConfig', () => {
         activeValue: 'priority',
         activeLabel: 'Fast',
         description: '1.5x speed',
+        isActive: false,
+      });
+    });
+
+    it('reports Fast active when the next query resolves to the Fast tier', () => {
+      const settings = withDiscoveredModels({
+        model: TEST_CODEX_MODEL,
+        serviceTier: 'fast',
+      });
+      const config = settings.providerConfigs as { codex: { discoveredModels: any[] } };
+      config.codex.discoveredModels[1] = {
+        ...config.codex.discoveredModels[1],
+        serviceTiers: [{ id: 'priority', name: 'Fast', description: '1.5x speed' }],
+        defaultServiceTier: null,
+      };
+
+      expect(codexChatUIConfig.getServiceTierToggle!(settings)).toMatchObject({
+        activeValue: 'priority',
+        isActive: true,
       });
     });
 


### PR DESCRIPTION
## Why

Fixes #1103 by making the Codex Fast-mode button accurately report whether the next query will use the Fast service tier, including when the model catalog defaults to Fast.

## What Changed

Codex now resolves service tiers through one provider-owned policy shared by execution and UI state, the toggle exposes that resolved state with Standard/Fast tooltips without changing its styling, and model-aware settings normalization plus focused tests cover explicit Standard, advertised tiers, legacy Fast values, and catalog fallbacks.

## Why This Approach

Keeping native tier interpretation in Codex prevents the provider-neutral chat feature from duplicating catalog policy, while normalizing only after the conversation model is known avoids resolving a saved value against the wrong model.

## Validation

`npm run typecheck`, `npm run lint`, `npm test -- --runInBand` (351 suites / 6,569 tests), `npm run build`, architecture checks, and `git diff --check` all pass; UI tests verify the existing active class and state-specific tooltip, so no screenshot is needed because styling is unchanged.

## Impact and Follow-ups

Legacy `fast` values remain compatible through provider-owned resolution, explicit `default` now reliably opts out of Fast mode, and no documentation follow-up is needed.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
