### PR TITLE
fix: make image previews keyboard accessible

### DIFF
--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -676,7 +676,13 @@ export class MessageRenderer {
     const imagesEl = containerEl.createDiv({ cls: 'claudian-message-images' });
 
     for (const image of images) {
-      const imageWrapper = imagesEl.createDiv({ cls: 'claudian-message-image' });
+      const imageWrapper = imagesEl.createEl('button', {
+        cls: 'claudian-message-image',
+        attr: {
+          'aria-label': `Preview ${image.name}`,
+          type: 'button',
+        },
+      });
       const imgEl = imageWrapper.createEl('img', {
         attr: {
           alt: image.name,
@@ -685,8 +691,7 @@ export class MessageRenderer {
 
       void this.setImageSrc(imgEl, image);
 
-      // Click to view full size
-      imgEl.addEventListener('click', () => {
+      imageWrapper.addEventListener('click', () => {
         void this.showFullImage(image);
       });
     }

--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -34,6 +34,7 @@ import {
 } from '../../../utils/markdownMath';
 import type { FeatureHost } from '../../FeatureHost';
 import { findRewindContext } from '../rewind';
+import { ImagePreviewModal } from '../ui/ImagePreviewModal';
 import { formatConversationDirectoryTitle } from '../utils/conversationDirectoryTitle';
 import { renderCitationGroup as renderCitationBlock } from './CitationRenderer';
 import {
@@ -76,7 +77,7 @@ export class MessageRenderer {
   private forkCallback?: (messageId: string) => Promise<void>;
   private liveMessageEls = new Map<string, HTMLElement>();
   private removeFileLinkHandler: () => void;
-  private closeImageModal: (() => void) | null = null;
+  private readonly imagePreviewModal = new ImagePreviewModal();
   private isDisposed = false;
 
   constructor(
@@ -122,7 +123,7 @@ export class MessageRenderer {
   dispose(): void {
     if (this.isDisposed) return;
     this.isDisposed = true;
-    this.closeImageModal?.();
+    this.imagePreviewModal.close();
     this.removeFileLinkHandler();
     this.removeFileLinkHandler = () => {};
     this.liveMessageEls.clear();
@@ -702,64 +703,9 @@ export class MessageRenderer {
    */
   showFullImage(image: ImageAttachment): void {
     if (this.isDisposed) return;
-    this.closeImageModal?.();
-
-    const dataUri = `data:${image.mediaType};base64,${image.data}`;
 
     const ownerDocument = this.messagesEl.ownerDocument ?? window.document;
-    const previouslyFocusedElement = ownerDocument.activeElement as HTMLElement | null;
-    const overlay = ownerDocument.body.createDiv({ cls: 'claudian-image-modal-overlay' });
-    const modal = overlay.createDiv({ cls: 'claudian-image-modal' });
-    modal.setAttribute('role', 'dialog');
-    modal.setAttribute('aria-modal', 'true');
-    modal.setAttribute('aria-label', `Image preview: ${image.name}`);
-
-    modal.createEl('img', {
-      attr: {
-        src: dataUri,
-        alt: image.name,
-      },
-    });
-
-    const closeBtn = modal.createEl('button', {
-      cls: 'claudian-image-modal-close',
-      attr: {
-        'aria-label': 'Close image preview',
-        type: 'button',
-      },
-    });
-    closeBtn.setText('\u00D7');
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        close();
-      } else if (e.key === 'Tab') {
-        e.preventDefault();
-        closeBtn.focus();
-      }
-    };
-
-    let isClosed = false;
-    const close = () => {
-      if (isClosed) return;
-      isClosed = true;
-      ownerDocument.removeEventListener('keydown', handleKeyDown);
-      overlay.remove();
-      if (this.closeImageModal === close) {
-        this.closeImageModal = null;
-      }
-      if (previouslyFocusedElement?.isConnected) {
-        previouslyFocusedElement.focus();
-      }
-    };
-
-    closeBtn.addEventListener('click', close);
-    overlay.addEventListener('click', (e) => {
-      if (e.target === overlay) close();
-    });
-    ownerDocument.addEventListener('keydown', handleKeyDown);
-    this.closeImageModal = close;
-    closeBtn.focus();
+    this.imagePreviewModal.open(ownerDocument, image);
   }
 
   /**

--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -712,7 +712,13 @@ export class MessageRenderer {
       },
     });
 
-    const closeBtn = modal.createDiv({ cls: 'claudian-image-modal-close' });
+    const closeBtn = modal.createEl('button', {
+      cls: 'claudian-image-modal-close',
+      attr: {
+        'aria-label': 'Close image preview',
+        type: 'button',
+      },
+    });
     closeBtn.setText('\u00D7');
 
     const handleEsc = (e: KeyboardEvent) => {

--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -707,8 +707,12 @@ export class MessageRenderer {
     const dataUri = `data:${image.mediaType};base64,${image.data}`;
 
     const ownerDocument = this.messagesEl.ownerDocument ?? window.document;
+    const previouslyFocusedElement = ownerDocument.activeElement as HTMLElement | null;
     const overlay = ownerDocument.body.createDiv({ cls: 'claudian-image-modal-overlay' });
     const modal = overlay.createDiv({ cls: 'claudian-image-modal' });
+    modal.setAttribute('role', 'dialog');
+    modal.setAttribute('aria-modal', 'true');
+    modal.setAttribute('aria-label', `Image preview: ${image.name}`);
 
     modal.createEl('img', {
       attr: {
@@ -741,6 +745,9 @@ export class MessageRenderer {
       if (this.closeImageModal === close) {
         this.closeImageModal = null;
       }
+      if (previouslyFocusedElement?.isConnected) {
+        previouslyFocusedElement.focus();
+      }
     };
 
     closeBtn.addEventListener('click', close);
@@ -749,6 +756,7 @@ export class MessageRenderer {
     });
     ownerDocument.addEventListener('keydown', handleEsc);
     this.closeImageModal = close;
+    closeBtn.focus();
   }
 
   /**

--- a/src/features/chat/rendering/MessageRenderer.ts
+++ b/src/features/chat/rendering/MessageRenderer.ts
@@ -730,9 +730,12 @@ export class MessageRenderer {
     });
     closeBtn.setText('\u00D7');
 
-    const handleEsc = (e: KeyboardEvent) => {
+    const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         close();
+      } else if (e.key === 'Tab') {
+        e.preventDefault();
+        closeBtn.focus();
       }
     };
 
@@ -740,7 +743,7 @@ export class MessageRenderer {
     const close = () => {
       if (isClosed) return;
       isClosed = true;
-      ownerDocument.removeEventListener('keydown', handleEsc);
+      ownerDocument.removeEventListener('keydown', handleKeyDown);
       overlay.remove();
       if (this.closeImageModal === close) {
         this.closeImageModal = null;
@@ -754,7 +757,7 @@ export class MessageRenderer {
     overlay.addEventListener('click', (e) => {
       if (e.target === overlay) close();
     });
-    ownerDocument.addEventListener('keydown', handleEsc);
+    ownerDocument.addEventListener('keydown', handleKeyDown);
     this.closeImageModal = close;
     closeBtn.focus();
   }

--- a/src/features/chat/ui/ImageContext.ts
+++ b/src/features/chat/ui/ImageContext.ts
@@ -327,7 +327,13 @@ export class ImageContextManager {
       },
     });
 
-    const closeBtn = modal.createDiv({ cls: 'claudian-image-modal-close' });
+    const closeBtn = modal.createEl('button', {
+      cls: 'claudian-image-modal-close',
+      attr: {
+        'aria-label': 'Close image preview',
+        type: 'button',
+      },
+    });
     closeBtn.setText('\u00D7');
 
     const handleEsc = (e: KeyboardEvent) => {

--- a/src/features/chat/ui/ImageContext.ts
+++ b/src/features/chat/ui/ImageContext.ts
@@ -340,9 +340,12 @@ export class ImageContextManager {
     });
     closeBtn.setText('\u00D7');
 
-    const handleEsc = (e: KeyboardEvent) => {
+    const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         close();
+      } else if (e.key === 'Tab') {
+        e.preventDefault();
+        closeBtn.focus();
       }
     };
 
@@ -350,7 +353,7 @@ export class ImageContextManager {
     const close = () => {
       if (isClosed) return;
       isClosed = true;
-      ownerDocument.removeEventListener('keydown', handleEsc);
+      ownerDocument.removeEventListener('keydown', handleKeyDown);
       overlay.remove();
       if (this.closeImageModal === close) {
         this.closeImageModal = null;
@@ -364,7 +367,7 @@ export class ImageContextManager {
     overlay.addEventListener('click', (e) => {
       if (e.target === overlay) close();
     });
-    ownerDocument.addEventListener('keydown', handleEsc);
+    ownerDocument.addEventListener('keydown', handleKeyDown);
     this.closeImageModal = close;
     closeBtn.focus();
   }

--- a/src/features/chat/ui/ImageContext.ts
+++ b/src/features/chat/ui/ImageContext.ts
@@ -317,8 +317,12 @@ export class ImageContextManager {
     this.closeImageModal?.();
 
     const ownerDocument = this.containerEl.ownerDocument ?? window.document;
+    const previouslyFocusedElement = ownerDocument.activeElement as HTMLElement | null;
     const overlay = ownerDocument.body.createDiv({ cls: 'claudian-image-modal-overlay' });
     const modal = overlay.createDiv({ cls: 'claudian-image-modal' });
+    modal.setAttribute('role', 'dialog');
+    modal.setAttribute('aria-modal', 'true');
+    modal.setAttribute('aria-label', `Image preview: ${image.name}`);
 
     modal.createEl('img', {
       attr: {
@@ -351,6 +355,9 @@ export class ImageContextManager {
       if (this.closeImageModal === close) {
         this.closeImageModal = null;
       }
+      if (previouslyFocusedElement?.isConnected) {
+        previouslyFocusedElement.focus();
+      }
     };
 
     closeBtn.addEventListener('click', close);
@@ -359,6 +366,7 @@ export class ImageContextManager {
     });
     ownerDocument.addEventListener('keydown', handleEsc);
     this.closeImageModal = close;
+    closeBtn.focus();
   }
 
   private generateId(): string {

--- a/src/features/chat/ui/ImageContext.ts
+++ b/src/features/chat/ui/ImageContext.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 
 import type { ImageAttachment, ImageMediaType } from '../../../core/types';
 import { ComposerContextTray } from './ComposerContextTray';
+import { ImagePreviewModal } from './ImagePreviewModal';
 
 const MAX_IMAGE_SIZE = 5 * 1024 * 1024;
 
@@ -28,7 +29,7 @@ export class ImageContextManager {
   private dropOverlay: HTMLElement | null = null;
   private dropZoneEl: HTMLElement | null = null;
   private attachedImages: Map<string, ImageAttachment> = new Map();
-  private closeImageModal: (() => void) | null = null;
+  private readonly imagePreviewModal = new ImagePreviewModal();
   private destroyed = false;
   private enabled = true;
   private readonly dragEnterHandler = (event: DragEvent): void => this.handleDragEnter(event);
@@ -112,7 +113,7 @@ export class ImageContextManager {
     }
     this.dropOverlay?.remove();
     this.dropOverlay = null;
-    this.closeImageModal?.();
+    this.imagePreviewModal.close();
     this.attachedImages.clear();
     this.contextTray.clearItems('images');
     this.ownedContextTray?.destroy();
@@ -314,62 +315,9 @@ export class ImageContextManager {
 
   private showFullImage(image: ImageAttachment) {
     if (this.destroyed) return;
-    this.closeImageModal?.();
 
     const ownerDocument = this.containerEl.ownerDocument ?? window.document;
-    const previouslyFocusedElement = ownerDocument.activeElement as HTMLElement | null;
-    const overlay = ownerDocument.body.createDiv({ cls: 'claudian-image-modal-overlay' });
-    const modal = overlay.createDiv({ cls: 'claudian-image-modal' });
-    modal.setAttribute('role', 'dialog');
-    modal.setAttribute('aria-modal', 'true');
-    modal.setAttribute('aria-label', `Image preview: ${image.name}`);
-
-    modal.createEl('img', {
-      attr: {
-        src: `data:${image.mediaType};base64,${image.data}`,
-        alt: image.name,
-      },
-    });
-
-    const closeBtn = modal.createEl('button', {
-      cls: 'claudian-image-modal-close',
-      attr: {
-        'aria-label': 'Close image preview',
-        type: 'button',
-      },
-    });
-    closeBtn.setText('\u00D7');
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        close();
-      } else if (e.key === 'Tab') {
-        e.preventDefault();
-        closeBtn.focus();
-      }
-    };
-
-    let isClosed = false;
-    const close = () => {
-      if (isClosed) return;
-      isClosed = true;
-      ownerDocument.removeEventListener('keydown', handleKeyDown);
-      overlay.remove();
-      if (this.closeImageModal === close) {
-        this.closeImageModal = null;
-      }
-      if (previouslyFocusedElement?.isConnected) {
-        previouslyFocusedElement.focus();
-      }
-    };
-
-    closeBtn.addEventListener('click', close);
-    overlay.addEventListener('click', (e) => {
-      if (e.target === overlay) close();
-    });
-    ownerDocument.addEventListener('keydown', handleKeyDown);
-    this.closeImageModal = close;
-    closeBtn.focus();
+    this.imagePreviewModal.open(ownerDocument, image);
   }
 
   private generateId(): string {

--- a/src/features/chat/ui/ImagePreviewModal.ts
+++ b/src/features/chat/ui/ImagePreviewModal.ts
@@ -1,0 +1,75 @@
+import type { ImageAttachment } from '@/core/types';
+
+function getFocusableActiveElement(ownerDocument: Document): HTMLElement | null {
+  const activeElement = ownerDocument.activeElement;
+  if (!activeElement || typeof (activeElement as HTMLElement).focus !== 'function') {
+    return null;
+  }
+  return activeElement as HTMLElement;
+}
+
+/** Owns the DOM and focus lifecycle of one open image preview. */
+export class ImagePreviewModal {
+  private closeCurrent: (() => void) | null = null;
+
+  open(ownerDocument: Document, image: ImageAttachment): void {
+    this.close();
+
+    const previouslyFocusedElement = getFocusableActiveElement(ownerDocument);
+    const overlay = ownerDocument.body.createDiv({ cls: 'claudian-image-modal-overlay' });
+    const modal = overlay.createDiv({ cls: 'claudian-image-modal' });
+    modal.setAttribute('role', 'dialog');
+    modal.setAttribute('aria-modal', 'true');
+    modal.setAttribute('aria-label', `Image preview: ${image.name}`);
+
+    modal.createEl('img', {
+      attr: {
+        src: `data:${image.mediaType};base64,${image.data}`,
+        alt: image.name,
+      },
+    });
+
+    const closeButton = modal.createEl('button', {
+      cls: 'claudian-image-modal-close',
+      attr: {
+        'aria-label': 'Close image preview',
+        type: 'button',
+      },
+    });
+    closeButton.setText('\u00D7');
+
+    let isClosed = false;
+    const close = () => {
+      if (isClosed) return;
+      isClosed = true;
+      ownerDocument.removeEventListener('keydown', handleKeyDown);
+      overlay.remove();
+      if (this.closeCurrent === close) {
+        this.closeCurrent = null;
+      }
+      if (previouslyFocusedElement?.isConnected) {
+        previouslyFocusedElement.focus();
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        close();
+      } else if (event.key === 'Tab') {
+        event.preventDefault();
+        closeButton.focus();
+      }
+    };
+
+    closeButton.addEventListener('click', close);
+    overlay.addEventListener('click', (event) => {
+      if (event.target === overlay) close();
+    });
+    ownerDocument.addEventListener('keydown', handleKeyDown);
+    this.closeCurrent = close;
+    closeButton.focus();
+  }
+
+  close(): void {
+    this.closeCurrent?.();
+  }
+}

--- a/src/style/features/image-context.css
+++ b/src/style/features/image-context.css
@@ -49,32 +49,40 @@
 }
 
 /* Individual image in message - standardized size */
-.claudian-message-image {
+button.claudian-message-image,
+button.claudian-message-image:active {
   appearance: none;
   width: 120px;
   height: 120px;
+  margin: 0;
   padding: 0;
   border-radius: 8px;
   overflow: hidden;
   cursor: pointer;
   transition: transform 0.15s ease, box-shadow 0.15s ease;
   background: var(--background-secondary);
+  background-image: none;
   border: 1px solid var(--background-modifier-border);
+  color: var(--text-muted);
   box-shadow: none;
 }
 
-.claudian-message-image:hover,
-.claudian-message-image:focus-visible {
+button.claudian-message-image:hover,
+button.claudian-message-image:focus-visible {
+  border: 1px solid var(--background-modifier-border);
+  background: var(--background-secondary);
+  background-image: none;
+  color: var(--text-normal);
   transform: scale(1.03);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
-.claudian-message-image:focus-visible {
+button.claudian-message-image:focus-visible {
   outline: 2px solid var(--interactive-accent);
   outline-offset: 2px;
 }
 
-.claudian-message-image img {
+button.claudian-message-image img {
   width: 100%;
   height: 100%;
   object-fit: cover;

--- a/src/style/features/image-context.css
+++ b/src/style/features/image-context.css
@@ -50,19 +50,28 @@
 
 /* Individual image in message - standardized size */
 .claudian-message-image {
+  appearance: none;
   width: 120px;
   height: 120px;
+  padding: 0;
   border-radius: 8px;
   overflow: hidden;
   cursor: pointer;
   transition: transform 0.15s ease, box-shadow 0.15s ease;
   background: var(--background-secondary);
   border: 1px solid var(--background-modifier-border);
+  box-shadow: none;
 }
 
-.claudian-message-image:hover {
+.claudian-message-image:hover,
+.claudian-message-image:focus-visible {
   transform: scale(1.03);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.claudian-message-image:focus-visible {
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: 2px;
 }
 
 .claudian-message-image img {

--- a/src/style/features/image-modal.css
+++ b/src/style/features/image-modal.css
@@ -34,6 +34,8 @@
   right: -12px;
   width: 32px;
   height: 32px;
+  padding: 0;
+  border: 0;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/style/features/image-modal.css
+++ b/src/style/features/image-modal.css
@@ -28,18 +28,23 @@
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 }
 
-.claudian-image-modal-close {
+button.claudian-image-modal-close,
+button.claudian-image-modal-close:focus,
+button.claudian-image-modal-close:active {
+  appearance: none;
   position: absolute;
   top: -12px;
   right: -12px;
   width: 32px;
   height: 32px;
+  margin: 0;
   padding: 0;
   border: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   background: var(--background-secondary);
+  background-image: none;
   border-radius: 50%;
   cursor: pointer;
   font-size: 20px;
@@ -48,7 +53,10 @@
   transition: background 0.15s ease, color 0.15s ease;
 }
 
-.claudian-image-modal-close:hover {
+button.claudian-image-modal-close:hover {
+  border: 0;
   background: var(--background-modifier-error);
+  background-image: none;
   color: var(--text-on-accent);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }

--- a/tests/unit/features/chat/rendering/MessageRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/MessageRenderer.test.ts
@@ -1275,7 +1275,7 @@ describe('MessageRenderer', () => {
     expect(imgEl.getAttribute('src')).toBe('data:image/png;base64,abc123');
   });
 
-  it('showFullImage creates overlay with image', () => {
+  it('showFullImage opens a preview that disposal closes without allowing another', () => {
     const { renderer } = createRenderer();
     const image: ImageAttachment = {
       id: 'img-1',
@@ -1286,8 +1286,8 @@ describe('MessageRenderer', () => {
       source: 'file',
     };
 
-    // Mock document.body.createDiv (document may not exist in node env)
     const overlayEl = createMockEl();
+    const removeOverlay = jest.spyOn(overlayEl, 'remove');
     const mockBody = { createDiv: jest.fn().mockReturnValue(overlayEl) };
     const origDocument = globalThis.document;
     (globalThis as any).document = { body: mockBody, addEventListener: jest.fn(), removeEventListener: jest.fn() };
@@ -1295,6 +1295,12 @@ describe('MessageRenderer', () => {
     try {
       renderer.showFullImage(image);
       expect(mockBody.createDiv).toHaveBeenCalledWith({ cls: 'claudian-image-modal-overlay' });
+
+      renderer.dispose();
+      renderer.showFullImage(image);
+
+      expect(removeOverlay).toHaveBeenCalledTimes(1);
+      expect(mockBody.createDiv).toHaveBeenCalledTimes(1);
     } finally {
       (globalThis as any).document = origDocument;
     }
@@ -1887,222 +1893,6 @@ describe('MessageRenderer', () => {
         outputToolCall,
         expect.anything(),
       );
-    });
-  });
-
-  // ============================================
-  // showFullImage - close behaviors
-  // ============================================
-
-  describe('showFullImage - close behaviors', () => {
-    const image: ImageAttachment = {
-      id: 'img-1',
-      name: 'test.png',
-      mediaType: 'image/png',
-      data: 'abc123',
-      size: 100,
-      source: 'file',
-    };
-
-    function setupDocumentMock() {
-      const overlayEl = createMockEl();
-      const previouslyFocusedEl = {
-        focus: jest.fn(),
-        isConnected: true,
-      };
-      let closeButtonFocus: jest.Mock | null = null;
-      const createModal = overlayEl.createDiv.bind(overlayEl);
-      overlayEl.createDiv = jest.fn((options: { cls?: string }) => {
-        const modalEl = createModal(options);
-        const createModalChild = modalEl.createEl.bind(modalEl);
-        modalEl.createEl = jest.fn((tag: string, childOptions?: unknown) => {
-          const child = createModalChild(tag, childOptions);
-          if (tag === 'button') {
-            closeButtonFocus = jest.fn();
-            child.focus = closeButtonFocus;
-          }
-          return child;
-        });
-        return modalEl;
-      });
-      const mockBody = { createDiv: jest.fn().mockReturnValue(overlayEl) };
-      const docListeners = new Map<string, ((...args: any[]) => void)[]>();
-      const origDocument = globalThis.document;
-
-      (globalThis as any).document = {
-        activeElement: previouslyFocusedEl,
-        body: mockBody,
-        addEventListener: jest.fn((event: string, handler: (...args: any[]) => void) => {
-          if (!docListeners.has(event)) docListeners.set(event, []);
-          docListeners.get(event)!.push(handler);
-        }),
-        removeEventListener: jest.fn((event: string, handler: (...args: any[]) => void) => {
-          const handlers = docListeners.get(event);
-          if (handlers) {
-            const idx = handlers.indexOf(handler);
-            if (idx !== -1) handlers.splice(idx, 1);
-          }
-        }),
-      };
-
-      return {
-        closeButtonFocus: () => closeButtonFocus,
-        docListeners,
-        mockBody,
-        origDocument,
-        overlayEl,
-        previouslyFocusedEl,
-      };
-    }
-
-    it('exposes a named dialog, moves focus inside, and restores it after close', () => {
-      const { renderer } = createRenderer();
-      const {
-        closeButtonFocus,
-        origDocument,
-        overlayEl,
-        previouslyFocusedEl,
-      } = setupDocumentMock();
-
-      try {
-        renderer.showFullImage(image);
-
-        const modalEl = overlayEl.children[0];
-        const closeBtn = modalEl.children[1];
-        expect(modalEl.getAttribute('role')).toBe('dialog');
-        expect(modalEl.getAttribute('aria-modal')).toBe('true');
-        expect(modalEl.getAttribute('aria-label')).toBe('Image preview: test.png');
-        expect(closeButtonFocus()).toHaveBeenCalledTimes(1);
-
-        closeBtn.click();
-
-        expect(previouslyFocusedEl.focus).toHaveBeenCalledTimes(1);
-      } finally {
-        (globalThis as any).document = origDocument;
-      }
-    });
-
-    it('keeps Tab focus on the only control in the image dialog', () => {
-      const { renderer } = createRenderer();
-      const {
-        closeButtonFocus,
-        docListeners,
-        origDocument,
-      } = setupDocumentMock();
-
-      try {
-        renderer.showFullImage(image);
-        const tabEvent = {
-          key: 'Tab',
-          preventDefault: jest.fn(),
-        };
-
-        docListeners.get('keydown')?.[0](tabEvent);
-
-        expect(tabEvent.preventDefault).toHaveBeenCalledTimes(1);
-        expect(closeButtonFocus()).toHaveBeenCalledTimes(2);
-      } finally {
-        (globalThis as any).document = origDocument;
-      }
-    });
-
-    it('closeBtn click removes overlay', () => {
-      const { renderer } = createRenderer();
-      const { overlayEl, origDocument } = setupDocumentMock();
-
-      try {
-        renderer.showFullImage(image);
-
-        // The overlay has a modal child, which has a close button child
-        const modalEl = overlayEl.children[0]; // claudian-image-modal
-        // Children: img (index 0), closeBtn (index 1)
-        const closeBtn = modalEl.children[1];
-        expect(closeBtn.hasClass('claudian-image-modal-close')).toBe(true);
-        expect(closeBtn.tagName).toBe('BUTTON');
-        expect(closeBtn.getAttribute('type')).toBe('button');
-        expect(closeBtn.getAttribute('aria-label')).toBe('Close image preview');
-
-        const removeSpy = jest.spyOn(overlayEl, 'remove');
-        closeBtn.click();
-
-        expect(removeSpy).toHaveBeenCalled();
-      } finally {
-        (globalThis as any).document = origDocument;
-      }
-    });
-
-    it('clicking overlay background removes overlay', () => {
-      const { renderer } = createRenderer();
-      const { overlayEl, origDocument } = setupDocumentMock();
-
-      try {
-        renderer.showFullImage(image);
-
-        const removeSpy = jest.spyOn(overlayEl, 'remove');
-
-        // Simulate click on the overlay itself (e.target === overlay)
-        const clickHandlers = overlayEl._eventListeners.get('click');
-        expect(clickHandlers).toBeDefined();
-        clickHandlers![0]({ target: overlayEl });
-
-        expect(removeSpy).toHaveBeenCalled();
-      } finally {
-        (globalThis as any).document = origDocument;
-      }
-    });
-
-    it('ESC key removes overlay', () => {
-      const { renderer } = createRenderer();
-      const { overlayEl, docListeners, origDocument } = setupDocumentMock();
-
-      try {
-        renderer.showFullImage(image);
-
-        const removeSpy = jest.spyOn(overlayEl, 'remove');
-
-        // Simulate ESC key press via the document keydown listener
-        const keydownHandlers = docListeners.get('keydown');
-        expect(keydownHandlers).toBeDefined();
-        expect(keydownHandlers!.length).toBeGreaterThan(0);
-        keydownHandlers![0]({ key: 'Escape' });
-
-        expect(removeSpy).toHaveBeenCalled();
-        // After close, the keydown handler should be removed
-        expect(document.removeEventListener).toHaveBeenCalledWith('keydown', expect.any(Function));
-      } finally {
-        (globalThis as any).document = origDocument;
-      }
-    });
-
-    it('dispose closes an open overlay and removes its document listener', () => {
-      const { renderer } = createRenderer();
-      const { overlayEl, docListeners, origDocument } = setupDocumentMock();
-
-      try {
-        renderer.showFullImage(image);
-        const removeSpy = jest.spyOn(overlayEl, 'remove');
-
-        renderer.dispose();
-
-        expect(removeSpy).toHaveBeenCalledTimes(1);
-        expect(docListeners.get('keydown')).toEqual([]);
-      } finally {
-        (globalThis as any).document = origDocument;
-      }
-    });
-
-    it('does not acquire another modal after disposal', () => {
-      const { renderer } = createRenderer();
-      const { mockBody, origDocument } = setupDocumentMock();
-
-      try {
-        renderer.dispose();
-        renderer.showFullImage(image);
-
-        expect(mockBody.createDiv).not.toHaveBeenCalled();
-      } finally {
-        (globalThis as any).document = origDocument;
-      }
     });
   });
 

--- a/tests/unit/features/chat/rendering/MessageRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/MessageRenderer.test.ts
@@ -1982,6 +1982,30 @@ describe('MessageRenderer', () => {
       }
     });
 
+    it('keeps Tab focus on the only control in the image dialog', () => {
+      const { renderer } = createRenderer();
+      const {
+        closeButtonFocus,
+        docListeners,
+        origDocument,
+      } = setupDocumentMock();
+
+      try {
+        renderer.showFullImage(image);
+        const tabEvent = {
+          key: 'Tab',
+          preventDefault: jest.fn(),
+        };
+
+        docListeners.get('keydown')?.[0](tabEvent);
+
+        expect(tabEvent.preventDefault).toHaveBeenCalledTimes(1);
+        expect(closeButtonFocus()).toHaveBeenCalledTimes(2);
+      } finally {
+        (globalThis as any).document = origDocument;
+      }
+    });
+
     it('closeBtn click removes overlay', () => {
       const { renderer } = createRenderer();
       const { overlayEl, origDocument } = setupDocumentMock();

--- a/tests/unit/features/chat/rendering/MessageRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/MessageRenderer.test.ts
@@ -2201,11 +2201,11 @@ describe('MessageRenderer', () => {
   });
 
   // ============================================
-  // renderMessageImages - click handler
+  // renderMessageImages - preview control
   // ============================================
 
-  describe('renderMessageImages - click handler', () => {
-    it('should add click handler on image elements', () => {
+  describe('renderMessageImages - preview control', () => {
+    it('opens the preview from a native named button', () => {
       const containerEl = createMockEl();
       const { renderer } = createRenderer();
       const showFullImageSpy = jest.spyOn(renderer, 'showFullImage').mockImplementation(() => {});
@@ -2219,15 +2219,19 @@ describe('MessageRenderer', () => {
 
       // Find the img element and check for click handler
       const imagesContainer = containerEl.children[0];
-      const wrapper = imagesContainer.children[0];
-      const imgEl = wrapper.children[0]; // The img element
+      const previewButton = imagesContainer.children[0];
+      const imgEl = previewButton.children[0];
 
-      // Check click handler is registered
-      const clickHandlers = imgEl._eventListeners?.get('click');
+      expect(previewButton.tagName).toBe('BUTTON');
+      expect(previewButton.getAttribute('type')).toBe('button');
+      expect(previewButton.getAttribute('aria-label')).toBe('Preview photo.png');
+      expect(imgEl.tagName).toBe('IMG');
+      expect(imgEl.getAttribute('alt')).toBe('photo.png');
+
+      const clickHandlers = previewButton._eventListeners?.get('click');
       expect(clickHandlers).toBeDefined();
       expect(clickHandlers!.length).toBe(1);
 
-      // Trigger click and verify showFullImage is called
       clickHandlers![0]();
       expect(showFullImageSpy).toHaveBeenCalledWith(images[0]);
     });

--- a/tests/unit/features/chat/rendering/MessageRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/MessageRenderer.test.ts
@@ -1940,6 +1940,9 @@ describe('MessageRenderer', () => {
         // Children: img (index 0), closeBtn (index 1)
         const closeBtn = modalEl.children[1];
         expect(closeBtn.hasClass('claudian-image-modal-close')).toBe(true);
+        expect(closeBtn.tagName).toBe('BUTTON');
+        expect(closeBtn.getAttribute('type')).toBe('button');
+        expect(closeBtn.getAttribute('aria-label')).toBe('Close image preview');
 
         const removeSpy = jest.spyOn(overlayEl, 'remove');
         closeBtn.click();

--- a/tests/unit/features/chat/rendering/MessageRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/MessageRenderer.test.ts
@@ -1906,11 +1906,31 @@ describe('MessageRenderer', () => {
 
     function setupDocumentMock() {
       const overlayEl = createMockEl();
+      const previouslyFocusedEl = {
+        focus: jest.fn(),
+        isConnected: true,
+      };
+      let closeButtonFocus: jest.Mock | null = null;
+      const createModal = overlayEl.createDiv.bind(overlayEl);
+      overlayEl.createDiv = jest.fn((options: { cls?: string }) => {
+        const modalEl = createModal(options);
+        const createModalChild = modalEl.createEl.bind(modalEl);
+        modalEl.createEl = jest.fn((tag: string, childOptions?: unknown) => {
+          const child = createModalChild(tag, childOptions);
+          if (tag === 'button') {
+            closeButtonFocus = jest.fn();
+            child.focus = closeButtonFocus;
+          }
+          return child;
+        });
+        return modalEl;
+      });
       const mockBody = { createDiv: jest.fn().mockReturnValue(overlayEl) };
       const docListeners = new Map<string, ((...args: any[]) => void)[]>();
       const origDocument = globalThis.document;
 
       (globalThis as any).document = {
+        activeElement: previouslyFocusedEl,
         body: mockBody,
         addEventListener: jest.fn((event: string, handler: (...args: any[]) => void) => {
           if (!docListeners.has(event)) docListeners.set(event, []);
@@ -1925,8 +1945,42 @@ describe('MessageRenderer', () => {
         }),
       };
 
-      return { overlayEl, mockBody, docListeners, origDocument };
+      return {
+        closeButtonFocus: () => closeButtonFocus,
+        docListeners,
+        mockBody,
+        origDocument,
+        overlayEl,
+        previouslyFocusedEl,
+      };
     }
+
+    it('exposes a named dialog, moves focus inside, and restores it after close', () => {
+      const { renderer } = createRenderer();
+      const {
+        closeButtonFocus,
+        origDocument,
+        overlayEl,
+        previouslyFocusedEl,
+      } = setupDocumentMock();
+
+      try {
+        renderer.showFullImage(image);
+
+        const modalEl = overlayEl.children[0];
+        const closeBtn = modalEl.children[1];
+        expect(modalEl.getAttribute('role')).toBe('dialog');
+        expect(modalEl.getAttribute('aria-modal')).toBe('true');
+        expect(modalEl.getAttribute('aria-label')).toBe('Image preview: test.png');
+        expect(closeButtonFocus()).toHaveBeenCalledTimes(1);
+
+        closeBtn.click();
+
+        expect(previouslyFocusedEl.focus).toHaveBeenCalledTimes(1);
+      } finally {
+        (globalThis as any).document = origDocument;
+      }
+    });
 
     it('closeBtn click removes overlay', () => {
       const { renderer } = createRenderer();

--- a/tests/unit/features/chat/ui/ImageContext.test.ts
+++ b/tests/unit/features/chat/ui/ImageContext.test.ts
@@ -695,6 +695,36 @@ describe('ImageContextManager - Private Helpers', () => {
       expect(manager['contextTray']['containerEl'].hasClass('has-content')).toBe(true);
     });
 
+    it('opens an image preview from the rendered attachment control and closes it on destroy', () => {
+      const overlayEl = createMockEl();
+      const removeOverlay = jest.spyOn(overlayEl, 'remove');
+      const mockBody = { createDiv: jest.fn().mockReturnValue(overlayEl) };
+      const originalDocument = globalThis.document;
+      (globalThis as any).document = {
+        activeElement: null,
+        body: mockBody,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      };
+
+      try {
+        manager.setImages([createImageAttachment({ name: 'photo.png' })]);
+        const previewButton = manager['contextTray']['containerEl']
+          .querySelector('.claudian-context-chip-main');
+
+        expect(previewButton.tagName).toBe('BUTTON');
+        previewButton.click();
+        expect(mockBody.createDiv).toHaveBeenCalledWith({
+          cls: 'claudian-image-modal-overlay',
+        });
+
+        manager.destroy();
+        expect(removeOverlay).toHaveBeenCalledTimes(1);
+      } finally {
+        (globalThis as any).document = originalDocument;
+      }
+    });
+
     it('renders a compact image pill without a thumbnail preview', () => {
       manager.setImages([createImageAttachment({ id: 'img-1', name: 'photo.png', size: 2048 })]);
 
@@ -746,133 +776,6 @@ describe('ImageContextManager - Private Helpers', () => {
       expect(mgr.getAttachedImages()).toHaveLength(1);
       expect(mgr.getAttachedImages()[0].id).toBe('img-2');
       expect(cb.onImagesChanged).toHaveBeenCalled();
-    });
-  });
-
-  describe('showFullImage', () => {
-    let origDocument: typeof globalThis.document;
-    let overlayEl: any;
-    let mockBody: any;
-    let addEventSpy: jest.Mock;
-    let removeEventSpy: jest.Mock;
-    let closeButtonFocus: jest.Mock;
-    let previouslyFocusedEl: { focus: jest.Mock; isConnected: boolean };
-
-    beforeEach(() => {
-      overlayEl = createMockEl();
-      closeButtonFocus = jest.fn();
-      previouslyFocusedEl = {
-        focus: jest.fn(),
-        isConnected: true,
-      };
-      const createModal = overlayEl.createDiv.bind(overlayEl);
-      overlayEl.createDiv = jest.fn((options: { cls?: string }) => {
-        const modalEl = createModal(options);
-        const createModalChild = modalEl.createEl.bind(modalEl);
-        modalEl.createEl = jest.fn((tag: string, childOptions?: unknown) => {
-          const child = createModalChild(tag, childOptions);
-          if (tag === 'button') {
-            child.focus = closeButtonFocus;
-          }
-          return child;
-        });
-        return modalEl;
-      });
-      addEventSpy = jest.fn();
-      removeEventSpy = jest.fn();
-      mockBody = { createDiv: jest.fn().mockReturnValue(overlayEl) };
-      origDocument = globalThis.document;
-      (globalThis as any).document = {
-        activeElement: previouslyFocusedEl,
-        body: mockBody,
-        addEventListener: addEventSpy,
-        removeEventListener: removeEventSpy,
-        createElementNS: jest.fn(() => mockSvgElement()),
-      };
-    });
-
-    afterEach(() => {
-      (globalThis as any).document = origDocument;
-    });
-
-    it('should create modal overlay with image', () => {
-      const image = createImageAttachment({ name: 'test.png', mediaType: 'image/png', data: 'abc123' });
-      manager['showFullImage'](image);
-
-      expect(mockBody.createDiv).toHaveBeenCalledWith({ cls: 'claudian-image-modal-overlay' });
-    });
-
-    it('exposes a named dialog, moves focus inside, and restores it after close', () => {
-      const image = createImageAttachment({ name: 'test.png' });
-      manager['showFullImage'](image);
-
-      const modalEl = overlayEl.children[0];
-      const closeBtn = modalEl.children[1];
-      expect(modalEl.getAttribute('role')).toBe('dialog');
-      expect(modalEl.getAttribute('aria-modal')).toBe('true');
-      expect(modalEl.getAttribute('aria-label')).toBe('Image preview: test.png');
-      expect(closeButtonFocus).toHaveBeenCalledTimes(1);
-
-      closeBtn.click();
-
-      expect(previouslyFocusedEl.focus).toHaveBeenCalledTimes(1);
-    });
-
-    it('keeps Tab focus on the only control in the image dialog', () => {
-      const image = createImageAttachment();
-      manager['showFullImage'](image);
-      const tabEvent = {
-        key: 'Tab',
-        preventDefault: jest.fn(),
-      };
-
-      const keydownHandler = addEventSpy.mock.calls[0][1];
-      keydownHandler(tabEvent);
-
-      expect(tabEvent.preventDefault).toHaveBeenCalledTimes(1);
-      expect(closeButtonFocus).toHaveBeenCalledTimes(2);
-    });
-
-    it('should register Escape key handler and close button', () => {
-      const image = createImageAttachment();
-      manager['showFullImage'](image);
-
-      expect(addEventSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
-
-      const modalEl = overlayEl.children[0];
-      const closeBtn = modalEl.children[1];
-      expect(closeBtn.tagName).toBe('BUTTON');
-      expect(closeBtn.getAttribute('type')).toBe('button');
-      expect(closeBtn.getAttribute('aria-label')).toBe('Close image preview');
-
-      const escHandler = addEventSpy.mock.calls[0][1];
-      escHandler({ key: 'Escape' });
-
-      expect(removeEventSpy).toHaveBeenCalledWith('keydown', escHandler);
-    });
-
-    it('should close modal when clicking on overlay background', () => {
-      const image = createImageAttachment();
-      manager['showFullImage'](image);
-
-      const clickHandler = overlayEl._eventListeners.get('click')?.[0];
-      expect(clickHandler).toBeDefined();
-
-      clickHandler({ target: overlayEl });
-
-      expect(removeEventSpy).toHaveBeenCalled();
-    });
-
-    it('should close an open modal during destruction', () => {
-      const image = createImageAttachment();
-      manager['showFullImage'](image);
-      const removeSpy = jest.spyOn(overlayEl, 'remove');
-      const escHandler = addEventSpy.mock.calls[0][1];
-
-      manager.destroy();
-
-      expect(removeSpy).toHaveBeenCalledTimes(1);
-      expect(removeEventSpy).toHaveBeenCalledWith('keydown', escHandler);
     });
   });
 

--- a/tests/unit/features/chat/ui/ImageContext.test.ts
+++ b/tests/unit/features/chat/ui/ImageContext.test.ts
@@ -787,6 +787,12 @@ describe('ImageContextManager - Private Helpers', () => {
 
       expect(addEventSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
 
+      const modalEl = overlayEl.children[0];
+      const closeBtn = modalEl.children[1];
+      expect(closeBtn.tagName).toBe('BUTTON');
+      expect(closeBtn.getAttribute('type')).toBe('button');
+      expect(closeBtn.getAttribute('aria-label')).toBe('Close image preview');
+
       const escHandler = addEventSpy.mock.calls[0][1];
       escHandler({ key: 'Escape' });
 

--- a/tests/unit/features/chat/ui/ImageContext.test.ts
+++ b/tests/unit/features/chat/ui/ImageContext.test.ts
@@ -755,14 +755,35 @@ describe('ImageContextManager - Private Helpers', () => {
     let mockBody: any;
     let addEventSpy: jest.Mock;
     let removeEventSpy: jest.Mock;
+    let closeButtonFocus: jest.Mock;
+    let previouslyFocusedEl: { focus: jest.Mock; isConnected: boolean };
 
     beforeEach(() => {
       overlayEl = createMockEl();
+      closeButtonFocus = jest.fn();
+      previouslyFocusedEl = {
+        focus: jest.fn(),
+        isConnected: true,
+      };
+      const createModal = overlayEl.createDiv.bind(overlayEl);
+      overlayEl.createDiv = jest.fn((options: { cls?: string }) => {
+        const modalEl = createModal(options);
+        const createModalChild = modalEl.createEl.bind(modalEl);
+        modalEl.createEl = jest.fn((tag: string, childOptions?: unknown) => {
+          const child = createModalChild(tag, childOptions);
+          if (tag === 'button') {
+            child.focus = closeButtonFocus;
+          }
+          return child;
+        });
+        return modalEl;
+      });
       addEventSpy = jest.fn();
       removeEventSpy = jest.fn();
       mockBody = { createDiv: jest.fn().mockReturnValue(overlayEl) };
       origDocument = globalThis.document;
       (globalThis as any).document = {
+        activeElement: previouslyFocusedEl,
         body: mockBody,
         addEventListener: addEventSpy,
         removeEventListener: removeEventSpy,
@@ -779,6 +800,22 @@ describe('ImageContextManager - Private Helpers', () => {
       manager['showFullImage'](image);
 
       expect(mockBody.createDiv).toHaveBeenCalledWith({ cls: 'claudian-image-modal-overlay' });
+    });
+
+    it('exposes a named dialog, moves focus inside, and restores it after close', () => {
+      const image = createImageAttachment({ name: 'test.png' });
+      manager['showFullImage'](image);
+
+      const modalEl = overlayEl.children[0];
+      const closeBtn = modalEl.children[1];
+      expect(modalEl.getAttribute('role')).toBe('dialog');
+      expect(modalEl.getAttribute('aria-modal')).toBe('true');
+      expect(modalEl.getAttribute('aria-label')).toBe('Image preview: test.png');
+      expect(closeButtonFocus).toHaveBeenCalledTimes(1);
+
+      closeBtn.click();
+
+      expect(previouslyFocusedEl.focus).toHaveBeenCalledTimes(1);
     });
 
     it('should register Escape key handler and close button', () => {

--- a/tests/unit/features/chat/ui/ImageContext.test.ts
+++ b/tests/unit/features/chat/ui/ImageContext.test.ts
@@ -818,6 +818,21 @@ describe('ImageContextManager - Private Helpers', () => {
       expect(previouslyFocusedEl.focus).toHaveBeenCalledTimes(1);
     });
 
+    it('keeps Tab focus on the only control in the image dialog', () => {
+      const image = createImageAttachment();
+      manager['showFullImage'](image);
+      const tabEvent = {
+        key: 'Tab',
+        preventDefault: jest.fn(),
+      };
+
+      const keydownHandler = addEventSpy.mock.calls[0][1];
+      keydownHandler(tabEvent);
+
+      expect(tabEvent.preventDefault).toHaveBeenCalledTimes(1);
+      expect(closeButtonFocus).toHaveBeenCalledTimes(2);
+    });
+
     it('should register Escape key handler and close button', () => {
       const image = createImageAttachment();
       manager['showFullImage'](image);

--- a/tests/unit/features/chat/ui/ImagePreviewModal.test.ts
+++ b/tests/unit/features/chat/ui/ImagePreviewModal.test.ts
@@ -1,0 +1,172 @@
+import { createMockEl } from '@test/helpers/MockElement';
+
+import type { ImageAttachment } from '@/core/types';
+import { ImagePreviewModal } from '@/features/chat/ui/ImagePreviewModal';
+
+const IMAGE: ImageAttachment = {
+  id: 'image-1',
+  name: 'diagram.png',
+  mediaType: 'image/png',
+  data: 'abc123',
+  size: 128,
+  source: 'file',
+};
+
+function createDocumentHarness(previouslyFocusedElement: unknown = {
+  focus: jest.fn(),
+  isConnected: true,
+}) {
+  const overlayEl = createMockEl();
+  const closeButtonFocus = jest.fn();
+  const createModal = overlayEl.createDiv.bind(overlayEl);
+  overlayEl.createDiv = jest.fn((options: { cls?: string }) => {
+    const modalEl = createModal(options);
+    const createModalChild = modalEl.createEl.bind(modalEl);
+    modalEl.createEl = jest.fn((tag: string, childOptions?: unknown) => {
+      const child = createModalChild(tag, childOptions);
+      if (tag === 'button') child.focus = closeButtonFocus;
+      return child;
+    });
+    return modalEl;
+  });
+
+  const listeners = new Map<string, Array<(event: any) => void>>();
+  const ownerDocument = {
+    activeElement: previouslyFocusedElement,
+    body: {
+      createDiv: jest.fn().mockReturnValue(overlayEl),
+    },
+    addEventListener: jest.fn((event: string, handler: (event: any) => void) => {
+      const handlers = listeners.get(event) ?? [];
+      handlers.push(handler);
+      listeners.set(event, handlers);
+    }),
+    removeEventListener: jest.fn((event: string, handler: (event: any) => void) => {
+      const handlers = listeners.get(event) ?? [];
+      listeners.set(event, handlers.filter(candidate => candidate !== handler));
+    }),
+  } as unknown as Document;
+
+  return {
+    closeButtonFocus,
+    listeners,
+    overlayEl,
+    ownerDocument,
+    previouslyFocusedElement,
+  };
+}
+
+describe('ImagePreviewModal', () => {
+  it('opens a named dialog with a focused native close button', () => {
+    const harness = createDocumentHarness();
+    const modal = new ImagePreviewModal();
+
+    modal.open(harness.ownerDocument, IMAGE);
+
+    const modalEl = harness.overlayEl.children[0];
+    const imageEl = modalEl.children[0];
+    const closeButton = modalEl.children[1];
+    expect(modalEl.getAttribute('role')).toBe('dialog');
+    expect(modalEl.getAttribute('aria-modal')).toBe('true');
+    expect(modalEl.getAttribute('aria-label')).toBe('Image preview: diagram.png');
+    expect(imageEl.getAttribute('src')).toBe('data:image/png;base64,abc123');
+    expect(imageEl.getAttribute('alt')).toBe('diagram.png');
+    expect(closeButton.tagName).toBe('BUTTON');
+    expect(closeButton.getAttribute('type')).toBe('button');
+    expect(closeButton.getAttribute('aria-label')).toBe('Close image preview');
+    expect(harness.closeButtonFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { shiftKey: false },
+    { shiftKey: true },
+  ])('contains $shiftKey Tab navigation on its only control', ({ shiftKey }) => {
+    const harness = createDocumentHarness();
+    const modal = new ImagePreviewModal();
+    modal.open(harness.ownerDocument, IMAGE);
+    const event = {
+      key: 'Tab',
+      shiftKey,
+      preventDefault: jest.fn(),
+    };
+
+    harness.listeners.get('keydown')?.[0](event);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(harness.closeButtonFocus).toHaveBeenCalledTimes(2);
+  });
+
+  it('closes idempotently, removes its listener, and restores connected focus', () => {
+    const harness = createDocumentHarness();
+    const previousFocus = (harness.previouslyFocusedElement as { focus: jest.Mock }).focus;
+    const modal = new ImagePreviewModal();
+    modal.open(harness.ownerDocument, IMAGE);
+    const removeOverlay = jest.spyOn(harness.overlayEl, 'remove');
+
+    modal.close();
+    modal.close();
+
+    expect(removeOverlay).toHaveBeenCalledTimes(1);
+    expect(harness.listeners.get('keydown')).toEqual([]);
+    expect(previousFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the current preview before opening its replacement', () => {
+    const firstHarness = createDocumentHarness();
+    const secondHarness = createDocumentHarness();
+    const modal = new ImagePreviewModal();
+    const removeFirstOverlay = jest.spyOn(firstHarness.overlayEl, 'remove');
+
+    modal.open(firstHarness.ownerDocument, IMAGE);
+    modal.open(secondHarness.ownerDocument, { ...IMAGE, name: 'replacement.png' });
+
+    expect(removeFirstOverlay).toHaveBeenCalledTimes(1);
+    expect(firstHarness.listeners.get('keydown')).toEqual([]);
+    expect(secondHarness.overlayEl.children[0].getAttribute('aria-label'))
+      .toBe('Image preview: replacement.png');
+  });
+
+  it('supports Escape, close-button, and overlay-background dismissal', () => {
+    const escapeHarness = createDocumentHarness();
+    const escapeModal = new ImagePreviewModal();
+    escapeModal.open(escapeHarness.ownerDocument, IMAGE);
+    const removeEscapeOverlay = jest.spyOn(escapeHarness.overlayEl, 'remove');
+    escapeHarness.listeners.get('keydown')?.[0]({ key: 'Escape' });
+    expect(removeEscapeOverlay).toHaveBeenCalledTimes(1);
+
+    const buttonHarness = createDocumentHarness();
+    const buttonModal = new ImagePreviewModal();
+    buttonModal.open(buttonHarness.ownerDocument, IMAGE);
+    const removeButtonOverlay = jest.spyOn(buttonHarness.overlayEl, 'remove');
+    buttonHarness.overlayEl.children[0].children[1].click();
+    expect(removeButtonOverlay).toHaveBeenCalledTimes(1);
+
+    const overlayHarness = createDocumentHarness();
+    const overlayModal = new ImagePreviewModal();
+    overlayModal.open(overlayHarness.ownerDocument, IMAGE);
+    const removeBackgroundOverlay = jest.spyOn(overlayHarness.overlayEl, 'remove');
+    const overlayClick = overlayHarness.overlayEl._eventListeners.get('click')?.[0];
+    overlayClick?.({ target: overlayHarness.overlayEl.children[0] });
+    expect(removeBackgroundOverlay).not.toHaveBeenCalled();
+    overlayClick?.({ target: overlayHarness.overlayEl });
+    expect(removeBackgroundOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not restore a disconnected prior focus target', () => {
+    const priorFocusTarget = { focus: jest.fn(), isConnected: false };
+    const harness = createDocumentHarness(priorFocusTarget);
+    const modal = new ImagePreviewModal();
+    modal.open(harness.ownerDocument, IMAGE);
+
+    expect(() => modal.close()).not.toThrow();
+    expect(priorFocusTarget.focus).not.toHaveBeenCalled();
+  });
+
+  it('ignores an active element without a focus operation', () => {
+    const harness = createDocumentHarness({ isConnected: true });
+    const modal = new ImagePreviewModal();
+    modal.open(harness.ownerDocument, IMAGE);
+
+    expect(() => modal.close()).not.toThrow();
+  });
+});

--- a/tests/unit/style/features/image-preview.test.ts
+++ b/tests/unit/style/features/image-preview.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+describe('Image preview button styles', () => {
+  const contextCss = readFileSync(
+    path.resolve('src/style/features/image-context.css'),
+    'utf8',
+  );
+  const modalCss = readFileSync(
+    path.resolve('src/style/features/image-modal.css'),
+    'utf8',
+  );
+
+  it('keeps the native thumbnail button on the existing image surface in every state', () => {
+    const baseRule = contextCss.match(
+      /button\.claudian-message-image,\s*button\.claudian-message-image:active\s*{[^}]*}/,
+    )?.[0];
+    expect(baseRule).toContain('padding: 0;');
+    expect(baseRule).toContain('border: 1px solid var(--background-modifier-border);');
+    expect(baseRule).toContain('background: var(--background-secondary);');
+    expect(baseRule).toContain('background-image: none;');
+    expect(baseRule).toContain('box-shadow: none;');
+
+    const interactionRule = contextCss.match(
+      /button\.claudian-message-image:hover,\s*button\.claudian-message-image:focus-visible\s*{[^}]*}/,
+    )?.[0];
+    expect(interactionRule).toContain('border: 1px solid var(--background-modifier-border);');
+    expect(interactionRule).toContain('background: var(--background-secondary);');
+    expect(interactionRule).toContain('background-image: none;');
+    expect(interactionRule).toContain('box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);');
+  });
+
+  it('keeps the native close button on the existing circular surface in every state', () => {
+    const baseRule = modalCss.match(
+      /button\.claudian-image-modal-close,\s*button\.claudian-image-modal-close:focus,\s*button\.claudian-image-modal-close:active\s*{[^}]*}/,
+    )?.[0];
+    expect(baseRule).toContain('padding: 0;');
+    expect(baseRule).toContain('border: 0;');
+    expect(baseRule).toContain('background: var(--background-secondary);');
+    expect(baseRule).toContain('background-image: none;');
+    expect(baseRule).toContain('box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);');
+
+    const hoverRule = modalCss.match(
+      /button\.claudian-image-modal-close:hover\s*{[^}]*}/,
+    )?.[0];
+    expect(hoverRule).toContain('border: 0;');
+    expect(hoverRule).toContain('background: var(--background-modifier-error);');
+    expect(hoverRule).toContain('background-image: none;');
+    expect(hoverRule).toContain('box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);');
+  });
+});


### PR DESCRIPTION
## Why

The image-preview flow has mouse-only controls at both ends: rendered-message thumbnails attach `click` directly to an image inside a `div`, while the full-size preview uses a clickable `div` for its close control in both the rendered-message and composer-attachment paths. These elements do not provide standard keyboard button behavior or an accessible control name. The overlay also lacks dialog semantics and focus management, so keyboard focus remains behind the modal while it is open.

No issue is needed for this narrowly scoped accessibility defect: the behavior is directly reproducible at the existing UI test seams and the visual design remains unchanged.

## What Changed

- Render stored-message image thumbnails as native `button` elements that retain the existing image and open the same preview.
- Label thumbnail controls with the image name and give them a visible keyboard-focus treatment.
- Render both image-preview close controls as native `button` elements labeled `Close image preview`.
- Expose each preview as a named modal dialog, move focus to its close button on open, contain Tab focus on that only modal control, and restore focus to the prior connected element on close.
- Reset native button chrome so the existing thumbnail and circular close-control appearance is preserved.
- Cover the thumbnail, both close-control entry points, modal semantics, and focus lifecycle with regression assertions.

## Why This Approach

Native buttons supply focusability and Enter/Space activation without duplicating browser behavior with `tabindex`, `role`, and activation handlers on non-interactive elements. The lightweight dialog attributes and explicit focus handoff complete the keyboard path while preserving the existing overlay rather than replacing the image-preview implementation. Because the close button is the only modal control, Tab and Shift+Tab both keep focus there instead of exposing background Obsidian controls. Focus restoration is guarded by `isConnected`, so view teardown does not target a detached control.

The existing image rendering, click, Escape, overlay-click, replacement, and disposal cleanup paths otherwise remain unchanged.

## Validation

- Initial TDD red: both close-control suites and the stored-message thumbnail test independently reported `Expected: "BUTTON", Received: "DIV"` before implementation.
- Focus-lifecycle TDD red: both modal seams reported missing `role="dialog"` before implementation.
- Focus-containment TDD red: both modal seams observed an uncancelled Tab event and no focus return before implementation.
- `npm run test:unit -- --runTestsByPath tests/unit/features/chat/rendering/MessageRenderer.test.ts tests/unit/features/chat/ui/ImageContext.test.ts --runInBand` (157 tests)
- `npm run typecheck`
- `npm run lint`
- `npm run test`: 14 protocol suites / 131 tests, 573 main suites / 8404 tests, and 61 architecture/policy tests passed.
- `npm run build`
- `git diff --check`
- GitHub CI on `133388e6`: workflow lint, lockfile, quality, diff hygiene, dependency review, protocol contract, full test, Collab scope, and build all passed.

## Impact and Follow-ups

No persistence, provider, protocol, or data compatibility impact. Thumbnail and close-control dimensions, image content, click handling, and Escape handling remain unchanged.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
