### PR TITLE
fix: distinguish review and action-required tab attention

### DIFF
--- a/src/features/chat/state/ChatState.ts
+++ b/src/features/chat/state/ChatState.ts
@@ -308,10 +308,6 @@ export class ChatState {
     return this.state.attention;
   }
 
-  get needsAttention(): boolean {
-    return this.state.attention !== null;
-  }
-
   get requiresAction(): boolean {
     return this.state.attention?.kind === 'action-required';
   }

--- a/src/features/chat/tabs/TabBar.ts
+++ b/src/features/chat/tabs/TabBar.ts
@@ -76,8 +76,10 @@ export class TabBar {
     let stateClass = 'claudian-tab-badge-idle';
     if (item.isActive) {
       stateClass = 'claudian-tab-badge-active';
-    } else if (item.needsAttention) {
-      stateClass = 'claudian-tab-badge-attention';
+    } else if (item.attention) {
+      stateClass = item.attention.kind === 'action-required'
+        ? 'claudian-tab-badge-action-required'
+        : 'claudian-tab-badge-review';
     } else if (item.isStreaming) {
       stateClass = 'claudian-tab-badge-streaming';
     }

--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -1156,7 +1156,7 @@ export class TabManager implements TabManagerInterface {
         providerId: getTabProviderId(tab, this.plugin),
         isActive: tab.id === this.activeTabId,
         isStreaming: tab.state.isStreaming,
-        needsAttention: tab.state.needsAttention,
+        attention: tab.state.attention,
         canClose: !tab.state.isRewinding && (this.tabs.size > 1 || !tab.state.isStreaming),
       });
     }

--- a/src/features/chat/tabs/types.ts
+++ b/src/features/chat/tabs/types.ts
@@ -308,6 +308,6 @@ export interface TabBarItem {
   providerId: ProviderId;
   isActive: boolean;
   isStreaming: boolean;
-  needsAttention: boolean;
+  attention: TabAttention;
   canClose: boolean;
 }

--- a/src/style/components/tabs.css
+++ b/src/style/components/tabs.css
@@ -90,7 +90,11 @@
   border-color: var(--claudian-brand-grok, #ffffff);
 }
 
-.claudian-tab-badge-attention {
+.claudian-tab-badge-review {
+  border-color: var(--color-green);
+}
+
+.claudian-tab-badge-action-required {
   border-color: var(--text-error);
 }
 

--- a/tests/unit/features/chat/state/ChatState.test.ts
+++ b/tests/unit/features/chat/state/ChatState.test.ts
@@ -331,7 +331,6 @@ describe('ChatState', () => {
       const chatState = new ChatState();
 
       expect(chatState.attention).toBeNull();
-      expect(chatState.needsAttention).toBe(false);
       expect(chatState.requiresAction).toBe(false);
     });
 
@@ -343,7 +342,6 @@ describe('ChatState', () => {
       chatState.markReviewRequired();
 
       expect(chatState.attention).toEqual({ kind: 'review', since: 123 });
-      expect(chatState.needsAttention).toBe(true);
       expect(chatState.requiresAction).toBe(false);
       expect(onAttentionChanged).toHaveBeenCalledWith({ kind: 'review', since: 123 });
 

--- a/tests/unit/features/chat/tabs/TabAttentionStyles.test.ts
+++ b/tests/unit/features/chat/tabs/TabAttentionStyles.test.ts
@@ -1,0 +1,18 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+describe('tab attention styles', () => {
+  const tabsCss = fs.readFileSync(
+    path.join(process.cwd(), 'src/style/components/tabs.css'),
+    'utf8',
+  );
+
+  it('visually distinguishes review from action-required attention', () => {
+    expect(tabsCss).toMatch(
+      /\.claudian-tab-badge-review \{[\s\S]*?border-color: var\(--color-green\);[\s\S]*?\}/,
+    );
+    expect(tabsCss).toMatch(
+      /\.claudian-tab-badge-action-required \{[\s\S]*?border-color: var\(--text-error\);[\s\S]*?\}/,
+    );
+  });
+});

--- a/tests/unit/features/chat/tabs/TabBar.test.ts
+++ b/tests/unit/features/chat/tabs/TabBar.test.ts
@@ -21,7 +21,7 @@ function createTabBarItem(overrides: Partial<TabBarItem> = {}): TabBarItem {
     providerId: 'claude',
     isActive: false,
     isStreaming: false,
-    needsAttention: false,
+    attention: null,
     canClose: true,
     ...overrides,
   };
@@ -249,7 +249,7 @@ describe('TabBar', () => {
       const callbacks = createMockCallbacks();
       const tabBar = new TabBar(containerEl, callbacks);
 
-      tabBar.update([createTabBarItem({ isActive: false, isStreaming: false, needsAttention: false })]);
+      tabBar.update([createTabBarItem({ isActive: false, isStreaming: false, attention: null })]);
 
       expect(containerEl._children[0]._classList.has('claudian-tab-badge-idle')).toBe(true);
     });
@@ -274,35 +274,60 @@ describe('TabBar', () => {
       expect(containerEl._children[0]._classList.has('claudian-tab-badge-streaming')).toBe(true);
     });
 
-    it('should apply attention class for tab needing attention', () => {
+    it('should apply review class for a completed turn awaiting review', () => {
       const containerEl = createMockEl();
       const callbacks = createMockCallbacks();
       const tabBar = new TabBar(containerEl, callbacks);
 
-      tabBar.update([createTabBarItem({ needsAttention: true })]);
+      tabBar.update([createTabBarItem({
+        attention: { kind: 'review', since: 1 },
+      })]);
 
-      expect(containerEl._children[0]._classList.has('claudian-tab-badge-attention')).toBe(true);
+      expect(containerEl._children[0]._classList.has('claudian-tab-badge-review')).toBe(true);
+      expect(containerEl._children[0]._classList.has('claudian-tab-badge-action-required')).toBe(false);
     });
 
-    it('should prioritize active over attention', () => {
+    it('should apply action-required class for a pending interaction', () => {
       const containerEl = createMockEl();
       const callbacks = createMockCallbacks();
       const tabBar = new TabBar(containerEl, callbacks);
 
-      tabBar.update([createTabBarItem({ isActive: true, needsAttention: true })]);
+      tabBar.update([createTabBarItem({
+        attention: { kind: 'action-required', since: 1 },
+      })]);
+
+      expect(containerEl._children[0]._classList.has('claudian-tab-badge-action-required')).toBe(true);
+      expect(containerEl._children[0]._classList.has('claudian-tab-badge-review')).toBe(false);
+    });
+
+    it('should prioritize active over attention states', () => {
+      const containerEl = createMockEl();
+      const callbacks = createMockCallbacks();
+      const tabBar = new TabBar(containerEl, callbacks);
+
+      tabBar.update([createTabBarItem({
+        isActive: true,
+        attention: { kind: 'action-required', since: 1 },
+      })]);
 
       expect(containerEl._children[0]._classList.has('claudian-tab-badge-active')).toBe(true);
-      expect(containerEl._children[0]._classList.has('claudian-tab-badge-attention')).toBe(false);
+      expect(containerEl._children[0]._classList.has('claudian-tab-badge-action-required')).toBe(false);
     });
 
-    it('should prioritize attention over streaming', () => {
+    it.each([
+      ['review', 'claudian-tab-badge-review'],
+      ['action-required', 'claudian-tab-badge-action-required'],
+    ] as const)('should prioritize %s attention over streaming', (kind, expectedClass) => {
       const containerEl = createMockEl();
       const callbacks = createMockCallbacks();
       const tabBar = new TabBar(containerEl, callbacks);
 
-      tabBar.update([createTabBarItem({ isStreaming: true, needsAttention: true })]);
+      tabBar.update([createTabBarItem({
+        isStreaming: true,
+        attention: { kind, since: 1 },
+      })]);
 
-      expect(containerEl._children[0]._classList.has('claudian-tab-badge-attention')).toBe(true);
+      expect(containerEl._children[0]._classList.has(expectedClass)).toBe(true);
       expect(containerEl._children[0]._classList.has('claudian-tab-badge-streaming')).toBe(false);
     });
 

--- a/tests/unit/features/chat/tabs/TabManager.test.ts
+++ b/tests/unit/features/chat/tabs/TabManager.test.ts
@@ -66,7 +66,6 @@ function createMockTab(options: Record<string, any>): any {
       isSwitchingConversation: false,
       messages: [],
       markReviewRequired: jest.fn(),
-      needsAttention: false,
       requiresAction: false,
     },
     controllers: {
@@ -266,6 +265,22 @@ describe('TabManager provider execution orchestration', () => {
     await manager.switchToTab(target!.id);
 
     expect(target!.state.acknowledgeReview).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the attention kind in tab bar items', async () => {
+    const { manager } = createManager();
+    const tab = await manager.createTab();
+    Object.defineProperty(tab!.state, 'attention', {
+      configurable: true,
+      value: { kind: 'review', since: 123 },
+    });
+
+    expect(manager.getTabBarItems()).toEqual([
+      expect.objectContaining({
+        attention: { kind: 'review', since: 123 },
+        id: tab!.id,
+      }),
+    ]);
   });
 
   it('waits for prior tab switching to settle', async () => {


### PR DESCRIPTION
## Why

Inactive tabs used the same red border for completed turns and genuinely blocking interactions, making informational review attention look urgent and obscuring the meaning of the indicator. Fixes #1112.

## What Changed

- Preserve `TabAttention.kind` through the tab-bar presentation contract instead of collapsing it to a boolean
- Render completed turns with a green review border and pending interactions with the existing red action-required border
- Remove the superseded `needsAttention` projection and add state, projection, DOM-class, priority, and CSS regression coverage

## Why This Approach

`ChatState` already owns the semantic distinction, so carrying its discriminator to the presentation boundary avoids duplicating state or inferring meaning from streaming lifecycle.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run test` — 6,573 tests across 352 suites
- `npm run build`
- Automated DOM and CSS tests verify the user-facing treatment; no manual screenshot was captured.

## Impact and Follow-ups

No persistence, provider, or compatibility behavior changes, and no documentation follow-up is needed.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
