### PR TITLE
chore: restore production bundle headroom

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "claudian",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.220",
+        "@anthropic-ai/claude-agent-sdk": "0.3.226",
         "@claudian-collab/protocol": "1.0.0",
         "@codemirror/commands": "6.10.0",
         "@codemirror/lang-markdown": "^6.5.2",
@@ -18,10 +18,9 @@
         "@pierre/theming": "1.0.1",
         "@shikijs/core": "4.4.3",
         "@shikijs/engine-javascript": "4.4.3",
-        "@shikijs/engine-oniguruma": "4.4.3",
         "bonjour-service": "1.4.4",
         "node-forge": "1.4.0",
-        "smol-toml": "^1.6.1",
+        "smol-toml": "1.7.1",
         "sql.js": "1.14.1",
         "tslib": "^2.8.1",
         "ws": "8.21.2",

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -10,6 +10,7 @@ import {
   readFileSync,
   rmSync,
 } from 'fs';
+import { assertRuntimeDependencyParity } from './scripts/runtimeDependencyParity.mjs';
 import rendererSafeUnrefHelpers from './scripts/rendererSafeUnref.js';
 import desktopRuntimeAliasHelpers from './scripts/desktopRuntimeAliases.js';
 import terserProductionBundleHelpers from './scripts/terserProductionBundle.js';
@@ -37,6 +38,7 @@ if (existsSync('.env.local')) {
 }
 
 const prod = process.argv[2] === 'production';
+if (prod) assertRuntimeDependencyParity(process.cwd());
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.220",
+        "@anthropic-ai/claude-agent-sdk": "0.3.226",
         "@claudian-collab/protocol": "1.0.0",
         "@codemirror/commands": "6.10.0",
         "@codemirror/lang-markdown": "^6.5.2",
@@ -23,10 +23,9 @@
         "@pierre/theming": "1.0.1",
         "@shikijs/core": "4.4.3",
         "@shikijs/engine-javascript": "4.4.3",
-        "@shikijs/engine-oniguruma": "4.4.3",
         "bonjour-service": "1.4.4",
         "node-forge": "1.4.0",
-        "smol-toml": "^1.6.1",
+        "smol-toml": "1.7.1",
         "sql.js": "1.14.1",
         "tslib": "^2.8.1",
         "ws": "8.21.2"
@@ -61,22 +60,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.220.tgz",
-      "integrity": "sha512-glc7SdwPkOkLw8oxwLo9PKTdLJGqW/PIR4urWXFoRtX9YllwozsEVc5Tc1+EvLSkfrsxPJqQWqOgpjUOQXf1oA==",
+      "version": "0.3.226",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.226.tgz",
+      "integrity": "sha512-RvaZCZSKGjNIN/bDrQbyq/XkjVaUAPThxFrwFz2jdl6DvGnUtsGlt7hmPsaGC6BDudbA8yvkZFSqaJveK3WhfQ==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.220",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.220"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.226",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.226",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.226",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.226",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.226",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.226",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.226",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.226"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -85,9 +84,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.220.tgz",
-      "integrity": "sha512-7VxlbEosK7DODiOnsjoVd0DSJzbnaPrM2jelMHI0y8zx1UnLS3WC6EFUXbvy74F2sXqEznh2tzn7EKWInaRN6Q==",
+      "version": "0.3.226",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.226.tgz",
+      "integrity": "sha512-ycyuSgN2XaSYdze1eM2wDwNmXS5wPqIh1RxiDs99ywPr9lpe3Y/Xcv0nz9JN5ahNoPIgWHIfI9Ac1EWCOdIF1Q==",
       "cpu": [
         "arm64"
       ],
@@ -98,9 +97,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.220.tgz",
-      "integrity": "sha512-X9RwDsSmbF6ultKZroaip+DL8WRgC64gHbrAwrRlAFSPNZV7zmJyP2ur8rW7KrxqmtuehdMMkw8+SAC/6hD2PA==",
+      "version": "0.3.226",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.226.tgz",
+      "integrity": "sha512-sOOCkhtMDGVKs6k3fpTAkCML974qOnt8Bm9zlC6rV0HkM0aP4bdDY1RAlKLF4fHmOP2s5fPTY3myZiHGDFnuUg==",
       "cpu": [
         "x64"
       ],
@@ -111,11 +110,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.220.tgz",
-      "integrity": "sha512-WkROPwWskqhKR9XgnmseHQ6rLi9zM9qt57IWoToIjL/eXOqDWipp7JXZ1L5ud+LrA42dunHPZfBwD/vXZ+A7LA==",
+      "version": "0.3.226",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.226.tgz",
+      "integrity": "sha512-YNwwC37m2vcY47mWZGqRmDh2ZSrO0Z01iTlIDsPmvKv03+7pwyaXVuq01Evtyp7see+KGeIYkMN37HhEt/h+8Q==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -124,11 +126,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.220.tgz",
-      "integrity": "sha512-OHoZOZ8Cf2TBr6oXIXPwyvUxj9jrq2w8E4poA8dMpacXszcPSPiCQCMuuOh4aWJzfeJE1+TtWxhKMVb2csXyZQ==",
+      "version": "0.3.226",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.226.tgz",
+      "integrity": "sha512-w/hsZ2SqJTyPxLgQiK6X0c2yQJ1W3jAJW5UV0gXLq6wnzUeOnHVtG+TnJu2LuHseHovRqDQ9t8EsDgnZE0vdlA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -137,11 +142,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.220.tgz",
-      "integrity": "sha512-tkTJFnpR9VifvWX2fmkCAPkT6+8Wk/gVu8B5jsVekKZPiZoWRHmMXO30BnZn+f0TZhgYP+82PSX3S8crH1kn+w==",
+      "version": "0.3.226",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.226.tgz",
+      "integrity": "sha512-gPoHNeko9E+bmKVPRiAcCAOyBBrVcIH/WdjmyaGVoTP2bKibTs978A42rMNtAnuPBcAGAiImQimUU7w1TXESFw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -150,11 +158,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.220.tgz",
-      "integrity": "sha512-K+FWj+LcGhC1Z7wqeWoLxm1iemcba5xKpLLFVwYm4V6HyMx3ruYd/2r2TiQtjT+JWeNFWIys0ScHiItR6vWAiA==",
+      "version": "0.3.226",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.226.tgz",
+      "integrity": "sha512-sMRt4ocfctoYLxPKpbOUd8hHhoMz2eQX8d3DN78Gl8r4uTpsDz5NCFLdkk7ikuRzXvoMPzUrFy+wFVIF0B7TLA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -163,9 +174,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.220.tgz",
-      "integrity": "sha512-rIwgq0UwQExWl6KrHUyC4w5KwpL9l6nd95aUTx6RitexaAuEw//xtfTVLnuE4hDDQZFkzEwpdKc3nxDWoGcUbA==",
+      "version": "0.3.226",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.226.tgz",
+      "integrity": "sha512-qkzWTR3Ns8PimC5rx4+cwfuyHlCRocGIAcdWDUgpnI70qH5GlqX9R0VfM7wGOCs/C+fJ04Hg0GfAkMv4xriZwA==",
       "cpu": [
         "arm64"
       ],
@@ -176,9 +187,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.220",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.220.tgz",
-      "integrity": "sha512-MuOuXhbr66HlGaWXD2f3w0k2PsvmnbkwcUZ0dAe2poFLdl72GC2dapwwOBefxm9QmoNqk9+jmv/dSKGOVWyvLw==",
+      "version": "0.3.226",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.226.tgz",
+      "integrity": "sha512-uxVbLwGSX6lvO5Tazv0gZu8WSg1o14DQsqGSY+5pDNUk28KmNbFIQAjky9KeDzk9lnf63/aQPPsaq6UAikWjqA==",
       "cpu": [
         "x64"
       ],
@@ -11096,9 +11107,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
-      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.1.tgz",
+      "integrity": "sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "typescript": "^6.0.2"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.220",
+    "@anthropic-ai/claude-agent-sdk": "0.3.226",
     "@claudian-collab/protocol": "1.0.0",
     "@codemirror/commands": "6.10.0",
     "@codemirror/lang-markdown": "^6.5.2",
@@ -76,10 +76,9 @@
     "@pierre/theming": "1.0.1",
     "@shikijs/core": "4.4.3",
     "@shikijs/engine-javascript": "4.4.3",
-    "@shikijs/engine-oniguruma": "4.4.3",
     "bonjour-service": "1.4.4",
     "node-forge": "1.4.0",
-    "smol-toml": "^1.6.1",
+    "smol-toml": "1.7.1",
     "sql.js": "1.14.1",
     "tslib": "^2.8.1",
     "ws": "8.21.2"

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -8,8 +8,12 @@ import { execSync } from 'child_process';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
+import { assertRuntimeDependencyParity } from './runtimeDependencyParity.mjs';
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
+
+assertRuntimeDependencyParity(ROOT);
 
 // Run CSS build silently
 execSync('node scripts/build-css.mjs', { cwd: ROOT, stdio: 'inherit' });

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -8,12 +8,8 @@ import { execSync } from 'child_process';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
-import { assertRuntimeDependencyParity } from './runtimeDependencyParity.mjs';
-
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
-
-assertRuntimeDependencyParity(ROOT);
 
 // Run CSS build silently
 execSync('node scripts/build-css.mjs', { cwd: ROOT, stdio: 'inherit' });

--- a/scripts/check-architecture-boundaries.test.mjs
+++ b/scripts/check-architecture-boundaries.test.mjs
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import test from 'node:test';
 import ts from 'typescript';
@@ -931,6 +933,57 @@ test('Bun lock parsing accepts the repository JSONC shape without weakening JSON
     () => parseBunLock('{ "packages": /* unsupported */ {} }'),
     /bun\.lock is not valid JSONC/,
   );
+});
+
+test('production artifact entry rejects dependency drift before emitting main.js', () => {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'claudian-build-parity-'));
+  try {
+    fs.writeFileSync(path.join(fixtureRoot, 'package.json'), JSON.stringify({
+      dependencies: {
+        '@anthropic-ai/claude-agent-sdk': '0.3.226',
+        'smol-toml': '1.7.1',
+      },
+    }));
+    fs.writeFileSync(path.join(fixtureRoot, 'package-lock.json'), JSON.stringify({
+      packages: {
+        '': {
+          dependencies: {
+            '@anthropic-ai/claude-agent-sdk': '0.3.226',
+            'smol-toml': '1.7.1',
+          },
+        },
+        'node_modules/@anthropic-ai/claude-agent-sdk': { version: '0.3.226' },
+        'node_modules/smol-toml': { version: '1.6.1' },
+      },
+    }));
+    fs.writeFileSync(path.join(fixtureRoot, 'bun.lock'), `{
+      "workspaces": { "": { "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "0.3.226",
+        "smol-toml": "1.7.1",
+      }, }, },
+      "packages": {
+        "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.226"],
+        "smol-toml": ["smol-toml@1.7.1"],
+      },
+    }`);
+
+    const result = spawnSync(
+      process.execPath,
+      [path.join(process.cwd(), 'esbuild.config.mjs'), 'production'],
+      {
+        cwd: fixtureRoot,
+        encoding: 'utf8',
+        env: { ...process.env, OBSIDIAN_VAULT: '' },
+      },
+    );
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Bundle-critical runtime dependency parity failed/);
+    assert.match(result.stderr, /package-lock\.json resolution: smol-toml/);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, 'main.js')), false);
+  } finally {
+    fs.rmSync(fixtureRoot, { force: true, recursive: true });
+  }
 });
 
 test('production bundle policy rejects plugin artifact filename references', () => {

--- a/scripts/check-architecture-boundaries.test.mjs
+++ b/scripts/check-architecture-boundaries.test.mjs
@@ -5,7 +5,6 @@ import test from 'node:test';
 import ts from 'typescript';
 
 import {
-  cloudAuthorityBindingAllowanceBytes,
   evaluationIndicatorMs,
   evaluationReviewThresholdMs,
   inspectArtifactSize,
@@ -13,9 +12,13 @@ import {
   inspectPluginArtifactReferences,
   mainBudgetBytes,
   preCollabReferenceMainBytes,
-  privateCloudBootstrapAllowanceBytes,
-  standaloneProtocolPackagingAllowanceBytes,
+  preStep11BundleHealthBaselineBytes,
 } from './check-startup-performance.mjs';
+import {
+  bundleCriticalRuntimeDependencies,
+  inspectRuntimeDependencyParity,
+  parseBunLock,
+} from './runtimeDependencyParity.mjs';
 
 function listTypeScriptFiles(root) {
   const files = [];
@@ -830,13 +833,12 @@ test('TypeScript resolves the Collab protocol through the installed registry pac
   );
 });
 
-test('performance policy enforces the main bundle budget and reports the pre-Collab delta', () => {
-  assert.equal(cloudAuthorityBindingAllowanceBytes, 50_000);
-  assert.equal(privateCloudBootstrapAllowanceBytes, 100_000);
-  assert.equal(standaloneProtocolPackagingAllowanceBytes, 20_000);
+test('performance policy enforces the main bundle budget and reports health deltas', () => {
+  assert.equal(preStep11BundleHealthBaselineBytes, 4_896_000);
   assert.equal(mainBudgetBytes, 5_170_000);
   assert.deepEqual(inspectArtifactSize(mainBudgetBytes), {
     budgetExceeded: false,
+    healthBaselineDeltaBytes: mainBudgetBytes - preStep11BundleHealthBaselineBytes,
     referenceDeltaBytes: mainBudgetBytes - preCollabReferenceMainBytes,
   });
   assert.equal(inspectArtifactSize(mainBudgetBytes + 1).budgetExceeded, true);
@@ -845,6 +847,89 @@ test('performance policy enforces the main bundle budget and reports the pre-Col
   assert.equal(
     inspectEvaluationDuration(evaluationReviewThresholdMs + 1),
     'review-required',
+  );
+});
+
+test('bundle-critical runtime dependencies require exact manifest and lock agreement', () => {
+  assert.deepEqual(bundleCriticalRuntimeDependencies, [
+    '@anthropic-ai/claude-agent-sdk',
+    'smol-toml',
+  ]);
+  const packageJson = {
+    dependencies: {
+      '@anthropic-ai/claude-agent-sdk': '0.3.226',
+      'smol-toml': '1.7.1',
+    },
+  };
+  const packageLock = {
+    packages: {
+      '': { dependencies: { ...packageJson.dependencies } },
+      'node_modules/@anthropic-ai/claude-agent-sdk': { version: '0.3.226' },
+      'node_modules/smol-toml': { version: '1.7.1' },
+    },
+  };
+  const bunLock = {
+    workspaces: {
+      '': { dependencies: { ...packageJson.dependencies } },
+    },
+    packages: {
+      '@anthropic-ai/claude-agent-sdk': ['@anthropic-ai/claude-agent-sdk@0.3.226'],
+      'smol-toml': ['smol-toml@1.7.1'],
+    },
+  };
+
+  assert.deepEqual(inspectRuntimeDependencyParity({ bunLock, packageJson, packageLock }), []);
+
+  const rangedManifest = structuredClone(packageJson);
+  rangedManifest.dependencies['@anthropic-ai/claude-agent-sdk'] = '^0.3.220';
+  assert.deepEqual(
+    inspectRuntimeDependencyParity({ bunLock, packageJson: rangedManifest, packageLock }),
+    [{
+      actual: '^0.3.220',
+      dependency: '@anthropic-ai/claude-agent-sdk',
+      expected: 'an exact version',
+      source: 'package.json',
+    }],
+  );
+
+  const staleNpmLock = structuredClone(packageLock);
+  staleNpmLock.packages['node_modules/smol-toml'].version = '1.6.1';
+  assert.deepEqual(
+    inspectRuntimeDependencyParity({ bunLock, packageJson, packageLock: staleNpmLock }),
+    [{
+      actual: '1.6.1',
+      dependency: 'smol-toml',
+      expected: '1.7.1',
+      source: 'package-lock.json resolution',
+    }],
+  );
+
+  const staleBunLock = structuredClone(bunLock);
+  staleBunLock.packages['@anthropic-ai/claude-agent-sdk'][0] = '@anthropic-ai/claude-agent-sdk@0.3.220';
+  assert.deepEqual(
+    inspectRuntimeDependencyParity({ bunLock: staleBunLock, packageJson, packageLock }),
+    [{
+      actual: '0.3.220',
+      dependency: '@anthropic-ai/claude-agent-sdk',
+      expected: '0.3.226',
+      source: 'bun.lock resolution',
+    }],
+  );
+});
+
+test('Bun lock parsing accepts the repository JSONC shape without weakening JSON validation', () => {
+  assert.deepEqual(parseBunLock(`{
+    "literal": "preserve ,} and escaped \\\"text\\\"",
+    "workspaces": { "": { "dependencies": { "smol-toml": "1.7.1", }, }, },
+    "packages": { "smol-toml": ["smol-toml@1.7.1",], },
+  }`), {
+    literal: 'preserve ,} and escaped "text"',
+    workspaces: { '': { dependencies: { 'smol-toml': '1.7.1' } } },
+    packages: { 'smol-toml': ['smol-toml@1.7.1'] },
+  });
+  assert.throws(
+    () => parseBunLock('{ "packages": /* unsupported */ {} }'),
+    /bun\.lock is not valid JSONC/,
   );
 });
 

--- a/scripts/check-startup-performance.mjs
+++ b/scripts/check-startup-performance.mjs
@@ -10,13 +10,8 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const mainPath = path.join(root, 'main.js');
 const requiredArtifacts = ['main.js', 'manifest.json', 'styles.css'];
 export const preCollabReferenceMainBytes = 3_739_584;
-export const privateCloudBootstrapAllowanceBytes = 100_000;
-export const cloudAuthorityBindingAllowanceBytes = 50_000;
-export const standaloneProtocolPackagingAllowanceBytes = 20_000;
-export const mainBudgetBytes = 5_000_000
-  + privateCloudBootstrapAllowanceBytes
-  + cloudAuthorityBindingAllowanceBytes
-  + standaloneProtocolPackagingAllowanceBytes;
+export const preStep11BundleHealthBaselineBytes = 4_896_000;
+export const mainBudgetBytes = 5_170_000;
 export const evaluationIndicatorMs = 50;
 export const evaluationReviewThresholdMs = 150;
 const pluginArtifactNames = ['main.js', 'manifest.json'];
@@ -24,6 +19,7 @@ const pluginArtifactNames = ['main.js', 'manifest.json'];
 export function inspectArtifactSize(mainBytes) {
   return {
     budgetExceeded: mainBytes > mainBudgetBytes,
+    healthBaselineDeltaBytes: mainBytes - preStep11BundleHealthBaselineBytes,
     referenceDeltaBytes: mainBytes - preCollabReferenceMainBytes,
   };
 }
@@ -200,6 +196,7 @@ process.stdout.write(JSON.stringify({
     `main.js ${(mainBytes / 1024 / 1024).toFixed(2)} MiB (${mainBytes} bytes); `
     + `pre-Collab reference delta ${signed(artifact.referenceDeltaBytes)} bytes `
     + `(${signed(deltaMiB.toFixed(2))} MiB); `
+    + `pre-Step-11 health baseline delta ${signed(artifact.healthBaselineDeltaBytes)} bytes; `
     + `median cold evaluation ${medianMs.toFixed(1)} ms`,
   );
   const evaluation = inspectEvaluationDuration(medianMs);

--- a/scripts/runtimeDependencyParity.mjs
+++ b/scripts/runtimeDependencyParity.mjs
@@ -1,0 +1,125 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const bundleCriticalRuntimeDependencies = Object.freeze([
+  '@anthropic-ai/claude-agent-sdk',
+  'smol-toml',
+]);
+
+const exactVersionPattern = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, 'utf8'));
+}
+
+function bunResolutionVersion(resolution) {
+  if (!Array.isArray(resolution) || typeof resolution[0] !== 'string') return undefined;
+  const separator = resolution[0].lastIndexOf('@');
+  return separator < 0 ? undefined : resolution[0].slice(separator + 1);
+}
+
+export function parseBunLock(source) {
+  try {
+    let normalized = '';
+    let escaped = false;
+    let inString = false;
+    for (let index = 0; index < source.length; index += 1) {
+      const character = source[index];
+      if (inString) {
+        normalized += character;
+        if (escaped) escaped = false;
+        else if (character === '\\') escaped = true;
+        else if (character === '"') inString = false;
+        continue;
+      }
+      if (character === '"') {
+        inString = true;
+        normalized += character;
+        continue;
+      }
+      if (character === ',') {
+        let next = index + 1;
+        while (/\s/.test(source[next] ?? '')) next += 1;
+        if (source[next] === '}' || source[next] === ']') continue;
+      }
+      normalized += character;
+    }
+    return JSON.parse(normalized);
+  } catch (error) {
+    throw new Error('bun.lock is not valid JSONC.', { cause: error });
+  }
+}
+
+export function inspectRuntimeDependencyParity({ bunLock, packageJson, packageLock }) {
+  const violations = [];
+  const sources = [
+    {
+      dependencies: packageLock.packages?.['']?.dependencies,
+      source: 'package-lock.json manifest',
+    },
+    {
+      dependencies: bunLock.workspaces?.['']?.dependencies,
+      source: 'bun.lock manifest',
+    },
+  ];
+
+  for (const dependency of bundleCriticalRuntimeDependencies) {
+    const expected = packageJson.dependencies?.[dependency];
+    if (typeof expected !== 'string' || !exactVersionPattern.test(expected)) {
+      violations.push({
+        actual: expected,
+        dependency,
+        expected: 'an exact version',
+        source: 'package.json',
+      });
+      continue;
+    }
+    for (const source of sources) {
+      const actual = source.dependencies?.[dependency];
+      if (actual !== expected) {
+        violations.push({ actual, dependency, expected, source: source.source });
+      }
+    }
+
+    const npmActual = packageLock.packages?.[`node_modules/${dependency}`]?.version;
+    if (npmActual !== expected) {
+      violations.push({
+        actual: npmActual,
+        dependency,
+        expected,
+        source: 'package-lock.json resolution',
+      });
+    }
+
+    const bunActual = bunResolutionVersion(bunLock.packages?.[dependency]);
+    if (bunActual !== expected) {
+      violations.push({
+        actual: bunActual,
+        dependency,
+        expected,
+        source: 'bun.lock resolution',
+      });
+    }
+  }
+
+  return violations;
+}
+
+export function assertRuntimeDependencyParity(root = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+)) {
+  const violations = inspectRuntimeDependencyParity({
+    bunLock: parseBunLock(readFileSync(path.join(root, 'bun.lock'), 'utf8')),
+    packageJson: readJson(path.join(root, 'package.json')),
+    packageLock: readJson(path.join(root, 'package-lock.json')),
+  });
+  if (violations.length === 0) return;
+
+  const details = violations.map(violation => (
+    `${violation.source}: ${violation.dependency} expected ${violation.expected}, `
+    + `found ${violation.actual ?? 'missing'}`
+  ));
+  throw new Error(`Bundle-critical runtime dependency parity failed:\n- ${details.join('\n- ')}`);
+}

--- a/src/features/collab/detail/review/CollabShikiAdapter.ts
+++ b/src/features/collab/detail/review/CollabShikiAdapter.ts
@@ -6,7 +6,6 @@ import {
   stringifyTokenStyle,
 } from '@shikijs/core';
 import { createJavaScriptRegexEngine } from '@shikijs/engine-javascript';
-import { createOnigurumaEngine } from '@shikijs/engine-oniguruma';
 
 export const bundledLanguages = Object.freeze({});
 
@@ -18,10 +17,13 @@ export const createHighlighter = createBundledHighlighter({
 
 export const { codeToHtml } = createSingletonShorthands(createHighlighter);
 
+export function createOnigurumaEngine(): never {
+  throw new Error('The Collab text diff renderer does not support Shiki Wasm.');
+}
+
 export {
   createCssVariablesTheme,
   createJavaScriptRegexEngine,
-  createOnigurumaEngine,
   getTokenStyleObject,
   stringifyTokenStyle,
 };

--- a/src/features/collab/shared/markdown/MarkdownDraftEditor.ts
+++ b/src/features/collab/shared/markdown/MarkdownDraftEditor.ts
@@ -4,14 +4,18 @@ import {
   historyKeymap,
   indentWithTab,
 } from '@codemirror/commands';
-import { markdown } from '@codemirror/lang-markdown';
+import {
+  commonmarkLanguage,
+  markdownKeymap,
+  pasteURLAsLink,
+} from '@codemirror/lang-markdown';
 import {
   bracketMatching,
   defaultHighlightStyle,
   indentOnInput,
   syntaxHighlighting,
 } from '@codemirror/language';
-import { EditorSelection, EditorState, type Extension } from '@codemirror/state';
+import { EditorSelection, EditorState, type Extension, Prec } from '@codemirror/state';
 import {
   drawSelection,
   dropCursor,
@@ -195,7 +199,9 @@ export class MarkdownDraftEditor {
       syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
       bracketMatching(),
       keymap.of([...defaultKeymap, ...historyKeymap, indentWithTab]),
-      markdown(),
+      Prec.high(keymap.of(markdownKeymap)),
+      pasteURLAsLink,
+      commonmarkLanguage,
       EditorView.lineWrapping,
       EditorView.updateListener.of(update => {
         if (!update.docChanged && !update.selectionSet) return;

--- a/tests/integration/build/collab-dependency-envelope.test.ts
+++ b/tests/integration/build/collab-dependency-envelope.test.ts
@@ -28,6 +28,7 @@ const {
 
 const root = path.resolve(__dirname, '../../..');
 const esbuildConfigPath = path.join(root, 'esbuild.config.mjs');
+const packageJsonPath = path.join(root, 'package.json');
 const performanceScriptPath = path.join(root, 'scripts/check-startup-performance.mjs');
 
 describe('Collab dependency envelope', () => {
@@ -204,6 +205,51 @@ describe('Collab dependency envelope', () => {
     expect(inlinedOnigurumaInputs).toEqual([]);
   });
 
+  it('does not declare or bundle the unsupported Oniguruma engine', () => {
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+    const normalizedInputs = bundleInputs.map(input => input.replaceAll('\\\\', '/'));
+
+    expect(packageJson.dependencies?.['@shikijs/engine-oniguruma']).toBeUndefined();
+    expect(normalizedInputs.filter(input => (
+      input.includes('/@shikijs/engine-oniguruma/dist/')
+    ))).toEqual([]);
+  });
+
+  it('keeps the Collab draft editor inside the strict CommonMark language envelope', async () => {
+    const result = await build({
+      absWorkingDir: root,
+      bundle: true,
+      entryPoints: [
+        path.join(root, 'src/features/collab/shared/markdown/MarkdownDraftEditor.ts'),
+      ],
+      external: [
+        'obsidian',
+        ...builtinModules,
+        ...builtinModules.map(moduleName => `node:${moduleName}`),
+      ],
+      logLevel: 'silent',
+      metafile: true,
+      platform: 'browser',
+      target: 'es2022',
+      treeShaking: true,
+      write: false,
+    });
+    const forbiddenInputs = Object.entries(Object.values(result.metafile.outputs)[0].inputs)
+      .filter(([, contribution]) => contribution.bytesInOutput > 0)
+      .map(([input]) => input)
+      .map(input => input.replaceAll('\\\\', '/'))
+      .filter(input => [
+        '/@codemirror/lang-css/',
+        '/@codemirror/lang-html/',
+        '/@codemirror/lang-javascript/',
+        '/@lezer/css/',
+        '/@lezer/html/',
+        '/@lezer/javascript/',
+      ].some(fragment => input.includes(fragment)));
+
+    expect(forbiddenInputs).toEqual([]);
+  });
+
   it('retains only the Pierre component surface used by Collab', () => {
     const normalizedInputs = bundleContributors.map(input => input.replaceAll('\\\\', '/'));
     const unusedComponentInputs = normalizedInputs.filter(input => (
@@ -265,13 +311,15 @@ describe('Collab dependency envelope', () => {
     `)).toBe('["function","function"]');
   });
 
-  it('enforces a 5 MB main bundle budget', () => {
+  it('enforces the hard bundle budget and reports the pre-Step-11 health baseline', () => {
     const script = readFileSync(performanceScriptPath, 'utf8');
 
     expect(script).toContain('preCollabReferenceMainBytes = 3_739_584');
-    expect(script).toContain('mainBudgetBytes = 5_000_000');
+    expect(script).toContain('preStep11BundleHealthBaselineBytes = 4_896_000');
+    expect(script).toContain('mainBudgetBytes = 5_170_000');
     expect(script).toContain('evaluationReviewThresholdMs = 150');
     expect(script).toContain('pre-Collab reference delta');
+    expect(script).toContain('pre-Step-11 health baseline delta');
     expect(script).toContain('artifact.budgetExceeded');
     expect(script).not.toContain('historicalMainWarningBytes');
     expect(script).not.toContain('mainReviewThresholdBytes');

--- a/tests/unit/features/collab/shared/markdown/MarkdownDraftEditor.test.ts
+++ b/tests/unit/features/collab/shared/markdown/MarkdownDraftEditor.test.ts
@@ -190,6 +190,49 @@ describe('MarkdownDraftEditor', () => {
     expect(root.querySelector('.claudian-collab-markdown-suggestion')).toBeNull();
     editor.destroy();
   });
+
+  it('continues and exits CommonMark bullet lists with the Markdown keymap', () => {
+    const root = document.createElement('div');
+    const editor = new MarkdownDraftEditor(root, {
+      ariaLabel: 'Description',
+      initialValue: '- first item',
+      renderMarkdown: jest.fn().mockResolvedValue(undefined),
+    });
+    editor.setSelection(editor.getValue().length);
+    const view = markdownEditor(root);
+    view.focus();
+
+    dispatchEditorKey(view, 'Enter');
+    expect(editor.getValue()).toBe('- first item\n- ');
+
+    dispatchEditorKey(view, 'Backspace');
+    expect(editor.getValue()).toBe('- first item\n  ');
+    dispatchEditorKey(view, 'Backspace');
+    expect(editor.getValue()).toBe('- first item\n');
+    editor.destroy();
+  });
+
+  it('pastes a URL around selected text as a Markdown link', () => {
+    const root = document.createElement('div');
+    const editor = new MarkdownDraftEditor(root, {
+      ariaLabel: 'Description',
+      initialValue: 'Claudian',
+      renderMarkdown: jest.fn().mockResolvedValue(undefined),
+    });
+    editor.setSelection(0, editor.getValue().length);
+    const view = markdownEditor(root);
+    view.focus();
+    const event = new Event('paste', { bubbles: true, cancelable: true });
+    Object.defineProperty(event, 'clipboardData', {
+      value: {
+        getData: (type: string) => type === 'text/plain' ? 'https://claudian.dev' : '',
+      },
+    });
+    view.contentDOM.dispatchEvent(event);
+
+    expect(editor.getValue()).toBe('[Claudian](https://claudian.dev)');
+    editor.destroy();
+  });
 });
 
 function markdownEditor(root: HTMLElement): EditorView {
@@ -202,6 +245,15 @@ function selectedSuggestions(root: HTMLElement): string[] {
   return [...root.querySelectorAll<HTMLElement>(
     '.claudian-collab-markdown-suggestion',
   )].map(item => item.getAttribute('aria-selected') ?? 'missing');
+}
+
+function dispatchEditorKey(view: EditorView, key: string): void {
+  view.contentDOM.dispatchEvent(new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    code: key,
+    key,
+  }));
 }
 
 function setEditorValue(root: HTMLElement, value: string): void {


### PR DESCRIPTION
## Summary

- pin the Claude SDK and TOML exactly and fail production builds when npm/Bun locks drift from `package.json`
- remove the unreachable real Oniguruma engine while retaining Pierre's explicit unsupported-Wasm compatibility export
- narrow the Collab draft editor to strict CommonMark language, list commands, and URL paste
- report the accepted 4,896,000-byte pre-Step-11 health baseline without raising the 5,170,000-byte hard ceiling

## Product tradeoff

This intentionally drops edit-time HTML tag completion, nested HTML/CSS/JavaScript syntax parsing, and package section-fold support in the Collab draft editor. Obsidian Markdown preview is unchanged. List continuation/exit, URL paste, Ticket/Member suggestions, selection, preview, and read-only rendering remain covered.

## Bundle evidence

Clean Linux `node:24.16.0-bookworm-slim`, `npm ci`:

- raw: 4,895,691 bytes
- gzip-9: 1,497,488 bytes
- Brotli-11: 1,248,928 bytes
- 273,949 bytes smaller than PR #1167
- 274,309 bytes below the unchanged hard ceiling
- cold evaluation median: 72.4 ms, with no eager child process, listener, or Wasm

## Verification

- [x] typecheck
- [x] TypeScript and CSS lint
- [x] architecture: 36/36
- [x] full suite: 582 suites / 8,472 tests pass; one pre-existing skip
- [x] cross-platform Collab scope: 24 suites / 200 tests
- [x] dependency envelope: 17/17, including SQL and real-DOM Pierre probes
- [x] frozen Bun lock install
- [x] clean Linux npm production build and performance harness
- [ ] installed Obsidian Ticket/Request edit and preview smoke; workstation is locked
- [ ] exact installed two-Cloud/one-LAN read regression; workstation is locked

## Delivery order

This PR is stacked on #1167 and should be reviewed after it. If #1167 merges first, this PR can be retargeted to `main`. The user remains the merge owner. Do not treat the complete pre-Step-11 gate as closed until the installed Obsidian smoke passes.
