### PR TITLE
Update protocol dependency to 3.2.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "claudian",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.226",
-        "@claudian-collab/protocol": "3.1.0",
+        "@claudian-collab/protocol": "3.2.1",
         "@codemirror/commands": "6.10.0",
         "@codemirror/lang-markdown": "^6.5.2",
         "@codemirror/language": "^6.12.4",
@@ -162,7 +162,7 @@
 
     "@cacheable/utils": ["@cacheable/utils@2.5.0", "", { "dependencies": { "hashery": "^1.5.1", "keyv": "^5.6.0" } }, "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA=="],
 
-    "@claudian-collab/protocol": ["@claudian-collab/protocol@3.1.0", "", { "dependencies": { "@lezer/markdown": "1.7.2" } }, "sha512-5ko6hcz/3Dr6eCMdyyZXQK62QY0GgEH9yP9Kur8OGXLwDW2qsN8D3b4j+3kqOB5KzP8RnzoMOv0oMskn4hc2mQ=="],
+    "@claudian-collab/protocol": ["@claudian-collab/protocol@3.2.1", "", { "dependencies": { "@lezer/markdown": "1.7.2" } }, "sha512-FqUca4/S9Jgu5QsMR4Gs3KgAfYytIdVn8V7w7Fn2hQjJ0nA9D9ULgJlvqOojqwaNh+ci+DblLcD5Z2oC7WJCcw=="],
 
     "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.226",
-        "@claudian-collab/protocol": "3.1.0",
+        "@claudian-collab/protocol": "3.2.1",
         "@codemirror/commands": "6.10.0",
         "@codemirror/lang-markdown": "^6.5.2",
         "@codemirror/language": "^6.12.4",
@@ -827,9 +827,9 @@
       }
     },
     "node_modules/@claudian-collab/protocol": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@claudian-collab/protocol/-/protocol-3.1.0.tgz",
-      "integrity": "sha512-5ko6hcz/3Dr6eCMdyyZXQK62QY0GgEH9yP9Kur8OGXLwDW2qsN8D3b4j+3kqOB5KzP8RnzoMOv0oMskn4hc2mQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@claudian-collab/protocol/-/protocol-3.2.1.tgz",
+      "integrity": "sha512-FqUca4/S9Jgu5QsMR4Gs3KgAfYytIdVn8V7w7Fn2hQjJ0nA9D9ULgJlvqOojqwaNh+ci+DblLcD5Z2oC7WJCcw==",
       "license": "MIT",
       "dependencies": {
         "@lezer/markdown": "1.7.2"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.226",
-    "@claudian-collab/protocol": "3.1.0",
+    "@claudian-collab/protocol": "3.2.1",
     "@codemirror/commands": "6.10.0",
     "@codemirror/lang-markdown": "^6.5.2",
     "@codemirror/language": "^6.12.4",

--- a/scripts/check-architecture-boundaries.test.mjs
+++ b/scripts/check-architecture-boundaries.test.mjs
@@ -623,21 +623,21 @@ test('Claudian consumes the standalone Collab protocol only from the exact regis
     'utf8',
   ));
 
-  assert.equal(manifest.dependencies?.[protocolPackageName], '3.1.0');
+  assert.equal(manifest.dependencies?.[protocolPackageName], '3.2.1');
   assert.equal(manifest.dependencies?.['@lezer/markdown'], '1.7.2');
   assert.equal(protocolManifest.dependencies?.['@lezer/markdown'], '1.7.2');
   assert.equal(manifest.dependencies?.['@claudian/collab-protocol'], undefined);
   assert.equal(manifest.workspaces, undefined);
-  assert.equal(lockfile.packages?.['']?.dependencies?.[protocolPackageName], '3.1.0');
-  assert.equal(lockfile.packages?.[protocolInstallPath]?.version, '3.1.0');
+  assert.equal(lockfile.packages?.['']?.dependencies?.[protocolPackageName], '3.2.1');
+  assert.equal(lockfile.packages?.[protocolInstallPath]?.version, '3.2.1');
   assert.equal(
     lockfile.packages?.[protocolInstallPath]?.integrity,
-    'sha512-5ko6hcz/3Dr6eCMdyyZXQK62QY0GgEH9yP9Kur8OGXLwDW2qsN8D3b4j+3kqOB5KzP8RnzoMOv0oMskn4hc2mQ==',
+    'sha512-FqUca4/S9Jgu5QsMR4Gs3KgAfYytIdVn8V7w7Fn2hQjJ0nA9D9ULgJlvqOojqwaNh+ci+DblLcD5Z2oC7WJCcw==',
   );
   assert.equal(lockfile.packages?.['node_modules/@lezer/markdown']?.version, '1.7.2');
   assert.match(
     lockfile.packages?.[protocolInstallPath]?.resolved ?? '',
-    /^https:\/\/registry\.npmjs\.org\/@claudian-collab\/protocol\/-\/protocol-3\.1\.0\.tgz$/u,
+    /^https:\/\/registry\.npmjs\.org\/@claudian-collab\/protocol\/-\/protocol-3\.2\.1\.tgz$/u,
   );
 
   for (const retiredPath of [

--- a/tests/integration/build/collab-dependency-envelope.test.ts
+++ b/tests/integration/build/collab-dependency-envelope.test.ts
@@ -306,15 +306,15 @@ describe('Collab dependency envelope', () => {
     expect(unusedForgeInputs).toEqual([]);
   });
 
-  it('forces Node WebSocket and bundles the installed registry protocol', () => {
+  it('forces Node WebSocket and bundles the installed registry protocol ESM entry', () => {
     const config = readFileSync(esbuildConfigPath, 'utf8');
     const aliases = {
       ...createDesktopRuntimeAliases(),
     };
     const normalizedInputs = bundleInputs.map(input => input.replaceAll('\\\\', '/'));
     const protocolInputs = normalizedInputs.filter(input => (
-      input.endsWith('/node_modules/@claudian-collab/protocol/dist/index.js')
-      || input === 'node_modules/@claudian-collab/protocol/dist/index.js'
+      input.endsWith('/node_modules/@claudian-collab/protocol/dist/esm/index.mjs')
+      || input === 'node_modules/@claudian-collab/protocol/dist/esm/index.mjs'
     ));
     const bundle = readFileSync(bundlePath, 'utf8');
 


### PR DESCRIPTION
## Summary

- pin `@claudian-collab/protocol` to the published `3.2.1` registry artifact in both npm and Bun locks
- update the exact dependency boundary assertions and integrity pin
- verify esbuild resolves the package root through the tree-shakeable ESM entry

## Validation

- `npm run check:lockfile`
- `npm run typecheck && npm run lint && npm run test && npm run build`
- 8,869 tests passed; 2 skipped