### PR TITLE
fix: restore Claude response duration from history

### DIFF
--- a/src/providers/claude/history/ClaudeHistoryStore.ts
+++ b/src/providers/claude/history/ClaudeHistoryStore.ts
@@ -2,7 +2,12 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
 import type { ProviderHistoryPathContext } from '../../../core/providers/types';
-import type { ChatMessage, SubagentInfo, ToolCallInfo } from '../../../core/types';
+import {
+  type ChatMessage,
+  isCanonicalUserMessage,
+  type SubagentInfo,
+  type ToolCallInfo,
+} from '../../../core/types';
 import { ClaudeTaskToolNormalizer } from '../normalization/ClaudeTaskToolNormalizer';
 import { isClaudeSubagentToolName } from '../subagentToolNames';
 import { buildAsyncSubagentInfo } from './sdkAsyncSubagent';
@@ -146,10 +151,24 @@ export async function loadSDKSessionMessages(
   const toolResults = collectToolResults(filteredEntries);
   const toolUseResults = collectStructuredPatchResults(filteredEntries);
   const asyncSubagentResults = collectAsyncSubagentResults(filteredEntries);
+  const nativeTurnDurations = collectNativeTurnDurations(filteredEntries);
 
   const chatMessages: ChatMessage[] = [];
   let pendingAssistant: ChatMessage | null = null;
   const taskToolNormalizer = new ClaudeTaskToolNormalizer();
+
+  const flushPendingAssistant = (includeDuration: boolean): void => {
+    if (pendingAssistant) {
+      const nativeDuration = pendingAssistant.assistantMessageId
+        ? nativeTurnDurations.get(pendingAssistant.assistantMessageId)
+        : undefined;
+      if (includeDuration && nativeDuration !== undefined && nativeDuration > 0) {
+        pendingAssistant.durationSeconds = nativeDuration;
+      }
+      chatMessages.push(pendingAssistant);
+    }
+    pendingAssistant = null;
+  };
 
   // Merge consecutive assistant messages until an actual user message appears
   for (const sdkMsg of filteredEntries) {
@@ -166,28 +185,20 @@ export async function loadSDKSessionMessages(
       // context_compacted must not merge with previous assistant (it's a standalone separator)
       const isCompactBoundary = chatMsg.contentBlocks?.some(b => b.type === 'context_compacted');
       if (isCompactBoundary) {
-        if (pendingAssistant) {
-          chatMessages.push(pendingAssistant);
-        }
+        flushPendingAssistant(true);
         chatMessages.push(chatMsg);
-        pendingAssistant = null;
       } else if (pendingAssistant) {
         mergeAssistantMessage(pendingAssistant, chatMsg);
       } else {
         pendingAssistant = chatMsg;
       }
     } else {
-      if (pendingAssistant) {
-        chatMessages.push(pendingAssistant);
-        pendingAssistant = null;
-      }
+      flushPendingAssistant(isCanonicalUserMessage(chatMsg));
       chatMessages.push(chatMsg);
     }
   }
 
-  if (pendingAssistant) {
-    chatMessages.push(pendingAssistant);
-  }
+  flushPendingAssistant(true);
 
   hydrateStructuredToolResults(chatMessages, toolUseResults);
   hydrateFallbackAskUserAnswers(chatMessages);
@@ -248,6 +259,27 @@ export async function loadSDKSessionMessages(
   chatMessages.sort((a, b) => a.timestamp - b.timestamp);
 
   return { messages: chatMessages, skippedLines: result.skippedLines };
+}
+
+function collectNativeTurnDurations(
+  entries: SDKNativeMessage[],
+): Map<string, number> {
+  const durations = new Map<string, number>();
+  for (const entry of entries) {
+    if (
+      entry.type !== 'system'
+      || entry.subtype !== 'turn_duration'
+      || typeof entry.parentUuid !== 'string'
+      || typeof entry.durationMs !== 'number'
+      || !Number.isFinite(entry.durationMs)
+      || entry.durationMs < 0
+    ) {
+      continue;
+    }
+    const durationSeconds = Math.floor(entry.durationMs / 1_000);
+    durations.set(entry.parentUuid, durationSeconds);
+  }
+  return durations;
 }
 
 export function getLastSDKSessionModel(

--- a/src/providers/claude/history/ClaudeHistoryStore.ts
+++ b/src/providers/claude/history/ClaudeHistoryStore.ts
@@ -151,7 +151,7 @@ export async function loadSDKSessionMessages(
   const toolResults = collectToolResults(filteredEntries);
   const toolUseResults = collectStructuredPatchResults(filteredEntries);
   const asyncSubagentResults = collectAsyncSubagentResults(filteredEntries);
-  const nativeTurnDurations = collectNativeTurnDurations(filteredEntries);
+  const nativeTurnDurations = collectNativeTurnDurations(result.messages);
 
   const chatMessages: ChatMessage[] = [];
   let pendingAssistant: ChatMessage | null = null;
@@ -265,6 +265,13 @@ function collectNativeTurnDurations(
   entries: SDKNativeMessage[],
 ): Map<string, number> {
   const durations = new Map<string, number>();
+  const entriesByUuid = new Map<string, SDKNativeMessage>();
+  for (const entry of entries) {
+    if (entry.uuid && !entriesByUuid.has(entry.uuid)) {
+      entriesByUuid.set(entry.uuid, entry);
+    }
+  }
+
   for (const entry of entries) {
     if (
       entry.type !== 'system'
@@ -276,10 +283,37 @@ function collectNativeTurnDurations(
     ) {
       continue;
     }
+    const assistantUuid = resolveTurnDurationAssistantUuid(
+      entry.parentUuid,
+      entriesByUuid,
+    );
+    if (!assistantUuid) continue;
+
     const durationSeconds = Math.floor(entry.durationMs / 1_000);
-    durations.set(entry.parentUuid, durationSeconds);
+    durations.set(assistantUuid, durationSeconds);
   }
   return durations;
+}
+
+function resolveTurnDurationAssistantUuid(
+  parentUuid: string,
+  entriesByUuid: ReadonlyMap<string, SDKNativeMessage>,
+): string | null {
+  const seen = new Set<string>();
+  let currentUuid: string | null = parentUuid;
+
+  while (currentUuid && !seen.has(currentUuid)) {
+    seen.add(currentUuid);
+    const entry = entriesByUuid.get(currentUuid);
+    if (!entry) return null;
+    if (entry.type === 'assistant') return currentUuid;
+    if (entry.type !== 'system') return null;
+    currentUuid = typeof entry.parentUuid === 'string'
+      ? entry.parentUuid
+      : null;
+  }
+
+  return null;
 }
 
 export function getLastSDKSessionModel(

--- a/src/providers/claude/history/ClaudeHistoryStore.ts
+++ b/src/providers/claude/history/ClaudeHistoryStore.ts
@@ -2,12 +2,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
 import type { ProviderHistoryPathContext } from '../../../core/providers/types';
-import {
-  type ChatMessage,
-  isCanonicalUserMessage,
-  type SubagentInfo,
-  type ToolCallInfo,
-} from '../../../core/types';
+import type { ChatMessage, SubagentInfo, ToolCallInfo } from '../../../core/types';
 import { ClaudeTaskToolNormalizer } from '../normalization/ClaudeTaskToolNormalizer';
 import { isClaudeSubagentToolName } from '../subagentToolNames';
 import { buildAsyncSubagentInfo } from './sdkAsyncSubagent';
@@ -193,7 +188,7 @@ export async function loadSDKSessionMessages(
         pendingAssistant = chatMsg;
       }
     } else {
-      flushPendingAssistant(isCanonicalUserMessage(chatMsg));
+      flushPendingAssistant(!chatMsg.isInterrupt);
       chatMessages.push(chatMsg);
     }
   }

--- a/src/providers/claude/history/sdkHistoryTypes.ts
+++ b/src/providers/claude/history/sdkHistoryTypes.ts
@@ -20,6 +20,7 @@ export interface SDKNativeMessage {
     model?: string;
   };
   subtype?: string;
+  durationMs?: number;
   duration_ms?: number;
   duration_api_ms?: number;
   toolUseResult?: unknown;

--- a/tests/unit/utils/sdkSession.test.ts
+++ b/tests/unit/utils/sdkSession.test.ts
@@ -1125,6 +1125,68 @@ describe('sdkSession', () => {
       expect(result.messages[2].content).toBe('Thanks');
     });
 
+    it('restores response duration from Claude turn metadata', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockFsPromises.readFile.mockResolvedValue([
+        '{"type":"user","uuid":"u1","timestamp":"2024-01-15T10:00:00Z","message":{"content":"Inspect the project"}}',
+        '{"type":"assistant","uuid":"a1","timestamp":"2024-01-15T10:00:02Z","message":{"content":[{"type":"tool_use","id":"tool-1","name":"Read","input":{"file_path":"README.md"}}]}}',
+        '{"type":"user","uuid":"tool-result-1","timestamp":"2024-01-15T10:00:03Z","toolUseResult":{},"message":{"content":[{"type":"tool_result","tool_use_id":"tool-1","content":"Project details"}]}}',
+        '{"type":"assistant","uuid":"a2","timestamp":"2024-01-15T10:00:09Z","message":{"content":[{"type":"text","text":"Inspection complete."}]}}',
+        '{"type":"system","subtype":"turn_duration","uuid":"duration-1","parentUuid":"a2","timestamp":"2024-01-15T10:00:09.100Z","durationMs":4500,"messageCount":4}',
+      ].join('\n'));
+
+      const result = await loadSDKSessionMessages('/Users/test/vault', 'session-native-duration');
+
+      expect(result.messages).toHaveLength(2);
+      expect(result.messages[1]).toMatchObject({
+        role: 'assistant',
+        content: 'Inspection complete.',
+        durationSeconds: 4,
+      });
+    });
+
+    it('treats a sub-second native turn duration as authoritative', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockFsPromises.readFile.mockResolvedValue([
+        '{"type":"user","uuid":"u1","timestamp":"2024-01-15T10:00:00Z","message":{"content":"Quick check"}}',
+        '{"type":"assistant","uuid":"a1","timestamp":"2024-01-15T10:00:03Z","message":{"content":[{"type":"text","text":"Done."}]}}',
+        '{"type":"system","subtype":"turn_duration","uuid":"duration-1","parentUuid":"a1","timestamp":"2024-01-15T10:00:03.100Z","durationMs":681}',
+      ].join('\n'));
+
+      const result = await loadSDKSessionMessages('/Users/test/vault', 'session-subsecond-duration');
+
+      expect(result.messages[1].durationSeconds).toBeUndefined();
+    });
+
+    it('does not infer response duration when native metadata is absent', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockFsPromises.readFile.mockResolvedValue([
+        '{"type":"user","uuid":"u1","timestamp":"2024-01-15T10:00:00Z","message":{"content":"Inspect"}}',
+        '{"type":"assistant","uuid":"a1","timestamp":"2024-01-15T10:00:07Z","message":{"content":[{"type":"text","text":"Complete."}]}}',
+      ].join('\n'));
+
+      const result = await loadSDKSessionMessages('/Users/test/vault', 'session-no-duration');
+
+      expect(result.messages).toHaveLength(2);
+      expect(result.messages[1].durationSeconds).toBeUndefined();
+    });
+
+    it('does not add response duration to assistant output from an interrupted turn', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockFsPromises.readFile.mockResolvedValue([
+        '{"type":"user","uuid":"u1","timestamp":"2024-01-15T10:00:00Z","message":{"content":"Start"}}',
+        '{"type":"assistant","uuid":"a1","timestamp":"2024-01-15T10:00:04Z","message":{"content":[{"type":"text","text":"Partial response"}]}}',
+        '{"type":"system","subtype":"turn_duration","uuid":"duration-1","parentUuid":"a1","timestamp":"2024-01-15T10:00:04.100Z","durationMs":4000}',
+        '{"type":"user","uuid":"interrupt-1","timestamp":"2024-01-15T10:00:05Z","message":{"content":"[Request interrupted by user]"}}',
+      ].join('\n'));
+
+      const result = await loadSDKSessionMessages('/Users/test/vault', 'session-interrupted-duration');
+      const assistant = result.messages.find(message => message.role === 'assistant');
+
+      expect(assistant).toBeDefined();
+      expect(assistant?.durationSeconds).toBeUndefined();
+    });
+
     it('sorts messages by timestamp ascending', async () => {
       mockExistsSync.mockReturnValue(true);
       mockFsPromises.readFile.mockResolvedValue([

--- a/tests/unit/utils/sdkSession.test.ts
+++ b/tests/unit/utils/sdkSession.test.ts
@@ -1145,6 +1145,48 @@ describe('sdkSession', () => {
       });
     });
 
+    it('resolves response duration through an intermediary stop hook record', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockFsPromises.readFile.mockResolvedValue([
+        '{"type":"user","uuid":"u1","timestamp":"2024-01-15T10:00:00Z","message":{"content":"Inspect the project"}}',
+        '{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2024-01-15T10:00:04Z","message":{"content":[{"type":"text","text":"Inspection complete."}]}}',
+        '{"type":"system","subtype":"stop_hook_summary","uuid":"stop-1","parentUuid":"a1","timestamp":"2024-01-15T10:00:04.050Z"}',
+        '{"type":"system","subtype":"turn_duration","uuid":"duration-1","parentUuid":"stop-1","timestamp":"2024-01-15T10:00:04.100Z","durationMs":4500}',
+      ].join('\n'));
+
+      const result = await loadSDKSessionMessages('/Users/test/vault', 'session-stop-hook-duration');
+
+      expect(result.messages[1]).toMatchObject({
+        role: 'assistant',
+        content: 'Inspection complete.',
+        durationSeconds: 4,
+      });
+    });
+
+    it('restores checkpoint duration from metadata beyond resume truncation', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockFsPromises.readFile.mockResolvedValue([
+        '{"type":"user","uuid":"u1","timestamp":"2024-01-15T10:00:00Z","message":{"content":"First turn"}}',
+        '{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2024-01-15T10:00:04Z","message":{"content":[{"type":"text","text":"First response"}]}}',
+        '{"type":"system","subtype":"turn_duration","uuid":"duration-1","parentUuid":"a1","timestamp":"2024-01-15T10:00:04.100Z","durationMs":4500}',
+        '{"type":"user","uuid":"u2","parentUuid":"duration-1","timestamp":"2024-01-15T10:00:05Z","message":{"content":"Later turn"}}',
+        '{"type":"assistant","uuid":"a2","parentUuid":"u2","timestamp":"2024-01-15T10:00:08Z","message":{"content":[{"type":"text","text":"Later response"}]}}',
+      ].join('\n'));
+
+      const result = await loadSDKSessionMessages(
+        '/Users/test/vault',
+        'session-checkpoint-duration',
+        'a1',
+      );
+
+      expect(result.messages).toHaveLength(2);
+      expect(result.messages[1]).toMatchObject({
+        role: 'assistant',
+        content: 'First response',
+        durationSeconds: 4,
+      });
+    });
+
     it('treats a sub-second native turn duration as authoritative', async () => {
       mockExistsSync.mockReturnValue(true);
       mockFsPromises.readFile.mockResolvedValue([

--- a/tests/unit/utils/sdkSession.test.ts
+++ b/tests/unit/utils/sdkSession.test.ts
@@ -1187,6 +1187,28 @@ describe('sdkSession', () => {
       });
     });
 
+    it('preserves response duration before rebuilt history context', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockFsPromises.readFile.mockResolvedValue([
+        '{"type":"user","uuid":"u1","timestamp":"2024-01-15T10:00:00Z","message":{"content":"First turn"}}',
+        '{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2024-01-15T10:00:04Z","message":{"content":[{"type":"text","text":"First response"}]}}',
+        '{"type":"system","subtype":"turn_duration","uuid":"duration-1","parentUuid":"a1","timestamp":"2024-01-15T10:00:04.100Z","durationMs":4500}',
+        '{"type":"user","uuid":"replay-1","parentUuid":"duration-1","timestamp":"2024-01-15T10:00:05Z","message":{"content":"User: Earlier question\\n\\nAssistant: Earlier response\\n\\nUser: Continue"}}',
+      ].join('\n'));
+
+      const result = await loadSDKSessionMessages('/Users/test/vault', 'session-rebuilt-context');
+
+      expect(result.messages[1]).toMatchObject({
+        role: 'assistant',
+        content: 'First response',
+        durationSeconds: 4,
+      });
+      expect(result.messages[2]).toMatchObject({
+        role: 'user',
+        isRebuiltContext: true,
+      });
+    });
+
     it('treats a sub-second native turn duration as authoritative', async () => {
       mockExistsSync.mockReturnValue(true);
       mockFsPromises.readFile.mockResolvedValue([


### PR DESCRIPTION
## Why

Refs #729.

Claude response duration is currently added only to the in-memory chat message when a live response finishes, so the footer disappears after the conversation is reloaded. Claude transcripts already persist authoritative system/turn_duration records, but the history loader did not consume them.

## What Changed

- Decode valid Claude turn_duration metadata and correlate it to the final native assistant entry through parentUuid.
- Restore durationSeconds on the merged assistant message while preserving the existing suppression for interrupted turns and sub-second responses.
- Add regression coverage for multi-entry tool-use turns, sub-second metadata, missing metadata, and interrupted turns.

## Why This Approach

The history boundary now consumes provider-native, read-only timing metadata instead of estimating duration from message timestamps or introducing a second persistence format. This keeps live execution unchanged, preserves the existing merged-message model, and leaves older transcripts without timing metadata untouched.

## Validation

- npm run test:unit -- --runTestsByPath tests/unit/utils/sdkSession.test.ts --runInBand (165 tests passed)
- npm run test -- --testTimeout=15000 (573 suites / 8404 tests plus 14 protocol suites / 131 tests passed; the wider timeout avoids a local real-server Collab timing flake that passes in isolation)
- npm run typecheck
- npm run lint
- npm run build
- git diff --check

## Impact and Follow-ups

This affects only Claude history replay. Live streaming and transcript files are unchanged. Older transcripts without turn_duration records continue to omit the footer, and durations below one second remain hidden to match live behavior.

Claude does not persist Claudian's randomly selected footer flavor word or per-thinking-block elapsed time. Reloaded responses therefore use the renderer's existing default flavor, and thinking-block duration reconstruction remains out of scope.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.