### PR TITLE
fix: keep Pi turns open through native retries

### DIFF
--- a/src/providers/pi/execution/PiExecutionSession.ts
+++ b/src/providers/pi/execution/PiExecutionSession.ts
@@ -123,6 +123,7 @@ interface ActiveRun {
   nativeRequestDispatched: boolean;
   nativeAssistantId?: string;
   nativeUserMessageId?: string;
+  pendingTerminalError: Error | null;
   sequence: number;
   terminal: boolean;
   terminalSignal: Deferred<void>;
@@ -368,6 +369,7 @@ implements ProviderExecutionSession, SteerableExecutionSession {
       accepted: false,
       assistantStarted: false,
       nativeRequestDispatched: false,
+      pendingTerminalError: null,
       sequence: 0,
       terminal: false,
       terminalSignal: createDeferred<void>(),
@@ -695,6 +697,16 @@ implements ProviderExecutionSession, SteerableExecutionSession {
     }
     if (event.type === 'agent_end') {
       this.ensureAccepted(active);
+      if (event.willRetry === true) {
+        active.pendingTerminalError = null;
+        return;
+      }
+      const pendingTerminalError = active.pendingTerminalError;
+      active.pendingTerminalError = null;
+      if (pendingTerminalError) {
+        active.terminalSignal.reject(pendingTerminalError);
+        return;
+      }
       active.terminalSignal.resolve();
       return;
     }
@@ -705,14 +717,17 @@ implements ProviderExecutionSession, SteerableExecutionSession {
       return;
     }
 
+    const terminalError = getPiTerminalErrorMessage(event);
+    if (terminalError) {
+      this.ensureAccepted(active);
+      active.pendingTerminalError = new Error(terminalError);
+      return;
+    }
+
     const chunks = normalizePiRpcEvent(event, this.normalizationState);
     if (chunks.length > 0) this.ensureAccepted(active);
     for (const chunk of chunks) {
       this.handleStreamChunk(kernel, generation, chunk);
-    }
-    const terminalError = getPiTerminalErrorMessage(event);
-    if (terminalError) {
-      active.terminalSignal.reject(new Error(terminalError));
     }
   }
 

--- a/src/providers/pi/normalizations/piEventNormalization.ts
+++ b/src/providers/pi/normalizations/piEventNormalization.ts
@@ -58,6 +58,7 @@ export function getPiTerminalErrorMessage(event: Record<string, unknown>): strin
 
   const terminalEvent = getNestedRecord(event, 'assistantMessageEvent')
     ?? getNestedRecord(event, 'assistant_message_event')
+    ?? getNestedRecord(event, 'message')
     ?? event;
   const records = terminalEvent === event ? [event] : [terminalEvent, event];
   const stopReason = getStringField(records, ['stopReason', 'stop_reason']);

--- a/tests/unit/providers/pi/execution/PiExecutionBackend.test.ts
+++ b/tests/unit/providers/pi/execution/PiExecutionBackend.test.ts
@@ -557,6 +557,165 @@ describe('PiExecutionBackend', () => {
     expect(new Set(events.map(event => event.scope.sequence)).size).toBe(events.length);
   });
 
+  it('keeps one execution open across native Pi retries and commits the recovered answer', async () => {
+    const harness = createHarness();
+    const run = harness.session.execute(createRequest());
+    const eventsPromise = collect(run.events);
+    let settled = false;
+    void eventsPromise.then(() => {
+      settled = true;
+    });
+    await flush();
+
+    const kernel = harness.kernels[0];
+    kernel.emit({ type: 'agent_start' });
+    kernel.emit({
+      message: {
+        content: [],
+        errorMessage: 'OpenRouter rate limit (attempt 1)',
+        role: 'assistant',
+        stopReason: 'error',
+      },
+      type: 'message_end',
+    });
+    kernel.emit({ messages: [], type: 'agent_end', willRetry: true });
+    kernel.emit({ attempt: 1, type: 'auto_retry_start' });
+    await flush();
+    await flush();
+    expect(settled).toBe(false);
+
+    kernel.emit({ type: 'agent_start' });
+    kernel.emit({
+      message: {
+        content: [],
+        errorMessage: 'OpenRouter rate limit (attempt 2)',
+        role: 'assistant',
+        stopReason: 'error',
+      },
+      type: 'message_end',
+    });
+    kernel.emit({ messages: [], type: 'agent_end', willRetry: true });
+    kernel.emit({ attempt: 2, type: 'auto_retry_start' });
+    await flush();
+    await flush();
+    expect(settled).toBe(false);
+
+    harness.responses.set('get_state', {
+      leafEntryId: 'assistant-recovered',
+      parentSession: 'parent-session',
+      sessionFile: '/tmp/pi-session.jsonl',
+      sessionId: 'pi-session-1',
+    });
+    kernel.emit({ type: 'agent_start' });
+    kernel.emit({
+      assistantMessageEvent: { text_delta: 'Recovered answer' },
+      type: 'message_update',
+    });
+    kernel.emit({
+      message: {
+        content: [{ text: 'Recovered answer', type: 'text' }],
+        role: 'assistant',
+        stopReason: 'stop',
+      },
+      type: 'message_end',
+    });
+    kernel.emit({ attempt: 2, success: true, type: 'auto_retry_end' });
+    kernel.emit({ messages: [], type: 'agent_end', willRetry: false });
+
+    const events = await eventsPromise;
+    expect(events.filter(event => event.type === 'text_delta')).toEqual([
+      expect.objectContaining({ text: 'Recovered answer' }),
+    ]);
+    expect(events.filter(event => event.type === 'notice')).toEqual([
+      expect.objectContaining({ message: 'Pi is retrying the turn.' }),
+      expect.objectContaining({ message: 'Pi is retrying the turn.' }),
+      expect.objectContaining({ message: 'Pi retry finished.' }),
+    ]);
+    expect(events).not.toContainEqual(expect.objectContaining({
+      type: 'execution_error',
+    }));
+    expect(events.at(-1)).toMatchObject({
+      nativeAssistantId: 'assistant-recovered',
+      nativeCheckpointId: 'assistant-recovered',
+      type: 'turn_completed',
+    });
+  });
+
+  it('surfaces a native Pi terminal error after a non-retrying agent end', async () => {
+    const harness = createHarness();
+    const run = harness.session.execute(createRequest());
+    const eventsPromise = collect(run.events);
+    await flush();
+
+    const kernel = harness.kernels[0];
+    kernel.emit({ type: 'agent_start' });
+    kernel.emit({
+      message: {
+        content: [],
+        errorMessage: 'OpenRouter retry budget exhausted',
+        role: 'assistant',
+        stopReason: 'error',
+      },
+      type: 'message_end',
+    });
+    kernel.emit({ messages: [], type: 'agent_end', willRetry: false });
+
+    const events = await eventsPromise;
+    expect(events.at(-1)).toMatchObject({
+      message: 'OpenRouter retry budget exhausted',
+      type: 'execution_error',
+    });
+    expect(events).not.toContainEqual(expect.objectContaining({
+      type: 'turn_completed',
+    }));
+  });
+
+  it('can cancel while native Pi is waiting to retry and fences later events', async () => {
+    const harness = createHarness();
+    const run = harness.session.execute(createRequest());
+    const eventsPromise = collect(run.events);
+    let settled = false;
+    void eventsPromise.then(() => {
+      settled = true;
+    });
+    await flush();
+
+    const kernel = harness.kernels[0];
+    kernel.emit({ type: 'agent_start' });
+    kernel.emit({
+      message: {
+        content: [],
+        errorMessage: 'OpenRouter rate limit',
+        role: 'assistant',
+        stopReason: 'error',
+      },
+      type: 'message_end',
+    });
+    kernel.emit({ messages: [], type: 'agent_end', willRetry: true });
+    kernel.emit({ attempt: 1, type: 'auto_retry_start' });
+    await flush();
+    await flush();
+    expect(settled).toBe(false);
+
+    run.cancel();
+    kernel.emit({
+      assistantMessageEvent: { text_delta: 'late recovered answer' },
+      type: 'message_update',
+    });
+    kernel.emit({ messages: [], type: 'agent_end', willRetry: false });
+
+    const events = await eventsPromise;
+    expect(events.filter(event => (
+      event.type === 'cancelled'
+      || event.type === 'execution_error'
+      || event.type === 'turn_completed'
+    ))).toEqual([expect.objectContaining({ type: 'cancelled' })]);
+    expect(events).not.toContainEqual(expect.objectContaining({
+      text: 'late recovered answer',
+      type: 'text_delta',
+    }));
+  });
+
   it('encodes path-only Linked content without changing the Vault-root process CWD', async () => {
     const harness = createHarness();
     const run = harness.session.execute(createRequest({


### PR DESCRIPTION
## Why

Pi owns transient provider retries and reports whether a low-level agent run will continue through `agent_end.willRetry`. Claudian currently terminates the execution at the first error/end pair, so later tokens and tool calls from a successful Pi retry are fenced out and the recovered native answer is not persisted in the conversation.

This affects Pi users whose provider briefly fails mid-stream, including the OpenRouter 429 report in #1173.

Fixes #1173.

## What Changed

- Recognize Pi 0.84.3 terminal errors from the native `message_end.message` payload.
- Stage a terminal assistant error until the corresponding `agent_end` determines whether Pi will retry.
- Keep the same Claudian execution open when `willRetry` is true, allowing repeated retry notices and later stream events to continue normally.
- Complete from the recovered native leaf after the final non-retrying run, while preserving terminal-error and cancellation behavior.

## Why This Approach

Pi already owns retry policy and exposes the authoritative lifecycle decision through `willRetry`. Following that signal avoids classifying provider error text, adding a Claudian timeout, polling history, or changing shared execution contracts.

The state remains private to `PiExecutionSession`. Older event shapes without `willRetry: true` keep the existing non-retrying completion/error behavior.

## Validation

- Red/green execution-session coverage for two failed attempts followed by a recovered answer and native checkpoint refresh.
- Regression coverage for exhausted/non-retrying terminal errors.
- Regression coverage for cancellation during retry backoff and fencing of late events.
- `npm run test:unit -- --runTestsByPath tests/unit/providers/pi/execution/PiExecutionBackend.test.ts tests/unit/providers/pi/runtime/PiEventNormalization.test.ts --runInBand` (58 passed)
- `npm run typecheck`
- `npm run lint`
- `npm run test` (589 suites passed; 8,597 tests passed; 1 existing test skipped)
- `npm run build`
- `git diff --check`

## Impact and Follow-ups

This fixes future live Pi executions. It does not migrate already persisted conversations whose recovered native answer was previously dropped.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] User-facing documentation is not needed because this changes no settings or interaction flow.