### PR TITLE
fix(chat): suppress response duration on execution errors

### DIFF
--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -492,6 +492,7 @@ export class InputController {
     let shouldReportReviewableSettlement = false;
     let currentReviewableSettlementReporter: (() => void) | null = null;
     let didCancelThisTurn = false;
+    let hadExecutionError = false;
     let planApprovalInvalidated = false;
     let scheduledContinuation = false;
     let continuationStaysInCurrentController = false;
@@ -579,6 +580,7 @@ export class InputController {
         new Notice(notice);
         wasInvalidated = true;
       } else if (result.status === 'error' && result.error) {
+        hadExecutionError = true;
         await streamController.appendText(`\n\n**Error:** ${result.error.message}`);
       }
     } catch (error) {
@@ -592,6 +594,7 @@ export class InputController {
         new Notice('Message was not sent. Please try again.');
         this.reportDeferredReviewableSettlement();
       } else {
+        hadExecutionError = true;
         shouldReportReviewableSettlement = true;
         const errorMsg = error instanceof Error ? error.message : 'Unknown error';
         await streamController.appendText(`\n\n**Error:** ${errorMsg}`);
@@ -622,9 +625,9 @@ export class InputController {
           state.isStreaming = false;
           state.cancelRequested = false;
 
-          // Capture response duration before resetting state (skip for interrupted responses and compaction)
+          // Capture response duration before resetting state (skip for interrupted responses, errors, and compaction)
           const hasCompactBoundary = finalAssistantMsg.contentBlocks?.some(b => b.type === 'context_compacted');
-          if (!didCancelThisTurn && !hasCompactBoundary) {
+          if (!didCancelThisTurn && !hadExecutionError && !hasCompactBoundary) {
             const durationSeconds = state.responseStartTime
               ? Math.floor((performance.now() - state.responseStartTime) / 1000)
               : 0;

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -1,7 +1,7 @@
 import { createMockEl } from '@test/helpers/MockElement';
 import { Notice } from 'obsidian';
 
-import type { ProviderExecutionEvent } from '@/core/execution';
+import type { ProviderExecutionErrorEvent, ProviderExecutionEvent } from '@/core/execution';
 import { ProviderRegistry } from '@/core/providers/ProviderRegistry';
 import { ProviderSettingsCoordinator } from '@/core/providers/ProviderSettingsCoordinator';
 import type { ImageAttachment } from '@/core/types';
@@ -143,7 +143,7 @@ function createFixture(overrides: Record<string, unknown> = {}) {
     renderer: {
       addMessage: jest.fn().mockImplementation(() => {
         const el = createMockEl();
-        el.querySelector = jest.fn().mockReturnValue(createMockEl());
+        el.createDiv({ cls: 'claudian-message-content' });
         return el;
       }),
       appendInterruptIndicator: jest.fn(),
@@ -683,6 +683,99 @@ describe('InputController coordinator execution', () => {
     expect(fixture.deps.streamController.appendText).toHaveBeenCalledWith(
       '\n\n**Error:** stream failed',
     );
+  });
+
+  it('stores and renders response duration footer on ordinary success when elapsed time exceeds one second', async () => {
+    let currentTime = 1000;
+    const nowSpy = jest.spyOn(performance, 'now').mockImplementation(() => currentTime);
+    try {
+      const fixture = createFixture();
+      fixture.coordinator.execute.mockImplementationOnce(async () => {
+        currentTime += 1500;
+        return { accepted: true, planCompleted: false, status: 'completed' };
+      });
+
+      await fixture.controller.sendMessage({ content: 'test request' });
+
+      const assistantMessage = fixture.state.messages[1];
+      expect(assistantMessage.durationSeconds).toBe(1);
+      expect(assistantMessage.durationFlavorWord).toBeDefined();
+
+      const assistantMsgEl = jest.mocked(fixture.deps.renderer.addMessage).mock.results.at(-1)?.value;
+      expect(assistantMsgEl?.querySelector('.claudian-response-footer')).not.toBeNull();
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('suppresses response duration and DOM footer on normalized execution errors when elapsed time exceeds one second', async () => {
+    let currentTime = 1000;
+    const nowSpy = jest.spyOn(performance, 'now').mockImplementation(() => currentTime);
+    try {
+      const fixture = createFixture();
+      const errorEvent: ProviderExecutionErrorEvent = {
+        category: 'provider',
+        message: 'Model overloaded',
+        recoverable: false,
+        scope: {
+          executionId: 'execution-1',
+          kind: 'requested',
+          sequence: 0,
+          sessionInstanceId: 'session-instance-1',
+          turnId: 'turn-1',
+        },
+        type: 'execution_error',
+      };
+      fixture.coordinator.execute.mockImplementationOnce(async () => {
+        currentTime += 1500;
+        return {
+          accepted: true,
+          error: errorEvent,
+          planCompleted: false,
+          status: 'error',
+        };
+      });
+
+      await fixture.controller.sendMessage({ content: 'test request' });
+
+      expect(fixture.deps.streamController.appendText).toHaveBeenCalledWith(
+        '\n\n**Error:** Model overloaded',
+      );
+      const assistantMessage = fixture.state.messages[1];
+      expect(assistantMessage.durationSeconds).toBeUndefined();
+      expect(assistantMessage.durationFlavorWord).toBeUndefined();
+
+      const assistantMsgEl = jest.mocked(fixture.deps.renderer.addMessage).mock.results.at(-1)?.value;
+      expect(assistantMsgEl?.querySelector('.claudian-response-footer')).toBeNull();
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('suppresses response duration and DOM footer on catch-path rejections when elapsed time exceeds one second', async () => {
+    let currentTime = 1000;
+    const nowSpy = jest.spyOn(performance, 'now').mockImplementation(() => currentTime);
+    try {
+      const fixture = createFixture();
+      fixture.coordinator.execute.mockImplementationOnce(async () => {
+        currentTime += 1500;
+        throw new Error('stream failed');
+      });
+
+      await fixture.controller.sendMessage({ content: 'test request' });
+
+      expect(fixture.deps.streamController.appendText).toHaveBeenCalledWith(
+        '\n\n**Error:** stream failed',
+      );
+      const assistantMessage = fixture.state.messages[1];
+      expect(assistantMessage.durationSeconds).toBeUndefined();
+      expect(assistantMessage.durationFlavorWord).toBeUndefined();
+
+      const assistantMsgEl = jest.mocked(fixture.deps.renderer.addMessage).mock.results.at(-1)?.value;
+      expect(assistantMsgEl?.querySelector('.claudian-response-footer')).toBeNull();
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 
   it('routes normalized requested output to StreamController', async () => {


### PR DESCRIPTION
### Summary of Changes

Adds a `hadExecutionError` guard in `InputController.sendMessage()` so the completion duration footer (`* Crunched for ...` and `finalAssistantMsg.durationSeconds`) is suppressed when a turn ends with a normalized execution error or a post-handoff rejection.

---

### Test Plan

- [x] Added unit tests in `tests/unit/features/chat/controllers/InputController.test.ts` verifying:
  - **Baseline**: response duration and DOM footer are stored and rendered on ordinary success when elapsed time exceeds one second (deterministic `performance.now()` mock advancing 1500ms).
  - **Normalized error**: fully-typed `ProviderExecutionErrorEvent` (with complete requested scope: `kind`, `sessionInstanceId`, `executionId`, `turnId`, `sequence`) without any type casts leaves no stored duration or DOM footer.
  - **Catch-path rejection**: post-handoff `throw new Error()` leaves no stored duration or DOM footer.
  - **Regression proof**: temporarily removing `!hadExecutionError` causes both failure tests to immediately fail with `Received: 1, Expected: undefined`.
- [x] Ran `npm run typecheck` (0 errors).
- [x] Ran `npm run lint` (0 errors).
- [x] Ran focused Jest suite `npm test -- tests/unit/features/chat/controllers/InputController.test.ts` (78/78 pass).
- [x] Ran standalone architecture tests `npm run test:architecture` (41/41 pass).
- [x] Ran script tests (53/53 pass).
