### PR TITLE
Fix session attention indicators

### DIFF
--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -110,6 +110,8 @@ export type HistoryConversationStatus = {
   tabIndex?: number;
 };
 
+type SessionStatusIndicatorKind = 'action-required' | 'error' | 'running';
+
 type HistoryRenderOptions = {
   onSelectConversation: (id: string) => Promise<void>;
   onOpenConversationInNewTab?: (id: string, activate?: boolean) => Promise<void>;
@@ -1064,17 +1066,21 @@ export class ConversationController {
     const conversationStatuses = section.conversations.map(conversation => (
       this.getHistoryConversationStatusForMetadata(conversation, options)
     ));
-    const hasRunningConversation = conversationStatuses.some(({ isRunning }) => isRunning);
-    const hasAttentionConversation = options.showAttentionState === true
+    const groupStatusKind = this.getGroupSessionStatusIndicatorKind(
+      conversationStatuses,
+      options,
+    );
+    const hasReviewConversation = options.showAttentionState === true
       && options.sessionScope !== 'archived'
       && conversationStatuses.some(({ attention }) => (
-        attention !== null && attention !== undefined
+        attention?.kind === 'review' && attention.outcome === 'completed'
       ));
+    const showGroupReviewState = groupStatusKind === null && hasReviewConversation;
     const groupHeader = list.createDiv({
       cls: [
         'claudian-session-group-header',
         `claudian-session-group-header--${section.kind}`,
-        hasAttentionConversation && isCollapsed
+        showGroupReviewState && isCollapsed
           ? 'claudian-session-group-header--attention'
           : '',
       ].filter(Boolean).join(' '),
@@ -1106,20 +1112,14 @@ export class ConversationController {
         text: 'Missing',
       });
     }
-    const groupRunningIndicator = hasRunningConversation
-      ? groupHeader.createSpan({
-          cls: [
-            'claudian-session-group-running-indicator',
-            isCollapsed
-              ? 'claudian-session-group-running-indicator--visible'
-              : '',
-          ].filter(Boolean).join(' '),
-        })
-      : null;
-    if (groupRunningIndicator) {
-      setIcon(groupRunningIndicator, 'loader-2');
-      groupRunningIndicator.setAttribute('aria-label', 'Running');
-    }
+    const groupStatusIndicator = groupStatusKind === null
+      ? null
+      : this.createSessionStatusIndicator(
+          groupHeader,
+          groupStatusKind,
+          true,
+          isCollapsed,
+        );
     if (
       section.kind === 'content'
       && section.contentPath
@@ -1171,11 +1171,15 @@ export class ConversationController {
       const collapsed = groupHeader.getAttribute('aria-expanded') === 'true';
       groupHeader.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
       groupBody.toggleClass('claudian-session-group-body--collapsed', collapsed);
-      groupRunningIndicator?.toggleClass(
-        'claudian-session-group-running-indicator--visible',
-        collapsed,
-      );
-      if (hasAttentionConversation) {
+      if (groupStatusIndicator) {
+        groupStatusIndicator.toggleClass(
+          groupStatusKind === 'running'
+            ? 'claudian-session-group-running-indicator--visible'
+            : 'claudian-session-group-status-indicator--visible',
+          collapsed,
+        );
+      }
+      if (showGroupReviewState) {
         groupHeader.toggleClass('claudian-session-group-header--attention', collapsed);
       }
       options.onGroupCollapseChange?.(section.key, collapsed);
@@ -1313,10 +1317,19 @@ export class ConversationController {
       options,
     );
     const { openState, isRunning } = conversationStatus;
-    const showAttentionState = options.showAttentionState === true
+    const hasAttentionState = options.showAttentionState === true
       && options.sessionScope !== 'archived'
       && conversationStatus.attention !== null
       && conversationStatus.attention !== undefined;
+    const showReviewState = hasAttentionState
+      && conversationStatus.attention?.kind === 'review'
+      && conversationStatus.attention.outcome === 'completed';
+    const sessionStatusKind = this.getSessionStatusIndicatorKind(
+      conversationStatus,
+      options,
+    );
+    const showRunningPresentation = isRunning
+      && sessionStatusKind !== 'action-required';
     const isCurrent = openState === 'current';
     const isOpen = openState === 'open';
     const isSelectable = !isCurrent && options.allowConversationSelection !== false;
@@ -1325,8 +1338,8 @@ export class ConversationController {
         'claudian-history-item',
         isCurrent ? 'active' : '',
         isOpen ? 'open' : '',
-        isRunning ? 'running' : '',
-        showAttentionState ? 'claudian-history-item--attention' : '',
+        showRunningPresentation ? 'running' : '',
+        showReviewState ? 'claudian-history-item--attention' : '',
         options.allowConversationSelection === false
           ? 'claudian-history-item--noninteractive'
           : '',
@@ -1341,7 +1354,7 @@ export class ConversationController {
     }
 
     const iconEl = item.createDiv({ cls: 'claudian-history-item-icon' });
-    setIcon(iconEl, this.getHistoryItemIcon(openState, isRunning));
+    setIcon(iconEl, this.getHistoryItemIcon(openState, showRunningPresentation));
 
     const content = item.createDiv({ cls: 'claudian-history-item-content' });
     const titleEl = content.createDiv({
@@ -1508,7 +1521,7 @@ export class ConversationController {
     }
 
     if (options.sessionActionMode === 'active') {
-      if (!showAttentionState) {
+      if (!hasAttentionState) {
         const isPinned = conversation.isPinned === true;
         if (options.showInlinePinAction !== false) {
           const pinBtn = actions.createEl('button', {
@@ -1579,13 +1592,85 @@ export class ConversationController {
       createDeleteButton();
     }
 
-    if (isRunning && options.showOpenStateLabels === false) {
-      const runningIndicator = item.createSpan({
-        cls: 'claudian-session-running-indicator',
-      });
-      setIcon(runningIndicator, 'loader-2');
-      runningIndicator.setAttribute('aria-label', 'Running');
+    if (sessionStatusKind) {
+      this.createSessionStatusIndicator(item, sessionStatusKind);
     }
+  }
+
+  private getSessionStatusIndicatorKind(
+    status: HistoryConversationStatus,
+    options: HistoryRenderOptions,
+  ): SessionStatusIndicatorKind | null {
+    if (options.showOpenStateLabels !== false) return null;
+
+    const canShowAttention = options.showAttentionState === true
+      && options.sessionScope !== 'archived';
+    if (canShowAttention && status.attention?.kind === 'action-required') {
+      return 'action-required';
+    }
+    if (status.isRunning) return 'running';
+    if (
+      canShowAttention
+      && status.attention?.kind === 'review'
+      && status.attention.outcome === 'error'
+    ) {
+      return 'error';
+    }
+    return null;
+  }
+
+  private getGroupSessionStatusIndicatorKind(
+    statuses: readonly HistoryConversationStatus[],
+    options: HistoryRenderOptions,
+  ): SessionStatusIndicatorKind | null {
+    const kinds = statuses.map(status => (
+      this.getSessionStatusIndicatorKind(status, options)
+    ));
+    if (kinds.includes('action-required')) return 'action-required';
+    if (kinds.includes('running')) return 'running';
+    if (kinds.includes('error')) return 'error';
+    return null;
+  }
+
+  private createSessionStatusIndicator(
+    parent: HTMLElement,
+    kind: SessionStatusIndicatorKind,
+    isGroup = false,
+    isVisible = true,
+  ): HTMLElement {
+    const isRunning = kind === 'running';
+    const indicator = parent.createSpan({
+      cls: isRunning
+        ? [
+            isGroup
+              ? 'claudian-session-group-running-indicator'
+              : 'claudian-session-running-indicator',
+            isGroup && isVisible
+              ? 'claudian-session-group-running-indicator--visible'
+              : '',
+          ].filter(Boolean).join(' ')
+        : [
+            'claudian-session-status-indicator',
+            `claudian-session-status-indicator--${kind}`,
+            isGroup ? 'claudian-session-group-status-indicator' : '',
+            isGroup && isVisible
+              ? 'claudian-session-group-status-indicator--visible'
+              : '',
+          ].filter(Boolean).join(' '),
+    });
+    const icon = kind === 'action-required'
+      ? 'alert-circle'
+      : kind === 'error'
+        ? 'x-circle'
+        : 'loader-2';
+    const label = kind === 'action-required'
+      ? 'Needs your input'
+      : kind === 'error'
+        ? 'Stopped with an error'
+        : 'Running';
+    setIcon(indicator, icon);
+    indicator.setAttribute('aria-label', label);
+    return indicator;
   }
 
   private getHistoryConversationStatusForMetadata(

--- a/src/features/chat/tabs/TabBar.ts
+++ b/src/features/chat/tabs/TabBar.ts
@@ -98,7 +98,6 @@ export class TabBar {
 
     // Obsidian uses aria-label for hover tooltips here; adding title causes duplicate tooltip text.
     badgeEl.setAttribute('aria-label', `${item.title}, ${this.getBadgeStatusLabel(item)}`);
-    badgeEl.setAttribute('data-provider', item.providerId);
     badgeEl.setAttribute('data-title-expanded', isTitleExpanded ? 'true' : 'false');
 
     // Click handler to switch tab

--- a/src/features/chat/tabs/TabManager.ts
+++ b/src/features/chat/tabs/TabManager.ts
@@ -1265,7 +1265,6 @@ export class TabManager implements TabManagerInterface {
         id: tab.id,
         index: index++,
         title: getTabTitle(tab, this.plugin),
-        providerId: getTabProviderId(tab, this.plugin),
         isActive: tab.id === this.activeTabId,
         isWorking: this.isTabWorking(tab.id),
         attention: tab.state.attention,

--- a/src/features/chat/tabs/types.ts
+++ b/src/features/chat/tabs/types.ts
@@ -319,7 +319,6 @@ export interface TabBarItem {
   /** 1-based index for display. */
   index: number;
   title: string;
-  providerId: ProviderId;
   isActive: boolean;
   /** True while any foreground, continuation, provider-background, or async-subagent work remains. */
   isWorking: boolean;

--- a/src/style/components/history.css
+++ b/src/style/components/history.css
@@ -439,6 +439,37 @@
   stroke-width: 2.5;
 }
 
+.claudian-session-status-indicator {
+  display: flex;
+  flex: 0 0 14px;
+  width: 14px;
+  height: 14px;
+  align-items: center;
+  justify-content: center;
+}
+
+.claudian-session-group-status-indicator {
+  display: none;
+}
+
+.claudian-session-group-status-indicator--visible {
+  display: flex;
+}
+
+.claudian-session-status-indicator svg {
+  width: 14px;
+  height: 14px;
+  stroke-width: 2.5;
+}
+
+.claudian-session-status-indicator--action-required {
+  color: var(--color-orange);
+}
+
+.claudian-session-status-indicator--error {
+  color: var(--text-error);
+}
+
 .claudian-session-group-new-action {
   display: none;
   flex: 0 0 18px;

--- a/src/style/components/tabs.css
+++ b/src/style/components/tabs.css
@@ -67,27 +67,15 @@
 }
 
 .claudian-tab-badge-streaming {
-  border-color: var(--claudian-brand, #da7756);
+  border-color: var(--text-normal);
 }
 
-.claudian-tab-badge-streaming[data-provider="claude"] {
-  border-color: var(--claudian-brand-claude, #D97757);
+body.theme-light .claudian-tab-badge-streaming {
+  border-color: #000000;
 }
 
-.claudian-tab-badge-streaming[data-provider="codex"] {
-  border-color: var(--claudian-brand-codex, #d0d0d0);
-}
-
-.claudian-tab-badge-streaming[data-provider="opencode"] {
-  border-color: var(--claudian-brand-opencode, #C8C8C8);
-}
-
-.claudian-tab-badge-streaming[data-provider="pi"] {
-  border-color: var(--claudian-brand-pi, #ffffff);
-}
-
-.claudian-tab-badge-streaming[data-provider="grok"] {
-  border-color: var(--claudian-brand-grok, #ffffff);
+body.theme-dark .claudian-tab-badge-streaming {
+  border-color: #ffffff;
 }
 
 .claudian-tab-badge-review {
@@ -95,11 +83,11 @@
 }
 
 .claudian-tab-badge-review-error {
-  border-color: var(--color-orange);
+  border-color: var(--text-error);
 }
 
 .claudian-tab-badge-action-required {
-  border-color: var(--text-error);
+  border-color: var(--color-orange);
 }
 
 .claudian-tab-badge-idle {

--- a/tests/unit/features/chat/controllers/ConversationController.test.ts
+++ b/tests/unit/features/chat/controllers/ConversationController.test.ts
@@ -1249,7 +1249,7 @@ describe('ConversationController', () => {
         expect(container.querySelector('.claudian-history-section--sessions')).not.toBeNull();
       });
 
-      it('marks attention rows for title animation without session action buttons', () => {
+      it('pulses completed reviews and hides actions for every attention state', () => {
         const container = createMockEl();
         (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
           {
@@ -1285,12 +1285,19 @@ describe('ConversationController', () => {
         expect(container.querySelector('.claudian-history-section--attention')).toBeNull();
         expect(container.querySelectorAll('.claudian-history-item')).toHaveLength(4);
         const attentionItems = container.querySelectorAll('.claudian-history-item--attention');
-        expect(attentionItems).toHaveLength(3);
+        expect(attentionItems).toHaveLength(2);
         expect(container.querySelector('.claudian-session-attention-indicator')).toBeNull();
-        for (const item of attentionItems) {
+        const attendedItems = container.querySelectorAll('.claudian-history-item').filter(
+          (item: HTMLElement) => item.getAttribute('data-conversation-id') !== 'normal',
+        );
+        for (const item of attendedItems) {
           expect(item.querySelector('.claudian-pin-btn')).toBeNull();
           expect(item.querySelector('.claudian-archive-btn')).toBeNull();
         }
+        const actionItem = attendedItems.find(
+          (item: HTMLElement) => item.getAttribute('data-conversation-id') === 'action',
+        )!;
+        expect(actionItem.hasClass('claudian-history-item--attention')).toBe(false);
         const normalItem = container.querySelectorAll('.claudian-history-item').find(
           (item: HTMLElement) => item.getAttribute('data-conversation-id') === 'normal',
         )!;
@@ -2095,6 +2102,74 @@ describe('ConversationController', () => {
         expect(setIcon).toHaveBeenCalledWith(runningIndicators[0], 'loader-2');
       });
 
+      it('replaces the dual-pane spinner with matched action and error badges', () => {
+        const container = createMockEl();
+        (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
+          { id: 'waiting', title: 'Waiting', createdAt: 5000 },
+          { id: 'working', title: 'Working', createdAt: 4000 },
+          { id: 'error', title: 'Error', createdAt: 3000 },
+          { id: 'review', title: 'Review', createdAt: 2000 },
+          { id: 'idle', title: 'Idle', createdAt: 1000 },
+        ]);
+
+        controller.renderHistoryDropdown(container, {
+          onSelectConversation: jest.fn(),
+          showAttentionState: true,
+          showOpenStateLabels: false,
+          getConversationStatus: (id) => ({
+            openState: 'open',
+            isRunning: id === 'waiting' || id === 'working',
+            attention: id === 'waiting'
+              ? { kind: 'action-required', since: 1 }
+              : id === 'error'
+                ? { kind: 'review', outcome: 'error', since: 2 }
+                : id === 'review'
+                  ? { kind: 'review', outcome: 'completed', since: 3 }
+                  : null,
+          }),
+        });
+
+        const items = container.querySelectorAll('.claudian-history-item');
+        const findItem = (id: string) => items.find(
+          (item: HTMLElement) => item.getAttribute('data-conversation-id') === id,
+        )!;
+        const waitingItem = findItem('waiting');
+        const waitingBadge = waitingItem.querySelector(
+          '.claudian-session-status-indicator--action-required',
+        )!;
+        const workingItem = findItem('working');
+        const errorItem = findItem('error');
+        const errorBadge = errorItem.querySelector(
+          '.claudian-session-status-indicator--error',
+        )!;
+
+        expect(waitingBadge).not.toBeNull();
+        expect(waitingBadge.hasClass('claudian-session-status-indicator')).toBe(true);
+        expect(waitingBadge.getAttribute('aria-label')).toBe('Needs your input');
+        expect(waitingItem.querySelector('.claudian-session-running-indicator')).toBeNull();
+        expect(waitingItem.hasClass('running')).toBe(false);
+        expect(waitingItem.getAttribute('data-running')).toBe('true');
+        expect(setIcon).toHaveBeenCalledWith(
+          waitingItem.querySelector('.claudian-history-item-icon'),
+          'message-square',
+        );
+        expect(waitingItem.hasClass('claudian-history-item--attention')).toBe(false);
+        expect(setIcon).toHaveBeenCalledWith(waitingBadge, 'alert-circle');
+
+        expect(workingItem.querySelector('.claudian-session-running-indicator')).not.toBeNull();
+        expect(workingItem.querySelector('.claudian-session-status-indicator')).toBeNull();
+
+        expect(errorBadge).not.toBeNull();
+        expect(errorBadge.hasClass('claudian-session-status-indicator')).toBe(true);
+        expect(errorBadge.getAttribute('aria-label')).toBe('Stopped with an error');
+        expect(errorItem.hasClass('claudian-history-item--attention')).toBe(false);
+        expect(setIcon).toHaveBeenCalledWith(errorBadge, 'x-circle');
+
+        expect(findItem('review').hasClass('claudian-history-item--attention')).toBe(true);
+        expect(findItem('review').querySelector('.claudian-session-status-indicator')).toBeNull();
+        expect(findItem('idle').querySelector('.claudian-session-status-indicator')).toBeNull();
+      });
+
       it('displays the timestamp selected by the session sort mode', () => {
         const container = createMockEl();
         jest.spyOn(controller, 'formatDate').mockImplementation(
@@ -2172,6 +2247,92 @@ describe('ConversationController', () => {
           'claudian-session-group-running-indicator--visible',
         )).toBe(true);
         expect(setIcon).toHaveBeenCalledWith(headerIndicator, 'loader-2');
+      });
+
+      it('prioritizes a waiting badge on a collapsed linked-content group', () => {
+        const container = createMockEl();
+        (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
+          {
+            id: 'waiting',
+            title: 'Waiting session',
+            createdAt: 1000,
+            linkedContentPath: 'Projects/Plan.md',
+          },
+          {
+            id: 'working',
+            title: 'Working session',
+            createdAt: 900,
+            linkedContentPath: 'Projects/Plan.md',
+          },
+        ]);
+
+        controller.renderHistoryDropdown(container, {
+          onSelectConversation: jest.fn(),
+          organization: 'linked-content',
+          sort: 'last-updated',
+          language: 'en',
+          showAttentionState: true,
+          showOpenStateLabels: false,
+          getConversationStatus: (id) => ({
+            openState: 'open',
+            isRunning: true,
+            attention: id === 'waiting'
+              ? { kind: 'action-required', since: 1 }
+              : null,
+          }),
+        });
+
+        const header = container.querySelector('.claudian-session-group-header')!;
+        const badge = header.querySelector(
+          '.claudian-session-group-status-indicator',
+        )!;
+        expect(badge).not.toBeNull();
+        expect(badge.hasClass('claudian-session-status-indicator--action-required')).toBe(true);
+        expect(badge.hasClass('claudian-session-group-status-indicator--visible')).toBe(false);
+        expect(header.querySelector('.claudian-session-group-running-indicator')).toBeNull();
+
+        header.click();
+
+        expect(badge.hasClass('claudian-session-group-status-indicator--visible')).toBe(true);
+        expect(badge.getAttribute('aria-label')).toBe('Needs your input');
+        expect(setIcon).toHaveBeenCalledWith(badge, 'alert-circle');
+      });
+
+      it('shows an error badge on a collapsed linked-content group without active work', () => {
+        const container = createMockEl();
+        (deps.plugin.getConversationList as jest.Mock).mockReturnValue([
+          {
+            id: 'error',
+            title: 'Failed session',
+            createdAt: 1000,
+            linkedContentPath: 'Projects/Plan.md',
+          },
+        ]);
+
+        controller.renderHistoryDropdown(container, {
+          onSelectConversation: jest.fn(),
+          organization: 'linked-content',
+          sort: 'last-updated',
+          language: 'en',
+          showAttentionState: true,
+          showOpenStateLabels: false,
+          getConversationStatus: () => ({
+            openState: 'open',
+            isRunning: false,
+            attention: { kind: 'review', outcome: 'error', since: 1 },
+          }),
+        });
+
+        const header = container.querySelector('.claudian-session-group-header')!;
+        const badge = header.querySelector(
+          '.claudian-session-group-status-indicator',
+        )!;
+        header.click();
+
+        expect(badge.hasClass('claudian-session-status-indicator--error')).toBe(true);
+        expect(badge.hasClass('claudian-session-group-status-indicator--visible')).toBe(true);
+        expect(badge.getAttribute('aria-label')).toBe('Stopped with an error');
+        expect(setIcon).toHaveBeenCalledWith(badge, 'x-circle');
       });
 
       it('marks a collapsed linked-content header when it contains attention', () => {

--- a/tests/unit/features/chat/tabs/TabAttentionStyles.test.ts
+++ b/tests/unit/features/chat/tabs/TabAttentionStyles.test.ts
@@ -12,10 +12,25 @@ describe('tab attention styles', () => {
       /\.claudian-tab-badge-review \{[\s\S]*?border-color: var\(--color-green\);[\s\S]*?\}/,
     );
     expect(tabsCss).toMatch(
-      /\.claudian-tab-badge-review-error \{[\s\S]*?border-color: var\(--color-orange\);[\s\S]*?\}/,
+      /\.claudian-tab-badge-review-error \{[\s\S]*?border-color: var\(--text-error\);[\s\S]*?\}/,
     );
     expect(tabsCss).toMatch(
-      /\.claudian-tab-badge-action-required \{[\s\S]*?border-color: var\(--text-error\);[\s\S]*?\}/,
+      /\.claudian-tab-badge-action-required \{[\s\S]*?border-color: var\(--color-orange\);[\s\S]*?\}/,
+    );
+  });
+
+  it('uses theme-neutral working borders without provider overrides', () => {
+    expect(tabsCss).toMatch(
+      /\.claudian-tab-badge-streaming \{[\s\S]*?border-color: var\(--text-normal\);[\s\S]*?\}/,
+    );
+    expect(tabsCss).toMatch(
+      /body\.theme-light \.claudian-tab-badge-streaming \{[\s\S]*?border-color: #000000;[\s\S]*?\}/,
+    );
+    expect(tabsCss).toMatch(
+      /body\.theme-dark \.claudian-tab-badge-streaming \{[\s\S]*?border-color: #ffffff;[\s\S]*?\}/,
+    );
+    expect(tabsCss).not.toMatch(
+      /\.claudian-tab-badge-streaming\[data-provider=/,
     );
   });
 });

--- a/tests/unit/features/chat/tabs/TabBar.test.ts
+++ b/tests/unit/features/chat/tabs/TabBar.test.ts
@@ -18,7 +18,6 @@ function createTabBarItem(overrides: Partial<TabBarItem> = {}): TabBarItem {
     id: 'tab-1',
     index: 1,
     title: 'Test Tab',
-    providerId: 'claude',
     isActive: false,
     isWorking: false,
     attention: null,
@@ -101,14 +100,14 @@ describe('TabBar', () => {
       expect(containerEl._children[0].getAttribute('title')).toBeNull();
     });
 
-    it('should set a provider attribute for per-tab streaming colors', () => {
+    it('does not expose a provider-specific tab styling hook', () => {
       const containerEl = createMockEl();
       const callbacks = createMockCallbacks();
       const tabBar = new TabBar(containerEl, callbacks);
 
-      tabBar.update([createTabBarItem({ providerId: 'opencode' })]);
+      tabBar.update([createTabBarItem()]);
 
-      expect(containerEl._children[0].getAttribute('data-provider')).toBe('opencode');
+      expect(containerEl._children[0].getAttribute('data-provider')).toBeNull();
     });
 
     it('should toggle between index and title labels on double click', () => {

--- a/tests/unit/providers/grok/ui/GrokBrandColor.test.ts
+++ b/tests/unit/providers/grok/ui/GrokBrandColor.test.ts
@@ -6,11 +6,6 @@ describe('Grok brand color', () => {
     path.join(process.cwd(), 'src/style/base/variables.css'),
     'utf8',
   );
-  const tabsCss = fs.readFileSync(
-    path.join(process.cwd(), 'src/style/components/tabs.css'),
-    'utf8',
-  );
-
   it('uses white in dark mode and black in light mode', () => {
     expect(variablesCss).toContain('--claudian-brand-grok: #ffffff;');
     expect(variablesCss).toContain('--claudian-brand-grok-rgb: 255, 255, 255;');
@@ -19,12 +14,9 @@ describe('Grok brand color', () => {
     );
   });
 
-  it('routes active and streaming Grok surfaces through its brand token', () => {
+  it('routes active Grok surfaces through its brand token', () => {
     expect(variablesCss).toMatch(
       /\.claudian-container\[data-provider="grok"\] \{[\s\S]*?--claudian-brand: var\(--claudian-brand-grok\);[\s\S]*?--claudian-brand-rgb: var\(--claudian-brand-grok-rgb\);[\s\S]*?\}/,
-    );
-    expect(tabsCss).toMatch(
-      /\.claudian-tab-badge-streaming\[data-provider="grok"\] \{[\s\S]*?border-color: var\(--claudian-brand-grok, #ffffff\);[\s\S]*?\}/,
     );
   });
 });

--- a/tests/unit/style/components/history.test.ts
+++ b/tests/unit/style/components/history.test.ts
@@ -26,6 +26,20 @@ describe('Persistent sidebar surface pager styles', () => {
       /\.claudian-session-sidebar:has\([^}]*clip-path:/,
     );
   });
+
+  it('uses one geometry for waiting and error status badges', () => {
+    const css = readFileSync(path.resolve('src/style/components/history.css'), 'utf8');
+
+    expect(css).toMatch(
+      /\.claudian-session-status-indicator\s*\{[^}]*display:\s*flex;[^}]*flex:\s*0 0 14px;[^}]*width:\s*14px;[^}]*height:\s*14px;/,
+    );
+    expect(css).toMatch(
+      /\.claudian-session-status-indicator--action-required\s*\{[^}]*color:\s*var\(--color-orange\);/,
+    );
+    expect(css).toMatch(
+      /\.claudian-session-status-indicator--error\s*\{[^}]*color:\s*var\(--text-error\);/,
+    );
+  });
 });
 
 describe('Single-pane history action styles', () => {


### PR DESCRIPTION
## Why

Blocked background sessions looked identical to actively working sessions, making permission prompts and questions easy to miss. Closes #1210.

## What Changed

- Added matching orange action-required and red error badges to the dual-pane Sessions panel, including collapsed-group precedence, while preserving existing working, review-ready, and idle treatments
- Replaced every spinner presentation for blocked sessions while retaining their underlying running state
- Updated single-pane attention/error colors and replaced provider-branded working borders with black/white theme borders
- Removed the obsolete provider-specific tab styling hook and added regression coverage for the new state matrix

## Why This Approach

The renderer derives presentation from existing provider-neutral runtime and attention state, keeping provider behavior and persisted conversation data unchanged.

## Validation

- `npm run typecheck && npm run lint && npm run test && npm run build`
- 607 suites passed; 8,897 tests passed; 2 suites and 2 tests skipped
- `git diff --check origin/main...`
- Screenshots not included; rendered DOM and CSS behavior covered by focused regression tests

## Impact and Follow-ups

No compatibility or data risks; no documentation follow-up required.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
