### PR TITLE
fix: preserve selection in detached chat views

### DIFF
--- a/src/features/chat/controllers/SelectionController.ts
+++ b/src/features/chat/controllers/SelectionController.ts
@@ -1,4 +1,4 @@
-import type { App } from 'obsidian';
+import type { App, WorkspaceLeaf } from 'obsidian';
 import { MarkdownView } from 'obsidian';
 
 import { hideSelectionHighlight, showSelectionHighlight } from '../../../shared/components/SelectionHighlight';
@@ -24,6 +24,7 @@ export class SelectionController {
   private focusScopeEls: HTMLElement[];
   private onVisibilityChange: (() => void) | null;
   private onUserSelectionChanged: (() => void) | null;
+  private owningLeaf: WorkspaceLeaf | null;
   private storedSelection: StoredSelection | null = null;
   private inputHandoffGraceUntil: number | null = null;
   private pollInterval: number | null = null;
@@ -44,6 +45,7 @@ export class SelectionController {
     onVisibilityChange?: () => void,
     focusScopeEl?: FocusScopeInput,
     onUserSelectionChanged?: () => void,
+    owningLeaf?: WorkspaceLeaf,
   ) {
     this.app = app;
     this.contextTray = contextTray;
@@ -51,6 +53,7 @@ export class SelectionController {
     this.focusScopeEls = this.normalizeFocusScopes(focusScopeEl);
     this.onVisibilityChange = onVisibilityChange ?? null;
     this.onUserSelectionChanged = onUserSelectionChanged ?? null;
+    this.owningLeaf = owningLeaf ?? null;
   }
 
   start(): void {
@@ -276,7 +279,12 @@ export class SelectionController {
 
   private isFocusWithinChatSidebar(): boolean {
     const activeElement = this.getActiveElement(this.getFocusScopeOwnerDocument()) as Node | null;
-    return activeElement !== null && this.isNodeWithinFocusScopes(activeElement);
+    if (activeElement !== null && this.isNodeWithinFocusScopes(activeElement)) {
+      return true;
+    }
+
+    return this.owningLeaf !== null
+      && this.app.workspace.getMostRecentLeaf() === this.owningLeaf;
   }
 
   private isNativeEditorSelectionVisible(sel: StoredSelection): boolean {

--- a/src/features/chat/tabs/runtime/TabRuntimeControllers.ts
+++ b/src/features/chat/tabs/runtime/TabRuntimeControllers.ts
@@ -67,6 +67,7 @@ export function buildTabRuntimeControllers(
 ): TabRuntimeControllerBundle {
   const { component, forkRequestCallback, isRuntimeLive, openConversation, plugin } = options;
   const viewHost = component as Partial<TabManagerViewHost>;
+  const owningLeaf = viewHost.leaf;
   const { dom, state } = shell;
   const ensureExecutionInitialized = async (): Promise<boolean> => {
     const tab = runtimeRef.requirePublished();
@@ -122,6 +123,7 @@ export function buildTabRuntimeControllers(
     undefined,
     [dom.contentEl, dom.inputComposerEl, ...getSharedSelectionFocusScopeEls(component)],
     () => commitProvisionalTab(runtimeRef.requirePublished()),
+    owningLeaf,
   );
   options.registerCleanup('tab editor selection controller', () => selectionController.stop());
 

--- a/tests/unit/features/chat/controllers/SelectionController.test.ts
+++ b/tests/unit/features/chat/controllers/SelectionController.test.ts
@@ -191,6 +191,55 @@ describe('SelectionController', () => {
     expect(contextTray.clearItems).not.toHaveBeenCalledWith('editor-selection');
   });
 
+  it('preserves selection when the owning chat view is active in a detached window', () => {
+    const owningLeaf = {};
+    app.workspace.getMostRecentLeaf = jest.fn().mockReturnValue(owningLeaf);
+    controller = new SelectionController(
+      app,
+      contextTray as any,
+      inputEl,
+      undefined,
+      focusScopeEl,
+      undefined,
+      owningLeaf as any,
+    );
+    controller.start();
+    jest.advanceTimersByTime(250);
+    expect(controller.hasSelection()).toBe(true);
+
+    app.workspace.getActiveViewOfType.mockReturnValue(null);
+    (global as any).document.activeElement = null;
+    jest.advanceTimersByTime(250);
+
+    expect(app.workspace.getMostRecentLeaf).toHaveBeenCalled();
+    expect(controller.hasSelection()).toBe(true);
+    expect(contextTray.clearItems).not.toHaveBeenCalledWith('editor-selection');
+  });
+
+  it('clears selection when a different chat leaf is active', () => {
+    const owningLeaf = {};
+    app.workspace.getMostRecentLeaf = jest.fn().mockReturnValue({});
+    controller = new SelectionController(
+      app,
+      contextTray as any,
+      inputEl,
+      undefined,
+      focusScopeEl,
+      undefined,
+      owningLeaf as any,
+    );
+    controller.start();
+    jest.advanceTimersByTime(250);
+    expect(controller.hasSelection()).toBe(true);
+
+    app.workspace.getActiveViewOfType.mockReturnValue(null);
+    (global as any).document.activeElement = null;
+    jest.advanceTimersByTime(250);
+
+    expect(controller.hasSelection()).toBe(false);
+    expect(contextTray.clearItems).toHaveBeenCalledWith('editor-selection');
+  });
+
   it('preserves selection when a relocated composer outside tab content has focus', () => {
     const contentScopeEl = createMockEventTarget();
     const composerScopeEl = createMockEventTarget();


### PR DESCRIPTION
## Why

Fixes #399.

When Claudian is opened in a detached window or its own workspace tab, moving focus from an editor selection into Claudian can leave the chat document's `activeElement` on `<body>`. The Markdown view is no longer active, so the next selection poll treats the editor context as unavailable and clears the captured selection even though the user moved into the same Claudian view.

## What Changed

- Pass the exact owning `WorkspaceLeaf` from the current chat view into `SelectionController`.
- Treat that leaf as chat focus when DOM focus is not contained by the normal chat focus scopes.
- Cover both the detached-window preservation case and the multi-view case where a different chat leaf must still clear stale selection.

## Why This Approach

The existing DOM containment check remains the first source of truth. The leaf check is only a fallback for the detached-window/own-tab focus shape where DOM focus lands on `<body>`.

Comparing exact leaf identity is narrower than matching the Claudian view type: if multiple Claudian views are open, activity in one view must not preserve stale selection owned by another. It also avoids the broader alternative of keeping selection whenever no Markdown view is active, which could retain context after navigating to an unrelated view.

This adapts the root-cause investigation and earlier fix attempt in #478 by @GeraldScott to the current per-tab runtime and multi-view architecture.

## Validation

- Established the regression test before the implementation; it failed because the detached owning view was not considered.
- `npm run test:unit -- --runTestsByPath tests/unit/features/chat/controllers/SelectionController.test.ts tests/unit/features/chat/tabs/TabRuntimeFactory.test.ts --runInBand` (86 tests)
- `npm run typecheck`
- `npm run lint`
- `npm run test` (protocol: 14 suites / 131 tests; main: 573 suites / 8402 tests; architecture/policy: 61 tests)
- `npm run build`
- `git diff --check`

## Impact and Follow-ups

The change is limited to editor-selection lifetime in the owning chat view. It does not change provider execution, persisted conversations, view state, or selection payloads. A different active leaf still clears the stored selection.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] User-facing documentation is not needed because this restores existing selection behavior without adding a setting or workflow.
