### PR TITLE
fix: reveal existing Linked content tabs

### DIFF
--- a/src/features/chat/linked-content/LinkedContentController.ts
+++ b/src/features/chat/linked-content/LinkedContentController.ts
@@ -1,11 +1,12 @@
-import type { App } from 'obsidian';
-import { Notice, TFile, TFolder } from 'obsidian';
+import type { App, WorkspaceLeaf } from 'obsidian';
+import { FileView, Notice, TFile, TFolder } from 'obsidian';
 
 import {
   assertLinkedContentPath,
   normalizeLinkedContentPath,
 } from '@/core/path/LinkedContentPath';
 import type { ComposerContextTray } from '@/features/chat/ui/ComposerContextTray';
+import { revealWorkspaceLeaf } from '@/utils/obsidianCompat';
 
 import { LinkedContentChip } from './LinkedContentChip';
 import { LinkedContentPickerSource } from './LinkedContentPickerSource';
@@ -272,7 +273,7 @@ export class LinkedContentController {
     }
     if (content.target instanceof TFile) {
       try {
-        await this.app.workspace.getLeaf().openFile(content.target);
+        await this.revealFile(content.target);
       } catch (error) {
         new Notice(
           `Failed to open Linked content: ${error instanceof Error ? error.message : String(error)}`,
@@ -384,6 +385,28 @@ export class LinkedContentController {
 
   private derivePresentation(path: string | null): LinkedContentPresentation | null {
     return path ? deriveLinkedContentPresentation(this.app, path) : null;
+  }
+
+  private async revealFile(file: TFile): Promise<void> {
+    const workspace = this.app.workspace;
+    let existingLeaf: WorkspaceLeaf | null = null;
+    workspace.iterateRootLeaves(leaf => {
+      if (
+        existingLeaf === null
+        && (
+          leaf.view instanceof FileView
+            ? leaf.view.file?.path === file.path
+            : leaf.isDeferred && leaf.getViewState().state?.file === file.path
+        )
+      ) {
+        existingLeaf = leaf;
+      }
+    });
+    if (existingLeaf) {
+      await revealWorkspaceLeaf(workspace, existingLeaf);
+      return;
+    }
+    await workspace.getLeaf('tab').openFile(file);
   }
 
   private async revealFolder(folder: TFolder): Promise<void> {

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -69,6 +69,12 @@ export class ItemView {
   }
 }
 
+export class FileView extends ItemView {
+  allowNoFile = false;
+  file: any = null;
+  navigation = true;
+}
+
 export class WorkspaceLeaf {}
 
 export class Scope {

--- a/tests/unit/features/chat/linked-content/LinkedContentController.dom.test.ts
+++ b/tests/unit/features/chat/linked-content/LinkedContentController.dom.test.ts
@@ -1,5 +1,5 @@
 import { createMockEl, type MockElement } from '@test/helpers/MockElement';
-import { Notice, TFile, TFolder } from 'obsidian';
+import { FileView, Notice, TFile, TFolder } from 'obsidian';
 
 import { LinkedContentController } from '@/features/chat/linked-content/LinkedContentController';
 import { createWelcomeElement, renderWelcomeContent } from '@/features/chat/rendering/WelcomeRenderer';
@@ -27,6 +27,12 @@ function createFolder(path: string): TFolder {
   return folder;
 }
 
+function createFileView(file: TFile): FileView {
+  const view = Object.create(FileView.prototype) as FileView;
+  Object.assign(view, { file });
+  return view;
+}
+
 async function flushPromises(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
@@ -34,6 +40,7 @@ async function flushPromises(): Promise<void> {
 
 function createHarness(options: {
   entries?: Array<TFile | TFolder>;
+  rootLeaves?: Array<{ view?: unknown }>;
 } = {}) {
   const root = createFolder('');
   const entries = new Map((options.entries ?? []).map(entry => [entry.path, entry]));
@@ -50,6 +57,9 @@ function createHarness(options: {
       getLeaf: jest.fn(() => ({ openFile })),
       getLeavesOfType: jest.fn(() => [explorerLeaf]),
       getLeftLeaf: jest.fn(() => null),
+      iterateRootLeaves: jest.fn((callback: (leaf: { view?: unknown }) => void) => {
+        for (const leaf of options.rootLeaves ?? []) callback(leaf);
+      }),
       revealLeaf: jest.fn().mockResolvedValue(undefined),
     },
     metadataCache: { getFileCache: jest.fn(() => null) },
@@ -331,6 +341,7 @@ describe('LinkedContentController DOM', () => {
     expect(noteChipMain?.getAttribute('title')).toBeNull();
     noteChipMain?.click();
     await flushPromises();
+    expect(harness.app.workspace.getLeaf).toHaveBeenCalledWith('tab');
     expect(harness.openFile).toHaveBeenCalledWith(note);
 
     harness.controller.selectExplicit(folder.path);
@@ -347,6 +358,39 @@ describe('LinkedContentController DOM', () => {
       .toContain('Missing content');
     chip.querySelector('.claudian-context-chip-main')?.click();
     expect(Notice).toHaveBeenCalledWith('Linked content is missing: Missing/Plan.md');
+  });
+
+  it('reveals the existing main editor tab showing the linked file', async () => {
+    const image = createFile('Images/Diagram.png');
+    const existingLeaf = { view: createFileView(image) };
+    const harness = createHarness({ entries: [image], rootLeaves: [existingLeaf] });
+    harness.controller.selectExplicit(image.path);
+
+    await harness.controller.activateCurrentContent();
+
+    expect(harness.app.workspace.revealLeaf).toHaveBeenCalledWith(existingLeaf);
+    expect(harness.app.workspace.getLeaf).not.toHaveBeenCalled();
+    expect(harness.openFile).not.toHaveBeenCalled();
+  });
+
+  it('reveals a deferred editor tab whose view state identifies the linked file', async () => {
+    const note = createFile('Notes/Restored.md');
+    const deferredLeaf = {
+      getViewState: jest.fn(() => ({
+        state: { file: note.path },
+        type: 'markdown',
+      })),
+      isDeferred: true,
+      view: {},
+    };
+    const harness = createHarness({ entries: [note], rootLeaves: [deferredLeaf] });
+    harness.controller.selectExplicit(note.path);
+
+    await harness.controller.activateCurrentContent();
+
+    expect(harness.app.workspace.revealLeaf).toHaveBeenCalledWith(deferredLeaf);
+    expect(harness.app.workspace.getLeaf).not.toHaveBeenCalled();
+    expect(harness.openFile).not.toHaveBeenCalled();
   });
 
   it('removes editable Linked content from the chip but keeps locked content immutable', () => {


### PR DESCRIPTION
## Why

Clicking file-type Linked content could replace the active editor tab even when that file was already open; fixes #1191.

## What Changed

- Reveal an existing root editor tab for loaded and deferred file views.
- Open the Linked content in a new tab only when no existing tab matches.
- Add regression coverage for loaded, non-Markdown, and restored deferred tabs.

## Why This Approach

The controller remains the single owner of Linked content activation, using Obsidian's public file-view and deferred view-state surfaces without changing folder behavior.

## Validation

- `npm run typecheck && npm run lint && npm run test && npm run build`
- 601 suites and 8,722 tests passed; one test skipped.
- `git diff --check`

## Impact and Follow-ups

No settings, persistence formats, or provider behavior changed; automatic tab-follow remains out of scope.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
