### PR TITLE
fix: debounce Vault mention suggestions

### DIFF
--- a/src/shared/composer-dropdown/ComposerDropdownController.ts
+++ b/src/shared/composer-dropdown/ComposerDropdownController.ts
@@ -11,6 +11,8 @@ interface ActiveFolder {
   readonly item: ComposerDropdownFolderItem;
 }
 
+const INPUT_LOAD_DEBOUNCE_MS = 200;
+
 export interface ComposerDropdownControllerOptions {
   readonly fixed?: boolean;
 }
@@ -25,6 +27,7 @@ export class ComposerDropdownController {
   private destroyed = false;
   private enabled = true;
   private generation = 0;
+  private inputLoadTimer: number | null = null;
   private items: readonly ComposerDropdownItem[] = [];
   private selectedIndex = -1;
 
@@ -55,14 +58,16 @@ export class ComposerDropdownController {
   destroy(): void {
     if (this.destroyed) return;
     this.destroyed = true;
-    this.generation++;
-    this.activeController?.abort();
-    this.activeController = null;
+    this.invalidateActiveLoad();
     for (const unsubscribe of this.sourceUnsubscribers.splice(0)) unsubscribe();
     this.view.destroy();
   }
 
   handleInputChange(): void {
+    this.rematchAndLoad(true);
+  }
+
+  private rematchAndLoad(inputDriven: boolean): void {
     if (!this.enabled || this.destroyed) {
       this.hide();
       return;
@@ -88,7 +93,7 @@ export class ComposerDropdownController {
     if (this.activeSource?.id !== sourceMatch.source.id) this.activeFolder = null;
     this.activeSource = sourceMatch.source;
     this.activeMatch = sourceMatch.match;
-    void this.loadActive();
+    this.requestActiveLoad(inputDriven);
   }
 
   handleKeydown(event: KeyboardEvent): boolean {
@@ -122,9 +127,7 @@ export class ComposerDropdownController {
   }
 
   hide(): void {
-    this.generation++;
-    this.activeController?.abort();
-    this.activeController = null;
+    this.invalidateActiveLoad();
     this.activeFolder = null;
     this.activeMatch = null;
     this.activeSource = null;
@@ -165,26 +168,48 @@ export class ComposerDropdownController {
 
   private rematchInput(): void {
     if (!this.activeSource || !this.activeMatch || this.destroyed) return;
-    this.handleInputChange();
+    this.rematchAndLoad(false);
   }
 
-  private async loadActive(): Promise<void> {
+  private requestActiveLoad(inputDriven: boolean): void {
     const source = this.activeSource;
     const match = this.activeMatch;
-    if (!source || !match || this.destroyed) return;
+    if (!source || !match || this.destroyed || !this.enabled) return;
 
     const folderQuery = this.currentFolderQuery(match);
     if (this.activeFolder && folderQuery === null) {
       this.activeFolder = null;
     }
 
-    const generation = ++this.generation;
-    this.activeController?.abort();
-    const controller = new AbortController();
-    this.activeController = controller;
+    const generation = this.invalidateActiveLoad();
     this.items = [{ id: 'loading', kind: 'status', label: 'Loading…', state: 'loading' }];
     this.selectedIndex = -1;
     this.view.render(this.items, this.selectedIndex);
+
+    if (inputDriven && source.inputLoadPolicy === 'debounced') {
+      this.inputLoadTimer = window.setTimeout(() => {
+        this.inputLoadTimer = null;
+        void this.loadActive(generation);
+      }, INPUT_LOAD_DEBOUNCE_MS);
+      return;
+    }
+
+    void this.loadActive(generation);
+  }
+
+  private async loadActive(generation: number): Promise<void> {
+    const source = this.activeSource;
+    const match = this.activeMatch;
+    if (
+      !source
+      || !match
+      || this.destroyed
+      || !this.enabled
+      || generation !== this.generation
+    ) return;
+
+    const controller = new AbortController();
+    this.activeController = controller;
 
     try {
       const items = await (this.activeFolder
@@ -208,6 +233,17 @@ export class ComposerDropdownController {
       this.selectedIndex = -1;
       this.view.render(this.items, this.selectedIndex);
     }
+  }
+
+  private invalidateActiveLoad(): number {
+    this.generation++;
+    if (this.inputLoadTimer !== null) {
+      window.clearTimeout(this.inputLoadTimer);
+      this.inputLoadTimer = null;
+    }
+    this.activeController?.abort();
+    this.activeController = null;
+    return this.generation;
   }
 
   private moveSelection(delta: number): void {
@@ -242,7 +278,7 @@ export class ComposerDropdownController {
         query: '',
       };
     }
-    void this.loadActive();
+    this.requestActiveLoad(false);
   }
 
   private selectIndex(index: number): void {
@@ -261,7 +297,7 @@ export class ComposerDropdownController {
           query: item.inputPrefix,
         };
       }
-      void this.loadActive();
+      this.requestActiveLoad(false);
       return;
     }
 

--- a/src/shared/composer-dropdown/MentionSource.ts
+++ b/src/shared/composer-dropdown/MentionSource.ts
@@ -37,6 +37,7 @@ export interface MentionSourceOptions {
 
 export class MentionSource implements ComposerDropdownSource {
   readonly id = 'mentions';
+  readonly inputLoadPolicy = 'debounced';
 
   private agentLoadPromise: Promise<void> | null = null;
   private agentService: AgentMentionProvider | null = null;

--- a/src/shared/composer-dropdown/types.ts
+++ b/src/shared/composer-dropdown/types.ts
@@ -63,6 +63,7 @@ export type ComposerSelectionAction =
 
 export interface ComposerDropdownSource {
   readonly id: string;
+  readonly inputLoadPolicy?: 'debounced' | 'immediate';
   load(
     match: ComposerTriggerMatch,
     signal: AbortSignal,

--- a/tests/unit/features/inline-edit/ui/InlineEditModal.openAndWait.test.ts
+++ b/tests/unit/features/inline-edit/ui/InlineEditModal.openAndWait.test.ts
@@ -179,7 +179,8 @@ describe('InlineEditModal - openAndWait', () => {
     );
   });
 
-  it('wires mention getCachedVaultFolders through VaultFolderCache.getFolders', async () => {
+  it('debounces Inline Edit Vault mention loading through the shared dropdown', async () => {
+    jest.useFakeTimers();
     const originalDocument = (global as any).document;
     (global as any).document = {
       body: createMockEl('body'),
@@ -263,10 +264,21 @@ describe('InlineEditModal - openAndWait', () => {
       const resultPromise = modal.openAndWait();
       await Promise.resolve();
 
-      const callbacks = widgetRef?.mentionSource?.callbacks;
-      expect(callbacks).toBeDefined();
-      expect(callbacks.getCachedVaultFolders()).toEqual([{ name: 'src', path: 'src' }]);
+      const inputEl = widgetRef?.inputEl;
+      inputEl.value = '@s';
+      inputEl.selectionStart = inputEl.selectionEnd = 2;
+      inputEl.dispatchEvent({ type: 'input' });
+      jest.advanceTimersByTime(199);
+      expect(getFoldersSpy).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(1);
+      await Promise.resolve();
+
       expect(getFoldersSpy).toHaveBeenCalledTimes(1);
+      const labels = (global as any).document.body
+        .querySelectorAll('.claudian-composer-dropdown-label')
+        .map((element: { textContent: string }) => element.textContent);
+      expect(labels).toEqual(['@src/']);
 
       widgetRef?.reject();
       await expect(resultPromise).resolves.toEqual({ decision: 'reject' });
@@ -275,6 +287,7 @@ describe('InlineEditModal - openAndWait', () => {
       getFoldersSpy.mockRestore();
     } finally {
       (global as any).document = originalDocument;
+      jest.useRealTimers();
     }
   });
 

--- a/tests/unit/shared/composer-dropdown/ComposerDropdownController.test.ts
+++ b/tests/unit/shared/composer-dropdown/ComposerDropdownController.test.ts
@@ -1,6 +1,8 @@
 import { createMockEl } from '@test/helpers/MockElement';
+import type { TFile } from 'obsidian';
 
 import { ComposerDropdownController } from '@/shared/composer-dropdown/ComposerDropdownController';
+import { MentionSource } from '@/shared/composer-dropdown/MentionSource';
 import type {
   ComposerDropdownItem,
   ComposerDropdownSource,
@@ -31,9 +33,11 @@ function key(key: string): KeyboardEvent {
 function source(
   trigger: string,
   items: readonly ComposerDropdownItem[],
+  inputLoadPolicy?: ComposerDropdownSource['inputLoadPolicy'],
 ): ComposerDropdownSource {
   return {
     id: `source-${trigger}`,
+    inputLoadPolicy,
     match(input, cursor): ComposerTriggerMatch | null {
       const before = input.slice(0, cursor);
       const index = before.lastIndexOf(trigger);
@@ -50,6 +54,218 @@ function source(
 }
 
 describe('ComposerDropdownController', () => {
+  describe('input load policy', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('waits for the latest debounced input and ignores an older async result', async () => {
+      const input = createInput();
+      let resolveFirst!: (items: readonly ComposerDropdownItem[]) => void;
+      const first = new Promise<readonly ComposerDropdownItem[]>(resolve => {
+        resolveFirst = resolve;
+      });
+      const mention = source('@', [], 'debounced');
+      (mention.load as jest.Mock)
+        .mockReturnValueOnce(first)
+        .mockResolvedValueOnce([
+          { id: 'new', kind: 'value', label: '@ab', replacement: '@ab ' },
+        ]);
+      const controller = new ComposerDropdownController(createMockEl(), input, [mention]);
+
+      input.value = '@a';
+      input.selectionStart = input.selectionEnd = 2;
+      controller.handleInputChange();
+      jest.advanceTimersByTime(199);
+      expect(mention.load).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(1);
+      expect(mention.load).toHaveBeenCalledWith(
+        expect.objectContaining({ query: 'a' }),
+        expect.any(AbortSignal),
+      );
+      const firstSignal = (mention.load as jest.Mock).mock.calls[0][1] as AbortSignal;
+
+      input.value = '@ab';
+      input.selectionStart = input.selectionEnd = 3;
+      controller.handleInputChange();
+      expect(firstSignal.aborted).toBe(true);
+      jest.advanceTimersByTime(199);
+      expect(mention.load).toHaveBeenCalledTimes(1);
+      jest.advanceTimersByTime(1);
+      await Promise.resolve();
+      expect(mention.load).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ query: 'ab' }),
+        expect.any(AbortSignal),
+      );
+
+      resolveFirst([{ id: 'old', kind: 'value', label: '@old', replacement: '@old ' }]);
+      await Promise.resolve();
+      controller.handleKeydown(key('Enter'));
+
+      expect(input.value).toBe('@ab ');
+      controller.destroy();
+    });
+
+    it('restarts the quiet window when debounced input changes', async () => {
+      const input = createInput();
+      const mention = source('@', [
+        { id: 'latest', kind: 'value', label: '@ab', replacement: '@ab ' },
+      ], 'debounced');
+      const controller = new ComposerDropdownController(createMockEl(), input, [mention]);
+
+      input.value = '@a';
+      input.selectionStart = input.selectionEnd = 2;
+      controller.handleInputChange();
+      jest.advanceTimersByTime(100);
+      input.value = '@ab';
+      input.selectionStart = input.selectionEnd = 3;
+      controller.handleInputChange();
+      jest.advanceTimersByTime(199);
+      expect(mention.load).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(1);
+      await Promise.resolve();
+
+      expect(mention.load).toHaveBeenCalledTimes(1);
+      expect(mention.load).toHaveBeenCalledWith(
+        expect.objectContaining({ query: 'ab' }),
+        expect.any(AbortSignal),
+      );
+      controller.destroy();
+    });
+
+    it('loads immediate sources without waiting and cancels a pending mention on source switch', async () => {
+      const input = createInput();
+      const mention = source('@', [], 'debounced');
+      const slash = source('/', [
+        { id: 'clear', kind: 'value', label: '/clear', replacement: '/clear ' },
+      ]);
+      const controller = new ComposerDropdownController(createMockEl(), input, [mention, slash]);
+
+      input.value = '@a';
+      input.selectionStart = input.selectionEnd = 2;
+      controller.handleInputChange();
+      input.value = '/cl';
+      input.selectionStart = input.selectionEnd = 3;
+      controller.handleInputChange();
+      await Promise.resolve();
+
+      expect(slash.load).toHaveBeenCalledTimes(1);
+      expect(slash.load).toHaveBeenCalledWith(
+        expect.objectContaining({ query: 'cl' }),
+        expect.any(AbortSignal),
+      );
+      jest.advanceTimersByTime(200);
+      expect(mention.load).not.toHaveBeenCalled();
+      controller.handleKeydown(key('Enter'));
+      expect(input.value).toBe('/clear ');
+      controller.destroy();
+    });
+
+    it.each([
+      ['hide', (controller: ComposerDropdownController) => controller.hide()],
+      ['disable', (controller: ComposerDropdownController) => controller.setEnabled(false)],
+      ['destroy', (controller: ComposerDropdownController) => controller.destroy()],
+    ])('does not load after %s cancels a pending debounce', (_name, cancel) => {
+      const input = createInput();
+      const mention = source('@', [], 'debounced');
+      const controller = new ComposerDropdownController(createMockEl(), input, [mention]);
+
+      input.value = '@a';
+      input.selectionStart = input.selectionEnd = 2;
+      controller.handleInputChange();
+      cancel(controller);
+      jest.advanceTimersByTime(200);
+
+      expect(mention.load).not.toHaveBeenCalled();
+      expect(controller.isVisible()).toBe(false);
+      controller.destroy();
+    });
+
+    it('loads a selected folder immediately even for a debounced source', async () => {
+      const input = createInput();
+      const loadFolder = jest.fn().mockResolvedValue([
+        { id: 'alice', kind: 'value', label: 'Alice', replacement: '@Agents/alice ' },
+      ]);
+      const mention = source('@', [{
+        id: 'agents',
+        inputPrefix: 'Agents/',
+        kind: 'folder',
+        label: 'Agents',
+        load: loadFolder,
+      }], 'debounced');
+      const controller = new ComposerDropdownController(createMockEl(), input, [mention]);
+
+      input.value = '@';
+      input.selectionStart = input.selectionEnd = 1;
+      controller.handleInputChange();
+      jest.advanceTimersByTime(200);
+      await Promise.resolve();
+      controller.handleKeydown(key('Enter'));
+
+      expect(loadFolder).toHaveBeenCalledTimes(1);
+      expect(loadFolder).toHaveBeenCalledWith('', expect.any(AbortSignal));
+      controller.destroy();
+    });
+
+    it('defers real Vault mention work and preserves its limit, sorting, and selection', async () => {
+      const input = createInput();
+      const container = createMockEl();
+      const files: TFile[] = [
+        {
+          name: 'Alpha.md',
+          path: 'Alpha.md',
+          stat: { ctime: 1_000, mtime: 1_000, size: 1 },
+        } as TFile,
+        ...Array.from({ length: 104 }, (_, index) => ({
+          name: `a-file-${index.toString().padStart(3, '0')}.md`,
+          path: `archive/a-file-${index.toString().padStart(3, '0')}.md`,
+          stat: { ctime: index, mtime: index, size: 1 },
+        } as TFile)),
+      ];
+      const getCachedVaultFiles = jest.fn(() => files);
+      const getCachedVaultFolders = jest.fn(() => []);
+      const onAttachFile = jest.fn();
+      const mention = new MentionSource({
+        getCachedVaultFiles,
+        getCachedVaultFolders,
+        getExternalContexts: () => [],
+        normalizePathForVault: path => path ?? null,
+        onAttachFile,
+      });
+      const controller = new ComposerDropdownController(container, input, [mention]);
+
+      input.value = '@a';
+      input.selectionStart = input.selectionEnd = 2;
+      controller.handleInputChange();
+      jest.advanceTimersByTime(199);
+      expect(getCachedVaultFiles).not.toHaveBeenCalled();
+      expect(getCachedVaultFolders).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(1);
+      await Promise.resolve();
+
+      expect(getCachedVaultFiles).toHaveBeenCalledTimes(1);
+      expect(getCachedVaultFolders).toHaveBeenCalledTimes(1);
+      const labels = container
+        .querySelectorAll('.claudian-composer-dropdown-label')
+        .map((element: { textContent: string }) => element.textContent);
+      expect(labels).toHaveLength(100);
+      expect(labels[0]).toBe('Alpha.md');
+
+      controller.handleKeydown(key('Enter'));
+      expect(input.value).toBe('@Alpha.md ');
+      expect(onAttachFile).toHaveBeenCalledWith('Alpha.md');
+      controller.destroy();
+      mention.destroy();
+    });
+  });
+
   it('arbitrates sources and replaces only the active token', async () => {
     const input = createInput();
     const controller = new ComposerDropdownController(

--- a/tests/unit/shared/composer-dropdown/MentionSource.test.ts
+++ b/tests/unit/shared/composer-dropdown/MentionSource.test.ts
@@ -29,6 +29,14 @@ function source(overrides: Record<string, unknown> = {}) {
 }
 
 describe('MentionSource', () => {
+  it('opts input-driven loads into debounce while keeping the source API otherwise unchanged', () => {
+    const { source: value } = source();
+
+    expect(value.inputLoadPolicy).toBe('debounced');
+
+    value.destroy();
+  });
+
   it('matches @ at a token boundary and preserves file names containing spaces', () => {
     const { source: value } = source();
     expect(value.match('Ask @Al', 7)).toEqual(expect.objectContaining({ query: 'Al' }));


### PR DESCRIPTION
## Why

Large Vaults can make the `@` mention picker feel unresponsive because the shared composer-dropdown refactor loads Vault-backed mention suggestions on every input event. The current Mention source already caches its Vault tree between Vault mutations, but each load still rebuilds, filters, and sorts its searchable entries.

Refs #1203.

## What Changed

- Added an opt-in input load policy to composer-dropdown sources.
- Made Vault-backed `@` mentions wait for a 200 ms input quiet window before loading suggestions.
- Kept slash commands, tickets, cache invalidation, and explicit folder navigation immediate.
- Cancelled pending timers and in-flight loads across replacement input, hide, disable, source changes, and destruction while retaining the existing abort and stale-generation fences.
- Covered the shared path used by both Main Chat and Inline Edit.

## Why This Approach

The delay belongs to the source's workload policy, while timer ownership belongs to the shared controller lifecycle. This keeps the expensive Vault-backed source opt-in and avoids a provider- or UI-specific branch. It also avoids changing mention ranking, adding a new Vault index, limiting results, or delaying lightweight sources.

The change restores the mention-only quiet window that was lost in the 2.2.0 composer-dropdown refactor. It does not establish the reporter's stated 2.1.0 regression boundary, so this PR references rather than closes the issue pending reporter validation on the affected Windows Vault.

## Validation

- Focused composer-dropdown and Inline Edit suites: 3 suites, 38 tests passed.
- `npm run typecheck`
- `npm run lint`
- `npm run test`: 607 suites passed, 2 skipped; 8,889 tests passed, 2 skipped; architecture checks 51/51 passed.
- `npm run build`
- `git diff --check`

## Impact and Follow-ups

No persistence, provider, ranking, selection, or visual behavior changes. Reporter validation is still needed on the same Windows Vault/profile and single-/dual-pane layouts before treating #1203 as fully resolved.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed, or no documentation change is required.
