### PR TITLE
Fix auto-linked content excluded tag refresh

### DIFF
--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -1700,6 +1700,11 @@ export class ClaudianView extends ItemView {
       .handleActiveFileChanged(file, true);
   }
 
+  private handleLinkedContentMetadataChanged(file: TFile | null): void {
+    this.tabManager?.getActiveTab()?.ui.linkedContentController
+      .handleActiveFileMetadataChanged(file);
+  }
+
   handleLinkedContentRenamed(
     oldPath: string,
     newPath: string,
@@ -2603,6 +2608,21 @@ export class ClaudianView extends ItemView {
     this.registerEvent(
       this.plugin.app.workspace.on('file-open', (file) => {
         this.handleWorkspaceFileOpen(file);
+      })
+    );
+    this.registerEvent(
+      this.plugin.app.metadataCache.on('changed', (file) => {
+        this.handleLinkedContentMetadataChanged(file);
+      })
+    );
+    this.registerEvent(
+      this.plugin.app.metadataCache.on('resolve', (file) => {
+        this.handleLinkedContentMetadataChanged(file);
+      })
+    );
+    this.registerEvent(
+      this.plugin.app.metadataCache.on('resolved', () => {
+        this.handleLinkedContentMetadataChanged(null);
       })
     );
 

--- a/src/features/chat/linked-content/LinkedContentController.ts
+++ b/src/features/chat/linked-content/LinkedContentController.ts
@@ -22,6 +22,8 @@ export interface LinkedContentSnapshot {
   readonly path: string | null;
 }
 
+type ExcludedTagState = 'excluded' | 'not-excluded' | 'unknown';
+
 export interface LinkedContentSubmissionToken {
   readonly path?: string;
 }
@@ -130,10 +132,14 @@ export class LinkedContentController {
 
   handleActiveFileChanged(file: TFile | null, isActiveOwner: boolean): void {
     if (this.destroyed || !isActiveOwner || this.mode !== 'auto-draft') return;
-    const nextPath = this.eligibleActiveFilePath(file);
-    if (nextPath === this.path) return;
-    this.path = nextPath;
-    this.publish();
+    this.reconcileAutoDraftPath(file);
+  }
+
+  handleActiveFileMetadataChanged(file: TFile | null): void {
+    if (this.destroyed || this.mode !== 'auto-draft') return;
+    const activeFile = this.app.workspace.getActiveFile();
+    if (file !== null && activeFile?.path !== file.path) return;
+    this.reconcileAutoDraftPath(activeFile);
   }
 
   lock(path: string | undefined): void {
@@ -312,18 +318,29 @@ export class LinkedContentController {
     return true;
   }
 
+  private reconcileAutoDraftPath(file: TFile | null): void {
+    const nextPath = this.eligibleActiveFilePath(file);
+    if (nextPath === this.path) return;
+    this.path = nextPath;
+    this.publish();
+  }
+
   private eligibleActiveFilePath(file: TFile | null): string | null {
-    if (!file || file.extension.toLocaleLowerCase() !== 'md' || this.hasExcludedTag(file)) {
+    if (
+      !file
+      || file.extension.toLocaleLowerCase() !== 'md'
+      || this.getExcludedTagState(file) !== 'not-excluded'
+    ) {
       return null;
     }
     return normalizeLinkedContentPath(file.path);
   }
 
-  private hasExcludedTag(file: TFile): boolean {
+  private getExcludedTagState(file: TFile): ExcludedTagState {
     const excludedTags = this.options.getExcludedTags();
-    if (excludedTags.length === 0) return false;
+    if (excludedTags.length === 0) return 'not-excluded';
     const cache = this.app.metadataCache.getFileCache(file);
-    if (!cache) return false;
+    if (!cache) return 'unknown';
     const fileTags: string[] = [];
     const frontmatterTags: unknown = cache.frontmatter?.tags;
     if (Array.isArray(frontmatterTags)) {
@@ -335,7 +352,9 @@ export class LinkedContentController {
     }
     if (cache.tags) fileTags.push(...cache.tags.map(tag => tag.tag));
     const normalizedExcluded = new Set(excludedTags.map(tag => tag.replace(/^#/, '')));
-    return fileTags.some(tag => normalizedExcluded.has(tag.replace(/^#/, '')));
+    return fileTags.some(tag => normalizedExcluded.has(tag.replace(/^#/, '')))
+      ? 'excluded'
+      : 'not-excluded';
   }
 
   private publish(): void {

--- a/tests/unit/features/chat/ClaudianView.test.ts
+++ b/tests/unit/features/chat/ClaudianView.test.ts
@@ -3718,6 +3718,13 @@ describe('ClaudianView Escape handling', () => {
             return ref;
           }),
         },
+        metadataCache: {
+          on: jest.fn((_event: string, handler: unknown) => {
+            const ref = { handler };
+            eventRefs.push(ref);
+            return ref;
+          }),
+        },
       },
     };
     view.tabManager = {
@@ -3733,6 +3740,9 @@ describe('ClaudianView Escape handling', () => {
             markFolderCacheDirty: jest.fn(),
             handleFileOpen: jest.fn(),
             handleClickOutside: jest.fn(),
+          },
+          linkedContentController: {
+            handleActiveFileMetadataChanged: jest.fn(),
           },
         },
       }),
@@ -3780,6 +3790,13 @@ describe('ClaudianView Escape handling', () => {
             return ref;
           }),
         },
+        metadataCache: {
+          on: jest.fn((_event: string, handler: unknown) => {
+            const ref = { handler };
+            eventRefs.push(ref);
+            return ref;
+          }),
+        },
       },
     };
     view.tabManager = {
@@ -3795,6 +3812,9 @@ describe('ClaudianView Escape handling', () => {
             markFolderCacheDirty: jest.fn(),
             handleFileOpen: jest.fn(),
             handleClickOutside: jest.fn(),
+          },
+          linkedContentController: {
+            handleActiveFileMetadataChanged: jest.fn(),
           },
         },
       }),
@@ -3944,6 +3964,45 @@ describe('ClaudianView Escape handling', () => {
 
     expect(cancelStreaming).not.toHaveBeenCalled();
     expect(result).toBe(false);
+  });
+
+  it('routes metadata cache refreshes to the active tab Linked content owner', () => {
+    const { view } = createEscapeHarness({ isStreaming: false });
+    const handleActiveFileMetadataChanged = jest.fn();
+    view.tabManager.getActiveTab.mockReturnValue({
+      state: { isStreaming: false },
+      controllers: {
+        conversationController: { cancelInlineRename: jest.fn().mockReturnValue(false) },
+        inputController: { cancelStreaming: jest.fn() },
+      },
+      ui: {
+        composerDropdown: {
+          containsElement: jest.fn().mockReturnValue(false),
+          hide: jest.fn(),
+        },
+        linkedContentController: { handleActiveFileMetadataChanged },
+      },
+    });
+    const file = { path: 'Notes/Current.md' };
+
+    view.wireEventHandlers();
+    const changedHandler = view.plugin.app.metadataCache.on.mock.calls.find(
+      (call: unknown[]) => call[0] === 'changed',
+    )?.[1] as (changedFile: unknown) => void;
+    const resolveHandler = view.plugin.app.metadataCache.on.mock.calls.find(
+      (call: unknown[]) => call[0] === 'resolve',
+    )?.[1] as (resolvedFile: unknown) => void;
+    const resolvedHandler = view.plugin.app.metadataCache.on.mock.calls.find(
+      (call: unknown[]) => call[0] === 'resolved',
+    )?.[1] as () => void;
+
+    changedHandler(file);
+    resolveHandler(file);
+    resolvedHandler();
+
+    expect(handleActiveFileMetadataChanged).toHaveBeenNthCalledWith(1, file);
+    expect(handleActiveFileMetadataChanged).toHaveBeenNthCalledWith(2, file);
+    expect(handleActiveFileMetadataChanged).toHaveBeenNthCalledWith(3, null);
   });
 
   it('commits a provisional preview before the Shift+Tab plan-mode action', () => {

--- a/tests/unit/features/chat/linked-content/LinkedContentController.test.ts
+++ b/tests/unit/features/chat/linked-content/LinkedContentController.test.ts
@@ -127,6 +127,51 @@ describe('LinkedContentController', () => {
     expect(excludedController.getSnapshot().path).toBeNull();
   });
 
+  it('waits for metadata before auto-linking when excluded tags are configured', () => {
+    const markdown = createFile('Notes/Startup.md');
+    const harness = createHarness([markdown]);
+    let cache: unknown = null;
+    (harness.app.metadataCache.getFileCache as jest.Mock).mockImplementation(() => cache);
+    const controller = new LinkedContentController({
+      app: harness.app as never,
+      getExcludedTags: () => ['private'],
+      getCachedVaultFiles: () => [],
+      getCachedVaultFolders: () => [],
+    });
+
+    harness.setActiveFile(markdown);
+    controller.resetAutoDraft();
+
+    expect(controller.getSnapshot().path).toBeNull();
+
+    cache = { tags: [] };
+    controller.handleActiveFileMetadataChanged(markdown);
+
+    expect(controller.getSnapshot().path).toBe('Notes/Startup.md');
+  });
+
+  it('unloads the auto-linked active Note when metadata gains an excluded tag', () => {
+    const markdown = createFile('Notes/Public.md');
+    const harness = createHarness([markdown]);
+    let cache: unknown = { tags: [] };
+    (harness.app.metadataCache.getFileCache as jest.Mock).mockImplementation(() => cache);
+    const controller = new LinkedContentController({
+      app: harness.app as never,
+      getExcludedTags: () => ['private'],
+      getCachedVaultFiles: () => [],
+      getCachedVaultFolders: () => [],
+    });
+
+    harness.setActiveFile(markdown);
+    controller.resetAutoDraft();
+    expect(controller.getSnapshot().path).toBe('Notes/Public.md');
+
+    cache = { tags: [{ tag: '#private' }] };
+    controller.handleActiveFileMetadataChanged(markdown);
+
+    expect(controller.getSnapshot().path).toBeNull();
+  });
+
   it('creates one immutable path token and locks only after durable creation', () => {
     const harness = createHarness([createFolder('Projects')]);
     harness.controller.selectExplicit('Projects');


### PR DESCRIPTION
## Why

Fixes #1179. Notes tagged with an excluded tag could still become auto-linked Linked content when Obsidian had not populated metadata yet, and adding an excluded tag to the active note did not unload the existing auto draft until focus changed.

## What Changed

- Re-evaluate active auto-draft Linked content when Obsidian metadata cache `changed`, `resolve`, or `resolved` events fire.
- Treat missing metadata as unknown when excluded tags are configured, so cold-start active notes are not linked before tag metadata is available.
- Add regression coverage for cold metadata readiness, hot excluded-tag unloads, and view event routing.

## Why This Approach

This keeps the behavior event-driven through Obsidian metadata cache notifications instead of adding polling, while preserving the existing active-tab ownership rule for auto drafts.

## Validation

- `npm run typecheck`
- `npm run lint:ts`
- `npm test`
- `npm run build`
- `git diff --check`

## Impact and Follow-ups

None.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
