### PR TITLE
feat: persist local authority transfer recovery

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "claudian",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.226",
-        "@claudian-collab/protocol": "2.0.0",
+        "@claudian-collab/protocol": "3.0.0",
         "@codemirror/commands": "6.10.0",
         "@codemirror/lang-markdown": "^6.5.2",
         "@codemirror/language": "^6.12.4",
@@ -162,7 +162,7 @@
 
     "@cacheable/utils": ["@cacheable/utils@2.5.0", "", { "dependencies": { "hashery": "^1.5.1", "keyv": "^5.6.0" } }, "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA=="],
 
-    "@claudian-collab/protocol": ["@claudian-collab/protocol@2.0.0", "", { "dependencies": { "@lezer/markdown": "1.7.2" } }, "sha512-ImjuXs4eSCMzfp3BEKw5gvXIdicQ8bjqJYcICcNxylFrwqwrtej9rLe9pMi6gqvnCQ6N2AbvTKUx/5dEl2fdPA=="],
+    "@claudian-collab/protocol": ["@claudian-collab/protocol@3.0.0", "", { "dependencies": { "@lezer/markdown": "1.7.2" } }, "sha512-PNmHr3YI/w272Gh0fHcpMoAhDN7oZYSNa+796UuQxXbLrpDB+Lv2Y4Le8pDYR+GMpWOK3Zk03MSnYtQKzvpsSg=="],
 
     "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.226",
-        "@claudian-collab/protocol": "2.0.0",
+        "@claudian-collab/protocol": "3.0.0",
         "@codemirror/commands": "6.10.0",
         "@codemirror/lang-markdown": "^6.5.2",
         "@codemirror/language": "^6.12.4",
@@ -829,9 +829,9 @@
       }
     },
     "node_modules/@claudian-collab/protocol": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@claudian-collab/protocol/-/protocol-2.0.0.tgz",
-      "integrity": "sha512-ImjuXs4eSCMzfp3BEKw5gvXIdicQ8bjqJYcICcNxylFrwqwrtej9rLe9pMi6gqvnCQ6N2AbvTKUx/5dEl2fdPA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@claudian-collab/protocol/-/protocol-3.0.0.tgz",
+      "integrity": "sha512-PNmHr3YI/w272Gh0fHcpMoAhDN7oZYSNa+796UuQxXbLrpDB+Lv2Y4Le8pDYR+GMpWOK3Zk03MSnYtQKzvpsSg==",
       "license": "MIT",
       "dependencies": {
         "@lezer/markdown": "1.7.2"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.226",
-    "@claudian-collab/protocol": "2.0.0",
+    "@claudian-collab/protocol": "3.0.0",
     "@codemirror/commands": "6.10.0",
     "@codemirror/lang-markdown": "^6.5.2",
     "@codemirror/language": "^6.12.4",

--- a/scripts/check-architecture-boundaries.test.mjs
+++ b/scripts/check-architecture-boundaries.test.mjs
@@ -570,21 +570,21 @@ test('Claudian consumes the standalone Collab protocol only from the exact regis
     'utf8',
   ));
 
-  assert.equal(manifest.dependencies?.[protocolPackageName], '2.0.0');
+  assert.equal(manifest.dependencies?.[protocolPackageName], '3.0.0');
   assert.equal(manifest.dependencies?.['@lezer/markdown'], '1.7.2');
   assert.equal(protocolManifest.dependencies?.['@lezer/markdown'], '1.7.2');
   assert.equal(manifest.dependencies?.['@claudian/collab-protocol'], undefined);
   assert.equal(manifest.workspaces, undefined);
-  assert.equal(lockfile.packages?.['']?.dependencies?.[protocolPackageName], '2.0.0');
-  assert.equal(lockfile.packages?.[protocolInstallPath]?.version, '2.0.0');
+  assert.equal(lockfile.packages?.['']?.dependencies?.[protocolPackageName], '3.0.0');
+  assert.equal(lockfile.packages?.[protocolInstallPath]?.version, '3.0.0');
   assert.equal(
     lockfile.packages?.[protocolInstallPath]?.integrity,
-    'sha512-ImjuXs4eSCMzfp3BEKw5gvXIdicQ8bjqJYcICcNxylFrwqwrtej9rLe9pMi6gqvnCQ6N2AbvTKUx/5dEl2fdPA==',
+    'sha512-PNmHr3YI/w272Gh0fHcpMoAhDN7oZYSNa+796UuQxXbLrpDB+Lv2Y4Le8pDYR+GMpWOK3Zk03MSnYtQKzvpsSg==',
   );
   assert.equal(lockfile.packages?.['node_modules/@lezer/markdown']?.version, '1.7.2');
   assert.match(
     lockfile.packages?.[protocolInstallPath]?.resolved ?? '',
-    /^https:\/\/registry\.npmjs\.org\/@claudian-collab\/protocol\/-\/protocol-2\.0\.0\.tgz$/u,
+    /^https:\/\/registry\.npmjs\.org\/@claudian-collab\/protocol\/-\/protocol-3\.0\.0\.tgz$/u,
   );
 
   for (const retiredPath of [

--- a/src/app/collab/ClaudianCollabService.ts
+++ b/src/app/collab/ClaudianCollabService.ts
@@ -22,6 +22,9 @@ import { RequestQueryGitPolicy } from '@/app/collab/authority/RequestQueryGitPol
 import { RequestQueryService } from '@/app/collab/authority/RequestQueryService';
 import { SqlJsProjectDatabase } from '@/app/collab/authority/SqlJsProjectDatabase';
 import { TicketService } from '@/app/collab/authority/TicketService';
+import {
+  AuthorityTransferPersistence,
+} from '@/app/collab/authority-transfer/persistence/AuthorityTransferPersistence';
 import { CloudBootstrapTransitionStore } from '@/app/collab/bootstrap/CloudBootstrapTransitionStore';
 import {
   type CollabFilesystemDiagnosticSink,
@@ -77,6 +80,10 @@ import {
 import type {
   CollabTerminalProjectService,
 } from '@/app/collab/lan/routes/RouteTypes';
+import type {
+  CollabProjectLifecycleAdmission,
+  CollabProjectLifecycleAuthorityAdmission,
+} from '@/app/collab/lifecycle/CollabProjectLifecycleAdmission';
 import { LanHostTransitionProofClient } from '@/app/collab/reconnect/LanHostTransitionProofClient';
 import { ReconnectProjectCoordinator } from '@/app/collab/reconnect/ReconnectProjectCoordinator';
 import { ProjectRetirementCoordinator } from '@/app/collab/retirement/ProjectRetirementCoordinator';
@@ -142,6 +149,7 @@ export interface ClaudianCollabServiceOptions {
 }
 
 interface RetirementCoordinatorFactoryInput {
+  readonly projectLifecycleAdmission: CollabProjectLifecycleAuthorityAdmission;
   readonly admission: {
     quiesceAndDrain(projectId: CollabProjectId): Promise<void>;
     resume(projectId: CollabProjectId): Promise<void>;
@@ -179,6 +187,7 @@ function environmentPath(environment: NodeJS.ProcessEnv): string | undefined {
 }
 
 export class ClaudianCollabService {
+  readonly authorityTransfers: AuthorityTransferPersistence;
   readonly cloudBootstrapTransitions: CloudBootstrapTransitionStore;
   readonly discovery: CollabLanDiscoveryService;
   readonly hostTransitionCandidates: HostTransitionCandidateResolver;
@@ -223,6 +232,7 @@ export class ClaudianCollabService {
     const projects = new CollabLocalProjectRepository(options.vaultRoot, {
       onDiagnostic: options.onDiagnostic,
     });
+    this.authorityTransfers = new AuthorityTransferPersistence(projects);
     this.local = Object.freeze({
       pathPolicy,
       projects,
@@ -270,9 +280,23 @@ export class ClaudianCollabService {
       discovery: this.discovery,
       localProjects: projects,
       openProject: projectId => this.openLanHostProject(projectId),
-      runWithProjectStartGuard: (projectId, operation) => (
-        this.cloudBootstrapTransitions.runWithLanHostStartGuard(projectId, operation)
-      ),
+      runWithProjectStartGuard: async (projectId, operation) => {
+        const tombstone = await projects.loadRetirementTombstone(projectId);
+        if (tombstone) {
+          throw new CollabError({
+            code: 'project-retired',
+            safeContext: {
+              projectId,
+              reason: 'retirement-tombstone-durable',
+              retiredAt: tombstone.retiredAt,
+            },
+          });
+        }
+        return this.cloudBootstrapTransitions.runWithLanHostStartGuard(
+          projectId,
+          () => this.authorityTransfers.runWithAuthorityStartGuard(projectId, operation),
+        );
+      },
       vaultRoot: options.vaultRoot,
     });
   }
@@ -392,17 +416,25 @@ export class ClaudianCollabService {
     this.retirementHandler = handler;
   }
 
-  async restoreRetirementResponders(): Promise<void> {
+  async restoreRetirementResponders(
+    projectRecoveryAdmission: CollabProjectLifecycleAdmission,
+  ): Promise<void> {
     this.assertOpen();
     const restored = await this.retirementTombstones.restore();
     let firstError: unknown;
     for (const projectId of restored.expiredProjectIds) {
-      await this.restoreExpiredRetirementResponder(projectId).catch(error => {
+      await projectRecoveryAdmission(
+        projectId,
+        () => this.restoreExpiredRetirementResponder(projectId),
+      ).catch(error => {
         firstError ??= error;
       });
     }
     for (const tombstone of restored.tombstones) {
-      await this.restoreRetirementResponder(tombstone).catch(error => {
+      await projectRecoveryAdmission(
+        tombstone.projectId,
+        () => this.restoreRetirementResponder(tombstone),
+      ).catch(error => {
         firstError ??= error;
       });
     }
@@ -413,6 +445,24 @@ export class ClaudianCollabService {
   }
 
   private async restoreExpiredRetirementResponder(projectId: CollabProjectId): Promise<void> {
+    const tombstone = await this.local.projects.loadRetirementTombstone(projectId);
+    if (!tombstone) {
+      throw new CollabError({
+        code: 'durable-progress-recovery-required',
+        recoveryActions: ['resume', 'open-diagnostics'],
+        safeContext: { projectId, reason: 'retirement-tombstone-missing' },
+      });
+    }
+    const [index, retirement] = await Promise.all([
+      this.local.projects.loadIndex(),
+      this.local.projects.loadRetirementRecord(projectId),
+    ]);
+    if (retirement !== null || index.projects.some(project => project.id === projectId)) {
+      if (!this.retirementHandler) {
+        throw collabServiceError('not-initialized', 'retirement-handler-missing');
+      }
+      await this.retirementHandler.handle(tombstone.result, 'terminal-fallback');
+    }
     await this.lanHost.stopTerminalProject(projectId).catch(() => undefined);
     await this.closeAuthority(projectId).catch(() => undefined);
     await this.local.projects.removeAuthorityDirectory(projectId);
@@ -484,6 +534,7 @@ export class ClaudianCollabService {
 
   createHostTransferService(
     snapshots: HostTransferModuleOptions['snapshots'],
+    projectRecoveryAdmission: CollabProjectLifecycleAdmission,
   ): CollabHostTransferService {
     this.assertOpen();
     if (this.hostTransferModule) {
@@ -510,6 +561,7 @@ export class ClaudianCollabService {
       },
       lanHost: this.lanHost,
       projects: this.local.projects,
+      projectRecoveryAdmission,
       requireGitFoundation: () => this.requireGitFoundation(),
       snapshots,
       workspace: this.local.workspace,
@@ -530,6 +582,9 @@ export class ClaudianCollabService {
       this.retirementResponders.clear();
       this.retirementResponderCleanupPending.clear();
       this.retiredAuthorityCleanupComplete.clear();
+      await this.authorityTransfers.close().catch(error => {
+        firstError ??= error;
+      });
       await this.lanHost.close().catch(error => {
         firstError ??= error;
       });
@@ -727,6 +782,7 @@ export class ClaudianCollabService {
             },
           },
           { teardown: retiredProjectId => input.teardown(retiredProjectId) },
+          input.projectLifecycleAdmission,
         );
         return {
           retireProject: (actorMemberId, request) => coordinator.retire(actorMemberId, {

--- a/src/app/collab/CollabFeatureSubcomposition.ts
+++ b/src/app/collab/CollabFeatureSubcomposition.ts
@@ -1,5 +1,8 @@
 import { randomUUID } from 'node:crypto';
 
+import {
+  AuthorityTransferRecovery,
+} from '@/app/collab/authority-transfer/recovery/AuthorityTransferRecovery';
 import { CloudBootstrapBindingFinalizer } from '@/app/collab/bootstrap/CloudBootstrapBindingFinalizer';
 import { CloudBootstrapCoordinator } from '@/app/collab/bootstrap/CloudBootstrapCoordinator';
 import { CloudBootstrapLocalFence } from '@/app/collab/bootstrap/CloudBootstrapLocalFence';
@@ -45,6 +48,9 @@ import {
   rotateCloudBootstrapOrigin,
 } from '@/app/collab/git/CollabGitOriginPolicy';
 import { CollabLifecycleJournalStore } from '@/app/collab/lifecycle/CollabLifecycleJournalStore';
+import {
+  createCollabProjectLifecycleDurableOwners,
+} from '@/app/collab/lifecycle/CollabProjectLifecycleOwners';
 import { CollabProjectLifecycleSubsystem } from '@/app/collab/lifecycle/CollabProjectLifecycleSubsystem';
 import { CollabMembershipService } from '@/app/collab/membership/CollabMembershipService';
 import {
@@ -93,6 +99,7 @@ export function createCollabFeatureSubcomposition(
 ): CollabFeatureSubcomposition {
   const { foundation, projectSetup, vaultRoot } = options;
   const journals = new CollabLifecycleJournalStore(vaultRoot);
+  const transitions = foundation.cloudBootstrapTransitions;
   const pendingLeaves = journals.pendingLeaves;
   const pendingLeaveAuthority = new PendingLeaveAuthorityService({
     hostTransitionCandidates: foundation.hostTransitionCandidates,
@@ -142,6 +149,15 @@ export function createCollabFeatureSubcomposition(
 
   let lifecycle: CollabProjectLifecycleSubsystem | null = null;
   let publication: CollabPublicationService | null = null;
+  const requireLifecycle = (): CollabProjectLifecycleSubsystem => {
+    if (!lifecycle) {
+      throw new CollabError({
+        code: 'not-initialized',
+        safeContext: { reason: 'collab-lifecycle-not-composed' },
+      });
+    }
+    return lifecycle;
+  };
   const requirePublication = (): CollabPublicationService => {
     if (!publication) {
       throw new CollabError({
@@ -155,6 +171,14 @@ export function createCollabFeatureSubcomposition(
     foundation.local.projects,
     {
       acknowledge: input => foundation.acknowledgeRetirement(input),
+    },
+    {
+      projectRecoveryAdmission: (projectId, operation) => requireLifecycle().runExclusive(
+        projectId,
+        'retirement',
+        'recovery',
+        operation,
+      ),
     },
   );
   const retirementHandler = new RetirementClientHandler(
@@ -190,6 +214,14 @@ export function createCollabFeatureSubcomposition(
     },
     {},
     {
+      managerResponsibilityAdmission: (projectId, operation) => (
+        requireLifecycle().runExclusive(
+          projectId,
+          'manager-responsibility',
+          'operation',
+          operation,
+        )
+      ),
       managerReceipts,
       managerResponsibilityOperations,
       pendingLeaves,
@@ -199,17 +231,33 @@ export function createCollabFeatureSubcomposition(
     discovery: foundation.discovery,
     isLocalHostRunning: projectId => foundation.lanHost.isProjectRunning(projectId),
     managerResponsibility: {
-      reconcileSnapshot: snapshot => membership
-        .reconcileManagerResponsibilitySnapshot(snapshot),
+      reconcileSnapshot: snapshot => requireLifecycle().runExclusive(
+          snapshot.project.id,
+          'manager-responsibility',
+          'continuation',
+          () => membership.reconcileManagerResponsibilitySnapshot(snapshot),
+      ),
     },
     reconnect: foundation.reconnect,
     retirement: retirementHandler,
+    retirementAdmission: (projectId, operation) => requireLifecycle().runRetirementAdoption(
+      projectId,
+      operation,
+    ),
     vaultRoot,
   });
   foundation.lanHost.bindConnectionProjection({
     resetProjectConnection: projectId => requirePublication().resetProjectConnection(projectId),
   });
-  const hostTransfer = foundation.createHostTransferService(publication);
+  const hostTransfer = foundation.createHostTransferService(
+    publication,
+    (projectId, operation) => requireLifecycle().runExclusive(
+      projectId,
+      'host-transfer',
+      'recovery',
+      operation,
+    ),
+  );
   let exitCoordinator: LocalProjectExitCoordinator | null = null;
   const requireExitCoordinator = (): Promise<LocalProjectExitCoordinator> => {
     if (!exitCoordinator) {
@@ -262,13 +310,24 @@ export function createCollabFeatureSubcomposition(
   };
   const pendingLeaveWorker = new PendingLeaveWorker(pendingLeaves, {
     resume: async (...args) => (await requireExitCoordinator()).resume(...args),
-  });
+  }, (projectId, operation) => requireLifecycle().runExclusive(
+    projectId,
+    'local-exit',
+    'recovery',
+    operation,
+  ));
   const retirementLocalRecovery = new RetirementLocalRecovery(
     foundation.local.projects,
     pendingLeaves,
     retiredCleanupRecords,
     retirementHandler,
     retiredFinalizer,
+    (projectId, operation) => requireLifecycle().runExclusive(
+      projectId,
+      'retirement',
+      'recovery',
+      operation,
+    ),
   );
   const retirement: CollabRetirementPort = {
     close: () => retirementHandler.close(),
@@ -283,7 +342,10 @@ export function createCollabFeatureSubcomposition(
     },
     retireProject: async (request, operationOptions): Promise<void> => {
       const result = await foundation.retireProject(request, operationOptions?.signal);
-      await retirementHandler.handle(result, 'response');
+      await requireLifecycle().runRetirementAdoption(
+        request.projectId,
+        () => retirementHandler.handle(result, 'response'),
+      );
     },
     retryProjectCleanup: async (projectId, operationOptions): Promise<void> => {
       if (operationOptions?.signal?.aborted) throw cancelled();
@@ -292,12 +354,29 @@ export function createCollabFeatureSubcomposition(
   };
   lifecycle = new CollabProjectLifecycleSubsystem({
     closeRecovery: () => acknowledgementWorker.close(),
+    durableOwners: createCollabProjectLifecycleDurableOwners({
+      cloudBootstrapTransitions: transitions,
+      hostTransferRecovery: foundation.local.projects.hostTransferRecovery,
+      localCleanup: foundation.local.projects.localCleanup,
+      managerReceipts,
+      pendingLeaves,
+      retiredCleanups: retiredCleanupRecords,
+      retirements: foundation.local.projects,
+      retirementTombstones: foundation.local.projects,
+    }),
     hostTransfer,
     localExit,
     recoveryStages: [
       {
         name: 'retirement-responders',
-        run: () => foundation.restoreRetirementResponders(),
+        run: () => foundation.restoreRetirementResponders(
+          (projectId, operation) => requireLifecycle().runExclusive(
+            projectId,
+            'retirement',
+            'recovery',
+            operation,
+          ),
+        ),
       },
       {
         name: 'host-transfers',
@@ -334,6 +413,31 @@ export function createCollabFeatureSubcomposition(
     ],
     retirement,
   });
+  const authorityTransferRecovery = new AuthorityTransferRecovery(
+    foundation.authorityTransfers,
+    {
+      resume: () => Promise.reject(new CollabError({
+        code: 'durable-progress-recovery-required',
+        recoveryActions: ['resume', 'open-diagnostics'],
+        safeContext: { reason: 'authority-transfer-runtime-not-composed' },
+      })),
+    },
+  );
+  authorityTransferRecovery.register(lifecycle);
+  foundation.lanHost.bindProjectLifecycleAdmissions({
+    hostTransfer: (projectId, operation) => requireLifecycle().runExclusive(
+      projectId,
+      'host-transfer',
+      'continuation',
+      operation,
+    ),
+    retirement: (projectId, operation) => requireLifecycle().runExclusive(
+      projectId,
+      'retirement',
+      'continuation',
+      operation,
+    ),
+  });
 
   const bootstrapWorkSessions: CloudBootstrapLocalFence = new CloudBootstrapLocalFence({
     admission: {
@@ -346,7 +450,6 @@ export function createCollabFeatureSubcomposition(
       suspendProject: projectId => requirePublication().suspendProject(projectId),
     },
   });
-  const transitions = foundation.cloudBootstrapTransitions;
   const source = new LocalDevelopmentBootstrapSource({ foundation, vaultRoot });
   const readiness = new CloudBootstrapReadinessCollector(
     new LocalCloudBootstrapReadinessInspector({
@@ -467,22 +570,33 @@ export function createCollabFeatureSubcomposition(
       })
     ),
     fenceUncertainProject: projectId => bootstrapWorkSessions.closeAndDrain(projectId),
-    recoverLocalArtifacts: () => source.recoverArtifacts(async manifest => {
-      const record = await transitions.load(manifest.comparison.projectId);
-      return record?.attemptId === manifest.attemptId
-        && record.manifestSha256 === developmentBootstrapManifestSha256(manifest);
-    }),
+    projectRecoveryAdmission: (projectId, operation) => requireLifecycle().runExclusive(
+      projectId,
+      'cloud-bootstrap',
+      'recovery',
+      operation,
+    ),
+    recoverLocalArtifacts: projectRecoveryAdmission => source.recoverArtifacts(
+      async manifest => {
+        const record = await transitions.load(manifest.comparison.projectId);
+        return record?.attemptId === manifest.attemptId
+          && record.manifestSha256 === developmentBootstrapManifestSha256(manifest);
+      },
+      projectRecoveryAdmission,
+    ),
     transitions,
   });
+  const lifecycleCloudBootstrap = lifecycle.bindCloudBootstrap(cloudBootstrap);
+  const lifecycleMembership = lifecycle.bindMembership(membership);
 
   const feature: CollabFeatureService = new CollabFeatureService(foundation, projectSetup, {
-    cloudBootstrap,
+    cloudBootstrap: lifecycleCloudBootstrap,
     hostTransfer: lifecycle.hostTransfer,
     join: foundation.join,
     lanHost: foundation.lanHost,
     lifecycleRecovery: lifecycle.lifecycleRecovery,
     localExit: lifecycle.localExit,
-    membership,
+    membership: lifecycleMembership,
     publication,
     retirement: lifecycle.retirement,
     vaultRoot,

--- a/src/app/collab/CollabLocalProjectRepository.ts
+++ b/src/app/collab/CollabLocalProjectRepository.ts
@@ -3,6 +3,21 @@ import { lstat, readdir, readFile, rename, rm } from 'node:fs/promises';
 import { COLLAB_CLOUD_BINDING_VERSION, COLLAB_PROTOCOL_VERSION, type CollabIsoTimestamp, type CollabMemberId, collabMemberRef, type CollabProjectId, type CollabRole, isCollabMemberId, isCollabOpaqueId, isCollabProjectId } from '@claudian-collab/protocol';
 
 import {
+  decodeAuthorityTransferRecord,
+} from '@/app/collab/authority-transfer/AuthorityTransferRecord';
+import {
+  decodeAuthorityTransferClaimBatchCommitmentRecord,
+} from '@/app/collab/authority-transfer/persistence/AuthorityTransferClaimBatchCommitmentRecord';
+import {
+  decodeAuthorityTransferClaimCustodyRecord,
+} from '@/app/collab/authority-transfer/persistence/AuthorityTransferClaimCustodyRecord';
+import type {
+  AuthorityTransferClaimCommitmentStorePort,
+  AuthorityTransferClaimCustodyStorePort,
+  AuthorityTransferProjectCatalog,
+  AuthorityTransferRecordStorePort,
+} from '@/app/collab/authority-transfer/persistence/AuthorityTransferPersistenceStores';
+import {
   type CollabFilesystemDiagnosticSink,
   ensureCollabContainerGuard,
   ensureCollabVaultDirectory,
@@ -158,6 +173,9 @@ export interface CollabLocalProjectPaths {
   readonly authorityDirectory: string;
   readonly conflictDirectory: string;
   readonly hostTransferRecovery: string;
+  readonly authorityTransfer: string;
+  readonly authorityTransferClaimCommitment: string;
+  readonly authorityTransferClaims: string;
   readonly localCleanup: string;
   readonly managerResponsibilityReceipt: string;
   readonly retirement: string;
@@ -173,6 +191,9 @@ export type CollabLifecycleProjectDocumentKind =
   | 'manager-responsibility-receipt'
   | 'local-cleanup'
   | 'host-transfer-recovery'
+  | 'authority-transfer'
+  | 'authority-transfer-claim-commitment'
+  | 'authority-transfer-claims'
   | 'retirement';
 
 export interface CollabLocalProjectDocumentBase {
@@ -194,6 +215,14 @@ type UnknownRecord = Record<string, unknown>;
 
 function isRecord(value: unknown): value is UnknownRecord {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isAuthorityTransferLifecycleKind(
+  kind: CollabLifecycleProjectDocumentKind,
+): kind is 'authority-transfer' | 'authority-transfer-claim-commitment' | 'authority-transfer-claims' {
+  return kind === 'authority-transfer'
+    || kind === 'authority-transfer-claim-commitment'
+    || kind === 'authority-transfer-claims';
 }
 
 function requireExactKeys(
@@ -651,6 +680,9 @@ function isJsonValue(value: unknown, seen = new WeakSet<object>()): boolean {
 }
 
 export class CollabLocalProjectRepository {
+  readonly authorityTransferClaimCommitments: AuthorityTransferClaimCommitmentStorePort;
+  readonly authorityTransferClaims: AuthorityTransferClaimCustodyStorePort;
+  readonly authorityTransferRecords: AuthorityTransferRecordStorePort;
   readonly hostTransferRecovery: HostTransferRecoveryStorePort;
   readonly localCleanup: LocalCleanupRecordPort;
   private readonly now: () => Date;
@@ -663,6 +695,64 @@ export class CollabLocalProjectRepository {
   ) {
     this.now = options.now ?? (() => new Date());
     this.onDiagnostic = options.onDiagnostic;
+    const authorityTransferRecords: AuthorityTransferRecordStorePort = {
+      listProjectIds: () => this.listAuthorityTransferProjectIds(),
+      scanProjectCatalog: () => this.scanAuthorityTransferProjectCatalog(),
+      load: projectId => this.loadLifecycleProjectDocument(
+        projectId,
+        'authority-transfer',
+        decodeAuthorityTransferRecord,
+      ),
+      remove: projectId => this.removeLifecycleProjectDocument(
+        projectId,
+        'authority-transfer',
+      ),
+      save: record => this.saveLifecycleProjectDocument(
+        record.projectId,
+        'authority-transfer',
+        record,
+        decodeAuthorityTransferRecord,
+      ),
+    };
+    this.authorityTransferRecords = Object.freeze(authorityTransferRecords);
+    const authorityTransferClaimCommitments: AuthorityTransferClaimCommitmentStorePort = {
+      load: projectId => this.loadLifecycleProjectDocument(
+        projectId,
+        'authority-transfer-claim-commitment',
+        decodeAuthorityTransferClaimBatchCommitmentRecord,
+      ),
+      remove: projectId => this.removeLifecycleProjectDocument(
+        projectId,
+        'authority-transfer-claim-commitment',
+      ),
+      save: record => this.saveLifecycleProjectDocument(
+        record.projectId,
+        'authority-transfer-claim-commitment',
+        record,
+        decodeAuthorityTransferClaimBatchCommitmentRecord,
+      ),
+    };
+    this.authorityTransferClaimCommitments = Object.freeze(
+      authorityTransferClaimCommitments,
+    );
+    const authorityTransferClaims: AuthorityTransferClaimCustodyStorePort = {
+      load: projectId => this.loadLifecycleProjectDocument(
+        projectId,
+        'authority-transfer-claims',
+        decodeAuthorityTransferClaimCustodyRecord,
+      ),
+      remove: projectId => this.removeLifecycleProjectDocument(
+        projectId,
+        'authority-transfer-claims',
+      ),
+      save: record => this.saveLifecycleProjectDocument(
+        record.projectId,
+        'authority-transfer-claims',
+        record,
+        decodeAuthorityTransferClaimCustodyRecord,
+      ),
+    };
+    this.authorityTransferClaims = Object.freeze(authorityTransferClaims);
     const hostTransferRecovery: HostTransferRecoveryStorePort = {
       load: async (projectId, direction) => {
         const record = await this.loadLifecycleProjectDocument(
@@ -1328,6 +1418,68 @@ export class CollabLocalProjectRepository {
     });
   }
 
+  listAuthorityTransferProjectIds(): Promise<readonly CollabProjectId[]> {
+    return this.operationQueue.run(async () => {
+      const catalog = await this.scanAuthorityTransferProjectCatalogUnlocked();
+      if (catalog.invalidEntryCount > 0) {
+        throw localRecordError('local-project-directory-invalid', 'authority-transfer');
+      }
+      return catalog.projectIds;
+    });
+  }
+
+  scanAuthorityTransferProjectCatalog(): Promise<AuthorityTransferProjectCatalog> {
+    return this.operationQueue.run(() => this.scanAuthorityTransferProjectCatalogUnlocked());
+  }
+
+  private async scanAuthorityTransferProjectCatalogUnlocked(
+  ): Promise<AuthorityTransferProjectCatalog> {
+    const projectsDirectory = await resolveCollabVaultPath(
+      this.vaultRoot,
+      `${PRIVATE_STATE_DIRECTORY}/projects`,
+    );
+    const entries = await readdir(projectsDirectory, { withFileTypes: true }).catch(error => {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw localRecordError('local-project-directory-read-failed', 'authority-transfer');
+    });
+    const projectIds: CollabProjectId[] = [];
+    let invalidEntryCount = 0;
+    for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+      if (!entry.isDirectory()) {
+        if (entry.isSymbolicLink()) {
+          invalidEntryCount += 1;
+        }
+        continue;
+      }
+      if (!isCollabProjectId(entry.name)) {
+        invalidEntryCount += 1;
+        continue;
+      }
+      let documentNames: readonly string[];
+      try {
+        const projectDirectory = await resolveCollabVaultPath(
+          this.vaultRoot,
+          `${PRIVATE_STATE_DIRECTORY}/projects/${entry.name}`,
+        );
+        documentNames = await readdir(projectDirectory);
+      } catch {
+        // Preserve the valid Project ID so its ordinary per-Project load can
+        // fail closed without preventing recovery of the rest of the catalog.
+        projectIds.push(entry.name);
+        invalidEntryCount += 1;
+        continue;
+      }
+      if (documentNames.some(name => (
+        name === 'authority-transfer.json'
+        || name === 'authority-transfer-claims.json'
+        || name === 'authority-transfer-claim-commitment.json'
+      ))) {
+        projectIds.push(entry.name);
+      }
+    }
+    return { invalidEntryCount, projectIds };
+  }
+
   saveProjectDocument<T extends CollabLocalProjectDocumentBase>(
     projectId: CollabProjectId,
     kind: CollabLocalProjectDocumentKind,
@@ -1400,13 +1552,20 @@ export class CollabLocalProjectRepository {
       return Promise.reject(localRecordError('local-record-corrupt', kind, projectId));
     }
     return this.operationQueue.run(async () => {
-      await this.ensurePrivateProjectDirectory(projectId);
+      const durable = isAuthorityTransferLifecycleKind(kind);
+      await this.ensurePrivateProjectDirectory(projectId, durable);
       await writeCollabFileAtomically(
         this.vaultRoot,
         this.lifecycleDocumentPath(projectId, kind),
         serializeJson(decoded),
         { mode: 0o600, onDiagnostic: this.onDiagnostic },
       );
+      if (durable) {
+        await syncCollabVaultDirectoryDurably(
+          this.vaultRoot,
+          `${PRIVATE_STATE_DIRECTORY}/projects/${projectId}`,
+        );
+      }
     });
   }
 
@@ -1415,11 +1574,20 @@ export class CollabLocalProjectRepository {
     kind: CollabLifecycleProjectDocumentKind,
   ): Promise<boolean> {
     this.requireProjectId(projectId);
-    return this.operationQueue.run(() => removeCollabFileDurably(
-      this.vaultRoot,
-      this.lifecycleDocumentPath(projectId, kind),
-      this.onDiagnostic,
-    ));
+    return this.operationQueue.run(async () => {
+      const removed = await removeCollabFileDurably(
+        this.vaultRoot,
+        this.lifecycleDocumentPath(projectId, kind),
+        this.onDiagnostic,
+      );
+      if (removed && isAuthorityTransferLifecycleKind(kind)) {
+        await syncCollabVaultDirectoryDurably(
+          this.vaultRoot,
+          `${PRIVATE_STATE_DIRECTORY}/projects/${projectId}`,
+        );
+      }
+      return removed;
+    });
   }
 
   loadRetirementTombstone(
@@ -1510,6 +1678,9 @@ export class CollabLocalProjectRepository {
     const projectDirectory = `${PRIVATE_STATE_DIRECTORY}/projects/${projectId}`;
     return {
       authorityDirectory: `${PRIVATE_STATE_DIRECTORY}/authorities/${projectId}`,
+      authorityTransfer: `${projectDirectory}/authority-transfer.json`,
+      authorityTransferClaimCommitment: `${projectDirectory}/authority-transfer-claim-commitment.json`,
+      authorityTransferClaims: `${projectDirectory}/authority-transfer-claims.json`,
       cache: `${projectDirectory}/cache.json`,
       conflictDirectory: this.getConflictDirectoryPath(),
       hostTransferRecovery: `${projectDirectory}/host-transfer-recovery.json`,
@@ -1742,12 +1913,15 @@ export class CollabLocalProjectRepository {
     });
   }
 
-  private async ensurePrivateProjectDirectory(projectId: CollabProjectId): Promise<void> {
+  private async ensurePrivateProjectDirectory(
+    projectId: CollabProjectId,
+    durable = false,
+  ): Promise<void> {
     await this.ensurePrivateStateContainer();
     await ensureCollabVaultDirectory(
       this.vaultRoot,
       `${PRIVATE_STATE_DIRECTORY}/projects/${projectId}`,
-      { mode: 0o700, onDiagnostic: this.onDiagnostic },
+      { durable, mode: 0o700, onDiagnostic: this.onDiagnostic },
     );
   }
 
@@ -1953,6 +2127,11 @@ export class CollabLocalProjectRepository {
     if (kind === 'manager-responsibility-receipt') return paths.managerResponsibilityReceipt;
     if (kind === 'local-cleanup') return paths.localCleanup;
     if (kind === 'host-transfer-recovery') return paths.hostTransferRecovery;
+    if (kind === 'authority-transfer') return paths.authorityTransfer;
+    if (kind === 'authority-transfer-claim-commitment') {
+      return paths.authorityTransferClaimCommitment;
+    }
+    if (kind === 'authority-transfer-claims') return paths.authorityTransferClaims;
     return paths.retirement;
   }
 

--- a/src/app/collab/authority-transfer/AuthorityTransferRecord.ts
+++ b/src/app/collab/authority-transfer/AuthorityTransferRecord.ts
@@ -1,0 +1,383 @@
+import {
+  COLLAB_AUTHORITY_TRANSFER_CANCELLATION_PHASES,
+  COLLAB_CLOUD_TO_LAN_TRANSFER_PHASES,
+  COLLAB_LAN_TO_CLOUD_TRANSFER_PHASES,
+  type CollabAuthorityTransferStatus,
+  type CollabIsoTimestamp,
+  type CollabProjectId,
+  decodeCollabAuthorityTransferStatus,
+  isCollabOpaqueId,
+} from '@claudian-collab/protocol';
+
+export const AUTHORITY_TRANSFER_RECORD_SCHEMA_VERSION = 1 as const;
+
+export type AuthorityTransferLocalRole = 'source' | 'target';
+export type AuthorityTransferLifecycleOwnership = 'owned' | 'proposal';
+export type AuthorityTransferRestartFence = 'open' | 'permanent' | 'temporary';
+export type AuthorityTransferTerminalResponderState = 'active' | 'expired' | 'pending';
+
+export interface AuthorityTransferTerminalResponder {
+  readonly expiresAt: CollabIsoTimestamp;
+  readonly state: AuthorityTransferTerminalResponderState;
+}
+
+export interface AuthorityTransferRecord {
+  readonly schemaVersion: typeof AUTHORITY_TRANSFER_RECORD_SCHEMA_VERSION;
+  readonly kind: 'authority-transfer';
+  readonly lifecycleOwnership: AuthorityTransferLifecycleOwnership;
+  readonly localRole: AuthorityTransferLocalRole;
+  readonly operationIntentId: string;
+  readonly projectId: CollabProjectId;
+  readonly restartFence: AuthorityTransferRestartFence;
+  readonly stagingDirectoryName: string;
+  readonly status: CollabAuthorityTransferStatus;
+  readonly terminalCleanupCompleted: boolean;
+  readonly terminalResponder: AuthorityTransferTerminalResponder | null;
+  readonly transferId: string;
+}
+
+const RECORD_KEYS = new Set([
+  'schemaVersion',
+  'kind',
+  'lifecycleOwnership',
+  'localRole',
+  'operationIntentId',
+  'projectId',
+  'restartFence',
+  'stagingDirectoryName',
+  'status',
+  'terminalCleanupCompleted',
+  'terminalResponder',
+  'transferId',
+]);
+const TERMINAL_KEYS = new Set(['expiresAt', 'state']);
+
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function exactKeys(value: UnknownRecord, keys: ReadonlySet<string>): boolean {
+  const actual = Object.keys(value);
+  return actual.length === keys.size && actual.every(key => keys.has(key));
+}
+
+function expectedRestartFence(
+  localRole: AuthorityTransferLocalRole,
+  lifecycleOwnership: AuthorityTransferLifecycleOwnership,
+  status: CollabAuthorityTransferStatus,
+): AuthorityTransferRestartFence {
+  if (lifecycleOwnership === 'proposal') return 'open';
+  if (status.phase === 'collecting-readiness') return 'temporary';
+  if (localRole === 'source') {
+    if (status.relinquishmentProof !== null) return 'permanent';
+    if (
+      status.phase === 'source-reopened'
+      || status.phase === 'cancelled'
+    ) {
+      return 'open';
+    }
+    return 'temporary';
+  }
+  if (
+    status.phase === 'target-staged'
+    || status.phase === 'claims-retained'
+    || status.phase === 'cloud-relinquished'
+    || status.phase === 'cancel-intent'
+    || status.phase === 'target-invalidated'
+  ) {
+    return 'temporary';
+  }
+  return 'open';
+}
+
+function expectedTerminalResponder(
+  localRole: AuthorityTransferLocalRole,
+  status: CollabAuthorityTransferStatus,
+): AuthorityTransferTerminalResponder | null {
+  if (localRole !== 'source' || status.direction !== 'lan-to-cloud') return null;
+  if (status.relinquishmentProof !== null) {
+    return { expiresAt: status.expiresAt, state: 'active' };
+  }
+  if (status.phase === 'claims-retained' || status.phase === 'repository-published') {
+    return { expiresAt: status.expiresAt, state: 'pending' };
+  }
+  return null;
+}
+
+function decodeTerminalResponder(
+  value: unknown,
+  localRole: AuthorityTransferLocalRole,
+  status: CollabAuthorityTransferStatus,
+): AuthorityTransferTerminalResponder | null {
+  if (value === null) {
+    if (expectedTerminalResponder(localRole, status) !== null) throw new TypeError();
+    return null;
+  }
+  if (!isRecord(value) || !exactKeys(value, TERMINAL_KEYS)) throw new TypeError();
+  const state = value.state;
+  const expiresAt = value.expiresAt;
+  if (
+    (state !== 'active' && state !== 'expired' && state !== 'pending')
+    || expiresAt !== status.expiresAt
+  ) {
+    throw new TypeError();
+  }
+  const expected = expectedTerminalResponder(localRole, status);
+  if (
+    expected === null
+    || (state === 'pending' && expected.state !== 'pending')
+    || (state === 'active' && expected.state !== 'active')
+    || (state === 'expired' && (expected.state !== 'active' || status.state !== 'completed'))
+  ) {
+    throw new TypeError();
+  }
+  return { expiresAt, state };
+}
+
+export function decodeAuthorityTransferRecord(value: unknown): AuthorityTransferRecord {
+  if (!isRecord(value) || !exactKeys(value, RECORD_KEYS)) {
+    throw new TypeError('Invalid authority transfer record');
+  }
+  if (value.schemaVersion !== 1 || value.kind !== 'authority-transfer') {
+    throw new TypeError('Invalid authority transfer record');
+  }
+  const localRole = value.localRole;
+  const lifecycleOwnership = value.lifecycleOwnership;
+  const operationIntentId = value.operationIntentId;
+  const stagingDirectoryName = value.stagingDirectoryName;
+  if (
+    (localRole !== 'source' && localRole !== 'target')
+    || (lifecycleOwnership !== 'owned' && lifecycleOwnership !== 'proposal')
+    || typeof operationIntentId !== 'string'
+    || !isCollabOpaqueId(operationIntentId)
+    || typeof stagingDirectoryName !== 'string'
+    || stagingDirectoryName.length > 160
+  ) {
+    throw new TypeError('Invalid authority transfer identity');
+  }
+  const status = decodeCollabAuthorityTransferStatus(value.status);
+  const relinquishmentProof = status.relinquishmentProof;
+  if (
+    value.projectId !== status.projectId
+    || value.transferId !== status.transferId
+    || stagingDirectoryName !== `.claudian-authority-transfer-${status.transferId}`
+    || (localRole === 'source') !== (status.direction === 'lan-to-cloud')
+    || (lifecycleOwnership === 'proposal' && status.phase !== 'collecting-readiness')
+  ) {
+    throw new TypeError('Invalid authority transfer ownership');
+  }
+  if (relinquishmentProof !== null && (
+    relinquishmentProof.operationIntentId !== operationIntentId
+    || relinquishmentProof.committedAt < status.createdAt
+    || relinquishmentProof.committedAt > status.updatedAt
+    || relinquishmentProof.committedAt >= status.expiresAt
+  )) {
+    throw new TypeError('Invalid authority transfer relinquishment proof');
+  }
+  const restartFence = expectedRestartFence(localRole, lifecycleOwnership, status);
+  if (value.restartFence !== restartFence) {
+    throw new TypeError('Invalid authority transfer restart fence');
+  }
+  const terminalResponder = decodeTerminalResponder(
+    value.terminalResponder,
+    localRole,
+    status,
+  );
+  const terminalCleanupCompleted = value.terminalCleanupCompleted;
+  if (
+    typeof terminalCleanupCompleted !== 'boolean'
+    || (terminalCleanupCompleted && !isAuthorityTransferTerminalStatus(status))
+    || (terminalCleanupCompleted && (
+      terminalResponder?.state === 'active'
+      || terminalResponder?.state === 'pending'
+    ))
+  ) {
+    throw new TypeError('Invalid authority transfer terminal cleanup');
+  }
+  return {
+    kind: 'authority-transfer',
+    lifecycleOwnership,
+    localRole,
+    operationIntentId,
+    projectId: status.projectId,
+    restartFence,
+    schemaVersion: 1,
+    stagingDirectoryName,
+    status,
+    terminalCleanupCompleted,
+    terminalResponder,
+    transferId: status.transferId,
+  };
+}
+
+export function createAuthorityTransferRecord(input: {
+  readonly localRole: AuthorityTransferLocalRole;
+  readonly lifecycleOwnership?: AuthorityTransferLifecycleOwnership;
+  readonly operationIntentId: string;
+  readonly stagingDirectoryName: string;
+  readonly status: CollabAuthorityTransferStatus;
+}): AuthorityTransferRecord {
+  const status = decodeCollabAuthorityTransferStatus(input.status);
+  const lifecycleOwnership = input.lifecycleOwnership
+    ?? (status.phase === 'collecting-readiness' ? 'proposal' : 'owned');
+  return decodeAuthorityTransferRecord({
+    kind: 'authority-transfer',
+    lifecycleOwnership,
+    localRole: input.localRole,
+    operationIntentId: input.operationIntentId,
+    projectId: status.projectId,
+    restartFence: expectedRestartFence(input.localRole, lifecycleOwnership, status),
+    schemaVersion: 1,
+    stagingDirectoryName: input.stagingDirectoryName,
+    status,
+    terminalCleanupCompleted: false,
+    terminalResponder: expectedTerminalResponder(input.localRole, status),
+    transferId: status.transferId,
+  });
+}
+
+export function expireAuthorityTransferTerminalResponder(
+  record: AuthorityTransferRecord,
+): AuthorityTransferRecord {
+  if (record.terminalResponder?.state !== 'active' || record.status.state !== 'completed') {
+    throw new TypeError('Authority transfer terminal responder is not expirable');
+  }
+  return decodeAuthorityTransferRecord({
+    ...record,
+    terminalResponder: {
+      ...record.terminalResponder,
+      state: 'expired',
+    },
+  });
+}
+
+export function isAuthorityTransferProposal(record: AuthorityTransferRecord): boolean {
+  return record.lifecycleOwnership === 'proposal';
+}
+
+export function isAuthorityTransferTerminal(record: AuthorityTransferRecord): boolean {
+  return isAuthorityTransferTerminalStatus(record.status);
+}
+
+function isAuthorityTransferTerminalStatus(status: CollabAuthorityTransferStatus): boolean {
+  return status.state === 'cancelled' || status.state === 'completed';
+}
+
+export function markAuthorityTransferTerminalCleanupCompleted(
+  record: AuthorityTransferRecord,
+): AuthorityTransferRecord {
+  if (
+    !isAuthorityTransferTerminal(record)
+    || record.terminalResponder?.state === 'active'
+    || record.terminalResponder?.state === 'pending'
+  ) {
+    throw new TypeError('Authority transfer terminal cleanup is not completable');
+  }
+  if (record.terminalCleanupCompleted) return record;
+  return decodeAuthorityTransferRecord({
+    ...record,
+    terminalCleanupCompleted: true,
+  });
+}
+
+export function assertAuthorityTransferTransition(
+  previous: AuthorityTransferRecord,
+  next: AuthorityTransferRecord,
+): void {
+  if (
+    previous.projectId !== next.projectId
+    || previous.transferId !== next.transferId
+    || previous.operationIntentId !== next.operationIntentId
+    || previous.localRole !== next.localRole
+    || previous.stagingDirectoryName !== next.stagingDirectoryName
+    || previous.terminalCleanupCompleted !== next.terminalCleanupCompleted
+    || previous.status.direction !== next.status.direction
+    || previous.status.sourceAuthority.kind !== next.status.sourceAuthority.kind
+    || previous.status.sourceAuthority.generation !== next.status.sourceAuthority.generation
+    || previous.status.targetAuthority.kind !== next.status.targetAuthority.kind
+    || previous.status.targetAuthority.generation !== next.status.targetAuthority.generation
+    || previous.status.targetUrl !== next.status.targetUrl
+    || previous.status.createdAt !== next.status.createdAt
+    || previous.status.expiresAt !== next.status.expiresAt
+  ) {
+    throw new TypeError('Authority transfer identity changed');
+  }
+  if (Date.parse(next.status.updatedAt) < Date.parse(previous.status.updatedAt)) {
+    throw new TypeError('Authority transfer time regressed');
+  }
+  if (
+    previous.terminalResponder?.state !== 'expired'
+    && next.terminalResponder?.state === 'expired'
+  ) {
+    throw new TypeError('Authority transfer terminal responder expiry is forbidden');
+  }
+  if (
+    previous.status.relinquishmentProof !== null
+    && COLLAB_AUTHORITY_TRANSFER_CANCELLATION_PHASES.includes(next.status.phase as never)
+  ) {
+    throw new TypeError('Authority transfer cancellation is forbidden');
+  }
+  if (
+    previous.status.checkpointSha256 !== null
+    && previous.status.checkpointSha256 !== next.status.checkpointSha256
+  ) {
+    throw new TypeError('Authority transfer checkpoint changed');
+  }
+  if (
+    previous.status.batchRevision !== null
+    && (
+      previous.status.batchRevision !== next.status.batchRevision
+      || previous.status.batchSha256 !== next.status.batchSha256
+    )
+  ) {
+    throw new TypeError('Authority transfer claim batch changed');
+  }
+  if (
+    previous.status.relinquishmentProof !== null
+    && JSON.stringify(previous.status.relinquishmentProof)
+      !== JSON.stringify(next.status.relinquishmentProof)
+  ) {
+    throw new TypeError('Authority transfer relinquishment proof changed');
+  }
+  if (previous.status.phase === next.status.phase) {
+    if (
+      previous.lifecycleOwnership === 'proposal'
+      && next.lifecycleOwnership === 'owned'
+      && next.status.phase === 'collecting-readiness'
+    ) {
+      return;
+    }
+    if (JSON.stringify(previous) !== JSON.stringify(next)) {
+      throw new TypeError('Authority transfer phase changed without advancement');
+    }
+    return;
+  }
+  const phases = previous.status.direction === 'lan-to-cloud'
+    ? COLLAB_LAN_TO_CLOUD_TRANSFER_PHASES
+    : COLLAB_CLOUD_TO_LAN_TRANSFER_PHASES;
+  const previousIndex = phases.indexOf(previous.status.phase as never);
+  const nextIndex = phases.indexOf(next.status.phase as never);
+  if (previousIndex >= 0 && nextIndex === previousIndex + 1) return;
+  const cancellationIndex = COLLAB_AUTHORITY_TRANSFER_CANCELLATION_PHASES.indexOf(
+    previous.status.phase as never,
+  );
+  const nextCancellationIndex = COLLAB_AUTHORITY_TRANSFER_CANCELLATION_PHASES.indexOf(
+    next.status.phase as never,
+  );
+  if (
+    previous.status.relinquishmentProof === null
+    && (
+      (previousIndex >= 0 && next.status.phase === 'cancel-intent')
+      || (cancellationIndex >= 0 && nextCancellationIndex === cancellationIndex + 1)
+    )
+  ) {
+    return;
+  }
+  throw new TypeError(
+    previous.status.relinquishmentProof !== null && nextCancellationIndex >= 0
+      ? 'Authority transfer cancellation is forbidden'
+      : 'Authority transfer phase is stale',
+  );
+}

--- a/src/app/collab/authority-transfer/persistence/AuthorityTransferClaimBatchCommitmentRecord.ts
+++ b/src/app/collab/authority-transfer/persistence/AuthorityTransferClaimBatchCommitmentRecord.ts
@@ -1,0 +1,123 @@
+import {
+  type CollabMemberId,
+  type CollabProjectId,
+  isCollabMemberId,
+  isCollabOpaqueId,
+  isCollabProjectId,
+} from '@claudian-collab/protocol';
+
+import type {
+  AuthorityTransferClaimCustodyRecord,
+} from '@/app/collab/authority-transfer/persistence/AuthorityTransferClaimCustodyRecord';
+
+export const AUTHORITY_TRANSFER_CLAIM_COMMITMENT_SCHEMA_VERSION = 1 as const;
+
+export interface AuthorityTransferClaimCommitment {
+  readonly claimSha256: string;
+  readonly memberId: CollabMemberId;
+}
+
+export interface AuthorityTransferClaimBatchCommitmentRecord {
+  readonly schemaVersion: typeof AUTHORITY_TRANSFER_CLAIM_COMMITMENT_SCHEMA_VERSION;
+  readonly kind: 'authority-transfer-claim-commitment';
+  readonly batchRevision: number;
+  readonly batchSha256: string;
+  readonly claims: readonly AuthorityTransferClaimCommitment[];
+  readonly operationIntentId: string;
+  readonly projectId: CollabProjectId;
+  readonly transferId: string;
+}
+
+const RECORD_KEYS = new Set([
+  'schemaVersion',
+  'kind',
+  'batchRevision',
+  'batchSha256',
+  'claims',
+  'operationIntentId',
+  'projectId',
+  'transferId',
+]);
+const CLAIM_KEYS = new Set(['claimSha256', 'memberId']);
+const SHA256 = /^[0-9a-f]{64}$/;
+
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function exactKeys(value: UnknownRecord, keys: ReadonlySet<string>): boolean {
+  const actual = Object.keys(value);
+  return actual.length === keys.size && actual.every(key => keys.has(key));
+}
+
+export function decodeAuthorityTransferClaimBatchCommitmentRecord(
+  value: unknown,
+): AuthorityTransferClaimBatchCommitmentRecord {
+  if (
+    !isRecord(value)
+    || !exactKeys(value, RECORD_KEYS)
+    || value.schemaVersion !== AUTHORITY_TRANSFER_CLAIM_COMMITMENT_SCHEMA_VERSION
+    || value.kind !== 'authority-transfer-claim-commitment'
+    || typeof value.projectId !== 'string'
+    || !isCollabProjectId(value.projectId)
+    || typeof value.transferId !== 'string'
+    || !isCollabOpaqueId(value.transferId)
+    || typeof value.operationIntentId !== 'string'
+    || !isCollabOpaqueId(value.operationIntentId)
+    || !Number.isSafeInteger(value.batchRevision)
+    || (value.batchRevision as number) < 1
+    || typeof value.batchSha256 !== 'string'
+    || !SHA256.test(value.batchSha256)
+    || !Array.isArray(value.claims)
+  ) {
+    throw new TypeError('Invalid authority transfer claim commitment');
+  }
+  const claims = value.claims.map(claim => {
+    if (
+      !isRecord(claim)
+      || !exactKeys(claim, CLAIM_KEYS)
+      || typeof claim.memberId !== 'string'
+      || !isCollabMemberId(claim.memberId)
+      || typeof claim.claimSha256 !== 'string'
+      || !SHA256.test(claim.claimSha256)
+    ) {
+      throw new TypeError('Invalid authority transfer claim commitment');
+    }
+    return { claimSha256: claim.claimSha256, memberId: claim.memberId };
+  });
+  if (claims.some((claim, index) => (
+    index > 0 && claims[index - 1].memberId.localeCompare(claim.memberId, 'en-US') >= 0
+  ))) {
+    throw new TypeError('Invalid authority transfer claim commitment order');
+  }
+  return {
+    batchRevision: value.batchRevision as number,
+    batchSha256: value.batchSha256,
+    claims: Object.freeze(claims),
+    kind: 'authority-transfer-claim-commitment',
+    operationIntentId: value.operationIntentId,
+    projectId: value.projectId,
+    schemaVersion: AUTHORITY_TRANSFER_CLAIM_COMMITMENT_SCHEMA_VERSION,
+    transferId: value.transferId,
+  };
+}
+
+export function createAuthorityTransferClaimBatchCommitmentRecord(
+  custody: AuthorityTransferClaimCustodyRecord,
+): AuthorityTransferClaimBatchCommitmentRecord {
+  return decodeAuthorityTransferClaimBatchCommitmentRecord({
+    batchRevision: custody.batchRevision,
+    batchSha256: custody.batchSha256,
+    claims: custody.claims.map(claim => ({
+      claimSha256: claim.claimSha256,
+      memberId: claim.memberId,
+    })),
+    kind: 'authority-transfer-claim-commitment',
+    operationIntentId: custody.operationIntentId,
+    projectId: custody.projectId,
+    schemaVersion: AUTHORITY_TRANSFER_CLAIM_COMMITMENT_SCHEMA_VERSION,
+    transferId: custody.transferId,
+  });
+}

--- a/src/app/collab/authority-transfer/persistence/AuthorityTransferClaimCustodyRecord.ts
+++ b/src/app/collab/authority-transfer/persistence/AuthorityTransferClaimCustodyRecord.ts
@@ -1,0 +1,291 @@
+import { createHash } from 'node:crypto';
+
+import {
+  type CollabIsoTimestamp,
+  type CollabMemberId,
+  type CollabProjectId,
+  type CollabTransferredMembershipClaimBatch,
+  type CollabTransferredMembershipClaimCustodyReceipt,
+  type CollabTransferredMembershipRedemptionReceipt,
+  decodeCollabTransferredMembershipClaimBatch,
+  decodeCollabTransferredMembershipClaimCustodyReceipt,
+  decodeCollabTransferredMembershipRedemptionReceipt,
+  isCollabMemberId,
+  isCollabOpaqueId,
+  isCollabProjectId,
+} from '@claudian-collab/protocol';
+
+export const AUTHORITY_TRANSFER_CLAIM_CUSTODY_SCHEMA_VERSION = 1 as const;
+
+export type AuthorityTransferClaimCustodyPurpose = 'source-terminal' | 'target-delivery';
+
+export interface AuthorityTransferRetainedClaim {
+  readonly claim: string | null;
+  readonly claimSha256: string;
+  readonly disposition: 'expired' | 'redeemed' | 'retained';
+  readonly memberId: CollabMemberId;
+  readonly redemptionReceipt: CollabTransferredMembershipRedemptionReceipt | null;
+  readonly scrubbedAt: CollabIsoTimestamp | null;
+}
+
+export interface AuthorityTransferClaimCustodyRecord {
+  readonly schemaVersion: typeof AUTHORITY_TRANSFER_CLAIM_CUSTODY_SCHEMA_VERSION;
+  readonly kind: 'authority-transfer-claim-custody';
+  readonly batchRevision: number;
+  readonly batchSha256: string;
+  readonly checkpointSha256: string;
+  readonly claims: readonly AuthorityTransferRetainedClaim[];
+  readonly createdAt: CollabIsoTimestamp;
+  readonly custodyReceipt: CollabTransferredMembershipClaimCustodyReceipt | null;
+  readonly expiresAt: CollabIsoTimestamp;
+  readonly operationIntentId: string;
+  readonly projectId: CollabProjectId;
+  readonly purpose: AuthorityTransferClaimCustodyPurpose;
+  readonly rotationPredecessor: {
+    readonly batchRevision: number;
+    readonly batchSha256: string;
+  } | null;
+  readonly targetAuthorityGeneration: number;
+  readonly transferId: string;
+  readonly updatedAt: CollabIsoTimestamp;
+}
+
+const RECORD_KEYS = new Set([
+  'schemaVersion',
+  'kind',
+  'batchRevision',
+  'batchSha256',
+  'checkpointSha256',
+  'claims',
+  'createdAt',
+  'custodyReceipt',
+  'expiresAt',
+  'operationIntentId',
+  'projectId',
+  'purpose',
+  'rotationPredecessor',
+  'targetAuthorityGeneration',
+  'transferId',
+  'updatedAt',
+]);
+const CLAIM_KEYS = new Set([
+  'claim',
+  'claimSha256',
+  'disposition',
+  'memberId',
+  'redemptionReceipt',
+  'scrubbedAt',
+]);
+const PREDECESSOR_KEYS = new Set(['batchRevision', 'batchSha256']);
+const BASE64URL = /^[A-Za-z0-9_-]+$/;
+const SHA256 = /^[0-9a-f]{64}$/;
+
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function exactKeys(value: UnknownRecord, keys: ReadonlySet<string>): boolean {
+  const actual = Object.keys(value);
+  return actual.length === keys.size && actual.every(key => keys.has(key));
+}
+
+function timestamp(value: unknown): CollabIsoTimestamp {
+  if (
+    typeof value !== 'string'
+    || value.length > 64
+    || !Number.isFinite(Date.parse(value))
+    || new Date(value).toISOString() !== value
+  ) {
+    throw new TypeError('Invalid authority transfer timestamp');
+  }
+  return value;
+}
+
+function decodeClaim(value: unknown): AuthorityTransferRetainedClaim {
+  if (!isRecord(value) || !exactKeys(value, CLAIM_KEYS)) throw new TypeError();
+  const claim = value.claim;
+  const claimSha256 = value.claimSha256;
+  const disposition = value.disposition;
+  const memberId = value.memberId;
+  const redemptionReceipt = value.redemptionReceipt === null
+    ? null
+    : decodeCollabTransferredMembershipRedemptionReceipt(value.redemptionReceipt);
+  const scrubbedAt = value.scrubbedAt === null ? null : timestamp(value.scrubbedAt);
+  if (
+    (claim !== null && (
+      typeof claim !== 'string'
+      || claim.length > 4096
+      || !BASE64URL.test(claim)
+    ))
+    || typeof claimSha256 !== 'string'
+    || !SHA256.test(claimSha256)
+    || (disposition !== 'expired' && disposition !== 'redeemed' && disposition !== 'retained')
+    || typeof memberId !== 'string'
+    || !isCollabMemberId(memberId)
+    || (disposition === 'retained') !== (claim !== null)
+    || (disposition === 'retained') !== (scrubbedAt === null)
+    || (disposition === 'redeemed') !== (redemptionReceipt !== null)
+    || (claim !== null && createHash('sha256').update(claim, 'utf8').digest('hex') !== claimSha256)
+    || (redemptionReceipt !== null && (
+      redemptionReceipt.claimSha256 !== claimSha256
+      || redemptionReceipt.memberId !== memberId
+    ))
+  ) {
+    throw new TypeError('Invalid retained authority transfer claim');
+  }
+  return {
+    claim,
+    claimSha256,
+    disposition,
+    memberId,
+    redemptionReceipt,
+    scrubbedAt,
+  };
+}
+
+export function decodeAuthorityTransferClaimCustodyRecord(
+  value: unknown,
+): AuthorityTransferClaimCustodyRecord {
+  if (!isRecord(value) || !exactKeys(value, RECORD_KEYS)) {
+    throw new TypeError('Invalid authority transfer claim custody');
+  }
+  if (value.schemaVersion !== 1 || value.kind !== 'authority-transfer-claim-custody') {
+    throw new TypeError('Invalid authority transfer claim custody');
+  }
+  const projectId = value.projectId;
+  const transferId = value.transferId;
+  const operationIntentId = value.operationIntentId;
+  const purpose = value.purpose;
+  const batchRevision = value.batchRevision;
+  const batchSha256 = value.batchSha256;
+  const checkpointSha256 = value.checkpointSha256;
+  const targetAuthorityGeneration = value.targetAuthorityGeneration;
+  const rotationPredecessor = value.rotationPredecessor;
+  if (
+    typeof projectId !== 'string'
+    || !isCollabProjectId(projectId)
+    || typeof transferId !== 'string'
+    || !isCollabOpaqueId(transferId)
+    || typeof operationIntentId !== 'string'
+    || !isCollabOpaqueId(operationIntentId)
+    || (purpose !== 'source-terminal' && purpose !== 'target-delivery')
+    || !Number.isSafeInteger(batchRevision)
+    || (batchRevision as number) < 1
+    || typeof batchSha256 !== 'string'
+    || !SHA256.test(batchSha256)
+    || typeof checkpointSha256 !== 'string'
+    || !SHA256.test(checkpointSha256)
+    || !Number.isSafeInteger(targetAuthorityGeneration)
+    || (targetAuthorityGeneration as number) < 1
+    || !Array.isArray(value.claims)
+  ) {
+    throw new TypeError('Invalid authority transfer claim identity');
+  }
+  let decodedRotationPredecessor: AuthorityTransferClaimCustodyRecord['rotationPredecessor'];
+  if (rotationPredecessor === null) {
+    decodedRotationPredecessor = null;
+  } else {
+    if (
+      !isRecord(rotationPredecessor)
+      || !exactKeys(rotationPredecessor, PREDECESSOR_KEYS)
+      || !Number.isSafeInteger(rotationPredecessor.batchRevision)
+      || rotationPredecessor.batchRevision !== (batchRevision as number) - 1
+      || typeof rotationPredecessor.batchSha256 !== 'string'
+      || !SHA256.test(rotationPredecessor.batchSha256)
+    ) {
+      throw new TypeError('Invalid authority transfer claim rotation predecessor');
+    }
+    decodedRotationPredecessor = {
+      batchRevision: rotationPredecessor.batchRevision,
+      batchSha256: rotationPredecessor.batchSha256,
+    };
+  }
+  const claims = value.claims.map(decodeClaim);
+  if (claims.some((claim, index) => (
+    index > 0 && claims[index - 1].memberId.localeCompare(claim.memberId, 'en-US') >= 0
+  )) || claims.some(claim => claim.redemptionReceipt !== null && (
+    claim.redemptionReceipt.checkpointSha256 !== checkpointSha256
+    || claim.redemptionReceipt.projectId !== projectId
+    || claim.redemptionReceipt.targetAuthorityGeneration !== targetAuthorityGeneration
+    || claim.redemptionReceipt.transferId !== transferId
+  ))) {
+    throw new TypeError('Invalid authority transfer claim ordering');
+  }
+  const createdAt = timestamp(value.createdAt);
+  const updatedAt = timestamp(value.updatedAt);
+  const expiresAt = timestamp(value.expiresAt);
+  if (
+    updatedAt < createdAt
+    || (expiresAt <= updatedAt && claims.some(claim => claim.disposition === 'retained'))
+  ) {
+    throw new TypeError('Invalid authority transfer claim timestamps');
+  }
+  const custodyReceipt = value.custodyReceipt === null
+    ? null
+    : decodeCollabTransferredMembershipClaimCustodyReceipt(value.custodyReceipt);
+  if (custodyReceipt !== null && (
+    custodyReceipt.projectId !== projectId
+    || custodyReceipt.transferId !== transferId
+    || custodyReceipt.operationIntentId !== operationIntentId
+    || custodyReceipt.batchRevision !== batchRevision
+    || custodyReceipt.batchSha256 !== batchSha256
+    || custodyReceipt.checkpointSha256 !== checkpointSha256
+    || custodyReceipt.targetAuthorityGeneration !== targetAuthorityGeneration
+  )) {
+    throw new TypeError('Invalid authority transfer custody receipt');
+  }
+  return {
+    batchRevision: batchRevision as number,
+    batchSha256,
+    checkpointSha256,
+    claims: Object.freeze(claims),
+    createdAt,
+    custodyReceipt,
+    expiresAt,
+    kind: 'authority-transfer-claim-custody',
+    operationIntentId,
+    projectId,
+    purpose,
+    rotationPredecessor: decodedRotationPredecessor,
+    schemaVersion: 1,
+    targetAuthorityGeneration: targetAuthorityGeneration as number,
+    transferId,
+    updatedAt,
+  };
+}
+
+export function createAuthorityTransferClaimCustodyRecord(input: {
+  readonly batch: CollabTransferredMembershipClaimBatch;
+  readonly createdAt: CollabIsoTimestamp;
+  readonly operationIntentId: string;
+  readonly purpose: AuthorityTransferClaimCustodyPurpose;
+}): AuthorityTransferClaimCustodyRecord {
+  const batch = decodeCollabTransferredMembershipClaimBatch(input.batch);
+  return decodeAuthorityTransferClaimCustodyRecord({
+    batchRevision: batch.batchRevision,
+    batchSha256: batch.batchSha256,
+    checkpointSha256: batch.checkpointSha256,
+    claims: batch.claims.map(item => ({
+      claim: item.claim,
+      claimSha256: createHash('sha256').update(item.claim, 'utf8').digest('hex'),
+      disposition: 'retained',
+      memberId: item.memberId,
+      redemptionReceipt: null,
+      scrubbedAt: null,
+    })),
+    createdAt: input.createdAt,
+    custodyReceipt: null,
+    expiresAt: batch.expiresAt,
+    kind: 'authority-transfer-claim-custody',
+    operationIntentId: input.operationIntentId,
+    projectId: batch.projectId,
+    purpose: input.purpose,
+    rotationPredecessor: null,
+    schemaVersion: 1,
+    targetAuthorityGeneration: batch.targetAuthorityGeneration,
+    transferId: batch.transferId,
+    updatedAt: input.createdAt,
+  });
+}

--- a/src/app/collab/authority-transfer/persistence/AuthorityTransferPersistence.ts
+++ b/src/app/collab/authority-transfer/persistence/AuthorityTransferPersistence.ts
@@ -1,0 +1,929 @@
+import { createHash } from 'node:crypto';
+
+import {
+  type CollabAuthorityTransferStatus,
+  type CollabIsoTimestamp,
+  type CollabMemberId,
+  type CollabProjectId,
+  type CollabTransferredMembershipClaim,
+  type CollabTransferredMembershipClaimBatch,
+  type CollabTransferredMembershipClaimCustodyReceipt,
+  type CollabTransferredMembershipRedemptionReceipt,
+  decodeCollabTransferredMembershipClaimBatch,
+  decodeCollabTransferredMembershipClaimCustodyReceipt,
+  decodeCollabTransferredMembershipRedemptionReceipt,
+  encodeCollabTransferredMembershipClaimBatchDigestInput,
+} from '@claudian-collab/protocol';
+
+import {
+  assertAuthorityTransferTransition,
+  type AuthorityTransferRecord,
+  decodeAuthorityTransferRecord,
+  expireAuthorityTransferTerminalResponder,
+  isAuthorityTransferProposal,
+  isAuthorityTransferTerminal,
+  markAuthorityTransferTerminalCleanupCompleted,
+} from '@/app/collab/authority-transfer/AuthorityTransferRecord';
+import {
+  type AuthorityTransferClaimBatchCommitmentRecord,
+  createAuthorityTransferClaimBatchCommitmentRecord,
+} from '@/app/collab/authority-transfer/persistence/AuthorityTransferClaimBatchCommitmentRecord';
+import {
+  type AuthorityTransferClaimCustodyPurpose,
+  type AuthorityTransferClaimCustodyRecord,
+  createAuthorityTransferClaimCustodyRecord,
+  decodeAuthorityTransferClaimCustodyRecord,
+} from '@/app/collab/authority-transfer/persistence/AuthorityTransferClaimCustodyRecord';
+import {
+  type AuthorityTransferPersistenceStores,
+  type AuthorityTransferProjectCatalog,
+} from '@/app/collab/authority-transfer/persistence/AuthorityTransferPersistenceStores';
+import { SerialTaskQueue } from '@/app/collab/SerialTaskQueue';
+import { CollabError } from '@/core/collab/ClaudianCollabError';
+
+export interface AuthorityTransferPersistenceOptions {
+  readonly now?: () => Date;
+}
+
+interface RetainClaimBatchInput {
+  readonly batch: CollabTransferredMembershipClaimBatch;
+  readonly operationIntentId: string;
+  readonly purpose: AuthorityTransferClaimCustodyPurpose;
+}
+
+interface RotateClaimBatchInput extends RetainClaimBatchInput {
+  readonly expectedBatchRevision: number;
+  readonly expectedBatchSha256: string;
+}
+
+interface ScrubClaimInput {
+  readonly acknowledgedAt: CollabIsoTimestamp;
+  readonly receipt: CollabTransferredMembershipRedemptionReceipt;
+}
+
+interface CompleteTerminalCleanupInput {
+  readonly operationIntentId: string;
+  readonly projectId: CollabProjectId;
+  readonly stagingDirectoryName: string;
+  readonly transferId: string;
+}
+
+function transferError(
+  code:
+    | 'authority-transfer-cancellation-forbidden'
+    | 'authority-transfer-not-found'
+    | 'authority-transfer-stale'
+    | 'durable-progress-recovery-required'
+    | 'membership-claim-already-redeemed'
+    | 'membership-claim-expired'
+    | 'membership-claim-invalid',
+  reason: string,
+): CollabError {
+  return new CollabError({
+    code,
+    recoveryActions: code === 'durable-progress-recovery-required' ? ['resume'] : [],
+    safeContext: { reason },
+  });
+}
+
+function sameValue(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function sameClaimBatch(
+  left: AuthorityTransferClaimCustodyRecord,
+  right: AuthorityTransferClaimCustodyRecord,
+): boolean {
+  return left.batchRevision === right.batchRevision
+    && left.batchSha256 === right.batchSha256
+    && left.checkpointSha256 === right.checkpointSha256
+    && left.expiresAt === right.expiresAt
+    && left.operationIntentId === right.operationIntentId
+    && left.projectId === right.projectId
+    && left.purpose === right.purpose
+    && left.targetAuthorityGeneration === right.targetAuthorityGeneration
+    && left.transferId === right.transferId
+    && left.claims.length === right.claims.length
+    && left.claims.every((claim, index) => (
+      claim.memberId === right.claims[index].memberId
+      && claim.claimSha256 === right.claims[index].claimSha256
+    ));
+}
+
+function claimCustodyMatchesStatus(
+  custody: AuthorityTransferClaimCustodyRecord,
+  status: CollabAuthorityTransferStatus,
+): boolean {
+  return custody.batchRevision === status.batchRevision
+    && custody.batchSha256 === status.batchSha256
+    && custody.checkpointSha256 === status.checkpointSha256
+    && custody.targetAuthorityGeneration === status.targetAuthority.generation
+    && custody.custodyReceipt !== null
+    && custody.custodyReceipt.custodyAuthority.kind === status.sourceAuthority.kind
+    && custody.custodyReceipt.custodyAuthority.generation
+      === status.sourceAuthority.generation;
+}
+
+function validTimestamp(value: string): boolean {
+  return Number.isFinite(Date.parse(value)) && new Date(value).toISOString() === value;
+}
+
+function batchDigest(batch: CollabTransferredMembershipClaimBatch): string {
+  return createHash('sha256')
+    .update(encodeCollabTransferredMembershipClaimBatchDigestInput(batch), 'utf8')
+    .digest('hex');
+}
+
+export class AuthorityTransferPersistence {
+  private closePromise: Promise<void> | null = null;
+  private closed = false;
+  private readonly enumerationQueue = new SerialTaskQueue();
+  private readonly now: () => Date;
+  private readonly projectQueues = new Map<CollabProjectId, SerialTaskQueue>();
+
+  constructor(
+    private readonly stores: AuthorityTransferPersistenceStores,
+    options: AuthorityTransferPersistenceOptions = {},
+  ) {
+    this.now = options.now ?? (() => new Date());
+  }
+
+  listProjectIds(): Promise<readonly CollabProjectId[]> {
+    if (this.closed) return Promise.reject(this.closedError());
+    return this.enumerationQueue.run(() => this.stores.authorityTransferRecords.listProjectIds());
+  }
+
+  scanProjectCatalog(): Promise<AuthorityTransferProjectCatalog> {
+    if (this.closed) return Promise.reject(this.closedError());
+    return this.enumerationQueue.run(
+      () => this.stores.authorityTransferRecords.scanProjectCatalog(),
+    );
+  }
+
+  close(): Promise<void> {
+    if (this.closePromise) return this.closePromise;
+    this.closed = true;
+    this.closePromise = Promise.all([
+      this.enumerationQueue.drain(),
+      ...[...this.projectQueues.values()].map(queue => queue.drain()),
+    ]).then(() => undefined);
+    return this.closePromise;
+  }
+
+  inspectLifecycleOwner(
+    projectId: CollabProjectId,
+  ): Promise<'absent' | 'nonterminal' | 'proposal' | 'terminal'> {
+    return this.runProject(projectId, async () => {
+      const [record, custody, commitment] = await Promise.all([
+        this.stores.authorityTransferRecords.load(projectId),
+        this.stores.authorityTransferClaims.load(projectId),
+        this.stores.authorityTransferClaimCommitments.load(projectId),
+      ]);
+      if (!record) return custody || commitment ? 'nonterminal' : 'absent';
+      if (custody || commitment) {
+        return 'nonterminal';
+      }
+      if (isAuthorityTransferProposal(record)) return 'proposal';
+      return isAuthorityTransferTerminal(record) && record.terminalCleanupCompleted
+        ? 'terminal'
+        : 'nonterminal';
+    });
+  }
+
+  recoverInterruptedClaimCommitment(projectId: CollabProjectId): Promise<void> {
+    return this.runProject(projectId, async () => {
+      const [record, custody, commitment] = await Promise.all([
+        this.stores.authorityTransferRecords.load(projectId),
+        this.stores.authorityTransferClaims.load(projectId),
+        this.stores.authorityTransferClaimCommitments.load(projectId),
+      ]);
+      if (!custody) {
+        if (!commitment) return;
+        if (
+          !record
+          || !isAuthorityTransferTerminal(record)
+          || record.terminalResponder?.state === 'active'
+          || record.terminalResponder?.state === 'pending'
+        ) {
+          throw transferError(
+            'durable-progress-recovery-required',
+            'authority-transfer-claim-commitment-orphaned',
+          );
+        }
+        await this.assertTerminalCleanupClaimOwner(record, null, commitment);
+        await this.stores.authorityTransferClaimCommitments.remove(projectId);
+        return;
+      }
+      const expected = createAuthorityTransferClaimBatchCommitmentRecord(custody);
+      if (sameValue(commitment, expected)) return;
+      await this.assertClaimBatchOwner(custody, undefined, false);
+      const recoverablePredecessor = commitment === null
+        ? custody.rotationPredecessor === null
+        : this.isRotationPredecessorCommitment(commitment, custody);
+      if (!recoverablePredecessor || !this.isCompleteUnacknowledgedBatch(custody)) {
+        throw transferError(
+          'durable-progress-recovery-required',
+          'authority-transfer-claim-commitment-mismatch',
+        );
+      }
+      await this.stores.authorityTransferClaimCommitments.save(expected);
+    });
+  }
+
+  completeTerminalCleanup(input: CompleteTerminalCleanupInput): Promise<void> {
+    // The direction owner calls this only after it has removed the exact
+    // operation-owned staging directory named by the durable record. This
+    // persistence boundary then removes claim custody before committing
+    // terminal settlement, so every interrupted phase remains recoverable.
+    return this.runProject(input.projectId, async () => {
+      const record = await this.stores.authorityTransferRecords.load(input.projectId);
+      if (
+        !record
+        || record.transferId !== input.transferId
+        || record.operationIntentId !== input.operationIntentId
+        || record.stagingDirectoryName !== input.stagingDirectoryName
+        || !isAuthorityTransferTerminal(record)
+      ) {
+        throw transferError(
+          'authority-transfer-stale',
+          'authority-transfer-terminal-cleanup-owner-stale',
+        );
+      }
+      if (
+        record.terminalResponder?.state === 'active'
+        || record.terminalResponder?.state === 'pending'
+      ) {
+        throw transferError(
+          'durable-progress-recovery-required',
+          'authority-transfer-terminal-responder-active',
+        );
+      }
+      const [custody, commitment] = await Promise.all([
+        this.stores.authorityTransferClaims.load(input.projectId),
+        this.stores.authorityTransferClaimCommitments.load(input.projectId),
+      ]);
+      await this.assertTerminalCleanupClaimOwner(record, custody, commitment);
+      await this.stores.authorityTransferClaims.remove(input.projectId);
+      await this.stores.authorityTransferClaimCommitments.remove(input.projectId);
+      if (record.terminalCleanupCompleted) return;
+      await this.stores.authorityTransferRecords.save(
+        markAuthorityTransferTerminalCleanupCompleted(record),
+      );
+    });
+  }
+
+  load(projectId: CollabProjectId): Promise<AuthorityTransferRecord | null> {
+    return this.runProject(projectId, async () => {
+      const record = await this.stores.authorityTransferRecords.load(projectId);
+      const custody = await this.stores.authorityTransferClaims.load(projectId);
+      const commitment = await this.stores.authorityTransferClaimCommitments.load(projectId);
+      if (!record && (custody || commitment)) {
+        throw transferError(
+          'durable-progress-recovery-required',
+          'authority-transfer-claim-custody-orphaned',
+        );
+      }
+      if (commitment && !custody) {
+        throw transferError(
+          'durable-progress-recovery-required',
+          'authority-transfer-claim-commitment-orphaned',
+        );
+      }
+      if (record && custody) await this.assertClaimBatchOwner(custody, record);
+      return record;
+    });
+  }
+
+  create(record: AuthorityTransferRecord): Promise<void> {
+    return this.saveAbsent(record);
+  }
+
+  advance(
+    record: AuthorityTransferRecord,
+    expectedPhase: CollabAuthorityTransferStatus['phase'],
+  ): Promise<void> {
+    let decoded: AuthorityTransferRecord;
+    try {
+      decoded = decodeAuthorityTransferRecord(record);
+    } catch {
+      return Promise.reject(transferError(
+        'authority-transfer-stale',
+        'authority-transfer-record-invalid',
+      ));
+    }
+    return this.runProject(decoded.projectId, async () => {
+      const previous = await this.stores.authorityTransferRecords.load(decoded.projectId);
+      if (!previous) {
+        throw transferError('authority-transfer-not-found', 'authority-transfer-record-missing');
+      }
+      if (previous.transferId !== decoded.transferId || previous.status.phase !== expectedPhase) {
+        throw transferError('authority-transfer-stale', 'authority-transfer-expected-phase-stale');
+      }
+      try {
+        assertAuthorityTransferTransition(previous, decoded);
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : '';
+        const cancellationForbidden = reason === 'Authority transfer cancellation is forbidden';
+        throw transferError(
+          cancellationForbidden
+            ? 'authority-transfer-cancellation-forbidden'
+            : 'authority-transfer-stale',
+          cancellationForbidden
+            ? 'authority-transfer-source-relinquished'
+            : 'authority-transfer-phase-invalid',
+        );
+      }
+      await this.assertClaimCustodyForStatus(decoded.status);
+      await this.stores.authorityTransferRecords.save(decoded);
+    });
+  }
+
+  retainClaimBatch(input: RetainClaimBatchInput): Promise<AuthorityTransferClaimCustodyRecord> {
+    let record: AuthorityTransferClaimCustodyRecord;
+    try {
+      const batch = decodeCollabTransferredMembershipClaimBatch(input.batch);
+      if (batchDigest(batch) !== batch.batchSha256) throw new TypeError();
+      record = createAuthorityTransferClaimCustodyRecord({
+        batch,
+        createdAt: this.now().toISOString(),
+        operationIntentId: input.operationIntentId,
+        purpose: input.purpose,
+      });
+    } catch {
+      return Promise.reject(transferError(
+        'membership-claim-invalid',
+        'authority-transfer-claim-batch-invalid',
+      ));
+    }
+    return this.runProject(record.projectId, async () => {
+      await this.assertClaimBatchOwner(record, undefined, false);
+      const existing = await this.stores.authorityTransferClaims.load(record.projectId);
+      if (existing) {
+        if (sameClaimBatch(existing, record)) {
+          await this.persistClaimCommitment(existing);
+          return existing;
+        }
+        throw transferError('authority-transfer-stale', 'authority-transfer-claim-batch-conflict');
+      }
+      await this.stores.authorityTransferClaims.save(record);
+      await this.persistClaimCommitment(record);
+      return record;
+    });
+  }
+
+  rotateClaimBatch(input: RotateClaimBatchInput): Promise<AuthorityTransferClaimCustodyRecord> {
+    let batch: CollabTransferredMembershipClaimBatch;
+    try {
+      batch = decodeCollabTransferredMembershipClaimBatch(input.batch);
+      if (batchDigest(batch) !== batch.batchSha256) throw new TypeError();
+    } catch {
+      return Promise.reject(transferError(
+        'membership-claim-invalid',
+        'authority-transfer-claim-batch-invalid',
+      ));
+    }
+    return this.runProject(batch.projectId, async () => {
+      const current = await this.requireClaimCustody(batch.projectId, batch.transferId);
+      await this.assertClaimBatchOwner(current, undefined, false);
+      const rotated = createAuthorityTransferClaimCustodyRecord({
+        batch,
+        createdAt: current.createdAt,
+        operationIntentId: current.operationIntentId,
+        purpose: current.purpose,
+      });
+      if (
+        input.operationIntentId === current.operationIntentId
+        && input.purpose === current.purpose
+        && sameClaimBatch(current, rotated)
+        && current.rotationPredecessor?.batchRevision === input.expectedBatchRevision
+        && current.rotationPredecessor.batchSha256 === input.expectedBatchSha256
+      ) {
+        await this.persistClaimCommitment(current);
+        return current;
+      }
+      await this.assertClaimBatchOwner(current);
+      if (
+        current.custodyReceipt !== null
+        || current.claims.some(claim => claim.disposition !== 'retained')
+        || current.batchRevision !== input.expectedBatchRevision
+        || current.batchSha256 !== input.expectedBatchSha256
+        || batch.batchRevision !== current.batchRevision + 1
+        || batch.projectId !== current.projectId
+        || batch.transferId !== current.transferId
+        || batch.checkpointSha256 !== current.checkpointSha256
+        || batch.targetAuthorityGeneration !== current.targetAuthorityGeneration
+        || batch.expiresAt !== current.expiresAt
+        || input.operationIntentId !== current.operationIntentId
+        || input.purpose !== current.purpose
+        || current.claims.length !== rotated.claims.length
+        || current.claims.some((claim, index) => (
+          claim.memberId !== rotated.claims[index].memberId
+          || claim.claimSha256 === rotated.claims[index].claimSha256
+        ))
+      ) {
+        throw transferError('authority-transfer-stale', 'authority-transfer-claim-rotation-stale');
+      }
+      const updatedAt = this.now().toISOString();
+      const persisted = decodeAuthorityTransferClaimCustodyRecord({
+        ...rotated,
+        rotationPredecessor: {
+          batchRevision: current.batchRevision,
+          batchSha256: current.batchSha256,
+        },
+        updatedAt: current.updatedAt < updatedAt
+          ? updatedAt
+          : current.updatedAt,
+      });
+      await this.stores.authorityTransferClaims.save(persisted);
+      await this.persistClaimCommitment(persisted);
+      return persisted;
+    });
+  }
+
+  acknowledgeClaimBatch(
+    value: CollabTransferredMembershipClaimCustodyReceipt,
+  ): Promise<CollabTransferredMembershipClaimCustodyReceipt> {
+    let receipt: CollabTransferredMembershipClaimCustodyReceipt;
+    try {
+      receipt = decodeCollabTransferredMembershipClaimCustodyReceipt(value);
+    } catch {
+      return Promise.reject(transferError(
+        'membership-claim-invalid',
+        'authority-transfer-custody-receipt-invalid',
+      ));
+    }
+    return this.runProject(receipt.projectId, async () => {
+      const current = await this.requireClaimCustody(receipt.projectId, receipt.transferId);
+      const record = await this.stores.authorityTransferRecords.load(receipt.projectId);
+      if (!record || record.transferId !== receipt.transferId) {
+        throw transferError('authority-transfer-stale', 'authority-transfer-custody-owner-stale');
+      }
+      await this.assertClaimBatchOwner(current, record);
+      if (current.custodyReceipt) {
+        if (sameValue(current.custodyReceipt, receipt)) return current.custodyReceipt;
+        throw transferError('authority-transfer-stale', 'authority-transfer-custody-receipt-stale');
+      }
+      if (
+        current.operationIntentId !== receipt.operationIntentId
+        || current.batchRevision !== receipt.batchRevision
+        || current.batchSha256 !== receipt.batchSha256
+        || current.checkpointSha256 !== receipt.checkpointSha256
+        || current.targetAuthorityGeneration !== receipt.targetAuthorityGeneration
+        || receipt.committedAt < current.createdAt
+        || receipt.committedAt >= current.expiresAt
+        || receipt.custodyAuthority.kind !== record.status.sourceAuthority.kind
+        || receipt.custodyAuthority.generation !== record.status.sourceAuthority.generation
+      ) {
+        throw transferError('authority-transfer-stale', 'authority-transfer-custody-receipt-stale');
+      }
+      const updated = decodeAuthorityTransferClaimCustodyRecord({
+        ...current,
+        custodyReceipt: receipt,
+        updatedAt: current.updatedAt < receipt.committedAt
+          ? receipt.committedAt
+          : current.updatedAt,
+      });
+      await this.stores.authorityTransferClaims.save(updated);
+      return receipt;
+    });
+  }
+
+  loadClaim(
+    projectId: CollabProjectId,
+    transferId: string,
+    memberId: CollabMemberId,
+  ): Promise<CollabTransferredMembershipClaim> {
+    return this.runProject(projectId, async () => {
+      const current = await this.requireClaimCustody(projectId, transferId);
+      const record = await this.stores.authorityTransferRecords.load(projectId);
+      await this.assertClaimBatchOwner(current, record ?? undefined);
+      if (
+        !record
+        || record.localRole !== 'source'
+        || current.purpose !== 'source-terminal'
+        || record.status.relinquishmentProof === null
+        || record.terminalResponder?.state !== 'active'
+        || !claimCustodyMatchesStatus(current, record.status)
+      ) {
+        throw transferError(
+          'durable-progress-recovery-required',
+          'authority-transfer-terminal-claim-unavailable',
+        );
+      }
+      if (Date.parse(current.expiresAt) <= this.now().getTime()) {
+        throw transferError('membership-claim-expired', 'authority-transfer-claim-expired');
+      }
+      const retained = current.claims.find(claim => claim.memberId === memberId);
+      if (!retained) {
+        throw transferError('membership-claim-invalid', 'authority-transfer-member-claim-missing');
+      }
+      if (retained.claim === null) {
+        throw transferError(
+          'membership-claim-already-redeemed',
+          'authority-transfer-member-claim-scrubbed',
+        );
+      }
+      return {
+        claim: retained.claim,
+        expiresAt: current.expiresAt,
+        memberId,
+        projectId,
+        targetAuthorityGeneration: current.targetAuthorityGeneration,
+        transferId,
+      };
+    });
+  }
+
+  /**
+   * Persists a scrub after the direction owner verifies the receipt signature
+   * against the pinned target key. This boundary revalidates every persisted
+   * transfer and claim fact before removing the raw claim.
+   */
+  scrubClaimWithVerifiedReceipt(input: ScrubClaimInput): Promise<void> {
+    let receipt: CollabTransferredMembershipRedemptionReceipt;
+    try {
+      receipt = decodeCollabTransferredMembershipRedemptionReceipt(input.receipt);
+      if (!validTimestamp(input.acknowledgedAt)) throw new TypeError();
+    } catch {
+      return Promise.reject(transferError(
+        'membership-claim-invalid',
+        'authority-transfer-redemption-acknowledgement-invalid',
+      ));
+    }
+    return this.runProject(receipt.projectId, async () => {
+      const current = await this.requireClaimCustody(receipt.projectId, receipt.transferId);
+      await this.assertClaimBatchOwner(current);
+      const retained = current.claims.find(claim => claim.memberId === receipt.memberId);
+      if (!retained) {
+        throw transferError('membership-claim-invalid', 'authority-transfer-member-claim-missing');
+      }
+      if (retained.claim === null) {
+        if (sameValue(retained.redemptionReceipt, receipt)) return;
+        throw transferError(
+          'membership-claim-already-redeemed',
+          'authority-transfer-member-claim-scrubbed',
+        );
+      }
+      if (
+        retained.claimSha256 !== receipt.claimSha256
+        || current.checkpointSha256 !== receipt.checkpointSha256
+        || current.targetAuthorityGeneration !== receipt.targetAuthorityGeneration
+        || receipt.redeemedAt >= current.expiresAt
+        || input.acknowledgedAt < receipt.redeemedAt
+      ) {
+        throw transferError(
+          'membership-claim-invalid',
+          'authority-transfer-redemption-receipt-stale',
+        );
+      }
+      const updated = decodeAuthorityTransferClaimCustodyRecord({
+        ...current,
+        claims: current.claims.map(claim => claim.memberId === receipt.memberId
+          ? {
+              ...claim,
+              claim: null,
+              disposition: 'redeemed',
+              redemptionReceipt: receipt,
+              scrubbedAt: input.acknowledgedAt,
+            }
+          : claim),
+        updatedAt: current.updatedAt < input.acknowledgedAt
+          ? input.acknowledgedAt
+          : current.updatedAt,
+      });
+      await this.stores.authorityTransferClaims.save(updated);
+    });
+  }
+
+  assertAuthorityRestartAllowed(projectId: CollabProjectId): Promise<void> {
+    return this.runProject(projectId, () => this.assertAuthorityRestartAllowedUnlocked(projectId));
+  }
+
+  runWithAuthorityStartGuard<T>(
+    projectId: CollabProjectId,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    return this.runProject(projectId, async () => {
+      await this.assertAuthorityRestartAllowedUnlocked(projectId);
+      return operation();
+    });
+  }
+
+  expireClaims(
+    projectId: CollabProjectId,
+    transferId: string,
+  ): Promise<void> {
+    return this.runProject(projectId, async () => {
+      const current = await this.requireClaimCustody(projectId, transferId);
+      const record = await this.stores.authorityTransferRecords.load(projectId);
+      await this.assertClaimBatchOwner(current, record ?? undefined);
+      if (!record || !claimCustodyMatchesStatus(current, record.status)) {
+        throw transferError(
+          'durable-progress-recovery-required',
+          'authority-transfer-claim-custody-incomplete',
+        );
+      }
+      const now = this.now();
+      const expiredAt = now.toISOString();
+      if (now.getTime() < Date.parse(current.expiresAt)) {
+        throw transferError('authority-transfer-stale', 'authority-transfer-claim-expiry-early');
+      }
+      if (current.claims.every(claim => claim.disposition !== 'retained')) return;
+      const updated = decodeAuthorityTransferClaimCustodyRecord({
+        ...current,
+        claims: current.claims.map(claim => claim.disposition === 'retained'
+          ? {
+              ...claim,
+              claim: null,
+              disposition: 'expired',
+              redemptionReceipt: null,
+              scrubbedAt: expiredAt,
+            }
+          : claim),
+        updatedAt: current.updatedAt < expiredAt ? expiredAt : current.updatedAt,
+      });
+      await this.stores.authorityTransferClaims.save(updated);
+    });
+  }
+
+  private async assertAuthorityRestartAllowedUnlocked(
+    projectId: CollabProjectId,
+  ): Promise<void> {
+    const record = await this.stores.authorityTransferRecords.load(projectId);
+    const custody = await this.stores.authorityTransferClaims.load(projectId);
+    const commitment = await this.stores.authorityTransferClaimCommitments.load(projectId);
+    if (!record && (custody || commitment)) {
+      throw transferError(
+        'durable-progress-recovery-required',
+        'authority-transfer-claim-custody-orphaned',
+      );
+    }
+    if (commitment && !custody) {
+      throw transferError(
+        'durable-progress-recovery-required',
+        'authority-transfer-claim-commitment-orphaned',
+      );
+    }
+    if (record && custody) await this.assertClaimBatchOwner(custody, record);
+    if (!record || record.restartFence === 'open') return;
+    throw transferError(
+      'durable-progress-recovery-required',
+      record.restartFence === 'permanent'
+        ? 'authority-transfer-source-relinquished'
+        : 'authority-transfer-authority-quiesced',
+    );
+  }
+
+  async expireTerminalResponder(
+    projectId: CollabProjectId,
+    transferId: string,
+  ): Promise<void> {
+    await this.runProject(projectId, async () => {
+      const record = await this.stores.authorityTransferRecords.load(projectId);
+      if (!record || record.transferId !== transferId) {
+        throw transferError('authority-transfer-not-found', 'authority-transfer-record-missing');
+      }
+      if (this.now().getTime() < Date.parse(record.status.expiresAt)) {
+        throw transferError('authority-transfer-stale', 'authority-transfer-terminal-expiry-early');
+      }
+      if (record.terminalResponder?.state === 'expired') return;
+      try {
+        expireAuthorityTransferTerminalResponder(record);
+      } catch {
+        throw transferError(
+          'authority-transfer-stale',
+          'authority-transfer-terminal-responder-not-expirable',
+        );
+      }
+    });
+    await this.expireClaims(projectId, transferId);
+    await this.runProject(projectId, async () => {
+      const record = await this.stores.authorityTransferRecords.load(projectId);
+      if (!record || record.transferId !== transferId) {
+        throw transferError('authority-transfer-not-found', 'authority-transfer-record-missing');
+      }
+      if (record.terminalResponder?.state === 'expired') return;
+      let expired: AuthorityTransferRecord;
+      try {
+        expired = expireAuthorityTransferTerminalResponder(record);
+      } catch {
+        throw transferError(
+          'authority-transfer-stale',
+          'authority-transfer-terminal-responder-not-expirable',
+        );
+      }
+      await this.stores.authorityTransferRecords.save(expired);
+    });
+  }
+
+  private runProject<T>(
+    projectId: CollabProjectId,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    if (this.closed) return Promise.reject(this.closedError());
+    let queue = this.projectQueues.get(projectId);
+    if (!queue) {
+      queue = new SerialTaskQueue();
+      this.projectQueues.set(projectId, queue);
+    }
+    return queue.run(operation);
+  }
+
+  private closedError(): CollabError {
+    return transferError(
+      'durable-progress-recovery-required',
+      'authority-transfer-persistence-closed',
+    );
+  }
+
+  private saveAbsent(record: AuthorityTransferRecord): Promise<void> {
+    let decoded: AuthorityTransferRecord;
+    try {
+      decoded = decodeAuthorityTransferRecord(record);
+      if (decoded.status.phase !== 'collecting-readiness') throw new TypeError();
+    } catch {
+      return Promise.reject(transferError(
+        'authority-transfer-stale',
+        'authority-transfer-record-invalid',
+      ));
+    }
+    return this.runProject(decoded.projectId, async () => {
+      const existing = await this.stores.authorityTransferRecords.load(decoded.projectId);
+      if (existing) {
+        if (sameValue(existing, decoded)) return;
+        if (
+          existing.status.state !== 'cancelled'
+          || !existing.terminalCleanupCompleted
+          || existing.restartFence !== 'open'
+        ) {
+          throw transferError('authority-transfer-stale', 'authority-transfer-record-conflict');
+        }
+        const [custody, commitment] = await Promise.all([
+          this.stores.authorityTransferClaims.load(decoded.projectId),
+          this.stores.authorityTransferClaimCommitments.load(decoded.projectId),
+        ]);
+        if (custody || commitment) {
+          throw transferError(
+            'durable-progress-recovery-required',
+            'authority-transfer-terminal-cleanup-incomplete',
+          );
+        }
+      }
+      await this.stores.authorityTransferRecords.save(decoded);
+    });
+  }
+
+  private async assertClaimCustodyForStatus(status: CollabAuthorityTransferStatus): Promise<void> {
+    if (status.batchRevision === null || status.batchSha256 === null) return;
+    const custody = await this.requireClaimCustody(status.projectId, status.transferId);
+    await this.assertClaimBatchOwner(custody);
+    if (!claimCustodyMatchesStatus(custody, status)) {
+      throw transferError(
+        'durable-progress-recovery-required',
+        'authority-transfer-claim-custody-incomplete',
+      );
+    }
+  }
+
+  private async assertClaimBatchOwner(
+    custody: AuthorityTransferClaimCustodyRecord,
+    knownRecord?: AuthorityTransferRecord,
+    requireCommitment = true,
+  ): Promise<void> {
+    const record = knownRecord
+      ?? await this.stores.authorityTransferRecords.load(custody.projectId);
+    const checkpointMatches = record?.status.checkpointSha256 === null
+      || record?.status.checkpointSha256 === custody.checkpointSha256;
+    if (
+      !record
+      || record.transferId !== custody.transferId
+      || record.operationIntentId !== custody.operationIntentId
+      || !checkpointMatches
+      || record.status.targetAuthority.generation !== custody.targetAuthorityGeneration
+      || record.status.expiresAt !== custody.expiresAt
+      || (record.localRole === 'source') !== (custody.purpose === 'source-terminal')
+    ) {
+      throw transferError(
+        'authority-transfer-stale',
+        'authority-transfer-claim-owner-stale',
+      );
+    }
+    if (!requireCommitment) return;
+    const commitment = await this.stores.authorityTransferClaimCommitments.load(
+      custody.projectId,
+    );
+    const expected = createAuthorityTransferClaimBatchCommitmentRecord(custody);
+    if (!commitment || !sameValue(commitment, expected)) {
+      throw transferError(
+        'durable-progress-recovery-required',
+        'authority-transfer-claim-commitment-mismatch',
+      );
+    }
+  }
+
+  private async assertTerminalCleanupClaimOwner(
+    record: AuthorityTransferRecord,
+    custody: AuthorityTransferClaimCustodyRecord | null,
+    commitment: AuthorityTransferClaimBatchCommitmentRecord | null,
+  ): Promise<void> {
+    if (custody) {
+      await this.assertClaimBatchOwner(custody, record);
+      if (
+        custody.batchRevision !== record.status.batchRevision
+        || custody.batchSha256 !== record.status.batchSha256
+        || custody.checkpointSha256 !== record.status.checkpointSha256
+        || custody.targetAuthorityGeneration !== record.status.targetAuthority.generation
+      ) {
+        throw transferError('authority-transfer-stale', 'authority-transfer-claim-owner-stale');
+      }
+      return;
+    }
+    if (!commitment) return;
+    if (
+      commitment.projectId !== record.projectId
+      || commitment.transferId !== record.transferId
+      || commitment.operationIntentId !== record.operationIntentId
+    ) {
+      throw transferError('authority-transfer-stale', 'authority-transfer-claim-owner-stale');
+    }
+    if (
+      commitment.batchRevision !== record.status.batchRevision
+      || commitment.batchSha256 !== record.status.batchSha256
+    ) {
+      throw transferError(
+        'durable-progress-recovery-required',
+        'authority-transfer-claim-commitment-mismatch',
+      );
+    }
+  }
+
+  private async persistClaimCommitment(
+    custody: AuthorityTransferClaimCustodyRecord,
+  ): Promise<void> {
+    const expected = createAuthorityTransferClaimBatchCommitmentRecord(custody);
+    const existing = await this.stores.authorityTransferClaimCommitments.load(
+      custody.projectId,
+    );
+    if (sameValue(existing, expected)) return;
+    if (existing && !this.isRotationPredecessorCommitment(existing, custody)) {
+      throw transferError(
+        'durable-progress-recovery-required',
+        'authority-transfer-claim-commitment-mismatch',
+      );
+    }
+    await this.stores.authorityTransferClaimCommitments.save(expected);
+  }
+
+  private isRotationPredecessorCommitment(
+    commitment: AuthorityTransferClaimBatchCommitmentRecord,
+    custody: AuthorityTransferClaimCustodyRecord,
+  ): boolean {
+    return custody.rotationPredecessor !== null
+      && commitment.projectId === custody.projectId
+      && commitment.transferId === custody.transferId
+      && commitment.operationIntentId === custody.operationIntentId
+      && commitment.batchRevision === custody.rotationPredecessor.batchRevision
+      && commitment.batchSha256 === custody.rotationPredecessor.batchSha256;
+  }
+
+  private isCompleteUnacknowledgedBatch(
+    custody: AuthorityTransferClaimCustodyRecord,
+  ): boolean {
+    if (
+      custody.custodyReceipt !== null
+      || custody.claims.some(claim => (
+        claim.disposition !== 'retained'
+        || claim.claim === null
+        || claim.redemptionReceipt !== null
+        || claim.scrubbedAt !== null
+      ))
+    ) {
+      return false;
+    }
+    const batch: CollabTransferredMembershipClaimBatch = {
+      batchRevision: custody.batchRevision,
+      batchSha256: custody.batchSha256,
+      checkpointSha256: custody.checkpointSha256,
+      claims: custody.claims.map(claim => ({
+        claim: claim.claim!,
+        memberId: claim.memberId,
+      })),
+      expiresAt: custody.expiresAt,
+      projectId: custody.projectId,
+      targetAuthorityGeneration: custody.targetAuthorityGeneration,
+      transferId: custody.transferId,
+    };
+    return batchDigest(batch) === custody.batchSha256;
+  }
+
+  private async requireClaimCustody(
+    projectId: CollabProjectId,
+    transferId: string,
+  ): Promise<AuthorityTransferClaimCustodyRecord> {
+    const current = await this.stores.authorityTransferClaims.load(projectId);
+    if (!current || current.transferId !== transferId) {
+      throw transferError('authority-transfer-not-found', 'authority-transfer-claim-custody-missing');
+    }
+    return current;
+  }
+}

--- a/src/app/collab/authority-transfer/persistence/AuthorityTransferPersistenceStores.ts
+++ b/src/app/collab/authority-transfer/persistence/AuthorityTransferPersistenceStores.ts
@@ -1,0 +1,40 @@
+import { type CollabProjectId } from '@claudian-collab/protocol';
+
+import { type AuthorityTransferRecord } from '@/app/collab/authority-transfer/AuthorityTransferRecord';
+import type {
+  AuthorityTransferClaimBatchCommitmentRecord,
+} from '@/app/collab/authority-transfer/persistence/AuthorityTransferClaimBatchCommitmentRecord';
+import {
+  type AuthorityTransferClaimCustodyRecord,
+} from '@/app/collab/authority-transfer/persistence/AuthorityTransferClaimCustodyRecord';
+
+export interface AuthorityTransferRecordStorePort {
+  listProjectIds(): Promise<readonly CollabProjectId[]>;
+  scanProjectCatalog(): Promise<AuthorityTransferProjectCatalog>;
+  load(projectId: CollabProjectId): Promise<AuthorityTransferRecord | null>;
+  remove(projectId: CollabProjectId): Promise<boolean>;
+  save(record: AuthorityTransferRecord): Promise<void>;
+}
+
+export interface AuthorityTransferProjectCatalog {
+  readonly invalidEntryCount: number;
+  readonly projectIds: readonly CollabProjectId[];
+}
+
+export interface AuthorityTransferClaimCustodyStorePort {
+  load(projectId: CollabProjectId): Promise<AuthorityTransferClaimCustodyRecord | null>;
+  remove(projectId: CollabProjectId): Promise<boolean>;
+  save(record: AuthorityTransferClaimCustodyRecord): Promise<void>;
+}
+
+export interface AuthorityTransferClaimCommitmentStorePort {
+  load(projectId: CollabProjectId): Promise<AuthorityTransferClaimBatchCommitmentRecord | null>;
+  remove(projectId: CollabProjectId): Promise<boolean>;
+  save(record: AuthorityTransferClaimBatchCommitmentRecord): Promise<void>;
+}
+
+export interface AuthorityTransferPersistenceStores {
+  readonly authorityTransferClaimCommitments: AuthorityTransferClaimCommitmentStorePort;
+  readonly authorityTransferClaims: AuthorityTransferClaimCustodyStorePort;
+  readonly authorityTransferRecords: AuthorityTransferRecordStorePort;
+}

--- a/src/app/collab/authority-transfer/recovery/AuthorityTransferRecovery.ts
+++ b/src/app/collab/authority-transfer/recovery/AuthorityTransferRecovery.ts
@@ -1,0 +1,93 @@
+import { type CollabProjectId } from '@claudian-collab/protocol';
+
+import {
+  type AuthorityTransferRecord,
+} from '@/app/collab/authority-transfer/AuthorityTransferRecord';
+import {
+  type AuthorityTransferPersistence,
+} from '@/app/collab/authority-transfer/persistence/AuthorityTransferPersistence';
+import {
+  type CollabProjectLifecycleDurableOwner,
+  type CollabProjectLifecycleRecoveryStage,
+  type CollabProjectLifecycleSubsystem,
+} from '@/app/collab/lifecycle/CollabProjectLifecycleSubsystem';
+import { type CollabOperationOptions } from '@/core/collab';
+import { CollabError } from '@/core/collab/ClaudianCollabError';
+
+export interface AuthorityTransferRecoveryHandler {
+  resume(record: AuthorityTransferRecord, options: CollabOperationOptions): Promise<void>;
+}
+
+function throwIfCancelled(signal?: AbortSignal): void {
+  if (!signal?.aborted) return;
+  throw new CollabError({ code: 'cancelled' });
+}
+
+export class AuthorityTransferRecovery implements CollabProjectLifecycleRecoveryStage {
+  readonly name = 'authority-transfers';
+  readonly durableOwner: CollabProjectLifecycleDurableOwner;
+  private lifecycle: CollabProjectLifecycleSubsystem | null = null;
+
+  constructor(
+    private readonly persistence: AuthorityTransferPersistence,
+    private readonly handler: AuthorityTransferRecoveryHandler,
+  ) {
+    this.durableOwner = Object.freeze({
+      name: 'authority-transfer',
+      inspect: (projectId: CollabProjectId) => this.inspect(projectId),
+    });
+  }
+
+  register(lifecycle: CollabProjectLifecycleSubsystem): void {
+    if (this.lifecycle) throw new Error('Authority transfer recovery is already registered');
+    lifecycle.registerDurableOwner(this.durableOwner);
+    lifecycle.registerRecoveryStage(this);
+    this.lifecycle = lifecycle;
+  }
+
+  async run(options: CollabOperationOptions = {}): Promise<void> {
+    if (!this.lifecycle) throw new Error('Authority transfer recovery is not registered');
+    const catalog = await this.persistence.scanProjectCatalog();
+    let firstError: unknown = catalog.invalidEntryCount > 0
+      ? new CollabError({
+        code: 'durable-progress-recovery-required',
+        recoveryActions: ['open-diagnostics'],
+        safeContext: { reason: 'authority-transfer-catalog-invalid' },
+      })
+      : undefined;
+    for (const projectId of catalog.projectIds) {
+      throwIfCancelled(options.signal);
+      await this.lifecycle.runExclusive(
+        projectId,
+        this.durableOwner.name,
+        'recovery',
+        async () => {
+          await this.persistence.recoverInterruptedClaimCommitment(projectId);
+          const ownerState = await this.persistence.inspectLifecycleOwner(projectId);
+          if (ownerState === 'absent' || ownerState === 'proposal' || ownerState === 'terminal') {
+            return;
+          }
+          const record = await this.persistence.load(projectId);
+          if (!record) return;
+          await this.handler.resume(record, options);
+        },
+      ).catch(error => {
+        firstError ??= error;
+      });
+    }
+    if (firstError instanceof Error) throw firstError;
+    if (firstError !== undefined) {
+      throw new CollabError({
+        code: 'durable-progress-recovery-required',
+        recoveryActions: ['resume'],
+        safeContext: { reason: 'authority-transfer-recovery-incomplete' },
+      });
+    }
+  }
+
+  private async inspect(
+    projectId: CollabProjectId,
+  ): Promise<'absent' | 'nonterminal' | 'proposal' | 'terminal'> {
+    return this.persistence.inspectLifecycleOwner(projectId);
+  }
+}

--- a/src/app/collab/bootstrap/CloudBootstrapService.ts
+++ b/src/app/collab/bootstrap/CloudBootstrapService.ts
@@ -20,7 +20,13 @@ export interface CloudBootstrapServiceOptions {
     readonly serverUrl: string;
   }) => CloudBootstrapCoordinator;
   readonly fenceUncertainProject: (projectId: CollabProjectId) => Promise<void>;
-  readonly recoverLocalArtifacts: () => Promise<void>;
+  readonly projectRecoveryAdmission: (
+    projectId: CollabProjectId,
+    operation: () => Promise<void>,
+  ) => Promise<void>;
+  readonly recoverLocalArtifacts: (
+    projectRecoveryAdmission: CloudBootstrapServiceOptions['projectRecoveryAdmission'],
+  ) => Promise<void>;
   readonly scheduleRetry?: (
     retryKey: string,
     retry: () => Promise<void>,
@@ -150,14 +156,17 @@ export class CloudBootstrapService {
     }
     let retryRequired = catalog.retryRequired;
     try {
-      await this.options.recoverLocalArtifacts();
+      await this.options.recoverLocalArtifacts(this.options.projectRecoveryAdmission);
     } catch {
       retryRequired = true;
     }
     if (retryRequired) this.requestCatalogRetry();
     else this.clearRetry('catalog');
     await Promise.allSettled(
-      catalog.records.map(record => this.recoverRecord(record, signal)),
+      catalog.records.map(record => this.options.projectRecoveryAdmission(
+        record.projectId,
+        () => this.recoverRecord(record, signal),
+      )),
     );
   }
 
@@ -179,7 +188,10 @@ export class CloudBootstrapService {
     }
     const fenceResults = await Promise.allSettled(
       [...uncertainProjects].map(projectId => (
-        this.options.fenceUncertainProject(projectId)
+        this.options.projectRecoveryAdmission(
+          projectId,
+          () => this.options.fenceUncertainProject(projectId),
+        )
       )),
     );
     if (signal.aborted) throw new CollabError({ code: 'cancelled' });
@@ -271,7 +283,10 @@ export class CloudBootstrapService {
       this.retryCancellations.delete(retryKey);
       this.retryScheduled.delete(retryKey);
       if (this.closing) return;
-      await this.run(signal => this.recoverRecord(record, signal));
+      await this.run(signal => this.options.projectRecoveryAdmission(
+        record.projectId,
+        () => this.recoverRecord(record, signal),
+      ));
     }, delayMs);
     if (cancellation) this.retryCancellations.set(retryKey, cancellation);
   }

--- a/src/app/collab/bootstrap/CloudBootstrapTransitionStore.ts
+++ b/src/app/collab/bootstrap/CloudBootstrapTransitionStore.ts
@@ -106,6 +106,7 @@ function assertMonotonic(
 }
 
 export class CloudBootstrapTransitionStore implements CloudBootstrapTransitionStorePort {
+  private blockedLifecycleProjectIds = new Set<CollabProjectId>();
   private readonly queue = new SerialTaskQueue();
 
   constructor(private readonly vaultRoot: string) {}
@@ -156,6 +157,17 @@ export class CloudBootstrapTransitionStore implements CloudBootstrapTransitionSt
 
   load(projectId: CollabProjectId): Promise<CloudBootstrapTransitionRecord | null> {
     return this.queue.run(() => this.loadUnlocked(projectId));
+  }
+
+  inspectLifecycleOwner(
+    projectId: CollabProjectId,
+  ): Promise<'absent' | 'nonterminal' | 'terminal'> {
+    return this.queue.run(async () => {
+      if (this.blockedLifecycleProjectIds.has(projectId)) return 'nonterminal';
+      const record = await this.loadUnlocked(projectId);
+      if (!record) return 'absent';
+      return record.terminalCleanupCompleted ? 'terminal' : 'nonterminal';
+    });
   }
 
   runWithLanHostStartGuard<T>(
@@ -230,6 +242,7 @@ export class CloudBootstrapTransitionStore implements CloudBootstrapTransitionSt
           throw error;
         }
       }
+      this.blockedLifecycleProjectIds = new Set(blockedProjectIds);
       return Object.freeze({
         blockedProjectIds: Object.freeze(blockedProjectIds.sort((left, right) => (
           left.localeCompare(right, 'en-US')

--- a/src/app/collab/bootstrap/LocalDevelopmentBootstrapSource.ts
+++ b/src/app/collab/bootstrap/LocalDevelopmentBootstrapSource.ts
@@ -346,29 +346,38 @@ export class LocalDevelopmentBootstrapSource {
     });
   }
 
-  recoverArtifacts(
+  async recoverArtifacts(
     isOwned: (manifest: DevelopmentBootstrapManifest) => Promise<boolean>,
+    projectRecoveryAdmission: (
+      projectId: string,
+      operation: () => Promise<void>,
+    ) => Promise<void>,
   ): Promise<void> {
-    return this.#queue.run(async () => {
+    const projectIds = await this.#queue.run(async () => {
       const directory = await resolveCollabVaultPath(this.#vaultRoot, ARTIFACT_DIRECTORY);
       const entries = await readdir(directory, { withFileTypes: true }).catch(error => {
         if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
         throw sourceOperationError('cloud-bootstrap-source-artifact-list-failed');
       });
-      for (const entry of entries.sort((left, right) => (
+      return entries.sort((left, right) => (
         left.name.localeCompare(right.name, 'en-US')
-      ))) {
-        if (/^\..+\.tmp$/u.test(entry.name) || entry.name.endsWith('.bundle')) continue;
+      )).flatMap(entry => {
+        if (/^\..+\.tmp$/u.test(entry.name) || entry.name.endsWith('.bundle')) return [];
         const match = /^(.+)\.json$/u.exec(entry.name);
         if (!match || !entry.isFile() || entry.isSymbolicLink() || !isCollabProjectId(match[1])) {
           throw sourceError('cloud-bootstrap-source-artifact-directory-invalid');
         }
-        const intent = await this.#loadIntent(match[1]);
-        if (!intent) continue;
-        if (intent.manifest && await isOwned(intent.manifest)) continue;
-        await this.#discardIntent(intent);
-      }
+        return [match[1]];
+      });
     });
+    for (const projectId of projectIds) {
+      await projectRecoveryAdmission(projectId, () => this.#queue.run(async () => {
+          const intent = await this.#loadIntent(projectId);
+          if (!intent) return;
+          if (intent.manifest && await isOwned(intent.manifest)) return;
+          await this.#discardIntent(intent);
+      }));
+    }
   }
 
   async #loadIntent(projectId: string): Promise<BootstrapArtifactIntent | null> {

--- a/src/app/collab/client/CollabClientProjection.ts
+++ b/src/app/collab/client/CollabClientProjection.ts
@@ -102,14 +102,29 @@ export type CollabClientProjectionEventFactory = (
   onInvalidation: (invalidation: ProjectEventInvalidation) => Promise<number>,
 ) => CollabClientProjectionEventPort;
 
-export interface CollabClientProjectionOptions {
+interface CollabClientProjectionBaseOptions {
   readonly authoritySessions?: CollabAuthoritySessionFactory;
   readonly createEventClient?: CollabClientProjectionEventFactory;
   readonly managerResponsibility?: CollabManagerResponsibilityProjectionPort;
   readonly now?: () => Date;
-  readonly retirement?: Pick<RetirementClientHandler, 'handle'>;
   readonly sessions?: CollabProjectWorkSessionRegistry;
 }
+
+export type CollabClientProjectionOptions = CollabClientProjectionBaseOptions & (
+  | {
+      readonly retirement?: undefined;
+      readonly retirementAdmission?: undefined;
+    }
+  | {
+      readonly retirement: Pick<RetirementClientHandler, 'handle'>;
+      readonly retirementAdmission: CollabClientRetirementAdmission;
+    }
+);
+
+export type CollabClientRetirementAdmission = (
+  projectId: string,
+  operation: () => Promise<void>,
+) => Promise<void>;
 
 export interface CollabManagerResponsibilityProjectionPort {
   reconcileSnapshot(
@@ -353,6 +368,7 @@ export class CollabClientProjection {
   private readonly now: () => Date;
   private readonly ownsSessions: boolean;
   private readonly retirement?: Pick<RetirementClientHandler, 'handle'>;
+  private readonly retirementAdmission?: CollabClientRetirementAdmission;
   private readonly sessions: CollabProjectWorkSessionRegistry;
 
   constructor(
@@ -367,6 +383,7 @@ export class CollabClientProjection {
     this.now = options.now ?? (() => new Date());
     this.ownsSessions = options.sessions === undefined;
     this.retirement = options.retirement;
+    this.retirementAdmission = options.retirementAdmission;
     this.sessions = options.sessions ?? new CollabProjectWorkSessionRegistry();
   }
 
@@ -695,9 +712,8 @@ export class CollabClientProjection {
     result: { readonly projectId: string; readonly retiredAt: string },
     source: 'response' | 'terminal-fallback',
   ): Promise<void> {
-    if (!this.retirement) return;
-    this.stopProjectConnection(result.projectId);
-    await this.retirement.handle(result, source);
+    if (!this.retirement || !this.retirementAdmission) return;
+    await this.deliverRetirement(result, source);
   }
 
   private readOnlineCoalesced(projectId: string): Promise<CollabProjectSnapshot> {
@@ -817,19 +833,19 @@ export class CollabClientProjection {
     );
   }
 
-  private async handleRetirementEvent(
+  private handleRetirementEvent(
     projectId: string,
     invalidation: Extract<ProjectEventInvalidation, { readonly kind: 'retired' }>,
   ): Promise<number> {
+    // The event callback is owned by this Project session. Detach it before
+    // convergence closes and drains that session, then let the lifecycle-owned
+    // handler settle independently so the callback cannot await itself.
+    this.resetProjectConnection(projectId);
     this.scheduleRetirement({
       projectId,
       retiredAt: invalidation.retiredAt,
     }, 'event');
-    return invalidation.sequence;
-  }
-
-  private stopProjectConnection(projectId: string): void {
-    this.sessions.acquire(projectId).resetProjection();
+    return Promise.resolve(invalidation.sequence);
   }
 
   private async runWithRetirementFallback<T>(
@@ -851,9 +867,18 @@ export class CollabClientProjection {
     result: { readonly projectId: string; readonly retiredAt: string },
     source: 'event' | 'terminal-fallback',
   ): void {
-    if (!this.retirement) return;
-    this.stopProjectConnection(result.projectId);
-    void this.retirement.handle(result, source).catch(() => undefined);
+    if (!this.retirement || !this.retirementAdmission) return;
+    void this.deliverRetirement(result, source).catch(() => undefined);
+  }
+
+  private deliverRetirement(
+    result: { readonly projectId: string; readonly retiredAt: string },
+    source: 'event' | 'response' | 'terminal-fallback',
+  ): Promise<void> {
+    if (!this.retirement || !this.retirementAdmission) return Promise.resolve();
+    return this.retirementAdmission(result.projectId, async () => {
+      await this.retirement!.handle(result, source);
+    });
   }
 
   private assertOpen(): void {

--- a/src/app/collab/exit/PendingLeaveWorker.ts
+++ b/src/app/collab/exit/PendingLeaveWorker.ts
@@ -2,6 +2,9 @@ import type { CollabProjectId } from '@claudian-collab/protocol';
 
 import type { LocalProjectExitCoordinator } from '@/app/collab/exit/LocalProjectExitCoordinator';
 import type { PendingLeaveJournalPort } from '@/app/collab/lifecycle/CollabLifecycleJournalStore';
+import type {
+  CollabProjectLifecycleAdmission,
+} from '@/app/collab/lifecycle/CollabProjectLifecycleAdmission';
 
 export interface PendingLeaveWorkerResult {
   readonly attempted: readonly CollabProjectId[];
@@ -14,6 +17,7 @@ export class PendingLeaveWorker {
   constructor(
     private readonly pendingLeaves: Pick<PendingLeaveJournalPort, 'list'>,
     private readonly exits: Pick<LocalProjectExitCoordinator, 'resume'>,
+    private readonly projectRecoveryAdmission: CollabProjectLifecycleAdmission,
   ) {}
 
   async runOnce(signal?: AbortSignal): Promise<PendingLeaveWorkerResult> {
@@ -34,9 +38,14 @@ export class PendingLeaveWorker {
       if (signal?.aborted) break;
       attempted.push(pending.projectId);
       try {
-        await this.exits.resume(
+        await this.projectRecoveryAdmission(
           pending.projectId,
-          signal ? { signal } : {},
+          async () => {
+            await this.exits.resume(
+              pending.projectId,
+              signal ? { signal } : {},
+            );
+          },
         );
       } catch {
         failed.push(pending.projectId);

--- a/src/app/collab/host-transfer/CollabHostTransferService.ts
+++ b/src/app/collab/host-transfer/CollabHostTransferService.ts
@@ -16,6 +16,9 @@ import type {
   IncomingHostTransferCoordinator,
 } from '@/app/collab/host-transfer/IncomingHostTransferCoordinator';
 import type { HostTransferControlClient } from '@/app/collab/lan/HostTransferControlClient';
+import type {
+  CollabProjectLifecycleAdmission,
+} from '@/app/collab/lifecycle/CollabProjectLifecycleAdmission';
 import { type CollabCoordinationSnapshot, type CollabCreateHostTransferRequest, type CollabHostTransferIntentRequest, type CollabLanProjectSnapshot, type CollabOperationOptions, isCollabLanProjectSnapshot } from '@/core/collab';
 import { CollabError } from '@/core/collab/ClaudianCollabError';
 
@@ -42,6 +45,7 @@ export interface CollabHostTransferServiceOptions {
     CollabLocalProjectRepository,
     'loadIndex' | 'loadMembership'
   >;
+  readonly projectRecoveryAdmission: CollabProjectLifecycleAdmission;
   readonly recovery: Pick<HostTransferRecoveryStorePort, 'load'>;
   readonly resumeOutgoing?: (projectId: CollabProjectId) => Promise<void>;
   readonly resumeCompletedOutgoing?: (record: HostTransferRecoveryRecord) => Promise<void>;
@@ -175,28 +179,41 @@ export class CollabHostTransferService {
         const record = await this.options.recovery.load(project.id, 'outgoing')
           ?? await this.options.recovery.load(project.id, 'incoming');
         if (!record) continue;
-        if (record.direction === 'outgoing') {
-          if (
-            record.phase === 'completed'
-            && record.targetTerminalResponseReceived
-            && this.options.resumeCompletedOutgoing
-          ) {
-            await this.options.resumeCompletedOutgoing(record);
-            continue;
-          }
-          await this.options.resumeOutgoing?.(project.id);
-          continue;
-        }
-        const membership = await this.requireMembership(project.id);
-        const incoming = await this.incomingCoordinator(membership);
-        if (options.signal) await incoming.resume(project.id, options.signal);
-        else await incoming.resume(project.id);
+        await this.options.projectRecoveryAdmission(
+          project.id,
+          () => this.resumeProject(project.id, options.signal),
+        );
       } catch (error) {
         firstError ??= error;
       }
     }
     if (firstError instanceof Error) throw firstError;
     if (firstError) throw serviceError('host-transfer-recovery-failed');
+  }
+
+  private async resumeProject(
+    projectId: CollabProjectId,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const record = await this.options.recovery.load(projectId, 'outgoing')
+      ?? await this.options.recovery.load(projectId, 'incoming');
+    if (!record) return;
+    if (record.direction === 'outgoing') {
+      if (
+        record.phase === 'completed'
+        && record.targetTerminalResponseReceived
+        && this.options.resumeCompletedOutgoing
+      ) {
+        await this.options.resumeCompletedOutgoing(record);
+        return;
+      }
+      await this.options.resumeOutgoing?.(projectId);
+      return;
+    }
+    const membership = await this.requireMembership(projectId);
+    const incoming = await this.incomingCoordinator(membership);
+    if (signal) await incoming.resume(projectId, signal);
+    else await incoming.resume(projectId);
   }
 
   close(): Promise<void> {

--- a/src/app/collab/host-transfer/HostTransferModule.ts
+++ b/src/app/collab/host-transfer/HostTransferModule.ts
@@ -31,6 +31,9 @@ import { PinnedCollabHttpClient } from '@/app/collab/lan/CollabHttpClient';
 import { HostTransferControlClient } from '@/app/collab/lan/HostTransferControlClient';
 import { HostTransferTargetTransport } from '@/app/collab/lan/HostTransferTargetTransport';
 import type { LanHostCoordinator } from '@/app/collab/lan/LanHostCoordinator';
+import type {
+  CollabProjectLifecycleAdmission,
+} from '@/app/collab/lifecycle/CollabProjectLifecycleAdmission';
 import { type CollabCoordinationSnapshot, type CollabOperationOptions } from '@/core/collab';
 import { CollabError } from '@/core/collab/ClaudianCollabError';
 
@@ -86,6 +89,7 @@ export interface HostTransferModuleOptions {
     | 'loadMembership'
     | 'saveMembership'
   >;
+  readonly projectRecoveryAdmission: CollabProjectLifecycleAdmission;
   readonly requireGitFoundation: () => Promise<HostTransferModuleGitFoundation>;
   readonly snapshots: {
     readCoordinationSnapshot(
@@ -129,6 +133,7 @@ export class HostTransferModule {
       createControlClient: membership => this.createControlClient(membership),
       createIncomingCoordinator: membership => this.createIncomingCoordinator(membership),
       projects: this.options.projects,
+      projectRecoveryAdmission: this.options.projectRecoveryAdmission,
       recovery: this.recovery,
       resumeCompletedOutgoing: async record => {
         await this.options.finalizeOldAuthority(record.projectId);

--- a/src/app/collab/lan/HostTransferLifecycleOrchestrator.ts
+++ b/src/app/collab/lan/HostTransferLifecycleOrchestrator.ts
@@ -6,6 +6,9 @@ import type {
 import type {
   CollabControlDeferredResult,
 } from '@/app/collab/lan/routes/RouteTypes';
+import type {
+  CollabProjectLifecycleAuthorityAdmission,
+} from '@/app/collab/lifecycle/CollabProjectLifecycleAdmission';
 import { SerialTaskQueue } from '@/app/collab/SerialTaskQueue';
 import type { CollabHostTransferSummary } from '@/core/collab';
 
@@ -30,6 +33,7 @@ export interface OutgoingHostTransferLifecyclePort {
 
 export interface HostTransferLifecycleOrchestratorOptions {
   readonly onBackgroundError?: (error: unknown) => void;
+  readonly projectLifecycleAdmission: CollabProjectLifecycleAuthorityAdmission;
 }
 
 export class HostTransferLifecycleOrchestrator {
@@ -41,7 +45,7 @@ export class HostTransferLifecycleOrchestrator {
       'acceptHostTransfer' | 'cancelHostTransfer'
     >,
     private readonly outgoing: OutgoingHostTransferLifecyclePort,
-    private readonly options: HostTransferLifecycleOrchestratorOptions = {},
+    private readonly options: HostTransferLifecycleOrchestratorOptions,
   ) {}
 
   async acceptHostTransfer(
@@ -49,7 +53,10 @@ export class HostTransferLifecycleOrchestrator {
     request: Parameters<HostedLifecycleControlPort['acceptHostTransfer']>[1],
   ): Promise<CollabControlDeferredResult<CollabHostTransferSummary>> {
     return this.operationQueue.run(
-      () => this.acceptHostTransferUnlocked(actorMemberId, request),
+      () => this.options.projectLifecycleAdmission(
+        request.projectId,
+        () => this.acceptHostTransferUnlocked(actorMemberId, request),
+      ),
     );
   }
 
@@ -84,7 +91,10 @@ export class HostTransferLifecycleOrchestrator {
     request: Parameters<HostedLifecycleControlPort['cancelHostTransfer']>[1],
   ): Promise<CollabHostTransferSummary> {
     return this.operationQueue.run(
-      () => this.cancelHostTransferUnlocked(actorMemberId, request),
+      () => this.options.projectLifecycleAdmission(
+        request.projectId,
+        () => this.cancelHostTransferUnlocked(actorMemberId, request),
+      ),
     );
   }
 

--- a/src/app/collab/lan/LanHostCoordinator.ts
+++ b/src/app/collab/lan/LanHostCoordinator.ts
@@ -67,6 +67,9 @@ import type { ProjectEventSocket } from '@/app/collab/lan/ProjectEventHub';
 import type {
   CollabTerminalProjectService,
 } from '@/app/collab/lan/routes/RouteTypes';
+import type {
+  CollabProjectLifecycleAuthorityAdmission,
+} from '@/app/collab/lifecycle/CollabProjectLifecycleAdmission';
 import { SerialTaskQueue } from '@/app/collab/SerialTaskQueue';
 import type { CollabRetirementResult } from '@/core/collab';
 import { type CollabHostSession, type CollabHostStatus, type CollabInvitationView } from '@/core/collab';
@@ -121,6 +124,7 @@ export interface LanHostProjectRuntime {
   readonly git: LanHostGitRuntime;
   readonly lifecycle: Omit<HostedLifecycleControlPort, 'retireProject'> & {
     createRetirementCoordinator(input: {
+      readonly projectLifecycleAdmission: CollabProjectLifecycleAuthorityAdmission;
       readonly admission: {
         quiesceAndDrain(projectId: CollabProjectId): Promise<void>;
         resume(projectId: CollabProjectId): Promise<void>;
@@ -195,6 +199,11 @@ export interface LanHostCoordinatorOptions {
 
 export interface LanHostConnectionProjectionPort {
   resetProjectConnection(projectId: CollabProjectId): void;
+}
+
+export interface LanHostProjectLifecycleAdmissions {
+  readonly hostTransfer: CollabProjectLifecycleAuthorityAdmission;
+  readonly retirement: CollabProjectLifecycleAuthorityAdmission;
 }
 
 interface HostLockRecord {
@@ -379,6 +388,7 @@ export class LanHostCoordinator {
     Extract<CollabHostStatus, 'starting' | 'stopping'>
   >();
   private readonly provisionalTransfers = new HostTransferProvisionalRouter();
+  private projectLifecycleAdmissions: LanHostProjectLifecycleAdmissions | null = null;
   private readonly recoveringHostTransfers = new Map<
     CollabProjectId,
     NonNullable<LanHostProjectRuntime['outgoingHostTransfer']>
@@ -405,6 +415,13 @@ export class LanHostCoordinator {
       throw new Error('LAN Host connection projection is already bound');
     }
     this.connectionProjection = projection;
+  }
+
+  bindProjectLifecycleAdmissions(admissions: LanHostProjectLifecycleAdmissions): void {
+    if (this.projectLifecycleAdmissions) {
+      throw new Error('LAN Host Project lifecycle admissions are already bound');
+    }
+    this.projectLifecycleAdmissions = admissions;
   }
 
   startProject(projectId: CollabProjectId): Promise<CollabHostSession & { endpoint: string }> {
@@ -887,6 +904,14 @@ export class LanHostCoordinator {
         ? new HostTransferLifecycleOrchestrator(
             openedRuntime.lifecycle,
             openedRuntime.outgoingHostTransfer,
+            {
+              projectLifecycleAdmission: (admissionProjectId, operation) => (
+                this.requireProjectLifecycleAdmissions().hostTransfer(
+                  admissionProjectId,
+                  operation,
+                )
+              ),
+            },
           )
         : null;
       const lifecycle = {
@@ -900,6 +925,12 @@ export class LanHostCoordinator {
           ),
         } : {}),
         ...openedRuntime.lifecycle.createRetirementCoordinator({
+          projectLifecycleAdmission: (admissionProjectId, operation) => (
+            this.requireProjectLifecycleAdmissions().retirement(
+              admissionProjectId,
+              operation,
+            )
+          ),
           admission: {
             quiesceAndDrain: async () => {
               await this.beginRetirement(projectId);
@@ -973,6 +1004,13 @@ export class LanHostCoordinator {
       }
       throw error;
     }
+  }
+
+  private requireProjectLifecycleAdmissions(): LanHostProjectLifecycleAdmissions {
+    if (!this.projectLifecycleAdmissions) {
+      throw hostError('host-stopped', 'project-lifecycle-admission-not-bound');
+    }
+    return this.projectLifecycleAdmissions;
   }
 
   private async stopProjectUnlocked(projectId: CollabProjectId): Promise<CollabHostSession> {

--- a/src/app/collab/lifecycle/CollabProjectLifecycleAdmission.ts
+++ b/src/app/collab/lifecycle/CollabProjectLifecycleAdmission.ts
@@ -1,0 +1,11 @@
+import { type CollabProjectId } from '@claudian-collab/protocol';
+
+export type CollabProjectLifecycleAdmission = (
+  projectId: CollabProjectId,
+  operation: () => Promise<void>,
+) => Promise<void>;
+
+export type CollabProjectLifecycleAuthorityAdmission = <T>(
+  projectId: CollabProjectId,
+  operation: () => Promise<T>,
+) => Promise<T>;

--- a/src/app/collab/lifecycle/CollabProjectLifecycleOwners.ts
+++ b/src/app/collab/lifecycle/CollabProjectLifecycleOwners.ts
@@ -1,0 +1,120 @@
+import { type CollabProjectId } from '@claudian-collab/protocol';
+
+import type { LocalCleanupRecord } from '@/app/collab/exit/LocalCleanupRecord';
+import type {
+  ManagerResponsibilityReceiptRecord,
+} from '@/app/collab/exit/ManagerResponsibilityReceiptRecord';
+import type { PendingLeaveRecord } from '@/app/collab/exit/PendingLeaveRecord';
+import type { HostTransferRecoveryRecord } from '@/app/collab/host-transfer/HostTransferRecoveryRecord';
+import type {
+  CollabProjectLifecycleDurableOwner,
+} from '@/app/collab/lifecycle/CollabProjectLifecycleSubsystem';
+import type { RetirementRecord } from '@/app/collab/retirement/RetirementRecord';
+import type { RetirementTombstoneRecord } from '@/app/collab/retirement/RetirementTombstoneRecord';
+
+export interface CollabProjectLifecycleOwnerStores {
+  readonly cloudBootstrapTransitions: {
+    inspectLifecycleOwner(
+      projectId: CollabProjectId,
+    ): Promise<'absent' | 'nonterminal' | 'terminal'>;
+  };
+  readonly hostTransferRecovery: {
+    load(
+      projectId: CollabProjectId,
+      direction: 'incoming' | 'outgoing',
+    ): Promise<HostTransferRecoveryRecord | null>;
+  };
+  readonly localCleanup: {
+    load(projectId: CollabProjectId): Promise<LocalCleanupRecord | null>;
+  };
+  readonly managerReceipts: {
+    load(projectId: CollabProjectId): Promise<ManagerResponsibilityReceiptRecord | null>;
+  };
+  readonly pendingLeaves: {
+    load(projectId: CollabProjectId): Promise<PendingLeaveRecord | null>;
+  };
+  readonly retiredCleanups: {
+    load(projectId: CollabProjectId): Promise<LocalCleanupRecord | null>;
+  };
+  readonly retirements: {
+    loadRetirementRecord(projectId: CollabProjectId): Promise<RetirementRecord | null>;
+  };
+  readonly retirementTombstones: {
+    loadRetirementTombstone(projectId: CollabProjectId): Promise<RetirementTombstoneRecord | null>;
+  };
+}
+
+export function createCollabProjectLifecycleDurableOwners(
+  stores: CollabProjectLifecycleOwnerStores,
+): readonly CollabProjectLifecycleDurableOwner[] {
+  return Object.freeze([
+    Object.freeze({
+      inspect: (projectId: CollabProjectId) => (
+        stores.cloudBootstrapTransitions.inspectLifecycleOwner(projectId)
+      ),
+      name: 'cloud-bootstrap',
+    }),
+    Object.freeze({
+      inspect: async (projectId: CollabProjectId) => {
+        const [incoming, outgoing] = await Promise.all([
+          stores.hostTransferRecovery.load(projectId, 'incoming'),
+          stores.hostTransferRecovery.load(projectId, 'outgoing'),
+        ]);
+        if (incoming && outgoing) {
+          throw new Error('Conflicting Host transfer recovery records');
+        }
+        return incoming || outgoing ? 'nonterminal' as const : 'absent' as const;
+      },
+      name: 'host-transfer',
+    }),
+    Object.freeze({
+      inspect: async (projectId: CollabProjectId) => {
+        const [receipt, pendingLeave] = await Promise.all([
+          stores.managerReceipts.load(projectId),
+          stores.pendingLeaves.load(projectId),
+        ]);
+        if (!receipt) return 'absent' as const;
+        // A durable pending Leave adopts responsibility for settling the
+        // acknowledged receipt. It must be the only nonterminal owner after a
+        // crash between recording the Leave and consuming the receipt.
+        if (pendingLeave) return 'terminal' as const;
+        // Source-created offers remain reversible authority proposals. This target-only
+        // receipt becomes a local lifecycle owner only after acknowledgement.
+        if (receipt.status === 'offered') return 'proposal' as const;
+        return receipt.status === 'acknowledged'
+          ? 'nonterminal' as const
+          : 'terminal' as const;
+      },
+      name: 'manager-responsibility',
+    }),
+    Object.freeze({
+      inspect: async (projectId: CollabProjectId) => {
+        const [pendingLeave, cleanup, retirement] = await Promise.all([
+          stores.pendingLeaves.load(projectId),
+          stores.localCleanup.load(projectId),
+          stores.retirements.loadRetirementRecord(projectId),
+        ]);
+        if (cleanup && cleanup.purpose !== 'leave') {
+          throw new Error('Invalid local-exit cleanup owner');
+        }
+        if (!pendingLeave && !cleanup) return 'absent' as const;
+        return retirement ? 'terminal' as const : 'nonterminal' as const;
+      },
+      name: 'local-exit',
+    }),
+    Object.freeze({
+      inspect: async (projectId: CollabProjectId) => {
+        const [retirement, cleanup, tombstone] = await Promise.all([
+          stores.retirements.loadRetirementRecord(projectId),
+          stores.retiredCleanups.load(projectId),
+          stores.retirementTombstones.loadRetirementTombstone(projectId),
+        ]);
+        if (cleanup && cleanup.purpose !== 'retire') {
+          throw new Error('Invalid retirement cleanup owner');
+        }
+        return retirement || cleanup || tombstone ? 'nonterminal' as const : 'absent' as const;
+      },
+      name: 'retirement',
+    }),
+  ]);
+}

--- a/src/app/collab/lifecycle/CollabProjectLifecycleSubsystem.ts
+++ b/src/app/collab/lifecycle/CollabProjectLifecycleSubsystem.ts
@@ -1,9 +1,11 @@
 import { type CollabProjectId } from '@claudian-collab/protocol';
 
 import type {
+  CollabCloudBootstrapPort,
   CollabHostTransferPort,
   CollabLifecycleRecoveryPort,
   CollabLocalExitPort,
+  CollabMembershipPort,
   CollabRetirementPort,
 } from '@/app/collab/CollabFeatureService';
 import { type CollabOperationOptions } from '@/core/collab';
@@ -19,8 +21,22 @@ export interface CollabProjectLifecycleRecoveryStage {
   run(options: CollabOperationOptions): Promise<void>;
 }
 
+export type CollabProjectLifecycleDurableState =
+  | 'absent'
+  | 'nonterminal'
+  | 'proposal'
+  | 'terminal';
+
+export interface CollabProjectLifecycleDurableOwner {
+  readonly name: string;
+  inspect(projectId: CollabProjectId): Promise<CollabProjectLifecycleDurableState>;
+}
+
+export type CollabProjectLifecycleAdmissionMode = 'continuation' | 'operation' | 'recovery';
+
 export interface CollabProjectLifecycleSubsystemOptions {
   readonly closeRecovery: () => Promise<void> | void;
+  readonly durableOwners: readonly CollabProjectLifecycleDurableOwner[];
   readonly hostTransfer: CollabHostTransferPort;
   readonly localExit: CollabLocalExitPort;
   readonly recoveryStages: readonly CollabProjectLifecycleRecoveryStage[];
@@ -37,16 +53,274 @@ export class CollabProjectLifecycleSubsystem {
   readonly lifecycleRecovery: CollabLifecycleRecoveryPort;
   readonly localExit: CollabLocalExitPort;
   readonly retirement: CollabRetirementPort;
+  private readonly activeRecoveryRuns = new Set<Promise<void>>();
+  private readonly closeRecovery: () => Promise<void> | void;
+  private readonly durableOwners = new Map<string, CollabProjectLifecycleDurableOwner>();
+  private readonly projectQueues = new Map<CollabProjectId, Promise<void>>();
+  private readonly recoveryStages: CollabProjectLifecycleRecoveryStage[];
+  private cloudBootstrapBound = false;
+  private closePromise: Promise<void> | null = null;
+  private closed = false;
+  private membershipBound = false;
   private projection: CollabProjectLifecycleProjectionPort | null = null;
+  private started = false;
 
   constructor(options: CollabProjectLifecycleSubsystemOptions) {
-    this.hostTransfer = options.hostTransfer;
-    this.localExit = options.localExit;
-    this.retirement = options.retirement;
+    this.closeRecovery = options.closeRecovery;
+    for (const owner of options.durableOwners) this.registerDurableOwner(owner);
+    this.hostTransfer = Object.freeze<CollabHostTransferPort>({
+      acceptHostTransfer: (request, operationOptions) => this.runExclusive(
+        request.projectId,
+        'host-transfer',
+        'continuation',
+        () => options.hostTransfer.acceptHostTransfer(request, operationOptions),
+      ),
+      // Cancellation mutates source authority only inside its trusted Host
+      // listener. The initiating client holds no separate durable local phase.
+      cancelHostTransfer: (request, operationOptions) => (
+        options.hostTransfer.cancelHostTransfer(request, operationOptions)
+      ),
+      close: () => options.hostTransfer.close(),
+      createHostTransfer: (request, operationOptions) => this.runExclusive(
+        request.projectId,
+        'host-transfer',
+        'operation',
+        () => options.hostTransfer.createHostTransfer(request, operationOptions),
+      ),
+      declineHostTransfer: (request, operationOptions) => this.runExclusive(
+        request.projectId,
+        'host-transfer',
+        'operation',
+        () => options.hostTransfer.declineHostTransfer(request, operationOptions),
+      ),
+    });
+    this.localExit = Object.freeze<CollabLocalExitPort>({
+      leaveProject: (request, operationOptions) => this.runExclusiveWithPredecessor(
+        request.projectId,
+        'local-exit',
+        'manager-responsibility',
+        'continuation',
+        () => options.localExit.leaveProject(request, operationOptions),
+      ),
+    });
+    this.retirement = Object.freeze<CollabRetirementPort>({
+      close: () => options.retirement.close(),
+      finalizeRetiredProject: (request, operationOptions) => this.runExclusive(
+        request.projectId,
+        'retirement',
+        'continuation',
+        () => options.retirement.finalizeRetiredProject(request, operationOptions),
+      ),
+      // The trusted authority listener arbitrates the remote retirement commit.
+      // This client adapter acquires local ownership only when it adopts the
+      // returned terminal result, avoiding a same-process client/listener lock.
+      retireProject: (request, operationOptions) => (
+        options.retirement.retireProject(request, operationOptions)
+      ),
+      retryProjectCleanup: (projectId, operationOptions) => this.runExclusive(
+        projectId,
+        'retirement',
+        'continuation',
+        () => options.retirement.retryProjectCleanup(projectId, operationOptions),
+      ),
+    });
+    this.recoveryStages = [...options.recoveryStages];
     this.lifecycleRecovery = {
-      close: options.closeRecovery,
-      resume: recoveryOptions => this.resume(options.recoveryStages, recoveryOptions),
+      close: () => this.close(),
+      resume: recoveryOptions => this.startRecovery(recoveryOptions),
     };
+  }
+
+  registerDurableOwner(owner: CollabProjectLifecycleDurableOwner): void {
+    this.assertRegistrationOpen();
+    if (!owner.name || this.durableOwners.has(owner.name)) {
+      throw new Error('Collab lifecycle durable owner is already registered');
+    }
+    this.durableOwners.set(owner.name, owner);
+  }
+
+  registerRecoveryStage(stage: CollabProjectLifecycleRecoveryStage): void {
+    this.assertRegistrationOpen();
+    if (!stage.name || this.recoveryStages.some(existing => existing.name === stage.name)) {
+      throw new Error('Collab lifecycle recovery stage is already registered');
+    }
+    this.recoveryStages.push(stage);
+  }
+
+  runExclusive<T>(
+    projectId: CollabProjectId,
+    ownerName: string,
+    mode: CollabProjectLifecycleAdmissionMode,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    return this.runExclusiveWithPredecessor(
+      projectId,
+      ownerName,
+      null,
+      mode,
+      operation,
+    );
+  }
+
+  runRetirementAdoption<T>(
+    projectId: CollabProjectId,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    return this.runExclusiveWithPredecessor(
+      projectId,
+      'retirement',
+      'local-exit',
+      'continuation',
+      operation,
+    );
+  }
+
+  private runExclusiveWithPredecessor<T>(
+    projectId: CollabProjectId,
+    ownerName: string,
+    predecessorOwnerName: string | null,
+    mode: CollabProjectLifecycleAdmissionMode,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    if (this.closed) {
+      return Promise.reject(new CollabError({
+        code: 'durable-progress-recovery-required',
+        recoveryActions: ['resume'],
+        safeContext: { reason: 'lifecycle-subsystem-closed' },
+      }));
+    }
+    this.started = true;
+    const previous = this.projectQueues.get(projectId) ?? Promise.resolve();
+    const result = previous.then(async () => {
+      const pendingOwners: string[] = [];
+      for (const owner of this.durableOwners.values()) {
+        const state = await owner.inspect(projectId).catch(error => {
+          throw new CollabError({
+            cause: error,
+            code: 'durable-progress-recovery-required',
+            recoveryActions: ['resume'],
+            safeContext: { reason: 'lifecycle-owner-inspection-failed' },
+          });
+        });
+        if (
+          state !== 'absent'
+          && state !== 'nonterminal'
+          && state !== 'proposal'
+          && state !== 'terminal'
+        ) {
+          throw new CollabError({
+            code: 'durable-progress-recovery-required',
+            recoveryActions: ['resume'],
+            safeContext: { reason: 'lifecycle-owner-inspection-invalid' },
+          });
+        }
+        if (state === 'nonterminal') pendingOwners.push(owner.name);
+      }
+      if (pendingOwners.length > 1) {
+        throw new CollabError({
+          code: 'durable-progress-recovery-required',
+          recoveryActions: ['resume'],
+          safeContext: { reason: 'lifecycle-owner-ambiguous' },
+        });
+      }
+      const pendingOwner = pendingOwners[0];
+      if (
+        pendingOwner !== undefined
+        && pendingOwner !== ownerName
+        && pendingOwner !== predecessorOwnerName
+      ) {
+        throw new CollabError({
+          code: 'durable-progress-recovery-required',
+          recoveryActions: ['resume'],
+          safeContext: { reason: 'lifecycle-owner-pending' },
+        });
+      }
+      if (pendingOwner === ownerName && mode === 'operation') {
+        throw new CollabError({
+          code: 'durable-progress-recovery-required',
+          recoveryActions: ['resume'],
+          safeContext: { reason: 'lifecycle-owner-recovery-required' },
+        });
+      }
+      return operation();
+    });
+    const tail = result.then(() => undefined, () => undefined);
+    this.projectQueues.set(projectId, tail);
+    void tail.finally(() => {
+      if (this.projectQueues.get(projectId) === tail) this.projectQueues.delete(projectId);
+    });
+    return result;
+  }
+
+  bindCloudBootstrap(cloudBootstrap: CollabCloudBootstrapPort): CollabCloudBootstrapPort {
+    this.assertRegistrationOpen();
+    if (this.cloudBootstrapBound) {
+      throw new Error('Cloud bootstrap lifecycle port is already bound');
+    }
+    this.cloudBootstrapBound = true;
+    return Object.freeze<CollabCloudBootstrapPort>({
+      cancel: projectId => this.runExclusive(
+        projectId,
+        'cloud-bootstrap',
+        'continuation',
+        () => cloudBootstrap.cancel(projectId),
+      ),
+      close: () => cloudBootstrap.close(),
+      prepareLocalRecovery: () => cloudBootstrap.prepareLocalRecovery(),
+      recoverPending: () => cloudBootstrap.recoverPending(),
+      startFormerHost: input => this.runExclusive(
+        input.projectId,
+        'cloud-bootstrap',
+        'operation',
+        () => cloudBootstrap.startFormerHost(input),
+      ),
+      submitParticipant: input => this.runExclusive(
+        input.projectId,
+        'cloud-bootstrap',
+        'operation',
+        () => cloudBootstrap.submitParticipant(input),
+      ),
+    });
+  }
+
+  bindMembership(membership: CollabMembershipPort): CollabMembershipPort {
+    this.assertRegistrationOpen();
+    if (this.membershipBound) {
+      throw new Error('Manager responsibility lifecycle port is already bound');
+    }
+    this.membershipBound = true;
+    return Object.freeze<CollabMembershipPort>({
+      cancelManagerResponsibilityOffer: (request, operationOptions) => this.runExclusive(
+        request.projectId,
+        'manager-responsibility',
+        'operation',
+        () => membership.cancelManagerResponsibilityOffer(request, operationOptions),
+      ),
+      createInvitation: (projectId, operationOptions) => (
+        membership.createInvitation(projectId, operationOptions)
+      ),
+      createManagerResponsibilityOffer: (request, operationOptions) => this.runExclusive(
+        request.projectId,
+        'manager-responsibility',
+        'operation',
+        () => membership.createManagerResponsibilityOffer(request, operationOptions),
+      ),
+      demoteManager: (request, operationOptions) => (
+        membership.demoteManager(request, operationOptions)
+      ),
+      listMembers: (projectId, operationOptions) => (
+        membership.listMembers(projectId, operationOptions)
+      ),
+      promoteManager: (request, operationOptions) => (
+        membership.promoteManager(request, operationOptions)
+      ),
+      removeMember: (request, operationOptions) => (
+        membership.removeMember(request, operationOptions)
+      ),
+      revokeInvitation: (projectId, operationOptions) => (
+        membership.revokeInvitation(projectId, operationOptions)
+      ),
+    });
   }
 
   bindProjection(projection: CollabProjectLifecycleProjectionPort): void {
@@ -84,5 +358,52 @@ export class CollabProjectLifecycleSubsystem {
         safeContext: { reason: 'collab-lifecycle-recovery-incomplete' },
       });
     }
+  }
+
+  private startRecovery(options: CollabOperationOptions = {}): Promise<void> {
+    if (this.closed) {
+      return Promise.reject(new CollabError({
+        code: 'durable-progress-recovery-required',
+        recoveryActions: ['resume'],
+        safeContext: { reason: 'lifecycle-subsystem-closed' },
+      }));
+    }
+    this.started = true;
+    const recovery = this.resume(this.recoveryStages, options);
+    this.activeRecoveryRuns.add(recovery);
+    void recovery.then(
+      () => this.activeRecoveryRuns.delete(recovery),
+      () => this.activeRecoveryRuns.delete(recovery),
+    );
+    return recovery;
+  }
+
+  private close(): Promise<void> {
+    if (this.closePromise) return this.closePromise;
+    this.closed = true;
+    this.closePromise = (async () => {
+      let closeFailure: unknown;
+      await Promise.resolve().then(() => this.closeRecovery()).catch(error => {
+        closeFailure = error;
+      });
+      const recoveryResults = await Promise.allSettled([...this.activeRecoveryRuns]);
+      await Promise.all([...this.projectQueues.values()]);
+      if (closeFailure instanceof Error) throw closeFailure;
+      if (closeFailure !== undefined) {
+        throw new CollabError({
+          code: 'durable-progress-recovery-required',
+          recoveryActions: ['resume'],
+          safeContext: { reason: 'collab-lifecycle-recovery-close-failed' },
+        });
+      }
+      const failure = recoveryResults.find(result => result.status === 'rejected');
+      if (failure?.status === 'rejected') throw failure.reason;
+    })();
+    return this.closePromise;
+  }
+
+  private assertRegistrationOpen(): void {
+    if (this.closed) throw new Error('Collab lifecycle subsystem is closed');
+    if (this.started) throw new Error('Collab lifecycle subsystem has already started');
   }
 }

--- a/src/app/collab/membership/CollabMembershipService.ts
+++ b/src/app/collab/membership/CollabMembershipService.ts
@@ -14,6 +14,9 @@ import type {
   PromoteManagerResponse,
 } from '@/app/collab/lan/LanCollabControlOperations';
 import type {
+  CollabProjectLifecycleAdmission,
+} from '@/app/collab/lifecycle/CollabProjectLifecycleAdmission';
+import type {
   ManagerResponsibilityOperationPort,
 } from '@/app/collab/membership/ManagerResponsibilityOperationCoordinator';
 import {
@@ -101,6 +104,7 @@ export interface CollabMembershipManagerReceiptPort {
 }
 
 export interface CollabMembershipSafetyContext {
+  readonly managerResponsibilityAdmission: CollabProjectLifecycleAdmission;
   readonly managerResponsibilityOperations: ManagerResponsibilityOperationPort;
   readonly managerReceipts: CollabMembershipManagerReceiptPort;
   readonly pendingLeaves: CollabMembershipPendingLeavePort;
@@ -204,18 +208,20 @@ export class CollabMembershipService {
     request: CollabPromoteManagerRequest,
     options: CollabOperationOptions = {},
   ): Promise<void> {
-    const session = await this.loadSession(request.projectId);
-    await session.client.promoteManager({
-      idempotencyKey: administrationIntentKey(
-        'promote-manager',
-        request.intentId,
-        this.createIdempotencyKey,
-      ),
-      managerResponsibilityOfferId: request.managerResponsibilityOfferId,
-      memberCredential: session.membership.member.credential,
-      projectId: request.projectId,
-      targetMemberId: request.targetMemberId,
-      ...(options.signal ? { signal: options.signal } : {}),
+    await this.safety.managerResponsibilityAdmission(request.projectId, async () => {
+      const session = await this.loadSession(request.projectId);
+      await session.client.promoteManager({
+        idempotencyKey: administrationIntentKey(
+          'promote-manager',
+          request.intentId,
+          this.createIdempotencyKey,
+        ),
+        managerResponsibilityOfferId: request.managerResponsibilityOfferId,
+        memberCredential: session.membership.member.credential,
+        projectId: request.projectId,
+        targetMemberId: request.targetMemberId,
+        ...(options.signal ? { signal: options.signal } : {}),
+      });
     });
     await this.refreshProjection(request.projectId, options);
   }

--- a/src/app/collab/publish/CollabPublicationService.ts
+++ b/src/app/collab/publish/CollabPublicationService.ts
@@ -12,6 +12,7 @@ import type {
 } from '@/app/collab/ClaudianCollabService';
 import {
   CollabClientProjection,
+  type CollabClientRetirementAdmission,
   type CollabManagerResponsibilityProjectionPort,
 } from '@/app/collab/client/CollabClientProjection';
 import type {
@@ -92,6 +93,7 @@ export interface CollabPublicationServiceOptions {
   readonly managerResponsibility: CollabManagerResponsibilityProjectionPort;
   readonly reconnect: CollabPublicationReconnectPort;
   readonly retirement: Pick<RetirementClientHandler, 'handle'>;
+  readonly retirementAdmission: CollabClientRetirementAdmission;
   readonly vaultRoot: string;
 }
 
@@ -176,6 +178,7 @@ export class CollabPublicationService {
       authoritySessions: this.authoritySessions,
       managerResponsibility: options.managerResponsibility,
       retirement: options.retirement,
+      retirementAdmission: options.retirementAdmission,
       sessions: this.sessions,
     });
   }

--- a/src/app/collab/retirement/ProjectRetirementCoordinator.ts
+++ b/src/app/collab/retirement/ProjectRetirementCoordinator.ts
@@ -1,6 +1,9 @@
 import type { CollabMemberId, CollabProjectId } from '@claudian-collab/protocol';
 
 import type { ProjectRetirementAuthorityRequest } from '@/app/collab/authority/ProjectRetirementAuthorityService';
+import type {
+  CollabProjectLifecycleAuthorityAdmission,
+} from '@/app/collab/lifecycle/CollabProjectLifecycleAdmission';
 import type { CollabRetirementResult } from '@/core/collab';
 
 export interface ProjectRetirementAdmissionPort {
@@ -43,6 +46,7 @@ export class ProjectRetirementCoordinator {
     private readonly terminal: ProjectRetirementTerminalPort,
     private readonly delivery: ProjectRetirementDeliveryPort,
     private readonly activeResources: ProjectRetirementActiveResourcesPort,
+    private readonly projectLifecycleAdmission: CollabProjectLifecycleAuthorityAdmission,
   ) {}
 
   retire(
@@ -51,7 +55,10 @@ export class ProjectRetirementCoordinator {
   ): Promise<CollabRetirementResult> {
     const existing = this.operations.get(request.projectId);
     if (existing) return existing;
-    const pending = this.retireUnlocked(actorMemberId, request);
+    const pending = this.projectLifecycleAdmission(
+      request.projectId,
+      () => this.retireUnlocked(actorMemberId, request),
+    );
     this.operations.set(request.projectId, pending);
     const clear = () => {
       if (this.operations.get(request.projectId) === pending) {

--- a/src/app/collab/retirement/RetirementAcknowledgementWorker.ts
+++ b/src/app/collab/retirement/RetirementAcknowledgementWorker.ts
@@ -1,6 +1,9 @@
 import { type CollabProjectId } from '@claudian-collab/protocol';
 
 import type { AcknowledgeRetirementResponse } from '@/app/collab/lan/LanCollabControlOperations';
+import type {
+  CollabProjectLifecycleAdmission,
+} from '@/app/collab/lifecycle/CollabProjectLifecycleAdmission';
 import type { RetirementRecord } from '@/app/collab/retirement/RetirementRecord';
 import { CollabError } from '@/core/collab/ClaudianCollabError';
 
@@ -32,6 +35,7 @@ export interface RetirementAcknowledgementScheduler {
 
 export interface RetirementAcknowledgementWorkerOptions {
   readonly now?: () => Date;
+  readonly projectRecoveryAdmission: CollabProjectLifecycleAdmission;
   readonly scheduleRetry?: (
     projectId: CollabProjectId,
     retry: () => Promise<void>,
@@ -63,6 +67,7 @@ implements RetirementAcknowledgementScheduler {
   private readonly controller = new AbortController();
   private closed = false;
   private readonly now: () => Date;
+  private readonly projectRecoveryAdmission: CollabProjectLifecycleAdmission;
   private readonly retryScheduled = new Set<CollabProjectId>();
   private readonly retryAttempts = new Map<CollabProjectId, number>();
   private readonly retryCancellations = new Map<CollabProjectId, () => void>();
@@ -71,9 +76,10 @@ implements RetirementAcknowledgementScheduler {
   constructor(
     private readonly store: RetirementClientStore,
     private readonly client: RetirementAcknowledgementClientPort,
-    options: RetirementAcknowledgementWorkerOptions = {},
+    options: RetirementAcknowledgementWorkerOptions,
   ) {
     this.now = options.now ?? (() => new Date());
+    this.projectRecoveryAdmission = options.projectRecoveryAdmission;
     this.scheduleRetry = options.scheduleRetry ?? ((_projectId, retry, delayMs) => {
       const timer = window.setTimeout(() => void retry().catch(() => undefined), delayMs);
       return () => window.clearTimeout(timer);
@@ -89,7 +95,7 @@ implements RetirementAcknowledgementScheduler {
     if (this.closed) return Promise.resolve('cancelled');
     const existing = this.active.get(projectId);
     if (existing) return existing;
-    const pending = this.runUnlocked(projectId);
+    const pending = this.runAdmitted(projectId);
     this.active.set(projectId, pending);
     const clear = () => {
       if (this.active.get(projectId) === pending) this.active.delete(projectId);
@@ -196,6 +202,21 @@ implements RetirementAcknowledgementScheduler {
     await this.store.removeRetirementAcknowledgement(projectId);
     this.clearRetry(projectId);
     return 'acknowledged';
+  }
+
+  private async runAdmitted(
+    projectId: CollabProjectId,
+  ): Promise<RetirementAcknowledgementRunResult> {
+    let result: RetirementAcknowledgementRunResult | null = null;
+    await this.projectRecoveryAdmission(projectId, async () => {
+      result = await this.runUnlocked(projectId);
+    });
+    if (result !== null) return result;
+    throw new CollabError({
+      code: 'durable-progress-recovery-required',
+      recoveryActions: ['resume'],
+      safeContext: { reason: 'retirement-acknowledgement-admission-incomplete' },
+    });
   }
 
   private requestRetry(projectId: CollabProjectId): void {

--- a/src/app/collab/retirement/RetirementLocalRecovery.ts
+++ b/src/app/collab/retirement/RetirementLocalRecovery.ts
@@ -5,6 +5,9 @@ import type {
 } from '@/app/collab/CollabLocalProjectRepository';
 import type { LocalCleanupRecord } from '@/app/collab/exit/LocalCleanupRecord';
 import type { PendingLeaveRecord } from '@/app/collab/exit/PendingLeaveRecord';
+import type {
+  CollabProjectLifecycleAdmission,
+} from '@/app/collab/lifecycle/CollabProjectLifecycleAdmission';
 import type { RetirementRecord } from '@/app/collab/retirement/RetirementRecord';
 import { type CollabOperationOptions } from '@/core/collab';
 import { CollabError } from '@/core/collab/ClaudianCollabError';
@@ -43,6 +46,7 @@ export class RetirementLocalRecovery {
     private readonly cleanupRecords: RetirementLocalRecoveryCleanupRecords,
     private readonly handler: { resume(projectId: CollabProjectId): Promise<void> },
     private readonly finalizer: RetirementLocalRecoveryFinalizer,
+    private readonly projectRecoveryAdmission: CollabProjectLifecycleAdmission,
   ) {}
 
   async resume(options: CollabOperationOptions = {}): Promise<void> {
@@ -70,7 +74,7 @@ export class RetirementLocalRecovery {
         && cleanupRecord?.purpose === 'retire'
         && cleanupRecord.phase === 'choice-applied'
       ) {
-        await this.finalizer.finalize({
+        await this.finalize({
           choice: cleanupRecord.choice,
           projectId: project.id,
         }, options).catch(error => {
@@ -79,7 +83,7 @@ export class RetirementLocalRecovery {
         continue;
       }
       if (retirement === null && (pendingLeave || project.lifecycle !== 'retired')) continue;
-      await this.handler.resume(project.id).catch(error => {
+      await this.resumeRetirement(project.id).catch(error => {
         firstError ??= error;
       });
     }
@@ -96,14 +100,14 @@ export class RetirementLocalRecovery {
         return [null, null, null] as const;
       });
       if (retirement && !acknowledgementOnly.has(projectId)) {
-        await this.handler.resume(projectId).catch(error => {
+        await this.resumeRetirement(projectId).catch(error => {
           firstError ??= error;
         });
         continue;
       }
       if (pendingLeave || !cleanupRecord) continue;
       if (cleanupRecord.purpose === 'retire' && cleanupRecord.phase === 'choice-applied') {
-        await this.finalizer.finalize({
+        await this.finalize({
           choice: cleanupRecord.choice,
           projectId,
         }, options).catch(error => {
@@ -128,6 +132,23 @@ export class RetirementLocalRecovery {
         safeContext: { reason: 'retirement-local-recovery-incomplete' },
       });
     }
+  }
+
+  private finalize(
+    intent: { readonly choice: 'delete-files' | 'keep-files'; readonly projectId: CollabProjectId },
+    options: CollabOperationOptions,
+  ): Promise<void> {
+    return this.projectRecoveryAdmission(
+      intent.projectId,
+      () => this.finalizer.finalize(intent, options),
+    );
+  }
+
+  private resumeRetirement(projectId: CollabProjectId): Promise<void> {
+    return this.projectRecoveryAdmission(
+      projectId,
+      () => this.handler.resume(projectId),
+    );
   }
 
 }

--- a/tests/helpers/collab/CollabFeatureTestHarness.ts
+++ b/tests/helpers/collab/CollabFeatureTestHarness.ts
@@ -119,6 +119,7 @@ type PublicationOptionsOverrides = {
   >;
   readonly reconnect?: Partial<CollabPublicationServiceOptions['reconnect']>;
   readonly retirement?: Partial<CollabPublicationServiceOptions['retirement']>;
+  readonly retirementAdmission?: CollabPublicationServiceOptions['retirementAdmission'];
   readonly vaultRoot: string;
 };
 
@@ -345,6 +346,8 @@ export function completeCollabPublicationOptions(
       handle: () => Promise.resolve(),
       ...overrides.retirement,
     },
+    retirementAdmission: overrides.retirementAdmission
+      ?? ((_projectId, operation) => operation()),
     vaultRoot: overrides.vaultRoot,
   };
 }

--- a/tests/integration/app/collab/accept/CloudAcceptRecovery.test.ts
+++ b/tests/integration/app/collab/accept/CloudAcceptRecovery.test.ts
@@ -340,7 +340,7 @@ function membership(): CollabLocalCloudMembershipRecord {
       gitRemoteUrl: `https://cloud.example.test/v2/projects/${PROJECT_ID}/repository.git`,
       kind: 'cloud',
       serverUrl: 'https://cloud.example.test',
-      wireVersion: 5,
+      wireVersion: 6,
     },
     createdAt: CREATED_AT,
     lastEventSequence: 0,

--- a/tests/integration/app/collab/authority-transfer/AuthorityTransferPersistence.test.ts
+++ b/tests/integration/app/collab/authority-transfer/AuthorityTransferPersistence.test.ts
@@ -175,9 +175,9 @@ describe('AuthorityTransferPersistence', () => {
   let vaultRoot: string;
 
   beforeEach(async () => {
-    jest.useFakeTimers();
-    jest.setSystemTime(new Date('2026-08-26T00:01:00.000Z'));
     vaultRoot = await mkdtemp(path.join(tmpdir(), 'claudian-authority-transfer-'));
+    jest.useFakeTimers();
+    jest.setSystemTime(Date.parse('2026-08-26T00:01:00.000Z'));
   });
 
   afterEach(async () => {

--- a/tests/integration/app/collab/authority-transfer/AuthorityTransferPersistence.test.ts
+++ b/tests/integration/app/collab/authority-transfer/AuthorityTransferPersistence.test.ts
@@ -1,0 +1,1324 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import {
+  type CollabAuthorityTransferStatus,
+  type CollabCloudToLanTransferPhase,
+  type CollabLanToCloudTransferPhase,
+  type CollabTransferredMembershipClaimBatch,
+  encodeCollabTransferredMembershipClaimBatchDigestInput,
+} from '@claudian-collab/protocol';
+
+import {
+  assertAuthorityTransferTransition,
+  createAuthorityTransferRecord,
+  expireAuthorityTransferTerminalResponder,
+} from '@/app/collab/authority-transfer/AuthorityTransferRecord';
+import {
+  createAuthorityTransferClaimBatchCommitmentRecord,
+} from '@/app/collab/authority-transfer/persistence/AuthorityTransferClaimBatchCommitmentRecord';
+import {
+  createAuthorityTransferClaimCustodyRecord,
+} from '@/app/collab/authority-transfer/persistence/AuthorityTransferClaimCustodyRecord';
+import {
+  AuthorityTransferPersistence,
+} from '@/app/collab/authority-transfer/persistence/AuthorityTransferPersistence';
+import { CollabLocalProjectRepository } from '@/app/collab/CollabLocalProjectRepository';
+
+const PROJECT_ID = 'project-alpha';
+const TRANSFER_ID = 'transfer-one';
+const OPERATION_INTENT_ID = 'intent-one';
+const CHECKPOINT_SHA256 = 'a'.repeat(64);
+const MEMBER_ALICE = 'member-alice';
+const MEMBER_BOB = 'member-bob';
+const EXPIRES_AT = '2026-09-30T00:00:00.000Z';
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+function claimBatch(
+  batchRevision = 1,
+  claimSuffix = 'A',
+  options: {
+    readonly claims?: CollabTransferredMembershipClaimBatch['claims'];
+    readonly expiresAt?: string;
+  } = {},
+): CollabTransferredMembershipClaimBatch {
+  const unsigned: CollabTransferredMembershipClaimBatch = {
+    batchRevision,
+    batchSha256: '0'.repeat(64),
+    checkpointSha256: CHECKPOINT_SHA256,
+    claims: options.claims ?? [
+      { claim: `${'A'.repeat(42)}${claimSuffix}`, memberId: MEMBER_ALICE },
+      { claim: `${'B'.repeat(42)}${claimSuffix}`, memberId: MEMBER_BOB },
+    ],
+    expiresAt: options.expiresAt ?? EXPIRES_AT,
+    projectId: PROJECT_ID,
+    targetAuthorityGeneration: 2,
+    transferId: TRANSFER_ID,
+  };
+  return {
+    ...unsigned,
+    batchSha256: sha256(encodeCollabTransferredMembershipClaimBatchDigestInput(unsigned)),
+  };
+}
+
+const LAN_TO_CLOUD_PHASES: readonly CollabLanToCloudTransferPhase[] = [
+  'collecting-readiness',
+  'source-quiesced',
+  'checkpoint-received',
+  'checkpoint-validated',
+  'claims-retained',
+  'repository-published',
+  'source-relinquished',
+  'cloud-activated',
+  'completed',
+];
+const CLOUD_TO_LAN_PHASES: readonly CollabCloudToLanTransferPhase[] = [
+  'collecting-readiness',
+  'cloud-quiesced',
+  'checkpoint-captured',
+  'target-staged',
+  'claims-retained',
+  'cloud-relinquished',
+  'lan-activated',
+  'completed',
+];
+
+function transferStatus(
+  phase: CollabLanToCloudTransferPhase,
+  updatedMinute = LAN_TO_CLOUD_PHASES.indexOf(phase),
+): CollabAuthorityTransferStatus {
+  const checkpointRequired = LAN_TO_CLOUD_PHASES.indexOf(phase) >= 2;
+  const batchRequired = LAN_TO_CLOUD_PHASES.indexOf(phase) >= 4;
+  const relinquished = LAN_TO_CLOUD_PHASES.indexOf(phase) >= 6;
+  const proof = relinquished
+    ? {
+        batchRevision: 1,
+        batchSha256: claimBatch().batchSha256,
+        certificate: 'A'.repeat(86),
+        certificateAlgorithm: 'ed25519' as const,
+        checkpointSha256: CHECKPOINT_SHA256,
+        committedAt: '2026-08-26T00:05:00.000Z',
+        operationIntentId: OPERATION_INTENT_ID,
+        projectId: PROJECT_ID,
+        sourceAuthority: { generation: 1, kind: 'lan' as const },
+        sourceHostMemberId: MEMBER_ALICE,
+        targetAuthority: { generation: 2, kind: 'cloud' as const },
+        transferId: TRANSFER_ID,
+      }
+    : null;
+  return {
+    batchRevision: batchRequired ? 1 : null,
+    batchSha256: batchRequired ? claimBatch().batchSha256 : null,
+    checkpointSha256: checkpointRequired ? CHECKPOINT_SHA256 : null,
+    createdAt: '2026-08-26T00:00:00.000Z',
+    direction: 'lan-to-cloud',
+    expiresAt: EXPIRES_AT,
+    phase,
+    projectId: PROJECT_ID,
+    relinquishmentProof: proof,
+    sourceAuthority: { generation: 1, kind: 'lan' },
+    state: phase === 'completed' ? 'completed' : 'active',
+    targetAuthority: { generation: 2, kind: 'cloud' },
+    targetUrl: 'http://127.0.0.1:8787/',
+    transferId: TRANSFER_ID,
+    updatedAt: `2026-08-26T00:${String(updatedMinute).padStart(2, '0')}:00.000Z`,
+  };
+}
+
+function cloudToLanStatus(
+  phase: CollabCloudToLanTransferPhase,
+): CollabAuthorityTransferStatus {
+  const phaseIndex = CLOUD_TO_LAN_PHASES.indexOf(phase);
+  const checkpointRequired = phaseIndex >= 2;
+  const batchRequired = phaseIndex >= 4;
+  const relinquished = phaseIndex >= 5;
+  return {
+    batchRevision: batchRequired ? 1 : null,
+    batchSha256: batchRequired ? claimBatch().batchSha256 : null,
+    checkpointSha256: checkpointRequired ? CHECKPOINT_SHA256 : null,
+    createdAt: '2026-08-26T00:00:00.000Z',
+    direction: 'cloud-to-lan',
+    expiresAt: EXPIRES_AT,
+    phase,
+    projectId: PROJECT_ID,
+    relinquishmentProof: relinquished
+      ? {
+          batchRevision: 1,
+          batchSha256: claimBatch().batchSha256,
+          certificate: 'A'.repeat(86),
+          certificateAlgorithm: 'ed25519',
+          checkpointSha256: CHECKPOINT_SHA256,
+          committedAt: '2026-08-26T00:04:30.000Z',
+          operationIntentId: OPERATION_INTENT_ID,
+          projectId: PROJECT_ID,
+          sourceAuthority: { generation: 1, kind: 'cloud' },
+          sourceHostMemberId: null,
+          targetAuthority: { generation: 2, kind: 'lan' },
+          transferId: TRANSFER_ID,
+        }
+      : null,
+    sourceAuthority: { generation: 1, kind: 'cloud' },
+    state: phase === 'completed' ? 'completed' : 'active',
+    targetAuthority: { generation: 2, kind: 'lan' },
+    targetUrl: 'https://192.168.1.20:27001/',
+    transferId: TRANSFER_ID,
+    updatedAt: `2026-08-26T00:${String(phaseIndex).padStart(2, '0')}:00.000Z`,
+  };
+}
+
+describe('AuthorityTransferPersistence', () => {
+  let vaultRoot: string;
+
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-08-26T00:01:00.000Z'));
+    vaultRoot = await mkdtemp(path.join(tmpdir(), 'claudian-authority-transfer-'));
+  });
+
+  afterEach(async () => {
+    jest.useRealTimers();
+    await rm(vaultRoot, { force: true, recursive: true });
+  });
+
+  it('recovers every exact LAN source phase and permanently fences the old authority', async () => {
+    let repository = new CollabLocalProjectRepository(vaultRoot);
+    let persistence = new AuthorityTransferPersistence(repository);
+    let record = createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: transferStatus('collecting-readiness'),
+    });
+    await persistence.create(record);
+    record = createAuthorityTransferRecord({
+      lifecycleOwnership: 'owned',
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: transferStatus('collecting-readiness'),
+    });
+    await persistence.advance(record, 'collecting-readiness');
+    persistence = new AuthorityTransferPersistence(
+      new CollabLocalProjectRepository(vaultRoot),
+    );
+    await expect(persistence.assertAuthorityRestartAllowed(PROJECT_ID))
+      .rejects.toMatchObject({ code: 'durable-progress-recovery-required' });
+
+    for (const phase of LAN_TO_CLOUD_PHASES.slice(1)) {
+      if (phase === 'claims-retained') {
+        const batch = claimBatch();
+        await persistence.retainClaimBatch({
+          batch,
+          operationIntentId: OPERATION_INTENT_ID,
+          purpose: 'source-terminal',
+        });
+        await persistence.acknowledgeClaimBatch({
+          batchRevision: batch.batchRevision,
+          batchSha256: batch.batchSha256,
+          checkpointSha256: batch.checkpointSha256,
+          committedAt: '2026-08-26T00:03:30.000Z',
+          custodyAuthority: { generation: 1, kind: 'lan' },
+          operationIntentId: OPERATION_INTENT_ID,
+          projectId: PROJECT_ID,
+          receiptId: 'custody-receipt-phase-loop',
+          submittedByMemberId: MEMBER_ALICE,
+          targetAuthorityGeneration: 2,
+          transferId: TRANSFER_ID,
+        });
+      }
+      record = createAuthorityTransferRecord({
+        localRole: 'source',
+        operationIntentId: OPERATION_INTENT_ID,
+        stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+        status: transferStatus(phase),
+      });
+      await persistence.advance(record, LAN_TO_CLOUD_PHASES[
+        LAN_TO_CLOUD_PHASES.indexOf(phase) - 1
+      ]);
+
+      repository = new CollabLocalProjectRepository(vaultRoot);
+      persistence = new AuthorityTransferPersistence(repository);
+      await expect(persistence.load(PROJECT_ID)).resolves.toEqual(record);
+    }
+
+    await expect(persistence.assertAuthorityRestartAllowed(PROJECT_ID)).rejects.toMatchObject({
+      code: 'durable-progress-recovery-required',
+      safeContext: { reason: 'authority-transfer-source-relinquished' },
+    });
+    await expect(repository.listAuthorityTransferProjectIds()).resolves.toEqual([PROJECT_ID]);
+  });
+
+  it('serializes LAN Host start against authority-transfer fence creation', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository);
+    let markStarted!: () => void;
+    const started = new Promise<void>(resolve => {
+      markStarted = resolve;
+    });
+    let releaseStart!: () => void;
+    const release = new Promise<void>(resolve => {
+      releaseStart = resolve;
+    });
+    const start = persistence.runWithAuthorityStartGuard(PROJECT_ID, async () => {
+      markStarted();
+      await release;
+      return 'running';
+    });
+    await started;
+    const collecting = createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: transferStatus('collecting-readiness'),
+    });
+    let recordCreated = false;
+    const create = persistence.create(collecting).then(record => {
+      recordCreated = true;
+      return record;
+    });
+    await Promise.resolve();
+    expect(recordCreated).toBe(false);
+
+    releaseStart();
+    await expect(start).resolves.toBe('running');
+    await create;
+    await persistence.advance(createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: transferStatus('source-quiesced'),
+    }), 'collecting-readiness');
+
+    await expect(persistence.runWithAuthorityStartGuard(
+      PROJECT_ID,
+      async () => 'unexpected',
+    )).rejects.toMatchObject({
+      code: 'durable-progress-recovery-required',
+      safeContext: { reason: 'authority-transfer-authority-quiesced' },
+    });
+  });
+
+  it('isolates Project guards and closes new persistence admission while draining', async () => {
+    const emptyStore = {
+      load: jest.fn().mockResolvedValue(null),
+      remove: jest.fn().mockResolvedValue(false),
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+    const persistence = new AuthorityTransferPersistence({
+      authorityTransferClaimCommitments: emptyStore,
+      authorityTransferClaims: emptyStore,
+      authorityTransferRecords: {
+        ...emptyStore,
+        listProjectIds: jest.fn().mockResolvedValue([]),
+        scanProjectCatalog: jest.fn().mockResolvedValue({
+          invalidEntryCount: 0,
+          projectIds: [],
+        }),
+      },
+    });
+    let releaseAlpha!: () => void;
+    let markAlphaStarted!: () => void;
+    const alphaStarted = new Promise<void>(resolve => { markAlphaStarted = resolve; });
+    const alphaBlocked = new Promise<void>(resolve => { releaseAlpha = resolve; });
+    const alpha = persistence.runWithAuthorityStartGuard(PROJECT_ID, async () => {
+      markAlphaStarted();
+      await alphaBlocked;
+      return 'alpha';
+    });
+    await alphaStarted;
+
+    let betaCompleted = false;
+    const beta = persistence.runWithAuthorityStartGuard(
+      'project-beta',
+      async () => 'beta',
+    ).then(result => {
+      betaCompleted = true;
+      return result;
+    });
+    for (let index = 0; index < 10; index += 1) await Promise.resolve();
+    const projectsWereIsolated = betaCompleted;
+
+    releaseAlpha();
+    await expect(alpha).resolves.toBe('alpha');
+    await expect(beta).resolves.toBe('beta');
+
+    let releaseDrain!: () => void;
+    let markDrainStarted!: () => void;
+    const drainStarted = new Promise<void>(resolve => { markDrainStarted = resolve; });
+    const drainBlocked = new Promise<void>(resolve => { releaseDrain = resolve; });
+    const admittedBeforeClose = persistence.runWithAuthorityStartGuard(
+      'project-gamma',
+      async () => {
+        markDrainStarted();
+        await drainBlocked;
+      },
+    );
+    await drainStarted;
+
+    const closing = persistence.close();
+    await expect(persistence.assertAuthorityRestartAllowed('project-beta'))
+      .rejects.toMatchObject({
+        code: 'durable-progress-recovery-required',
+        safeContext: { reason: 'authority-transfer-persistence-closed' },
+      });
+    releaseDrain();
+    await admittedBeforeClose;
+    await expect(closing).resolves.toBeUndefined();
+    expect(projectsWereIsolated).toBe(true);
+  });
+
+  it('rotates only an unacknowledged exact batch and scrubs one verified claim at a time', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    let persistence = new AuthorityTransferPersistence(repository);
+    const first = claimBatch();
+    const rotated = claimBatch(2, 'C');
+    await persistence.create(createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: transferStatus('collecting-readiness'),
+    }));
+    const retained = await persistence.retainClaimBatch({
+      batch: first,
+      operationIntentId: OPERATION_INTENT_ID,
+      purpose: 'source-terminal',
+    });
+    await expect(persistence.retainClaimBatch({
+      batch: first,
+      operationIntentId: OPERATION_INTENT_ID,
+      purpose: 'source-terminal',
+    })).resolves.toEqual(retained);
+    const persistedRotation = await persistence.rotateClaimBatch({
+      batch: rotated,
+      expectedBatchRevision: first.batchRevision,
+      expectedBatchSha256: first.batchSha256,
+      operationIntentId: OPERATION_INTENT_ID,
+      purpose: 'source-terminal',
+    });
+    await expect(persistence.rotateClaimBatch({
+      batch: rotated,
+      expectedBatchRevision: first.batchRevision,
+      expectedBatchSha256: first.batchSha256,
+      operationIntentId: OPERATION_INTENT_ID,
+      purpose: 'source-terminal',
+    })).resolves.toEqual(persistedRotation);
+    await expect(persistence.rotateClaimBatch({
+      batch: rotated,
+      expectedBatchRevision: first.batchRevision,
+      expectedBatchSha256: first.batchSha256,
+      operationIntentId: 'intent-replayed-under-another-operation',
+      purpose: 'source-terminal',
+    })).rejects.toMatchObject({ code: 'authority-transfer-stale' });
+
+    const receipt = {
+      batchRevision: rotated.batchRevision,
+      batchSha256: rotated.batchSha256,
+      checkpointSha256: CHECKPOINT_SHA256,
+      committedAt: '2026-08-26T00:03:00.000Z',
+      custodyAuthority: { generation: 1, kind: 'lan' as const },
+      operationIntentId: OPERATION_INTENT_ID,
+      projectId: PROJECT_ID,
+      receiptId: 'custody-receipt-one',
+      submittedByMemberId: MEMBER_ALICE,
+      targetAuthorityGeneration: 2,
+      transferId: TRANSFER_ID,
+    };
+    await expect(persistence.acknowledgeClaimBatch({
+      ...receipt,
+      custodyAuthority: { generation: 1, kind: 'cloud' },
+      receiptId: 'custody-receipt-wrong-source',
+    })).rejects.toMatchObject({ code: 'authority-transfer-stale' });
+    await expect(persistence.acknowledgeClaimBatch({
+      ...receipt,
+      committedAt: EXPIRES_AT,
+      receiptId: 'custody-receipt-after-expiry',
+    })).rejects.toMatchObject({ code: 'authority-transfer-stale' });
+    await expect(persistence.acknowledgeClaimBatch(receipt)).resolves.toEqual(receipt);
+
+    persistence = new AuthorityTransferPersistence(new CollabLocalProjectRepository(vaultRoot));
+    await expect(persistence.acknowledgeClaimBatch(receipt)).resolves.toEqual(receipt);
+    await expect(persistence.rotateClaimBatch({
+      batch: claimBatch(3, 'D'),
+      expectedBatchRevision: rotated.batchRevision,
+      expectedBatchSha256: rotated.batchSha256,
+      operationIntentId: OPERATION_INTENT_ID,
+      purpose: 'source-terminal',
+    })).rejects.toMatchObject({ code: 'authority-transfer-stale' });
+    await expect(persistence.loadClaim(PROJECT_ID, TRANSFER_ID, MEMBER_BOB))
+      .rejects.toMatchObject({
+        code: 'durable-progress-recovery-required',
+        safeContext: { reason: 'authority-transfer-terminal-claim-unavailable' },
+      });
+    const relinquishedStatus = transferStatus('source-relinquished');
+    await repository.authorityTransferRecords.save(createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: {
+        ...relinquishedStatus,
+        batchRevision: rotated.batchRevision,
+        batchSha256: rotated.batchSha256,
+        relinquishmentProof: {
+          ...relinquishedStatus.relinquishmentProof!,
+          batchRevision: rotated.batchRevision,
+          batchSha256: rotated.batchSha256,
+        },
+      },
+    }));
+    await expect(persistence.loadClaim(PROJECT_ID, TRANSFER_ID, MEMBER_BOB))
+      .resolves.toMatchObject({ claim: rotated.claims[1].claim, memberId: MEMBER_BOB });
+
+    const redemptionReceipt = {
+      checkpointSha256: CHECKPOINT_SHA256,
+      claimSha256: sha256(rotated.claims[1].claim),
+      memberId: MEMBER_BOB,
+      operationIntentId: 'claim-intent-bob',
+      projectId: PROJECT_ID,
+      receiptId: 'redemption-receipt-bob',
+      receiptKeyId: 'receipt-key-one',
+      redeemedAt: '2026-08-26T00:03:59.000Z',
+      signature: 'A'.repeat(86),
+      signatureAlgorithm: 'ed25519' as const,
+      targetAuthorityGeneration: 2,
+      transferId: TRANSFER_ID,
+    };
+    await expect(persistence.scrubClaimWithVerifiedReceipt({
+      acknowledgedAt: EXPIRES_AT,
+      receipt: {
+        ...redemptionReceipt,
+        receiptId: 'redemption-receipt-after-expiry',
+        redeemedAt: EXPIRES_AT,
+      },
+    })).rejects.toMatchObject({ code: 'membership-claim-invalid' });
+    await persistence.scrubClaimWithVerifiedReceipt({
+      acknowledgedAt: '2026-08-26T00:04:00.000Z',
+      receipt: redemptionReceipt,
+    });
+    await expect(persistence.loadClaim(PROJECT_ID, TRANSFER_ID, MEMBER_BOB))
+      .rejects.toMatchObject({ code: 'membership-claim-already-redeemed' });
+    await expect(persistence.loadClaim(PROJECT_ID, TRANSFER_ID, MEMBER_ALICE))
+      .resolves.toMatchObject({ claim: rotated.claims[0].claim, memberId: MEMBER_ALICE });
+
+    const claimPath = path.join(
+      vaultRoot,
+      '.claudian',
+      'collab',
+      'projects',
+      PROJECT_ID,
+      'authority-transfer-claims.json',
+    );
+    expect((await stat(claimPath)).mode & 0o777).toBe(0o600);
+    expect(await readFile(claimPath, 'utf8')).not.toContain(rotated.claims[1].claim);
+    const summary = await readFile(path.join(
+      vaultRoot,
+      '.claudian',
+      'collab',
+      'projects',
+      PROJECT_ID,
+      'authority-transfer.json',
+    ), 'utf8').catch(() => '');
+    expect(summary).not.toContain(rotated.claims[0].claim);
+  });
+
+  it('requires rotation to replace the exact retained member set and transfer lifetime', async () => {
+    const persistence = new AuthorityTransferPersistence(
+      new CollabLocalProjectRepository(vaultRoot),
+    );
+    const first = claimBatch();
+    await persistence.create(createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: transferStatus('collecting-readiness'),
+    }));
+    await persistence.retainClaimBatch({
+      batch: first,
+      operationIntentId: OPERATION_INTENT_ID,
+      purpose: 'source-terminal',
+    });
+
+    await expect(persistence.rotateClaimBatch({
+      batch: claimBatch(2, 'C', {
+        claims: [
+          first.claims[0],
+          { claim: `${'B'.repeat(42)}C`, memberId: MEMBER_BOB },
+        ],
+      }),
+      expectedBatchRevision: first.batchRevision,
+      expectedBatchSha256: first.batchSha256,
+      operationIntentId: OPERATION_INTENT_ID,
+      purpose: 'source-terminal',
+    })).rejects.toMatchObject({ code: 'authority-transfer-stale' });
+    await expect(persistence.rotateClaimBatch({
+      batch: claimBatch(2, 'C', {
+        claims: [
+          { claim: `${'A'.repeat(42)}C`, memberId: MEMBER_ALICE },
+        ],
+      }),
+      expectedBatchRevision: first.batchRevision,
+      expectedBatchSha256: first.batchSha256,
+      operationIntentId: OPERATION_INTENT_ID,
+      purpose: 'source-terminal',
+    })).rejects.toMatchObject({ code: 'authority-transfer-stale' });
+    await expect(persistence.rotateClaimBatch({
+      batch: claimBatch(2, 'C', { expiresAt: '2026-10-01T00:00:00.000Z' }),
+      expectedBatchRevision: first.batchRevision,
+      expectedBatchSha256: first.batchSha256,
+      operationIntentId: OPERATION_INTENT_ID,
+      purpose: 'source-terminal',
+    })).rejects.toMatchObject({ code: 'authority-transfer-stale' });
+  });
+
+  it('rejects coherently tampered raw custody against its durable batch commitment', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    let persistence = new AuthorityTransferPersistence(repository);
+    const batch = claimBatch();
+    await repository.authorityTransferRecords.save(createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: transferStatus('source-relinquished'),
+    }));
+    await persistence.retainClaimBatch({
+      batch,
+      operationIntentId: OPERATION_INTENT_ID,
+      purpose: 'source-terminal',
+    });
+    await persistence.acknowledgeClaimBatch({
+      batchRevision: batch.batchRevision,
+      batchSha256: batch.batchSha256,
+      checkpointSha256: batch.checkpointSha256,
+      committedAt: '2026-08-26T00:03:30.000Z',
+      custodyAuthority: { generation: 1, kind: 'lan' },
+      operationIntentId: OPERATION_INTENT_ID,
+      projectId: PROJECT_ID,
+      receiptId: 'custody-receipt-tamper',
+      submittedByMemberId: MEMBER_ALICE,
+      targetAuthorityGeneration: 2,
+      transferId: TRANSFER_ID,
+    });
+    const claimPath = path.join(
+      vaultRoot,
+      '.claudian',
+      'collab',
+      'projects',
+      PROJECT_ID,
+      'authority-transfer-claims.json',
+    );
+    const custody = JSON.parse(await readFile(claimPath, 'utf8')) as {
+      claims: Array<{ claim: string; claimSha256: string }>;
+    };
+    const tamperedClaim = `${'C'.repeat(42)}A`;
+    custody.claims[0].claim = tamperedClaim;
+    custody.claims[0].claimSha256 = sha256(tamperedClaim);
+    await writeFile(claimPath, JSON.stringify(custody), { mode: 0o600 });
+
+    persistence = new AuthorityTransferPersistence(new CollabLocalProjectRepository(vaultRoot));
+    await expect(persistence.loadClaim(PROJECT_ID, TRANSFER_ID, MEMBER_ALICE))
+      .rejects.toMatchObject({
+        code: 'durable-progress-recovery-required',
+        safeContext: { reason: 'authority-transfer-claim-commitment-mismatch' },
+      });
+  });
+
+  it('recovers every exact LAN target phase without creating a terminal responder', async () => {
+    let repository = new CollabLocalProjectRepository(vaultRoot);
+    let persistence = new AuthorityTransferPersistence(repository);
+    let record = createAuthorityTransferRecord({
+      localRole: 'target',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: cloudToLanStatus('collecting-readiness'),
+    });
+    await persistence.create(record);
+    record = createAuthorityTransferRecord({
+      lifecycleOwnership: 'owned',
+      localRole: 'target',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: cloudToLanStatus('collecting-readiness'),
+    });
+    await persistence.advance(record, 'collecting-readiness');
+
+    for (const phase of CLOUD_TO_LAN_PHASES.slice(1)) {
+      if (phase === 'claims-retained') {
+        const batch = claimBatch();
+        await persistence.retainClaimBatch({
+          batch,
+          operationIntentId: OPERATION_INTENT_ID,
+          purpose: 'target-delivery',
+        });
+        await persistence.acknowledgeClaimBatch({
+          batchRevision: batch.batchRevision,
+          batchSha256: batch.batchSha256,
+          checkpointSha256: batch.checkpointSha256,
+          committedAt: '2026-08-26T00:03:30.000Z',
+          custodyAuthority: { generation: 1, kind: 'cloud' },
+          operationIntentId: OPERATION_INTENT_ID,
+          projectId: PROJECT_ID,
+          receiptId: 'target-custody-receipt',
+          submittedByMemberId: MEMBER_ALICE,
+          targetAuthorityGeneration: 2,
+          transferId: TRANSFER_ID,
+        });
+      }
+      record = createAuthorityTransferRecord({
+        localRole: 'target',
+        operationIntentId: OPERATION_INTENT_ID,
+        stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+        status: cloudToLanStatus(phase),
+      });
+      await persistence.advance(record, CLOUD_TO_LAN_PHASES[
+        CLOUD_TO_LAN_PHASES.indexOf(phase) - 1
+      ]);
+
+      repository = new CollabLocalProjectRepository(vaultRoot);
+      persistence = new AuthorityTransferPersistence(repository);
+      await expect(persistence.load(PROJECT_ID)).resolves.toEqual(record);
+      expect(record.terminalResponder).toBeNull();
+    }
+
+    await expect(persistence.assertAuthorityRestartAllowed(PROJECT_ID)).resolves.toBeUndefined();
+    await expect(persistence.inspectLifecycleOwner(PROJECT_ID)).resolves.toBe('nonterminal');
+    await repository.authorityTransferClaims.remove(PROJECT_ID);
+    persistence = new AuthorityTransferPersistence(repository);
+    await expect(persistence.inspectLifecycleOwner(PROJECT_ID)).resolves.toBe('nonterminal');
+    const completeTerminalCleanup = () => (
+      persistence as unknown as {
+        completeTerminalCleanup(input: {
+          operationIntentId: string;
+          projectId: string;
+          stagingDirectoryName: string;
+          transferId: string;
+        }): Promise<void>;
+      }
+    ).completeTerminalCleanup({
+      operationIntentId: OPERATION_INTENT_ID,
+      projectId: PROJECT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      transferId: TRANSFER_ID,
+    });
+    await expect(completeTerminalCleanup()).resolves.toBeUndefined();
+    await expect(repository.authorityTransferClaims.load(PROJECT_ID)).resolves.toBeNull();
+    await expect(repository.authorityTransferClaimCommitments.load(PROJECT_ID))
+      .resolves.toBeNull();
+    await expect(persistence.inspectLifecycleOwner(PROJECT_ID)).resolves.toBe('terminal');
+    await expect(persistence.load(PROJECT_ID)).resolves.toMatchObject({
+      terminalCleanupCompleted: true,
+    });
+  });
+
+  it('reopens a cancelled source only after durable target cleanup and source recovery', async () => {
+    const persistence = new AuthorityTransferPersistence(
+      new CollabLocalProjectRepository(vaultRoot),
+    );
+    let record = createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: transferStatus('collecting-readiness'),
+    });
+    await persistence.create(record);
+    record = createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: transferStatus('source-quiesced'),
+    });
+    await persistence.advance(record, 'collecting-readiness');
+
+    const cancellationPhases = [
+      'cancel-intent',
+      'target-invalidated',
+      'target-cleaned',
+      'source-reopened',
+      'cancelled',
+    ] as const;
+    let previousPhase: CollabAuthorityTransferStatus['phase'] = 'source-quiesced';
+    const restartOutcomes: string[] = [];
+    for (const [index, phase] of cancellationPhases.entries()) {
+      record = createAuthorityTransferRecord({
+        localRole: 'source',
+        operationIntentId: OPERATION_INTENT_ID,
+        stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+        status: {
+          ...transferStatus('source-quiesced', index + 2),
+          phase,
+          state: phase === 'cancelled' ? 'cancelled' : 'active',
+        },
+      });
+      await persistence.advance(record, previousPhase);
+      previousPhase = phase;
+      await persistence.assertAuthorityRestartAllowed(PROJECT_ID).then(
+        () => restartOutcomes.push('allowed'),
+        error => restartOutcomes.push((error as { code: string }).code),
+      );
+    }
+    expect(restartOutcomes).toEqual([
+      'durable-progress-recovery-required',
+      'durable-progress-recovery-required',
+      'durable-progress-recovery-required',
+      'allowed',
+      'allowed',
+    ]);
+  });
+
+  it('replaces only a fully cleaned safe cancellation with a new transfer attempt', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository);
+    const cancelled = createAuthorityTransferRecord({
+      lifecycleOwnership: 'owned',
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: {
+        ...transferStatus('source-quiesced', 8),
+        phase: 'cancelled',
+        state: 'cancelled',
+      },
+    });
+    await repository.authorityTransferRecords.save(cancelled);
+    await persistence.completeTerminalCleanup({
+      operationIntentId: OPERATION_INTENT_ID,
+      projectId: PROJECT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      transferId: TRANSFER_ID,
+    });
+    const replacement = createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: 'replacement-intent',
+      stagingDirectoryName: '.claudian-authority-transfer-replacement-transfer',
+      status: {
+        ...transferStatus('collecting-readiness', 9),
+        transferId: 'replacement-transfer',
+      },
+    });
+
+    await expect(persistence.create(replacement)).resolves.toBeUndefined();
+    await expect(persistence.load(PROJECT_ID)).resolves.toEqual(replacement);
+  });
+
+  it('refuses terminal cleanup when claim custody belongs to a different durable owner', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository);
+    const cancelled = createAuthorityTransferRecord({
+      lifecycleOwnership: 'owned',
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: {
+        ...transferStatus('source-quiesced', 8),
+        phase: 'cancelled',
+        state: 'cancelled',
+      },
+    });
+    const divergentCustody = createAuthorityTransferClaimCustodyRecord({
+      batch: claimBatch(),
+      createdAt: '2026-08-26T00:01:00.000Z',
+      operationIntentId: 'different-operation-intent',
+      purpose: 'source-terminal',
+    });
+    await repository.authorityTransferRecords.save(cancelled);
+    await repository.authorityTransferClaims.save(divergentCustody);
+    await repository.authorityTransferClaimCommitments.save(
+      createAuthorityTransferClaimBatchCommitmentRecord(divergentCustody),
+    );
+
+    await expect(persistence.completeTerminalCleanup({
+      operationIntentId: OPERATION_INTENT_ID,
+      projectId: PROJECT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      transferId: TRANSFER_ID,
+    })).rejects.toMatchObject({
+      code: 'authority-transfer-stale',
+      safeContext: { reason: 'authority-transfer-claim-owner-stale' },
+    });
+    await expect(repository.authorityTransferClaims.load(PROJECT_ID))
+      .resolves.toEqual(divergentCustody);
+    await expect(repository.authorityTransferClaimCommitments.load(PROJECT_ID))
+      .resolves.toEqual(createAuthorityTransferClaimBatchCommitmentRecord(divergentCustody));
+    await expect(repository.authorityTransferRecords.load(PROJECT_ID)).resolves.toMatchObject({
+      terminalCleanupCompleted: false,
+    });
+  });
+
+  it('refuses claim expiry when custody belongs to a different durable owner', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository, {
+      now: () => new Date(EXPIRES_AT),
+    });
+    const completed = createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: transferStatus('completed'),
+    });
+    const divergentCustody = createAuthorityTransferClaimCustodyRecord({
+      batch: claimBatch(),
+      createdAt: '2026-08-26T00:01:00.000Z',
+      operationIntentId: 'different-operation-intent',
+      purpose: 'source-terminal',
+    });
+    await repository.authorityTransferRecords.save(completed);
+    await repository.authorityTransferClaims.save(divergentCustody);
+    await repository.authorityTransferClaimCommitments.save(
+      createAuthorityTransferClaimBatchCommitmentRecord(divergentCustody),
+    );
+
+    await expect(persistence.expireTerminalResponder(PROJECT_ID, TRANSFER_ID))
+      .rejects.toMatchObject({
+        code: 'authority-transfer-stale',
+        safeContext: { reason: 'authority-transfer-claim-owner-stale' },
+      });
+    await expect(repository.authorityTransferClaims.load(PROJECT_ID)).resolves.toMatchObject({
+      claims: [
+        expect.objectContaining({ disposition: 'retained' }),
+        expect.objectContaining({ disposition: 'retained' }),
+      ],
+    });
+    await expect(repository.authorityTransferRecords.load(PROJECT_ID)).resolves.toMatchObject({
+      terminalResponder: { state: 'active' },
+    });
+  });
+
+  it('expires the terminal responder only after scrubbing every retained raw claim', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    let persistence = new AuthorityTransferPersistence(repository, {
+      now: () => new Date('2026-08-26T00:00:00.000Z'),
+    });
+    const completed = createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: transferStatus('completed'),
+    });
+    await repository.authorityTransferRecords.save(completed);
+    await persistence.retainClaimBatch({
+      batch: claimBatch(),
+      operationIntentId: OPERATION_INTENT_ID,
+      purpose: 'source-terminal',
+    });
+    await persistence.acknowledgeClaimBatch({
+      batchRevision: 1,
+      batchSha256: claimBatch().batchSha256,
+      checkpointSha256: CHECKPOINT_SHA256,
+      committedAt: '2026-08-26T00:03:00.000Z',
+      custodyAuthority: { generation: 1, kind: 'lan' },
+      operationIntentId: OPERATION_INTENT_ID,
+      projectId: PROJECT_ID,
+      receiptId: 'custody-receipt-expiry',
+      submittedByMemberId: MEMBER_ALICE,
+      targetAuthorityGeneration: 2,
+      transferId: TRANSFER_ID,
+    });
+
+    await expect(persistence.expireTerminalResponder(
+      PROJECT_ID,
+      TRANSFER_ID,
+    )).rejects.toMatchObject({ code: 'authority-transfer-stale' });
+    const completeTerminalCleanup = () => persistence.completeTerminalCleanup({
+      operationIntentId: OPERATION_INTENT_ID,
+      projectId: PROJECT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      transferId: TRANSFER_ID,
+    });
+    await expect(completeTerminalCleanup()).rejects.toMatchObject({
+      code: 'durable-progress-recovery-required',
+      safeContext: { reason: 'authority-transfer-terminal-responder-active' },
+    });
+    await expect(persistence.loadClaim(PROJECT_ID, TRANSFER_ID, MEMBER_ALICE))
+      .resolves.toMatchObject({ memberId: MEMBER_ALICE });
+
+    persistence = new AuthorityTransferPersistence(repository, {
+      now: () => new Date(EXPIRES_AT),
+    });
+    await persistence.expireTerminalResponder(PROJECT_ID, TRANSFER_ID);
+
+    await expect(repository.authorityTransferClaims.load(PROJECT_ID)).resolves.toMatchObject({
+      claims: [
+        expect.objectContaining({ claim: null, disposition: 'expired' }),
+        expect.objectContaining({ claim: null, disposition: 'expired' }),
+      ],
+    });
+    await expect(persistence.load(PROJECT_ID)).resolves.toMatchObject({
+      restartFence: 'permanent',
+      terminalCleanupCompleted: false,
+      terminalResponder: { state: 'expired' },
+    });
+    await expect(persistence.inspectLifecycleOwner(PROJECT_ID)).resolves.toBe('nonterminal');
+    await expect(completeTerminalCleanup()).resolves.toBeUndefined();
+    await expect(persistence.inspectLifecycleOwner(PROJECT_ID)).resolves.toBe('terminal');
+    await expect(repository.authorityTransferClaims.load(PROJECT_ID)).resolves.toBeNull();
+  });
+
+  it('expires and cleans a single-member transfer with an exact empty claim batch', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    let persistence = new AuthorityTransferPersistence(repository, {
+      now: () => new Date('2026-08-26T00:00:00.000Z'),
+    });
+    const batchSha256 = '001a79c6e03aa40c576542ab21f7a692e5e8ec0d930f705101a29dd2809a66b3';
+    const batch: CollabTransferredMembershipClaimBatch = {
+      batchRevision: 1,
+      batchSha256,
+      checkpointSha256: CHECKPOINT_SHA256,
+      claims: [],
+      expiresAt: EXPIRES_AT,
+      projectId: PROJECT_ID,
+      targetAuthorityGeneration: 2,
+      transferId: TRANSFER_ID,
+    };
+    const status: CollabAuthorityTransferStatus = {
+      ...transferStatus('completed'),
+      batchSha256,
+      relinquishmentProof: {
+        ...transferStatus('completed').relinquishmentProof!,
+        batchSha256,
+      },
+    };
+    const completed = createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status,
+    });
+    await repository.authorityTransferRecords.save(completed);
+    await persistence.retainClaimBatch({
+      batch,
+      operationIntentId: OPERATION_INTENT_ID,
+      purpose: 'source-terminal',
+    });
+    await persistence.acknowledgeClaimBatch({
+      batchRevision: 1,
+      batchSha256,
+      checkpointSha256: CHECKPOINT_SHA256,
+      committedAt: '2026-08-26T00:03:00.000Z',
+      custodyAuthority: { generation: 1, kind: 'lan' },
+      operationIntentId: OPERATION_INTENT_ID,
+      projectId: PROJECT_ID,
+      receiptId: 'custody-receipt-empty',
+      submittedByMemberId: MEMBER_ALICE,
+      targetAuthorityGeneration: 2,
+      transferId: TRANSFER_ID,
+    });
+
+    persistence = new AuthorityTransferPersistence(repository, {
+      now: () => new Date(EXPIRES_AT),
+    });
+    await persistence.expireTerminalResponder(PROJECT_ID, TRANSFER_ID);
+    await expect(repository.authorityTransferClaims.load(PROJECT_ID)).resolves.toMatchObject({
+      claims: [],
+    });
+    await persistence.completeTerminalCleanup({
+      operationIntentId: OPERATION_INTENT_ID,
+      projectId: PROJECT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      transferId: TRANSFER_ID,
+    });
+
+    await expect(persistence.load(PROJECT_ID)).resolves.toMatchObject({
+      terminalCleanupCompleted: true,
+      terminalResponder: { state: 'expired' },
+    });
+    await expect(repository.authorityTransferClaims.load(PROJECT_ID)).resolves.toBeNull();
+    await expect(repository.authorityTransferClaimCommitments.load(PROJECT_ID))
+      .resolves.toBeNull();
+  });
+
+  it('repairs only an unacknowledged interrupted claim commitment write', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    let persistence = new AuthorityTransferPersistence(repository);
+    await persistence.create(createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: transferStatus('collecting-readiness'),
+    }));
+    const first = await persistence.retainClaimBatch({
+      batch: claimBatch(),
+      operationIntentId: OPERATION_INTENT_ID,
+      purpose: 'source-terminal',
+    });
+    await repository.authorityTransferClaimCommitments.remove(PROJECT_ID);
+
+    persistence = new AuthorityTransferPersistence(repository);
+    const recoverInterruptedCommitment = () => (
+      persistence as unknown as {
+        recoverInterruptedClaimCommitment(projectId: string): Promise<void>;
+      }
+    ).recoverInterruptedClaimCommitment(PROJECT_ID);
+    const inspectLifecycleOwner = () => (
+      persistence as unknown as {
+        inspectLifecycleOwner(projectId: string): Promise<string>;
+      }
+    ).inspectLifecycleOwner(PROJECT_ID);
+    await expect(inspectLifecycleOwner()).resolves.toBe('nonterminal');
+    await expect(recoverInterruptedCommitment()).resolves.toBeUndefined();
+    await expect(persistence.load(PROJECT_ID)).resolves.toMatchObject({
+      projectId: PROJECT_ID,
+    });
+
+    const rotated = await persistence.rotateClaimBatch({
+      batch: claimBatch(2, 'C'),
+      expectedBatchRevision: first.batchRevision,
+      expectedBatchSha256: first.batchSha256,
+      operationIntentId: OPERATION_INTENT_ID,
+      purpose: 'source-terminal',
+    });
+    await repository.authorityTransferClaimCommitments.save(
+      createAuthorityTransferClaimBatchCommitmentRecord(first),
+    );
+
+    persistence = new AuthorityTransferPersistence(repository);
+    await expect(inspectLifecycleOwner()).resolves.toBe('nonterminal');
+    await expect(recoverInterruptedCommitment()).resolves.toBeUndefined();
+    await expect(repository.authorityTransferClaimCommitments.load(PROJECT_ID))
+      .resolves.toEqual(createAuthorityTransferClaimBatchCommitmentRecord(rotated));
+  });
+
+  it('refuses interrupted cleanup of a commitment owned by another operation', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository);
+    const cancelled = createAuthorityTransferRecord({
+      lifecycleOwnership: 'owned',
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: {
+        ...transferStatus('claims-retained', 8),
+        phase: 'cancelled',
+        state: 'cancelled',
+      },
+    });
+    const divergentCustody = createAuthorityTransferClaimCustodyRecord({
+      batch: claimBatch(),
+      createdAt: '2026-08-26T00:01:00.000Z',
+      operationIntentId: 'different-operation-intent',
+      purpose: 'source-terminal',
+    });
+    const divergentCommitment = createAuthorityTransferClaimBatchCommitmentRecord(
+      divergentCustody,
+    );
+    await repository.authorityTransferRecords.save(cancelled);
+    await repository.authorityTransferClaimCommitments.save(divergentCommitment);
+
+    await expect(persistence.recoverInterruptedClaimCommitment(PROJECT_ID))
+      .rejects.toMatchObject({
+        code: 'authority-transfer-stale',
+        safeContext: { reason: 'authority-transfer-claim-owner-stale' },
+      });
+    await expect(repository.authorityTransferClaimCommitments.load(PROJECT_ID))
+      .resolves.toEqual(divergentCommitment);
+  });
+
+  it('rejects phase regression and cancellation after source relinquishment', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository);
+    const relinquished = createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: transferStatus('source-relinquished'),
+    });
+    await repository.authorityTransferRecords.save(relinquished);
+
+    await expect(persistence.advance(createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: {
+        ...transferStatus('repository-published', 7),
+        phase: 'cancel-intent',
+      },
+    }), 'source-relinquished')).rejects.toMatchObject({
+      code: 'authority-transfer-cancellation-forbidden',
+    });
+    await expect(persistence.advance(createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: transferStatus('repository-published', 8),
+    }), 'source-relinquished')).rejects.toMatchObject({
+      code: 'authority-transfer-stale',
+    });
+  });
+
+  it('rejects terminal-cleanup completion forged through normal phase advancement', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository);
+    await repository.authorityTransferRecords.save(createAuthorityTransferRecord({
+      lifecycleOwnership: 'owned',
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: {
+        ...transferStatus('source-quiesced', 6),
+        phase: 'source-reopened',
+      },
+    }));
+    const cancelled = createAuthorityTransferRecord({
+      lifecycleOwnership: 'owned',
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: {
+        ...transferStatus('source-quiesced', 7),
+        phase: 'cancelled',
+        state: 'cancelled',
+      },
+    });
+
+    await expect(persistence.advance({
+      ...cancelled,
+      terminalCleanupCompleted: true,
+    }, 'source-reopened')).rejects.toMatchObject({
+      code: 'authority-transfer-stale',
+      safeContext: { reason: 'authority-transfer-phase-invalid' },
+    });
+    await expect(persistence.inspectLifecycleOwner(PROJECT_ID)).resolves.toBe('nonterminal');
+  });
+
+  it('rejects terminal-responder expiry forged through normal phase advancement', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository);
+    await repository.authorityTransferRecords.save(createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: transferStatus('cloud-activated'),
+    }));
+    const batch = claimBatch();
+    await persistence.retainClaimBatch({
+      batch,
+      operationIntentId: OPERATION_INTENT_ID,
+      purpose: 'source-terminal',
+    });
+    await persistence.acknowledgeClaimBatch({
+      batchRevision: batch.batchRevision,
+      batchSha256: batch.batchSha256,
+      checkpointSha256: batch.checkpointSha256,
+      committedAt: '2026-08-26T00:03:00.000Z',
+      custodyAuthority: { generation: 1, kind: 'lan' },
+      operationIntentId: OPERATION_INTENT_ID,
+      projectId: PROJECT_ID,
+      receiptId: 'custody-receipt-forged-expiry',
+      submittedByMemberId: MEMBER_ALICE,
+      targetAuthorityGeneration: 2,
+      transferId: TRANSFER_ID,
+    });
+    const forgedExpiry = expireAuthorityTransferTerminalResponder(
+      createAuthorityTransferRecord({
+        localRole: 'source',
+        operationIntentId: OPERATION_INTENT_ID,
+        stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+        status: transferStatus('completed'),
+      }),
+    );
+
+    await expect(persistence.advance(forgedExpiry, 'cloud-activated')).rejects.toMatchObject({
+      code: 'authority-transfer-stale',
+      safeContext: { reason: 'authority-transfer-phase-invalid' },
+    });
+    await expect(persistence.load(PROJECT_ID)).resolves.toMatchObject({
+      status: { phase: 'cloud-activated' },
+      terminalResponder: { state: 'active' },
+    });
+  });
+
+  it('freezes checkpoint and relinquishment proof identity across phase advancement', () => {
+    const checkpointReceived = createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: transferStatus('checkpoint-received'),
+    });
+    const replacedCheckpoint = createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: {
+        ...transferStatus('checkpoint-validated'),
+        checkpointSha256: 'b'.repeat(64),
+      },
+    });
+    expect(() => assertAuthorityTransferTransition(checkpointReceived, replacedCheckpoint))
+      .toThrow('Authority transfer checkpoint changed');
+
+    const relinquished = createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: transferStatus('source-relinquished'),
+    });
+    const activatedStatus = transferStatus('cloud-activated');
+    const replacedProof = createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: {
+        ...activatedStatus,
+        relinquishmentProof: {
+          ...activatedStatus.relinquishmentProof!,
+          certificate: `${'A'.repeat(85)}Q`,
+        },
+      },
+    });
+    expect(() => assertAuthorityTransferTransition(relinquished, replacedProof))
+      .toThrow('Authority transfer relinquishment proof changed');
+  });
+
+  it('rejects a relinquishment proof outside the exact operation intent and lifetime', () => {
+    const status = transferStatus('source-relinquished');
+    expect(() => createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: {
+        ...status,
+        relinquishmentProof: {
+          ...status.relinquishmentProof!,
+          operationIntentId: 'intent-from-another-attempt',
+        },
+      },
+    })).toThrow('Invalid authority transfer relinquishment proof');
+    expect(() => createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: {
+        ...status,
+        relinquishmentProof: {
+          ...status.relinquishmentProof!,
+          committedAt: '2026-08-25T23:59:59.000Z',
+        },
+      },
+    })).toThrow('Invalid authority transfer relinquishment proof');
+  });
+
+  it('fails startup enumeration closed for raw claim custody without its transfer owner', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    await repository.authorityTransferClaims.save(createAuthorityTransferClaimCustodyRecord({
+      batch: claimBatch(),
+      createdAt: '2026-08-26T00:00:00.000Z',
+      operationIntentId: OPERATION_INTENT_ID,
+      purpose: 'source-terminal',
+    }));
+    const persistence = new AuthorityTransferPersistence(repository);
+
+    await expect(persistence.listProjectIds()).resolves.toEqual([PROJECT_ID]);
+    await expect(persistence.load(PROJECT_ID)).rejects.toMatchObject({
+      code: 'durable-progress-recovery-required',
+      safeContext: { reason: 'authority-transfer-claim-custody-orphaned' },
+    });
+    await expect(persistence.assertAuthorityRestartAllowed(PROJECT_ID)).rejects.toMatchObject({
+      code: 'durable-progress-recovery-required',
+      safeContext: { reason: 'authority-transfer-claim-custody-orphaned' },
+    });
+    await expect(persistence.loadClaim(PROJECT_ID, TRANSFER_ID, MEMBER_ALICE))
+      .rejects.toMatchObject({ code: 'authority-transfer-stale' });
+  });
+});

--- a/tests/integration/app/collab/bootstrap/FormerHostFence.test.ts
+++ b/tests/integration/app/collab/bootstrap/FormerHostFence.test.ts
@@ -12,6 +12,7 @@ import {
   CloudBootstrapReadinessCollector,
   type CloudBootstrapReadinessObservation,
 } from '@/app/collab/bootstrap/CloudBootstrapReadiness';
+import { CloudBootstrapService } from '@/app/collab/bootstrap/CloudBootstrapService';
 import {
   createCloudBootstrapTransitionRecord,
   developmentBootstrapManifestSha256,
@@ -19,6 +20,7 @@ import {
   observeCloudBootstrapAttemptStatus,
 } from '@/app/collab/bootstrap/CloudBootstrapTransitionRecord';
 import { CloudBootstrapTransitionStore } from '@/app/collab/bootstrap/CloudBootstrapTransitionStore';
+import { CollabProjectLifecycleSubsystem } from '@/app/collab/lifecycle/CollabProjectLifecycleSubsystem';
 
 import {
   ATTEMPT_ID,
@@ -295,6 +297,47 @@ describe('Former Host Cloud bootstrap fence', () => {
       records: [valid],
       retryRequired: false,
     });
+    const inspectLifecycleOwner = (projectId: string) => (
+      transitionStore as unknown as {
+        inspectLifecycleOwner(candidateProjectId: string): Promise<
+          'absent' | 'nonterminal' | 'terminal'
+        >;
+      }
+    ).inspectLifecycleOwner(projectId);
+    await expect(inspectLifecycleOwner('project-corrupt')).resolves.toBe('nonterminal');
+    await expect(inspectLifecycleOwner('project-directory')).resolves.toBe('nonterminal');
+    const lifecycle = new CollabProjectLifecycleSubsystem({
+      closeRecovery: async () => undefined,
+      durableOwners: [{
+        inspect: inspectLifecycleOwner,
+        name: 'cloud-bootstrap',
+      }],
+      hostTransfer: {} as never,
+      localExit: {} as never,
+      recoveryStages: [],
+      retirement: {} as never,
+    });
+    const fenceUncertainProject = jest.fn(async (_projectId: string) => undefined);
+    const bootstrap = new CloudBootstrapService({
+      createCoordinator: () => ({}) as never,
+      fenceUncertainProject,
+      projectRecoveryAdmission: (projectId, operation) => lifecycle.runExclusive(
+        projectId,
+        'cloud-bootstrap',
+        'recovery',
+        operation,
+      ),
+      recoverLocalArtifacts: async () => undefined,
+      transitions: transitionStore,
+    });
+    await expect(bootstrap.prepareLocalRecovery()).resolves.toBeUndefined();
+    expect(fenceUncertainProject.mock.calls.map(([projectId]) => projectId).sort()).toEqual([
+      PROJECT_ID,
+      'project-corrupt',
+      'project-directory',
+    ]);
+    await bootstrap.close();
+    await lifecycle.lifecycleRecovery.close();
     await expect(transitionStore.load('project-corrupt')).rejects.toMatchObject({
       safeContext: {
         projectId: 'project-corrupt',
@@ -309,6 +352,7 @@ describe('Former Host Cloud bootstrap fence', () => {
       records: [],
       retryRequired: true,
     });
+    await expect(inspectLifecycleOwner(PROJECT_ID)).resolves.toBe('nonterminal');
     await chmod(validPath, 0o600);
   });
 

--- a/tests/integration/app/collab/gates/CloudPublishGate.test.ts
+++ b/tests/integration/app/collab/gates/CloudPublishGate.test.ts
@@ -304,7 +304,7 @@ function membership(
       gitRemoteUrl: `${origin}/v2/projects/${PROJECT_ID}/repository.git`,
       kind: 'cloud',
       serverUrl: origin,
-      wireVersion: 5,
+      wireVersion: 6,
     },
     createdAt: CREATED_AT,
     lastEventSequence: 0,

--- a/tests/integration/app/collab/gates/CloudReadBindingGate.test.ts
+++ b/tests/integration/app/collab/gates/CloudReadBindingGate.test.ts
@@ -628,6 +628,7 @@ describe('Cloud read and binding gate', () => {
         const restartService = new CloudBootstrapService({
           createCoordinator: () => ({ recoverProject } as unknown as CloudBootstrapCoordinator),
           fenceUncertainProject,
+          projectRecoveryAdmission: async (_projectId, operation) => operation(),
           recoverLocalArtifacts: async () => undefined,
           transitions: client.store,
         });

--- a/tests/integration/app/collab/gates/LocalProjectMilestoneGate.test.ts
+++ b/tests/integration/app/collab/gates/LocalProjectMilestoneGate.test.ts
@@ -6,6 +6,7 @@ import {
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
+import { type CollabAuthorityTransferStatus } from '@claudian-collab/protocol';
 import initSqlJs, { type SqlJsStatic } from 'sql.js';
 
 import {
@@ -14,6 +15,9 @@ import {
   createCollabFeatureSubcomposition,
 } from '@/app/collab';
 import { SqlJsProjectDatabase } from '@/app/collab/authority/SqlJsProjectDatabase';
+import {
+  createAuthorityTransferRecord,
+} from '@/app/collab/authority-transfer/AuthorityTransferRecord';
 
 const PROJECT_ID = 'project-m2';
 const MEMBER_ID = 'member-host';
@@ -138,5 +142,61 @@ describe('G3 local Project milestone gate', () => {
       });
     await reopenedFeature.close();
     await reopenedFoundation.close();
+  });
+
+  it('registers transfer recovery and fences ordinary LAN Host restart', async () => {
+    const foundation = createFoundation();
+    const transferStatus = (
+      phase: 'collecting-readiness' | 'source-quiesced',
+    ): CollabAuthorityTransferStatus => ({
+      batchRevision: null,
+      batchSha256: null,
+      checkpointSha256: null,
+      createdAt: '2026-08-26T00:00:00.000Z',
+      direction: 'lan-to-cloud',
+      expiresAt: '2026-09-26T00:00:00.000Z',
+      phase,
+      projectId: PROJECT_ID,
+      relinquishmentProof: null,
+      sourceAuthority: { generation: 1, kind: 'lan' },
+      state: 'active',
+      targetAuthority: { generation: 2, kind: 'cloud' },
+      targetUrl: 'https://cloud.example.test/',
+      transferId: 'transfer-l2',
+      updatedAt: phase === 'collecting-readiness'
+        ? '2026-08-26T00:00:00.000Z'
+        : '2026-08-26T00:01:00.000Z',
+    });
+    const collecting = createAuthorityTransferRecord({
+      lifecycleOwnership: 'owned',
+      localRole: 'source',
+      operationIntentId: 'intent-l2',
+      stagingDirectoryName: '.claudian-authority-transfer-transfer-l2',
+      status: transferStatus('collecting-readiness'),
+    });
+    await foundation.authorityTransfers.create(collecting);
+    const feature = createCollabFeatureSubcomposition({
+      foundation,
+      projectSetup: new CollabProjectSetupService(foundation, { vaultRoot }),
+      vaultRoot,
+    }).feature;
+
+    await expect(feature.restoreLifecycle()).rejects.toMatchObject({
+      code: 'durable-progress-recovery-required',
+      safeContext: { reason: 'authority-transfer-runtime-not-composed' },
+    });
+    await foundation.authorityTransfers.advance(createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: 'intent-l2',
+      stagingDirectoryName: '.claudian-authority-transfer-transfer-l2',
+      status: transferStatus('source-quiesced'),
+    }), 'collecting-readiness');
+    await expect(foundation.lanHost.startProject(PROJECT_ID)).rejects.toMatchObject({
+      code: 'durable-progress-recovery-required',
+      safeContext: { reason: 'authority-transfer-authority-quiesced' },
+    });
+
+    await feature.close();
+    await foundation.close();
   });
 });

--- a/tests/integration/app/collab/lan/LanHostCoordinator.test.ts
+++ b/tests/integration/app/collab/lan/LanHostCoordinator.test.ts
@@ -36,6 +36,7 @@ import {
   type CollabHostTrustStore,
   CollabHttpClient,
   type CollabTrustedHost,
+  PinnedCollabHttpClient,
 } from '@/app/collab/lan/CollabHttpClient';
 import { HostTransferTargetTransport } from '@/app/collab/lan/HostTransferTargetTransport';
 import { InvitationCodec } from '@/app/collab/lan/InvitationCodec';
@@ -53,6 +54,9 @@ import {
   ProjectEventHub,
   SqlJsProjectEventSource,
 } from '@/app/collab/lan/ProjectEventHub';
+import type {
+  CollabProjectLifecycleAuthorityAdmission,
+} from '@/app/collab/lifecycle/CollabProjectLifecycleAdmission';
 import { CollabMembershipService } from '@/app/collab/membership/CollabMembershipService';
 import {
   ManagerResponsibilityOperationCoordinator,
@@ -124,6 +128,7 @@ function membershipAccess(
       projection.readSnapshot(projectId, options)
     ),
   }, {}, {
+    managerResponsibilityAdmission: async (_projectId, operation) => operation(),
     managerReceipts: {
       load: async () => null,
       remove: async () => false,
@@ -158,9 +163,18 @@ describe('LanHostCoordinator production transport', () => {
   let privateAddresses: readonly string[];
   let openProjectCount: number;
   let resetProjectConnection: jest.Mock;
+  let acceptHostTransferAuthority: jest.Mock;
+  let cancelHostTransferAuthority: jest.Mock;
+  let retireProjectAuthority: jest.Mock;
+  let admittedLifecycleOwners: string[];
+  let lifecycleAdmissionErrors: {
+    hostTransfer: Error | null;
+    retirement: Error | null;
+  };
   let outgoingHostTransfer: {
     close?: jest.Mock;
     inspectStartupRecovery: jest.Mock;
+    prepareAccepted?: jest.Mock;
     prepareCancellation?: jest.Mock;
     prepareTerminalRecoveryBeforeStartup?: jest.Mock;
     resume: jest.Mock;
@@ -235,6 +249,17 @@ describe('LanHostCoordinator production transport', () => {
     issueServerIdentity = address => sharedTlsIdentity.issueServerIdentity(address);
     privateAddresses = ['127.0.0.1'];
     outgoingHostTransfer = null;
+    acceptHostTransferAuthority = jest.fn(async () => {
+      throw new Error('Unexpected Host-transfer acceptance');
+    });
+    cancelHostTransferAuthority = jest.fn(async () => {
+      throw new Error('Unexpected Host-transfer cancellation');
+    });
+    retireProjectAuthority = jest.fn(async () => {
+      throw new Error('Unexpected Project retirement');
+    });
+    admittedLifecycleOwners = [];
+    lifecycleAdmissionErrors = { hostTransfer: null, retirement: null };
     openProjectCount = 0;
     resetProjectConnection = jest.fn();
     root = await mkdtemp(path.join(tmpdir(), 'claudian-lan-host-'));
@@ -328,11 +353,11 @@ describe('LanHostCoordinator production transport', () => {
           events: eventHub,
           git: gitRuntime(),
           lifecycle: {
-            acceptHostTransfer: unsupportedLifecycle,
+            acceptHostTransfer: acceptHostTransferAuthority,
             acknowledgeManagerResponsibility: (actorMemberId, request) => (
               managerResponsibilities.acknowledge(actorMemberId, request)
             ),
-            cancelHostTransfer: unsupportedLifecycle,
+            cancelHostTransfer: cancelHostTransferAuthority,
             cancelManagerResponsibilityOffer: (actorMemberId, request) => (
               managerResponsibilities.cancel(actorMemberId, request)
             ),
@@ -340,8 +365,13 @@ describe('LanHostCoordinator production transport', () => {
             createManagerResponsibilityOffer: (actorMemberId, request) => (
               managerResponsibilities.create(actorMemberId, request)
             ),
-            createRetirementCoordinator: () => ({
-              retireProject: unsupportedLifecycle,
+            createRetirementCoordinator: input => ({
+              retireProject: (actorMemberId, request) => (
+                input.projectLifecycleAdmission(
+                  request.projectId,
+                  () => retireProjectAuthority(actorMemberId, request),
+                )
+              ),
             }),
             declineHostTransfer: unsupportedLifecycle,
             declineManagerResponsibility: (actorMemberId, request) => (
@@ -373,7 +403,7 @@ describe('LanHostCoordinator production transport', () => {
             cancelBeforeRelinquishment: jest.fn(),
             close: outgoingHostTransfer.close ?? jest.fn().mockResolvedValue(undefined),
             inspectStartupRecovery: outgoingHostTransfer.inspectStartupRecovery,
-            prepareAccepted: jest.fn(),
+            prepareAccepted: outgoingHostTransfer.prepareAccepted ?? jest.fn(),
             prepareCancellation: outgoingHostTransfer.prepareCancellation ?? jest.fn(),
             prepareTerminalRecoveryBeforeStartup:
               outgoingHostTransfer.prepareTerminalRecoveryBeforeStartup ?? jest.fn(),
@@ -391,6 +421,23 @@ describe('LanHostCoordinator production transport', () => {
       vaultRoot: root,
     });
     coordinator.bindConnectionProjection({ resetProjectConnection });
+    const admission = (
+      owner: 'host-transfer' | 'retirement',
+    ): CollabProjectLifecycleAuthorityAdmission => async <T>(
+      _projectId: string,
+      operation: () => Promise<T>,
+    ): Promise<T> => {
+      admittedLifecycleOwners.push(owner);
+      const error = owner === 'host-transfer'
+        ? lifecycleAdmissionErrors.hostTransfer
+        : lifecycleAdmissionErrors.retirement;
+      if (error) throw error;
+      return operation();
+    };
+    coordinator.bindProjectLifecycleAdmissions({
+      hostTransfer: admission('host-transfer'),
+      retirement: admission('retirement'),
+    });
   });
 
   afterEach(async () => {
@@ -677,6 +724,132 @@ describe('LanHostCoordinator production transport', () => {
       .rejects.toThrow();
   });
 
+  it('rejects listener Host acceptance before authority mutation under a competing owner', async () => {
+    const prepareAccepted = jest.fn().mockResolvedValue(undefined);
+    outgoingHostTransfer = {
+      inspectStartupRecovery: jest.fn().mockResolvedValue('none'),
+      prepareAccepted,
+      resume: jest.fn().mockResolvedValue(undefined),
+    };
+    lifecycleAdmissionErrors.hostTransfer = new Error('competing lifecycle owner');
+    const host = await coordinator.startProject(PROJECT_ID);
+    const membership = await localProjects.loadMembership(PROJECT_ID);
+    if (
+      !membership
+      || !isCollabLocalLanMembership(membership)
+      || !membership.authority.hostCaCertificatePem
+      || !membership.authority.hostCaFingerprint
+    ) {
+      throw new Error('Stored LAN Host trust missing');
+    }
+    const client = new PinnedCollabHttpClient({
+      caCertificatePem: membership.authority.hostCaCertificatePem,
+      caFingerprint: membership.authority.hostCaFingerprint,
+      endpoint: host.endpoint,
+      projectId: PROJECT_ID,
+    }, 10_000);
+
+    await expect(client.requestWithMember({
+      body: {
+        idempotencyKey: 'accept-listener',
+        projectId: PROJECT_ID,
+        receiverCredential: Buffer.alloc(32, 2).toString('base64url'),
+        targetCaCertificatePem: '-----BEGIN CERTIFICATE-----\nQUJD\n-----END CERTIFICATE-----\n',
+        targetCaFingerprint: 'b'.repeat(64),
+        targetEndpoint: 'https://192.168.1.20:54545',
+        transferId: 'transfer-listener',
+      },
+      decode: value => value,
+      idempotencyKey: 'accept-listener',
+      method: 'POST',
+      path: `/v9/projects/${PROJECT_ID}/host-transfers/transfer-listener/accept`,
+    }, HOST_CREDENTIAL)).rejects.toMatchObject({ code: 'operation-failed' });
+
+    expect(admittedLifecycleOwners).toContain('host-transfer');
+    expect(acceptHostTransferAuthority).not.toHaveBeenCalled();
+    expect(prepareAccepted).not.toHaveBeenCalled();
+  });
+
+  it('rejects listener Host cancellation before recovery mutation under a competing owner', async () => {
+    const prepareCancellation = jest.fn().mockResolvedValue(undefined);
+    outgoingHostTransfer = {
+      inspectStartupRecovery: jest.fn().mockResolvedValue('none'),
+      prepareCancellation,
+      resume: jest.fn().mockResolvedValue(undefined),
+    };
+    lifecycleAdmissionErrors.hostTransfer = new Error('competing lifecycle owner');
+    const host = await coordinator.startProject(PROJECT_ID);
+    const membership = await localProjects.loadMembership(PROJECT_ID);
+    if (
+      !membership
+      || !isCollabLocalLanMembership(membership)
+      || !membership.authority.hostCaCertificatePem
+      || !membership.authority.hostCaFingerprint
+    ) {
+      throw new Error('Stored LAN Host trust missing');
+    }
+    const client = new PinnedCollabHttpClient({
+      caCertificatePem: membership.authority.hostCaCertificatePem,
+      caFingerprint: membership.authority.hostCaFingerprint,
+      endpoint: host.endpoint,
+      projectId: PROJECT_ID,
+    }, 10_000);
+
+    await expect(client.requestWithMember({
+      body: {
+        expectedHostMemberId: 'member-host',
+        idempotencyKey: 'cancel-listener',
+        projectId: PROJECT_ID,
+        transferId: 'transfer-listener',
+      },
+      decode: value => value,
+      idempotencyKey: 'cancel-listener',
+      method: 'DELETE',
+      path: `/v9/projects/${PROJECT_ID}/host-transfers/transfer-listener`,
+    }, HOST_CREDENTIAL)).rejects.toMatchObject({ code: 'operation-failed' });
+
+    expect(admittedLifecycleOwners).toContain('host-transfer');
+    expect(prepareCancellation).not.toHaveBeenCalled();
+    expect(cancelHostTransferAuthority).not.toHaveBeenCalled();
+  });
+
+  it('rejects listener Retire before quiescing under a competing owner', async () => {
+    lifecycleAdmissionErrors.retirement = new Error('competing lifecycle owner');
+    const host = await coordinator.startProject(PROJECT_ID);
+    const membership = await localProjects.loadMembership(PROJECT_ID);
+    if (
+      !membership
+      || !isCollabLocalLanMembership(membership)
+      || !membership.authority.hostCaCertificatePem
+      || !membership.authority.hostCaFingerprint
+    ) {
+      throw new Error('Stored LAN Host trust missing');
+    }
+    const client = new PinnedCollabHttpClient({
+      caCertificatePem: membership.authority.hostCaCertificatePem,
+      caFingerprint: membership.authority.hostCaFingerprint,
+      endpoint: host.endpoint,
+      projectId: PROJECT_ID,
+    }, 10_000);
+
+    await expect(client.requestWithMember({
+      body: {
+        expectedHostMemberId: 'member-host',
+        idempotencyKey: 'retire-listener',
+        managerActorMemberId: 'member-host',
+        projectId: PROJECT_ID,
+      },
+      decode: value => value,
+      idempotencyKey: 'retire-listener',
+      method: 'POST',
+      path: `/v9/projects/${PROJECT_ID}/retire`,
+    }, HOST_CREDENTIAL)).rejects.toMatchObject({ code: 'operation-failed' });
+
+    expect(admittedLifecycleOwners).toContain('retirement');
+    expect(retireProjectAuthority).not.toHaveBeenCalled();
+    expect(coordinator.isProjectRunning(PROJECT_ID)).toBe(true);
+  });
+
   it('rejects Cloud membership before opening LAN authority state', async () => {
     const existing = await localProjects.loadMembership(PROJECT_ID);
     if (!existing) throw new Error('Missing membership fixture');
@@ -687,7 +860,7 @@ describe('LanHostCoordinator production transport', () => {
         gitRemoteUrl: `http://127.0.0.1:8787/v2/projects/${PROJECT_ID}/repository.git`,
         kind: 'cloud',
         serverUrl: 'http://127.0.0.1:8787/',
-        wireVersion: 5,
+        wireVersion: 6,
       },
       createdAt: existing.createdAt,
       lastEventSequence: existing.lastEventSequence,

--- a/tests/integration/app/collab/local/CollabLocalProjectRepository.test.ts
+++ b/tests/integration/app/collab/local/CollabLocalProjectRepository.test.ts
@@ -95,7 +95,7 @@ function cloudMembershipRecord(): CollabLocalCloudMembershipRecord {
       gitRemoteUrl: `http://127.0.0.1:8787/v2/projects/${PROJECT_ID}/repository.git`,
       kind: 'cloud',
       serverUrl: 'http://127.0.0.1:8787/',
-      wireVersion: 5,
+      wireVersion: 6,
     },
     createdAt: '2026-08-08T00:00:00.000Z',
     lastEventSequence: 7,

--- a/tests/integration/app/collab/publish/CloudPublishRecovery.test.ts
+++ b/tests/integration/app/collab/publish/CloudPublishRecovery.test.ts
@@ -250,7 +250,7 @@ function membership(gitRemoteUrl: string): CollabLocalCloudMembershipRecord {
       gitRemoteUrl,
       kind: 'cloud',
       serverUrl: 'https://cloud.example.test',
-      wireVersion: 5,
+      wireVersion: 6,
     },
     createdAt: CREATED_AT,
     lastEventSequence: 0,

--- a/tests/unit/app/collab/ClaudianCollabService.test.ts
+++ b/tests/unit/app/collab/ClaudianCollabService.test.ts
@@ -15,6 +15,13 @@ const { PinnedCollabHttpClient } = jest.requireMock('@/app/collab/lan/CollabHttp
   PinnedCollabHttpClient: jest.Mock;
 };
 
+async function admitProjectRecovery(
+  _projectId: string,
+  operation: () => Promise<void>,
+): Promise<void> {
+  await operation();
+}
+
 describe('ClaudianCollabService retirement recovery', () => {
   afterEach(() => {
     jest.restoreAllMocks();
@@ -71,6 +78,27 @@ describe('ClaudianCollabService retirement recovery', () => {
     );
   });
 
+  it('fences LAN Host startup as soon as a retirement tombstone is durable', async () => {
+    const service = new ClaudianCollabService({
+      getConfiguredGitPath: () => '',
+      obsidianConfigDirectory: '.obsidian',
+      vaultRoot: '/tmp/claudian-retirement-start-fence',
+    });
+    const internal = service as never as {
+      local: { projects: { loadRetirementTombstone: jest.Mock } };
+    };
+    internal.local.projects.loadRetirementTombstone = jest.fn().mockResolvedValue({
+      projectId: 'project-a',
+      result: { projectId: 'project-a', retiredAt: '2026-08-13T00:00:00.000Z' },
+    });
+
+    await expect(service.lanHost.startProject('project-a')).rejects.toMatchObject({
+      code: 'project-retired',
+      safeContext: { reason: 'retirement-tombstone-durable' },
+    });
+    expect(internal.local.projects.loadRetirementTombstone).toHaveBeenCalledWith('project-a');
+  });
+
   it('restores a terminal responder without recreating finalized local projection', async () => {
     const service = new ClaudianCollabService({
       getConfiguredGitPath: () => '',
@@ -106,9 +134,17 @@ describe('ClaudianCollabService retirement recovery', () => {
     internal.local.projects.removeAuthorityDirectory = jest.fn().mockResolvedValue(undefined);
     internal.closeAuthority = jest.fn().mockResolvedValue(undefined);
     internal.retirementHandler = { handle: jest.fn() };
+    const projectRecoveryAdmission = jest.fn(async (
+      _projectId: string,
+      operation: () => Promise<void>,
+    ) => operation());
 
-    await service.restoreRetirementResponders();
+    await service.restoreRetirementResponders(projectRecoveryAdmission);
 
+    expect(projectRecoveryAdmission).toHaveBeenCalledWith(
+      'project-a',
+      expect.any(Function),
+    );
     expect(internal.startRetirementResponder).toHaveBeenCalledWith('project-a');
     expect(internal.retirementHandler.handle).not.toHaveBeenCalled();
     expect(internal.retiredAuthorityCleanupComplete.has('project-a')).toBe(true);
@@ -152,7 +188,8 @@ describe('ClaudianCollabService retirement recovery', () => {
       handle: jest.fn().mockRejectedValue(new Error('local cleanup failed')),
     };
 
-    await expect(service.restoreRetirementResponders()).resolves.toBeUndefined();
+    await expect(service.restoreRetirementResponders(admitProjectRecovery))
+      .resolves.toBeUndefined();
 
     expect(internal.retirementHandler.handle).toHaveBeenCalledWith(
       { projectId: 'project-a', retiredAt: '2026-08-13T00:00:00.000Z' },
@@ -199,9 +236,69 @@ describe('ClaudianCollabService retirement recovery', () => {
     internal.closeAuthority = jest.fn().mockResolvedValue(undefined);
     internal.retirementHandler = { handle: jest.fn() };
 
-    await expect(service.restoreRetirementResponders()).rejects.toThrow('no private address');
+    await expect(service.restoreRetirementResponders(admitProjectRecovery))
+      .rejects.toThrow('no private address');
 
     expect(internal.startRetirementResponder).toHaveBeenCalledTimes(2);
     expect(internal.startRetirementResponder).toHaveBeenLastCalledWith('project-b');
+  });
+
+  it('converges an expired tombstone before removing its terminal state', async () => {
+    const service = new ClaudianCollabService({
+      getConfiguredGitPath: () => '',
+      obsidianConfigDirectory: '.obsidian',
+      vaultRoot: '/tmp/claudian-expired-retirement-convergence',
+    });
+    const order: string[] = [];
+    const result = { projectId: 'project-a', retiredAt: '2026-07-14T00:00:00.000Z' };
+    const internal = service as never as {
+      closeAuthority: jest.Mock;
+      lanHost: { stopTerminalProject: jest.Mock };
+      local: { projects: {
+        loadIndex: jest.Mock;
+        loadRetirementRecord: jest.Mock;
+        loadRetirementTombstone: jest.Mock;
+        removeAuthorityDirectory: jest.Mock;
+      } };
+      retirementHandler: { handle: jest.Mock };
+      retirementTombstones: { remove: jest.Mock; restore: jest.Mock };
+    };
+    internal.retirementTombstones.restore = jest.fn().mockResolvedValue({
+      expiredProjectIds: ['project-a'],
+      tombstones: [],
+    });
+    internal.local.projects.loadRetirementTombstone = jest.fn().mockResolvedValue({
+      projectId: 'project-a',
+      result,
+    });
+    internal.local.projects.loadIndex = jest.fn().mockResolvedValue({
+      projects: [{ id: 'project-a' }],
+      schemaVersion: 2,
+      selectedProjectId: 'project-a',
+    });
+    internal.local.projects.loadRetirementRecord = jest.fn().mockResolvedValue(null);
+    internal.retirementHandler = {
+      handle: jest.fn(async () => { order.push('local-retired'); }),
+    };
+    internal.lanHost.stopTerminalProject = jest.fn(async () => { order.push('host-stopped'); });
+    internal.closeAuthority = jest.fn(async () => { order.push('authority-closed'); });
+    internal.local.projects.removeAuthorityDirectory = jest.fn(async () => {
+      order.push('authority-removed');
+    });
+    internal.retirementTombstones.remove = jest.fn(async () => {
+      order.push('tombstone-removed');
+      return true;
+    });
+
+    await service.restoreRetirementResponders(admitProjectRecovery);
+
+    expect(internal.retirementHandler.handle).toHaveBeenCalledWith(result, 'terminal-fallback');
+    expect(order).toEqual([
+      'local-retired',
+      'host-stopped',
+      'authority-closed',
+      'authority-removed',
+      'tombstone-removed',
+    ]);
   });
 });

--- a/tests/unit/app/collab/authority-transfer/recovery/AuthorityTransferRecovery.test.ts
+++ b/tests/unit/app/collab/authority-transfer/recovery/AuthorityTransferRecovery.test.ts
@@ -1,0 +1,456 @@
+import { createHash } from 'node:crypto';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import {
+  type CollabAuthorityTransferStatus,
+  type CollabTransferredMembershipClaimBatch,
+  encodeCollabTransferredMembershipClaimBatchDigestInput,
+} from '@claudian-collab/protocol';
+
+import {
+  createAuthorityTransferRecord,
+} from '@/app/collab/authority-transfer/AuthorityTransferRecord';
+import {
+  createAuthorityTransferClaimBatchCommitmentRecord,
+} from '@/app/collab/authority-transfer/persistence/AuthorityTransferClaimBatchCommitmentRecord';
+import {
+  createAuthorityTransferClaimCustodyRecord,
+} from '@/app/collab/authority-transfer/persistence/AuthorityTransferClaimCustodyRecord';
+import {
+  AuthorityTransferPersistence,
+} from '@/app/collab/authority-transfer/persistence/AuthorityTransferPersistence';
+import {
+  AuthorityTransferRecovery,
+} from '@/app/collab/authority-transfer/recovery/AuthorityTransferRecovery';
+import { CollabLocalProjectRepository } from '@/app/collab/CollabLocalProjectRepository';
+import {
+  createHostTransferRecoveryRecord,
+} from '@/app/collab/host-transfer/HostTransferRecovery';
+import {
+  type CollabProjectLifecycleDurableOwner,
+  CollabProjectLifecycleSubsystem,
+} from '@/app/collab/lifecycle/CollabProjectLifecycleSubsystem';
+
+const PROJECT_ID = 'project-alpha';
+
+function claimBatch(): CollabTransferredMembershipClaimBatch {
+  const unsigned: CollabTransferredMembershipClaimBatch = {
+    batchRevision: 1,
+    batchSha256: '0'.repeat(64),
+    checkpointSha256: 'a'.repeat(64),
+    claims: [
+      { claim: 'A'.repeat(43), memberId: 'member-alpha' },
+      { claim: 'B'.repeat(43), memberId: 'member-beta' },
+    ],
+    expiresAt: '2026-09-30T00:00:00.000Z',
+    projectId: PROJECT_ID,
+    targetAuthorityGeneration: 2,
+    transferId: 'transfer-one',
+  };
+  return {
+    ...unsigned,
+    batchSha256: createHash('sha256')
+      .update(encodeCollabTransferredMembershipClaimBatchDigestInput(unsigned), 'utf8')
+      .digest('hex'),
+  };
+}
+
+function status(
+  phase: 'cancelled' | 'collecting-readiness' | 'source-quiesced',
+  projectId = PROJECT_ID,
+  transferId = 'transfer-one',
+): CollabAuthorityTransferStatus {
+  return {
+    batchRevision: null,
+    batchSha256: null,
+    checkpointSha256: null,
+    createdAt: '2026-08-26T00:00:00.000Z',
+    direction: 'lan-to-cloud',
+    expiresAt: '2026-09-30T00:00:00.000Z',
+    phase,
+    projectId,
+    relinquishmentProof: null,
+    sourceAuthority: { generation: 1, kind: 'lan' },
+    state: phase === 'cancelled' ? 'cancelled' : 'active',
+    targetAuthority: { generation: 2, kind: 'cloud' },
+    targetUrl: 'http://127.0.0.1:8787/',
+    transferId,
+    updatedAt: phase === 'collecting-readiness'
+      ? '2026-08-26T00:00:00.000Z'
+      : phase === 'source-quiesced'
+        ? '2026-08-26T00:01:00.000Z'
+        : '2026-08-26T00:02:00.000Z',
+  };
+}
+
+function lifecycle() {
+  return new CollabProjectLifecycleSubsystem({
+    closeRecovery: jest.fn().mockResolvedValue(undefined),
+    durableOwners: [],
+    hostTransfer: {} as never,
+    localExit: {} as never,
+    recoveryStages: [],
+    retirement: {} as never,
+  });
+}
+
+describe('AuthorityTransferRecovery', () => {
+  let vaultRoot: string;
+
+  beforeEach(async () => {
+    vaultRoot = await mkdtemp(path.join(tmpdir(), 'claudian-transfer-recovery-'));
+  });
+
+  afterEach(async () => {
+    await rm(vaultRoot, { force: true, recursive: true });
+  });
+
+  it('enumerates startup state and reacquires the lifecycle arbiter for recovery', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository);
+    await repository.authorityTransferRecords.save(createAuthorityTransferRecord({
+      lifecycleOwnership: 'owned',
+      localRole: 'source',
+      operationIntentId: 'intent-one',
+      stagingDirectoryName: '.claudian-authority-transfer-transfer-one',
+      status: status('collecting-readiness'),
+    }));
+    const resume = jest.fn().mockResolvedValue(undefined);
+    const recovery = new AuthorityTransferRecovery(persistence, { resume });
+    const subsystem = lifecycle();
+    recovery.register(subsystem);
+
+    await subsystem.lifecycleRecovery.resume();
+
+    expect(resume).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: PROJECT_ID, transferId: 'transfer-one' }),
+      {},
+    );
+  });
+
+  it('repairs an interrupted unacknowledged commitment before resuming its owner', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository);
+    await repository.authorityTransferRecords.save(createAuthorityTransferRecord({
+      lifecycleOwnership: 'owned',
+      localRole: 'source',
+      operationIntentId: 'intent-one',
+      stagingDirectoryName: '.claudian-authority-transfer-transfer-one',
+      status: status('collecting-readiness'),
+    }));
+    await repository.authorityTransferClaims.save(createAuthorityTransferClaimCustodyRecord({
+      batch: claimBatch(),
+      createdAt: '2026-08-26T00:00:30.000Z',
+      operationIntentId: 'intent-one',
+      purpose: 'source-terminal',
+    }));
+    const resume = jest.fn().mockResolvedValue(undefined);
+    const recovery = new AuthorityTransferRecovery(persistence, { resume });
+    const subsystem = lifecycle();
+    recovery.register(subsystem);
+
+    await expect(subsystem.lifecycleRecovery.resume()).resolves.toBeUndefined();
+
+    expect(resume).toHaveBeenCalledTimes(1);
+    await expect(repository.authorityTransferClaimCommitments.load(PROJECT_ID))
+      .resolves.toMatchObject({ batchRevision: 1, projectId: PROJECT_ID });
+  });
+
+  it('resumes a terminal checkpoint until exact operation cleanup is durable', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository);
+    await repository.authorityTransferRecords.save(createAuthorityTransferRecord({
+      lifecycleOwnership: 'owned',
+      localRole: 'source',
+      operationIntentId: 'intent-one',
+      stagingDirectoryName: '.claudian-authority-transfer-transfer-one',
+      status: status('cancelled'),
+    }));
+    const resume = jest.fn(async record => persistence.completeTerminalCleanup({
+      operationIntentId: record.operationIntentId,
+      projectId: record.projectId,
+      stagingDirectoryName: record.stagingDirectoryName,
+      transferId: record.transferId,
+    }));
+    const recovery = new AuthorityTransferRecovery(persistence, { resume });
+    const subsystem = lifecycle();
+    recovery.register(subsystem);
+
+    await expect(subsystem.lifecycleRecovery.resume()).resolves.toBeUndefined();
+
+    expect(resume).toHaveBeenCalledWith(expect.objectContaining({
+      terminalCleanupCompleted: false,
+      transferId: 'transfer-one',
+    }), {});
+    await expect(persistence.inspectLifecycleOwner(PROJECT_ID)).resolves.toBe('terminal');
+  });
+
+  it('resumes terminal cleanup after custody removal but before commitment removal', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository);
+    const batch = claimBatch();
+    await repository.authorityTransferRecords.save(createAuthorityTransferRecord({
+      lifecycleOwnership: 'owned',
+      localRole: 'source',
+      operationIntentId: 'intent-one',
+      stagingDirectoryName: '.claudian-authority-transfer-transfer-one',
+      status: {
+        ...status('cancelled'),
+        batchRevision: batch.batchRevision,
+        batchSha256: batch.batchSha256,
+        checkpointSha256: batch.checkpointSha256,
+      },
+    }));
+    const custody = createAuthorityTransferClaimCustodyRecord({
+      batch,
+      createdAt: '2026-08-26T00:00:30.000Z',
+      operationIntentId: 'intent-one',
+      purpose: 'source-terminal',
+    });
+    await repository.authorityTransferClaimCommitments.save(
+      createAuthorityTransferClaimBatchCommitmentRecord(custody),
+    );
+    const resume = jest.fn(async record => persistence.completeTerminalCleanup({
+      operationIntentId: record.operationIntentId,
+      projectId: record.projectId,
+      stagingDirectoryName: record.stagingDirectoryName,
+      transferId: record.transferId,
+    }));
+    const recovery = new AuthorityTransferRecovery(persistence, { resume });
+    const subsystem = lifecycle();
+    recovery.register(subsystem);
+
+    await expect(subsystem.lifecycleRecovery.resume()).resolves.toBeUndefined();
+
+    expect(resume).toHaveBeenCalledTimes(1);
+    await expect(repository.authorityTransferClaimCommitments.load(PROJECT_ID))
+      .resolves.toBeNull();
+    await expect(persistence.inspectLifecycleOwner(PROJECT_ID)).resolves.toBe('terminal');
+  });
+
+  it('does not let a competing lifecycle owner bypass a nonterminal transfer', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository);
+    await repository.authorityTransferRecords.save(createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: 'intent-one',
+      stagingDirectoryName: '.claudian-authority-transfer-transfer-one',
+      status: status('source-quiesced'),
+    }));
+    const recovery = new AuthorityTransferRecovery(persistence, {
+      resume: jest.fn().mockResolvedValue(undefined),
+    });
+    const subsystem = lifecycle();
+    recovery.register(subsystem);
+
+    await expect(subsystem.runExclusive(
+      PROJECT_ID,
+      'retirement',
+      'operation',
+      async () => 'must-not-run',
+    )).rejects.toMatchObject({
+      code: 'durable-progress-recovery-required',
+      safeContext: { reason: 'lifecycle-owner-pending' },
+    });
+  });
+
+  it('fails closed when two real owner records are simultaneously nonterminal', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository);
+    await repository.authorityTransferRecords.save(createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: 'intent-one',
+      stagingDirectoryName: '.claudian-authority-transfer-transfer-one',
+      status: status('source-quiesced'),
+    }));
+    await repository.hostTransferRecovery.save(createHostTransferRecoveryRecord({
+      createdAt: '2026-08-26T00:00:00.000Z',
+      direction: 'incoming',
+      projectId: PROJECT_ID,
+      receiverCredential: 'A'.repeat(43),
+      sourceHostMemberId: 'member-source',
+      stagingDirectoryName: '.claudian-host-transfer-transfer-host',
+      targetCaCertificatePem: '-----BEGIN CERTIFICATE-----\nQUJD\n-----END CERTIFICATE-----\n',
+      targetCaFingerprint: 'b'.repeat(64),
+      targetEndpoint: 'https://192.168.1.20:27001',
+      targetHostMemberId: 'member-target',
+      transferId: 'transfer-host',
+    }));
+    const hostTransferOwner: CollabProjectLifecycleDurableOwner = {
+      name: 'host-transfer',
+      inspect: async projectId => {
+        const record = await repository.hostTransferRecovery.load(projectId, 'incoming');
+        return record ? 'nonterminal' : 'absent';
+      },
+    };
+    const recovery = new AuthorityTransferRecovery(persistence, {
+      resume: jest.fn().mockResolvedValue(undefined),
+    });
+    const subsystem = lifecycle();
+    subsystem.registerDurableOwner(hostTransferOwner);
+    recovery.register(subsystem);
+
+    await expect(subsystem.lifecycleRecovery.resume()).rejects.toMatchObject({
+      code: 'durable-progress-recovery-required',
+      safeContext: { reason: 'lifecycle-owner-ambiguous' },
+    });
+  });
+
+  it('does not treat a proposal as irreversible lifecycle ownership', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository);
+    await persistence.create(createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: 'intent-one',
+      stagingDirectoryName: '.claudian-authority-transfer-transfer-one',
+      status: status('collecting-readiness'),
+    }));
+    const recovery = new AuthorityTransferRecovery(persistence, {
+      resume: jest.fn().mockResolvedValue(undefined),
+    });
+    const subsystem = lifecycle();
+    recovery.register(subsystem);
+    const operation = jest.fn().mockResolvedValue('admitted');
+
+    await expect(subsystem.runExclusive(
+      PROJECT_ID,
+      'retirement',
+      'operation',
+      operation,
+    )).resolves.toBe('admitted');
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues recovering later Projects before reporting the first failure', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository);
+    for (const [projectId, transferId] of [
+      ['project-alpha', 'transfer-alpha'],
+      ['project-beta', 'transfer-beta'],
+    ] as const) {
+      await repository.authorityTransferRecords.save(createAuthorityTransferRecord({
+        lifecycleOwnership: 'owned',
+        localRole: 'source',
+        operationIntentId: `intent-${projectId}`,
+        stagingDirectoryName: `.claudian-authority-transfer-${transferId}`,
+        status: status('collecting-readiness', projectId, transferId),
+      }));
+    }
+    const firstError = new Error('alpha recovery unavailable');
+    const resumed: string[] = [];
+    const recovery = new AuthorityTransferRecovery(persistence, {
+      resume: jest.fn(async record => {
+        resumed.push(record.projectId);
+        if (record.projectId === 'project-alpha') throw firstError;
+      }),
+    });
+    const subsystem = lifecycle();
+    recovery.register(subsystem);
+
+    await expect(subsystem.lifecycleRecovery.resume()).rejects.toBe(firstError);
+    expect(resumed).toEqual(['project-alpha', 'project-beta']);
+  });
+
+  it('isolates a corrupt Project document while recovering later Projects', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository);
+    await repository.authorityTransferRecords.save(createAuthorityTransferRecord({
+      lifecycleOwnership: 'owned',
+      localRole: 'source',
+      operationIntentId: 'intent-beta',
+      stagingDirectoryName: '.claudian-authority-transfer-transfer-beta',
+      status: status('collecting-readiness', 'project-beta', 'transfer-beta'),
+    }));
+    const corruptPath = path.join(vaultRoot, repository.getProjectPaths(PROJECT_ID).authorityTransfer);
+    await mkdir(path.dirname(corruptPath), { recursive: true });
+    await writeFile(corruptPath, '{', { mode: 0o600 });
+    const resumed: string[] = [];
+    const recovery = new AuthorityTransferRecovery(persistence, {
+      resume: jest.fn(async record => { resumed.push(record.projectId); }),
+    });
+    const subsystem = lifecycle();
+    recovery.register(subsystem);
+
+    await expect(subsystem.lifecycleRecovery.resume()).rejects.toMatchObject({
+      code: 'durable-progress-recovery-required',
+      safeContext: { reason: 'lifecycle-owner-inspection-failed' },
+    });
+    expect(resumed).toEqual(['project-beta']);
+  });
+
+  it('recovers valid Projects before reporting a malformed catalog entry', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository);
+    await repository.authorityTransferRecords.save(createAuthorityTransferRecord({
+      lifecycleOwnership: 'owned',
+      localRole: 'source',
+      operationIntentId: 'intent-beta',
+      stagingDirectoryName: '.claudian-authority-transfer-transfer-beta',
+      status: status('collecting-readiness', 'project-beta', 'transfer-beta'),
+    }));
+    await mkdir(path.join(vaultRoot, '.claudian', 'collab', 'projects', 'invalid project'), {
+      recursive: true,
+    });
+    const resumed: string[] = [];
+    const recovery = new AuthorityTransferRecovery(persistence, {
+      resume: jest.fn(async record => { resumed.push(record.projectId); }),
+    });
+    const subsystem = lifecycle();
+    recovery.register(subsystem);
+
+    await expect(subsystem.lifecycleRecovery.resume()).rejects.toMatchObject({
+      code: 'durable-progress-recovery-required',
+      safeContext: { reason: 'authority-transfer-catalog-invalid' },
+    });
+    expect(resumed).toEqual(['project-beta']);
+  });
+
+  it('reloads durable state after waiting for the Project lifecycle arbiter', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository);
+    await persistence.create(createAuthorityTransferRecord({
+      lifecycleOwnership: 'owned',
+      localRole: 'source',
+      operationIntentId: 'intent-one',
+      stagingDirectoryName: '.claudian-authority-transfer-transfer-one',
+      status: status('collecting-readiness'),
+    }));
+    const resume = jest.fn().mockResolvedValue(undefined);
+    const recovery = new AuthorityTransferRecovery(persistence, { resume });
+    const subsystem = lifecycle();
+    recovery.register(subsystem);
+    let releaseBlocker!: () => void;
+    let enteredBlocker!: () => void;
+    const blockerEntered = new Promise<void>(resolve => {
+      enteredBlocker = resolve;
+    });
+    const blocker = new Promise<void>(resolve => {
+      releaseBlocker = resolve;
+    });
+    const admitted = subsystem.runExclusive(
+      PROJECT_ID,
+      'authority-transfer',
+      'recovery',
+      async () => {
+        enteredBlocker();
+        await blocker;
+      },
+    );
+    await blockerEntered;
+    const recovering = subsystem.lifecycleRecovery.resume();
+    const advanced = createAuthorityTransferRecord({
+      localRole: 'source',
+      operationIntentId: 'intent-one',
+      stagingDirectoryName: '.claudian-authority-transfer-transfer-one',
+      status: status('source-quiesced'),
+    });
+    await persistence.advance(advanced, 'collecting-readiness');
+    releaseBlocker();
+
+    await admitted;
+    await recovering;
+    expect(resume).toHaveBeenCalledWith(advanced, {});
+  });
+});

--- a/tests/unit/app/collab/bootstrap/CloudBootstrapService.test.ts
+++ b/tests/unit/app/collab/bootstrap/CloudBootstrapService.test.ts
@@ -28,14 +28,26 @@ function pendingTransition(
   } as CloudBootstrapTransitionRecord;
 }
 
+function admitProjectRecovery(
+  _projectId: string,
+  operation: () => Promise<void>,
+): Promise<void> {
+  return operation();
+}
+
 describe('CloudBootstrapService', () => {
   it('fences every uncertain transition before local recovery preparation completes', async () => {
     const fenceUncertainProject = jest.fn(async (_projectId: string) => undefined);
     const recoverLocalArtifacts = jest.fn(async () => undefined);
     const createCoordinator = jest.fn();
+    const projectRecoveryAdmission = jest.fn(async (
+      _projectId: string,
+      operation: () => Promise<void>,
+    ) => operation());
     const service = new CloudBootstrapService({
       createCoordinator,
       fenceUncertainProject,
+      projectRecoveryAdmission,
       recoverLocalArtifacts,
       transitions: {
         load: async () => null,
@@ -66,6 +78,11 @@ describe('CloudBootstrapService', () => {
     await service.prepareLocalRecovery();
 
     expect(fenceUncertainProject.mock.calls.map(([projectId]) => projectId).sort()).toEqual([
+      'project-cancelling',
+      'project-corrupt',
+      'project-pending',
+    ]);
+    expect(projectRecoveryAdmission.mock.calls.map(([projectId]) => projectId).sort()).toEqual([
       'project-cancelling',
       'project-corrupt',
       'project-pending',
@@ -143,6 +160,7 @@ describe('CloudBootstrapService', () => {
     const service = new CloudBootstrapService({
       createCoordinator,
       fenceUncertainProject: async () => undefined,
+      projectRecoveryAdmission: admitProjectRecovery,
       recoverLocalArtifacts: async () => undefined,
       transitions,
     });
@@ -168,10 +186,18 @@ describe('CloudBootstrapService', () => {
     const fenceUncertainProject = jest.fn(async (projectId: string) => {
       events.push(`fence:${projectId}`);
     });
+    const projectRecoveryAdmission = jest.fn(async (
+      _projectId: string,
+      operation: () => Promise<void>,
+    ) => operation());
     const service = new CloudBootstrapService({
       createCoordinator,
       fenceUncertainProject,
-      recoverLocalArtifacts: async () => { events.push('artifacts'); },
+      projectRecoveryAdmission,
+      recoverLocalArtifacts: async admit => admit(
+        'project-artifact',
+        async () => { events.push('artifacts'); },
+      ),
       transitions: {
         load: async () => null,
         list: async () => ({
@@ -221,6 +247,15 @@ describe('CloudBootstrapService', () => {
       'project-complete',
       expect.any(AbortSignal),
     );
+    expect(projectRecoveryAdmission.mock.calls.map(([projectId]) => projectId))
+      .toEqual([
+        'project-corrupt',
+        PROJECT_ID,
+        'project-complete',
+        'project-artifact',
+        PROJECT_ID,
+        'project-complete',
+      ]);
   });
 
   it('fails closed before recovery or cancellation with a mismatched durable actor', async () => {
@@ -228,6 +263,7 @@ describe('CloudBootstrapService', () => {
     const service = new CloudBootstrapService({
       createCoordinator,
       fenceUncertainProject: async () => undefined,
+      projectRecoveryAdmission: admitProjectRecovery,
       recoverLocalArtifacts: async () => undefined,
       transitions: {
         load: async () => ({
@@ -267,6 +303,7 @@ describe('CloudBootstrapService', () => {
         submitParticipant,
       }) as unknown as CloudBootstrapCoordinator,
       fenceUncertainProject: async () => undefined,
+      projectRecoveryAdmission: admitProjectRecovery,
       recoverLocalArtifacts: async () => undefined,
       transitions: {
         list: async () => ({ blockedProjectIds: [], records: [], retryRequired: false }),
@@ -312,6 +349,7 @@ describe('CloudBootstrapService', () => {
         startFormerHost,
       }) as unknown as CloudBootstrapCoordinator,
       fenceUncertainProject: async () => undefined,
+      projectRecoveryAdmission: admitProjectRecovery,
       recoverLocalArtifacts: async () => undefined,
       scheduleRetry,
       transitions: {
@@ -359,6 +397,7 @@ describe('CloudBootstrapService', () => {
         startFormerHost,
       }) as unknown as CloudBootstrapCoordinator,
       fenceUncertainProject: async () => undefined,
+      projectRecoveryAdmission: admitProjectRecovery,
       recoverLocalArtifacts: async () => undefined,
       scheduleRetry,
       transitions: {
@@ -393,6 +432,7 @@ describe('CloudBootstrapService', () => {
         startFormerHost,
       }) as unknown as CloudBootstrapCoordinator,
       fenceUncertainProject: async () => undefined,
+      projectRecoveryAdmission: admitProjectRecovery,
       recoverLocalArtifacts: async () => undefined,
       scheduleRetry,
       transitions: {
@@ -413,6 +453,7 @@ describe('CloudBootstrapService', () => {
 
   it('continues bounded Project polling after a successful pending recovery', async () => {
     const record = pendingTransition();
+    const projectRecoveryAdmission = jest.fn(admitProjectRecovery);
     const recoverProject = jest.fn()
       .mockResolvedValueOnce(record)
       .mockResolvedValueOnce({ ...record, attemptState: 'activated' as const });
@@ -424,6 +465,7 @@ describe('CloudBootstrapService', () => {
     const service = new CloudBootstrapService({
       createCoordinator: () => ({ recoverProject }) as unknown as CloudBootstrapCoordinator,
       fenceUncertainProject: async () => undefined,
+      projectRecoveryAdmission,
       recoverLocalArtifacts: async () => undefined,
       scheduleRetry,
       transitions: {
@@ -441,6 +483,16 @@ describe('CloudBootstrapService', () => {
     expect(scheduleRetry).toHaveBeenCalledWith(PROJECT_ID, expect.any(Function), 1_000);
     await retry?.();
     expect(recoverProject).toHaveBeenCalledTimes(2);
+    expect(projectRecoveryAdmission).toHaveBeenNthCalledWith(
+      1,
+      PROJECT_ID,
+      expect.any(Function),
+    );
+    expect(projectRecoveryAdmission).toHaveBeenNthCalledWith(
+      2,
+      PROJECT_ID,
+      expect.any(Function),
+    );
     await service.close();
   });
 
@@ -469,6 +521,7 @@ describe('CloudBootstrapService', () => {
           : recoverOther,
       }) as unknown as CloudBootstrapCoordinator,
       fenceUncertainProject: async () => undefined,
+      projectRecoveryAdmission: admitProjectRecovery,
       recoverLocalArtifacts: async () => undefined,
       scheduleRetry,
       transitions: {
@@ -517,6 +570,7 @@ describe('CloudBootstrapService', () => {
     const service = new CloudBootstrapService({
       createCoordinator: () => ({ recoverProject }) as unknown as CloudBootstrapCoordinator,
       fenceUncertainProject: async () => undefined,
+      projectRecoveryAdmission: admitProjectRecovery,
       recoverLocalArtifacts: async () => undefined,
       scheduleRetry,
       transitions: {
@@ -562,6 +616,7 @@ describe('CloudBootstrapService', () => {
     const service = new CloudBootstrapService({
       createCoordinator: () => ({ recoverProject }) as unknown as CloudBootstrapCoordinator,
       fenceUncertainProject: async () => undefined,
+      projectRecoveryAdmission: admitProjectRecovery,
       recoverLocalArtifacts,
       scheduleRetry,
       transitions: { list, load: async () => null },
@@ -603,6 +658,7 @@ describe('CloudBootstrapService', () => {
     const service = new CloudBootstrapService({
       createCoordinator: () => ({ recoverProject }) as unknown as CloudBootstrapCoordinator,
       fenceUncertainProject: async () => undefined,
+      projectRecoveryAdmission: admitProjectRecovery,
       recoverLocalArtifacts: async () => undefined,
       transitions: {
         load: async () => null,

--- a/tests/unit/app/collab/bootstrap/LocalCloudBootstrapBindingEffects.test.ts
+++ b/tests/unit/app/collab/bootstrap/LocalCloudBootstrapBindingEffects.test.ts
@@ -213,7 +213,7 @@ describe('LocalCloudBootstrapBindingEffects', () => {
       gitRemoteUrl: record.newAuthority.gitRemoteUrl,
       kind: 'cloud',
       serverUrl: record.newAuthority.serverUrl,
-      wireVersion: 5,
+      wireVersion: 6,
     });
     expect(JSON.stringify(membership)).not.toContain('credential');
     expect(JSON.stringify(membership)).not.toContain('PRIVATE CA');

--- a/tests/unit/app/collab/bootstrap/LocalDevelopmentBootstrapSource.test.ts
+++ b/tests/unit/app/collab/bootstrap/LocalDevelopmentBootstrapSource.test.ts
@@ -19,6 +19,13 @@ import {
   PROJECT_ID,
 } from './fixtures';
 
+function admitProjectRecovery(
+  _projectId: string,
+  operation: () => Promise<void>,
+): Promise<void> {
+  return operation();
+}
+
 describe('LocalDevelopmentBootstrapSource', () => {
   let vaultRoot: string;
 
@@ -218,15 +225,39 @@ describe('LocalDevelopmentBootstrapSource', () => {
     sourceEventSequence = 12;
     latestEventActorMemberId = sourceHostMemberId;
     const ownership = jest.fn(async () => true);
-    await expect(source.recoverArtifacts(ownership)).resolves.toBeUndefined();
+    const projectRecoveryAdmission = jest.fn(admitProjectRecovery);
+    await expect(source.recoverArtifacts(ownership, projectRecoveryAdmission))
+      .resolves.toBeUndefined();
     expect(ownership).toHaveBeenCalledWith(manifest);
+    expect(projectRecoveryAdmission).toHaveBeenCalledWith(
+      PROJECT_ID,
+      expect.any(Function),
+    );
     const preservedChunks: Buffer[] = [];
     for await (const chunk of source.openBundle(manifest)) {
       preservedChunks.push(Buffer.from(chunk));
     }
     expect(Buffer.concat(preservedChunks)).toEqual(Buffer.from([1, 2, 3]));
 
-    await expect(source.recoverArtifacts(async () => false)).resolves.toBeUndefined();
+    const rejectedAdmission = jest.fn(async () => {
+      throw new Error('lifecycle owner conflict');
+    });
+    await expect(source.recoverArtifacts(async () => false, rejectedAdmission))
+      .rejects.toThrow('lifecycle owner conflict');
+    const stillPreservedChunks: Buffer[] = [];
+    for await (const chunk of source.openBundle(manifest)) {
+      stillPreservedChunks.push(Buffer.from(chunk));
+    }
+    expect(Buffer.concat(stillPreservedChunks)).toEqual(Buffer.from([1, 2, 3]));
+
+    const recovery = source.recoverArtifacts(async () => false, async (_projectId, operation) => {
+      await source.discardBundle(manifest);
+      await operation();
+    });
+    await expect(Promise.race([
+      recovery.then(() => 'complete'),
+      new Promise(resolve => setTimeout(() => resolve('deadlocked'), 100)),
+    ])).resolves.toBe('complete');
     await expect(source.discardBundle(manifest)).resolves.toBeUndefined();
     await expect(source.discardBundle(manifest)).resolves.toBeUndefined();
     await expect(lstat(path.join(

--- a/tests/unit/app/collab/client/CollabClientProjection.test.ts
+++ b/tests/unit/app/collab/client/CollabClientProjection.test.ts
@@ -24,6 +24,13 @@ import { CollabError } from '@/core/collab/ClaudianCollabError';
 const CREATED_AT = '2026-08-08T00:00:00.000Z';
 const HEAD = 'a'.repeat(40);
 
+function admitProjectRetirement(
+  _projectId: string,
+  operation: () => Promise<void>,
+): Promise<void> {
+  return operation();
+}
+
 describe('CollabClientProjection', () => {
   it('coalesces online snapshot reads and durably projects cache plus event cursor', async () => {
     const store = new MemoryProjectionStore();
@@ -477,12 +484,14 @@ describe('CollabClientProjection', () => {
       start: jest.fn(),
     };
     const retirement = { handle: jest.fn().mockResolvedValue(undefined) };
+    const retirementAdmission = jest.fn(admitProjectRetirement);
     const projection = new CollabClientProjection(store, control, {
       createEventClient: (_input, callback) => {
         invalidate = callback;
         return eventClient;
       },
       retirement,
+      retirementAdmission,
     });
     await projection.subscribe('project-a', jest.fn());
 
@@ -508,7 +517,6 @@ describe('CollabClientProjection', () => {
       { projectId: 'project-a', retiredAt: CREATED_AT },
       'terminal-fallback',
     );
-
     control.readRequest.mockRejectedValue(new CollabError({
       code: 'project-retired',
       safeContext: { projectId: 'project-a', retiredAt: CREATED_AT },
@@ -519,6 +527,44 @@ describe('CollabClientProjection', () => {
       { projectId: 'project-a', retiredAt: CREATED_AT },
       'terminal-fallback',
     );
+    expect(retirementAdmission).toHaveBeenCalledTimes(3);
+  });
+
+  it('detaches a retired event session without awaiting its own convergence', async () => {
+    const store = new MemoryProjectionStore();
+    const control = controlPort();
+    let invalidate: ((event: ProjectEventInvalidation) => Promise<number>) | null = null;
+    const eventClient: CollabClientProjectionEventPort = {
+      dispose: jest.fn(),
+      start: jest.fn(),
+    };
+    const holder: { projection?: CollabClientProjection } = {};
+    const retirement = {
+      handle: jest.fn(() => holder.projection!.closeProject('project-a')),
+    };
+    const projection = new CollabClientProjection(store, control, {
+      createEventClient: (_input, callback) => {
+        invalidate = callback;
+        return eventClient;
+      },
+      retirement,
+      retirementAdmission: admitProjectRetirement,
+    });
+    holder.projection = projection;
+    await projection.subscribe('project-a', jest.fn());
+    const retired = {
+      kind: 'retired' as const,
+      retiredAt: CREATED_AT,
+      sequence: 6,
+    };
+
+    await expect(Promise.race([
+      invalidate!(retired),
+      new Promise(resolve => setTimeout(() => resolve('deadlocked'), 100)),
+    ])).resolves.toBe(6);
+    expect(eventClient.dispose).toHaveBeenCalledTimes(1);
+    await expect(retirement.handle.mock.results[0]?.value).resolves.toBeUndefined();
+    expect(retirement.handle).toHaveBeenCalledTimes(1);
   });
 
   it('does not await terminal convergence from work owned by the closing Project session', async () => {
@@ -529,7 +575,10 @@ describe('CollabClientProjection', () => {
       safeContext: { projectId: 'project-a', retiredAt: CREATED_AT },
     }));
     const retirement = { handle: jest.fn(() => new Promise<void>(() => undefined)) };
-    const projection = new CollabClientProjection(store, control, { retirement });
+    const projection = new CollabClientProjection(store, control, {
+      retirement,
+      retirementAdmission: admitProjectRetirement,
+    });
 
     await expect(projection.readSnapshot('project-a')).rejects.toMatchObject({
       code: 'project-retired',
@@ -538,6 +587,52 @@ describe('CollabClientProjection', () => {
       { projectId: 'project-a', retiredAt: CREATED_AT },
       'terminal-fallback',
     );
+  });
+
+  it('leaves event and fallback retirement untouched when lifecycle admission rejects', async () => {
+    const store = new MemoryProjectionStore();
+    const control = controlPort();
+    let invalidate: ((event: ProjectEventInvalidation) => Promise<number>) | null = null;
+    const eventClient: CollabClientProjectionEventPort = {
+      dispose: jest.fn(),
+      start: jest.fn(),
+    };
+    const retirement = { handle: jest.fn().mockResolvedValue(undefined) };
+    const retirementAdmission = jest.fn(async () => {
+      throw new CollabError({
+        code: 'durable-progress-recovery-required',
+        safeContext: { reason: 'project-lifecycle-owner-conflict' },
+      });
+    });
+    const projection = new CollabClientProjection(store, control, {
+      createEventClient: (_input, callback) => {
+        invalidate = callback;
+        return eventClient;
+      },
+      retirement,
+      retirementAdmission,
+    });
+    await projection.subscribe('project-a', jest.fn());
+
+    await expect(invalidate!({
+      kind: 'retired',
+      retiredAt: CREATED_AT,
+      sequence: 6,
+    })).resolves.toBe(6);
+    await Promise.resolve();
+
+    control.readSnapshot.mockRejectedValue(new CollabError({
+      code: 'project-retired',
+      safeContext: { projectId: 'project-a', retiredAt: CREATED_AT },
+    }));
+    await expect(projection.readSnapshot('project-a')).rejects.toMatchObject({
+      code: 'project-retired',
+    });
+    await Promise.resolve();
+
+    expect(retirementAdmission).toHaveBeenCalledTimes(2);
+    expect(retirement.handle).not.toHaveBeenCalled();
+    expect(eventClient.dispose).toHaveBeenCalledTimes(1);
   });
 
   it('disposes the old event client and reloads membership after a Project reset', async () => {
@@ -840,7 +935,7 @@ function cloudMembership(): CollabLocalCloudMembershipRecord {
       gitRemoteUrl: 'https://cloud.example.test/v2/projects/project-a/repository.git',
       kind: 'cloud',
       serverUrl: 'https://cloud.example.test',
-      wireVersion: 5,
+      wireVersion: 6,
     },
     createdAt: CREATED_AT,
     lastEventSequence: 0,

--- a/tests/unit/app/collab/client/ProjectEventClient.test.ts
+++ b/tests/unit/app/collab/client/ProjectEventClient.test.ts
@@ -152,6 +152,38 @@ describe('ProjectEventClient', () => {
     expect(socket.close).toHaveBeenCalledWith(1000, 'Client stopped');
     expect(scheduled).toEqual([]);
   });
+
+  it('reconnects from the prior cursor when terminal retirement delivery rejects', async () => {
+    const sockets = [new FakeClientSocket(), new FakeClientSocket()];
+    const createSocket = jest.fn(() => sockets.shift()!);
+    const scheduled: Array<() => void> = [];
+    const onInvalidation = jest.fn().mockRejectedValue(new Error('lifecycle owner pending'));
+    const client = createClient(createSocket, onInvalidation, 3, {
+      random: () => 0,
+      setTimeout: callback => {
+        scheduled.push(callback);
+        return scheduled.length;
+      },
+    });
+    client.start();
+
+    createSocket.mock.results[0].value.emitMessage(JSON.stringify(event(
+      4,
+      'project-retired',
+      { retiredAt: CREATED_AT },
+    )));
+    await flushTasks();
+    expect(createSocket.mock.results[0].value.close)
+      .toHaveBeenCalledWith(1011, 'Event refresh failed');
+    expect(client.lastSequence).toBe(3);
+
+    createSocket.mock.results[0].value.emitClose(1011);
+    scheduled.shift()?.();
+    expect(createSocket).toHaveBeenLastCalledWith(expect.objectContaining({
+      lastSequence: 3,
+    }));
+    client.dispose();
+  });
 });
 
 function createClient(

--- a/tests/unit/app/collab/exit/LocalProjectExitCoordinator.test.ts
+++ b/tests/unit/app/collab/exit/LocalProjectExitCoordinator.test.ts
@@ -689,7 +689,15 @@ describe('LocalProjectExitCoordinator', () => {
       cleanupChoice: 'keep-files',
       projectId: 'project-alpha',
     });
-    const worker = new PendingLeaveWorker(pending, coordinator);
+    const projectRecoveryAdmission = jest.fn(async (
+      _projectId: string,
+      operation: () => Promise<void>,
+    ) => operation());
+    const worker = new PendingLeaveWorker(
+      pending,
+      coordinator,
+      projectRecoveryAdmission,
+    );
 
     await expect(worker.runOnce()).resolves.toEqual({
       attempted: ['project-alpha'],
@@ -700,6 +708,10 @@ describe('LocalProjectExitCoordinator', () => {
       .toEqual(['leave-stable', 'leave-stable']);
     expect(authority.prepareLeave).toHaveBeenCalledTimes(1);
     expect(pending.records.size).toBe(0);
+    expect(projectRecoveryAdmission).toHaveBeenCalledWith(
+      'project-alpha',
+      expect.any(Function),
+    );
   });
 
   it('retains a prepared Manager Leave after timeout and resumes its exact accepted offer', async () => {
@@ -806,7 +818,11 @@ describe('LocalProjectExitCoordinator', () => {
       projectId: 'project-alpha',
     });
 
-    await expect(new PendingLeaveWorker(pending, coordinator).runOnce()).resolves.toEqual({
+    await expect(new PendingLeaveWorker(
+      pending,
+      coordinator,
+      async (_projectId, operation) => operation(),
+    ).runOnce()).resolves.toEqual({
       attempted: ['project-alpha'],
       failed: ['project-alpha'],
     });

--- a/tests/unit/app/collab/host-transfer/CollabHostTransferService.test.ts
+++ b/tests/unit/app/collab/host-transfer/CollabHostTransferService.test.ts
@@ -89,10 +89,14 @@ describe('CollabHostTransferService', () => {
         projectId: 'project-a',
       }),
     };
+    const projectRecoveryAdmission = jest.fn(async (
+      _projectId: string,
+      operation: () => Promise<void>,
+    ) => operation());
     const resumeOutgoing = jest.fn().mockResolvedValue(undefined);
     const resumeCompletedOutgoing = jest.fn().mockResolvedValue(undefined);
     const snapshots = { readCoordinationSnapshot: jest.fn().mockResolvedValue(snapshot) };
-    const service = new CollabHostTransferService({
+    const serviceOptions = {
       createControlClient: () => control,
       ...(useInjectedIdempotency
         ? { createIdempotencyKey: (kind: string) => `${kind}-key` }
@@ -103,10 +107,13 @@ describe('CollabHostTransferService', () => {
       resumeCompletedOutgoing,
       resumeOutgoing,
       snapshots,
-    });
+      projectRecoveryAdmission,
+    };
+    const service = new CollabHostTransferService(serviceOptions);
     return {
       control,
       incoming,
+      projectRecoveryAdmission,
       projects,
       recovery,
       resumeCompletedOutgoing,
@@ -221,11 +228,24 @@ describe('CollabHostTransferService', () => {
   });
 
   it('restores incoming provisional state during nonblocking startup recovery', async () => {
-    const { incoming, service } = create();
+    const { incoming, projectRecoveryAdmission, service } = create();
 
     await service.resume();
 
+    expect(projectRecoveryAdmission).toHaveBeenCalledWith(
+      'project-a',
+      expect.any(Function),
+    );
     expect(incoming.resume).toHaveBeenCalledWith('project-a');
+  });
+
+  it('does not touch Host state when Project recovery admission fails closed', async () => {
+    const { incoming, projectRecoveryAdmission, service } = create();
+    projectRecoveryAdmission.mockRejectedValueOnce(new Error('ambiguous lifecycle owners'));
+
+    await expect(service.resume()).rejects.toThrow('ambiguous lifecycle owners');
+
+    expect(incoming.resume).not.toHaveBeenCalled();
   });
 
   it('finishes completed outgoing recovery without reopening deleted authority', async () => {
@@ -325,6 +345,7 @@ describe('CollabHostTransferService', () => {
       createControlClient: () => harness.control,
       createIncomingCoordinator,
       projects: harness.projects,
+      projectRecoveryAdmission: async (_projectId, operation) => operation(),
       recovery: harness.recovery,
       snapshots: harness.snapshots,
     });
@@ -369,6 +390,7 @@ describe('CollabHostTransferService', () => {
         return construction;
       },
       projects: harness.projects,
+      projectRecoveryAdmission: async (_projectId, operation) => operation(),
       recovery: harness.recovery,
       snapshots: harness.snapshots,
     });

--- a/tests/unit/app/collab/host-transfer/HostTransferModule.test.ts
+++ b/tests/unit/app/collab/host-transfer/HostTransferModule.test.ts
@@ -81,6 +81,10 @@ describe('HostTransferModule', () => {
       finalizeOldAuthority: jest.fn(),
       lanHost: {},
       projects,
+      projectRecoveryAdmission: async (
+        _projectId: string,
+        operation: () => Promise<void>,
+      ) => operation(),
       requireGitFoundation: jest.fn(),
       snapshots: { readCoordinationSnapshot: jest.fn().mockResolvedValue(coordination) },
       workspace: {},
@@ -158,6 +162,10 @@ describe('HostTransferModule', () => {
           projects: [{ id: 'project-a', name: 'Project A', workspacePath: 'workspace/a' }],
         })),
       },
+      projectRecoveryAdmission: async (
+        _projectId: string,
+        operation: () => Promise<void>,
+      ) => operation(),
       requireGitFoundation: jest.fn(),
       snapshots: { readCoordinationSnapshot: jest.fn() },
       workspace: {},

--- a/tests/unit/app/collab/lan/HostTransferLifecycleOrchestrator.test.ts
+++ b/tests/unit/app/collab/lan/HostTransferLifecycleOrchestrator.test.ts
@@ -25,17 +25,52 @@ describe('HostTransferLifecycleOrchestrator', () => {
       run: jest.fn().mockResolvedValue(undefined),
     };
     const onBackgroundError = jest.fn();
+    const projectLifecycleAdmissionState: { error: Error | null } = { error: null };
+    const projectLifecycleAdmission = async <T>(
+      _projectId: string,
+      operation: () => Promise<T>,
+    ): Promise<T> => {
+      if (projectLifecycleAdmissionState.error) {
+        throw projectLifecycleAdmissionState.error;
+      }
+      return operation();
+    };
     return {
       lifecycle,
       onBackgroundError,
       orchestrator: new HostTransferLifecycleOrchestrator(
         lifecycle,
         outgoing,
-        { onBackgroundError },
+        { onBackgroundError, projectLifecycleAdmission },
       ),
       outgoing,
+      projectLifecycleAdmission,
+      projectLifecycleAdmissionState,
     };
   }
+
+  it('acquires source lifecycle ownership before accepting authority transfer', async () => {
+    const {
+      lifecycle,
+      orchestrator,
+      outgoing,
+      projectLifecycleAdmissionState,
+    } = create();
+    projectLifecycleAdmissionState.error = new Error('competing lifecycle owner');
+
+    await expect(orchestrator.acceptHostTransfer('member-target', {
+      idempotencyKey: 'accept-a',
+      projectId: 'project-a',
+      receiverCredential: Buffer.alloc(32, 1).toString('base64url'),
+      targetCaCertificatePem: '-----BEGIN CERTIFICATE-----\nQUJD\n-----END CERTIFICATE-----\n',
+      targetCaFingerprint: 'b'.repeat(64),
+      targetEndpoint: 'https://192.168.1.20:27001',
+      transferId: 'transfer-a',
+    })).rejects.toThrow('competing lifecycle owner');
+
+    expect(lifecycle.acceptHostTransfer).not.toHaveBeenCalled();
+    expect(outgoing.prepareAccepted).not.toHaveBeenCalled();
+  });
 
   it('starts outgoing transfer only after the Accept response is flushed', async () => {
     const { lifecycle, orchestrator, outgoing } = create();
@@ -155,6 +190,26 @@ describe('HostTransferLifecycleOrchestrator', () => {
     expect(outgoing.prepareCancellation.mock.invocationCallOrder[0]).toBeLessThan(
       lifecycle.cancelHostTransfer.mock.invocationCallOrder[0],
     );
+  });
+
+  it('acquires source lifecycle ownership before cancellation recovery', async () => {
+    const {
+      lifecycle,
+      orchestrator,
+      outgoing,
+      projectLifecycleAdmissionState,
+    } = create();
+    projectLifecycleAdmissionState.error = new Error('competing lifecycle owner');
+
+    await expect(orchestrator.cancelHostTransfer('member-source', {
+      expectedHostMemberId: 'member-source',
+      idempotencyKey: 'cancel-a',
+      projectId: 'project-a',
+      transferId: 'transfer-a',
+    })).rejects.toThrow('competing lifecycle owner');
+
+    expect(outgoing.prepareCancellation).not.toHaveBeenCalled();
+    expect(lifecycle.cancelHostTransfer).not.toHaveBeenCalled();
   });
 
   it('does not discard the authority credential when cancellation recovery cannot persist', async () => {

--- a/tests/unit/app/collab/lifecycle/CollabProjectLifecycleOwners.test.ts
+++ b/tests/unit/app/collab/lifecycle/CollabProjectLifecycleOwners.test.ts
@@ -1,0 +1,115 @@
+import {
+  createCollabProjectLifecycleDurableOwners,
+} from '@/app/collab/lifecycle/CollabProjectLifecycleOwners';
+
+function stores() {
+  return {
+    cloudBootstrapTransitions: { inspectLifecycleOwner: jest.fn().mockResolvedValue('absent') },
+    hostTransferRecovery: { load: jest.fn().mockResolvedValue(null) },
+    localCleanup: { load: jest.fn().mockResolvedValue(null) },
+    managerReceipts: { load: jest.fn().mockResolvedValue(null) },
+    pendingLeaves: { load: jest.fn().mockResolvedValue(null) },
+    retiredCleanups: { load: jest.fn().mockResolvedValue(null) },
+    retirements: { loadRetirementRecord: jest.fn().mockResolvedValue(null) },
+    retirementTombstones: { loadRetirementTombstone: jest.fn().mockResolvedValue(null) },
+  };
+}
+
+describe('CollabProjectLifecycleOwners', () => {
+  it('projects real durable lifecycle records into the shared arbiter', async () => {
+    const backing = stores();
+    backing.hostTransferRecovery.load.mockImplementation(async (_projectId, direction) => (
+      direction === 'incoming' ? { direction: 'incoming' } : null
+    ));
+    backing.pendingLeaves.load.mockResolvedValue({ phase: 'queued' });
+    backing.managerReceipts.load.mockResolvedValue({ status: 'acknowledged' });
+    backing.retirements.loadRetirementRecord.mockResolvedValue({ cleanupStatus: 'complete' });
+    backing.cloudBootstrapTransitions.inspectLifecycleOwner.mockResolvedValue('nonterminal');
+    const owners = createCollabProjectLifecycleDurableOwners(backing);
+
+    await expect(Promise.all(owners.map(async owner => ({
+      name: owner.name,
+      state: await owner.inspect('project-alpha'),
+    })))).resolves.toEqual([
+      { name: 'cloud-bootstrap', state: 'nonterminal' },
+      { name: 'host-transfer', state: 'nonterminal' },
+      { name: 'manager-responsibility', state: 'terminal' },
+      { name: 'local-exit', state: 'terminal' },
+      { name: 'retirement', state: 'nonterminal' },
+    ]);
+  });
+
+  it('treats completed bootstrap cleanup as terminal and absent stores as absent', async () => {
+    const backing = stores();
+    backing.cloudBootstrapTransitions.inspectLifecycleOwner.mockResolvedValue('terminal');
+    const owners = createCollabProjectLifecycleDurableOwners(backing);
+
+    await expect(Promise.all(owners.map(async owner => ({
+      name: owner.name,
+      state: await owner.inspect('project-alpha'),
+    })))).resolves.toEqual([
+      { name: 'cloud-bootstrap', state: 'terminal' },
+      { name: 'host-transfer', state: 'absent' },
+      { name: 'manager-responsibility', state: 'absent' },
+      { name: 'local-exit', state: 'absent' },
+      { name: 'retirement', state: 'absent' },
+    ]);
+  });
+
+  it('classifies a reversible Manager offer as a proposal until the target acknowledges it', async () => {
+    const backing = stores();
+    backing.managerReceipts.load.mockResolvedValue({ status: 'offered' });
+    const owner = createCollabProjectLifecycleDurableOwners(backing)
+      .find(candidate => candidate.name === 'manager-responsibility')!;
+
+    await expect(owner.inspect('project-alpha')).resolves.toBe('proposal');
+
+    backing.managerReceipts.load.mockResolvedValue({ status: 'acknowledged' });
+    await expect(owner.inspect('project-alpha')).resolves.toBe('nonterminal');
+  });
+
+  it('lets a pending Leave durably subsume an acknowledged Manager receipt', async () => {
+    const backing = stores();
+    backing.managerReceipts.load.mockResolvedValue({ status: 'acknowledged' });
+    backing.pendingLeaves.load.mockResolvedValue({ phase: 'queued' });
+    const owners = createCollabProjectLifecycleDurableOwners(backing);
+    const managerResponsibility = owners.find(owner => owner.name === 'manager-responsibility')!;
+    const localExit = owners.find(owner => owner.name === 'local-exit')!;
+
+    await expect(managerResponsibility.inspect('project-alpha')).resolves.toBe('terminal');
+    await expect(localExit.inspect('project-alpha')).resolves.toBe('nonterminal');
+  });
+
+  it('fails closed when both Host-transfer directions exist', async () => {
+    const backing = stores();
+    backing.hostTransferRecovery.load.mockResolvedValue({ phase: 'accepted' });
+    const hostTransfer = createCollabProjectLifecycleDurableOwners(backing)
+      .find(owner => owner.name === 'host-transfer')!;
+
+    await expect(hostTransfer.inspect('project-alpha'))
+      .rejects.toThrow('Conflicting Host transfer recovery records');
+  });
+
+  it('lets a durable retirement absorb an overlapping pending Leave', async () => {
+    const backing = stores();
+    backing.pendingLeaves.load.mockResolvedValue({ phase: 'recovery-required' });
+    backing.retirements.loadRetirementRecord.mockResolvedValue({ cleanupStatus: 'pending' });
+    const owners = createCollabProjectLifecycleDurableOwners(backing);
+    const localExit = owners.find(owner => owner.name === 'local-exit')!;
+    const retirement = owners.find(owner => owner.name === 'retirement')!;
+
+    await expect(localExit.inspect('project-alpha')).resolves.toBe('terminal');
+    await expect(retirement.inspect('project-alpha')).resolves.toBe('nonterminal');
+  });
+
+  it('keeps retirement ownership after the authority tombstone commits before local delivery', async () => {
+    const backing = stores();
+    backing.retirementTombstones.loadRetirementTombstone.mockResolvedValue({
+      kind: 'retirement-tombstone',
+    });
+    const retirement = createCollabProjectLifecycleDurableOwners(backing)
+      .find(owner => owner.name === 'retirement')!;
+
+    await expect(retirement.inspect('project-alpha')).resolves.toBe('nonterminal');
+  });
+});

--- a/tests/unit/app/collab/lifecycle/CollabProjectLifecycleSubsystem.test.ts
+++ b/tests/unit/app/collab/lifecycle/CollabProjectLifecycleSubsystem.test.ts
@@ -6,6 +6,7 @@ import {
 function ports() {
   return {
     closeRecovery: jest.fn().mockResolvedValue(undefined),
+    durableOwners: [],
     hostTransfer: {} as never,
     localExit: {} as never,
     retirement: {} as never,
@@ -61,6 +62,66 @@ describe('CollabProjectLifecycleSubsystem', () => {
     expect(later).not.toHaveBeenCalled();
   });
 
+  it('fails closed before a recovery handler when durable owners are ambiguous', async () => {
+    const resumeHost = jest.fn().mockResolvedValue(undefined);
+    const holder: { subsystem?: CollabProjectLifecycleSubsystem } = {};
+    const subsystem = new CollabProjectLifecycleSubsystem({
+      ...ports(),
+      durableOwners: [
+        { inspect: async () => 'nonterminal', name: 'authority-transfer' },
+        { inspect: async () => 'nonterminal', name: 'host-transfer' },
+      ],
+      recoveryStages: [{
+        name: 'host-transfers',
+        run: () => holder.subsystem!.runExclusive(
+          'project-alpha',
+          'host-transfer',
+          'recovery',
+          resumeHost,
+        ),
+      }],
+    });
+    holder.subsystem = subsystem;
+
+    await expect(subsystem.lifecycleRecovery.resume()).rejects.toMatchObject({
+      code: 'durable-progress-recovery-required',
+      safeContext: { reason: 'lifecycle-owner-ambiguous' },
+    });
+    expect(resumeHost).not.toHaveBeenCalled();
+  });
+
+  it('blocks a fresh same-owner operation but admits explicit continuation and recovery', async () => {
+    const subsystem = new CollabProjectLifecycleSubsystem({
+      ...ports(),
+      durableOwners: [{ inspect: async () => 'nonterminal', name: 'host-transfer' }],
+      recoveryStages: [],
+    });
+    const fresh = jest.fn().mockResolvedValue('fresh');
+
+    await expect(subsystem.runExclusive(
+      'project-alpha',
+      'host-transfer',
+      'operation',
+      fresh,
+    )).rejects.toMatchObject({
+      code: 'durable-progress-recovery-required',
+      safeContext: { reason: 'lifecycle-owner-recovery-required' },
+    });
+    expect(fresh).not.toHaveBeenCalled();
+    await expect(subsystem.runExclusive(
+      'project-alpha',
+      'host-transfer',
+      'continuation',
+      async () => 'continued',
+    )).resolves.toBe('continued');
+    await expect(subsystem.runExclusive(
+      'project-alpha',
+      'host-transfer',
+      'recovery',
+      async () => 'recovered',
+    )).resolves.toBe('recovered');
+  });
+
   it('binds one feature projection and forwards lifecycle invalidation', async () => {
     const closeProjectAdmission = jest.fn();
     const refreshLifecycleProjection = jest.fn().mockResolvedValue(undefined);
@@ -87,6 +148,7 @@ describe('CollabProjectLifecycleSubsystem', () => {
     const retirementClose = jest.fn();
     const subsystem = new CollabProjectLifecycleSubsystem({
       closeRecovery,
+      durableOwners: [],
       hostTransfer: { close: hostClose } as never,
       localExit: {} as never,
       recoveryStages: [],
@@ -98,5 +160,343 @@ describe('CollabProjectLifecycleSubsystem', () => {
     expect(closeRecovery).toHaveBeenCalledTimes(1);
     expect(hostClose).not.toHaveBeenCalled();
     expect(retirementClose).not.toHaveBeenCalled();
+  });
+
+  it('serializes one Project while allowing a different Project to proceed', async () => {
+    const subsystem = new CollabProjectLifecycleSubsystem({
+      ...ports(),
+      recoveryStages: [],
+    });
+    let releaseFirst!: () => void;
+    const firstBlocked = new Promise<void>(resolve => {
+      releaseFirst = resolve;
+    });
+    const order: string[] = [];
+    const first = subsystem.runExclusive(
+      'project-alpha',
+      'authority-transfer',
+      'operation',
+      async () => {
+        order.push('alpha-first-start');
+        await firstBlocked;
+        order.push('alpha-first-end');
+      },
+    );
+    const second = subsystem.runExclusive(
+      'project-alpha',
+      'retirement',
+      'operation',
+      async () => {
+        order.push('alpha-second');
+      },
+    );
+    const otherProject = subsystem.runExclusive(
+      'project-beta',
+      'retirement',
+      'operation',
+      async () => {
+        order.push('beta');
+      },
+    );
+
+    await otherProject;
+    expect(order).toEqual(['alpha-first-start', 'beta']);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(order).toEqual([
+      'alpha-first-start',
+      'beta',
+      'alpha-first-end',
+      'alpha-second',
+    ]);
+  });
+
+  it('serializes same-owner authority entries and closes their alternate admission path', async () => {
+    const subsystem = new CollabProjectLifecycleSubsystem({
+      ...ports(),
+      recoveryStages: [],
+    });
+    let release!: () => void;
+    let entered!: () => void;
+    const blocked = new Promise<void>(resolve => { release = resolve; });
+    const started = new Promise<void>(resolve => { entered = resolve; });
+    const first = subsystem.runExclusive(
+      'project-alpha',
+      'retirement',
+      'operation',
+      async () => {
+        entered();
+        await blocked;
+      },
+    );
+    await started;
+    const authorityMutation = jest.fn().mockResolvedValue('retired');
+    const second = subsystem.runExclusive(
+      'project-alpha',
+      'retirement',
+      'operation',
+      authorityMutation,
+    );
+    await Promise.resolve();
+    expect(authorityMutation).not.toHaveBeenCalled();
+
+    const closing = subsystem.lifecycleRecovery.close();
+    await expect(subsystem.runExclusive(
+      'project-alpha',
+      'retirement',
+      'operation',
+      async () => 'must-not-run',
+    )).rejects.toMatchObject({
+      code: 'durable-progress-recovery-required',
+      safeContext: { reason: 'lifecycle-subsystem-closed' },
+    });
+
+    release();
+    await expect(second).resolves.toBe('retired');
+    await first;
+    await closing;
+    expect(authorityMutation).toHaveBeenCalledTimes(1);
+  });
+
+  it('admits only the declared durable predecessor into an owner handoff', async () => {
+    const localExit = { leaveProject: jest.fn().mockResolvedValue(undefined) };
+    const subsystem = new CollabProjectLifecycleSubsystem({
+      ...ports(),
+      durableOwners: [{
+        inspect: async () => 'nonterminal',
+        name: 'manager-responsibility',
+      }],
+      localExit: localExit as never,
+      recoveryStages: [],
+    });
+
+    await expect(subsystem.localExit.leaveProject({
+      cleanupChoice: 'keep-files',
+      managerResponsibilityOfferId: 'offer-one',
+      projectId: 'project-alpha',
+    })).resolves.toBeUndefined();
+    expect(localExit.leaveProject).toHaveBeenCalledTimes(1);
+
+    const blockedRetirement = jest.fn().mockResolvedValue('retired');
+    await expect(subsystem.runRetirementAdoption(
+      'project-alpha',
+      blockedRetirement,
+    )).rejects.toMatchObject({
+      code: 'durable-progress-recovery-required',
+      safeContext: { reason: 'lifecycle-owner-pending' },
+    });
+    expect(blockedRetirement).not.toHaveBeenCalled();
+
+    const localExitOwner = new CollabProjectLifecycleSubsystem({
+      ...ports(),
+      durableOwners: [{ inspect: async () => 'nonterminal', name: 'local-exit' }],
+      recoveryStages: [],
+    });
+    const retirement = jest.fn().mockResolvedValue('retired');
+    await expect(localExitOwner.runRetirementAdoption(
+      'project-alpha',
+      retirement,
+    )).resolves.toBe('retired');
+    expect(retirement).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes every locally stateful lifecycle mutation through the Project arbiter', async () => {
+    const hostTransfer = {
+      acceptHostTransfer: jest.fn().mockResolvedValue(undefined),
+      cancelHostTransfer: jest.fn().mockResolvedValue(undefined),
+      close: jest.fn().mockResolvedValue(undefined),
+      createHostTransfer: jest.fn().mockResolvedValue(undefined),
+      declineHostTransfer: jest.fn().mockResolvedValue(undefined),
+    };
+    const localExit = { leaveProject: jest.fn().mockResolvedValue(undefined) };
+    const membership = {
+      cancelManagerResponsibilityOffer: jest.fn().mockResolvedValue({}),
+      createInvitation: jest.fn().mockResolvedValue({}),
+      createManagerResponsibilityOffer: jest.fn().mockResolvedValue({}),
+      demoteManager: jest.fn().mockResolvedValue(undefined),
+      listMembers: jest.fn().mockResolvedValue([]),
+      promoteManager: jest.fn().mockResolvedValue(undefined),
+      removeMember: jest.fn().mockResolvedValue(undefined),
+      revokeInvitation: jest.fn().mockResolvedValue(undefined),
+    };
+    const cloudBootstrap = {
+      cancel: jest.fn().mockResolvedValue({}),
+      close: jest.fn().mockResolvedValue(undefined),
+      prepareLocalRecovery: jest.fn().mockResolvedValue(undefined),
+      recoverPending: jest.fn().mockResolvedValue(undefined),
+      startFormerHost: jest.fn().mockResolvedValue({}),
+      submitParticipant: jest.fn().mockResolvedValue({}),
+    };
+    const retirement = {
+      close: jest.fn().mockResolvedValue(undefined),
+      finalizeRetiredProject: jest.fn().mockResolvedValue(undefined),
+      retireProject: jest.fn().mockResolvedValue(undefined),
+      retryProjectCleanup: jest.fn().mockResolvedValue(undefined),
+    };
+    const subsystem = new CollabProjectLifecycleSubsystem({
+      closeRecovery: jest.fn().mockResolvedValue(undefined),
+      durableOwners: [],
+      hostTransfer,
+      localExit,
+      recoveryStages: [],
+      retirement,
+    });
+    const guardedCloudBootstrap = subsystem.bindCloudBootstrap(cloudBootstrap as never);
+    const guardedMembership = subsystem.bindMembership(membership as never);
+    subsystem.registerDurableOwner({
+      inspect: async () => 'nonterminal',
+      name: 'authority-transfer',
+    });
+
+    const blocked = [
+      subsystem.hostTransfer.createHostTransfer({
+        projectId: 'project-alpha',
+        targetMemberId: 'member-target',
+      }),
+      subsystem.hostTransfer.acceptHostTransfer({
+        projectId: 'project-alpha',
+        transferId: 'transfer-one',
+      }),
+      subsystem.hostTransfer.declineHostTransfer({
+        projectId: 'project-alpha',
+        transferId: 'transfer-one',
+      }),
+      subsystem.localExit.leaveProject({
+        cleanupChoice: 'keep-files',
+        projectId: 'project-alpha',
+      }),
+      subsystem.retirement.finalizeRetiredProject({
+        cleanupChoice: 'keep-files',
+        projectId: 'project-alpha',
+      }),
+      subsystem.retirement.retryProjectCleanup('project-alpha'),
+      guardedCloudBootstrap.startFormerHost({
+        memberId: 'member-host',
+        projectId: 'project-alpha',
+        serverUrl: 'https://cloud.example.test/',
+      }),
+      guardedCloudBootstrap.submitParticipant({
+        memberId: 'member-host',
+        projectId: 'project-alpha',
+        serverUrl: 'https://cloud.example.test/',
+      } as never),
+      guardedCloudBootstrap.cancel('project-alpha'),
+      guardedMembership.createManagerResponsibilityOffer({
+        projectId: 'project-alpha',
+        purpose: 'manager-promotion',
+        targetMemberId: 'member-target',
+      }),
+      guardedMembership.cancelManagerResponsibilityOffer({
+        offerId: 'offer-one',
+        projectId: 'project-alpha',
+      }),
+    ];
+    for (const operation of blocked) {
+      await expect(operation).rejects.toMatchObject({
+        code: 'durable-progress-recovery-required',
+        safeContext: { reason: 'lifecycle-owner-pending' },
+      });
+    }
+    await expect(subsystem.hostTransfer.cancelHostTransfer({
+      projectId: 'project-alpha',
+      transferId: 'transfer-one',
+    })).resolves.toBeUndefined();
+    await expect(subsystem.retirement.retireProject({
+      expectedHostMemberId: 'member-host',
+      managerActorMemberId: 'member-manager',
+      projectId: 'project-alpha',
+    })).resolves.toBeUndefined();
+    expect(hostTransfer.createHostTransfer).not.toHaveBeenCalled();
+    expect(hostTransfer.acceptHostTransfer).not.toHaveBeenCalled();
+    expect(hostTransfer.declineHostTransfer).not.toHaveBeenCalled();
+    expect(hostTransfer.cancelHostTransfer).toHaveBeenCalledTimes(1);
+    expect(localExit.leaveProject).not.toHaveBeenCalled();
+    expect(retirement.retireProject).toHaveBeenCalledTimes(1);
+    expect(retirement.finalizeRetiredProject).not.toHaveBeenCalled();
+    expect(retirement.retryProjectCleanup).not.toHaveBeenCalled();
+    expect(cloudBootstrap.startFormerHost).not.toHaveBeenCalled();
+    expect(cloudBootstrap.submitParticipant).not.toHaveBeenCalled();
+    expect(cloudBootstrap.cancel).not.toHaveBeenCalled();
+    expect(membership.createManagerResponsibilityOffer).not.toHaveBeenCalled();
+    expect(membership.cancelManagerResponsibilityOffer).not.toHaveBeenCalled();
+  });
+
+  it('closes recovery producers before draining admitted Project operations', async () => {
+    const closeRecovery = jest.fn().mockResolvedValue(undefined);
+    const subsystem = new CollabProjectLifecycleSubsystem({
+      ...ports(),
+      closeRecovery,
+      recoveryStages: [],
+    });
+    let release!: () => void;
+    const blocked = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    const admitted = subsystem.runExclusive(
+      'project-alpha',
+      'authority-transfer',
+      'operation',
+      () => blocked,
+    );
+    const queuedOperation = jest.fn().mockResolvedValue(undefined);
+    const queued = subsystem.runExclusive(
+      'project-alpha',
+      'authority-transfer',
+      'operation',
+      queuedOperation,
+    );
+    await Promise.resolve();
+
+    const closing = subsystem.lifecycleRecovery.close();
+    await expect(subsystem.runExclusive(
+      'project-beta',
+      'retirement',
+      'operation',
+      async () => undefined,
+    )).rejects.toMatchObject({
+      code: 'durable-progress-recovery-required',
+      safeContext: { reason: 'lifecycle-subsystem-closed' },
+    });
+    expect(closeRecovery).toHaveBeenCalledTimes(1);
+    release();
+    await admitted;
+    await queued;
+    await closing;
+    expect(queuedOperation).toHaveBeenCalledTimes(1);
+    expect(closeRecovery).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes recovery resources before draining an active recovery run', async () => {
+    const closeRecovery = jest.fn().mockResolvedValue(undefined);
+    let release!: () => void;
+    let entered!: () => void;
+    const stageEntered = new Promise<void>(resolve => {
+      entered = resolve;
+    });
+    const blocked = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    const subsystem = new CollabProjectLifecycleSubsystem({
+      ...ports(),
+      closeRecovery,
+      recoveryStages: [{
+        name: 'authority-transfers',
+        run: async () => {
+          entered();
+          await blocked;
+        },
+      }],
+    });
+    const recovering = subsystem.lifecycleRecovery.resume();
+    await stageEntered;
+
+    const closing = subsystem.lifecycleRecovery.close();
+    await Promise.resolve();
+    expect(closeRecovery).toHaveBeenCalledTimes(1);
+    release();
+    await recovering;
+    await closing;
+
+    expect(closeRecovery).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/app/collab/membership/CollabMembershipService.test.ts
+++ b/tests/unit/app/collab/membership/CollabMembershipService.test.ts
@@ -130,6 +130,7 @@ function safetyContext(
   overrides: Partial<CollabMembershipSafetyContext> = {},
 ): CollabMembershipSafetyContext {
   return {
+    managerResponsibilityAdmission: async (_projectId, operation) => operation(),
     managerReceipts: {
       load: jest.fn(async () => null),
       remove: jest.fn(async () => false),
@@ -223,6 +224,34 @@ describe('CollabMembershipService', () => {
       projectId: 'project-alpha',
     });
     expect(snapshot.readCoordinationSnapshot).toHaveBeenCalledTimes(3);
+  });
+
+  it('fails closed before promotion when another Project lifecycle owns admission', async () => {
+    const control = client();
+    const managerResponsibilityAdmission = jest.fn().mockRejectedValue(new CollabError({
+      code: 'durable-progress-recovery-required',
+      recoveryActions: ['resume'],
+      safeContext: { reason: 'lifecycle-owner-pending' },
+    }));
+    const snapshot: jest.Mocked<CollabMembershipSnapshotPort> = {
+      readCoordinationSnapshot: jest.fn().mockResolvedValue(coordination()),
+    };
+    const service = new CollabMembershipService({
+      loadMembership: jest.fn().mockResolvedValue(membership()),
+    }, snapshot, {
+      createClient: () => control,
+    }, safetyContext({ managerResponsibilityAdmission }));
+
+    await expect(service.promoteManager({
+      managerResponsibilityOfferId: 'offer-transfer',
+      projectId: 'project-alpha',
+      targetMemberId: 'member-a',
+    })).rejects.toMatchObject({
+      safeContext: { reason: 'lifecycle-owner-pending' },
+    });
+
+    expect(control.promoteManager).not.toHaveBeenCalled();
+    expect(snapshot.readCoordinationSnapshot).not.toHaveBeenCalled();
   });
 
   it('reuses a caller mutation intent after a lost administration response', async () => {

--- a/tests/unit/app/collab/publish/CollabPublicationService.test.ts
+++ b/tests/unit/app/collab/publish/CollabPublicationService.test.ts
@@ -52,7 +52,7 @@ function cloudMembership(serverUrl: string): CollabLocalCloudMembershipRecord {
       gitRemoteUrl: `${serverUrl}/v2/projects/${CLOUD_PROJECT_ID}/repository.git`,
       kind: 'cloud',
       serverUrl,
-      wireVersion: 5,
+      wireVersion: 6,
     },
     createdAt: CLOUD_CREATED_AT,
     lastEventSequence: 0,

--- a/tests/unit/app/collab/remote-authority/CloudAuthorityAdapter.test.ts
+++ b/tests/unit/app/collab/remote-authority/CloudAuthorityAdapter.test.ts
@@ -77,7 +77,7 @@ function membership(): CollabLocalCloudMembershipRecord {
       gitRemoteUrl: `https://cloud.example.test/v2/projects/${PROJECT_ID}/repository.git`,
       kind: 'cloud',
       serverUrl: 'https://cloud.example.test',
-      wireVersion: 5,
+      wireVersion: 6,
     },
     createdAt: '2026-08-22T00:00:00.000Z',
     lastEventSequence: 3,
@@ -313,7 +313,7 @@ describe('CloudAuthorityAdapter', () => {
           idempotencyKey: 'publish-head',
           projectId: PROJECT_ID,
         },
-        protocolVersion: 5,
+        protocolVersion: 6,
         requestId: 'request-ensure',
       },
       headers: { 'x-claudian-development-actor': ACTOR_ID },
@@ -371,7 +371,7 @@ describe('CloudAuthorityAdapter', () => {
           projectId: PROJECT_ID,
           requestId: 'request-one',
         },
-        protocolVersion: 5,
+        protocolVersion: 6,
         requestId: expect.any(String),
       },
       headers: { 'x-claudian-development-actor': ACTOR_ID },
@@ -823,7 +823,7 @@ describe('CloudProjectEventClient', () => {
       occurredAt: '2026-08-22T00:00:00.000Z',
       payload: { requestId: 'request-one' },
       projectId: PROJECT_ID,
-      protocolVersion: 5,
+      protocolVersion: 6,
       sequence: 4,
     }));
     sockets[0]!.closed(1006);
@@ -861,7 +861,7 @@ describe('CloudProjectEventClient', () => {
         occurredAt: '2026-08-22T00:00:00.000Z',
         payload: { requestId: `request-${sequence}` },
         projectId: PROJECT_ID,
-        protocolVersion: 5,
+        protocolVersion: 6,
         sequence,
       }));
     }
@@ -897,7 +897,7 @@ describe('CloudProjectEventClient', () => {
       occurredAt: '2026-08-22T00:00:00.000Z',
       payload: { requestId: 'request-four' },
       projectId: PROJECT_ID,
-      protocolVersion: 5,
+      protocolVersion: 6,
       sequence: 4,
     }));
     await flush();

--- a/tests/unit/app/collab/remote-authority/CollabAuthoritySessionFactory.test.ts
+++ b/tests/unit/app/collab/remote-authority/CollabAuthoritySessionFactory.test.ts
@@ -10,7 +10,7 @@ function cloudMembership(): CollabLocalCloudMembershipRecord {
       gitRemoteUrl: 'https://cloud.example.test/v2/projects/project-cloud/repository.git',
       kind: 'cloud',
       serverUrl: 'https://cloud.example.test',
-      wireVersion: 5,
+      wireVersion: 6,
     },
     createdAt: '2026-08-22T00:00:00.000Z',
     lastEventSequence: 0,

--- a/tests/unit/app/collab/retirement/ProjectRetirementCoordinator.test.ts
+++ b/tests/unit/app/collab/retirement/ProjectRetirementCoordinator.test.ts
@@ -8,8 +8,46 @@ import {
 } from '@/app/collab/retirement/ProjectRetirementCoordinator';
 
 const RETIRED_AT = '2026-08-13T00:00:00.000Z';
+const admitProjectLifecycle = <T>(
+  _projectId: string,
+  operation: () => Promise<T>,
+): Promise<T> => operation();
 
 describe('ProjectRetirementCoordinator', () => {
+  it('acquires authority lifecycle ownership before quiescing the Project', async () => {
+    const admission: jest.Mocked<ProjectRetirementAdmissionPort> = {
+      quiesceAndDrain: jest.fn().mockResolvedValue(undefined),
+      resume: jest.fn().mockResolvedValue(undefined),
+    };
+    const authority: jest.Mocked<ProjectRetirementAuthorityPort> = {
+      inspectDurableResult: jest.fn().mockResolvedValue(null),
+      retire: jest.fn().mockResolvedValue({ projectId: 'project-a', retiredAt: RETIRED_AT }),
+    };
+    const projectLifecycleAdmission = async <T>(): Promise<T> => {
+      throw new Error('competing lifecycle owner');
+    };
+    const coordinator = new ProjectRetirementCoordinator(
+      admission,
+      authority,
+      { activate: jest.fn().mockResolvedValue(undefined) },
+      { deliver: jest.fn().mockResolvedValue(undefined) },
+      { teardown: jest.fn().mockResolvedValue(undefined) },
+      projectLifecycleAdmission,
+    );
+
+    await expect(coordinator.retire('member-manager', {
+      expectedHostMemberId: 'member-host',
+      managerActorMemberId: 'member-manager',
+      idempotencyKey: 'retire-one',
+      operationId: 'retire-one',
+      projectId: 'project-a',
+      requestFingerprint: 'a'.repeat(64),
+    })).rejects.toThrow('competing lifecycle owner');
+
+    expect(admission.quiesceAndDrain).not.toHaveBeenCalled();
+    expect(authority.retire).not.toHaveBeenCalled();
+  });
+
   it('drains before terminal commit and exposes the tombstone before delivery or teardown', async () => {
     const order: string[] = [];
     const admission: jest.Mocked<ProjectRetirementAdmissionPort> = {
@@ -38,6 +76,7 @@ describe('ProjectRetirementCoordinator', () => {
       terminal,
       delivery,
       active,
+      admitProjectLifecycle,
     );
 
     await expect(coordinator.retire('member-manager', {
@@ -69,6 +108,7 @@ describe('ProjectRetirementCoordinator', () => {
       { activate: jest.fn(async (_result) => undefined) },
       { deliver: jest.fn(async (_result) => undefined) },
       { teardown: jest.fn(async (_projectId) => undefined) },
+      admitProjectLifecycle,
     );
 
     await expect(coordinator.retire('member-manager', {
@@ -105,6 +145,7 @@ describe('ProjectRetirementCoordinator', () => {
       { activate: jest.fn(async (_result) => { order.push('terminal'); }) },
       { deliver: jest.fn(async (_result) => { order.push('deliver'); }) },
       { teardown: jest.fn(async (_projectId) => { order.push('teardown'); }) },
+      admitProjectLifecycle,
     );
 
     await expect(coordinator.retire('member-manager', {
@@ -142,6 +183,7 @@ describe('ProjectRetirementCoordinator', () => {
       { activate: jest.fn(async () => undefined) },
       { deliver: jest.fn(async () => { throw new Error('local cleanup failed'); }) },
       { teardown },
+      admitProjectLifecycle,
     );
 
     await expect(coordinator.retire('member-manager', {
@@ -174,6 +216,7 @@ describe('ProjectRetirementCoordinator', () => {
       { activate: jest.fn().mockResolvedValue(undefined) },
       { deliver: jest.fn(() => delivery) },
       { teardown },
+      admitProjectLifecycle,
     );
 
     await expect(coordinator.retire('member-manager', {
@@ -209,6 +252,7 @@ describe('ProjectRetirementCoordinator', () => {
       { activate: jest.fn(async (_result) => undefined) },
       { deliver: jest.fn(async (_result) => undefined) },
       { teardown: jest.fn(async (_projectId) => undefined) },
+      admitProjectLifecycle,
     );
 
     await expect(coordinator.retire('member-manager', {
@@ -243,6 +287,7 @@ describe('ProjectRetirementCoordinator', () => {
       terminal,
       { deliver: jest.fn(async (_result) => undefined) },
       { teardown: jest.fn(async (_projectId) => undefined) },
+      admitProjectLifecycle,
     );
 
     await expect(coordinator.retire('member-manager', {
@@ -275,6 +320,7 @@ describe('ProjectRetirementCoordinator', () => {
       { activate: jest.fn(async (_result) => { throw new Error('terminal bind failed'); }) },
       { deliver: jest.fn(async (_result) => undefined) },
       { teardown: jest.fn(async (_projectId) => undefined) },
+      admitProjectLifecycle,
     );
 
     await expect(coordinator.retire('member-manager', {

--- a/tests/unit/app/collab/retirement/RetirementAcknowledgementWorker.test.ts
+++ b/tests/unit/app/collab/retirement/RetirementAcknowledgementWorker.test.ts
@@ -9,9 +9,20 @@ import { CollabError } from '@/core/collab/ClaudianCollabError';
 const RETIRED_AT = '2026-08-13T00:00:00.000Z';
 const ACKNOWLEDGED_AT = '2026-08-13T00:01:00.000Z';
 
+async function admitProjectRecovery(
+  _projectId: string,
+  operation: () => Promise<void>,
+): Promise<void> {
+  await operation();
+}
+
 describe('RetirementAcknowledgementWorker', () => {
   it('uses one durable acknowledgement identity and scrubs network credentials', async () => {
     const store = new MemoryRetirementStore(record());
+    const projectRecoveryAdmission = jest.fn(async (
+      _projectId: string,
+      operation: () => Promise<void>,
+    ) => operation());
     const client: jest.Mocked<RetirementAcknowledgementClientPort> = {
       acknowledge: jest.fn().mockResolvedValue({
         acknowledgedAt: ACKNOWLEDGED_AT,
@@ -19,7 +30,9 @@ describe('RetirementAcknowledgementWorker', () => {
         retiredAt: RETIRED_AT,
       }),
     };
-    const worker = new RetirementAcknowledgementWorker(store, client);
+    const worker = new RetirementAcknowledgementWorker(store, client, {
+      projectRecoveryAdmission,
+    });
 
     await expect(worker.run('project-a')).resolves.toBe('acknowledged');
     await expect(worker.run('project-a')).resolves.toBe('acknowledged');
@@ -40,6 +53,10 @@ describe('RetirementAcknowledgementWorker', () => {
       memberCredential: null,
     });
     expect(store.removed).toBe(true);
+    expect(projectRecoveryAdmission).toHaveBeenCalledWith(
+      'project-a',
+      expect.any(Function),
+    );
   });
 
   it.each(['endpoint-unreachable', 'tls-untrusted'] as const)(
@@ -57,6 +74,7 @@ describe('RetirementAcknowledgementWorker', () => {
         }),
     };
     const worker = new RetirementAcknowledgementWorker(store, client, {
+      projectRecoveryAdmission: admitProjectRecovery,
       scheduleRetry: retry,
     });
 
@@ -79,7 +97,10 @@ describe('RetirementAcknowledgementWorker', () => {
         throw new CollabError({ code: 'endpoint-unreachable' });
       }),
     };
-    const worker = new RetirementAcknowledgementWorker(store, client, { scheduleRetry });
+    const worker = new RetirementAcknowledgementWorker(store, client, {
+      projectRecoveryAdmission: admitProjectRecovery,
+      scheduleRetry,
+    });
 
     await expect(worker.run('project-a')).resolves.toBe('retry-pending');
     expect(observedSignal?.aborted).toBe(false);
@@ -97,6 +118,7 @@ describe('RetirementAcknowledgementWorker', () => {
     };
     const worker = new RetirementAcknowledgementWorker(store, client, {
       now: () => new Date('2026-09-12T00:00:00.000Z'),
+      projectRecoveryAdmission: admitProjectRecovery,
     });
 
     await expect(worker.run('project-a')).resolves.toBe('expired');

--- a/tests/unit/app/collab/retirement/RetirementLocalRecovery.test.ts
+++ b/tests/unit/app/collab/retirement/RetirementLocalRecovery.test.ts
@@ -36,9 +36,20 @@ const CLEANUP = {
   workspacePath: 'workspace/project-one',
 } as const satisfies LocalCleanupRecord;
 
+async function admitProjectRecovery(
+  _projectId: string,
+  operation: () => Promise<void>,
+): Promise<void> {
+  await operation();
+}
+
 describe('RetirementLocalRecovery', () => {
   it('resumes a durable retirement record even when the index still says Active', async () => {
     const handler = { resume: jest.fn(async () => undefined) };
+    const projectRecoveryAdmission = jest.fn(async (
+      _projectId: string,
+      operation: () => Promise<void>,
+    ) => operation());
     const recovery = new RetirementLocalRecovery({
       loadIndex: jest.fn(async () => ({
         projects: [{
@@ -60,11 +71,15 @@ describe('RetirementLocalRecovery', () => {
     }, {
       listProjectIds: jest.fn(async () => []),
       load: jest.fn(async () => null),
-    }, handler, { finalize: jest.fn(async () => undefined) });
+    }, handler, { finalize: jest.fn(async () => undefined) }, projectRecoveryAdmission);
 
     await recovery.resume();
 
     expect(handler.resume).toHaveBeenCalledWith(RETIREMENT.projectId);
+    expect(projectRecoveryAdmission).toHaveBeenCalledWith(
+      RETIREMENT.projectId,
+      expect.any(Function),
+    );
   });
 
   it('removes an applied cleanup journal after its projection is already gone', async () => {
@@ -84,7 +99,7 @@ describe('RetirementLocalRecovery', () => {
       load: jest.fn(async () => CLEANUP),
     }, {
       resume: jest.fn(async () => undefined),
-    }, { finalize });
+    }, { finalize }, admitProjectRecovery);
 
     await recovery.resume();
 
@@ -111,7 +126,7 @@ describe('RetirementLocalRecovery', () => {
       load: jest.fn(async () => CLEANUP),
     }, {
       resume: jest.fn(async () => undefined),
-    }, { finalize });
+    }, { finalize }, admitProjectRecovery);
 
     await recovery.resume();
 
@@ -134,7 +149,7 @@ describe('RetirementLocalRecovery', () => {
     }, {
       listProjectIds: jest.fn(async () => ['project-one']),
       load: jest.fn(async () => CLEANUP),
-    }, handler, { finalize });
+    }, handler, { finalize }, admitProjectRecovery);
 
     await recovery.resume();
 
@@ -171,7 +186,7 @@ describe('RetirementLocalRecovery', () => {
     }, {
       listProjectIds: jest.fn(async () => ['project-one']),
       load: jest.fn(async () => CLEANUP),
-    }, handler, { finalize });
+    }, handler, { finalize }, admitProjectRecovery);
 
     await recovery.resume();
 
@@ -208,7 +223,7 @@ describe('RetirementLocalRecovery', () => {
     }, {
       listProjectIds: jest.fn(async () => ['project-one']),
       load: jest.fn(async () => CLEANUP),
-    }, handler, { finalize });
+    }, handler, { finalize }, admitProjectRecovery);
 
     await recovery.resume();
 


### PR DESCRIPTION
## Summary
- add durable local authority-transfer records, claim custody and commitments, restart fences, cancellation cleanup, and restart recovery
- introduce one per-Project lifecycle arbiter across bootstrap, Host transfer, local exit, retirement, and authority transfer
- fence LAN Host restart after authority transfer or retirement tombstones and converge expired retirement results before cleanup
- consume exact @claudian-collab/protocol 3.0.0 / wire v6, including canonical empty claim batches for single-member Projects

## Verification
- npm test: 586 suites passed, 8,546 tests passed, 1 skipped
- npm run typecheck
- npm run lint:ts
- npm run build
- npm run check:performance: main.js 4.78 MiB, 89.6 ms median cold evaluation
- npm run check:lockfile
- node --test scripts/check-architecture-boundaries.test.mjs: 37 passed
- git diff --check
- review-and-repair final isolated review: no material L2 findings

## Scope
This is the Step 11 L2 local durability foundation. L3-L6 runtime transfer binding, Cloud adapter wiring, direction coordinators, and user-visible migration entry remain downstream and fail closed where not yet composed.