### PR TITLE
feat: add LAN authority checkpoint foundation

### DIFF
--- a/scripts/check-architecture-boundaries.test.mjs
+++ b/scripts/check-architecture-boundaries.test.mjs
@@ -718,7 +718,7 @@ test('production consumes protocol-owned canonical Collab Git refs', () => {
   ), []);
   assert.deepEqual(findForbiddenSymbolInventoryViolations(
     /refs\/heads\/members\//,
-    new Map([['src/app/collab/authority/AuthoritySchema.ts', 1]]),
+    new Map(),
   ), []);
   assert.deepEqual(findForbiddenSymbolInventoryViolations(
     /refs\/remotes\/origin\/main/,

--- a/src/app/collab/CollabSchemaVersions.ts
+++ b/src/app/collab/CollabSchemaVersions.ts
@@ -1,2 +1,2 @@
 export const COLLAB_LOCAL_PROJECT_SCHEMA_VERSION = 3 as const;
-export const COLLAB_AUTHORITY_SCHEMA_VERSION = 11 as const;
+export const COLLAB_AUTHORITY_SCHEMA_VERSION = 12 as const;

--- a/src/app/collab/authority-transfer/checkpoint/AuthorityTransferAdmissionSettlement.ts
+++ b/src/app/collab/authority-transfer/checkpoint/AuthorityTransferAdmissionSettlement.ts
@@ -1,0 +1,156 @@
+import {
+  COLLAB_MAIN_REF,
+  COLLAB_MEMBER_REF_PREFIX,
+  type CollabMemberId,
+  collabMemberRef,
+  isCollabMemberId,
+} from '@claudian-collab/protocol';
+
+import type {
+  AuthorityDatabaseConnection,
+  SqlJsMutationResult,
+} from '@/app/collab/authority/SqlJsProjectDatabase';
+import type { GitCommandRunner } from '@/app/collab/git/GitCommandRunner';
+import { CollabError } from '@/core/collab/ClaudianCollabError';
+
+interface AdmissionSettlementDatabase {
+  read<T>(reader: (connection: AuthorityDatabaseConnection) => T): Promise<T>;
+  mutate<T>(
+    mutation: (connection: AuthorityDatabaseConnection) => T,
+  ): Promise<SqlJsMutationResult<T>>;
+}
+
+interface PendingAdmissionIdentity {
+  readonly memberId: CollabMemberId;
+  readonly personalRef: string;
+}
+
+export interface AuthorityTransferAdmissionSettlementOptions {
+  readonly database: AdmissionSettlementDatabase;
+  readonly runner: Pick<GitCommandRunner, 'run'>;
+}
+
+export interface SettleAuthorityTransferAdmissionInput {
+  readonly repositoryPath: string;
+  readonly settledAt: string;
+  readonly signal?: AbortSignal;
+}
+
+function settlementError(reason: string): CollabError {
+  return new CollabError({
+    code: 'authority-integrity-error',
+    recoveryActions: ['resume', 'open-diagnostics'],
+    safeContext: { reason },
+  });
+}
+
+function pendingAdmissions(
+  connection: AuthorityDatabaseConnection,
+): readonly PendingAdmissionIdentity[] {
+  return connection.all(`
+    SELECT member_id, personal_ref
+    FROM members
+    WHERE status = 'pending'
+    ORDER BY member_id
+  `).map((row) => {
+    const memberId = row.member_id;
+    const personalRef = row.personal_ref;
+    if (
+      typeof memberId !== 'string'
+      || !isCollabMemberId(memberId)
+      || personalRef !== collabMemberRef(memberId)
+    ) throw settlementError('authority-transfer-pending-member-invalid');
+    return { memberId, personalRef };
+  });
+}
+
+function samePendingAdmissions(
+  left: readonly PendingAdmissionIdentity[],
+  right: readonly PendingAdmissionIdentity[],
+): boolean {
+  return left.length === right.length && left.every((item, index) => (
+    item.memberId === right[index]?.memberId
+    && item.personalRef === right[index]?.personalRef
+  ));
+}
+
+function parseRefs(stdout: Buffer): ReadonlyMap<string, string> {
+  const refs = new Map<string, string>();
+  const lines = stdout.toString('utf8').trim();
+  if (lines.length === 0) return refs;
+  for (const line of lines.split('\n')) {
+    const separator = line.indexOf(' ');
+    if (separator < 1) throw settlementError('authority-transfer-ref-inventory-invalid');
+    refs.set(line.slice(separator + 1), line.slice(0, separator));
+  }
+  return refs;
+}
+
+export class AuthorityTransferAdmissionSettlement {
+  constructor(private readonly options: AuthorityTransferAdmissionSettlementOptions) {}
+
+  async settle(input: SettleAuthorityTransferAdmissionInput): Promise<void> {
+    if (
+      Number.isNaN(Date.parse(input.settledAt))
+      || new Date(input.settledAt).toISOString() !== input.settledAt
+    ) throw settlementError('authority-transfer-settlement-time-invalid');
+    const pending = await this.options.database.read((connection) => {
+      const state = connection.get('SELECT state FROM project WHERE singleton = 1')?.state;
+      if (state !== 'active') throw settlementError('authority-transfer-source-not-active');
+      return pendingAdmissions(connection);
+    });
+    const inventory = parseRefs((await this.options.runner.run({
+      args: [
+        'for-each-ref',
+        '--format=%(objectname) %(refname)',
+        COLLAB_MAIN_REF,
+        COLLAB_MEMBER_REF_PREFIX,
+      ],
+      cwd: input.repositoryPath,
+      maxStdoutBytes: 1024 * 1024,
+      signal: input.signal,
+      suppressHooks: true,
+    })).stdout);
+    const mainOid = inventory.get(COLLAB_MAIN_REF);
+    if (!mainOid) throw settlementError('authority-transfer-main-ref-missing');
+    for (const member of pending) {
+      const oid = inventory.get(member.personalRef);
+      if (oid !== undefined && oid !== mainOid) {
+        throw settlementError('authority-transfer-pending-ref-diverged');
+      }
+    }
+
+    for (const member of pending) {
+      const oid = inventory.get(member.personalRef);
+      if (oid === undefined) continue;
+      await this.options.runner.run({
+        args: ['update-ref', '-d', member.personalRef, oid],
+        cwd: input.repositoryPath,
+        maxStdoutBytes: 64 * 1024,
+        signal: input.signal,
+        suppressHooks: true,
+      });
+    }
+
+    await this.options.database.mutate((connection) => {
+      const current = pendingAdmissions(connection);
+      if (!samePendingAdmissions(current, pending)) {
+        throw settlementError('authority-transfer-pending-admission-stale');
+      }
+      connection.run(`
+        UPDATE invitations
+        SET revoked_at = ?
+        WHERE revoked_at IS NULL
+      `, [input.settledAt]);
+      for (const member of pending) {
+        const changes = connection.run(`
+          DELETE FROM members
+          WHERE member_id = ? AND status = 'pending' AND personal_ref = ?
+        `, [member.memberId, member.personalRef]);
+        if (changes !== 1) {
+          throw settlementError('authority-transfer-pending-admission-stale');
+        }
+      }
+    });
+  }
+}

--- a/src/app/collab/authority-transfer/checkpoint/AuthorityTransferCheckpointGit.ts
+++ b/src/app/collab/authority-transfer/checkpoint/AuthorityTransferCheckpointGit.ts
@@ -1,0 +1,324 @@
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { lstat, mkdir, rm } from 'node:fs/promises';
+import path from 'node:path';
+
+import {
+  COLLAB_CHECKPOINT_ARTIFACT_LIMITS,
+  COLLAB_MAIN_REF,
+  COLLAB_MEMBER_REF_PREFIX,
+  type CollabCheckpointArtifactFact,
+  type CollabCheckpointGitRef,
+  type CollabProjectCheckpointManifest,
+  isCollabGitOid,
+} from '@claudian-collab/protocol';
+
+import { verifyAuthorityTransferCheckpointManifest } from '@/app/collab/authority-transfer/checkpoint/AuthorityTransferCheckpointManifest';
+import type { GitCommandRunner } from '@/app/collab/git/GitCommandRunner';
+import { CollabError } from '@/core/collab/ClaudianCollabError';
+
+export interface AuthorityTransferCheckpointGitInput {
+  readonly bundlePath: string;
+  readonly refs: readonly CollabCheckpointGitRef[];
+  readonly repositoryPath: string;
+  readonly signal?: AbortSignal;
+}
+
+export interface ImportAuthorityTransferCheckpointGitInput {
+  readonly bundlePath: string;
+  readonly manifest: CollabProjectCheckpointManifest;
+  readonly signal?: AbortSignal;
+  readonly targetRepositoryPath: string;
+}
+
+function gitError(
+  reason: string,
+  code: 'authority-integrity-error' | 'cancelled' | 'operation-failed' | 'quota-exceeded'
+    = 'authority-integrity-error',
+): CollabError {
+  return new CollabError({
+    code,
+    recoveryActions: code === 'cancelled' ? ['retry'] : ['open-diagnostics'],
+    safeContext: { reason },
+  });
+}
+
+function assertRefs(refs: readonly CollabCheckpointGitRef[]): void {
+  if (
+    refs.length === 0
+    || refs[0]?.name !== COLLAB_MAIN_REF
+    || refs.some((ref, index) => (
+      !isCollabGitOid(ref.oid)
+      || (ref.name !== COLLAB_MAIN_REF && !ref.name.startsWith(COLLAB_MEMBER_REF_PREFIX))
+      || (index > 0 && refs[index - 1].name.localeCompare(ref.name, 'en-US') >= 0)
+    ))
+  ) throw gitError('checkpoint-git-refs-invalid');
+}
+
+function parseHeads(stdout: Buffer): readonly CollabCheckpointGitRef[] {
+  const text = stdout.toString('utf8').trim();
+  if (text.length === 0) throw gitError('checkpoint-git-bundle-empty');
+  return text.split('\n').map((line) => {
+    const separator = line.indexOf(' ');
+    if (separator < 1) throw gitError('checkpoint-git-bundle-head-invalid');
+    const oid = line.slice(0, separator);
+    const name = line.slice(separator + 1);
+    if (!isCollabGitOid(oid)) throw gitError('checkpoint-git-bundle-head-invalid');
+    return { name, oid };
+  });
+}
+
+function assertExactHeads(
+  actual: readonly CollabCheckpointGitRef[],
+  expected: readonly CollabCheckpointGitRef[],
+): void {
+  if (
+    actual.length !== expected.length
+    || actual.some((ref, index) => (
+      ref.name !== expected[index]?.name || ref.oid !== expected[index]?.oid
+    ))
+  ) throw gitError('checkpoint-git-bundle-ref-mismatch');
+}
+
+function assertArtifactFact(
+  actual: CollabCheckpointArtifactFact,
+  expected: CollabCheckpointArtifactFact,
+): void {
+  if (
+    actual.name !== expected.name
+    || actual.byteCount !== expected.byteCount
+    || actual.sha256 !== expected.sha256
+  ) throw gitError('checkpoint-git-bundle-artifact-mismatch');
+}
+
+async function inspectBundle(
+  bundlePath: string,
+  signal?: AbortSignal,
+): Promise<CollabCheckpointArtifactFact> {
+  const info = await lstat(bundlePath).catch(() => null);
+  if (!info || !info.isFile() || info.isSymbolicLink()) {
+    throw gitError('checkpoint-git-bundle-file-invalid');
+  }
+  if (
+    info.size < 1
+    || info.size > COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxRepositoryBundleBytes
+  ) throw gitError('checkpoint-git-bundle-size-invalid', 'quota-exceeded');
+  const digest = createHash('sha256');
+  let byteCount = 0;
+  try {
+    for await (const chunk of createReadStream(bundlePath)) {
+      if (signal?.aborted) throw gitError('checkpoint-git-bundle-cancelled', 'cancelled');
+      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      byteCount += bytes.byteLength;
+      if (byteCount > COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxRepositoryBundleBytes) {
+        throw gitError('checkpoint-git-bundle-size-invalid', 'quota-exceeded');
+      }
+      digest.update(bytes);
+    }
+  } catch (error) {
+    if (error instanceof CollabError) throw error;
+    throw gitError('checkpoint-git-bundle-read-failed', 'operation-failed');
+  }
+  if (byteCount !== info.size) throw gitError('checkpoint-git-bundle-changed');
+  return {
+    byteCount,
+    name: 'repository.bundle',
+    sha256: digest.digest('hex'),
+  };
+}
+
+export class AuthorityTransferCheckpointGit {
+  constructor(private readonly runner: Pick<GitCommandRunner, 'run'>) {}
+
+  async createBundle(
+    input: AuthorityTransferCheckpointGitInput,
+  ): Promise<CollabCheckpointArtifactFact> {
+    assertRefs(input.refs);
+    await this.assertRepositoryRefs(input.repositoryPath, input.refs, input.signal);
+    await rm(input.bundlePath, { force: true }).catch(() => undefined);
+    try {
+      await this.runner.run({
+        args: ['bundle', 'create', input.bundlePath, ...input.refs.map(ref => ref.name)],
+        cwd: input.repositoryPath,
+        maxStdoutBytes: 64 * 1024,
+        signal: input.signal,
+        suppressHooks: true,
+      });
+      return await this.verifyBundle(input);
+    } catch (error) {
+      await rm(input.bundlePath, { force: true }).catch(() => undefined);
+      throw error;
+    }
+  }
+
+  async verifyBundle(
+    input: AuthorityTransferCheckpointGitInput,
+  ): Promise<CollabCheckpointArtifactFact> {
+    assertRefs(input.refs);
+    await this.runner.run({
+      args: ['bundle', 'verify', input.bundlePath],
+      cwd: input.repositoryPath,
+      maxStdoutBytes: 1024 * 1024,
+      signal: input.signal,
+      suppressHooks: true,
+    });
+    const heads = await this.runner.run({
+      args: ['bundle', 'list-heads', input.bundlePath],
+      cwd: input.repositoryPath,
+      maxStdoutBytes: 1024 * 1024,
+      signal: input.signal,
+      suppressHooks: true,
+    });
+    assertExactHeads(parseHeads(heads.stdout), input.refs);
+    return inspectBundle(input.bundlePath, input.signal);
+  }
+
+  async importIntoEmptyBareRepository(
+    input: ImportAuthorityTransferCheckpointGitInput,
+  ): Promise<void> {
+    const manifest = verifyAuthorityTransferCheckpointManifest(input.manifest);
+    const refs = manifest.refs;
+    assertRefs(refs);
+    const expectedArtifact = manifest.artifacts.find(
+      artifact => artifact.name === 'repository.bundle',
+    );
+    if (expectedArtifact === undefined) throw gitError('checkpoint-git-bundle-artifact-missing');
+    assertArtifactFact(await inspectBundle(input.bundlePath, input.signal), expectedArtifact);
+    if (!path.isAbsolute(input.targetRepositoryPath)) {
+      throw gitError('checkpoint-git-target-path-invalid');
+    }
+    let created = false;
+    try {
+      try {
+        await mkdir(input.targetRepositoryPath, { mode: 0o700 });
+        created = true;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+          throw gitError('checkpoint-git-target-not-empty');
+        }
+        throw gitError('checkpoint-git-target-create-failed', 'operation-failed');
+      }
+      await this.runner.run({
+        args: [
+          'init',
+          '--bare',
+          '--initial-branch=main',
+          `--object-format=${manifest.gitObjectFormat}`,
+          '.',
+        ],
+        cwd: input.targetRepositoryPath,
+        maxStdoutBytes: 64 * 1024,
+        signal: input.signal,
+        suppressHooks: true,
+      });
+      await this.assertRepositoryIdentity(
+        input.targetRepositoryPath,
+        manifest.gitObjectFormat,
+        input.signal,
+      );
+      await this.runner.run({
+        args: ['bundle', 'verify', input.bundlePath],
+        cwd: input.targetRepositoryPath,
+        maxStdoutBytes: 1024 * 1024,
+        signal: input.signal,
+        suppressHooks: true,
+      });
+      const heads = await this.runner.run({
+        args: ['bundle', 'list-heads', input.bundlePath],
+        cwd: input.targetRepositoryPath,
+        maxStdoutBytes: 1024 * 1024,
+        signal: input.signal,
+        suppressHooks: true,
+      });
+      assertExactHeads(parseHeads(heads.stdout), refs);
+      assertArtifactFact(await inspectBundle(input.bundlePath, input.signal), expectedArtifact);
+      await this.runner.run({
+        args: [
+          'fetch',
+          '--no-tags',
+          input.bundlePath,
+          ...refs.map(ref => `${ref.name}:${ref.name}`),
+        ],
+        cwd: input.targetRepositoryPath,
+        maxStdoutBytes: 1024 * 1024,
+        signal: input.signal,
+        suppressHooks: true,
+      });
+      await this.assertRepositoryRefs(
+        input.targetRepositoryPath,
+        refs,
+        input.signal,
+        true,
+      );
+      const integrity = await this.runner.run({
+        args: ['fsck', '--strict', '--unreachable', '--no-reflogs', '--no-progress'],
+        cwd: input.targetRepositoryPath,
+        maxStdoutBytes: 1024 * 1024,
+        signal: input.signal,
+        suppressHooks: true,
+      });
+      if (
+        integrity.stdout.toString('utf8').trim().length > 0
+        || integrity.stderr.trim().length > 0
+      ) throw gitError('checkpoint-git-target-unreachable-object');
+      assertArtifactFact(await inspectBundle(input.bundlePath, input.signal), expectedArtifact);
+    } catch (error) {
+      if (created) {
+        await rm(input.targetRepositoryPath, { force: true, recursive: true })
+          .catch(() => undefined);
+      }
+      throw error;
+    }
+  }
+
+  private async assertRepositoryIdentity(
+    repositoryPath: string,
+    objectFormat: 'sha1' | 'sha256',
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const [head, actualObjectFormat] = await Promise.all([
+      this.runner.run({
+        args: ['symbolic-ref', 'HEAD'],
+        cwd: repositoryPath,
+        maxStdoutBytes: 64 * 1024,
+        signal,
+        suppressHooks: true,
+      }),
+      this.runner.run({
+        args: ['rev-parse', '--show-object-format'],
+        cwd: repositoryPath,
+        maxStdoutBytes: 64 * 1024,
+        signal,
+        suppressHooks: true,
+      }),
+    ]);
+    if (
+      head.stdout.toString('utf8').trim() !== COLLAB_MAIN_REF
+      || actualObjectFormat.stdout.toString('utf8').trim() !== objectFormat
+    ) throw gitError('checkpoint-git-target-identity-invalid');
+  }
+
+  private async assertRepositoryRefs(
+    repositoryPath: string,
+    refs: readonly CollabCheckpointGitRef[],
+    signal?: AbortSignal,
+    requireNoOtherHeads = false,
+  ): Promise<void> {
+    const result = await this.runner.run({
+      args: ['for-each-ref', '--format=%(objectname) %(refname)', 'refs/heads/'],
+      cwd: repositoryPath,
+      maxStdoutBytes: 1024 * 1024,
+      signal,
+      suppressHooks: true,
+    });
+    const allHeads = result.stdout.toString('utf8').trim();
+    const parsed = allHeads.length === 0 ? [] : parseHeads(result.stdout);
+    const selected = parsed
+      .filter(ref => refs.some(expected => expected.name === ref.name))
+      .sort((left, right) => left.name.localeCompare(right.name, 'en-US'));
+    assertExactHeads(selected, refs);
+    if (requireNoOtherHeads && parsed.length !== refs.length) {
+      throw gitError('checkpoint-git-target-extra-ref');
+    }
+  }
+}

--- a/src/app/collab/authority-transfer/checkpoint/AuthorityTransferCheckpointManifest.ts
+++ b/src/app/collab/authority-transfer/checkpoint/AuthorityTransferCheckpointManifest.ts
@@ -1,0 +1,87 @@
+import { createHash } from 'node:crypto';
+
+import {
+  COLLAB_PROJECT_CHECKPOINT_MANIFEST_SCHEMA_VERSION,
+  COLLAB_PROJECT_COORDINATION_FORMAT_VERSION,
+  COLLAB_PROTOCOL_VERSION,
+  type CollabCheckpointArtifactFact,
+  type CollabCheckpointAuthority,
+  type CollabCheckpointGitRef,
+  type CollabCheckpointObjectFormat,
+  type CollabIsoTimestamp,
+  type CollabProjectCheckpointManifest,
+  type CollabProjectId,
+  decodeCollabProjectCheckpointManifest,
+  encodeCollabProjectCheckpointManifestDigestInput,
+} from '@claudian-collab/protocol';
+
+import { CollabError } from '@/core/collab/ClaudianCollabError';
+
+export interface CreateAuthorityTransferCheckpointManifestInput {
+  readonly artifacts: readonly CollabCheckpointArtifactFact[];
+  readonly createdAt: CollabIsoTimestamp;
+  readonly expectedMainOid: string;
+  readonly gitObjectFormat: CollabCheckpointObjectFormat;
+  readonly operationId: string;
+  readonly projectId: CollabProjectId;
+  readonly refs: readonly CollabCheckpointGitRef[];
+  readonly sourceAuthority: CollabCheckpointAuthority;
+  readonly targetAuthority: CollabCheckpointAuthority;
+}
+
+function manifestError(): CollabError {
+  return new CollabError({
+    code: 'authority-integrity-error',
+    recoveryActions: ['open-diagnostics'],
+    safeContext: { reason: 'checkpoint-manifest-invalid' },
+  });
+}
+
+function digest(manifest: CollabProjectCheckpointManifest): string {
+  return createHash('sha256')
+    .update(encodeCollabProjectCheckpointManifestDigestInput(manifest), 'utf8')
+    .digest('hex');
+}
+
+export function createAuthorityTransferCheckpointManifest(
+  input: CreateAuthorityTransferCheckpointManifestInput,
+): CollabProjectCheckpointManifest {
+  try {
+    const unsigned = decodeCollabProjectCheckpointManifest({
+      artifacts: input.artifacts,
+      coordinationFormatVersion: COLLAB_PROJECT_COORDINATION_FORMAT_VERSION,
+      createdAt: input.createdAt,
+      expectedMainOid: input.expectedMainOid,
+      gitObjectFormat: input.gitObjectFormat,
+      manifestSchemaVersion: COLLAB_PROJECT_CHECKPOINT_MANIFEST_SCHEMA_VERSION,
+      manifestSha256: '0'.repeat(64),
+      operationId: input.operationId,
+      profile: 'authority-transfer',
+      projectId: input.projectId,
+      protocolVersion: COLLAB_PROTOCOL_VERSION,
+      refs: input.refs,
+      sourceAuthority: input.sourceAuthority,
+      targetAuthority: input.targetAuthority,
+    });
+    return decodeCollabProjectCheckpointManifest({
+      ...unsigned,
+      manifestSha256: digest(unsigned),
+    });
+  } catch {
+    throw manifestError();
+  }
+}
+
+export function verifyAuthorityTransferCheckpointManifest(
+  manifest: CollabProjectCheckpointManifest,
+): CollabProjectCheckpointManifest {
+  try {
+    const decoded = decodeCollabProjectCheckpointManifest(manifest);
+    if (decoded.profile !== 'authority-transfer' || decoded.manifestSha256 !== digest(decoded)) {
+      throw manifestError();
+    }
+    return decoded;
+  } catch {
+    throw manifestError();
+  }
+}

--- a/src/app/collab/authority-transfer/checkpoint/AuthorityTransferCheckpointRepository.ts
+++ b/src/app/collab/authority-transfer/checkpoint/AuthorityTransferCheckpointRepository.ts
@@ -1,0 +1,537 @@
+import { createHash } from 'node:crypto';
+
+import {
+  COLLAB_MAIN_REF,
+  type CollabCheckpointPortableRecord,
+  type CollabMemberId,
+  type CollabProjectCheckpointManifest,
+  decodeCollabProjectCheckpointCoordinationNdjson,
+  encodeCollabProjectCheckpointCoordinationNdjson,
+  validateCollabProjectCheckpointConsistency,
+} from '@claudian-collab/protocol';
+
+import { AuthorityMetadataRepository } from '@/app/collab/authority/AuthorityMetadataRepository';
+import type {
+  AuthorityDatabaseConnection,
+  AuthoritySqlRow,
+  AuthoritySqlValue,
+} from '@/app/collab/authority/SqlJsProjectDatabase';
+import { verifyAuthorityTransferCheckpointManifest } from '@/app/collab/authority-transfer/checkpoint/AuthorityTransferCheckpointManifest';
+import { CollabError } from '@/core/collab/ClaudianCollabError';
+
+export interface ExportAuthorityTransferCoordinationInput {
+  readonly expectedMainOid: string;
+}
+
+export interface ImportAuthorityTransferCoordinationInput {
+  readonly coordinationNdjson: string;
+  readonly manifest: CollabProjectCheckpointManifest;
+  readonly targetHostCredentialHash: Uint8Array;
+  readonly targetHostMemberId: CollabMemberId;
+}
+
+function checkpointError(reason: string): CollabError {
+  return new CollabError({
+    code: 'authority-integrity-error',
+    recoveryActions: ['open-diagnostics'],
+    safeContext: { reason },
+  });
+}
+
+function runCheckpointSql(
+  connection: AuthorityDatabaseConnection,
+  sql: string,
+  params: Parameters<AuthorityDatabaseConnection['run']>[1],
+  reason: string,
+): number {
+  try {
+    return connection.run(sql, params);
+  } catch {
+    throw checkpointError(reason);
+  }
+}
+
+function text(row: AuthoritySqlRow, field: string, nullable = false): string | null {
+  const value = row[field];
+  if (nullable && value === null) return null;
+  if (typeof value !== 'string') throw checkpointError('checkpoint-row-invalid');
+  return value;
+}
+
+function integer(row: AuthoritySqlRow, field: string, minimum = 0): number {
+  const value = row[field];
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < minimum) {
+    throw checkpointError('checkpoint-row-invalid');
+  }
+  return value;
+}
+
+function status(value: AuthoritySqlValue): 'active' | 'left' | 'revoked' {
+  if (value !== 'active' && value !== 'left' && value !== 'revoked') {
+    throw checkpointError('checkpoint-member-status-invalid');
+  }
+  return value;
+}
+
+function role(value: AuthoritySqlValue): 'manager' | 'member' {
+  if (value !== 'manager' && value !== 'member') {
+    throw checkpointError('checkpoint-member-role-invalid');
+  }
+  return value;
+}
+
+function sorted(rows: readonly AuthoritySqlRow[], field: string): readonly AuthoritySqlRow[] {
+  return [...rows].sort((left, right) => (
+    String(left[field]).localeCompare(String(right[field]), 'en-US')
+  ));
+}
+
+function mentionRecordId(row: AuthoritySqlRow): string {
+  const identity = [
+    text(row, 'ticket_id'),
+    text(row, 'source_kind'),
+    text(row, 'source_id'),
+    text(row, 'mentioned_member_id'),
+  ].join('\u0000');
+  return `ticket-mention-${createHash('sha256').update(identity, 'utf8').digest('hex')}`;
+}
+
+function assertCaptureReady(connection: AuthorityDatabaseConnection): void {
+  const blocked = connection.get(`
+    SELECT
+      (SELECT COUNT(*) FROM members WHERE status = 'pending') AS pending_members,
+      (SELECT COUNT(*) FROM invitations WHERE revoked_at IS NULL) AS live_invitations,
+      (SELECT COUNT(*) FROM accept_operations WHERE state != 'completed') AS pending_accepts,
+      (SELECT COUNT(*) FROM manager_responsibility_offers
+        WHERE status IN ('offered', 'acknowledged')) AS pending_manager_offers,
+      (SELECT COUNT(*) FROM host_transfer_operations
+        WHERE phase IN (
+          'offered', 'accepted', 'quiescing', 'staged',
+          'authority-relinquished', 'target-active'
+        )) AS pending_host_transfers,
+      (SELECT COUNT(*) FROM project_terminal_transitions
+        WHERE phase = 'quiescing') AS pending_terminal_transitions
+  `);
+  if (!blocked) throw checkpointError('checkpoint-readiness-invalid');
+  if (Object.values(blocked).some(value => value !== 0)) {
+    throw checkpointError('checkpoint-admission-unsettled');
+  }
+}
+
+function portableRecords(
+  connection: AuthorityDatabaseConnection,
+  input: ExportAuthorityTransferCoordinationInput,
+): readonly CollabCheckpointPortableRecord[] {
+  assertCaptureReady(connection);
+  const project = connection.get(`
+    SELECT
+      project_id, name, manager_set_generation, created_at, snapshot_generation
+    FROM project
+    WHERE singleton = 1 AND state = 'active'
+  `);
+  if (!project) throw checkpointError('checkpoint-project-not-active');
+  const projectId = text(project, 'project_id')!;
+  const authorityGeneration = new AuthorityMetadataRepository().getGeneration(connection);
+  const records: unknown[] = [{
+    kind: 'project',
+    recordId: projectId,
+    revision: integer(project, 'snapshot_generation') + 1,
+    value: {
+      activatedAt: text(project, 'created_at'),
+      authorityGeneration,
+      createdAt: text(project, 'created_at'),
+      expectedMainOid: input.expectedMainOid,
+      managerSetGeneration: integer(project, 'manager_set_generation'),
+      name: text(project, 'name'),
+      projectId,
+    },
+  }];
+
+  for (const row of sorted(connection.all(`
+    SELECT
+      member_id, display_name, personal_ref, role, status,
+      created_at, activated_at, revoked_at
+    FROM members
+    WHERE status IN ('active', 'left', 'revoked')
+  `), 'member_id')) {
+    const memberStatus = status(row.status);
+    const createdAt = text(row, 'created_at')!;
+    const activatedAt = text(row, 'activated_at', true);
+    const revokedAt = text(row, 'revoked_at', true);
+    records.push({
+      kind: 'member',
+      recordId: text(row, 'member_id'),
+      revision: 1,
+      value: {
+        activatedAt,
+        createdAt,
+        displayName: text(row, 'display_name'),
+        memberId: text(row, 'member_id'),
+        personalRef: text(row, 'personal_ref'),
+        projectId,
+        role: role(row.role),
+        status: memberStatus,
+        revokedAt,
+        updatedAt: revokedAt ?? activatedAt ?? createdAt,
+      },
+    });
+  }
+
+  for (const row of sorted(connection.all(`
+    SELECT
+      request_id, member_id, status, first_base_oid, latest_head_oid,
+      merged_oid, description, revision, created_at, updated_at
+    FROM change_requests
+  `), 'request_id')) {
+    records.push({
+      kind: 'request',
+      recordId: text(row, 'request_id'),
+      revision: integer(row, 'revision') + 1,
+      value: {
+        createdAt: text(row, 'created_at'),
+        description: text(row, 'description'),
+        firstBaseOid: text(row, 'first_base_oid'),
+        latestHeadOid: text(row, 'latest_head_oid'),
+        memberId: text(row, 'member_id'),
+        mergedOid: text(row, 'merged_oid', true),
+        projectId,
+        requestId: text(row, 'request_id'),
+        status: text(row, 'status'),
+        updatedAt: text(row, 'updated_at'),
+      },
+    });
+  }
+
+  for (const row of sorted(connection.all(`
+    SELECT comment_id, request_id, author_member_id, body, created_at
+    FROM comments
+  `), 'comment_id')) {
+    records.push({
+      kind: 'request-comment',
+      recordId: text(row, 'comment_id'),
+      revision: 1,
+      value: {
+        authorMemberId: text(row, 'author_member_id'),
+        body: text(row, 'body'),
+        commentId: text(row, 'comment_id'),
+        createdAt: text(row, 'created_at'),
+        projectId,
+        requestId: text(row, 'request_id'),
+      },
+    });
+  }
+
+  for (const row of sorted(connection.all(`
+    SELECT
+      ticket_number, ticket_id, title, body, status, author_member_id,
+      revision, created_at, updated_at, closed_at, closed_by_member_id
+    FROM tickets
+  `), 'ticket_id')) {
+    records.push({
+      kind: 'ticket',
+      recordId: text(row, 'ticket_id'),
+      revision: integer(row, 'revision', 1),
+      value: {
+        authorMemberId: text(row, 'author_member_id'),
+        body: text(row, 'body'),
+        closedAt: text(row, 'closed_at', true),
+        closedByMemberId: text(row, 'closed_by_member_id', true),
+        createdAt: text(row, 'created_at'),
+        number: integer(row, 'ticket_number', 1),
+        projectId,
+        status: text(row, 'status'),
+        ticketId: text(row, 'ticket_id'),
+        title: text(row, 'title'),
+        updatedAt: text(row, 'updated_at'),
+      },
+    });
+  }
+
+  for (const row of sorted(connection.all(`
+    SELECT comment_id, ticket_id, author_member_id, body, created_at
+    FROM ticket_comments
+  `), 'comment_id')) {
+    records.push({
+      kind: 'ticket-comment',
+      recordId: text(row, 'comment_id'),
+      revision: 1,
+      value: {
+        authorMemberId: text(row, 'author_member_id'),
+        body: text(row, 'body'),
+        commentId: text(row, 'comment_id'),
+        createdAt: text(row, 'created_at'),
+        projectId,
+        ticketId: text(row, 'ticket_id'),
+      },
+    });
+  }
+
+  for (const row of sorted(connection.all(`
+    SELECT
+      relation_id, request_id, ticket_id, commit_oid, kind, state,
+      created_by_member_id, created_at, updated_at, accepted_at,
+      accepted_merge_oid
+    FROM request_ticket_relations
+  `), 'relation_id')) {
+    records.push({
+      kind: 'ticket-relation',
+      recordId: text(row, 'relation_id'),
+      revision: 1,
+      value: {
+        acceptedAt: text(row, 'accepted_at', true),
+        acceptedMergeOid: text(row, 'accepted_merge_oid', true),
+        commitOid: text(row, 'commit_oid'),
+        createdAt: text(row, 'created_at'),
+        createdByMemberId: text(row, 'created_by_member_id'),
+        kind: text(row, 'kind'),
+        projectId,
+        relationId: text(row, 'relation_id'),
+        requestId: text(row, 'request_id'),
+        state: text(row, 'state'),
+        ticketId: text(row, 'ticket_id'),
+        updatedAt: text(row, 'updated_at'),
+      },
+    });
+  }
+
+  const mentions = connection.all(`
+    SELECT ticket_id, mentioned_member_id, source_kind, source_id, created_at
+    FROM ticket_mentions
+  `).map(row => ({ row, recordId: mentionRecordId(row) }))
+    .sort((left, right) => left.recordId.localeCompare(right.recordId, 'en-US'));
+  for (const { recordId, row } of mentions) {
+    records.push({
+      kind: 'ticket-mention',
+      recordId,
+      revision: 1,
+      value: {
+        createdAt: text(row, 'created_at'),
+        mentionedMemberId: text(row, 'mentioned_member_id'),
+        projectId,
+        sourceId: text(row, 'source_id'),
+        sourceKind: text(row, 'source_kind'),
+        ticketId: text(row, 'ticket_id'),
+      },
+    });
+  }
+
+  const candidate = `${records.map(record => JSON.stringify(record)).join('\n')}\n`;
+  return decodeCollabProjectCheckpointCoordinationNdjson(
+    candidate,
+    'authority-transfer',
+  ) as readonly CollabCheckpointPortableRecord[];
+}
+
+function requireEmptyAuthority(connection: AuthorityDatabaseConnection): void {
+  const row = connection.get(`
+    SELECT
+      (SELECT COUNT(*) FROM project) AS projects,
+      (SELECT COUNT(*) FROM members) AS members,
+      (SELECT COUNT(*) FROM invitations) AS invitations,
+      (SELECT COUNT(*) FROM change_requests) AS requests,
+      (SELECT COUNT(*) FROM tickets) AS tickets
+  `);
+  if (!row || Object.values(row).some(value => value !== 0)) {
+    throw checkpointError('checkpoint-import-target-not-empty');
+  }
+}
+
+export class AuthorityTransferCheckpointRepository {
+  exportCoordination(
+    connection: AuthorityDatabaseConnection,
+    input: ExportAuthorityTransferCoordinationInput,
+  ): string {
+    return encodeCollabProjectCheckpointCoordinationNdjson(
+      portableRecords(connection, input),
+      'authority-transfer',
+    );
+  }
+
+  importCoordination(
+    connection: AuthorityDatabaseConnection,
+    input: ImportAuthorityTransferCoordinationInput,
+  ): void {
+    if (input.targetHostCredentialHash.byteLength !== 32) {
+      throw checkpointError('checkpoint-target-credential-invalid');
+    }
+    const manifest = verifyAuthorityTransferCheckpointManifest(input.manifest);
+    const coordinationArtifact = manifest.artifacts.find(
+      artifact => artifact.name === 'coordination.ndjson',
+    );
+    if (
+      coordinationArtifact === undefined
+      || coordinationArtifact.byteCount !== Buffer.byteLength(input.coordinationNdjson, 'utf8')
+      || coordinationArtifact.sha256 !== createHash('sha256')
+        .update(input.coordinationNdjson, 'utf8')
+        .digest('hex')
+    ) throw checkpointError('checkpoint-coordination-artifact-mismatch');
+    const records = decodeCollabProjectCheckpointCoordinationNdjson(
+      input.coordinationNdjson,
+      'authority-transfer',
+    );
+    validateCollabProjectCheckpointConsistency(manifest, records);
+    const target = manifest.targetAuthority;
+    if (target?.kind !== 'lan') throw checkpointError('checkpoint-target-authority-invalid');
+    const portable = records as readonly CollabCheckpointPortableRecord[];
+    const project = portable[0];
+    if (project?.kind !== 'project') throw checkpointError('checkpoint-project-missing');
+    const members = portable.filter(record => record.kind === 'member');
+    const targetHost = members.find(record => record.value.memberId === input.targetHostMemberId);
+    if (targetHost?.kind !== 'member' || targetHost.value.status !== 'active') {
+      throw checkpointError('checkpoint-target-host-invalid');
+    }
+    requireEmptyAuthority(connection);
+
+    for (const record of members) {
+      if (record.kind !== 'member') continue;
+      const bound = record.value.memberId === input.targetHostMemberId;
+      runCheckpointSql(connection, `
+        INSERT INTO members (
+          member_id, display_name, personal_ref, role, status, access_state,
+          credential_hash, join_attempt_id, created_at, activated_at, revoked_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)
+      `, [
+        record.value.memberId,
+        record.value.displayName,
+        record.value.personalRef,
+        record.value.role,
+        record.value.status,
+        bound ? 'bound' : 'unbound',
+        bound ? input.targetHostCredentialHash : null,
+        record.value.createdAt,
+        record.value.activatedAt,
+        record.value.revokedAt,
+      ], 'checkpoint-import-member-failed');
+    }
+
+    new AuthorityMetadataRepository().installGeneration(connection, target.generation);
+    runCheckpointSql(connection, `
+      INSERT INTO project (
+        singleton, project_id, name, state, host_member_id,
+        manager_set_generation, main_ref, created_at, snapshot_generation
+      ) VALUES (1, ?, ?, 'disabled', ?, ?, ?, ?, ?)
+    `, [
+      project.value.projectId,
+      project.value.name,
+      input.targetHostMemberId,
+      project.value.managerSetGeneration,
+      COLLAB_MAIN_REF,
+      project.value.createdAt,
+      project.revision - 1,
+    ], 'checkpoint-import-project-failed');
+
+    for (const record of portable) {
+      switch (record.kind) {
+        case 'project':
+        case 'member':
+          break;
+        case 'request':
+          runCheckpointSql(connection, `
+            INSERT INTO change_requests (
+              request_id, member_id, status, first_base_oid, latest_head_oid,
+              merged_oid, created_at, updated_at, description, revision
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `, [
+            record.value.requestId,
+            record.value.memberId,
+            record.value.status,
+            record.value.firstBaseOid,
+            record.value.latestHeadOid,
+            record.value.mergedOid,
+            record.value.createdAt,
+            record.value.updatedAt,
+            record.value.description,
+            record.revision - 1,
+          ], 'checkpoint-import-request-failed');
+          break;
+        case 'request-comment':
+          runCheckpointSql(connection, `
+            INSERT INTO comments (
+              comment_id, request_id, author_member_id, body, created_at
+            ) VALUES (?, ?, ?, ?, ?)
+          `, [
+            record.value.commentId,
+            record.value.requestId,
+            record.value.authorMemberId,
+            record.value.body,
+            record.value.createdAt,
+          ], 'checkpoint-import-request-comment-failed');
+          break;
+        case 'ticket': {
+          const commentCount = portable.filter(candidate => (
+            candidate.kind === 'ticket-comment'
+            && candidate.value.ticketId === record.value.ticketId
+          )).length;
+          runCheckpointSql(connection, `
+            INSERT INTO tickets (
+              ticket_number, ticket_id, title, body, status, author_member_id,
+              revision, comment_count, created_at, updated_at, closed_at,
+              closed_by_member_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `, [
+            record.value.number,
+            record.value.ticketId,
+            record.value.title,
+            record.value.body,
+            record.value.status,
+            record.value.authorMemberId,
+            record.revision,
+            commentCount,
+            record.value.createdAt,
+            record.value.updatedAt,
+            record.value.closedAt,
+            record.value.closedByMemberId,
+          ], 'checkpoint-import-ticket-failed');
+          break;
+        }
+        case 'ticket-comment':
+          runCheckpointSql(connection, `
+            INSERT INTO ticket_comments (
+              comment_id, ticket_id, author_member_id, body, created_at
+            ) VALUES (?, ?, ?, ?, ?)
+          `, [
+            record.value.commentId,
+            record.value.ticketId,
+            record.value.authorMemberId,
+            record.value.body,
+            record.value.createdAt,
+          ], 'checkpoint-import-ticket-comment-failed');
+          break;
+        case 'ticket-relation':
+          runCheckpointSql(connection, `
+            INSERT INTO request_ticket_relations (
+              relation_id, request_id, ticket_id, commit_oid, kind, state,
+              created_by_member_id, created_at, updated_at, accepted_at,
+              accepted_merge_oid
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `, [
+            record.value.relationId,
+            record.value.requestId,
+            record.value.ticketId,
+            record.value.commitOid,
+            record.value.kind,
+            record.value.state,
+            record.value.createdByMemberId,
+            record.value.createdAt,
+            record.value.updatedAt,
+            record.value.acceptedAt,
+            record.value.acceptedMergeOid,
+          ], 'checkpoint-import-ticket-relation-failed');
+          break;
+        case 'ticket-mention':
+          runCheckpointSql(connection, `
+            INSERT INTO ticket_mentions (
+              ticket_id, mentioned_member_id, source_kind, source_id, created_at
+            ) VALUES (?, ?, ?, ?, ?)
+          `, [
+            record.value.ticketId,
+            record.value.mentionedMemberId,
+            record.value.sourceKind,
+            record.value.sourceId,
+            record.value.createdAt,
+          ], 'checkpoint-import-ticket-mention-failed');
+          break;
+      }
+    }
+  }
+}

--- a/src/app/collab/authority/AuthorityMetadataRepository.ts
+++ b/src/app/collab/authority/AuthorityMetadataRepository.ts
@@ -1,0 +1,59 @@
+import type { AuthorityDatabaseConnection } from '@/app/collab/authority/SqlJsProjectDatabase';
+import { CollabError } from '@/core/collab/ClaudianCollabError';
+
+function metadataError(reason: string): CollabError {
+  return new CollabError({
+    code: 'authority-integrity-error',
+    recoveryActions: ['open-diagnostics'],
+    safeContext: { reason },
+  });
+}
+
+function assertGeneration(generation: number): void {
+  if (!Number.isSafeInteger(generation) || generation < 1) {
+    throw metadataError('authority-generation-invalid');
+  }
+}
+
+export class AuthorityMetadataRepository {
+  getGeneration(connection: AuthorityDatabaseConnection): number {
+    const generation = connection.get(`
+      SELECT authority_generation
+      FROM authority_metadata
+      WHERE singleton = 1
+    `)?.authority_generation;
+    if (typeof generation !== 'number') {
+      throw metadataError('authority-generation-missing');
+    }
+    assertGeneration(generation);
+    return generation;
+  }
+
+  setGeneration(
+    connection: AuthorityDatabaseConnection,
+    expectedGeneration: number,
+    nextGeneration: number,
+  ): void {
+    assertGeneration(expectedGeneration);
+    assertGeneration(nextGeneration);
+    if (nextGeneration !== expectedGeneration + 1) {
+      throw metadataError('authority-generation-transition-invalid');
+    }
+    const changes = connection.run(`
+      UPDATE authority_metadata
+      SET authority_generation = ?
+      WHERE singleton = 1 AND authority_generation = ?
+    `, [nextGeneration, expectedGeneration]);
+    if (changes !== 1) throw metadataError('authority-generation-stale');
+  }
+
+  installGeneration(connection: AuthorityDatabaseConnection, generation: number): void {
+    assertGeneration(generation);
+    const changes = connection.run(`
+      UPDATE authority_metadata
+      SET authority_generation = ?
+      WHERE singleton = 1
+    `, [generation]);
+    if (changes !== 1) throw metadataError('authority-generation-missing');
+  }
+}

--- a/src/app/collab/authority/AuthoritySchema.ts
+++ b/src/app/collab/authority/AuthoritySchema.ts
@@ -1,4 +1,4 @@
-import { COLLAB_LIMITS } from '@claudian-collab/protocol';
+import { COLLAB_LIMITS, COLLAB_MEMBER_REF_PREFIX } from '@claudian-collab/protocol';
 import type { Database, SqlValue } from 'sql.js';
 
 import { COLLAB_AUTHORITY_SCHEMA_VERSION } from '@/app/collab/CollabSchemaVersions';
@@ -13,7 +13,7 @@ const AUTHORITY_SCHEMA_V1 = `
     ),
     display_name TEXT NOT NULL CHECK(length(display_name) BETWEEN 1 AND 200),
     personal_ref TEXT NOT NULL UNIQUE
-      CHECK(personal_ref = 'refs/heads/members/' || member_id),
+      CHECK(personal_ref = '${COLLAB_MEMBER_REF_PREFIX}' || member_id),
     role TEXT NOT NULL CHECK(role IN ('manager', 'member')),
     status TEXT NOT NULL CHECK(status IN ('pending', 'active', 'revoked', 'left')),
     credential_hash BLOB NOT NULL CHECK(length(credential_hash) = 32),
@@ -653,6 +653,54 @@ const AUTHORITY_SCHEMA_V11_FINITE_COLLECTION_TRIGGERS = `
     END;
 `;
 
+const AUTHORITY_SCHEMA_V12_MEMBERS_SQL = `
+  CREATE TABLE members_v12 (
+    member_id TEXT PRIMARY KEY CHECK(
+      length(member_id) BETWEEN 1 AND 64
+      AND substr(member_id, 1, 1) GLOB '[A-Za-z0-9]'
+      AND member_id NOT GLOB '*[^A-Za-z0-9_-]*'
+    ),
+    display_name TEXT NOT NULL CHECK(length(display_name) BETWEEN 1 AND 200),
+    personal_ref TEXT NOT NULL UNIQUE
+      CHECK(personal_ref = '${COLLAB_MEMBER_REF_PREFIX}' || member_id),
+    role TEXT NOT NULL CHECK(role IN ('manager', 'member')),
+    status TEXT NOT NULL CHECK(status IN ('pending', 'active', 'revoked', 'left')),
+    access_state TEXT NOT NULL DEFAULT 'bound'
+      CHECK(access_state IN ('bound', 'unbound')),
+    credential_hash BLOB CHECK(
+      credential_hash IS NULL OR length(credential_hash) = 32
+    ),
+    join_attempt_id TEXT UNIQUE,
+    created_at TEXT NOT NULL CHECK(length(created_at) > 0),
+    activated_at TEXT,
+    revoked_at TEXT,
+    CHECK(role != 'manager' OR status = 'active'),
+    CHECK(
+      (status = 'pending' AND activated_at IS NULL AND revoked_at IS NULL)
+      OR (status = 'active' AND activated_at IS NOT NULL AND revoked_at IS NULL)
+      OR (status IN ('revoked', 'left') AND revoked_at IS NOT NULL)
+    ),
+    CHECK(
+      (access_state = 'bound' AND credential_hash IS NOT NULL)
+      OR (
+        access_state = 'unbound'
+        AND credential_hash IS NULL
+        AND status != 'pending'
+        AND join_attempt_id IS NULL
+      )
+    )
+  );
+`;
+
+const AUTHORITY_SCHEMA_V12_METADATA_SQL = `
+  CREATE TABLE authority_metadata (
+    singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+    authority_generation INTEGER NOT NULL CHECK(
+      typeof(authority_generation) = 'integer' AND authority_generation >= 1
+    )
+  );
+`;
+
 function pragmaNumber(database: Database, pragma: string): number {
   const result = database.exec(pragma);
   const value = result[0]?.values[0]?.[0];
@@ -1007,6 +1055,54 @@ function repairAndAssertAuthorityV11Schema(database: Database): boolean {
   return repaired;
 }
 
+function authorityV12SchemaIsComplete(database: Database): boolean {
+  return authorityV11SchemaIsComplete(database)
+    && hasExactColumns(database, 'members', [
+      'member_id',
+      'display_name',
+      'personal_ref',
+      'role',
+      'status',
+      'access_state',
+      'credential_hash',
+      'join_attempt_id',
+      'created_at',
+      'activated_at',
+      'revoked_at',
+    ])
+    && hasExactSchemaSql(
+      database,
+      'table',
+      'members',
+      AUTHORITY_SCHEMA_V12_MEMBERS_SQL.replace('members_v12', 'members'),
+    )
+    && hasExactColumns(database, 'authority_metadata', [
+      'singleton',
+      'authority_generation',
+    ])
+    && hasExactSchemaSql(
+      database,
+      'table',
+      'authority_metadata',
+      AUTHORITY_SCHEMA_V12_METADATA_SQL,
+    )
+    && firstColumn(database, `
+      SELECT singleton FROM authority_metadata
+      WHERE singleton != 1 OR authority_generation < 1
+    `).length === 0
+    && firstColumn(database, `
+      SELECT singleton FROM authority_metadata
+    `).length === 1;
+}
+
+function repairAndAssertAuthorityV12Schema(database: Database): boolean {
+  const repaired = repairAndAssertAuthorityV11Schema(database);
+  if (!authorityV12SchemaIsComplete(database)) {
+    throw new Error('Authority V12 portability schema is incomplete');
+  }
+  return repaired;
+}
+
 function applyAuthoritySchemaV3(database: Database): void {
   const requestColumns = tableColumns(database, 'change_requests');
   const presentRequestColumns = AUTHORITY_SCHEMA_V3_REQUEST_COLUMNS.filter(column => (
@@ -1251,6 +1347,43 @@ function applyAuthoritySchemaV11(database: Database): void {
   database.run(AUTHORITY_SCHEMA_V11_FINITE_COLLECTION_TRIGGERS);
 }
 
+function applyAuthoritySchemaV12(database: Database): void {
+  repairAndAssertAuthorityV11Schema(database);
+  const memberColumns = tableColumns(database, 'members');
+  const hasAccessState = memberColumns.has('access_state');
+  const hasMetadata = tableExists(database, 'authority_metadata');
+  if (hasAccessState || hasMetadata) {
+    if (!hasAccessState || !hasMetadata || !authorityV12SchemaIsComplete(database)) {
+      throw new Error('Authority V12 portability schema is incomplete');
+    }
+    return;
+  }
+
+  database.run('PRAGMA defer_foreign_keys = ON');
+  database.run(AUTHORITY_SCHEMA_V12_MEMBERS_SQL);
+  database.run(`
+    INSERT INTO members_v12 (
+      member_id, display_name, personal_ref, role, status, access_state,
+      credential_hash, join_attempt_id, created_at, activated_at, revoked_at
+    )
+    SELECT
+      member_id, display_name, personal_ref, role, status, 'bound',
+      credential_hash, join_attempt_id, created_at, activated_at, revoked_at
+    FROM members;
+    DROP TABLE members;
+    ALTER TABLE members_v12 RENAME TO members;
+  `);
+  database.run(AUTHORITY_SCHEMA_V12_METADATA_SQL);
+  database.run(`
+    INSERT INTO authority_metadata (singleton, authority_generation)
+    VALUES (1, 1)
+  `);
+  if (firstColumn(database, 'PRAGMA foreign_key_check').length > 0) {
+    throw new Error('Authority V12 foreign key migration failed');
+  }
+  repairAndAssertAuthorityV12Schema(database);
+}
+
 export function applyAuthorityMigrations(database: Database): boolean {
   const version = pragmaNumber(database, 'PRAGMA user_version');
   if (version > COLLAB_AUTHORITY_SCHEMA_VERSION) {
@@ -1259,7 +1392,7 @@ export function applyAuthorityMigrations(database: Database): boolean {
   if (version === COLLAB_AUTHORITY_SCHEMA_VERSION) {
     database.run('BEGIN IMMEDIATE');
     try {
-      const repaired = repairAndAssertAuthorityV11Schema(database);
+      const repaired = repairAndAssertAuthorityV12Schema(database);
       database.run('COMMIT');
       return repaired;
     } catch (error) {
@@ -1268,8 +1401,12 @@ export function applyAuthorityMigrations(database: Database): boolean {
     }
   }
 
-  database.run('BEGIN IMMEDIATE');
+  const restoreForeignKeys = pragmaNumber(database, 'PRAGMA foreign_keys') === 1;
+  if (restoreForeignKeys) database.run('PRAGMA foreign_keys = OFF');
+  let transactionStarted = false;
   try {
+    database.run('BEGIN IMMEDIATE');
+    transactionStarted = true;
     if (version < 1) database.run(AUTHORITY_SCHEMA_V1);
     if (version < 3) applyAuthoritySchemaV3(database);
     if (version < 4) applyAuthoritySchemaV4(database);
@@ -1278,12 +1415,16 @@ export function applyAuthorityMigrations(database: Database): boolean {
     if (version < 9) applyAuthoritySchemaV9(database);
     if (version < 10) applyAuthoritySchemaV10(database);
     if (version < 11) applyAuthoritySchemaV11(database);
-    repairAndAssertAuthorityV11Schema(database);
+    if (version < 12) applyAuthoritySchemaV12(database);
+    repairAndAssertAuthorityV12Schema(database);
     database.run(`PRAGMA user_version = ${COLLAB_AUTHORITY_SCHEMA_VERSION}`);
     database.run('COMMIT');
+    transactionStarted = false;
   } catch (error) {
-    database.run('ROLLBACK');
+    if (transactionStarted) database.run('ROLLBACK');
     throw error;
+  } finally {
+    if (restoreForeignKeys) database.run('PRAGMA foreign_keys = ON');
   }
   return true;
 }
@@ -1294,7 +1435,7 @@ export function applyAuthorityMigrations(database: Database): boolean {
  */
 export function migrateLegacyAuthorityDatabaseToCurrent(database: Database): number {
   const version = pragmaNumber(database, 'PRAGMA user_version');
-  if (version !== 8 && version !== 9 && version !== 10) {
+  if (version !== 8 && version !== 9 && version !== 10 && version !== 11) {
     throw new RangeError('Host transfer authority schema is not a supported legacy version');
   }
   applyAuthorityMigrations(database);
@@ -1320,6 +1461,16 @@ export function assertAuthorityDatabaseIntegrity(
 
   if (!finiteCollectionCapacityIsValid(database)) {
     throw new Error('Authority finite collection invariant failed');
+  }
+  if (firstColumn(database, `
+    SELECT singleton FROM authority_metadata
+    WHERE singleton != 1
+      OR typeof(authority_generation) != 'integer'
+      OR authority_generation < 1
+  `).length > 0 || firstColumn(database, `
+    SELECT singleton FROM authority_metadata
+  `).length !== 1) {
+    throw new Error('Authority generation invariant failed');
   }
 
   if (firstColumn(database, `

--- a/src/app/collab/authority/PendingMembershipRepository.ts
+++ b/src/app/collab/authority/PendingMembershipRepository.ts
@@ -1,3 +1,5 @@
+import { timingSafeEqual } from 'node:crypto';
+
 import { type CollabChangeRequest, type CollabMember, type CollabMemberId, collabMemberRef, type CollabMemberStatus, isCollabMemberId, isCollabOpaqueId } from '@claudian-collab/protocol';
 
 import { RequestTicketRelationRepository } from '@/app/collab/authority/RequestTicketRelationRepository';
@@ -14,7 +16,8 @@ export interface AuthorityInvitationRecord {
 }
 
 export interface AuthorityMemberCredentialRecord {
-  readonly credentialHash: Uint8Array;
+  readonly accessState: 'bound' | 'unbound';
+  readonly credentialHash: Uint8Array | null;
   readonly joinAttemptId: string | null;
   readonly member: CollabMember;
 }
@@ -33,6 +36,11 @@ export interface CreatePendingMembershipInput {
   readonly displayName: string;
   readonly joinAttemptId: string;
   readonly memberId: CollabMemberId;
+}
+
+export interface BindImportedActiveResult {
+  readonly record: AuthorityMemberCredentialRecord;
+  readonly status: 'bound' | 'existing';
 }
 
 function membershipError(reason: string): CollabError {
@@ -60,6 +68,13 @@ function bytes(row: Readonly<Record<string, unknown>>, field: string): Uint8Arra
     throw membershipError('authority-credential-hash-invalid');
   }
   return Uint8Array.from(value);
+}
+
+function nullableCredentialHash(
+  row: Readonly<Record<string, unknown>>,
+): Uint8Array | null {
+  if (row.credential_hash === null) return null;
+  return bytes(row, 'credential_hash');
 }
 
 function assertTimestamp(value: string, field: string): void {
@@ -90,12 +105,14 @@ function decodeMember(row: Readonly<Record<string, unknown>>): AuthorityMemberCr
   const activatedAt = text(row, 'activated_at', true);
   const revokedAt = text(row, 'revoked_at', true);
   const joinAttemptId = text(row, 'join_attempt_id', true);
+  const accessState = text(row, 'access_state');
   if (
     (role !== 'manager' && role !== 'member')
     || !isMemberStatus(status)
     || !isCollabMemberId(id)
     || (joinAttemptId !== null && !isCollabOpaqueId(joinAttemptId))
     || personalRef !== collabMemberRef(id)
+    || (accessState !== 'bound' && accessState !== 'unbound')
   ) {
     throw membershipError('authority-member-row-invalid');
   }
@@ -103,7 +120,8 @@ function decodeMember(row: Readonly<Record<string, unknown>>): AuthorityMemberCr
   if (activatedAt !== null) assertTimestamp(activatedAt, 'member-activated-at');
   if (revokedAt !== null) assertTimestamp(revokedAt, 'member-revoked-at');
   return {
-    credentialHash: bytes(row, 'credential_hash'),
+    accessState,
+    credentialHash: nullableCredentialHash(row),
     joinAttemptId,
     member: {
       ...(activatedAt === null ? {} : { activatedAt }),
@@ -184,7 +202,7 @@ function decodeChangeRequest(
 }
 
 const MEMBER_COLUMNS = `
-  member_id, display_name, personal_ref, role, status, credential_hash,
+  member_id, display_name, personal_ref, role, status, access_state, credential_hash,
   join_attempt_id, created_at, activated_at, revoked_at
 `;
 
@@ -335,6 +353,50 @@ export class PendingMembershipRepository {
     `, [memberId]);
     if (!row) throw membershipError('pending-member-missing');
     return decodeMember(row);
+  }
+
+  bindImportedActive(
+    connection: AuthorityDatabaseConnection,
+    memberId: CollabMemberId,
+    credentialHash: Uint8Array,
+  ): BindImportedActiveResult {
+    assertMemberId(memberId, 'member-id');
+    if (credentialHash.byteLength !== 32) {
+      throw membershipError('member-credential-hash-invalid');
+    }
+    const row = connection.get(`
+      SELECT ${MEMBER_COLUMNS}
+      FROM members
+      WHERE member_id = ?
+    `, [memberId]);
+    if (!row) throw membershipError('member-missing');
+    const existing = decodeMember(row);
+    if (existing.member.status !== 'active') {
+      throw membershipError('imported-member-not-active');
+    }
+    if (existing.accessState === 'bound') {
+      if (
+        existing.credentialHash !== null
+        && timingSafeEqual(existing.credentialHash, credentialHash)
+      ) return { record: existing, status: 'existing' };
+      throw membershipError('imported-member-binding-conflict');
+    }
+    const changes = connection.run(`
+      UPDATE members
+      SET access_state = 'bound', credential_hash = ?
+      WHERE member_id = ?
+        AND status = 'active'
+        AND access_state = 'unbound'
+        AND credential_hash IS NULL
+    `, [credentialHash, memberId]);
+    if (changes !== 1) throw membershipError('imported-member-binding-stale');
+    const updated = connection.get(`
+      SELECT ${MEMBER_COLUMNS}
+      FROM members
+      WHERE member_id = ?
+    `, [memberId]);
+    if (!updated) throw membershipError('member-missing');
+    return { record: decodeMember(updated), status: 'bound' };
   }
 
   activate(

--- a/src/app/collab/authority/ProjectAuthorityRepository.ts
+++ b/src/app/collab/authority/ProjectAuthorityRepository.ts
@@ -16,6 +16,7 @@ export interface ProjectAuthorityInitializeInput {
 }
 
 export interface AuthorityProjectRecord {
+  readonly authorityGeneration: number;
   readonly createdAt: string;
   readonly hostMemberId: CollabMemberId;
   readonly mainRef: typeof COLLAB_MAIN_REF;
@@ -115,6 +116,8 @@ export class ProjectAuthorityRepository {
   get(connection: AuthorityDatabaseConnection): AuthorityProjectRecord | null {
     const row = connection.get(`
       SELECT
+        (SELECT authority_generation FROM authority_metadata WHERE singleton = 1)
+          AS authority_generation,
         project_id,
         name,
         state,
@@ -131,6 +134,7 @@ export class ProjectAuthorityRepository {
     const state = row.state;
     const mainRef = row.main_ref;
     const managerSetGeneration = row.manager_set_generation;
+    const authorityGeneration = row.authority_generation;
     if (
       typeof generation !== 'number'
       || !Number.isSafeInteger(generation)
@@ -140,10 +144,14 @@ export class ProjectAuthorityRepository {
       || typeof managerSetGeneration !== 'number'
       || !Number.isSafeInteger(managerSetGeneration)
       || managerSetGeneration < 0
+      || typeof authorityGeneration !== 'number'
+      || !Number.isSafeInteger(authorityGeneration)
+      || authorityGeneration < 1
     ) {
       throw projectError('project-row-invalid');
     }
     const project: AuthorityProjectRecord = {
+      authorityGeneration,
       createdAt: text(row, 'created_at'),
       hostMemberId: text(row, 'host_member_id'),
       mainRef,

--- a/src/app/collab/authority/ProjectRetirementRepository.ts
+++ b/src/app/collab/authority/ProjectRetirementRepository.ts
@@ -204,13 +204,24 @@ export class ProjectRetirementRepository {
       throw retirementError('authority-integrity-error', 'retirement-row-invalid');
     }
     const formerMembers = connection.all(`
-      SELECT member_id, credential_hash
+      SELECT member_id, access_state, credential_hash
       FROM members WHERE status = 'active'
       ORDER BY created_at, member_id
     `).map(member => {
       if (
         typeof member.member_id !== 'string'
-        || !(member.credential_hash instanceof Uint8Array)
+        || (member.access_state !== 'bound' && member.access_state !== 'unbound')
+      ) {
+        throw retirementError('authority-integrity-error', 'retirement-member-row-invalid');
+      }
+      if (member.access_state === 'unbound') {
+        if (member.credential_hash !== null) {
+          throw retirementError('authority-integrity-error', 'retirement-member-row-invalid');
+        }
+        return null;
+      }
+      if (
+        !(member.credential_hash instanceof Uint8Array)
         || member.credential_hash.byteLength !== 32
       ) {
         throw retirementError('authority-integrity-error', 'retirement-member-row-invalid');
@@ -219,7 +230,7 @@ export class ProjectRetirementRepository {
         credentialHash: Buffer.from(member.credential_hash).toString('hex'),
         memberId: member.member_id,
       };
-    });
+    }).filter((member): member is ProjectRetirementFormerMember => member !== null);
     if (formerMembers.length === 0) {
       throw retirementError('authority-integrity-error', 'retirement-member-set-empty');
     }

--- a/src/app/collab/host-transfer/HostTransferAuthoritySnapshot.ts
+++ b/src/app/collab/host-transfer/HostTransferAuthoritySnapshot.ts
@@ -114,7 +114,7 @@ function decodeProofChain(
   });
 }
 
-function assertSchema(database: Database, expectedVersion: 8 | 9 | 10 | 11): void {
+function assertSchema(database: Database, expectedVersion: 8 | 9 | 10 | 11 | 12): void {
   const version = one(database, 'PRAGMA user_version').user_version;
   if (version !== expectedVersion) {
     throw snapshotError('host-transfer-authority-schema-mismatch');
@@ -383,7 +383,7 @@ export class HostTransferAuthoritySnapshot {
 
   private async openRaw(
     bytes: Uint8Array,
-    expectedSchemaVersion: 8 | 9 | 10 | 11,
+    expectedSchemaVersion: 8 | 9 | 10 | 11 | 12,
   ): Promise<Database> {
     if (bytes.byteLength < 16 || Buffer.from(bytes.subarray(0, 16)).toString('binary') !== 'SQLite format 3\u0000') {
       throw snapshotError('host-transfer-authority-header-invalid');
@@ -421,12 +421,24 @@ export class HostTransferAuthoritySnapshot {
              receiver_credential, manifest_digest, activation_certificate
       FROM host_transfer_operations WHERE transfer_id = ?
     `, [input.manifest.transferId]);
-    const invalidCredential = query(database, `
-      SELECT member_id FROM members
-      WHERE status = 'active'
-        AND (typeof(credential_hash) != 'blob' OR length(credential_hash) != 32)
-      LIMIT 1
-    `).length > 0;
+    const invalidCredential = query(database, input.manifest.authoritySchemaVersion === 12
+      ? `
+        SELECT member_id FROM members
+        WHERE status = 'active' AND (
+          access_state NOT IN ('bound', 'unbound')
+          OR (access_state = 'bound' AND (
+            typeof(credential_hash) != 'blob' OR length(credential_hash) != 32
+          ))
+          OR (access_state = 'unbound' AND credential_hash IS NOT NULL)
+        )
+        LIMIT 1
+      `
+      : `
+        SELECT member_id FROM members
+        WHERE status = 'active'
+          AND (typeof(credential_hash) != 'blob' OR length(credential_hash) != 32)
+        LIMIT 1
+      `).length > 0;
     if (
       project.project_id !== input.manifest.projectId
       || project.host_member_id !== input.manifest.targetHostMemberId

--- a/src/app/collab/host-transfer/HostTransferPackage.ts
+++ b/src/app/collab/host-transfer/HostTransferPackage.ts
@@ -25,7 +25,7 @@ export interface HostTransferArtifactIdentity {
 export interface HostTransferPackageManifest {
   readonly schemaVersion: typeof HOST_TRANSFER_MANIFEST_SCHEMA_VERSION;
   readonly protocolVersion: typeof COLLAB_HOST_TRANSFER_PROTOCOL_VERSION;
-  readonly authoritySchemaVersion: 8 | 9 | 10 | typeof COLLAB_AUTHORITY_SCHEMA_VERSION;
+  readonly authoritySchemaVersion: 8 | 9 | 10 | 11 | typeof COLLAB_AUTHORITY_SCHEMA_VERSION;
   readonly projectId: CollabProjectId;
   readonly transferId: CollabOperationId;
   readonly sourceAuthorityGeneration: number;
@@ -127,6 +127,7 @@ function assertManifest(
           manifest.authoritySchemaVersion !== 8
           && manifest.authoritySchemaVersion !== 9
           && manifest.authoritySchemaVersion !== 10
+          && manifest.authoritySchemaVersion !== 11
         )
       )
     )

--- a/src/app/collab/lan/PendingMembershipService.ts
+++ b/src/app/collab/lan/PendingMembershipService.ts
@@ -550,7 +550,11 @@ export class PendingMembershipService {
     const actualHash = hashCredential(credential);
     let matched: AuthorityMemberCredentialRecord | null = null;
     for (const record of this.repository.listCredentialRecords(connection, statuses)) {
-      if (credentialMatches(actualHash, record.credentialHash)) matched = record;
+      if (
+        record.accessState === 'bound'
+        && record.credentialHash !== null
+        && credentialMatches(actualHash, record.credentialHash)
+      ) matched = record;
     }
     if (!matched) {
       const allMembers = this.repository.listCredentialRecords(connection, [
@@ -560,7 +564,9 @@ export class PendingMembershipService {
         'left',
       ]);
       const known = allMembers.find(record => (
-        credentialMatches(actualHash, record.credentialHash)
+        record.accessState === 'bound'
+        && record.credentialHash !== null
+        && credentialMatches(actualHash, record.credentialHash)
       ));
       if (known?.member.status === 'revoked' || known?.member.status === 'left') {
         throw serviceError('membership-revoked', 'membership-no-longer-active');

--- a/tests/integration/app/collab/authority-transfer/AuthorityTransferCheckpoint.test.ts
+++ b/tests/integration/app/collab/authority-transfer/AuthorityTransferCheckpoint.test.ts
@@ -1,0 +1,580 @@
+import { createHash } from 'node:crypto';
+import { lstat, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import type {
+  CollabCheckpointArtifactFact,
+  CollabCheckpointGitRef,
+  CollabCheckpointObjectFormat,
+  CollabProjectCheckpointManifest,
+} from '@claudian-collab/protocol';
+import initSqlJs, { type SqlJsStatic } from 'sql.js';
+
+import { ProjectAuthorityRepository } from '@/app/collab/authority/ProjectAuthorityRepository';
+import { SqlJsProjectDatabase } from '@/app/collab/authority/SqlJsProjectDatabase';
+import { AuthorityTransferAdmissionSettlement } from '@/app/collab/authority-transfer/checkpoint/AuthorityTransferAdmissionSettlement';
+import { AuthorityTransferCheckpointGit } from '@/app/collab/authority-transfer/checkpoint/AuthorityTransferCheckpointGit';
+import { createAuthorityTransferCheckpointManifest } from '@/app/collab/authority-transfer/checkpoint/AuthorityTransferCheckpointManifest';
+import { AuthorityTransferCheckpointRepository } from '@/app/collab/authority-transfer/checkpoint/AuthorityTransferCheckpointRepository';
+import { GitCommandRunner } from '@/app/collab/git/GitCommandRunner';
+
+const CREATED_AT = '2026-08-26T00:00:00.000Z';
+const MAIN_OID = 'a'.repeat(40);
+const MEMBER_OID = 'b'.repeat(40);
+
+describe('AuthorityTransferCheckpoint', () => {
+  let SQL: SqlJsStatic;
+  let root: string;
+  let source: SqlJsProjectDatabase;
+  let target: SqlJsProjectDatabase;
+
+  beforeAll(async () => {
+    SQL = await initSqlJs();
+  });
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'claudian-authority-transfer-checkpoint-'));
+    source = await createDatabase(path.join(root, 'source-authority'));
+    target = await createDatabase(path.join(root, 'target-authority'));
+    await source.mutate(connection => {
+      new ProjectAuthorityRepository().initialize(connection, {
+        createdAt: CREATED_AT,
+        hostCredentialHash: new Uint8Array(32).fill(7),
+        hostDisplayName: 'Host',
+        hostMemberId: 'member-host',
+        name: 'Alpha',
+        projectId: 'project-alpha',
+      });
+      connection.run(`
+        INSERT INTO members (
+          member_id, display_name, personal_ref, role, status, credential_hash,
+          join_attempt_id, created_at, activated_at, revoked_at
+        ) VALUES (
+          'member-a', 'Alice', 'refs/heads/members/member-a', 'member',
+          'active', ?, NULL, ?, ?, NULL
+        )
+      `, [new Uint8Array(32).fill(8), CREATED_AT, CREATED_AT]);
+      connection.run(`
+        INSERT INTO change_requests (
+          request_id, member_id, status, first_base_oid, latest_head_oid,
+          merged_oid, created_at, updated_at, description, revision
+        ) VALUES (
+          'request-one', 'member-a', 'open', ?, ?, NULL, ?, ?, 'Review', 2
+        )
+      `, [MAIN_OID, MEMBER_OID, CREATED_AT, CREATED_AT]);
+      connection.run(`
+        INSERT INTO comments (
+          comment_id, request_id, author_member_id, body, created_at
+        ) VALUES ('request-comment-one', 'request-one', 'member-host', 'Looks good', ?)
+      `, [CREATED_AT]);
+      connection.run(`
+        INSERT INTO tickets (
+          ticket_number, ticket_id, title, body, status, author_member_id,
+          revision, comment_count, created_at, updated_at
+        ) VALUES (
+          1, 'ticket-one', 'Portable', 'Keep this record', 'open',
+          'member-a', 3, 1, ?, ?
+        )
+      `, [CREATED_AT, CREATED_AT]);
+      connection.run(`
+        INSERT INTO ticket_comments (
+          comment_id, ticket_id, author_member_id, body, created_at
+        ) VALUES ('ticket-comment-one', 'ticket-one', 'member-host', 'Tracked', ?)
+      `, [CREATED_AT]);
+      connection.run(`
+        INSERT INTO request_ticket_relations (
+          relation_id, request_id, ticket_id, commit_oid, kind, state,
+          created_by_member_id, created_at, updated_at, accepted_at,
+          accepted_merge_oid
+        ) VALUES (
+          'relation-one', 'request-one', 'ticket-one', ?, 'references',
+          'pending', 'member-a', ?, ?, NULL, NULL
+        )
+      `, [MEMBER_OID, CREATED_AT, CREATED_AT]);
+      connection.run(`
+        INSERT INTO ticket_mentions (
+          ticket_id, mentioned_member_id, source_kind, source_id, created_at
+        ) VALUES ('ticket-one', 'member-host', 'description', 'ticket-one', ?)
+      `, [CREATED_AT]);
+    });
+  });
+
+  afterEach(async () => {
+    await Promise.all([source.close(), target.close()]);
+    await rm(root, { force: true, recursive: true });
+  });
+
+  it('exports deterministic portable records and imports one inert target authority', async () => {
+    const repository = new AuthorityTransferCheckpointRepository();
+    const first = await source.read(connection => repository.exportCoordination(connection, {
+      expectedMainOid: MAIN_OID,
+    }));
+    const second = await source.read(connection => repository.exportCoordination(connection, {
+      expectedMainOid: MAIN_OID,
+    }));
+
+    expect(second).toBe(first);
+    expect(first.split('\n').slice(0, 3).map(line => JSON.parse(line))).toEqual([
+      {
+        kind: 'project',
+        recordId: 'project-alpha',
+        revision: 2,
+        value: {
+          activatedAt: CREATED_AT,
+          authorityGeneration: 1,
+          createdAt: CREATED_AT,
+          expectedMainOid: MAIN_OID,
+          managerSetGeneration: 0,
+          name: 'Alpha',
+          projectId: 'project-alpha',
+        },
+      },
+      expect.objectContaining({
+        kind: 'member',
+        recordId: 'member-a',
+        value: expect.objectContaining({
+          memberId: 'member-a',
+          status: 'active',
+        }),
+      }),
+      expect.objectContaining({
+        kind: 'member',
+        recordId: 'member-host',
+        value: expect.objectContaining({
+          memberId: 'member-host',
+          role: 'manager',
+        }),
+      }),
+    ]);
+    expect(first).toContain('"kind":"ticket-mention"');
+    expect(first).not.toContain('credential');
+    expect(first).not.toContain(Buffer.alloc(32, 7).toString('hex'));
+    expect(first).not.toContain('invitation');
+
+    const manifest = checkpointManifest(first);
+    const targetCredentialHash = new Uint8Array(32).fill(9);
+    await expect(target.mutate(connection => repository.importCoordination(connection, {
+      coordinationNdjson: first,
+      manifest: checkpointManifest(first, 'f'.repeat(64)),
+      targetHostCredentialHash: targetCredentialHash,
+      targetHostMemberId: 'member-a',
+    }))).rejects.toMatchObject({
+      safeContext: { reason: 'checkpoint-coordination-artifact-mismatch' },
+    });
+    await target.mutate(connection => repository.importCoordination(connection, {
+      coordinationNdjson: first,
+      manifest,
+      targetHostCredentialHash: targetCredentialHash,
+      targetHostMemberId: 'member-a',
+    }));
+
+    expect(await target.read(connection => connection.get(`
+      SELECT p.project_id, p.state, p.host_member_id, m.authority_generation
+      FROM project p CROSS JOIN authority_metadata m
+      WHERE p.singleton = 1 AND m.singleton = 1
+    `))).toEqual({
+      authority_generation: 2,
+      host_member_id: 'member-a',
+      project_id: 'project-alpha',
+      state: 'disabled',
+    });
+    expect(await target.read(connection => connection.all(`
+      SELECT member_id, access_state, credential_hash
+      FROM members ORDER BY member_id
+    `))).toEqual([
+      {
+        access_state: 'bound',
+        credential_hash: targetCredentialHash,
+        member_id: 'member-a',
+      },
+      {
+        access_state: 'unbound',
+        credential_hash: null,
+        member_id: 'member-host',
+      },
+    ]);
+    expect(await target.read(connection => connection.get(`
+      SELECT
+        (SELECT COUNT(*) FROM change_requests) AS requests,
+        (SELECT COUNT(*) FROM comments) AS request_comments,
+        (SELECT COUNT(*) FROM tickets) AS tickets,
+        (SELECT COUNT(*) FROM ticket_comments) AS ticket_comments,
+        (SELECT COUNT(*) FROM request_ticket_relations) AS relations,
+        (SELECT COUNT(*) FROM ticket_mentions) AS mentions
+    `))).toEqual({
+      mentions: 1,
+      relations: 1,
+      request_comments: 1,
+      requests: 1,
+      ticket_comments: 1,
+      tickets: 1,
+    });
+  });
+
+  it('refuses capture while invitation or pending Join admission is live', async () => {
+    await source.mutate(connection => {
+      connection.run(`
+        INSERT INTO invitations (
+          invitation_id, token_hash, expires_at, revoked_at,
+          created_by_member_id, created_at
+        ) VALUES ('invite-one', ?, ?, NULL, 'member-host', ?)
+      `, [new Uint8Array(32).fill(4), '2026-08-27T00:00:00.000Z', CREATED_AT]);
+    });
+
+    await expect(source.read(connection => (
+      new AuthorityTransferCheckpointRepository().exportCoordination(connection, {
+        expectedMainOid: MAIN_OID,
+      })
+    ))).rejects.toMatchObject({
+      safeContext: { reason: 'checkpoint-admission-unsettled' },
+    });
+  });
+
+  it('creates, verifies, and imports a bundle containing only exact portable refs', async () => {
+    const repositoryPath = path.join(root, 'repository');
+    const targetPath = path.join(root, 'target.git');
+    const bundlePath = path.join(root, 'repository.bundle');
+    await mkdir(repositoryPath);
+    await writeFile(path.join(root, 'empty-gitconfig'), '');
+    const runner = new GitCommandRunner({
+      emptyConfigPath: path.join(root, 'empty-gitconfig'),
+      executablePath: 'git',
+    });
+    await git(runner, repositoryPath, ['init', '--initial-branch=main']);
+    await writeFile(path.join(repositoryPath, 'note.md'), 'portable\n');
+    await git(runner, repositoryPath, ['add', 'note.md']);
+    await git(runner, repositoryPath, ['commit', '-m', 'portable'], true);
+    const oid = (await git(runner, repositoryPath, ['rev-parse', 'HEAD'])).trim();
+    await git(runner, repositoryPath, ['update-ref', 'refs/heads/members/member-a', oid]);
+    await git(runner, repositoryPath, ['update-ref', 'refs/claudian/private/secret', oid]);
+    const refs = [
+      { name: 'refs/heads/main', oid },
+      { name: 'refs/heads/members/member-a', oid },
+    ] as const;
+    const checkpointGit = new AuthorityTransferCheckpointGit(runner);
+
+    const identity = await checkpointGit.createBundle({
+      bundlePath,
+      refs,
+      repositoryPath,
+    });
+    await expect(checkpointGit.verifyBundle({
+      bundlePath,
+      refs,
+      repositoryPath,
+    })).resolves.toEqual(identity);
+    await checkpointGit.importIntoEmptyBareRepository({
+      bundlePath,
+      manifest: repositoryManifest(identity, refs),
+      targetRepositoryPath: targetPath,
+    });
+
+    const list = await git(runner, targetPath, ['for-each-ref', '--format=%(refname) %(objectname)']);
+    expect(list.trim().split('\n')).toEqual([
+      `refs/heads/main ${oid}`,
+      `refs/heads/members/member-a ${oid}`,
+    ]);
+    await expect(git(runner, targetPath, ['symbolic-ref', 'HEAD']))
+      .resolves.toBe('refs/heads/main\n');
+    await expect(git(runner, targetPath, ['rev-parse', '--show-object-format']))
+      .resolves.toBe('sha1\n');
+    expect((await readFile(bundlePath)).byteLength).toBe(identity.byteCount);
+    await expect(checkpointGit.verifyBundle({
+      bundlePath,
+      refs: [{ ...refs[0], oid: 'f'.repeat(40) }, refs[1]],
+      repositoryPath,
+    })).rejects.toMatchObject({ code: 'authority-integrity-error' });
+  });
+
+  it('rejects a manifest-authenticated bundle that advertises an extra private ref', async () => {
+    const repositoryPath = path.join(root, 'private-object-repository');
+    const targetPath = path.join(root, 'private-object-target.git');
+    const bundlePath = path.join(root, 'private-object.bundle');
+    await mkdir(repositoryPath);
+    await writeFile(path.join(root, 'private-object-gitconfig'), '');
+    const runner = new GitCommandRunner({
+      emptyConfigPath: path.join(root, 'private-object-gitconfig'),
+      executablePath: 'git',
+    });
+    await git(runner, repositoryPath, ['init', '--initial-branch=main']);
+    await writeFile(path.join(repositoryPath, 'public.md'), 'public\n');
+    await git(runner, repositoryPath, ['add', 'public.md']);
+    await git(runner, repositoryPath, ['commit', '-m', 'public'], true);
+    const mainOid = (await git(runner, repositoryPath, ['rev-parse', 'HEAD'])).trim();
+    await git(runner, repositoryPath, ['checkout', '--orphan', 'private']);
+    await git(runner, repositoryPath, ['rm', '-rf', '.']);
+    await writeFile(path.join(repositoryPath, 'private.md'), 'must not transfer\n');
+    await git(runner, repositoryPath, ['add', 'private.md']);
+    await git(runner, repositoryPath, ['commit', '-m', 'private'], true);
+    const privateOid = (await git(runner, repositoryPath, ['rev-parse', 'HEAD'])).trim();
+    await git(runner, repositoryPath, [
+      'update-ref', 'refs/claudian/private/secret', privateOid,
+    ]);
+    await git(runner, repositoryPath, ['update-ref', 'refs/heads/main', mainOid]);
+    await git(runner, repositoryPath, ['symbolic-ref', 'HEAD', 'refs/heads/main']);
+    await git(runner, repositoryPath, ['branch', '-D', 'private']);
+    await git(runner, repositoryPath, [
+      'bundle', 'create', bundlePath, 'refs/heads/main', 'refs/claudian/private/secret',
+    ]);
+    const bytes = await readFile(bundlePath);
+    const artifact = {
+      byteCount: bytes.byteLength,
+      name: 'repository.bundle',
+      sha256: createHash('sha256').update(bytes).digest('hex'),
+    } as const;
+    const refs = [{ name: 'refs/heads/main', oid: mainOid }] as const;
+
+    await expect(new AuthorityTransferCheckpointGit(runner)
+      .importIntoEmptyBareRepository({
+        bundlePath,
+        manifest: repositoryManifest(artifact, refs),
+        targetRepositoryPath: targetPath,
+      })).rejects.toMatchObject({ code: 'authority-integrity-error' });
+    await expect(lstat(targetPath)).rejects.toMatchObject({ code: 'ENOENT' });
+
+    const headerEnd = bytes.indexOf(Buffer.from('\n\n'));
+    expect(headerEnd).toBeGreaterThan(0);
+    const concealedHeader = bytes.subarray(0, headerEnd).toString('utf8')
+      .split('\n')
+      .filter(line => !line.endsWith(' refs/claudian/private/secret'))
+      .join('\n');
+    const concealed = Buffer.concat([
+      Buffer.from(`${concealedHeader}\n\n`, 'utf8'),
+      bytes.subarray(headerEnd + 2),
+    ]);
+    await writeFile(bundlePath, concealed);
+    const concealedArtifact = {
+      byteCount: concealed.byteLength,
+      name: 'repository.bundle',
+      sha256: createHash('sha256').update(concealed).digest('hex'),
+    } as const;
+    const concealedTargetPath = path.join(root, 'concealed-object-target.git');
+
+    await expect(new AuthorityTransferCheckpointGit(runner)
+      .importIntoEmptyBareRepository({
+        bundlePath,
+        manifest: repositoryManifest(concealedArtifact, refs),
+        targetRepositoryPath: concealedTargetPath,
+      })).rejects.toMatchObject({ code: 'authority-integrity-error' });
+    await expect(lstat(concealedTargetPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('imports a SHA-256 bundle into a canonical SHA-256 bare repository', async () => {
+    const repositoryPath = path.join(root, 'sha256-repository');
+    const targetPath = path.join(root, 'sha256-target.git');
+    const bundlePath = path.join(root, 'sha256.bundle');
+    await mkdir(repositoryPath);
+    await writeFile(path.join(root, 'sha256-gitconfig'), '');
+    const runner = new GitCommandRunner({
+      emptyConfigPath: path.join(root, 'sha256-gitconfig'),
+      executablePath: 'git',
+    });
+    await git(runner, repositoryPath, [
+      'init', '--object-format=sha256', '--initial-branch=main',
+    ]);
+    await writeFile(path.join(repositoryPath, 'note.md'), 'sha256\n');
+    await git(runner, repositoryPath, ['add', 'note.md']);
+    await git(runner, repositoryPath, ['commit', '-m', 'sha256'], true);
+    const oid = (await git(runner, repositoryPath, ['rev-parse', 'HEAD'])).trim();
+    const refs = [{ name: 'refs/heads/main', oid }] as const;
+    const checkpointGit = new AuthorityTransferCheckpointGit(runner);
+    const artifact = await checkpointGit.createBundle({ bundlePath, refs, repositoryPath });
+
+    await checkpointGit.importIntoEmptyBareRepository({
+      bundlePath,
+      manifest: repositoryManifest(artifact, refs, 'sha256'),
+      targetRepositoryPath: targetPath,
+    });
+
+    await expect(git(runner, targetPath, ['rev-parse', '--show-object-format']))
+      .resolves.toBe('sha256\n');
+    await expect(git(runner, targetPath, ['symbolic-ref', 'HEAD']))
+      .resolves.toBe('refs/heads/main\n');
+  });
+
+  it('removes an import repository when initialization fails after creating it', async () => {
+    const targetPath = path.join(root, 'failed-target.git');
+    await writeFile(path.join(root, 'failed-import-gitconfig'), '');
+    const runner = new GitCommandRunner({
+      emptyConfigPath: path.join(root, 'failed-import-gitconfig'),
+      executablePath: 'git',
+    });
+    const failingRunner: Pick<GitCommandRunner, 'run'> = {
+      run: async (request) => {
+        const result = await runner.run(request);
+        if (request.args[0] === 'init') throw new Error('injected-init-failure');
+        return result;
+      },
+    };
+    const checkpointGit = new AuthorityTransferCheckpointGit(failingRunner);
+    const bundlePath = path.join(root, 'unused.bundle');
+    await writeFile(bundlePath, 'x');
+    const artifact = {
+      byteCount: 1,
+      name: 'repository.bundle',
+      sha256: createHash('sha256').update('x').digest('hex'),
+    } as const;
+    const refs = [{ name: 'refs/heads/main', oid: MAIN_OID }] as const;
+
+    await expect(checkpointGit.importIntoEmptyBareRepository({
+      bundlePath,
+      manifest: repositoryManifest(artifact, refs),
+      targetRepositoryPath: targetPath,
+    })).rejects.toThrow('injected-init-failure');
+
+    await expect(lstat(targetPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('revokes invitation admission and deletes only canonical pending refs', async () => {
+    const repositoryPath = path.join(root, 'settlement-repository');
+    await mkdir(repositoryPath);
+    await writeFile(path.join(root, 'settlement-gitconfig'), '');
+    const runner = new GitCommandRunner({
+      emptyConfigPath: path.join(root, 'settlement-gitconfig'),
+      executablePath: 'git',
+    });
+    await git(runner, repositoryPath, ['init', '--initial-branch=main']);
+    await writeFile(path.join(repositoryPath, 'note.md'), 'main\n');
+    await git(runner, repositoryPath, ['add', 'note.md']);
+    await git(runner, repositoryPath, ['commit', '-m', 'main'], true);
+    const mainOid = (await git(runner, repositoryPath, ['rev-parse', 'HEAD'])).trim();
+    await git(runner, repositoryPath, [
+      'update-ref', 'refs/heads/members/member-pending-safe', mainOid,
+    ]);
+    await writeFile(path.join(repositoryPath, 'note.md'), 'diverged\n');
+    await git(runner, repositoryPath, ['commit', '-am', 'diverged'], true);
+    const divergentOid = (await git(runner, repositoryPath, ['rev-parse', 'HEAD'])).trim();
+    await git(runner, repositoryPath, ['update-ref', 'refs/heads/main', mainOid]);
+    await git(runner, repositoryPath, [
+      'update-ref', 'refs/heads/members/member-pending-diverged', divergentOid,
+    ]);
+    await source.mutate(connection => {
+      connection.run(`
+        INSERT INTO invitations (
+          invitation_id, token_hash, expires_at, revoked_at,
+          created_by_member_id, created_at
+        ) VALUES ('invite-settlement', ?, '2026-08-27T00:00:00.000Z', NULL,
+          'member-host', ?)
+      `, [new Uint8Array(32).fill(4), CREATED_AT]);
+      for (const memberId of ['member-pending-safe', 'member-pending-diverged']) {
+        connection.run(`
+          INSERT INTO members (
+            member_id, display_name, personal_ref, role, status, credential_hash,
+            join_attempt_id, created_at, activated_at, revoked_at
+          ) VALUES (?, ?, ?, 'member', 'pending', ?, ?, ?, NULL, NULL)
+        `, [
+          memberId,
+          memberId,
+          `refs/heads/members/${memberId}`,
+          new Uint8Array(32).fill(5),
+          `join-${memberId}`,
+          CREATED_AT,
+        ]);
+      }
+    });
+    const settlement = new AuthorityTransferAdmissionSettlement({
+      database: source,
+      runner,
+    });
+
+    await expect(settlement.settle({
+      repositoryPath,
+      settledAt: CREATED_AT,
+    })).rejects.toMatchObject({
+      safeContext: { reason: 'authority-transfer-pending-ref-diverged' },
+    });
+    expect(await source.read(connection => connection.get(`
+      SELECT
+        (SELECT COUNT(*) FROM members WHERE status = 'pending') AS pending,
+        (SELECT COUNT(*) FROM invitations WHERE revoked_at IS NULL) AS live
+    `))).toEqual({ live: 1, pending: 2 });
+
+    await git(runner, repositoryPath, [
+      'update-ref', 'refs/heads/members/member-pending-diverged', mainOid, divergentOid,
+    ]);
+    await settlement.settle({ repositoryPath, settledAt: CREATED_AT });
+
+    expect(await source.read(connection => connection.get(`
+      SELECT
+        (SELECT COUNT(*) FROM members WHERE status = 'pending') AS pending,
+        (SELECT COUNT(*) FROM invitations WHERE revoked_at IS NULL) AS live,
+        (SELECT COUNT(*) FROM invitations WHERE revoked_at = ?) AS revoked
+    `, [CREATED_AT]))).toEqual({ live: 0, pending: 0, revoked: 1 });
+    expect((await git(runner, repositoryPath, [
+      'for-each-ref', '--format=%(refname)', 'refs/heads/members/member-pending-',
+    ])).trim()).toBe('');
+  });
+
+  async function createDatabase(directory: string): Promise<SqlJsProjectDatabase> {
+    await mkdir(directory);
+    const database = new SqlJsProjectDatabase(directory, { loadSqlJs: async () => SQL });
+    await database.open();
+    return database;
+  }
+});
+
+function checkpointManifest(
+  coordination: string,
+  coordinationSha256 = createHash('sha256').update(coordination).digest('hex'),
+): CollabProjectCheckpointManifest {
+  return createAuthorityTransferCheckpointManifest({
+    artifacts: [
+      {
+        byteCount: Buffer.byteLength(coordination),
+        name: 'coordination.ndjson',
+        sha256: coordinationSha256,
+      },
+      { byteCount: 1, name: 'repository.bundle', sha256: 'c'.repeat(64) },
+    ],
+    createdAt: CREATED_AT,
+    expectedMainOid: MAIN_OID,
+    gitObjectFormat: 'sha1',
+    operationId: 'transfer-one',
+    projectId: 'project-alpha',
+    refs: [
+      { name: 'refs/heads/main', oid: MAIN_OID },
+      { name: 'refs/heads/members/member-a', oid: MEMBER_OID },
+      { name: 'refs/heads/members/member-host', oid: MEMBER_OID },
+    ],
+    sourceAuthority: { generation: 1, kind: 'cloud' },
+    targetAuthority: { generation: 2, kind: 'lan' },
+  });
+}
+
+function repositoryManifest(
+  repositoryArtifact: CollabCheckpointArtifactFact,
+  refs: readonly CollabCheckpointGitRef[],
+  gitObjectFormat: CollabCheckpointObjectFormat = 'sha1',
+): CollabProjectCheckpointManifest {
+  return createAuthorityTransferCheckpointManifest({
+    artifacts: [
+      { byteCount: 1, name: 'coordination.ndjson', sha256: 'a'.repeat(64) },
+      repositoryArtifact,
+    ],
+    createdAt: CREATED_AT,
+    expectedMainOid: refs[0]!.oid,
+    gitObjectFormat,
+    operationId: 'transfer-git',
+    projectId: 'project-alpha',
+    refs,
+    sourceAuthority: { generation: 1, kind: 'lan' },
+    targetAuthority: { generation: 2, kind: 'cloud' },
+  });
+}
+
+async function git(
+  runner: GitCommandRunner,
+  cwd: string,
+  args: readonly string[],
+  identity = false,
+): Promise<string> {
+  const result = await runner.run({
+    args,
+    cwd,
+    ...(identity ? { identity: { email: 'test@example.com', name: 'Test' } } : {}),
+    maxStdoutBytes: 1024 * 1024,
+    suppressHooks: true,
+  });
+  return result.stdout.toString('utf8');
+}

--- a/tests/integration/app/collab/gates/ProjectExitFoundationGate.test.ts
+++ b/tests/integration/app/collab/gates/ProjectExitFoundationGate.test.ts
@@ -60,12 +60,12 @@ describe('Project exit foundation gate', () => {
     await rm(root, { force: true, recursive: true });
   });
 
-  it('freezes the v9/v2/v11 contract and strict lifecycle envelopes', () => {
+  it('freezes the v9/v2/v12 contract and strict lifecycle envelopes', () => {
     expect({
       authority: COLLAB_AUTHORITY_SCHEMA_VERSION,
       local: COLLAB_LOCAL_PROJECT_SCHEMA_VERSION,
       protocol: COLLAB_CONTROL_PROTOCOL_VERSION,
-    }).toEqual({ authority: 11, local: 3, protocol: 9 });
+    }).toEqual({ authority: 12, local: 3, protocol: 9 });
     expect(lanCollabControlOperationCodec('leaveProject').decodeRequest({
       expectedHostMemberId: 'member-host',
       expectedMemberId: 'member-target',

--- a/tests/unit/app/collab/CollabSchemaVersions.test.ts
+++ b/tests/unit/app/collab/CollabSchemaVersions.test.ts
@@ -6,6 +6,6 @@ import {
 describe('CollabSchemaVersions', () => {
   it('freezes the app-owned persistence schema versions', () => {
     expect(COLLAB_LOCAL_PROJECT_SCHEMA_VERSION).toBe(3);
-    expect(COLLAB_AUTHORITY_SCHEMA_VERSION).toBe(11);
+    expect(COLLAB_AUTHORITY_SCHEMA_VERSION).toBe(12);
   });
 });

--- a/tests/unit/app/collab/authority/AuthoritySchemaLifecycle.test.ts
+++ b/tests/unit/app/collab/authority/AuthoritySchemaLifecycle.test.ts
@@ -169,11 +169,121 @@ function insertProject(database: Database, managerMemberId = 'member-host'): voi
   `, [managerMemberId]);
 }
 
+function downgradeCurrentSchemaToV11(database: Database): void {
+  database.run(`
+    CREATE TABLE members_v11 (
+      member_id TEXT PRIMARY KEY,
+      display_name TEXT NOT NULL,
+      personal_ref TEXT NOT NULL UNIQUE,
+      role TEXT NOT NULL CHECK(role IN ('manager', 'member')),
+      status TEXT NOT NULL CHECK(status IN ('pending', 'active', 'revoked', 'left')),
+      credential_hash BLOB NOT NULL CHECK(length(credential_hash) = 32),
+      join_attempt_id TEXT UNIQUE,
+      created_at TEXT NOT NULL,
+      activated_at TEXT,
+      revoked_at TEXT
+    );
+    INSERT INTO members_v11 (
+      member_id, display_name, personal_ref, role, status, credential_hash,
+      join_attempt_id, created_at, activated_at, revoked_at
+    )
+    SELECT
+      member_id, display_name, personal_ref, role, status, credential_hash,
+      join_attempt_id, created_at, activated_at, revoked_at
+    FROM members;
+    DROP TABLE members;
+    ALTER TABLE members_v11 RENAME TO members;
+    DROP TABLE authority_metadata;
+    PRAGMA user_version = 11;
+  `);
+}
+
 describe('AuthoritySchema lifecycle migration', () => {
   let SQL: SqlJsStatic;
 
   beforeAll(async () => {
     SQL = await initSqlJs();
+  });
+
+  it('initializes generation one and credential-bound access for new authorities', () => {
+    const database = new SQL.Database();
+    applyAuthorityMigrations(database);
+    insertMembers(database);
+    database.run(`
+      INSERT INTO project (
+        singleton, project_id, name, state, host_member_id,
+        manager_set_generation, main_ref, created_at, snapshot_generation
+      ) VALUES (
+        1, 'project-alpha', 'Alpha', 'active', 'member-host', 0,
+        'refs/heads/main', '${CREATED_AT}', 0
+      )
+    `);
+
+    expect(database.exec(`
+      SELECT authority_generation FROM authority_metadata WHERE singleton = 1
+    `)[0]?.values).toEqual([[1]]);
+    expect(database.exec(`
+      SELECT member_id, access_state, length(credential_hash)
+      FROM members ORDER BY member_id
+    `)[0]?.values).toEqual([
+      ['member-a', 'bound', 32],
+      ['member-host', 'bound', 32],
+    ]);
+    expect(() => database.run(`
+      INSERT INTO members (
+        member_id, display_name, personal_ref, role, status, access_state,
+        credential_hash, join_attempt_id, created_at, activated_at, revoked_at
+      ) VALUES (
+        'member-unbound', 'Unbound', 'refs/heads/members/member-unbound',
+        'member', 'active', 'unbound', NULL, NULL,
+        '${CREATED_AT}', '${CREATED_AT}', NULL
+      )
+    `)).not.toThrow();
+    expect(() => database.run(`
+      INSERT INTO members (
+        member_id, display_name, personal_ref, role, status, access_state,
+        credential_hash, join_attempt_id, created_at, activated_at, revoked_at
+      ) VALUES (
+        'member-pending-unbound', 'Pending',
+        'refs/heads/members/member-pending-unbound', 'member', 'pending',
+        'unbound', NULL, 'join-unbound', '${CREATED_AT}', NULL, NULL
+      )
+    `)).toThrow();
+  });
+
+  it('backfills a populated v11 authority without changing Member credentials', () => {
+    const database = new SQL.Database();
+    applyAuthorityMigrations(database);
+    insertMembers(database);
+    database.run(`
+      INSERT INTO project (
+        singleton, project_id, name, state, host_member_id,
+        manager_set_generation, main_ref, created_at, snapshot_generation
+      ) VALUES (
+        1, 'project-alpha', 'Alpha', 'active', 'member-host', 4,
+        'refs/heads/main', '${CREATED_AT}', 6
+      )
+    `);
+    const before = database.exec(`
+      SELECT member_id, hex(credential_hash) FROM members ORDER BY member_id
+    `)[0]?.values;
+    downgradeCurrentSchemaToV11(database);
+    database.run('PRAGMA foreign_keys = ON');
+
+    expect(applyAuthorityMigrations(database)).toBe(true);
+    expect(database.exec('PRAGMA user_version')[0]?.values[0]?.[0])
+      .toBe(COLLAB_AUTHORITY_SCHEMA_VERSION);
+    expect(database.exec(`
+      SELECT authority_generation FROM authority_metadata WHERE singleton = 1
+    `)[0]?.values).toEqual([[1]]);
+    expect(database.exec(`
+      SELECT member_id, access_state, hex(credential_hash)
+      FROM members ORDER BY member_id
+    `)[0]?.values).toEqual(before?.map(row => [row[0], 'bound', row[1]]));
+    expect(assertAuthorityDatabaseIntegrity(database, {
+      full: true,
+      requireProject: true,
+    })).toBe(6);
   });
 
   it('atomically migrates a populated v8 authority to the finite multi-Manager v11 schema', () => {
@@ -400,7 +510,7 @@ describe('AuthoritySchema lifecycle migration', () => {
       },
       name: 'malformed responsibility index',
     },
-  ])('rejects a current v11 database with a $name', ({ corrupt }) => {
+  ])('rejects a current database with a $name', ({ corrupt }) => {
     const database = new SQL.Database();
     applyAuthorityMigrations(database);
     corrupt(database);
@@ -408,7 +518,8 @@ describe('AuthoritySchema lifecycle migration', () => {
     expect(() => applyAuthorityMigrations(database)).toThrow(
       'Authority V10 Manager schema is incomplete',
     );
-    expect(database.exec('PRAGMA user_version')[0]?.values[0]?.[0]).toBe(11);
+    expect(database.exec('PRAGMA user_version')[0]?.values[0]?.[0])
+      .toBe(COLLAB_AUTHORITY_SCHEMA_VERSION);
   });
 
   it('rejects a renamed unique index that still enforces one active Manager', () => {

--- a/tests/unit/app/collab/authority/ProjectRetirementAuthorityService.test.ts
+++ b/tests/unit/app/collab/authority/ProjectRetirementAuthorityService.test.ts
@@ -105,6 +105,34 @@ describe('ProjectRetirementAuthorityService', () => {
     });
   });
 
+  it('retires with an imported active Member still unbound', async () => {
+    await database.mutate(connection => {
+      connection.run(`
+        UPDATE members
+        SET access_state = 'unbound', credential_hash = NULL
+        WHERE member_id = 'member-third' AND status = 'active'
+      `);
+    });
+    const service = new ProjectRetirementAuthorityService(
+      database,
+      new RetirementTombstoneRepository(localProjects, { now: () => NOW }),
+      { now: () => NOW },
+    );
+
+    await expect(service.retire('member-host', request())).resolves.toEqual({
+      projectId: 'project-alpha',
+      retiredAt: NOW.toISOString(),
+    });
+
+    await expect(localProjects.loadRetirementTombstone('project-alpha'))
+      .resolves.toEqual(expect.objectContaining({
+        formerMembers: [
+          expect.objectContaining({ memberId: 'member-host' }),
+          expect.objectContaining({ memberId: 'member-second' }),
+        ],
+      }));
+  });
+
   it('allows an active Manager who is neither Host nor Project creator to Retire', async () => {
     const service = new ProjectRetirementAuthorityService(
       database,

--- a/tests/unit/app/collab/authority/database/AuthorityRepositories.test.ts
+++ b/tests/unit/app/collab/authority/database/AuthorityRepositories.test.ts
@@ -10,6 +10,7 @@ import initSqlJs, { type SqlJsStatic } from 'sql.js';
 
 import { AuthorityEventRepository } from '@/app/collab/authority/AuthorityEventRepository';
 import { AuthorityIdempotencyRepository } from '@/app/collab/authority/AuthorityIdempotencyRepository';
+import { PendingMembershipRepository } from '@/app/collab/authority/PendingMembershipRepository';
 import { ProjectAuthorityRepository } from '@/app/collab/authority/ProjectAuthorityRepository';
 import { RequestTicketRelationRepository } from '@/app/collab/authority/RequestTicketRelationRepository';
 import {
@@ -80,6 +81,36 @@ describe('Collab authority schema and base repositories', () => {
         ['b'.repeat(40), 'request-one'],
       );
     })).rejects.toMatchObject({ code: 'authority-integrity-error' });
+  });
+
+  it('binds one imported active identity idempotently without accepting another hash', async () => {
+    const memberships = new PendingMembershipRepository();
+    const credentialHash = new Uint8Array(32).fill(6);
+    await database.mutate(connection => connection.run(`
+      INSERT INTO members (
+        member_id, display_name, personal_ref, role, status, access_state,
+        credential_hash, join_attempt_id, created_at, activated_at, revoked_at
+      ) VALUES (
+        'member-unbound', 'Unbound', 'refs/heads/members/member-unbound',
+        'member', 'active', 'unbound', NULL, NULL, ?, ?, NULL
+      )
+    `, [CREATED_AT, CREATED_AT]));
+
+    await expect(database.mutate(connection => memberships.bindImportedActive(
+      connection,
+      'member-unbound',
+      credentialHash,
+    ))).resolves.toMatchObject({ value: { status: 'bound' } });
+    await expect(database.mutate(connection => memberships.bindImportedActive(
+      connection,
+      'member-unbound',
+      credentialHash,
+    ))).resolves.toMatchObject({ value: { status: 'existing' } });
+    await expect(database.mutate(connection => memberships.bindImportedActive(
+      connection,
+      'member-unbound',
+      new Uint8Array(32).fill(7),
+    ))).rejects.toMatchObject({ code: 'authority-integrity-error' });
   });
 
   it('stores redacted monotonic events and restores them in sequence order', async () => {

--- a/tests/unit/app/collab/host-transfer/HostTransferAuthoritySnapshot.test.ts
+++ b/tests/unit/app/collab/host-transfer/HostTransferAuthoritySnapshot.test.ts
@@ -107,6 +107,17 @@ describe('HostTransferAuthoritySnapshot', () => {
   });
 
   it('creates and validates an inert snapshot without mutating the live authority', async () => {
+    await database.mutate(connection => {
+      connection.run(`
+        INSERT INTO members (
+          member_id, display_name, personal_ref, role, status, access_state,
+          credential_hash, join_attempt_id, created_at, activated_at, revoked_at
+        ) VALUES (
+          'member-offline', 'Offline', 'refs/heads/members/member-offline',
+          'member', 'active', 'unbound', NULL, NULL, ?, ?, NULL
+        )
+      `, [NOW, NOW]);
+    });
     const sourceGeneration = database.generation;
     const codec = new HostTransferAuthoritySnapshot({
       loadSqlJs: async () => SQL,

--- a/tests/unit/app/collab/host-transfer/HostTransferPackage.test.ts
+++ b/tests/unit/app/collab/host-transfer/HostTransferPackage.test.ts
@@ -94,7 +94,7 @@ describe('HostTransferPackage', () => {
     })).toThrow();
   });
 
-  it.each([8, 9, 10] as const)(
+  it.each([8, 9, 10, 11] as const)(
     'accepts schema %s only through the explicit incoming recovery decoder',
     authoritySchemaVersion => {
     const legacy = {

--- a/tests/unit/app/collab/lan/PendingMembershipService.test.ts
+++ b/tests/unit/app/collab/lan/PendingMembershipService.test.ts
@@ -126,6 +126,23 @@ describe('PendingMembershipService', () => {
     });
   });
 
+  it('rejects an imported active Member until an exact credential is bound', async () => {
+    await database.mutate(connection => connection.run(`
+      INSERT INTO members (
+        member_id, display_name, personal_ref, role, status, access_state,
+        credential_hash, join_attempt_id, created_at, activated_at, revoked_at
+      ) VALUES (
+        'member-unbound', 'Unbound', 'refs/heads/members/member-unbound',
+        'member', 'active', 'unbound', NULL, NULL, ?, ?, NULL
+      )
+    `, [now.toISOString(), now.toISOString()]));
+
+    await expect(service.authenticateMemberCredential(
+      Buffer.alloc(32, 8).toString('base64url'),
+      ['active'],
+    )).rejects.toMatchObject({ code: 'authentication-failed' });
+  });
+
   it('reuses one pending membership and rotates its credential on a retry', async () => {
     const invitation = await service.createInvitation(HOST_CREDENTIAL, {
       idempotencyKey: 'create-invite-1',


### PR DESCRIPTION
## Summary

- migrate LAN authority storage to generation-aware bound/unbound Member access
- add deterministic logical authority checkpoint and manifest-bound exact Git bundle import/export
- settle safe pending admission before capture and preserve offline unbound Members across Retire and Host transfer

## Verification

- npm test (583 suites passed, 1 skipped; 8,485 tests passed, 1 skipped)
- npm run typecheck
- npm run lint
- npm run build
- four-pass review-and-repair; final review clean