### PR TITLE
chore: update protocol dependency to 3.3.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "claudian",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.226",
-        "@claudian-collab/protocol": "3.3.0",
+        "@claudian-collab/protocol": "3.3.1",
         "@codemirror/commands": "6.10.0",
         "@codemirror/lang-markdown": "^6.5.2",
         "@codemirror/language": "^6.12.4",
@@ -162,7 +162,7 @@
 
     "@cacheable/utils": ["@cacheable/utils@2.5.0", "", { "dependencies": { "hashery": "^1.5.1", "keyv": "^5.6.0" } }, "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA=="],
 
-    "@claudian-collab/protocol": ["@claudian-collab/protocol@3.3.0", "", { "dependencies": { "@lezer/markdown": "1.7.2" } }, "sha512-7Wc275dddo7ajn+jJQ6P0njXG8g17zmHHfglZ7ZZK/+7GHzcDR/tCiO9yqv4axiEcv4pBnZ3XwDBSqeC85BHaw=="],
+    "@claudian-collab/protocol": ["@claudian-collab/protocol@3.3.1", "", { "dependencies": { "@lezer/markdown": "1.7.2" } }, "sha512-F+D1Y8RbTbZAWu13HYI6mv9feoLDMII0mEZTapoDLqRNm+ZZ6VAgqOH3h9kGMNb6uR9dVTMiNb8nQ4KABEHZZw=="],
 
     "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "claudian",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.226",
-        "@claudian-collab/protocol": "3.2.1",
+        "@claudian-collab/protocol": "3.3.0",
         "@codemirror/commands": "6.10.0",
         "@codemirror/lang-markdown": "^6.5.2",
         "@codemirror/language": "^6.12.4",
@@ -162,7 +162,7 @@
 
     "@cacheable/utils": ["@cacheable/utils@2.5.0", "", { "dependencies": { "hashery": "^1.5.1", "keyv": "^5.6.0" } }, "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA=="],
 
-    "@claudian-collab/protocol": ["@claudian-collab/protocol@3.2.1", "", { "dependencies": { "@lezer/markdown": "1.7.2" } }, "sha512-FqUca4/S9Jgu5QsMR4Gs3KgAfYytIdVn8V7w7Fn2hQjJ0nA9D9ULgJlvqOojqwaNh+ci+DblLcD5Z2oC7WJCcw=="],
+    "@claudian-collab/protocol": ["@claudian-collab/protocol@3.3.0", "", { "dependencies": { "@lezer/markdown": "1.7.2" } }, "sha512-7Wc275dddo7ajn+jJQ6P0njXG8g17zmHHfglZ7ZZK/+7GHzcDR/tCiO9yqv4axiEcv4pBnZ3XwDBSqeC85BHaw=="],
 
     "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.226",
-        "@claudian-collab/protocol": "3.2.1",
+        "@claudian-collab/protocol": "3.3.0",
         "@codemirror/commands": "6.10.0",
         "@codemirror/lang-markdown": "^6.5.2",
         "@codemirror/language": "^6.12.4",
@@ -829,9 +829,9 @@
       }
     },
     "node_modules/@claudian-collab/protocol": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@claudian-collab/protocol/-/protocol-3.2.1.tgz",
-      "integrity": "sha512-FqUca4/S9Jgu5QsMR4Gs3KgAfYytIdVn8V7w7Fn2hQjJ0nA9D9ULgJlvqOojqwaNh+ci+DblLcD5Z2oC7WJCcw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@claudian-collab/protocol/-/protocol-3.3.0.tgz",
+      "integrity": "sha512-7Wc275dddo7ajn+jJQ6P0njXG8g17zmHHfglZ7ZZK/+7GHzcDR/tCiO9yqv4axiEcv4pBnZ3XwDBSqeC85BHaw==",
       "license": "MIT",
       "dependencies": {
         "@lezer/markdown": "1.7.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.226",
-        "@claudian-collab/protocol": "3.3.0",
+        "@claudian-collab/protocol": "3.3.1",
         "@codemirror/commands": "6.10.0",
         "@codemirror/lang-markdown": "^6.5.2",
         "@codemirror/language": "^6.12.4",
@@ -829,9 +829,9 @@
       }
     },
     "node_modules/@claudian-collab/protocol": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@claudian-collab/protocol/-/protocol-3.3.0.tgz",
-      "integrity": "sha512-7Wc275dddo7ajn+jJQ6P0njXG8g17zmHHfglZ7ZZK/+7GHzcDR/tCiO9yqv4axiEcv4pBnZ3XwDBSqeC85BHaw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@claudian-collab/protocol/-/protocol-3.3.1.tgz",
+      "integrity": "sha512-F+D1Y8RbTbZAWu13HYI6mv9feoLDMII0mEZTapoDLqRNm+ZZ6VAgqOH3h9kGMNb6uR9dVTMiNb8nQ4KABEHZZw==",
       "license": "MIT",
       "dependencies": {
         "@lezer/markdown": "1.7.2"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.226",
-    "@claudian-collab/protocol": "3.2.1",
+    "@claudian-collab/protocol": "3.3.0",
     "@codemirror/commands": "6.10.0",
     "@codemirror/lang-markdown": "^6.5.2",
     "@codemirror/language": "^6.12.4",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.226",
-    "@claudian-collab/protocol": "3.3.0",
+    "@claudian-collab/protocol": "3.3.1",
     "@codemirror/commands": "6.10.0",
     "@codemirror/lang-markdown": "^6.5.2",
     "@codemirror/language": "^6.12.4",

--- a/scripts/check-architecture-boundaries.test.mjs
+++ b/scripts/check-architecture-boundaries.test.mjs
@@ -44,6 +44,41 @@ function findMatches(roots, pattern) {
   return matches;
 }
 
+const step12ProjectMembershipOperations = Object.freeze([
+  'createCloudProject',
+  'createProjectInvitation',
+  'listProjectInvitations',
+  'revokeProjectInvitation',
+  'joinCloudProject',
+  'listProjectMembers',
+  'reissueTransferredMembershipClaim',
+  'revokeTransferredMembershipClaim',
+  'createManagerResponsibilityOffer',
+  'listCurrentManagerResponsibilityOffers',
+  'getManagerResponsibilityOffer',
+  'acknowledgeManagerResponsibility',
+  'declineManagerResponsibility',
+  'cancelManagerResponsibilityOffer',
+  'promoteManager',
+  'demoteManager',
+  'removeMember',
+  'leaveProject',
+]);
+
+const step12CloudCapabilityTokens = Object.freeze([
+  'cloud-imported-membership-claims',
+  'cloud-project-create',
+  'cloud-project-invitations',
+  'cloud-project-join',
+  'cloud-project-leave',
+  'cloud-project-manager-responsibility',
+  'cloud-project-membership',
+]);
+
+function symbolPattern(symbols) {
+  return new RegExp(`\\b(?:${symbols.join('|')})\\b`, 'u');
+}
+
 function inspectForbiddenSymbolInventory(entries, pattern, allowedOccurrences) {
   const counts = new Map();
   const matcherFlags = pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`;
@@ -612,7 +647,7 @@ test('only TabRuntimeFactory can register runtime resource ownership', () => {
   ].sort());
 });
 
-test('Claudian consumes the standalone Collab protocol only from the exact registry package', () => {
+test('Claudian consumes the standalone Collab protocol only from the exact registry package', async () => {
   const root = process.cwd();
   const manifest = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
   const lockfile = JSON.parse(fs.readFileSync(path.join(root, 'package-lock.json'), 'utf8'));
@@ -623,21 +658,34 @@ test('Claudian consumes the standalone Collab protocol only from the exact regis
     'utf8',
   ));
 
-  assert.equal(manifest.dependencies?.[protocolPackageName], '3.2.1');
+  const protocol = await import(protocolPackageName);
+
+  assert.equal(manifest.dependencies?.[protocolPackageName], '3.3.0');
   assert.equal(manifest.dependencies?.['@lezer/markdown'], '1.7.2');
   assert.equal(protocolManifest.dependencies?.['@lezer/markdown'], '1.7.2');
   assert.equal(manifest.dependencies?.['@claudian/collab-protocol'], undefined);
   assert.equal(manifest.workspaces, undefined);
-  assert.equal(lockfile.packages?.['']?.dependencies?.[protocolPackageName], '3.2.1');
-  assert.equal(lockfile.packages?.[protocolInstallPath]?.version, '3.2.1');
+  assert.equal(lockfile.packages?.['']?.dependencies?.[protocolPackageName], '3.3.0');
+  assert.equal(lockfile.packages?.[protocolInstallPath]?.version, '3.3.0');
   assert.equal(
     lockfile.packages?.[protocolInstallPath]?.integrity,
-    'sha512-FqUca4/S9Jgu5QsMR4Gs3KgAfYytIdVn8V7w7Fn2hQjJ0nA9D9ULgJlvqOojqwaNh+ci+DblLcD5Z2oC7WJCcw==',
+    'sha512-7Wc275dddo7ajn+jJQ6P0njXG8g17zmHHfglZ7ZZK/+7GHzcDR/tCiO9yqv4axiEcv4pBnZ3XwDBSqeC85BHaw==',
   );
   assert.equal(lockfile.packages?.['node_modules/@lezer/markdown']?.version, '1.7.2');
   assert.match(
     lockfile.packages?.[protocolInstallPath]?.resolved ?? '',
-    /^https:\/\/registry\.npmjs\.org\/@claudian-collab\/protocol\/-\/protocol-3\.2\.1\.tgz$/u,
+    /^https:\/\/registry\.npmjs\.org\/@claudian-collab\/protocol\/-\/protocol-3\.3\.0\.tgz$/u,
+  );
+  assert.equal(protocol.COLLAB_PROTOCOL_VERSION, 6);
+  assert.equal(protocol.COLLAB_CLOUD_BINDING_VERSION, 2);
+  assert.equal(protocol.COLLAB_PROJECT_BACKUP_COORDINATION_FORMAT_VERSION, 3);
+  assert.deepEqual(
+    protocol.COLLAB_PROJECT_MEMBERSHIP_OPERATIONS,
+    step12ProjectMembershipOperations,
+  );
+  assert.deepEqual(
+    Object.keys(protocol.COLLAB_PROJECT_MEMBERSHIP_OPERATION_CODECS),
+    protocol.COLLAB_PROJECT_MEMBERSHIP_OPERATIONS,
   );
 
   for (const retiredPath of [
@@ -672,6 +720,43 @@ test('Claudian consumes the standalone Collab protocol only from the exact regis
 test('standalone Collab protocol registry and contract constants are not redefined', () => {
   const pattern = /export\s+(?:const|interface|type|class|function)\s+(?:COLLAB_CONTROL_OPERATION_CODECS|CollabControlOperationMap|COLLAB_EVENT_KINDS|COLLAB_ERROR_CODES|COLLAB_LIMITS|COLLAB_PROTOCOL_VERSION|COLLAB_MAIN_REF|COLLAB_MEMBER_REF_PREFIX)\b/;
   assert.deepEqual(findMatches([sourceRoot], pattern), []);
+});
+
+test('the protocol pin does not expose Step 12 Cloud management behavior', () => {
+  const cloudAuthorityAdapterSource = fs.readFileSync(path.join(
+    appRoot,
+    'collab',
+    'remote-authority',
+    'CloudAuthorityAdapter.ts',
+  ), 'utf8');
+  const packageManagementSurface = [
+    'COLLAB_PROJECT_MEMBERSHIP_LIMITS',
+    'COLLAB_PROJECT_MEMBERSHIP_OPERATIONS',
+    'COLLAB_PROJECT_MEMBERSHIP_OPERATION_CODECS',
+    'decodeCollabProjectMembershipOperationRequest',
+    'decodeCollabProjectMembershipOperationResponse',
+  ];
+  const cloudAdapterSurface = symbolPattern([
+    ...step12CloudCapabilityTokens,
+    ...step12ProjectMembershipOperations,
+    ...packageManagementSurface,
+  ]);
+  const cloudPresentationSurface = symbolPattern([
+    ...step12CloudCapabilityTokens,
+    'createCloudProject',
+    'createProjectInvitation',
+    'joinCloudProject',
+    'listCurrentManagerResponsibilityOffers',
+    'listProjectInvitations',
+    'listProjectMembers',
+    'reissueTransferredMembershipClaim',
+    'revokeProjectInvitation',
+    'revokeTransferredMembershipClaim',
+    ...packageManagementSurface,
+  ]);
+
+  assert.doesNotMatch(cloudAuthorityAdapterSource, cloudAdapterSurface);
+  assert.deepEqual(findMatches([featuresRoot], cloudPresentationSurface), []);
 });
 
 test('active Collab consumers use protocol-owned semantic identity predicates', () => {

--- a/scripts/check-architecture-boundaries.test.mjs
+++ b/scripts/check-architecture-boundaries.test.mjs
@@ -660,21 +660,21 @@ test('Claudian consumes the standalone Collab protocol only from the exact regis
 
   const protocol = await import(protocolPackageName);
 
-  assert.equal(manifest.dependencies?.[protocolPackageName], '3.3.0');
+  assert.equal(manifest.dependencies?.[protocolPackageName], '3.3.1');
   assert.equal(manifest.dependencies?.['@lezer/markdown'], '1.7.2');
   assert.equal(protocolManifest.dependencies?.['@lezer/markdown'], '1.7.2');
   assert.equal(manifest.dependencies?.['@claudian/collab-protocol'], undefined);
   assert.equal(manifest.workspaces, undefined);
-  assert.equal(lockfile.packages?.['']?.dependencies?.[protocolPackageName], '3.3.0');
-  assert.equal(lockfile.packages?.[protocolInstallPath]?.version, '3.3.0');
+  assert.equal(lockfile.packages?.['']?.dependencies?.[protocolPackageName], '3.3.1');
+  assert.equal(lockfile.packages?.[protocolInstallPath]?.version, '3.3.1');
   assert.equal(
     lockfile.packages?.[protocolInstallPath]?.integrity,
-    'sha512-7Wc275dddo7ajn+jJQ6P0njXG8g17zmHHfglZ7ZZK/+7GHzcDR/tCiO9yqv4axiEcv4pBnZ3XwDBSqeC85BHaw==',
+    'sha512-F+D1Y8RbTbZAWu13HYI6mv9feoLDMII0mEZTapoDLqRNm+ZZ6VAgqOH3h9kGMNb6uR9dVTMiNb8nQ4KABEHZZw==',
   );
   assert.equal(lockfile.packages?.['node_modules/@lezer/markdown']?.version, '1.7.2');
   assert.match(
     lockfile.packages?.[protocolInstallPath]?.resolved ?? '',
-    /^https:\/\/registry\.npmjs\.org\/@claudian-collab\/protocol\/-\/protocol-3\.3\.0\.tgz$/u,
+    /^https:\/\/registry\.npmjs\.org\/@claudian-collab\/protocol\/-\/protocol-3\.3\.1\.tgz$/u,
   );
   assert.equal(protocol.COLLAB_PROTOCOL_VERSION, 6);
   assert.equal(protocol.COLLAB_CLOUD_BINDING_VERSION, 2);

--- a/src/app/collab/remote-authority/AGENTS.md
+++ b/src/app/collab/remote-authority/AGENTS.md
@@ -13,6 +13,7 @@
 
 - Publication, projection, review, reconciliation, feature, UI, and Agent-facing services depend on the neutral ports and never construct LAN or Cloud transports directly.
 - Cloud Projects expose only negotiated complete capabilities. Physical Host transfer, membership administration, Manager responsibility, ordinary Leave, and LAN diagnostics remain LAN-only until their own accepted Cloud capability exists; authority transfer and Retire use only the exact negotiated Cloud package binding and must not fall back to a stale LAN session.
+- Capability negotiation intersects the server document with the adapter's explicit implemented-capability inventory. A protocol package addition alone never makes `supports` expose an application capability whose Cloud port is absent.
 - The Obsidian desktop Cloud path must not depend on renderer `fetch` or server-side browser CORS permission. Plain HTTP remains restricted to canonical loopback origins by `CloudAuthorityUrls`; non-loopback Cloud origins require HTTPS.
 - Canonicalize self-host URLs once and compare exact normalized values. Git environments may carry multiple headers and an optional CA path. Credential-bearing headers are sensitive by default and their values plus private paths never enter process arguments, logs, errors, or persisted diagnostics. A non-credential routing header must be explicitly marked non-sensitive so its domain identifier may independently appear in a Git ref argument; the header itself still enters Git only through the isolated environment.
 

--- a/src/app/collab/remote-authority/CloudAuthorityAdapter.ts
+++ b/src/app/collab/remote-authority/CloudAuthorityAdapter.ts
@@ -64,6 +64,27 @@ import { CollabError } from '@/core/collab/ClaudianCollabError';
 
 const MIN_RECONNECT_DELAY_MS = 1_000;
 const MAX_RECONNECT_DELAY_MS = 30_000;
+const IMPLEMENTED_CLOUD_CAPABILITIES: ReadonlySet<CollabCloudCapability> = new Set([
+  'accept',
+  'authority-transfer',
+  'development-bootstrap',
+  'git-receive-pack-personal-ref',
+  'git-upload-pack',
+  'project-checkpoint-export',
+  'project-events',
+  'project-retirement',
+  'project-snapshot',
+  'requests',
+  'tickets',
+]);
+
+function cloudCapabilityImplemented(
+  document: CollabCloudCapabilityDocument,
+  capability: CollabCloudCapability,
+): boolean {
+  return IMPLEMENTED_CLOUD_CAPABILITIES.has(capability)
+    && collabCloudCapabilitySupported(document, capability);
+}
 
 export interface CloudProjectEventSocket {
   close(code: number, reason: string): void;
@@ -980,7 +1001,7 @@ export class CloudAuthorityAdapter implements CollabAuthorityAdapter {
         remoteUrl: membership.authority.gitRemoteUrl,
       },
       lifecycle: control,
-      supports: capability => collabCloudCapabilitySupported(document, capability),
+      supports: capability => cloudCapabilityImplemented(document, capability),
     };
   }
 
@@ -1011,7 +1032,7 @@ export class CloudAuthorityAdapter implements CollabAuthorityAdapter {
       projectId: binding.projectId,
       readSnapshot: (projectId, options) => lifecycle.readSnapshot(projectId, options),
       serverUrl: origin,
-      supports: capability => collabCloudCapabilitySupported(document, capability),
+      supports: capability => cloudCapabilityImplemented(document, capability),
     };
   }
 

--- a/tests/unit/app/collab/remote-authority/CloudAuthorityAdapter.test.ts
+++ b/tests/unit/app/collab/remote-authority/CloudAuthorityAdapter.test.ts
@@ -6,6 +6,7 @@ import {
   COLLAB_CLOUD_PROJECT_SNAPSHOT_CODEC,
   COLLAB_LIMITS,
   type CollabAuthorityTransferStatus,
+  type CollabCloudCapability,
   collabCloudCapabilityDocument,
   collabCloudSuccessEnvelope,
 } from '@claudian-collab/protocol';
@@ -27,6 +28,15 @@ const CREATED_AT = '2026-08-22T00:00:00.000Z';
 const MAIN_OID = 'a'.repeat(40);
 const HEAD_OID = 'b'.repeat(40);
 const MERGED_OID = 'c'.repeat(40);
+const STEP_12_CLOUD_MANAGEMENT_CAPABILITIES = Object.freeze([
+  'cloud-imported-membership-claims',
+  'cloud-project-create',
+  'cloud-project-invitations',
+  'cloud-project-join',
+  'cloud-project-leave',
+  'cloud-project-manager-responsibility',
+  'cloud-project-membership',
+] satisfies readonly CollabCloudCapability[]);
 
 function changeRequest(overrides: Readonly<Record<string, unknown>> = {}) {
   return {
@@ -150,6 +160,32 @@ function cloudSnapshot() {
 }
 
 describe('CloudAuthorityAdapter', () => {
+  it('does not expose unimplemented Step 12 management capabilities', async () => {
+    const request = jest.fn(async () => ({
+      body: collabCloudCapabilityDocument(
+        STEP_12_CLOUD_MANAGEMENT_CAPABILITIES,
+        limits,
+      ),
+      contentType: 'application/json',
+      status: 200,
+    }));
+    const adapter = new CloudAuthorityAdapter({ request });
+    const [session, lifecycle] = await Promise.all([
+      adapter.create(membership()),
+      adapter.createLifecycle({
+        developmentActorId: ACTOR_ID,
+        projectId: PROJECT_ID,
+        serverUrl: 'https://cloud.example.test',
+      }),
+    ]);
+
+    for (const capability of STEP_12_CLOUD_MANAGEMENT_CAPABILITIES) {
+      expect(session.supports(capability)).toBe(false);
+      expect(lifecycle.supports(capability)).toBe(false);
+    }
+    expect(session.membership).toBeUndefined();
+  });
+
   it('binds a lifecycle-only snapshot to the canonical Member ref', async () => {
     const request = jest.fn(async (input: CloudAuthorityHttpRequest) => ({
       body: input.method === 'GET'


### PR DESCRIPTION
## Summary

- pin the exact published @claudian-collab/protocol 3.3.1 registry artifact in npm and Bun locks
- verify wire v6, Cloud binding v2, backup format v3, and the exact 18-operation membership registry through the production ESM export
- include the 3.3.1 backup-v3 membership idempotency tombstone correction without adding a Claudian management surface
- preserve pre-pin behavior by intersecting negotiated capabilities with the eleven capabilities Claudian actually implements
- keep all seven Step 12 Cloud management capabilities hidden from ordinary and lifecycle sessions; add no UI, Gomami, LAN v9, or presence changes

## Verification

- npm run typecheck
- npm run lint
- npm run test (607 suites, 8,890 tests passed; 2 suites and 2 tests skipped)
- npm run build
- three isolated review-fix passes; final pass reported no material findings