### PR TITLE
fix: preserve Pi terminal errors on process exit

### DIFF
--- a/src/providers/pi/execution/PiExecutionSession.ts
+++ b/src/providers/pi/execution/PiExecutionSession.ts
@@ -847,12 +847,14 @@ implements ProviderExecutionSession, SteerableExecutionSession {
     }
     const active = this.activeRun;
     if (active && !active.terminal) {
-      active.terminalSignal.reject(
-        error ?? new Error('Pi subprocess exited.'),
-      );
+      const runError = active.pendingTerminalError
+        ?? error
+        ?? new Error('Pi subprocess exited.');
+      active.pendingTerminalError = null;
+      active.terminalSignal.reject(runError);
       this.finishError(
         active,
-        error ?? new Error('Pi subprocess exited.'),
+        runError,
         missingProviderSessionId
           ? 'provider-session-missing'
           : 'process-exited',

--- a/tests/unit/providers/pi/execution/PiExecutionBackend.test.ts
+++ b/tests/unit/providers/pi/execution/PiExecutionBackend.test.ts
@@ -670,6 +670,36 @@ describe('PiExecutionBackend', () => {
     }));
   });
 
+  it('preserves a pending native Pi error when the process exits before agent end', async () => {
+    const harness = createHarness();
+    const run = harness.session.execute(createRequest());
+    const eventsPromise = collect(run.events);
+    await flush();
+
+    const kernel = harness.kernels[0];
+    kernel.emit({ type: 'agent_start' });
+    kernel.emit({
+      message: {
+        content: [],
+        errorMessage: 'OpenRouter quota exceeded',
+        role: 'assistant',
+        stopReason: 'error',
+      },
+      type: 'message_end',
+    });
+    kernel.close(new Error('Pi process exited'));
+
+    const events = await eventsPromise;
+    expect(events.at(-1)).toMatchObject({
+      category: 'process-exited',
+      message: 'OpenRouter quota exceeded',
+      type: 'execution_error',
+    });
+    expect(events).not.toContainEqual(expect.objectContaining({
+      type: 'turn_completed',
+    }));
+  });
+
   it('can cancel while native Pi is waiting to retry and fences later events', async () => {
     const harness = createHarness();
     const run = harness.session.execute(createRequest());

--- a/tests/unit/providers/pi/runtime/PiEventNormalization.test.ts
+++ b/tests/unit/providers/pi/runtime/PiEventNormalization.test.ts
@@ -1,5 +1,6 @@
 import {
   createPiEventNormalizationState,
+  getPiTerminalErrorMessage,
   normalizePiRpcEvent,
 } from '@/providers/pi/normalizations/piEventNormalization';
 
@@ -171,5 +172,17 @@ describe('Pi event normalization', () => {
       },
       type: 'turn_end',
     }, state)).toEqual([{ type: 'error', content: 'Authentication failed' }]);
+  });
+
+  it('reads terminal errors from the native Pi message payload', () => {
+    expect(getPiTerminalErrorMessage({
+      message: {
+        content: [],
+        errorMessage: 'OpenRouter quota exceeded',
+        role: 'assistant',
+        stopReason: 'error',
+      },
+      type: 'message_end',
+    })).toBe('OpenRouter quota exceeded');
   });
 });


### PR DESCRIPTION
## Why

PR #1185 stages Pi 0.84.3 terminal errors until the corresponding `agent_end` so the provider can declare `willRetry`. If the Pi process exits after the native `message_end.message` error but before `agent_end`, the close path currently replaces that actionable provider message with the generic process-exit error.

This is a focused post-merge follow-up to #1185. No new Issue is needed because the edge was independently reproduced against the merged behavior and remains within the same provider-owned lifecycle boundary.

## What Changed

- Prefer the active run's pending native terminal error when the Pi kernel closes before `agent_end`.
- Preserve the existing `process-exited` category and session invalidation behavior.
- Add an execution regression test for the exact `message_end.message -> process close` sequence.
- Add direct coverage for Pi 0.84.3's nested terminal-error payload.

## Why This Approach

`PiExecutionSession` already owns both the pending terminal error and kernel-close lifecycle, so selecting the most specific error there keeps the change provider-local. Runs without a pending terminal error continue to use the kernel close error or the existing fallback.

This does not change shared contracts, retry timing, stop-reason semantics, or persisted history.

## Validation

- Verified red/green: the new execution test initially returned `Pi process exited`, then passed with `OpenRouter quota exceeded`.
- Focused Pi tests: 2 suites, 60 tests passed.
- `npm run typecheck`
- `npm run lint`
- `npm run test`: 601 suites and 8,724 tests passed; 1 suite and 1 test skipped by the existing repository configuration.
- `npm run build`
- `git diff --check`

## Impact and Follow-ups

Only active Pi runs that already hold a native terminal error when the subprocess exits change behavior. They remain classified as process exits but now surface the provider's actionable message.

Failed-attempt partial-output rollback is intentionally excluded because it requires a separate cross-layer design and final persisted-message tests. Already persisted conversations are not modified.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.