### PR TITLE
chore: pin Collab protocol v2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "claudian",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.226",
-        "@claudian-collab/protocol": "1.0.0",
+        "@claudian-collab/protocol": "2.0.0",
         "@codemirror/commands": "6.10.0",
         "@codemirror/lang-markdown": "^6.5.2",
         "@codemirror/language": "^6.12.4",
@@ -162,7 +162,7 @@
 
     "@cacheable/utils": ["@cacheable/utils@2.5.0", "", { "dependencies": { "hashery": "^1.5.1", "keyv": "^5.6.0" } }, "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA=="],
 
-    "@claudian-collab/protocol": ["@claudian-collab/protocol@1.0.0", "", { "dependencies": { "@lezer/markdown": "1.7.2" } }, "sha512-kNq57tIDzcaMl+o+N4lwETN+QPJybzq4nSD4fjhgdhx/H9qMkJGraf4LX5ELqElMmFG+f5QGxnYQMVLh9/XwdQ=="],
+    "@claudian-collab/protocol": ["@claudian-collab/protocol@2.0.0", "", { "dependencies": { "@lezer/markdown": "1.7.2" } }, "sha512-ImjuXs4eSCMzfp3BEKw5gvXIdicQ8bjqJYcICcNxylFrwqwrtej9rLe9pMi6gqvnCQ6N2AbvTKUx/5dEl2fdPA=="],
 
     "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.226",
-        "@claudian-collab/protocol": "1.0.0",
+        "@claudian-collab/protocol": "2.0.0",
         "@codemirror/commands": "6.10.0",
         "@codemirror/lang-markdown": "^6.5.2",
         "@codemirror/language": "^6.12.4",
@@ -829,9 +829,9 @@
       }
     },
     "node_modules/@claudian-collab/protocol": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@claudian-collab/protocol/-/protocol-1.0.0.tgz",
-      "integrity": "sha512-kNq57tIDzcaMl+o+N4lwETN+QPJybzq4nSD4fjhgdhx/H9qMkJGraf4LX5ELqElMmFG+f5QGxnYQMVLh9/XwdQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@claudian-collab/protocol/-/protocol-2.0.0.tgz",
+      "integrity": "sha512-ImjuXs4eSCMzfp3BEKw5gvXIdicQ8bjqJYcICcNxylFrwqwrtej9rLe9pMi6gqvnCQ6N2AbvTKUx/5dEl2fdPA==",
       "license": "MIT",
       "dependencies": {
         "@lezer/markdown": "1.7.2"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.226",
-    "@claudian-collab/protocol": "1.0.0",
+    "@claudian-collab/protocol": "2.0.0",
     "@codemirror/commands": "6.10.0",
     "@codemirror/lang-markdown": "^6.5.2",
     "@codemirror/language": "^6.12.4",

--- a/scripts/check-architecture-boundaries.test.mjs
+++ b/scripts/check-architecture-boundaries.test.mjs
@@ -570,17 +570,21 @@ test('Claudian consumes the standalone Collab protocol only from the exact regis
     'utf8',
   ));
 
-  assert.equal(manifest.dependencies?.[protocolPackageName], '1.0.0');
+  assert.equal(manifest.dependencies?.[protocolPackageName], '2.0.0');
   assert.equal(manifest.dependencies?.['@lezer/markdown'], '1.7.2');
   assert.equal(protocolManifest.dependencies?.['@lezer/markdown'], '1.7.2');
   assert.equal(manifest.dependencies?.['@claudian/collab-protocol'], undefined);
   assert.equal(manifest.workspaces, undefined);
-  assert.equal(lockfile.packages?.['']?.dependencies?.[protocolPackageName], '1.0.0');
-  assert.equal(lockfile.packages?.[protocolInstallPath]?.version, '1.0.0');
+  assert.equal(lockfile.packages?.['']?.dependencies?.[protocolPackageName], '2.0.0');
+  assert.equal(lockfile.packages?.[protocolInstallPath]?.version, '2.0.0');
+  assert.equal(
+    lockfile.packages?.[protocolInstallPath]?.integrity,
+    'sha512-ImjuXs4eSCMzfp3BEKw5gvXIdicQ8bjqJYcICcNxylFrwqwrtej9rLe9pMi6gqvnCQ6N2AbvTKUx/5dEl2fdPA==',
+  );
   assert.equal(lockfile.packages?.['node_modules/@lezer/markdown']?.version, '1.7.2');
   assert.match(
     lockfile.packages?.[protocolInstallPath]?.resolved ?? '',
-    /^https:\/\/registry\.npmjs\.org\/@claudian-collab\/protocol\/-\/protocol-1\.0\.0\.tgz$/u,
+    /^https:\/\/registry\.npmjs\.org\/@claudian-collab\/protocol\/-\/protocol-2\.0\.0\.tgz$/u,
   );
 
   for (const retiredPath of [

--- a/src/app/collab/lan/LanCollabControlOperationCodecs.ts
+++ b/src/app/collab/lan/LanCollabControlOperationCodecs.ts
@@ -1,4 +1,9 @@
-import { COLLAB_CONTROL_OPERATION_CODECS, type CollabControlOperationCodec, type CollabDecodeResult } from '@claudian-collab/protocol';
+import {
+  COLLAB_CONTROL_OPERATION_CODECS,
+  type CollabControlOperationCodec,
+  type CollabDecodeResult,
+  type CollabRequestTicketOperation,
+} from '@claudian-collab/protocol';
 
 import type {
   LanCollabControlOperation,
@@ -42,7 +47,7 @@ function lifecycleResponse(
 
 function codec<Operation extends Exclude<
   LanCollabControlOperation,
-  keyof typeof COLLAB_CONTROL_OPERATION_CODECS
+  CollabRequestTicketOperation
 >>(
   operation: Operation,
   decodeRequest: (input: unknown) => CollabDecodeResult<
@@ -74,7 +79,7 @@ function lifecycleCodec<Operation extends LanCollabLifecycleControlOperation>(
   );
 }
 
-function sharedCodec<Operation extends keyof typeof COLLAB_CONTROL_OPERATION_CODECS>(
+function sharedCodec<Operation extends CollabRequestTicketOperation>(
   operation: Operation,
 ): LanCodecMap[Operation] {
   const shared = COLLAB_CONTROL_OPERATION_CODECS[operation];

--- a/src/app/collab/lan/LanCollabControlOperations.ts
+++ b/src/app/collab/lan/LanCollabControlOperations.ts
@@ -8,6 +8,7 @@ import type {
   CollabOperationId,
   CollabProjectId,
   CollabRequestId,
+  CollabRequestTicketOperation,
 } from '@claudian-collab/protocol';
 
 import type { LanCollabInvitation } from '@/app/collab/lan/InvitationCodec';
@@ -182,7 +183,12 @@ export interface LanRefreshEndpointRequest {
   readonly projectId: string;
 }
 
-export interface LanCollabControlOperationMap extends CollabControlOperationMap {
+type SharedCollabControlOperationMap = Pick<
+  CollabControlOperationMap,
+  CollabRequestTicketOperation
+>;
+
+export interface LanCollabControlOperationMap extends SharedCollabControlOperationMap {
   createJoinAttempt: CollabControlOperationDefinition<
     CreateJoinAttemptRequest,
     CreateJoinAttemptResponse

--- a/tests/integration/app/collab/accept/CloudAcceptRecovery.test.ts
+++ b/tests/integration/app/collab/accept/CloudAcceptRecovery.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import {
+  COLLAB_CHECKPOINT_ARTIFACT_LIMITS,
   COLLAB_LIMITS,
   collabCloudCapabilityDocument,
   collabCloudSuccessEnvelope,
@@ -334,12 +335,12 @@ function fixedProject(context: PublishProjectContext) {
 function membership(): CollabLocalCloudMembershipRecord {
   return {
     authority: {
-      bindingVersion: 1,
+      bindingVersion: 2,
       developmentActorId: MANAGER_ID,
-      gitRemoteUrl: `https://cloud.example.test/v1/projects/${PROJECT_ID}/repository.git`,
+      gitRemoteUrl: `https://cloud.example.test/v2/projects/${PROJECT_ID}/repository.git`,
       kind: 'cloud',
       serverUrl: 'https://cloud.example.test',
-      wireVersion: 4,
+      wireVersion: 5,
     },
     createdAt: CREATED_AT,
     lastEventSequence: 0,
@@ -413,6 +414,11 @@ function acceptedRequest(baseOid: string, acceptedOid: string) {
 
 function capabilityLimits() {
   return {
+    maxCheckpointCoordinationBytes: COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxCoordinationBytes,
+    maxCheckpointManifestUtf8Bytes: COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxManifestBytes,
+    maxCheckpointRepositoryBundleBytes:
+      COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxRepositoryBundleBytes,
+    maxCheckpointStagingBytes: COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxStagingBytes,
     maxDevelopmentBootstrapGitBundleBytes: 1_024,
     maxDevelopmentBootstrapManifestUtf8Bytes: 1_024,
     maxDevelopmentBootstrapReportUtf8Bytes: 1_024,

--- a/tests/integration/app/collab/bootstrap/CloudBindingRecovery.test.ts
+++ b/tests/integration/app/collab/bootstrap/CloudBindingRecovery.test.ts
@@ -54,7 +54,7 @@ const OTHER_PERSONAL_REF = collabMemberRef(OTHER_MEMBER_ID);
 const OLD_ENDPOINT = 'https://192.168.1.20:54545/';
 const OLD_REMOTE = `${OLD_ENDPOINT}v1/git/${PROJECT_ID}/repository.git`;
 const CLOUD_ORIGIN = 'https://cloud.example.test';
-const CLOUD_REMOTE = `${CLOUD_ORIGIN}/v1/projects/${PROJECT_ID}/repository.git`;
+const CLOUD_REMOTE = `${CLOUD_ORIGIN}/v2/projects/${PROJECT_ID}/repository.git`;
 const CRASH = new Error('simulated process crash');
 
 jest.setTimeout(30_000);

--- a/tests/integration/app/collab/gates/CloudLocalMilestoneGate.test.ts
+++ b/tests/integration/app/collab/gates/CloudLocalMilestoneGate.test.ts
@@ -333,7 +333,7 @@ async function createClient(
   const stored = await projects.loadMembership(projectId);
   expect(stored && isCollabLocalCloudMembership(stored)).toBe(true);
   expect(await git(repositoryPath, ['remote', 'get-url', 'origin']))
-    .toBe(`${descriptor.origin}/v1/projects/${projectId}/repository.git`);
+    .toBe(`${descriptor.origin}/v2/projects/${projectId}/repository.git`);
   return {
     git: repositories,
     memberId,

--- a/tests/integration/app/collab/gates/CloudPublishGate.test.ts
+++ b/tests/integration/app/collab/gates/CloudPublishGate.test.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { promisify } from 'node:util';
 
 import {
+  COLLAB_CHECKPOINT_ARTIFACT_LIMITS,
   COLLAB_CLOUD_BINDING_LIMITS,
   COLLAB_LIMITS,
   COLLAB_MAIN_REF,
@@ -164,6 +165,11 @@ async function runGitHttpBackend(
 
 function capabilityLimits() {
   return {
+    maxCheckpointCoordinationBytes: COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxCoordinationBytes,
+    maxCheckpointManifestUtf8Bytes: COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxManifestBytes,
+    maxCheckpointRepositoryBundleBytes:
+      COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxRepositoryBundleBytes,
+    maxCheckpointStagingBytes: COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxStagingBytes,
     maxDevelopmentBootstrapGitBundleBytes:
       COLLAB_CLOUD_BINDING_LIMITS.maxDevelopmentBootstrapGitBundleBytes,
     maxDevelopmentBootstrapManifestUtf8Bytes:
@@ -209,7 +215,7 @@ async function startGateServer(repository: RepositoryFixture): Promise<GateServe
         || match.kind === 'git-receive-pack'
         || match.kind === 'git-upload-pack'
       ) {
-        const prefix = `/v1/projects/${PROJECT_ID}/repository.git`;
+        const prefix = `/v2/projects/${PROJECT_ID}/repository.git`;
         const pathname = new URL(request.url ?? '/', 'http://127.0.0.1').pathname;
         await runGitHttpBackend(
           request,
@@ -293,12 +299,12 @@ function membership(
 ): CollabLocalCloudMembershipRecord {
   return {
     authority: {
-      bindingVersion: 1,
+      bindingVersion: 2,
       developmentActorId: actor,
-      gitRemoteUrl: `${origin}/v1/projects/${PROJECT_ID}/repository.git`,
+      gitRemoteUrl: `${origin}/v2/projects/${PROJECT_ID}/repository.git`,
       kind: 'cloud',
       serverUrl: origin,
-      wireVersion: 4,
+      wireVersion: 5,
     },
     createdAt: CREATED_AT,
     lastEventSequence: 0,
@@ -428,7 +434,7 @@ describe('Cloud Publish gate', () => {
           'remote',
           'set-url',
           'origin',
-          `${server.origin}/v1/projects/${PROJECT_ID}/repository.git`,
+          `${server.origin}/v2/projects/${PROJECT_ID}/repository.git`,
         ]);
         await writeFile(path.join(repositoryPath, `${actor}.md`), `${actor}\n`);
 

--- a/tests/integration/app/collab/gates/CloudReadBindingGate.test.ts
+++ b/tests/integration/app/collab/gates/CloudReadBindingGate.test.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { promisify } from 'node:util';
 
 import {
+  COLLAB_CHECKPOINT_ARTIFACT_LIMITS,
   COLLAB_CLOUD_BINDING_LIMITS,
   COLLAB_LIMITS,
   COLLAB_MAIN_REF,
@@ -262,6 +263,11 @@ async function runGitHttpBackend(
 async function startGateServer(repository: RepositoryFixture): Promise<GateServer> {
   const manifest = bootstrapManifest(repository);
   const limits = {
+    maxCheckpointCoordinationBytes: COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxCoordinationBytes,
+    maxCheckpointManifestUtf8Bytes: COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxManifestBytes,
+    maxCheckpointRepositoryBundleBytes:
+      COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxRepositoryBundleBytes,
+    maxCheckpointStagingBytes: COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxStagingBytes,
     maxDevelopmentBootstrapGitBundleBytes: 1024,
     maxDevelopmentBootstrapManifestUtf8Bytes: 1024,
     maxDevelopmentBootstrapReportUtf8Bytes: 1024,
@@ -334,7 +340,7 @@ async function startGateServer(repository: RepositoryFixture): Promise<GateServe
         match.kind === 'git-info-refs'
         || match.kind === 'git-upload-pack'
       ) {
-        const prefix = `/v1/projects/${PROJECT_ID}/repository.git`;
+        const prefix = `/v2/projects/${PROJECT_ID}/repository.git`;
         const pathname = new URL(request.url ?? '/', 'http://127.0.0.1').pathname;
         await runGitHttpBackend(request, response, repository, pathname.slice(prefix.length));
         return;
@@ -590,7 +596,7 @@ describe('Cloud read and binding gate', () => {
         expect(JSON.stringify(storedMembership)).not.toContain('CERTIFICATE');
         expect((await client.projects.loadIndex()).projects[0]?.authorityKind).toBe('cloud');
         expect(await git(client.repositoryPath, ['remote', 'get-url', 'origin']))
-          .toBe(`${server.origin}/v1/projects/${PROJECT_ID}/repository.git`);
+          .toBe(`${server.origin}/v2/projects/${PROJECT_ID}/repository.git`);
         expect(await readFile(path.join(client.repositoryPath, 'unpublished.md'), 'utf8'))
           .toBe(`${storedMembership?.member.id} local work\n`);
 

--- a/tests/integration/app/collab/lan/LanHostCoordinator.test.ts
+++ b/tests/integration/app/collab/lan/LanHostCoordinator.test.ts
@@ -682,12 +682,12 @@ describe('LanHostCoordinator production transport', () => {
     if (!existing) throw new Error('Missing membership fixture');
     await localProjects.saveMembership({
       authority: {
-        bindingVersion: 1,
+        bindingVersion: 2,
         developmentActorId: existing.member.id,
-        gitRemoteUrl: `http://127.0.0.1:8787/v1/projects/${PROJECT_ID}/repository.git`,
+        gitRemoteUrl: `http://127.0.0.1:8787/v2/projects/${PROJECT_ID}/repository.git`,
         kind: 'cloud',
         serverUrl: 'http://127.0.0.1:8787/',
-        wireVersion: 4,
+        wireVersion: 5,
       },
       createdAt: existing.createdAt,
       lastEventSequence: existing.lastEventSequence,

--- a/tests/integration/app/collab/local/CollabLocalProjectRepository.test.ts
+++ b/tests/integration/app/collab/local/CollabLocalProjectRepository.test.ts
@@ -90,12 +90,12 @@ function membershipRecord(
 function cloudMembershipRecord(): CollabLocalCloudMembershipRecord {
   return {
     authority: {
-      bindingVersion: 1,
+      bindingVersion: 2,
       developmentActorId: 'member-alice',
-      gitRemoteUrl: `http://127.0.0.1:8787/v1/projects/${PROJECT_ID}/repository.git`,
+      gitRemoteUrl: `http://127.0.0.1:8787/v2/projects/${PROJECT_ID}/repository.git`,
       kind: 'cloud',
       serverUrl: 'http://127.0.0.1:8787/',
-      wireVersion: 4,
+      wireVersion: 5,
     },
     createdAt: '2026-08-08T00:00:00.000Z',
     lastEventSequence: 7,

--- a/tests/integration/app/collab/publish/CloudPublishRecovery.test.ts
+++ b/tests/integration/app/collab/publish/CloudPublishRecovery.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import {
+  COLLAB_CHECKPOINT_ARTIFACT_LIMITS,
   COLLAB_LIMITS,
   collabCloudCapabilityDocument,
   collabCloudSuccessEnvelope,
@@ -244,12 +245,12 @@ class MemoryPublicationState {
 function membership(gitRemoteUrl: string): CollabLocalCloudMembershipRecord {
   return {
     authority: {
-      bindingVersion: 1,
+      bindingVersion: 2,
       developmentActorId: ACTOR_ID,
       gitRemoteUrl,
       kind: 'cloud',
       serverUrl: 'https://cloud.example.test',
-      wireVersion: 4,
+      wireVersion: 5,
     },
     createdAt: CREATED_AT,
     lastEventSequence: 0,
@@ -272,6 +273,11 @@ function membership(gitRemoteUrl: string): CollabLocalCloudMembershipRecord {
 
 function capabilityLimits() {
   return {
+    maxCheckpointCoordinationBytes: COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxCoordinationBytes,
+    maxCheckpointManifestUtf8Bytes: COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxManifestBytes,
+    maxCheckpointRepositoryBundleBytes:
+      COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxRepositoryBundleBytes,
+    maxCheckpointStagingBytes: COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxStagingBytes,
     maxDevelopmentBootstrapGitBundleBytes: 1_024,
     maxDevelopmentBootstrapManifestUtf8Bytes: 1_024,
     maxDevelopmentBootstrapReportUtf8Bytes: 1_024,

--- a/tests/unit/app/collab/bootstrap/CloudBootstrapCoordinator.test.ts
+++ b/tests/unit/app/collab/bootstrap/CloudBootstrapCoordinator.test.ts
@@ -330,7 +330,7 @@ describe('CloudBootstrapCoordinator', () => {
       terminalCleanupCompleted: true,
     });
     expect(result.newAuthority.gitRemoteUrl).toBe(
-      `https://cloud.example.test/v1/projects/${PROJECT_ID}/repository.git`,
+      `https://cloud.example.test/v2/projects/${PROJECT_ID}/repository.git`,
     );
   });
 

--- a/tests/unit/app/collab/bootstrap/CloudBootstrapTransitionRecord.test.ts
+++ b/tests/unit/app/collab/bootstrap/CloudBootstrapTransitionRecord.test.ts
@@ -52,7 +52,7 @@ describe('CloudBootstrapTransitionRecord', () => {
       memberId: HOST_MEMBER_ID,
       newAuthority: {
         bindingVersion: COLLAB_CLOUD_BINDING_VERSION,
-        gitRemoteUrl: `https://cloud.example.test/v1/projects/${PROJECT_ID}/repository.git`,
+        gitRemoteUrl: `https://cloud.example.test/v2/projects/${PROJECT_ID}/repository.git`,
         serverUrl: 'https://cloud.example.test/',
         wireVersion: COLLAB_PROTOCOL_VERSION,
       },
@@ -117,7 +117,7 @@ describe('CloudBootstrapTransitionRecord', () => {
     });
 
     expect(record.newAuthority).toMatchObject({
-      gitRemoteUrl: `http://127.0.0.1:8787/v1/projects/${PROJECT_ID}/repository.git`,
+      gitRemoteUrl: `http://127.0.0.1:8787/v2/projects/${PROJECT_ID}/repository.git`,
       serverUrl: 'http://127.0.0.1:8787/',
     });
     expect(() => createCloudBootstrapTransitionRecord({

--- a/tests/unit/app/collab/bootstrap/LocalCloudBootstrapBindingEffects.test.ts
+++ b/tests/unit/app/collab/bootstrap/LocalCloudBootstrapBindingEffects.test.ts
@@ -208,12 +208,12 @@ describe('LocalCloudBootstrapBindingEffects', () => {
       undefined,
     );
     expect(membership.authority).toEqual({
-      bindingVersion: 1,
+      bindingVersion: 2,
       developmentActorId: HOST_MEMBER_ID,
       gitRemoteUrl: record.newAuthority.gitRemoteUrl,
       kind: 'cloud',
       serverUrl: record.newAuthority.serverUrl,
-      wireVersion: 4,
+      wireVersion: 5,
     });
     expect(JSON.stringify(membership)).not.toContain('credential');
     expect(JSON.stringify(membership)).not.toContain('PRIVATE CA');

--- a/tests/unit/app/collab/client/CollabClientProjection.test.ts
+++ b/tests/unit/app/collab/client/CollabClientProjection.test.ts
@@ -835,12 +835,12 @@ function membership(): CollabLocalLanMembershipRecord {
 function cloudMembership(): CollabLocalCloudMembershipRecord {
   return {
     authority: {
-      bindingVersion: 1,
+      bindingVersion: 2,
       developmentActorId: 'member-a',
-      gitRemoteUrl: 'https://cloud.example.test/v1/projects/project-a/repository.git',
+      gitRemoteUrl: 'https://cloud.example.test/v2/projects/project-a/repository.git',
       kind: 'cloud',
       serverUrl: 'https://cloud.example.test',
-      wireVersion: 4,
+      wireVersion: 5,
     },
     createdAt: CREATED_AT,
     lastEventSequence: 0,

--- a/tests/unit/app/collab/git/CollabGitOriginPolicy.test.ts
+++ b/tests/unit/app/collab/git/CollabGitOriginPolicy.test.ts
@@ -83,7 +83,7 @@ describe('CollabGitOriginPolicy', () => {
   });
 
   it('rotates an exact LAN origin to the canonical Cloud Project route idempotently', async () => {
-    const cloudUrl = 'https://cloud.example.test/v1/projects/project-a/repository.git';
+    const cloudUrl = 'https://cloud.example.test/v2/projects/project-a/repository.git';
     const repository = git([oldUrl]);
 
     await rotateCloudBootstrapOrigin(repository, {
@@ -103,7 +103,7 @@ describe('CollabGitOriginPolicy', () => {
   });
 
   it('rotates a stale generated same-Project LAN origin after Host readdressing', async () => {
-    const cloudUrl = 'https://cloud.example.test/v1/projects/project-a/repository.git';
+    const cloudUrl = 'https://cloud.example.test/v2/projects/project-a/repository.git';
     const staleLanUrl = 'https://192.168.1.5:54545/v1/git/project-a/repository.git';
     const repository = git([staleLanUrl]);
 
@@ -125,7 +125,7 @@ describe('CollabGitOriginPolicy', () => {
     const repository = git([oldUrl]);
 
     await expect(rotateCloudBootstrapOrigin(repository, {
-      newRemoteUrl: 'https://cloud.example.test/v1/projects/project-b/repository.git',
+      newRemoteUrl: 'https://cloud.example.test/v2/projects/project-b/repository.git',
       oldRemoteUrl: oldUrl,
       projectId,
       repositoryPath: '/vault/workspace/project-a',
@@ -137,7 +137,7 @@ describe('CollabGitOriginPolicy', () => {
     const repository = git([oldUrl]);
 
     await rotateCloudBootstrapOrigin(repository, {
-      newRemoteUrl: 'http://127.0.0.1:8787/v1/projects/project-a/repository.git',
+      newRemoteUrl: 'http://127.0.0.1:8787/v2/projects/project-a/repository.git',
       oldRemoteUrl: oldUrl,
       projectId,
       repositoryPath: '/vault/workspace/project-a',

--- a/tests/unit/app/collab/publish/CollabPublicationService.test.ts
+++ b/tests/unit/app/collab/publish/CollabPublicationService.test.ts
@@ -1,6 +1,7 @@
 import { createServer } from 'node:http';
 
 import {
+  COLLAB_CHECKPOINT_ARTIFACT_LIMITS,
   COLLAB_CLOUD_PROJECT_SNAPSHOT_CODEC,
   COLLAB_LIMITS,
   collabCloudCapabilityDocument,
@@ -46,12 +47,12 @@ const CLOUD_CREATED_AT = '2026-08-24T00:00:00.000Z';
 function cloudMembership(serverUrl: string): CollabLocalCloudMembershipRecord {
   return {
     authority: {
-      bindingVersion: 1,
+      bindingVersion: 2,
       developmentActorId: CLOUD_MEMBER_ID,
-      gitRemoteUrl: `${serverUrl}/v1/projects/${CLOUD_PROJECT_ID}/repository.git`,
+      gitRemoteUrl: `${serverUrl}/v2/projects/${CLOUD_PROJECT_ID}/repository.git`,
       kind: 'cloud',
       serverUrl,
-      wireVersion: 4,
+      wireVersion: 5,
     },
     createdAt: CLOUD_CREATED_AT,
     lastEventSequence: 0,
@@ -100,6 +101,11 @@ function cloudSnapshot() {
 }
 
 const cloudLimits = {
+  maxCheckpointCoordinationBytes: COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxCoordinationBytes,
+  maxCheckpointManifestUtf8Bytes: COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxManifestBytes,
+  maxCheckpointRepositoryBundleBytes:
+    COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxRepositoryBundleBytes,
+  maxCheckpointStagingBytes: COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxStagingBytes,
   maxDevelopmentBootstrapGitBundleBytes: 1_024,
   maxDevelopmentBootstrapManifestUtf8Bytes: 1_024,
   maxDevelopmentBootstrapReportUtf8Bytes: 1_024,
@@ -152,7 +158,7 @@ describe('CollabPublicationService reconnect', () => {
       });
       expect(routes).toEqual([
         '/collab/capabilities',
-        `/v1/projects/${CLOUD_PROJECT_ID}/operations/getProjectSnapshot`,
+        `/v2/projects/${CLOUD_PROJECT_ID}/operations/getProjectSnapshot`,
       ]);
     } finally {
       fetchMock.mockRestore();

--- a/tests/unit/app/collab/remote-authority/CloudAuthorityAdapter.test.ts
+++ b/tests/unit/app/collab/remote-authority/CloudAuthorityAdapter.test.ts
@@ -1,6 +1,7 @@
 import { createServer } from 'node:http';
 
 import {
+  COLLAB_CHECKPOINT_ARTIFACT_LIMITS,
   COLLAB_CLOUD_PROJECT_SNAPSHOT_CODEC,
   COLLAB_LIMITS,
   collabCloudCapabilityDocument,
@@ -71,12 +72,12 @@ function ticketDetail(overrides: Readonly<Record<string, unknown>> = {}) {
 function membership(): CollabLocalCloudMembershipRecord {
   return {
     authority: {
-      bindingVersion: 1,
+      bindingVersion: 2,
       developmentActorId: ACTOR_ID,
-      gitRemoteUrl: `https://cloud.example.test/v1/projects/${PROJECT_ID}/repository.git`,
+      gitRemoteUrl: `https://cloud.example.test/v2/projects/${PROJECT_ID}/repository.git`,
       kind: 'cloud',
       serverUrl: 'https://cloud.example.test',
-      wireVersion: 4,
+      wireVersion: 5,
     },
     createdAt: '2026-08-22T00:00:00.000Z',
     lastEventSequence: 3,
@@ -98,6 +99,11 @@ function membership(): CollabLocalCloudMembershipRecord {
 }
 
 const limits = {
+  maxCheckpointCoordinationBytes: COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxCoordinationBytes,
+  maxCheckpointManifestUtf8Bytes: COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxManifestBytes,
+  maxCheckpointRepositoryBundleBytes:
+    COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxRepositoryBundleBytes,
+  maxCheckpointStagingBytes: COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxStagingBytes,
   maxDevelopmentBootstrapGitBundleBytes: 1_024,
   maxDevelopmentBootstrapManifestUtf8Bytes: 1_024,
   maxDevelopmentBootstrapReportUtf8Bytes: 1_024,
@@ -187,7 +193,7 @@ describe('CloudAuthorityAdapter', () => {
         { actor: ACTOR_ID, url: '/collab/capabilities' },
         {
           actor: ACTOR_ID,
-          url: `/v1/projects/${PROJECT_ID}/operations/getProjectSnapshot`,
+          url: `/v2/projects/${PROJECT_ID}/operations/getProjectSnapshot`,
         },
       ]);
     } finally {
@@ -247,7 +253,7 @@ describe('CloudAuthorityAdapter', () => {
         sensitive: false,
         value: ACTOR_ID,
       }],
-      remoteUrl: `https://cloud.example.test/v1/projects/${PROJECT_ID}/repository.git`,
+      remoteUrl: `https://cloud.example.test/v2/projects/${PROJECT_ID}/repository.git`,
     });
     expect(requests).toEqual([
       expect.objectContaining({
@@ -259,7 +265,7 @@ describe('CloudAuthorityAdapter', () => {
         body: expect.objectContaining({ data: { projectId: PROJECT_ID } }),
         headers: { 'x-claudian-development-actor': ACTOR_ID },
         method: 'POST',
-        url: `https://cloud.example.test/v1/projects/${PROJECT_ID}/operations/getProjectSnapshot`,
+        url: `https://cloud.example.test/v2/projects/${PROJECT_ID}/operations/getProjectSnapshot`,
       }),
     ]);
   });
@@ -307,13 +313,13 @@ describe('CloudAuthorityAdapter', () => {
           idempotencyKey: 'publish-head',
           projectId: PROJECT_ID,
         },
-        protocolVersion: 4,
+        protocolVersion: 5,
         requestId: 'request-ensure',
       },
       headers: { 'x-claudian-development-actor': ACTOR_ID },
       method: 'POST',
       signal: controller.signal,
-      url: `https://cloud.example.test/v1/projects/${PROJECT_ID}/operations/ensureMyRequest`,
+      url: `https://cloud.example.test/v2/projects/${PROJECT_ID}/operations/ensureMyRequest`,
     });
   });
 
@@ -365,13 +371,13 @@ describe('CloudAuthorityAdapter', () => {
           projectId: PROJECT_ID,
           requestId: 'request-one',
         },
-        protocolVersion: 4,
+        protocolVersion: 5,
         requestId: expect.any(String),
       },
       headers: { 'x-claudian-development-actor': ACTOR_ID },
       method: 'POST',
       signal: controller.signal,
-      url: `https://cloud.example.test/v1/projects/${PROJECT_ID}/operations/acceptRequest`,
+      url: `https://cloud.example.test/v2/projects/${PROJECT_ID}/operations/acceptRequest`,
     });
   });
 
@@ -701,7 +707,7 @@ describe('CloudAuthorityAdapter', () => {
     const document = collabCloudCapabilityDocument(['project-snapshot'], limits);
     const adapter = new CloudAuthorityAdapter({
       request: async () => ({
-        body: { ...document, bindingVersions: [2] },
+        body: { ...document, bindingVersions: [1] },
         contentType: 'application/json',
         status: 200,
       }),
@@ -749,7 +755,7 @@ describe('CloudProjectEventClient', () => {
         sockets.push(socket);
         expect(input).toEqual({
           headers: { 'x-claudian-development-actor': ACTOR_ID },
-          url: `wss://cloud.example.test/v1/projects/${PROJECT_ID}/events?afterSequence=${
+          url: `wss://cloud.example.test/v2/projects/${PROJECT_ID}/events?afterSequence=${
             sockets.length === 1 ? 3 : 5
           }`,
         });
@@ -797,7 +803,7 @@ describe('CloudProjectEventClient', () => {
         const socket = new FakeSocket();
         sockets.push(socket);
         expect(input.url).toBe(
-          `wss://cloud.example.test/v1/projects/${PROJECT_ID}/events?afterSequence=${
+          `wss://cloud.example.test/v2/projects/${PROJECT_ID}/events?afterSequence=${
             sockets.length === 1 ? 3 : 4
           }`,
         );
@@ -817,7 +823,7 @@ describe('CloudProjectEventClient', () => {
       occurredAt: '2026-08-22T00:00:00.000Z',
       payload: { requestId: 'request-one' },
       projectId: PROJECT_ID,
-      protocolVersion: 4,
+      protocolVersion: 5,
       sequence: 4,
     }));
     sockets[0]!.closed(1006);
@@ -855,7 +861,7 @@ describe('CloudProjectEventClient', () => {
         occurredAt: '2026-08-22T00:00:00.000Z',
         payload: { requestId: `request-${sequence}` },
         projectId: PROJECT_ID,
-        protocolVersion: 4,
+        protocolVersion: 5,
         sequence,
       }));
     }
@@ -891,7 +897,7 @@ describe('CloudProjectEventClient', () => {
       occurredAt: '2026-08-22T00:00:00.000Z',
       payload: { requestId: 'request-four' },
       projectId: PROJECT_ID,
-      protocolVersion: 4,
+      protocolVersion: 5,
       sequence: 4,
     }));
     await flush();

--- a/tests/unit/app/collab/remote-authority/CollabAuthoritySessionFactory.test.ts
+++ b/tests/unit/app/collab/remote-authority/CollabAuthoritySessionFactory.test.ts
@@ -5,12 +5,12 @@ import { CollabAuthoritySessionFactory } from '@/app/collab/remote-authority/Col
 function cloudMembership(): CollabLocalCloudMembershipRecord {
   return {
     authority: {
-      bindingVersion: 1,
+      bindingVersion: 2,
       developmentActorId: 'member-alice',
-      gitRemoteUrl: 'https://cloud.example.test/v1/git/project-cloud/repository.git',
+      gitRemoteUrl: 'https://cloud.example.test/v2/projects/project-cloud/repository.git',
       kind: 'cloud',
       serverUrl: 'https://cloud.example.test',
-      wireVersion: 4,
+      wireVersion: 5,
     },
     createdAt: '2026-08-22T00:00:00.000Z',
     lastEventSequence: 0,


### PR DESCRIPTION
## Summary
- pin the published protocol 2.0.0 registry artifact exactly
- adopt Cloud wire v5 and binding v2 routes and envelopes
- keep LAN Project-control v9 independent from the expanded Cloud lifecycle registry
- add exact registry artifact boundary checks

## Verification
- npm run typecheck
- npm run lint
- full test suite: 8,472 passed, 1 skipped
- production build: main.js 4.7 MB
- independent review-and-repair: no material findings