### PR TITLE
fix: use desktop transport for cloud requests

### DIFF
--- a/src/app/collab/remote-authority/AGENTS.md
+++ b/src/app/collab/remote-authority/AGENTS.md
@@ -5,14 +5,17 @@
 - `CollabAuthoritySessionFactory` is stateless. It constructs one membership-generation session composed of authority-neutral control, event, and Git-network ports, then transfers disposal ownership to `CollabProjectWorkSession`.
 - `CollabProjectWorkSessionRegistry` remains the sole retained per-Project lifecycle registry. A work session owns at most one authority session, event connection, refresh queue, and mutation queue and closes them before its membership generation changes.
 - `LanAuthorityAdapter` wraps the existing LAN clients and lifecycle extensions without changing LAN v9 binding, credentials, CA pinning, discovery, Host, or transfer semantics.
-- `CloudAuthorityAdapter` owns Cloud binding-v1 capability negotiation, package-owned route construction and codecs, development-principal presentation, snapshot/event transport, safe error mapping, and Git endpoint construction. It never implements server Project policy or translates Cloud lifecycle into LAN lifecycle.
+- `CloudAuthorityAdapter` owns Cloud binding-v1 capability negotiation, package-owned route construction and codecs, development-principal presentation, snapshot and event adaptation, safe binding-error mapping, and Git endpoint construction. It never implements server Project policy or translates Cloud lifecycle into LAN lifecycle.
+- `NodeCloudAuthorityHttpTransport` owns the production desktop JSON request lifecycle behind `CloudAuthorityHttpTransport`: Node HTTP/HTTPS dispatch, caller cancellation, deadline teardown, bounded response consumption, JSON decoding, and sanitized transport failures. It is stateless across calls, never follows redirects, and never disables native TLS verification.
 
 ## Dependency and safety
 
 - Publication, projection, review, reconciliation, feature, UI, and Agent-facing services depend on the neutral ports and never construct LAN or Cloud transports directly.
 - Cloud Projects expose only negotiated capabilities. Host transfer, membership administration, Manager responsibility, Leave, Retire, and LAN diagnostics remain LAN-only and must not fall back to a stale LAN session.
+- The Obsidian desktop Cloud path must not depend on renderer `fetch` or server-side browser CORS permission. Plain HTTP remains restricted to canonical loopback origins by `CloudAuthorityUrls`; non-loopback Cloud origins require HTTPS.
 - Canonicalize self-host URLs once and compare exact normalized values. Git environments may carry multiple headers and an optional CA path. Credential-bearing headers are sensitive by default and their values plus private paths never enter process arguments, logs, errors, or persisted diagnostics. A non-credential routing header must be explicitly marked non-sensitive so its domain identifier may independently appear in a Git ref argument; the header itself still enters Git only through the isolated environment.
 
 ## Verification
 
 - Adapter contract tests keep owned application modules real, prove LAN behavior is preserved, prove unknown Cloud capabilities are ignored while unknown binding/wire/schema values fail closed, and prove replacing a membership generation disposes the old session exactly once.
+- Default Cloud transport tests use real loopback HTTP with renderer `fetch` disabled and cover cancellation, deadline, response bounds, redirect containment, cleanup, and sanitized failures. Headless Node adapter success alone does not prove the installed Obsidian composition path.

--- a/src/app/collab/remote-authority/AGENTS.md
+++ b/src/app/collab/remote-authority/AGENTS.md
@@ -6,6 +6,7 @@
 - `CollabProjectWorkSessionRegistry` remains the sole retained per-Project lifecycle registry. A work session owns at most one authority session, event connection, refresh queue, and mutation queue and closes them before its membership generation changes.
 - `LanAuthorityAdapter` wraps the existing LAN clients and lifecycle extensions without changing LAN v9 binding, credentials, CA pinning, discovery, Host, or transfer semantics.
 - `CloudAuthorityAdapter` owns Cloud binding-v1 capability negotiation, package-owned route construction and codecs, development-principal presentation, snapshot and event adaptation, safe binding-error mapping, and Git endpoint construction. It never implements server Project policy or translates Cloud lifecycle into LAN lifecycle.
+- `CloudAuthorityError` centralizes only the shared safe-error construction mechanics used by the Cloud adapter and transport. Each caller still owns when a binding or transport condition maps to that vocabulary.
 - `NodeCloudAuthorityHttpTransport` owns the production desktop JSON request lifecycle behind `CloudAuthorityHttpTransport`: Node HTTP/HTTPS dispatch, caller cancellation, deadline teardown, bounded response consumption, JSON decoding, and sanitized transport failures. It is stateless across calls, never follows redirects, and never disables native TLS verification.
 
 ## Dependency and safety

--- a/src/app/collab/remote-authority/CloudAuthorityAdapter.ts
+++ b/src/app/collab/remote-authority/CloudAuthorityAdapter.ts
@@ -25,6 +25,10 @@ import type {
   CollabLocalMembershipRecord,
 } from '@/app/collab/CollabLocalProjectRepository';
 import { isCollabLocalCloudMembership } from '@/app/collab/CollabLocalProjectRepository';
+import {
+  cloudAuthorityOperationError,
+  cloudAuthorityProtocolError,
+} from '@/app/collab/remote-authority/CloudAuthorityError';
 import { canonicalCloudOrigin } from '@/app/collab/remote-authority/CloudAuthorityUrls';
 import { decodeCloudAuthorityProjectSnapshot } from '@/app/collab/remote-authority/CloudProjectSnapshotMapper';
 import type { CollabAuthorityControlPort } from '@/app/collab/remote-authority/CollabAuthorityControlPort';
@@ -102,20 +106,6 @@ function createDefaultEventSocket(input: CloudProjectEventSocketInput): CloudPro
   }));
 }
 
-function adapterError(
-  code: 'cancelled' | 'endpoint-unreachable' | 'operation-failed'
-    | 'operation-timeout' | 'protocol-payload-invalid',
-  reason: string,
-): CollabError {
-  return new CollabError({
-    code,
-    recoveryActions: code === 'protocol-payload-invalid'
-      ? ['open-diagnostics']
-      : ['retry', 'open-diagnostics'],
-    safeContext: { reason },
-  });
-}
-
 function controlIntegrityError(reason: string): CollabError {
   return new CollabError({
     code: 'authority-integrity-error',
@@ -162,7 +152,7 @@ function assertJsonResponse(response: CloudAuthorityHttpResponse): void {
     response.contentType === null
     || !/^application\/json(?:;\s*charset=utf-8)?$/iu.test(response.contentType)
   ) {
-    throw adapterError('protocol-payload-invalid', 'cloud-authority-content-type-invalid');
+    throw cloudAuthorityProtocolError('cloud-authority-content-type-invalid');
   }
 }
 
@@ -499,7 +489,7 @@ class CloudAuthorityControl implements CollabAuthorityControlPort {
 
   private requireCapability(capability: CollabCloudCapability): void {
     if (!this.capabilities.has(capability)) {
-      throw adapterError('operation-failed', 'cloud-authority-capability-unavailable');
+      throw cloudAuthorityOperationError('cloud-authority-capability-unavailable');
     }
   }
 
@@ -730,7 +720,7 @@ export class CloudProjectEventClient {
       const applied = await this.onInvalidation(invalidation);
       if (this.disposed) return;
       if (!Number.isSafeInteger(applied) || applied < invalidation.sequence) {
-        throw adapterError('operation-failed', 'cloud-event-cursor-not-applied');
+        throw cloudAuthorityOperationError('cloud-event-cursor-not-applied');
       }
       this.acknowledgedSequence = Math.max(this.acknowledgedSequence, applied);
       this.observedSequence = Math.max(this.observedSequence, applied);
@@ -817,7 +807,7 @@ export class CloudAuthorityAdapter implements CollabAuthorityAdapter {
     });
     assertJsonResponse(response);
     if (response.status !== 200) {
-      throw adapterError('operation-failed', 'cloud-capability-negotiation-failed');
+      throw cloudAuthorityOperationError('cloud-capability-negotiation-failed');
     }
     const document = decodeCollabCloudCapabilityDocument(response.body);
     const capabilities = new Set(document.capabilities);
@@ -838,7 +828,7 @@ export class CloudAuthorityAdapter implements CollabAuthorityAdapter {
       events: {
         connect: ({ afterSequence, onInvalidation }: CollabAuthorityEventConnectionInput) => {
           if (!collabCloudCapabilitySupported(document, 'project-events')) {
-            throw adapterError('operation-failed', 'cloud-authority-capability-unavailable');
+            throw cloudAuthorityOperationError('cloud-authority-capability-unavailable');
           }
           const client = this.createEventClient({
             afterSequence,

--- a/src/app/collab/remote-authority/CloudAuthorityAdapter.ts
+++ b/src/app/collab/remote-authority/CloudAuthorityAdapter.ts
@@ -34,30 +34,16 @@ import type {
   CollabAuthorityEventInvalidation,
   CollabAuthoritySession,
 } from '@/app/collab/remote-authority/CollabAuthoritySession';
+import {
+  type CloudAuthorityHttpResponse,
+  type CloudAuthorityHttpTransport,
+  NodeCloudAuthorityHttpTransport,
+} from '@/app/collab/remote-authority/NodeCloudAuthorityHttpTransport';
 import type { CollabCloudProjectSnapshot } from '@/core/collab';
 import { CollabError } from '@/core/collab/ClaudianCollabError';
 
-const REQUEST_TIMEOUT_MS = 30_000;
 const MIN_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 30_000;
-
-export interface CloudAuthorityHttpRequest {
-  readonly body?: unknown;
-  readonly headers: Readonly<Record<string, string>>;
-  readonly method: 'GET' | 'POST' | 'PUT';
-  readonly signal?: AbortSignal;
-  readonly url: string;
-}
-
-export interface CloudAuthorityHttpResponse {
-  readonly body: unknown;
-  readonly contentType: string | null;
-  readonly status: number;
-}
-
-export type CloudAuthorityHttpTransport = (
-  input: CloudAuthorityHttpRequest,
-) => Promise<CloudAuthorityHttpResponse>;
 
 export interface CloudProjectEventSocket {
   close(code: number, reason: string): void;
@@ -177,88 +163,6 @@ function assertJsonResponse(response: CloudAuthorityHttpResponse): void {
     || !/^application\/json(?:;\s*charset=utf-8)?$/iu.test(response.contentType)
   ) {
     throw adapterError('protocol-payload-invalid', 'cloud-authority-content-type-invalid');
-  }
-}
-
-async function readBoundedResponseBody(response: Response): Promise<Uint8Array> {
-  if (!response.body) return new Uint8Array();
-  const reader = response.body.getReader();
-  const chunks: Uint8Array[] = [];
-  let byteLength = 0;
-  try {
-    for (;;) {
-      const next = await reader.read();
-      if (next.done) break;
-      byteLength += next.value.byteLength;
-      if (byteLength > COLLAB_LIMITS.maxJsonPayloadUtf8Bytes) {
-        await reader.cancel('response-too-large');
-        throw adapterError('protocol-payload-invalid', 'cloud-authority-response-too-large');
-      }
-      chunks.push(next.value);
-    }
-  } finally {
-    reader.releaseLock();
-  }
-  const bytes = new Uint8Array(byteLength);
-  let offset = 0;
-  for (const chunk of chunks) {
-    bytes.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return bytes;
-}
-
-async function defaultHttpTransport(
-  input: CloudAuthorityHttpRequest,
-): Promise<CloudAuthorityHttpResponse> {
-  const controller = new AbortController();
-  const onAbort = (): void => controller.abort('cancelled');
-  input.signal?.addEventListener('abort', onAbort, { once: true });
-  const timer = window.setTimeout(() => controller.abort('timeout'), REQUEST_TIMEOUT_MS);
-  try {
-    const response = await fetch(input.url, {
-      body: input.body === undefined ? undefined : JSON.stringify(input.body),
-      headers: {
-        ...input.headers,
-        ...(input.body === undefined
-          ? {}
-          : { 'content-type': 'application/json; charset=utf-8' }),
-      },
-      method: input.method,
-      signal: controller.signal,
-    });
-    const contentLength = response.headers.get('content-length');
-    if (
-      contentLength !== null
-      && (!/^(?:0|[1-9][0-9]*)$/u.test(contentLength)
-        || Number(contentLength) > COLLAB_LIMITS.maxJsonPayloadUtf8Bytes)
-    ) {
-      await response.body?.cancel('response-too-large').catch(() => undefined);
-      throw adapterError('protocol-payload-invalid', 'cloud-authority-response-too-large');
-    }
-    const bytes = await readBoundedResponseBody(response);
-    let body: unknown;
-    try {
-      body = JSON.parse(new TextDecoder().decode(bytes)) as unknown;
-    } catch {
-      throw adapterError('protocol-payload-invalid', 'cloud-authority-response-invalid');
-    }
-    return {
-      body,
-      contentType: response.headers.get('content-type'),
-      status: response.status,
-    };
-  } catch (error: unknown) {
-    if (error instanceof CollabError) throw error;
-    if (controller.signal.aborted) {
-      throw controller.signal.reason === 'timeout'
-        ? adapterError('operation-timeout', 'cloud-authority-request-timeout')
-        : adapterError('cancelled', 'cloud-authority-request-cancelled');
-    }
-    throw adapterError('endpoint-unreachable', 'cloud-authority-request-failed');
-  } finally {
-    window.clearTimeout(timer);
-    input.signal?.removeEventListener('abort', onAbort);
   }
 }
 
@@ -893,7 +797,7 @@ export class CloudAuthorityAdapter implements CollabAuthorityAdapter {
   constructor(options: CloudAuthorityAdapterOptions = {}) {
     this.createEventClient = options.createEventClient
       ?? ((input, onInvalidation) => new CloudProjectEventClient(input, onInvalidation));
-    this.request = options.request ?? defaultHttpTransport;
+    this.request = options.request ?? new NodeCloudAuthorityHttpTransport().request;
     this.requestId = options.requestIdFactory
       ?? (() => `cloud-${randomUUID().replaceAll('-', '')}`);
   }

--- a/src/app/collab/remote-authority/CloudAuthorityError.ts
+++ b/src/app/collab/remote-authority/CloudAuthorityError.ts
@@ -1,0 +1,23 @@
+import { CollabError } from '@/core/collab/ClaudianCollabError';
+
+export function cloudAuthorityError(
+  code: 'cancelled' | 'endpoint-unreachable' | 'operation-failed'
+    | 'operation-timeout' | 'protocol-payload-invalid',
+  reason: string,
+): CollabError {
+  return new CollabError({
+    code,
+    recoveryActions: code === 'protocol-payload-invalid'
+      ? ['open-diagnostics']
+      : ['retry', 'open-diagnostics'],
+    safeContext: { reason },
+  });
+}
+
+export function cloudAuthorityOperationError(reason: string): CollabError {
+  return cloudAuthorityError('operation-failed', reason);
+}
+
+export function cloudAuthorityProtocolError(reason: string): CollabError {
+  return cloudAuthorityError('protocol-payload-invalid', reason);
+}

--- a/src/app/collab/remote-authority/NodeCloudAuthorityHttpTransport.ts
+++ b/src/app/collab/remote-authority/NodeCloudAuthorityHttpTransport.ts
@@ -7,7 +7,12 @@ import { request as requestHttps } from 'node:https';
 
 import { COLLAB_LIMITS } from '@claudian-collab/protocol';
 
-import { CollabError } from '@/core/collab/ClaudianCollabError';
+import {
+  cloudAuthorityError,
+  cloudAuthorityOperationError,
+  cloudAuthorityProtocolError,
+} from '@/app/collab/remote-authority/CloudAuthorityError';
+import type { CollabError } from '@/core/collab/ClaudianCollabError';
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 
@@ -29,114 +34,68 @@ export type CloudAuthorityHttpTransport = (
   input: CloudAuthorityHttpRequest,
 ) => Promise<CloudAuthorityHttpResponse>;
 
-export interface NodeCloudAuthorityHttpTransportOptions {
-  readonly timeoutMs?: number;
-}
-
-function transportError(
-  code: 'cancelled' | 'endpoint-unreachable' | 'operation-failed'
-    | 'operation-timeout' | 'protocol-payload-invalid',
-  reason: string,
-): CollabError {
-  return new CollabError({
-    code,
-    recoveryActions: code === 'protocol-payload-invalid'
-      ? ['open-diagnostics']
-      : ['retry', 'open-diagnostics'],
-    safeContext: { reason },
-  });
-}
-
 function responseTooLarge(): CollabError {
-  return transportError(
-    'protocol-payload-invalid',
-    'cloud-authority-response-too-large',
-  );
+  return cloudAuthorityProtocolError('cloud-authority-response-too-large');
 }
 
 function invalidResponse(): CollabError {
-  return transportError(
-    'protocol-payload-invalid',
-    'cloud-authority-response-invalid',
-  );
+  return cloudAuthorityProtocolError('cloud-authority-response-invalid');
 }
 
-function declaredResponseLength(response: IncomingMessage): number | null {
-  const header = response.headers['content-length'];
-  if (header === undefined) return null;
-  if (
-    typeof header !== 'string'
-    || !/^(?:0|[1-9][0-9]*)$/u.test(header)
-    || Number(header) > COLLAB_LIMITS.maxJsonPayloadUtf8Bytes
-  ) {
-    throw responseTooLarge();
-  }
-  return Number(header);
+function cancelledRequest(): CollabError {
+  return cloudAuthorityError('cancelled', 'cloud-authority-request-cancelled');
 }
 
-function encodedRequestBody(input: CloudAuthorityHttpRequest): Buffer | undefined {
+function invalidRequestBody(): CollabError {
+  return cloudAuthorityOperationError('cloud-authority-request-body-invalid');
+}
+
+function unreachableAuthority(): CollabError {
+  return cloudAuthorityError('endpoint-unreachable', 'cloud-authority-request-failed');
+}
+
+function encodedRequestBody(
+  input: CloudAuthorityHttpRequest,
+): Buffer | null | undefined {
   if (input.body === undefined) return undefined;
   try {
     const serialized = JSON.stringify(input.body);
-    if (serialized === undefined) throw new TypeError('JSON body is undefined');
-    return Buffer.from(serialized, 'utf8');
+    return serialized === undefined ? null : Buffer.from(serialized, 'utf8');
   } catch {
-    throw transportError('operation-failed', 'cloud-authority-request-body-invalid');
+    return null;
   }
 }
 
 export class NodeCloudAuthorityHttpTransport {
   readonly #timeoutMs: number;
 
-  constructor(options: NodeCloudAuthorityHttpTransportOptions = {}) {
-    const timeoutMs = options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
-    if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
-      throw new TypeError('Invalid Cloud authority request timeout');
-    }
+  constructor(timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS) {
     this.#timeoutMs = timeoutMs;
   }
 
   readonly request: CloudAuthorityHttpTransport = input => {
     if (input.signal?.aborted) {
-      return Promise.reject(transportError(
-        'cancelled',
-        'cloud-authority-request-cancelled',
-      ));
+      return Promise.reject(cancelledRequest());
     }
 
     let url: URL;
     try {
       url = new URL(input.url);
     } catch {
-      return Promise.reject(transportError(
-        'endpoint-unreachable',
-        'cloud-authority-request-failed',
-      ));
+      return Promise.reject(unreachableAuthority());
     }
     if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-      return Promise.reject(transportError(
-        'endpoint-unreachable',
-        'cloud-authority-request-failed',
-      ));
+      return Promise.reject(unreachableAuthority());
     }
 
-    let body: Buffer | undefined;
-    try {
-      body = encodedRequestBody(input);
-    } catch (error) {
-      return Promise.reject(error instanceof CollabError
-        ? error
-        : transportError('operation-failed', 'cloud-authority-request-body-invalid'));
+    const encodedBody = encodedRequestBody(input);
+    if (encodedBody === null) return Promise.reject(invalidRequestBody());
+    const body = encodedBody;
+    const headers: Record<string, string> = { ...input.headers };
+    if (body !== undefined) {
+      headers['content-length'] = String(body.byteLength);
+      headers['content-type'] = 'application/json; charset=utf-8';
     }
-    const headers = {
-      ...input.headers,
-      ...(body === undefined
-        ? {}
-        : {
-          'content-length': String(body.byteLength),
-          'content-type': 'application/json; charset=utf-8',
-        }),
-    };
     const request = url.protocol === 'https:' ? requestHttps : requestHttp;
 
     return new Promise<CloudAuthorityHttpResponse>((resolve, reject) => {
@@ -149,41 +108,43 @@ export class NodeCloudAuthorityHttpTransport {
         if (timer !== null) window.clearTimeout(timer);
         input.signal?.removeEventListener('abort', onCallerAbort);
       };
-      const finish = (operation: () => void, destroy: boolean): void => {
-        if (settled) return;
+      const finish = (destroy: boolean): boolean => {
+        if (settled) return false;
         settled = true;
         cleanup();
         if (destroy) {
           incoming?.destroy();
           outgoing?.destroy();
         }
-        operation();
+        return true;
       };
       const fail = (error: CollabError, destroy = true): void => {
-        finish(() => reject(error), destroy);
+        if (finish(destroy)) reject(error);
       };
       const onCallerAbort = (): void => {
-        fail(transportError('cancelled', 'cloud-authority-request-cancelled'));
+        fail(cancelledRequest());
       };
       const onRequestError = (): void => {
-        fail(transportError(
-          'endpoint-unreachable',
-          'cloud-authority-request-failed',
-        ), false);
+        fail(unreachableAuthority(), false);
       };
 
       try {
         outgoing = request(url, { headers, method: input.method }, response => {
           incoming = response;
-          try {
-            declaredResponseLength(response);
-          } catch (error) {
-            fail(error instanceof CollabError ? error : invalidResponse());
+          const declaredLength = response.headers['content-length'];
+          if (
+            declaredLength !== undefined
+            && (
+              typeof declaredLength !== 'string'
+              || !/^(?:0|[1-9][0-9]*)$/u.test(declaredLength)
+              || Number(declaredLength) > COLLAB_LIMITS.maxJsonPayloadUtf8Bytes
+            )
+          ) {
+            fail(responseTooLarge());
             return;
           }
           const chunks: Buffer[] = [];
           let byteLength = 0;
-          let ended = false;
           response.on('data', (chunk: Buffer) => {
             if (settled) return;
             const bytes = Buffer.from(chunk);
@@ -194,13 +155,10 @@ export class NodeCloudAuthorityHttpTransport {
             }
             chunks.push(bytes);
           });
-          response.once('aborted', () => {
-            if (!ended) fail(invalidResponse());
-          });
+          response.once('aborted', () => fail(invalidResponse()));
           response.once('error', () => fail(invalidResponse()));
           response.once('end', () => {
             if (settled) return;
-            ended = true;
             let parsed: unknown;
             try {
               parsed = JSON.parse(Buffer.concat(chunks, byteLength).toString('utf8')) as unknown;
@@ -208,23 +166,21 @@ export class NodeCloudAuthorityHttpTransport {
               fail(invalidResponse(), false);
               return;
             }
-            finish(() => resolve({
-              body: parsed,
-              contentType: typeof response.headers['content-type'] === 'string'
-                ? response.headers['content-type']
-                : null,
-              status: response.statusCode ?? 0,
-            }), false);
+            const contentType = response.headers['content-type'];
+            if (finish(false)) {
+              resolve({
+                body: parsed,
+                contentType: typeof contentType === 'string' ? contentType : null,
+                status: response.statusCode ?? 0,
+              });
+            }
           });
           response.once('close', () => {
-            if (!ended && !settled) fail(invalidResponse());
+            if (!settled) fail(invalidResponse());
           });
         });
       } catch {
-        fail(transportError(
-          'endpoint-unreachable',
-          'cloud-authority-request-failed',
-        ), false);
+        fail(unreachableAuthority(), false);
         return;
       }
 
@@ -235,7 +191,7 @@ export class NodeCloudAuthorityHttpTransport {
         return;
       }
       timer = window.setTimeout(() => {
-        fail(transportError('operation-timeout', 'cloud-authority-request-timeout'));
+        fail(cloudAuthorityError('operation-timeout', 'cloud-authority-request-timeout'));
       }, this.#timeoutMs);
       outgoing.end(body);
     });

--- a/src/app/collab/remote-authority/NodeCloudAuthorityHttpTransport.ts
+++ b/src/app/collab/remote-authority/NodeCloudAuthorityHttpTransport.ts
@@ -1,0 +1,243 @@
+import {
+  type ClientRequest,
+  type IncomingMessage,
+  request as requestHttp,
+} from 'node:http';
+import { request as requestHttps } from 'node:https';
+
+import { COLLAB_LIMITS } from '@claudian-collab/protocol';
+
+import { CollabError } from '@/core/collab/ClaudianCollabError';
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+export interface CloudAuthorityHttpRequest {
+  readonly body?: unknown;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly method: 'GET' | 'POST' | 'PUT';
+  readonly signal?: AbortSignal;
+  readonly url: string;
+}
+
+export interface CloudAuthorityHttpResponse {
+  readonly body: unknown;
+  readonly contentType: string | null;
+  readonly status: number;
+}
+
+export type CloudAuthorityHttpTransport = (
+  input: CloudAuthorityHttpRequest,
+) => Promise<CloudAuthorityHttpResponse>;
+
+export interface NodeCloudAuthorityHttpTransportOptions {
+  readonly timeoutMs?: number;
+}
+
+function transportError(
+  code: 'cancelled' | 'endpoint-unreachable' | 'operation-failed'
+    | 'operation-timeout' | 'protocol-payload-invalid',
+  reason: string,
+): CollabError {
+  return new CollabError({
+    code,
+    recoveryActions: code === 'protocol-payload-invalid'
+      ? ['open-diagnostics']
+      : ['retry', 'open-diagnostics'],
+    safeContext: { reason },
+  });
+}
+
+function responseTooLarge(): CollabError {
+  return transportError(
+    'protocol-payload-invalid',
+    'cloud-authority-response-too-large',
+  );
+}
+
+function invalidResponse(): CollabError {
+  return transportError(
+    'protocol-payload-invalid',
+    'cloud-authority-response-invalid',
+  );
+}
+
+function declaredResponseLength(response: IncomingMessage): number | null {
+  const header = response.headers['content-length'];
+  if (header === undefined) return null;
+  if (
+    typeof header !== 'string'
+    || !/^(?:0|[1-9][0-9]*)$/u.test(header)
+    || Number(header) > COLLAB_LIMITS.maxJsonPayloadUtf8Bytes
+  ) {
+    throw responseTooLarge();
+  }
+  return Number(header);
+}
+
+function encodedRequestBody(input: CloudAuthorityHttpRequest): Buffer | undefined {
+  if (input.body === undefined) return undefined;
+  try {
+    const serialized = JSON.stringify(input.body);
+    if (serialized === undefined) throw new TypeError('JSON body is undefined');
+    return Buffer.from(serialized, 'utf8');
+  } catch {
+    throw transportError('operation-failed', 'cloud-authority-request-body-invalid');
+  }
+}
+
+export class NodeCloudAuthorityHttpTransport {
+  readonly #timeoutMs: number;
+
+  constructor(options: NodeCloudAuthorityHttpTransportOptions = {}) {
+    const timeoutMs = options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+      throw new TypeError('Invalid Cloud authority request timeout');
+    }
+    this.#timeoutMs = timeoutMs;
+  }
+
+  readonly request: CloudAuthorityHttpTransport = input => {
+    if (input.signal?.aborted) {
+      return Promise.reject(transportError(
+        'cancelled',
+        'cloud-authority-request-cancelled',
+      ));
+    }
+
+    let url: URL;
+    try {
+      url = new URL(input.url);
+    } catch {
+      return Promise.reject(transportError(
+        'endpoint-unreachable',
+        'cloud-authority-request-failed',
+      ));
+    }
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return Promise.reject(transportError(
+        'endpoint-unreachable',
+        'cloud-authority-request-failed',
+      ));
+    }
+
+    let body: Buffer | undefined;
+    try {
+      body = encodedRequestBody(input);
+    } catch (error) {
+      return Promise.reject(error instanceof CollabError
+        ? error
+        : transportError('operation-failed', 'cloud-authority-request-body-invalid'));
+    }
+    const headers = {
+      ...input.headers,
+      ...(body === undefined
+        ? {}
+        : {
+          'content-length': String(body.byteLength),
+          'content-type': 'application/json; charset=utf-8',
+        }),
+    };
+    const request = url.protocol === 'https:' ? requestHttps : requestHttp;
+
+    return new Promise<CloudAuthorityHttpResponse>((resolve, reject) => {
+      let incoming: IncomingMessage | null = null;
+      let settled = false;
+      let timer: number | null = null;
+      let outgoing: ClientRequest | null = null;
+
+      const cleanup = (): void => {
+        if (timer !== null) window.clearTimeout(timer);
+        input.signal?.removeEventListener('abort', onCallerAbort);
+      };
+      const finish = (operation: () => void, destroy: boolean): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        if (destroy) {
+          incoming?.destroy();
+          outgoing?.destroy();
+        }
+        operation();
+      };
+      const fail = (error: CollabError, destroy = true): void => {
+        finish(() => reject(error), destroy);
+      };
+      const onCallerAbort = (): void => {
+        fail(transportError('cancelled', 'cloud-authority-request-cancelled'));
+      };
+      const onRequestError = (): void => {
+        fail(transportError(
+          'endpoint-unreachable',
+          'cloud-authority-request-failed',
+        ), false);
+      };
+
+      try {
+        outgoing = request(url, { headers, method: input.method }, response => {
+          incoming = response;
+          try {
+            declaredResponseLength(response);
+          } catch (error) {
+            fail(error instanceof CollabError ? error : invalidResponse());
+            return;
+          }
+          const chunks: Buffer[] = [];
+          let byteLength = 0;
+          let ended = false;
+          response.on('data', (chunk: Buffer) => {
+            if (settled) return;
+            const bytes = Buffer.from(chunk);
+            byteLength += bytes.byteLength;
+            if (byteLength > COLLAB_LIMITS.maxJsonPayloadUtf8Bytes) {
+              fail(responseTooLarge());
+              return;
+            }
+            chunks.push(bytes);
+          });
+          response.once('aborted', () => {
+            if (!ended) fail(invalidResponse());
+          });
+          response.once('error', () => fail(invalidResponse()));
+          response.once('end', () => {
+            if (settled) return;
+            ended = true;
+            let parsed: unknown;
+            try {
+              parsed = JSON.parse(Buffer.concat(chunks, byteLength).toString('utf8')) as unknown;
+            } catch {
+              fail(invalidResponse(), false);
+              return;
+            }
+            finish(() => resolve({
+              body: parsed,
+              contentType: typeof response.headers['content-type'] === 'string'
+                ? response.headers['content-type']
+                : null,
+              status: response.statusCode ?? 0,
+            }), false);
+          });
+          response.once('close', () => {
+            if (!ended && !settled) fail(invalidResponse());
+          });
+        });
+      } catch {
+        fail(transportError(
+          'endpoint-unreachable',
+          'cloud-authority-request-failed',
+        ), false);
+        return;
+      }
+
+      outgoing.once('error', onRequestError);
+      input.signal?.addEventListener('abort', onCallerAbort, { once: true });
+      if (input.signal?.aborted) {
+        onCallerAbort();
+        return;
+      }
+      timer = window.setTimeout(() => {
+        fail(transportError('operation-timeout', 'cloud-authority-request-timeout'));
+      }, this.#timeoutMs);
+      outgoing.end(body);
+    });
+  };
+}

--- a/tests/integration/app/collab/accept/CloudAcceptRecovery.test.ts
+++ b/tests/integration/app/collab/accept/CloudAcceptRecovery.test.ts
@@ -36,9 +36,11 @@ import { ReconciliationMutationSafety } from '@/app/collab/reconciliation/Reconc
 import { ReconciliationRepository } from '@/app/collab/reconciliation/ReconciliationRepository';
 import {
   CloudAuthorityAdapter,
-  type CloudAuthorityHttpRequest,
-  type CloudAuthorityHttpResponse,
 } from '@/app/collab/remote-authority/CloudAuthorityAdapter';
+import type {
+  CloudAuthorityHttpRequest,
+  CloudAuthorityHttpResponse,
+} from '@/app/collab/remote-authority/NodeCloudAuthorityHttpTransport';
 import { CollabError } from '@/core/collab/ClaudianCollabError';
 
 jest.setTimeout(30_000);

--- a/tests/integration/app/collab/publish/CloudPublishRecovery.test.ts
+++ b/tests/integration/app/collab/publish/CloudPublishRecovery.test.ts
@@ -28,9 +28,11 @@ import {
 } from '@/app/collab/publish/PublishCoordinator';
 import {
   CloudAuthorityAdapter,
-  type CloudAuthorityHttpRequest,
-  type CloudAuthorityHttpResponse,
 } from '@/app/collab/remote-authority/CloudAuthorityAdapter';
+import type {
+  CloudAuthorityHttpRequest,
+  CloudAuthorityHttpResponse,
+} from '@/app/collab/remote-authority/NodeCloudAuthorityHttpTransport';
 import { CollabError } from '@/core/collab/ClaudianCollabError';
 
 jest.setTimeout(30_000);

--- a/tests/unit/app/collab/publish/CollabPublicationService.test.ts
+++ b/tests/unit/app/collab/publish/CollabPublicationService.test.ts
@@ -1,7 +1,17 @@
+import { createServer } from 'node:http';
+
+import {
+  COLLAB_CLOUD_PROJECT_SNAPSHOT_CODEC,
+  COLLAB_LIMITS,
+  collabCloudCapabilityDocument,
+  collabCloudSuccessEnvelope,
+} from '@claudian-collab/protocol';
 import {
   completeCollabPublicationOptions,
 } from '@test/helpers/collab/CollabFeatureTestHarness';
 
+import type { CollabLocalCloudMembershipRecord } from '@/app/collab/CollabLocalProjectRepository';
+import { COLLAB_LOCAL_PROJECT_SCHEMA_VERSION } from '@/app/collab/CollabSchemaVersions';
 import {
   type CollabPublicationFoundationPort,
   CollabPublicationService,
@@ -29,7 +39,132 @@ function publicationOptions(
   return completeCollabPublicationOptions({ ...overrides, vaultRoot: '/vault' });
 }
 
+const CLOUD_PROJECT_ID = 'project-cloud';
+const CLOUD_MEMBER_ID = 'member-cloud';
+const CLOUD_CREATED_AT = '2026-08-24T00:00:00.000Z';
+
+function cloudMembership(serverUrl: string): CollabLocalCloudMembershipRecord {
+  return {
+    authority: {
+      bindingVersion: 1,
+      developmentActorId: CLOUD_MEMBER_ID,
+      gitRemoteUrl: `${serverUrl}/v1/projects/${CLOUD_PROJECT_ID}/repository.git`,
+      kind: 'cloud',
+      serverUrl,
+      wireVersion: 4,
+    },
+    createdAt: CLOUD_CREATED_AT,
+    lastEventSequence: 0,
+    lifecycle: 'active',
+    member: {
+      displayName: 'Cloud member',
+      id: CLOUD_MEMBER_ID,
+      personalRef: `refs/heads/members/${CLOUD_MEMBER_ID}`,
+      role: 'manager',
+    },
+    project: {
+      id: CLOUD_PROJECT_ID,
+      name: 'Cloud Project',
+      workspacePath: `workspace/${CLOUD_PROJECT_ID}`,
+    },
+    schemaVersion: COLLAB_LOCAL_PROJECT_SCHEMA_VERSION,
+    updatedAt: CLOUD_CREATED_AT,
+  };
+}
+
+function cloudSnapshot() {
+  const currentMember = {
+    activatedAt: CLOUD_CREATED_AT,
+    createdAt: CLOUD_CREATED_AT,
+    displayName: 'Cloud member',
+    id: CLOUD_MEMBER_ID,
+    personalRef: `refs/heads/members/${CLOUD_MEMBER_ID}`,
+    role: 'manager' as const,
+    status: 'active' as const,
+  };
+  return COLLAB_CLOUD_PROJECT_SNAPSHOT_CODEC.decodeResponse({
+    currentMember,
+    eventSequence: 1,
+    members: [currentMember],
+    openRequests: [],
+    openTicketCount: 0,
+    project: {
+      createdAt: CLOUD_CREATED_AT,
+      expectedMainOid: 'a'.repeat(40),
+      id: CLOUD_PROJECT_ID,
+      mainRef: 'refs/heads/main',
+      name: 'Cloud Project',
+    },
+    ticketHighlights: [],
+  });
+}
+
+const cloudLimits = {
+  maxDevelopmentBootstrapGitBundleBytes: 1_024,
+  maxDevelopmentBootstrapManifestUtf8Bytes: 1_024,
+  maxDevelopmentBootstrapReportUtf8Bytes: 1_024,
+  maxEventReplay: 100,
+  maxGitReceivePackBytes: 1_024,
+  maxJsonPayloadUtf8Bytes: COLLAB_LIMITS.maxJsonPayloadUtf8Bytes,
+  maxRepositoryBytes: 1_024,
+};
+
 describe('CollabPublicationService reconnect', () => {
+  it('uses the production Cloud adapter composition without renderer fetch', async () => {
+    const routes: string[] = [];
+    const server = createServer((request, response) => {
+      routes.push(request.url ?? '');
+      response.setHeader('content-type', 'application/json; charset=utf-8');
+      if (request.method === 'GET') {
+        response.end(JSON.stringify(collabCloudCapabilityDocument([
+          'project-snapshot',
+        ], cloudLimits)));
+        return;
+      }
+      response.end(JSON.stringify(collabCloudSuccessEnvelope(
+        'response-snapshot',
+        cloudSnapshot(),
+      )));
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('server address missing');
+    const membership = cloudMembership(`http://127.0.0.1:${address.port}`);
+    const projects = {
+      loadMembership: jest.fn().mockResolvedValue(membership),
+      loadProjectDocument: jest.fn().mockResolvedValue(null),
+      removeProjectDocument: jest.fn().mockResolvedValue(false),
+      saveProjectDocument: jest.fn().mockResolvedValue(undefined),
+      updateMembershipProjection: jest.fn().mockResolvedValue(membership),
+    };
+    const service = new CollabPublicationService({
+      local: { pathPolicy: {}, projects, workspace: {} },
+      requireGitFoundation: jest.fn(),
+    } as unknown as CollabPublicationFoundationPort, publicationOptions());
+    const fetchMock = jest.spyOn(globalThis, 'fetch').mockRejectedValue(
+      new Error('renderer fetch is disabled'),
+    );
+
+    try {
+      await expect(service.readSnapshot(CLOUD_PROJECT_ID)).resolves.toMatchObject({
+        currentMember: { id: CLOUD_MEMBER_ID },
+        project: { authorityKind: 'cloud', id: CLOUD_PROJECT_ID },
+      });
+      expect(routes).toEqual([
+        '/collab/capabilities',
+        `/v1/projects/${CLOUD_PROJECT_ID}/operations/getProjectSnapshot`,
+      ]);
+    } finally {
+      fetchMock.mockRestore();
+      await service.close();
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => server.close(error => {
+        if (error) reject(error);
+        else resolve();
+      }));
+    }
+  });
+
   it('forwards terminal fallback delivery to the configured retirement handler', async () => {
     const retirement = { handle: jest.fn().mockResolvedValue(undefined) };
     const service = new CollabPublicationService({

--- a/tests/unit/app/collab/remote-authority/CloudAuthorityAdapter.test.ts
+++ b/tests/unit/app/collab/remote-authority/CloudAuthorityAdapter.test.ts
@@ -1,3 +1,5 @@
+import { createServer } from 'node:http';
+
 import {
   COLLAB_CLOUD_PROJECT_SNAPSHOT_CODEC,
   COLLAB_LIMITS,
@@ -9,10 +11,12 @@ import type { CollabLocalCloudMembershipRecord } from '@/app/collab/CollabLocalP
 import { COLLAB_LOCAL_PROJECT_SCHEMA_VERSION } from '@/app/collab/CollabSchemaVersions';
 import {
   CloudAuthorityAdapter,
-  type CloudAuthorityHttpRequest,
   CloudProjectEventClient,
   type CloudProjectEventSocket,
 } from '@/app/collab/remote-authority/CloudAuthorityAdapter';
+import type {
+  CloudAuthorityHttpRequest,
+} from '@/app/collab/remote-authority/NodeCloudAuthorityHttpTransport';
 
 const PROJECT_ID = 'project-cloud';
 const ACTOR_ID = 'member-alice';
@@ -138,6 +142,63 @@ function cloudSnapshot() {
 }
 
 describe('CloudAuthorityAdapter', () => {
+  it('uses the desktop transport for default capability and snapshot reads', async () => {
+    const requests: Array<{ readonly actor: string | undefined; readonly url: string }> = [];
+    const server = createServer((request, response) => {
+      requests.push({
+        actor: typeof request.headers['x-claudian-development-actor'] === 'string'
+          ? request.headers['x-claudian-development-actor']
+          : undefined,
+        url: request.url ?? '',
+      });
+      response.setHeader('content-type', 'application/json; charset=utf-8');
+      if (request.method === 'GET') {
+        response.end(JSON.stringify(collabCloudCapabilityDocument([
+          'project-snapshot',
+        ], limits)));
+        return;
+      }
+      response.end(JSON.stringify(collabCloudSuccessEnvelope(
+        'request-snapshot',
+        cloudSnapshot(),
+      )));
+    });
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('server address missing');
+    const fetchMock = jest.spyOn(globalThis, 'fetch').mockRejectedValue(
+      new Error('renderer fetch is disabled'),
+    );
+    const localMembership = {
+      ...membership(),
+      authority: {
+        ...membership().authority,
+        serverUrl: `http://127.0.0.1:${address.port}`,
+      },
+    } satisfies CollabLocalCloudMembershipRecord;
+
+    try {
+      const session = await new CloudAuthorityAdapter().create(localMembership);
+      await expect(session.control.readSnapshot(PROJECT_ID)).resolves.toMatchObject({
+        currentMember: { id: ACTOR_ID },
+        project: { authorityKind: 'cloud', id: PROJECT_ID },
+      });
+      expect(requests).toEqual([
+        { actor: ACTOR_ID, url: '/collab/capabilities' },
+        {
+          actor: ACTOR_ID,
+          url: `/v1/projects/${PROJECT_ID}/operations/getProjectSnapshot`,
+        },
+      ]);
+    } finally {
+      fetchMock.mockRestore();
+      await new Promise<void>((resolve, reject) => server.close(error => {
+        if (error) reject(error);
+        else resolve();
+      }));
+    }
+  });
+
   it('negotiates package capabilities and maps the strict Cloud snapshot', async () => {
     const requests: CloudAuthorityHttpRequest[] = [];
     const request = jest.fn(async (input: CloudAuthorityHttpRequest) => {
@@ -670,51 +731,6 @@ describe('CloudAuthorityAdapter', () => {
     });
   });
 
-  it('cancels a chunked JSON response as soon as the payload limit is crossed', async () => {
-    let pullCount = 0;
-    let cancelled = false;
-    const chunk = new Uint8Array(Math.floor(COLLAB_LIMITS.maxJsonPayloadUtf8Bytes / 2) + 1);
-    const body = new ReadableStream<Uint8Array>({
-      cancel: () => { cancelled = true; },
-      pull: controller => {
-        pullCount += 1;
-        if (pullCount <= 2) controller.enqueue(chunk);
-        else controller.close();
-      },
-    }, { highWaterMark: 0 });
-    const fetchMock = jest.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(body, {
-      headers: { 'content-type': 'application/json' },
-      status: 200,
-    }));
-
-    await expect(new CloudAuthorityAdapter().create(membership())).rejects.toMatchObject({
-      code: 'protocol-payload-invalid',
-      safeContext: { reason: 'cloud-authority-response-too-large' },
-    });
-    expect(cancelled).toBe(true);
-    fetchMock.mockRestore();
-  });
-
-  it('cancels a response rejected by its declared content length', async () => {
-    let cancelled = false;
-    const body = new ReadableStream<Uint8Array>({
-      cancel: () => { cancelled = true; },
-    });
-    const fetchMock = jest.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(body, {
-      headers: {
-        'content-length': String(COLLAB_LIMITS.maxJsonPayloadUtf8Bytes + 1),
-        'content-type': 'application/json',
-      },
-      status: 200,
-    }));
-
-    await expect(new CloudAuthorityAdapter().create(membership())).rejects.toMatchObject({
-      code: 'protocol-payload-invalid',
-      safeContext: { reason: 'cloud-authority-response-too-large' },
-    });
-    expect(cancelled).toBe(true);
-    fetchMock.mockRestore();
-  });
 });
 
 describe('CloudProjectEventClient', () => {

--- a/tests/unit/app/collab/remote-authority/NodeCloudAuthorityHttpTransport.test.ts
+++ b/tests/unit/app/collab/remote-authority/NodeCloudAuthorityHttpTransport.test.ts
@@ -112,6 +112,19 @@ describe('NodeCloudAuthorityHttpTransport', () => {
     });
   });
 
+  it('maps a non-serializable request body to a sanitized error', async () => {
+    const body: { self?: unknown } = {};
+    body.self = body;
+
+    await expect(new NodeCloudAuthorityHttpTransport().request(request(
+      'http://127.0.0.1:1/invalid-body',
+      { body, method: 'POST' },
+    ))).rejects.toMatchObject({
+      code: 'operation-failed',
+      safeContext: { reason: 'cloud-authority-request-body-invalid' },
+    });
+  });
+
   it('rejects an already-cancelled request without opening a connection', async () => {
     const controller = new AbortController();
     controller.abort();
@@ -147,7 +160,7 @@ describe('NodeCloudAuthorityHttpTransport', () => {
   it('destroys a stalled request at its configured deadline', async () => {
     const origin = await listen(createServer(() => undefined));
 
-    await expect(new NodeCloudAuthorityHttpTransport({ timeoutMs: 20 }).request(
+    await expect(new NodeCloudAuthorityHttpTransport(20).request(
       request(`${origin}/stalled`),
     )).rejects.toMatchObject({
       code: 'operation-timeout',

--- a/tests/unit/app/collab/remote-authority/NodeCloudAuthorityHttpTransport.test.ts
+++ b/tests/unit/app/collab/remote-authority/NodeCloudAuthorityHttpTransport.test.ts
@@ -1,0 +1,288 @@
+import { createServer, type Server } from 'node:http';
+
+import { COLLAB_LIMITS } from '@claudian-collab/protocol';
+
+import {
+  type CloudAuthorityHttpRequest,
+  NodeCloudAuthorityHttpTransport,
+} from '@/app/collab/remote-authority/NodeCloudAuthorityHttpTransport';
+
+const servers: Server[] = [];
+
+async function listen(server: Server): Promise<string> {
+  servers.push(server);
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('server address missing');
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function closeServer(server: Server): Promise<void> {
+  server.closeAllConnections();
+  if (!server.listening) return;
+  await new Promise<void>((resolve, reject) => server.close(error => {
+    if (error) reject(error);
+    else resolve();
+  }));
+}
+
+function request(
+  url: string,
+  overrides: Partial<CloudAuthorityHttpRequest> = {},
+): CloudAuthorityHttpRequest {
+  return {
+    headers: { 'x-test-actor': 'actor-test' },
+    method: 'GET',
+    url,
+    ...overrides,
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map(closeServer));
+});
+
+describe('NodeCloudAuthorityHttpTransport', () => {
+  it('sends one bounded JSON request and projects the response metadata', async () => {
+    type ReceivedRequest = {
+      readonly body: string;
+      readonly contentLength: string | undefined;
+      readonly contentType: string | undefined;
+      readonly actor: string | undefined;
+    };
+    let resolveReceived!: (value: ReceivedRequest) => void;
+    const received = new Promise<ReceivedRequest>(resolve => { resolveReceived = resolve; });
+    const origin = await listen(createServer(async (incoming, response) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of incoming) chunks.push(Buffer.from(chunk));
+      resolveReceived({
+        actor: typeof incoming.headers['x-test-actor'] === 'string'
+          ? incoming.headers['x-test-actor']
+          : undefined,
+        body: Buffer.concat(chunks).toString('utf8'),
+        contentLength: incoming.headers['content-length'],
+        contentType: incoming.headers['content-type'],
+      });
+      response.statusCode = 201;
+      response.setHeader('content-type', 'application/json; charset=utf-8');
+      response.end('{"accepted":true}');
+    }));
+    const transport = new NodeCloudAuthorityHttpTransport();
+
+    await expect(transport.request(request(`${origin}/operation`, {
+      body: { projectId: 'project-test' },
+      method: 'POST',
+    }))).resolves.toEqual({
+      body: { accepted: true },
+      contentType: 'application/json; charset=utf-8',
+      status: 201,
+    });
+    await expect(received).resolves.toEqual({
+      actor: 'actor-test',
+      body: '{"projectId":"project-test"}',
+      contentLength: String(Buffer.byteLength('{"projectId":"project-test"}')),
+      contentType: 'application/json; charset=utf-8',
+    });
+  });
+
+  it('does not add body headers to a bodyless request', async () => {
+    let resolveHeaders!: (value: {
+      readonly contentLength: string | undefined;
+      readonly contentType: string | undefined;
+    }) => void;
+    const receivedHeaders = new Promise<{
+      readonly contentLength: string | undefined;
+      readonly contentType: string | undefined;
+    }>(resolve => { resolveHeaders = resolve; });
+    const origin = await listen(createServer((incoming, response) => {
+      resolveHeaders({
+        contentLength: incoming.headers['content-length'],
+        contentType: incoming.headers['content-type'],
+      });
+      response.setHeader('content-type', 'application/json');
+      response.end('{}');
+    }));
+
+    await expect(new NodeCloudAuthorityHttpTransport().request(
+      request(`${origin}/bodyless`),
+    )).resolves.toMatchObject({ body: {}, status: 200 });
+    await expect(receivedHeaders).resolves.toEqual({
+      contentLength: undefined,
+      contentType: undefined,
+    });
+  });
+
+  it('rejects an already-cancelled request without opening a connection', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(new NodeCloudAuthorityHttpTransport().request(request(
+      'http://127.0.0.1:1/cancelled',
+      { signal: controller.signal },
+    ))).rejects.toMatchObject({
+      code: 'cancelled',
+      safeContext: { reason: 'cloud-authority-request-cancelled' },
+    });
+  });
+
+  it('destroys a stalled request when the caller cancels it', async () => {
+    let requestReceived!: () => void;
+    const received = new Promise<void>(resolve => { requestReceived = resolve; });
+    const origin = await listen(createServer(() => requestReceived()));
+    const controller = new AbortController();
+    const pending = new NodeCloudAuthorityHttpTransport().request(request(
+      `${origin}/stalled`,
+      { signal: controller.signal },
+    ));
+    await received;
+
+    controller.abort();
+
+    await expect(pending).rejects.toMatchObject({
+      code: 'cancelled',
+      safeContext: { reason: 'cloud-authority-request-cancelled' },
+    });
+  });
+
+  it('destroys a stalled request at its configured deadline', async () => {
+    const origin = await listen(createServer(() => undefined));
+
+    await expect(new NodeCloudAuthorityHttpTransport({ timeoutMs: 20 }).request(
+      request(`${origin}/stalled`),
+    )).rejects.toMatchObject({
+      code: 'operation-timeout',
+      safeContext: { reason: 'cloud-authority-request-timeout' },
+    });
+  });
+
+  it.each([
+    '0001',
+    String(COLLAB_LIMITS.maxJsonPayloadUtf8Bytes + 1),
+  ])('rejects invalid or oversized declared response length %s', async contentLength => {
+    const origin = await listen(createServer((_request, response) => {
+      response.setHeader('content-length', contentLength);
+      response.setHeader('content-type', 'application/json');
+      response.end('0');
+    }));
+
+    await expect(new NodeCloudAuthorityHttpTransport().request(
+      request(`${origin}/declared-size`),
+    )).rejects.toMatchObject({
+      code: 'protocol-payload-invalid',
+      safeContext: { reason: 'cloud-authority-response-too-large' },
+    });
+  });
+
+  it('accepts a valid JSON response exactly at the payload limit', async () => {
+    const body = JSON.stringify(
+      'x'.repeat(COLLAB_LIMITS.maxJsonPayloadUtf8Bytes - 2),
+    );
+    const origin = await listen(createServer((_request, response) => {
+      response.setHeader('content-length', String(Buffer.byteLength(body)));
+      response.setHeader('content-type', 'application/json');
+      response.end(body);
+    }));
+
+    await expect(new NodeCloudAuthorityHttpTransport().request(
+      request(`${origin}/exact-size`),
+    )).resolves.toEqual({
+      body: 'x'.repeat(COLLAB_LIMITS.maxJsonPayloadUtf8Bytes - 2),
+      contentType: 'application/json',
+      status: 200,
+    });
+  });
+
+  it('stops a chunked response as soon as the streamed limit is crossed', async () => {
+    const chunk = Buffer.alloc(Math.floor(COLLAB_LIMITS.maxJsonPayloadUtf8Bytes / 2) + 1);
+    const origin = await listen(createServer((_request, response) => {
+      response.setHeader('content-type', 'application/json');
+      response.write(chunk);
+      response.write(chunk);
+      response.end();
+    }));
+
+    await expect(new NodeCloudAuthorityHttpTransport().request(
+      request(`${origin}/streamed-size`),
+    )).rejects.toMatchObject({
+      code: 'protocol-payload-invalid',
+      safeContext: { reason: 'cloud-authority-response-too-large' },
+    });
+  });
+
+  it.each(['', '{"incomplete":'])('rejects an invalid JSON response %#', async body => {
+    const origin = await listen(createServer((_request, response) => {
+      response.setHeader('content-type', 'application/json');
+      response.end(body);
+    }));
+
+    await expect(new NodeCloudAuthorityHttpTransport().request(
+      request(`${origin}/invalid-json`),
+    )).rejects.toMatchObject({
+      code: 'protocol-payload-invalid',
+      safeContext: { reason: 'cloud-authority-response-invalid' },
+    });
+  });
+
+  it('rejects a response stream that closes before completion', async () => {
+    const origin = await listen(createServer((_request, response) => {
+      response.setHeader('content-type', 'application/json');
+      response.flushHeaders();
+      response.write('{"incomplete":');
+      setImmediate(() => response.destroy());
+    }));
+
+    await expect(new NodeCloudAuthorityHttpTransport().request(
+      request(`${origin}/closed`),
+    )).rejects.toMatchObject({
+      code: 'protocol-payload-invalid',
+      safeContext: { reason: 'cloud-authority-response-invalid' },
+    });
+  });
+
+  it('maps an unreachable endpoint without exposing the native error', async () => {
+    const closed = createServer();
+    const origin = await listen(closed);
+    await closeServer(closed);
+    servers.splice(servers.indexOf(closed), 1);
+
+    await expect(new NodeCloudAuthorityHttpTransport().request(
+      request(`${origin}/unreachable`),
+    )).rejects.toMatchObject({
+      code: 'endpoint-unreachable',
+      safeContext: { reason: 'cloud-authority-request-failed' },
+    });
+  });
+
+  it('returns a redirect without contacting its target', async () => {
+    let redirectedRequests = 0;
+    const targetOrigin = await listen(createServer((_request, response) => {
+      redirectedRequests += 1;
+      response.setHeader('content-type', 'application/json');
+      response.end('{"unexpected":true}');
+    }));
+    const origin = await listen(createServer((_request, response) => {
+      response.statusCode = 307;
+      response.setHeader('content-type', 'application/json');
+      response.setHeader('location', `${targetOrigin}/target`);
+      response.end('{"redirected":true}');
+    }));
+
+    await expect(new NodeCloudAuthorityHttpTransport().request(
+      request(`${origin}/redirect`),
+    )).resolves.toEqual({
+      body: { redirected: true },
+      contentType: 'application/json',
+      status: 307,
+    });
+    expect(redirectedRequests).toBe(0);
+  });
+
+  it('fails closed on a non-HTTP request URL', async () => {
+    await expect(new NodeCloudAuthorityHttpTransport().request(
+      request('ftp://cloud.example.test/project'),
+    )).rejects.toMatchObject({
+      code: 'endpoint-unreachable',
+      safeContext: { reason: 'cloud-authority-request-failed' },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- replace the Cloud adapter's renderer-bound JSON default with a bounded Node HTTP/HTTPS desktop transport
- retain `CloudAuthorityAdapter` as binding owner and the existing injected transport seam
- prove the default adapter and hard-coded `CollabPublicationService` production composition without global `fetch`
- preserve package-owned routes/codecs/limits, native TLS verification, redirect containment, LAN behavior, and Cloud management capability boundaries

## Root cause and ownership

Transitioned Cloud Projects negotiated capabilities through renderer `fetch`. In installed Obsidian that request was subject to browser CORS and failed before the authority session existed, even though the same authority, membership, and protocol worked through a CORS-independent Node client.

The fix belongs at the existing Claudian `CloudAuthorityHttpTransport` seam. `NodeCloudAuthorityHttpTransport` now owns Node request dispatch, JSON bytes, cancellation, deadline teardown, declared and streamed response bounds, strict JSON decoding, redirect non-following, cleanup, and sanitized transport failures. `CloudAuthorityAdapter` still owns capability negotiation, canonical routes/codecs, development-principal presentation, binding interpretation, events, and Git endpoint construction. Project session ownership remains unchanged.

## TDD and verification

- recorded the default-adapter tracer failing while global `fetch` threw, then made the real loopback capability/snapshot path pass through the Node default
- added loopback tests for bodyful/bodyless requests, cancellation, timeout, exact/exceeded response bounds, malformed and incomplete responses, endpoint failure, redirect containment, and response projection
- added a real production-composition regression through the public publication-service snapshot seam
- focused gate: 10 suites and 78 tests passed; one environment-conditional test skipped
- architecture gate: 34 checks passed
- full gate after the size repair: 582 suites and 8468 tests passed; one environment-conditional test skipped
- open-handle gate repeated the full lane and passed
- typecheck, lint, build, and diff checks passed
- Linux clean production build: `5,169,640` bytes under the `5,170,000`-byte budget; the failed pre-repair artifact was `5,170,345` bytes
- current macOS-built `main.js` SHA-256: `103c904bbc886bdd26b234c93373eacdfafe437b5e8075539fa191ab6048e680`
- repaired GitHub CI: all jobs pass, including Linux production build and macOS/Windows cross-platform smoke

## Installed smoke

The original behavior-complete production bundle passed in installed Obsidian through the retained private Gomami loopback bridge:

- both transitioned Cloud demo Projects loaded Changes, Tickets, and readable members without CORS or Cloud transport diagnostics
- Cloud Project Management exposed readable membership and no LAN-only lifecycle actions
- the retained LAN Project loaded the same read surfaces and retained its existing LAN Host, invitation, Leave, and Retire actions

Gomami was not changed or restarted.

The follow-up size repair only collapses duplicated safe-error construction and redundant transport settlement/validation state. Its full automated, architecture, Linux clean-build, and performance gates pass. The optimized bundle was installed and Obsidian relaunched, but the machine locked before the complete three-Project UI matrix could be repeated; that final read-only recheck remains a local handoff item and does not weaken the earlier behavior evidence.

## Explicitly unchanged

- no `@claudian-collab/protocol` version, wire, route, codec, capability, or package-pin change
- no Cloud Server, CORS, trusted-ingress, or deployment change
- no Gomami service or persistent-state change
- no ordinary-user Cloud migration or management-write entry
- no bootstrap-client or WebSocket-event refactor

## Residual risk

Native HTTPS verification is retained by using Node's unmodified HTTPS defaults and passing no custom agent or permissive certificate option. This slice proves that through source/bundle inspection rather than a dedicated private-CA integration fixture.

The repaired Linux CI artifact reports a `195.3 ms` median cold evaluation, above the existing `150 ms` review threshold. The check is advisory and passed, but broader bundle/startup attribution remains worthwhile; this PR's 705-byte repair should not be treated as a general bundle-size optimization.
