### PR TITLE
Fix slash command dropdown ghosting

### DIFF
--- a/src/style/features/slash-commands.css
+++ b/src/style/features/slash-commands.css
@@ -7,8 +7,6 @@
   right: 0;
   margin-bottom: 4px;
   background: var(--background-secondary);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
   border: 1px solid var(--background-modifier-border);
   border-radius: 6px;
   box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.2);

--- a/tests/unit/style/features/slash-commands.test.ts
+++ b/tests/unit/style/features/slash-commands.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+describe('Slash command dropdown styles', () => {
+  it('avoids backdrop-filter compositing when the filtered list shrinks', () => {
+    const css = readFileSync(path.resolve('src/style/features/slash-commands.css'), 'utf8');
+    const dropdownRule = css.match(/\.claudian-slash-dropdown\s*{([^}]*)}/)?.[1];
+
+    expect(dropdownRule).toBeDefined();
+    expect(dropdownRule).toContain('background: var(--background-secondary);');
+    expect(dropdownRule).not.toContain('backdrop-filter');
+  });
+});


### PR DESCRIPTION
## Why

Fixes #1111, where filtering a long slash-command list could leave stale dropdown pixels visible in Obsidian on macOS.

## What Changed

- Removed the slash dropdown's standard and WebKit backdrop filters while retaining its existing background, border, and shadow.
- Added a stylesheet regression test that prevents the compositing filters from being restored.

## Why This Approach

Removing the decorative layer promotion addresses the reported Chromium/Electron invalidation trigger without changing dropdown lifecycle or filtering behavior.

## Validation

`npm run typecheck && npm run lint && npm run test && npm run build` (6,570 tests passed).

## Impact and Follow-ups

None; other dropdown styles remain unchanged because the artifact was only reproduced for slash commands.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
