### PR TITLE
Fix welcome linked note name truncation

### DIFF
--- a/src/style/components/messages.css
+++ b/src/style/components/messages.css
@@ -71,6 +71,8 @@
 
 .claudian-linked-content-selector {
   appearance: none;
+  display: block;
+  flex: 0 1 auto;
   min-width: 0;
   max-width: 100%;
   padding: 0;
@@ -83,6 +85,8 @@
   font-size: inherit;
   line-height: inherit;
   overflow: hidden;
+  direction: ltr;
+  text-align: left;
   text-overflow: ellipsis;
   white-space: nowrap;
   cursor: pointer;

--- a/tests/unit/style/components/linked-content.test.ts
+++ b/tests/unit/style/components/linked-content.test.ts
@@ -32,6 +32,15 @@ describe('Linked content styles', () => {
     expect(messagesCss).not.toContain('.claudian-linked-content-picker-retry');
   });
 
+  it('truncates a long welcome selector only at its right edge', () => {
+    const selectorRule = messagesCss.match(/\.claudian-linked-content-selector\s*{[^}]*}/)?.[0];
+    expect(selectorRule).toMatch(/display:\s*block;/);
+    expect(selectorRule).toMatch(/flex:\s*0\s+1\s+auto;/);
+    expect(selectorRule).toMatch(/direction:\s*ltr;/);
+    expect(selectorRule).toMatch(/text-align:\s*left;/);
+    expect(selectorRule).toMatch(/text-overflow:\s*ellipsis;/);
+  });
+
   it('inherits menu and selected-item visuals from the shared composer dropdown', () => {
     expect(composerDropdownCss).toMatch(/\.claudian-composer-dropdown\s*{[^}]*background:\s*var\(--background-secondary\);[^}]*border:/);
     expect(composerDropdownCss).toMatch(/\.claudian-composer-dropdown-item:hover,[\s\S]*?\.claudian-composer-dropdown-item\.is-selected\s*{[^}]*background:\s*var\(--background-modifier-hover\);/);


### PR DESCRIPTION
## Why

Long linked note names beneath the welcome greeting could be clipped at both ends, hiding the beginning users need to identify the note. No issue is needed because this focused visual defect was reported directly.

## What Changed

Made the welcome linked-content selector a left-aligned, shrinkable block so overflow preserves the start and adds an ellipsis only on the right, with regression coverage for the CSS contract.

## Why This Approach

The selector itself owns overflow, so overriding Obsidian's centered flex-button presentation fixes the clipping at the correct boundary without changing linked-content data or other context chips.

## Validation

- `npm run typecheck && npm run lint && npm run test && npm run build`
- 8,259 tests passed across 555 suites
- Reviewed the reported screenshot to confirm the affected welcome-linked-content surface

## Impact and Follow-ups

None.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
