### PR TITLE
fix(model-selector): read the model display name from Claude Code settings

### DIFF
--- a/src/core/types/chat.ts
+++ b/src/core/types/chat.ts
@@ -291,6 +291,8 @@ export type StreamChunk =
  */
 export interface UsageInfo {
   model?: string;
+  /** Actual model served by the provider runtime, when it differs from `model`. */
+  runtimeModel?: string;
   inputTokens: number;
   /** Prompt caching: tokens used to create cache entries. Claude-specific; 0 if omitted. */
   cacheCreationInputTokens?: number;

--- a/src/features/chat/tabs/runtime/TabRuntimeUI.ts
+++ b/src/features/chat/tabs/runtime/TabRuntimeUI.ts
@@ -274,6 +274,10 @@ function buildInputToolbar(
     getCapabilities: () => getTabCapabilities(shell, plugin),
     getSettings: () => getTabSettingsSnapshot(shell, plugin),
     getEnvironmentVariables: () => plugin.getActiveEnvironmentVariables(),
+    getRuntimeModel: () => {
+      const tab = runtimeRef.current();
+      return tab?.state?.usage?.runtimeModel ?? null;
+    },
     onModelChange: async (model: string) => {
       const tab = runtimeRef.requirePublished();
       if (!options.isRuntimeLive(tab)) return;

--- a/src/features/chat/ui/InputToolbar.ts
+++ b/src/features/chat/ui/InputToolbar.ts
@@ -57,8 +57,18 @@ export interface ToolbarCallbacks {
   onPermissionModeChange: (mode: string) => Promise<void>;
   getSettings: () => ToolbarSettings;
   getEnvironmentVariables?: () => string;
+  /** Actual model served by the running session, when known. */
+  getRuntimeModel?: () => string | null;
   getUIConfig: () => ProviderChatUIConfig;
   getCapabilities: () => ProviderCapabilities;
+}
+
+/** Normalize a model id for display comparison: drop the provider prefix and the [1m] context modifier. */
+function normalizeModelReference(modelId: string): string {
+  const trimmed = modelId.trim().toLowerCase();
+  const separatorIndex = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf(':'));
+  const base = separatorIndex >= 0 ? trimmed.slice(separatorIndex + 1) : trimmed;
+  return base.endsWith('[1m]') ? base.slice(0, -4) : base;
 }
 
 export class ModelSelector {
@@ -115,8 +125,25 @@ export class ModelSelector {
         width: 12,
       });
     }
+    const displayLabel = displayModel?.label || 'Unknown';
+    const runtimeModel = this.callbacks.getRuntimeModel?.()?.trim() || null;
+    let label = displayLabel;
+    if (runtimeModel && displayModel) {
+      const runtimeRef = normalizeModelReference(runtimeModel);
+      const optionRef = normalizeModelReference(displayModel.value);
+      if (runtimeRef && runtimeRef !== optionRef) {
+        // The session reports a different model than the selected option: show
+        // its display name (settings _NAME, else raw request name), falling
+        // back to the option label when the model is not configured.
+        const runtimeOption = models.find(m => normalizeModelReference(m.value) === runtimeRef);
+        label = runtimeOption?.label ?? displayLabel;
+      }
+    }
     const labelEl = this.buttonEl.createSpan({ cls: 'claudian-model-label' });
-    labelEl.setText(displayModel?.label || 'Unknown');
+    labelEl.setText(label);
+    if (runtimeModel) {
+      this.buttonEl.setAttribute('title', label === displayLabel ? runtimeModel : displayLabel);
+    }
   }
 
   renderOptions() {

--- a/src/providers/claude/env/claudeUserSettingsEnv.ts
+++ b/src/providers/claude/env/claudeUserSettingsEnv.ts
@@ -1,0 +1,86 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { resolveClaudeConfigDir } from '../config/ClaudeConfigDir';
+import { CLAUDE_MODEL_ENV_KEYS } from './claudeModelEnv';
+
+/**
+ * Model-related environment read from the user-level Claude Code settings file
+ * (the file CC Switch and the Claude Code CLI rewrite when the provider or
+ * model changes). Claudian only reads this file; it never modifies it.
+ */
+export interface ClaudeUserSettingsModelEnvironment {
+  /** Model selection env vars (ANTHROPIC_MODEL / ANTHROPIC_DEFAULT_*_MODEL). */
+  env: Record<string, string>;
+  /** Display names (ANTHROPIC_DEFAULT_*_MODEL_NAME) keyed by their model id. */
+  displayNames: Record<string, string>;
+}
+
+const EMPTY_ENVIRONMENT: ClaudeUserSettingsModelEnvironment = {
+  env: {},
+  displayNames: {},
+};
+
+/**
+ * Extract the model-related env block of a Claude Code settings file.
+ * Only model selection keys and their display-name counterparts are read;
+ * auth tokens and other secrets never leave this function.
+ */
+export function readClaudeUserSettingsModelFile(
+  filePath: string,
+): ClaudeUserSettingsModelEnvironment {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return { ...EMPTY_ENVIRONMENT };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { ...EMPTY_ENVIRONMENT };
+  }
+
+  const record = parsed as { env?: Record<string, unknown> } | null;
+  const env = record && typeof record === 'object' && record.env
+    && typeof record.env === 'object' && !Array.isArray(record.env)
+    ? record.env
+    : {};
+  const result: Record<string, string> = {};
+  const displayNames: Record<string, string> = {};
+
+  for (const envKey of CLAUDE_MODEL_ENV_KEYS) {
+    const value = env[envKey];
+    if (typeof value !== 'string' || value.length === 0) {
+      continue;
+    }
+    result[envKey] = value;
+    if (envKey === 'ANTHROPIC_MODEL') {
+      continue;
+    }
+    const name = env[envKey + '_NAME'];
+    if (typeof name === 'string' && name.length > 0) {
+      displayNames[value] = name;
+    }
+  }
+
+  return { env: result, displayNames };
+}
+
+/**
+ * Resolve the user-level Claude Code settings file and read its model
+ * environment. The file is read live on each call (it is a few KB) so
+ * provider switches made through CC Switch are reflected without a plugin
+ * restart. Test runs are skipped so unit tests stay hermetic.
+ */
+export function getClaudeUserSettingsModelEnvironment(
+  configDir?: string,
+): ClaudeUserSettingsModelEnvironment {
+  if (process.env.NODE_ENV === 'test') {
+    return { ...EMPTY_ENVIRONMENT };
+  }
+  const directory = configDir ?? resolveClaudeConfigDir();
+  return readClaudeUserSettingsModelFile(path.join(directory, 'settings.json'));
+}

--- a/src/providers/claude/execution/ClaudeExecutionEventNormalizer.ts
+++ b/src/providers/claude/execution/ClaudeExecutionEventNormalizer.ts
@@ -148,6 +148,9 @@ export class ClaudeExecutionEventNormalizer {
       }
       if (isContextWindowEvent(event)) {
         const model = options.intendedModel ?? state.lastUsage?.model ?? 'sonnet';
+        const runtimeModel = typeof event.model === 'string' && event.model !== model
+          ? event.model
+          : undefined;
         const authoritativeContextWindow = isFinitePositiveNumber(
           options.authoritativeContextWindow,
         )
@@ -172,6 +175,19 @@ export class ClaudeExecutionEventNormalizer {
             event: {
               type: 'usage_updated',
               usage: correctedUsage,
+            },
+          });
+        }
+        // Streaming usage only knows the intended model; surface the actual
+        // model reported by the runtime for display, not for selection.
+        if (runtimeModel && state.lastUsage && state.lastUsage.runtimeModel !== runtimeModel) {
+          const labeledUsage = { ...state.lastUsage, runtimeModel };
+          state.lastUsage = labeledUsage;
+          normalized.push({
+            type: 'output',
+            event: {
+              type: 'usage_updated',
+              usage: labeledUsage,
             },
           });
         }

--- a/src/providers/claude/modelOptions.ts
+++ b/src/providers/claude/modelOptions.ts
@@ -4,6 +4,7 @@ import {
   type ClaudeModelEnvType,
   getModelsFromEnvironment,
 } from './env/claudeModelEnv';
+import { getClaudeUserSettingsModelEnvironment } from './env/claudeUserSettingsEnv';
 import { formatCustomModelLabel } from './modelLabels';
 import { encodeClaudeModelSelectionId, toClaudeRuntimeModelId } from './modelSelection';
 import { isClaudeModelTier } from './modelTiers';
@@ -53,13 +54,29 @@ function normalizeCustomModelAliases(value: unknown): Record<string, string> {
 
 export function getClaudeModelOptions(settings: Record<string, unknown>): ClaudeModelOption[] {
   const customModelAliases = normalizeCustomModelAliases(settings.customModelAliases);
+  const userModelEnvironment = getClaudeUserSettingsModelEnvironment();
+  const modelAliases = {
+    ...userModelEnvironment.displayNames,
+    ...customModelAliases,
+  };
   const customModels = getModelsFromEnvironment(
-    getRuntimeEnvironmentVariables(settings, 'claude'),
-    customModelAliases,
+    // The user-level Claude Code settings file (rewritten by CC Switch on
+    // provider switches) backs the plugin environment, which wins on conflicts.
+    {
+      ...userModelEnvironment.env,
+      ...getRuntimeEnvironmentVariables(settings, 'claude'),
+    },
+    modelAliases,
   );
   if (customModels.length > 0) {
+    const settingsConfiguredModelIds = new Set(Object.values(userModelEnvironment.env));
     return customModels.map((model) => ({
       ...model,
+      // Settings file models show the display name when present, otherwise
+      // their raw request name; other models keep the author-derived label.
+      ...(!modelAliases[model.value] && settingsConfiguredModelIds.has(model.value)
+        ? { label: model.value }
+        : {}),
       value: encodeClaudeModelSelectionId(model.value),
     }));
   }

--- a/src/providers/claude/sdk/types.ts
+++ b/src/providers/claude/sdk/types.ts
@@ -19,6 +19,8 @@ export interface SessionInitEvent {
 export interface ContextWindowEvent {
   type: 'context_window';
   contextWindow: number;
+  /** Actual model served by the provider runtime, when known. */
+  model?: string;
 }
 
 export type TransformEvent =

--- a/src/providers/claude/stream/transformClaudeMessage.ts
+++ b/src/providers/claude/stream/transformClaudeMessage.ts
@@ -619,7 +619,11 @@ export function* transformSDKMessage(
         const modelUsage = message.modelUsage as Record<string, { contextWindow?: number }>;
         const selectedEntry = selectContextWindowEntry(modelUsage, options?.intendedModel);
         if (selectedEntry) {
-          yield { type: 'context_window', contextWindow: selectedEntry.contextWindow };
+          yield {
+            type: 'context_window',
+            contextWindow: selectedEntry.contextWindow,
+            model: selectedEntry.model,
+          };
         }
       }
       if (isResultError(message)) {

--- a/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
+++ b/tests/unit/providers/claude/stream/transformSDKMessage.test.ts
@@ -1244,7 +1244,7 @@ describe('transformSDKMessage', () => {
       const results = [...transformSDKMessage(message)];
 
       expect(results).toEqual([
-        { type: 'context_window', contextWindow: 200000 },
+        { type: 'context_window', contextWindow: 200000, model: 'claude-sonnet-4-5-20250514' },
       ]);
     });
 
@@ -1258,7 +1258,7 @@ describe('transformSDKMessage', () => {
       const results = [...transformSDKMessage(message)];
 
       expect(results).toEqual([
-        { type: 'context_window', contextWindow: 200000 },
+        { type: 'context_window', contextWindow: 200000, model: 'claude-sonnet-test' },
         { type: 'error', content: 'Hit maximum turn limit' },
       ]);
     });
@@ -1283,7 +1283,7 @@ describe('transformSDKMessage', () => {
       const results = [...transformSDKMessage(message)];
 
       expect(results).toEqual([
-        { type: 'context_window', contextWindow: 1000000 },
+        { type: 'context_window', contextWindow: 1000000, model: 'claude-opus-4-6[1m]' },
       ]);
     });
 
@@ -1317,7 +1317,7 @@ describe('transformSDKMessage', () => {
       const results = [...transformSDKMessage(message, { intendedModel: 'custom-main-model' })];
 
       expect(results).toEqual([
-        { type: 'context_window', contextWindow: 200000 },
+        { type: 'context_window', contextWindow: 200000, model: 'custom-main-model' },
       ]);
     });
 
@@ -1351,7 +1351,7 @@ describe('transformSDKMessage', () => {
       const results = [...transformSDKMessage(message, { intendedModel: 'opus[1m]' })];
 
       expect(results).toEqual([
-        { type: 'context_window', contextWindow: 1000000 },
+        { type: 'context_window', contextWindow: 1000000, model: 'claude-opus-4-6[1m]' },
       ]);
     });
 
@@ -1385,7 +1385,7 @@ describe('transformSDKMessage', () => {
       const results = [...transformSDKMessage(message, { intendedModel: 'fable' })];
 
       expect(results).toEqual([
-        { type: 'context_window', contextWindow: 1000000 },
+        { type: 'context_window', contextWindow: 1000000, model: 'claude-fable-5-v1:0' },
       ]);
     });
 
@@ -1419,7 +1419,7 @@ describe('transformSDKMessage', () => {
       const results = [...transformSDKMessage(message, { intendedModel: 'anthropic/claude-opus-4-6[1m]' })];
 
       expect(results).toEqual([
-        { type: 'context_window', contextWindow: 1000000 },
+        { type: 'context_window', contextWindow: 1000000, model: 'claude-opus-4-6[1m]' },
       ]);
     });
 
@@ -1453,7 +1453,7 @@ describe('transformSDKMessage', () => {
       const results = [...transformSDKMessage(message, { intendedModel: 'eu.anthropic.claude-opus-4-6[1m]' })];
 
       expect(results).toEqual([
-        { type: 'context_window', contextWindow: 1000000 },
+        { type: 'context_window', contextWindow: 1000000, model: 'eu.anthropic.claude-opus-4-6[1m]' },
       ]);
     });
 
@@ -1487,7 +1487,7 @@ describe('transformSDKMessage', () => {
       const results = [...transformSDKMessage(message, { intendedModel: 'anthropic/claude-opus-4-6[1M]' })];
 
       expect(results).toEqual([
-        { type: 'context_window', contextWindow: 1000000 },
+        { type: 'context_window', contextWindow: 1000000, model: 'claude-opus-4-6[1m]' },
       ]);
     });
 


### PR DESCRIPTION
## Why

When using Claude Code, display names and request names should both come from `~/.claude/settings.json`. Requests are sent correctly, but the plugin never reads the display name from this file. The dropdown and the button show hardcoded tier labels or names derived from the model id, which do not match the actual requested model.

Claude Code's model names now read and display correctly without affecting other harnesses (Pi, Codex, etc.) or the plugin's existing configuration.

## What Changed

- Read the model configuration and display names from `~/.claude/settings.json` (read-only).
- List the settings models, using the name from plugin config, display name, or request name in that order.
- Show the actual runtime model (`modelUsage`), replacing the label when it differs, falling back when unknown.

## Why This Approach

The design follows the minimal-change principle: no new configuration, no change to persistence, only connecting the existing pipeline with the runtime model. Existing conversations are unaffected.

## Validation

- The 9 `context_window` assertions now include the `model` field and pass (`transformSDKMessage.test.ts`).
- Existing tests for `ClaudeExecutionEventNormalizer`, `InputToolbar`, and `claudeModelEnv` pass.
- `npm run typecheck`
- `npm run lint`
- `npm run test` (8,572 passed; 138 pre-existing Windows failures also occur on unmodified main; 1 skipped)
- `npm run build`

## Impact and Follow-ups

Only affects Claude Code model display. Existing conversations are not migrated.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I explained why no issue is needed (standalone fix).
- [x] I updated tests for the behavior change (the 9 existing `context_window` assertions now include the `model` field; no new tests were added).
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] User-facing documentation is not needed because this changes no settings or interaction flow.
