### PR TITLE
feat: surface Claude prompt suggestions in chat

### DIFF
--- a/src/core/execution/ProviderExecutionEvent.ts
+++ b/src/core/execution/ProviderExecutionEvent.ts
@@ -305,6 +305,14 @@ export type ProviderSessionErrorEvent = ProviderEventBase<
     readonly recoverable: boolean;
   };
 
+export type ProviderPromptSuggestionEvent = ProviderEventBase<
+  'prompt_suggestion',
+  ProviderSessionEventScope
+> & {
+  readonly originatingTurnId: string;
+  readonly suggestion: string;
+};
+
 export type ProviderBackgroundOutputEvent =
   | (ProviderUserMessageStartedEvent & { readonly scope: ProviderBackgroundEventScope })
   | (ProviderAssistantMessageStartedEvent & { readonly scope: ProviderBackgroundEventScope })
@@ -325,6 +333,7 @@ export type ProviderSessionEvent =
   | ProviderBackgroundOutputEvent
   | ProviderBackgroundTurnCompletedEvent
   | ProviderAsyncSubagentCompletedEvent
+  | ProviderPromptSuggestionEvent
   | (ProviderSessionStateChangedEvent & { readonly scope: ProviderSessionEventScope })
   | (ProviderModeChangedEvent & { readonly scope: ProviderSessionEventScope })
   | ProviderSessionErrorEvent;

--- a/src/core/execution/index.ts
+++ b/src/core/execution/index.ts
@@ -21,6 +21,7 @@ export {
   type ProviderExecutionEventScope,
   type ProviderModeChangedEvent,
   type ProviderNoticeEvent,
+  type ProviderPromptSuggestionEvent,
   type ProviderRequestedEventScope,
   type ProviderRequestedExecutionEvent,
   type ProviderSessionErrorEvent,

--- a/src/features/chat/tabs/TabLifecycle.ts
+++ b/src/features/chat/tabs/TabLifecycle.ts
@@ -50,6 +50,7 @@ export function activateTab(tab: AssembledTabRuntime): void {
 }
 
 export function deactivateTab(tab: AssembledTabRuntime): void {
+  tab.ui.promptSuggestionController.clear();
   tab.controllers.streamController.setTabActive(false);
   tab.dom.contentEl.addClass('claudian-hidden');
   tab.controllers.selectionController.stop();

--- a/src/features/chat/tabs/TabSessionEvents.ts
+++ b/src/features/chat/tabs/TabSessionEvents.ts
@@ -70,6 +70,29 @@ async function handleTabSessionEvent(
     new Notice(event.message);
     return;
   }
+  if (event.type === 'prompt_suggestion') {
+    if (
+      tab.dom.contentEl.hasClass('claudian-hidden')
+      || tab.lifecycleState === 'closing'
+      || tab.ui.instructionModeManager.isActive()
+      || tab.ui.bangBashModeManager?.isActive()
+      || tab.ui.composerDropdown.isVisible()
+    ) {
+      return;
+    }
+    const revision = tab.ui.promptSuggestionController.revision;
+    const activeTurn = tab.session.activeTurn;
+    if (activeTurn) await activeTurn.catch(() => undefined);
+    if (
+      !isCurrent()
+      || tab.ui.promptSuggestionController.revision !== revision
+      || tab.session.activeTurn !== null
+    ) {
+      return;
+    }
+    tab.ui.promptSuggestionController.show(event.suggestion);
+    return;
+  }
   if (event.scope.kind !== 'background') return;
 
   const turns = getBackgroundTurnBuffers(tab, context.bindingId);

--- a/src/features/chat/tabs/runtime/TabRuntimeControllers.ts
+++ b/src/features/chat/tabs/runtime/TabRuntimeControllers.ts
@@ -256,6 +256,7 @@ export function buildTabRuntimeControllers(
       isDisposed: () => shell.lifecycleState === 'closing',
       ensureExecutionForConversation: async (conversation) => {
         const tab = runtimeRef.requirePublished();
+        tab.ui.promptSuggestionController.clear();
         const nextProviderId = getTabProviderId(tab, plugin, conversation);
         const nextConversationId = conversation?.id ?? null;
         const providerChanged = tab.providerId !== nextProviderId;
@@ -291,6 +292,7 @@ export function buildTabRuntimeControllers(
     {
       onNewConversation: () => {
         const tab = runtimeRef.requirePublished();
+        tab.ui.promptSuggestionController.clear();
         const previousProviderId = tab.providerId;
         const nextModel = resolveNewConversationModel(plugin.settings);
         void shell.executionCoordinator.bindConversation(null);
@@ -308,11 +310,13 @@ export function buildTabRuntimeControllers(
       },
       onConversationLoaded: () => {
         const tab = runtimeRef.requirePublished();
+        tab.ui.promptSuggestionController.clear();
         invalidateTabProviderCommands(tab, shell.providerCatalogResolver);
         tab.controllers.inputController.onConversationActivated();
       },
       onConversationSwitched: () => {
         const tab = runtimeRef.requirePublished();
+        tab.ui.promptSuggestionController.clear();
         invalidateTabProviderCommands(tab, shell.providerCatalogResolver);
         tab.controllers.inputController.onConversationActivated();
       },

--- a/src/features/chat/tabs/runtime/TabRuntimeInputBindings.ts
+++ b/src/features/chat/tabs/runtime/TabRuntimeInputBindings.ts
@@ -39,6 +39,7 @@ export function buildTabRuntimeInputBindings(
     }
 
     if (ui.bangBashModeManager?.handleTriggerKey(event)) {
+      ui.promptSuggestionController.clear();
       syncBangBashSuppression();
       return;
     }
@@ -60,6 +61,10 @@ export function buildTabRuntimeInputBindings(
       return;
     }
 
+    if (ui.promptSuggestionController.handleKeydown(event)) {
+      return;
+    }
+
     if (event.key === 'Escape' && !event.isComposing && state.isStreaming) {
       event.preventDefault();
       controllers.inputController.cancelStreaming();
@@ -78,6 +83,7 @@ export function buildTabRuntimeInputBindings(
 
   const inputHandler = () => {
     commitProvisionalTab(runtimeRef.requirePublished());
+    ui.promptSuggestionController.handleInputChange();
     ui.instructionModeManager.handleInputChange();
     if (
       !ui.bangBashModeManager?.isActive()

--- a/src/features/chat/tabs/runtime/TabRuntimeUI.ts
+++ b/src/features/chat/tabs/runtime/TabRuntimeUI.ts
@@ -25,6 +25,7 @@ import { ImageContextManager } from '../../ui/ImageContext';
 import { createInputToolbar } from '../../ui/InputToolbar';
 import { InstructionModeManager as InstructionModeManagerClass } from '../../ui/InstructionModeManager';
 import { NavigationSidebar } from '../../ui/NavigationSidebar';
+import { PromptSuggestionController } from '../../ui/PromptSuggestionController';
 import { StatusPanel } from '../../ui/StatusPanel';
 import { autoResizeTextarea } from '../../ui/textareaResize';
 import { recalculateUsageForModel } from '../../utils/usageInfo';
@@ -141,6 +142,7 @@ function buildInstructionComponents(
   options: TabRuntimeConstructionContext,
   runtimeRef: PublishedTabRuntimeRef,
   composerDropdown: MainChatComposerDropdown,
+  promptSuggestionController: PromptSuggestionController,
 ): Pick<
   TabUIComponents,
   'instructionModeManager' | 'bangBashModeManager' | 'statusPanel'
@@ -156,7 +158,10 @@ function buildInstructionComponents(
       },
       getInputWrapper: () => dom.inputWrapper,
       onActiveChange: active => {
-        if (active) composerDropdown.hide();
+        if (active) {
+          promptSuggestionController.clear();
+          composerDropdown.hide();
+        }
       },
     },
   );
@@ -460,7 +465,13 @@ export function buildTabRuntimeUI(
 ): TabUIComponents {
   const { dom } = shell;
   const { plugin } = options;
+  const promptSuggestionController = new PromptSuggestionController(dom.inputEl);
+  options.registerCleanup(
+    'tab prompt suggestion controller',
+    () => promptSuggestionController.destroy(),
+  );
   const onUserModified = (): void => {
+    promptSuggestionController.clear();
     commitProvisionalTab(runtimeRef.requirePublished());
   };
   const contextTray = new ComposerContextTray(dom.contextRowEl, {
@@ -494,6 +505,7 @@ export function buildTabRuntimeUI(
     options,
     runtimeRef,
     composerDropdown,
+    promptSuggestionController,
   );
   const navigationSidebar = new NavigationSidebar(
     dom.messagesWrapperEl,
@@ -511,6 +523,7 @@ export function buildTabRuntimeUI(
     permissionToggle: toolbar.permissionToggle,
     serviceTierToggle: toolbar.serviceTierToggle,
     composerDropdown,
+    promptSuggestionController,
     ...instructionComponents,
     contextUsageMeter: toolbar.contextUsageMeter,
     navigationSidebar,

--- a/src/features/chat/tabs/types.ts
+++ b/src/features/chat/tabs/types.ts
@@ -33,6 +33,7 @@ import type {
 } from '../ui/InputToolbar';
 import type { InstructionModeManager } from '../ui/InstructionModeManager';
 import type { NavigationSidebar } from '../ui/NavigationSidebar';
+import type { PromptSuggestionController } from '../ui/PromptSuggestionController';
 import type { StatusPanel } from '../ui/StatusPanel';
 import type { TabSession } from './TabSession';
 
@@ -134,6 +135,7 @@ export interface TabUIComponents {
   readonly contextUsageMeter: ContextUsageMeter;
   readonly statusPanel: StatusPanel;
   readonly navigationSidebar: NavigationSidebar;
+  readonly promptSuggestionController: PromptSuggestionController;
 }
 
 /**

--- a/src/features/chat/ui/PromptSuggestionController.ts
+++ b/src/features/chat/ui/PromptSuggestionController.ts
@@ -1,0 +1,70 @@
+export class PromptSuggestionController {
+  private readonly defaultPlaceholder: string;
+  private suggestion: string | null = null;
+  private revisionValue = 0;
+
+  constructor(private readonly inputEl: HTMLTextAreaElement) {
+    this.defaultPlaceholder = inputEl.placeholder
+      || inputEl.getAttribute('placeholder')
+      || '';
+  }
+
+  get isVisible(): boolean {
+    return this.suggestion !== null;
+  }
+
+  get revision(): number {
+    return this.revisionValue;
+  }
+
+  show(rawSuggestion: string): boolean {
+    const suggestion = rawSuggestion.trim();
+    if (!suggestion || this.inputEl.value.length > 0) return false;
+
+    this.suggestion = suggestion;
+    this.inputEl.placeholder = suggestion;
+    return true;
+  }
+
+  handleKeydown(event: KeyboardEvent): boolean {
+    const suggestion = this.suggestion;
+    if (
+      !suggestion
+      || this.inputEl.value.length > 0
+      || event.isComposing
+      || event.altKey
+      || event.ctrlKey
+      || event.metaKey
+      || event.shiftKey
+      || (event.key !== 'Tab' && event.key !== 'ArrowRight')
+    ) {
+      return false;
+    }
+
+    event.preventDefault();
+    this.inputEl.value = suggestion;
+    this.clear();
+    this.inputEl.setSelectionRange?.(suggestion.length, suggestion.length);
+    this.inputEl.focus?.();
+    const EventConstructor = this.inputEl.ownerDocument?.defaultView?.Event ?? Event;
+    this.inputEl.dispatchEvent(new EventConstructor('input', { bubbles: true }));
+    return true;
+  }
+
+  handleInputChange(): void {
+    this.clear();
+  }
+
+  clear(): void {
+    this.revisionValue += 1;
+    const suggestion = this.suggestion;
+    this.suggestion = null;
+    if (suggestion !== null && this.inputEl.placeholder === suggestion) {
+      this.inputEl.placeholder = this.defaultPlaceholder;
+    }
+  }
+
+  destroy(): void {
+    this.clear();
+  }
+}

--- a/src/providers/claude/execution/ClaudeExecutionEventNormalizer.ts
+++ b/src/providers/claude/execution/ClaudeExecutionEventNormalizer.ts
@@ -85,6 +85,10 @@ export type ClaudeNormalizedExecutionEvent =
     readonly contextWindow: number;
   }
   | {
+    readonly type: 'prompt_suggestion';
+    readonly suggestion: string;
+  }
+  | {
     readonly type: 'result';
   };
 
@@ -127,6 +131,12 @@ export class ClaudeExecutionEventNormalizer {
   ): ClaudeNormalizedExecutionEvent[] {
     const state = this.states[channel];
     const normalized: ClaudeNormalizedExecutionEvent[] = [];
+    if (message.type === 'prompt_suggestion') {
+      const suggestion = message.suggestion.trim();
+      return suggestion
+        ? [{ type: 'prompt_suggestion', suggestion }]
+        : [];
+    }
     for (const event of transformSDKMessage(message, {
       ...options,
       streamState: state.streamState,

--- a/src/providers/claude/execution/ClaudeExecutionRequestEncoder.ts
+++ b/src/providers/claude/execution/ClaudeExecutionRequestEncoder.ts
@@ -171,6 +171,9 @@ export class ClaudeExecutionRequestEncoder {
       spawnClaudeCodeProcess: createCustomSpawnFunction(enhancedPath),
       includePartialMessages: true,
       enableFileCheckpointing: true,
+      ...(sessionConfig.lifecycle === 'persistent'
+        ? { promptSuggestions: true }
+        : {}),
       canUseTool,
       disallowedTools: [
         ...UNSUPPORTED_SDK_TOOLS,

--- a/src/providers/claude/execution/ClaudeExecutionSession.ts
+++ b/src/providers/claude/execution/ClaudeExecutionSession.ts
@@ -70,6 +70,11 @@ interface BackgroundTurn {
   sequence: number;
 }
 
+interface PendingPromptSuggestionTurn {
+  readonly queryToken: number;
+  readonly turnId: string;
+}
+
 type ClaudeExecutionSessionServices = Pick<
   ClaudeWorkspaceServices,
   'agentManager' | 'commandCatalog' | 'pluginManager'
@@ -103,6 +108,7 @@ ClaudeExecutionStrategySink {
   private activeRun: ActiveRequestedRun | null = null;
   private backgroundTurn: BackgroundTurn | null = null;
   private backgroundCounter = 0;
+  private pendingPromptSuggestionTurn: PendingPromptSuggestionTurn | null = null;
   private sessionSequence = 0;
   private queryToken = 0;
   private latestCommandQueryToken = -1;
@@ -185,6 +191,8 @@ ClaudeExecutionStrategySink {
       throw new Error('Claude execution session already has an active run');
     }
 
+    this.pendingPromptSuggestionTurn = null;
+
     const executionId = randomUUID();
     const turnId = randomUUID();
     const abortController = new AbortController();
@@ -234,6 +242,7 @@ ClaudeExecutionStrategySink {
   cancel(): void {
     const active = this.activeRun;
     if (!active || active.terminal) return;
+    this.pendingPromptSuggestionTurn = null;
     this.setStatus('cancelling');
     this.emitRequestedState(active);
     active.abortController.abort();
@@ -318,6 +327,7 @@ ClaudeExecutionStrategySink {
     });
     this.sessionListeners.clear();
     this.backgroundTurn = null;
+    this.pendingPromptSuggestionTurn = null;
     this.suppressedPersistentQueryTokens.clear();
     this.suppressedEphemeralQueryTokens.clear();
   }
@@ -459,6 +469,13 @@ ClaudeExecutionStrategySink {
     }
 
     const active = this.activeRun;
+    if (
+      !active
+      && this.pendingPromptSuggestionTurn
+      && isRequestedTurnEvidence(message)
+    ) {
+      this.pendingPromptSuggestionTurn = null;
+    }
     const intendedModel = this.lastEncodedRequest?.model;
     const authoritativeContextWindow = intendedModel
       && this.authoritativeContextWindow?.model === intendedModel
@@ -511,6 +528,22 @@ ClaudeExecutionStrategySink {
           snapshotRevision: this.revision,
           providerPayload: event,
         });
+        continue;
+      }
+      if (normalized.type === 'prompt_suggestion') {
+        const pending = this.pendingPromptSuggestionTurn;
+        this.pendingPromptSuggestionTurn = null;
+        if (
+          pending
+          && pending.queryToken === queryToken
+          && !this.activeRun
+        ) {
+          this.emitSession({
+            type: 'prompt_suggestion',
+            originatingTurnId: pending.turnId,
+            suggestion: normalized.suggestion,
+          });
+        }
         continue;
       }
       if (normalized.type === 'output') {
@@ -1035,6 +1068,9 @@ ClaudeExecutionStrategySink {
       planCompleted: active.planCompleted || undefined,
       reason,
     });
+    this.pendingPromptSuggestionTurn = reason === 'completed'
+      ? { queryToken: active.queryToken, turnId: active.turnId }
+      : null;
     this.endActiveRun(active);
   }
 
@@ -1044,6 +1080,7 @@ ClaudeExecutionStrategySink {
     missingProviderSessionId?: string,
   ): void {
     if (active.terminal) return;
+    this.pendingPromptSuggestionTurn = null;
     const details = classifyClaudeError(
       error,
       this.providerSessionId,

--- a/src/providers/claude/execution/ClaudeExecutionStrategies.ts
+++ b/src/providers/claude/execution/ClaudeExecutionStrategies.ts
@@ -77,6 +77,7 @@ implements ClaudeExecutionStrategy {
     readonly model: string;
     readonly promise: Promise<void>;
   } | null = null;
+  private pendingPromptSuggestionQueryToken: number | null = null;
   private preparingTurnToken: number | null = null;
   private disposed = false;
 
@@ -182,6 +183,7 @@ implements ClaudeExecutionStrategy {
     this.abortController = null;
     this.authoritativeContextWindow = null;
     this.contextWindowDiscovery = null;
+    this.pendingPromptSuggestionQueryToken = null;
     if (query) {
       this.sink.handleNativeQueryClosed(query);
       this.finishNativeTurn(query, {
@@ -332,9 +334,13 @@ implements ClaudeExecutionStrategy {
           this.sink.publishCommands(query, queryToken);
         }
         const nativeTurn = this.getNativeTurn(query);
+        const nativeTurnToken = nativeTurn?.queryToken ?? queryToken;
+        const messageQueryToken = message.type === 'prompt_suggestion'
+          ? (this.pendingPromptSuggestionQueryToken ?? nativeTurnToken)
+          : nativeTurnToken;
         await this.sink.handleNativeMessage(
           message,
-          nativeTurn?.queryToken ?? queryToken,
+          messageQueryToken,
         );
         if (
           message.type === 'system'
@@ -344,8 +350,11 @@ implements ClaudeExecutionStrategy {
           this.messageChannel?.setSessionId(message.session_id);
         }
         if (message.type === 'result') {
+          this.pendingPromptSuggestionQueryToken = messageQueryToken;
           this.messageChannel?.onTurnComplete();
           this.finishNativeTurn(query, { type: 'completed' });
+        } else if (message.type === 'prompt_suggestion') {
+          this.pendingPromptSuggestionQueryToken = null;
         }
       }
       if (this.query === query && !this.disposed) {
@@ -407,6 +416,7 @@ implements ClaudeExecutionStrategy {
     this.currentConfig = null;
     this.authoritativeContextWindow = null;
     this.contextWindowDiscovery = null;
+    this.pendingPromptSuggestionQueryToken = null;
     this.sink.handleNativeQueryClosed(query);
   }
 }

--- a/tests/unit/features/chat/tabs/TabRuntimeFactory.test.ts
+++ b/tests/unit/features/chat/tabs/TabRuntimeFactory.test.ts
@@ -1741,6 +1741,123 @@ describe('Tab provider execution ownership', () => {
     expect(coordinatorDeps[0].warmExecution?.canCool()).toBe(true);
   });
 
+  it('shows and accepts a trailing prompt suggestion after the active turn settles', async () => {
+    const plugin = createPlugin();
+    const tab = await createTestTab({ plugin, containerEl: createMockEl() as any });
+    tab.dom.contentEl.removeClass('claudian-hidden');
+    const activeTurn = deferred<void>();
+    tab.session.activeTurn = activeTurn.promise;
+    const eventPromise = coordinatorDeps[0].onSessionEvent?.({
+      type: 'prompt_suggestion',
+      originatingTurnId: 'turn-1',
+      suggestion: 'Review the changed files',
+      scope: {
+        kind: 'session',
+        sequence: 1,
+        sessionInstanceId: 'session-instance-1',
+      },
+    }, createEventContext());
+
+    expect(tab.dom.inputEl.placeholder).not.toBe('Review the changed files');
+    activeTurn.resolve(undefined);
+    tab.session.activeTurn = null;
+    await eventPromise;
+    expect(tab.dom.inputEl.placeholder).toBe('Review the changed files');
+
+    const preventDefault = jest.fn();
+    tab.dom.inputEl.dispatchEvent({
+      type: 'keydown',
+      key: 'Tab',
+      target: tab.dom.inputEl,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      isComposing: false,
+      preventDefault,
+    });
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(tab.dom.inputEl.value).toBe('Review the changed files');
+  });
+
+  it('does not resurrect a delayed suggestion after the composer changes', async () => {
+    const plugin = createPlugin();
+    const tab = await createTestTab({ plugin, containerEl: createMockEl() as any });
+    tab.dom.contentEl.removeClass('claudian-hidden');
+    const activeTurn = deferred<void>();
+    tab.session.activeTurn = activeTurn.promise;
+    const eventPromise = coordinatorDeps[0].onSessionEvent?.({
+      type: 'prompt_suggestion',
+      originatingTurnId: 'turn-1',
+      suggestion: 'Stale suggestion',
+      scope: {
+        kind: 'session',
+        sequence: 1,
+        sessionInstanceId: 'session-instance-1',
+      },
+    }, createEventContext());
+
+    tab.dom.inputEl.value = 'New draft';
+    tab.dom.inputEl.dispatchEvent('input');
+    activeTurn.resolve(undefined);
+    tab.session.activeTurn = null;
+    await eventPromise;
+
+    expect(tab.dom.inputEl.placeholder).not.toBe('Stale suggestion');
+    expect(tab.dom.inputEl.value).toBe('New draft');
+  });
+
+  it('keeps composer dropdown key handling ahead of prompt-suggestion acceptance', async () => {
+    const plugin = createPlugin();
+    const tab = await createTestTab({ plugin, containerEl: createMockEl() as any });
+    tab.dom.contentEl.removeClass('claudian-hidden');
+    await coordinatorDeps[0].onSessionEvent?.({
+      type: 'prompt_suggestion',
+      originatingTurnId: 'turn-1',
+      suggestion: 'Review the changed files',
+      scope: {
+        kind: 'session',
+        sequence: 1,
+        sessionInstanceId: 'session-instance-1',
+      },
+    }, createEventContext());
+    jest.spyOn(tab.ui.composerDropdown, 'handleKeydown').mockReturnValue(true);
+
+    tab.dom.inputEl.dispatchEvent({
+      type: 'keydown',
+      key: 'Tab',
+      target: tab.dom.inputEl,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      isComposing: false,
+      preventDefault: jest.fn(),
+    });
+
+    expect(tab.dom.inputEl.value).toBe('');
+    expect(tab.dom.inputEl.placeholder).toBe('Review the changed files');
+  });
+
+  it('ignores a prompt suggestion for an inactive tab', async () => {
+    const plugin = createPlugin();
+    const tab = await createTestTab({ plugin, containerEl: createMockEl() as any });
+
+    await coordinatorDeps[0].onSessionEvent?.({
+      type: 'prompt_suggestion',
+      originatingTurnId: 'turn-1',
+      suggestion: 'Review the changed files',
+      scope: {
+        kind: 'session',
+        sequence: 1,
+        sessionInstanceId: 'session-instance-1',
+      },
+    }, createEventContext());
+
+    expect(tab.dom.inputEl.placeholder).not.toBe('Review the changed files');
+  });
+
   it('buffers normalized background output and persists it on completion', async () => {
     const plugin = createPlugin();
     const onReviewableSettlement = jest.fn();

--- a/tests/unit/features/chat/ui/PromptSuggestionController.test.ts
+++ b/tests/unit/features/chat/ui/PromptSuggestionController.test.ts
@@ -1,0 +1,86 @@
+import { createMockEl } from '@test/helpers/MockElement';
+
+import { PromptSuggestionController } from '@/features/chat/ui/PromptSuggestionController';
+
+describe('PromptSuggestionController', () => {
+  function createController(): {
+    controller: PromptSuggestionController;
+    inputEl: HTMLTextAreaElement;
+  } {
+    const inputEl = createMockEl('textarea') as HTMLTextAreaElement;
+    inputEl.placeholder = 'Ask Claude';
+    return {
+      controller: new PromptSuggestionController(inputEl),
+      inputEl,
+    };
+  }
+
+  it.each(['Tab', 'ArrowRight'])('accepts a visible suggestion with %s', (key) => {
+    const { controller, inputEl } = createController();
+    const inputEvents: Event[] = [];
+    inputEl.addEventListener('input', event => inputEvents.push(event));
+    controller.show('Review the changed files');
+    const preventDefault = jest.fn();
+    const event = {
+      key,
+      altKey: false,
+      ctrlKey: false,
+      isComposing: false,
+      metaKey: false,
+      preventDefault,
+      shiftKey: false,
+    } as unknown as KeyboardEvent;
+
+    expect(controller.handleKeydown(event)).toBe(true);
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(inputEl.value).toBe('Review the changed files');
+    expect(inputEl.placeholder).toBe('Ask Claude');
+    expect(inputEvents).toHaveLength(1);
+    expect(controller.isVisible).toBe(false);
+  });
+
+  it('does not take modified, composing, or non-empty input keydowns', () => {
+    const { controller, inputEl } = createController();
+    controller.show('Review the changed files');
+
+    expect(controller.handleKeydown({
+      key: 'Tab',
+      altKey: false,
+      ctrlKey: true,
+      isComposing: false,
+      metaKey: false,
+      shiftKey: false,
+    } as KeyboardEvent)).toBe(false);
+    expect(controller.handleKeydown({
+      key: 'ArrowRight',
+      altKey: false,
+      ctrlKey: false,
+      isComposing: true,
+      metaKey: false,
+      shiftKey: false,
+    } as KeyboardEvent)).toBe(false);
+    inputEl.value = 'draft';
+    expect(controller.handleKeydown({
+      key: 'Tab',
+      altKey: false,
+      ctrlKey: false,
+      isComposing: false,
+      metaKey: false,
+      shiftKey: false,
+    } as KeyboardEvent)).toBe(false);
+    expect(inputEl.value).toBe('draft');
+  });
+
+  it('invalidates a suggestion on input without overwriting another mode placeholder', () => {
+    const { controller, inputEl } = createController();
+    controller.show('Review the changed files');
+    inputEl.placeholder = 'Run a bash command';
+    inputEl.value = '!';
+
+    controller.handleInputChange();
+
+    expect(controller.isVisible).toBe(false);
+    expect(inputEl.placeholder).toBe('Run a bash command');
+  });
+});

--- a/tests/unit/providers/claude/execution/ClaudeExecutionBackend.test.ts
+++ b/tests/unit/providers/claude/execution/ClaudeExecutionBackend.test.ts
@@ -263,6 +263,59 @@ describe('ClaudeExecutionBackend', () => {
         source: 'sdk',
       },
     ]);
+    expect(sdkMock.getLastOptions()?.promptSuggestions).toBe(true);
+  });
+
+  it('routes a trailing second-turn prompt suggestion through the session channel', async () => {
+    let turn = 0;
+    let query!: ScriptedQuery;
+    jest.spyOn(
+      await import('@/providers/claude/loadClaudeAgentSdk'),
+      'loadClaudeAgentQuery',
+    ).mockImplementationOnce(async () => ((request: {
+      prompt: AsyncIterable<sdkModule.SDKUserMessage>;
+    }) => {
+      query = createPromptDrivenPersistentQuery(request.prompt, () => {
+        turn += 1;
+        if (turn === 1) {
+          return [
+            { type: 'system', subtype: 'init', session_id: 'session-1' },
+            { type: 'result', subtype: 'success' },
+          ];
+        }
+        return [
+          { type: 'result', subtype: 'success' },
+          {
+            type: 'prompt_suggestion',
+            suggestion: 'Review the changed files',
+            uuid: 'suggestion-2',
+            session_id: 'session-1',
+          },
+        ];
+      });
+      return query;
+    }) as never);
+    const { services } = createServices();
+    const session = new ClaudeExecutionBackend(createHost(), services)
+      .createSession(createConfig());
+    const sessionEvents: ProviderSessionEvent[] = [];
+    session.onEvent(event => sessionEvents.push(event));
+
+    await collectEvents(session.execute(createRequest()).events);
+    const secondRun = session.execute(createRequest({
+      input: [{ type: 'text', text: 'Continue' }],
+    }));
+    await collectEvents(secondRun.events);
+    await waitFor(() => sessionEvents.some(event => event.type === 'prompt_suggestion'));
+
+    expect(sessionEvents).toContainEqual(expect.objectContaining({
+      type: 'prompt_suggestion',
+      originatingTurnId: secondRun.turnId,
+      suggestion: 'Review the changed files',
+      scope: expect.objectContaining({ kind: 'session' }),
+    }));
+    await session.dispose();
+    await query.finished;
   });
 
   it('resumes and materializes a pending fork without losing opaque provider state', async () => {
@@ -369,6 +422,7 @@ describe('ClaudeExecutionBackend', () => {
       tools: [],
     }));
     expect(sdkMock.getLastOptions()?.thinking).toBeUndefined();
+    expect(sdkMock.getLastOptions()?.promptSuggestions).toBeUndefined();
     expect(oneShot.getSnapshot().providerSessionId).toBeUndefined();
   });
 
@@ -1591,6 +1645,12 @@ describe('ClaudeExecutionBackend', () => {
         },
         { type: 'result', subtype: 'success' },
         {
+          type: 'prompt_suggestion',
+          suggestion: 'Follow up on the automatic turn',
+          uuid: 'background-suggestion',
+          session_id: 'session-1',
+        },
+        {
           type: 'system',
           subtype: 'task_notification',
           session_id: 'session-1',
@@ -1630,6 +1690,7 @@ describe('ClaudeExecutionBackend', () => {
       subagentId: 'task-1',
       result: 'Subagent result',
     }));
+    expect(sessionEvents.some(({ type }) => type === 'prompt_suggestion')).toBe(false);
   });
 
   it('cancels one active run, fences late output, and rejects execution after disposal', async () => {

--- a/tests/unit/providers/claude/execution/ClaudeExecutionEventNormalizer.test.ts
+++ b/tests/unit/providers/claude/execution/ClaudeExecutionEventNormalizer.test.ts
@@ -137,3 +137,34 @@ describe('ClaudeExecutionEventNormalizer task tools', () => {
     }));
   });
 });
+
+describe('ClaudeExecutionEventNormalizer prompt suggestions', () => {
+  it('normalizes a non-empty native suggestion without rendering it as output', () => {
+    const normalizer = new ClaudeExecutionEventNormalizer();
+
+    const events = normalizer.normalize({
+      type: 'prompt_suggestion',
+      suggestion: 'Review the changed files',
+      uuid: '00000000-0000-4000-8000-000000000001',
+      session_id: 'session-1',
+    }, 'background');
+
+    expect(events).toEqual([{
+      type: 'prompt_suggestion',
+      suggestion: 'Review the changed files',
+    }]);
+  });
+
+  it('ignores a whitespace-only native suggestion', () => {
+    const normalizer = new ClaudeExecutionEventNormalizer();
+
+    const events = normalizer.normalize({
+      type: 'prompt_suggestion',
+      suggestion: '   ',
+      uuid: '00000000-0000-4000-8000-000000000001',
+      session_id: 'session-1',
+    }, 'background');
+
+    expect(events).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

Claudian already bundles an Agent SDK version that can generate contextual follow-up prompts, but main-chat queries never enable the capability and the trailing `prompt_suggestion` message is not represented across the execution boundary. Users therefore cannot see or accept the SDK suggestion described in #1136.

Fixes #1136

## What Changed

- Enable `promptSuggestions` only for persistent Claude main-chat sessions; ephemeral title, inline-edit, and auxiliary runs remain unchanged.
- Normalize a non-empty native suggestion into a provider-neutral session event associated with the completed requested turn.
- Preserve the completed turn token after `result`, including second and later turns, while rejecting stale, superseded, and provider-triggered background suggestions.
- Show the suggestion as transient muted placeholder text only in the empty composer of the active tab.
- Accept it with unmodified Tab or Right Arrow, after existing mode and composer-dropdown keyboard handlers.
- Clear it on typing, tab/conversation/provider/model/context changes, instruction or bang-bash mode, and teardown. Suggestions are never persisted.

## Why This Approach

Generation and opt-out policy stay native to Claude: the SDK still respects `promptSuggestionEnabled: false`, the environment override, plan mode, API errors, and its first-turn suppression. Claudian only adapts the resulting UI intent.

A session-scoped event is necessary because the SDK emits the suggestion after the requested event stream has already ended at `result`. Carrying the originating turn ID and the existing session binding fences avoids reopening the completed stream or storing UI-only data in provider state. The composer uses its existing placeholder styling instead of adding a second overlay DOM surface, and the controller revision prevents a delayed event from reviving stale text.

## Validation

TDD red/green coverage includes:

- persistent enablement and ephemeral exclusion;
- second-turn post-result correlation;
- provider-triggered background isolation;
- whitespace filtering;
- Tab and Right Arrow acceptance plus modifier/IME guards;
- active-turn settling, inactive-tab rejection, stale-composer fencing, and dropdown precedence.

Full validation:

- `npm run typecheck`
- `npm run lint`
- `npm run test` — 566 suites / 8,340 tests, plus 14 protocol suites / 131 tests and 61 architecture checks
- `npm run build`
- `git diff --check`

## Impact and Follow-ups

No persisted schema, provider state, transcript, setting, or auxiliary execution behavior changes. Suggestions remain subject to the native SDK suppression rules and are intentionally discarded rather than restored across tab or conversation changes. No documentation update is needed for this focused UI behavior.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.