### PR TITLE
test: stabilize Windows Pi integration timeout

### DIFF
--- a/tests/integration/providers/pi/PiSubprocess.windows.test.ts
+++ b/tests/integration/providers/pi/PiSubprocess.windows.test.ts
@@ -52,7 +52,7 @@ describeOnWindows('PiSubprocess Windows argv integration', () => {
       await subprocess?.shutdown();
       await fs.rm(npmPrefix, { force: true, recursive: true });
     }
-  });
+  }, 20_000);
 });
 
 function createWindowsCommandShim(commandPath: string, targetPath: string): string {


### PR DESCRIPTION
## Why

The Windows-only Pi argv integration intermittently exceeded Jest's default 5-second timeout even though its own output deadline and bounded subprocess cleanup can take up to 16 seconds; no issue was filed because this was detected directly in `main` CI.

## What Changed

- Set an explicit 20-second timeout for the Windows Pi subprocess integration test.

## Why This Approach

This aligns the outer test deadline with its existing diagnostic and cleanup bounds without changing production behavior.

## Validation

- `npm run typecheck`
- `npx eslint tests/integration/providers/pi/PiSubprocess.windows.test.ts`
- `npm run test:unit -- --runInBand tests/integration/providers/pi/PiSubprocess.windows.test.ts` (skipped as expected on macOS)
- `git diff --check`
- Build not run because the change only adjusts test configuration and cannot affect production artifacts.

## Impact and Follow-ups

None.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
