### PR TITLE
Fix Pi session resume on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,9 @@ jobs:
               src/core/process/ManagedStdioProcess.ts | \
               tests/unit/utils/windowsCmdShim.test.ts | \
               tests/unit/core/process/ManagedStdioProcess.test.ts | \
+              src/providers/pi/runtime/PiSubprocess.ts | \
+              tests/unit/providers/pi/runtime/PiSubprocess.test.ts | \
+              tests/integration/providers/pi/PiSubprocess.windows.test.ts | \
               scripts/*collab* | \
               scripts/build* | \
               scripts/check-architecture-boundaries.test.mjs | \
@@ -184,6 +187,10 @@ jobs:
 
       - name: Run OS-sensitive Collab tests
         run: npm run test:cross-platform-collab
+
+      - name: Run Windows Pi launch integration
+        if: runner.os == 'Windows'
+        run: npm run test:unit -- --runInBand tests/integration/providers/pi/PiSubprocess.windows.test.ts
 
   build:
     needs: [quality, test]

--- a/src/core/process/ManagedStdioProcess.ts
+++ b/src/core/process/ManagedStdioProcess.ts
@@ -17,6 +17,7 @@ export interface ManagedStdioProcessOptions {
   cwd: string;
   env: NodeJS.ProcessEnv;
   finalShutdownTimeoutMs?: number;
+  killProcessTree?: boolean;
   sigkillTimeoutMs?: number;
   stderrBufferLimit?: number;
   stdio?: 'pipe' | ['pipe', 'pipe', 'pipe'];

--- a/src/providers/pi/AGENTS.md
+++ b/src/providers/pi/AGENTS.md
@@ -20,6 +20,7 @@
 ## Protocol Rules
 
 - Launch arguments are built in `PiLaunchSpec.ts`. Keep command-line shape there instead of scattering flags across runtime code.
+- On Windows, treat an npm-family `pi.cmd` as an installation locator only: resolve the package-owned `bin.pi` target recorded by npm, pnpm, or Yarn shims and launch that entry through Node with structured arguments. Never serialize Pi prompts or session targets through `cmd.exe`; fail closed when the entrypoint cannot be established.
 - Live events are normalized through `normalizePiRpcEvent()` and `PiEventNormalizationState`.
 - Extension UI requests are routed through `PiExtensionUiBridge` and rendered by `ObsidianPiExtensionUiRenderer`; execution code must not manipulate Obsidian DOM directly.
 - Compact turns call the `compact` RPC request and emit a `context_compacted` stream chunk.
@@ -28,6 +29,7 @@
 
 - `PiProviderState` may store `sessionId`, `sessionFile`, `leafEntryId`, `parentSession`, `previousSessions`, and fork metadata. Do not infer these fields in feature code.
 - Pi can resume by session ID or absolute session file. Absolute session files can be switched in a live process; other target changes require process restart.
+- A relaunched kernel must prove that its initial `get_state` identity matches the requested resume file or ID before any prompt, steer request, or extension dialog response can carry user input. A mismatch fails the turn without replacing persisted session state.
 - History hydration reads Pi JSONL sessions from vault-local (`.pi/agent/sessions/`) and user-level (`~/.pi/agent/sessions/`) roots.
 - Forking creates a new Pi session file by copying the source branch up to `resumeAt` without altering or truncating the source. Keep fork materialization provider-owned.
 - Historical selected-model recovery walks the active JSONL branch to `leafEntryId` and preserves the last native provider/model pair. A missing persisted leaf must fail closed instead of using another branch; never promote `previousSessions` or a recovery-only locator into the live binding.

--- a/src/providers/pi/execution/PiCommandMetadataProbe.ts
+++ b/src/providers/pi/execution/PiCommandMetadataProbe.ts
@@ -66,7 +66,7 @@ export class PiCommandMetadataProbe {
             onClose: () => undefined,
             onEvent: () => undefined,
             onExtensionChunk: () => undefined,
-            onExtensionRequest: () => undefined,
+            onExtensionRequest: () => false,
           },
           null,
         );

--- a/src/providers/pi/execution/PiExecutionKernel.ts
+++ b/src/providers/pi/execution/PiExecutionKernel.ts
@@ -14,7 +14,7 @@ export interface PiExecutionKernelCallbacks {
   onClose(error?: Error): void;
   onEvent(event: PiRpcRecord): void;
   onExtensionChunk(chunk: StreamChunk): void;
-  onExtensionRequest(request: PiRpcRecord): void;
+  onExtensionRequest(request: PiRpcRecord): boolean;
 }
 
 export interface PiExecutionKernel {
@@ -70,13 +70,13 @@ export class PiRpcSessionKernel implements PiExecutionKernel {
       transport,
       this.extensionUiRenderer,
       chunk => this.callbacks.onExtensionChunk(chunk),
+      request => this.callbacks.onExtensionRequest(request),
     );
     this.transport = transport;
     this.extensionBridge = extensionBridge;
     transport.start();
     this.removeEventListener = transport.onEvent((event) => {
       if (event.type === 'extension_ui_request') {
-        this.callbacks.onExtensionRequest(event);
         extensionBridge.handleRequest(event);
         return;
       }

--- a/src/providers/pi/execution/PiExecutionSession.ts
+++ b/src/providers/pi/execution/PiExecutionSession.ts
@@ -157,6 +157,7 @@ implements ProviderExecutionSession, SteerableExecutionSession {
   private kernelGeneration = 0;
   private processKey: string | null = null;
   private readonly kernelSessionTargets = new Set<string>();
+  private kernelResumeValidationTarget: string | null = null;
   private lifecycleError: Error | null = null;
   private normalizationState: PiEventNormalizationState =
     createPiEventNormalizationState();
@@ -269,6 +270,7 @@ implements ProviderExecutionSession, SteerableExecutionSession {
       this.disposed
       || !active
       || !kernel
+      || this.kernelResumeValidationTarget !== null
       || request.signal.aborted
     ) {
       return false;
@@ -386,6 +388,8 @@ implements ProviderExecutionSession, SteerableExecutionSession {
       await this.ensureKernel(encoded.launchSpec, active);
       if (!this.isActive(active) || !this.kernel) return;
 
+      await this.validateKernelResume(active.abortController.signal);
+      if (!this.isActive(active) || !this.kernel) return;
       await this.applyModelConfiguration(encoded, active.abortController.signal);
       if (!this.isActive(active)) return;
       const previousLeafId = getPiState(this.providerState).leafEntryId ?? null;
@@ -612,9 +616,14 @@ implements ProviderExecutionSession, SteerableExecutionSession {
         onExtensionChunk: chunk =>
           this.handleStreamChunk(kernel, generation, chunk),
         onExtensionRequest: () => {
-          if (this.isCurrentKernel(kernel, generation) && this.activeRun) {
-            this.ensureAccepted(this.activeRun);
-          }
+          const currentActive = this.activeRun;
+          if (
+            !this.isCurrentKernel(kernel, generation)
+            || !currentActive
+            || this.kernelResumeValidationTarget !== null
+          ) return false;
+          this.ensureAccepted(currentActive);
+          return true;
         },
       },
       this.config.lifecycle === 'persistent'
@@ -627,6 +636,7 @@ implements ProviderExecutionSession, SteerableExecutionSession {
     }
     this.kernel = kernel;
     this.processKey = launchSpec.processKey;
+    this.kernelResumeValidationTarget = launchSpec.sessionTarget;
     this.replaceKernelSessionTargets(launchSpec.sessionTarget);
     if (
       !this.isActive(active)
@@ -651,6 +661,39 @@ implements ProviderExecutionSession, SteerableExecutionSession {
       return;
     }
     void this.publishCommands(kernel, generation);
+  }
+
+  private async validateKernelResume(signal: AbortSignal): Promise<void> {
+    const expectedTarget = this.kernelResumeValidationTarget;
+    const kernel = this.kernel;
+    if (!expectedTarget || !kernel) return;
+
+    const response = await kernel.request<unknown>(
+      'get_state',
+      {},
+      10_000,
+      signal,
+    );
+    if (
+      this.kernel !== kernel
+      || this.kernelResumeValidationTarget !== expectedTarget
+    ) return;
+    const reportedIdentity = extractReportedPiSessionIdentity(response);
+    if (matchesExpectedPiSession(
+      expectedTarget,
+      getPiState(this.providerState),
+      reportedIdentity,
+    )) {
+      this.kernelResumeValidationTarget = null;
+      return;
+    }
+
+    const error = new PiProviderSessionMismatchError(
+      expectedTarget,
+      reportedIdentity.sessionFile ?? reportedIdentity.sessionId,
+    );
+    await this.shutdownKernel().catch(() => undefined);
+    throw error;
   }
 
   private async applyModelConfiguration(
@@ -841,6 +884,7 @@ implements ProviderExecutionSession, SteerableExecutionSession {
     );
     this.kernel = null;
     this.processKey = null;
+    this.kernelResumeValidationTarget = null;
     this.kernelSessionTargets.clear();
     if (!this.hasNativeSessionState()) {
       this.nativeConversationContextEstablished = false;
@@ -1244,6 +1288,7 @@ implements ProviderExecutionSession, SteerableExecutionSession {
     const kernel = this.kernel;
     this.kernel = null;
     this.processKey = null;
+    this.kernelResumeValidationTarget = null;
     this.kernelSessionTargets.clear();
     this.kernelGeneration += 1;
     if (!this.hasNativeSessionState()) {
@@ -1379,6 +1424,15 @@ class PiProviderSessionMissingError extends Error {
   constructor(readonly providerSessionId: string) {
     super(`Pi session is unavailable: ${providerSessionId}`);
     this.name = 'PiProviderSessionMissingError';
+  }
+}
+
+class PiProviderSessionMismatchError extends Error {
+  constructor(expected: string, reported: string | null) {
+    super(
+      `Pi resumed an unexpected native session. Expected ${expected}, received ${reported ?? 'no session identity'}. The original conversation session was preserved.`,
+    );
+    this.name = 'PiProviderSessionMismatchError';
   }
 }
 
@@ -1576,7 +1630,11 @@ function getFirstRejectedError(
 }
 
 function isSamePath(left: string, right: string): boolean {
-  return path.resolve(left) === path.resolve(right);
+  const resolvedLeft = path.resolve(left);
+  const resolvedRight = path.resolve(right);
+  return process.platform === 'win32'
+    ? resolvedLeft.toLowerCase() === resolvedRight.toLowerCase()
+    : resolvedLeft === resolvedRight;
 }
 
 function toError(error: unknown): Error {
@@ -1630,6 +1688,55 @@ function getPiMissingSessionTarget(
 function extractStateRecord(response: unknown): Record<string, unknown> {
   const record = getRecord(response);
   return getRecord(record.state ?? record.session ?? response);
+}
+
+interface ReportedPiSessionIdentity {
+  readonly sessionFile: string | null;
+  readonly sessionId: string | null;
+}
+
+function extractReportedPiSessionIdentity(response: unknown): ReportedPiSessionIdentity {
+  const state = extractStateRecord(response);
+  return {
+    sessionFile: getString(state.sessionFile)
+      ?? getString(state.session_file)
+      ?? getString(state.sessionPath)
+      ?? getString(state.session_path)
+      ?? getString(state.path),
+    sessionId: getString(state.sessionId)
+      ?? getString(state.session_id)
+      ?? getString(getRecord(state.session).id),
+  };
+}
+
+function matchesExpectedPiSession(
+  expectedTarget: string,
+  expectedState: PiProviderState,
+  reported: ReportedPiSessionIdentity,
+): boolean {
+  const expectedFile = expectedState.sessionFile
+    ?? (isPiSessionPathReference(expectedState.sessionId)
+      ? expectedState.sessionId
+      : isPiSessionPathReference(expectedTarget)
+        ? expectedTarget
+        : null);
+  const expectedId = expectedState.sessionId
+    && !isPiSessionPathReference(expectedState.sessionId)
+    ? expectedState.sessionId
+    : !isPiSessionPathReference(expectedTarget)
+      ? expectedTarget
+      : null;
+  let compared = false;
+
+  if (expectedFile && reported.sessionFile) {
+    compared = true;
+    if (!isSamePath(expectedFile, reported.sessionFile)) return false;
+  }
+  if (expectedId && reported.sessionId) {
+    compared = true;
+    if (expectedId !== reported.sessionId) return false;
+  }
+  return compared;
 }
 
 function findLastRoleId(

--- a/src/providers/pi/runtime/PiExtensionUiBridge.ts
+++ b/src/providers/pi/runtime/PiExtensionUiBridge.ts
@@ -42,6 +42,7 @@ export class PiExtensionUiBridge {
     private readonly transport: PiRpcTransport,
     private readonly renderer: PiExtensionUiRenderer | null,
     private readonly emit?: (chunk: StreamChunk) => void,
+    private readonly admitDialog: (request: PiRpcRecord) => boolean = () => true,
   ) {}
 
   handleRequest(request: PiRpcRecord): boolean {
@@ -113,7 +114,7 @@ export class PiExtensionUiBridge {
     ) => Promise<Record<string, unknown>>,
   ): void {
     const id = getString(request.id);
-    if (!id || !this.renderer) {
+    if (!id || !this.renderer || !this.admitDialog(request)) {
       this.sendCancellation(request);
       return;
     }

--- a/src/providers/pi/runtime/PiSubprocess.ts
+++ b/src/providers/pi/runtime/PiSubprocess.ts
@@ -1,10 +1,16 @@
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { Readable, Writable } from 'node:stream';
 
 import { ManagedStdioProcess } from '@/core/process/ManagedStdioProcess';
-import { getEnhancedPath } from '@/utils/env';
+import {
+  cliPathRequiresNode,
+  findNodeExecutable,
+  getEnhancedPath,
+} from '@/utils/env';
 
 const STDERR_BUFFER_LIMIT = 8_000;
+const PI_PACKAGE_NAME = '@earendil-works/pi-coding-agent';
 
 export interface PiSubprocessLaunchSpec {
   args: string[];
@@ -22,14 +28,17 @@ export class PiSubprocess {
   private readonly process: ManagedStdioProcess;
 
   constructor(launchSpec: PiSubprocessLaunchSpec) {
+    const enhancedPath = getEnhancedPath(
+      launchSpec.env.PATH,
+      path.isAbsolute(launchSpec.command) ? launchSpec.command : undefined,
+    );
+    const processSpec = resolvePiProcessSpec(launchSpec, enhancedPath);
     this.process = new ManagedStdioProcess({
       ...launchSpec,
+      ...processSpec,
       env: {
         ...launchSpec.env,
-        PATH: getEnhancedPath(
-          launchSpec.env.PATH,
-          path.isAbsolute(launchSpec.command) ? launchSpec.command : undefined,
-        ),
+        PATH: enhancedPath,
       },
       stderrBufferLimit: STDERR_BUFFER_LIMIT,
     });
@@ -97,6 +106,140 @@ export class PiSubprocess {
       }
     }
     this.closeListeners.clear();
+  }
+}
+
+function resolvePiProcessSpec(
+  launchSpec: PiSubprocessLaunchSpec,
+  enhancedPath: string,
+): Pick<
+  ConstructorParameters<typeof ManagedStdioProcess>[0],
+  'args' | 'command' | 'killProcessTree'
+> {
+  const command = launchSpec.command.trim();
+  if (process.platform !== 'win32') {
+    return { args: launchSpec.args, command, killProcessTree: false };
+  }
+
+  let nodeEntrypoint: string | null = null;
+  if (command.toLowerCase().endsWith('.cmd')) {
+    nodeEntrypoint = resolveInstalledPiBin(command);
+    if (!nodeEntrypoint) {
+      throw new Error(
+        `The Pi Windows launcher could not be resolved to its Node.js entry point: ${command}`,
+      );
+    }
+  } else if (cliPathRequiresNode(command)) {
+    nodeEntrypoint = command;
+  }
+
+  if (!nodeEntrypoint) {
+    return { args: launchSpec.args, command, killProcessTree: false };
+  }
+
+  const nodeExecutable = findNodeExecutable(enhancedPath);
+  if (!nodeExecutable) {
+    throw new Error(
+      'Pi requires Node.js, but node.exe was not found on PATH. Install Node.js or configure a native Pi executable.',
+    );
+  }
+  return {
+    args: [nodeEntrypoint, ...launchSpec.args],
+    command: nodeExecutable,
+    killProcessTree: true,
+  };
+}
+
+function resolveInstalledPiBin(command: string): string | null {
+  if (path.basename(command).toLowerCase() !== 'pi.cmd') return null;
+
+  const shimTarget = readWindowsCommandShimTarget(command);
+  return shimTarget ? resolveOwningPiPackageBin(shimTarget) : null;
+}
+
+function readWindowsCommandShimTarget(command: string): string | null {
+  try {
+    const contents = fs.readFileSync(command, 'utf8');
+    for (const rawLine of contents.split(/\r?\n/u)) {
+      const line = rawLine.trim();
+      const relativeMatch = /"%(?:~dp0|dp0%)\\([^"\r\n]+?)"\s+%\*\s*$/iu.exec(line);
+      if (
+        relativeMatch?.[1]
+        && isSupportedWindowsNodeInvocation(line.slice(0, relativeMatch.index))
+      ) {
+        const relativeTarget = relativeMatch[1].replace(/[\\/]/gu, path.sep);
+        return path.resolve(path.dirname(command), relativeTarget);
+      }
+
+      const absoluteMatch = /"([^"\r\n]+)"\s+%\*\s*$/u.exec(line);
+      if (
+        absoluteMatch?.[1]
+        && path.isAbsolute(absoluteMatch[1])
+        && isSupportedWindowsNodeInvocation(line.slice(0, absoluteMatch.index))
+      ) {
+        return path.normalize(absoluteMatch[1]);
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function isSupportedWindowsNodeInvocation(value: string): boolean {
+  const invocation = value.trim().replace(/^@/u, '').trim();
+  if (/^node(?:\.exe)?$/iu.test(invocation)) return true;
+  if (/^"%~dp0\\node(?:\.exe)?"$/iu.test(invocation)) return true;
+  if (/^"(?:[a-z]:[\\/]|\\\\)[^"\r\n]*[\\/]node(?:\.exe)?"$/iu.test(invocation)) {
+    return true;
+  }
+  return /^endLocal\s+&\s+goto\s+#_undefined_#\s+2>NUL\s+\|\|\s+title\s+%COMSPEC%\s+&\s+(?:set\s+PATHEXT=[^&\r\n]+\s+&\s+)?"%_prog%"$/iu.test(invocation);
+}
+
+function resolveOwningPiPackageBin(target: string): string | null {
+  const resolvedTarget = path.resolve(target);
+  let current = path.dirname(resolvedTarget);
+  while (true) {
+    const binPath = readPiPackageBin(current);
+    if (binPath && pathsEqual(binPath, resolvedTarget)) return binPath;
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return null;
+}
+
+function pathsEqual(left: string, right: string): boolean {
+  const normalizedLeft = path.normalize(left);
+  const normalizedRight = path.normalize(right);
+  return process.platform === 'win32'
+    ? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
+    : normalizedLeft === normalizedRight;
+}
+
+function readPiPackageBin(packageRoot: string): string | null {
+  try {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'),
+    ) as {
+      bin?: string | Record<string, unknown>;
+      name?: unknown;
+    };
+    if (packageJson.name !== PI_PACKAGE_NAME) return null;
+    const relativeBin = typeof packageJson.bin === 'object'
+      && packageJson.bin !== null
+      && typeof packageJson.bin.pi === 'string'
+      ? packageJson.bin.pi
+      : null;
+    if (!relativeBin) return null;
+
+    const resolvedRoot = path.resolve(packageRoot);
+    const resolvedBin = path.resolve(resolvedRoot, relativeBin);
+    const relative = path.relative(resolvedRoot, resolvedBin);
+    if (relative.startsWith('..') || path.isAbsolute(relative)) return null;
+    return fs.statSync(resolvedBin).isFile() ? resolvedBin : null;
+  } catch {
+    return null;
   }
 }
 

--- a/src/utils/windowsCmdShim.ts
+++ b/src/utils/windowsCmdShim.ts
@@ -48,6 +48,12 @@ export function resolveWindowsCmdShimSpawnSpec(
     };
   }
 
+  if (spec.args.some(value => /[\r\n]/u.test(value))) {
+    throw new Error(
+      'Windows command shims cannot safely receive multiline arguments. Use a native executable or launch the underlying script directly.',
+    );
+  }
+
   const shellCommand = [command, ...spec.args]
     .map(value => quoteWindowsShellArgument(value))
     .join(' ');

--- a/tests/integration/providers/pi/PiSubprocess.windows.test.ts
+++ b/tests/integration/providers/pi/PiSubprocess.windows.test.ts
@@ -1,0 +1,110 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { PiSubprocess } from '@/providers/pi/runtime/PiSubprocess';
+
+const describeOnWindows = process.platform === 'win32' ? describe : describe.skip;
+
+describeOnWindows('PiSubprocess Windows argv integration', () => {
+  it('preserves opaque arguments after bypassing the npm command shim', async () => {
+    const npmPrefix = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-argv-integration-'));
+    const packageRoot = path.join(
+      npmPrefix,
+      'node_modules',
+      '@earendil-works',
+      'pi-coding-agent',
+    );
+    const cliPath = path.join(packageRoot, 'dist', 'bundle', 'cli.js');
+    const commandPath = path.join(npmPrefix, 'pi.cmd');
+    const expectedArgs = [
+      '--mode',
+      'rpc',
+      '--system-prompt',
+      'First line\r\nSecond line with "%PATH%" and !caret^',
+      '--session',
+      'D:\\文档\\Pi Sessions\\session.jsonl',
+    ];
+    let subprocess: PiSubprocess | null = null;
+
+    try {
+      await fs.mkdir(path.dirname(cliPath), { recursive: true });
+      await fs.writeFile(path.join(packageRoot, 'package.json'), JSON.stringify({
+        bin: { pi: 'dist/bundle/cli.js' },
+        name: '@earendil-works/pi-coding-agent',
+      }));
+      await fs.writeFile(cliPath, [
+        'process.stdout.write(`${JSON.stringify(process.argv.slice(2))}\\n`);',
+        'process.stdin.resume();',
+      ].join('\n'));
+      await fs.writeFile(commandPath, createWindowsCommandShim(commandPath, cliPath));
+
+      subprocess = new PiSubprocess({
+        args: expectedArgs,
+        command: commandPath,
+        cwd: npmPrefix,
+        env: { ...process.env },
+      });
+      subprocess.start();
+
+      await expect(readFirstLine(subprocess)).resolves.toEqual(expectedArgs);
+    } finally {
+      await subprocess?.shutdown();
+      await fs.rm(npmPrefix, { force: true, recursive: true });
+    }
+  });
+});
+
+function createWindowsCommandShim(commandPath: string, targetPath: string): string {
+  const relativeTarget = path.relative(path.dirname(commandPath), targetPath)
+    .split(path.sep)
+    .join('\\');
+  return [
+    '@ECHO off',
+    'GOTO start',
+    ':find_dp0',
+    'SET dp0=%~dp0',
+    'EXIT /b',
+    ':start',
+    'SETLOCAL',
+    'CALL :find_dp0',
+    'IF EXIST "%dp0%\\node.exe" (',
+    '  SET "_prog=%dp0%\\node.exe"',
+    ') ELSE (',
+    '  SET "_prog=node"',
+    ')',
+    `endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\${relativeTarget}" %*`,
+    '',
+  ].join('\r\n');
+}
+
+function readFirstLine(subprocess: PiSubprocess): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let buffered = '';
+    const timeout = window.setTimeout(() => {
+      cleanup();
+      reject(new Error('Timed out waiting for the Pi argv fixture'));
+    }, 10_000);
+    const onData = (chunk: Buffer | string): void => {
+      buffered += chunk.toString();
+      const newlineIndex = buffered.indexOf('\n');
+      if (newlineIndex < 0) return;
+      cleanup();
+      try {
+        resolve(JSON.parse(buffered.slice(0, newlineIndex)) as unknown);
+      } catch (error) {
+        reject(error);
+      }
+    };
+    const removeCloseListener = subprocess.onClose(error => {
+      cleanup();
+      reject(error ?? new Error('Pi argv fixture exited before producing output'));
+    });
+    const cleanup = (): void => {
+      window.clearTimeout(timeout);
+      subprocess.stdout.off('data', onData);
+      removeCloseListener();
+    };
+    subprocess.stdout.on('data', onData);
+  });
+}

--- a/tests/unit/providers/pi/execution/PiExecutionBackend.test.ts
+++ b/tests/unit/providers/pi/execution/PiExecutionBackend.test.ts
@@ -57,8 +57,8 @@ class FakeKernel implements PiExecutionKernel {
     this.callbacks.onExtensionChunk(chunk);
   }
 
-  emitExtensionRequest(request: Record<string, unknown>): void {
-    this.callbacks.onExtensionRequest(request);
+  emitExtensionRequest(request: Record<string, unknown>): boolean {
+    return this.callbacks.onExtensionRequest(request);
   }
 
   getStderrSnapshot(): string {
@@ -751,6 +751,11 @@ describe('PiExecutionBackend', () => {
       },
       vaultWorkingDirectory: sessionDir,
     }));
+    harness.responses.set('get_state', {
+      leafEntryId: 'assistant-1',
+      sessionFile,
+      sessionId: 'pi-session-1',
+    });
     harness.host.settings.providerConfigs.pi.environmentVariables =
       `PI_CODING_AGENT_SESSION_DIR=${sessionDir}`;
     const run = harness.session.execute(createRequest({
@@ -770,10 +775,184 @@ describe('PiExecutionBackend', () => {
       payload: { message: 'Hello Pi' },
       type: 'prompt',
     });
+    const requestTypes = harness.kernels[0].requests.map(request => request.type);
+    expect(requestTypes.indexOf('get_state')).toBeLessThan(requestTypes.indexOf('prompt'));
     expect(harness.session.getSnapshot().providerState).toMatchObject({
       customState: 'preserved',
       sessionId: 'pi-session-1',
     });
+    await fs.rm(sessionDir, { force: true, recursive: true });
+  });
+
+  it('fails before dispatch when Pi reports a replacement for the requested session', async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-resume-mismatch-'));
+    const requestedSessionFile = path.join(sessionDir, 'session-a.jsonl');
+    const replacementSessionFile = path.join(sessionDir, 'session-b.jsonl');
+    await fs.writeFile(
+      requestedSessionFile,
+      '{"type":"session","id":"session-a"}\n',
+    );
+    const harness = createHarness(createConfig({
+      resumeSeed: {
+        providerSessionId: 'session-a',
+        providerState: {
+          customState: 'preserved',
+          sessionFile: requestedSessionFile,
+          sessionId: 'session-a',
+        },
+      },
+      vaultWorkingDirectory: sessionDir,
+    }));
+    harness.host.settings.providerConfigs.pi.environmentVariables =
+      `PI_CODING_AGENT_SESSION_DIR=${sessionDir}`;
+    harness.responses.set('get_state', {
+      leafEntryId: 'replacement-assistant',
+      sessionFile: replacementSessionFile,
+      sessionId: 'session-b',
+    });
+
+    const eventsPromise = collect(harness.session.execute(createRequest()).events);
+    await waitFor(() => harness.kernels.length === 1);
+    await waitFor(() => harness.kernels[0].requests.some(request => request.type === 'get_state'));
+    const events = await eventsPromise;
+
+    expect(getPromptMessages(harness.kernels[0])).toEqual([]);
+    expect(harness.kernels[0].shutdown).toHaveBeenCalledTimes(1);
+    expect(events.at(-1)).toMatchObject({
+      category: 'provider',
+      recoverable: true,
+      type: 'execution_error',
+    });
+    expect(harness.session.getSnapshot()).toMatchObject({
+      providerSessionId: 'session-a',
+      providerState: {
+        customState: 'preserved',
+        sessionFile: requestedSessionFile,
+        sessionId: 'session-a',
+      },
+    });
+    await fs.rm(sessionDir, { force: true, recursive: true });
+  });
+
+  it('rejects steer while a relaunched kernel is awaiting resume validation', async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-resume-steer-'));
+    const requestedSessionFile = path.join(sessionDir, 'session-a.jsonl');
+    const replacementSessionFile = path.join(sessionDir, 'session-b.jsonl');
+    await fs.writeFile(
+      requestedSessionFile,
+      '{"type":"session","id":"session-a"}\n',
+    );
+    const getState = createRejectableDeferred<unknown>();
+    const harness = createHarness(createConfig({
+      resumeSeed: {
+        providerSessionId: 'session-a',
+        providerState: {
+          sessionFile: requestedSessionFile,
+          sessionId: 'session-a',
+        },
+      },
+      vaultWorkingDirectory: sessionDir,
+    }), undefined, async <T>(type: string): Promise<T> => {
+      if (type === 'get_state') return getState.promise as Promise<T>;
+      return {} as T;
+    });
+    harness.host.settings.providerConfigs.pi.environmentVariables =
+      `PI_CODING_AGENT_SESSION_DIR=${sessionDir}`;
+    const session = harness.session;
+    if (!isSteerableExecutionSession(session)) {
+      throw new Error('Pi session must expose steer');
+    }
+
+    const eventsPromise = collect(session.execute(createRequest()).events);
+    await waitFor(() => harness.kernels.length === 1);
+    await waitFor(() => harness.kernels[0].requests.some(
+      request => request.type === 'get_state',
+    ));
+
+    await expect(session.steer(createRequest({
+      input: [{ text: 'Do not send this', type: 'text' }],
+    }))).resolves.toBe(false);
+    expect(harness.kernels[0].emitExtensionRequest({
+      id: 'startup-input',
+      method: 'input',
+      type: 'extension_ui_request',
+    })).toBe(false);
+    expect(harness.kernels[0].requests).not.toContainEqual(expect.objectContaining({
+      type: 'steer',
+    }));
+
+    getState.resolve({
+      sessionFile: replacementSessionFile,
+      sessionId: 'session-b',
+    });
+    await eventsPromise;
+    await fs.rm(sessionDir, { force: true, recursive: true });
+  });
+
+  it('ignores stale resume validation from a replaced kernel', async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-resume-stale-'));
+    const requestedSessionFile = path.join(sessionDir, 'session-a.jsonl');
+    const replacementSessionFile = path.join(sessionDir, 'session-b.jsonl');
+    await fs.writeFile(
+      requestedSessionFile,
+      '{"type":"session","id":"session-a"}\n',
+    );
+    const firstGetState = createRejectableDeferred<unknown>();
+    const secondGetState = createRejectableDeferred<unknown>();
+    let getStateCount = 0;
+    const harness = createHarness(createConfig({
+      resumeSeed: {
+        providerSessionId: 'session-a',
+        providerState: {
+          sessionFile: requestedSessionFile,
+          sessionId: 'session-a',
+        },
+      },
+      vaultWorkingDirectory: sessionDir,
+    }), undefined, async <T>(type: string): Promise<T> => {
+      if (type !== 'get_state') return {} as T;
+      getStateCount += 1;
+      return (getStateCount === 1
+        ? firstGetState.promise
+        : secondGetState.promise) as Promise<T>;
+    });
+    harness.host.settings.providerConfigs.pi.environmentVariables =
+      `PI_CODING_AGENT_SESSION_DIR=${sessionDir}`;
+    const session = harness.session;
+    if (!isSteerableExecutionSession(session)) {
+      throw new Error('Pi session must expose steer');
+    }
+
+    const firstRun = session.execute(createRequest());
+    const firstEvents = collect(firstRun.events);
+    await waitFor(() => harness.kernels[0]?.requests.some(
+      request => request.type === 'get_state',
+    ));
+    firstRun.cancel();
+    await firstEvents;
+
+    const secondEvents = collect(session.execute(createRequest()).events);
+    await waitFor(() => harness.kernels[1]?.requests.some(
+      request => request.type === 'get_state',
+    ));
+    firstGetState.resolve({
+      sessionFile: requestedSessionFile,
+      sessionId: 'session-a',
+    });
+    await flush();
+
+    await expect(session.steer(createRequest({
+      input: [{ text: 'Do not send this either', type: 'text' }],
+    }))).resolves.toBe(false);
+    expect(harness.kernels[1].requests).not.toContainEqual(expect.objectContaining({
+      type: 'steer',
+    }));
+
+    secondGetState.resolve({
+      sessionFile: replacementSessionFile,
+      sessionId: 'session-b',
+    });
+    await secondEvents;
     await fs.rm(sessionDir, { force: true, recursive: true });
   });
 
@@ -1863,6 +2042,7 @@ describe('PiExecutionBackend', () => {
       createForkSessionFile,
       rollbackForkSessionFile,
     });
+    harness.responses.set('get_state', retryTarget);
     const firstRun = harness.session.execute(createRequest({
       input: [{ text: 'A', type: 'text' }],
     }));
@@ -2010,6 +2190,7 @@ describe('PiExecutionBackend', () => {
       createForkSessionFile,
       rollbackForkSessionFile,
     });
+    harness.responses.set('get_state', retryTarget);
     const firstRun = harness.session.execute(createRequest({
       input: [{ text: 'A', type: 'text' }],
     }));
@@ -2113,7 +2294,11 @@ describe('PiExecutionBackend', () => {
         },
       },
       vaultWorkingDirectory: tempDir,
-    }));
+    }), kernel => {
+      harness.responses.set('get_state', {
+        sessionFile: kernel.launchSpec.sessionTarget,
+      });
+    });
     const run = harness.session.execute(createRequest());
     const eventsPromise = collect(run.events);
     await waitFor(() => harness.kernels.length === 1);

--- a/tests/unit/providers/pi/runtime/PiExtensionUiBridge.test.ts
+++ b/tests/unit/providers/pi/runtime/PiExtensionUiBridge.test.ts
@@ -1,11 +1,19 @@
 import { PiExtensionUiBridge, type PiExtensionUiRenderer } from '@/providers/pi/runtime/PiExtensionUiBridge';
 import type { PiRpcTransport } from '@/providers/pi/runtime/PiRpcTransport';
 
-function createBridge(renderer: Partial<PiExtensionUiRenderer>) {
+function createBridge(
+  renderer: Partial<PiExtensionUiRenderer>,
+  admitDialog: () => boolean = () => true,
+) {
   const transport = {
     send: jest.fn(),
   } as unknown as PiRpcTransport;
-  const bridge = new PiExtensionUiBridge(transport, renderer as PiExtensionUiRenderer);
+  const bridge = new PiExtensionUiBridge(
+    transport,
+    renderer as PiExtensionUiRenderer,
+    undefined,
+    admitDialog,
+  );
   return { bridge, transport };
 }
 
@@ -35,6 +43,22 @@ describe('PiExtensionUiBridge', () => {
 
     bridge.handleRequest({ id: 'ui-1', method: 'confirm', type: 'extension_ui_request' });
 
+    expect(transport.send).toHaveBeenCalledWith({
+      cancelled: true,
+      id: 'ui-1',
+      type: 'extension_ui_response',
+    });
+  });
+
+  it('cancels a denied dialog before invoking the renderer', () => {
+    const renderer = {
+      input: jest.fn().mockResolvedValue({ value: 'must-not-be-sent' }),
+    };
+    const { bridge, transport } = createBridge(renderer, () => false);
+
+    bridge.handleRequest({ id: 'ui-1', method: 'input', type: 'extension_ui_request' });
+
+    expect(renderer.input).not.toHaveBeenCalled();
     expect(transport.send).toHaveBeenCalledWith({
       cancelled: true,
       id: 'ui-1',

--- a/tests/unit/providers/pi/runtime/PiSubprocess.test.ts
+++ b/tests/unit/providers/pi/runtime/PiSubprocess.test.ts
@@ -1,4 +1,7 @@
 import { EventEmitter } from 'node:events';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { Readable, Writable } from 'node:stream';
 
 jest.mock('node:child_process', () => ({
@@ -29,6 +32,117 @@ function createMockProcess(): any {
 describe('PiSubprocess', () => {
   const originalPlatform = process.platform;
   let proc: any;
+  let windowsNpmPrefix: string;
+  let windowsAbsolutePiCommand: string;
+  let windowsMalformedCommands: string[];
+  let windowsPackageRoot: string;
+  let windowsPiBin: string;
+  let windowsPiCommand: string;
+  let windowsPnpmBin: string;
+  let windowsPnpmCommand: string;
+  let windowsUnownedCommand: string;
+  let windowsUnknownCommand: string;
+  let windowsYarnBin: string;
+  let windowsYarnCommand: string;
+
+  beforeAll(async () => {
+    windowsNpmPrefix = await fs.mkdtemp(path.join(os.tmpdir(), 'pi-windows-launch-'));
+    windowsPackageRoot = path.join(
+      windowsNpmPrefix,
+      'node_modules',
+      '@earendil-works',
+      'pi-coding-agent',
+    );
+    windowsPiBin = path.join(windowsPackageRoot, 'dist', 'bundle', 'cli.js');
+    windowsPiCommand = path.join(windowsNpmPrefix, 'pi.cmd');
+    await fs.mkdir(path.dirname(windowsPiBin), { recursive: true });
+    await fs.writeFile(windowsPiBin, '#!/usr/bin/env node\n');
+    await fs.writeFile(path.join(windowsPackageRoot, 'package.json'), JSON.stringify({
+      bin: { pi: 'dist/bundle/cli.js' },
+      name: '@earendil-works/pi-coding-agent',
+    }));
+    await fs.writeFile(windowsPiCommand, createWindowsCommandShim(
+      windowsPiCommand,
+      windowsPiBin,
+    ));
+    windowsAbsolutePiCommand = path.join(windowsNpmPrefix, 'absolute-bin', 'pi.cmd');
+    await fs.mkdir(path.dirname(windowsAbsolutePiCommand), { recursive: true });
+    await fs.writeFile(
+      windowsAbsolutePiCommand,
+      `@ECHO off\r\nnode "${windowsPiBin}" %*\r\n`,
+    );
+
+    const pnpmPackageRoot = path.join(
+      windowsNpmPrefix,
+      'global',
+      '5',
+      '.pnpm',
+      '@earendil-works+pi-coding-agent@0.84.3',
+      'node_modules',
+      '@earendil-works',
+      'pi-coding-agent',
+    );
+    windowsPnpmBin = path.join(pnpmPackageRoot, 'dist', 'bundle', 'cli.js');
+    windowsPnpmCommand = path.join(windowsNpmPrefix, 'pnpm-bin', 'pi.cmd');
+    await writePiPackage(pnpmPackageRoot, windowsPnpmBin);
+    await fs.mkdir(path.dirname(windowsPnpmCommand), { recursive: true });
+    await fs.writeFile(windowsPnpmCommand, createWindowsCommandShim(
+      windowsPnpmCommand,
+      windowsPnpmBin,
+    ));
+
+    const yarnPackageRoot = path.join(
+      windowsNpmPrefix,
+      'Yarn',
+      'Data',
+      'global',
+      'node_modules',
+      '@earendil-works',
+      'pi-coding-agent',
+    );
+    windowsYarnBin = path.join(yarnPackageRoot, 'dist', 'bundle', 'cli.js');
+    windowsYarnCommand = path.join(windowsNpmPrefix, 'Yarn', 'bin', 'pi.cmd');
+    await writePiPackage(yarnPackageRoot, windowsYarnBin);
+    await fs.mkdir(path.dirname(windowsYarnCommand), { recursive: true });
+    await fs.writeFile(windowsYarnCommand, createWindowsCommandShim(
+      windowsYarnCommand,
+      windowsYarnBin,
+    ));
+
+    const unownedBin = path.join(windowsNpmPrefix, 'unowned', 'cli.js');
+    windowsUnownedCommand = path.join(windowsNpmPrefix, 'unowned-bin', 'pi.cmd');
+    await fs.mkdir(path.dirname(unownedBin), { recursive: true });
+    await fs.mkdir(path.dirname(windowsUnownedCommand), { recursive: true });
+    await fs.writeFile(unownedBin, '#!/usr/bin/env node\n');
+    await fs.writeFile(windowsUnownedCommand, createWindowsCommandShim(
+      windowsUnownedCommand,
+      unownedBin,
+    ));
+
+    windowsUnknownCommand = path.join(windowsNpmPrefix, 'unknown-bin', 'pi.cmd');
+    await fs.mkdir(path.dirname(windowsUnknownCommand), { recursive: true });
+    await fs.writeFile(windowsUnknownCommand, '@ECHO off\r\nunknown-wrapper %*\r\n');
+
+    const malformedDir = path.join(windowsNpmPrefix, 'malformed-bin');
+    await fs.mkdir(malformedDir, { recursive: true });
+    windowsMalformedCommands = await Promise.all([
+      (target: string) => `REM ${target}`,
+      (target: string) => `unknown-wrapper & node ${target}`,
+      (target: string) => `call ${target}`,
+    ].map(async (buildContents, index) => {
+      const command = path.join(malformedDir, String(index), 'pi.cmd');
+      await fs.mkdir(path.dirname(command), { recursive: true });
+      await fs.writeFile(
+        command,
+        `${buildContents(createWindowsCommandTarget(command, windowsPiBin))}\r\n`,
+      );
+      return command;
+    }));
+  });
+
+  afterAll(async () => {
+    await fs.rm(windowsNpmPrefix, { force: true, recursive: true });
+  });
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -61,62 +175,123 @@ describe('PiSubprocess', () => {
     }));
   });
 
-  it('wraps Windows .cmd shims through cmd.exe', () => {
+  it('launches the Pi package entry directly for Windows npm shims', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
     const subprocess = new PiSubprocess({
-      args: ['--mode', 'rpc', '--system-prompt', 'Use R&D policy'],
-      command: 'C:\\Users\\R&D\\AppData\\Roaming\\npm\\pi.cmd',
+      args: [
+        '--mode',
+        'rpc',
+        '--system-prompt',
+        'First line\nUse R&D policy',
+        '--session',
+        'D:\\文档\\Pi Sessions\\session.jsonl',
+      ],
+      command: windowsPiCommand,
       cwd: 'C:\\Vault',
-      env: { PATH: 'C:\\Windows\\System32' },
+      env: { PATH: process.env.PATH },
     });
 
     subprocess.start();
 
     expect(mockSpawn).toHaveBeenCalledWith(
-      process.env.ComSpec || process.env.comspec || 'cmd.exe',
-      ['/d', '/s', '/c', '""C:\\Users\\R&D\\AppData\\Roaming\\npm\\pi.cmd" --mode rpc --system-prompt "Use R&D policy""'],
+      expect.stringMatching(/node(?:\.exe)?$/i),
+      [
+        windowsPiBin,
+        '--mode',
+        'rpc',
+        '--system-prompt',
+        'First line\nUse R&D policy',
+        '--session',
+        'D:\\文档\\Pi Sessions\\session.jsonl',
+      ],
       expect.objectContaining({
         cwd: 'C:\\Vault',
         windowsHide: true,
-        windowsVerbatimArguments: true,
       }),
+    );
+    expect(mockSpawn).not.toHaveBeenCalledWith(
+      process.env.ComSpec || process.env.comspec || 'cmd.exe',
+      expect.anything(),
+      expect.anything(),
     );
   });
 
-  it('preserves Unicode Windows session paths when resuming through a .cmd shim', () => {
+  it('fails closed when a Windows Pi shim targets an unowned script', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
-    const sessionFile = 'D:\\文档\\Documents\\Atlas\\Pi Sessions\\session.jsonl';
+
+    expect(() => new PiSubprocess({
+      args: ['--mode', 'rpc', '--system-prompt', 'First line\nSecond line'],
+      command: windowsUnownedCommand,
+      cwd: 'C:\\Vault',
+      env: { PATH: process.env.PATH },
+    })).toThrow('could not be resolved to its Node.js entry point');
+  });
+
+  it('does not replace an unknown Windows shim with PI_PACKAGE_DIR', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+
+    expect(() => new PiSubprocess({
+      args: ['--mode', 'rpc', '--system-prompt', 'First line\nSecond line'],
+      command: windowsUnknownCommand,
+      cwd: 'C:\\Vault',
+      env: {
+        PATH: process.env.PATH,
+        PI_PACKAGE_DIR: windowsPackageRoot,
+      },
+    })).toThrow('could not be resolved to its Node.js entry point');
+  });
+
+  it.each([
+    ['commented', 0],
+    ['prefixed', 1],
+    ['malformed', 2],
+  ])('rejects a %s owned-bin reference in an unsupported shim layout', (
+    _layout,
+    commandIndex,
+  ) => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+
+    expect(() => new PiSubprocess({
+      args: ['--mode', 'rpc'],
+      command: windowsMalformedCommands[commandIndex],
+      cwd: 'C:\\Vault',
+      env: { PATH: process.env.PATH },
+    })).toThrow('could not be resolved to its Node.js entry point');
+  });
+
+  it.each([
+    ['pnpm', () => windowsPnpmCommand, () => windowsPnpmBin],
+    ['Yarn', () => windowsYarnCommand, () => windowsYarnBin],
+    ['cross-volume', () => windowsAbsolutePiCommand, () => windowsPiBin],
+  ])('resolves the package entry referenced by a %s Windows shim', (
+    _packageManager,
+    getCommand,
+    getBin,
+  ) => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
     const subprocess = new PiSubprocess({
-      args: ['--mode', 'rpc', '--session', sessionFile],
-      command: 'C:\\Users\\dev\\AppData\\Roaming\\npm\\pi.cmd',
-      cwd: 'D:\\文档\\Documents\\Atlas',
-      env: { PATH: 'C:\\Windows\\System32' },
+      args: ['--mode', 'rpc', '--system-prompt', 'First line\nSecond line'],
+      command: getCommand(),
+      cwd: 'C:\\Vault',
+      env: { PATH: process.env.PATH },
     });
 
     subprocess.start();
 
     expect(mockSpawn).toHaveBeenCalledWith(
-      process.env.ComSpec || process.env.comspec || 'cmd.exe',
-      [
-        '/d',
-        '/s',
-        '/c',
-        '"C:\\Users\\dev\\AppData\\Roaming\\npm\\pi.cmd --mode rpc --session "D:\\文档\\Documents\\Atlas\\Pi Sessions\\session.jsonl""',
-      ],
-      expect.objectContaining({
-        cwd: 'D:\\文档\\Documents\\Atlas',
-        windowsVerbatimArguments: true,
-      }),
+      expect.stringMatching(/node(?:\.exe)?$/i),
+      [getBin(), '--mode', 'rpc', '--system-prompt', 'First line\nSecond line'],
+      expect.objectContaining({ windowsHide: true }),
     );
   });
 
-  it('kills the process tree when shutting down Windows .cmd shims', async () => {
+  it('kills the process tree when shutting down a direct Windows Pi launch', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
     const subprocess = new PiSubprocess({
       args: ['--mode', 'rpc'],
-      command: 'C:\\Users\\R&D\\AppData\\Roaming\\npm\\pi.cmd',
+      command: windowsPiCommand,
       cwd: 'C:\\Vault',
-      env: { PATH: 'C:\\Windows\\System32' },
+      env: { PATH: process.env.PATH },
     });
     subprocess.start();
 
@@ -211,3 +386,39 @@ describe('PiSubprocess', () => {
     await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined]);
   });
 });
+
+function createWindowsCommandShim(commandPath: string, targetPath: string): string {
+  return [
+    '@ECHO off',
+    'GOTO start',
+    ':find_dp0',
+    'SET dp0=%~dp0',
+    'EXIT /b',
+    ':start',
+    'SETLOCAL',
+    'CALL :find_dp0',
+    'IF EXIST "%dp0%\\node.exe" (',
+    '  SET "_prog=%dp0%\\node.exe"',
+    ') ELSE (',
+    '  SET "_prog=node"',
+    ')',
+    `endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  ${createWindowsCommandTarget(commandPath, targetPath)}`,
+    '',
+  ].join('\r\n');
+}
+
+function createWindowsCommandTarget(commandPath: string, targetPath: string): string {
+  const relativeTarget = path.relative(path.dirname(commandPath), targetPath)
+    .split(path.sep)
+    .join('\\');
+  return `"%~dp0\\${relativeTarget}" %*`;
+}
+
+async function writePiPackage(packageRoot: string, binPath: string): Promise<void> {
+  await fs.mkdir(path.dirname(binPath), { recursive: true });
+  await fs.writeFile(binPath, '#!/usr/bin/env node\n');
+  await fs.writeFile(path.join(packageRoot, 'package.json'), JSON.stringify({
+    bin: { pi: path.relative(packageRoot, binPath) },
+    name: '@earendil-works/pi-coding-agent',
+  }));
+}

--- a/tests/unit/utils/windowsCmdShim.test.ts
+++ b/tests/unit/utils/windowsCmdShim.test.ts
@@ -26,6 +26,15 @@ describe('windowsCmdShim', () => {
     });
   });
 
+  it('rejects multiline arguments instead of corrupting them through cmd.exe', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+
+    expect(() => resolveWindowsCmdShimSpawnSpec({
+      args: ['--system-prompt', 'first line\nsecond line', '--session', 'session.jsonl'],
+      command: 'C:\\Users\\dev\\AppData\\Roaming\\npm\\pi.cmd',
+    })).toThrow('Windows command shims cannot safely receive multiline arguments');
+  });
+
   it('waits for taskkill to finish terminating the Windows process tree', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
     const proc = { kill: jest.fn().mockReturnValue(true), pid: 4312 };


### PR DESCRIPTION
## Why

Fixes #1186: npm-family Pi command shims on Windows truncated the multiline system prompt before the session argument, creating a replacement native session and silently rebinding conversation metadata.

## What Changed

Resolve active npm, pnpm, and Yarn shim targets to their package-owned Pi entrypoint, preserve structured arguments through Node, validate resumed session identity before all user input, fence stale kernels, and fail closed for unsafe shim layouts.

## Why This Approach

Bypassing cmd.exe removes the lossy serialization boundary, while provider-owned identity and input-admission checks prevent any future launch regression from mutating or adopting the wrong Pi session.

## Validation

Typecheck, lint, build, actionlint, 8,732 tests across 601 suites, focused adversarial review passes, and a real Windows argv integration test wired into the Windows PR gate all cover the change.

## Impact and Follow-ups

Other providers and Pi transcript files are unchanged; the Windows-only real-process test will execute in CI because the local host is macOS.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
