### PR TITLE
fix(model-selector): show the model configured in Claude Code settings

### DIFF
--- a/src/core/types/chat.ts
+++ b/src/core/types/chat.ts
@@ -291,6 +291,8 @@ export type StreamChunk =
  */
 export interface UsageInfo {
   model?: string;
+  /** Actual model served by the provider runtime, when it differs from `model`. */
+  runtimeModel?: string;
   inputTokens: number;
   /** Prompt caching: tokens used to create cache entries. Claude-specific; 0 if omitted. */
   cacheCreationInputTokens?: number;

--- a/src/features/chat/tabs/runtime/TabRuntimeUI.ts
+++ b/src/features/chat/tabs/runtime/TabRuntimeUI.ts
@@ -274,6 +274,10 @@ function buildInputToolbar(
     getCapabilities: () => getTabCapabilities(shell, plugin),
     getSettings: () => getTabSettingsSnapshot(shell, plugin),
     getEnvironmentVariables: () => plugin.getActiveEnvironmentVariables(),
+    getRuntimeModel: () => {
+      const tab = runtimeRef.current();
+      return tab?.state?.usage?.runtimeModel ?? null;
+    },
     onModelChange: async (model: string) => {
       const tab = runtimeRef.requirePublished();
       if (!options.isRuntimeLive(tab)) return;

--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -57,8 +57,18 @@ export interface ToolbarCallbacks {
   onPermissionModeChange: (mode: string) => Promise<void>;
   getSettings: () => ToolbarSettings;
   getEnvironmentVariables?: () => string;
+  /** Actual model served by the running session, when known. */
+  getRuntimeModel?: () => string | null;
   getUIConfig: () => ProviderChatUIConfig;
   getCapabilities: () => ProviderCapabilities;
+}
+
+/** Normalize a model id for display comparison: drop the provider prefix and the [1m] context modifier. */
+function normalizeModelReference(modelId: string): string {
+  const trimmed = modelId.trim().toLowerCase();
+  const separatorIndex = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf(':'));
+  const base = separatorIndex >= 0 ? trimmed.slice(separatorIndex + 1) : trimmed;
+  return base.endsWith('[1m]') ? base.slice(0, -4) : base;
 }
 
 export class ModelSelector {
@@ -115,8 +125,25 @@ export class ModelSelector {
         width: 12,
       });
     }
+    const displayLabel = displayModel?.label || 'Unknown';
+    const runtimeModel = this.callbacks.getRuntimeModel?.()?.trim() || null;
+    let label = displayLabel;
+    if (runtimeModel && displayModel) {
+      const runtimeRef = normalizeModelReference(runtimeModel);
+      const optionRef = normalizeModelReference(displayModel.value);
+      if (runtimeRef && runtimeRef !== optionRef) {
+        // The session reports a different model than the selected option: show
+        // its display name (settings _NAME, else raw request name), falling
+        // back to the option label when the model is not configured.
+        const runtimeOption = models.find(m => normalizeModelReference(m.value) === runtimeRef);
+        label = runtimeOption?.label ?? displayLabel;
+      }
+    }
     const labelEl = this.buttonEl.createSpan({ cls: 'claudian-model-label' });
-    labelEl.setText(displayModel?.label || 'Unknown');
+    labelEl.setText(label);
+    if (runtimeModel) {
+      this.buttonEl.setAttribute('title', label === displayLabel ? runtimeModel : displayLabel);
+    }
   }
 
   renderOptions() {

--- a/src/providers/claude/env/claudeUserSettingsEnv.ts
+++ b/src/providers/claude/env/claudeUserSettingsEnv.ts
@@ -1,0 +1,86 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { resolveClaudeConfigDir } from '../config/ClaudeConfigDir';
+import { CLAUDE_MODEL_ENV_KEYS } from './claudeModelEnv';
+
+/**
+ * Model-related environment read from the user-level Claude Code settings file
+ * (the file CC Switch and the Claude Code CLI rewrite when the provider or
+ * model changes). Claudian only reads this file; it never modifies it.
+ */
+export interface ClaudeUserSettingsModelEnvironment {
+  /** Model selection env vars (ANTHROPIC_MODEL / ANTHROPIC_DEFAULT_*_MODEL). */
+  env: Record<string, string>;
+  /** Display names (ANTHROPIC_DEFAULT_*_MODEL_NAME) keyed by their model id. */
+  displayNames: Record<string, string>;
+}
+
+const EMPTY_ENVIRONMENT: ClaudeUserSettingsModelEnvironment = {
+  env: {},
+  displayNames: {},
+};
+
+/**
+ * Extract the model-related env block of a Claude Code settings file.
+ * Only model selection keys and their display-name counterparts are read;
+ * auth tokens and other secrets never leave this function.
+ */
+export function readClaudeUserSettingsModelFile(
+  filePath: string,
+): ClaudeUserSettingsModelEnvironment {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return { ...EMPTY_ENVIRONMENT };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { ...EMPTY_ENVIRONMENT };
+  }
+
+  const record = parsed as { env?: Record<string, unknown> } | null;
+  const env = record && typeof record === 'object' && record.env
+    && typeof record.env === 'object' && !Array.isArray(record.env)
+    ? record.env
+    : {};
+  const result: Record<string, string> = {};
+  const displayNames: Record<string, string> = {};
+
+  for (const envKey of CLAUDE_MODEL_ENV_KEYS) {
+    const value = env[envKey];
+    if (typeof value !== 'string' || value.length === 0) {
+      continue;
+    }
+    result[envKey] = value;
+    if (envKey === 'ANTHROPIC_MODEL') {
+      continue;
+    }
+    const name = env[envKey + '_NAME'];
+    if (typeof name === 'string' && name.length > 0) {
+      displayNames[value] = name;
+    }
+  }
+
+  return { env: result, displayNames };
+}
+
+/**
+ * Resolve the user-level Claude Code settings file and read its model
+ * environment. The file is read live on each call (it is a few KB) so
+ * provider switches made through CC Switch are reflected without a plugin
+ * restart. Test runs are skipped so unit tests stay hermetic.
+ */
+export function getClaudeUserSettingsModelEnvironment(
+  configDir?: string,
+): ClaudeUserSettingsModelEnvironment {
+  if (process.env.NODE_ENV === 'test') {
+    return { ...EMPTY_ENVIRONMENT };
+  }
+  const directory = configDir ?? resolveClaudeConfigDir();
+  return readClaudeUserSettingsModelFile(path.join(directory, 'settings.json'));
+}

--- a/src/providers/claude/execution/ClaudeExecutionEventNormalizer.ts
+++ b/src/providers/claude/execution/ClaudeExecutionEventNormalizer.ts
@@ -148,6 +148,9 @@ export class ClaudeExecutionEventNormalizer {
       }
       if (isContextWindowEvent(event)) {
         const model = options.intendedModel ?? state.lastUsage?.model ?? 'sonnet';
+        const runtimeModel = typeof event.model === 'string' && event.model !== model
+          ? event.model
+          : undefined;
         const authoritativeContextWindow = isFinitePositiveNumber(
           options.authoritativeContextWindow,
         )
@@ -172,6 +175,19 @@ export class ClaudeExecutionEventNormalizer {
             event: {
               type: 'usage_updated',
               usage: correctedUsage,
+            },
+          });
+        }
+        // Streaming usage only knows the intended model; surface the actual
+        // model reported by the runtime for display, not for selection.
+        if (runtimeModel && state.lastUsage && state.lastUsage.runtimeModel !== runtimeModel) {
+          const labeledUsage = { ...state.lastUsage, runtimeModel };
+          state.lastUsage = labeledUsage;
+          normalized.push({
+            type: 'output',
+            event: {
+              type: 'usage_updated',
+              usage: labeledUsage,
             },
           });
         }

--- a/src/providers/claude/modelOptions.ts
+++ b/src/providers/claude/modelOptions.ts
@@ -4,6 +4,7 @@ import {
   type ClaudeModelEnvType,
   getModelsFromEnvironment,
 } from './env/claudeModelEnv';
+import { getClaudeUserSettingsModelEnvironment } from './env/claudeUserSettingsEnv';
 import { formatCustomModelLabel } from './modelLabels';
 import { encodeClaudeModelSelectionId, toClaudeRuntimeModelId } from './modelSelection';
 import { isClaudeModelTier } from './modelTiers';
@@ -53,13 +54,29 @@ function normalizeCustomModelAliases(value: unknown): Record<string, string> {
 
 export function getClaudeModelOptions(settings: Record<string, unknown>): ClaudeModelOption[] {
   const customModelAliases = normalizeCustomModelAliases(settings.customModelAliases);
+  const userModelEnvironment = getClaudeUserSettingsModelEnvironment();
+  const modelAliases = {
+    ...userModelEnvironment.displayNames,
+    ...customModelAliases,
+  };
   const customModels = getModelsFromEnvironment(
-    getRuntimeEnvironmentVariables(settings, 'claude'),
-    customModelAliases,
+    // The user-level Claude Code settings file (rewritten by CC Switch on
+    // provider switches) backs the plugin environment, which wins on conflicts.
+    {
+      ...userModelEnvironment.env,
+      ...getRuntimeEnvironmentVariables(settings, 'claude'),
+    },
+    modelAliases,
   );
   if (customModels.length > 0) {
+    const settingsConfiguredModelIds = new Set(Object.values(userModelEnvironment.env));
     return customModels.map((model) => ({
       ...model,
+      // Settings file models show the display name when present, otherwise
+      // their raw request name; other models keep the author-derived label.
+      ...(!modelAliases[model.value] && settingsConfiguredModelIds.has(model.value)
+        ? { label: model.value }
+        : {}),
       value: encodeClaudeModelSelectionId(model.value),
     }));
   }

--- a/src/providers/claude/sdk/types.ts
+++ b/src/providers/claude/sdk/types.ts
@@ -19,6 +19,8 @@ export interface SessionInitEvent {
 export interface ContextWindowEvent {
   type: 'context_window';
   contextWindow: number;
+  /** Actual model served by the provider runtime, when known. */
+  model?: string;
 }
 
 export type TransformEvent =

--- a/src/providers/claude/stream/transformClaudeMessage.ts
+++ b/src/providers/claude/stream/transformClaudeMessage.ts
@@ -619,7 +619,11 @@ export function* transformSDKMessage(
         const modelUsage = message.modelUsage as Record<string, { contextWindow?: number }>;
         const selectedEntry = selectContextWindowEntry(modelUsage, options?.intendedModel);
         if (selectedEntry) {
-          yield { type: 'context_window', contextWindow: selectedEntry.contextWindow };
+          yield {
+            type: 'context_window',
+            contextWindow: selectedEntry.contextWindow,
+            model: selectedEntry.model,
+          };
         }
       }
       if (isResultError(message)) {

--- a/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
+++ b/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
@@ -1244,7 +1244,7 @@ describe('transformSDKMessage', () => {
       const results = [...transformSDKMessage(message)];
 
       expect(results).toEqual([
-        { type: 'context_window', contextWindow: 200000 },
+        { type: 'context_window', contextWindow: 200000, model: 'claude-sonnet-4-5-20250514' },
       ]);
     });
 
@@ -1258,7 +1258,7 @@ describe('transformSDKMessage', () => {
       const results = [...transformSDKMessage(message)];
 
       expect(results).toEqual([
-        { type: 'context_window', contextWindow: 200000 },
+        { type: 'context_window', contextWindow: 200000, model: 'claude-sonnet-test' },
         { type: 'error', content: 'Hit maximum turn limit' },
       ]);
     });
@@ -1283,7 +1283,7 @@ describe('transformSDKMessage', () => {
       const results = [...transformSDKMessage(message)];
 
       expect(results).toEqual([
-        { type: 'context_window', contextWindow: 1000000 },
+        { type: 'context_window', contextWindow: 1000000, model: 'claude-opus-4-6[1m]' },
       ]);
     });
 
@@ -1317,7 +1317,7 @@ describe('transformSDKMessage', () => {
       const results = [...transformSDKMessage(message, { intendedModel: 'custom-main-model' })];
 
       expect(results).toEqual([
-        { type: 'context_window', contextWindow: 200000 },
+        { type: 'context_window', contextWindow: 200000, model: 'custom-main-model' },
       ]);
     });
 
@@ -1351,7 +1351,7 @@ describe('transformSDKMessage', () => {
       const results = [...transformSDKMessage(message, { intendedModel: 'opus[1m]' })];
 
       expect(results).toEqual([
-        { type: 'context_window', contextWindow: 1000000 },
+        { type: 'context_window', contextWindow: 1000000, model: 'claude-opus-4-6[1m]' },
       ]);
     });
 
@@ -1385,7 +1385,7 @@ describe('transformSDKMessage', () => {
       const results = [...transformSDKMessage(message, { intendedModel: 'fable' })];
 
       expect(results).toEqual([
-        { type: 'context_window', contextWindow: 1000000 },
+        { type: 'context_window', contextWindow: 1000000, model: 'claude-fable-5-v1:0' },
       ]);
     });
 
@@ -1419,7 +1419,7 @@ describe('transformSDKMessage', () => {
       const results = [...transformSDKMessage(message, { intendedModel: 'anthropic/claude-opus-4-6[1m]' })];
 
       expect(results).toEqual([
-        { type: 'context_window', contextWindow: 1000000 },
+        { type: 'context_window', contextWindow: 1000000, model: 'claude-opus-4-6[1m]' },
       ]);
     });
 
@@ -1453,7 +1453,7 @@ describe('transformSDKMessage', () => {
       const results = [...transformSDKMessage(message, { intendedModel: 'eu.anthropic.claude-opus-4-6[1m]' })];
 
       expect(results).toEqual([
-        { type: 'context_window', contextWindow: 1000000 },
+        { type: 'context_window', contextWindow: 1000000, model: 'eu.anthropic.claude-opus-4-6[1m]' },
       ]);
     });
 
@@ -1487,7 +1487,7 @@ describe('transformSDKMessage', () => {
       const results = [...transformSDKMessage(message, { intendedModel: 'anthropic/claude-opus-4-6[1M]' })];
 
       expect(results).toEqual([
-        { type: 'context_window', contextWindow: 1000000 },
+        { type: 'context_window', contextWindow: 1000000, model: 'claude-opus-4-6[1m]' },
       ]);
     });
 


### PR DESCRIPTION
## Why

- When the provider/model is switched through CC Switch, it only rewrites the env of ~/.claude/settings.json. The Claude Code runtime reads those values (via settingSources) and actually runs the new model, but the claudian model selector/button still shows hardcoded tier labels (Haiku/Sonnet/Opus/Fable) or a name derived from the model id: the plugin never reads the model env from the settings file, never reads the display-name fields (`ANTHROPIC_DEFAULT_*_MODEL_NAME`), and drops the real model reported by the SDK result message (`modelUsage` keys).
- Affects every claudian user who switches providers/models through CC Switch (or hand-edits ~/.claude/settings.json): the displayed model name no longer matches what actually runs, which is misleading when selecting and troubleshooting.
- No issue filed; this is a standalone fix.

## What Changed

- **New read-only reader** `src/providers/claude/env/claudeUserSettingsEnv.ts`: resolves ~/.claude/settings.json via `resolveClaudeConfigDir()` (honors `CLAUDE_CONFIG_DIR`), extracts only the model env keys (`ANTHROPIC_MODEL`, `ANTHROPIC_DEFAULT_*_MODEL`) and display names (`ANTHROPIC_DEFAULT_*_MODEL_NAME`); secrets are never read; missing/invalid JSON is tolerated; the file is read live on each call (a few KB); skipped under `NODE_ENV === "test"` so unit tests stay hermetic.
- **Option merge** (`getClaudeModelOptions` in `modelOptions.ts`): the settings model env backs the plugin env (the plugin wins on conflicts), reusing the existing `getModelsFromEnvironment` pipeline. Label rules: display name (`_NAME`, or the plugin `customModelAliases`) → raw request name for settings models without one (the `[1M]` suffix is part of the request name and is kept verbatim) → the author original label logic for models not in settings (untouched).
- **Runtime model for display only**: the real model picked from the result message `modelUsage` now flows with the `context_window` event (`transformClaudeMessage.ts`, `sdk/types.ts`), is published as a new `UsageInfo.runtimeModel` field (`core/types/chat.ts`, `ClaudeExecutionEventNormalizer.ts`), and the model button shows it per the same label rules when it differs from the selected option (`InputToolbar.ts`, `TabRuntimeUI.ts`).
- Tests: only the 9 existing `context_window` assertions in `transformSDKMessage.test.ts` were updated for the new `model` field; no new tests.

## Why This Approach

- Follows the plugin design: model options are already env-driven (`getModelsFromEnvironment` → the `ProviderUIOption` value/label split), and the runtime already carries the real model, which was simply dropped at the transformer; this change reconnects it.
- Reading the same settings file Claude Code itself reads keeps the UI consistent with the runtime by construction, with the plugin env kept as the higher-priority override.
- `runtimeModel` is an additive display-only field: the existing `usage.model` (intended model), model recovery, context-window math, and the env-fingerprint/session-invalidation behavior are untouched, so provider switches keep existing conversations resumable.
- Alternatives considered: changing labels only at the UI layer (rejected: keeps the selector and other option consumers inconsistent), and stripping `[1M]` from request names for display (rejected: `[1M]` selects the 1M-context deployment at the gateway, so it is real request data, not decoration).

## Validation

- `tsc --noEmit` passes; `eslint --max-warnings=0` passes on the 9 changed files; the claude unit suites pass 46/47 (the only failing AgentManager suite fails identically on unmodified main on this Windows machine; unrelated to this change).
- Live check on this machine: calling `getClaudeModelOptions` against the real ~/.claude/settings.json yields 5 models whose labels match the rules exactly: `kimi-k3[1M]` → kimi-k3 (OPUS `_NAME`), `glm-5.2[1M]` → glm-5.2 (FABLE `_NAME`), `deepseek-v4-pro-0813[1M]` → deepseek-v4-pro-0813 (SONNET `_NAME`), `deepseek-v4-flash-0731[1M]` (ANTHROPIC_MODEL without `_NAME` → raw request name, `[1M]` kept).
- Rebuilding main.js from HEAD produces a byte-identical SHA-256 with the repo artifact and the installed plugin.

## Impact and Follow-ups

- Compatibility: no persistence-structure change (option values still go through `encodeClaudeModelSelectionId`); `runtimeModel` is an optional display field, and old data without it behaves as before.
- The behavior change only appears when ~/.claude/settings.json contains model env; the file is read live on each call, so provider switches are reflected immediately.
- Known limitation: the runtime model on the button appears after the first result message of a turn arrives (that is when `modelUsage` is available); before that it falls back to the option label, as expected.
- Follow-ups: none required; the local claudian-fix replay layer can be removed once this is merged upstream.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I explained why no issue is needed (standalone fix).
- [x] I updated tests for the behavior change (the 9 existing `context_window` assertions now include the `model` field; no new tests added to keep the diff minimal).
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed (no repo docs describe model labels; the claudian-fix companion docs were updated).
