### PR TITLE
fix: emit Codex Responses final answer once

### DIFF
--- a/src/providers/codex/runtime/CodexNotificationRouter.ts
+++ b/src/providers/codex/runtime/CodexNotificationRouter.ts
@@ -189,6 +189,15 @@ export class CodexNotificationRouter {
 
     if (!this.currentAssistantSegmentId) {
       this.currentAssistantSegmentId = itemId;
+      if (
+        this.currentAssistantSegmentText
+        && !this.streamedAgentMessageTextById.has(itemId)
+      ) {
+        this.streamedAgentMessageTextById.set(
+          itemId,
+          this.currentAssistantSegmentText,
+        );
+      }
     }
   }
 

--- a/tests/unit/providers/codex/runtime/CodexNotificationRouter.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexNotificationRouter.test.ts
@@ -17,6 +17,53 @@ describe('CodexNotificationRouter', () => {
   });
 
   describe('text streaming', () => {
+    const emitEventMessage = (text: string) => {
+      router.handleNotification('event_msg', {
+        type: 'agent_message',
+        message: text,
+      });
+    };
+
+    const emitRawAssistantMessage = (text: string) => {
+      router.handleNotification('rawResponseItem/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text }],
+        },
+      });
+    };
+
+    const startAgentMessage = (itemId: string) => {
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'agentMessage',
+          id: itemId,
+          text: '',
+          phase: 'streaming',
+          memoryCitation: null,
+        },
+      });
+    };
+
+    const completeAgentMessage = (itemId: string, text: string) => {
+      router.handleNotification('item/completed', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'agentMessage',
+          id: itemId,
+          text,
+          phase: 'final',
+          memoryCitation: null,
+        },
+      });
+    };
+
     it('maps item/agentMessage/delta to a text chunk', () => {
       router.handleNotification('item/agentMessage/delta', {
         threadId: 't1',
@@ -141,6 +188,82 @@ describe('CodexNotificationRouter', () => {
           memoryCitation: null,
         },
       });
+
+      expect(chunks.filter(chunk => chunk.type === 'text')).toEqual([
+        { type: 'text', content: 'First' },
+        { type: 'text', content: 'Second' },
+      ]);
+    });
+
+    it('emits a Responses final answer once when its item ID arrives after fallback text', () => {
+      emitEventMessage('Answer');
+      emitRawAssistantMessage('Answer');
+      startAgentMessage('msg1');
+      completeAgentMessage('msg1', 'Answer');
+
+      expect(chunks.filter(chunk => chunk.type === 'text')).toEqual([
+        { type: 'text', content: 'Answer' },
+      ]);
+    });
+
+    it('emits a recovered Responses final answer once without an item start notification', () => {
+      emitRawAssistantMessage('Answer');
+      emitEventMessage('Answer');
+      completeAgentMessage('msg1', 'Answer');
+
+      expect(chunks.filter(chunk => chunk.type === 'text')).toEqual([
+        { type: 'text', content: 'Answer' },
+      ]);
+    });
+
+    it('emits only the missing suffix after fallback text is claimed by a late item ID', () => {
+      emitEventMessage('Ans');
+      startAgentMessage('msg1');
+      completeAgentMessage('msg1', 'Answer');
+
+      expect(chunks.filter(chunk => chunk.type === 'text')).toEqual([
+        { type: 'text', content: 'Ans' },
+        { type: 'text', content: 'wer' },
+      ]);
+    });
+
+    it('preserves a non-prefix completion after fallback text is claimed by a late item ID', () => {
+      emitEventMessage('Draft');
+      startAgentMessage('msg1');
+      completeAgentMessage('msg1', 'Final');
+
+      expect(chunks.filter(chunk => chunk.type === 'text')).toEqual([
+        { type: 'text', content: 'Draft' },
+        { type: 'text', content: 'Final' },
+      ]);
+    });
+
+    it('does not overwrite known item text when claiming a later anonymous segment', () => {
+      router.handleNotification('item/agentMessage/delta', {
+        threadId: 't1',
+        turnId: 'turn1',
+        itemId: 'msg1',
+        delta: 'First',
+      });
+      router.handleNotification('item/started', {
+        threadId: 't1',
+        turnId: 'turn1',
+        item: {
+          type: 'commandExecution',
+          id: 'call_abc',
+          command: 'echo tool',
+          cwd: '/workspace',
+          processId: '123',
+          source: 'unifiedExecStartup',
+          status: 'inProgress',
+          commandActions: [{ type: 'unknown', command: 'echo tool' }],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      });
+      emitEventMessage('Second');
+      completeAgentMessage('msg1', 'First');
 
       expect(chunks.filter(chunk => chunk.type === 'text')).toEqual([
         { type: 'text', content: 'First' },


### PR DESCRIPTION
## Why

Fixes #1143.

Codex Responses-compatible runtimes can expose the same final assistant text through fallback notifications before the canonical `agentMessage` item ID is available. `CodexNotificationRouter` retained that text at the current anonymous-segment level, while canonical completion deduplication consulted the item-scoped accumulator. When the item ID arrived late, the empty item-scoped state caused the full answer to be emitted again in the same bubble.

This affects live rendering only. The persisted JSONL replay path already deduplicates adjacent `event_msg` and `response_item` representations.

## What Changed

- Seed the item-scoped assistant-text accumulator when an existing anonymous segment first claims its canonical item ID.
- Preserve any text already tracked for that item ID instead of overwriting it with anonymous segment state.
- Add regression coverage for reported Responses-style fallback ordering, recovery without `item/started`, prefix completion, non-prefix completion, and late completion of an already tracked item.

## Why This Approach

`CodexNotificationRouter` owns projection of provider-native live notifications into stream chunks, so reconciling its two text accumulators at the point where an anonymous segment gains an ID keeps the behavior provider-local.

The fix does not add text replacement semantics to shared stream chunks, perform chat-layer content deduplication, or assume that raw and canonical item IDs match. Those alternatives would either leak Codex protocol behavior into shared layers or be fragile with older and compatible runtimes. Non-prefix completions are still emitted in full, and the existing per-item state wins when it is already present.

## Validation

- TDD red: the Responses fallback, recovery-without-start, and prefix-completion cases failed before the implementation by emitting duplicate/full text.
- `npm run test:unit -- --runTestsByPath tests/unit/providers/codex/runtime/CodexNotificationRouter.test.ts --runInBand` — 1 suite / 134 tests passed.
- `npm run typecheck`
- `npm run lint`
- `npm run test` — 565 suites / 8,334 tests passed, plus 14 protocol suites / 131 tests and 61 architecture checks.
- `npm run build`
- `git diff --check`

## Impact and Follow-ups

The change is limited to live Codex notification projection. It does not modify transcript history, storage, raw item ID handling, public types, provider interfaces, or shared execution protocols. No user-facing documentation change is needed.

If #1143's reporter confirms that duplication also survives reopening the conversation, the wider sanitized JSONL record window should be investigated separately rather than expanding this live-path fix.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
