### PR TITLE
chore: verify Cloud integration branches with existing CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, codex/cloud-integration]
   pull_request:
-    branches: [main]
+    branches: [main, codex/cloud-integration]
   workflow_call:
 
 permissions:

--- a/scripts/check-architecture-boundaries.test.mjs
+++ b/scripts/check-architecture-boundaries.test.mjs
@@ -901,6 +901,8 @@ test('CI gates releases, cross-platform behavior, and security', () => {
   const nightly = fs.readFileSync(path.join(workflowsRoot, 'nightly.yml'), 'utf8');
   const codeql = fs.readFileSync(path.join(workflowsRoot, 'codeql.yml'), 'utf8');
 
+  assert.match(ci, /^  push:\n    branches: \[main, codex\/cloud-integration\]$/m);
+  assert.match(ci, /^  pull_request:\n    branches: \[main, codex\/cloud-integration\]$/m);
   assert.match(ci, /workflow_call:/);
   assert.match(ci, /rhysd\/actionlint:1\.7\.12/);
   assert.match(ci, /diff-hygiene:/);
@@ -919,6 +921,7 @@ test('CI gates releases, cross-platform behavior, and security', () => {
   assert.match(ci, /needs:\s*cross-platform-collab-scope/);
   assert.match(ci, /needs\.cross-platform-collab-scope\.outputs\.run == 'true'/);
 
+  assert.match(release, /^on:\n  push:\n    tags:\n      - '\*'\n\njobs:/m);
   assert.match(release, /uses:\s*\.\/\.github\/workflows\/ci\.yml/);
   assert.match(release, /needs:\s*verify/);
 


### PR DESCRIPTION
## Summary

- Run the existing CI workflow for pushes to `main` and `codex/cloud-integration`, and pull requests targeting either exact branch.
- Retain reusable `workflow_call` and every existing job, permission, security gate, and cross-platform check.
- Extend the existing workflow-policy test to cover the branch triggers and unchanged tag-only release trigger.

## Scope and delivery

This is pre-Step-13 preparation only. The PR targets `codex/cloud-integration`, not `main`, so partial Cloud feature development remains isolated. No application, UI, protocol, package, deployment, tag, or release change is included. Later integration-to-main delivery still requires explicit user authorization.

## Verification

- TDD: the focused workflow-policy test failed against the original main-only trigger, then passed with this change.
- All 52 Node tooling tests passed (architecture, ESLint configuration, open-handle diagnostics, release-version validation, and Stylelint configuration).
- `git diff --check` passed.
- Fresh independent read-only review against `e66f41c2674f03664788996851490512b3875744`: no material in-scope findings; independent parsed comparison confirmed all existing CI jobs and permissions are unchanged.
- Hosted CI, including actionlint, the full test suite, production build, dependency/security checks, and Windows/macOS smoke checks, must pass before merge.
