### PR TITLE
fix: normalize LAN origin during Cloud binding

### DIFF
--- a/src/app/collab/bootstrap/LocalCloudBootstrapBindingEffects.ts
+++ b/src/app/collab/bootstrap/LocalCloudBootstrapBindingEffects.ts
@@ -85,6 +85,15 @@ function normalizedFingerprint(value: string): string {
   return value.replaceAll(':', '').toLocaleLowerCase('en-US');
 }
 
+function hasSameOrigin(left: string | null, right: string): boolean {
+  if (left === null) return false;
+  try {
+    return new URL(left).origin === new URL(right).origin;
+  } catch {
+    return false;
+  }
+}
+
 export class LocalCloudBootstrapBindingEffects implements CloudBootstrapBindingEffects {
   private readonly now: () => Date;
 
@@ -256,7 +265,7 @@ export class LocalCloudBootstrapBindingEffects implements CloudBootstrapBindingE
     const membership = await this.loadExactMembership(record);
     if (
       !isCollabLocalLanMembership(membership)
-      || membership.authority.endpoint !== record.oldAuthority.endpoint
+      || !hasSameOrigin(membership.authority.endpoint, record.oldAuthority.endpoint)
       || membership.authority.gitRemoteUrl !== record.oldAuthority.gitRemoteUrl
       || membership.authority.hostCaFingerprint === null
       || normalizedFingerprint(membership.authority.hostCaFingerprint)

--- a/tests/unit/app/collab/bootstrap/LocalCloudBootstrapBindingEffects.test.ts
+++ b/tests/unit/app/collab/bootstrap/LocalCloudBootstrapBindingEffects.test.ts
@@ -77,7 +77,7 @@ describe('LocalCloudBootstrapBindingEffects', () => {
     const record = activatedRecord();
     let membership: CollabLocalMembershipRecord = {
       authority: {
-        endpoint: record.oldAuthority.endpoint,
+        endpoint: record.oldAuthority.endpoint.replace(/\/$/u, ''),
         gitRemoteUrl: record.oldAuthority.gitRemoteUrl,
         hostCaCertificatePem: 'PRIVATE CA',
         hostCaFingerprint: record.oldAuthority.caFingerprint,
@@ -191,6 +191,7 @@ describe('LocalCloudBootstrapBindingEffects', () => {
       workspace: { resolveManagedProjectPath: jest.fn(async () => '/vault/workspace/project-alpha') },
     });
 
+    await effects.confirmReadiness(record);
     await effects.verifyCloud(record);
     await effects.verifyActivation(record);
     await effects.replaceMembership(record);


### PR DESCRIPTION
## Summary

- compare the former LAN authority by canonical URL origin during post-activation binding
- accept equivalent persisted endpoints with or without the URL trailing slash
- retain exact Git remote and CA fingerprint checks

## Validation

- `npm test` (581 suites passed, 1 skipped; 8451 tests passed, 1 skipped)
- `npm run typecheck -- --pretty false`
- `npm run lint:ts`