### PR TITLE
fix: accept a quoted CLI path in provider settings and resolution

### DIFF
--- a/src/providers/claude/runtime/ClaudeCliResolver.ts
+++ b/src/providers/claude/runtime/ClaudeCliResolver.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import { getRuntimeEnvironmentText } from '../../../core/providers/providerEnvironment';
 import type { HostnameCliPaths } from '../../../core/types/settings';
 import { getHostnameKey, parseEnvironmentVariables } from '../../../utils/env';
-import { expandHomePath } from '../../../utils/path';
+import { normalizeConfiguredCliPath } from '../../../utils/path';
 import { findClaudeCLIPath } from '../cli/findClaudeCLIPath';
 import { getClaudeProviderSettings } from '../settings';
 
@@ -68,10 +68,9 @@ export class ClaudeCliResolver {
 }
 
 function resolveConfiguredPath(rawPath: string | undefined): string | null {
-  const trimmed = (rawPath ?? '').trim();
-  if (!trimmed) return null;
   try {
-    const expanded = expandHomePath(trimmed);
+    const expanded = normalizeConfiguredCliPath(rawPath);
+    if (!expanded) return null;
     if (fs.existsSync(expanded) && fs.statSync(expanded).isFile()) {
       return expanded;
     }

--- a/src/providers/claude/ui/ClaudeSettingsTab.ts
+++ b/src/providers/claude/ui/ClaudeSettingsTab.ts
@@ -10,7 +10,7 @@ import { renderNativeMcpSettingsSection } from '../../../shared/settings/NativeM
 import { renderProviderEnablementSetting } from '../../../shared/settings/ProviderEnablementSetting';
 import { renderLastEnabledProviderWarning } from '../../../shared/settings/ProviderModelEnablementWarning';
 import { getHostnameKey } from '../../../utils/env';
-import { expandHomePath } from '../../../utils/path';
+import { normalizeConfiguredCliPath } from '../../../utils/path';
 import { getClaudeWorkspaceServices } from '../app/ClaudeWorkspaceServices';
 import {
   getClaudeModelOptions,
@@ -100,7 +100,7 @@ export const claudeSettingsTabRenderer: ProviderSettingsTabRenderer = {
       const trimmed = value.trim();
       if (!trimmed) return null;
 
-      const expandedPath = expandHomePath(trimmed);
+      const expandedPath = normalizeConfiguredCliPath(trimmed);
 
       if (!fs.existsSync(expandedPath)) {
         return t('settings.cliPath.validation.notExist');

--- a/src/providers/codex/runtime/CodexBinaryLocator.ts
+++ b/src/providers/codex/runtime/CodexBinaryLocator.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 
 import { findCliBinaryPath, resolveConfiguredCliPath } from '../../../utils/cliBinaryLocator';
 import { parseEnvironmentVariables } from '../../../utils/env';
-import { expandHomePath } from '../../../utils/path';
+import { expandHomePath, stripSurroundingQuotes } from '../../../utils/path';
 import type { CodexInstallationMethod } from '../settings';
 import type { CodexExecutionTarget } from './codexLaunchTypes';
 
@@ -116,16 +116,6 @@ function parsePathEntriesForPlatform(pathValue: string | undefined, platform: No
     .map(segment => expandHomePath(segment));
 }
 
-function stripSurroundingQuotes(value: string): string {
-  if (
-    (value.startsWith('"') && value.endsWith('"')) ||
-    (value.startsWith("'") && value.endsWith("'"))
-  ) {
-    return value.slice(1, -1);
-  }
-  return value;
-}
-
 export function resolveCodexCliPath(
   hostnamePath: string | undefined,
   legacyPath: string | undefined,
@@ -143,7 +133,7 @@ export function resolveCodexCliPath(
 
   if (isWslTarget) {
     const configuredCommand = [hostnamePath, legacyPath]
-      .map(value => (value ?? '').trim())
+      .map(value => stripSurroundingQuotes((value ?? '').trim()))
       .find(value => value.length > 0 && !isWindowsStyleCliReference(value));
     return configuredCommand || 'codex';
   }

--- a/src/providers/codex/ui/CodexSettingsTab.ts
+++ b/src/providers/codex/ui/CodexSettingsTab.ts
@@ -13,7 +13,7 @@ import {
   renderProviderModelEnablementWarning,
 } from '../../../shared/settings/ProviderModelEnablementWarning';
 import { getHostnameKey } from '../../../utils/env';
-import { normalizeConfiguredCliPath } from '../../../utils/path';
+import { normalizeConfiguredCliPath, stripSurroundingQuotes } from '../../../utils/path';
 import { getCodexWorkspaceServices } from '../app/CodexWorkspaceServices';
 import { getCodexModelOptions } from '../modelOptions';
 import { getDefaultCodexModel } from '../models';
@@ -139,7 +139,7 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
       if (!trimmed) return null;
 
       if (!shouldValidateCliPathAsFile()) {
-        if (isWindowsStyleCliReference(trimmed)) {
+        if (isWindowsStyleCliReference(stripSurroundingQuotes(trimmed))) {
           return t('settings.codex.cliPath.validation.wslWindowsPath');
         }
         return null;

--- a/src/providers/codex/ui/CodexSettingsTab.ts
+++ b/src/providers/codex/ui/CodexSettingsTab.ts
@@ -13,7 +13,7 @@ import {
   renderProviderModelEnablementWarning,
 } from '../../../shared/settings/ProviderModelEnablementWarning';
 import { getHostnameKey } from '../../../utils/env';
-import { expandHomePath } from '../../../utils/path';
+import { normalizeConfiguredCliPath } from '../../../utils/path';
 import { getCodexWorkspaceServices } from '../app/CodexWorkspaceServices';
 import { getCodexModelOptions } from '../modelOptions';
 import { getDefaultCodexModel } from '../models';
@@ -145,7 +145,7 @@ export const codexSettingsTabRenderer: ProviderSettingsTabRenderer = {
         return null;
       }
 
-      const expandedPath = expandHomePath(trimmed);
+      const expandedPath = normalizeConfiguredCliPath(trimmed);
 
       if (!fs.existsSync(expandedPath)) {
         return t('settings.cliPath.validation.notExist');

--- a/src/providers/grok/ui/GrokSettingsTab.ts
+++ b/src/providers/grok/ui/GrokSettingsTab.ts
@@ -25,7 +25,7 @@ import {
   renderProviderModelPicker,
 } from '../../../shared/settings/ProviderModelPicker';
 import { getHostnameKey } from '../../../utils/env';
-import { expandHomePath } from '../../../utils/path';
+import { normalizeConfiguredCliPath } from '../../../utils/path';
 import type { GrokWorkspaceServices } from '../app/GrokWorkspaceServices';
 import type { GrokDiscoveredModel } from '../models';
 import {
@@ -269,7 +269,7 @@ function validateCliPath(value: string): string | null {
   if (!trimmed) {
     return null;
   }
-  const expandedPath = expandHomePath(trimmed);
+  const expandedPath = normalizeConfiguredCliPath(trimmed);
   if (!path.posix.isAbsolute(expandedPath) && !path.win32.isAbsolute(expandedPath)) {
     return 'Path must be absolute';
   }

--- a/src/providers/opencode/ui/OpencodeSettingsTab.ts
+++ b/src/providers/opencode/ui/OpencodeSettingsTab.ts
@@ -21,7 +21,7 @@ import {
   renderProviderModelPicker,
 } from '../../../shared/settings/ProviderModelPicker';
 import { getHostnameKey } from '../../../utils/env';
-import { expandHomePath } from '../../../utils/path';
+import { normalizeConfiguredCliPath } from '../../../utils/path';
 import { maybeGetOpencodeWorkspaceServices } from '../app/OpencodeWorkspaceServices';
 import { clearOpencodeDiscoveryState } from '../discoveryState';
 import { sameStringList } from '../internal/compareCollections';
@@ -268,7 +268,7 @@ function validateCliPath(value: string): string | null {
     return null;
   }
 
-  const expandedPath = expandHomePath(trimmed);
+  const expandedPath = normalizeConfiguredCliPath(trimmed);
   if (!fs.existsSync(expandedPath)) {
     return 'Path does not exist';
   }

--- a/src/providers/pi/ui/PiSettingsTab.ts
+++ b/src/providers/pi/ui/PiSettingsTab.ts
@@ -21,7 +21,7 @@ import {
   renderProviderModelPicker,
 } from '../../../shared/settings/ProviderModelPicker';
 import { getHostnameKey } from '../../../utils/env';
-import { expandHomePath } from '../../../utils/path';
+import { normalizeConfiguredCliPath } from '../../../utils/path';
 import { maybeGetPiWorkspaceServices } from '../app/PiWorkspaceServices';
 import { sameDiscoveredModels, sameStringList } from '../internal/compareCollections';
 import { decodePiModelId, type PiDiscoveredModel } from '../models';
@@ -216,7 +216,7 @@ function validateCliPath(value: string): string | null {
     return null;
   }
 
-  const expandedPath = expandHomePath(trimmed);
+  const expandedPath = normalizeConfiguredCliPath(trimmed);
   if (!fs.existsSync(expandedPath)) {
     return 'Path does not exist';
   }

--- a/src/utils/cliBinaryLocator.ts
+++ b/src/utils/cliBinaryLocator.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { getEnhancedPath } from './env';
-import { expandHomePath, parsePathEntries } from './path';
+import { expandHomePath, normalizeConfiguredCliPath, parsePathEntries, stripSurroundingQuotes } from './path';
 
 export function isExistingFile(filePath: string): boolean {
   try {
@@ -13,13 +13,11 @@ export function isExistingFile(filePath: string): boolean {
 }
 
 export function resolveConfiguredCliPath(configuredPath: string | undefined): string | null {
-  const trimmed = (configuredPath ?? '').trim();
-  if (!trimmed) {
-    return null;
-  }
-
   try {
-    const expandedPath = expandHomePath(trimmed);
+    const expandedPath = normalizeConfiguredCliPath(configuredPath);
+    if (!expandedPath) {
+      return null;
+    }
     return isExistingFile(expandedPath) ? expandedPath : null;
   } catch {
     return null;
@@ -67,16 +65,6 @@ function parsePathEntriesForPlatform(pathValue: string | undefined, platform: No
       return upper !== '$PATH' && upper !== '${PATH}' && upper !== '%PATH%';
     })
     .map(segment => translateMsysPathForPlatform(expandHomePath(segment), platform));
-}
-
-function stripSurroundingQuotes(value: string): string {
-  if (
-    (value.startsWith('"') && value.endsWith('"')) ||
-    (value.startsWith("'") && value.endsWith("'"))
-  ) {
-    return value.slice(1, -1);
-  }
-  return value;
 }
 
 function translateMsysPathForPlatform(value: string, platform: NodeJS.Platform): string {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -83,7 +83,7 @@ export function expandHomePath(p: string): string {
   return expanded;
 }
 
-function stripSurroundingQuotes(value: string): string {
+export function stripSurroundingQuotes(value: string): string {
   if (
     (value.startsWith('"') && value.endsWith('"')) ||
     (value.startsWith("'") && value.endsWith("'"))
@@ -91,6 +91,20 @@ function stripSurroundingQuotes(value: string): string {
     return value.slice(1, -1);
   }
   return value;
+}
+
+/**
+ * Normalizes a user-configured CLI path. Windows Explorer's "Copy as path" wraps the
+ * path in double quotes exactly when it contains a space, so a configured path field
+ * receives a quoted value far more often than a PATH segment does. Unquoting before
+ * expansion mirrors `parsePathEntries`, so `"%APPDATA%\..."` still expands.
+ *
+ * Returns an empty string when nothing is configured; callers treat that as "unset".
+ */
+export function normalizeConfiguredCliPath(rawPath: string | undefined): string {
+  const trimmed = (rawPath ?? '').trim();
+  if (!trimmed) return '';
+  return expandHomePath(stripSurroundingQuotes(trimmed));
 }
 
 export function parsePathEntries(pathValue?: string): string[] {

--- a/tests/unit/providers/claude/runtime/ClaudeCliResolver.test.ts
+++ b/tests/unit/providers/claude/runtime/ClaudeCliResolver.test.ts
@@ -1,0 +1,50 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { resolveClaudeCliPath } from '@/providers/claude/runtime/ClaudeCliResolver';
+
+describe('resolveClaudeCliPath', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-cli-resolver-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const createExecutable = (...segments: string[]): string => {
+    const filePath = path.join(tempDir, ...segments);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, '');
+    return filePath;
+  };
+
+  it('resolves a configured CLI path that was pasted with surrounding quotes', () => {
+    const cliPath = createExecutable('my tools', 'claude');
+
+    expect(resolveClaudeCliPath(`"${cliPath}"`, '', '')).toBe(cliPath);
+  });
+
+  it('does not fall back to PATH discovery when the configured path is quoted', () => {
+    const configured = createExecutable('configured dir', 'claude');
+    const discoverable = createExecutable('path dir', 'claude');
+    const envText = `PATH=${path.dirname(discoverable)}`;
+
+    expect(resolveClaudeCliPath(`"${configured}"`, '', envText)).toBe(configured);
+  });
+
+  it('resolves a quoted legacy CLI path when no host-scoped path is set', () => {
+    const cliPath = createExecutable('legacy dir', 'claude');
+
+    expect(resolveClaudeCliPath('', `"${cliPath}"`, '')).toBe(cliPath);
+  });
+
+  it('still resolves an unquoted configured path', () => {
+    const cliPath = createExecutable('plain', 'claude');
+
+    expect(resolveClaudeCliPath(cliPath, '', '')).toBe(cliPath);
+  });
+});

--- a/tests/unit/providers/claude/ui/ClaudeSettingsTab.test.ts
+++ b/tests/unit/providers/claude/ui/ClaudeSettingsTab.test.ts
@@ -549,6 +549,33 @@ describe('ClaudeSettingsTab', () => {
     expect(mockCliResolverReset).toHaveBeenCalledTimes(1);
   });
 
+  it('persists a CLI path pasted with surrounding quotes', async () => {
+    mockedExistsSync.mockImplementation((filePath: fs.PathLike) => (
+      String(filePath) === '/custom dir/claude'
+    ));
+    const plugin = createPlugin();
+    plugin.mutateSettings.mockImplementation(async (
+      mutation: (settings: any) => void | Promise<void>,
+    ) => {
+      await mutation(plugin.settings);
+      await plugin.saveSettings();
+    });
+    plugin.runProviderExecutionTransition.mockImplementation(async (
+      _providerIds: string[],
+      mutation: () => Promise<unknown>,
+    ) => mutation());
+    mockCliResolverReset.mockImplementation(() => undefined);
+
+    claudeSettingsTabRenderer.render(createContainer(), createContext(plugin));
+    await findSetting('settings.cliPath.name')
+      .textComponents[0]
+      .onChangeCallback?.('"/custom dir/claude"');
+
+    expect(plugin.settings.providerConfigs.claude.cliPathsByHost).toEqual({
+      'host-a': '"/custom dir/claude"',
+    });
+  });
+
   it('directs MCP setup to the native Claude CLI', () => {
     const plugin = createPlugin();
 

--- a/tests/unit/providers/codex/runtime/CodexBinaryLocator.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexBinaryLocator.test.ts
@@ -110,6 +110,46 @@ describe('CodexBinaryLocator', () => {
     )).toBe('codex');
   });
 
+  it('strips matching surrounding quotes from configured Linux commands in WSL mode', () => {
+    expect(resolveCodexCliPath(
+      '"/home/user/my tools/codex"',
+      '',
+      '',
+      { installationMethod: 'wsl', hostPlatform: 'win32' },
+    )).toBe('/home/user/my tools/codex');
+    expect(resolveCodexCliPath(
+      "'/home/user/codex'",
+      '',
+      '',
+      { installationMethod: 'wsl', hostPlatform: 'win32' },
+    )).toBe('/home/user/codex');
+  });
+
+  it('keeps Linux-side home and environment references literal in WSL mode', () => {
+    const originalRoot = process.env.TEST_WSL_CODEX_ROOT;
+    process.env.TEST_WSL_CODEX_ROOT = 'C:\\host-tools';
+    try {
+      expect(resolveCodexCliPath(
+        '"~/tools/codex"',
+        '',
+        '',
+        { installationMethod: 'wsl', hostPlatform: 'win32' },
+      )).toBe('~/tools/codex');
+      expect(resolveCodexCliPath(
+        '"$TEST_WSL_CODEX_ROOT/bin/codex"',
+        '',
+        '',
+        { installationMethod: 'wsl', hostPlatform: 'win32' },
+      )).toBe('$TEST_WSL_CODEX_ROOT/bin/codex');
+    } finally {
+      if (originalRoot === undefined) {
+        delete process.env.TEST_WSL_CODEX_ROOT;
+      } else {
+        process.env.TEST_WSL_CODEX_ROOT = originalRoot;
+      }
+    }
+  });
+
   it('falls back to the default Linux command in WSL mode', () => {
     expect(resolveCodexCliPath(
       '',
@@ -122,6 +162,24 @@ describe('CodexBinaryLocator', () => {
   it('ignores a Windows-native CLI path in WSL mode and falls back to the Linux command', () => {
     expect(resolveCodexCliPath(
       'C:\\Users\\user\\AppData\\Roaming\\npm\\codex.exe',
+      '',
+      '',
+      { installationMethod: 'wsl', hostPlatform: 'win32' },
+    )).toBe('codex');
+  });
+
+  it('ignores a quoted Windows path and selects a quoted legacy Linux command in WSL mode', () => {
+    expect(resolveCodexCliPath(
+      '"C:\\Users\\user\\AppData\\Roaming\\npm\\codex.exe"',
+      '"/home/user/legacy tools/codex"',
+      '',
+      { installationMethod: 'wsl', hostPlatform: 'win32' },
+    )).toBe('/home/user/legacy tools/codex');
+  });
+
+  it('ignores a quoted Windows-native CLI path in WSL mode and uses the default command', () => {
+    expect(resolveCodexCliPath(
+      '"C:\\Users\\user\\AppData\\Roaming\\npm\\codex.exe"',
       '',
       '',
       { installationMethod: 'wsl', hostPlatform: 'win32' },

--- a/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
+++ b/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
@@ -762,6 +762,25 @@ describe('CodexSettingsTab', () => {
     expect(mockRefreshModelCatalog).toHaveBeenCalledTimes(1);
   });
 
+  it('accepts a quoted Linux-side CLI path when installation method is WSL', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const plugin = createPlugin();
+
+    codexSettingsTabRenderer.render(createContainer(), createContext(plugin));
+
+    const installationMethodSetting = findSetting('Installation method');
+    await installationMethodSetting.dropdownComponents[0].onChangeCallback?.('wsl');
+    mockSaveSettings.mockClear();
+
+    const cliPathSetting = findSetting('Codex CLI path');
+    await cliPathSetting.textComponents[0].onChangeCallback?.('"/home/user/my tools/codex"');
+
+    expect(plugin.settings.providerConfigs.codex.cliPathsByHost['host-a']).toBe(
+      '"/home/user/my tools/codex"',
+    );
+    expect(mockSaveSettings).toHaveBeenCalledTimes(1);
+  });
+
   it('rejects a Windows-native CLI path when installation method is WSL', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
     const plugin = createPlugin({
@@ -789,6 +808,40 @@ describe('CodexSettingsTab', () => {
     });
     expect(plugin.settings.providerConfigs.codex.cliPathsByHost['host-a']).toBe(
       'C:\\Users\\me\\AppData\\Roaming\\npm\\codex.exe',
+    );
+  });
+
+  it('rejects a quoted Windows-native CLI path when installation method is WSL', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const plugin = createPlugin();
+    const container = createContainer();
+
+    codexSettingsTabRenderer.render(container, createContext(plugin));
+
+    const installationMethodSetting = findSetting('Installation method');
+    await installationMethodSetting.dropdownComponents[0].onChangeCallback?.('wsl');
+    mockSaveSettings.mockClear();
+
+    const cliPathSetting = findSetting('Codex CLI path');
+    await cliPathSetting.textComponents[0].onChangeCallback?.(
+      '"C:\\Users\\me\\AppData\\Roaming\\npm\\codex.exe"',
+    );
+
+    expect(plugin.settings.providerConfigs.codex.cliPathsByHost['host-a']).toBeUndefined();
+    expect(mockSaveSettings).not.toHaveBeenCalled();
+
+    const validationCallIndex = container.createDiv.mock.calls.findIndex(
+      ([options]: [{ cls?: string }?]) => options?.cls?.includes('claudian-cli-path-validation'),
+    );
+    const validationEl = container.createDiv.mock.results[validationCallIndex]?.value;
+    expect(validationCallIndex).toBeGreaterThanOrEqual(0);
+    expect(validationEl.setText).toHaveBeenLastCalledWith(
+      'WSL mode expects a Linux command or Linux absolute path, not a Windows executable path.',
+    );
+    expect(validationEl.hasClass('claudian-hidden')).toBe(false);
+    expect(cliPathSetting.textComponents[0].inputEl.toggleClass).toHaveBeenLastCalledWith(
+      'claudian-input-error',
+      true,
     );
   });
 

--- a/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
+++ b/tests/unit/providers/codex/ui/CodexSettingsTab.test.ts
@@ -696,6 +696,27 @@ describe('CodexSettingsTab', () => {
     expect(mockSaveSettings).toHaveBeenCalledTimes(0);
   });
 
+  it('accepts a CLI path pasted with surrounding quotes', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    mockedExistsSync.mockImplementation((filePath: fs.PathLike) => String(filePath) === '/my tools/codex');
+    const plugin = createPlugin();
+    plugin.runProviderExecutionTransition.mockImplementation(async (
+      _providerIds: string[],
+      mutation: () => Promise<unknown>,
+    ) => mutation());
+    plugin.mutateSettings.mockImplementation(async (
+      mutation: (settings: any) => void | Promise<void>,
+    ) => {
+      await mutation(plugin.settings);
+      await plugin.saveSettings();
+    });
+
+    codexSettingsTabRenderer.render(createContainer(), createContext(plugin));
+    await findSetting('Codex CLI path').textComponents[0].onChangeCallback?.('"/my tools/codex"');
+
+    expect(plugin.settings.providerConfigs.codex.cliPathsByHost['host-a']).toBe('"/my tools/codex"');
+  });
+
   it('accepts a Linux-side CLI command when installation method is WSL', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
     const plugin = createPlugin();

--- a/tests/unit/providers/grok/ui/GrokSettingsTab.test.ts
+++ b/tests/unit/providers/grok/ui/GrokSettingsTab.test.ts
@@ -418,6 +418,18 @@ describe('GrokSettingsTab', () => {
     });
   });
 
+  it('accepts a CLI path pasted with surrounding quotes', async () => {
+    const plugin = createPlugin();
+    grokSettingsTabRenderer.render(createContainer(), createContext(plugin));
+
+    mockedExistsSync.mockImplementation((filePath: fs.PathLike) => String(filePath) === '/my tools/grok');
+    await findSetting('CLI path').textComponents[0].onChangeCallback?.('"/my tools/grok"');
+
+    expect(getGrokProviderSettings(plugin.settings).cliPathsByHost).toEqual({
+      'device:current': '"/my tools/grok"',
+    });
+  });
+
   it('restores CLI path closure and input state after a pre-commit write failure', async () => {
     const plugin = createPlugin();
     const writeError = new Error('write failed');

--- a/tests/unit/providers/opencode/OpencodeSettingsTab.test.ts
+++ b/tests/unit/providers/opencode/OpencodeSettingsTab.test.ts
@@ -547,6 +547,28 @@ describe('OpencodeSettingsTab', () => {
     },
   );
 
+  it('accepts a CLI path pasted with surrounding quotes', async () => {
+    mockedExistsSync.mockImplementation((filePath: fs.PathLike) => String(filePath) === '/my tools/opencode');
+    const plugin = createPlugin();
+    plugin.runProviderExecutionTransition.mockImplementation(async (
+      _providerIds: string[],
+      mutation: () => Promise<unknown>,
+    ) => mutation());
+    plugin.mutateSettings.mockImplementation(async (
+      mutation: (settings: any) => void | Promise<void>,
+    ) => {
+      await mutation(plugin.settings);
+      await plugin.saveSettings();
+    });
+
+    opencodeSettingsTabRenderer.render(createContainer(), createContext(plugin));
+    await findSetting('CLI path').textComponents[0].onChangeCallback?.('"/my tools/opencode"');
+
+    expect(plugin.settings.providerConfigs.opencode.cliPathsByHost).toEqual({
+      'host-a': '"/my tools/opencode"',
+    });
+  });
+
   it('stores the CLI path and resets provider state inside an execution transition', async () => {
     mockedExistsSync.mockImplementation((filePath: fs.PathLike) => String(filePath) === '/custom/opencode');
     let transitionActive = false;

--- a/tests/unit/providers/pi/ui/PiSettingsTab.test.ts
+++ b/tests/unit/providers/pi/ui/PiSettingsTab.test.ts
@@ -563,6 +563,20 @@ describe('PiSettingsTab', () => {
     expect(context.plugin.saveSettings).toHaveBeenCalled();
   });
 
+  it('accepts a CLI path pasted with surrounding quotes', async () => {
+    const settings: Record<string, unknown> = { providerConfigs: { pi: {} } };
+    render(settings);
+    const cliInput = findSetting('CLI path').textComponents[0];
+
+    mockedExists.mockImplementation((filePath: unknown) => String(filePath) === '/my tools/pi');
+    mockedStat.mockReturnValue({ isFile: () => true });
+    await cliInput.onChangeCallback?.('"/my tools/pi"');
+
+    expect(getPiProviderSettings(settings).cliPathsByHost).toEqual({
+      'current-host': '"/my tools/pi"',
+    });
+  });
+
   it('commits the Pi CLI path and clears discovery inside the execution transition', async () => {
     const settings: Record<string, unknown> = {
       providerConfigs: {

--- a/tests/unit/utils/cliBinaryLocator.test.ts
+++ b/tests/unit/utils/cliBinaryLocator.test.ts
@@ -22,6 +22,15 @@ describe('cliBinaryLocator', () => {
     expect(resolveConfiguredCliPath(cliPath)).toBe(cliPath);
   });
 
+  it('resolves a configured CLI path that was pasted with surrounding quotes', () => {
+    const binDir = path.join(tempDir, 'my tools');
+    const cliPath = path.join(binDir, 'pi');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(cliPath, '');
+
+    expect(resolveConfiguredCliPath(`"${cliPath}"`)).toBe(cliPath);
+  });
+
   it('finds Windows npm .cmd shims on a PATH entry', () => {
     const binDir = path.join(tempDir, 'bin');
     const shimPath = path.join(binDir, 'pi.cmd');

--- a/tests/unit/utils/path.test.ts
+++ b/tests/unit/utils/path.test.ts
@@ -12,6 +12,7 @@ import {
   getVaultPath,
   isPathWithinDirectory,
   isPathWithinVault,
+  normalizeConfiguredCliPath,
   normalizePathForComparison,
   normalizePathForFilesystem,
   normalizePathForVault,
@@ -673,5 +674,47 @@ describe('expandHomePath - Windows environment variable formats', () => {
       if (original === undefined) delete process.env.MY_CI_VAR;
       else process.env.MY_CI_VAR = original;
     }
+  });
+});
+
+describe('normalizeConfiguredCliPath', () => {
+  it('strips surrounding double quotes from a path containing a space', () => {
+    expect(normalizeConfiguredCliPath('"/opt/my cli/claude"')).toBe('/opt/my cli/claude');
+  });
+
+  it('strips surrounding single quotes', () => {
+    expect(normalizeConfiguredCliPath("'/opt/claude'")).toBe('/opt/claude');
+  });
+
+  it('leaves an unquoted path unchanged', () => {
+    expect(normalizeConfiguredCliPath('/opt/my cli/claude')).toBe('/opt/my cli/claude');
+  });
+
+  it('leaves a path with only a leading quote unchanged', () => {
+    expect(normalizeConfiguredCliPath('"/opt/claude')).toBe('"/opt/claude');
+  });
+
+  it('trims surrounding whitespace before unquoting', () => {
+    expect(normalizeConfiguredCliPath('  "/opt/claude"  ')).toBe('/opt/claude');
+  });
+
+  it('expands environment variables after unquoting', () => {
+    const original = process.env.TEST_QUOTED_CLI_DIR;
+    process.env.TEST_QUOTED_CLI_DIR = '/opt/tools';
+    try {
+      expect(normalizeConfiguredCliPath('"$TEST_QUOTED_CLI_DIR/my cli"')).toBe('/opt/tools/my cli');
+    } finally {
+      if (original === undefined) delete process.env.TEST_QUOTED_CLI_DIR;
+      else process.env.TEST_QUOTED_CLI_DIR = original;
+    }
+  });
+
+  it('expands a home-relative path after unquoting', () => {
+    expect(normalizeConfiguredCliPath('"~/bin/my cli"')).toBe(path.join(os.homedir(), 'bin/my cli'));
+  });
+
+  it('returns an empty string for blank or missing input', () => {
+    expect(normalizeConfiguredCliPath('   ')).toBe('');
+    expect(normalizeConfiguredCliPath(undefined)).toBe('');
   });
 });


### PR DESCRIPTION
## Why

Related to #1064.

A CLI path pasted with surrounding quotes is rejected by every provider's "CLI path" setting, and the value is then silently discarded. Windows Explorer's **Copy as path** wraps the path in double quotes *exactly when it contains a space*, so this is the normal way a Windows user copies the path they are being asked to paste:

```
"C:\Users\mack mane\AppData\Roaming\Claude\claude-code\2.1.221\claude.exe"
```

What happens today:

1. The validator expands the raw string, so `fs.existsSync('"C:\...exe"')` is `false` → **Path does not exist**.
2. `renderHostnameCliPathSetting` gates persistence on validation (`if (!updateValidation(value)) return;`), so the value is **never saved** — the error is sticky rather than advisory.
3. The resolver has the same gap, so even a saved quoted path would return `null` and fall through to PATH auto-detection.

That produces the confusing combination reported in #1064: the settings field insists the path does not exist, while leaving the field empty and relying on auto-detection works fine.

`stripSurroundingQuotes` already exists in this repo and is already applied to PATH segments (`parsePathEntries`, `parsePathEntriesForPlatform`). The configured-path entry point is the only place it was never applied. This is not a new policy — it closes the one gap in an existing convention.

## What Changed

- `src/utils/path.ts`: exported the existing `stripSurroundingQuotes` and added `normalizeConfiguredCliPath()` = `trim → unquote → expandHomePath`, matching the ordering already used by `parsePathEntries` so `"%APPDATA%\..."` still expands.
- `src/utils/cliBinaryLocator.ts`: dropped the verbatim duplicate of `stripSurroundingQuotes` and imported the shared one; `resolveConfiguredCliPath` now normalizes.
- `src/providers/claude/runtime/ClaudeCliResolver.ts`: `resolveConfiguredPath` now normalizes.
- The five settings validators (claude, codex, grok, opencode, pi) now normalize.

No new types, no change to what is persisted, no change to how the CLI is spawned.

## Why This Approach

**Both ends had to change, not just the validator.** `HostnameCliPathSetting` persists `value.trim()` — the raw string, not a normalized one. Fixing only the validator would let the quoted string through the gate and into settings, where the resolver would still reject it and fall back to PATH. That is strictly worse than today's behavior: the field would look accepted while the configured CLI was quietly ignored. The invariant this PR restores is that **the settings validator and the runtime resolver accept the same set of strings**, and `tests/unit/providers/claude/runtime/ClaudeCliResolver.test.ts` pins it directly.

**Not `expandHomePath` itself.** It also serves PATH segments (`parsePathEntries`) and `normalizePathForFilesystem`; unquoting there would change PATH semantics for unrelated callers.

**Placement inside Grok's validator** is before the `path.posix/win32.isAbsolute` check — otherwise a quoted absolute path fails with "Path must be absolute" instead. Placement inside Codex's validator is after the win32+WSL bypass, leaving that bypass untouched.

Alternative considered and rejected: normalizing inside `HostnameCliPathSetting` so the *stored* value is unquoted. That component is shared and runs `onChange` per keystroke; rewriting the user's text mid-typing is a larger and riskier behavior change than accepting the quoted form at both read points.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run test` — 556 suites / 8276 tests
- `npm run build`
- `git diff --check`, clean `git status`

New coverage (no test anywhere previously exercised a quoted or space-containing configured CLI path):

- `tests/unit/utils/path.test.ts` — 8 cases for `normalizeConfiguredCliPath`: double/single quotes, unquoted passthrough, mismatched leading quote left alone, whitespace trimmed before unquoting, env-var and `~` expansion *after* unquoting, blank/undefined input.
- `tests/unit/utils/cliBinaryLocator.test.ts` — resolves a quoted path under a directory containing a space (real temp dir, no fs mock).
- `tests/unit/providers/claude/runtime/ClaudeCliResolver.test.ts` (new) — quoted host-scoped path, quoted legacy path, unquoted path still works, and **`does not fall back to PATH discovery when the configured path is quoted`**, which is the assertion a validator-only fix would fail.
- The five `*SettingsTab` tests — one case each asserting the quoted value is **persisted**, not merely that no error string is rendered; persistence is the actual gate.

## Impact and Follow-ups

- **Tradeoff:** a POSIX filename may legally contain `'` or `"`, so a path that both starts and ends with the same quote character is now unquoted. That is vanishingly rare, and `parsePathEntries` has already made exactly this tradeoff for PATH segments since it was written; this change keeps the two consistent rather than introducing a new rule.
- The stored settings value keeps whatever the user typed, including quotes. Round-tripping is correct because both readers normalize, but the field will display the quoted form. Normalizing at write time is possible as a follow-up if you'd prefer that.
- Nothing changes for unquoted paths — every existing CLI-path test passes unmodified.

Follow-ups I noticed while tracing this and am happy to open separately, deliberately kept out of this PR:

1. Only Grok's validator wraps its `fs` calls in `try/catch`; the other four let a throwing `fs.statSync` (EPERM, ELOOP) escape the Obsidian `onChange` handler.
2. grok/opencode/pi hardcode English `'Path does not exist'` while claude/codex use `settings.cliPath.validation.notExist`.
3. The five validators are near-duplicates with three genuine rule differences (Grok's absolute + `X_OK` checks, Codex's WSL bypass); they could share a base.

Finally, on #1064: the reporter states their pasted string had no quotes, so I am not claiming this fixes their exact input — hence `Related to`, not `Fixes`. It is a reproducible defect in the same code path with the same symptom, and it would be worth having them retest with this change before that issue is closed.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
