### PR TITLE
fix: normalize architecture test paths on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run Windows architecture boundaries
+        if: runner.os == 'Windows'
+        run: npm run test:architecture
+
       - name: Build production plugin
         run: npm run build
 

--- a/scripts/check-architecture-boundaries.test.mjs
+++ b/scripts/check-architecture-boundaries.test.mjs
@@ -32,12 +32,16 @@ function listTypeScriptFiles(root) {
   return files;
 }
 
+function normalizeRepositoryPath(filePath) {
+  return filePath.replaceAll('\\', '/');
+}
+
 function findMatches(roots, pattern) {
   const matches = [];
   for (const root of roots) {
     for (const file of listTypeScriptFiles(root)) {
       if (pattern.test(fs.readFileSync(file, 'utf8'))) {
-        matches.push(path.relative(process.cwd(), file));
+        matches.push(normalizeRepositoryPath(path.relative(process.cwd(), file)));
       }
     }
   }
@@ -99,7 +103,7 @@ function inspectForbiddenSymbolInventory(entries, pattern, allowedOccurrences) {
 function findForbiddenSymbolInventoryViolations(pattern, allowedOccurrences) {
   return inspectForbiddenSymbolInventory(
     listTypeScriptFiles(sourceRoot).map(file => ({
-      file: path.relative(process.cwd(), file),
+      file: normalizeRepositoryPath(path.relative(process.cwd(), file)),
       source: fs.readFileSync(file, 'utf8'),
     })),
     pattern,
@@ -277,6 +281,11 @@ const allowedProviderAppImports = new Set([
     path.join(appRoot, 'settings', 'ClaudianSettingsStorage'),
   ),
 ]);
+
+test('repository paths use POSIX separators for stable cross-platform comparison', () => {
+  assert.equal(normalizeRepositoryPath('src\\main.ts'), 'src/main.ts');
+  assert.equal(normalizeRepositoryPath('src/main.ts'), 'src/main.ts');
+});
 
 test('concrete provider pattern covers every registered provider directory', () => {
   assert.notEqual(concreteProviderNames.length, 0);
@@ -567,7 +576,9 @@ test('tab runtime construction stays private to the factory boundary', () => {
     new RegExp(`\\b${assemblySymbol}\\b`),
   ).sort();
 
-  assert.deepEqual(assemblyReferences, [path.relative(process.cwd(), factorySource)]);
+  assert.deepEqual(assemblyReferences, [
+    normalizeRepositoryPath(path.relative(process.cwd(), factorySource)),
+  ]);
   assert.equal(fs.existsSync(tabSource), false);
 
   const factory = fs.readFileSync(factorySource, 'utf8');
@@ -642,8 +653,8 @@ test('only TabRuntimeFactory can register runtime resource ownership', () => {
   ).sort();
 
   assert.deepEqual(registrationReferences, [
-    path.relative(process.cwd(), factorySource),
-    path.relative(process.cwd(), lifecycleSource),
+    normalizeRepositoryPath(path.relative(process.cwd(), factorySource)),
+    normalizeRepositoryPath(path.relative(process.cwd(), lifecycleSource)),
   ].sort());
 });
 
@@ -764,7 +775,7 @@ test('active Collab consumers use protocol-owned semantic identity predicates', 
     ...listTypeScriptFiles(path.join(appRoot, 'collab')),
     ...listTypeScriptFiles(path.join(featuresRoot, 'collab')),
   ].map(file => ({
-    file: path.relative(process.cwd(), file),
+    file: normalizeRepositoryPath(path.relative(process.cwd(), file)),
     source: fs.readFileSync(file, 'utf8'),
   }));
 
@@ -879,6 +890,10 @@ test('Collab consumer CI does not retain protocol producer gates', () => {
   assert.doesNotMatch(workflow, /protocol-contract:|verify:protocol|check:protocol-compatibility/);
   assert.doesNotMatch(workflow, /packages\/collab-protocol/);
   assert.match(crossPlatformJob, /npm run build/);
+  assert.match(
+    crossPlatformJob,
+    /name: Run Windows architecture boundaries\s+if: runner\.os == 'Windows'\s+run: npm run test:architecture/,
+  );
   assert.match(crossPlatformJob, /npm run test:cross-platform-collab/);
 });
 
@@ -970,10 +985,20 @@ test('TypeScript resolves the Collab protocol through the installed registry pac
     parsed.options,
     ts.sys,
   ).resolvedModule;
+  const expectedFileName = path.join(
+    process.cwd(),
+    'node_modules',
+    '@claudian-collab',
+    'protocol',
+    'dist',
+    'index.d.ts',
+  );
 
   assert.equal(
-    resolution?.resolvedFileName,
-    path.join(process.cwd(), 'node_modules', '@claudian-collab', 'protocol', 'dist', 'index.d.ts'),
+    resolution?.resolvedFileName
+      ? normalizeRepositoryPath(resolution.resolvedFileName)
+      : undefined,
+    normalizeRepositoryPath(expectedFileName),
   );
 });
 


### PR DESCRIPTION
## Why

Windows uses backslashes for `path.relative()`, causing false failures in architecture assertions that compare repository paths with POSIX literals; this focused infrastructure fix does not need a user-facing issue.

## What Changed

Normalized comparison paths through one helper, added a Windows-style regression test, and run the architecture suite in the Windows cross-platform PR job.

## Why This Approach

Keeping normalization inside the architecture script preserves native filesystem behavior elsewhere and reuses the existing cross-platform workflow instead of creating another CI owner.

## Validation

`npm run typecheck && npm run lint && npm run test && npm run build`, `npm run test:architecture` (41/41), and `actionlint .github/workflows/ci.yml` pass.

## Impact and Follow-ups

No production runtime, storage, or provider behavior changes; Windows PR CI will now catch regressions immediately.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
