### PR TITLE
feat: add one-click compact tab continuation

### DIFF
--- a/src/features/chat/state/ChatState.ts
+++ b/src/features/chat/state/ChatState.ts
@@ -51,6 +51,8 @@ export class ChatState {
   private state: ChatStateData;
   private _callbacks: ChatStateCallbacks;
   private readonly pendingActionIds = new Set<string>();
+  private readonly messageObservers = new Set<() => void>();
+  private readonly usageObservers = new Set<() => void>();
   private pendingReview: {
     outcome: TabReviewOutcome;
     since: number;
@@ -82,16 +84,19 @@ export class ChatState {
   set messages(value: ChatMessage[]) {
     this.state.messages = value;
     this._callbacks.onMessagesChanged?.();
+    this.notifyObservers(this.messageObservers);
   }
 
   addMessage(msg: ChatMessage): void {
     this.state.messages.push(msg);
     this._callbacks.onMessagesChanged?.();
+    this.notifyObservers(this.messageObservers);
   }
 
   clearMessages(): void {
     this.state.messages = [];
     this._callbacks.onMessagesChanged?.();
+    this.notifyObservers(this.messageObservers);
   }
 
   truncateAt(messageId: string): number {
@@ -100,6 +105,7 @@ export class ChatState {
     const removed = this.state.messages.length - idx;
     this.state.messages = this.state.messages.slice(0, idx);
     this._callbacks.onMessagesChanged?.();
+    this.notifyObservers(this.messageObservers);
     return removed;
   }
 
@@ -279,6 +285,27 @@ export class ChatState {
   set usage(value: UsageInfo | null) {
     this.state.usage = value;
     this._callbacks.onUsageChanged?.(value);
+    this.notifyObservers(this.usageObservers);
+  }
+
+  observeMessages(observer: () => void): () => void {
+    this.messageObservers.add(observer);
+    return () => this.messageObservers.delete(observer);
+  }
+
+  observeUsage(observer: () => void): () => void {
+    this.usageObservers.add(observer);
+    return () => this.usageObservers.delete(observer);
+  }
+
+  private notifyObservers(observers: ReadonlySet<() => void>): void {
+    for (const observer of observers) {
+      try {
+        observer();
+      } catch {
+        // Observers are presentation-only and must not make state mutations fail.
+      }
+    }
   }
 
   get ignoreUsageUpdates(): boolean {

--- a/src/features/chat/tabs/ContinuationAction.ts
+++ b/src/features/chat/tabs/ContinuationAction.ts
@@ -1,0 +1,59 @@
+import type { ChatState } from '../state/ChatState';
+
+export const CONTINUATION_CONTEXT_TOKEN_THRESHOLD = 200_000;
+export const CONTINUATION_TOOL_CALL_THRESHOLD = 80;
+
+export function shouldRecommendContinuation(state: ChatState): boolean {
+  const contextTokens = state.usage?.contextTokens ?? 0;
+  const toolCalls = countToolCalls(state.messages);
+  return contextTokens >= CONTINUATION_CONTEXT_TOKEN_THRESHOLD || toolCalls >= CONTINUATION_TOOL_CALL_THRESHOLD;
+}
+
+type CountableToolCall = { id?: string; subagent?: { toolCalls: readonly CountableToolCall[] } };
+
+export function countToolCalls(messages: readonly { toolCalls?: readonly CountableToolCall[] }[]): number {
+  const seen = new Set<CountableToolCall>();
+  const count = (toolCall: CountableToolCall): number => {
+    if (seen.has(toolCall)) return 0;
+    seen.add(toolCall);
+    return 1 + (toolCall.subagent?.toolCalls.reduce((total, nested) => total + count(nested), 0) ?? 0);
+  };
+  return messages.reduce((total, message) => total + (message.toolCalls?.reduce(
+    (counted, toolCall) => counted + count(toolCall), 0,
+  ) ?? 0), 0);
+}
+
+export interface ContinuationAction {
+  readonly buttonEl: HTMLButtonElement;
+  refresh(): void;
+}
+
+export function createContinuationAction(
+  parentEl: HTMLElement,
+  state: ChatState,
+  onContinue: () => void | Promise<void>,
+  isPending: () => boolean = () => false,
+): ContinuationAction {
+  const button = parentEl.createEl('button', {
+    cls: 'claudian-continue-new-tab-button',
+    text: 'Continue in new tab',
+  });
+  button.type = 'button';
+  button.setAttribute('aria-label', 'Continue in a new tab with a compact handoff');
+  button.setAttribute('data-tooltip', 'Continue in new tab. Creates a local compact handoff and sends it automatically.');
+  button.setAttribute('aria-description', 'The current tab stays unchanged.');
+  const refresh = (): void => {
+    const pending = isPending();
+    const recommended = shouldRecommendContinuation(state) && !pending;
+    button.toggleClass('mod-cta', recommended);
+    button.disabled = pending;
+    button.setAttribute('aria-busy', String(pending));
+    button.setAttribute('data-recommended', String(recommended));
+    button.setAttribute('aria-label', pending
+      ? 'Continuation in new tab is queued'
+      : `${recommended ? 'Recommended: ' : ''}Continue in a new tab with a compact handoff`);
+  };
+  refresh();
+  button.addEventListener('click', () => { void Promise.resolve(onContinue()).finally(refresh); });
+  return { buttonEl: button, refresh };
+}

--- a/src/features/chat/tabs/ContinuationCapsule.ts
+++ b/src/features/chat/tabs/ContinuationCapsule.ts
@@ -1,0 +1,151 @@
+import type { TodoItem } from '../../../core/tools/todo';
+import type { ChatMessage, ToolCallInfo } from '../../../core/types';
+import { normalizePathForComparison } from '../../../utils/path';
+
+const DEFAULT_MAX_CHARS = 12_000;
+const NARRATIVE_LIMIT = 3_000;
+const APPROVAL_PATTERN = /^(?:a|ok|okay|yes|ja|resume|continue|go|mach|los|passt)[!. ]*$/i;
+
+export interface ContinuationCapsuleInput {
+  messages: readonly ChatMessage[];
+  todos?: readonly TodoItem[] | null;
+  maxChars?: number;
+}
+
+/** Builds a local safe handoff; provider payloads/results are intentionally unread. */
+export function buildContinuationCapsule(input: ContinuationCapsuleInput): string {
+  const maxChars = Math.max(1, Math.min(input.maxChars ?? DEFAULT_MAX_CHARS, DEFAULT_MAX_CHARS));
+  const messages = input.messages.filter(message => !message.isRebuiltContext && !message.isInterrupt);
+  const userMessages = messages.filter(message => message.role === 'user');
+  const latestUser = userMessages.at(-1);
+  const goal = [...userMessages].reverse().find(message => isSubstantive(canonicalText(message)));
+  const latestAssistant = [...messages].reverse().find(message => (
+    message.role === 'assistant' && canonicalText(message).length > 0
+  ));
+  const changedPaths = latestChangedPaths(messages);
+  const latestInstruction = latestUser && latestUser !== goal && isTerseInstruction(canonicalText(latestUser))
+    ? canonicalText(latestUser)
+    : '';
+  const linkedPath = latestUser?.linkedContentPath ?? goal?.linkedContentPath;
+  const todos = todoLines(input.todos);
+  return bounded([
+    '# Continue this work in a new tab',
+    goal ? `## Current goal\n${bounded(canonicalText(goal), NARRATIVE_LIMIT)}` : '',
+    latestInstruction ? `## Latest instruction\n${latestInstruction}` : '',
+    latestAssistant ? `## Current state\n${bounded(canonicalText(latestAssistant), NARRATIVE_LIMIT)}` : '',
+    linkedPath ? `## Linked note\n${linkedPath}` : '',
+    changedPaths.length ? `## Changed files\n${changedPaths.map(path => `- ${path}`).join('\n')}` : '',
+    todos.length ? `## Open next steps\n${todos.map(todo => `- ${todo}`).join('\n')}` : '',
+    'Continue from this handoff. Inspect files before changing them and do not assume provider-native transcript context.',
+  ].filter(Boolean).join('\n\n'), maxChars);
+}
+
+/** Root selection uses raw inputs locally, but never serializes them into the capsule. */
+export function selectRelevantExternalRoots(
+  roots: readonly string[], messages: readonly ChatMessage[],
+): string[] {
+  const normalizedRoots = roots.map(root => ({
+    normalized: normalizeComparisonPath(root),
+    original: root,
+  })).filter(root => root.normalized && isAbsolute(root.normalized));
+  const absoluteEvidence = new Set<string>();
+  forEachToolCall(messages, (call) => {
+    collectAbsolutePaths(call.input, absoluteEvidence);
+  });
+  const changed = latestChangedPaths(messages)
+    .map(normalizeComparisonPath)
+    .filter(isAbsolute);
+  return normalizedRoots.filter(root => changed.some(path => isWithin(root.normalized, path))
+    || [...absoluteEvidence].some(path => isWithin(root.normalized, path)))
+    .map(root => root.original);
+}
+
+export function latestChangedPaths(messages: readonly ChatMessage[]): string[] {
+  const paths: string[] = []; const seen = new Set<string>();
+  forEachToolCall(messages, (toolCall) => {
+    const path = toolCall.diffData?.filePath?.trim();
+    if (path && !seen.has(path)) { seen.add(path); paths.push(path); }
+  });
+  return paths;
+}
+
+function canonicalText(message: ChatMessage): string {
+  return message.executionInput?.canonicalText?.trim() || message.content.trim();
+}
+function isSubstantive(value: string): boolean { return value.length > 0 && !APPROVAL_PATTERN.test(value); }
+function isTerseInstruction(value: string): boolean { return value.length <= 80 && (APPROVAL_PATTERN.test(value) || value.length > 0); }
+function todoLines(todos: readonly TodoItem[] | null | undefined): string[] {
+  return (todos ?? []).filter(todo => todo.status !== 'completed').map(todo => todo.content.trim()).filter(Boolean);
+}
+function normalizeComparisonPath(value: string): string {
+  const normalized = normalizePathForComparison(value.trim());
+  return /^[a-z]:\//i.test(normalized) ? normalized.toLowerCase() : normalized;
+}
+function isAbsolute(value: string): boolean { return /^\/[\s\S]*/.test(value) || /^[a-z]:\//i.test(value); }
+function isWithin(root: string, value: string): boolean { return value === root || value.startsWith(`${root}/`); }
+function collectAbsolutePaths(value: unknown, paths: Set<string>, seen = new Set<object>()): void {
+  if (typeof value === 'string') {
+    for (const candidate of extractPathCandidates(value)) {
+      const path = normalizeComparisonPath(candidate);
+      if (isAbsolute(path)) paths.add(path);
+    }
+    return;
+  }
+  if (!value || typeof value !== 'object' || seen.has(value)) return;
+  seen.add(value);
+  for (const child of Array.isArray(value) ? value : Object.values(value)) collectAbsolutePaths(child, paths, seen);
+}
+
+function forEachToolCall(
+  messages: readonly ChatMessage[],
+  visit: (toolCall: ToolCallInfo) => void,
+): void {
+  const seen = new Set<object>();
+  const traverse = (toolCall: ToolCallInfo): void => {
+    if (seen.has(toolCall)) return;
+    seen.add(toolCall);
+    visit(toolCall);
+    for (const nested of toolCall.subagent?.toolCalls ?? []) traverse(nested);
+  };
+  for (const message of messages) for (const toolCall of message.toolCalls ?? []) traverse(toolCall);
+}
+
+/** Tokenizes strings without executing or retaining them; candidates are used for comparison only. */
+function extractPathCandidates(value: string): string[] {
+  const candidates = new Set<string>();
+  const completeValue = value.trim();
+  if (isAbsolute(completeValue.replace(/\\/g, '/'))) candidates.add(completeValue);
+  const tokens: string[] = [];
+  let token = '';
+  let quote: '"' | "'" | null = null;
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (quote) {
+      if (character === quote) quote = null;
+      else token += character;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+    } else if (/\s/.test(character)) {
+      if (token) tokens.push(token);
+      token = '';
+    } else {
+      token += character;
+    }
+  }
+  if (token) tokens.push(token);
+
+  for (const rawToken of tokens) {
+    for (const rawCandidate of [rawToken, rawToken.slice(rawToken.indexOf('=') + 1)]) {
+      const candidate = rawCandidate
+        .replace(/^[([{]+/, '')
+        .replace(/[,;:)\]}]+$/, '');
+      if (isAbsolute(candidate.replace(/\\/g, '/'))) candidates.add(candidate);
+    }
+  }
+  return [...candidates];
+}
+function bounded(value: string, maxChars: number): string {
+  return value.length <= maxChars ? value : `${value.slice(0, Math.max(0, maxChars - 1)).trimEnd()}…`;
+}

--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -20,6 +20,7 @@ import { scheduleAnimationFrame } from '../../../utils/animationFrame';
 import { revealWorkspaceLeaf } from '../../../utils/obsidianCompat';
 import { getVaultPath } from '../../../utils/path';
 import type { FeatureHost } from '../../FeatureHost';
+import { buildContinuationCapsule, selectRelevantExternalRoots } from './ContinuationCapsule';
 import { getTabProviderId } from './providerResolution';
 import type { ForkContext } from './TabForking';
 import {
@@ -31,6 +32,7 @@ import {
   getTabTitle,
 } from './TabLifecycle';
 import {
+  getTabSelectedModel,
   onProviderAvailabilityChanged,
   refreshTabWorkspaceServices,
 } from './TabProviderState';
@@ -55,6 +57,7 @@ function isTabManagerViewHost(value: unknown): value is TabManagerViewHost {
 type CreateTabOptions = {
   activate?: boolean;
   draftModel?: string;
+  draftProviderId?: ProviderId;
   lifecycleState?: Extract<AssembledTabRuntime['lifecycleState'], 'provisional' | 'cold'>;
 };
 
@@ -169,6 +172,10 @@ export class TabManager implements TabManagerInterface {
   private shutdownDrainPromise: Promise<void> | null = null;
   private destroyed = false;
   private shutdownSnapshotOpen = false;
+  /** One deferred handoff per source tab; it is never persisted or provider-owned. */
+  private pendingContinuations = new Set<TabId>();
+  private continuationAdmissions = new Set<TabId>();
+  private continuationStateObservers = new Map<TabId, Set<() => void>>();
 
   constructor(
     plugin: FeatureHost,
@@ -270,6 +277,7 @@ export class TabManager implements TabManagerInterface {
         conversation: conversation ?? undefined,
         tabId: runtimeTabId,
         ...(typeof draftModel === 'string' ? { draftModel } : {}),
+        ...(options.draftProviderId ? { draftProviderId: options.draftProviderId } : {}),
         lifecycleState,
         getProviderCatalogConfig: runtime => this.getProviderCatalogConfig(runtime),
         isRuntimeLive: runtime => this.isTabAlive(runtime),
@@ -286,11 +294,15 @@ export class TabManager implements TabManagerInterface {
         onStreamingChanged: (runtime, isStreaming) => {
           if (!this.isTabStateMutable(runtime)) return;
           this.callbacks.onTabStreamingChanged?.(runtime.id, isStreaming);
-          if (!isStreaming) runtime.session.executionCoordinator.notifyMayCool();
+          if (!isStreaming) {
+            runtime.session.executionCoordinator.notifyMayCool();
+            void this.runPendingContinuation(runtime.id);
+          }
         },
         onWorkChanged: runtime => {
           if (!this.isTabStateMutable(runtime)) return;
           this.callbacks.onTabWorkChanged?.(runtime.id);
+          void this.runPendingContinuation(runtime.id);
         },
         onRewindingChanged: (runtime, isRewinding) => {
           if (!this.isTabStateMutable(runtime)) return;
@@ -330,6 +342,12 @@ export class TabManager implements TabManagerInterface {
           if (!this.isTabStateMutable(runtime)) return;
           this.callbacks.onTabDraftChanged?.(runtime.id, draftModel);
         },
+        onContinueInNewTab: runtime => this.requestContinuationInNewTab(runtime),
+        isContinuationPending: runtime => this.pendingContinuations.has(runtime.id)
+          || this.continuationAdmissions.has(runtime.id),
+        observeContinuationPending: (tabId, observer) => (
+          this.observeContinuationPending(tabId, observer)
+        ),
         onCommandContextChanged: runtime => {
           this.bumpTabCommandContextRevision(runtime.id);
         },
@@ -1097,6 +1115,134 @@ export class TabManager implements TabManagerInterface {
       if (!this.isTabAlive(tab)) return;
       void this.switchToTab(tab.id);
     });
+  }
+
+  /** Provider-neutral compact continuation. The provider sees it only as a new user turn. */
+  private async requestContinuationInNewTab(source: AssembledTabRuntime): Promise<void> {
+    if (!this.isTabAlive(source) || this.pendingContinuations.has(source.id) || this.continuationAdmissions.has(source.id)) return;
+    if (this.isTabWorking(source.id)) {
+      this.setContinuationQueued(source.id, true);
+      return;
+    }
+    await this.createContinuationTarget(source);
+  }
+
+  private async runPendingContinuation(sourceTabId: TabId): Promise<void> {
+    if (!this.pendingContinuations.has(sourceTabId)) return;
+    const source = this.tabs.get(sourceTabId);
+    if (!source || !this.isTabAlive(source)) {
+      this.setContinuationQueued(sourceTabId, false);
+      return;
+    }
+    if (this.isTabWorking(source.id) || this.continuationAdmissions.has(source.id)) return;
+    await this.createContinuationTarget(source);
+  }
+
+  private async createContinuationTarget(source: AssembledTabRuntime): Promise<void> {
+    if (!this.isTabAlive(source) || this.destroyed || this.continuationAdmissions.has(source.id)) return;
+    this.setContinuationAdmission(source.id, true);
+    this.setContinuationQueued(source.id, false);
+    let target: AssembledTabRuntime | null = null;
+    let sendInvoked = false;
+    try {
+      // Capture only after all source work settles so the capsule is latest-state-wins.
+      if (this.isTabWorking(source.id)) {
+        this.setContinuationQueued(source.id, true);
+        return;
+      }
+      const capsule = buildContinuationCapsule({ messages: source.state.messages, todos: source.state.currentTodos });
+      let sourceModel = source.draftModel;
+      try { sourceModel = getTabSelectedModel(source, this.plugin) ?? source.draftModel; } catch { /* blank draft remains explicit */ }
+      if (!sourceModel) {
+        new Notice('Could not continue in a new tab because the source model is unavailable.');
+        return;
+      }
+      target = await this.createTab(null, undefined, {
+        activate: true, draftModel: sourceModel, draftProviderId: source.providerId,
+      });
+      if (!target || !this.isTabAlive(target)) return;
+      if (!this.isTabAlive(source)) {
+        await this.discardPristineContinuationTarget(target);
+        return;
+      }
+      const roots = source.ui.externalContextSelector.getExternalContexts();
+      target.ui.externalContextSelector.setExternalContexts(selectRelevantExternalRoots(roots, source.state.messages));
+      if (!this.isTabAlive(source)) {
+        await this.discardPristineContinuationTarget(target);
+        return;
+      }
+      sendInvoked = true;
+      await target.controllers.inputController.sendMessage({ content: capsule });
+    } catch {
+      if (sendInvoked) {
+        new Notice('Sending the continuation may have started. The new tab was kept so you can inspect it before retrying.');
+      } else {
+        if (target) await this.discardPristineContinuationTarget(target).catch(() => false);
+        const sourceRestored = await this.restoreContinuationSource(source);
+        new Notice(sourceRestored
+          ? 'Could not prepare the continuation tab. The source tab was restored.'
+          : 'Could not prepare the continuation tab. No message was sent.');
+      }
+    } finally {
+      this.setContinuationAdmission(source.id, false);
+    }
+  }
+
+  private async discardPristineContinuationTarget(target: AssembledTabRuntime): Promise<boolean> {
+    if (
+      !this.isTabAlive(target)
+      || target.conversationId !== null
+      || target.state.messages.length > 0
+      || this.isTabWorking(target.id)
+    ) return false;
+    return await this.discardTab(target.id);
+  }
+
+  private async restoreContinuationSource(source: AssembledTabRuntime): Promise<boolean> {
+    if (!this.isTabAlive(source) || this.destroyed) return false;
+    if (this.activeTabId !== source.id) {
+      try {
+        await this.switchToTab(source.id);
+      } catch {
+        return false;
+      }
+    }
+    return this.activeTabId === source.id;
+  }
+
+  private observeContinuationPending(tabId: TabId, observer: () => void): () => void {
+    let observers = this.continuationStateObservers.get(tabId);
+    if (!observers) {
+      observers = new Set();
+      this.continuationStateObservers.set(tabId, observers);
+    }
+    observers.add(observer);
+    return () => {
+      observers?.delete(observer);
+      if (observers?.size === 0) this.continuationStateObservers.delete(tabId);
+    };
+  }
+
+  private setContinuationQueued(tabId: TabId, queued: boolean): void {
+    this.setContinuationState(this.pendingContinuations, tabId, queued);
+  }
+
+  private setContinuationAdmission(tabId: TabId, admitted: boolean): void {
+    this.setContinuationState(this.continuationAdmissions, tabId, admitted);
+  }
+
+  private setContinuationState(set: Set<TabId>, tabId: TabId, active: boolean): void {
+    const changed = active ? !set.has(tabId) : set.has(tabId);
+    if (!changed) return;
+    if (active) set.add(tabId);
+    else set.delete(tabId);
+    for (const observer of this.continuationStateObservers.get(tabId) ?? []) {
+      try {
+        observer();
+      } catch {
+        // Presentation observers must not affect continuation admission.
+      }
+    }
   }
 
   // ============================================
@@ -2112,6 +2258,8 @@ export class TabManager implements TabManagerInterface {
   }
 
   private releaseTabRuntimeMetadata(tabId: TabId): readonly unknown[] {
+    this.setContinuationQueued(tabId, false);
+    this.setContinuationAdmission(tabId, false);
     const errors: unknown[] = [];
     try {
       this.cancelProviderRuntimeCommandWarmup(tabId);
@@ -2394,6 +2542,9 @@ export class TabManager implements TabManagerInterface {
     const tabs = Array.from(this.tabs.values());
     const metadataTabIds = new Set<TabId>([
       ...tabs.map(tab => tab.id),
+      ...this.pendingContinuations,
+      ...this.continuationAdmissions,
+      ...this.continuationStateObservers.keys(),
       ...this.providerRuntimeCommandWarmups.keys(),
       ...this.providerRuntimeCommandCache.keys(),
       ...this.providerCommandDiscoveryStores.keys(),
@@ -2413,6 +2564,9 @@ export class TabManager implements TabManagerInterface {
     }
     const finalMetadataTabIds = new Set<TabId>([
       ...tabs.map(tab => tab.id),
+      ...this.pendingContinuations,
+      ...this.continuationAdmissions,
+      ...this.continuationStateObservers.keys(),
       ...this.providerRuntimeCommandWarmups.keys(),
       ...this.providerRuntimeCommandCache.keys(),
       ...this.providerCommandDiscoveryStores.keys(),
@@ -2429,6 +2583,9 @@ export class TabManager implements TabManagerInterface {
     this.providerCommandDiscoveryStores.clear();
     this.tabCommandContextRevisions.clear();
     this.tabActivationRevisions.clear();
+    this.pendingContinuations.clear();
+    this.continuationAdmissions.clear();
+    this.continuationStateObservers.clear();
     this.closingTabIds.clear();
     this.activeTabId = null;
     this.committedActiveTabId = null;

--- a/src/features/chat/tabs/TabRuntimeFactory.ts
+++ b/src/features/chat/tabs/TabRuntimeFactory.ts
@@ -42,6 +42,7 @@ export interface TabRuntimeFactoryOptions {
   conversation?: Conversation;
   tabId?: TabId;
   draftModel?: string | null;
+  draftProviderId?: ProviderId;
   lifecycleState?: Extract<
     AssembledTabRuntime['lifecycleState'],
     'provisional' | 'cold'
@@ -69,6 +70,9 @@ export interface TabRuntimeFactoryOptions {
     providerId: ProviderId,
   ) => void | Promise<void>;
   onCommandContextChanged?: (tab: AssembledTabRuntime) => void;
+  onContinueInNewTab?: (tab: AssembledTabRuntime) => void | Promise<void>;
+  isContinuationPending?: (tab: AssembledTabRuntime) => boolean;
+  observeContinuationPending?: (tabId: TabId, observer: () => void) => () => void;
   captureReviewableSettlement?: (
     tab: AssembledTabRuntime,
     outcome: TabReviewOutcome,

--- a/src/features/chat/tabs/providerResolution.ts
+++ b/src/features/chat/tabs/providerResolution.ts
@@ -1,4 +1,3 @@
-import { getEnabledProviderForModel } from '../../../core/providers/modelRouting';
 import type { ProviderId } from '../../../core/providers/types';
 import type { Conversation } from '../../../core/types';
 import type { FeatureHost } from '../../FeatureHost';
@@ -13,13 +12,6 @@ function getStoredConversationProviderId(
     if (conversation?.providerId) {
       return conversation.providerId;
     }
-  }
-
-  if (tab.conversationId === null && tab.draftModel) {
-    return getEnabledProviderForModel(
-      tab.draftModel,
-      plugin.settings,
-    );
   }
 
   return tab.providerId;

--- a/src/features/chat/tabs/runtime/TabRuntimeConstruction.ts
+++ b/src/features/chat/tabs/runtime/TabRuntimeConstruction.ts
@@ -30,6 +30,8 @@ export interface TabRuntimeConstructionContext {
   conversation?: Conversation;
   tabId?: TabId;
   draftModel?: string | null;
+  /** Explicit provider paired with a continuation draft model; never inferred across providers. */
+  draftProviderId?: ProviderId;
   lifecycleState?: Extract<AssembledTabRuntime['lifecycleState'], 'provisional' | 'cold'>;
   getProviderCatalogConfig: (
     tab: TabProviderCatalogContext,
@@ -54,6 +56,9 @@ export interface TabRuntimeConstructionContext {
     providerId: ProviderId,
   ) => void | Promise<void>;
   onCommandContextChanged?: (tab: AssembledTabRuntime) => void;
+  onContinueInNewTab?: (tab: AssembledTabRuntime) => void | Promise<void>;
+  isContinuationPending?: (tab: AssembledTabRuntime) => boolean;
+  observeContinuationPending?: (tabId: TabId, observer: () => void) => () => void;
   captureReviewableSettlement?: (
     tab: AssembledTabRuntime,
     outcome: TabReviewOutcome,

--- a/src/features/chat/tabs/runtime/TabRuntimeControllers.ts
+++ b/src/features/chat/tabs/runtime/TabRuntimeControllers.ts
@@ -2,7 +2,6 @@ import type { Component } from 'obsidian';
 import { Notice } from 'obsidian';
 
 import { resolveNewConversationModel } from '../../../../core/providers/conversationModel';
-import { getEnabledProviderForModel } from '../../../../core/providers/modelRouting';
 import { ProviderRegistry } from '../../../../core/providers/ProviderRegistry';
 import { DEFAULT_CHAT_PROVIDER_ID } from '../../../../core/providers/types';
 import { getVaultPath } from '../../../../utils/path';
@@ -79,10 +78,6 @@ export function buildTabRuntimeControllers(
     }
 
     try {
-      if (tab.conversationId === null && tab.draftModel) {
-        tab.providerId = getEnabledProviderForModel(tab.draftModel, plugin.settings);
-      }
-
       await initializeTabExecution(tab, plugin);
       if (isClosingLifecycleState(tab.lifecycleState)) {
         return false;

--- a/src/features/chat/tabs/runtime/TabRuntimeShell.ts
+++ b/src/features/chat/tabs/runtime/TabRuntimeShell.ts
@@ -1,7 +1,10 @@
 import { Notice } from 'obsidian';
 
 import type { ProviderInteractionPort } from '../../../../core/execution';
-import { resolveNewConversationModel } from '../../../../core/providers/conversationModel';
+import {
+  findProviderModelOption,
+  resolveNewConversationModel,
+} from '../../../../core/providers/conversationModel';
 import { getEnabledProviderForModel } from '../../../../core/providers/modelRouting';
 import { ProviderRegistry } from '../../../../core/providers/ProviderRegistry';
 import { DEFAULT_CHAT_PROVIDER_ID } from '../../../../core/providers/types';
@@ -67,10 +70,22 @@ export function buildTabRuntimeShell(
   const newConversationModel = !isBound && !restoredDraftModel
     ? resolveNewConversationModel(plugin.settings)
     : null;
+  const explicitDraftProviderId = options.draftProviderId;
+  const explicitDraftModel = !isBound && explicitDraftProviderId
+    ? (
+        restoredDraftModel
+        && ProviderRegistry.isEnabled(explicitDraftProviderId, plugin.settings)
+        && findProviderModelOption(explicitDraftProviderId, restoredDraftModel, plugin.settings)
+      )
+    : null;
+  if (!isBound && explicitDraftProviderId && !explicitDraftModel) {
+    throw new Error('The requested draft provider/model selection is not currently available');
+  }
   const draftModel = isBound
     ? null
-    : (restoredDraftModel || newConversationModel?.model || null);
+    : (explicitDraftModel || restoredDraftModel || newConversationModel?.model || null);
   const initialProviderId = conversation?.providerId
+    ?? explicitDraftProviderId
     ?? newConversationModel?.providerId
     ?? (draftModel
       ? getEnabledProviderForModel(draftModel, plugin.settings)

--- a/src/features/chat/tabs/runtime/TabRuntimeUI.ts
+++ b/src/features/chat/tabs/runtime/TabRuntimeUI.ts
@@ -28,6 +28,7 @@ import { NavigationSidebar } from '../../ui/NavigationSidebar';
 import { StatusPanel } from '../../ui/StatusPanel';
 import { autoResizeTextarea } from '../../ui/textareaResize';
 import { recalculateUsageForModel } from '../../utils/usageInfo';
+import { createContinuationAction } from '../ContinuationAction';
 import { getTabProviderId } from '../providerResolution';
 import { commitProvisionalTab } from '../TabLifecycle';
 import { TabModelSelectionCoordinator } from '../TabModelSelectionCoordinator';
@@ -515,6 +516,33 @@ export function buildTabRuntimeUI(
     contextUsageMeter: toolbar.contextUsageMeter,
     navigationSidebar,
   };
+
+  if (options.onContinueInNewTab) {
+    const continuationAction = createContinuationAction(
+      dom.navRowEl,
+      shell.state,
+      () => {
+        const runtime = runtimeRef.current();
+        if (runtime) return options.onContinueInNewTab?.(runtime);
+      },
+      () => {
+        const runtime = runtimeRef.current();
+        return runtime ? (options.isContinuationPending?.(runtime) ?? false) : false;
+      },
+    );
+    const removeMessageObserver = shell.state.observeMessages(() => continuationAction.refresh());
+    const removeUsageObserver = shell.state.observeUsage(() => continuationAction.refresh());
+    const removePendingObserver = options.observeContinuationPending?.(
+      shell.id,
+      () => continuationAction.refresh(),
+    ) ?? (() => undefined);
+    options.registerCleanup('tab continuation action', () => {
+      removeMessageObserver();
+      removeUsageObserver();
+      removePendingObserver();
+      continuationAction.buttonEl.remove();
+    });
+  }
 
   ui.externalContextSelector.setOnChange(() => {
     ui.fileContextManager.preScanExternalContexts();

--- a/src/style/components/input.css
+++ b/src/style/components/input.css
@@ -271,3 +271,47 @@ button.claudian-input-nav-btn[aria-disabled='true'] {
 .claudian-input-wrapper.claudian-input-bang-bash-mode .claudian-input {
   font-family: var(--font-monospace);
 }
+
+button.claudian-continue-new-tab-button {
+  width: auto;
+  min-height: 24px;
+  padding: 0 8px;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+button.claudian-continue-new-tab-button:hover,
+button.claudian-continue-new-tab-button:focus-visible,
+button.claudian-continue-new-tab-button:active {
+  padding: 0 8px;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--text-normal);
+}
+
+button.claudian-continue-new-tab-button.mod-cta {
+  color: var(--text-accent);
+  font-weight: var(--font-semibold);
+}
+
+button.claudian-continue-new-tab-button.mod-cta:hover,
+button.claudian-continue-new-tab-button.mod-cta:focus-visible,
+button.claudian-continue-new-tab-button.mod-cta:active {
+  color: var(--text-accent-hover);
+}
+
+button.claudian-continue-new-tab-button:disabled,
+button.claudian-continue-new-tab-button:disabled:hover,
+button.claudian-continue-new-tab-button:disabled:focus-visible,
+button.claudian-continue-new-tab-button:disabled:active {
+  padding: 0 8px;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--text-faint);
+  cursor: default;
+}

--- a/tests/unit/features/chat/state/ChatState.test.ts
+++ b/tests/unit/features/chat/state/ChatState.test.ts
@@ -760,3 +760,14 @@ describe('ChatState', () => {
     });
   });
 });
+
+describe('ChatState observers', () => {
+  it('isolates observer failures while continuing notification', () => {
+    const state = new ChatState();
+    const received = jest.fn();
+    state.observeMessages(() => { throw new Error('observer failure'); });
+    state.observeMessages(received);
+    expect(() => { state.messages = []; }).not.toThrow();
+    expect(received).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/features/chat/tabs/ContinuationAction.test.ts
+++ b/tests/unit/features/chat/tabs/ContinuationAction.test.ts
@@ -1,0 +1,66 @@
+import { createMockEl } from '@test/helpers/MockElement';
+
+import { ChatState } from '@/features/chat/state/ChatState';
+import {
+  countToolCalls,
+  createContinuationAction,
+  shouldRecommendContinuation,
+} from '@/features/chat/tabs/ContinuationAction';
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(resolver => { resolve = resolver; });
+  return { promise, resolve };
+}
+
+describe('ContinuationAction', () => {
+  it('recommends at the context and recursive tool thresholds without looping cycles', () => {
+    const nested: any = { id: 'nested' };
+    const parent: any = { id: 'parent', subagent: { toolCalls: [nested] } };
+    nested.subagent = { toolCalls: [parent] };
+    expect(countToolCalls([{ toolCalls: [parent] }])).toBe(2);
+    const state = new ChatState();
+    state.usage = { inputTokens: 0, contextTokens: 200_000, contextWindow: 200_000, percentage: 100 };
+    expect(shouldRecommendContinuation(state)).toBe(true);
+  });
+
+  it('renders the recommendation class and restores enabled aria state after deferred completion', async () => {
+    const parent = createMockEl();
+    const state = new ChatState();
+    state.usage = { inputTokens: 0, contextTokens: 200_000, contextWindow: 200_000, percentage: 100 };
+    const completion = deferred<void>();
+    let pending = false;
+    let refresh = (): void => undefined;
+    const action = createContinuationAction(
+      parent as any,
+      state,
+      async () => {
+        pending = true;
+        refresh();
+        await completion.promise;
+        pending = false;
+      },
+      () => pending,
+    );
+    refresh = action.refresh;
+
+    expect((action.buttonEl as any).hasClass('claudian-continue-new-tab-button')).toBe(true);
+    expect((action.buttonEl as any).hasClass('mod-cta')).toBe(true);
+    expect(action.buttonEl.getAttribute('data-recommended')).toBe('true');
+    expect(action.buttonEl.getAttribute('aria-label')).toContain('Recommended:');
+
+    (action.buttonEl as any).click();
+    expect(action.buttonEl.disabled).toBe(true);
+    expect(action.buttonEl.getAttribute('aria-busy')).toBe('true');
+    expect(action.buttonEl.getAttribute('data-recommended')).toBe('false');
+    expect((action.buttonEl as any).hasClass('mod-cta')).toBe(false);
+
+    completion.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(action.buttonEl.disabled).toBe(false);
+    expect(action.buttonEl.getAttribute('aria-busy')).toBe('false');
+    expect((action.buttonEl as any).hasClass('mod-cta')).toBe(true);
+  });
+});

--- a/tests/unit/features/chat/tabs/ContinuationCapsule.test.ts
+++ b/tests/unit/features/chat/tabs/ContinuationCapsule.test.ts
@@ -1,0 +1,107 @@
+import {
+  buildContinuationCapsule,
+  latestChangedPaths,
+  selectRelevantExternalRoots,
+} from '@/features/chat/tabs/ContinuationCapsule';
+
+describe('ContinuationCapsule', () => {
+  it('keeps latest narrative and safe changed paths within a bounded deterministic capsule', () => {
+    const capsule = buildContinuationCapsule({
+      messages: [
+        { id: 'u1', role: 'user', content: 'Initial goal', timestamp: 1 },
+        { id: 'a1', role: 'assistant', content: 'Old progress', timestamp: 2 },
+        { id: 'u2', role: 'user', content: 'Finish the focused task', timestamp: 3, linkedContentPath: 'notes/brief.md' },
+        { id: 'a2', role: 'assistant', content: 'Latest progress', timestamp: 4, toolCalls: [{ id: 't', name: 'Write', input: { secret: 'never copy' }, result: 'never copy', status: 'completed', diffData: { filePath: 'src/changed.ts', diffLines: [], stats: { added: 1, removed: 0 } } }] },
+      ],
+      todos: [{ content: 'Verify change', status: 'in_progress', activeForm: 'Verifying' }],
+      maxChars: 500,
+    });
+
+    expect(capsule).toContain('Finish the focused task');
+    expect(capsule).toContain('Latest progress');
+    expect(capsule).toContain('src/changed.ts');
+    expect(capsule).toContain('notes/brief.md');
+    expect(capsule).not.toContain('never copy');
+    expect(capsule.length).toBeLessThanOrEqual(500);
+  });
+
+  it('treats any nonempty non-approval user text as substantive', () => {
+    const capsule = buildContinuationCapsule({ messages: [
+      { id: 'u1', role: 'user', content: 'Fix bug', timestamp: 1 },
+      { id: 'a', role: 'assistant', content: 'Plan is ready.', timestamp: 2 },
+      { id: 'u2', role: 'user', content: 'a', timestamp: 3 },
+    ] });
+
+    expect(capsule).toContain('## Current goal\nFix bug');
+    expect(capsule).toContain('## Latest instruction\na');
+  });
+
+  it('skips empty assistant entries and uses nonempty canonical narrative content', () => {
+    const capsule = buildContinuationCapsule({ messages: [
+      { id: 'u', role: 'user', content: 'Fix it', timestamp: 1 },
+      { id: 'a1', role: 'assistant', content: 'Rendered fallback', timestamp: 2, executionInput: { schemaVersion: 1, canonicalText: 'Canonical state' } },
+      { id: 'a2', role: 'assistant', content: '   ', timestamp: 3 },
+    ] });
+
+    expect(capsule).toContain('## Current state\nCanonical state');
+    expect(capsule).not.toContain('Rendered fallback');
+  });
+
+  it('collects changed paths recursively and terminates on tool-call cycles', () => {
+    const parent: any = { id: 'parent', name: 'Agent', input: {}, status: 'completed' };
+    const nested: any = {
+      id: 'nested',
+      name: 'Edit',
+      input: {},
+      status: 'completed',
+      diffData: { filePath: 'src/nested.ts', diffLines: [], stats: { added: 1, removed: 0 } },
+    };
+    parent.subagent = { id: 'sub', description: '', isExpanded: false, status: 'completed', toolCalls: [nested] };
+    nested.subagent = { id: 'cycle', description: '', isExpanded: false, status: 'completed', toolCalls: [parent] };
+
+    expect(latestChangedPaths([
+      { id: 'a', role: 'assistant', content: 'Done', timestamp: 1, toolCalls: [parent] },
+    ])).toEqual(['src/nested.ts']);
+  });
+
+  it('selects roots from structured absolute evidence, including a Bash command, without serializing input', () => {
+    const cyclicInput: any = { command: 'cd "/Repo With Space" && npm test', secret: 'do-not-serialize' };
+    cyclicInput.self = cyclicInput;
+    const messages: any = [{
+      id: 'a', role: 'assistant', content: 'Done', timestamp: 1,
+      toolCalls: [{
+        id: 'agent', name: 'Agent', input: {}, status: 'completed',
+        subagent: {
+          id: 'sub', description: '', isExpanded: false, status: 'completed',
+          toolCalls: [{
+            id: 'bash', name: 'Bash', input: cyclicInput, status: 'completed',
+            diffData: { filePath: 'src/file.ts', diffLines: [], stats: { added: 1, removed: 0 } },
+          }],
+        },
+      }],
+    }];
+
+    expect(selectRelevantExternalRoots(['/Repo With Space/', '/other'], messages)).toEqual(['/Repo With Space/']);
+    expect(buildContinuationCapsule({ messages })).not.toContain('do-not-serialize');
+  });
+
+  it('keeps POSIX case sensitivity and rejects sibling-prefix and relative-only guesses', () => {
+    const absoluteLowercase: any = [{ id: 'a', role: 'assistant', content: '', timestamp: 1, toolCalls: [{ id: 'x', name: 'Write', input: { path: '/repo/file.ts' }, status: 'completed' }] }];
+    const sibling: any = [{ id: 'a', role: 'assistant', content: '', timestamp: 1, toolCalls: [{ id: 'x', name: 'Write', input: { path: '/repo-other/file.ts' }, status: 'completed' }] }];
+    const relativeOnly: any = [{ id: 'a', role: 'assistant', content: '', timestamp: 1, toolCalls: [{ id: 'x', name: 'Write', input: {}, status: 'completed', diffData: { filePath: 'src/file.ts', diffLines: [], stats: { added: 1, removed: 0 } } }] }];
+
+    expect(selectRelevantExternalRoots(['/Repo'], absoluteLowercase)).toEqual([]);
+    expect(selectRelevantExternalRoots(['/repo'], sibling)).toEqual([]);
+    expect(selectRelevantExternalRoots(['/repo'], relativeOnly)).toEqual([]);
+  });
+
+  it('matches Windows drive paths case-insensitively across separators and trailing slashes', () => {
+    const messages: any = [{
+      id: 'a', role: 'assistant', content: '', timestamp: 1,
+      toolCalls: [{ id: 'x', name: 'Bash', input: { command: 'git -C C:\\Work\\Repo status' }, status: 'completed' }],
+    }];
+
+    expect(selectRelevantExternalRoots(['c:/work/repo/', 'C:/work/repository'], messages))
+      .toEqual(['c:/work/repo/']);
+  });
+});

--- a/tests/unit/features/chat/tabs/TabManager.test.ts
+++ b/tests/unit/features/chat/tabs/TabManager.test.ts
@@ -47,7 +47,7 @@ function createMockTab(options: Record<string, any>): any {
   const tab = {
     id: options.tabId ?? `tab-${mockTabs.length + 1}`,
     conversationId: options.conversation?.id ?? null,
-    draftModel: options.conversation ? null : 'claude-default',
+    draftModel: options.conversation ? null : (options.draftModel ?? 'claude-default'),
     executionCoordinator: {
       copyInputsForFork: jest.fn().mockResolvedValue(undefined),
       hasBackgroundWork: false,
@@ -57,7 +57,7 @@ function createMockTab(options: Record<string, any>): any {
     },
     hydrationState: options.conversation ? 'idle' : 'ready',
     lifecycleState: options.lifecycleState ?? 'cold',
-    providerId: options.conversation?.providerId ?? 'claude',
+    providerId: options.conversation?.providerId ?? options.draftProviderId ?? 'claude',
     session,
     captureReviewableSettlement: options.captureReviewableSettlement ?? null,
     state: {
@@ -88,6 +88,7 @@ function createMockTab(options: Record<string, any>): any {
       },
       inputController: {
         resumeQueuedTurnAfterIntentAdmission: jest.fn(),
+        sendMessage: jest.fn().mockResolvedValue(undefined),
       },
     },
     dom: {
@@ -97,6 +98,7 @@ function createMockTab(options: Record<string, any>): any {
     ui: {
       externalContextSelector: {
         getExternalContexts: jest.fn().mockReturnValue([]),
+        setExternalContexts: jest.fn(),
       },
     },
   };
@@ -2573,5 +2575,222 @@ describe('TabManager provider execution orchestration', () => {
     })).rejects.toThrow('fork state failed');
 
     expect(plugin.deleteConversation).toHaveBeenCalledWith('forked');
+  });
+});
+
+
+describe('provider-neutral continuation handoff', () => {
+  beforeEach(() => {
+    mockTabs.length = 0;
+    jest.clearAllMocks();
+    mockCreateTab.mockImplementation((options) => createMockTab(options));
+    mockCreateTabRuntime.mockImplementation(async (options: Record<string, any>) => {
+      const runtimeRef: { tab?: any } = {};
+      const captureReviewableSettlement = options.captureReviewableSettlement
+        ? (outcome: 'completed' | 'error' = 'completed') => (
+            options.captureReviewableSettlement(runtimeRef.tab, outcome)
+          )
+        : undefined;
+      const tab = mockCreateTab({ ...options, captureReviewableSettlement });
+      runtimeRef.tab = tab;
+      return tab;
+    });
+  });
+
+  it('creates a new inherited draft and auto-sends a local capsule when the source is idle', async () => {
+    const { manager } = createManager();
+    const source = await manager.createTab();
+    source!.state.messages = [
+      { id: 'u', role: 'user', content: 'Finish task', timestamp: 1 },
+      { id: 'a', role: 'assistant', content: 'Current state', timestamp: 2 },
+    ];
+
+    await (manager as any).requestContinuationInNewTab(source);
+
+    const target = manager.getActiveTab()!;
+    expect(target.id).not.toBe(source!.id);
+    expect(target.draftModel).toBe(source!.draftModel);
+    expect(target.controllers.inputController.sendMessage).toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining('Finish task'),
+    }));
+  });
+
+  it('inherits the source provider together with a duplicate model id', async () => {
+    const { manager } = createManager();
+    const source = await manager.createTab();
+    source!.providerId = 'codex';
+    source!.draftModel = 'shared-model';
+
+    await (manager as any).requestContinuationInNewTab(source);
+
+    const target = manager.getActiveTab()!;
+    expect(target.providerId).toBe('codex');
+    expect(target.draftModel).toBe('shared-model');
+    expect(mockCreateTabRuntime.mock.calls[1]?.[0]).toEqual(expect.objectContaining({
+      draftModel: 'shared-model',
+      draftProviderId: 'codex',
+    }));
+  });
+
+  it('publishes admission changes through the manager-owned continuation observer seam', async () => {
+    const { manager } = createManager();
+    const source = await manager.createTab();
+    const factoryOptions = mockCreateTabRuntime.mock.calls[0]?.[0];
+    const observer = jest.fn();
+    const removeObserver = factoryOptions.observeContinuationPending(source!.id, observer);
+    source!.state.isStreaming = true;
+
+    await (manager as any).requestContinuationInNewTab(source);
+
+    expect(factoryOptions.isContinuationPending(source)).toBe(true);
+    expect(observer).toHaveBeenCalled();
+
+    source!.state.isStreaming = false;
+    await (manager as any).runPendingContinuation(source!.id);
+
+    expect(factoryOptions.isContinuationPending(source)).toBe(false);
+    expect(observer.mock.calls.length).toBeGreaterThanOrEqual(3);
+    removeObserver();
+  });
+
+  it('queues exactly one continuation until a busy source settles', async () => {
+    const { manager } = createManager();
+    const source = await manager.createTab();
+    source!.state.isStreaming = true;
+
+    await (manager as any).requestContinuationInNewTab(source);
+    await (manager as any).requestContinuationInNewTab(source);
+    expect(manager.getTabCount()).toBe(1);
+
+    source!.state.isStreaming = false;
+    await (manager as any).runPendingContinuation(source!.id);
+    expect(manager.getTabCount()).toBe(2);
+  });
+
+  it('drops a queued continuation when its source runtime is gone', async () => {
+    const { manager } = createManager();
+    const source = await manager.createTab();
+    source!.state.isStreaming = true;
+    await (manager as any).requestContinuationInNewTab(source);
+
+    (manager as any).tabs.delete(source!.id);
+    source!.state.isStreaming = false;
+    await (manager as any).runPendingContinuation(source!.id);
+
+    expect(manager.getTabCount()).toBe(0);
+    expect((manager as any).pendingContinuations.has(source!.id)).toBe(false);
+  });
+
+  it('discards a pristine target through discardTab when the source dies during admission', async () => {
+    const { manager } = createManager();
+    const source = await manager.createTab();
+    const targetAssembly = deferred<any>();
+    let targetOptions: Record<string, any> | null = null;
+    mockCreateTabRuntime.mockImplementationOnce((options) => {
+      targetOptions = options;
+      return targetAssembly.promise;
+    });
+    const discard = jest.spyOn(manager, 'discardTab').mockResolvedValue(true);
+
+    const continuation = (manager as any).requestContinuationInNewTab(source);
+    (manager as any).tabs.delete(source!.id);
+    source!.lifecycleState = 'closing';
+    const capturedTargetOptions = targetOptions as unknown as Record<string, any>;
+    const target = createMockTab({
+      ...capturedTargetOptions,
+      draftModel: source!.draftModel,
+    });
+    targetAssembly.resolve(target);
+
+    await continuation;
+
+    expect(discard).toHaveBeenCalledWith(target.id);
+    expect(target.controllers.inputController.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('discards an unsent target and restores the live source after setup failure', async () => {
+    const { manager } = createManager();
+    const source = await manager.createTab();
+    mockCreateTab.mockImplementationOnce((options) => {
+      const target = createMockTab(options);
+      target.ui.externalContextSelector.setExternalContexts.mockImplementation(() => {
+        throw new Error('setup failed');
+      });
+      return target;
+    });
+
+    await (manager as any).requestContinuationInNewTab(source);
+
+    expect(manager.getActiveTab()).toBe(source);
+    expect(manager.getTabCount()).toBe(1);
+    expect(Notice).toHaveBeenCalledWith(expect.stringContaining('source tab was restored'));
+  });
+
+  it('preserves the target and reports uncertainty when send invocation rejects', async () => {
+    const { manager } = createManager();
+    const source = await manager.createTab();
+    const factoryOptions = mockCreateTabRuntime.mock.calls[0]?.[0];
+    const observer = jest.fn();
+    factoryOptions.observeContinuationPending(source!.id, observer);
+    mockCreateTab.mockImplementationOnce((options) => {
+      const target = createMockTab(options);
+      target.controllers.inputController.sendMessage.mockRejectedValueOnce(new Error('uncertain send'));
+      return target;
+    });
+
+    await (manager as any).requestContinuationInNewTab(source);
+
+    expect(manager.getTabCount()).toBe(2);
+    expect(manager.getActiveTab()?.id).not.toBe(source!.id);
+    expect(Notice).toHaveBeenCalledWith(expect.stringContaining('may have started'));
+    expect(Notice).not.toHaveBeenCalledWith(expect.stringContaining('left unchanged'));
+    expect(factoryOptions.isContinuationPending(source)).toBe(false);
+    expect(observer.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('fences continuation metadata after the source closes while send is in flight', async () => {
+    const { manager } = createManager();
+    const source = await manager.createTab();
+    const factoryOptions = mockCreateTabRuntime.mock.calls[0]?.[0];
+    const observer = jest.fn();
+    factoryOptions.observeContinuationPending(source!.id, observer);
+    const send = deferred<void>();
+    mockCreateTab.mockImplementationOnce((options) => {
+      const target = createMockTab(options);
+      target.controllers.inputController.sendMessage.mockImplementationOnce(() => send.promise);
+      return target;
+    });
+
+    const continuation = (manager as any).requestContinuationInNewTab(source);
+    while (manager.getTabCount() < 2) await Promise.resolve();
+    const target = manager.getActiveTab()!;
+    while (!(target.controllers.inputController.sendMessage as jest.Mock).mock.calls.length) {
+      await Promise.resolve();
+    }
+    await manager.discardTab(source!.id);
+    send.reject(new Error('uncertain send'));
+    await continuation;
+
+    expect(manager.getTab(source!.id)).toBeNull();
+    expect(manager.getTab(target.id)).toBe(target);
+    expect((manager as any).pendingContinuations.has(source!.id)).toBe(false);
+    expect((manager as any).continuationAdmissions.has(source!.id)).toBe(false);
+    expect(factoryOptions.isContinuationPending(source)).toBe(false);
+    expect(observer.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('clears continuation-only metadata during destroy', async () => {
+    const { manager } = createManager();
+    const observer = jest.fn();
+    (manager as any).pendingContinuations.add('queued-only');
+    (manager as any).continuationAdmissions.add('admitted-only');
+    (manager as any).continuationStateObservers.set('queued-only', new Set([observer]));
+
+    await manager.destroy();
+
+    expect((manager as any).pendingContinuations.size).toBe(0);
+    expect((manager as any).continuationAdmissions.size).toBe(0);
+    expect((manager as any).continuationStateObservers.size).toBe(0);
+    expect(observer).toHaveBeenCalled();
   });
 });

--- a/tests/unit/features/chat/tabs/TabRuntimeFactory.test.ts
+++ b/tests/unit/features/chat/tabs/TabRuntimeFactory.test.ts
@@ -35,6 +35,7 @@ interface MockCoordinator {
   bindConversation: jest.Mock;
   cancel: jest.Mock;
   dispose: jest.Mock;
+  execute: jest.Mock;
   isEventContextCurrent: jest.Mock;
   notifyMayCool: jest.Mock;
   prepare: jest.Mock;
@@ -52,6 +53,11 @@ jest.mock('@/features/chat/execution/ChatExecutionCoordinator', () => ({
       dispose: jest.fn().mockImplementation(() => coordinatorDisposeError
         ? Promise.reject(coordinatorDisposeError)
         : Promise.resolve()),
+      execute: jest.fn().mockResolvedValue({
+        accepted: false,
+        planCompleted: false,
+        status: 'cancelled',
+      }),
       isEventContextCurrent: jest.fn().mockReturnValue(true),
       notifyMayCool: jest.fn(),
       prepare: jest.fn().mockResolvedValue(undefined),
@@ -399,6 +405,107 @@ describe('Tab provider execution ownership', () => {
 
     expect(tab.executionCoordinator).toBe(coordinatorInstances[0]);
     expect(coordinatorInstances).toHaveLength(1);
+  });
+
+  it('keeps an explicit enabled provider for a draft model shared by providers', async () => {
+    const registry = ProviderRegistry as jest.Mocked<typeof ProviderRegistry>;
+    const baseConfig = registry.getChatUIConfig('claude');
+    const codexConfig = {
+      ...baseConfig,
+      getModelOptions: jest.fn().mockReturnValue([
+        { label: 'Shared', value: 'shared-model' },
+      ]),
+    };
+    (registry.getChatUIConfig as jest.Mock).mockImplementation((providerId: string) => (
+      providerId === 'codex' ? codexConfig : baseConfig
+    ));
+    (registry.isEnabled as jest.Mock).mockReturnValue(true);
+    try {
+      const plugin = createPlugin({
+        createConversation: jest.fn().mockResolvedValue({
+          ...createConversation(),
+          id: 'continuation-conversation',
+          providerId: 'codex',
+          selectedModel: 'shared-model',
+        }),
+        renameConversation: jest.fn().mockResolvedValue(undefined),
+        updateConversation: jest.fn().mockResolvedValue(undefined),
+      });
+      plugin.settings.enableAutoTitleGeneration = false;
+      const tab = await createTestTab({
+        plugin,
+        containerEl: createMockEl() as any,
+        draftModel: 'shared-model',
+        draftProviderId: 'codex',
+      });
+
+      expect(tab.providerId).toBe('codex');
+      expect(tab.draftModel).toBe('shared-model');
+
+      await tab.controllers.inputController.sendMessage({ content: 'Continue' });
+
+      expect(tab.providerId).toBe('codex');
+      expect(ensureInitialized).toHaveBeenCalledWith(
+        plugin.providerHost,
+        'codex',
+        'tab-execution',
+      );
+    } finally {
+      (registry.getChatUIConfig as jest.Mock).mockReturnValue(baseConfig);
+      (registry.isEnabled as jest.Mock).mockReturnValue(true);
+    }
+  });
+
+  it('fails closed when an explicit draft provider is disabled or does not expose the model', async () => {
+    const registry = ProviderRegistry as jest.Mocked<typeof ProviderRegistry>;
+    const baseConfig = registry.getChatUIConfig('claude');
+    (registry.isEnabled as jest.Mock).mockImplementation((providerId: string) => providerId !== 'codex');
+    try {
+      await expect(createTestTab({
+        plugin: createPlugin(),
+        containerEl: createMockEl() as any,
+        draftModel: 'shared-model',
+        draftProviderId: 'codex',
+      })).rejects.toThrow('provider/model selection is not currently available');
+    } finally {
+      (registry.getChatUIConfig as jest.Mock).mockReturnValue(baseConfig);
+      (registry.isEnabled as jest.Mock).mockReturnValue(true);
+    }
+  });
+
+  it('refreshes continuation DOM state immediately from the manager observer seam', async () => {
+    const completion = deferred<void>();
+    let observer: (() => void) | null = null;
+    let pending = false;
+    const tab = await createTestTab({
+      plugin: createPlugin(),
+      containerEl: createMockEl() as any,
+      isContinuationPending: () => pending,
+      observeContinuationPending: (_tabId, nextObserver) => {
+        observer = nextObserver;
+        return () => { observer = null; };
+      },
+      onContinueInNewTab: async () => {
+        pending = true;
+        observer?.();
+        await completion.promise;
+        pending = false;
+        observer?.();
+      },
+    });
+    const button = tab.dom.navRowEl.querySelector('.claudian-continue-new-tab-button') as any;
+
+    expect(button).not.toBeNull();
+    button.click();
+    expect(button.disabled).toBe(true);
+    expect(button.getAttribute('aria-busy')).toBe('true');
+
+    completion.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(button.disabled).toBe(false);
+    expect(button.getAttribute('aria-busy')).toBe('false');
   });
 
   it('publishes work changes from turn, provider-background, and async-subagent owners', async () => {

--- a/tests/unit/features/chat/tabs/providerResolution.test.ts
+++ b/tests/unit/features/chat/tabs/providerResolution.test.ts
@@ -1,0 +1,32 @@
+import { getTabProviderId } from '@/features/chat/tabs/providerResolution';
+
+describe('getTabProviderId', () => {
+  it('keeps the blank tab provider when multiple providers own the same model id', () => {
+    const tab = {
+      conversationId: null,
+      draftModel: 'shared-model',
+      providerId: 'codex',
+    } as any;
+    const plugin = {
+      getConversationSync: jest.fn(),
+      settings: {},
+    } as any;
+
+    expect(getTabProviderId(tab, plugin)).toBe('codex');
+    expect(plugin.getConversationSync).not.toHaveBeenCalled();
+  });
+
+  it('prefers durable conversation ownership over a stale runtime provider', () => {
+    const tab = {
+      conversationId: 'conversation-1',
+      draftModel: null,
+      providerId: 'codex',
+    } as any;
+    const plugin = {
+      getConversationSync: jest.fn().mockReturnValue({ providerId: 'claude' }),
+      settings: {},
+    } as any;
+
+    expect(getTabProviderId(tab, plugin)).toBe('claude');
+  });
+});


### PR DESCRIPTION
## Summary
- add an always-available **Continue in new tab** action with recommendation thresholds at 200k context tokens or 80 recursive tool calls
- build a deterministic local handoff capsule capped at 12k characters without provider payloads, raw tool inputs/results, diffs, images, or subagent logs
- queue exactly one handoff while the source is busy, rebuild it after settlement, inherit the explicit provider/model pair, transfer only evidence-relevant external roots, and auto-send in the target tab
- add lifecycle cleanup, accessible pending/recommended states, provider-collision protection, and focused regression coverage

## Verification
- `npm run typecheck`
- `npm run lint`
- `npx stylelint --config stylelint.config.mjs src/style/components/input.css`
- `npm run build`
- 6 focused suites: 234 tests passed
- collab protocol: 11 suites / 83 tests passed
- full main suite locally: 556/557 suites and 8,272/8,273 tests passed; the only failure was the machine-wide Git push allowlist hook intercepting a temporary-repository integration fixture
- `git diff --check`
- staged gitleaks scan: no leaks

## Compatibility
- intentionally separate from #1125's provider-native `/compact` command
- exact changed-path intersection with #1125: none
