### PR TITLE
feat: close chat tabs with middle click

### DIFF
--- a/src/features/chat/tabs/TabBar.ts
+++ b/src/features/chat/tabs/TabBar.ts
@@ -120,6 +120,10 @@ export class TabBar {
         this.callbacks.onTabClose(item.id);
       });
 
+      badgeEl.addEventListener('mousedown', (e) => {
+        if (e.button === 1) e.preventDefault();
+      });
+
       badgeEl.addEventListener('auxclick', (e) => {
         if (e.button !== 1) return;
         e.preventDefault();

--- a/src/features/chat/tabs/TabBar.ts
+++ b/src/features/chat/tabs/TabBar.ts
@@ -113,10 +113,17 @@ export class TabBar {
       this.toggleBadgeTitle(item, badgeEl);
     });
 
-    // Right-click to close (if allowed)
+    // Right- or middle-click to close (if allowed)
     if (item.canClose) {
       badgeEl.addEventListener('contextmenu', (e) => {
         e.preventDefault();
+        this.callbacks.onTabClose(item.id);
+      });
+
+      badgeEl.addEventListener('auxclick', (e) => {
+        if (e.button !== 1) return;
+        e.preventDefault();
+        e.stopPropagation();
         this.callbacks.onTabClose(item.id);
       });
     }

--- a/tests/unit/features/chat/tabs/TabBar.test.ts
+++ b/tests/unit/features/chat/tabs/TabBar.test.ts
@@ -416,15 +416,53 @@ describe('TabBar', () => {
       expect(callbacks.onTabClose).toHaveBeenCalledWith('closeable-tab');
     });
 
-    it('should not register contextmenu handler when canClose is false', () => {
+    it('closes a closeable tab on middle click', () => {
+      const containerEl = createMockEl();
+      const callbacks = createMockCallbacks();
+      const tabBar = new TabBar(containerEl, callbacks);
+
+      tabBar.update([createTabBarItem({ id: 'middle-close-tab', canClose: true })]);
+
+      const event = {
+        button: 1,
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+      };
+      containerEl._children[0].dispatchEvent('auxclick', event);
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+      expect(callbacks.onTabClose).toHaveBeenCalledWith('middle-close-tab');
+    });
+
+    it('ignores other auxiliary mouse buttons', () => {
+      const containerEl = createMockEl();
+      const callbacks = createMockCallbacks();
+      const tabBar = new TabBar(containerEl, callbacks);
+
+      tabBar.update([createTabBarItem({ id: 'auxiliary-tab', canClose: true })]);
+
+      const event = {
+        button: 2,
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+      };
+      containerEl._children[0].dispatchEvent('auxclick', event);
+
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(event.stopPropagation).not.toHaveBeenCalled();
+      expect(callbacks.onTabClose).not.toHaveBeenCalled();
+    });
+
+    it('should not register close handlers when canClose is false', () => {
       const containerEl = createMockEl();
       const callbacks = createMockCallbacks();
       const tabBar = new TabBar(containerEl, callbacks);
 
       tabBar.update([createTabBarItem({ id: 'uncloseable-tab', canClose: false })]);
 
-      // Check that contextmenu handler was not registered
       expect(containerEl._children[0]._eventListeners.has('contextmenu')).toBe(false);
+      expect(containerEl._children[0]._eventListeners.has('auxclick')).toBe(false);
     });
   });
 

--- a/tests/unit/features/chat/tabs/TabBar.test.ts
+++ b/tests/unit/features/chat/tabs/TabBar.test.ts
@@ -435,6 +435,34 @@ describe('TabBar', () => {
       expect(callbacks.onTabClose).toHaveBeenCalledWith('middle-close-tab');
     });
 
+    it('prevents the middle-button down default before the auxiliary close', () => {
+      const containerEl = createMockEl();
+      const callbacks = createMockCallbacks();
+      const tabBar = new TabBar(containerEl, callbacks);
+
+      tabBar.update([createTabBarItem({ id: 'middle-close-tab', canClose: true })]);
+
+      const middleDown = { button: 1, preventDefault: jest.fn() };
+      containerEl._children[0].dispatchEvent('mousedown', middleDown);
+
+      expect(middleDown.preventDefault).toHaveBeenCalledTimes(1);
+      expect(callbacks.onTabClose).not.toHaveBeenCalled();
+    });
+
+    it('does not prevent primary-button down behavior', () => {
+      const containerEl = createMockEl();
+      const callbacks = createMockCallbacks();
+      const tabBar = new TabBar(containerEl, callbacks);
+
+      tabBar.update([createTabBarItem({ id: 'primary-tab', canClose: true })]);
+
+      const primaryDown = { button: 0, preventDefault: jest.fn() };
+      containerEl._children[0].dispatchEvent('mousedown', primaryDown);
+
+      expect(primaryDown.preventDefault).not.toHaveBeenCalled();
+      expect(callbacks.onTabClose).not.toHaveBeenCalled();
+    });
+
     it('ignores other auxiliary mouse buttons', () => {
       const containerEl = createMockEl();
       const callbacks = createMockCallbacks();
@@ -462,6 +490,7 @@ describe('TabBar', () => {
       tabBar.update([createTabBarItem({ id: 'uncloseable-tab', canClose: false })]);
 
       expect(containerEl._children[0]._eventListeners.has('contextmenu')).toBe(false);
+      expect(containerEl._children[0]._eventListeners.has('mousedown')).toBe(false);
       expect(containerEl._children[0]._eventListeners.has('auxclick')).toBe(false);
     });
   });


### PR DESCRIPTION
## Why

Claudian chat tabs can currently be closed with the context menu, but they do not support the standard middle-click close interaction used by browsers and other tabbed applications. This adds that shortcut for mouse users without changing which tabs are allowed to close.

A consumed `auxclick` also needs a down-phase guard. `auxclick` fires only after `mousedown` and `mouseup`; on non-navigation elements, [MDN's auxclick guidance](https://developer.mozilla.org/en-US/docs/Web/API/Element/auxclick_event#preventing_default_actions) recommends cancelling middle-button down defaults to avoid Windows autoscroll and platform paste behavior before the later auxiliary click is handled.

Refs #744
Refs #536

## What Changed

- Handle middle-button `auxclick` events on closeable tab badges.
- Prevent only the middle-button `mousedown` default before the auxiliary close is dispatched.
- Route the interaction through the existing `onTabClose` callback.
- Ignore non-middle auxiliary buttons and avoid registering close handlers for tabs whose `canClose` flag is false.
- Add focused TabBar regression coverage for the down and auxiliary-click interaction boundaries.

## Why This Approach

`TabBar` already owns badge pointer interactions and exposes a single close callback to the tab lifecycle owner. Handling the browser-native events there keeps the change local and preserves all existing close policy in `TabManager`; it does not add state, public APIs, or a parallel close path.

The down handler prevents the platform default only for middle-button input on closeable badges, without closing the tab. The existing `auxclick` handler remains the sole close trigger and stops propagation only for the middle button it consumes. Primary click/down, double click, right click, other auxiliary buttons, and uncloseable badges retain their existing behavior.

## Validation

TDD red evidence:
- The focused middle-click test initially failed because no `auxclick` handler prevented the event or requested tab closure.
- The follow-up down-phase test failed while the `auxclick` tests were green, proving the platform default was still not cancelled before the close event.

Passing validation:
- `npm run test:unit -- --runTestsByPath tests/unit/features/chat/tabs/TabBar.test.ts --runInBand` — 39/39 tests passed.
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`
- GitHub Actions full test, quality, protocol, build, workflow, dependency, diff, and scope checks are green for `4603f6f0`; the full test job passed in 3m02s.

## Impact and Follow-ups

The change affects only pointer input on closeable chat tab badges. Existing primary-click selection, double-click title expansion, right-click closure, and uncloseable-tab protection remain unchanged. No persistence, provider, protocol, or data compatibility impact is expected.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
