### PR TITLE
fix: surface Claude API error text instead of the bare error code

### DIFF
--- a/src/providers/claude/execution/ClaudeExecutionEventNormalizer.ts
+++ b/src/providers/claude/execution/ClaudeExecutionEventNormalizer.ts
@@ -248,12 +248,16 @@ export class ClaudeExecutionEventNormalizer {
     if (chunk.type === 'error') {
       target.push({
         type: 'native_error',
-        message: chunk.content,
+        message: (isSyntheticApiErrorMessage(message) ? extractApiErrorText(message) : null)
+          ?? chunk.content,
         code: chunk.code,
         providerSessionId: chunk.providerSessionId,
       });
       return;
     }
+
+    // The native_error above already carries this text; rendering it again would duplicate it.
+    if (chunk.type === 'text' && isSyntheticApiErrorMessage(message)) return;
 
     if (
       (chunk.type === 'text' || chunk.type === 'thinking')
@@ -500,6 +504,44 @@ function normalizeToolCompleted(
     isBlocked: state.blockedToolIds.has(chunk.id),
     toolUseResult: chunk.toolUseResult,
   };
+}
+
+// Claude reports quota and other API failures as a synthetic assistant message whose only
+// payload is human-readable text (e.g. the session-limit reset time). `error` alone is not
+// enough to detect it: errors such as `max_output_tokens` ride on real assistant messages
+// carrying real partial prose, which must not be mistaken for error copy. `isApiErrorMessage`
+// and `apiErrorStatus` are wire-only fields the SDK does not declare, so they are treated as
+// optional hints alongside the typed `<synthetic>` model marker.
+function isSyntheticApiErrorMessage(message: SDKMessage): boolean {
+  if (message.type !== 'assistant') return false;
+  if (typeof message.error !== 'string' || message.error.trim() === '') return false;
+  const wireOnly = message as unknown as {
+    isApiErrorMessage?: unknown;
+    apiErrorStatus?: unknown;
+  };
+  return (
+    wireOnly.isApiErrorMessage === true
+    || typeof wireOnly.apiErrorStatus === 'number'
+    || (message.message as { model?: unknown } | undefined)?.model === '<synthetic>'
+  );
+}
+
+function extractApiErrorText(message: SDKMessage): string | null {
+  if (message.type !== 'assistant') return null;
+  const content = (message.message as { content?: unknown } | undefined)?.content;
+  if (!Array.isArray(content)) return null;
+  const text = content
+    .filter((block): block is { type: 'text'; text: string } => (
+      typeof block === 'object'
+      && block !== null
+      && (block as { type?: unknown }).type === 'text'
+      && typeof (block as { text?: unknown }).text === 'string'
+      && (block as { text: string }).text.trim() !== '(no content)'
+    ))
+    .map(block => block.text)
+    .join('\n')
+    .trim();
+  return text === '' ? null : text;
 }
 
 function isAssistantOutputChunk(chunk: StreamChunk): boolean {

--- a/tests/unit/providers/claude/execution/ClaudeExecutionEventNormalizer.test.ts
+++ b/tests/unit/providers/claude/execution/ClaudeExecutionEventNormalizer.test.ts
@@ -137,3 +137,180 @@ describe('ClaudeExecutionEventNormalizer task tools', () => {
     }));
   });
 });
+
+describe('ClaudeExecutionEventNormalizer api error messages', () => {
+  const RESET_TEXT = "You've hit your session limit · resets 4:10pm (Europe/Berlin)";
+
+  const apiErrorMessage = (content: unknown[]) => msg({
+    type: 'assistant',
+    error: 'rate_limit',
+    isApiErrorMessage: true,
+    apiErrorStatus: 429,
+    message: { model: '<synthetic>', content },
+  });
+
+  it('uses the human-readable text of a synthetic API error message as the native error message', () => {
+    const normalizer = new ClaudeExecutionEventNormalizer();
+
+    const events = normalizer.normalize(
+      apiErrorMessage([{ type: 'text', text: RESET_TEXT }]),
+      'requested',
+    );
+
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'native_error',
+      message: RESET_TEXT,
+    }));
+  });
+
+  it('does not also emit the API error text as assistant output', () => {
+    const normalizer = new ClaudeExecutionEventNormalizer();
+
+    const events = normalizer.normalize(
+      apiErrorMessage([{ type: 'text', text: RESET_TEXT }]),
+      'requested',
+    );
+
+    expect(events).not.toContainEqual(expect.objectContaining({
+      type: 'output',
+      event: expect.objectContaining({ type: 'text_delta' }),
+    }));
+    expect(events).not.toContainEqual(expect.objectContaining({
+      type: 'output',
+      event: expect.objectContaining({ type: 'assistant_message_started' }),
+    }));
+  });
+
+  it('falls back to the error code when the API error message has no text block', () => {
+    const normalizer = new ClaudeExecutionEventNormalizer();
+
+    const events = normalizer.normalize(apiErrorMessage([]), 'requested');
+
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'native_error',
+      message: 'rate_limit',
+    }));
+  });
+
+  it('falls back to the error code when the API error text is only whitespace', () => {
+    const normalizer = new ClaudeExecutionEventNormalizer();
+
+    const events = normalizer.normalize(
+      apiErrorMessage([{ type: 'text', text: '  \n\t ' }]),
+      'requested',
+    );
+
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'native_error',
+      message: 'rate_limit',
+    }));
+  });
+
+  it('ignores the (no content) placeholder on API error messages', () => {
+    const normalizer = new ClaudeExecutionEventNormalizer();
+
+    const events = normalizer.normalize(
+      apiErrorMessage([{ type: 'text', text: '(no content)' }]),
+      'requested',
+    );
+
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'native_error',
+      message: 'rate_limit',
+    }));
+  });
+
+  it('joins multiple text blocks of an API error message', () => {
+    const normalizer = new ClaudeExecutionEventNormalizer();
+
+    const events = normalizer.normalize(
+      apiErrorMessage([
+        { type: 'text', text: 'first line' },
+        { type: 'text', text: 'second line' },
+      ]),
+      'requested',
+    );
+
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'native_error',
+      message: 'first line\nsecond line',
+    }));
+  });
+
+  it('surfaces API error text even after partial text streamed earlier in the turn', () => {
+    const normalizer = new ClaudeExecutionEventNormalizer();
+
+    normalizer.normalize(msg({
+      type: 'stream_event',
+      event: {
+        type: 'content_block_delta',
+        delta: { type: 'text_delta', text: 'Partial ' },
+      },
+    }), 'requested');
+
+    const events = normalizer.normalize(
+      apiErrorMessage([{ type: 'text', text: RESET_TEXT }]),
+      'requested',
+    );
+
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'native_error',
+      message: RESET_TEXT,
+    }));
+  });
+
+  it('keeps the error code for an assistant error without synthetic markers', () => {
+    const normalizer = new ClaudeExecutionEventNormalizer();
+
+    const events = normalizer.normalize(msg({
+      type: 'assistant',
+      error: 'max_output_tokens',
+      message: {
+        model: 'claude-sonnet-4-5',
+        content: [{ type: 'text', text: 'Partial response' }],
+      },
+    }), 'requested');
+
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'native_error',
+      message: 'max_output_tokens',
+    }));
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'output',
+      event: expect.objectContaining({ type: 'text_delta', text: 'Partial response' }),
+    }));
+  });
+
+  it('leaves synthetic assistant messages without an error field unchanged', () => {
+    const normalizer = new ClaudeExecutionEventNormalizer();
+
+    const events = normalizer.normalize(msg({
+      type: 'assistant',
+      message: {
+        model: '<synthetic>',
+        content: [{ type: 'text', text: 'No response requested.' }],
+      },
+    }), 'requested');
+
+    expect(events).not.toContainEqual(expect.objectContaining({ type: 'native_error' }));
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'output',
+      event: expect.objectContaining({ type: 'text_delta', text: 'No response requested.' }),
+    }));
+  });
+
+  it('keeps result-error messages using the transformer content', () => {
+    const normalizer = new ClaudeExecutionEventNormalizer();
+
+    const events = normalizer.normalize(msg({
+      type: 'result',
+      subtype: 'error_during_execution',
+      errors: ['SDK reported an execution error'],
+    }), 'requested');
+
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'native_error',
+      message: 'SDK reported an execution error',
+    }));
+  });
+});


### PR DESCRIPTION
## Why

Fixes #1102.

When a Claude subscription session limit is reached, the SDK sends a synthetic assistant message whose only payload is the actionable text:

```json
{ "type": "assistant",
  "message": { "model": "<synthetic>", "content": [{ "type": "text", "text": "You've hit your session limit · resets 4:10pm (Europe/Berlin)" }] },
  "error": "rate_limit", "isApiErrorMessage": true, "apiErrorStatus": 429 }
```

Claudian renders only `**Error:** rate_limit`. The reset time is received and then discarded, so the user has to leave Claudian to find out when they can continue. This is information loss in the existing error path, not a request for a usage meter.

The text is dropped because `transformSDKMessage` yields the `error` chunk before the text chunk, and `ClaudeExecutionSession.handleNativeMessage()` returns from the whole handler on the first `native_error` — abandoning every remaining event in the normalized array.

## What Changed

`ClaudeExecutionEventNormalizer` now reads the human-readable text off the raw SDK message when it builds a `native_error` for a synthetic API-error message, and falls back to the short code when there is no usable text.

- `isSyntheticApiErrorMessage()` — requires a non-empty `error` **and** one of `isApiErrorMessage === true`, a numeric `apiErrorStatus`, or `message.model === '<synthetic>'`.
- `extractApiErrorText()` — joins text blocks with `\n`, skips the `(no content)` sentinel, returns `null` when the result is blank. Follows the existing convention in `src/providers/claude/history/sdkMessageParsing.ts`.
- The matching text chunk is no longer emitted as assistant output, so the text is not rendered twice.

Both helpers are module-private; no new types and no public surface.

## Why This Approach

The fix reads from the SDK message inside `normalizeStreamChunk`'s error branch rather than post-processing the normalized array. That matters: `sawStreamText` (`ClaudeExecutionEventNormalizer.ts`) is **turn-scoped**, not message-scoped, so in the common case — the assistant streams some prose, then the limit trips mid-turn — the synthetic message's text chunk is already suppressed by the existing stream/assistant dedupe. An array-based fix passes a naive unit test and silently no-ops in production. The test `surfaces API error text even after partial text streamed earlier in the turn` pins exactly this.

Requiring both `error` and a synthetic marker is deliberate:
- `error` alone would catch `max_output_tokens`, which rides on a **real** assistant message with **real** partial prose — that prose is not error copy.
- A synthetic marker alone would catch the post-`/compact` `"No response requested."` message, which is also `<synthetic>` (see the existing note at `src/providers/claude/history/ClaudeHistoryStore.ts`).

`isApiErrorMessage` and `apiErrorStatus` are not declared on `SDKAssistantMessage` in `@anthropic-ai/claude-agent-sdk`, so they are read as wire-only hints behind a single cast, with `model === '<synthetic>'` as the typed fallback.

Alternatives rejected:
- **In `transformClaudeMessage`** — it is a pure per-event generator feeding several consumers; collapsing the two yields would change `StreamChunk` for all of them and would require rewriting the existing assertion at `tests/unit/providers/claude/stream/transformSDKMessage.test.ts`. That file is deliberately **unchanged and still passing** here, which is the evidence the fix stayed at the adaptation layer.
- **In `ClaudeExecutionSession`** — 1415 lines with no test file, and per `AGENTS.md` the session should receive already-normalized events. `execution/` owns event adaptation.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run test` — 554 suites / 8263 tests, plus 11 protocol suites and the architecture check, all passing
- `npm run build`
- `git diff --check`

10 new cases in `tests/unit/providers/claude/execution/ClaudeExecutionEventNormalizer.test.ts` (the file previously had no `native_error` coverage at all): the reported repro; no duplicate assistant output; fallback for missing / whitespace-only / `(no content)` text; multi-block joining; the post-streaming case above; `max_output_tokens` on a real message left unchanged; `<synthetic>` without `error` left unchanged; result-error messages left unchanged.

## Impact and Follow-ups

- `classifyClaudeError()` matches on substrings. It now sees prose instead of a short code. The reported rate-limit text hits none of its branches and still classifies as `provider`. But an `authentication_failed` API-error message whose text mentions authentication would now classify as `authentication` and take the `setStatus('idle')` path rather than `setInvalidated(...)`. Arguably more correct, but it is a behavior change worth naming.
- The message string also reaches the invalidated-session banner and `execution_error.message` (consumed by `TextResponseCollector` and `ChatExecutionCoordinator`). It is no longer guaranteed to be a single short token and may be multi-line.
- If the untyped wire fields disappear in a future SDK, the `<synthetic>` leg still carries the fix; if all three markers disappear, behavior degrades to today's (short code) rather than breaking.
- Suppressing the duplicate text output is a no-op for users today, since the session's early return already discarded it. It makes the normalizer's contract self-consistent instead of depending on that return.
- **Out of scope:** `ClaudeHistoryStore` skips `model === '<synthetic>'` assistant messages when rehydrating, so the improved text is live-render only and will not survive a conversation reload. Happy to follow up separately if that is wanted.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
