### PR TITLE
fix: keep long approval details scrollable

### DIFF
--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -1934,7 +1934,22 @@ export class InputController {
       headerEl.createDiv({ text: `Agent: ${approvalOptions.agentID}`, cls: 'claudian-ask-approval-agent' });
     }
 
-    headerEl.createDiv({ text: description, cls: 'claudian-ask-approval-desc' });
+    const descriptionEl = headerEl.createDiv({
+      text: description,
+      cls: 'claudian-ask-approval-desc',
+    });
+    descriptionEl.setAttribute('aria-label', `${toolName} approval details`);
+    descriptionEl.setAttribute('role', 'region');
+    descriptionEl.setAttribute('tabindex', '0');
+    descriptionEl.addEventListener('keydown', (event) => {
+      if (
+        event.key === 'ArrowDown'
+        || event.key === 'ArrowUp'
+        || event.key === 'Enter'
+      ) {
+        event.stopPropagation();
+      }
+    });
 
     const decisionOptions = approvalOptions?.decisionOptions ?? DEFAULT_APPROVAL_DECISION_OPTIONS;
     const optionDecisionMap = new Map<string, ApprovalDecision>();

--- a/src/style/features/ask-user-question.css
+++ b/src/style/features/ask-user-question.css
@@ -305,6 +305,9 @@
 }
 
 .claudian-ask-approval-desc {
+  max-height: min(30vh, 240px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 8px 10px;
   background: var(--background-primary-alt);
   border-radius: 6px;

--- a/src/style/features/ask-user-question.css
+++ b/src/style/features/ask-user-question.css
@@ -316,3 +316,8 @@
   color: var(--text-normal);
   word-break: break-all;
 }
+
+.claudian-ask-approval-desc:focus-visible {
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: -2px;
+}

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -224,6 +224,50 @@ function createFixture(overrides: Record<string, unknown> = {}) {
   };
 }
 
+describe('InputController approval details', () => {
+  it('makes long approval details a named keyboard-scrollable region', () => {
+    const parentEl = createMockEl();
+    const inputContainerEl = createMockEl();
+    inputContainerEl.parentElement = parentEl;
+    parentEl.appendChild(inputContainerEl);
+    const fixture = createFixture({
+      getInputContainerEl: () => inputContainerEl as any,
+    });
+
+    const pending = fixture.controller.handleApprovalRequest(
+      'Bash',
+      {},
+      'A long command description',
+    );
+    const descriptionEl = parentEl.querySelector('.claudian-ask-approval-desc');
+
+    expect(descriptionEl?.getAttribute('tabindex')).toBe('0');
+    expect(descriptionEl?.getAttribute('role')).toBe('region');
+    expect(descriptionEl?.getAttribute('aria-label')).toBe('Bash approval details');
+
+    const stopPropagation = jest.fn();
+    const preventDefault = jest.fn();
+    descriptionEl?.dispatchEvent({
+      type: 'keydown',
+      key: 'ArrowDown',
+      preventDefault,
+      stopPropagation,
+    });
+    descriptionEl?.dispatchEvent({
+      type: 'keydown',
+      key: 'Enter',
+      preventDefault,
+      stopPropagation,
+    });
+
+    expect(stopPropagation).toHaveBeenCalledTimes(2);
+    expect(preventDefault).not.toHaveBeenCalled();
+
+    fixture.controller.dismissPendingApprovalPrompt();
+    return pending;
+  });
+});
+
 describe('InputController coordinator execution', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/tests/unit/style/features/ask-user-question.test.ts
+++ b/tests/unit/style/features/ask-user-question.test.ts
@@ -5,10 +5,15 @@ describe('Ask user question styles', () => {
   it('keeps long approval descriptions inside a bounded scroll area', () => {
     const css = readFileSync(path.resolve('src/style/features/ask-user-question.css'), 'utf8');
     const descriptionRule = css.match(/\.claudian-ask-approval-desc\s*{([^}]*)}/)?.[1];
+    const focusRule = css.match(
+      /\.claudian-ask-approval-desc:focus-visible\s*{([^}]*)}/,
+    )?.[1];
 
     expect(descriptionRule).toBeDefined();
     expect(descriptionRule).toContain('max-height: min(30vh, 240px);');
     expect(descriptionRule).toContain('overflow-y: auto;');
     expect(descriptionRule).toContain('overscroll-behavior: contain;');
+    expect(focusRule).toContain('outline: 2px solid var(--interactive-accent);');
+    expect(focusRule).toContain('outline-offset: -2px;');
   });
 });

--- a/tests/unit/style/features/ask-user-question.test.ts
+++ b/tests/unit/style/features/ask-user-question.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+describe('Ask user question styles', () => {
+  it('keeps long approval descriptions inside a bounded scroll area', () => {
+    const css = readFileSync(path.resolve('src/style/features/ask-user-question.css'), 'utf8');
+    const descriptionRule = css.match(/\.claudian-ask-approval-desc\s*{([^}]*)}/)?.[1];
+
+    expect(descriptionRule).toBeDefined();
+    expect(descriptionRule).toContain('max-height: min(30vh, 240px);');
+    expect(descriptionRule).toContain('overflow-y: auto;');
+    expect(descriptionRule).toContain('overscroll-behavior: contain;');
+  });
+});


### PR DESCRIPTION
## Why

Provider approval descriptions can contain large prompts, schemas, or serialized tool arguments. The current inline permission UI renders that description without any height bound, so a long value can push the decision controls outside the usable chat area and force scrolling on the entire panel.

Issue #791 was closed only by the stale workflow, and the current inline approval selector still has the same unbounded layout behavior.

Refs #791
Refs #296

## What Changed

- Bound the approval description to the smaller of 30 percent of the viewport height or 240 pixels.
- Make overflow scroll inside the description while containing scroll chaining.
- Expose the description as a named, focusable region so keyboard users can inspect long content.
- Keep Arrow Up, Arrow Down, and Enter inside the focused description instead of letting the parent approval widget reinterpret them as option navigation or approval.
- Add an explicit focus-visible outline and focused regression coverage for the layout and keyboard contracts.

## Why This Approach

The description is the only unbounded, provider-supplied part of this approval surface. Constraining that element keeps the tool identity and decision choices visible while preserving the full description for inspection.

Bounding the whole inline widget would also make the decision controls scroll away, while truncating or modifying the provider text would hide information needed for a permission decision. The focusable region preserves the existing immediate-selection keyboard model: Tab can enter and leave the details, scrolling keys retain their browser behavior, and Enter cannot accidentally approve the currently highlighted option while focus is inside the details.

## Validation

TDD red evidence:
- The focused stylesheet test failed before implementation because the approval description had no maximum height, vertical overflow owner, or scroll containment.
- The InputController seam test failed before the follow-up because the description had no keyboard focus target or accessible region semantics.

Passing validation:
- `npm run test:unit -- --runTestsByPath tests/unit/features/chat/controllers/InputController.test.ts tests/unit/style/features/ask-user-question.test.ts --runInBand` — 76/76 tests passed.
- `npm run lint:css`
- `npm run build:css`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`
- GitHub Actions full test, quality, protocol-contract, build, lockfile, dependency-review, workflow-lint, diff-hygiene, and Collab scope checks are green for `c0f44999`.

The local default-timeout full run reached the unrelated Collab integration gate added by #1142 and timed out at 5.996 seconds; the same real gate passed 1/1 with a diagnostic 15-second timeout in 6.55 seconds. The clean GitHub full-suite run passed in 2m58s.

## Impact and Follow-ups

This changes only the layout and keyboard accessibility of inline tool-approval descriptions. Short descriptions remain visually unchanged, long content remains fully available through internal scrolling, and the approval decision protocol is untouched. No provider, persistence, protocol, or data compatibility impact is expected.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
