### PR TITLE
fix: make OpenCode command timeout retryable

### DIFF
--- a/src/providers/opencode/metadata/OpencodeMetadataService.ts
+++ b/src/providers/opencode/metadata/OpencodeMetadataService.ts
@@ -21,7 +21,7 @@ import {
 
 export interface OpencodeMetadataCatalogResult
   extends OpencodeMetadataProjectionInput {
-  readonly commands: readonly SlashCommand[];
+  readonly commands: readonly SlashCommand[] | null;
 }
 
 export interface OpencodeMetadataWarmResult
@@ -81,9 +81,11 @@ export class OpencodeMetadataService {
         ownedSignal.throwIfAborted();
         await projectOpencodeMetadata(this.plugin, catalog);
         ownedSignal.throwIfAborted();
-        this.options.commandCatalog?.setCommandSnapshot(
-          catalog.commands.map((command) => ({ ...command })),
-        );
+        if (catalog.commands !== null) {
+          this.options.commandCatalog?.setCommandSnapshot(
+            catalog.commands.map((command) => ({ ...command })),
+          );
+        }
         return true;
       },
       signal,
@@ -105,6 +107,9 @@ export class OpencodeMetadataService {
         ownedSignal.throwIfAborted();
         await projectOpencodeMetadata(this.plugin, catalog);
         ownedSignal.throwIfAborted();
+        if (catalog.commands === null) {
+          return { commands: [], loaded: false };
+        }
         const commands = catalog.commands.map((command) => ({ ...command }));
         this.options.commandCatalog?.setCommandSnapshot(commands);
         return { commands, loaded: true };
@@ -210,7 +215,7 @@ class DefaultOpencodeMetadataProbe implements OpencodeMetadataProbe {
       );
     }
     return {
-      commands: this.commands ?? [],
+      commands: this.commands,
       configOptions: native.configOptions,
       models: native.models,
       modes: native.modes,

--- a/tests/unit/providers/opencode/OpencodeMetadataService.timeout.test.ts
+++ b/tests/unit/providers/opencode/OpencodeMetadataService.timeout.test.ts
@@ -1,0 +1,157 @@
+import type { ProviderCommandLoaderContext } from '@/core/providers/types';
+import { OpencodeCommandLoader } from '@/providers/opencode/app/OpencodeCommandLoader';
+import { OpencodeMetadataService } from '@/providers/opencode/metadata/OpencodeMetadataService';
+import { getOpencodeProviderSettings } from '@/providers/opencode/settings';
+
+interface MockKernelOptions {
+  readonly onNotification: (notification: {
+    sessionId: string;
+    update: Record<string, unknown>;
+  }) => void;
+}
+
+const mockKernelOptions: MockKernelOptions[] = [];
+
+jest.mock('@/providers/opencode/execution/OpencodeAcpSessionKernel', () => ({
+  DefaultOpencodeAcpSessionKernel: jest.fn().mockImplementation((options) => {
+    mockKernelOptions.push(options);
+    return {
+      connect: jest.fn(async () => undefined),
+      dispose: jest.fn(async () => undefined),
+      openSession: jest.fn(async () => ({
+        configOptions: [],
+        databasePath: ':memory:',
+        models: {
+          availableModels: [{ modelId: 'anthropic/claude', name: 'Claude' }],
+          currentModelId: 'anthropic/claude',
+        },
+        sessionId: 'metadata-session',
+      })),
+      setConfigOption: jest.fn(),
+    };
+  }),
+}));
+
+function createPlugin(): any {
+  const plugin: any = {
+    app: {
+      vault: {
+        adapter: { basePath: '/vault' },
+      },
+    },
+    executionLifecycleRegistry: {
+      registerTransitionHook: jest.fn(() => jest.fn()),
+    },
+    mutateSettings: jest.fn(async (
+      mutation: (settings: Record<string, unknown>) => void,
+    ): Promise<void> => {
+      mutation(plugin.settings);
+    }),
+    notifyProviderChatOptionsChanged: jest.fn(),
+    settings: {
+      providerConfigs: {
+        opencode: {
+          discoveredModels: [],
+          visibleModels: [],
+        },
+      },
+    },
+  };
+  return plugin;
+}
+
+function createContext(plugin: any): ProviderCommandLoaderContext {
+  return {
+    allowIsolatedMetadataCreation: true,
+    conversation: null,
+    externalContextPaths: [],
+    plugin,
+  };
+}
+
+async function waitForKernel(): Promise<MockKernelOptions> {
+  for (let attempt = 0; attempt < 10 && mockKernelOptions.length === 0; attempt += 1) {
+    await Promise.resolve();
+  }
+  const options = mockKernelOptions[0];
+  if (!options) throw new Error('OpenCode metadata kernel was not created');
+  return options;
+}
+
+describe('OpencodeMetadataService command update timeout', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockKernelOptions.length = 0;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('reports retryable command discovery when no command update arrives', async () => {
+    const plugin = createPlugin();
+    const commandCatalog = { setCommandSnapshot: jest.fn() };
+    const service = new OpencodeMetadataService(plugin, { commandCatalog });
+    const loader = new OpencodeCommandLoader(service);
+
+    try {
+      const result = loader.loadCommands(createContext(plugin));
+      await waitForKernel();
+      await jest.advanceTimersByTimeAsync(5_000);
+
+      await expect(result).resolves.toEqual({
+        message: 'Could not load OpenCode commands.',
+        retryable: true,
+        status: 'error',
+      });
+      expect(commandCatalog.setCommandSnapshot).not.toHaveBeenCalled();
+    } finally {
+      await service.dispose();
+    }
+  });
+
+  it('still publishes model metadata when the command update is absent', async () => {
+    const plugin = createPlugin();
+    const commandCatalog = { setCommandSnapshot: jest.fn() };
+    const service = new OpencodeMetadataService(plugin, { commandCatalog });
+
+    try {
+      const loaded = service.loadCatalog();
+      await waitForKernel();
+      await jest.advanceTimersByTimeAsync(5_000);
+
+      await expect(loaded).resolves.toBe(true);
+      expect(getOpencodeProviderSettings(plugin.settings).discoveredModels).toEqual([
+        { label: 'Claude', rawId: 'anthropic/claude' },
+      ]);
+      expect(commandCatalog.setCommandSnapshot).not.toHaveBeenCalled();
+    } finally {
+      await service.dispose();
+    }
+  });
+
+  it('treats an observed empty command update as a valid empty catalog', async () => {
+    const plugin = createPlugin();
+    const commandCatalog = { setCommandSnapshot: jest.fn() };
+    const service = new OpencodeMetadataService(plugin, { commandCatalog });
+    const loader = new OpencodeCommandLoader(service);
+
+    try {
+      const result = loader.loadCommands(createContext(plugin));
+      const kernelOptions = await waitForKernel();
+      kernelOptions.onNotification({
+        sessionId: 'metadata-session',
+        update: {
+          availableCommands: [],
+          sessionUpdate: 'available_commands_update',
+        },
+      });
+
+      await expect(result).resolves.toEqual({ status: 'empty' });
+      expect(commandCatalog.setCommandSnapshot).toHaveBeenCalledWith([]);
+    } finally {
+      await service.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Why

Refs #1131.

OpenCode metadata probes wait up to five seconds for the first ACP `available_commands_update`. When no update arrived, Claudian converted that unobserved state into `commands: []` and reported discovery as successfully loaded. The slash menu then cached a legitimate-looking empty provider catalog with no Retry action.

This pull request fixes that independently reproducible client-side state distinction. It does not scan skill directories or claim that the timeout is the confirmed root cause of every environment reported in #1131.

## What Changed

- Represent an unobserved OpenCode command update as `null` inside the provider-local metadata result.
- Return retryable command discovery failure when the probe times out without an update.
- Continue publishing models, modes, and config metadata when command discovery is incomplete.
- Preserve an observed `available_commands_update` with an empty array as a valid empty catalog.
- Add provider-boundary regression tests using the real metadata service and command loader with a mocked ACP session kernel and fake timers.

## Why This Approach

ACP distinguishes “no command update was observed” from “the provider published an empty command list.” Preserving that distinction at the OpenCode metadata boundary lets the existing command loader surface its standard retryable error state without changing shared timeout policy or command-store behavior.

The settings catalog still consumes the model metadata returned by `session/new`; it is not failed merely because the separate command notification did not arrive. No filesystem scanner, shared API, or provider execution protocol is added.

## Validation

- TDD red: missing `available_commands_update` returned `status: empty` and published an empty command snapshot before the implementation.
- `npm run test:unit -- --runTestsByPath tests/unit/providers/opencode/OpencodeMetadataService.timeout.test.ts tests/unit/providers/opencode/OpencodeMetadataService.test.ts tests/unit/providers/opencode/OpencodeCommandLoader.test.ts --runInBand` — 3 suites / 14 tests passed.
- `npm run test:unit -- tests/unit/providers/opencode --runInBand` — 24 suites / 239 tests passed.
- `npm run typecheck`
- `npm run lint`
- `npm run test` — 566 suites / 8,332 tests passed, plus 14 protocol suites / 131 tests and 61 architecture checks.
- `npm run build`
- `git diff --check`

## Impact and Follow-ups

The change is limited to OpenCode metadata and command discovery. Users can retry when the first command update is missing, while settings model discovery and genuine empty catalogs keep their existing behavior.

The exact OpenCode version and ACP notification trace requested in #1131 are still needed before treating this as a complete fix for that report. If evidence identifies a different upstream discovery or projection failure, it should be handled separately rather than adding a competing directory scanner here.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
