### PR TITLE
feat: add native /model and /compact slash commands

### DIFF
--- a/src/core/commands/builtInCommands.ts
+++ b/src/core/commands/builtInCommands.ts
@@ -8,7 +8,7 @@
 import { ProviderRegistry } from '../providers/ProviderRegistry';
 import type { ProviderCapabilities, ProviderId } from '../providers/types';
 
-export type BuiltInCommandAction = 'clear' | 'add-dir' | 'resume' | 'fork';
+export type BuiltInCommandAction = 'clear' | 'add-dir' | 'resume' | 'fork' | 'model' | 'compact';
 type BuiltInCommandCapability = 'supportsNativeHistory' | 'supportsFork';
 type BuiltInCommandSupportContext = ProviderId | Pick<ProviderCapabilities, BuiltInCommandCapability>;
 
@@ -23,6 +23,12 @@ export interface BuiltInCommand {
   argumentHint?: string;
   /** When set, provider capabilities must expose this feature. */
   requiredCapability?: BuiltInCommandCapability;
+  /**
+   * When true, the command is only surfaced for discovery (dropdown listing).
+   * Submission is not intercepted client-side; the raw text still reaches the
+   * active provider, which recognizes and executes the command natively.
+   */
+  providerRouted?: boolean;
 }
 
 export interface BuiltInCommandResult {
@@ -56,6 +62,19 @@ export const BUILT_IN_COMMANDS: BuiltInCommand[] = [
     description: 'Fork entire conversation to new session',
     action: 'fork',
     requiredCapability: 'supportsFork',
+  },
+  {
+    name: 'model',
+    description: 'Switch the model used for this conversation',
+    action: 'model',
+    hasArgs: true,
+    argumentHint: '[model name]',
+  },
+  {
+    name: 'compact',
+    description: 'Compact the conversation to free up context',
+    action: 'compact',
+    providerRouted: true,
   },
 ];
 

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -6,6 +6,7 @@ import {
   isBuiltInCommandSupported,
 } from '../../../core/commands/builtInCommands';
 import { ProviderRegistry } from '../../../core/providers/ProviderRegistry';
+import type { ProviderUIOption } from '../../../core/providers/types';
 import {
   DEFAULT_CHAT_PROVIDER_ID,
   type InstructionRefineService,
@@ -27,6 +28,7 @@ import type {
 import { TOOL_EXIT_PLAN_MODE } from '../../../core/tools/toolNames';
 import type { ApprovalDecision, ChatMessage, ExitPlanModeDecision, StreamChunk } from '../../../core/types';
 import type ClaudianPlugin from '../../../main';
+import { ModelCommandDropdown } from '../../../shared/components/ModelCommandDropdown';
 import { ResumeSessionDropdown } from '../../../shared/components/ResumeSessionDropdown';
 import { InstructionModal } from '../../../shared/modals/InstructionConfirmModal';
 import type { BrowserSelectionContext } from '../../../utils/browser';
@@ -108,6 +110,15 @@ export interface InputControllerDeps {
   openConversation?: (conversationId: string) => Promise<void>;
   onForkAll?: () => Promise<void>;
   restorePrePlanPermissionModeIfNeeded?: () => void;
+  /** Model picker for the active tab, used by the `/model` built-in command. */
+  getModelSelectorHandle?: () => ModelSelectorHandle | null;
+}
+
+/** Minimal surface the `/model` command needs from the tab's model picker. */
+export interface ModelSelectorHandle {
+  getOptions: () => ProviderUIOption[];
+  getCurrentValue: () => string;
+  selectValue: (value: string) => Promise<void>;
 }
 
 export class InputController {
@@ -118,6 +129,7 @@ export class InputController {
   private pendingPlanApproval: InlinePlanApproval | null = null;
   private pendingPlanApprovalInvalidated = false;
   private activeResumeDropdown: ResumeSessionDropdown | null = null;
+  private activeModelDropdown: ModelCommandDropdown | null = null;
   private inputContainerHideDepth = 0;
   private steerInFlight = false;
   private pendingSteerMessage: QueuedMessage | null = null;
@@ -224,9 +236,11 @@ export class InputController {
       : (imageContextManager?.hasImages() ?? false);
     if (!content && !hasImages) return;
 
-    // Check for built-in commands first (e.g., /clear, /new, /add-dir)
+    // Check for built-in commands first (e.g., /clear, /new, /add-dir).
+    // Provider-routed commands (e.g. /compact) are discoverable in the dropdown
+    // but must still reach the provider, so they fall through to normal submission.
     const builtInCmd = detectBuiltInCommand(content);
-    if (builtInCmd) {
+    if (builtInCmd && !builtInCmd.command.providerRouted) {
       if (shouldUseInput) {
         inputEl.value = '';
         this.deps.resetInputHeight();
@@ -1639,6 +1653,9 @@ export class InputController {
         await this.deps.onForkAll();
         break;
       }
+      case 'model':
+        this.handleModelCommand(args);
+        break;
       default: {
         // Unknown command - notify user
         const unknownAction = typeof (command as { action?: unknown }).action === 'string'
@@ -1700,6 +1717,89 @@ export class InputController {
         },
         onDismiss: () => {
           this.destroyResumeDropdown();
+        },
+      }
+    );
+  }
+
+  // ============================================
+  // Model Command Dropdown
+  // ============================================
+
+  handleModelKeydown(e: KeyboardEvent): boolean {
+    if (!this.activeModelDropdown?.isVisible()) return false;
+    return this.activeModelDropdown.handleKeydown(e);
+  }
+
+  isModelDropdownVisible(): boolean {
+    return this.activeModelDropdown?.isVisible() ?? false;
+  }
+
+  destroyModelDropdown(): void {
+    if (this.activeModelDropdown) {
+      this.activeModelDropdown.destroy();
+      this.activeModelDropdown = null;
+    }
+  }
+
+  private handleModelCommand(args: string): void {
+    const modelSelector = this.deps.getModelSelectorHandle?.();
+    if (!modelSelector) {
+      new Notice('Model switching is not available for this tab.');
+      return;
+    }
+
+    const options = modelSelector.getOptions();
+    if (options.length === 0) {
+      new Notice('No models available.');
+      return;
+    }
+
+    if (!args) {
+      this.showModelDropdown(modelSelector, options);
+      return;
+    }
+
+    const query = args.trim().toLowerCase();
+    const matches = options.filter((option) => (
+      option.value.toLowerCase().includes(query) || option.label.toLowerCase().includes(query)
+    ));
+
+    if (matches.length === 1) {
+      modelSelector.selectValue(matches[0].value).catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        new Notice(`Failed to change model: ${msg}`);
+      });
+      return;
+    }
+
+    if (matches.length === 0) {
+      new Notice(`No model matches "${args}".`);
+      return;
+    }
+
+    // Ambiguous argument - fall back to the picker, scoped to the matches.
+    this.showModelDropdown(modelSelector, matches);
+  }
+
+  private showModelDropdown(modelSelector: ModelSelectorHandle, options: ProviderUIOption[]): void {
+    this.destroyModelDropdown();
+
+    this.activeModelDropdown = new ModelCommandDropdown(
+      this.deps.getInputContainerEl(),
+      this.deps.getInputEl(),
+      options,
+      modelSelector.getCurrentValue(),
+      {
+        onSelect: (value) => {
+          this.destroyModelDropdown();
+          modelSelector.selectValue(value).catch((err: unknown) => {
+            const msg = err instanceof Error ? err.message : String(err);
+            new Notice(`Failed to change model: ${msg}`);
+          });
+        },
+        onDismiss: () => {
+          this.destroyModelDropdown();
         },
       }
     );

--- a/src/features/chat/tabs/Tab.ts
+++ b/src/features/chat/tabs/Tab.ts
@@ -1446,6 +1446,7 @@ export function initializeTabControllers(
     onForkAll: forkRequestCallback
       ? () => handleForkAll(tab, plugin, forkRequestCallback)
       : undefined,
+    getModelSelectorHandle: () => tab.ui.modelSelector,
     restorePrePlanPermissionModeIfNeeded: () => {
       if (getTabPermissionMode(tab, plugin) === 'plan') {
         const restoreMode = tab.state.prePlanPermissionMode ?? 'normal';
@@ -1464,6 +1465,7 @@ export function initializeTabControllers(
       if (ui.instructionModeManager?.isActive()) return true;
       if (ui.bangBashModeManager?.isActive()) return true;
       if (tab.controllers.inputController?.isResumeDropdownVisible()) return true;
+      if (tab.controllers.inputController?.isModelDropdownVisible()) return true;
       if (ui.slashCommandDropdown?.isVisible()) return true;
       if (ui.fileContextManager?.isMentionDropdownVisible()) return true;
       return false;
@@ -1517,6 +1519,10 @@ export function wireTabInputEvents(tab: TabData, plugin: ClaudianPlugin): void {
     }
 
     if (controllers.inputController?.handleResumeKeydown(e)) {
+      return;
+    }
+
+    if (controllers.inputController?.handleModelKeydown(e)) {
       return;
     }
 
@@ -1646,6 +1652,7 @@ export async function destroyTab(tab: TabData): Promise<void> {
   tab.controllers.inputController?.dismissPendingApproval();
 
   tab.controllers.inputController?.destroyResumeDropdown();
+  tab.controllers.inputController?.destroyModelDropdown();
   tab.ui.fileContextManager?.destroy();
   tab.ui.slashCommandDropdown?.destroy();
   tab.ui.slashCommandDropdown = null;

--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -79,6 +79,23 @@ export class ModelSelector {
     });
   }
 
+  /** Available model options, for callers that need to build their own picker (e.g. `/model`). */
+  getOptions(): ProviderUIOption[] {
+    return this.getAvailableModels();
+  }
+
+  /** The model value currently selected for this tab. */
+  getCurrentValue(): string {
+    return this.callbacks.getSettings().model;
+  }
+
+  /** Selects a model by value, reusing the same change path as clicking a dropdown option. */
+  async selectValue(value: string): Promise<void> {
+    await this.callbacks.onModelChange(value);
+    this.updateDisplay();
+    this.renderOptions();
+  }
+
   private render() {
     this.container.empty();
 

--- a/src/providers/codex/commands/CodexSkillCatalog.ts
+++ b/src/providers/codex/commands/CodexSkillCatalog.ts
@@ -19,21 +19,6 @@ import {
 
 const CODEX_SKILL_ID_PREFIX = 'codex-skill-';
 
-const CODEX_COMPACT_COMMAND: ProviderCommandEntry = {
-  id: 'codex-builtin-compact',
-  providerId: 'codex',
-  kind: 'command',
-  name: 'compact',
-  description: 'Compact conversation history',
-  content: '',
-  scope: 'system',
-  source: 'builtin',
-  isEditable: false,
-  isDeletable: false,
-  displayPrefix: '/',
-  insertPrefix: '/',
-};
-
 function buildSkillId(
   skill: Pick<SkillMetadata, 'name' | 'path' | 'scope'>,
   location?: { rootId: string; name: string } | null,
@@ -88,12 +73,11 @@ export class CodexSkillCatalog implements ProviderCommandCatalog {
     // Codex dropdown entries come from app-server metadata; runtime commands are ignored.
   }
 
-  async listDropdownEntries(context: { includeBuiltIns: boolean }): Promise<ProviderCommandEntry[]> {
+  async listDropdownEntries(_context: { includeBuiltIns: boolean }): Promise<ProviderCommandEntry[]> {
     const skills = (await this.listProvider.listSkills())
       .filter(skill => skill.enabled)
       .sort(compareCodexSkillPriority);
-    const entries = skills.map(skill => listedSkillToProviderEntry(skill, this.vaultPath));
-    return context.includeBuiltIns ? [CODEX_COMPACT_COMMAND, ...entries] : entries;
+    return skills.map(skill => listedSkillToProviderEntry(skill, this.vaultPath));
   }
 
   async listVaultEntries(): Promise<ProviderCommandEntry[]> {

--- a/src/shared/components/ModelCommandDropdown.ts
+++ b/src/shared/components/ModelCommandDropdown.ts
@@ -1,0 +1,180 @@
+/**
+ * Claudian - Model command dropdown
+ *
+ * Dropup UI for picking a model. Shown when the /model built-in command is
+ * executed without a matching argument.
+ */
+
+import type { ProviderUIOption } from '../../core/providers/types';
+import { createProviderIconSvg } from '../icons';
+
+export interface ModelCommandDropdownCallbacks {
+  onSelect: (value: string) => void;
+  onDismiss: () => void;
+}
+
+export class ModelCommandDropdown {
+  private containerEl: HTMLElement;
+  private inputEl: HTMLTextAreaElement;
+  private dropdownEl: HTMLElement;
+  private callbacks: ModelCommandDropdownCallbacks;
+  private options: ProviderUIOption[];
+  private currentValue: string;
+  private selectedIndex: number;
+  private onInput: () => void;
+
+  constructor(
+    containerEl: HTMLElement,
+    inputEl: HTMLTextAreaElement,
+    options: ProviderUIOption[],
+    currentValue: string,
+    callbacks: ModelCommandDropdownCallbacks
+  ) {
+    this.containerEl = containerEl;
+    this.inputEl = inputEl;
+    this.options = options;
+    this.currentValue = currentValue;
+    this.callbacks = callbacks;
+    this.selectedIndex = Math.max(0, options.findIndex((option) => option.value === currentValue));
+
+    this.dropdownEl = this.containerEl.createDiv({ cls: 'claudian-modelcmd-dropdown' });
+    this.render();
+    this.dropdownEl.addClass('visible');
+
+    // Auto-dismiss when user starts typing
+    this.onInput = () => this.dismiss();
+    this.inputEl.addEventListener('input', this.onInput);
+  }
+
+  handleKeydown(e: KeyboardEvent): boolean {
+    if (!this.isVisible()) return false;
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        this.navigate(1);
+        return true;
+      case 'ArrowUp':
+        e.preventDefault();
+        this.navigate(-1);
+        return true;
+      case 'Enter':
+      case 'Tab':
+        if (this.options.length > 0) {
+          e.preventDefault();
+          this.selectItem();
+          return true;
+        }
+        return false;
+      case 'Escape':
+        e.preventDefault();
+        this.dismiss();
+        return true;
+    }
+    return false;
+  }
+
+  isVisible(): boolean {
+    return this.dropdownEl?.hasClass('visible') ?? false;
+  }
+
+  destroy(): void {
+    this.inputEl.removeEventListener('input', this.onInput);
+    this.dropdownEl?.remove();
+  }
+
+  private dismiss(): void {
+    this.dropdownEl.removeClass('visible');
+    this.callbacks.onDismiss();
+  }
+
+  private selectItem(): void {
+    if (this.options.length === 0) return;
+    const selected = this.options[this.selectedIndex];
+    if (!selected) return;
+
+    if (selected.value === this.currentValue) {
+      this.dismiss();
+      return;
+    }
+
+    this.callbacks.onSelect(selected.value);
+  }
+
+  private navigate(direction: number): void {
+    const maxIndex = this.options.length - 1;
+    this.selectedIndex = Math.max(0, Math.min(maxIndex, this.selectedIndex + direction));
+    this.updateSelection();
+  }
+
+  private updateSelection(): void {
+    const items = this.dropdownEl.querySelectorAll('.claudian-modelcmd-item');
+    items?.forEach((item, index) => {
+      if (index === this.selectedIndex) {
+        item.addClass('selected');
+        (item as HTMLElement).scrollIntoView({ block: 'nearest' });
+      } else {
+        item.removeClass('selected');
+      }
+    });
+  }
+
+  private render(): void {
+    this.dropdownEl.empty();
+
+    const header = this.dropdownEl.createDiv({ cls: 'claudian-modelcmd-header' });
+    header.createSpan({ text: 'Switch model' });
+
+    if (this.options.length === 0) {
+      this.dropdownEl.createDiv({ cls: 'claudian-modelcmd-empty', text: 'No models available' });
+      return;
+    }
+
+    const list = this.dropdownEl.createDiv({ cls: 'claudian-modelcmd-list' });
+
+    let lastGroup: string | undefined;
+    for (let i = 0; i < this.options.length; i++) {
+      const option = this.options[i];
+      const isCurrent = option.value === this.currentValue;
+
+      if (option.group && option.group !== lastGroup) {
+        const separator = list.createDiv({ cls: 'claudian-modelcmd-group' });
+        separator.setText(option.group);
+        lastGroup = option.group;
+      }
+
+      const item = list.createDiv({ cls: 'claudian-modelcmd-item' });
+      if (isCurrent) item.addClass('current');
+      if (i === this.selectedIndex) item.addClass('selected');
+
+      if (option.providerIcon) {
+        const iconEl = item.createDiv({ cls: 'claudian-modelcmd-item-icon' });
+        iconEl.appendChild(createProviderIconSvg(option.providerIcon, {
+          className: 'claudian-modelcmd-provider-icon',
+          height: 14,
+          ownerDocument: item.ownerDocument,
+          width: 14,
+        }));
+      }
+
+      const content = item.createDiv({ cls: 'claudian-modelcmd-item-content' });
+      content.createDiv({ cls: 'claudian-modelcmd-item-label', text: option.label });
+      if (option.description) {
+        content.createDiv({ cls: 'claudian-modelcmd-item-description', text: option.description });
+      }
+
+      item.addEventListener('click', () => {
+        if (isCurrent) {
+          this.dismiss();
+          return;
+        }
+        this.callbacks.onSelect(option.value);
+      });
+
+      item.addEventListener('mouseenter', () => {
+        this.selectedIndex = i;
+        this.updateSelection();
+      });
+    }
+  }
+}

--- a/src/style/features/model-command.css
+++ b/src/style/features/model-command.css
@@ -1,0 +1,127 @@
+/* Model Command Dropdown */
+.claudian-modelcmd-dropdown {
+  display: none;
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  right: 0;
+  margin-bottom: 4px;
+  background: var(--background-secondary);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 6px;
+  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+  max-height: 400px;
+  overflow: hidden;
+}
+
+.claudian-modelcmd-dropdown.visible {
+  display: block;
+}
+
+.claudian-modelcmd-header {
+  padding: 8px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.claudian-modelcmd-list {
+  max-height: 350px;
+  overflow-y: auto;
+}
+
+.claudian-modelcmd-empty {
+  padding: 16px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.claudian-modelcmd-group {
+  padding: 6px 12px 2px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.claudian-modelcmd-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--background-modifier-border);
+  transition: background 0.1s ease;
+}
+
+.claudian-modelcmd-item:last-child {
+  border-bottom: none;
+}
+
+.claudian-modelcmd-item:hover,
+.claudian-modelcmd-item.selected {
+  background: var(--background-modifier-hover);
+}
+
+.claudian-modelcmd-item.current {
+  background: var(--background-secondary);
+  border-inline-start: 2px solid var(--interactive-accent);
+  padding-inline-start: 10px;
+}
+
+.claudian-modelcmd-item-icon {
+  display: flex;
+  align-items: center;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.claudian-modelcmd-item-icon svg {
+  width: 14px;
+  height: 14px;
+}
+
+.claudian-modelcmd-item-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.claudian-modelcmd-item-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-normal);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.claudian-modelcmd-item-description {
+  font-size: 11px;
+  color: var(--text-faint);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Scrollbar */
+.claudian-modelcmd-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.claudian-modelcmd-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.claudian-modelcmd-list::-webkit-scrollbar-thumb {
+  background: var(--background-modifier-border);
+  border-radius: 3px;
+}

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -39,6 +39,7 @@
 @import "./features/diff.css";
 @import "./features/slash-commands.css";
 @import "./features/resume-session.css";
+@import "./features/model-command.css";
 @import "./features/ask-user-question.css";
 @import "./features/plan-mode.css";
 

--- a/tests/unit/core/commands/builtInCommands.test.ts
+++ b/tests/unit/core/commands/builtInCommands.test.ts
@@ -98,6 +98,29 @@ describe('builtInCommands', () => {
       expect(detectBuiltInCommand('/FORK')).not.toBeNull();
       expect(detectBuiltInCommand('/Fork')).not.toBeNull();
     });
+
+    it('detects /model command with argument', () => {
+      const result = detectBuiltInCommand('/model opus');
+      expect(result).not.toBeNull();
+      expect(result?.command.name).toBe('model');
+      expect(result?.command.action).toBe('model');
+      expect(result?.args).toBe('opus');
+    });
+
+    it('detects /model command without argument', () => {
+      const result = detectBuiltInCommand('/model');
+      expect(result).not.toBeNull();
+      expect(result?.command.name).toBe('model');
+      expect(result?.args).toBe('');
+    });
+
+    it('detects /compact as a provider-routed command', () => {
+      const result = detectBuiltInCommand('/compact');
+      expect(result).not.toBeNull();
+      expect(result?.command.name).toBe('compact');
+      expect(result?.command.action).toBe('compact');
+      expect(result?.command.providerRouted).toBe(true);
+    });
   });
 
   describe('getBuiltInCommandsForDropdown', () => {
@@ -174,6 +197,22 @@ describe('builtInCommands', () => {
       const cmd = BUILT_IN_COMMANDS.find((c) => c.name === 'fork');
       expect(cmd?.requiredCapability).toBe('supportsFork');
     });
+
+    it('has model command that accepts args and no provider restriction', () => {
+      const modelCmd = BUILT_IN_COMMANDS.find((c) => c.name === 'model');
+      expect(modelCmd).toBeDefined();
+      expect(modelCmd?.action).toBe('model');
+      expect(modelCmd?.hasArgs).toBe(true);
+      expect(modelCmd?.requiredCapability).toBeUndefined();
+    });
+
+    it('has provider-routed compact command with no args', () => {
+      const compactCmd = BUILT_IN_COMMANDS.find((c) => c.name === 'compact');
+      expect(compactCmd).toBeDefined();
+      expect(compactCmd?.action).toBe('compact');
+      expect(compactCmd?.providerRouted).toBe(true);
+      expect(compactCmd?.requiredCapability).toBeUndefined();
+    });
   });
 
   describe('getBuiltInCommandsForDropdown - provider filtering', () => {
@@ -189,6 +228,8 @@ describe('builtInCommands', () => {
       expect(commands.map(c => c.name)).toContain('add-dir');
       expect(commands.map(c => c.name)).toContain('resume');
       expect(commands.map(c => c.name)).toContain('fork');
+      expect(commands.map(c => c.name)).toContain('model');
+      expect(commands.map(c => c.name)).toContain('compact');
     });
 
     it('returns all capability-supported commands for codex provider', () => {
@@ -198,12 +239,14 @@ describe('builtInCommands', () => {
       expect(names).toContain('add-dir');
       expect(names).toContain('resume');
       expect(names).toContain('fork');
+      expect(names).toContain('model');
+      expect(names).toContain('compact');
     });
 
     it('returns only commands supported by codex capabilities', () => {
       const commands = getBuiltInCommandsForDropdown('codex');
-      expect(commands.length).toBe(4);
-      expect(commands.map(c => c.name)).toEqual(['clear', 'add-dir', 'resume', 'fork']);
+      expect(commands.length).toBe(6);
+      expect(commands.map(c => c.name)).toEqual(['clear', 'add-dir', 'resume', 'fork', 'model', 'compact']);
     });
   });
 

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -4,10 +4,15 @@ import { Notice } from 'obsidian';
 import { InputController, type InputControllerDeps } from '@/features/chat/controllers/InputController';
 import { ChatState } from '@/features/chat/state/ChatState';
 import { encodeClaudeTurn } from '@/providers/claude/prompt/ClaudeTurnEncoder';
+import { ModelCommandDropdown } from '@/shared/components/ModelCommandDropdown';
 import { ResumeSessionDropdown } from '@/shared/components/ResumeSessionDropdown';
 
 jest.mock('@/shared/components/ResumeSessionDropdown', () => ({
   ResumeSessionDropdown: jest.fn(),
+}));
+
+jest.mock('@/shared/components/ModelCommandDropdown', () => ({
+  ModelCommandDropdown: jest.fn(),
 }));
 
 beforeAll(() => {
@@ -1822,6 +1827,123 @@ describe('InputController - Message Queue', () => {
 
       expect(mockNotice).toHaveBeenCalledWith('Fork not available.');
       expect(inputEl.value).toBe('');
+    });
+  });
+
+  describe('Built-in commands - /model', () => {
+    const options = [
+      { value: 'model-a', label: 'Model A' },
+      { value: 'model-b', label: 'Model B' },
+    ];
+    let mockSelectorHandle: {
+      getOptions: jest.Mock;
+      getCurrentValue: jest.Mock;
+      selectValue: jest.Mock;
+    };
+    let mockDropdownInstance: {
+      isVisible: jest.Mock;
+      handleKeydown: jest.Mock;
+      destroy: jest.Mock;
+    };
+
+    beforeEach(() => {
+      mockNotice.mockClear();
+      (ModelCommandDropdown as jest.Mock).mockClear();
+      mockSelectorHandle = {
+        getOptions: jest.fn().mockReturnValue(options),
+        getCurrentValue: jest.fn().mockReturnValue('model-a'),
+        selectValue: jest.fn().mockResolvedValue(undefined),
+      };
+      mockDropdownInstance = {
+        isVisible: jest.fn().mockReturnValue(true),
+        handleKeydown: jest.fn().mockReturnValue(false),
+        destroy: jest.fn(),
+      };
+      (ModelCommandDropdown as jest.Mock).mockImplementation(() => mockDropdownInstance);
+      deps.getModelSelectorHandle = () => mockSelectorHandle as any;
+    });
+
+    it('should show notice when no model selector is available for the tab', async () => {
+      deps.getModelSelectorHandle = () => null;
+      inputEl.value = '/model';
+      controller = new InputController(deps);
+
+      await controller.sendMessage();
+
+      expect(mockNotice).toHaveBeenCalledWith('Model switching is not available for this tab.');
+      expect(ModelCommandDropdown).not.toHaveBeenCalled();
+    });
+
+    it('should open the picker dropdown when no argument is given', async () => {
+      inputEl.value = '/model';
+      controller = new InputController(deps);
+
+      await controller.sendMessage();
+
+      expect(ModelCommandDropdown).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        options,
+        'model-a',
+        expect.objectContaining({ onSelect: expect.any(Function), onDismiss: expect.any(Function) }),
+      );
+      expect(controller.isModelDropdownVisible()).toBe(true);
+      expect(inputEl.value).toBe('');
+    });
+
+    it('should select the model directly when the argument matches exactly one option', async () => {
+      inputEl.value = '/model model-b';
+      controller = new InputController(deps);
+
+      await controller.sendMessage();
+
+      expect(mockSelectorHandle.selectValue).toHaveBeenCalledWith('model-b');
+      expect(ModelCommandDropdown).not.toHaveBeenCalled();
+    });
+
+    it('should match by label case-insensitively', async () => {
+      inputEl.value = '/model model a';
+      controller = new InputController(deps);
+
+      await controller.sendMessage();
+
+      expect(mockSelectorHandle.selectValue).toHaveBeenCalledWith('model-a');
+    });
+
+    it('should show notice when the argument matches no option', async () => {
+      inputEl.value = '/model nonexistent';
+      controller = new InputController(deps);
+
+      await controller.sendMessage();
+
+      expect(mockNotice).toHaveBeenCalledWith('No model matches "nonexistent".');
+      expect(mockSelectorHandle.selectValue).not.toHaveBeenCalled();
+    });
+
+    it('should call selectValue on dropdown select callback', async () => {
+      inputEl.value = '/model';
+      controller = new InputController(deps);
+
+      await controller.sendMessage();
+
+      const callbacks = (ModelCommandDropdown as jest.Mock).mock.calls[0][4];
+      callbacks.onSelect('model-b');
+
+      expect(mockSelectorHandle.selectValue).toHaveBeenCalledWith('model-b');
+      expect(mockDropdownInstance.destroy).toHaveBeenCalled();
+    });
+
+    it('should destroy dropdown on dismiss callback', async () => {
+      inputEl.value = '/model';
+      controller = new InputController(deps);
+
+      await controller.sendMessage();
+
+      const callbacks = (ModelCommandDropdown as jest.Mock).mock.calls[0][4];
+      callbacks.onDismiss();
+
+      expect(mockDropdownInstance.destroy).toHaveBeenCalled();
+      expect(controller.isModelDropdownVisible()).toBe(false);
     });
   });
 

--- a/tests/unit/features/chat/tabs/Tab.test.ts
+++ b/tests/unit/features/chat/tabs/Tab.test.ts
@@ -236,6 +236,9 @@ const createMockInputController = () => ({
   handleResumeKeydown: jest.fn().mockReturnValue(false),
   isResumeDropdownVisible: jest.fn().mockReturnValue(false),
   destroyResumeDropdown: jest.fn(),
+  handleModelKeydown: jest.fn().mockReturnValue(false),
+  isModelDropdownVisible: jest.fn().mockReturnValue(false),
+  destroyModelDropdown: jest.fn(),
   dismissPendingApproval: jest.fn(),
 });
 
@@ -1366,8 +1369,9 @@ describe('Tab - Destruction', () => {
       const cancelTitleGeneration = jest.fn();
       const destroyTodoPanel = jest.fn();
       const destroyResumeDropdown = jest.fn();
+      const destroyModelDropdown = jest.fn();
 
-      tab.controllers.inputController = { destroyResumeDropdown, dismissPendingApproval: jest.fn() } as any;
+      tab.controllers.inputController = { destroyResumeDropdown, destroyModelDropdown, dismissPendingApproval: jest.fn() } as any;
       tab.ui.fileContextManager = { destroy: destroyFileContext } as any;
       tab.ui.slashCommandDropdown = { destroy: destroySlashDropdown } as any;
       tab.ui.instructionModeManager = { destroy: destroyInstructionMode } as any;
@@ -1378,6 +1382,7 @@ describe('Tab - Destruction', () => {
       await destroyTab(tab);
 
       expect(destroyResumeDropdown).toHaveBeenCalled();
+      expect(destroyModelDropdown).toHaveBeenCalled();
       expect(destroyFileContext).toHaveBeenCalled();
       expect(destroySlashDropdown).toHaveBeenCalled();
       expect(destroyInstructionMode).toHaveBeenCalled();

--- a/tests/unit/providers/codex/commands/CodexSkillCatalog.test.ts
+++ b/tests/unit/providers/codex/commands/CodexSkillCatalog.test.ts
@@ -358,7 +358,10 @@ Prompt`,
   });
 
   describe('built-in /compact command', () => {
-    it('includes /compact in dropdown entries', async () => {
+    // /compact is now a cross-provider entry in core/commands/builtInCommands.ts,
+    // surfaced by SlashCommandDropdown independently of the provider catalog.
+    // See tests/unit/core/commands/builtInCommands.test.ts.
+    it('does not inject /compact into dropdown entries (owned by the shared built-in catalog)', async () => {
       const adapter = createMockAdapter({});
       const storage = new CodexSkillStorage(adapter);
       const catalog = new CodexSkillCatalog(storage, createMockSkillListProvider(), '/test/vault');
@@ -366,37 +369,7 @@ Prompt`,
       const entries = await catalog.listDropdownEntries({ includeBuiltIns: true });
       const compactEntry = entries.find(e => e.name === 'compact');
 
-      expect(compactEntry).toBeDefined();
-      expect(compactEntry!.providerId).toBe('codex');
-      expect(compactEntry!.kind).toBe('command');
-      expect(compactEntry!.displayPrefix).toBe('/');
-      expect(compactEntry!.insertPrefix).toBe('/');
-      expect(compactEntry!.isEditable).toBe(false);
-      expect(compactEntry!.isDeletable).toBe(false);
-      expect(compactEntry!.source).toBe('builtin');
-    });
-
-    it('places /compact before scan-backed skills', async () => {
-      const storage = new CodexSkillStorage(createMockAdapter({}), createMockAdapter({}));
-      const listProvider = createMockSkillListProvider([
-        {
-          name: 'my-skill',
-          description: 'A skill',
-          path: '/test/vault/.codex/skills/my-skill/SKILL.md',
-          scope: 'repo',
-          enabled: true,
-        },
-      ]);
-      const catalog = new CodexSkillCatalog(storage, listProvider, '/test/vault');
-
-      const entries = await catalog.listDropdownEntries({ includeBuiltIns: true });
-
-      const compactIndex = entries.findIndex(e => e.name === 'compact');
-      const skillIndex = entries.findIndex(e => e.name === 'my-skill');
-
-      expect(compactIndex).toBeGreaterThanOrEqual(0);
-      expect(skillIndex).toBeGreaterThanOrEqual(0);
-      expect(compactIndex).toBeLessThan(skillIndex);
+      expect(compactEntry).toBeUndefined();
     });
 
     it('does not include /compact in vault entries', async () => {


### PR DESCRIPTION
## Summary
- Adds `/model` as a client-side built-in command. With no argument it opens a picker dropdown; with an argument it fuzzy-matches a single model and switches directly. Reuses the existing toolbar model-change path (`ModelSelector.selectValue`) rather than duplicating switching logic.
- Makes `/compact` discoverable in the slash-command dropdown for both providers via a shared `providerRouted` built-in entry. Execution is unchanged — the raw text still reaches the active provider's own compact handling (Claude SDK-native, Codex `thread/compact/start`).
- Removes the Codex-only duplicate `/compact` catalog entry now that it's covered by the shared built-in command list, so Claude and Codex both surface it consistently.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test -- --selectProjects unit` (5585 tests passing, including new coverage for `/model` picking/matching/dismiss flows and updated `/compact` discoverability tests)
- [x] `npm run build`