### PR TITLE
fix: use pushed Pi commands as probe fallback

### DIFF
--- a/src/providers/pi/AGENTS.md
+++ b/src/providers/pi/AGENTS.md
@@ -38,7 +38,7 @@
 
 ## Commands and Models
 
-- Runtime commands come from the `get_commands` RPC and are exposed through `PiCommandCatalog`.
+- Runtime commands prefer the `get_commands` RPC and may fall back to a pushed `available_commands_update` catalog when compatibility shims omit `get_commands`; expose the normalized result through `PiCommandCatalog`.
 - Model discovery uses a separate subprocess and may receive extension UI requests. Keep model normalization in `models.ts`.
 - Use model-provided context windows when available; otherwise preserve the existing fallback behavior.
 

--- a/src/providers/pi/capabilities.ts
+++ b/src/providers/pi/capabilities.ts
@@ -2,6 +2,7 @@ import type { ProviderCapabilities } from '../../core/providers/types';
 
 export const PI_PROVIDER_CAPABILITIES: Readonly<ProviderCapabilities> = Object.freeze({
   providerId: 'pi',
+  commandDiscoveryDeadline: 'provider-owned',
   supportsNativeHistory: true,
   supportsPlanMode: false,
   supportsRewind: false,

--- a/src/providers/pi/execution/PiCommandMetadataProbe.ts
+++ b/src/providers/pi/execution/PiCommandMetadataProbe.ts
@@ -16,9 +16,14 @@ import {
 const ABORT_MESSAGE = 'Pi command metadata probe aborted';
 const DISPOSED_MESSAGE = 'Pi command metadata probe is disposed.';
 
+type PiCommandMetadataProbeSession = {
+  readonly getPushedCommands: () => SlashCommand[] | null;
+  readonly kernel: PiExecutionKernel;
+};
+
 export class PiCommandMetadataProbe {
   private disposeFlight: Promise<void> | null = null;
-  private readonly probes: OwnedProbeRegistry<PiExecutionKernel>;
+  private readonly probes: OwnedProbeRegistry<PiCommandMetadataProbeSession>;
   private readonly transitionFence = new ProviderTransitionFence({
     abortMessage: ABORT_MESSAGE,
   });
@@ -28,9 +33,9 @@ export class PiCommandMetadataProbe {
     private readonly createKernel: PiExecutionKernelFactory =
       createPiExecutionKernel,
   ) {
-    this.probes = new OwnedProbeRegistry({
+    this.probes = new OwnedProbeRegistry<PiCommandMetadataProbeSession>({
       abortMessage: ABORT_MESSAGE,
-      dispose: kernel => kernel.shutdown(),
+      dispose: probe => probe.kernel.shutdown(),
       unavailableError: () => new Error(DISPOSED_MESSAGE),
     });
   }
@@ -60,26 +65,40 @@ export class PiCommandMetadataProbe {
           noSession: true,
           settings: getPiProviderSettings(this.host.settings),
         });
-        return this.createKernel(
+        let pushedCommands: SlashCommand[] | null = null;
+        const kernel = this.createKernel(
           launchSpec,
           {
             onClose: () => undefined,
-            onEvent: () => undefined,
+            onEvent: (event) => {
+              const record = getRecord(event);
+              if (record.type !== 'available_commands_update') return;
+              pushedCommands = normalizePiRuntimeCommands(
+                Array.isArray(record.commands) ? record : record.data,
+              );
+            },
             onExtensionChunk: () => undefined,
             onExtensionRequest: () => false,
           },
           null,
         );
+        return { kernel, getPushedCommands: () => pushedCommands };
       },
-      initialize: kernel => kernel.start(),
-      query: async (kernel, ownedSignal) => {
-        const response = await kernel.request<unknown>(
-          'get_commands',
-          {},
-          10_000,
-          ownedSignal,
-        );
-        return normalizePiRuntimeCommands(response);
+      initialize: probe => probe.kernel.start(),
+      query: async (probe, ownedSignal) => {
+        try {
+          const response = await probe.kernel.request<unknown>(
+            'get_commands',
+            {},
+            10_000,
+            ownedSignal,
+          );
+          return normalizePiRuntimeCommands(response);
+        } catch (error) {
+          const pushedCommands = probe.getPushedCommands();
+          if (pushedCommands) return pushedCommands;
+          throw error;
+        }
       },
     }, signal);
   }

--- a/tests/unit/providers/pi/capabilities.test.ts
+++ b/tests/unit/providers/pi/capabilities.test.ts
@@ -4,6 +4,7 @@ describe('PI_PROVIDER_CAPABILITIES', () => {
   it('exposes the Pi capability contract', () => {
     expect(PI_PROVIDER_CAPABILITIES).toEqual({
       providerId: 'pi',
+      commandDiscoveryDeadline: 'provider-owned',
       supportsNativeHistory: true,
       supportsPlanMode: false,
       supportsRewind: false,

--- a/tests/unit/providers/pi/execution/PiCommandMetadataProbe.test.ts
+++ b/tests/unit/providers/pi/execution/PiCommandMetadataProbe.test.ts
@@ -1,4 +1,7 @@
+import type { ProviderCommandDiscoveryResult } from '@/core/providers/commands/ProviderCommandDiscoveryResult';
+import { ProviderCommandDiscoveryStore } from '@/core/providers/commands/ProviderCommandDiscoveryStore';
 import type { ProviderHost } from '@/core/providers/ProviderHost';
+import { PI_PROVIDER_CAPABILITIES } from '@/providers/pi/capabilities';
 import { PiCommandMetadataProbe } from '@/providers/pi/execution/PiCommandMetadataProbe';
 
 class Deferred<T> {
@@ -65,5 +68,116 @@ describe('PiCommandMetadataProbe', () => {
     });
     expect(createKernel).not.toHaveBeenCalled();
     await probe.dispose();
+  });
+
+  it('falls back to a pushed command catalog when get_commands is unsupported', async () => {
+    const kernel = {
+      request: jest.fn(async () => {
+        throw new Error('Request timeout: get_commands (10000ms)');
+      }),
+      shutdown: jest.fn(async () => undefined),
+      start: jest.fn(),
+    };
+    const createKernel = jest.fn((_spec, callbacks) => {
+      queueMicrotask(() => callbacks.onEvent({
+        commands: [
+          { name: 'skill:project-probe', source: 'skill' },
+          { description: 'Run tests', name: 'test', source: 'runtime' },
+        ],
+        type: 'available_commands_update',
+      }));
+      return kernel as any;
+    });
+    const host = {
+      getResolvedProviderCliPath: jest.fn(async () => '/bin/pi'),
+      settings: {},
+    } as unknown as ProviderHost;
+    const probe = new PiCommandMetadataProbe(host, createKernel);
+
+    await expect(probe.load('/vault')).resolves.toEqual([
+      expect.objectContaining({
+        id: 'pi:skill:skill:project-probe',
+        kind: 'skill',
+        name: 'skill:project-probe',
+      }),
+      expect.objectContaining({
+        id: 'pi:runtime:test',
+        kind: 'command',
+        name: 'test',
+      }),
+    ]);
+    expect(kernel.request).toHaveBeenCalledWith(
+      'get_commands',
+      {},
+      10_000,
+      expect.any(AbortSignal),
+    );
+    await probe.dispose();
+  });
+
+  it('lets the pushed fallback settle after the provider-owned RPC deadline', async () => {
+    jest.useFakeTimers();
+    try {
+      const kernel = {
+        request: jest.fn((_method, _params, timeoutMs: number, signal?: AbortSignal) =>
+          new Promise((_resolve, reject) => {
+            const timer = window.setTimeout(
+              () => reject(new Error(`Request timeout: get_commands (${timeoutMs}ms)`)),
+              timeoutMs,
+            );
+            signal?.addEventListener('abort', () => {
+              window.clearTimeout(timer);
+              reject(signal.reason ?? new Error('aborted'));
+            }, { once: true });
+          })),
+        shutdown: jest.fn(async () => undefined),
+        start: jest.fn(),
+      };
+      const createKernel = jest.fn((_spec, callbacks) => {
+        queueMicrotask(() => callbacks.onEvent({
+          commands: [{ name: 'skill:project-probe', source: 'skill' }],
+          type: 'available_commands_update',
+        }));
+        return kernel as any;
+      });
+      const host = {
+        getResolvedProviderCliPath: jest.fn(async () => '/bin/pi'),
+        settings: {},
+      } as unknown as ProviderHost;
+      const probe = new PiCommandMetadataProbe(host, createKernel);
+      const store = new ProviderCommandDiscoveryStore(
+        async (signal): Promise<ProviderCommandDiscoveryResult<string>> => {
+          const commands = await probe.load('/vault', signal);
+          return {
+            status: 'ready',
+            items: commands.map(command => command.name) as [string, ...string[]],
+          };
+        },
+        {
+          resolveTimeoutMs: () => PI_PROVIDER_CAPABILITIES.commandDiscoveryDeadline
+            === 'provider-owned'
+            ? null
+            : undefined,
+        },
+      );
+
+      const load = store.load();
+      await jest.advanceTimersByTimeAsync(8_000);
+
+      expect(store.getSnapshot()).toEqual({ status: 'loading' });
+
+      await jest.advanceTimersByTimeAsync(2_000);
+      await expect(load).resolves.toEqual({
+        status: 'ready',
+        items: ['skill:project-probe'],
+      });
+      expect(store.getSnapshot()).toEqual({
+        status: 'ready',
+        items: ['skill:project-probe'],
+      });
+      await probe.dispose();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## Why

Refs #1131.

The OMP-backed Pi compatibility path reported in #1131 publishes the full command catalog through `available_commands_update`, but does not implement the `get_commands` request that Claudian's isolated Pi command probe uses. Because the id-less unsupported-method response is dropped by the transport, the probe times out and the slash command loader falls back to the built-ins only even though the provider already pushed the skills.

## What Changed

- Record `available_commands_update` payloads observed by the isolated Pi command metadata probe.
- Keep `get_commands` as the preferred path for stock Pi.
- If `get_commands` fails or times out after a pushed catalog was observed, normalize that pushed catalog instead of returning an empty/error catalog.
- Add regression coverage for the unsupported-`get_commands` compatibility seam.

## Validation

- TDD red: `npm run test:unit -- --runTestsByPath tests/unit/providers/pi/execution/PiCommandMetadataProbe.test.ts --runInBand` failed with the new fallback test before the implementation.
- `npm run typecheck`
- `npm run lint`
- `npm run test:unit -- --runTestsByPath tests/unit/providers/pi/execution/PiCommandMetadataProbe.test.ts tests/unit/providers/pi/execution/PiExecutionBackend.test.ts --runInBand` — 2 suites / 51 tests passed.
- `npm run build`
- `git diff --check`

I also attempted full `npm run test`; provider and package tests passed, but local collab/native-git integration suites failed because this Linux environment lacks Claudian's required Native Git / Smart HTTP capability (`git-capability-missing`, `Native Git Smart HTTP is required for integration tests`). Those failures are outside the Pi provider files changed here.
