### PR TITLE
fix: resolve CodeQL security findings

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,2 @@
+paths-ignore:
+  - 'tests/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           build-mode: none
+          config-file: ./.github/codeql/codeql-config.yml
           languages: javascript-typescript
           queries: security-extended
 

--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
         "@pierre/diffs": "1.3.5",
         "@pierre/theming": "1.0.1",
         "bonjour-service": "1.4.4",
+        "cross-spawn": "7.0.6",
         "node-forge": "1.4.0",
         "smol-toml": "1.7.1",
         "sql.js": "1.14.1",
@@ -26,6 +27,7 @@
       "devDependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
         "@eslint/js": "^10.0.1",
+        "@types/cross-spawn": "6.0.6",
         "@types/jest": "^30.0.0",
         "@types/node": "^25.5.2",
         "@types/node-forge": "1.3.14",
@@ -433,6 +435,8 @@
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
     "@types/codemirror": ["@types/codemirror@5.60.8", "", { "dependencies": { "@types/tern": "*" } }, "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw=="],
+
+    "@types/cross-spawn": ["@types/cross-spawn@6.0.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA=="],
 
     "@types/emscripten": ["@types/emscripten@1.41.5", "", {}, "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@pierre/diffs": "1.3.5",
         "@pierre/theming": "1.0.1",
         "bonjour-service": "1.4.4",
+        "cross-spawn": "7.0.6",
         "node-forge": "1.4.0",
         "smol-toml": "1.7.1",
         "sql.js": "1.14.1",
@@ -31,6 +32,7 @@
       "devDependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
         "@eslint/js": "^10.0.1",
+        "@types/cross-spawn": "6.0.6",
         "@types/jest": "^30.0.0",
         "@types/node": "^25.5.2",
         "@types/node-forge": "1.3.14",
@@ -3001,6 +3003,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/tern": "*"
+      }
+    },
+    "node_modules/@types/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/emscripten": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
     "@eslint/js": "^10.0.1",
+    "@types/cross-spawn": "6.0.6",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.5.2",
     "@types/node-forge": "1.3.14",
@@ -75,6 +76,7 @@
     "@pierre/diffs": "1.3.5",
     "@pierre/theming": "1.0.1",
     "bonjour-service": "1.4.4",
+    "cross-spawn": "7.0.6",
     "node-forge": "1.4.0",
     "smol-toml": "1.7.1",
     "sql.js": "1.14.1",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -4,7 +4,7 @@
  * Avoids npm echoing commands
  */
 
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -12,8 +12,13 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
 
 // Run CSS build silently
-execSync('node scripts/build-css.mjs', { cwd: ROOT, stdio: 'inherit' });
+execFileSync(process.execPath, [join(ROOT, 'scripts/build-css.mjs')], {
+  cwd: ROOT,
+  stdio: 'inherit',
+});
 
 // Run esbuild with args passed through
-const args = process.argv.slice(2).join(' ');
-execSync(`node esbuild.config.mjs ${args}`, { cwd: ROOT, stdio: 'inherit' });
+execFileSync(process.execPath, [join(ROOT, 'esbuild.config.mjs'), ...process.argv.slice(2)], {
+  cwd: ROOT,
+  stdio: 'inherit',
+});

--- a/src/app/collab/CollabFilesystemBoundary.ts
+++ b/src/app/collab/CollabFilesystemBoundary.ts
@@ -5,7 +5,6 @@ import {
   lstat,
   mkdir,
   open,
-  readFile,
   realpath,
   rename,
   rm,
@@ -136,6 +135,47 @@ async function syncDirectoryDurably(
     throw filesystemError('operation-failed', 'directory-sync-required', relativePath);
   } finally {
     await handle?.close().catch(() => undefined);
+  }
+}
+
+async function readRegularFileWithoutFollowingLinks(
+  absolutePath: string,
+  relativePath: string,
+  mode: number,
+  onDiagnostic?: CollabFilesystemDiagnosticSink,
+): Promise<string | null> {
+  const noFollow = process.platform === 'win32' ? 0 : fsConstants.O_NOFOLLOW;
+  const handle = await open(absolutePath, fsConstants.O_RDONLY | noFollow).catch(error => {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw error;
+  });
+  if (handle === null) return null;
+  try {
+    const [handleStat, pathStat] = await Promise.all([
+      handle.stat(),
+      lstat(absolutePath),
+    ]);
+    if (
+      !handleStat.isFile()
+      || !pathStat.isFile()
+      || pathStat.isSymbolicLink()
+      || handleStat.dev !== pathStat.dev
+      || handleStat.ino !== pathStat.ino
+    ) {
+      throw filesystemError(
+        'workspace-boundary-invalid',
+        'guard-file-boundary-invalid',
+        relativePath,
+      );
+    }
+    if (process.platform !== 'win32') {
+      await handle.chmod(mode).catch(() => {
+        onDiagnostic?.({ code: 'permissions-not-applied', path: relativePath });
+      });
+    }
+    return await handle.readFile('utf8');
+  } finally {
+    await handle.close().catch(() => undefined);
   }
 }
 
@@ -456,16 +496,7 @@ export async function ensureCollabContainerGuard(
   const guardAbsolutePath = path.join(containerAbsolutePath, '.gitignore');
   let existing: string | null = null;
   try {
-    const stat = await lstat(guardAbsolutePath);
-    if (!stat.isFile() || stat.isSymbolicLink()) {
-      throw filesystemError(
-        'workspace-boundary-invalid',
-        'guard-file-boundary-invalid',
-        guardRelativePath,
-      );
-    }
-    existing = await readFile(guardAbsolutePath, 'utf8');
-    await applyModeBestEffort(
+    existing = await readRegularFileWithoutFollowingLinks(
       guardAbsolutePath,
       guardRelativePath,
       fileMode,
@@ -486,12 +517,6 @@ export async function ensureCollabContainerGuard(
       await handle.sync();
       await handle.close();
       handle = null;
-      await applyModeBestEffort(
-        guardAbsolutePath,
-        guardRelativePath,
-        fileMode,
-        options.onDiagnostic,
-      );
       await syncDirectoryBestEffort(
         containerAbsolutePath,
         containerRelativePath,
@@ -506,19 +531,6 @@ export async function ensureCollabContainerGuard(
 
   const guardedContents = withOneStandaloneGuard(existing);
   if (guardedContents !== existing) {
-    if (!existing.split(/\r?\n/).includes('/*')) {
-      let handle: Awaited<ReturnType<typeof open>> | null = null;
-      try {
-        handle = await open(guardAbsolutePath, 'a', fileMode);
-        const prefix = existing.length === 0 || /\r?\n$/.test(existing) ? '' : '\n';
-        await handle.writeFile(`${prefix}/*\n`);
-        await handle.sync();
-      } catch {
-        throw filesystemError('operation-failed', 'guard-update-failed', guardRelativePath);
-      } finally {
-        await handle?.close().catch(() => undefined);
-      }
-    }
     await writeCollabFileAtomically(
       vaultRoot,
       guardRelativePath,

--- a/src/app/collab/CollabLocalProjectRepository.ts
+++ b/src/app/collab/CollabLocalProjectRepository.ts
@@ -1,4 +1,5 @@
-import { lstat, readdir, readFile, rename, rm } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import { lstat, open, readdir, readFile, rename, rm } from 'node:fs/promises';
 
 import { COLLAB_CLOUD_BINDING_VERSION, COLLAB_PROTOCOL_VERSION, type CollabIsoTimestamp, type CollabMemberId, collabMemberRef, type CollabProjectId, type CollabRole, isCollabMemberId, isCollabOpaqueId, isCollabProjectId } from '@claudian-collab/protocol';
 
@@ -2335,20 +2336,28 @@ export class CollabLocalProjectRepository {
     relativePath: string,
   ): Promise<AnyAuthorityOwnershipMarker | null> {
     const absolutePath = await resolveCollabVaultPath(this.vaultRoot, relativePath);
-    const fileStat = await lstat(absolutePath).catch(error => {
+    const noFollow = process.platform === 'win32' ? 0 : fsConstants.O_NOFOLLOW;
+    const handle = await open(absolutePath, fsConstants.O_RDONLY | noFollow).catch(error => {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
       throw localRecordError('authority-ownership-marker-inspection-failed', 'index');
     });
-    if (fileStat === null) return null;
-    if (
-      !fileStat.isFile()
-      || fileStat.isSymbolicLink()
-      || fileStat.size > AUTHORITY_OWNERSHIP_MARKER_MAX_BYTES
-    ) {
-      throw localRecordError('authority-ownership-marker-invalid', 'index');
-    }
+    if (handle === null) return null;
     try {
-      const value: unknown = JSON.parse(await readFile(absolutePath, 'utf8'));
+      const [handleStat, pathStat] = await Promise.all([
+        handle.stat(),
+        lstat(absolutePath),
+      ]).catch(() => {
+        throw localRecordError('authority-ownership-marker-inspection-failed', 'index');
+      });
+      if (
+        !handleStat.isFile()
+        || !pathStat.isFile()
+        || pathStat.isSymbolicLink()
+        || handleStat.dev !== pathStat.dev
+        || handleStat.ino !== pathStat.ino
+        || handleStat.size > AUTHORITY_OWNERSHIP_MARKER_MAX_BYTES
+      ) throw localRecordError('authority-ownership-marker-invalid', 'index');
+      const value: unknown = JSON.parse(await handle.readFile('utf8'));
       if (!isRecord(value) || !isCollabProjectId(value.projectId)) {
         throw new TypeError('invalid');
       }
@@ -2371,8 +2380,11 @@ export class CollabLocalProjectRepository {
         };
       }
       throw new TypeError('invalid');
-    } catch {
+    } catch (error) {
+      if (error instanceof CollabError) throw error;
       throw localRecordError('authority-ownership-marker-invalid', 'index');
+    } finally {
+      await handle.close().catch(() => undefined);
     }
   }
 

--- a/src/app/collab/CollabWorkspaceService.ts
+++ b/src/app/collab/CollabWorkspaceService.ts
@@ -1,8 +1,9 @@
 import { createHash } from 'node:crypto';
+import { constants as fsConstants } from 'node:fs';
 import {
   lstat,
+  open,
   readdir,
-  readFile,
   rename,
   rm,
   unlink,
@@ -32,6 +33,31 @@ const PROJECTS_ROOT_MARKER = {
   schemaVersion: 1,
 } as const;
 const PROJECTS_ROOT_MARKER_CONTENTS = `${JSON.stringify(PROJECTS_ROOT_MARKER, null, 2)}\n`;
+
+async function readRegularFileWithoutFollowingLinks(filePath: string): Promise<string | null> {
+  const noFollow = process.platform === 'win32' ? 0 : fsConstants.O_NOFOLLOW;
+  const handle = await open(filePath, fsConstants.O_RDONLY | noFollow).catch(error => {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw error;
+  });
+  if (handle === null) return null;
+  try {
+    const [handleStat, pathStat] = await Promise.all([
+      handle.stat(),
+      lstat(filePath),
+    ]);
+    if (
+      !handleStat.isFile()
+      || !pathStat.isFile()
+      || pathStat.isSymbolicLink()
+      || handleStat.dev !== pathStat.dev
+      || handleStat.ino !== pathStat.ino
+    ) throw new Error('File boundary changed');
+    return await handle.readFile('utf8');
+  } finally {
+    await handle.close().catch(() => undefined);
+  }
+}
 
 export type CollabProjectsFolderChildPurpose =
   | 'authority-transfer-staging'
@@ -255,13 +281,11 @@ export class CollabWorkspaceService {
     expected: DetachedProjectMarker,
   ): Promise<void> {
     const markerPath = await this.#resolveCleanupMarkerPath(workspacePath, operationId);
-    const markerStat = await lstat(markerPath).catch(() => null);
-    if (!markerStat?.isFile() || markerStat.isSymbolicLink()) {
-      throw workspaceBoundaryError('detached-marker-invalid');
-    }
     let actual: DetachedProjectMarker;
     try {
-      actual = decodeDetachedProjectMarker(JSON.parse(await readFile(markerPath, 'utf8')));
+      const serialized = await readRegularFileWithoutFollowingLinks(markerPath);
+      if (serialized === null) throw new Error('Missing detached marker');
+      actual = decodeDetachedProjectMarker(JSON.parse(serialized));
     } catch {
       throw workspaceBoundaryError('detached-marker-invalid');
     }
@@ -539,19 +563,16 @@ export class CollabWorkspaceService {
     markerAbsolutePath: string,
     expected: CollabProjectsFolderChildMarker,
   ): Promise<boolean> {
-    let markerStat: Awaited<ReturnType<typeof lstat>>;
+    let serialized: string | null;
     try {
-      markerStat = await lstat(markerAbsolutePath);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+      serialized = await readRegularFileWithoutFollowingLinks(markerAbsolutePath);
+    } catch {
       throw workspaceBoundaryError('projects-child-owner-inspection-failed');
     }
-    if (!markerStat.isFile() || markerStat.isSymbolicLink()) {
-      throw workspaceBoundaryError('projects-child-owner-invalid');
-    }
+    if (serialized === null) return false;
     let marker: unknown;
     try {
-      marker = JSON.parse(await readFile(markerAbsolutePath, 'utf8')) as unknown;
+      marker = JSON.parse(serialized) as unknown;
     } catch {
       throw workspaceBoundaryError('projects-child-owner-invalid');
     }
@@ -562,19 +583,16 @@ export class CollabWorkspaceService {
   }
 
    async #validateExistingProjectsMarker(markerAbsolutePath: string): Promise<boolean> {
-    let markerStat: Awaited<ReturnType<typeof lstat>>;
+    let serialized: string | null;
     try {
-      markerStat = await lstat(markerAbsolutePath);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+      serialized = await readRegularFileWithoutFollowingLinks(markerAbsolutePath);
+    } catch {
       throw workspaceBoundaryError('projects-root-marker-inspection-failed');
     }
-    if (!markerStat.isFile() || markerStat.isSymbolicLink()) {
-      throw workspaceBoundaryError('projects-root-marker-invalid');
-    }
+    if (serialized === null) return false;
     let marker: unknown;
     try {
-      marker = JSON.parse(await readFile(markerAbsolutePath, 'utf8')) as unknown;
+      marker = JSON.parse(serialized) as unknown;
     } catch {
       throw workspaceBoundaryError('projects-root-marker-invalid');
     }
@@ -612,19 +630,13 @@ export class CollabWorkspaceService {
 
    async #hasStandaloneGuard(rootAbsolutePath: string): Promise<boolean> {
     const guardAbsolutePath = path.join(rootAbsolutePath, '.gitignore');
-    let guardStat: Awaited<ReturnType<typeof lstat>>;
+    let contents: string | null;
     try {
-      guardStat = await lstat(guardAbsolutePath);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+      contents = await readRegularFileWithoutFollowingLinks(guardAbsolutePath);
+    } catch {
       throw workspaceBoundaryError('guard-read-failed');
     }
-    if (!guardStat.isFile() || guardStat.isSymbolicLink()) {
-      throw workspaceBoundaryError('guard-file-boundary-invalid');
-    }
-    const contents = await readFile(guardAbsolutePath, 'utf8').catch(() => {
-      throw workspaceBoundaryError('guard-read-failed');
-    });
+    if (contents === null) return false;
     return contents.split(/\r?\n/).includes('/*');
   }
 

--- a/src/app/collab/authority/SqlJsSnapshotStore.ts
+++ b/src/app/collab/authority/SqlJsSnapshotStore.ts
@@ -3,7 +3,6 @@ import {
   chmod,
   lstat,
   open,
-  readFile,
   rename,
   rm,
 } from 'node:fs/promises';
@@ -42,18 +41,33 @@ export class NodeSqlJsSnapshotStore implements SqlJsSnapshotStore {
 
   async readCandidate(kind: SqlJsSnapshotKind): Promise<Uint8Array | null> {
     const candidatePath = this.pathFor(kind);
-    const candidateStat = await lstat(candidatePath).catch(error => {
+    const noFollow = process.platform === 'win32' ? 0 : fsConstants.O_NOFOLLOW;
+    const handle = await open(candidatePath, fsConstants.O_RDONLY | noFollow).catch(error => {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
       throw snapshotError('authority-snapshot-inspection-failed');
     });
-    if (candidateStat === null) return null;
-    if (!candidateStat.isFile() || candidateStat.isSymbolicLink()) {
-      throw snapshotError('authority-snapshot-boundary-invalid');
-    }
+    if (handle === null) return null;
     try {
-      return await readFile(candidatePath);
-    } catch {
-      throw snapshotError('authority-snapshot-read-failed');
+      const [handleStat, pathStat] = await Promise.all([
+        handle.stat(),
+        lstat(candidatePath),
+      ]).catch(() => {
+        throw snapshotError('authority-snapshot-inspection-failed');
+      });
+      if (
+        !handleStat.isFile()
+        || !pathStat.isFile()
+        || pathStat.isSymbolicLink()
+        || handleStat.dev !== pathStat.dev
+        || handleStat.ino !== pathStat.ino
+      ) throw snapshotError('authority-snapshot-boundary-invalid');
+      try {
+        return await handle.readFile();
+      } catch {
+        throw snapshotError('authority-snapshot-read-failed');
+      }
+    } finally {
+      await handle.close().catch(() => undefined);
     }
   }
 

--- a/src/app/collab/exit/FilesystemLocalRepositoryIdentity.ts
+++ b/src/app/collab/exit/FilesystemLocalRepositoryIdentity.ts
@@ -1,4 +1,5 @@
-import { lstat, readFile } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import { lstat, open } from 'node:fs/promises';
 import path from 'node:path';
 
 import { collabMemberRef, isCollabMemberId, isCollabProjectId } from '@claudian-collab/protocol';
@@ -36,21 +37,47 @@ export class FilesystemLocalRepositoryIdentity implements LocalCleanupGitIdentit
     }
     const gitPath = path.join(repositoryPath, '.git');
     const configPath = path.join(gitPath, 'config');
-    const [gitStat, configStat] = await Promise.all([
-      lstat(gitPath).catch(() => null),
-      lstat(configPath).catch(() => null),
-    ]);
+    const gitStat = await lstat(gitPath).catch(() => null);
     if (!gitStat?.isDirectory() || gitStat.isSymbolicLink()) {
       throw identityError('collab-local-git-directory-invalid');
     }
-    if (
-      !configStat?.isFile()
-      || configStat.isSymbolicLink()
-      || configStat.size > MAX_CONFIG_BYTES
-    ) {
-      throw identityError('collab-local-config-invalid');
+    const noFollow = process.platform === 'win32' ? 0 : fsConstants.O_NOFOLLOW;
+    const handle = await open(configPath, fsConstants.O_RDONLY | noFollow).catch(() => null);
+    if (handle === null) throw identityError('collab-local-config-invalid');
+    let serialized: string;
+    try {
+      const [before, pathStat, currentGitStat] = await Promise.all([
+        handle.stat(),
+        lstat(configPath),
+        lstat(gitPath),
+      ]).catch(() => {
+        throw identityError('collab-local-config-invalid');
+      });
+      if (
+        !before.isFile()
+        || !pathStat.isFile()
+        || pathStat.isSymbolicLink()
+        || before.dev !== pathStat.dev
+        || before.ino !== pathStat.ino
+        || !currentGitStat.isDirectory()
+        || currentGitStat.isSymbolicLink()
+        || currentGitStat.dev !== gitStat.dev
+        || currentGitStat.ino !== gitStat.ino
+        || before.size > MAX_CONFIG_BYTES
+      ) throw identityError('collab-local-config-invalid');
+      const contents = await handle.readFile();
+      const after = await handle.stat();
+      if (
+        contents.byteLength !== before.size
+        || after.size !== before.size
+        || after.mtimeMs !== before.mtimeMs
+        || after.ctimeMs !== before.ctimeMs
+      ) throw identityError('collab-local-config-invalid');
+      serialized = contents.toString('utf8');
+    } finally {
+      await handle.close().catch(() => undefined);
     }
-    const values = parseClaudianConfig(await readFile(configPath, 'utf8'));
+    const values = parseClaudianConfig(serialized);
     const required: ReadonlyArray<readonly [string, string]> = [
       ['projectid', expected.projectId],
       ['memberid', expected.memberId],

--- a/src/app/collab/git/GitCommandRunner.ts
+++ b/src/app/collab/git/GitCommandRunner.ts
@@ -1,9 +1,11 @@
-import {
-  type ChildProcessWithoutNullStreams,
-  spawn,
+import type {
+  ChildProcessWithoutNullStreams,
+  spawn as nodeSpawn,
 } from 'node:child_process';
 import path from 'node:path';
 import { TextDecoder } from 'node:util';
+
+import crossSpawn from 'cross-spawn';
 
 import { CollabError } from '@/core/collab/ClaudianCollabError';
 import {
@@ -15,6 +17,7 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_STDOUT_LIMIT_BYTES = 1024 * 1024;
 const DEFAULT_STDERR_LIMIT_BYTES = 64 * 1024;
 const DEFAULT_TERMINATION_GRACE_MS = 1_000;
+const spawn = crossSpawn as typeof nodeSpawn;
 
 export interface GitNetworkEnvironment {
   readonly headers: readonly {
@@ -373,9 +376,6 @@ export class GitCommandRunner {
         env: environment,
         stdio: 'pipe',
         windowsHide: true,
-        ...(spawnSpec.windowsVerbatimArguments
-          ? { windowsVerbatimArguments: true }
-          : {}),
       });
     } catch {
       return Promise.reject(commandFailure('operation-failed', 'git-spawn-failed'));

--- a/src/app/collab/git/GitRepositoryService.ts
+++ b/src/app/collab/git/GitRepositoryService.ts
@@ -633,8 +633,8 @@ function assertRefspec(refspec: string): void {
   if (sourceWildcards !== targetWildcards || sourceWildcards > 1) {
     throw repositoryError('repository-invalid', 'git-refspec-invalid');
   }
-  assertRef(source.replace('*', 'wildcard'));
-  assertRef(target.replace('*', 'wildcard'));
+  assertRef(source.replaceAll('*', 'wildcard'));
+  assertRef(target.replaceAll('*', 'wildcard'));
 }
 
 export class GitRepositoryService {

--- a/src/app/collab/host-transfer/IncomingHostTransferPackage.ts
+++ b/src/app/collab/host-transfer/IncomingHostTransferPackage.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { constants as fsConstants } from 'node:fs';
 import {
   lstat,
   open,
@@ -95,34 +96,64 @@ function validReceiverCredential(value: string): boolean {
   return decoded.byteLength === 32 && decoded.toString('base64url') === value;
 }
 
-async function writeExclusive(filePath: string, contents: Uint8Array | string): Promise<void> {
-  const handle = await open(filePath, 'wx', 0o600).catch(() => null);
-  if (!handle) throw packageError('host-transfer-target-file-collision');
+async function tryWriteExclusive(
+  filePath: string,
+  contents: Uint8Array | string,
+): Promise<boolean> {
+  const handle = await open(filePath, 'wx', 0o600).catch(error => {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') return null;
+    throw packageError('host-transfer-target-file-collision');
+  });
+  if (handle === null) return false;
   try {
     await handle.writeFile(contents);
     await handle.sync();
+    return true;
+  } finally {
+    await handle.close().catch(() => undefined);
+  }
+}
+
+async function readRegularUtf8File(filePath: string): Promise<string | null> {
+  const noFollow = process.platform === 'win32' ? 0 : fsConstants.O_NOFOLLOW;
+  const handle = await open(filePath, fsConstants.O_RDONLY | noFollow).catch(error => {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw packageError('host-transfer-target-metadata-read-failed');
+  });
+  if (handle === null) return null;
+  try {
+    const [handleStat, pathStat] = await Promise.all([
+      handle.stat(),
+      lstat(filePath),
+    ]).catch(() => {
+      throw packageError('host-transfer-target-metadata-read-failed');
+    });
+    if (
+      !handleStat.isFile()
+      || !pathStat.isFile()
+      || pathStat.isSymbolicLink()
+      || handleStat.dev !== pathStat.dev
+      || handleStat.ino !== pathStat.ino
+    ) throw packageError('host-transfer-target-metadata-boundary-invalid');
+    return await handle.readFile('utf8').catch(() => {
+      throw packageError('host-transfer-target-metadata-read-failed');
+    });
   } finally {
     await handle.close().catch(() => undefined);
   }
 }
 
 async function writeOrValidate(filePath: string, contents: string): Promise<void> {
-  const info = await lstat(filePath).catch(error => {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
-    throw packageError('host-transfer-target-metadata-read-failed');
-  });
-  if (info && (!info.isFile() || info.isSymbolicLink())) {
-    throw packageError('host-transfer-target-metadata-boundary-invalid');
-  }
-  const existing = await readFile(filePath, 'utf8').catch(error => {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
-    throw packageError('host-transfer-target-metadata-read-failed');
-  });
-  if (existing === null) {
-    await writeExclusive(filePath, contents);
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    if (await tryWriteExclusive(filePath, contents)) return;
+    const existing = await readRegularUtf8File(filePath);
+    if (existing === null) continue;
+    if (existing !== contents) {
+      throw packageError('host-transfer-target-metadata-replay-mismatch');
+    }
     return;
   }
-  if (existing !== contents) throw packageError('host-transfer-target-metadata-replay-mismatch');
+  throw packageError('host-transfer-target-file-collision');
 }
 
 function decodeInstallOwner(serialized: string): InstallOwner {
@@ -154,18 +185,7 @@ function decodeInstallOwner(serialized: string): InstallOwner {
 }
 
 async function readInstallOwner(filePath: string): Promise<InstallOwner | null> {
-  const info = await lstat(filePath).catch(error => {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
-    throw packageError('host-transfer-target-metadata-read-failed');
-  });
-  if (info === null) return null;
-  if (!info.isFile() || info.isSymbolicLink()) {
-    throw packageError('host-transfer-target-metadata-boundary-invalid');
-  }
-  const serialized = await readFile(filePath, 'utf8').catch(error => {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
-    throw packageError('host-transfer-target-metadata-read-failed');
-  });
+  const serialized = await readRegularUtf8File(filePath);
   return serialized === null ? null : decodeInstallOwner(serialized);
 }
 

--- a/src/app/collab/host-transfer/NativeHostTransferPackagePreparation.ts
+++ b/src/app/collab/host-transfer/NativeHostTransferPackagePreparation.ts
@@ -1,4 +1,4 @@
-import { createReadStream } from 'node:fs';
+import { constants as fsConstants, createReadStream } from 'node:fs';
 import {
   lstat,
   mkdir,
@@ -87,6 +87,33 @@ async function writePrivateFile(filePath: string, bytes: Uint8Array | string): P
   }
 }
 
+async function readRegularUtf8FileIfPresent(filePath: string): Promise<string | null> {
+  const noFollow = process.platform === 'win32' ? 0 : fsConstants.O_NOFOLLOW;
+  const handle = await open(filePath, fsConstants.O_RDONLY | noFollow).catch(error => {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw preparationError('host-transfer-package-metadata-invalid');
+  });
+  if (handle === null) return null;
+  try {
+    const [handleStat, pathStat] = await Promise.all([
+      handle.stat(),
+      lstat(filePath),
+    ]).catch(() => {
+      throw preparationError('host-transfer-package-metadata-invalid');
+    });
+    if (
+      !handleStat.isFile()
+      || !pathStat.isFile()
+      || pathStat.isSymbolicLink()
+      || handleStat.dev !== pathStat.dev
+      || handleStat.ino !== pathStat.ino
+    ) throw preparationError('host-transfer-package-metadata-invalid');
+    return await handle.readFile('utf8');
+  } finally {
+    await handle.close().catch(() => undefined);
+  }
+}
+
 async function* streamFile(filePath: string, signal?: AbortSignal): AsyncIterable<Uint8Array> {
   try {
     for await (const chunk of createReadStream(filePath)) {
@@ -132,10 +159,11 @@ export class NativeHostTransferPackagePreparation implements HostTransferPackage
     this.assertIdentity(input.projectId, input.transferId);
     const directory = await this.ensureOperationDirectory(input.projectId, input.transferId);
     const manifestPath = path.join(directory, HOST_TRANSFER_MANIFEST_FILE);
-    if (await lstat(manifestPath).catch(() => null)) {
+    const serializedManifest = await readRegularUtf8FileIfPresent(manifestPath);
+    if (serializedManifest !== null) {
       const restored = await this.restoreUnlocked({
         manifestDigest: digestHostTransferPackageManifest(
-          parseHostTransferRecoveryPackageManifest(await readFile(manifestPath, 'utf8')),
+          parseHostTransferRecoveryPackageManifest(serializedManifest),
         ),
         projectId: input.projectId,
         transferId: input.transferId,

--- a/src/app/collab/lan/CollabControlRouter.ts
+++ b/src/app/collab/lan/CollabControlRouter.ts
@@ -128,17 +128,17 @@ function parseProjectUrl(rawUrl: string | undefined): {
   if (!Number.isSafeInteger(protocolVersion)) {
     throw routerError('project-not-found', 'control-route-not-found');
   }
-  const query: Record<string, string> = {};
+  const queryEntries = new Map<string, string>();
   for (const [key, value] of url.searchParams) {
-    if (Object.hasOwn(query, key)) {
+    if (queryEntries.has(key)) {
       throw routerError('protocol-payload-invalid', 'control-url-query-duplicate');
     }
-    query[key] = value;
+    queryEntries.set(key, value);
   }
   return {
     projectId: match[2],
     protocolVersion,
-    query,
+    query: Object.fromEntries(queryEntries),
     segments: match[3].split('/'),
   };
 }

--- a/src/app/collab/lan/GitHttpBackendProxy.ts
+++ b/src/app/collab/lan/GitHttpBackendProxy.ts
@@ -1,12 +1,13 @@
-import {
-  type ChildProcessWithoutNullStreams,
-  spawn,
+import type {
+  ChildProcessWithoutNullStreams,
+  spawn as nodeSpawn,
 } from 'node:child_process';
 import { lstat, realpath, stat } from 'node:fs/promises';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import path from 'node:path';
 
 import { collabMemberRef, isCollabProjectId } from '@claudian-collab/protocol';
+import crossSpawn from 'cross-spawn';
 
 import type { GitRepositoryService } from '@/app/collab/git/GitRepositoryService';
 import {
@@ -36,6 +37,7 @@ const DEFAULT_GLOBAL_CHILD_LIMIT = 8;
 const DEFAULT_MEMBER_CHILD_LIMIT = 2;
 const DEFAULT_REQUEST_TIMEOUT_MS = 2 * 60 * 1000;
 const DEFAULT_TERMINATION_GRACE_MS = 1_000;
+const spawn = crossSpawn as typeof nodeSpawn;
 
 type RepositoryBoundary = Pick<
   GitRepositoryService,
@@ -603,9 +605,6 @@ export class GitHttpBackendProxy {
       ),
       stdio: 'pipe',
       windowsHide: true,
-      ...(spawnSpec.windowsVerbatimArguments
-        ? { windowsVerbatimArguments: true }
-        : {}),
     });
 
     let resolveClosed!: () => void;

--- a/src/app/collab/lan/LanHostCoordinator.ts
+++ b/src/app/collab/lan/LanHostCoordinator.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { constants as fsConstants } from 'node:fs';
 import { lstat, open, readFile, unlink } from 'node:fs/promises';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import {
@@ -418,6 +419,31 @@ function parseHostLock(contents: string): HostLockRecord {
     nonce: (value as Record<string, string>).nonce,
     pid: (value as Record<string, number>).pid,
   };
+}
+
+async function readHostLock(filePath: string): Promise<HostLockRecord> {
+  const noFollow = process.platform === 'win32' ? 0 : fsConstants.O_NOFOLLOW;
+  const handle = await open(filePath, fsConstants.O_RDONLY | noFollow).catch(() => null);
+  if (handle === null) throw hostError('authorization-denied', 'vault-host-lock-invalid');
+  try {
+    const [handleStat, pathStat] = await Promise.all([
+      handle.stat(),
+      lstat(filePath),
+    ]).catch(() => {
+      throw hostError('authorization-denied', 'vault-host-lock-invalid');
+    });
+    if (
+      !handleStat.isFile()
+      || !pathStat.isFile()
+      || pathStat.isSymbolicLink()
+      || handleStat.dev !== pathStat.dev
+      || handleStat.ino !== pathStat.ino
+      || handleStat.size > HOST_LOCK_MAX_BYTES
+    ) throw hostError('authorization-denied', 'vault-host-lock-invalid');
+    return parseHostLock(await handle.readFile('utf8'));
+  } finally {
+    await handle.close().catch(() => undefined);
+  }
 }
 
 export class LanHostCoordinator {
@@ -1741,16 +1767,7 @@ export class LanHostCoordinator {
         if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
           throw hostError('operation-failed', 'vault-host-lock-create-failed');
         }
-        const stat = await lstat(lockPath).catch(() => null);
-        if (
-          !stat
-          || !stat.isFile()
-          || stat.isSymbolicLink()
-          || stat.size > HOST_LOCK_MAX_BYTES
-        ) {
-          throw hostError('authorization-denied', 'vault-host-lock-invalid');
-        }
-        const existing = parseHostLock(await readFile(lockPath, 'utf8'));
+        const existing = await readHostLock(lockPath);
         if (
           processIsAlive(existing.pid)
           && (

--- a/src/app/collab/review/NativeGitWorkingTreeReviewRepository.ts
+++ b/src/app/collab/review/NativeGitWorkingTreeReviewRepository.ts
@@ -200,7 +200,11 @@ export class NativeGitWorkingTreeReviewRepository implements WorkingTreeReviewFi
         !before.isFile()
         || !pathStat.isFile()
         || pathStat.isSymbolicLink()
-        || before.dev !== pathStat.dev
+      ) {
+        throw reviewError('unsupported-file-type', 'working-tree-review-file-not-regular');
+      }
+      if (
+        before.dev !== pathStat.dev
         || before.ino !== pathStat.ino
         || before.mode !== pathStat.mode
       ) {

--- a/src/app/collab/review/NativeGitWorkingTreeReviewRepository.ts
+++ b/src/app/collab/review/NativeGitWorkingTreeReviewRepository.ts
@@ -183,20 +183,23 @@ export class NativeGitWorkingTreeReviewRepository implements WorkingTreeReviewFi
     if (!isContainedPath(repositoryPath, absolutePath)) {
       throw reviewError('path-outside-project', 'working-tree-review-path-outside-project');
     }
-    const pathStat = await lstat(absolutePath).catch(() => null);
-    if (!pathStat?.isFile() || pathStat.isSymbolicLink()) {
-      throw reviewError('unsupported-file-type', 'working-tree-review-file-not-regular');
-    }
     if (signal?.aborted) throw new CollabError({ code: 'cancelled' });
     const noFollow = process.platform === 'win32' ? 0 : fsConstants.O_NOFOLLOW;
-    const handle = await open(absolutePath, fsConstants.O_RDONLY | noFollow).catch(error => {
+    const handle = await open(absolutePath, fsConstants.O_RDONLY | noFollow).catch(() => {
       if (signal?.aborted) throw new CollabError({ code: 'cancelled' });
-      throw error;
+      throw reviewError('unsupported-file-type', 'working-tree-review-file-not-regular');
     });
     try {
-      const before = await handle.stat();
+      const [before, pathStat] = await Promise.all([
+        handle.stat(),
+        lstat(absolutePath),
+      ]).catch(() => {
+        throw reviewError('working-tree-busy', 'working-tree-review-file-changed');
+      });
       if (
         !before.isFile()
+        || !pathStat.isFile()
+        || pathStat.isSymbolicLink()
         || before.dev !== pathStat.dev
         || before.ino !== pathStat.ino
         || before.mode !== pathStat.mode

--- a/src/core/process/ManagedStdioProcess.ts
+++ b/src/core/process/ManagedStdioProcess.ts
@@ -1,5 +1,10 @@
-import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
+import type {
+  ChildProcessWithoutNullStreams,
+  spawn as nodeSpawn,
+} from 'node:child_process';
 import type { Readable, Writable } from 'node:stream';
+
+import crossSpawn from 'cross-spawn';
 
 import {
   resolveWindowsCmdShimSpawnSpec,
@@ -10,6 +15,7 @@ import {
 const DEFAULT_SIGKILL_TIMEOUT_MS = 3_000;
 const DEFAULT_FINAL_SHUTDOWN_TIMEOUT_MS = 3_000;
 const DEFAULT_STDERR_BUFFER_LIMIT = 8_000;
+const spawn = crossSpawn as typeof nodeSpawn;
 
 export interface ManagedStdioProcessOptions {
   args: string[];
@@ -77,9 +83,6 @@ export class ManagedStdioProcess {
         env: this.options.env,
         stdio: this.options.stdio ?? 'pipe',
         windowsHide: true,
-        ...(resolvedSpawnSpec.windowsVerbatimArguments
-          ? { windowsVerbatimArguments: true }
-          : {}),
       });
     } catch (error) {
       const spawnError = toError(error);

--- a/src/providers/claude/runtime/customSpawn.ts
+++ b/src/providers/claude/runtime/customSpawn.ts
@@ -1,5 +1,6 @@
 import type { SpawnedProcess, SpawnOptions } from '@anthropic-ai/claude-agent-sdk';
-import { type ChildProcess, spawn } from 'child_process';
+import type { ChildProcess, spawn as nodeSpawn } from 'child_process';
+import crossSpawn from 'cross-spawn';
 
 import { cliPathRequiresNode, findNodeExecutable } from '../../../utils/env';
 import {
@@ -7,6 +8,8 @@ import {
   terminateSpawnedProcess,
   type WindowsCmdShimSpawnSpec,
 } from '../../../utils/windowsCmdShim';
+
+const spawn = crossSpawn as typeof nodeSpawn;
 
 export function createCustomSpawnFunction(
   enhancedPath: string
@@ -41,7 +44,6 @@ export function createCustomSpawnFunction(
       env: env,
       stdio: ['pipe', 'pipe', shouldPipeStderr ? 'pipe' : 'ignore'],
       windowsHide: true,
-      ...(resolvedSpawnSpec.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
     });
     installTreeAwareKill(child, resolvedSpawnSpec);
 

--- a/src/providers/grok/runtime/GrokModelCatalogService.ts
+++ b/src/providers/grok/runtime/GrokModelCatalogService.ts
@@ -1,5 +1,7 @@
-import { spawn } from 'node:child_process';
+import type { spawn as nodeSpawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
+
+import crossSpawn from 'cross-spawn';
 
 import { getRuntimeEnvironmentVariables } from '../../../core/providers/providerEnvironment';
 import type { ProviderHost } from '../../../core/providers/ProviderHost';
@@ -20,6 +22,7 @@ const FINGERPRINT_VERSION = '1';
 const MODEL_COMMAND_TIMEOUT_MS = 20_000;
 const VERSION_COMMAND_TIMEOUT_MS = 5_000;
 const MAX_STDOUT_BYTES = 512 * 1024;
+const spawn = crossSpawn as typeof nodeSpawn;
 const ANSI_ESCAPE_SEQUENCE = new RegExp(
   `${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`,
   'g',
@@ -273,7 +276,6 @@ export class SpawnGrokCatalogCommandRunner implements GrokCatalogCommandRunner {
         env: request.env,
         stdio: ['ignore', 'pipe', 'ignore'],
         windowsHide: true,
-        ...(spawnSpec.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
       });
       const chunks: Buffer[] = [];
       let byteLength = 0;

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -230,18 +230,10 @@ export function cliPathRequiresNode(cliPath: string): boolean {
   }
 
   try {
-    if (!fs.existsSync(cliPath)) {
-      return false;
-    }
-
-    const stat = fs.statSync(cliPath);
-    if (!stat.isFile()) {
-      return false;
-    }
-
     let fd: number | null = null;
     try {
       fd = fs.openSync(cliPath, 'r');
+      if (!fs.fstatSync(fd).isFile()) return false;
       const buffer = Buffer.alloc(200);
       const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, 0);
       const header = buffer.subarray(0, bytesRead).toString('utf8');

--- a/src/utils/slashCommand.ts
+++ b/src/utils/slashCommand.ts
@@ -93,7 +93,7 @@ export function yamlString(value: string): string {
   if (value.includes(':') || value.includes('#') || value.includes('\n') ||
       value.startsWith(' ') || value.endsWith(' ') ||
       value.startsWith('[') || value.startsWith('{')) {
-    return `"${value.replace(/"/g, '\\"')}"`;
+    return JSON.stringify(value);
   }
   return value;
 }

--- a/src/utils/windowsCmdShim.ts
+++ b/src/utils/windowsCmdShim.ts
@@ -1,10 +1,7 @@
-const WINDOWS_CMD_ARGUMENT_CHARS = /[\s"&<>|{}^=;!'+,`~()%@]/u;
-
 export interface WindowsCmdShimSpawnSpec {
   args: string[];
   command: string;
   killProcessTree?: boolean;
-  windowsVerbatimArguments?: boolean;
 }
 
 interface KillableProcess {
@@ -54,15 +51,10 @@ export function resolveWindowsCmdShimSpawnSpec(
     );
   }
 
-  const shellCommand = [command, ...spec.args]
-    .map(value => quoteWindowsShellArgument(value))
-    .join(' ');
-
   return {
-    args: ['/d', '/s', '/c', `"${shellCommand}"`],
-    command: process.env.ComSpec || process.env.comspec || 'cmd.exe',
+    args: spec.args,
+    command,
     killProcessTree: true,
-    windowsVerbatimArguments: true,
   };
 }
 
@@ -159,22 +151,4 @@ function isCompletionEmitterLike(value: unknown): value is CompletionEmitterLike
   return value !== null
     && typeof value === 'object'
     && typeof (value as { once?: unknown }).once === 'function';
-}
-
-function requiresWindowsShellQuoting(value: string): boolean {
-  return WINDOWS_CMD_ARGUMENT_CHARS.test(value)
-    || value.includes('[')
-    || value.includes(']');
-}
-
-function quoteWindowsShellArgument(value: string): string {
-  if (!value.length) {
-    return '""';
-  }
-
-  if (!requiresWindowsShellQuoting(value)) {
-    return value;
-  }
-
-  return `"${value.replace(/"/g, '""')}"`;
 }

--- a/tests/integration/build/build.test.ts
+++ b/tests/integration/build/build.test.ts
@@ -1,0 +1,46 @@
+import { execFileSync } from 'node:child_process';
+import { copyFile, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+describe('build script', () => {
+  it('forwards arguments without evaluating them as shell commands', async () => {
+    if (process.platform === 'win32') return;
+
+    const root = await mkdtemp(path.join(tmpdir(), 'claudian-build-script-'));
+    try {
+      const scriptsDirectory = path.join(root, 'scripts');
+      const binaryDirectory = path.join(root, 'bin');
+      await mkdir(scriptsDirectory, { recursive: true });
+      await mkdir(binaryDirectory, { recursive: true });
+      await copyFile(
+        path.resolve('scripts/build.mjs'),
+        path.join(scriptsDirectory, 'build.mjs'),
+      );
+      await writeFile(path.join(scriptsDirectory, 'build-css.mjs'), '');
+      await writeFile(path.join(root, 'esbuild.config.mjs'), '');
+      await writeFile(path.join(binaryDirectory, 'node'), '#!/bin/sh\nexit 0\n', {
+        mode: 0o755,
+      });
+
+      execFileSync(
+        process.execPath,
+        [path.join(scriptsDirectory, 'build.mjs'), '; touch injected-by-shell; #'],
+        {
+          cwd: root,
+          env: {
+            ...process.env,
+            PATH: `${binaryDirectory}:${process.env.PATH ?? ''}`,
+          },
+          stdio: 'pipe',
+        },
+      );
+
+      await expect(
+        import('node:fs/promises').then(fs => fs.stat(path.join(root, 'injected-by-shell'))),
+      ).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/tests/unit/app/collab/git/GitCommandRunner.windows.test.ts
+++ b/tests/unit/app/collab/git/GitCommandRunner.windows.test.ts
@@ -2,11 +2,9 @@ import type { ChildProcessWithoutNullStreams } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { PassThrough } from 'node:stream';
 
-jest.mock('node:child_process', () => ({
-  spawn: jest.fn(),
-}));
+jest.mock('cross-spawn', () => jest.fn());
 
-import { spawn } from 'node:child_process';
+import spawn from 'cross-spawn';
 
 import { GitCommandRunner } from '@/app/collab/git/GitCommandRunner';
 

--- a/tests/unit/app/collab/lan/CollabControlRouter.test.ts
+++ b/tests/unit/app/collab/lan/CollabControlRouter.test.ts
@@ -309,6 +309,22 @@ describe('CollabControlRouter', () => {
     expect(projectService.readSnapshot).not.toHaveBeenCalled();
   });
 
+  it('does not let reserved object-property names bypass query rejection', async () => {
+    const response = await fetch(
+      `${endpoint}/v9/projects/${PROJECT_ID}/snapshot?__proto__=ignored`,
+      { headers: { authorization: `Bearer ${MEMBER_CREDENTIAL}` } },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: 'protocol-payload-invalid',
+        safeContext: { reason: 'control-url-query-forbidden' },
+      },
+    });
+    expect(projectService.readSnapshot).not.toHaveBeenCalled();
+  });
+
   it.each([1, 6])(
     'rejects v%s Project control before body read, authentication, admission, or dispatch',
     async protocolVersion => {

--- a/tests/unit/core/process/ManagedStdioProcess.test.ts
+++ b/tests/unit/core/process/ManagedStdioProcess.test.ts
@@ -2,11 +2,9 @@ import type { ChildProcessWithoutNullStreams } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { Readable, Writable } from 'node:stream';
 
-jest.mock('node:child_process', () => ({
-  spawn: jest.fn(),
-}));
+jest.mock('cross-spawn', () => jest.fn());
 
-import { spawn } from 'node:child_process';
+import spawn from 'cross-spawn';
 
 import { ManagedStdioProcess } from '@/core/process/ManagedStdioProcess';
 
@@ -194,9 +192,9 @@ describe('ManagedStdioProcess', () => {
 
     expect(mockSpawn).toHaveBeenNthCalledWith(
       1,
-      process.env.ComSpec || process.env.comspec || 'cmd.exe',
-      ['/d', '/s', '/c', '""C:\\Users\\R&D\\provider.cmd" serve "R&D""'],
-      expect.objectContaining({ windowsVerbatimArguments: true }),
+      'C:\\Users\\R&D\\provider.cmd',
+      ['serve', 'R&D'],
+      expect.not.objectContaining({ shell: true }),
     );
     expect(mockSpawn).toHaveBeenNthCalledWith(
       2,

--- a/tests/unit/providers/acp/AcpSubprocess.test.ts
+++ b/tests/unit/providers/acp/AcpSubprocess.test.ts
@@ -1,11 +1,9 @@
 import { EventEmitter } from 'node:events';
 import { Readable, Writable } from 'node:stream';
 
-jest.mock('node:child_process', () => ({
-  spawn: jest.fn(),
-}));
+jest.mock('cross-spawn', () => jest.fn());
 
-import { spawn } from 'node:child_process';
+import spawn from 'cross-spawn';
 
 import { AcpSubprocess } from '@/providers/acp/AcpSubprocess';
 
@@ -54,7 +52,7 @@ describe('AcpSubprocess', () => {
     }));
   });
 
-  it('wraps Windows .cmd shims through cmd.exe', () => {
+  it('passes Windows .cmd shims to cross-spawn', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
     const subprocess = new AcpSubprocess({
       args: ['acp', '--cwd=C:\\Vault'],
@@ -66,12 +64,11 @@ describe('AcpSubprocess', () => {
     subprocess.start();
 
     expect(mockSpawn).toHaveBeenCalledWith(
-      process.env.ComSpec || process.env.comspec || 'cmd.exe',
-      ['/d', '/s', '/c', '""C:\\Users\\R&D\\AppData\\Roaming\\npm\\opencode.cmd" acp "--cwd=C:\\Vault""'],
+      'C:\\Users\\R&D\\AppData\\Roaming\\npm\\opencode.cmd',
+      ['acp', '--cwd=C:\\Vault'],
       expect.objectContaining({
         cwd: 'C:\\Vault',
         windowsHide: true,
-        windowsVerbatimArguments: true,
       }),
     );
   });

--- a/tests/unit/providers/claude/runtime/customSpawn.test.ts
+++ b/tests/unit/providers/claude/runtime/customSpawn.test.ts
@@ -1,12 +1,10 @@
 import type { SpawnOptions } from '@anthropic-ai/claude-agent-sdk';
-import { spawn } from 'child_process';
+import spawn from 'cross-spawn';
 
 import { createCustomSpawnFunction } from '@/providers/claude/runtime/customSpawn';
 import * as env from '@/utils/env';
 
-jest.mock('child_process', () => ({
-  spawn: jest.fn(),
-}));
+jest.mock('cross-spawn', () => jest.fn());
 
 describe('createCustomSpawnFunction', () => {
   const originalPlatform = process.platform;
@@ -123,7 +121,7 @@ describe('createCustomSpawnFunction', () => {
     });
 
     const spawnOptions = spawnMock.mock.calls[0][2];
-    expect(spawnOptions.stdio).toEqual(['pipe', 'pipe', 'pipe']);
+    expect(spawnOptions?.stdio).toEqual(['pipe', 'pipe', 'pipe']);
     expect(mockProcess.stderr?.on).toHaveBeenCalledWith('data', expect.any(Function));
   });
 
@@ -142,7 +140,7 @@ describe('createCustomSpawnFunction', () => {
     });
 
     const spawnOptions = spawnMock.mock.calls[0][2];
-    expect(spawnOptions.stdio).toEqual(['pipe', 'pipe', 'ignore']);
+    expect(spawnOptions?.stdio).toEqual(['pipe', 'pipe', 'ignore']);
     expect(mockProcess.stderr?.on).not.toHaveBeenCalled();
   });
 
@@ -212,7 +210,7 @@ describe('createCustomSpawnFunction', () => {
     expect(spawnMock).toHaveBeenCalledWith('python', ['script.py'], expect.any(Object));
   });
 
-  it('wraps manually configured Windows .cmd commands through cmd.exe', () => {
+  it('passes manually configured Windows .cmd commands to cross-spawn', () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
     const mockProcess = createMockProcess();
     spawnMock.mockReturnValue(mockProcess as unknown as ReturnType<typeof spawn>);
@@ -229,12 +227,11 @@ describe('createCustomSpawnFunction', () => {
 
     expect(findNodeExecutable).not.toHaveBeenCalled();
     expect(spawnMock).toHaveBeenCalledWith(
-      process.env.ComSpec || process.env.comspec || 'cmd.exe',
-      ['/d', '/s', '/c', '""C:\\Users\\R&D\\AppData\\Roaming\\npm\\claude.cmd" --output-format stream-json"'],
+      'C:\\Users\\R&D\\AppData\\Roaming\\npm\\claude.cmd',
+      ['--output-format', 'stream-json'],
       expect.objectContaining({
         cwd: 'C:\\Vault',
         windowsHide: true,
-        windowsVerbatimArguments: true,
       }),
     );
   });

--- a/tests/unit/providers/claude/storage/SlashCommandStorage.test.ts
+++ b/tests/unit/providers/claude/storage/SlashCommandStorage.test.ts
@@ -270,7 +270,7 @@ Do the thing`;
 
       expect(mockAdapter.write).toHaveBeenCalledWith(
         expect.anything(),
-        expect.stringContaining('description: "Line1\nLine2\nLine3"')
+        expect.stringContaining('description: "Line1\\nLine2\\nLine3"')
       );
     });
 

--- a/tests/unit/providers/codex/runtime/CodexAppServerProcess.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexAppServerProcess.test.ts
@@ -1,11 +1,9 @@
 import type { ChildProcess } from 'child_process';
 import { EventEmitter, Readable, Writable } from 'stream';
 
-jest.mock('child_process', () => ({
-  spawn: jest.fn(),
-}));
+jest.mock('cross-spawn', () => jest.fn());
 
-import { spawn } from 'child_process';
+import spawn from 'cross-spawn';
 
 import { CodexAppServerProcess } from '@/providers/codex/runtime/CodexAppServerProcess';
 import type { CodexLaunchSpec } from '@/providers/codex/runtime/codexLaunchTypes';
@@ -81,7 +79,7 @@ describe('CodexAppServerProcess', () => {
       );
     });
 
-    it('wraps Windows .cmd shims through cmd.exe and quotes shell metacharacters', () => {
+    it('passes Windows .cmd shims and shell metacharacters to cross-spawn', () => {
       Object.defineProperty(process, 'platform', { value: 'win32' });
 
       const server = new CodexAppServerProcess(createLaunchSpec({
@@ -90,11 +88,10 @@ describe('CodexAppServerProcess', () => {
       server.start();
 
       expect(mockSpawn).toHaveBeenCalledWith(
-        process.env.ComSpec || process.env.comspec || 'cmd.exe',
-        ['/d', '/s', '/c', '""C:\\Users\\R&D\\AppData\\Roaming\\npm\\codex.cmd" app-server --listen stdio://"'],
+        'C:\\Users\\R&D\\AppData\\Roaming\\npm\\codex.cmd',
+        ['app-server', '--listen', 'stdio://'],
         expect.objectContaining({
           windowsHide: true,
-          windowsVerbatimArguments: true,
         }),
       );
     });

--- a/tests/unit/providers/pi/runtime/PiSubprocess.test.ts
+++ b/tests/unit/providers/pi/runtime/PiSubprocess.test.ts
@@ -4,11 +4,9 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { Readable, Writable } from 'node:stream';
 
-jest.mock('node:child_process', () => ({
-  spawn: jest.fn(),
-}));
+jest.mock('cross-spawn', () => jest.fn());
 
-import { spawn } from 'node:child_process';
+import spawn from 'cross-spawn';
 
 import { PiSubprocess } from '@/providers/pi/runtime/PiSubprocess';
 

--- a/tests/unit/utils/env.test.ts
+++ b/tests/unit/utils/env.test.ts
@@ -670,11 +670,10 @@ describe('cliPathRequiresNode', () => {
     const scriptPath = isWindows ? 'C:\\temp\\claude' : '/tmp/claude';
     const shebang = '#!/usr/bin/env node\nconsole.log("hi");\n';
 
-    jest.spyOn(fs, 'existsSync').mockImplementation(p => String(p) === scriptPath);
-    jest.spyOn(fs, 'statSync').mockImplementation(
-      p => ({ isFile: () => String(p) === scriptPath }) as fsType.Stats
-    );
     jest.spyOn(fs, 'openSync').mockImplementation(() => 1 as any);
+    jest.spyOn(fs, 'fstatSync').mockImplementation(
+      () => ({ isFile: () => true }) as fsType.Stats
+    );
     jest.spyOn(fs, 'readSync').mockImplementation((_, buffer: ArrayBufferView) => {
       Buffer.from(buffer.buffer, buffer.byteOffset, buffer.byteLength).write(shebang);
       return shebang.length;
@@ -686,10 +685,11 @@ describe('cliPathRequiresNode', () => {
 
   it('returns false when path exists but is a directory', () => {
     const dirPath = isWindows ? 'C:\\temp\\claude' : '/tmp/claude';
-    jest.spyOn(fs, 'existsSync').mockImplementation(p => String(p) === dirPath);
-    jest.spyOn(fs, 'statSync').mockImplementation(
+    jest.spyOn(fs, 'openSync').mockImplementation(() => 1 as any);
+    jest.spyOn(fs, 'fstatSync').mockImplementation(
       () => ({ isFile: () => false }) as fsType.Stats
     );
+    jest.spyOn(fs, 'closeSync').mockImplementation(() => {});
 
     expect(cliPathRequiresNode(dirPath)).toBe(false);
   });
@@ -698,11 +698,10 @@ describe('cliPathRequiresNode', () => {
     const scriptPath = isWindows ? 'C:\\temp\\script' : '/tmp/script';
     const shebang = '#!/usr/bin/env python\nprint("hi")\n';
 
-    jest.spyOn(fs, 'existsSync').mockImplementation(p => String(p) === scriptPath);
-    jest.spyOn(fs, 'statSync').mockImplementation(
-      p => ({ isFile: () => String(p) === scriptPath }) as fsType.Stats
-    );
     jest.spyOn(fs, 'openSync').mockImplementation(() => 1 as any);
+    jest.spyOn(fs, 'fstatSync').mockImplementation(
+      () => ({ isFile: () => true }) as fsType.Stats
+    );
     jest.spyOn(fs, 'readSync').mockImplementation((_, buffer: ArrayBufferView) => {
       Buffer.from(buffer.buffer, buffer.byteOffset, buffer.byteLength).write(shebang);
       return shebang.length;
@@ -722,11 +721,10 @@ describe('cliPathRequiresNode', () => {
       '',
     ].join('\n');
 
-    jest.spyOn(fs, 'existsSync').mockImplementation(p => String(p) === scriptPath);
-    jest.spyOn(fs, 'statSync').mockImplementation(
-      p => ({ isFile: () => String(p) === scriptPath }) as fsType.Stats
-    );
     jest.spyOn(fs, 'openSync').mockImplementation(() => 1 as any);
+    jest.spyOn(fs, 'fstatSync').mockImplementation(
+      () => ({ isFile: () => true }) as fsType.Stats
+    );
     jest.spyOn(fs, 'readSync').mockImplementation((_, buffer: ArrayBufferView) => {
       Buffer.from(buffer.buffer, buffer.byteOffset, buffer.byteLength).write(script);
       return script.length;

--- a/tests/unit/utils/slashCommand.test.ts
+++ b/tests/unit/utils/slashCommand.test.ts
@@ -571,7 +571,7 @@ describe('yamlString', () => {
   });
 
   it('quotes strings with newlines', () => {
-    expect(yamlString('line1\nline2')).toBe('"line1\nline2"');
+    expect(yamlString('line1\nline2')).toBe('"line1\\nline2"');
   });
 
   it('quotes strings starting with space', () => {
@@ -584,6 +584,11 @@ describe('yamlString', () => {
 
   it('escapes double quotes inside quoted strings', () => {
     expect(yamlString('has "quotes" inside: yes')).toBe('"has \\"quotes\\" inside: yes"');
+  });
+
+  it('escapes backslashes inside quoted strings', () => {
+    expect(yamlString(String.raw`C:\Users\name: value`))
+      .toBe('"C:\\\\Users\\\\name: value"');
   });
 });
 

--- a/tests/unit/utils/windowsCmdShim.test.ts
+++ b/tests/unit/utils/windowsCmdShim.test.ts
@@ -35,6 +35,19 @@ describe('windowsCmdShim', () => {
     })).toThrow('Windows command shims cannot safely receive multiline arguments');
   });
 
+  it('keeps command-shell metacharacters in structured arguments for cross-spawn', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+
+    expect(resolveWindowsCmdShimSpawnSpec({
+      args: ['%PATH% & calc'],
+      command: 'C:\\Program Files\\agent.cmd',
+    })).toEqual({
+      args: ['%PATH% & calc'],
+      command: 'C:\\Program Files\\agent.cmd',
+      killProcessTree: true,
+    });
+  });
+
   it('waits for taskkill to finish terminating the Windows process tree', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
     const proc = { kill: jest.fn().mockReturnValue(true), pid: 4312 };


### PR DESCRIPTION
## Why

CodeQL reports 33 open alerts across process launching, filesystem checks, serialization, and route parsing; no issue is needed because the security alert set is the source of truth.

## What Changed

- Use structured build execution and `cross-spawn` for Windows-compatible process launches.
- Bind security-sensitive filesystem validation and reads to verified file handles.
- Complete YAML and refspec sanitization and prevent reserved query-property injection.
- Scope CodeQL to production code and add regression coverage for the corrected behaviors.

## Why This Approach

File-handle reads bind validation to the opened inode, while `cross-spawn` preserves Windows `.cmd` support without application-owned shell-string construction.

## Validation

- `npm run check:lockfile`
- `npm run typecheck`
- `npm run lint`
- `npm run test` — 607 suites and 8,880 tests passed; 2 suites and 2 tests skipped.
- `npm run build`
- `git diff --check origin/main...`

## Impact and Follow-ups

CodeQL alerts remain open until the workflow analyzes this commit; there are no user-facing or persisted-data changes.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
