### PR TITLE
feat: enable Cloud publication controls

### DIFF
--- a/src/app/collab/remote-authority/CloudAuthorityAdapter.ts
+++ b/src/app/collab/remote-authority/CloudAuthorityAdapter.ts
@@ -9,6 +9,11 @@ import {
   collabCloudCapabilitySupported,
   collabCloudProjectEventsRoute,
   collabCloudProjectOperationRoute,
+  type CollabControlOperation,
+  collabControlOperationCodec,
+  type CollabControlOperationMap,
+  type CollabRequestDetail,
+  type CollabTicketDetail,
   decodeCollabCloudCapabilityDocument,
   decodeCollabCloudErrorEnvelope,
   decodeCollabCloudProjectEventMessage,
@@ -125,6 +130,47 @@ function adapterError(
   });
 }
 
+function controlIntegrityError(reason: string): CollabError {
+  return new CollabError({
+    code: 'authority-integrity-error',
+    recoveryActions: ['open-diagnostics'],
+    safeContext: { reason },
+  });
+}
+
+function assertCompleteRequestComments(detail: CollabRequestDetail): void {
+  if (detail.comments.comments.length > COLLAB_LIMITS.maxRequestComments) {
+    throw controlIntegrityError('cloud-control-request-comment-limit-exceeded');
+  }
+  if (detail.comments.comments.length !== detail.request.commentCount) {
+    throw controlIntegrityError('cloud-control-request-comment-count-mismatch');
+  }
+  if (detail.comments.comments.some(comment => comment.requestId !== detail.request.id)) {
+    throw controlIntegrityError('cloud-control-request-comment-owner-mismatch');
+  }
+}
+
+function assertCompleteTicketCollections(detail: CollabTicketDetail): void {
+  if (detail.comments.comments.length !== detail.ticket.commentCount) {
+    throw controlIntegrityError('cloud-control-ticket-comment-count-mismatch');
+  }
+  if (detail.comments.comments.length > COLLAB_LIMITS.maxTicketComments) {
+    throw controlIntegrityError('cloud-control-ticket-comment-limit-exceeded');
+  }
+  if (
+    detail.acceptedRelations.acceptedRelations.length
+    > COLLAB_LIMITS.maxTicketAcceptedRelations
+  ) {
+    throw controlIntegrityError('cloud-control-ticket-relation-limit-exceeded');
+  }
+  if (
+    detail.acceptedRelations.acceptedRelations.length
+    !== detail.ticket.acceptedRelationCount
+  ) {
+    throw controlIntegrityError('cloud-control-ticket-relation-count-mismatch');
+  }
+}
+
 function assertJsonResponse(response: CloudAuthorityHttpResponse): void {
   if (
     response.contentType === null
@@ -220,7 +266,9 @@ class CloudAuthorityControl implements CollabAuthorityControlPort {
   constructor(
     private readonly actorId: string,
     private readonly capabilities: ReadonlySet<string>,
+    private readonly memberId: string,
     private readonly origin: string,
+    private readonly personalRef: string,
     private readonly projectId: string,
     private readonly request: CloudAuthorityHttpTransport,
     private readonly requestId: () => string,
@@ -254,95 +302,380 @@ class CloudAuthorityControl implements CollabAuthorityControlPort {
       throw new CollabError(envelope.error);
     }
     const envelope = decodeCollabCloudSuccessEnvelope(response.body);
-    return decodeCloudAuthorityProjectSnapshot(envelope.data);
+    const snapshot = decodeCloudAuthorityProjectSnapshot(envelope.data);
+    if (
+      snapshot.project.id !== projectId
+      || snapshot.currentMember.id !== this.memberId
+      || snapshot.currentMember.personalRef !== this.personalRef
+    ) {
+      throw controlIntegrityError('cloud-control-snapshot-response-mismatch');
+    }
+    return snapshot;
   }
 
-  ensure(_input: Parameters<CollabAuthorityControlPort['ensure']>[0]) {
-    return this.unavailable('requests');
+  async ensure(input: Parameters<CollabAuthorityControlPort['ensure']>[0]) {
+    const { signal, ...request } = input;
+    const response = await this.execute(
+      'requests',
+      'ensureMyRequest',
+      request,
+      signal ? { signal } : {},
+    );
+    if (
+      response.request.memberId !== this.memberId
+      || response.request.latestHeadOid !== input.headOid
+      || response.request.status !== 'open'
+      || response.mainOid !== input.expectedMainOid
+    ) {
+      throw controlIntegrityError('cloud-control-request-response-mismatch');
+    }
+    return response.request;
   }
   acceptRequest(_input: Parameters<CollabAuthorityControlPort['acceptRequest']>[0]) {
     return this.unavailable('accept');
   }
-  createComment(_input: Parameters<CollabAuthorityControlPort['createComment']>[0]) {
-    return this.unavailable('requests');
+  async createComment(input: Parameters<CollabAuthorityControlPort['createComment']>[0]) {
+    const { signal, ...request } = input;
+    const response = await this.execute(
+      'requests',
+      'createComment',
+      request,
+      signal ? { signal } : {},
+    );
+    if (
+      response.comment.authorMemberId !== this.memberId
+      || response.comment.requestId !== input.requestId
+      || response.request.id !== input.requestId
+    ) {
+      throw controlIntegrityError('cloud-control-comment-response-mismatch');
+    }
+    return { comment: response.comment };
   }
-  createTicket(
-    _request: Parameters<CollabAuthorityControlPort['createTicket']>[0],
-    _idempotencyKey: string,
-    _options?: Parameters<CollabAuthorityControlPort['createTicket']>[2],
-  ) { return this.unavailable('tickets'); }
-  updateTicketContent(
-    _request: Parameters<CollabAuthorityControlPort['updateTicketContent']>[0],
-    _idempotencyKey: string,
-    _options?: Parameters<CollabAuthorityControlPort['updateTicketContent']>[2],
-  ) { return this.unavailable('tickets'); }
-  addTicketComment(
-    _request: Parameters<CollabAuthorityControlPort['addTicketComment']>[0],
-    _idempotencyKey: string,
-    _options?: Parameters<CollabAuthorityControlPort['addTicketComment']>[2],
-  ) { return this.unavailable('tickets'); }
-  closeTicket(
-    _request: Parameters<CollabAuthorityControlPort['closeTicket']>[0],
-    _idempotencyKey: string,
-    _options?: Parameters<CollabAuthorityControlPort['closeTicket']>[2],
-  ) { return this.unavailable('tickets'); }
-  reopenTicket(
-    _request: Parameters<CollabAuthorityControlPort['reopenTicket']>[0],
-    _idempotencyKey: string,
-    _options?: Parameters<CollabAuthorityControlPort['reopenTicket']>[2],
-  ) { return this.unavailable('tickets'); }
+  async createTicket(
+    request: Parameters<CollabAuthorityControlPort['createTicket']>[0],
+    idempotencyKey: string,
+    options: Parameters<CollabAuthorityControlPort['createTicket']>[2] = {},
+  ) {
+    const response = await this.execute('tickets', 'createTicket', {
+      body: request.body,
+      idempotencyKey,
+      projectId: request.projectId,
+      title: request.title,
+    }, options);
+    if (response.ticket.ticket.authorMemberId !== this.memberId) {
+      throw controlIntegrityError('cloud-control-ticket-create-mismatch');
+    }
+    return response.ticket;
+  }
+  async updateTicketContent(
+    request: Parameters<CollabAuthorityControlPort['updateTicketContent']>[0],
+    idempotencyKey: string,
+    options: Parameters<CollabAuthorityControlPort['updateTicketContent']>[2] = {},
+  ) {
+    const response = await this.execute('tickets', 'updateTicketContent', {
+      body: request.body,
+      expectedRevision: request.expectedRevision,
+      idempotencyKey,
+      projectId: request.projectId,
+      ticketId: request.ticketId,
+      title: request.title,
+    }, options);
+    return this.checkedTicketMutation(request.ticketId, response.ticket);
+  }
+  async addTicketComment(
+    request: Parameters<CollabAuthorityControlPort['addTicketComment']>[0],
+    idempotencyKey: string,
+    options: Parameters<CollabAuthorityControlPort['addTicketComment']>[2] = {},
+  ) {
+    const response = await this.execute('tickets', 'createTicketComment', {
+      body: request.body,
+      idempotencyKey,
+      projectId: request.projectId,
+      ticketId: request.ticketId,
+    }, options);
+    if (
+      response.comment.authorMemberId !== this.memberId
+      || response.comment.ticketId !== request.ticketId
+      || response.ticket.id !== request.ticketId
+    ) {
+      throw controlIntegrityError('cloud-control-ticket-comment-mismatch');
+    }
+    return response.comment;
+  }
+  async closeTicket(
+    request: Parameters<CollabAuthorityControlPort['closeTicket']>[0],
+    idempotencyKey: string,
+    options: Parameters<CollabAuthorityControlPort['closeTicket']>[2] = {},
+  ) {
+    const response = await this.execute('tickets', 'closeTicket', {
+      expectedRevision: request.expectedRevision,
+      idempotencyKey,
+      projectId: request.projectId,
+      ticketId: request.ticketId,
+    }, options);
+    return this.checkedTicketMutation(request.ticketId, response.ticket);
+  }
+  async reopenTicket(
+    request: Parameters<CollabAuthorityControlPort['reopenTicket']>[0],
+    idempotencyKey: string,
+    options: Parameters<CollabAuthorityControlPort['reopenTicket']>[2] = {},
+  ) {
+    const response = await this.execute('tickets', 'reopenTicket', {
+      expectedRevision: request.expectedRevision,
+      idempotencyKey,
+      projectId: request.projectId,
+      ticketId: request.ticketId,
+    }, options);
+    return this.checkedTicketMutation(request.ticketId, response.ticket);
+  }
   updateRequestMetadata(
-    _request: Parameters<CollabAuthorityControlPort['updateRequestMetadata']>[0],
-    _idempotencyKey: string,
-    _options?: Parameters<CollabAuthorityControlPort['updateRequestMetadata']>[2],
-  ) { return this.unavailable('requests'); }
+    request: Parameters<CollabAuthorityControlPort['updateRequestMetadata']>[0],
+    idempotencyKey: string,
+    options: Parameters<CollabAuthorityControlPort['updateRequestMetadata']>[2] = {},
+  ) {
+    return this.updateRequest(request, idempotencyKey, options);
+  }
   listTickets(
-    _request: Parameters<CollabAuthorityControlPort['listTickets']>[0],
-    _options?: Parameters<CollabAuthorityControlPort['listTickets']>[1],
-  ) { return this.unavailable('tickets'); }
-  listRequestComments(
-    _projectId: string,
-    _requestId: string,
-    _query: Parameters<CollabAuthorityControlPort['listRequestComments']>[2],
-    _options?: Parameters<CollabAuthorityControlPort['listRequestComments']>[3],
-  ) { return this.unavailable('requests'); }
-  listTicketComments(
-    _projectId: string,
-    _ticketId: string,
-    _query: Parameters<CollabAuthorityControlPort['listTicketComments']>[2],
-    _options?: Parameters<CollabAuthorityControlPort['listTicketComments']>[3],
-  ) { return this.unavailable('tickets'); }
+    request: Parameters<CollabAuthorityControlPort['listTickets']>[0],
+    options: Parameters<CollabAuthorityControlPort['listTickets']>[1] = {},
+  ) { return this.execute('tickets', 'listTickets', request, options); }
+  async listRequestComments(
+    projectId: string,
+    requestId: string,
+    query: Parameters<CollabAuthorityControlPort['listRequestComments']>[2],
+    options: Parameters<CollabAuthorityControlPort['listRequestComments']>[3] = {},
+  ) {
+    const page = await this.execute('requests', 'listRequestComments', {
+      ...query,
+      projectId,
+      requestId,
+    }, options);
+    if (page.comments.some(comment => comment.requestId !== requestId)) {
+      throw controlIntegrityError('cloud-control-request-comment-owner-mismatch');
+    }
+    return page;
+  }
+  async listTicketComments(
+    projectId: string,
+    ticketId: string,
+    query: Parameters<CollabAuthorityControlPort['listTicketComments']>[2],
+    options: Parameters<CollabAuthorityControlPort['listTicketComments']>[3] = {},
+  ) {
+    const page = await this.execute('tickets', 'listTicketComments', {
+      ...query,
+      projectId,
+      ticketId,
+    }, options);
+    if (page.comments.some(comment => comment.ticketId !== ticketId)) {
+      throw controlIntegrityError('cloud-control-ticket-comment-owner-mismatch');
+    }
+    return page;
+  }
   listTicketAcceptedRelations(
-    _projectId: string,
-    _ticketId: string,
-    _query: Parameters<CollabAuthorityControlPort['listTicketAcceptedRelations']>[2],
-    _options?: Parameters<CollabAuthorityControlPort['listTicketAcceptedRelations']>[3],
-  ) { return this.unavailable('tickets'); }
-  readRequest(
-    _projectId: string,
-    _requestId: string,
-    _options?: Parameters<CollabAuthorityControlPort['readRequest']>[2],
-  ) { return this.unavailable('requests'); }
+    projectId: string,
+    ticketId: string,
+    query: Parameters<CollabAuthorityControlPort['listTicketAcceptedRelations']>[2],
+    options: Parameters<CollabAuthorityControlPort['listTicketAcceptedRelations']>[3] = {},
+  ) {
+    return this.execute('tickets', 'listTicketAcceptedRelations', {
+      ...query,
+      projectId,
+      ticketId,
+    }, options);
+  }
+  async readRequest(
+    projectId: string,
+    requestId: string,
+    options: Parameters<CollabAuthorityControlPort['readRequest']>[2] = {},
+  ) {
+    const detail = await this.readRequestDetail(projectId, requestId, options);
+    if (!detail.comments.nextCursor) {
+      assertCompleteRequestComments(detail);
+      return detail;
+    }
+    const comments = [...detail.comments.comments];
+    const visited = new Set<string>();
+    let cursor: string | undefined = detail.comments.nextCursor;
+    while (cursor) {
+      if (visited.has(cursor)) {
+        throw controlIntegrityError('cloud-control-comment-cursor-cycled');
+      }
+      visited.add(cursor);
+      const page = await this.listRequestComments(projectId, requestId, {
+        cursor,
+        limit: COLLAB_LIMITS.maxCommentPageSize,
+      }, options);
+      comments.push(...page.comments);
+      if (comments.length > COLLAB_LIMITS.maxRequestComments) {
+        throw controlIntegrityError('cloud-control-request-comment-limit-exceeded');
+      }
+      cursor = page.nextCursor;
+    }
+    const complete = { ...detail, comments: { comments } };
+    assertCompleteRequestComments(complete);
+    return complete;
+  }
   readRequestPage(
-    _projectId: string,
-    _requestId: string,
-    _options?: Parameters<CollabAuthorityControlPort['readRequestPage']>[2],
-  ) { return this.unavailable('requests'); }
-  readTicket(
-    _projectId: string,
-    _ticketId: string,
-    _options?: Parameters<CollabAuthorityControlPort['readTicket']>[2],
-  ) { return this.unavailable('tickets'); }
+    projectId: string,
+    requestId: string,
+    options: Parameters<CollabAuthorityControlPort['readRequestPage']>[2] = {},
+  ) { return this.readRequestDetail(projectId, requestId, options); }
+  async readTicket(
+    projectId: string,
+    ticketId: string,
+    options: Parameters<CollabAuthorityControlPort['readTicket']>[2] = {},
+  ) {
+    const detail = await this.readTicketDetail(projectId, ticketId, options);
+    if (!detail.comments.nextCursor && !detail.acceptedRelations.nextCursor) {
+      assertCompleteTicketCollections(detail);
+      return detail;
+    }
+    const comments = [...detail.comments.comments];
+    const acceptedRelations = [...detail.acceptedRelations.acceptedRelations];
+    const visited = new Set<string>();
+    let commentCursor: string | undefined = detail.comments.nextCursor;
+    while (commentCursor) {
+      if (visited.has(commentCursor)) {
+        throw controlIntegrityError('cloud-control-comment-cursor-cycled');
+      }
+      visited.add(commentCursor);
+      const page = await this.listTicketComments(projectId, ticketId, {
+        cursor: commentCursor,
+        limit: COLLAB_LIMITS.maxCommentPageSize,
+      }, options);
+      comments.push(...page.comments);
+      if (comments.length > COLLAB_LIMITS.maxTicketComments) {
+        throw controlIntegrityError('cloud-control-ticket-comment-limit-exceeded');
+      }
+      commentCursor = page.nextCursor;
+    }
+    let relationCursor: string | undefined = detail.acceptedRelations.nextCursor;
+    while (relationCursor) {
+      if (visited.has(relationCursor)) {
+        throw controlIntegrityError('cloud-control-relation-cursor-cycled');
+      }
+      visited.add(relationCursor);
+      const page = await this.listTicketAcceptedRelations(projectId, ticketId, {
+        cursor: relationCursor,
+        limit: COLLAB_LIMITS.maxRelationsPerPage,
+      }, options);
+      acceptedRelations.push(...page.acceptedRelations);
+      if (acceptedRelations.length > COLLAB_LIMITS.maxTicketAcceptedRelations) {
+        throw controlIntegrityError('cloud-control-ticket-relation-limit-exceeded');
+      }
+      relationCursor = page.nextCursor;
+    }
+    const complete = {
+      ...detail,
+      acceptedRelations: { acceptedRelations },
+      comments: { comments },
+    };
+    assertCompleteTicketCollections(complete);
+    return complete;
+  }
   readTicketPage(
-    _projectId: string,
-    _ticketId: string,
-    _options?: Parameters<CollabAuthorityControlPort['readTicketPage']>[2],
-  ) { return this.unavailable('tickets'); }
+    projectId: string,
+    ticketId: string,
+    options: Parameters<CollabAuthorityControlPort['readTicketPage']>[2] = {},
+  ) { return this.readTicketDetail(projectId, ticketId, options); }
 
   private requireCapability(capability: CollabCloudCapability): void {
     if (!this.capabilities.has(capability)) {
       throw adapterError('operation-failed', 'cloud-authority-capability-unavailable');
     }
+  }
+
+  private async execute<Operation extends CollabControlOperation>(
+    capability: CollabCloudCapability,
+    operation: Operation,
+    input: CollabControlOperationMap[Operation]['request'],
+    options: { readonly signal?: AbortSignal } = {},
+  ): Promise<CollabControlOperationMap[Operation]['response']> {
+    this.requireCapability(capability);
+    if (input.projectId !== this.projectId) {
+      throw new CollabError({ code: 'project-not-found' });
+    }
+    const codec = collabControlOperationCodec(operation);
+    const decoded = codec.decodeRequest(input);
+    if (decoded.status !== 'ok') throw decoded.error;
+    const route = collabCloudProjectOperationRoute(input.projectId, operation);
+    const response = await this.request({
+      body: {
+        data: decoded.value,
+        protocolVersion: COLLAB_PROTOCOL_VERSION,
+        requestId: this.requestId(),
+      },
+      headers: { 'x-claudian-development-actor': this.actorId },
+      method: route.method,
+      ...(options.signal ? { signal: options.signal } : {}),
+      url: new URL(route.target, this.origin).toString(),
+    });
+    assertJsonResponse(response);
+    if (response.status < 200 || response.status >= 300) {
+      const envelope = decodeCollabCloudErrorEnvelope(response.body);
+      throw new CollabError(envelope.error);
+    }
+    const envelope = decodeCollabCloudSuccessEnvelope(response.body);
+    return codec.decodeResponse(envelope.data);
+  }
+
+  private async readRequestDetail(
+    projectId: string,
+    requestId: string,
+    options: { readonly signal?: AbortSignal },
+  ) {
+    const detail = await this.execute('requests', 'getRequest', {
+      projectId,
+      requestId,
+    }, options);
+    if (detail.request.id !== requestId) {
+      throw controlIntegrityError('cloud-control-request-detail-mismatch');
+    }
+    return detail;
+  }
+
+  private async readTicketDetail(
+    projectId: string,
+    ticketId: string,
+    options: { readonly signal?: AbortSignal },
+  ) {
+    const detail = await this.execute('tickets', 'getTicket', {
+      projectId,
+      ticketId,
+    }, options);
+    if (detail.ticket.id !== ticketId) {
+      throw controlIntegrityError('cloud-control-ticket-detail-mismatch');
+    }
+    return detail;
+  }
+
+  private checkedTicketMutation<Ticket extends { readonly id: string }>(
+    ticketId: string,
+    ticket: Ticket,
+  ): Ticket {
+    if (ticket.id !== ticketId) {
+      throw controlIntegrityError('cloud-control-ticket-mutation-mismatch');
+    }
+    return ticket;
+  }
+
+  private async updateRequest(
+    request: Parameters<CollabAuthorityControlPort['updateRequestMetadata']>[0],
+    idempotencyKey: string,
+    options: { readonly signal?: AbortSignal },
+  ) {
+    const response = await this.execute('requests', 'updateMyRequestMetadata', {
+      description: request.description,
+      expectedHeadOid: request.expectedHeadOid,
+      expectedRequestRevision: request.expectedRequestRevision,
+      idempotencyKey,
+      projectId: request.projectId,
+      requestId: request.requestId,
+    }, options);
+    if (response.request.id !== request.requestId || response.request.memberId !== this.memberId) {
+      throw controlIntegrityError('cloud-control-request-metadata-mismatch');
+    }
+    return response.request;
   }
 
   private unavailable(capability: CollabCloudCapability): Promise<never> {
@@ -580,7 +913,9 @@ export class CloudAuthorityAdapter implements CollabAuthorityAdapter {
     const control = new CloudAuthorityControl(
       membership.authority.developmentActorId,
       capabilities,
+      membership.member.id,
       origin,
+      membership.member.personalRef,
       membership.project.id,
       this.request,
       this.requestId,

--- a/tests/integration/app/collab/publish/CloudPublishRecovery.test.ts
+++ b/tests/integration/app/collab/publish/CloudPublishRecovery.test.ts
@@ -1,0 +1,308 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import {
+  COLLAB_LIMITS,
+  collabCloudCapabilityDocument,
+  collabCloudSuccessEnvelope,
+} from '@claudian/collab-protocol';
+
+import type { CollabLocalCloudMembershipRecord } from '@/app/collab/CollabLocalProjectRepository';
+import { COLLAB_LOCAL_PROJECT_SCHEMA_VERSION } from '@/app/collab/CollabSchemaVersions';
+import { GitCommandRunner } from '@/app/collab/git/GitCommandRunner';
+import { GitRepositoryService } from '@/app/collab/git/GitRepositoryService';
+import { GitRuntimeResolver } from '@/app/collab/git/GitRuntimeResolver';
+import {
+  COLLAB_PUBLICATION_STATE_SCHEMA_VERSION,
+  type CollabPublicationStateRecord,
+} from '@/app/collab/publish/CollabPublicationStateRecord';
+import {
+  NativeGitPublishRepository,
+  type PublishAcceptedStatePort,
+  type PublishGitNetworkPort,
+} from '@/app/collab/publish/NativeGitPublishRepository';
+import {
+  PublishCoordinator,
+  type PublishProjectContext,
+} from '@/app/collab/publish/PublishCoordinator';
+import {
+  CloudAuthorityAdapter,
+  type CloudAuthorityHttpRequest,
+  type CloudAuthorityHttpResponse,
+} from '@/app/collab/remote-authority/CloudAuthorityAdapter';
+import { CollabError } from '@/core/collab/ClaudianCollabError';
+
+jest.setTimeout(30_000);
+
+const ACTOR_ID = 'member-a';
+const CREATED_AT = '2026-08-23T00:00:00.000Z';
+const PERSONAL_REF = `refs/heads/members/${ACTOR_ID}`;
+const PROJECT_ID = 'project-a';
+
+describe('Cloud Publish recovery integration', () => {
+  let git: GitRepositoryService;
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'claudian-cloud-publish-'));
+    const emptyConfigPath = path.join(root, 'empty.gitconfig');
+    await writeFile(emptyConfigPath, '');
+    const resolution = await new GitRuntimeResolver().resolve();
+    if (resolution.status !== 'available') {
+      throw new Error('Native Git is required for integration tests');
+    }
+    git = new GitRepositoryService(new GitCommandRunner({
+      emptyConfigPath,
+      executablePath: resolution.runtime.executablePath,
+    }));
+  });
+
+  afterEach(async () => {
+    await rm(root, { force: true, recursive: true });
+  });
+
+  it('replays one durable Request after its first Cloud JSON response is lost', async () => {
+    const authorityPath = path.join(root, 'authority.git');
+    const clonesPath = path.join(root, 'clones');
+    const seedPath = path.join(root, 'seed');
+    await Promise.all([mkdir(authorityPath), mkdir(clonesPath), mkdir(seedPath)]);
+    await git.initializeWorkingRepository(seedPath);
+    await git.configureLocalRepository(seedPath, {
+      memberId: ACTOR_ID,
+      personalRef: PERSONAL_REF,
+      projectId: PROJECT_ID,
+      userDisplayName: 'Alice',
+    });
+    await git.stageAll(seedPath);
+    const mainOid = await git.createCommitFromIndex(seedPath, {
+      expectedRefOid: null,
+      message: 'Initial project',
+      parents: [],
+      ref: 'refs/heads/main',
+    });
+    await git.createRef(seedPath, PERSONAL_REF, mainOid);
+    await git.initializeBareRepository(authorityPath);
+    await git.addRemote(seedPath, 'origin', authorityPath);
+    await git.push(seedPath, 'origin', 'refs/heads/main:refs/heads/main');
+    await git.push(seedPath, 'origin', `${PERSONAL_REF}:${PERSONAL_REF}`);
+
+    const repositoryPath = await git.cloneRepository({
+      branch: `members/${ACTOR_ID}`,
+      directoryName: PROJECT_ID,
+      parentDirectory: clonesPath,
+      remoteUrl: authorityPath,
+    });
+    await git.configureLocalRepository(repositoryPath, {
+      memberId: ACTOR_ID,
+      personalRef: PERSONAL_REF,
+      projectId: PROJECT_ID,
+      userDisplayName: 'Alice',
+    });
+    await writeFile(path.join(repositoryPath, 'note.md'), 'Cloud contribution\n');
+
+    const transport = new LostResponseCloudTransport(mainOid);
+    const authority = await new CloudAuthorityAdapter({
+      request: input => transport.request(input),
+    }).create(membership(authorityPath));
+    const context: PublishProjectContext = {
+      allowHostRemoteRepair: false,
+      memberId: ACTOR_ID,
+      personalRef: PERSONAL_REF,
+      projectId: PROJECT_ID,
+      remoteUrl: authority.git.remoteUrl,
+      repositoryPath,
+    };
+    const repository = new NativeGitPublishRepository(git, {
+      acceptedState: rejectingAcceptedState(),
+      network: new DirectNetwork(),
+    });
+    const state = new MemoryPublicationState(mainOid);
+    const createCoordinator = () => new PublishCoordinator(
+      fixedProject(context),
+      repository,
+      authority.control,
+      { assertSafe: async () => undefined },
+      state,
+      unusedCandidates(),
+      { compare: async () => [] },
+      { createOperationId: () => 'cloud-publish' },
+    );
+
+    await expect(createCoordinator().publish({
+      description: 'Cloud contribution',
+      projectId: PROJECT_ID,
+    })).resolves.toMatchObject({
+      status: 'success',
+      value: { state: 'pushed' },
+    });
+    expect(state.current.operation).toMatchObject({ phase: 'pushed' });
+    const committedOid = await git.resolveRef(repositoryPath, PERSONAL_REF);
+    expect(await git.resolveRef(authorityPath, PERSONAL_REF)).toBe(committedOid);
+
+    await expect(createCoordinator().publish({
+      description: 'Cloud contribution',
+      projectId: PROJECT_ID,
+    })).resolves.toMatchObject({
+      status: 'success',
+      value: {
+        request: { id: 'request-cloud' },
+        state: 'request-synchronized',
+      },
+    });
+
+    expect(transport.createdRequests).toBe(1);
+    expect(transport.requestIntents).toHaveLength(2);
+    expect(transport.requestIntents[1]).toBe(transport.requestIntents[0]);
+    expect(await git.countDivergence(repositoryPath, committedOid!, mainOid))
+      .toEqual({ leftOnly: 1, rightOnly: 0 });
+    expect(state.current.operation).toBeNull();
+  });
+});
+
+class LostResponseCloudTransport {
+  createdRequests = 0;
+  private lostFirstResponse = false;
+  requestIntents: string[] = [];
+  private requestRecord: Readonly<Record<string, unknown>> | null = null;
+
+  constructor(private readonly mainOid: string) {}
+
+  async request(input: CloudAuthorityHttpRequest): Promise<CloudAuthorityHttpResponse> {
+    if (input.method === 'GET') {
+      return {
+        body: collabCloudCapabilityDocument(['requests'], capabilityLimits()),
+        contentType: 'application/json',
+        status: 200,
+      };
+    }
+    const envelope = input.body as {
+      readonly data: Readonly<Record<string, unknown>>;
+      readonly requestId: string;
+    };
+    const intent = String(envelope.data.idempotencyKey);
+    this.requestIntents.push(intent);
+    if (!this.requestRecord) {
+      this.createdRequests += 1;
+      this.requestRecord = {
+        commentCount: 0,
+        createdAt: CREATED_AT,
+        description: envelope.data.description,
+        firstBaseOid: this.mainOid,
+        id: 'request-cloud',
+        latestHeadOid: envelope.data.headOid,
+        memberId: ACTOR_ID,
+        revision: 1,
+        status: 'open',
+        ticketRelations: [],
+        updatedAt: CREATED_AT,
+      };
+    }
+    if (!this.lostFirstResponse) {
+      this.lostFirstResponse = true;
+      throw new CollabError({ code: 'endpoint-unreachable' });
+    }
+    return {
+      body: collabCloudSuccessEnvelope(envelope.requestId, {
+        mainOid: this.mainOid,
+        request: this.requestRecord,
+      }),
+      contentType: 'application/json',
+      status: 200,
+    };
+  }
+}
+
+class DirectNetwork implements PublishGitNetworkPort {
+  withNetwork<T>(
+    _context: PublishProjectContext,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    return operation();
+  }
+}
+
+class MemoryPublicationState {
+  current: CollabPublicationStateRecord;
+
+  constructor(baseMainOid: string) {
+    this.current = {
+      baseMainOid,
+      operation: null,
+      projectId: PROJECT_ID,
+      schemaVersion: COLLAB_PUBLICATION_STATE_SCHEMA_VERSION,
+      updatedAt: CREATED_AT,
+    };
+  }
+
+  async load(): Promise<CollabPublicationStateRecord> { return this.current; }
+  async save(record: CollabPublicationStateRecord): Promise<void> { this.current = record; }
+}
+
+function membership(gitRemoteUrl: string): CollabLocalCloudMembershipRecord {
+  return {
+    authority: {
+      bindingVersion: 1,
+      developmentActorId: ACTOR_ID,
+      gitRemoteUrl,
+      kind: 'cloud',
+      serverUrl: 'https://cloud.example.test',
+      wireVersion: 4,
+    },
+    createdAt: CREATED_AT,
+    lastEventSequence: 0,
+    lifecycle: 'active',
+    member: {
+      displayName: 'Alice',
+      id: ACTOR_ID,
+      personalRef: PERSONAL_REF,
+      role: 'member',
+    },
+    project: {
+      id: PROJECT_ID,
+      name: 'Cloud Project',
+      workspacePath: `workspace/${PROJECT_ID}`,
+    },
+    schemaVersion: COLLAB_LOCAL_PROJECT_SCHEMA_VERSION,
+    updatedAt: CREATED_AT,
+  };
+}
+
+function capabilityLimits() {
+  return {
+    maxDevelopmentBootstrapGitBundleBytes: 1_024,
+    maxDevelopmentBootstrapManifestUtf8Bytes: 1_024,
+    maxDevelopmentBootstrapReportUtf8Bytes: 1_024,
+    maxEventReplay: 100,
+    maxGitReceivePackBytes: 1_024,
+    maxJsonPayloadUtf8Bytes: COLLAB_LIMITS.maxJsonPayloadUtf8Bytes,
+    maxRepositoryBytes: 1_024,
+  };
+}
+
+function fixedProject(context: PublishProjectContext) {
+  return {
+    load: async () => context,
+    revalidate: async () => undefined,
+  };
+}
+
+function rejectingAcceptedState(): PublishAcceptedStatePort {
+  return {
+    classifyDivergence: async () => {
+      throw new Error('Accepted integration is not expected');
+    },
+  };
+}
+
+function unusedCandidates() {
+  const unused = async () => {
+    throw new Error('A current-base Publish must not use a publication candidate');
+  };
+  return {
+    apply: unused,
+    assertRetained: unused,
+    cleanup: unused,
+    prepare: unused,
+  };
+}

--- a/tests/unit/app/collab/publish/PublishCoordinator.test.ts
+++ b/tests/unit/app/collab/publish/PublishCoordinator.test.ts
@@ -493,6 +493,59 @@ describe('PublishCoordinator', () => {
     expect(repository.commitCount).toBe(1);
   });
 
+  it('reconciles a successful personal push whose transport response was lost', async () => {
+    const fixture = createSubject();
+    fixture.repository.current = snapshot({
+      changedFiles: [{ path: 'note.md', status: 'modified' }],
+      workingTreeClean: false,
+    });
+    const push = jest.spyOn(fixture.repository, 'pushPersonal')
+      .mockImplementationOnce(async () => {
+        fixture.repository.calls.push('push');
+        fixture.repository.current = {
+          ...fixture.repository.current,
+          personalAheadBy: 0,
+          personalBehindBy: 0,
+          personalRemoteOid: fixture.repository.current.headOid,
+        };
+        throw new CollabError({ code: 'endpoint-unreachable' });
+      });
+
+    await expect(fixture.subject.publish(PUBLISH_REQUEST)).resolves.toMatchObject({
+      status: 'success',
+      value: { state: 'committed-locally' },
+    });
+    expect(fixture.state.current.operation).toMatchObject({ phase: 'applied' });
+
+    await expect(fixture.subject.publish(PUBLISH_REQUEST)).resolves.toMatchObject({
+      status: 'success',
+      value: { state: 'request-synchronized' },
+    });
+    expect(push).toHaveBeenCalledTimes(1);
+    expect(fixture.requests.calls).toHaveLength(1);
+  });
+
+  it('replays the same Request intent after a successful response is lost', async () => {
+    const fixture = createSubject();
+    fixture.requests.error = new CollabError({ code: 'endpoint-unreachable' });
+
+    await expect(fixture.subject.publish(PUBLISH_REQUEST)).resolves.toMatchObject({
+      status: 'success',
+      value: { state: 'pushed' },
+    });
+    expect(fixture.state.current.operation).toMatchObject({ phase: 'pushed' });
+    const firstIntent = fixture.requests.calls[0]!.idempotencyKey;
+
+    fixture.requests.error = null;
+    await expect(fixture.subject.publish(PUBLISH_REQUEST)).resolves.toMatchObject({
+      status: 'success',
+      value: { request: { id: 'request-a' }, state: 'request-synchronized' },
+    });
+    expect(fixture.requests.calls).toHaveLength(2);
+    expect(fixture.requests.calls[1]!.idempotencyKey).toBe(firstIntent);
+    expect(fixture.state.current.operation).toBeNull();
+  });
+
   it('surfaces a conflict during Publish without pushing a misleading head', async () => {
     const fixture = createSubject({ state: new FakeState(BASE) });
     fixture.repository.acceptedState = { conflict: conflict(), kind: 'conflicting' };

--- a/tests/unit/app/collab/remote-authority/CloudAuthorityAdapter.test.ts
+++ b/tests/unit/app/collab/remote-authority/CloudAuthorityAdapter.test.ts
@@ -16,6 +16,52 @@ import {
 
 const PROJECT_ID = 'project-cloud';
 const ACTOR_ID = 'member-alice';
+const CREATED_AT = '2026-08-22T00:00:00.000Z';
+const MAIN_OID = 'a'.repeat(40);
+const HEAD_OID = 'b'.repeat(40);
+
+function changeRequest(overrides: Readonly<Record<string, unknown>> = {}) {
+  return {
+    commentCount: 0,
+    createdAt: CREATED_AT,
+    description: 'Published change',
+    firstBaseOid: MAIN_OID,
+    id: 'request-one',
+    latestHeadOid: HEAD_OID,
+    memberId: ACTOR_ID,
+    revision: 1,
+    status: 'open',
+    ticketRelations: [],
+    updatedAt: CREATED_AT,
+    ...overrides,
+  };
+}
+
+function ticketSummary(overrides: Readonly<Record<string, unknown>> = {}) {
+  return {
+    acceptedRelationCount: 0,
+    authorMemberId: ACTOR_ID,
+    commentCount: 0,
+    createdAt: CREATED_AT,
+    id: 'ticket-one',
+    number: 1,
+    revision: 1,
+    status: 'open',
+    title: 'Ticket title',
+    updatedAt: CREATED_AT,
+    ...overrides,
+  };
+}
+
+function ticketDetail(overrides: Readonly<Record<string, unknown>> = {}) {
+  return {
+    acceptedRelations: { acceptedRelations: [] },
+    body: 'Ticket body',
+    comments: { comments: [] },
+    ticket: ticketSummary(),
+    ...overrides,
+  };
+}
 
 function membership(): CollabLocalCloudMembershipRecord {
   return {
@@ -152,6 +198,372 @@ describe('CloudAuthorityAdapter', () => {
     ]);
   });
 
+  it('ensures the current member Request through the package-owned Cloud operation', async () => {
+    const requests: CloudAuthorityHttpRequest[] = [];
+    const request = jest.fn(async (input: CloudAuthorityHttpRequest) => {
+      requests.push(input);
+      if (input.method === 'GET') {
+        return {
+          body: collabCloudCapabilityDocument(['requests'], limits),
+          contentType: 'application/json; charset=utf-8',
+          status: 200,
+        };
+      }
+      return {
+        body: collabCloudSuccessEnvelope('response-ensure', {
+          mainOid: MAIN_OID,
+          request: changeRequest(),
+        }),
+        contentType: 'application/json; charset=utf-8',
+        status: 200,
+      };
+    });
+    const session = await new CloudAuthorityAdapter({
+      request,
+      requestIdFactory: () => 'request-ensure',
+    }).create(membership());
+    const controller = new AbortController();
+
+    await expect(session.control.ensure({
+      description: 'Published change',
+      expectedMainOid: MAIN_OID,
+      headOid: HEAD_OID,
+      idempotencyKey: 'publish-head',
+      projectId: PROJECT_ID,
+      signal: controller.signal,
+    })).resolves.toMatchObject({ id: 'request-one', latestHeadOid: HEAD_OID });
+    expect(requests[1]).toEqual({
+      body: {
+        data: {
+          description: 'Published change',
+          expectedMainOid: MAIN_OID,
+          headOid: HEAD_OID,
+          idempotencyKey: 'publish-head',
+          projectId: PROJECT_ID,
+        },
+        protocolVersion: 4,
+        requestId: 'request-ensure',
+      },
+      headers: { 'x-claudian-development-actor': ACTOR_ID },
+      method: 'POST',
+      signal: controller.signal,
+      url: `https://cloud.example.test/v1/projects/${PROJECT_ID}/operations/ensureMyRequest`,
+    });
+  });
+
+  it('keeps Accept unavailable until the dedicated Cloud authority tranche', async () => {
+    const request = jest.fn(async () => ({
+      body: collabCloudCapabilityDocument(['accept'], limits),
+      contentType: 'application/json',
+      status: 200,
+    }));
+    const control = (await new CloudAuthorityAdapter({ request }).create(membership())).control;
+
+    await expect(control.acceptRequest({
+      expectedHeadOid: HEAD_OID,
+      expectedMainOid: MAIN_OID,
+      expectedRequestRevision: 1,
+      expectedResolvingTickets: [],
+      idempotencyKey: 'accept-intent',
+      projectId: PROJECT_ID,
+      requestId: 'request-one',
+    })).rejects.toMatchObject({
+      code: 'operation-failed',
+      safeContext: { reason: 'cloud-authority-operation-not-wired' },
+    });
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes Request reads, comments, and metadata through canonical Cloud operations', async () => {
+    const operations: string[] = [];
+    const request = jest.fn(async (input: CloudAuthorityHttpRequest) => {
+      if (input.method === 'GET') {
+        return {
+          body: collabCloudCapabilityDocument(['requests'], limits),
+          contentType: 'application/json',
+          status: 200,
+        };
+      }
+      const operation = input.url.split('/').at(-1)!;
+      operations.push(operation);
+      const data = operation === 'getRequest'
+        ? {
+          comments: { comments: [] },
+          currentMainOid: MAIN_OID,
+          request: changeRequest(),
+          reviewedHeadOid: HEAD_OID,
+          reviewCondition: 'clean',
+        }
+        : operation === 'listRequestComments'
+          ? { comments: [] }
+          : operation === 'createComment'
+            ? {
+              comment: {
+                authorMemberId: ACTOR_ID,
+                body: 'Looks good',
+                createdAt: CREATED_AT,
+                id: 'comment-one',
+                requestId: 'request-one',
+              },
+              request: changeRequest({ commentCount: 1 }),
+            }
+            : { request: changeRequest({ description: 'Updated description', revision: 2 }) };
+      return {
+        body: collabCloudSuccessEnvelope(`response-${operation}`, data),
+        contentType: 'application/json',
+        status: 200,
+      };
+    });
+    const control = (await new CloudAuthorityAdapter({ request }).create(membership())).control;
+
+    await expect(control.readRequestPage(PROJECT_ID, 'request-one')).resolves.toMatchObject({
+      request: { id: 'request-one' },
+    });
+    await expect(control.readRequest(PROJECT_ID, 'request-one')).resolves.toMatchObject({
+      request: { id: 'request-one' },
+    });
+    await expect(control.listRequestComments(PROJECT_ID, 'request-one', {})).resolves.toEqual({
+      comments: [],
+    });
+    await expect(control.createComment({
+      body: 'Looks good',
+      idempotencyKey: 'comment-intent',
+      projectId: PROJECT_ID,
+      requestId: 'request-one',
+    })).resolves.toMatchObject({ comment: { id: 'comment-one' } });
+    await expect(control.updateRequestMetadata({
+      description: 'Updated description',
+      expectedHeadOid: HEAD_OID,
+      expectedRequestRevision: 1,
+      intentId: 'ui-intent',
+      projectId: PROJECT_ID,
+      requestId: 'request-one',
+    }, 'metadata-intent')).resolves.toMatchObject({
+      description: 'Updated description',
+      id: 'request-one',
+    });
+    expect(operations).toEqual([
+      'getRequest',
+      'getRequest',
+      'listRequestComments',
+      'createComment',
+      'updateMyRequestMetadata',
+    ]);
+    expect(request).toHaveBeenLastCalledWith(expect.objectContaining({
+      body: expect.objectContaining({
+        data: expect.not.objectContaining({ intentId: expect.anything() }),
+      }),
+    }));
+  });
+
+  it('routes all Ticket reads and mutations through canonical Cloud operations', async () => {
+    const requests: CloudAuthorityHttpRequest[] = [];
+    const request = jest.fn(async (input: CloudAuthorityHttpRequest) => {
+      requests.push(input);
+      if (input.method === 'GET') {
+        return {
+          body: collabCloudCapabilityDocument(['tickets'], limits),
+          contentType: 'application/json',
+          status: 200,
+        };
+      }
+      const operation = input.url.split('/').at(-1)!;
+      const data = operation === 'listTickets'
+        ? { tickets: [ticketSummary()] }
+        : operation === 'getTicket'
+          ? ticketDetail()
+          : operation === 'listTicketComments'
+            ? { comments: [] }
+            : operation === 'listTicketAcceptedRelations'
+              ? { acceptedRelations: [] }
+              : operation === 'createTicket'
+                ? { ticket: ticketDetail() }
+                : operation === 'createTicketComment'
+                  ? {
+                    comment: {
+                      authorMemberId: ACTOR_ID,
+                      body: 'Ticket comment',
+                      createdAt: CREATED_AT,
+                      id: 'ticket-comment-one',
+                      ticketId: 'ticket-one',
+                    },
+                    ticket: ticketSummary({ commentCount: 1, revision: 2 }),
+                  }
+                  : { ticket: ticketSummary({ revision: 2 }) };
+      return {
+        body: collabCloudSuccessEnvelope(`response-${operation}`, data),
+        contentType: 'application/json',
+        status: 200,
+      };
+    });
+    const control = (await new CloudAuthorityAdapter({ request }).create(membership())).control;
+
+    await expect(control.listTickets({ projectId: PROJECT_ID, status: 'open' })).resolves
+      .toMatchObject({ tickets: [{ id: 'ticket-one' }] });
+    await expect(control.readTicketPage(PROJECT_ID, 'ticket-one')).resolves
+      .toMatchObject({ ticket: { id: 'ticket-one' } });
+    await expect(control.readTicket(PROJECT_ID, 'ticket-one')).resolves
+      .toMatchObject({ ticket: { id: 'ticket-one' } });
+    await expect(control.listTicketComments(PROJECT_ID, 'ticket-one', {})).resolves
+      .toEqual({ comments: [] });
+    await expect(control.listTicketAcceptedRelations(PROJECT_ID, 'ticket-one', {})).resolves
+      .toEqual({ acceptedRelations: [] });
+    await expect(control.createTicket({
+      body: 'Ticket body',
+      intentId: 'ui-create-ticket',
+      projectId: PROJECT_ID,
+      title: 'Ticket title',
+    }, 'create-ticket')).resolves.toMatchObject({ ticket: { id: 'ticket-one' } });
+    await expect(control.updateTicketContent({
+      body: 'Updated body',
+      expectedRevision: 1,
+      intentId: 'ui-update-ticket',
+      projectId: PROJECT_ID,
+      ticketId: 'ticket-one',
+      title: 'Updated title',
+    }, 'update-ticket')).resolves.toMatchObject({ id: 'ticket-one', revision: 2 });
+    await expect(control.addTicketComment({
+      body: 'Ticket comment',
+      intentId: 'ui-comment-ticket',
+      projectId: PROJECT_ID,
+      ticketId: 'ticket-one',
+    }, 'comment-ticket')).resolves.toMatchObject({ id: 'ticket-comment-one' });
+    await expect(control.closeTicket({
+      expectedRevision: 1,
+      intentId: 'ui-close-ticket',
+      projectId: PROJECT_ID,
+      ticketId: 'ticket-one',
+    }, 'close-ticket')).resolves.toMatchObject({ id: 'ticket-one' });
+    await expect(control.reopenTicket({
+      expectedRevision: 1,
+      intentId: 'ui-reopen-ticket',
+      projectId: PROJECT_ID,
+      ticketId: 'ticket-one',
+    }, 'reopen-ticket')).resolves.toMatchObject({ id: 'ticket-one' });
+
+    expect(requests.slice(1).map(input => input.url.split('/').at(-1))).toEqual([
+      'listTickets',
+      'getTicket',
+      'getTicket',
+      'listTicketComments',
+      'listTicketAcceptedRelations',
+      'createTicket',
+      'updateTicketContent',
+      'createTicketComment',
+      'closeTicket',
+      'reopenTicket',
+    ]);
+    for (const input of requests.slice(6)) {
+      expect(input.body).toEqual(expect.objectContaining({
+        data: expect.not.objectContaining({ intentId: expect.anything() }),
+      }));
+    }
+  });
+
+  it('assembles bounded Cloud Request and Ticket pages for complete reads', async () => {
+    const requestComment = (id: string) => ({
+      authorMemberId: ACTOR_ID,
+      body: id,
+      createdAt: CREATED_AT,
+      id,
+      requestId: 'request-one',
+    });
+    const ticketComment = (id: string) => ({
+      authorMemberId: ACTOR_ID,
+      body: id,
+      createdAt: CREATED_AT,
+      id,
+      ticketId: 'ticket-one',
+    });
+    const acceptedRelation = {
+      acceptedAt: CREATED_AT,
+      acceptedMergeOid: MAIN_OID,
+      commitOid: HEAD_OID,
+      id: 'relation-one',
+      kind: 'resolves',
+      requestId: 'request-one',
+    };
+    const request = jest.fn(async (input: CloudAuthorityHttpRequest) => {
+      if (input.method === 'GET') {
+        return {
+          body: collabCloudCapabilityDocument(['requests', 'tickets'], limits),
+          contentType: 'application/json',
+          status: 200,
+        };
+      }
+      const operation = input.url.split('/').at(-1)!;
+      const body = input.body as { readonly data: Readonly<Record<string, unknown>> };
+      const data = operation === 'getRequest'
+        ? {
+          comments: { comments: [requestComment('request-comment-one')], nextCursor: 'request-next' },
+          currentMainOid: MAIN_OID,
+          request: changeRequest({ commentCount: 2 }),
+          reviewedHeadOid: HEAD_OID,
+          reviewCondition: 'clean',
+        }
+        : operation === 'listRequestComments'
+          ? { comments: [requestComment('request-comment-two')] }
+          : operation === 'getTicket'
+            ? ticketDetail({
+              acceptedRelations: { acceptedRelations: [], nextCursor: 'relation-next' },
+              comments: { comments: [ticketComment('ticket-comment-one')], nextCursor: 'comment-next' },
+              ticket: ticketSummary({ acceptedRelationCount: 1, commentCount: 2 }),
+            })
+            : operation === 'listTicketComments'
+              ? { comments: [ticketComment(`ticket-${String(body.data.cursor)}`)] }
+              : { acceptedRelations: [acceptedRelation] };
+      return {
+        body: collabCloudSuccessEnvelope(`response-${operation}`, data),
+        contentType: 'application/json',
+        status: 200,
+      };
+    });
+    const control = (await new CloudAuthorityAdapter({ request }).create(membership())).control;
+
+    await expect(control.readRequest(PROJECT_ID, 'request-one')).resolves.toMatchObject({
+      comments: { comments: [{ id: 'request-comment-one' }, { id: 'request-comment-two' }] },
+    });
+    await expect(control.readTicket(PROJECT_ID, 'ticket-one')).resolves.toMatchObject({
+      acceptedRelations: { acceptedRelations: [{ id: 'relation-one' }] },
+      comments: {
+        comments: [{ id: 'ticket-comment-one' }, { id: 'ticket-comment-next' }],
+      },
+    });
+  });
+
+  it('rejects continuation comments returned for a different owner', async () => {
+    const request = jest.fn(async (input: CloudAuthorityHttpRequest) => {
+      if (input.method === 'GET') {
+        return {
+          body: collabCloudCapabilityDocument(['requests', 'tickets'], limits),
+          contentType: 'application/json',
+          status: 200,
+        };
+      }
+      const operation = input.url.split('/').at(-1)!;
+      const comment = {
+        authorMemberId: ACTOR_ID,
+        body: 'Wrong owner',
+        createdAt: CREATED_AT,
+        id: 'comment-wrong-owner',
+        ...(operation === 'listRequestComments'
+          ? { requestId: 'request-other' }
+          : { ticketId: 'ticket-other' }),
+      };
+      return {
+        body: collabCloudSuccessEnvelope(`response-${operation}`, { comments: [comment] }),
+        contentType: 'application/json',
+        status: 200,
+      };
+    });
+    const control = (await new CloudAuthorityAdapter({ request }).create(membership())).control;
+
+    await expect(control.listRequestComments(PROJECT_ID, 'request-one', {})).rejects
+      .toMatchObject({ code: 'authority-integrity-error' });
+    await expect(control.listTicketComments(PROJECT_ID, 'ticket-one', {})).rejects
+      .toMatchObject({ code: 'authority-integrity-error' });
+  });
+
   it('fails closed on unsupported binding or wire versions', async () => {
     const document = collabCloudCapabilityDocument(['project-snapshot'], limits);
     const adapter = new CloudAuthorityAdapter({
@@ -164,6 +576,25 @@ describe('CloudAuthorityAdapter', () => {
 
     await expect(adapter.create(membership())).rejects.toMatchObject({
       code: 'protocol-version-unsupported',
+    });
+  });
+
+  it('rejects a Cloud snapshot bound to a different Project', async () => {
+    const request = jest.fn(async (input: CloudAuthorityHttpRequest) => ({
+      body: input.method === 'GET'
+        ? collabCloudCapabilityDocument(['project-snapshot'], limits)
+        : collabCloudSuccessEnvelope('response-snapshot', {
+          ...cloudSnapshot(),
+          project: { ...cloudSnapshot().project, id: 'project-other' },
+        }),
+      contentType: 'application/json',
+      status: 200,
+    }));
+    const control = (await new CloudAuthorityAdapter({ request }).create(membership())).control;
+
+    await expect(control.readSnapshot(PROJECT_ID)).rejects.toMatchObject({
+      code: 'authority-integrity-error',
+      safeContext: { reason: 'cloud-control-snapshot-response-mismatch' },
     });
   });
 


### PR DESCRIPTION
## Summary
- route all canonical non-Accept Request and Ticket operations through the Cloud authority adapter
- preserve bounded page assembly, response integrity, cancellation, and Accept capability gating
- prove lost push and lost JSON response recovery with deterministic publication intents and real Git

## Validation
- npm test (8,541 tests)
- npm run typecheck -- --pretty false
- npm run lint
- npm run build
- npm run test:cross-platform-collab (198 tests)
- npm run verify:protocol
- git diff --check