### PR TITLE
test: normalize workflow line endings in CI policy checks

### DIFF
--- a/scripts/check-architecture-boundaries.test.mjs
+++ b/scripts/check-architecture-boundaries.test.mjs
@@ -896,8 +896,8 @@ test('Collab Git process owners await Windows process-tree termination', () => {
 
 test('CI gates releases, cross-platform behavior, and security', () => {
   const workflowsRoot = path.join(process.cwd(), '.github', 'workflows');
-  const ci = fs.readFileSync(path.join(workflowsRoot, 'ci.yml'), 'utf8');
-  const release = fs.readFileSync(path.join(workflowsRoot, 'release.yml'), 'utf8');
+  const ci = fs.readFileSync(path.join(workflowsRoot, 'ci.yml'), 'utf8').replace(/\r\n/g, '\n');
+  const release = fs.readFileSync(path.join(workflowsRoot, 'release.yml'), 'utf8').replace(/\r\n/g, '\n');
   const nightly = fs.readFileSync(path.join(workflowsRoot, 'nightly.yml'), 'utf8');
   const codeql = fs.readFileSync(path.join(workflowsRoot, 'codeql.yml'), 'utf8');
 


### PR DESCRIPTION
## Summary

Normalize CRLF to LF when the workflow-policy test reads CI and release YAML. The policy assertions still require exactly `main` and `codex/cloud-integration` for CI and tag-only releases.

This follows integration preparation PR #1219. A Windows-style CRLF filesystem-input probe reproduced a false-negative in its newly added multiline assertions. The correction remains local to test input; no workflow behavior, feature code, dependencies, permissions, or release settings change.

## Delivery scope

Target `codex/cloud-integration`, not `main`. This remains pre-Step-13 preparation only; no release, deployment, or user-visible Cloud implementation is authorized.

## Verification

- Executed the real focused Node test with CRLF workflow contents supplied at its filesystem-read boundary: failed before the correction and passed afterward.
- All 52 local Node tooling tests pass with ordinary checkout inputs; `git diff --check` passes.
- Fresh independent read-only review covers the entire cumulative CI preparation against original baseline `e66f41c2674f03664788996851490512b3875744`.
- All hosted PR checks must pass before merge, followed by integration-push verification.
