### PR TITLE
fix: defer linked content until excluded tags resolve

### DIFF
--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -1700,6 +1700,10 @@ export class ClaudianView extends ItemView {
       .handleActiveFileChanged(file, true);
   }
 
+  private handleMetadataCacheResolved(): void {
+    this.handleWorkspaceFileOpen(this.plugin.app.workspace.getActiveFile());
+  }
+
   handleLinkedContentRenamed(
     oldPath: string,
     newPath: string,
@@ -2603,6 +2607,11 @@ export class ClaudianView extends ItemView {
     this.registerEvent(
       this.plugin.app.workspace.on('file-open', (file) => {
         this.handleWorkspaceFileOpen(file);
+      })
+    );
+    this.registerEvent(
+      this.plugin.app.metadataCache.on('resolved', () => {
+        this.handleMetadataCacheResolved();
       })
     );
 

--- a/src/features/chat/linked-content/LinkedContentController.ts
+++ b/src/features/chat/linked-content/LinkedContentController.ts
@@ -313,17 +313,21 @@ export class LinkedContentController {
   }
 
   private eligibleActiveFilePath(file: TFile | null): string | null {
-    if (!file || file.extension.toLocaleLowerCase() !== 'md' || this.hasExcludedTag(file)) {
+    if (
+      !file
+      || file.extension.toLocaleLowerCase() !== 'md'
+      || this.hasExcludedTag(file) !== false
+    ) {
       return null;
     }
     return normalizeLinkedContentPath(file.path);
   }
 
-  private hasExcludedTag(file: TFile): boolean {
+  private hasExcludedTag(file: TFile): boolean | null {
     const excludedTags = this.options.getExcludedTags();
     if (excludedTags.length === 0) return false;
     const cache = this.app.metadataCache.getFileCache(file);
-    if (!cache) return false;
+    if (!cache) return null;
     const fileTags: string[] = [];
     const frontmatterTags: unknown = cache.frontmatter?.tags;
     if (Array.isArray(frontmatterTags)) {

--- a/tests/unit/features/chat/ClaudianView.test.ts
+++ b/tests/unit/features/chat/ClaudianView.test.ts
@@ -348,6 +348,26 @@ describe('ClaudianView tab controls', () => {
     expect(handleActiveFileChanged).toHaveBeenLastCalledWith(null, true);
   });
 
+  it('rechecks the active tab Linked content after metadata resolution', () => {
+    const handleActiveFileChanged = jest.fn();
+    const activeFile = { path: 'Projects/Plan.md' };
+    const view = Object.create(ClaudianView.prototype) as any;
+    view.plugin = {
+      app: {
+        workspace: { getActiveFile: jest.fn().mockReturnValue(activeFile) },
+      },
+    };
+    view.tabManager = {
+      getActiveTab: jest.fn().mockReturnValue({
+        ui: { linkedContentController: { handleActiveFileChanged } },
+      }),
+    };
+
+    view.handleMetadataCacheResolved();
+
+    expect(handleActiveFileChanged).toHaveBeenCalledWith(activeFile, true);
+  });
+
   it('fans Vault path events to every tab Linked content owner', () => {
     const first = {
       handleCreated: jest.fn(),
@@ -3704,6 +3724,13 @@ describe('ClaudianView Escape handling', () => {
     view.eventRefs = eventRefs;
     view.plugin = {
       app: {
+        metadataCache: {
+          on: jest.fn((_event: string, handler: unknown) => {
+            const ref = { handler };
+            eventRefs.push(ref);
+            return ref;
+          }),
+        },
         vault: {
           on: jest.fn((_event: string, handler: unknown) => {
             const ref = { handler };
@@ -3766,6 +3793,13 @@ describe('ClaudianView Escape handling', () => {
     view.eventRefs = eventRefs;
     view.plugin = {
       app: {
+        metadataCache: {
+          on: jest.fn((_event: string, handler: unknown) => {
+            const ref = { handler };
+            eventRefs.push(ref);
+            return ref;
+          }),
+        },
         vault: {
           on: jest.fn((_event: string, handler: unknown) => {
             const ref = { handler };
@@ -3817,6 +3851,19 @@ describe('ClaudianView Escape handling', () => {
       expect.any(Function),
       { capture: true }
     );
+  });
+
+  it('registers metadata resolution through the Obsidian view lifecycle', () => {
+    const { view } = createEscapeHarness({ isStreaming: false });
+
+    view.wireEventHandlers();
+
+    expect(view.plugin.app.metadataCache.on).toHaveBeenCalledWith(
+      'resolved',
+      expect.any(Function),
+    );
+    const metadataRef = view.plugin.app.metadataCache.on.mock.results[0].value;
+    expect(view.registerEvent).toHaveBeenCalledWith(metadataRef);
   });
 
   it('cancels streaming and consumes scoped Escape', () => {

--- a/tests/unit/features/chat/linked-content/LinkedContentController.test.ts
+++ b/tests/unit/features/chat/linked-content/LinkedContentController.test.ts
@@ -127,6 +127,47 @@ describe('LinkedContentController', () => {
     expect(excludedController.getSnapshot().path).toBeNull();
   });
 
+  it('waits for excluded-tag metadata before auto-attaching an active Note', () => {
+    const markdown = createFile('Notes/Potentially-Private.md');
+    const harness = createHarness([markdown]);
+    const excludedController = new LinkedContentController({
+      app: harness.app as never,
+      getExcludedTags: () => ['private'],
+      getCachedVaultFiles: () => [],
+      getCachedVaultFolders: () => [],
+    });
+
+    harness.setActiveFile(markdown);
+    excludedController.resetAutoDraft();
+    expect(excludedController.getSnapshot()).toMatchObject({
+      mode: 'auto-draft',
+      path: null,
+    });
+
+    (harness.app.metadataCache.getFileCache as jest.Mock).mockReturnValue({
+      tags: [],
+    });
+    excludedController.handleActiveFileChanged(markdown, true);
+    expect(excludedController.getSnapshot()).toMatchObject({
+      mode: 'auto-draft',
+      path: 'Notes/Potentially-Private.md',
+    });
+
+    excludedController.selectExplicit('Projects/Explicit.md');
+    excludedController.handleActiveFileChanged(markdown, true);
+    expect(excludedController.getSnapshot()).toMatchObject({
+      mode: 'explicit-draft',
+      path: 'Projects/Explicit.md',
+    });
+
+    excludedController.lock('Projects/Locked.md');
+    excludedController.handleActiveFileChanged(markdown, true);
+    expect(excludedController.getSnapshot()).toMatchObject({
+      mode: 'locked',
+      path: 'Projects/Locked.md',
+    });
+  });
+
   it('creates one immutable path token and locks only after durable creation', () => {
     const harness = createHarness([createFolder('Projects')]);
     harness.controller.selectExplicit('Projects');


### PR DESCRIPTION
## Why

On a cold Obsidian start, `MetadataCache.getFileCache()` can temporarily return `null`. When excluded tags are configured, Linked content treated that unresolved state as safe and could auto-attach the active Note before its excluded tag was known. That can expose content the user explicitly configured Claudian to exclude.

Fixes #1179.

## What Changed

- Treat unresolved active-Note metadata as ineligible for auto-attachment when excluded tags are configured.
- Re-evaluate only the active tab auto draft when Obsidian reports that metadata resolution has completed.
- Preserve existing explicit-draft, submitting, and locked selection behavior.
- Add regression coverage for cold-start deferral, post-resolution recovery, state-mode fencing, active-tab routing, and lifecycle-owned event registration.

## Why This Approach

The fix stays at the existing owners: `LinkedContentController` decides eligibility, while `ClaudianView` owns Obsidian event wiring. Using the native `resolved` event avoids timers or polling. Vaults without excluded tags retain the current immediate auto-attachment behavior, and the controller state machine prevents a late metadata event from replacing explicit or locked content.

## Validation

- Confirmed the new controller and view tests fail before the implementation and pass afterward.
- `npm run test:unit -- --runTestsByPath tests/unit/features/chat/linked-content/LinkedContentController.test.ts tests/unit/features/chat/ClaudianView.test.ts --runInBand`
- `npm run typecheck`
- `npm run lint`
- `npm run test` — 589 suites passed, 8,594 tests passed, 1 existing test skipped.
- `npm run build`
- `git diff --check`

## Impact and Follow-ups

No settings, persistence, provider, protocol, or user-facing documentation changes. No follow-up is required for this focused fix.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.