### PR TITLE
fix(env): include user bin directory in extra binary search paths

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -122,6 +122,7 @@ function getExtraBinaryPaths(): string[] {
 
     // User bin (if exists)
     if (home) {
+      paths.push(path.join(home, 'bin'));
       paths.push(path.join(home, '.local', 'bin'));
       paths.push(path.join(home, '.bun', 'bin'));
       paths.push(path.join(home, '.opencode', 'bin'));
@@ -161,6 +162,7 @@ function getExtraBinaryPaths(): string[] {
     }
 
     if (home) {
+      paths.push(path.join(home, 'bin'));
       paths.push(path.join(home, '.local', 'bin'));
       paths.push(path.join(home, '.bun', 'bin'));
       paths.push(path.join(home, '.opencode', 'bin'));

--- a/tests/unit/utils/env.test.ts
+++ b/tests/unit/utils/env.test.ts
@@ -253,6 +253,14 @@ describe('getEnhancedPath', () => {
 
       expect(segments).toContain(path.join('/mock/home', '.opencode', 'bin'));
     });
+
+    it('includes the user bin path from HOME', () => {
+      process.env.HOME = '/mock/home';
+      const result = getEnhancedPath();
+      const segments = result.split(SEP);
+
+      expect(segments).toContain(path.join('/mock/home', 'bin'));
+    });
   });
 
   describe('Unix environment variable paths', () => {


### PR DESCRIPTION
### Why
Obsidian on macOS/Linux runs in a GUI environment that does not inherit shell profile `PATH` configurations (such as `$HOME/bin`). When tools like `opencode`, `pi`, or `codex` are installed in `~/bin`, Claudian cannot automatically resolve the CLI path out-of-the-box, resulting in failure to discover models or launch providers unless explicitly configured in settings.

### What
- Added `~/bin` (`path.join(home, "bin")`) to the extra binary paths probing list in `getExtraBinaryPaths()` in `src/utils/env.ts` for both Unix and Windows platforms.
- Added unit test coverage in `tests/unit/utils/env.test.ts` verifying that `~/bin` is included in `getEnhancedPath()`.

### Why this approach
`getExtraBinaryPaths()` already includes standard user-level directories such as `~/.local/bin`, `~/.bun/bin`, and `~/.opencode/bin`. Adding `~/bin` follows the existing design pattern and provides seamless CLI discovery for users using the standard user binary directory.

### Validation
- `npm run typecheck` passed cleanly.
- `npm run lint` passed.
- `npm run test:unit -- tests/unit/utils/env.test.ts` passed with all 124 tests passing.
- `npm run build` succeeded.