### PR TITLE
fix: stabilize Collab CI and consume protocol 3.3.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "claudian",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.226",
-        "@claudian-collab/protocol": "3.3.1",
+        "@claudian-collab/protocol": "3.3.2",
         "@codemirror/commands": "6.10.0",
         "@codemirror/lang-markdown": "^6.5.2",
         "@codemirror/language": "^6.12.4",
@@ -165,7 +165,7 @@
 
     "@cacheable/utils": ["@cacheable/utils@2.5.0", "", { "dependencies": { "hashery": "^1.5.1", "keyv": "^5.6.0" } }, "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA=="],
 
-    "@claudian-collab/protocol": ["@claudian-collab/protocol@3.3.1", "", { "dependencies": { "@lezer/markdown": "1.7.2" } }, "sha512-F+D1Y8RbTbZAWu13HYI6mv9feoLDMII0mEZTapoDLqRNm+ZZ6VAgqOH3h9kGMNb6uR9dVTMiNb8nQ4KABEHZZw=="],
+    "@claudian-collab/protocol": ["@claudian-collab/protocol@3.3.2", "", { "dependencies": { "@lezer/markdown": "1.7.2" } }, "sha512-oOSfYrCZNSjVbDK9tE2d8wlhvIf9nUi5mCHf/lLQwQ2jeZ4sW7dLgygE+NEhZFqfICXwF3V++UTsAfcle5AAdg=="],
 
     "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.226",
-        "@claudian-collab/protocol": "3.3.1",
+        "@claudian-collab/protocol": "3.3.2",
         "@codemirror/commands": "6.10.0",
         "@codemirror/lang-markdown": "^6.5.2",
         "@codemirror/language": "^6.12.4",
@@ -831,9 +831,9 @@
       }
     },
     "node_modules/@claudian-collab/protocol": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@claudian-collab/protocol/-/protocol-3.3.1.tgz",
-      "integrity": "sha512-F+D1Y8RbTbZAWu13HYI6mv9feoLDMII0mEZTapoDLqRNm+ZZ6VAgqOH3h9kGMNb6uR9dVTMiNb8nQ4KABEHZZw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@claudian-collab/protocol/-/protocol-3.3.2.tgz",
+      "integrity": "sha512-oOSfYrCZNSjVbDK9tE2d8wlhvIf9nUi5mCHf/lLQwQ2jeZ4sW7dLgygE+NEhZFqfICXwF3V++UTsAfcle5AAdg==",
       "license": "MIT",
       "dependencies": {
         "@lezer/markdown": "1.7.2"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.226",
-    "@claudian-collab/protocol": "3.3.1",
+    "@claudian-collab/protocol": "3.3.2",
     "@codemirror/commands": "6.10.0",
     "@codemirror/lang-markdown": "^6.5.2",
     "@codemirror/language": "^6.12.4",

--- a/scripts/check-architecture-boundaries.test.mjs
+++ b/scripts/check-architecture-boundaries.test.mjs
@@ -660,21 +660,21 @@ test('Claudian consumes the standalone Collab protocol only from the exact regis
 
   const protocol = await import(protocolPackageName);
 
-  assert.equal(manifest.dependencies?.[protocolPackageName], '3.3.1');
+  assert.equal(manifest.dependencies?.[protocolPackageName], '3.3.2');
   assert.equal(manifest.dependencies?.['@lezer/markdown'], '1.7.2');
   assert.equal(protocolManifest.dependencies?.['@lezer/markdown'], '1.7.2');
   assert.equal(manifest.dependencies?.['@claudian/collab-protocol'], undefined);
   assert.equal(manifest.workspaces, undefined);
-  assert.equal(lockfile.packages?.['']?.dependencies?.[protocolPackageName], '3.3.1');
-  assert.equal(lockfile.packages?.[protocolInstallPath]?.version, '3.3.1');
+  assert.equal(lockfile.packages?.['']?.dependencies?.[protocolPackageName], '3.3.2');
+  assert.equal(lockfile.packages?.[protocolInstallPath]?.version, '3.3.2');
   assert.equal(
     lockfile.packages?.[protocolInstallPath]?.integrity,
-    'sha512-F+D1Y8RbTbZAWu13HYI6mv9feoLDMII0mEZTapoDLqRNm+ZZ6VAgqOH3h9kGMNb6uR9dVTMiNb8nQ4KABEHZZw==',
+    'sha512-oOSfYrCZNSjVbDK9tE2d8wlhvIf9nUi5mCHf/lLQwQ2jeZ4sW7dLgygE+NEhZFqfICXwF3V++UTsAfcle5AAdg==',
   );
   assert.equal(lockfile.packages?.['node_modules/@lezer/markdown']?.version, '1.7.2');
   assert.match(
     lockfile.packages?.[protocolInstallPath]?.resolved ?? '',
-    /^https:\/\/registry\.npmjs\.org\/@claudian-collab\/protocol\/-\/protocol-3\.3\.1\.tgz$/u,
+    /^https:\/\/registry\.npmjs\.org\/@claudian-collab\/protocol\/-\/protocol-3\.3\.2\.tgz$/u,
   );
   assert.equal(protocol.COLLAB_PROTOCOL_VERSION, 6);
   assert.equal(protocol.COLLAB_CLOUD_BINDING_VERSION, 2);

--- a/tests/integration/app/collab/authority-transfer/AuthorityTransferPersistence.test.ts
+++ b/tests/integration/app/collab/authority-transfer/AuthorityTransferPersistence.test.ts
@@ -257,7 +257,7 @@ describe('AuthorityTransferPersistence', () => {
       safeContext: { reason: 'authority-transfer-source-relinquished' },
     });
     await expect(repository.listAuthorityTransferProjectIds()).resolves.toEqual([PROJECT_ID]);
-  });
+  }, 30_000); // The complete phase walk includes real file and directory synchronization.
 
   it('serializes LAN Host start against authority-transfer fence creation', async () => {
     const repository = new CollabLocalProjectRepository(vaultRoot);

--- a/tests/integration/app/collab/gates/ReviewAcceptanceMilestoneGate.test.ts
+++ b/tests/integration/app/collab/gates/ReviewAcceptanceMilestoneGate.test.ts
@@ -21,7 +21,7 @@ import type { CollabFeatureService } from '@/app/collab/CollabFeatureService';
 import { createCollabFeatureSubcomposition } from '@/app/collab/CollabFeatureSubcomposition';
 import { InvitationCodec } from '@/app/collab/lan/InvitationCodec';
 import { CollabProjectSetupService } from '@/app/collab/project/CollabProjectSetupService';
-import { type CollabResult } from '@/core/collab';
+import { type CollabCoordinationSnapshot, type CollabResult, isCollabLanProjectSnapshot } from '@/core/collab';
 
 jest.setTimeout(120_000);
 
@@ -192,7 +192,11 @@ describe('M5 review and Accept gate', () => {
       targetMemberId: managerMembership.member.id,
     }), 'Manager responsibility offer');
     unwrap(
-      await managerFeature.readSnapshot(projectId),
+      await readEventuallySnapshot(managerFeature, projectId, ({ snapshot }) => (
+        isCollabLanProjectSnapshot(snapshot)
+        && snapshot.managerResponsibilityOffer?.offerId === responsibility.offerId
+        && snapshot.managerResponsibilityOffer.status === 'acknowledged'
+      )),
       'Automatic Manager responsibility reconciliation',
     );
     unwrap(await hostFeature.promoteManager({
@@ -201,11 +205,16 @@ describe('M5 review and Accept gate', () => {
       targetMemberId: managerMembership.member.id,
     }), 'Manager promotion');
     expect(unwrap(
-      await managerFeature.readSnapshot(projectId),
+      await readEventuallySnapshot(managerFeature, projectId, value => (
+        value.source === 'online' && value.snapshot.currentMember.role === 'manager'
+      )),
       'Manager snapshot',
-    ).snapshot.currentMember).toMatchObject({
-      id: managerMembership.member.id,
-      role: 'manager',
+    )).toMatchObject({
+      source: 'online',
+      stale: false,
+      snapshot: {
+        currentMember: { id: managerMembership.member.id, role: 'manager' },
+      },
     });
     const firstManagerReview = unwrap(
       await managerFeature.prepareReview(projectId, requestId),
@@ -233,7 +242,11 @@ describe('M5 review and Accept gate', () => {
     });
 
     unwrap(await hostFeature.stopHost(projectId), 'Host stop');
-    await expect(readEventuallyCached(managerFeature, projectId)).resolves.toMatchObject({
+    await expect(readEventuallySnapshot(
+      managerFeature,
+      projectId,
+      value => value.source === 'cache',
+    )).resolves.toMatchObject({
       status: 'success',
       value: { source: 'cache', stale: true },
     });
@@ -437,13 +450,15 @@ describe('M5 review and Accept gate', () => {
     return feature;
   }
 
-  async function readEventuallyCached(
+  async function readEventuallySnapshot(
     feature: CollabFeatureService,
     projectId: string,
+    isReady: (value: CollabCoordinationSnapshot) => boolean,
   ) {
+    // Event refreshes can share a snapshot request started before the remote transition.
     let latest = await feature.readSnapshot(projectId);
     for (let attempt = 0; attempt < 20; attempt += 1) {
-      if (latest.status === 'success' && latest.value.source === 'cache') return latest;
+      if (latest.status !== 'success' || isReady(latest.value)) return latest;
       await new Promise(resolve => setTimeout(resolve, 25));
       latest = await feature.readSnapshot(projectId);
     }

--- a/tests/unit/app/collab/remote-authority/NodeCloudAuthorityArtifactTransport.test.ts
+++ b/tests/unit/app/collab/remote-authority/NodeCloudAuthorityArtifactTransport.test.ts
@@ -1,4 +1,4 @@
-import { createServer, type Server } from 'node:http';
+import { createServer, type Server, type ServerResponse } from 'node:http';
 import { PassThrough, Readable } from 'node:stream';
 
 import { collabCloudErrorEnvelope,CollabError } from '@claudian-collab/protocol';
@@ -17,6 +17,7 @@ async function listen(server: Server): Promise<string> {
 }
 
 afterEach(async () => {
+  jest.useRealTimers();
   await Promise.all(servers.splice(0).map(server => new Promise<void>(resolve => {
     server.closeAllConnections();
     server.close(() => resolve());
@@ -99,21 +100,15 @@ describe('NodeCloudAuthorityArtifactTransport', () => {
   });
 
   it('resets the idle timeout while a download continues making progress', async () => {
+    jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
+    let serverResponse!: ServerResponse;
     const origin = await listen(createServer((_request, response) => {
+      serverResponse = response;
       response.writeHead(200, {
         'content-length': '5',
         'content-type': 'application/octet-stream',
       });
-      let remaining = 5;
-      const interval = setInterval(() => {
-        response.write('x');
-        remaining -= 1;
-        if (remaining === 0) {
-          clearInterval(interval);
-          response.end();
-        }
-      }, 10);
-      response.once('close', () => clearInterval(interval));
+      response.write('x');
     }));
     const response = await new NodeCloudAuthorityArtifactTransport(20, 200).download({
       headers: {},
@@ -122,10 +117,16 @@ describe('NodeCloudAuthorityArtifactTransport', () => {
     });
     if (!('byteCount' in response)) throw new Error('expected artifact response');
 
-    const chunks: Buffer[] = [];
-    for await (const chunk of response.body) chunks.push(Buffer.from(chunk));
+    const chunks = response.body[Symbol.asyncIterator]();
+    await expect(chunks.next()).resolves.toEqual({ done: false, value: Buffer.from('x') });
+    for (let index = 1; index < 5; index += 1) {
+      await jest.advanceTimersByTimeAsync(10);
+      serverResponse.write('x');
+      await expect(chunks.next()).resolves.toEqual({ done: false, value: Buffer.from('x') });
+    }
+    serverResponse.end();
 
-    expect(Buffer.concat(chunks).toString('utf8')).toBe('xxxxx');
+    await expect(chunks.next()).resolves.toEqual({ done: true, value: undefined });
   });
 
   it('closes the HTTP response when the artifact consumer destroys its body', async () => {
@@ -155,6 +156,7 @@ describe('NodeCloudAuthorityArtifactTransport', () => {
   });
 
   it('times out an idle stream even when its absolute deadline remains open', async () => {
+    jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
     const origin = await listen(createServer((_request, response) => {
       response.writeHead(200, {
         'content-length': '2',
@@ -169,19 +171,24 @@ describe('NodeCloudAuthorityArtifactTransport', () => {
     });
     if (!('byteCount' in response)) throw new Error('expected artifact response');
 
-    await expect((async () => {
-      for await (const chunk of response.body) void chunk;
-    })()).rejects.toMatchObject({ code: 'operation-timeout' });
+    const chunks = response.body[Symbol.asyncIterator]();
+    await expect(chunks.next()).resolves.toEqual({ done: false, value: Buffer.from('x') });
+    await Promise.all([
+      expect(chunks.next()).rejects.toMatchObject({ code: 'operation-timeout' }),
+      jest.advanceTimersByTimeAsync(20),
+    ]);
   });
 
   it('enforces the absolute deadline despite continuous stream progress', async () => {
+    jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
+    let serverResponse!: ServerResponse;
     const origin = await listen(createServer((_request, response) => {
+      serverResponse = response;
       response.writeHead(200, {
         'content-length': '10',
         'content-type': 'application/octet-stream',
       });
-      const interval = setInterval(() => response.write('x'), 10);
-      response.once('close', () => clearInterval(interval));
+      response.write('x');
     }));
     const response = await new NodeCloudAuthorityArtifactTransport(20, 45).download({
       headers: {},
@@ -190,9 +197,17 @@ describe('NodeCloudAuthorityArtifactTransport', () => {
     });
     if (!('byteCount' in response)) throw new Error('expected artifact response');
 
-    await expect((async () => {
-      for await (const chunk of response.body) void chunk;
-    })()).rejects.toMatchObject({ code: 'operation-timeout' });
+    const chunks = response.body[Symbol.asyncIterator]();
+    await expect(chunks.next()).resolves.toEqual({ done: false, value: Buffer.from('x') });
+    for (let elapsed = 10; elapsed <= 40; elapsed += 10) {
+      await jest.advanceTimersByTimeAsync(10);
+      serverResponse.write('x');
+      await expect(chunks.next()).resolves.toEqual({ done: false, value: Buffer.from('x') });
+    }
+    await Promise.all([
+      expect(chunks.next()).rejects.toMatchObject({ code: 'operation-timeout' }),
+      jest.advanceTimersByTimeAsync(5),
+    ]);
   });
 
   it('rejects invalid lengths and destroys a mismatched response stream', async () => {


### PR DESCRIPTION
## Summary

- Consume the published exact `@claudian-collab/protocol@3.3.2` registry artifact in the manifest and npm/Bun locks; enforce its immutable URL and integrity through the existing architecture test.
- Repair the two test-timing failures from [post-merge main CI 33353438578](https://github.com/YishenTu/claudian/actions/runs/33353438578). Keep the complete real-filesystem authority-transfer phase walk under a scoped 30-second test limit. Verify idle progress, idle expiration, and the absolute stream deadline with real HTTP and explicitly controlled time.
- Repair the additional M5 cross-participant snapshot convergence failure exposed by [PR CI 33355056644](https://github.com/YishenTu/claudian/actions/runs/33355056644): wait within a bounded window for responsibility acknowledgement and the promoted Manager projection, retaining exact identity, role, online state, review, and Accept assertions.
- Preserve production timeout policy, real durable synchronization, recovery/fencing assertions, all application code, wire v6, Cloud binding v2, and backup v3.

## Release evidence

[Protocol v3.3.2](https://github.com/YishenTu/claudian-collab-protocol/releases/tag/v3.3.2) was published from `f657da7983757654375369a9716424a60d69cbd9` by the [trusted publication workflow](https://github.com/YishenTu/claudian-collab-protocol/actions/runs/33353488291). Registry bytes match the reviewed release manifest: 131,052 bytes, 66 files, SHA-256 `31c7fc6099091fac4b467322385f16df478ef46fa0eae3165b8960d8bbb709eb`. npm signatures/provenance verify the exact artifact, tag, commit, and workflow. Both lockfiles change only the protocol entries.

## Verification

- Exact dependency test: RED on `3.3.1`, then GREEN on published `3.3.2`.
- Main-CI failures were recorded before editing. Local baseline execution of the two affected suites passed, so local baseline success was not treated as proof against the CI scheduling failure.
- Both repaired suites: 33 tests passed, including an additional `--detectOpenHandles` run with no reported leaks.
- Expanded focused verification includes M5 plus projection, work-session, transport, and persistence tests: 81 passed with open-handle detection. A negative control that omitted the actual authority promotion still failed on `member` instead of `manager`; that temporary edit was restored. The existing snapshot coalescing and authority behavior are unchanged.
- Node 24.16.0/npm 11.13.0 clean install; `bun install --frozen-lockfile --ignore-scripts` passed, then clean npm installation restored the npm verification graph.
- Final full `npm run typecheck && npm run lint && npm run test && npm run build`, including all three timing repairs, passed: 607 Jest suites and 8,904 tests, plus 52 Node architecture/tooling checks. Only the existing Windows-only Pi and external Cloud milestone local skips remain. Production build ran with Obsidian auto-copy disabled.
- `git diff --check` passes. Final fresh-context cumulative review of all seven changed files against `bbe59a4df96f5e559ea06c3a22a24261ad71d36f` found no material in-scope findings. The reviewer independently passed all 34 tests in the three changed suites and the exact-registry check, traced the snapshot-coalescing owner, and matched all 66 installed protocol files to the published tarball and release inventory.

No Step 13/UI exposure, Gomami operation, workload/soak run, legacy Cloud path, Claudian LAN migration deletion, production policy relaxation, blanket test retries, or new skips. The separate pre-existing scheduled Windows full-suite failures are not changed by this scoped post-merge-CI repair.
