### PR TITLE
fix: distinguish working and finished tab states

### DIFF
--- a/src/features/FeatureHost.ts
+++ b/src/features/FeatureHost.ts
@@ -17,6 +17,7 @@ export interface FeatureTabManagerHost {
   canCreateTab(): boolean;
   getAllTabs(): AssembledTabRuntime[];
   getTab(tabId: TabId): AssembledTabRuntime | null;
+  isTabWorking(tabId: TabId): boolean;
   switchToTab(tabId: TabId): Promise<void>;
   closeTab(tabId: TabId, force?: boolean): Promise<boolean>;
   primeProviderExecution(providerIds?: ProviderId | ProviderId[]): void;

--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -333,6 +333,10 @@ export class ClaudianView extends ItemView {
           this.updateTabBar();
           this.notifyConversationNavigationChanged();
         },
+        onTabWorkChanged: () => {
+          this.updateTabBar();
+          this.notifyConversationNavigationChanged();
+        },
         onTabRewindingChanged: () => this.updateTabBar(),
         onTabTitleChanged: () => this.updateTabBar(),
         onTabAttentionChanged: () => {
@@ -2034,7 +2038,7 @@ export class ClaudianView extends ItemView {
       return {
         attention: activeTab.state.attention,
         openState: 'current',
-        isRunning: activeTab.state.isStreaming,
+        isRunning: this.tabManager?.isTabWorking(activeTab.id) ?? false,
         location: 'current-view',
         tabIndex: this.getHistoryTabIndex(activeTab),
       };
@@ -2045,7 +2049,7 @@ export class ClaudianView extends ItemView {
       return {
         attention: localTab.state.attention,
         openState: 'open',
-        isRunning: localTab.state.isStreaming,
+        isRunning: this.tabManager?.isTabWorking(localTab.id) ?? false,
         location: 'current-view',
         tabIndex: this.getHistoryTabIndex(localTab),
       };
@@ -2053,11 +2057,12 @@ export class ClaudianView extends ItemView {
 
     const crossViewResult = this.plugin.findConversationAcrossViews(conversationId);
     if (crossViewResult && crossViewResult.view !== this) {
-      const crossViewTab = crossViewResult.view.getTabManager()?.getTab(crossViewResult.tabId);
+      const crossViewManager = crossViewResult.view.getTabManager();
+      const crossViewTab = crossViewManager?.getTab(crossViewResult.tabId);
       return {
         attention: crossViewTab?.state.attention,
         openState: 'open',
-        isRunning: crossViewTab?.state.isStreaming ?? false,
+        isRunning: crossViewManager?.isTabWorking(crossViewResult.tabId) ?? false,
         location: 'other-view',
       };
     }

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -47,8 +47,7 @@ import type { MessageRenderer } from '../rendering/MessageRenderer';
 import { setToolIcon, updateToolCallResult } from '../rendering/ToolCallRenderer';
 import type { SubagentManager } from '../services/SubagentManager';
 import type { ChatState } from '../state/ChatState';
-import type { QueuedMessage } from '../state/types';
-import type { ChatTurnRequest } from '../state/types';
+import type { ChatTurnRequest, QueuedMessage, TabReviewOutcome } from '../state/types';
 import type { FileContextManager } from '../ui/FileContext';
 import type { ImageContextManager } from '../ui/ImageContext';
 import type { AddExternalContextResult } from '../ui/InputToolbar';
@@ -139,7 +138,7 @@ export interface InputControllerDeps {
   toggleFastMode?: () => Promise<boolean>;
   restorePrePlanPermissionModeIfNeeded?: () => void | Promise<void>;
   /** Captures a review reporter when a terminal provider turn becomes visible. */
-  captureReviewableSettlement?: () => () => void;
+  captureReviewableSettlement?: (outcome: TabReviewOutcome) => () => void;
   canStartTurn?: () => boolean;
   turnOwner?: ActiveTurnOwner;
 }
@@ -518,8 +517,9 @@ export class InputController {
       shouldReportReviewableSettlement = result.status === 'completed'
         || (result.status === 'error' && result.accepted);
       if (shouldReportReviewableSettlement) {
-        currentReviewableSettlementReporter =
-          this.deps.captureReviewableSettlement?.() ?? null;
+        currentReviewableSettlementReporter = this.deps.captureReviewableSettlement?.(
+          result.status === 'error' ? 'error' : 'completed',
+        ) ?? null;
       }
       if (result.status === 'cancelled') {
         wasInterrupted = true;
@@ -575,7 +575,7 @@ export class InputController {
         const errorMsg = error instanceof Error ? error.message : 'Unknown error';
         await streamController.appendText(`\n\n**Error:** ${errorMsg}`);
         currentReviewableSettlementReporter =
-          this.deps.captureReviewableSettlement?.() ?? null;
+          this.deps.captureReviewableSettlement?.('error') ?? null;
       }
     } finally {
       const finalAssistantMsg = this.activeStreamingAssistantMessage ?? assistantMsg;

--- a/src/features/chat/execution/ChatExecutionCoordinator.ts
+++ b/src/features/chat/execution/ChatExecutionCoordinator.ts
@@ -142,6 +142,7 @@ export interface ChatExecutionCoordinatorDeps {
     event: ProviderSessionEvent,
     context: ChatExecutionEventContext,
   ) => void | Promise<void>;
+  readonly onBackgroundWorkChanged?: (isWorking: boolean) => void;
   readonly resolveMissingProviderSession: (
     conversationId: string,
     missingProviderSessionId?: string,
@@ -251,6 +252,10 @@ export class ChatExecutionCoordinator {
 
   get snapshot(): ProviderSessionSnapshot | null {
     return this.sessionBinding?.session.getSnapshot() ?? null;
+  }
+
+  get hasBackgroundWork(): boolean {
+    return (this.sessionBinding?.backgroundSequences.size ?? 0) > 0;
   }
 
   isEventContextCurrent(context: ChatExecutionEventContext): boolean {
@@ -928,7 +933,9 @@ export class ChatExecutionCoordinator {
         ) {
           return;
         }
+        const wasIdle = binding.backgroundSequences.size === 0;
         binding.backgroundSequences.set(event.scope.turnId, event.scope.sequence);
+        if (wasIdle) this.deps.onBackgroundWorkChanged?.(true);
         this.fireAndReport(this.touchWarmSlot());
       } else {
         if (previous === undefined || event.scope.sequence <= previous) return;
@@ -954,6 +961,9 @@ export class ChatExecutionCoordinator {
     if (event.type === 'background_turn_completed') {
       binding.backgroundSequences.delete(event.scope.turnId);
       binding.completedBackgroundTurns.add(event.scope.turnId);
+      if (binding.backgroundSequences.size === 0) {
+        this.deps.onBackgroundWorkChanged?.(false);
+      }
       this.notifyMayCool();
     }
   }
@@ -1002,6 +1012,9 @@ export class ChatExecutionCoordinator {
     const binding = this.sessionBinding;
     if (!binding) return;
     this.sessionBinding = null;
+    if (binding.backgroundSequences.size > 0) {
+      this.deps.onBackgroundWorkChanged?.(false);
+    }
     this.stale = true;
     this.pendingSteerAttempts.clear();
     this.invalidateActiveExecution('invalidated', 'provider-transition');
@@ -1015,6 +1028,9 @@ export class ChatExecutionCoordinator {
   private async releaseSessionBinding(): Promise<void> {
     const binding = this.sessionBinding;
     this.sessionBinding = null;
+    if (binding && binding.backgroundSequences.size > 0) {
+      this.deps.onBackgroundWorkChanged?.(false);
+    }
     if (binding) {
       this.deps.persistence.releaseExecutionBinding(
         binding.conversation.conversationId,

--- a/src/features/chat/services/SubagentManager.ts
+++ b/src/features/chat/services/SubagentManager.ts
@@ -519,6 +519,12 @@ export class SubagentManager {
     return this._spawnedThisStream;
   }
 
+  public hasActiveAsyncSubagents(): boolean {
+    return Array.from(this.asyncSubagents.values()).some(({ info }) => (
+      info.asyncStatus === 'pending' || info.asyncStatus === 'running'
+    ));
+  }
+
   public resetSpawnedCount(): void {
     this._spawnedThisStream = 0;
   }

--- a/src/features/chat/state/ChatState.ts
+++ b/src/features/chat/state/ChatState.ts
@@ -6,6 +6,7 @@ import type {
   PendingToolCall,
   QueuedMessage,
   TabAttention,
+  TabReviewOutcome,
   ThinkingBlockState,
   TodoItem,
   WriteEditState,
@@ -50,7 +51,10 @@ export class ChatState {
   private state: ChatStateData;
   private _callbacks: ChatStateCallbacks;
   private readonly pendingActionIds = new Set<string>();
-  private pendingReviewSince: number | null = null;
+  private pendingReview: {
+    outcome: TabReviewOutcome;
+    since: number;
+  } | null = null;
   private thinkingIndicatorTimeoutWindow: Window | null = null;
   private flavorTimerIntervalWindow: Window | null = null;
 
@@ -316,8 +320,11 @@ export class ChatState {
     if (this.pendingActionIds.has(interactionId)) return;
 
     this.pendingActionIds.add(interactionId);
-    if (this.state.attention?.kind === 'review' && this.pendingReviewSince === null) {
-      this.pendingReviewSince = this.state.attention.since;
+    if (this.state.attention?.kind === 'review' && this.pendingReview === null) {
+      this.pendingReview = {
+        outcome: this.state.attention.outcome,
+        since: this.state.attention.since,
+      };
     }
     if (!this.requiresAction) {
       this.setAttention({ kind: 'action-required', since: Date.now() });
@@ -327,25 +334,37 @@ export class ChatState {
   endActionRequired(interactionId: string): void {
     if (!this.pendingActionIds.delete(interactionId)) return;
     if (this.pendingActionIds.size === 0 && this.requiresAction) {
-      const reviewSince = this.pendingReviewSince;
-      this.pendingReviewSince = null;
-      this.setAttention(reviewSince === null
+      const review = this.pendingReview;
+      this.pendingReview = null;
+      this.setAttention(review === null
         ? null
-        : { kind: 'review', since: reviewSince });
+        : { kind: 'review', ...review });
     }
   }
 
-  markReviewRequired(): void {
-    if (this.state.attention?.kind === 'review') return;
-    if (this.requiresAction) {
-      this.pendingReviewSince ??= Date.now();
+  markReviewRequired(outcome: TabReviewOutcome = 'completed'): void {
+    if (this.state.attention?.kind === 'review') {
+      if (this.state.attention.outcome === 'error' || outcome === 'completed') return;
+      this.setAttention({
+        kind: 'review',
+        outcome: 'error',
+        since: this.state.attention.since,
+      });
       return;
     }
-    this.setAttention({ kind: 'review', since: Date.now() });
+    if (this.requiresAction) {
+      if (this.pendingReview === null) {
+        this.pendingReview = { outcome, since: Date.now() };
+      } else if (outcome === 'error') {
+        this.pendingReview.outcome = 'error';
+      }
+      return;
+    }
+    this.setAttention({ kind: 'review', outcome, since: Date.now() });
   }
 
   acknowledgeReview(): void {
-    this.pendingReviewSince = null;
+    this.pendingReview = null;
     if (this.state.attention?.kind === 'review') {
       this.setAttention(null);
     }
@@ -353,7 +372,7 @@ export class ChatState {
 
   clearAttention(): void {
     this.pendingActionIds.clear();
-    this.pendingReviewSince = null;
+    this.pendingReview = null;
     this.setAttention(null);
   }
 
@@ -497,7 +516,10 @@ export class ChatState {
       || (current !== null
         && attention !== null
         && current.kind === attention.kind
-        && current.since === attention.since)
+        && current.since === attention.since
+        && (current.kind !== 'review'
+          || attention.kind !== 'review'
+          || current.outcome === attention.outcome))
     ) {
       return;
     }

--- a/src/features/chat/state/types.ts
+++ b/src/features/chat/state/types.ts
@@ -43,10 +43,19 @@ export interface PendingToolCall {
 
 export type TabAttentionKind = 'review' | 'action-required';
 
-export type TabAttention = {
-  kind: TabAttentionKind;
-  since: number;
-} | null;
+export type TabReviewOutcome = 'completed' | 'error';
+
+export type TabAttention =
+  | {
+      kind: 'review';
+      outcome: TabReviewOutcome;
+      since: number;
+    }
+  | {
+      kind: 'action-required';
+      since: number;
+    }
+  | null;
 
 /** Stored selection state from editor polling. */
 export interface StoredSelection {

--- a/src/features/chat/tabs/TabBar.ts
+++ b/src/features/chat/tabs/TabBar.ts
@@ -72,16 +72,18 @@ export class TabBar {
 
   /** Renders a single tab badge. */
   private renderBadge(item: TabBarItem): void {
-    // Determine state class (priority: active > attention > streaming > idle)
+    // Determine state class (priority: active > action required > working > review > idle)
     let stateClass = 'claudian-tab-badge-idle';
     if (item.isActive) {
       stateClass = 'claudian-tab-badge-active';
-    } else if (item.attention) {
-      stateClass = item.attention.kind === 'action-required'
-        ? 'claudian-tab-badge-action-required'
-        : 'claudian-tab-badge-review';
-    } else if (item.isStreaming) {
+    } else if (item.attention?.kind === 'action-required') {
+      stateClass = 'claudian-tab-badge-action-required';
+    } else if (item.isWorking) {
       stateClass = 'claudian-tab-badge-streaming';
+    } else if (item.attention?.kind === 'review') {
+      stateClass = item.attention.outcome === 'error'
+        ? 'claudian-tab-badge-review-error'
+        : 'claudian-tab-badge-review';
     }
 
     const isTitleExpanded = this.expandedTitleTabIds.has(item.id);
@@ -95,7 +97,7 @@ export class TabBar {
     });
 
     // Obsidian uses aria-label for hover tooltips here; adding title causes duplicate tooltip text.
-    badgeEl.setAttribute('aria-label', item.title);
+    badgeEl.setAttribute('aria-label', `${item.title}, ${this.getBadgeStatusLabel(item)}`);
     badgeEl.setAttribute('data-provider', item.providerId);
     badgeEl.setAttribute('data-title-expanded', isTitleExpanded ? 'true' : 'false');
 
@@ -180,6 +182,18 @@ export class TabBar {
     }
 
     return this.truncateExpandedTitle(item.title);
+  }
+
+  private getBadgeStatusLabel(item: TabBarItem): string {
+    if (item.isActive) return 'active';
+    if (item.attention?.kind === 'action-required') return 'needs your input';
+    if (item.isWorking) return 'working';
+    if (item.attention?.kind === 'review') {
+      return item.attention.outcome === 'error'
+        ? 'stopped with an error, ready to review'
+        : 'finished, ready to review';
+    }
+    return 'idle';
   }
 
   private truncateExpandedTitle(title: string): string {

--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -280,6 +280,10 @@ export class TabManager implements TabManagerInterface {
           this.callbacks.onTabStreamingChanged?.(runtime.id, isStreaming);
           if (!isStreaming) runtime.session.executionCoordinator.notifyMayCool();
         },
+        onWorkChanged: runtime => {
+          if (!this.isTabStateMutable(runtime)) return;
+          this.callbacks.onTabWorkChanged?.(runtime.id);
+        },
         onRewindingChanged: (runtime, isRewinding) => {
           if (!this.isTabStateMutable(runtime)) return;
           this.callbacks.onTabRewindingChanged?.(runtime.id, isRewinding);
@@ -292,7 +296,7 @@ export class TabManager implements TabManagerInterface {
             runtime.session.executionCoordinator.notifyMayCool();
           }
         },
-        captureReviewableSettlement: runtime => {
+        captureReviewableSettlement: (runtime, outcome) => {
           const shouldReport = this.isTabStateMutable(runtime) && this.activeTabId !== runtime.id;
           const activationRevision = this.tabActivationRevisions.get(runtime.id) ?? 0;
           return () => {
@@ -301,7 +305,7 @@ export class TabManager implements TabManagerInterface {
               && this.isTabStateMutable(runtime)
               && (this.tabActivationRevisions.get(runtime.id) ?? 0) === activationRevision
             ) {
-              runtime.state.markReviewRequired();
+              runtime.state.markReviewRequired(outcome);
             }
           };
         },
@@ -1080,6 +1084,16 @@ export class TabManager implements TabManagerInterface {
     return Array.from(this.tabs.values());
   }
 
+  /** True while the tab has any user-visible foreground or background work in progress. */
+  isTabWorking(tabId: TabId): boolean {
+    const tab = this.tabs.get(tabId);
+    if (!tab) return false;
+    return tab.state.isStreaming
+      || tab.session.activeTurn !== null
+      || tab.executionCoordinator.hasBackgroundWork
+      || tab.services.subagentManager.hasActiveAsyncSubagents();
+  }
+
   /** Reconciles blank drafts after provider/model availability changes. */
   reconcileProviderAvailability(): void {
     for (const tab of this.tabs.values()) {
@@ -1155,7 +1169,7 @@ export class TabManager implements TabManagerInterface {
         title: getTabTitle(tab, this.plugin),
         providerId: getTabProviderId(tab, this.plugin),
         isActive: tab.id === this.activeTabId,
-        isStreaming: tab.state.isStreaming,
+        isWorking: this.isTabWorking(tab.id),
         attention: tab.state.attention,
         canClose: !tab.state.isRewinding && (this.tabs.size > 1 || !tab.state.isStreaming),
       });

--- a/src/features/chat/tabs/TabRuntimeFactory.ts
+++ b/src/features/chat/tabs/TabRuntimeFactory.ts
@@ -2,7 +2,7 @@ import type { Component } from 'obsidian';
 
 import type { ProviderId } from '@/core/providers/types';
 import type { Conversation } from '@/core/types';
-import type { TabAttention } from '@/features/chat/state/types';
+import type { TabAttention, TabReviewOutcome } from '@/features/chat/state/types';
 import type { FeatureHost } from '@/features/FeatureHost';
 
 import type {
@@ -53,6 +53,7 @@ export interface TabRuntimeFactoryOptions {
   forkRequestCallback?: (forkContext: ForkContext) => Promise<void>;
   openConversation?: (conversationId: string) => Promise<void>;
   onStreamingChanged?: (tab: AssembledTabRuntime, isStreaming: boolean) => void;
+  onWorkChanged?: (tab: AssembledTabRuntime) => void;
   onRewindingChanged?: (tab: AssembledTabRuntime, isRewinding: boolean) => void;
   onAttentionChanged?: (tab: AssembledTabRuntime, attention: TabAttention) => void;
   onConversationIdChanged?: (
@@ -64,7 +65,10 @@ export interface TabRuntimeFactoryOptions {
     providerId: ProviderId,
   ) => void | Promise<void>;
   onCommandContextChanged?: (tab: AssembledTabRuntime) => void;
-  captureReviewableSettlement?: (tab: AssembledTabRuntime) => () => void;
+  captureReviewableSettlement?: (
+    tab: AssembledTabRuntime,
+    outcome: TabReviewOutcome,
+  ) => () => void;
 }
 
 interface CleanupEntry {

--- a/src/features/chat/tabs/TabSession.ts
+++ b/src/features/chat/tabs/TabSession.ts
@@ -21,6 +21,7 @@ export class TabSession {
   constructor(
     private readonly state: TabSessionState,
     private readonly coordinator: ChatExecutionCoordinator,
+    private readonly onWorkChanged?: () => void,
   ) {}
 
   get id(): string { return this.state.id; }
@@ -37,7 +38,9 @@ export class TabSession {
   get userOwnershipRevision(): number { return this.userOwnershipRevisionValue; }
   get activeTurn(): Promise<void> | null { return this.activeTurnValue; }
   set activeTurn(value: Promise<void> | null) {
+    const wasActive = this.activeTurnValue !== null;
     this.activeTurnValue = value;
+    if (wasActive !== (value !== null)) this.onWorkChanged?.();
     if (value === null) this.coordinator.notifyMayCool();
   }
 

--- a/src/features/chat/tabs/TabSessionEvents.ts
+++ b/src/features/chat/tabs/TabSessionEvents.ts
@@ -57,7 +57,7 @@ async function handleTabSessionEvent(
       ...(event.result !== undefined ? { result: event.result } : {}),
     });
     if (applied && isCurrent()) {
-      const reportReviewableSettlement = tab.captureReviewableSettlement?.();
+      const reportReviewableSettlement = tab.captureReviewableSettlement?.(event.status);
       try {
         await tab.controllers.conversationController.save(true);
       } finally {
@@ -96,7 +96,7 @@ async function handleTabSessionEvent(
     }, isCurrent);
     if (isCurrent()) {
       const reportReviewableSettlement = hasVisibleOutput
-        ? tab.captureReviewableSettlement?.()
+        ? tab.captureReviewableSettlement?.('completed')
         : null;
       try {
         await tab.controllers.conversationController.save(true);

--- a/src/features/chat/tabs/runtime/TabRuntimeConstruction.ts
+++ b/src/features/chat/tabs/runtime/TabRuntimeConstruction.ts
@@ -6,7 +6,7 @@ import type { FeatureHost } from '../../../FeatureHost';
 import type { ChatExecutionCoordinator } from '../../execution/ChatExecutionCoordinator';
 import type { MessageRenderer } from '../../rendering/MessageRenderer';
 import type { ChatState } from '../../state/ChatState';
-import type { TabAttention } from '../../state/types';
+import type { TabAttention, TabReviewOutcome } from '../../state/types';
 import type { ForkContext } from '../TabForking';
 import type { TabSession } from '../TabSession';
 import type {
@@ -38,6 +38,7 @@ export interface TabRuntimeConstructionContext {
   forkRequestCallback?: (forkContext: ForkContext) => Promise<void>;
   openConversation?: (conversationId: string) => Promise<void>;
   onStreamingChanged?: (tab: AssembledTabRuntime, isStreaming: boolean) => void;
+  onWorkChanged?: (tab: AssembledTabRuntime) => void;
   onRewindingChanged?: (tab: AssembledTabRuntime, isRewinding: boolean) => void;
   onAttentionChanged?: (tab: AssembledTabRuntime, attention: TabAttention) => void;
   onConversationIdChanged?: (
@@ -49,7 +50,10 @@ export interface TabRuntimeConstructionContext {
     providerId: ProviderId,
   ) => void | Promise<void>;
   onCommandContextChanged?: (tab: AssembledTabRuntime) => void;
-  captureReviewableSettlement?: (tab: AssembledTabRuntime) => () => void;
+  captureReviewableSettlement?: (
+    tab: AssembledTabRuntime,
+    outcome: TabReviewOutcome,
+  ) => () => void;
   registerCleanup: (resource: string, cleanup: TabRuntimeCleanup) => void;
   resourceOwner: TabRuntimeResourceOwner;
 }
@@ -66,7 +70,7 @@ export interface TabRuntimeShellBundle extends TabProviderContext {
   hydrationState: AssembledTabRuntime['hydrationState'];
   readonly executionCoordinator: ChatExecutionCoordinator;
   readonly providerCatalogResolver: ProviderCatalogResolver;
-  readonly captureReviewableSettlement: (() => () => void) | null;
+  readonly captureReviewableSettlement: ((outcome: TabReviewOutcome) => () => void) | null;
   readonly state: ChatState;
   readonly dom: TabDOMElements;
 }

--- a/src/features/chat/tabs/runtime/TabRuntimeServices.ts
+++ b/src/features/chat/tabs/runtime/TabRuntimeServices.ts
@@ -15,6 +15,7 @@ export function buildTabRuntimeServices(
 ): TabServices {
   const subagentManager = new SubagentManager((subagent) => {
     runtimeRef.requirePublished().controllers.streamController.onAsyncSubagentStateChange(subagent);
+    options.onWorkChanged?.(runtimeRef.requirePublished());
   });
   options.registerCleanup('tab subagent state', () => subagentManager.clear());
 

--- a/src/features/chat/tabs/runtime/TabRuntimeShell.ts
+++ b/src/features/chat/tabs/runtime/TabRuntimeShell.ts
@@ -88,7 +88,11 @@ export function buildTabRuntimeShell(
     options,
     runtimeRef,
   );
-  const session = new TabSession(sessionState, executionCoordinator);
+  const session = new TabSession(
+    sessionState,
+    executionCoordinator,
+    () => options.onWorkChanged?.(runtimeRef.requirePublished()),
+  );
   options.registerCleanup(
     'tab execution coordinator',
     () => session.disposeExecutionCoordinator(),
@@ -144,7 +148,7 @@ export function buildTabRuntimeShell(
     executionCoordinator,
     providerCatalogResolver: () => options.getProviderCatalogConfig(providerCatalogContext),
     captureReviewableSettlement: options.captureReviewableSettlement
-      ? () => options.captureReviewableSettlement!(runtimeRef.requirePublished())
+      ? outcome => options.captureReviewableSettlement!(runtimeRef.requirePublished(), outcome)
       : null,
     state,
     dom,
@@ -292,6 +296,9 @@ function createTabExecutionCoordinator(
       event,
       context,
     ),
+    onBackgroundWorkChanged: () => {
+      options.onWorkChanged?.(runtimeRef.requirePublished());
+    },
     resolveMissingProviderSession: (conversationId, missingProviderSessionId) =>
       plugin.handleMissingProviderSession(conversationId, missingProviderSessionId),
     onError: error => {

--- a/src/features/chat/tabs/types.ts
+++ b/src/features/chat/tabs/types.ts
@@ -16,7 +16,7 @@ import type { ChatExecutionCoordinator } from '../execution/ChatExecutionCoordin
 import type { MessageRenderer } from '../rendering/MessageRenderer';
 import type { SubagentManager } from '../services/SubagentManager';
 import type { ChatState } from '../state/ChatState';
-import type { TabAttention } from '../state/types';
+import type { TabAttention, TabReviewOutcome } from '../state/types';
 import type { BangBashModeManager } from '../ui/BangBashModeManager';
 import type { ComposerContextTray } from '../ui/ComposerContextTray';
 import type { FileContextManager } from '../ui/FileContext';
@@ -70,6 +70,9 @@ export interface TabManagerInterface {
 
   /** Gets all tabs. */
   getAllTabs(): AssembledTabRuntime[];
+
+  /** Reports aggregate user-visible work for a runtime tab. */
+  isTabWorking(tabId: TabId): boolean;
 }
 
 /** Tab identifier type. */
@@ -221,7 +224,7 @@ export interface AssembledTabRuntime {
   readonly providerCatalogResolver: ProviderCatalogResolver;
 
   /** Captures whether completed runtime work will need review after finalization. */
-  readonly captureReviewableSettlement: (() => () => void) | null;
+  readonly captureReviewableSettlement: ((outcome: TabReviewOutcome) => () => void) | null;
 
   /** Per-tab chat state. */
   readonly state: ChatState;
@@ -281,6 +284,9 @@ export interface TabManagerCallbacks {
   /** Called when tab streaming state changes. */
   onTabStreamingChanged?: (tabId: TabId, isStreaming: boolean) => void;
 
+  /** Called when foreground, continuation, provider-background, or async-subagent work changes. */
+  onTabWorkChanged?: (tabId: TabId) => void;
+
   /** Called when tab rewind transaction state changes. */
   onTabRewindingChanged?: (tabId: TabId, isRewinding: boolean) => void;
 
@@ -307,7 +313,8 @@ export interface TabBarItem {
   title: string;
   providerId: ProviderId;
   isActive: boolean;
-  isStreaming: boolean;
+  /** True while any foreground, continuation, provider-background, or async-subagent work remains. */
+  isWorking: boolean;
   attention: TabAttention;
   canClose: boolean;
 }

--- a/src/style/components/tabs.css
+++ b/src/style/components/tabs.css
@@ -94,6 +94,10 @@
   border-color: var(--color-green);
 }
 
+.claudian-tab-badge-review-error {
+  border-color: var(--color-orange);
+}
+
 .claudian-tab-badge-action-required {
   border-color: var(--text-error);
 }

--- a/tests/unit/features/chat/ClaudianView.test.ts
+++ b/tests/unit/features/chat/ClaudianView.test.ts
@@ -2024,23 +2024,27 @@ describe('ClaudianView tab controls', () => {
       conversationId: 'local',
       id: 'tab-local',
       state: {
-        attention: { kind: 'review', since: 10 },
+        attention: { kind: 'review', outcome: 'completed', since: 10 },
         isStreaming: false,
       },
     };
     const crossViewTab = {
       state: {
-        attention: { kind: 'review', since: 5 },
+        attention: { kind: 'review', outcome: 'error', since: 5 },
         isStreaming: false,
       },
     };
     const otherView = {
-      getTabManager: () => ({ getTab: () => crossViewTab }),
+      getTabManager: () => ({
+        getTab: () => crossViewTab,
+        isTabWorking: () => false,
+      }),
     };
     const view = Object.create(ClaudianView.prototype) as any;
     view.tabManager = {
       getActiveTab: () => activeTab,
       getAllTabs: () => [activeTab, localTab],
+      isTabWorking: (tabId: string) => tabId === 'tab-active',
     };
     view.plugin = {
       findConversationAcrossViews: (id: string) => id === 'cross'
@@ -2051,9 +2055,12 @@ describe('ClaudianView tab controls', () => {
     expect(view.getHistoryConversationStatus('active').attention)
       .toEqual({ kind: 'action-required', since: 20 });
     expect(view.getHistoryConversationStatus('local').attention)
-      .toEqual({ kind: 'review', since: 10 });
+      .toEqual({ kind: 'review', outcome: 'completed', since: 10 });
     expect(view.getHistoryConversationStatus('cross').attention)
-      .toEqual({ kind: 'review', since: 5 });
+      .toEqual({ kind: 'review', outcome: 'error', since: 5 });
+    expect(view.getHistoryConversationStatus('active').isRunning).toBe(true);
+    expect(view.getHistoryConversationStatus('local').isRunning).toBe(false);
+    expect(view.getHistoryConversationStatus('cross').isRunning).toBe(false);
     expect(view.getHistoryConversationStatus('closed').attention).toBeUndefined();
   });
 
@@ -2384,10 +2391,15 @@ describe('ClaudianView runtime tab initialization', () => {
     expect(createTab).toHaveBeenCalledTimes(1);
     expect(tabManagerCallbacks).not.toHaveProperty('onPersistedStateChanged');
 
-    tabManagerCallbacks.onTabAttentionChanged('tab-1', { kind: 'review', since: 1 });
+    tabManagerCallbacks.onTabAttentionChanged('tab-1', {
+      kind: 'review',
+      outcome: 'completed',
+      since: 1,
+    });
+    tabManagerCallbacks.onTabWorkChanged('tab-1');
 
-    expect(view.updateTabBar).toHaveBeenCalledTimes(1);
-    expect(view.notifyConversationNavigationChanged).toHaveBeenCalledTimes(1);
+    expect(view.updateTabBar).toHaveBeenCalledTimes(2);
+    expect(view.notifyConversationNavigationChanged).toHaveBeenCalledTimes(2);
   });
 
   it('abandons deferred restoration when view shutdown begins', async () => {

--- a/tests/unit/features/chat/controllers/ConversationController.test.ts
+++ b/tests/unit/features/chat/controllers/ConversationController.test.ts
@@ -1316,9 +1316,9 @@ describe('ConversationController', () => {
           { id: 'normal', title: 'Normal', createdAt: 1 },
         ]);
         const attentionById = new Map([
-          ['review-pinned', { kind: 'review' as const, since: 300 }],
+          ['review-pinned', { kind: 'review' as const, outcome: 'completed' as const, since: 300 }],
           ['action', { kind: 'action-required' as const, since: 100 }],
-          ['review', { kind: 'review' as const, since: 200 }],
+          ['review', { kind: 'review' as const, outcome: 'completed' as const, since: 200 }],
         ]);
 
         controller.renderHistoryDropdown(container, {
@@ -2198,7 +2198,7 @@ describe('ConversationController', () => {
             openState: 'open',
             isRunning: false,
             attention: id === 'attention'
-              ? { kind: 'review', since: 1000 }
+              ? { kind: 'review', outcome: 'completed', since: 1000 }
               : null,
           }),
         });

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -196,7 +196,11 @@ function createFixture(overrides: Record<string, unknown> = {}) {
     ensureExecutionInitialized: jest.fn().mockResolvedValue(true),
     ...dependencyOverrides,
     ...(typeof onReviewableSettlement === 'function'
-      ? { captureReviewableSettlement: () => onReviewableSettlement as () => void }
+      ? {
+          captureReviewableSettlement: jest.fn(
+            () => onReviewableSettlement as () => void,
+          ),
+        }
       : {}),
   } as unknown as InputControllerDeps;
   return {
@@ -1465,6 +1469,7 @@ describe('InputController coordinator execution', () => {
 
     await fixture.controller.sendMessage({ content: 'finish this' });
 
+    expect(fixture.deps.captureReviewableSettlement).toHaveBeenCalledWith('completed');
     expect(onReviewableSettlement).toHaveBeenCalledTimes(1);
   });
 
@@ -1480,6 +1485,7 @@ describe('InputController coordinator execution', () => {
 
     await fixture.controller.sendMessage({ content: 'finish this' });
 
+    expect(fixture.deps.captureReviewableSettlement).toHaveBeenCalledWith('error');
     expect(onReviewableSettlement).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/unit/features/chat/execution/ChatExecutionCoordinator.test.ts
+++ b/tests/unit/features/chat/execution/ChatExecutionCoordinator.test.ts
@@ -229,6 +229,7 @@ function createSubmission(overrides: Partial<ChatTurnSubmission> = {}): ChatTurn
 }
 
 function createHarness(options: {
+  onBackgroundWorkChanged?: (isWorking: boolean) => void;
   onError?: (error: unknown) => void;
   onRequestedEvent?: (
     event: ProviderExecutionEvent,
@@ -296,6 +297,7 @@ function createHarness(options: {
       sessionEventContexts.push(context);
       return options.onSessionEvent?.(event, context);
     },
+    onBackgroundWorkChanged: options.onBackgroundWorkChanged,
     onError: options.onError,
     resolveMissingProviderSession: missingSession,
     ...(options.warmExecution ? { warmExecution: options.warmExecution } : {}),
@@ -1770,7 +1772,8 @@ describe('ChatExecutionCoordinator', () => {
   });
 
   it('routes correlated background turns, persists their snapshots, and rejects stale output', async () => {
-    const harness = createHarness();
+    const onBackgroundWorkChanged = jest.fn();
+    const harness = createHarness({ onBackgroundWorkChanged });
     await harness.coordinator.bindConversation({
       conversationId: 'conversation-1',
       providerId: 'claude',
@@ -1791,6 +1794,8 @@ describe('ChatExecutionCoordinator', () => {
     };
 
     session.emit({ type: 'background_turn_started', scope: backgroundScope });
+    expect(harness.coordinator.hasBackgroundWork).toBe(true);
+    expect(onBackgroundWorkChanged).toHaveBeenLastCalledWith(true);
     session.emit({
       type: 'text_delta',
       scope: { ...backgroundScope, sequence: 2 },
@@ -1806,6 +1811,8 @@ describe('ChatExecutionCoordinator', () => {
       scope: { ...backgroundScope, sequence: 4 },
       reason: 'completed',
     });
+    expect(harness.coordinator.hasBackgroundWork).toBe(false);
+    expect(onBackgroundWorkChanged).toHaveBeenLastCalledWith(false);
     session.emit({
       type: 'text_delta',
       scope: { ...backgroundScope, sequence: 5 },

--- a/tests/unit/features/chat/services/SubagentManager.test.ts
+++ b/tests/unit/features/chat/services/SubagentManager.test.ts
@@ -64,6 +64,31 @@ describe('SubagentManager', () => {
   // ============================================
 
   describe('async lifecycle', () => {
+    it('reports whether any async subagent remains active', () => {
+      const { manager } = createManager();
+      const parentEl = createMockEl();
+
+      expect(manager.hasActiveAsyncSubagents()).toBe(false);
+
+      manager.handleTaskToolUse(
+        'task-1',
+        { description: 'Background', run_in_background: true },
+        parentEl,
+      );
+      expect(manager.hasActiveAsyncSubagents()).toBe(true);
+
+      manager.handleAsyncSubagentCompletion({
+        type: 'async_subagent_completion',
+        providerSessionId: 'session-1',
+        taskId: 'provider-task-1',
+        toolUseId: 'task-1',
+        status: 'completed',
+        result: 'Done',
+      });
+
+      expect(manager.hasActiveAsyncSubagents()).toBe(false);
+    });
+
     it('keeps one canonical task record across notification and late launch events', () => {
       const { manager } = createManager();
       const parentEl = createMockEl();

--- a/tests/unit/features/chat/state/ChatState.test.ts
+++ b/tests/unit/features/chat/state/ChatState.test.ts
@@ -341,9 +341,13 @@ describe('ChatState', () => {
 
       chatState.markReviewRequired();
 
-      expect(chatState.attention).toEqual({ kind: 'review', since: 123 });
+      expect(chatState.attention).toEqual({ kind: 'review', outcome: 'completed', since: 123 });
       expect(chatState.requiresAction).toBe(false);
-      expect(onAttentionChanged).toHaveBeenCalledWith({ kind: 'review', since: 123 });
+      expect(onAttentionChanged).toHaveBeenCalledWith({
+        kind: 'review',
+        outcome: 'completed',
+        since: 123,
+      });
 
       chatState.acknowledgeReview();
 
@@ -393,7 +397,11 @@ describe('ChatState', () => {
       chatState.markReviewRequired();
       chatState.endActionRequired('approval-1');
 
-      expect(chatState.attention).toEqual({ kind: 'review', since: 200 });
+      expect(chatState.attention).toEqual({
+        kind: 'review',
+        outcome: 'completed',
+        since: 200,
+      });
     });
 
     it('restores existing review after action-required attention settles', () => {
@@ -406,7 +414,11 @@ describe('ChatState', () => {
       chatState.beginActionRequired('approval-1');
       chatState.endActionRequired('approval-1');
 
-      expect(chatState.attention).toEqual({ kind: 'review', since: 100 });
+      expect(chatState.attention).toEqual({
+        kind: 'review',
+        outcome: 'completed',
+        since: 100,
+      });
     });
 
     it('acknowledges review hidden beneath action-required attention', () => {
@@ -444,8 +456,47 @@ describe('ChatState', () => {
       chatState.markReviewRequired();
       chatState.markReviewRequired();
 
-      expect(chatState.attention).toEqual({ kind: 'review', since: 100 });
+      expect(chatState.attention).toEqual({
+        kind: 'review',
+        outcome: 'completed',
+        since: 100,
+      });
       expect(onAttentionChanged).toHaveBeenCalledTimes(1);
+    });
+
+    it('upgrades unread completion attention when a later result fails', () => {
+      jest.spyOn(Date, 'now')
+        .mockReturnValueOnce(100)
+        .mockReturnValueOnce(200);
+      const chatState = new ChatState();
+
+      chatState.markReviewRequired('completed');
+      chatState.markReviewRequired('error');
+
+      expect(chatState.attention).toEqual({
+        kind: 'review',
+        outcome: 'error',
+        since: 100,
+      });
+    });
+
+    it('restores the strongest unread outcome after action-required settles', () => {
+      jest.spyOn(Date, 'now')
+        .mockReturnValueOnce(100)
+        .mockReturnValueOnce(200)
+        .mockReturnValueOnce(300);
+      const chatState = new ChatState();
+
+      chatState.markReviewRequired('completed');
+      chatState.beginActionRequired('approval-1');
+      chatState.markReviewRequired('error');
+      chatState.endActionRequired('approval-1');
+
+      expect(chatState.attention).toEqual({
+        kind: 'review',
+        outcome: 'error',
+        since: 100,
+      });
     });
 
     it('clears visible attention and pending action tokens', () => {

--- a/tests/unit/features/chat/tabs/TabAttentionStyles.test.ts
+++ b/tests/unit/features/chat/tabs/TabAttentionStyles.test.ts
@@ -12,6 +12,9 @@ describe('tab attention styles', () => {
       /\.claudian-tab-badge-review \{[\s\S]*?border-color: var\(--color-green\);[\s\S]*?\}/,
     );
     expect(tabsCss).toMatch(
+      /\.claudian-tab-badge-review-error \{[\s\S]*?border-color: var\(--color-orange\);[\s\S]*?\}/,
+    );
+    expect(tabsCss).toMatch(
       /\.claudian-tab-badge-action-required \{[\s\S]*?border-color: var\(--text-error\);[\s\S]*?\}/,
     );
   });

--- a/tests/unit/features/chat/tabs/TabBar.test.ts
+++ b/tests/unit/features/chat/tabs/TabBar.test.ts
@@ -20,7 +20,7 @@ function createTabBarItem(overrides: Partial<TabBarItem> = {}): TabBarItem {
     title: 'Test Tab',
     providerId: 'claude',
     isActive: false,
-    isStreaming: false,
+    isWorking: false,
     attention: null,
     canClose: true,
     ...overrides,
@@ -97,7 +97,7 @@ describe('TabBar', () => {
 
       tabBar.update([createTabBarItem({ title: 'My Conversation' })]);
 
-      expect(containerEl._children[0].getAttribute('aria-label')).toBe('My Conversation');
+      expect(containerEl._children[0].getAttribute('aria-label')).toBe('My Conversation, idle');
       expect(containerEl._children[0].getAttribute('title')).toBeNull();
     });
 
@@ -249,7 +249,7 @@ describe('TabBar', () => {
       const callbacks = createMockCallbacks();
       const tabBar = new TabBar(containerEl, callbacks);
 
-      tabBar.update([createTabBarItem({ isActive: false, isStreaming: false, attention: null })]);
+      tabBar.update([createTabBarItem({ isActive: false, isWorking: false, attention: null })]);
 
       expect(containerEl._children[0]._classList.has('claudian-tab-badge-idle')).toBe(true);
     });
@@ -269,7 +269,7 @@ describe('TabBar', () => {
       const callbacks = createMockCallbacks();
       const tabBar = new TabBar(containerEl, callbacks);
 
-      tabBar.update([createTabBarItem({ isStreaming: true })]);
+      tabBar.update([createTabBarItem({ isWorking: true })]);
 
       expect(containerEl._children[0]._classList.has('claudian-tab-badge-streaming')).toBe(true);
     });
@@ -280,11 +280,24 @@ describe('TabBar', () => {
       const tabBar = new TabBar(containerEl, callbacks);
 
       tabBar.update([createTabBarItem({
-        attention: { kind: 'review', since: 1 },
+        attention: { kind: 'review', outcome: 'completed', since: 1 },
       })]);
 
       expect(containerEl._children[0]._classList.has('claudian-tab-badge-review')).toBe(true);
       expect(containerEl._children[0]._classList.has('claudian-tab-badge-action-required')).toBe(false);
+    });
+
+    it('should apply error-review class for a failed turn awaiting review', () => {
+      const containerEl = createMockEl();
+      const callbacks = createMockCallbacks();
+      const tabBar = new TabBar(containerEl, callbacks);
+
+      tabBar.update([createTabBarItem({
+        attention: { kind: 'review', outcome: 'error', since: 1 },
+      })]);
+
+      expect(containerEl._children[0]._classList.has('claudian-tab-badge-review-error')).toBe(true);
+      expect(containerEl._children[0]._classList.has('claudian-tab-badge-review')).toBe(false);
     });
 
     it('should apply action-required class for a pending interaction', () => {
@@ -314,32 +327,63 @@ describe('TabBar', () => {
       expect(containerEl._children[0]._classList.has('claudian-tab-badge-action-required')).toBe(false);
     });
 
-    it.each([
-      ['review', 'claudian-tab-badge-review'],
-      ['action-required', 'claudian-tab-badge-action-required'],
-    ] as const)('should prioritize %s attention over streaming', (kind, expectedClass) => {
+    it('should prioritize action-required attention over ongoing work', () => {
       const containerEl = createMockEl();
       const callbacks = createMockCallbacks();
       const tabBar = new TabBar(containerEl, callbacks);
 
       tabBar.update([createTabBarItem({
-        isStreaming: true,
-        attention: { kind, since: 1 },
+        isWorking: true,
+        attention: { kind: 'action-required', since: 1 },
       })]);
 
-      expect(containerEl._children[0]._classList.has(expectedClass)).toBe(true);
+      expect(containerEl._children[0]._classList.has('claudian-tab-badge-action-required')).toBe(true);
       expect(containerEl._children[0]._classList.has('claudian-tab-badge-streaming')).toBe(false);
     });
+
+    it.each(['completed', 'error'] as const)(
+      'should keep showing ongoing work over an unread %s result',
+      (outcome) => {
+        const containerEl = createMockEl();
+        const callbacks = createMockCallbacks();
+        const tabBar = new TabBar(containerEl, callbacks);
+
+        tabBar.update([createTabBarItem({
+          isWorking: true,
+          attention: { kind: 'review', outcome, since: 1 },
+        })]);
+
+        expect(containerEl._children[0]._classList.has('claudian-tab-badge-streaming')).toBe(true);
+        expect(containerEl._children[0]._classList.has('claudian-tab-badge-review')).toBe(false);
+        expect(containerEl._children[0]._classList.has('claudian-tab-badge-review-error')).toBe(false);
+      },
+    );
 
     it('should prioritize active over streaming', () => {
       const containerEl = createMockEl();
       const callbacks = createMockCallbacks();
       const tabBar = new TabBar(containerEl, callbacks);
 
-      tabBar.update([createTabBarItem({ isActive: true, isStreaming: true })]);
+      tabBar.update([createTabBarItem({ isActive: true, isWorking: true })]);
 
       expect(containerEl._children[0]._classList.has('claudian-tab-badge-active')).toBe(true);
       expect(containerEl._children[0]._classList.has('claudian-tab-badge-streaming')).toBe(false);
+    });
+
+    it.each([
+      [createTabBarItem(), 'idle'],
+      [createTabBarItem({ isWorking: true }), 'working'],
+      [createTabBarItem({ attention: { kind: 'review', outcome: 'completed', since: 1 } }), 'finished, ready to review'],
+      [createTabBarItem({ attention: { kind: 'review', outcome: 'error', since: 1 } }), 'stopped with an error, ready to review'],
+      [createTabBarItem({ attention: { kind: 'action-required', since: 1 } }), 'needs your input'],
+    ] as const)('should expose the color state in the accessible label', (item, status) => {
+      const containerEl = createMockEl();
+      const callbacks = createMockCallbacks();
+      const tabBar = new TabBar(containerEl, callbacks);
+
+      tabBar.update([item]);
+
+      expect(containerEl._children[0].getAttribute('aria-label')).toBe(`Test Tab, ${status}`);
     });
   });
 

--- a/tests/unit/features/chat/tabs/TabManager.test.ts
+++ b/tests/unit/features/chat/tabs/TabManager.test.ts
@@ -14,7 +14,9 @@ const mockTabs: any[] = [];
 const mockCreateTab = jest.fn((options: Record<string, any>) => createMockTab(options));
 const mockCreateTabRuntime = jest.fn(async (options: Record<string, any>) => {
   const captureReviewableSettlement = options.captureReviewableSettlement
-    ? () => options.captureReviewableSettlement(tab)
+    ? (outcome: 'completed' | 'error' = 'completed') => (
+        options.captureReviewableSettlement(tab, outcome)
+      )
     : undefined;
   const tab = mockCreateTab({
     ...options,
@@ -27,6 +29,7 @@ const mockChooseForkTarget = jest.fn();
 function createMockTab(options: Record<string, any>): any {
   let intentAdmissionPauseDepth = 0;
   const session = {
+    activeTurn: null,
     userOwnershipRevision: 0,
     get acceptsIntents() {
       return intentAdmissionPauseDepth === 0;
@@ -47,6 +50,7 @@ function createMockTab(options: Record<string, any>): any {
     draftModel: options.conversation ? null : 'claude-default',
     executionCoordinator: {
       copyInputsForFork: jest.fn().mockResolvedValue(undefined),
+      hasBackgroundWork: false,
       notifyMayCool: jest.fn(),
       prepare: jest.fn().mockResolvedValue(undefined),
       state: 'absent',
@@ -67,6 +71,11 @@ function createMockTab(options: Record<string, any>): any {
       messages: [],
       markReviewRequired: jest.fn(),
       requiresAction: false,
+    },
+    services: {
+      subagentManager: {
+        hasActiveAsyncSubagents: jest.fn().mockReturnValue(false),
+      },
     },
     controllers: {
       conversationController: {
@@ -272,13 +281,52 @@ describe('TabManager provider execution orchestration', () => {
     const tab = await manager.createTab();
     Object.defineProperty(tab!.state, 'attention', {
       configurable: true,
-      value: { kind: 'review', since: 123 },
+      value: { kind: 'review', outcome: 'completed', since: 123 },
     });
 
     expect(manager.getTabBarItems()).toEqual([
       expect.objectContaining({
-        attention: { kind: 'review', since: 123 },
+        attention: { kind: 'review', outcome: 'completed', since: 123 },
         id: tab!.id,
+      }),
+    ]);
+  });
+
+  it.each([
+    ['foreground streaming', (tab: any) => { tab.state.isStreaming = true; }],
+    ['turn orchestration', (tab: any) => { tab.session.activeTurn = Promise.resolve(); }],
+    ['provider background work', (tab: any) => { tab.executionCoordinator.hasBackgroundWork = true; }],
+    ['async subagent work', (tab: any) => {
+      tab.services.subagentManager.hasActiveAsyncSubagents.mockReturnValue(true);
+    }],
+  ])('projects %s as working in tab bar items', async (_source, makeWorking) => {
+    const { manager } = createManager();
+    const tab = await manager.createTab();
+
+    makeWorking(tab);
+
+    expect(manager.getTabBarItems()).toEqual([
+      expect.objectContaining({ id: tab!.id, isWorking: true }),
+    ]);
+  });
+
+  it('keeps an unread result while projecting later work as active', async () => {
+    const { manager } = createManager();
+    const tab = await manager.createTab();
+    Object.defineProperty(tab!.state, 'attention', {
+      configurable: true,
+      value: { kind: 'review', outcome: 'completed', since: 123 },
+    });
+    Object.defineProperty(tab!.executionCoordinator, 'hasBackgroundWork', {
+      configurable: true,
+      value: true,
+    });
+
+    expect(manager.getTabBarItems()).toEqual([
+      expect.objectContaining({
+        attention: { kind: 'review', outcome: 'completed', since: 123 },
+        id: tab!.id,
+        isWorking: true,
       }),
     ]);
   });
@@ -368,11 +416,11 @@ describe('TabManager provider execution orchestration', () => {
     const activeSettlement = mockCreateTab.mock.calls[0]?.[0].captureReviewableSettlement;
     const backgroundSettlement = mockCreateTab.mock.calls[1]?.[0].captureReviewableSettlement;
 
-    activeSettlement()();
-    backgroundSettlement()();
+    activeSettlement('completed')();
+    backgroundSettlement('error')();
 
     expect(active!.state.markReviewRequired).not.toHaveBeenCalled();
-    expect(background!.state.markReviewRequired).toHaveBeenCalledTimes(1);
+    expect(background!.state.markReviewRequired).toHaveBeenCalledWith('error');
   });
 
   it('uses activity at completion and invalidates review after activation', async () => {
@@ -381,8 +429,8 @@ describe('TabManager provider execution orchestration', () => {
     const background = await manager.createTab(null, undefined, { activate: false });
     const activeSettlement = mockCreateTab.mock.calls[0]?.[0].captureReviewableSettlement;
     const backgroundSettlement = mockCreateTab.mock.calls[1]?.[0].captureReviewableSettlement;
-    const reportActiveCompletion = activeSettlement();
-    const reportBackgroundCompletion = backgroundSettlement();
+    const reportActiveCompletion = activeSettlement('completed');
+    const reportBackgroundCompletion = backgroundSettlement('completed');
 
     await manager.switchToTab(background!.id);
     await manager.switchToTab(active!.id);

--- a/tests/unit/features/chat/tabs/TabRuntimeFactory.test.ts
+++ b/tests/unit/features/chat/tabs/TabRuntimeFactory.test.ts
@@ -400,6 +400,32 @@ describe('Tab provider execution ownership', () => {
     expect(coordinatorInstances).toHaveLength(1);
   });
 
+  it('publishes work changes from turn, provider-background, and async-subagent owners', async () => {
+    const onWorkChanged = jest.fn();
+    const tab = await createTestTab({
+      plugin: createPlugin(),
+      containerEl: createMockEl() as any,
+      onWorkChanged,
+    });
+
+    tab.session.activeTurn = Promise.resolve();
+    tab.session.activeTurn = null;
+    coordinatorDeps[0].onBackgroundWorkChanged?.(true);
+    tab.services.subagentManager.refreshAsyncSubagent({
+      asyncStatus: 'running',
+      description: 'Background',
+      id: 'task-1',
+      isExpanded: false,
+      mode: 'async',
+      prompt: '',
+      status: 'running',
+      toolCalls: [],
+    });
+
+    expect(onWorkChanged).toHaveBeenCalledTimes(4);
+    expect(onWorkChanged).toHaveBeenCalledWith(tab);
+  });
+
   it('lets later navigation override bottom auto-scroll intent', async () => {
     const plugin = createPlugin();
     plugin.settings.keyboardNavigation = {
@@ -1982,10 +2008,11 @@ describe('Tab provider execution ownership', () => {
   it('routes async subagent completion without transcript mutation', async () => {
     const plugin = createPlugin();
     const onReviewableSettlement = jest.fn();
+    const captureReviewableSettlement = jest.fn(() => onReviewableSettlement);
     const tab = await createTestTab({
       plugin,
       containerEl: createMockEl() as any,
-      captureReviewableSettlement: () => onReviewableSettlement,
+      captureReviewableSettlement,
     });
     const handleAsyncSubagentCompletion = jest.fn().mockResolvedValue(true);
     tab.controllers.streamController = { handleAsyncSubagentCompletion } as any;
@@ -2015,6 +2042,7 @@ describe('Tab provider execution ownership', () => {
       type: 'async_subagent_completion',
     });
     expect(tab.controllers.conversationController!.save).toHaveBeenCalledWith(true);
+    expect(captureReviewableSettlement).toHaveBeenCalledWith(tab, 'completed');
     expect(onReviewableSettlement).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Why

Background work could leave tabs green while still running, making working versus finished status ambiguous for multi-tab users. Closes #1121.

## What Changed

Tabs now derive aggregate work across foreground turns, continuations, provider background work, and async subagents, using provider color while working, green for completed review, orange for error review, red for required input, and gray for idle; the UI remains color-only with accessible status labels.

## Why This Approach

Centralizing the derived work state at the tab manager keeps lifecycle ownership explicit and prevents presentation components from guessing about provider activity.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run test` (6,594 tests passed)
- `npm run build`
- `git diff --check`
- Screenshots: not included; DOM and CSS state coverage verifies the color priority.

## Impact and Follow-ups

None.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
