### PR TITLE
fix: restore dual-pane session scrolling

### DIFF
--- a/src/style/components/history.css
+++ b/src/style/components/history.css
@@ -126,6 +126,7 @@
   background: transparent;
 }
 
+.claudian-session-surface,
 .claudian-collab-surface {
   display: flex;
   flex: 1 1 auto;

--- a/tests/unit/style/components/history.test.ts
+++ b/tests/unit/style/components/history.test.ts
@@ -2,6 +2,14 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
 describe('Persistent sidebar surface pager styles', () => {
+  it('keeps the session surface bounded so its nested lists can scroll', () => {
+    const css = readFileSync(path.resolve('src/style/components/history.css'), 'utf8');
+
+    expect(css).toMatch(
+      /\.claudian-session-surface(?:,\s*\.claudian-collab-surface)?\s*{[^}]*display:\s*flex;[^}]*flex-direction:\s*column;[^}]*min-height:\s*0;[^}]*overflow:\s*hidden;/,
+    );
+  });
+
   it('keeps the sidebar footer visible without overlaying or clipping content', () => {
     const css = readFileSync(path.resolve('src/style/components/history.css'), 'utf8');
 


### PR DESCRIPTION
## Why

Dual-pane session lists expanded beyond the pager viewport and were clipped, preventing users from scrolling; no linked issue is needed because this is a focused regression fix for the layout lost in #1117.

## What Changed

Restored the bounded column-flex contract for the session surface and added a CSS regression test that preserves the nested list scroll chain.

## Why This Approach

The session and Collab pager pages have the same sizing responsibility, so sharing the existing surface rule restores the prior behavior at the owning CSS boundary without event handling or DOM workarounds.

## Validation

- `npm run typecheck && npm run lint && npm run test && npm run build`
- 8,591 tests passed; one unrelated test remained skipped.
- No screenshot is included because this changes overflow behavior without changing the rendered appearance.

## Impact and Follow-ups

None.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
