### PR TITLE
fix: focus chat input after opening view

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -510,24 +510,32 @@ export default class ClaudianPlugin extends Plugin {
 
   async activateView() {
     const { workspace } = this.app;
-    let leaf = workspace.getLeavesOfType(VIEW_TYPE_CLAUDIAN)[0];
+    const existingLeaf = workspace.getLeavesOfType(VIEW_TYPE_CLAUDIAN)[0];
+    const leaf = existingLeaf
+      ?? this.getLeafForPlacement(this.settings.chatViewPlacement);
+    if (!leaf) return;
 
-    if (!leaf) {
-      const newLeaf = this.getLeafForPlacement(this.settings.chatViewPlacement);
-      if (newLeaf) {
-        await newLeaf.setViewState({
+    let focusSuperseded = false;
+    const focusIntentRef = workspace.on('active-leaf-change', (activeLeaf) => {
+      if (activeLeaf && activeLeaf !== leaf) {
+        focusSuperseded = true;
+      }
+    });
+
+    try {
+      if (!existingLeaf) {
+        await leaf.setViewState({
           type: VIEW_TYPE_CLAUDIAN,
           active: true,
         });
-        leaf = newLeaf;
       }
-    }
 
-    if (leaf) {
       await revealWorkspaceLeaf(workspace, leaf);
-      if (isClaudianView(leaf.view)) {
+      if (!focusSuperseded && isClaudianView(leaf.view)) {
         leaf.view.focusActiveInput();
       }
+    } finally {
+      workspace.offref(focusIntentRef);
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -525,6 +525,9 @@ export default class ClaudianPlugin extends Plugin {
 
     if (leaf) {
       await revealWorkspaceLeaf(workspace, leaf);
+      if (isClaudianView(leaf.view)) {
+        leaf.view.focusActiveInput();
+      }
     }
   }
 

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -169,6 +169,7 @@ describe('ClaudianPlugin', () => {
         layoutReady: true,
         detachLeavesOfType: jest.fn(),
         on: jest.fn().mockReturnValue({ id: 'workspace-event' }),
+        offref: jest.fn(),
         onLayoutReady: jest.fn(),
         getLeavesOfType: jest.fn().mockReturnValue([]),
         getMostRecentLeaf: jest.fn().mockReturnValue(null),
@@ -1944,6 +1945,45 @@ describe('ClaudianPlugin', () => {
       expect(mockApp.workspace.revealLeaf.mock.invocationCallOrder[0]).toBeLessThan(
         focusActiveInput.mock.invocationCallOrder[0],
       );
+    });
+
+    it('does not reclaim focus when another leaf activates during cold view setup', async () => {
+      let resolveViewSetup!: () => void;
+      const focusActiveInput = jest.fn();
+      const mockRightLeaf = {
+        setViewState: jest.fn().mockImplementation(() => new Promise<void>((resolve) => {
+          resolveViewSetup = resolve;
+        })),
+        view: {
+          getTabManager: jest.fn(),
+          focusActiveInput,
+        },
+      };
+      const activeLeafListeners = new Map<object, (leaf: unknown) => void>();
+      mockApp.workspace.getLeavesOfType.mockReturnValue([]);
+      mockApp.workspace.getRightLeaf.mockReturnValue(mockRightLeaf);
+      mockApp.workspace.on.mockImplementation((event: string, listener: (leaf: unknown) => void) => {
+        const eventRef = { event, listener };
+        if (event === 'active-leaf-change') {
+          activeLeafListeners.set(eventRef, listener);
+        }
+        return eventRef;
+      });
+      mockApp.workspace.offref = jest.fn((eventRef: object) => {
+        activeLeafListeners.delete(eventRef);
+      });
+
+      await plugin.onload();
+      const activation = plugin.activateView();
+      for (const listener of activeLeafListeners.values()) {
+        listener({ id: 'newer-editor-leaf' });
+      }
+      resolveViewSetup();
+      await activation;
+
+      expect(mockApp.workspace.revealLeaf).toHaveBeenCalledWith(mockRightLeaf);
+      expect(focusActiveInput).not.toHaveBeenCalled();
+      expect(activeLeafListeners.size).toBe(0);
     });
 
     it('should create new leaf in left sidebar when chatViewPlacement is left-sidebar', async () => {

--- a/tests/integration/main.test.ts
+++ b/tests/integration/main.test.ts
@@ -1889,13 +1889,21 @@ describe('ClaudianPlugin', () => {
 
   describe('activateView', () => {
     it('should reveal existing leaf if view already exists', async () => {
-      const mockLeaf = { id: 'existing-leaf' };
+      const focusActiveInput = jest.fn();
+      const mockLeaf = {
+        id: 'existing-leaf',
+        view: {
+          getTabManager: jest.fn(),
+          focusActiveInput,
+        },
+      };
       mockApp.workspace.getLeavesOfType.mockReturnValue([mockLeaf]);
 
       await plugin.onload();
       await plugin.activateView();
 
       expect(mockApp.workspace.revealLeaf).toHaveBeenCalledWith(mockLeaf);
+      expect(focusActiveInput).toHaveBeenCalledTimes(1);
     });
 
     it('should create new leaf in right sidebar by default if view does not exist', async () => {
@@ -1913,6 +1921,29 @@ describe('ClaudianPlugin', () => {
         type: VIEW_TYPE_CLAUDIAN,
         active: true,
       });
+    });
+
+    it('focuses a newly revealed right-sidebar chat even when the root editor stays most recent', async () => {
+      const focusActiveInput = jest.fn();
+      const mockRightLeaf = {
+        setViewState: jest.fn().mockResolvedValue(undefined),
+        view: {
+          getTabManager: jest.fn(),
+          focusActiveInput,
+        },
+      };
+      mockApp.workspace.getLeavesOfType.mockReturnValue([]);
+      mockApp.workspace.getRightLeaf.mockReturnValue(mockRightLeaf);
+      mockApp.workspace.getMostRecentLeaf.mockReturnValue({ id: 'previous-editor-leaf' });
+
+      await plugin.onload();
+      await plugin.activateView();
+
+      expect(mockApp.workspace.revealLeaf).toHaveBeenCalledWith(mockRightLeaf);
+      expect(focusActiveInput).toHaveBeenCalledTimes(1);
+      expect(mockApp.workspace.revealLeaf.mock.invocationCallOrder[0]).toBeLessThan(
+        focusActiveInput.mock.invocationCallOrder[0],
+      );
     });
 
     it('should create new leaf in left sidebar when chatViewPlacement is left-sidebar', async () => {


### PR DESCRIPTION
## Why

Refs #739.

Opening Claudian through the command, hotkey, or ribbon reveals the chat leaf but does not move keyboard focus into the composer. Users therefore have to click the input before typing, for both newly created sidebar leaves and already-open chat views.

The earlier #807 attempt was closed after review identified that its root-only getMostRecentLeaf guard skipped the default sidebar placement. The issue remains on current main.

## What Changed

- Focus the active Claudian composer immediately after the target leaf has been revealed.
- Cover both an already-open Claudian leaf and a newly created right-sidebar leaf.
- Pin the sidebar case where getMostRecentLeaf still reports the previous root editor, matching the review feedback on #807.

## Why This Approach

ClaudianView already owns the active composer and exposes focusActiveInput, so the composition root can request focus without querying tab DOM. Obsidian's awaited revealLeaf contract guarantees that the view is fully loaded before the focus request.

This avoids timers, retry state, raw textarea queries, and the root-only getMostRecentLeaf cancellation guard that made #807 ineffective for sidebar leaves.

## Validation

- TDD red: the new right-sidebar integration test observed zero focus calls after reveal.
- npm run test:unit -- --runTestsByPath tests/integration/main.test.ts --runInBand (159 tests passed)
- npm run test (573 suites / 8401 tests plus 14 protocol suites / 131 tests passed)
- npm run typecheck
- npm run lint
- npm run build
- git diff --check

## Impact and Follow-ups

This changes only the explicit Claudian view activation path. It does not alter tab membership, conversation state, or provider execution. If a revealed Claudian view has no active runtime tab, the existing focusActiveInput implementation remains a no-op.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.