### PR TITLE
feat: add LAN authority transfer binding

### DIFF
--- a/src/app/collab/lan/authority-transfer/LanAuthorityTransferBinding.ts
+++ b/src/app/collab/lan/authority-transfer/LanAuthorityTransferBinding.ts
@@ -1,0 +1,66 @@
+import {
+  COLLAB_AUTHORITY_TRANSFER_OPERATIONS,
+  type CollabAuthorityTransferOperation,
+  type CollabProjectId,
+  isCollabProjectId,
+} from '@claudian-collab/protocol';
+
+export const COLLAB_LAN_AUTHORITY_TRANSFER_BINDING_VERSION = 1 as const;
+
+const ROUTE_PREFIX = '/authority-transfer';
+const ROUTE_PATTERN = /^\/authority-transfer\/v(\d+)\/projects\/([^/]+)\/operations\/([^/]+)$/;
+const OPERATION_SET: ReadonlySet<string> = new Set(
+  COLLAB_AUTHORITY_TRANSFER_OPERATIONS,
+);
+
+export interface CollabLanAuthorityTransferRouteMatch {
+  readonly operation: CollabAuthorityTransferOperation;
+  readonly projectId: CollabProjectId;
+  readonly version: number;
+}
+
+export function collabLanAuthorityTransferOperationPath(
+  projectId: string,
+  operation: CollabAuthorityTransferOperation,
+): string {
+  if (!isCollabProjectId(projectId) || !OPERATION_SET.has(operation)) {
+    throw new RangeError('Invalid LAN authority-transfer route input');
+  }
+  return `${ROUTE_PREFIX}/v${COLLAB_LAN_AUTHORITY_TRANSFER_BINDING_VERSION}`
+    + `/projects/${projectId}/operations/${operation}`;
+}
+
+export function matchCollabLanAuthorityTransferRoute(
+  method: string | undefined,
+  target: string | undefined,
+): CollabLanAuthorityTransferRouteMatch | null {
+  if (method !== 'POST' || !target || target.length > 2_048) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(target, 'https://claudian.invalid');
+  } catch {
+    return null;
+  }
+  if (
+    parsed.origin !== 'https://claudian.invalid'
+    || parsed.search.length > 0
+    || parsed.hash.length > 0
+    || parsed.pathname !== target
+  ) return null;
+  const match = ROUTE_PATTERN.exec(parsed.pathname);
+  if (!match) return null;
+  const version = Number(match[1]);
+  const projectId = match[2];
+  const operation = match[3];
+  if (
+    !Number.isSafeInteger(version)
+    || version < 1
+    || !isCollabProjectId(projectId)
+    || !OPERATION_SET.has(operation)
+  ) return null;
+  return {
+    operation: operation as CollabAuthorityTransferOperation,
+    projectId,
+    version,
+  };
+}

--- a/src/app/collab/lan/authority-transfer/LanAuthorityTransferClient.ts
+++ b/src/app/collab/lan/authority-transfer/LanAuthorityTransferClient.ts
@@ -1,0 +1,504 @@
+import { randomUUID, X509Certificate } from 'node:crypto';
+import { request as httpsRequest } from 'node:https';
+
+import {
+  type ClaimTransferredMembershipRequest,
+  COLLAB_ERROR_CODES,
+  COLLAB_LIMITS,
+  COLLAB_PROTOCOL_VERSION,
+  type CollabAuthorityTransferOperation,
+  type CollabAuthorityTransferOperationMap,
+  type CollabErrorCode as SharedCollabErrorCode,
+  type CollabProjectId,
+  type CollabRecoveryAction as SharedCollabRecoveryAction,
+  decodeCollabAuthorityTransferOperationRequest,
+  decodeCollabAuthorityTransferOperationResponse,
+  isCollabProjectId,
+} from '@claudian-collab/protocol';
+
+import {
+  COLLAB_LAN_AUTHORITY_TRANSFER_BINDING_VERSION,
+  collabLanAuthorityTransferOperationPath,
+} from '@/app/collab/lan/authority-transfer/LanAuthorityTransferBinding';
+import { fingerprintCertificatePem } from '@/app/collab/lan/LanTlsIdentity';
+import { CollabError } from '@/core/collab/ClaudianCollabError';
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const MEMBER_CREDENTIAL_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+const REQUEST_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const SHARED_ERROR_CODE_SET: ReadonlySet<string> = new Set(COLLAB_ERROR_CODES);
+const SHARED_RECOVERY_ACTION_SET: ReadonlySet<string> = new Set([
+  'request-access',
+  'retry',
+  'review-conflicts',
+]);
+
+export type LanAuthorityTransferMemberOperation =
+  | 'acceptLanToCloudTransferTarget'
+  | 'acknowledgeTransferredMembershipClaimRedemption'
+  | 'cancelProjectAuthorityTransfer'
+  | 'getProjectAuthorityTransfer'
+  | 'getTransferredMembershipClaim'
+  | 'requestLanToCloudTransfer';
+
+export type LanAuthorityTransferStagedOperation =
+  | 'acceptCloudToLanTransferTarget'
+  | 'confirmCloudToLanTargetActive'
+  | 'getProjectAuthorityTransfer'
+  | 'reportCloudToLanTargetStaged';
+
+type OperationRequest<Operation extends CollabAuthorityTransferOperation> =
+  CollabAuthorityTransferOperationMap[Operation]['request'];
+type OperationResponse<Operation extends CollabAuthorityTransferOperation> =
+  CollabAuthorityTransferOperationMap[Operation]['response'];
+type LanClaimTransferredMembershipRequest = Extract<
+  ClaimTransferredMembershipRequest,
+  { readonly credentialHash: string }
+>;
+
+export interface LanAuthorityTransferTrustedHost {
+  readonly caCertificatePem: string;
+  readonly caFingerprint: string;
+  readonly endpoint: string;
+  readonly projectId: CollabProjectId;
+}
+
+export interface LanAuthorityTransferClientOptions {
+  readonly timeoutMs?: number;
+}
+
+export interface LanAuthorityTransferOperationOptions {
+  readonly signal?: AbortSignal;
+  readonly timeoutMs?: number;
+}
+
+interface RequestAuthentication {
+  readonly authorization: string;
+}
+
+function clientError(
+  code:
+    | 'authentication-failed'
+    | 'cancelled'
+    | 'endpoint-unreachable'
+    | 'operation-failed'
+    | 'operation-timeout'
+    | 'protocol-payload-invalid'
+    | 'protocol-version-unsupported'
+    | 'tls-ca-mismatch'
+    | 'tls-untrusted',
+  reason: string,
+  safeContext: Readonly<Record<string, unknown>> = {},
+): CollabError {
+  return new CollabError({
+    code,
+    recoveryActions: code === 'cancelled' ? ['retry'] : ['retry', 'open-diagnostics'],
+    safeContext: { reason, ...safeContext },
+  });
+}
+
+function validateTimeout(timeoutMs: number): number {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw clientError('operation-failed', 'authority-transfer-timeout-invalid');
+  }
+  return Math.floor(timeoutMs);
+}
+
+function validateCredential(credential: string): void {
+  if (!MEMBER_CREDENTIAL_PATTERN.test(credential)) {
+    throw clientError('authentication-failed', 'authority-transfer-credential-invalid');
+  }
+  const decoded = Buffer.from(credential, 'base64url');
+  if (decoded.byteLength !== 32 || decoded.toString('base64url') !== credential) {
+    throw clientError('authentication-failed', 'authority-transfer-credential-invalid');
+  }
+}
+
+interface ValidatedTrust {
+  readonly caCertificatePem: string;
+  readonly endpoint: URL;
+}
+
+function validateTrust(trust: LanAuthorityTransferTrustedHost): ValidatedTrust {
+  if (!isCollabProjectId(trust.projectId)) {
+    throw clientError('operation-failed', 'authority-transfer-project-id-invalid');
+  }
+  const certificateBlocks = trust.caCertificatePem.match(
+    /-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/g,
+  );
+  const contentOutsideCertificate = trust.caCertificatePem.replace(
+    /-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/g,
+    '',
+  );
+  if (certificateBlocks?.length !== 1 || contentOutsideCertificate.trim().length > 0) {
+    throw clientError('tls-ca-mismatch', 'authority-transfer-ca-mismatch');
+  }
+  const caCertificatePem = `${certificateBlocks[0].trim()}\n`;
+  let certificate: X509Certificate;
+  try {
+    certificate = new X509Certificate(caCertificatePem);
+  } catch {
+    throw clientError('tls-untrusted', 'authority-transfer-ca-invalid');
+  }
+  if (
+    !certificate.ca
+    || !certificate.verify(certificate.publicKey)
+    || fingerprintCertificatePem(caCertificatePem) !== trust.caFingerprint
+  ) {
+    throw clientError('tls-ca-mismatch', 'authority-transfer-ca-mismatch');
+  }
+  let endpoint: URL;
+  try {
+    endpoint = new URL(trust.endpoint);
+  } catch {
+    throw clientError('operation-failed', 'authority-transfer-endpoint-invalid');
+  }
+  if (
+    endpoint.protocol !== 'https:'
+    || endpoint.username.length > 0
+    || endpoint.password.length > 0
+    || endpoint.pathname !== '/'
+    || endpoint.search.length > 0
+    || endpoint.hash.length > 0
+    || endpoint.port.length === 0
+  ) {
+    throw clientError('operation-failed', 'authority-transfer-endpoint-invalid');
+  }
+  return { caCertificatePem, endpoint };
+}
+
+function isTlsValidationError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException)?.code ?? '';
+  return code.includes('CERT')
+    || code.includes('TLS')
+    || code === 'DEPTH_ZERO_SELF_SIGNED_CERT'
+    || code === 'SELF_SIGNED_CERT_IN_CHAIN'
+    || code === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'
+    || code === 'ERR_TLS_CERT_ALTNAME_INVALID';
+}
+
+function record(value: unknown): Readonly<Record<string, unknown>> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Readonly<Record<string, unknown>>
+    : null;
+}
+
+function exactKeys(
+  value: Readonly<Record<string, unknown>>,
+  expected: readonly string[],
+): boolean {
+  const keys = Object.keys(value);
+  const set = new Set(expected);
+  return keys.length === expected.length && keys.every(key => set.has(key));
+}
+
+function responseVersionError(
+  envelope: Readonly<Record<string, unknown>>,
+): CollabError | null {
+  if (envelope.bindingVersion !== COLLAB_LAN_AUTHORITY_TRANSFER_BINDING_VERSION) {
+    return clientError(
+      'protocol-version-unsupported',
+      'authority-transfer-binding-version-unsupported',
+      {
+        receivedVersion: typeof envelope.bindingVersion === 'number'
+          ? envelope.bindingVersion
+          : 0,
+        supportedVersion: COLLAB_LAN_AUTHORITY_TRANSFER_BINDING_VERSION,
+      },
+    );
+  }
+  if (envelope.protocolVersion !== COLLAB_PROTOCOL_VERSION) {
+    return clientError(
+      'protocol-version-unsupported',
+      'authority-transfer-protocol-version-unsupported',
+      {
+        receivedVersion: typeof envelope.protocolVersion === 'number'
+          ? envelope.protocolVersion
+          : 0,
+        supportedVersion: COLLAB_PROTOCOL_VERSION,
+      },
+    );
+  }
+  return null;
+}
+
+function decodeErrorEnvelope(
+  value: unknown,
+  requestId: string,
+): CollabError | null {
+  const envelope = record(value);
+  if (!envelope) return null;
+  const versionError = responseVersionError(envelope);
+  if (versionError) return versionError;
+  if (
+    !exactKeys(envelope, [
+      'bindingVersion',
+      'error',
+      'protocolVersion',
+      'requestId',
+    ])
+    || typeof envelope.requestId !== 'string'
+    || !REQUEST_ID_PATTERN.test(envelope.requestId)
+    || envelope.requestId !== requestId
+  ) return null;
+  const error = record(envelope.error);
+  if (
+    !error
+    || typeof error.code !== 'string'
+    || !SHARED_ERROR_CODE_SET.has(error.code)
+  ) return null;
+  const safeContext = record(error.safeContext) ?? {};
+  const recoveryActions = Array.isArray(error.recoveryActions)
+    ? error.recoveryActions.filter(
+      (action): action is SharedCollabRecoveryAction => (
+        typeof action === 'string' && SHARED_RECOVERY_ACTION_SET.has(action)
+      ),
+    )
+    : [];
+  return new CollabError({
+    code: error.code as SharedCollabErrorCode,
+    recoveryActions,
+    safeContext,
+  });
+}
+
+function statusError(statusCode: number): CollabError {
+  if (statusCode === 401) {
+    return clientError('authentication-failed', 'authority-transfer-authentication-failed');
+  }
+  if (statusCode === 404) {
+    return clientError('operation-failed', 'authority-transfer-route-not-found');
+  }
+  if (statusCode === 408 || statusCode === 504) {
+    return clientError('operation-timeout', 'authority-transfer-request-timeout');
+  }
+  if (statusCode === 426) {
+    return clientError(
+      'protocol-version-unsupported',
+      'authority-transfer-binding-version-unsupported',
+    );
+  }
+  return clientError('operation-failed', 'authority-transfer-request-rejected');
+}
+
+export class LanAuthorityTransferClient {
+  private readonly caCertificatePem: string;
+  private readonly defaultTimeoutMs: number;
+  private readonly endpoint: URL;
+
+  constructor(
+    private readonly trust: LanAuthorityTransferTrustedHost,
+    options: LanAuthorityTransferClientOptions = {},
+  ) {
+    const validatedTrust = validateTrust(trust);
+    this.caCertificatePem = validatedTrust.caCertificatePem;
+    this.endpoint = validatedTrust.endpoint;
+    this.defaultTimeoutMs = validateTimeout(options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  }
+
+  requestWithMember<Operation extends LanAuthorityTransferMemberOperation>(
+    operation: Operation,
+    request: OperationRequest<Operation>,
+    memberCredential: string,
+    options: LanAuthorityTransferOperationOptions = {},
+  ): Promise<OperationResponse<Operation>> {
+    validateCredential(memberCredential);
+    return this.request(operation, request, {
+      authorization: `Bearer ${memberCredential}`,
+    }, options);
+  }
+
+  requestWithTransferCredential<Operation extends LanAuthorityTransferStagedOperation>(
+    operation: Operation,
+    request: OperationRequest<Operation>,
+    transferCredential: string,
+    options: LanAuthorityTransferOperationOptions = {},
+  ): Promise<OperationResponse<Operation>> {
+    validateCredential(transferCredential);
+    return this.request(operation, request, {
+      authorization: `Claudian-Authority-Transfer ${transferCredential}`,
+    }, options);
+  }
+
+  claimTransferredMembership(
+    request: LanClaimTransferredMembershipRequest,
+    options: LanAuthorityTransferOperationOptions = {},
+  ): Promise<OperationResponse<'claimTransferredMembership'>> {
+    return this.request('claimTransferredMembership', request, {
+      authorization: `Claudian-Transfer-Claim ${request.claim}`,
+    }, options);
+  }
+
+  private async request<Operation extends CollabAuthorityTransferOperation>(
+    operation: Operation,
+    request: OperationRequest<Operation>,
+    authentication: RequestAuthentication,
+    options: LanAuthorityTransferOperationOptions,
+  ): Promise<OperationResponse<Operation>> {
+    if (options.signal?.aborted) {
+      throw clientError('cancelled', 'authority-transfer-request-cancelled');
+    }
+    let decodedRequest: OperationRequest<Operation>;
+    try {
+      decodedRequest = decodeCollabAuthorityTransferOperationRequest(
+        operation,
+        request,
+      );
+    } catch {
+      throw clientError('protocol-payload-invalid', 'authority-transfer-request-invalid');
+    }
+    if (decodedRequest.projectId !== this.trust.projectId) {
+      throw clientError('operation-failed', 'authority-transfer-project-mismatch');
+    }
+    const body = Buffer.from(JSON.stringify(decodedRequest), 'utf8');
+    if (body.byteLength > COLLAB_LIMITS.maxJsonPayloadUtf8Bytes) {
+      throw clientError('protocol-payload-invalid', 'authority-transfer-request-too-large');
+    }
+    const timeoutMs = validateTimeout(options.timeoutMs ?? this.defaultTimeoutMs);
+    const requestId = randomUUID();
+    const path = collabLanAuthorityTransferOperationPath(
+      this.trust.projectId,
+      operation,
+    );
+    const responseValue = await new Promise<unknown>((resolve, reject) => {
+      let settled = false;
+      const finish = (action: () => void) => {
+        if (settled) return;
+        settled = true;
+        window.clearTimeout(timer);
+        options.signal?.removeEventListener('abort', onAbort);
+        action();
+      };
+      const outgoing = httpsRequest({
+        ca: this.caCertificatePem,
+        headers: {
+          accept: 'application/json',
+          authorization: authentication.authorization,
+          'content-length': String(body.byteLength),
+          'content-type': 'application/json',
+          'x-request-id': requestId,
+        },
+        hostname: this.endpoint.hostname,
+        method: 'POST',
+        minVersion: 'TLSv1.2',
+        path,
+        port: Number(this.endpoint.port),
+        rejectUnauthorized: true,
+      }, incoming => {
+        const chunks: Buffer[] = [];
+        let observed = 0;
+        incoming.on('data', chunk => {
+          const bytes = Buffer.from(chunk as Uint8Array);
+          observed += bytes.byteLength;
+          if (observed > COLLAB_LIMITS.maxJsonPayloadUtf8Bytes) {
+            incoming.destroy();
+            finish(() => reject(clientError(
+              'protocol-payload-invalid',
+              'authority-transfer-response-too-large',
+            )));
+            return;
+          }
+          chunks.push(bytes);
+        });
+        incoming.once('error', () => finish(() => reject(clientError(
+          'endpoint-unreachable',
+          'authority-transfer-response-failed',
+        ))));
+        incoming.once('end', () => {
+          if (settled) return;
+          const statusCode = incoming.statusCode ?? 0;
+          const contentType = incoming.headers['content-type'];
+          if (
+            typeof contentType !== 'string'
+            || !/^application\/json(?:\s*;|$)/i.test(contentType)
+          ) {
+            finish(() => reject(clientError(
+              'protocol-payload-invalid',
+              'authority-transfer-response-content-type-invalid',
+            )));
+            return;
+          }
+          try {
+            const value = JSON.parse(
+              Buffer.concat(chunks).toString('utf8'),
+            ) as unknown;
+            if (statusCode !== 200) {
+              finish(() => reject(
+                decodeErrorEnvelope(value, requestId) ?? statusError(statusCode),
+              ));
+              return;
+            }
+            finish(() => resolve(value));
+          } catch {
+            finish(() => reject(
+              statusCode === 200
+                ? clientError(
+                  'protocol-payload-invalid',
+                  'authority-transfer-response-json-invalid',
+                )
+                : statusError(statusCode),
+            ));
+          }
+        });
+      });
+      const onAbort = () => finish(() => {
+        outgoing.destroy();
+        reject(clientError('cancelled', 'authority-transfer-request-cancelled'));
+      });
+      const timer = window.setTimeout(() => finish(() => {
+        outgoing.destroy();
+        reject(clientError('operation-timeout', 'authority-transfer-request-timeout'));
+      }), timeoutMs);
+      options.signal?.addEventListener('abort', onAbort, { once: true });
+      outgoing.once('error', error => finish(() => reject(clientError(
+        isTlsValidationError(error) ? 'tls-untrusted' : 'endpoint-unreachable',
+        isTlsValidationError(error)
+          ? 'authority-transfer-tls-validation-failed'
+          : 'authority-transfer-connection-failed',
+      ))));
+      if (options.signal?.aborted) {
+        onAbort();
+        return;
+      }
+      outgoing.end(body);
+    });
+    const envelope = record(responseValue);
+    if (!envelope) {
+      throw clientError('protocol-payload-invalid', 'authority-transfer-response-invalid');
+    }
+    const versionError = responseVersionError(envelope);
+    if (versionError) throw versionError;
+    if (
+      !exactKeys(envelope, [
+        'bindingVersion',
+        'data',
+        'protocolVersion',
+        'requestId',
+      ])
+      || typeof envelope.requestId !== 'string'
+      || !REQUEST_ID_PATTERN.test(envelope.requestId)
+      || envelope.requestId !== requestId
+    ) {
+      throw clientError('protocol-payload-invalid', 'authority-transfer-response-invalid');
+    }
+    let decodedResponse: OperationResponse<Operation>;
+    try {
+      decodedResponse = decodeCollabAuthorityTransferOperationResponse(
+        operation,
+        envelope.data,
+      );
+    } catch {
+      throw clientError('protocol-payload-invalid', 'authority-transfer-response-invalid');
+    }
+    if (
+      decodedResponse.projectId !== this.trust.projectId
+      || (
+        'transferId' in decodedRequest
+        && decodedResponse.transferId !== decodedRequest.transferId
+      )
+    ) {
+      throw clientError('protocol-payload-invalid', 'authority-transfer-response-mismatch');
+    }
+    return decodedResponse;
+  }
+}

--- a/src/app/collab/lan/authority-transfer/LanAuthorityTransferRouter.ts
+++ b/src/app/collab/lan/authority-transfer/LanAuthorityTransferRouter.ts
@@ -1,0 +1,646 @@
+import { createHash, randomUUID, timingSafeEqual } from 'node:crypto';
+import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from 'node:http';
+
+import {
+  type AcceptCloudToLanTransferTargetRequest,
+  type AcceptLanToCloudTransferTargetRequest,
+  type AcknowledgeTransferredMembershipClaimRedemptionRequest,
+  type CancelProjectAuthorityTransferRequest,
+  type ClaimTransferredMembershipRequest,
+  COLLAB_LIMITS,
+  COLLAB_PROTOCOL_VERSION,
+  type CollabAuthorityTransferOperation,
+  type CollabAuthorityTransferOperationMap,
+  type CollabMemberId,
+  type CollabProjectId,
+  type ConfirmCloudToLanTargetActiveRequest,
+  decodeCollabAuthorityTransferOperationRequest,
+  decodeCollabAuthorityTransferOperationResponse,
+  type GetProjectAuthorityTransferRequest,
+  type GetTransferredMembershipClaimRequest,
+  isCollabMemberId,
+  type ReportCloudToLanTargetStagedRequest,
+  type RequestLanToCloudTransferRequest,
+} from '@claudian-collab/protocol';
+
+import {
+  COLLAB_LAN_AUTHORITY_TRANSFER_BINDING_VERSION,
+  matchCollabLanAuthorityTransferRoute,
+} from '@/app/collab/lan/authority-transfer/LanAuthorityTransferBinding';
+import { CollabError } from '@/core/collab/ClaudianCollabError';
+
+const REQUEST_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const MEMBER_CREDENTIAL_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+export interface LanAuthorityTransferActor {
+  readonly memberId: CollabMemberId;
+}
+
+export interface LanAuthorityTransferMemberAuthenticator {
+  authenticateMemberCredential(
+    credential: string,
+  ): Promise<LanAuthorityTransferActor>;
+}
+
+type OperationRequest<Operation extends CollabAuthorityTransferOperation> =
+  CollabAuthorityTransferOperationMap[Operation]['request'];
+type OperationResponse<Operation extends CollabAuthorityTransferOperation> =
+  CollabAuthorityTransferOperationMap[Operation]['response'];
+type LanClaimTransferredMembershipRequest = Extract<
+  ClaimTransferredMembershipRequest,
+  { readonly credentialHash: string }
+>;
+
+export interface LanAuthorityTransferSourceActiveService
+  extends LanAuthorityTransferMemberAuthenticator {
+  requestLanToCloudTransfer(
+    actor: LanAuthorityTransferActor,
+    request: RequestLanToCloudTransferRequest,
+  ): Promise<OperationResponse<'requestLanToCloudTransfer'>>;
+  acceptLanToCloudTransferTarget(
+    actor: LanAuthorityTransferActor,
+    request: AcceptLanToCloudTransferTargetRequest,
+  ): Promise<OperationResponse<'acceptLanToCloudTransferTarget'>>;
+  getProjectAuthorityTransfer(
+    actor: LanAuthorityTransferActor,
+    request: GetProjectAuthorityTransferRequest,
+  ): Promise<OperationResponse<'getProjectAuthorityTransfer'>>;
+  cancelProjectAuthorityTransfer(
+    actor: LanAuthorityTransferActor,
+    request: CancelProjectAuthorityTransferRequest,
+  ): Promise<OperationResponse<'cancelProjectAuthorityTransfer'>>;
+}
+
+export interface LanAuthorityTransferTargetStagedService {
+  acceptCloudToLanTransferTarget(
+    request: AcceptCloudToLanTransferTargetRequest,
+  ): Promise<OperationResponse<'acceptCloudToLanTransferTarget'>>;
+  getProjectAuthorityTransfer(
+    request: GetProjectAuthorityTransferRequest,
+  ): Promise<OperationResponse<'getProjectAuthorityTransfer'>>;
+  reportCloudToLanTargetStaged(
+    request: ReportCloudToLanTargetStagedRequest,
+  ): Promise<OperationResponse<'reportCloudToLanTargetStaged'>>;
+  confirmCloudToLanTargetActive(
+    request: ConfirmCloudToLanTargetActiveRequest,
+  ): Promise<OperationResponse<'confirmCloudToLanTargetActive'>>;
+}
+
+export interface LanAuthorityTransferTargetActiveService {
+  claimTransferredMembership(
+    request: LanClaimTransferredMembershipRequest,
+  ): Promise<OperationResponse<'claimTransferredMembership'>>;
+}
+
+export interface LanAuthorityTransferTerminalSourceService
+  extends LanAuthorityTransferMemberAuthenticator {
+  getProjectAuthorityTransfer(
+    actor: LanAuthorityTransferActor,
+    request: GetProjectAuthorityTransferRequest,
+  ): Promise<OperationResponse<'getProjectAuthorityTransfer'>>;
+  getTransferredMembershipClaim(
+    actor: LanAuthorityTransferActor,
+    request: GetTransferredMembershipClaimRequest,
+  ): Promise<OperationResponse<'getTransferredMembershipClaim'>>;
+  acknowledgeTransferredMembershipClaimRedemption(
+    actor: LanAuthorityTransferActor,
+    request: AcknowledgeTransferredMembershipClaimRedemptionRequest,
+  ): Promise<OperationResponse<'acknowledgeTransferredMembershipClaimRedemption'>>;
+}
+
+interface RouteRegistrationBase {
+  readonly projectId: CollabProjectId;
+}
+
+export interface LanAuthorityTransferSourceActiveRegistration
+  extends RouteRegistrationBase {
+  readonly hostMemberId: CollabMemberId;
+  readonly service: LanAuthorityTransferSourceActiveService;
+  readonly state: 'source-active';
+}
+
+export interface LanAuthorityTransferTargetOnlyStagedRegistration
+  extends RouteRegistrationBase {
+  readonly credentialHash: string;
+  readonly service: LanAuthorityTransferTargetStagedService;
+  readonly state: 'target-only-staged';
+  readonly transferId: string;
+}
+
+export interface LanAuthorityTransferTargetActiveRegistration
+  extends RouteRegistrationBase {
+  readonly service: LanAuthorityTransferTargetActiveService;
+  readonly state: 'target-active';
+  readonly transferId: string;
+}
+
+export interface LanAuthorityTransferTerminalSourceRegistration
+  extends RouteRegistrationBase {
+  readonly service: LanAuthorityTransferTerminalSourceService;
+  readonly state: 'terminal-source';
+}
+
+export type LanAuthorityTransferRouteRegistration =
+  | LanAuthorityTransferSourceActiveRegistration
+  | LanAuthorityTransferTargetOnlyStagedRegistration
+  | LanAuthorityTransferTargetActiveRegistration
+  | LanAuthorityTransferTerminalSourceRegistration;
+
+export type LanAuthorityTransferRouteAdmissionResult<T> =
+  | { readonly admitted: false }
+  | { readonly admitted: true; readonly value: T };
+
+export interface LanAuthorityTransferRouteAccess {
+  resolve(
+    projectId: CollabProjectId,
+  ): LanAuthorityTransferRouteRegistration | null;
+
+  /**
+   * The lifecycle owner rechecks the exact registration and holds its Project
+   * replacement lane for the full callback. A state transition closes and
+   * drains this same lane before replacing the registration.
+   */
+  runIfCurrent<T>(
+    projectId: CollabProjectId,
+    expected: LanAuthorityTransferRouteRegistration,
+    operation: () => Promise<T>,
+  ): Promise<LanAuthorityTransferRouteAdmissionResult<T>>;
+}
+
+function routeError(
+  code:
+    | 'authentication-failed'
+    | 'authorization-denied'
+    | 'operation-failed'
+    | 'project-not-found'
+    | 'protocol-payload-invalid'
+    | 'protocol-version-unsupported',
+  reason: string,
+  safeContext: Readonly<Record<string, unknown>> = {},
+): CollabError {
+  return new CollabError({ code, safeContext: { reason, ...safeContext } });
+}
+
+function validateCanonicalCredential(credential: string, reason: string): Buffer {
+  if (!MEMBER_CREDENTIAL_PATTERN.test(credential)) {
+    throw routeError('authentication-failed', reason);
+  }
+  const decoded = Buffer.from(credential, 'base64url');
+  if (decoded.byteLength !== 32 || decoded.toString('base64url') !== credential) {
+    throw routeError('authentication-failed', reason);
+  }
+  return decoded;
+}
+
+function transferCredentialHash(credential: string): Buffer {
+  return createHash('sha256')
+    .update(validateCanonicalCredential(
+      credential,
+      'authority-transfer-credential-invalid',
+    ))
+    .digest();
+}
+
+function decodeCredentialHash(value: string): Buffer {
+  if (!/^[0-9a-f]{64}$/.test(value)) {
+    throw routeError('operation-failed', 'authority-transfer-credential-hash-invalid');
+  }
+  return Buffer.from(value, 'hex');
+}
+
+function singleHeader(headers: IncomingHttpHeaders, name: string): string | null {
+  const value = headers[name];
+  return typeof value === 'string' ? value : null;
+}
+
+function requestId(headers: IncomingHttpHeaders): string {
+  const supplied = singleHeader(headers, 'x-request-id');
+  return supplied && REQUEST_ID_PATTERN.test(supplied) ? supplied : randomUUID();
+}
+
+async function readRequestBody(request: IncomingMessage): Promise<Buffer> {
+  const contentType = singleHeader(request.headers, 'content-type');
+  if (
+    contentType === null
+    || !/^application\/json(?:\s*;\s*charset=utf-8)?$/i.test(contentType)
+  ) {
+    request.resume();
+    throw routeError(
+      'protocol-payload-invalid',
+      'authority-transfer-request-content-type-invalid',
+    );
+  }
+  const declared = singleHeader(request.headers, 'content-length');
+  if (declared !== null && Number(declared) > COLLAB_LIMITS.maxJsonPayloadUtf8Bytes) {
+    request.resume();
+    throw routeError(
+      'protocol-payload-invalid',
+      'authority-transfer-request-too-large',
+    );
+  }
+  const chunks: Buffer[] = [];
+  let observed = 0;
+  for await (const chunk of request) {
+    const bytes = Buffer.from(chunk as Uint8Array);
+    observed += bytes.byteLength;
+    if (observed > COLLAB_LIMITS.maxJsonPayloadUtf8Bytes) {
+      throw routeError(
+        'protocol-payload-invalid',
+        'authority-transfer-request-too-large',
+      );
+    }
+    chunks.push(bytes);
+  }
+  if (chunks.length === 0) {
+    throw routeError('protocol-payload-invalid', 'authority-transfer-request-body-missing');
+  }
+  return Buffer.concat(chunks);
+}
+
+function parseJsonBody(bytes: Buffer): unknown {
+  try {
+    return JSON.parse(bytes.toString('utf8')) as unknown;
+  } catch {
+    throw routeError('protocol-payload-invalid', 'authority-transfer-request-json-invalid');
+  }
+}
+
+function statusForError(error: CollabError): number {
+  if (error.safeContext.reason === 'authority-transfer-request-too-large') return 413;
+  switch (error.code) {
+    case 'authentication-failed':
+    case 'membership-claim-invalid': return 401;
+    case 'authorization-denied': return 403;
+    case 'project-not-found':
+    case 'authority-transfer-not-found': return 404;
+    case 'protocol-version-unsupported': return 426;
+    case 'authority-transfer-stale':
+    case 'authority-transfer-cancellation-forbidden':
+    case 'idempotency-conflict':
+    case 'membership-claim-already-redeemed': return 409;
+    case 'membership-claim-expired':
+    case 'membership-claim-revoked': return 410;
+    case 'operation-timeout': return 408;
+    case 'protocol-payload-invalid': return 400;
+    default: return 500;
+  }
+}
+
+function asCollabError(error: unknown): CollabError {
+  return error instanceof CollabError
+    ? error
+    : routeError('operation-failed', 'authority-transfer-route-failed');
+}
+
+function writeJson(
+  response: ServerResponse,
+  statusCode: number,
+  requestIdValue: string,
+  payload: Readonly<Record<string, unknown>>,
+): void {
+  if (response.headersSent || response.destroyed) return;
+  let bytes = Buffer.from(JSON.stringify({
+    bindingVersion: COLLAB_LAN_AUTHORITY_TRANSFER_BINDING_VERSION,
+    ...payload,
+    protocolVersion: COLLAB_PROTOCOL_VERSION,
+    requestId: requestIdValue,
+  }), 'utf8');
+  if (bytes.byteLength > COLLAB_LIMITS.maxJsonPayloadUtf8Bytes) {
+    statusCode = 500;
+    bytes = Buffer.from(JSON.stringify({
+      bindingVersion: COLLAB_LAN_AUTHORITY_TRANSFER_BINDING_VERSION,
+      error: routeError(
+        'operation-failed',
+        'authority-transfer-response-too-large',
+      ).toJSON(),
+      protocolVersion: COLLAB_PROTOCOL_VERSION,
+      requestId: requestIdValue,
+    }), 'utf8');
+  }
+  response.writeHead(statusCode, {
+    'cache-control': 'no-store',
+    'content-length': String(bytes.byteLength),
+    'content-type': 'application/json; charset=utf-8',
+    'x-content-type-options': 'nosniff',
+    'x-request-id': requestIdValue,
+  });
+  response.end(bytes);
+}
+
+function isOperationAllowed(
+  registration: LanAuthorityTransferRouteRegistration,
+  operation: CollabAuthorityTransferOperation,
+): boolean {
+  switch (registration.state) {
+    case 'source-active':
+      return operation === 'requestLanToCloudTransfer'
+        || operation === 'acceptLanToCloudTransferTarget'
+        || operation === 'getProjectAuthorityTransfer'
+        || operation === 'cancelProjectAuthorityTransfer';
+    case 'target-only-staged':
+      return operation === 'acceptCloudToLanTransferTarget'
+        || operation === 'getProjectAuthorityTransfer'
+        || operation === 'reportCloudToLanTargetStaged'
+        || operation === 'confirmCloudToLanTargetActive';
+    case 'target-active':
+      return operation === 'claimTransferredMembership';
+    case 'terminal-source':
+      return operation === 'getProjectAuthorityTransfer'
+        || operation === 'getTransferredMembershipClaim'
+        || operation === 'acknowledgeTransferredMembershipClaimRedemption';
+  }
+}
+
+function bearerCredential(request: IncomingMessage): string {
+  const authorization = singleHeader(request.headers, 'authorization');
+  const match = authorization
+    ? /^Bearer ([A-Za-z0-9_-]{43})$/.exec(authorization)
+    : null;
+  if (!match) {
+    throw routeError('authentication-failed', 'authority-transfer-authentication-failed');
+  }
+  validateCanonicalCredential(
+    match[1],
+    'authority-transfer-authentication-failed',
+  );
+  return match[1];
+}
+
+function requireTransferCredential(
+  request: IncomingMessage,
+  registration: LanAuthorityTransferTargetOnlyStagedRegistration,
+): void {
+  const authorization = singleHeader(request.headers, 'authorization');
+  const match = authorization
+    ? /^Claudian-Authority-Transfer ([A-Za-z0-9_-]{43})$/.exec(authorization)
+    : null;
+  if (!match) {
+    throw routeError('authentication-failed', 'authority-transfer-authentication-failed');
+  }
+  let actual: Buffer;
+  try {
+    actual = transferCredentialHash(match[1]);
+  } catch {
+    throw routeError('authentication-failed', 'authority-transfer-authentication-failed');
+  }
+  const expected = decodeCredentialHash(registration.credentialHash);
+  if (!timingSafeEqual(actual, expected)) {
+    throw routeError('authentication-failed', 'authority-transfer-authentication-failed');
+  }
+}
+
+function requireLanClaimRequest(
+  request: IncomingMessage,
+  operation: CollabAuthorityTransferOperation,
+  body: Buffer,
+): LanClaimTransferredMembershipRequest {
+  const authorization = singleHeader(request.headers, 'authorization');
+  const match = authorization
+    ? /^Claudian-Transfer-Claim ([A-Za-z0-9_-]+)$/.exec(authorization)
+    : null;
+  if (!match || operation !== 'claimTransferredMembership') {
+    throw routeError('authentication-failed', 'authority-transfer-authentication-failed');
+  }
+  let decoded: ClaimTransferredMembershipRequest;
+  try {
+    decoded = decodeCollabAuthorityTransferOperationRequest(
+      'claimTransferredMembership',
+      parseJsonBody(body),
+    );
+  } catch {
+    throw routeError('authentication-failed', 'authority-transfer-authentication-failed');
+  }
+  if (
+    !('credentialHash' in decoded)
+    || typeof decoded.credentialHash !== 'string'
+  ) {
+    throw routeError('authentication-failed', 'authority-transfer-authentication-failed');
+  }
+  if (
+    !BASE64URL_PATTERN.test(decoded.claim)
+    || match[1].length !== decoded.claim.length
+    || !timingSafeEqual(Buffer.from(match[1]), Buffer.from(decoded.claim))
+  ) {
+    throw routeError('authentication-failed', 'authority-transfer-authentication-failed');
+  }
+  return decoded;
+}
+
+export class LanAuthorityTransferRouter {
+  constructor(private readonly routes: LanAuthorityTransferRouteAccess) {}
+
+  async handle(request: IncomingMessage, response: ServerResponse): Promise<boolean> {
+    const route = matchCollabLanAuthorityTransferRoute(request.method, request.url);
+    if (!route) return false;
+    const requestIdValue = requestId(request.headers);
+    try {
+      if (route.version !== COLLAB_LAN_AUTHORITY_TRANSFER_BINDING_VERSION) {
+        request.resume();
+        throw routeError(
+          'protocol-version-unsupported',
+          'authority-transfer-binding-version-unsupported',
+          {
+            receivedVersion: route.version,
+            supportedVersion: COLLAB_LAN_AUTHORITY_TRANSFER_BINDING_VERSION,
+          },
+        );
+      }
+      const body = await readRequestBody(request);
+      const registration = this.routes.resolve(route.projectId);
+      if (
+        !registration
+        || registration.projectId !== route.projectId
+      ) {
+        throw routeError(
+          'authentication-failed',
+          'authority-transfer-authentication-failed',
+        );
+      }
+      const admission = await this.routes.runIfCurrent(
+        route.projectId,
+        registration,
+        async () => {
+          let actor: LanAuthorityTransferActor | null = null;
+          let lanClaimRequest: LanClaimTransferredMembershipRequest | null = null;
+          if (
+            registration.state === 'source-active'
+            || registration.state === 'terminal-source'
+          ) {
+            try {
+              actor = await registration.service.authenticateMemberCredential(
+                bearerCredential(request),
+              );
+            } catch {
+              throw routeError(
+                'authentication-failed',
+                'authority-transfer-authentication-failed',
+              );
+            }
+            if (!isCollabMemberId(actor.memberId)) {
+              throw routeError(
+                'authentication-failed',
+                'authority-transfer-authentication-failed',
+              );
+            }
+          } else if (registration.state === 'target-only-staged') {
+            requireTransferCredential(request, registration);
+          } else {
+            lanClaimRequest = requireLanClaimRequest(
+              request,
+              route.operation,
+              body,
+            );
+          }
+          if (!isOperationAllowed(registration, route.operation)) {
+            throw routeError('project-not-found', 'authority-transfer-route-not-found');
+          }
+          const decoded = lanClaimRequest
+            ?? decodeCollabAuthorityTransferOperationRequest(
+              route.operation,
+              parseJsonBody(body),
+            );
+          if (decoded.projectId !== registration.projectId) {
+            throw routeError('project-not-found', 'authority-transfer-project-mismatch');
+          }
+          if (
+            (registration.state === 'target-only-staged'
+              || registration.state === 'target-active')
+            && (
+              !('transferId' in decoded)
+              || decoded.transferId !== registration.transferId
+            )
+          ) {
+            throw routeError('project-not-found', 'authority-transfer-route-not-found');
+          }
+          const result = await this.dispatch(
+            registration,
+            route.operation,
+            decoded,
+            actor,
+            lanClaimRequest,
+          );
+          const decodedResponse = decodeCollabAuthorityTransferOperationResponse(
+            route.operation,
+            result,
+          );
+          if (
+            decodedResponse.projectId !== decoded.projectId
+            || (
+              'transferId' in decoded
+              && decodedResponse.transferId !== decoded.transferId
+            )
+          ) {
+            throw routeError('operation-failed', 'authority-transfer-response-mismatch');
+          }
+          return decodedResponse;
+        },
+      );
+      if (!admission.admitted) {
+        throw routeError(
+          'authentication-failed',
+          'authority-transfer-authentication-failed',
+        );
+      }
+      writeJson(response, 200, requestIdValue, { data: admission.value });
+    } catch (error) {
+      const collabError = asCollabError(error);
+      writeJson(response, statusForError(collabError), requestIdValue, {
+        error: collabError.toJSON(),
+      });
+    }
+    return true;
+  }
+
+  private dispatch(
+    registration: LanAuthorityTransferRouteRegistration,
+    operation: CollabAuthorityTransferOperation,
+    request: OperationRequest<CollabAuthorityTransferOperation>,
+    actor: LanAuthorityTransferActor | null,
+    lanClaimRequest: LanClaimTransferredMembershipRequest | null,
+  ): Promise<unknown> {
+    switch (registration.state) {
+      case 'source-active': {
+        const authenticated = actor!;
+        switch (operation) {
+          case 'requestLanToCloudTransfer':
+            return registration.service.requestLanToCloudTransfer(
+              authenticated,
+              request as RequestLanToCloudTransferRequest,
+            );
+          case 'acceptLanToCloudTransferTarget':
+            if (authenticated.memberId !== registration.hostMemberId) {
+              throw routeError('authorization-denied', 'authority-transfer-host-required');
+            }
+            return registration.service.acceptLanToCloudTransferTarget(
+              authenticated,
+              request as AcceptLanToCloudTransferTargetRequest,
+            );
+          case 'getProjectAuthorityTransfer':
+            return registration.service.getProjectAuthorityTransfer(
+              authenticated,
+              request as GetProjectAuthorityTransferRequest,
+            );
+          case 'cancelProjectAuthorityTransfer':
+            return registration.service.cancelProjectAuthorityTransfer(
+              authenticated,
+              request as CancelProjectAuthorityTransferRequest,
+            );
+          default: break;
+        }
+        break;
+      }
+      case 'target-only-staged':
+        switch (operation) {
+          case 'acceptCloudToLanTransferTarget':
+            return registration.service.acceptCloudToLanTransferTarget(
+              request as AcceptCloudToLanTransferTargetRequest,
+            );
+          case 'getProjectAuthorityTransfer':
+            return registration.service.getProjectAuthorityTransfer(
+              request as GetProjectAuthorityTransferRequest,
+            );
+          case 'reportCloudToLanTargetStaged':
+            return registration.service.reportCloudToLanTargetStaged(
+              request as ReportCloudToLanTargetStagedRequest,
+            );
+          case 'confirmCloudToLanTargetActive':
+            return registration.service.confirmCloudToLanTargetActive(
+              request as ConfirmCloudToLanTargetActiveRequest,
+            );
+          default: break;
+        }
+        break;
+      case 'target-active':
+        if (operation === 'claimTransferredMembership' && lanClaimRequest) {
+          return registration.service.claimTransferredMembership(
+            lanClaimRequest,
+          );
+        }
+        break;
+      case 'terminal-source': {
+        const authenticated = actor!;
+        switch (operation) {
+          case 'getProjectAuthorityTransfer':
+            return registration.service.getProjectAuthorityTransfer(
+              authenticated,
+              request as GetProjectAuthorityTransferRequest,
+            );
+          case 'getTransferredMembershipClaim':
+            return registration.service.getTransferredMembershipClaim(
+              authenticated,
+              request as GetTransferredMembershipClaimRequest,
+            );
+          case 'acknowledgeTransferredMembershipClaimRedemption':
+            return registration.service.acknowledgeTransferredMembershipClaimRedemption(
+              authenticated,
+              request as AcknowledgeTransferredMembershipClaimRedemptionRequest,
+            );
+          default: break;
+        }
+        break;
+      }
+    }
+    throw routeError('project-not-found', 'authority-transfer-route-not-found');
+  }
+}

--- a/tests/integration/app/collab/lan/authority-transfer/LanAuthorityTransferClient.test.ts
+++ b/tests/integration/app/collab/lan/authority-transfer/LanAuthorityTransferClient.test.ts
@@ -1,0 +1,203 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { createServer, type Server } from 'node:https';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import type { CollabAuthorityTransferStatus } from '@claudian-collab/protocol';
+
+import { LanAuthorityTransferClient } from '@/app/collab/lan/authority-transfer/LanAuthorityTransferClient';
+import {
+  LanAuthorityTransferRouter,
+  type LanAuthorityTransferRouteRegistration,
+  type LanAuthorityTransferSourceActiveService,
+} from '@/app/collab/lan/authority-transfer/LanAuthorityTransferRouter';
+import { LanTlsIdentity } from '@/app/collab/lan/LanTlsIdentity';
+import { CollabError } from '@/core/collab/ClaudianCollabError';
+
+const PROJECT_ID = 'project-alpha';
+const HOST_MEMBER_ID = 'member-host';
+const MEMBER_CREDENTIAL = Buffer.alloc(32, 8).toString('base64url');
+
+function status(): CollabAuthorityTransferStatus {
+  return {
+    batchRevision: null,
+    batchSha256: null,
+    checkpointSha256: null,
+    createdAt: '2026-08-26T00:00:00.000Z',
+    direction: 'lan-to-cloud',
+    expiresAt: '2026-09-25T00:00:00.000Z',
+    phase: 'collecting-readiness',
+    projectId: PROJECT_ID,
+    relinquishmentProof: null,
+    sourceAuthority: { generation: 1, kind: 'lan' },
+    state: 'active',
+    targetAuthority: { generation: 2, kind: 'cloud' },
+    targetUrl: 'https://cloud.example.test',
+    transferId: 'transfer-alpha',
+    updatedAt: '2026-08-26T00:00:00.000Z',
+  };
+}
+
+describe('LanAuthorityTransferClient', () => {
+  let directory: string;
+  let server: Server;
+
+  afterEach(async () => {
+    await new Promise<void>(resolve => {
+      if (!server?.listening) return resolve();
+      server.close(() => resolve());
+      server.closeAllConnections();
+    });
+    if (directory) await rm(directory, { force: true, recursive: true });
+  });
+
+  it('uses pinned TLS, sends Member auth, decodes the independent envelope, and replays', async () => {
+    directory = await mkdtemp(path.join(tmpdir(), 'claudian-authority-transfer-client-'));
+    const identity = await new LanTlsIdentity(directory).issueServerIdentity('127.0.0.1');
+    const requestLanToCloudTransfer = jest.fn(async () => status());
+    const service: LanAuthorityTransferSourceActiveService = {
+      acceptLanToCloudTransferTarget: jest.fn(),
+      authenticateMemberCredential: jest.fn(async credential => {
+        if (credential !== MEMBER_CREDENTIAL) {
+          throw new CollabError({ code: 'authentication-failed' });
+        }
+        return { memberId: HOST_MEMBER_ID };
+      }),
+      cancelProjectAuthorityTransfer: jest.fn(),
+      getProjectAuthorityTransfer: jest.fn(),
+      requestLanToCloudTransfer,
+    };
+    const registration: LanAuthorityTransferRouteRegistration = {
+      hostMemberId: HOST_MEMBER_ID,
+      projectId: PROJECT_ID,
+      service,
+      state: 'source-active',
+    };
+    const router = new LanAuthorityTransferRouter({
+      resolve: projectId => projectId === PROJECT_ID ? registration : null,
+      runIfCurrent: async (projectId, expected, operation) => (
+        projectId === PROJECT_ID && registration === expected
+          ? { admitted: true, value: await operation() }
+          : { admitted: false }
+      ),
+    });
+    server = createServer({
+      cert: identity.certificateChainPem,
+      key: identity.privateKeyPem,
+    }, (request, response) => {
+      void router.handle(request, response).then(handled => {
+        if (!handled) {
+          response.statusCode = 404;
+          response.end();
+        }
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Missing server address');
+    const client = new LanAuthorityTransferClient({
+      caCertificatePem: identity.caCertificatePem,
+      caFingerprint: identity.caFingerprint,
+      endpoint: `https://127.0.0.1:${address.port}`,
+      projectId: PROJECT_ID,
+    });
+    const request = {
+      expectedAuthorityGeneration: 1,
+      idempotencyKey: 'intent-propose',
+      projectId: PROJECT_ID,
+      targetUrl: 'https://cloud.example.test',
+    } as const;
+
+    await expect(client.requestWithMember(
+      'requestLanToCloudTransfer',
+      request,
+      MEMBER_CREDENTIAL,
+    )).resolves.toEqual(status());
+    await expect(client.requestWithMember(
+      'requestLanToCloudTransfer',
+      request,
+      MEMBER_CREDENTIAL,
+    )).resolves.toEqual(status());
+    expect(requestLanToCloudTransfer).toHaveBeenCalledTimes(2);
+
+    requestLanToCloudTransfer.mockRejectedValueOnce(new CollabError({
+      code: 'authority-transfer-stale',
+      safeContext: { reason: 'authority-transfer-phase-stale' },
+    }));
+    await expect(client.requestWithMember(
+      'requestLanToCloudTransfer',
+      request,
+      MEMBER_CREDENTIAL,
+    )).rejects.toMatchObject({
+      code: 'authority-transfer-stale',
+      safeContext: { reason: 'authority-transfer-phase-stale' },
+    });
+  });
+
+  it('rejects an appended CA even when the pinned CA is first', async () => {
+    directory = await mkdtemp(path.join(tmpdir(), 'claudian-authority-transfer-ca-'));
+    const pinnedDirectory = path.join(directory, 'pinned');
+    const attackerDirectory = path.join(directory, 'attacker');
+    await Promise.all([
+      mkdir(pinnedDirectory),
+      mkdir(attackerDirectory),
+    ]);
+    const pinnedIdentity = await new LanTlsIdentity(
+      pinnedDirectory,
+    ).issueServerIdentity('127.0.0.1');
+    const attackerIdentity = await new LanTlsIdentity(
+      attackerDirectory,
+    ).issueServerIdentity('127.0.0.1');
+
+    expect(() => new LanAuthorityTransferClient({
+      caCertificatePem: `${pinnedIdentity.caCertificatePem}${attackerIdentity.caCertificatePem}`,
+      caFingerprint: pinnedIdentity.caFingerprint,
+      endpoint: 'https://127.0.0.1:443',
+      projectId: PROJECT_ID,
+    })).toThrow(expect.objectContaining({
+      code: 'tls-ca-mismatch',
+      safeContext: { reason: 'authority-transfer-ca-mismatch' },
+    }));
+  }, 20_000);
+
+  it('rejects a response with the wrong LAN binding version', async () => {
+    directory = await mkdtemp(path.join(tmpdir(), 'claudian-authority-transfer-version-'));
+    const identity = await new LanTlsIdentity(directory).issueServerIdentity('127.0.0.1');
+    server = createServer({
+      cert: identity.certificateChainPem,
+      key: identity.privateKeyPem,
+    }, (_request, response) => {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({
+        bindingVersion: 2,
+        data: status(),
+        protocolVersion: 6,
+        requestId: 'wrong-request',
+      }));
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Missing server address');
+    const client = new LanAuthorityTransferClient({
+      caCertificatePem: identity.caCertificatePem,
+      caFingerprint: identity.caFingerprint,
+      endpoint: `https://127.0.0.1:${address.port}`,
+      projectId: PROJECT_ID,
+    });
+
+    await expect(client.requestWithMember(
+      'getProjectAuthorityTransfer',
+      { projectId: PROJECT_ID, transferId: 'transfer-alpha' },
+      MEMBER_CREDENTIAL,
+    )).rejects.toMatchObject({
+      code: 'protocol-version-unsupported',
+      safeContext: { receivedVersion: 2, supportedVersion: 1 },
+    });
+  });
+});

--- a/tests/unit/app/collab/lan/authority-transfer/LanAuthorityTransferBinding.test.ts
+++ b/tests/unit/app/collab/lan/authority-transfer/LanAuthorityTransferBinding.test.ts
@@ -1,0 +1,49 @@
+import {
+  COLLAB_AUTHORITY_TRANSFER_OPERATIONS,
+} from '@claudian-collab/protocol';
+
+import {
+  COLLAB_LAN_AUTHORITY_TRANSFER_BINDING_VERSION,
+  collabLanAuthorityTransferOperationPath,
+  matchCollabLanAuthorityTransferRoute,
+} from '@/app/collab/lan/authority-transfer/LanAuthorityTransferBinding';
+
+describe('LAN authority-transfer binding', () => {
+  it('owns an independent version and round-trips every package operation', () => {
+    expect(COLLAB_LAN_AUTHORITY_TRANSFER_BINDING_VERSION).toBe(1);
+
+    for (const operation of COLLAB_AUTHORITY_TRANSFER_OPERATIONS) {
+      const path = collabLanAuthorityTransferOperationPath('project-alpha', operation);
+      expect(path).toBe(
+        `/authority-transfer/v1/projects/project-alpha/operations/${operation}`,
+      );
+      expect(matchCollabLanAuthorityTransferRoute('POST', path)).toEqual({
+        operation,
+        projectId: 'project-alpha',
+        version: 1,
+      });
+    }
+  });
+
+  it.each([
+    ['GET', '/authority-transfer/v1/projects/project-alpha/operations/getProjectAuthorityTransfer'],
+    ['POST', '/v9/projects/project-alpha/snapshot'],
+    ['POST', '/v6/host-transfers/transfer-alpha/probe'],
+    ['POST', '/v1/projects/project-alpha/repository.git/git-upload-pack'],
+    ['POST', '/authority-transfer/v1/projects/project-alpha/operations/notAnOperation'],
+    ['POST', '/authority-transfer/v1/projects/project-alpha/operations/getProjectAuthorityTransfer?extra=true'],
+  ])('does not claim %s %s', (method, path) => {
+    expect(matchCollabLanAuthorityTransferRoute(method, path)).toBeNull();
+  });
+
+  it('recognizes an unsupported binding version without treating it as v1', () => {
+    expect(matchCollabLanAuthorityTransferRoute(
+      'POST',
+      '/authority-transfer/v2/projects/project-alpha/operations/getProjectAuthorityTransfer',
+    )).toEqual({
+      operation: 'getProjectAuthorityTransfer',
+      projectId: 'project-alpha',
+      version: 2,
+    });
+  });
+});

--- a/tests/unit/app/collab/lan/authority-transfer/LanAuthorityTransferRouter.test.ts
+++ b/tests/unit/app/collab/lan/authority-transfer/LanAuthorityTransferRouter.test.ts
@@ -1,0 +1,686 @@
+import { createHash } from 'node:crypto';
+import { createServer, type Server } from 'node:http';
+
+import type {
+  AcceptCloudToLanTransferTargetRequest,
+  AcceptLanToCloudTransferTargetRequest,
+  ClaimTransferredMembershipRequest,
+  CollabAuthorityTransferStatus,
+  GetTransferredMembershipClaimRequest,
+  RequestLanToCloudTransferRequest,
+} from '@claudian-collab/protocol';
+
+import { collabLanAuthorityTransferOperationPath } from '@/app/collab/lan/authority-transfer/LanAuthorityTransferBinding';
+import {
+  LanAuthorityTransferRouter,
+  type LanAuthorityTransferRouteRegistration,
+  type LanAuthorityTransferSourceActiveService,
+  type LanAuthorityTransferTargetActiveService,
+  type LanAuthorityTransferTargetStagedService,
+  type LanAuthorityTransferTerminalSourceService,
+} from '@/app/collab/lan/authority-transfer/LanAuthorityTransferRouter';
+
+const PROJECT_ID = 'project-alpha';
+const HOST_MEMBER_ID = 'member-host';
+const OTHER_MEMBER_ID = 'member-other';
+const HOST_CREDENTIAL = Buffer.alloc(32, 1).toString('base64url');
+const OTHER_CREDENTIAL = Buffer.alloc(32, 2).toString('base64url');
+const TRANSFER_CREDENTIAL = Buffer.alloc(32, 3).toString('base64url');
+const NONCANONICAL_CREDENTIAL = `${HOST_CREDENTIAL.slice(0, -1)}B`;
+const CLAIM = Buffer.alloc(32, 4).toString('base64url');
+
+function mockAsync<Method extends (...args: never[]) => Promise<unknown>>(
+  implementation: Method,
+): jest.MockedFunction<Method> {
+  return jest.fn(implementation) as unknown as jest.MockedFunction<Method>;
+}
+
+function status(): CollabAuthorityTransferStatus {
+  return {
+    batchRevision: null,
+    batchSha256: null,
+    checkpointSha256: null,
+    createdAt: '2026-08-26T00:00:00.000Z',
+    direction: 'lan-to-cloud',
+    expiresAt: '2026-09-25T00:00:00.000Z',
+    phase: 'collecting-readiness',
+    projectId: PROJECT_ID,
+    relinquishmentProof: null,
+    sourceAuthority: { generation: 1, kind: 'lan' },
+    state: 'active',
+    targetAuthority: { generation: 2, kind: 'cloud' },
+    targetUrl: 'https://cloud.example.test',
+    transferId: 'transfer-alpha',
+    updatedAt: '2026-08-26T00:00:00.000Z',
+  };
+}
+
+function sourceService(): jest.Mocked<LanAuthorityTransferSourceActiveService> {
+  const transferStatus = status();
+  return {
+    acceptLanToCloudTransferTarget: mockAsync<
+      LanAuthorityTransferSourceActiveService['acceptLanToCloudTransferTarget']
+    >(async () => transferStatus),
+    authenticateMemberCredential: mockAsync<
+      LanAuthorityTransferSourceActiveService['authenticateMemberCredential']
+    >(async credential => ({
+        memberId: credential === HOST_CREDENTIAL ? HOST_MEMBER_ID : OTHER_MEMBER_ID,
+      })),
+    cancelProjectAuthorityTransfer: mockAsync<
+      LanAuthorityTransferSourceActiveService['cancelProjectAuthorityTransfer']
+    >(async () => transferStatus),
+    getProjectAuthorityTransfer: mockAsync<
+      LanAuthorityTransferSourceActiveService['getProjectAuthorityTransfer']
+    >(async () => transferStatus),
+    requestLanToCloudTransfer: mockAsync<
+      LanAuthorityTransferSourceActiveService['requestLanToCloudTransfer']
+    >(async () => transferStatus),
+  };
+}
+
+async function responseJson(response: Response): Promise<Record<string, unknown>> {
+  return response.json() as Promise<Record<string, unknown>>;
+}
+
+describe('LanAuthorityTransferRouter', () => {
+  let registration: LanAuthorityTransferRouteRegistration | null;
+  let router: LanAuthorityTransferRouter;
+  let server: Server;
+  let endpoint: string;
+
+  beforeEach(async () => {
+    registration = null;
+    router = new LanAuthorityTransferRouter({
+      resolve: projectId => projectId === PROJECT_ID ? registration : null,
+      runIfCurrent: async (projectId, expected, operation) => {
+        if (projectId !== PROJECT_ID || registration !== expected) {
+          return { admitted: false };
+        }
+        return { admitted: true, value: await operation() };
+      },
+    });
+    server = createServer((request, response) => {
+      void router.handle(request, response).then(handled => {
+        if (!handled) {
+          response.statusCode = 404;
+          response.end();
+        }
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Missing server address');
+    endpoint = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>(resolve => {
+      server.close(() => resolve());
+      server.closeAllConnections();
+    });
+  });
+
+  async function post(
+    operation: Parameters<typeof collabLanAuthorityTransferOperationPath>[1],
+    body: unknown,
+    authorization?: string,
+    version = 1,
+  ): Promise<Response> {
+    const path = collabLanAuthorityTransferOperationPath(PROJECT_ID, operation)
+      .replace('/v1/', `/v${version}/`);
+    return fetch(`${endpoint}${path}`, {
+      body: JSON.stringify(body),
+      headers: {
+        ...(authorization ? { authorization } : {}),
+        'content-type': 'application/json',
+        'x-request-id': 'request-alpha',
+      },
+      method: 'POST',
+    });
+  }
+
+  it('allows any authenticated Member to propose but only the exact Host to accept', async () => {
+    const service = sourceService();
+    registration = {
+      hostMemberId: HOST_MEMBER_ID,
+      projectId: PROJECT_ID,
+      service,
+      state: 'source-active',
+    };
+    const proposal: RequestLanToCloudTransferRequest = {
+      expectedAuthorityGeneration: 1,
+      idempotencyKey: 'intent-propose',
+      projectId: PROJECT_ID,
+      targetUrl: 'https://cloud.example.test',
+    };
+
+    const proposed = await post(
+      'requestLanToCloudTransfer',
+      proposal,
+      `Bearer ${OTHER_CREDENTIAL}`,
+    );
+    expect(proposed.status).toBe(200);
+    expect(await responseJson(proposed)).toMatchObject({
+      bindingVersion: 1,
+      data: { projectId: PROJECT_ID, transferId: 'transfer-alpha' },
+      protocolVersion: 6,
+      requestId: 'request-alpha',
+    });
+    expect(service.requestLanToCloudTransfer).toHaveBeenCalledWith(
+      { memberId: OTHER_MEMBER_ID },
+      proposal,
+    );
+
+    const acceptance: AcceptLanToCloudTransferTargetRequest = {
+      expectedAuthorityGeneration: 1,
+      idempotencyKey: 'intent-accept',
+      projectId: PROJECT_ID,
+      targetUrl: 'https://cloud.example.test',
+      transferId: 'transfer-alpha',
+    };
+    const denied = await post(
+      'acceptLanToCloudTransferTarget',
+      acceptance,
+      `Bearer ${OTHER_CREDENTIAL}`,
+    );
+    expect(denied.status).toBe(403);
+    expect(service.acceptLanToCloudTransferTarget).not.toHaveBeenCalled();
+
+    const accepted = await post(
+      'acceptLanToCloudTransferTarget',
+      acceptance,
+      `Bearer ${HOST_CREDENTIAL}`,
+    );
+    expect(accepted.status).toBe(200);
+    expect(service.acceptLanToCloudTransferTarget).toHaveBeenCalledWith(
+      { memberId: HOST_MEMBER_ID },
+      acceptance,
+    );
+  });
+
+  it('rejects an unsupported binding version before body read or authentication', async () => {
+    const service = sourceService();
+    registration = {
+      hostMemberId: HOST_MEMBER_ID,
+      projectId: PROJECT_ID,
+      service,
+      state: 'source-active',
+    };
+    const response = await post(
+      'requestLanToCloudTransfer',
+      { malformed: true },
+      `Bearer ${HOST_CREDENTIAL}`,
+      2,
+    );
+
+    expect(response.status).toBe(426);
+    expect(await responseJson(response)).toMatchObject({
+      bindingVersion: 1,
+      error: {
+        code: 'protocol-version-unsupported',
+        safeContext: { receivedVersion: 2, supportedVersion: 1 },
+      },
+      protocolVersion: 6,
+    });
+    expect(service.authenticateMemberCredential).not.toHaveBeenCalled();
+  });
+
+  it('rejects a resolver registration belonging to another Project', async () => {
+    const service = sourceService();
+    registration = {
+      hostMemberId: HOST_MEMBER_ID,
+      projectId: 'project-beta',
+      service,
+      state: 'source-active',
+    };
+
+    const response = await post(
+      'requestLanToCloudTransfer',
+      {
+        expectedAuthorityGeneration: 1,
+        idempotencyKey: 'intent-cross-project',
+        projectId: 'project-beta',
+        targetUrl: 'https://cloud.example.test',
+      } satisfies RequestLanToCloudTransferRequest,
+      `Bearer ${HOST_CREDENTIAL}`,
+    );
+
+    expect(response.status).toBe(401);
+    expect(await responseJson(response)).toMatchObject({
+      error: {
+        code: 'authentication-failed',
+        safeContext: { reason: 'authority-transfer-authentication-failed' },
+      },
+    });
+    expect(service.authenticateMemberCredential).not.toHaveBeenCalled();
+    expect(service.requestLanToCloudTransfer).not.toHaveBeenCalled();
+  });
+
+  it('does not expose Project existence or route state to invalid credentials', async () => {
+    const transferStatus = status();
+    const staged: jest.Mocked<LanAuthorityTransferTargetStagedService> = {
+      acceptCloudToLanTransferTarget: mockAsync<
+        LanAuthorityTransferTargetStagedService['acceptCloudToLanTransferTarget']
+      >(async () => transferStatus),
+      confirmCloudToLanTargetActive: jest.fn(),
+      getProjectAuthorityTransfer: jest.fn(),
+      reportCloudToLanTargetStaged: jest.fn(),
+    };
+    const request: AcceptCloudToLanTransferTargetRequest = {
+      idempotencyKey: 'intent-private-route',
+      projectId: PROJECT_ID,
+      targetHostMemberId: HOST_MEMBER_ID,
+      targetProof: 'target-proof',
+      transferId: 'transfer-alpha',
+    };
+
+    registration = null;
+    const missing = await post(
+      'acceptCloudToLanTransferTarget',
+      request,
+      `Claudian-Authority-Transfer ${HOST_CREDENTIAL}`,
+    );
+    const missingBody = await responseJson(missing);
+
+    registration = {
+      hostMemberId: HOST_MEMBER_ID,
+      projectId: PROJECT_ID,
+      service: sourceService(),
+      state: 'source-active',
+    };
+    const source = await post(
+      'acceptCloudToLanTransferTarget',
+      request,
+      `Claudian-Authority-Transfer ${HOST_CREDENTIAL}`,
+    );
+
+    registration = {
+      credentialHash: createHash('sha256')
+        .update(Buffer.from(TRANSFER_CREDENTIAL, 'base64url'))
+        .digest('hex'),
+      projectId: PROJECT_ID,
+      service: staged,
+      state: 'target-only-staged',
+      transferId: 'transfer-alpha',
+    };
+    const target = await post(
+      'acceptCloudToLanTransferTarget',
+      request,
+      `Claudian-Authority-Transfer ${HOST_CREDENTIAL}`,
+    );
+    const noncanonicalTarget = await post(
+      'acceptCloudToLanTransferTarget',
+      request,
+      `Claudian-Authority-Transfer ${NONCANONICAL_CREDENTIAL}`,
+    );
+
+    expect([
+      missing.status,
+      source.status,
+      target.status,
+      noncanonicalTarget.status,
+    ]).toEqual([401, 401, 401, 401]);
+    await expect(responseJson(source)).resolves.toEqual(missingBody);
+    await expect(responseJson(target)).resolves.toEqual(missingBody);
+    await expect(responseJson(noncanonicalTarget)).resolves.toEqual(missingBody);
+    expect(staged.acceptCloudToLanTransferTarget).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['Project', { ...status(), projectId: 'project-beta' }],
+    ['transfer', { ...status(), transferId: 'transfer-beta' }],
+  ])('rejects a service response for a different %s', async (_field, serviceStatus) => {
+    const service = sourceService();
+    service.getProjectAuthorityTransfer.mockResolvedValueOnce(serviceStatus);
+    registration = {
+      hostMemberId: HOST_MEMBER_ID,
+      projectId: PROJECT_ID,
+      service,
+      state: 'source-active',
+    };
+
+    const response = await post(
+      'getProjectAuthorityTransfer',
+      { projectId: PROJECT_ID, transferId: 'transfer-alpha' },
+      `Bearer ${HOST_CREDENTIAL}`,
+    );
+
+    expect(response.status).toBe(500);
+    expect(await responseJson(response)).toMatchObject({
+      error: {
+        code: 'operation-failed',
+        safeContext: { reason: 'authority-transfer-response-mismatch' },
+      },
+    });
+  });
+
+  it('admits only staged operations under the exact transfer credential', async () => {
+    const transferStatus = status();
+    const service: jest.Mocked<LanAuthorityTransferTargetStagedService> = {
+      acceptCloudToLanTransferTarget: mockAsync<
+        LanAuthorityTransferTargetStagedService['acceptCloudToLanTransferTarget']
+      >(async () => transferStatus),
+      confirmCloudToLanTargetActive: mockAsync<
+        LanAuthorityTransferTargetStagedService['confirmCloudToLanTargetActive']
+      >(async () => transferStatus),
+      getProjectAuthorityTransfer: mockAsync<
+        LanAuthorityTransferTargetStagedService['getProjectAuthorityTransfer']
+      >(async () => transferStatus),
+      reportCloudToLanTargetStaged: jest.fn(),
+    };
+    registration = {
+      credentialHash: createHash('sha256')
+        .update(Buffer.from(TRANSFER_CREDENTIAL, 'base64url'))
+        .digest('hex'),
+      projectId: PROJECT_ID,
+      service,
+      state: 'target-only-staged',
+      transferId: 'transfer-alpha',
+    };
+    const request: AcceptCloudToLanTransferTargetRequest = {
+      idempotencyKey: 'intent-target-accept',
+      projectId: PROJECT_ID,
+      targetHostMemberId: HOST_MEMBER_ID,
+      targetProof: 'target-proof',
+      transferId: 'transfer-alpha',
+    };
+
+    const accepted = await post(
+      'acceptCloudToLanTransferTarget',
+      request,
+      `Claudian-Authority-Transfer ${TRANSFER_CREDENTIAL}`,
+    );
+    expect(accepted.status).toBe(200);
+    expect(service.acceptCloudToLanTransferTarget).toHaveBeenCalledWith(request);
+
+    const wrongCredential = await post(
+      'acceptCloudToLanTransferTarget',
+      request,
+      `Claudian-Authority-Transfer ${HOST_CREDENTIAL}`,
+    );
+    expect(wrongCredential.status).toBe(401);
+
+    const sourceOnly = await post(
+      'requestLanToCloudTransfer',
+      {
+        expectedAuthorityGeneration: 1,
+        idempotencyKey: 'intent-propose',
+        projectId: PROJECT_ID,
+        targetUrl: 'https://cloud.example.test',
+      } satisfies RequestLanToCloudTransferRequest,
+      `Claudian-Authority-Transfer ${TRANSFER_CREDENTIAL}`,
+    );
+    expect(sourceOnly.status).toBe(404);
+  });
+
+  it('admits only LAN claim redemption on an owner-provided target-active route', async () => {
+    const staged: jest.Mocked<LanAuthorityTransferTargetStagedService> = {
+      acceptCloudToLanTransferTarget: jest.fn(),
+      confirmCloudToLanTargetActive: jest.fn(),
+      getProjectAuthorityTransfer: jest.fn(),
+      reportCloudToLanTargetStaged: jest.fn(),
+    };
+    registration = {
+      credentialHash: createHash('sha256')
+        .update(Buffer.from(TRANSFER_CREDENTIAL, 'base64url'))
+        .digest('hex'),
+      projectId: PROJECT_ID,
+      service: staged,
+      state: 'target-only-staged',
+      transferId: 'transfer-alpha',
+    };
+    const active: jest.Mocked<LanAuthorityTransferTargetActiveService> = {
+      claimTransferredMembership: mockAsync<
+        LanAuthorityTransferTargetActiveService['claimTransferredMembership']
+      >(async () => ({
+        checkpointSha256: 'a'.repeat(64),
+        claimSha256: 'b'.repeat(64),
+        memberId: OTHER_MEMBER_ID,
+        operationIntentId: 'intent-claim',
+        projectId: PROJECT_ID,
+        receiptId: 'receipt-alpha',
+        receiptKeyId: 'key-alpha',
+        redeemedAt: '2026-08-26T00:01:00.000Z',
+        signature: Buffer.alloc(64, 5).toString('base64url'),
+        signatureAlgorithm: 'ed25519' as const,
+        targetAuthorityGeneration: 2,
+        transferId: 'transfer-alpha',
+      })),
+    };
+
+    registration = {
+      projectId: PROJECT_ID,
+      service: active,
+      state: 'target-active',
+      transferId: 'transfer-alpha',
+    };
+    const request: ClaimTransferredMembershipRequest = {
+      claim: CLAIM,
+      credentialHash: 'c'.repeat(64),
+      idempotencyKey: 'intent-claim',
+      projectId: PROJECT_ID,
+      transferId: 'transfer-alpha',
+    };
+    const claimed = await post(
+      'claimTransferredMembership',
+      request,
+      `Claudian-Transfer-Claim ${CLAIM}`,
+    );
+    expect(claimed.status).toBe(200);
+    const replayed = await post(
+      'claimTransferredMembership',
+      request,
+      `Claudian-Transfer-Claim ${CLAIM}`,
+    );
+    expect(replayed.status).toBe(200);
+    expect(await responseJson(replayed)).toEqual(await responseJson(claimed));
+    expect(active.claimTransferredMembership).toHaveBeenCalledWith(request);
+
+    const mismatchedClaim = await post(
+      'claimTransferredMembership',
+      request,
+      `Claudian-Transfer-Claim ${Buffer.alloc(32, 6).toString('base64url')}`,
+    );
+    expect(mismatchedClaim.status).toBe(401);
+    expect(active.claimTransferredMembership).toHaveBeenCalledTimes(2);
+
+    const hashless = await post(
+      'claimTransferredMembership',
+      {
+        claim: CLAIM,
+        idempotencyKey: 'intent-cloud-variant',
+        projectId: PROJECT_ID,
+        transferId: 'transfer-alpha',
+      },
+      `Claudian-Transfer-Claim ${CLAIM}`,
+    );
+    expect(hashless.status).toBe(401);
+    expect(active.claimTransferredMembership).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps terminal status, own-claim retrieval, and receipt forwarding Member-bound', async () => {
+    const transferStatus = status();
+    const service: jest.Mocked<LanAuthorityTransferTerminalSourceService> = {
+      acknowledgeTransferredMembershipClaimRedemption: mockAsync<
+        LanAuthorityTransferTerminalSourceService[
+          'acknowledgeTransferredMembershipClaimRedemption'
+        ]
+      >(async (_actor, request) => ({
+        acknowledgedAt: '2026-08-26T00:02:00.000Z',
+        memberId: OTHER_MEMBER_ID,
+        projectId: PROJECT_ID,
+        receiptId: request.receipt.receiptId,
+        transferId: request.transferId,
+      })),
+      authenticateMemberCredential: mockAsync<
+        LanAuthorityTransferTerminalSourceService['authenticateMemberCredential']
+      >(async () => ({ memberId: OTHER_MEMBER_ID })),
+      getProjectAuthorityTransfer: mockAsync<
+        LanAuthorityTransferTerminalSourceService['getProjectAuthorityTransfer']
+      >(async () => transferStatus),
+      getTransferredMembershipClaim: mockAsync<
+        LanAuthorityTransferTerminalSourceService['getTransferredMembershipClaim']
+      >(async actor => ({
+        claim: CLAIM,
+        expiresAt: '2026-09-25T00:00:00.000Z',
+        memberId: actor.memberId,
+        projectId: PROJECT_ID,
+        targetAuthorityGeneration: 2,
+        transferId: 'transfer-alpha',
+      })),
+    };
+    registration = {
+      projectId: PROJECT_ID,
+      service,
+      state: 'terminal-source',
+    };
+    const request: GetTransferredMembershipClaimRequest = {
+      projectId: PROJECT_ID,
+      transferId: 'transfer-alpha',
+    };
+    const response = await post(
+      'getTransferredMembershipClaim',
+      request,
+      `Bearer ${OTHER_CREDENTIAL}`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(service.getTransferredMembershipClaim).toHaveBeenCalledWith(
+      { memberId: OTHER_MEMBER_ID },
+      request,
+    );
+  });
+
+  it('fails closed when the lifecycle owner replaces a route before admission', async () => {
+    const source = sourceService();
+    let reportAdmission!: () => void;
+    const admissionStarted = new Promise<void>(resolve => {
+      reportAdmission = resolve;
+    });
+    let releaseAdmission!: () => void;
+    const admissionReleased = new Promise<void>(resolve => {
+      releaseAdmission = resolve;
+    });
+    registration = {
+      hostMemberId: HOST_MEMBER_ID,
+      projectId: PROJECT_ID,
+      service: source,
+      state: 'source-active',
+    };
+    router = new LanAuthorityTransferRouter({
+      resolve: projectId => projectId === PROJECT_ID ? registration : null,
+      runIfCurrent: async (projectId, expected, operation) => {
+        reportAdmission();
+        await admissionReleased;
+        if (projectId !== PROJECT_ID || registration !== expected) {
+          return { admitted: false };
+        }
+        return { admitted: true, value: await operation() };
+      },
+    });
+    const terminal: jest.Mocked<LanAuthorityTransferTerminalSourceService> = {
+      acknowledgeTransferredMembershipClaimRedemption: jest.fn(),
+      authenticateMemberCredential: mockAsync<
+        LanAuthorityTransferTerminalSourceService['authenticateMemberCredential']
+      >(async () => ({ memberId: OTHER_MEMBER_ID })),
+      getProjectAuthorityTransfer: mockAsync<
+        LanAuthorityTransferTerminalSourceService['getProjectAuthorityTransfer']
+      >(async () => status()),
+      getTransferredMembershipClaim: jest.fn(),
+    };
+
+    const pending = post(
+      'requestLanToCloudTransfer',
+      {
+        expectedAuthorityGeneration: 1,
+        idempotencyKey: 'intent-racing',
+        projectId: PROJECT_ID,
+        targetUrl: 'https://cloud.example.test',
+      },
+      `Bearer ${HOST_CREDENTIAL}`,
+    );
+    await admissionStarted;
+    registration = {
+      projectId: PROJECT_ID,
+      service: terminal,
+      state: 'terminal-source',
+    };
+    releaseAdmission();
+
+    expect((await pending).status).toBe(401);
+    expect(source.authenticateMemberCredential).not.toHaveBeenCalled();
+    expect(source.requestLanToCloudTransfer).not.toHaveBeenCalled();
+  });
+
+  it('bounds JSON requests and leaves legacy LAN paths unclaimed', async () => {
+    const service = sourceService();
+    registration = {
+      hostMemberId: HOST_MEMBER_ID,
+      projectId: PROJECT_ID,
+      service,
+      state: 'source-active',
+    };
+    const legacy = await fetch(`${endpoint}/v9/projects/${PROJECT_ID}/snapshot`);
+    expect(legacy.status).toBe(404);
+
+    const path = collabLanAuthorityTransferOperationPath(
+      PROJECT_ID,
+      'getProjectAuthorityTransfer',
+    );
+    const response = await fetch(`${endpoint}${path}`, {
+      body: JSON.stringify({
+        padding: 'x'.repeat(1024 * 1024),
+        projectId: PROJECT_ID,
+        transferId: 'transfer-alpha',
+      }),
+      headers: {
+        authorization: `Bearer ${HOST_CREDENTIAL}`,
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    });
+    expect(response.status).toBe(413);
+    expect(service.getProjectAuthorityTransfer).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-JSON media type before authentication or dispatch', async () => {
+    const service = sourceService();
+    registration = {
+      hostMemberId: HOST_MEMBER_ID,
+      projectId: PROJECT_ID,
+      service,
+      state: 'source-active',
+    };
+    const path = collabLanAuthorityTransferOperationPath(
+      PROJECT_ID,
+      'getProjectAuthorityTransfer',
+    );
+
+    const response = await fetch(`${endpoint}${path}`, {
+      body: JSON.stringify({
+        projectId: PROJECT_ID,
+        transferId: 'transfer-alpha',
+      }),
+      headers: {
+        authorization: `Bearer ${HOST_CREDENTIAL}`,
+        'content-type': 'text/plain',
+      },
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(400);
+    expect(await responseJson(response)).toMatchObject({
+      error: {
+        code: 'protocol-payload-invalid',
+        safeContext: {
+          reason: 'authority-transfer-request-content-type-invalid',
+        },
+      },
+    });
+    expect(service.authenticateMemberCredential).not.toHaveBeenCalled();
+    expect(service.getProjectAuthorityTransfer).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- add an independent v1 LAN Project-authority-transfer HTTP binding and pinned-TLS client over protocol v6
- keep listener lifecycle, route transitions, expiry, restart, and shutdown ownership in the later `LanHostCoordinator` integration
- enforce exact Host acceptance, Member/transfer/claim authentication, LAN-only credential hash redemption, parameter matching, bounded JSON envelopes, generic unauthenticated failures, and fail-closed route replacement admission

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm test` (589 passed suites, 1 skipped; 8,569 passed tests, 1 skipped)
- `npm run test:architecture` (37/37)
- `npm run build`
- `npm run check:performance` (4.78 MiB / 5,013,827 bytes)
- `npm run check:lockfile`
- `npm run test:cross-platform-collab` (24 suites, 200 tests)
- final isolated security and architecture review-and-repair passes: no material findings

## Downstream boundary

L6 must implement the real `LanHostCoordinator` route-access owner and prove close-and-drain transitions, listener replacement/restart, 30-day terminal expiry, and shutdown cleanup.