### PR TITLE
feat: enable cloud accept integration

### DIFF
--- a/src/app/collab/remote-authority/CloudAuthorityAdapter.ts
+++ b/src/app/collab/remote-authority/CloudAuthorityAdapter.ts
@@ -331,8 +331,22 @@ class CloudAuthorityControl implements CollabAuthorityControlPort {
     }
     return response.request;
   }
-  acceptRequest(_input: Parameters<CollabAuthorityControlPort['acceptRequest']>[0]) {
-    return this.unavailable('accept');
+  async acceptRequest(input: Parameters<CollabAuthorityControlPort['acceptRequest']>[0]) {
+    const { signal, ...request } = input;
+    const response = await this.execute(
+      'accept',
+      'acceptRequest',
+      request,
+      signal ? { signal } : {},
+    );
+    if (
+      response.request.id !== input.requestId
+      || response.request.latestHeadOid !== input.expectedHeadOid
+      || response.request.revision !== input.expectedRequestRevision
+    ) {
+      throw controlIntegrityError('cloud-control-accept-response-mismatch');
+    }
+    return response;
   }
   async createComment(input: Parameters<CollabAuthorityControlPort['createComment']>[0]) {
     const { signal, ...request } = input;
@@ -678,13 +692,6 @@ class CloudAuthorityControl implements CollabAuthorityControlPort {
     return response.request;
   }
 
-  private unavailable(capability: CollabCloudCapability): Promise<never> {
-    this.requireCapability(capability);
-    return Promise.reject(adapterError(
-      'operation-failed',
-      'cloud-authority-operation-not-wired',
-    ));
-  }
 }
 
 export class CloudProjectEventClient {

--- a/tests/integration/app/collab/accept/CloudAcceptRecovery.test.ts
+++ b/tests/integration/app/collab/accept/CloudAcceptRecovery.test.ts
@@ -1,0 +1,422 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import {
+  COLLAB_LIMITS,
+  collabCloudCapabilityDocument,
+  collabCloudSuccessEnvelope,
+} from '@claudian/collab-protocol';
+
+import { CollabClientProjection } from '@/app/collab/client/CollabClientProjection';
+import {
+  type CollabLocalCloudMembershipRecord,
+  CollabLocalProjectRepository,
+} from '@/app/collab/CollabLocalProjectRepository';
+import { COLLAB_LOCAL_PROJECT_SCHEMA_VERSION } from '@/app/collab/CollabSchemaVersions';
+import { GitCommandRunner } from '@/app/collab/git/GitCommandRunner';
+import { GitRepositoryService } from '@/app/collab/git/GitRepositoryService';
+import { GitRuntimeResolver } from '@/app/collab/git/GitRuntimeResolver';
+import {
+  COLLAB_PUBLICATION_STATE_SCHEMA_VERSION,
+} from '@/app/collab/publish/CollabPublicationStateRecord';
+import { CollabPublicationStateStore } from '@/app/collab/publish/CollabPublicationStateStore';
+import {
+  COLLAB_REQUEST_DRAFT_SCHEMA_VERSION,
+} from '@/app/collab/publish/CollabRequestDraftRecord';
+import { CollabRequestDraftStore } from '@/app/collab/publish/CollabRequestDraftStore';
+import {
+  NativeGitPublishRepository,
+  type PublishGitNetworkPort,
+} from '@/app/collab/publish/NativeGitPublishRepository';
+import type { PublishProjectContext } from '@/app/collab/publish/PublishCoordinator';
+import { NativeGitAcceptedStateIntegrator } from '@/app/collab/reconciliation/NativeGitAcceptedStateIntegrator';
+import { ReconciliationCoordinator } from '@/app/collab/reconciliation/ReconciliationCoordinator';
+import { ReconciliationMutationSafety } from '@/app/collab/reconciliation/ReconciliationMutationSafety';
+import { ReconciliationRepository } from '@/app/collab/reconciliation/ReconciliationRepository';
+import {
+  CloudAuthorityAdapter,
+  type CloudAuthorityHttpRequest,
+  type CloudAuthorityHttpResponse,
+} from '@/app/collab/remote-authority/CloudAuthorityAdapter';
+import { CollabError } from '@/core/collab/ClaudianCollabError';
+
+jest.setTimeout(30_000);
+
+const PROJECT_ID = 'project-a';
+const MANAGER_ID = 'member-a';
+const CONTRIBUTOR_ID = 'member-b';
+const MANAGER_REF = `refs/heads/members/${MANAGER_ID}`;
+const CONTRIBUTOR_REF = `refs/heads/members/${CONTRIBUTOR_ID}`;
+const CREATED_AT = '2026-08-23T00:00:00.000Z';
+const ACCEPTED_AT = '2026-08-23T00:01:00.000Z';
+
+describe('Cloud Accept recovery integration', () => {
+  let root: string;
+
+  afterEach(async () => {
+    if (root) await rm(root, { force: true, recursive: true });
+  });
+
+  it('recovers a committed Accept from snapshot, detail, and main without repeating it', async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'claudian-cloud-accept-'));
+    const authorityPath = path.join(root, 'authority.git');
+    const clonesPath = path.join(root, 'clones');
+    const seedPath = path.join(root, 'seed');
+    const vaultRoot = path.join(root, 'vault');
+    await Promise.all([
+      mkdir(authorityPath),
+      mkdir(clonesPath),
+      mkdir(seedPath),
+      mkdir(vaultRoot),
+    ]);
+    const emptyConfigPath = path.join(root, 'empty.gitconfig');
+    await writeFile(emptyConfigPath, '');
+    const resolution = await new GitRuntimeResolver().resolve();
+    if (resolution.status !== 'available') {
+      throw new Error('Native Git is required for integration tests');
+    }
+    const runner = new GitCommandRunner({
+      emptyConfigPath,
+      executablePath: resolution.runtime.executablePath,
+    });
+    const git = new GitRepositoryService(runner);
+    await git.initializeWorkingRepository(seedPath);
+    await git.configureLocalRepository(seedPath, {
+      memberId: MANAGER_ID,
+      personalRef: MANAGER_REF,
+      projectId: PROJECT_ID,
+      userDisplayName: 'Alice',
+    });
+    await writeFile(path.join(seedPath, 'base.md'), 'Base\n');
+    await git.stageAll(seedPath);
+    const baseOid = await git.createCommitFromIndex(seedPath, {
+      expectedRefOid: null,
+      message: 'Initial project',
+      parents: [],
+      ref: 'refs/heads/main',
+    });
+    await git.createRef(seedPath, MANAGER_REF, baseOid);
+    await writeFile(path.join(seedPath, 'accepted.md'), 'Accepted contribution\n');
+    await git.stageAll(seedPath);
+    const acceptedOid = await git.createCommitFromIndex(seedPath, {
+      expectedRefOid: null,
+      message: 'Contribution',
+      parents: [baseOid],
+      ref: CONTRIBUTOR_REF,
+    });
+    await git.initializeBareRepository(authorityPath);
+    await git.addRemote(seedPath, 'origin', authorityPath);
+    await git.push(seedPath, 'origin', 'refs/heads/main:refs/heads/main');
+    await git.push(seedPath, 'origin', `${MANAGER_REF}:${MANAGER_REF}`);
+    await git.push(seedPath, 'origin', `${CONTRIBUTOR_REF}:${CONTRIBUTOR_REF}`);
+
+    const repositoryPath = await git.cloneRepository({
+      branch: `members/${MANAGER_ID}`,
+      directoryName: PROJECT_ID,
+      parentDirectory: clonesPath,
+      remoteUrl: authorityPath,
+    });
+    await git.configureLocalRepository(repositoryPath, {
+      memberId: MANAGER_ID,
+      personalRef: MANAGER_REF,
+      projectId: PROJECT_ID,
+      userDisplayName: 'Alice',
+    });
+
+    const projects = new CollabLocalProjectRepository(vaultRoot, {
+      now: () => new Date(CREATED_AT),
+    });
+    await projects.saveMembership(membership());
+    const drafts = new CollabRequestDraftStore(projects);
+    const retainedDraft = {
+      createdAt: CREATED_AT,
+      description: 'Keep this unpublished draft',
+      projectId: PROJECT_ID,
+      schemaVersion: COLLAB_REQUEST_DRAFT_SCHEMA_VERSION,
+      syncState: 'local' as const,
+      updatedAt: CREATED_AT,
+    };
+    await drafts.save(retainedDraft);
+    const publicationState = new CollabPublicationStateStore(projects);
+    await publicationState.save({
+      baseMainOid: baseOid,
+      operation: null,
+      projectId: PROJECT_ID,
+      schemaVersion: COLLAB_PUBLICATION_STATE_SCHEMA_VERSION,
+      updatedAt: CREATED_AT,
+    });
+
+    const transport = new CommitThenDisconnectTransport(
+      git,
+      authorityPath,
+      baseOid,
+      acceptedOid,
+    );
+    const firstAuthority = await new CloudAuthorityAdapter({
+      request: input => transport.request(input),
+    }).create(membership());
+    const firstProjection = new CollabClientProjection(projects, firstAuthority.control);
+
+    await expect(firstProjection.acceptRequest(
+      PROJECT_ID,
+      'request-one',
+      baseOid,
+      acceptedOid,
+      1,
+      [],
+      {},
+      'accept-lost-response',
+    )).rejects.toMatchObject({ code: 'endpoint-unreachable' });
+    expect(await git.resolveRef(authorityPath, 'refs/heads/main')).toBe(acceptedOid);
+    firstProjection.dispose();
+    firstAuthority.dispose();
+
+    const restartedAuthority = await new CloudAuthorityAdapter({
+      request: input => transport.request(input),
+    }).create(await projects.loadMembership(PROJECT_ID) as CollabLocalCloudMembershipRecord);
+    const projection = new CollabClientProjection(
+      new CollabLocalProjectRepository(vaultRoot),
+      restartedAuthority.control,
+      { now: () => new Date(ACCEPTED_AT) },
+    );
+
+    await expect(projection.readSnapshot(PROJECT_ID)).resolves.toMatchObject({
+      snapshot: {
+        eventSequence: 1,
+        openRequests: [],
+        project: { authorityKind: 'cloud', mainOid: acceptedOid },
+      },
+      source: 'online',
+      stale: false,
+    });
+    await expect(projection.readRequest(PROJECT_ID, 'request-one')).resolves.toMatchObject({
+      currentMainOid: acceptedOid,
+      request: {
+        id: 'request-one',
+        mergedOid: acceptedOid,
+        status: 'merged',
+      },
+      reviewedHeadOid: acceptedOid,
+    });
+    expect((await projects.loadMembership(PROJECT_ID))?.lastEventSequence).toBe(1);
+
+    const context: PublishProjectContext = {
+      allowHostRemoteRepair: false,
+      memberId: MANAGER_ID,
+      personalRef: MANAGER_REF,
+      projectId: PROJECT_ID,
+      remoteUrl: authorityPath,
+      repositoryPath,
+    };
+    const acceptedState = new NativeGitAcceptedStateIntegrator(git, runner);
+    const repository = new NativeGitPublishRepository(git, {
+      acceptedState,
+      network: new DirectNetwork(),
+    });
+    const reconciliation = new ReconciliationCoordinator(
+      fixedProject(context),
+      new ReconciliationRepository(repository, acceptedState),
+      restartedAuthority.control,
+      new ReconciliationMutationSafety(acceptedState),
+      publicationState,
+      { createOperationId: () => 'cloud-accept-recovery' },
+    );
+
+    await expect(reconciliation.reconcile(PROJECT_ID)).resolves.toEqual({
+      status: 'success',
+      value: {
+        headOid: acceptedOid,
+        projectId: PROJECT_ID,
+        state: 'fast-forwarded',
+      },
+    });
+    expect(await git.resolveRef(repositoryPath, MANAGER_REF)).toBe(acceptedOid);
+    expect(await git.resolveRef(authorityPath, MANAGER_REF)).toBe(acceptedOid);
+    await expect(drafts.load(PROJECT_ID)).resolves.toEqual(retainedDraft);
+    await expect(publicationState.load(PROJECT_ID)).resolves.toMatchObject({
+      baseMainOid: acceptedOid,
+      operation: null,
+    });
+    expect(transport.acceptCalls).toBe(1);
+    expect(transport.acceptIntents).toEqual(['accept-lost-response']);
+
+    projection.dispose();
+    restartedAuthority.dispose();
+  });
+});
+
+class CommitThenDisconnectTransport {
+  acceptCalls = 0;
+  acceptIntents: string[] = [];
+  private accepted = false;
+
+  constructor(
+    private readonly git: GitRepositoryService,
+    private readonly authorityPath: string,
+    private readonly baseOid: string,
+    private readonly acceptedOid: string,
+  ) {}
+
+  async request(input: CloudAuthorityHttpRequest): Promise<CloudAuthorityHttpResponse> {
+    if (input.method === 'GET') {
+      return {
+        body: collabCloudCapabilityDocument(
+          ['accept', 'project-snapshot', 'requests'],
+          capabilityLimits(),
+        ),
+        contentType: 'application/json',
+        status: 200,
+      };
+    }
+    const operation = input.url.split('/').at(-1);
+    const envelope = input.body as {
+      readonly data: Readonly<Record<string, unknown>>;
+      readonly requestId: string;
+    };
+    if (operation === 'acceptRequest') {
+      this.acceptCalls += 1;
+      this.acceptIntents.push(String(envelope.data.idempotencyKey));
+      if (!this.accepted) {
+        const result = await this.git.compareAndSwapRef(
+          this.authorityPath,
+          'refs/heads/main',
+          this.acceptedOid,
+          this.baseOid,
+        );
+        if (!result.updated) throw new Error('Expected authoritative main to advance');
+        this.accepted = true;
+      }
+      throw new CollabError({ code: 'endpoint-unreachable' });
+    }
+    if (operation === 'getProjectSnapshot') {
+      return this.success(envelope.requestId, cloudSnapshot(this.acceptedOid));
+    }
+    if (operation === 'getRequest') {
+      return this.success(envelope.requestId, {
+        comments: { comments: [] },
+        currentMainOid: this.acceptedOid,
+        request: acceptedRequest(this.baseOid, this.acceptedOid),
+        reviewedHeadOid: this.acceptedOid,
+        reviewCondition: 'clean',
+      });
+    }
+    throw new Error(`Unexpected Cloud operation: ${String(operation)}`);
+  }
+
+  private success(requestId: string, data: unknown): CloudAuthorityHttpResponse {
+    return {
+      body: collabCloudSuccessEnvelope(requestId, data),
+      contentType: 'application/json; charset=utf-8',
+      status: 200,
+    };
+  }
+}
+
+class DirectNetwork implements PublishGitNetworkPort {
+  withNetwork<T>(
+    _context: PublishProjectContext,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    return operation();
+  }
+}
+
+function fixedProject(context: PublishProjectContext) {
+  return {
+    load: async () => context,
+    revalidate: async () => undefined,
+  };
+}
+
+function membership(): CollabLocalCloudMembershipRecord {
+  return {
+    authority: {
+      bindingVersion: 1,
+      developmentActorId: MANAGER_ID,
+      gitRemoteUrl: `https://cloud.example.test/v1/projects/${PROJECT_ID}/repository.git`,
+      kind: 'cloud',
+      serverUrl: 'https://cloud.example.test',
+      wireVersion: 4,
+    },
+    createdAt: CREATED_AT,
+    lastEventSequence: 0,
+    lifecycle: 'active',
+    member: {
+      displayName: 'Alice',
+      id: MANAGER_ID,
+      personalRef: MANAGER_REF,
+      role: 'manager',
+    },
+    project: {
+      id: PROJECT_ID,
+      name: 'Cloud Project',
+      workspacePath: `workspace/${PROJECT_ID}`,
+    },
+    schemaVersion: COLLAB_LOCAL_PROJECT_SCHEMA_VERSION,
+    updatedAt: CREATED_AT,
+  };
+}
+
+function member(id: string, displayName: string, role: 'manager' | 'member') {
+  return {
+    activatedAt: CREATED_AT,
+    createdAt: CREATED_AT,
+    displayName,
+    id,
+    personalRef: `refs/heads/members/${id}`,
+    role,
+    status: 'active',
+  };
+}
+
+function cloudSnapshot(mainOid: string) {
+  const currentMember = member(MANAGER_ID, 'Alice', 'manager');
+  return {
+    currentMember,
+    eventSequence: 1,
+    members: [
+      currentMember,
+      member(CONTRIBUTOR_ID, 'Bob', 'member'),
+    ],
+    openRequests: [],
+    openTicketCount: 0,
+    project: {
+      createdAt: CREATED_AT,
+      expectedMainOid: mainOid,
+      id: PROJECT_ID,
+      mainRef: 'refs/heads/main',
+      name: 'Cloud Project',
+    },
+    ticketHighlights: [],
+  };
+}
+
+function acceptedRequest(baseOid: string, acceptedOid: string) {
+  return {
+    commentCount: 0,
+    createdAt: CREATED_AT,
+    description: 'Accepted contribution',
+    firstBaseOid: baseOid,
+    id: 'request-one',
+    latestHeadOid: acceptedOid,
+    memberId: CONTRIBUTOR_ID,
+    mergedOid: acceptedOid,
+    revision: 1,
+    status: 'merged',
+    ticketRelations: [],
+    updatedAt: ACCEPTED_AT,
+  };
+}
+
+function capabilityLimits() {
+  return {
+    maxDevelopmentBootstrapGitBundleBytes: 1_024,
+    maxDevelopmentBootstrapManifestUtf8Bytes: 1_024,
+    maxDevelopmentBootstrapReportUtf8Bytes: 1_024,
+    maxEventReplay: 100,
+    maxGitReceivePackBytes: 1_024,
+    maxJsonPayloadUtf8Bytes: COLLAB_LIMITS.maxJsonPayloadUtf8Bytes,
+    maxRepositoryBytes: 1_024,
+  };
+}

--- a/tests/unit/app/agent-runtime/AgentRuntimeReadMethods.test.ts
+++ b/tests/unit/app/agent-runtime/AgentRuntimeReadMethods.test.ts
@@ -463,6 +463,57 @@ describe('Agent Runtime Collab read methods', () => {
     expect(serialized).not.toContain('package');
   });
 
+  it('keeps the Cloud Agent Runtime projection authority-neutral and local', async () => {
+    const port = readPort();
+    const cloudProject: CollabLocalProjectSummary = {
+      ...PROJECT,
+      authorityKind: 'cloud',
+      hostStatus: 'not-host',
+    };
+    const cloudCoordination: CollabCoordinationSnapshot = {
+      ...COORDINATION,
+      snapshot: {
+        ...COORDINATION.snapshot,
+        project: {
+          authorityKind: 'cloud',
+          createdAt: COORDINATION.snapshot.project.createdAt,
+          id: PROJECT.id,
+          mainOid: COORDINATION.snapshot.project.mainOid,
+          mainRef: COORDINATION.snapshot.project.mainRef,
+          name: PROJECT.name,
+        },
+      },
+    };
+    port.inspectProject.mockResolvedValue(success({
+      ...INSPECTION,
+      coordination: cloudCoordination,
+      project: cloudProject,
+    }));
+
+    const detail = await call(port, 'collab.projects.get', { projectId: PROJECT.id });
+
+    expect(detail).toMatchObject({
+      result: {
+        project: {
+          authorityKind: 'cloud',
+          coordination: {
+            mainOid: COORDINATION.snapshot.project.mainOid,
+            managerMemberIds: ['member-manager', 'member-manager-2'],
+          },
+          hostStatus: 'not-host',
+          workspacePath: PROJECT.workspacePath,
+        },
+      },
+    });
+    const serialized = JSON.stringify(detail);
+    expect(serialized).not.toContain('hostMemberId');
+    expect(serialized).not.toContain('managerSetGeneration');
+    expect(serialized).not.toContain('personalRef');
+    expect(serialized).not.toContain('providerSession');
+    expect(serialized).not.toContain('transcript');
+    expect(serialized).not.toContain('credential');
+  });
+
   it('fails closed when Project selection changes during a Project list read', async () => {
     const port = readPort();
     port.readProjectSelection.mockResolvedValue(success({

--- a/tests/unit/app/collab/remote-authority/CloudAuthorityAdapter.test.ts
+++ b/tests/unit/app/collab/remote-authority/CloudAuthorityAdapter.test.ts
@@ -19,6 +19,7 @@ const ACTOR_ID = 'member-alice';
 const CREATED_AT = '2026-08-22T00:00:00.000Z';
 const MAIN_OID = 'a'.repeat(40);
 const HEAD_OID = 'b'.repeat(40);
+const MERGED_OID = 'c'.repeat(40);
 
 function changeRequest(overrides: Readonly<Record<string, unknown>> = {}) {
   return {
@@ -255,9 +256,77 @@ describe('CloudAuthorityAdapter', () => {
     });
   });
 
-  it('keeps Accept unavailable until the dedicated Cloud authority tranche', async () => {
-    const request = jest.fn(async () => ({
-      body: collabCloudCapabilityDocument(['accept'], limits),
+  it('routes Accept through the canonical Cloud operation with its exact authority tuple', async () => {
+    const request = jest.fn(async (input: CloudAuthorityHttpRequest) => input.method === 'GET'
+      ? {
+        body: collabCloudCapabilityDocument(['accept'], limits),
+        contentType: 'application/json',
+        status: 200,
+      }
+      : {
+        body: collabCloudSuccessEnvelope('response-accept', {
+          mainOid: MERGED_OID,
+          mergeCommitOid: MERGED_OID,
+          request: changeRequest({
+            latestHeadOid: HEAD_OID,
+            mergedOid: MERGED_OID,
+            revision: 1,
+            status: 'merged',
+          }),
+        }),
+        contentType: 'application/json; charset=utf-8',
+        status: 200,
+      });
+    const control = (await new CloudAuthorityAdapter({ request }).create(membership())).control;
+    const controller = new AbortController();
+
+    await expect(control.acceptRequest({
+      expectedHeadOid: HEAD_OID,
+      expectedMainOid: MAIN_OID,
+      expectedRequestRevision: 1,
+      expectedResolvingTickets: [],
+      idempotencyKey: 'accept-intent',
+      projectId: PROJECT_ID,
+      requestId: 'request-one',
+      signal: controller.signal,
+    })).resolves.toMatchObject({
+      mainOid: MERGED_OID,
+      request: { id: 'request-one', mergedOid: MERGED_OID, status: 'merged' },
+    });
+    expect(request.mock.calls[1]?.[0]).toEqual({
+      body: {
+        data: {
+          expectedHeadOid: HEAD_OID,
+          expectedMainOid: MAIN_OID,
+          expectedRequestRevision: 1,
+          expectedResolvingTickets: [],
+          idempotencyKey: 'accept-intent',
+          projectId: PROJECT_ID,
+          requestId: 'request-one',
+        },
+        protocolVersion: 4,
+        requestId: expect.any(String),
+      },
+      headers: { 'x-claudian-development-actor': ACTOR_ID },
+      method: 'POST',
+      signal: controller.signal,
+      url: `https://cloud.example.test/v1/projects/${PROJECT_ID}/operations/acceptRequest`,
+    });
+  });
+
+  it('rejects an Accept response for a different reviewed Request tuple', async () => {
+    const request = jest.fn(async (input: CloudAuthorityHttpRequest) => ({
+      body: input.method === 'GET'
+        ? collabCloudCapabilityDocument(['accept'], limits)
+        : collabCloudSuccessEnvelope('response-accept', {
+          mainOid: MERGED_OID,
+          mergeCommitOid: MERGED_OID,
+          request: changeRequest({
+            id: 'request-other',
+            mergedOid: MERGED_OID,
+            status: 'merged',
+          }),
+        }),
       contentType: 'application/json',
       status: 200,
     }));
@@ -272,10 +341,9 @@ describe('CloudAuthorityAdapter', () => {
       projectId: PROJECT_ID,
       requestId: 'request-one',
     })).rejects.toMatchObject({
-      code: 'operation-failed',
-      safeContext: { reason: 'cloud-authority-operation-not-wired' },
+      code: 'authority-integrity-error',
+      safeContext: { reason: 'cloud-control-accept-response-mismatch' },
     });
-    expect(request).toHaveBeenCalledTimes(1);
   });
 
   it('routes Request reads, comments, and metadata through canonical Cloud operations', async () => {

--- a/tests/unit/features/collab/modals/project/ProjectManagementModal.test.ts
+++ b/tests/unit/features/collab/modals/project/ProjectManagementModal.test.ts
@@ -161,6 +161,7 @@ describe('ProjectManagementModal', () => {
       'retire-project',
       'start-host',
       'stop-host',
+      'host-diagnostics',
       'create-host-transfer',
       'promote-manager',
       'demote-manager',


### PR DESCRIPTION
## Summary

- route Accept through the canonical Cloud authority session and validate the returned reviewed Request tuple
- recover a commit-then-disconnect Accept after restart from authoritative snapshot, Request detail, and Git main without repeating the mutation
- preserve the projection cursor, unrelated local drafts, LAN behavior, Cloud lifecycle gating, and local Agent Runtime projection

## Verification

- `npm test` — 14 protocol suites / 131 tests and 577 application suites / 8,439 tests pass; architecture/tooling checks pass
- `npm run lint`
- `npm run typecheck`
- `npm run check:protocol-compatibility`
- `npm run verify:protocol`
- `npm run build`
- focused S8C/LAN regression — 11 suites / 215 tests pass

## Boundaries

- Cloud remains the merge authority for Cloud Projects; LAN Host Accept remains unchanged
- no provider session, conversation, credential, transcript, or Vault state is sent to Cloud
- no protocol package change or npm publication
- no Gomami deployment or service change
