### PR TITLE
fix: preserve streaming auto-scroll continuity

### DIFF
--- a/src/features/chat/controllers/StreamController.ts
+++ b/src/features/chat/controllers/StreamController.ts
@@ -1746,6 +1746,7 @@ export class StreamController {
     if (state.thinkingEl) {
       state.currentContentEl.appendChild(state.thinkingEl);
       this.deps.updateQueueIndicator();
+      this.scrollToBottom();
       return;
     }
 
@@ -1785,7 +1786,7 @@ export class StreamController {
       }
       const thinkingWindow = state.currentContentEl.ownerDocument.defaultView ?? timerWindow;
       state.setFlavorTimerInterval(thinkingWindow.setInterval(updateTimer, 1000), thinkingWindow);
-
+      this.scrollToBottom();
     }, StreamController.THINKING_INDICATOR_DELAY), timerWindow);
   }
 

--- a/src/features/chat/tabs/runtime/TabRuntimeInputBindings.ts
+++ b/src/features/chat/tabs/runtime/TabRuntimeInputBindings.ts
@@ -110,21 +110,17 @@ export function buildTabRuntimeInputBindings(
   );
 
   const scrollThreshold = 20;
-  const reEnableDelay = 150;
-  let reEnableTimeout: number | null = null;
-  let bottomNavigationInProgress = false;
+  let navigationScrollIntent: 'away' | 'bottom' | null = null;
 
   const isAutoScrollAllowed = (): boolean => plugin.settings.enableAutoScroll ?? true;
-  const cancelReEnableTimeout = (): void => {
-    if (reEnableTimeout === null) return;
-    window.clearTimeout(reEnableTimeout);
-    reEnableTimeout = null;
+  const isMessagesAtBottom = (): boolean => {
+    const { scrollTop, scrollHeight, clientHeight } = dom.messagesEl;
+    return scrollHeight - scrollTop - clientHeight <= scrollThreshold;
   };
 
   ui.navigationSidebar.setOnScrollIntent((intent) => {
-    cancelReEnableTimeout();
+    navigationScrollIntent = intent;
     const enabled = intent === 'bottom' && isAutoScrollAllowed();
-    bottomNavigationInProgress = enabled;
     state.autoScrollEnabled = enabled;
   });
   options.registerCleanup('tab scroll navigation binding', () => {
@@ -135,6 +131,14 @@ export function buildTabRuntimeInputBindings(
   const nativePageScrollKeys = new Set(['pagedown', 'pageup']);
   const nativeArrowScrollKeys = new Set(['arrowdown', 'arrowup']);
   const userScrollIntentHandler = (event: Event) => {
+    if (event.type === 'wheel') {
+      const wheelEvent = event as WheelEvent;
+      if (wheelEvent.deltaY > 0 && isMessagesAtBottom()) {
+        if (navigationScrollIntent === 'away') return;
+        state.autoScrollEnabled = isAutoScrollAllowed();
+        return;
+      }
+    }
     if (event.type === 'keydown') {
       const keyboardEvent = event as KeyboardEvent;
       const settings = plugin.settings.keyboardNavigation;
@@ -197,8 +201,7 @@ export function buildTabRuntimeInputBindings(
         : pointerX >= bounds.width - scrollbarWidth;
       if (!isInScrollbarGutter) return;
     }
-    cancelReEnableTimeout();
-    bottomNavigationInProgress = false;
+    navigationScrollIntent = null;
     state.autoScrollEnabled = false;
   };
   const userScrollIntentEvents = [
@@ -218,36 +221,25 @@ export function buildTabRuntimeInputBindings(
 
   const scrollHandler = () => {
     if (!isAutoScrollAllowed()) {
-      bottomNavigationInProgress = false;
-      cancelReEnableTimeout();
+      navigationScrollIntent = null;
       state.autoScrollEnabled = false;
       return;
     }
 
-    const { scrollTop, scrollHeight, clientHeight } = dom.messagesEl;
-    const isAtBottom = scrollHeight - scrollTop - clientHeight <= scrollThreshold;
+    if (navigationScrollIntent === 'bottom') return;
 
-    if (!isAtBottom) {
-      if (bottomNavigationInProgress) return;
-      cancelReEnableTimeout();
+    if (!isMessagesAtBottom()) {
+      navigationScrollIntent = null;
       state.autoScrollEnabled = false;
-    } else {
-      if (state.autoScrollEnabled) return;
-      if (reEnableTimeout === null) {
-        reEnableTimeout = window.setTimeout(() => {
-          reEnableTimeout = null;
-          const { scrollTop, scrollHeight, clientHeight } = dom.messagesEl;
-          if (scrollHeight - scrollTop - clientHeight <= scrollThreshold) {
-            state.autoScrollEnabled = true;
-          }
-        }, reEnableDelay);
-      }
+      return;
     }
+
+    if (navigationScrollIntent === 'away') return;
+    state.autoScrollEnabled = true;
   };
   dom.messagesEl.addEventListener('scroll', scrollHandler, { passive: true });
   options.registerCleanup('tab message scroll binding', () => {
     dom.messagesEl.removeEventListener('scroll', scrollHandler);
-    cancelReEnableTimeout();
   });
   return { installed: true };
 }

--- a/tests/unit/features/chat/controllers/StreamController.test.ts
+++ b/tests/unit/features/chat/controllers/StreamController.test.ts
@@ -1293,6 +1293,31 @@ describe('StreamController - Text Content', () => {
   });
 
   describe('Timer lifecycle', () => {
+    it('should scroll to a newly shown thinking indicator when auto-scroll is enabled', () => {
+      const messagesEl = deps.getMessagesEl();
+      Object.defineProperty(messagesEl, 'scrollHeight', { value: 1_000, configurable: true });
+      messagesEl.scrollTop = 0;
+
+      controller.showThinkingIndicator();
+      jest.advanceTimersByTime(416);
+
+      expect(deps.state.thinkingEl).not.toBeNull();
+      expect(messagesEl.scrollTop).toBe(1_000);
+    });
+
+    it('should not scroll to a newly shown thinking indicator when auto-scroll is paused', () => {
+      const messagesEl = deps.getMessagesEl();
+      Object.defineProperty(messagesEl, 'scrollHeight', { value: 1_000, configurable: true });
+      messagesEl.scrollTop = 0;
+      deps.state.autoScrollEnabled = false;
+
+      controller.showThinkingIndicator();
+      jest.advanceTimersByTime(416);
+
+      expect(deps.state.thinkingEl).not.toBeNull();
+      expect(messagesEl.scrollTop).toBe(0);
+    });
+
     it('should create timer interval when showing thinking indicator', () => {
       deps.state.responseStartTime = performance.now();
 

--- a/tests/unit/features/chat/tabs/TabRuntimeFactory.test.ts
+++ b/tests/unit/features/chat/tabs/TabRuntimeFactory.test.ts
@@ -578,6 +578,80 @@ describe('Tab provider execution ownership', () => {
     expect(tab.state.autoScrollEnabled).toBe(false);
   });
 
+  it('re-arms auto-scroll when a streaming user manually returns to the bottom', async () => {
+    jest.useFakeTimers();
+    try {
+      const tab = await createTestTab({
+        plugin: createPlugin(),
+        containerEl: createMockEl() as any,
+      });
+      tab.state.isStreaming = true;
+      tab.dom.messagesEl.scrollHeight = 1_000;
+      tab.dom.messagesEl.clientHeight = 500;
+      tab.dom.messagesEl.scrollTop = 500;
+
+      tab.dom.messagesEl.dispatchEvent({ type: 'wheel' });
+      tab.dom.messagesEl.scrollTop = 250;
+      tab.dom.messagesEl.dispatchEvent('scroll');
+
+      expect(tab.state.autoScrollEnabled).toBe(false);
+
+      tab.dom.messagesEl.scrollTop = 500;
+      tab.dom.messagesEl.dispatchEvent('scroll');
+
+      expect(tab.state.autoScrollEnabled).toBe(true);
+
+      tab.dom.messagesEl.scrollHeight = 1_200;
+      await tab.controllers.streamController.handleStreamChunk(
+        { type: 'text', content: 'continued' },
+        { content: '', role: 'assistant' },
+      );
+      jest.advanceTimersByTime(16);
+
+      expect(tab.dom.messagesEl.scrollTop).toBe(1_200);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('keeps auto-scroll armed during downward wheel momentum at the bottom', async () => {
+    jest.useFakeTimers();
+    try {
+      const tab = await createTestTab({
+        plugin: createPlugin(),
+        containerEl: createMockEl() as any,
+      });
+      tab.state.isStreaming = true;
+      tab.dom.messagesEl.scrollHeight = 1_000;
+      tab.dom.messagesEl.clientHeight = 500;
+      tab.dom.messagesEl.scrollTop = 250;
+      tab.state.autoScrollEnabled = false;
+
+      tab.dom.messagesEl.dispatchEvent({ type: 'wheel', deltaY: 120 });
+      tab.dom.messagesEl.scrollTop = 500;
+      tab.dom.messagesEl.dispatchEvent('scroll');
+
+      expect(tab.state.autoScrollEnabled).toBe(true);
+
+      for (let index = 0; index < 3; index++) {
+        tab.dom.messagesEl.dispatchEvent({ type: 'wheel', deltaY: 120 });
+      }
+
+      expect(tab.state.autoScrollEnabled).toBe(true);
+
+      tab.dom.messagesEl.scrollHeight = 1_200;
+      await tab.controllers.streamController.handleStreamChunk(
+        { type: 'text', content: 'continued' },
+        { content: '', role: 'assistant' },
+      );
+      jest.advanceTimersByTime(16);
+
+      expect(tab.dom.messagesEl.scrollTop).toBe(1_200);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('does not let a pending bottom re-arm override newer navigation', async () => {
     jest.useFakeTimers();
     try {
@@ -593,6 +667,7 @@ describe('Tab provider execution ownership', () => {
 
       tab.dom.messagesEl.dispatchEvent('scroll');
       tab.dom.messagesWrapperEl.querySelector('.claudian-nav-btn-top')?.click();
+      tab.dom.messagesEl.dispatchEvent({ type: 'wheel', deltaY: 120 });
       jest.advanceTimersByTime(150);
 
       expect(tab.state.autoScrollEnabled).toBe(false);


### PR DESCRIPTION
## Why

Follow-up to #1101: streaming auto-scroll could fail to resume after manually returning to the bottom, continuous mouse-wheel momentum could disable it again, and the delayed thinking indicator could render below the viewport.

## What Changed

- Re-arm auto-scroll immediately when the viewport returns to the bottom.
- Preserve auto-scroll through downward free-spin wheel events while keeping explicit navigation-away intent authoritative.
- Follow newly mounted or repositioned thinking indicators when auto-scroll is enabled.
- Add regression coverage for bottom return, wheel momentum, navigation ordering, streamed growth, and thinking-indicator behavior.

## Why This Approach

The runtime input binding continues to own scroll intent and `ChatState` remains the single auto-scroll authority, while `StreamController` requests scrolling only when it adds stream-owned content.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test` — 353 suites and 6,578 tests passed
- `npm run build`
- No screenshot: behavior-only change with no new UI.

## Impact and Follow-ups

No compatibility, persistence, or migration impact; the existing auto-scroll setting and navigation controls are unchanged.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
