### PR TITLE
test: stabilize Cloud binding integration gates

### DIFF
--- a/tests/integration/app/collab/bootstrap/CloudBindingRecovery.test.ts
+++ b/tests/integration/app/collab/bootstrap/CloudBindingRecovery.test.ts
@@ -57,6 +57,8 @@ const CLOUD_ORIGIN = 'https://cloud.example.test';
 const CLOUD_REMOTE = `${CLOUD_ORIGIN}/v1/projects/${PROJECT_ID}/repository.git`;
 const CRASH = new Error('simulated process crash');
 
+jest.setTimeout(30_000);
+
 interface RecoveryFixture {
   readonly mainOid: string;
   readonly manifest: DevelopmentBootstrapManifest;

--- a/tests/integration/app/collab/gates/CloudReadBindingGate.test.ts
+++ b/tests/integration/app/collab/gates/CloudReadBindingGate.test.ts
@@ -65,6 +65,8 @@ const OTHER_MEMBER_ID = 'member-bob';
 const OLD_ENDPOINT = 'https://192.168.1.20:54545/';
 const OLD_REMOTE = `${OLD_ENDPOINT}v1/git/${PROJECT_ID}/repository.git`;
 
+jest.setTimeout(30_000);
+
 interface RepositoryFixture {
   readonly barePath: string;
   readonly mainOid: string;


### PR DESCRIPTION
## Why

The two Cloud binding integration suites added by #1142 exercise real Git repositories, HTTP upload-pack, two client workspaces, and durable recovery. They currently inherit Jest's 5-second unit-test default even though comparable Collab integration suites use explicit 30–120 second limits.

On a loaded macOS development host, `CloudReadBindingGate` failed at 5.996s and 6.574s while completing successfully in 6.55s with a diagnostic timeout override. A subsequent full run exposed the same boundary in five `CloudBindingRecovery` cases. The timed-out run can also strand Jest workers until the still-running integration body finishes cleanup.

This is a follow-up to #1142; no separate product Issue is needed because only its test harness timing is affected.

## What Changed

- Give `CloudBindingRecovery.test.ts` a file-local 30-second Jest timeout.
- Give `CloudReadBindingGate.test.ts` the same file-local 30-second timeout.
- Leave the global Jest default and every production source file unchanged.

## Why This Approach

These suites deliberately perform real native Git and filesystem/network work, so treating them like 5-second unit tests makes the result depend on host load. Thirty seconds matches the existing baseline used by `GitRepositoryService`, `GitRuntimeResolver`, `LocalFoundationGate`, `CollabProjectSetupService`, and other real-Git Collab integration suites.

Latest `main` independently reinforces this exact convention: #1157 added `CloudPublishRecovery.test.ts`, another real Git/Cloud recovery integration suite, with the same file-local `jest.setTimeout(30_000)`. This PR brings the two older Cloud binding suites into alignment with that newly adopted upstream pattern.

The limit remains local to the two affected files. Assertion failures, rejected operations, resource leaks, and tests exceeding 30 seconds still fail normally; this does not retry tests or weaken their behavioral expectations.

## Validation

Red evidence before the change:
- `CloudReadBindingGate` exceeded the default 5-second timeout twice at 5.996s and 6.574s.
- The full suite then reported five default-timeout failures in `CloudBindingRecovery`.
- The unchanged gate completed 1/1 in 6.55s under a diagnostic 15-second CLI override.

Green evidence after the change:
- Focused original command, without a CLI timeout override: 2 suites / 20 tests passed in 44.586s.
- `npm run typecheck`
- `npm run lint`
- `npm run test` — 14 protocol suites / 131 tests; 573 repository suites / 8,400 tests; 61 architecture and policy checks.
- `npm run build`
- `git diff --check`
- GitHub Actions full test, quality, protocol, build, workflow, dependency, diff, and scope checks are green for `6e2b889d`.
- Cross-platform Collab smoke is green on macOS (1m53s) and Windows (3m46s).

## Impact and Follow-ups

Test-only change. No production code, package, protocol, provider, persistence, build artifact, or public API changes.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
