### PR TITLE
fix: make LAN projects bootstrap-ready

### DIFF
--- a/src/app/collab/bootstrap/LocalDevelopmentBootstrapSource.ts
+++ b/src/app/collab/bootstrap/LocalDevelopmentBootstrapSource.ts
@@ -293,8 +293,24 @@ export class LocalDevelopmentBootstrapSource {
       signal,
     );
     throwIfCancelled(signal);
+    const capturedEventSequence = decoded.comparison.sourceEventSequence;
+    const observedEventSequence = observation.comparison.sourceEventSequence;
+    const expectedHostStopAdvance = (
+      observedEventSequence === capturedEventSequence + 1
+      && observation.latestEvent?.sequence === observedEventSequence
+      && observation.latestEvent.kind === 'host.stopped'
+      && observation.latestEvent.actorMemberId === decoded.comparison.sourceHostMemberId
+    );
+    const normalizedObservedComparison = {
+      ...observation.comparison,
+      sourceEventSequence: capturedEventSequence,
+    };
     if (
-      JSON.stringify(observation.comparison) !== JSON.stringify(decoded.comparison)
+      (
+        observedEventSequence !== capturedEventSequence
+        && !expectedHostStopAdvance
+      )
+      || JSON.stringify(normalizedObservedComparison) !== JSON.stringify(decoded.comparison)
       || observation.objectFormat !== decoded.git.objectFormat
       || JSON.stringify(observation.refs) !== JSON.stringify(decoded.git.refs)
       || JSON.stringify(observation.sourceEligibility)
@@ -504,7 +520,32 @@ export class LocalDevelopmentBootstrapSource {
         connection,
         'SELECT COALESCE(MAX(sequence), 0) AS count FROM events',
       );
-      return { eligibility, members, project, sourceEventSequence };
+      const latestEventRow = connection.get(`
+        SELECT sequence, event_kind, actor_member_id
+        FROM events
+        ORDER BY sequence DESC
+        LIMIT 1
+      `);
+      const latestEvent = latestEventRow === null || latestEventRow === undefined
+        ? null
+        : {
+          actorMemberId: text(latestEventRow, 'actor_member_id'),
+          kind: text(latestEventRow, 'event_kind'),
+          sequence: latestEventRow.sequence,
+        };
+      if (
+        (sourceEventSequence === 0) !== (latestEvent === null)
+        || (
+          latestEvent !== null
+          && (
+            !Number.isSafeInteger(latestEvent.sequence)
+            || latestEvent.sequence !== sourceEventSequence
+          )
+        )
+      ) {
+        throw sourceError('cloud-bootstrap-authority-event-invalid');
+      }
+      return { eligibility, latestEvent, members, project, sourceEventSequence };
     });
     throwIfCancelled(signal);
 
@@ -575,6 +616,7 @@ export class LocalDevelopmentBootstrapSource {
       repositoryPath,
       runner: git.runner,
       sourceEligibility: source.eligibility,
+      latestEvent: source.latestEvent,
     };
   }
 

--- a/src/app/collab/join/JoinProjectCoordinator.ts
+++ b/src/app/collab/join/JoinProjectCoordinator.ts
@@ -26,6 +26,7 @@ import type {
   CollabProjectsFolderChildOwnership,
   CollabWorkspaceService,
 } from '@/app/collab/CollabWorkspaceService';
+import { COLLAB_MAIN_FETCH_REFSPEC } from '@/app/collab/git/collabGitRefs';
 import {
   type GitNetworkEnvironment,
   parseGitNulFields,
@@ -495,6 +496,13 @@ export class JoinProjectCoordinator {
         remoteUrl: gitRemoteUrl(record),
         signal,
       });
+      await git.repositories.fetch(
+        clonePath,
+        'origin',
+        [COLLAB_MAIN_FETCH_REFSPEC],
+        this.gitNetwork(record, caPath),
+        signal,
+      );
       await git.repositories.configureLocalRepository(clonePath, {
         memberId: record.memberId!,
         personalRef: collabMemberRef(record.memberId!),

--- a/tests/integration/app/collab/join/JoinProjectCoordinator.test.ts
+++ b/tests/integration/app/collab/join/JoinProjectCoordinator.test.ts
@@ -559,6 +559,7 @@ function fakeGitFoundation(
         return clonePath;
       }),
       configureLocalRepository: jest.fn(),
+      fetch: jest.fn(),
       getWorkingTreeStatus: jest.fn(async () => []),
       resolveRef: jest.fn(async () => OID),
     },

--- a/tests/integration/app/collab/join/JoinProjectLanIntegration.test.ts
+++ b/tests/integration/app/collab/join/JoinProjectLanIntegration.test.ts
@@ -19,6 +19,7 @@ import { ProjectAuthorityRepository } from '@/app/collab/authority/ProjectAuthor
 import { SqlJsProjectDatabase } from '@/app/collab/authority/SqlJsProjectDatabase';
 import { ClaudianCollabService } from '@/app/collab/ClaudianCollabService';
 import { isCollabLocalLanMembership } from '@/app/collab/CollabLocalProjectRepository';
+import { COLLAB_ORIGIN_MAIN_REF } from '@/app/collab/git/collabGitRefs';
 import { GitCommandRunner } from '@/app/collab/git/GitCommandRunner';
 import { GitRepositoryService } from '@/app/collab/git/GitRepositoryService';
 import { type GitRuntime,GitRuntimeResolver } from '@/app/collab/git/GitRuntimeResolver';
@@ -248,6 +249,10 @@ describe('Join Project same-device LAN integration', () => {
     expect(await hostGit.resolveRef(
       workingCopy,
       localMembership.member.personalRef,
+    )).toBe(initialOid);
+    expect(await hostGit.resolveRef(
+      workingCopy,
+      COLLAB_ORIGIN_MAIN_REF,
     )).toBe(initialOid);
     expect(await hostGit.resolveRef(
       bareRepositoryPath,

--- a/tests/unit/app/collab/bootstrap/LocalDevelopmentBootstrapSource.test.ts
+++ b/tests/unit/app/collab/bootstrap/LocalDevelopmentBootstrapSource.test.ts
@@ -34,6 +34,8 @@ describe('LocalDevelopmentBootstrapSource', () => {
     const sourceHostMemberId = 'member-zulu';
     const otherMemberId = 'member-alpha';
     let sourceEventSequence = 12;
+    let latestEventActorMemberId = sourceHostMemberId;
+    let latestEventKind = 'project.updated';
     const authorityDirectory = path.join(vaultRoot, '.claudian', 'collab', 'authorities', PROJECT_ID);
     await mkdir(path.join(authorityDirectory, 'repository.git'), { recursive: true });
     const refs = [
@@ -133,6 +135,13 @@ describe('LocalDevelopmentBootstrapSource', () => {
             all: (sql: string) => sql.includes('FROM members') ? members : [],
             get: (sql: string) => {
               if (sql.includes('MAX(sequence)')) return { count: sourceEventSequence };
+              if (sql.includes('ORDER BY sequence DESC')) {
+                return {
+                  actor_member_id: latestEventActorMemberId,
+                  event_kind: latestEventKind,
+                  sequence: sourceEventSequence,
+                };
+              }
               return { count: 0 };
             },
           }),
@@ -197,11 +206,17 @@ describe('LocalDevelopmentBootstrapSource', () => {
       .resolves.toBeUndefined();
 
     sourceEventSequence = 13;
+    latestEventKind = 'host.stopped';
+    await expect(source.assertManifestCurrent(manifest, controller.signal))
+      .resolves.toBeUndefined();
+
+    latestEventActorMemberId = otherMemberId;
     await expect(source.assertManifestCurrent(manifest, controller.signal)).rejects.toMatchObject({
       safeContext: { reason: 'cloud-bootstrap-source-manifest-authority-changed' },
     });
 
     sourceEventSequence = 12;
+    latestEventActorMemberId = sourceHostMemberId;
     const ownership = jest.fn(async () => true);
     await expect(source.recoverArtifacts(ownership)).resolves.toBeUndefined();
     expect(ownership).toHaveBeenCalledWith(manifest);


### PR DESCRIPTION
## Summary

- accept the single `host.stopped` authority event emitted by the fenced former Host during Cloud bootstrap manifest revalidation
- fetch the canonical main ref when a participant joins a LAN Project so Cloud readiness can compare both clients
- cover the lifecycle and real LAN join behavior with regression tests

## Validation

- `npm test` (581 suites passed, 1 skipped; 8451 tests passed, 1 skipped)
- `npm run typecheck -- --pretty false`
- `npm run lint:ts`