### PR TITLE
fix: repair stale LAN origin during bootstrap

### DIFF
--- a/src/app/collab/git/CollabGitOriginPolicy.ts
+++ b/src/app/collab/git/CollabGitOriginPolicy.ts
@@ -38,6 +38,11 @@ function isGeneratedLanHostRemoteUrl(remoteUrl: string, projectId: string): bool
     && parsed.pathname === `/v1/git/${projectId}/repository.git`;
 }
 
+function isRepairableLanHostRemoteUrl(remoteUrl: string, projectId: string): boolean {
+  return remoteUrl === collabStoppedHostRemoteUrl(projectId)
+    || isGeneratedLanHostRemoteUrl(remoteUrl, projectId);
+}
+
 function originError(reason: string): CollabError {
   return new CollabError({
     code: 'repository-invalid',
@@ -94,7 +99,11 @@ export async function rotateCloudBootstrapOrigin(
   const urls = await git.listRemoteUrls(transition.repositoryPath, 'origin');
   if (urls.length !== 1) throw originError('collab-origin-transition-mismatch');
   if (urls[0] === transition.newRemoteUrl) return;
-  if (urls[0] !== transition.oldRemoteUrl) {
+  const currentUrl = urls[0];
+  if (
+    currentUrl === undefined
+    || !isRepairableLanHostRemoteUrl(currentUrl, transition.projectId)
+  ) {
     throw originError('collab-origin-transition-mismatch');
   }
   await git.addRemote(transition.repositoryPath, 'origin', transition.newRemoteUrl);
@@ -115,10 +124,7 @@ export async function ensureTrustedCollabOrigin(
     context.allowHostRemoteRepair
     && urls.length === 1
     && currentUrl !== undefined
-    && (
-      currentUrl === collabStoppedHostRemoteUrl(context.projectId)
-      || isGeneratedLanHostRemoteUrl(currentUrl, context.projectId)
-    )
+    && isRepairableLanHostRemoteUrl(currentUrl, context.projectId)
   ) {
     await git.addRemote(context.repositoryPath, 'origin', context.remoteUrl);
     urls = await git.listRemoteUrls(context.repositoryPath, 'origin');

--- a/tests/unit/app/collab/git/CollabGitOriginPolicy.test.ts
+++ b/tests/unit/app/collab/git/CollabGitOriginPolicy.test.ts
@@ -102,6 +102,25 @@ describe('CollabGitOriginPolicy', () => {
     expect(repository.addRemote).toHaveBeenCalledTimes(1);
   });
 
+  it('rotates a stale generated same-Project LAN origin after Host readdressing', async () => {
+    const cloudUrl = 'https://cloud.example.test/v1/projects/project-a/repository.git';
+    const staleLanUrl = 'https://192.168.1.5:54545/v1/git/project-a/repository.git';
+    const repository = git([staleLanUrl]);
+
+    await rotateCloudBootstrapOrigin(repository, {
+      newRemoteUrl: cloudUrl,
+      oldRemoteUrl: oldUrl,
+      projectId,
+      repositoryPath: '/vault/workspace/project-a',
+    });
+
+    expect(repository.addRemote).toHaveBeenCalledWith(
+      '/vault/workspace/project-a',
+      'origin',
+      cloudUrl,
+    );
+  });
+
   it('rejects a non-canonical Cloud Project route', async () => {
     const repository = git([oldUrl]);
 


### PR DESCRIPTION
## Summary

- allow Cloud bootstrap to rotate a stale generated LAN origin for the same Project after Host readdressing
- reuse the existing narrow stopped/generated LAN origin repair classification
- keep exact host-transfer transitions and arbitrary or cross-Project origins fail-closed

## Validation

- `npm test` (581 suites passed, 1 skipped; 8452 tests passed, 1 skipped)
- `npm run typecheck -- --pretty false`
- `npm run lint:ts`