### PR TITLE
fix: preserve slow OpenCode command discovery

### DIFF
--- a/src/core/providers/commands/ProviderCommandDiscoveryStore.ts
+++ b/src/core/providers/commands/ProviderCommandDiscoveryStore.ts
@@ -20,6 +20,8 @@ export interface ProviderCommandDiscoveryController<T>
 export interface ProviderCommandDiscoveryStoreOptions {
   /** Evicts upstream discovery state before retry observers can start a new load. */
   onBeforeRetry?: () => void;
+  /** Re-resolves the deadline for each load; null delegates the bound to the loader. */
+  resolveTimeoutMs?: () => number | null | undefined;
   timeoutMs?: number;
 }
 
@@ -46,6 +48,7 @@ implements ProviderCommandDiscoveryController<T> {
   private generation = 0;
   private readonly listeners = new Set<() => void>();
   private readonly onBeforeRetry: (() => void) | undefined;
+  private readonly resolveTimeoutMs: (() => number | null | undefined) | undefined;
   private readonly timeoutMs: number;
 
   constructor(
@@ -55,6 +58,7 @@ implements ProviderCommandDiscoveryController<T> {
     options: ProviderCommandDiscoveryStoreOptions = {},
   ) {
     this.onBeforeRetry = options.onBeforeRetry;
+    this.resolveTimeoutMs = options.resolveTimeoutMs;
     this.timeoutMs = options.timeoutMs ?? DEFAULT_DISCOVERY_TIMEOUT_MS;
   }
 
@@ -133,6 +137,14 @@ implements ProviderCommandDiscoveryController<T> {
   private async loadWithTimeout(
     abortController: AbortController,
   ): Promise<ProviderCommandDiscoveryResult<T>> {
+    const resolvedTimeoutMs = this.resolveTimeoutMs?.();
+    const timeoutMs = resolvedTimeoutMs === undefined
+      ? this.timeoutMs
+      : resolvedTimeoutMs;
+    if (timeoutMs === null) {
+      return await this.loader(abortController.signal);
+    }
+
     let timeoutId: number | null = null;
     const timeout = new Promise<ProviderCommandDiscoveryResult<T>>(resolve => {
       timeoutId = window.setTimeout(() => {
@@ -142,7 +154,7 @@ implements ProviderCommandDiscoveryController<T> {
           retryable: true,
         });
         abortController.abort();
-      }, this.timeoutMs);
+      }, timeoutMs);
     });
 
     try {

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -31,6 +31,8 @@ export interface ProviderCapabilities {
   supportsRewind: boolean;
   supportsFork: boolean;
   supportsProviderCommands: boolean;
+  /** Whether command discovery uses the shared UI deadline or provider-owned bounds. */
+  commandDiscoveryDeadline?: 'shared' | 'provider-owned';
   supportsImageAttachments: boolean;
   supportsInstructionMode: boolean;
   supportsTurnSteer?: boolean;

--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -2263,6 +2263,15 @@ export class TabManager implements TabManagerInterface {
         onBeforeRetry: () => {
           this.advanceTabCommandContextRevision(tabId);
         },
+        resolveTimeoutMs: () => {
+          const tab = this.tabs.get(tabId);
+          if (!tab || !this.isTabAlive(tab)) return undefined;
+          const providerId = getTabProviderId(tab, this.plugin);
+          return ProviderRegistry.getCapabilities(providerId).commandDiscoveryDeadline
+            === 'provider-owned'
+            ? null
+            : undefined;
+        },
       },
     );
     this.providerCommandDiscoveryStores.set(tabId, discovery);

--- a/src/providers/opencode/capabilities.ts
+++ b/src/providers/opencode/capabilities.ts
@@ -2,6 +2,7 @@ import type { ProviderCapabilities } from '../../core/providers/types';
 
 export const OPENCODE_PROVIDER_CAPABILITIES: Readonly<ProviderCapabilities> = Object.freeze({
   providerId: 'opencode',
+  commandDiscoveryDeadline: 'provider-owned',
   supportsNativeHistory: true,
   supportsPlanMode: true,
   supportsRewind: false,

--- a/tests/unit/core/providers/commands/ProviderCommandDiscoveryStore.test.ts
+++ b/tests/unit/core/providers/commands/ProviderCommandDiscoveryStore.test.ts
@@ -151,4 +151,72 @@ describe('ProviderCommandDiscoveryStore', () => {
       jest.useRealTimers();
     }
   });
+
+  it('lets provider-owned discovery outlive the shared deadline', async () => {
+    jest.useFakeTimers();
+    try {
+      const response = deferred<ProviderCommandDiscoveryResult<string>>();
+      let loaderSignal: AbortSignal | null = null;
+      const store = new ProviderCommandDiscoveryStore<string>(
+        (signal) => {
+          loaderSignal = signal;
+          return response.promise;
+        },
+        { resolveTimeoutMs: () => null },
+      );
+
+      const load = store.load();
+      await jest.advanceTimersByTimeAsync(8_000);
+
+      expect((loaderSignal as AbortSignal | null)?.aborted).toBe(false);
+      expect(store.getSnapshot()).toEqual({ status: 'loading' });
+
+      response.resolve({ status: 'ready', items: ['review'] });
+      await expect(load).resolves.toEqual({ status: 'ready', items: ['review'] });
+      expect(store.getSnapshot()).toEqual({ status: 'ready', items: ['review'] });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('resolves the shared deadline again after invalidation', async () => {
+    jest.useFakeTimers();
+    try {
+      const first = deferred<ProviderCommandDiscoveryResult<string>>();
+      let timeoutMs: number | null = null;
+      const signals: AbortSignal[] = [];
+      const store = new ProviderCommandDiscoveryStore<string>(
+        (signal) => {
+          signals.push(signal);
+          return signals.length === 1
+            ? first.promise
+            : new Promise(() => undefined);
+        },
+        { resolveTimeoutMs: () => timeoutMs },
+      );
+
+      const firstLoad = store.load();
+      await jest.advanceTimersByTimeAsync(8_000);
+      expect(store.getSnapshot()).toEqual({ status: 'loading' });
+
+      store.invalidate();
+      expect(signals[0]?.aborted).toBe(true);
+      timeoutMs = 100;
+
+      const secondLoad = store.load();
+      await jest.advanceTimersByTimeAsync(100);
+      await secondLoad;
+
+      expect(signals[1]?.aborted).toBe(true);
+      first.resolve({ status: 'ready', items: ['review'] });
+      await firstLoad;
+      expect(store.getSnapshot()).toEqual({
+        status: 'error',
+        message: 'Provider command discovery timed out',
+        retryable: true,
+      });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });

--- a/tests/unit/features/chat/tabs/TabManager.test.ts
+++ b/tests/unit/features/chat/tabs/TabManager.test.ts
@@ -241,6 +241,10 @@ describe('TabManager provider execution orchestration', () => {
   beforeEach(() => {
     mockTabs.length = 0;
     jest.clearAllMocks();
+    (ProviderRegistry.getCapabilities as jest.Mock).mockReturnValue({
+      providerId: 'claude',
+      supportsProviderCommands: true,
+    });
     warmupPolicy.resolveMode.mockReturnValue('none');
     commandLoader.loadCommands.mockResolvedValue({
       status: 'ready',
@@ -1746,6 +1750,48 @@ describe('TabManager provider execution orchestration', () => {
       externalContextPaths: [],
     }));
     expect(commandLoader.loadCommands.mock.calls[0][0]).not.toHaveProperty('runtime');
+  });
+
+  it('lets provider-owned command discovery outlive the shared deadline', async () => {
+    jest.useFakeTimers();
+    const commandResult = deferred<any>();
+    commandLoader.loadCommands.mockReturnValueOnce(commandResult.promise);
+    commandCatalog.listDropdownEntries.mockResolvedValueOnce([{
+      id: 'opencode:review',
+      name: 'review',
+    }]);
+    (ProviderRegistry.getCapabilities as jest.Mock).mockReturnValue({
+      providerId: 'opencode',
+      supportsProviderCommands: true,
+      commandDiscoveryDeadline: 'provider-owned',
+    });
+    const { manager } = createManager();
+
+    try {
+      const tab = await manager.createTab();
+      tab!.providerId = 'opencode';
+      const catalogResolver = mockCreateTabRuntime.mock.calls[0]?.[0]
+        .getProviderCatalogConfig as (runtime: any) => any;
+      const discovery = catalogResolver(tab).discovery;
+
+      const load = discovery.load();
+      for (let attempt = 0;
+        attempt < 10 && commandLoader.loadCommands.mock.calls.length === 0;
+        attempt += 1) {
+        await Promise.resolve();
+      }
+      await jest.advanceTimersByTimeAsync(8_000);
+
+      expect(discovery.getSnapshot()).toEqual({ status: 'loading' });
+      commandResult.resolve({
+        status: 'ready',
+        items: [{ description: 'Review changes', name: 'review' }],
+      });
+      await expect(load).resolves.toMatchObject({ status: 'ready' });
+    } finally {
+      jest.useRealTimers();
+      await manager.destroy();
+    }
   });
 
   it('rejects command context loaded for a conversation rebound during lookup', async () => {

--- a/tests/unit/providers/opencode/capabilities.test.ts
+++ b/tests/unit/providers/opencode/capabilities.test.ts
@@ -25,6 +25,10 @@ describe('OPENCODE_PROVIDER_CAPABILITIES', () => {
     expect(OPENCODE_PROVIDER_CAPABILITIES.supportsProviderCommands).toBe(true);
   });
 
+  it('should let provider-owned deadlines bound command discovery', () => {
+    expect(OPENCODE_PROVIDER_CAPABILITIES.commandDiscoveryDeadline).toBe('provider-owned');
+  });
+
   it('should use effort-based reasoning control', () => {
     expect(OPENCODE_PROVIDER_CAPABILITIES.reasoningControl).toBe('effort');
   });


### PR DESCRIPTION
## Why

Refs #1131 and #1060.

A current Windows report uses Claudian 2.2.4 with OpenCode 1.18.21 and 62 skills. Native OpenCode discovers the same skills from the same vault, while Claudian settles on its built-ins after command discovery. Raising the compiled shared discovery deadline lets the catalog load, which isolates the failure to the client-side deadline rather than skill paths or OpenCode discovery.

The shared store starts its eight-second deadline before the OpenCode metadata process has completed its provider-owned ACP initialization and session requests. When cold startup exceeds that deadline, the store aborts discovery even though OpenCode already has bounded JSON-RPC requests and a bounded post-session command notification wait.

## What Changed

- Add a provider capability that selects the shared command-discovery deadline or provider-owned bounds; the default remains shared.
- Resolve that policy on every store load so a provider change cannot retain the previous provider deadline.
- Let OpenCode use its provider-owned bounds instead of the shared eight-second deadline.
- Preserve explicit invalidation, Retry, stale-generation fencing, and the existing shared timeout behavior for every other provider.

## Why This Approach

This keeps the provider distinction in `ProviderCapabilities` instead of branching on an OpenCode ID in Chat. It also avoids an arbitrary 600-second constant or an unused numeric workspace-registration API.

The change does not remove the shared timeout. It delegates only OpenCode discovery to the existing ACP request deadlines and metadata notification bound. An actual loader rejection still becomes the standard retryable error, and tab or provider invalidation still aborts the load.

This is distinct from #1148, which preserves the difference between an unobserved OpenCode command update and a genuine empty update after a session opens. It is also distinct from the Pi/OMP pushed-command compatibility work in #1162.

## Validation

- TDD red: the new core, Chat-boundary, and capability assertions failed under the existing shared timeout.
- Focused tests: 5 suites / 121 tests passed.
- `npm run typecheck`
- `npm run lint`
- `npm run test` — 582 suites / 8,476 tests passed, with one existing skip; all 49 architecture checks passed.
- `npm run build`
- `git diff --check`

## Impact and Follow-ups

The behavior change is limited to OpenCode command discovery. There is no settings, persistence, protocol, command-content, or skill-directory change.

The reporter should verify this branch on the affected Windows cold-start environment. This PR deliberately uses `Refs` rather than `Fixes` because #1131 also contains separate Pi/OMP evidence and the report that no Retry row appeared is not explained by this deadline alone.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.