### PR TITLE
fix: honor custom context window overrides

### DIFF
--- a/src/core/providers/modelSelection.ts
+++ b/src/core/providers/modelSelection.ts
@@ -71,3 +71,25 @@ export function toProviderRuntimeModelId(
   const decoded = decodeProviderModelSelectionId(value);
   return decoded && decoded.providerId === providerId ? decoded.modelId : value;
 }
+
+export function resolveProviderCustomContextLimit(
+  providerId: ProviderId,
+  model: string,
+  customLimits?: Record<string, number>,
+): number | undefined {
+  if (!customLimits) {
+    return undefined;
+  }
+
+  const normalizedModel = model.trim();
+  const runtimeModel = toProviderRuntimeModelId(providerId, normalizedModel).trim();
+  const namespacedModel = encodeProviderModelSelectionId(providerId, runtimeModel);
+  for (const candidate of new Set([normalizedModel, runtimeModel, namespacedModel])) {
+    const limit = customLimits[candidate];
+    if (Number.isFinite(limit) && limit > 0) {
+      return limit;
+    }
+  }
+
+  return undefined;
+}

--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -14,6 +14,7 @@ import {
   getProviderSettingsSnapshotWithModel,
   resolveConversationModel,
 } from '../../core/providers/conversationModel';
+import { resolveProviderCustomContextLimit } from '../../core/providers/modelSelection';
 import { ProviderRegistry } from '../../core/providers/ProviderRegistry';
 import { ProviderSettingsCoordinator } from '../../core/providers/ProviderSettingsCoordinator';
 import { type AppTabManagerState, DEFAULT_CHAT_PROVIDER_ID, type ProviderId } from '../../core/providers/types';
@@ -266,7 +267,16 @@ export class ClaudianView extends ItemView {
       );
 
       if (tab.state.usage) {
-        tab.state.usage = recalculateUsageForModel(tab.state.usage, model, contextWindow);
+        tab.state.usage = recalculateUsageForModel(
+          tab.state.usage,
+          model,
+          contextWindow,
+          resolveProviderCustomContextLimit(
+            providerId,
+            model,
+            providerSettings.customContextLimits,
+          ),
+        );
       }
 
       tab.ui.modelSelector.updateDisplay();

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -4,6 +4,7 @@ import type {
   ChatRewindConflict,
   ChatRewindMode,
 } from '../../../core/execution';
+import { resolveProviderCustomContextLimit } from '../../../core/providers/modelSelection';
 import type { ProviderIconSvg, TitleGenerationService } from '../../../core/providers/types';
 import type {
   ChatMessage,
@@ -38,6 +39,7 @@ import type { FileContextManager } from '../ui/FileContext';
 import type { ImageContextManager } from '../ui/ImageContext';
 import type { ExternalContextSelector } from '../ui/InputToolbar';
 import type { StatusPanel } from '../ui/StatusPanel';
+import { recalculateUsageForModel } from '../utils/usageInfo';
 
 function runConversationAction(action: () => Promise<void>, failureMessage: string): void {
   void action().catch(() => {
@@ -657,7 +659,23 @@ export class ConversationController {
 
     state.currentConversationId = conversation.id;
     state.messages = [...conversation.messages];
-    state.usage = conversation.usage ?? null;
+    const persistedUsage = conversation.usage ?? null;
+    const usageModel = conversation.selectedModel ?? persistedUsage?.model;
+    const customContextLimit = usageModel
+      ? resolveProviderCustomContextLimit(
+          conversation.providerId,
+          usageModel,
+          plugin.settings.customContextLimits,
+        )
+      : undefined;
+    state.usage = persistedUsage && usageModel && customContextLimit
+      ? recalculateUsageForModel(
+          persistedUsage,
+          usageModel,
+          customContextLimit,
+          customContextLimit,
+        )
+      : persistedUsage;
     state.autoScrollEnabled = plugin.settings.enableAutoScroll ?? true;
     state.hasPendingConversationSave = false;
 

--- a/src/features/chat/controllers/StreamController.ts
+++ b/src/features/chat/controllers/StreamController.ts
@@ -5,6 +5,7 @@ import type {
   ProviderExecutionEvent,
 } from '../../../core/execution';
 import { resolveConversationModel } from '../../../core/providers/conversationModel';
+import { resolveProviderCustomContextLimit } from '../../../core/providers/modelSelection';
 import { ProviderRegistry } from '../../../core/providers/ProviderRegistry';
 import { ProviderSettingsCoordinator } from '../../../core/providers/ProviderSettingsCoordinator';
 import {
@@ -78,6 +79,7 @@ import type { SubagentManager } from '../services/SubagentManager';
 import type { AsyncSubagentCompletion } from '../services/SubagentManager';
 import type { ChatState } from '../state/ChatState';
 import type { FileContextManager } from '../ui/FileContext';
+import { recalculateUsageForModel } from '../utils/usageInfo';
 import { StreamingRenderCoordinator } from './StreamingRenderCoordinator';
 
 export interface StreamControllerDeps {
@@ -313,9 +315,24 @@ export class StreamController {
         }
         if (!state.ignoreUsageUpdates) {
           const activeModel = this.getActiveProviderModel();
-          state.usage = activeModel && !chunk.usage.model
+          const usage = activeModel && !chunk.usage.model
             ? { ...chunk.usage, model: activeModel }
             : chunk.usage;
+          const customContextLimit = activeModel
+            ? resolveProviderCustomContextLimit(
+                this.getActiveProviderId(),
+                activeModel,
+                this.deps.plugin.settings.customContextLimits,
+              )
+            : undefined;
+          state.usage = activeModel && customContextLimit
+            ? recalculateUsageForModel(
+                usage,
+                activeModel,
+                customContextLimit,
+                customContextLimit,
+              )
+            : usage;
         }
         break;
       }

--- a/src/features/chat/tabs/runtime/TabRuntimeUI.ts
+++ b/src/features/chat/tabs/runtime/TabRuntimeUI.ts
@@ -8,6 +8,7 @@ import {
   getEnabledProviderForModel,
   getProviderForModel,
 } from '../../../../core/providers/modelRouting';
+import { resolveProviderCustomContextLimit } from '../../../../core/providers/modelSelection';
 import { ProviderRegistry } from '../../../../core/providers/ProviderRegistry';
 import type {
   ProviderChatUIConfig,
@@ -392,6 +393,11 @@ function buildInputToolbar(
           currentUsage,
           normalizedModel,
           newContextWindow,
+          resolveProviderCustomContextLimit(
+            boundProvider,
+            normalizedModel,
+            providerSettings.customContextLimits,
+          ),
         );
       }
     },

--- a/src/features/chat/utils/usageInfo.ts
+++ b/src/features/chat/utils/usageInfo.ts
@@ -10,11 +10,18 @@ export function recalculateUsageForModel(
   usage: UsageInfo,
   model: string,
   fallbackContextWindow: number,
+  explicitContextWindow?: number,
 ): UsageInfo {
-  const preserveAuthoritativeWindow = usage.contextWindowIsAuthoritative === true
+  const validExplicitContextWindow = Number.isFinite(explicitContextWindow)
+    && explicitContextWindow! > 0
+    ? explicitContextWindow
+    : undefined;
+  const preserveAuthoritativeWindow = validExplicitContextWindow === undefined
+    && usage.contextWindowIsAuthoritative === true
     && usage.contextWindow > 0
     && usage.model === model;
-  const contextWindow = preserveAuthoritativeWindow ? usage.contextWindow : fallbackContextWindow;
+  const contextWindow = validExplicitContextWindow
+    ?? (preserveAuthoritativeWindow ? usage.contextWindow : fallbackContextWindow);
 
   return {
     ...usage,

--- a/src/features/settings/ClaudianSettings.ts
+++ b/src/features/settings/ClaudianSettings.ts
@@ -146,6 +146,8 @@ export class ClaudianSettingTab extends PluginSettingTab {
   private activeProviderTab: ProviderId | null = null;
   private refreshTitleModelOptions: (() => void) | null = null;
   private renderGeneration = 0;
+  private customContextLimitRefreshTimer: number | null = null;
+  private readonly pendingCustomContextLimitRefreshProviders = new Set<ProviderId>();
   private readonly agentSkillCoordinator: AgentSkillManagementCoordinator;
 
   constructor(app: App, plugin: FeatureHost & Plugin) {
@@ -325,6 +327,11 @@ export class ClaudianSettingTab extends PluginSettingTab {
       this.renderGeneration += 1;
       this.agentSkillCoordinator.resetSubscriptions();
       this.refreshTitleModelOptions = null;
+      if (this.customContextLimitRefreshTimer !== null) {
+        window.clearTimeout(this.customContextLimitRefreshTimer);
+        this.customContextLimitRefreshTimer = null;
+      }
+      this.flushPendingCustomContextLimitRefreshes();
     };
   }
 
@@ -842,6 +849,41 @@ export class ClaudianSettingTab extends PluginSettingTab {
     this.refreshTitleModelOptions?.();
   }
 
+  private scheduleCustomContextLimitRefresh(providerId: ProviderId): void {
+    this.pendingCustomContextLimitRefreshProviders.add(providerId);
+    if (this.customContextLimitRefreshTimer !== null) {
+      window.clearTimeout(this.customContextLimitRefreshTimer);
+    }
+    this.customContextLimitRefreshTimer = window.setTimeout(() => {
+      this.customContextLimitRefreshTimer = null;
+      this.flushPendingCustomContextLimitRefreshes();
+    }, 150);
+  }
+
+  private flushPendingCustomContextLimitRefreshes(): void {
+    const providers = Array.from(this.pendingCustomContextLimitRefreshProviders);
+    this.pendingCustomContextLimitRefreshProviders.clear();
+    for (const providerId of providers) {
+      this.notifyProviderModelOptionsChanged(providerId);
+    }
+  }
+
+  private async updateCustomContextLimit(
+    providerId: ProviderId,
+    modelId: string,
+    limit: number | null,
+  ): Promise<void> {
+    await this.plugin.mutateSettings((settings) => {
+      settings.customContextLimits ??= {};
+      if (limit === null) {
+        delete settings.customContextLimits[modelId];
+      } else {
+        settings.customContextLimits[modelId] = limit;
+      }
+    });
+    this.scheduleCustomContextLimitRefresh(providerId);
+  }
+
   private refreshDualPaneLayouts(): void {
     for (const view of this.plugin.getAllViews()) {
       view.refreshDualPaneLayout();
@@ -965,14 +1007,11 @@ export class ClaudianSettingTab extends PluginSettingTab {
           validationEl.toggleClass('claudian-hidden', true);
           inputEl.classList.remove('claudian-input-error');
         }
-        await this.plugin.mutateSettings((settings) => {
-          settings.customContextLimits ??= {};
-          if (!trimmed) {
-            delete settings.customContextLimits[modelId];
-          } else {
-            settings.customContextLimits[modelId] = parseContextLimit(trimmed)!;
-          }
-        });
+        await this.updateCustomContextLimit(
+          providerId,
+          modelId,
+          trimmed ? parseContextLimit(trimmed)! : null,
+        );
       };
 
       inputEl.addEventListener('input', () => {

--- a/src/providers/codex/ui/CodexChatUIConfig.ts
+++ b/src/providers/codex/ui/CodexChatUIConfig.ts
@@ -1,3 +1,4 @@
+import { resolveProviderCustomContextLimit } from '../../../core/providers/modelSelection';
 import {
   DEFAULT_REASONING_VALUE,
   formatReasoningValueLabel,
@@ -124,8 +125,9 @@ export const codexChatUIConfig: ProviderChatUIConfig = {
       : DEFAULT_REASONING_VALUE;
   },
 
-  getContextWindowSize(): number {
-    return DEFAULT_CONTEXT_WINDOW;
+  getContextWindowSize(model: string, customLimits?: Record<string, number>): number {
+    return resolveProviderCustomContextLimit('codex', model, customLimits)
+      ?? DEFAULT_CONTEXT_WINDOW;
   },
 
   isDefaultModel(model: string): boolean {

--- a/tests/unit/core/providers/modelSelection.test.ts
+++ b/tests/unit/core/providers/modelSelection.test.ts
@@ -3,6 +3,7 @@ import {
   encodeProviderModelSelectionId,
   getProviderModelSelectionPrefix,
   isProviderModelSelectionId,
+  resolveProviderCustomContextLimit,
   toProviderRuntimeModelId,
 } from '@/core/providers/modelSelection';
 
@@ -137,6 +138,40 @@ describe('model selection namespacing', () => {
 
     it('returns an empty string unchanged', () => {
       expect(toProviderRuntimeModelId('claude', '')).toBe('');
+    });
+  });
+
+  describe('resolveProviderCustomContextLimit', () => {
+    it('resolves a raw-keyed limit for a namespaced Codex selection', () => {
+      expect(resolveProviderCustomContextLimit(
+        'codex',
+        'openai-codex/my-custom-model',
+        { 'my-custom-model': 1_000_000 },
+      )).toBe(1_000_000);
+    });
+
+    it('resolves a namespaced limit for a raw model id', () => {
+      expect(resolveProviderCustomContextLimit(
+        'codex',
+        'my-custom-model',
+        { 'openai-codex/my-custom-model': 500_000 },
+      )).toBe(500_000);
+    });
+
+    it('prefers the exact model key and rejects invalid limits', () => {
+      expect(resolveProviderCustomContextLimit(
+        'codex',
+        'openai-codex/my-custom-model',
+        {
+          'openai-codex/my-custom-model': 750_000,
+          'my-custom-model': 1_000_000,
+        },
+      )).toBe(750_000);
+      expect(resolveProviderCustomContextLimit(
+        'codex',
+        'openai-codex/my-custom-model',
+        { 'my-custom-model': 0 },
+      )).toBeUndefined();
     });
   });
 

--- a/tests/unit/features/chat/controllers/ConversationController.test.ts
+++ b/tests/unit/features/chat/controllers/ConversationController.test.ts
@@ -511,6 +511,38 @@ describe('ConversationController', () => {
   });
 
   describe('loadActive with existing conversation', () => {
+    it('applies a custom context limit when restoring persisted usage', async () => {
+      const model = 'openai-codex/my-custom-model';
+      deps.state.currentConversationId = 'codex-conv';
+      deps.plugin.settings.customContextLimits = { 'my-custom-model': 1_000_000 };
+      (deps.plugin.getConversationById as jest.Mock).mockResolvedValue({
+        id: 'codex-conv',
+        messages: [{ id: '1', role: 'user', content: 'test', timestamp: Date.now() }],
+        providerId: 'codex',
+        selectedModel: model,
+        sessionId: 'session-1',
+        usage: {
+          model,
+          inputTokens: 0,
+          cacheCreationInputTokens: 0,
+          cacheReadInputTokens: 0,
+          contextWindow: 200_000,
+          contextWindowIsAuthoritative: true,
+          contextTokens: 200_000,
+          percentage: 98,
+        },
+      });
+
+      await controller.loadActive();
+
+      expect(deps.state.usage).toMatchObject({
+        model,
+        contextWindow: 1_000_000,
+        contextWindowIsAuthoritative: false,
+        percentage: 20,
+      });
+    });
+
     it('should restore linkedContentPath when conversation has one', async () => {
       const linkedContentController = deps.getLinkedContentController();
       deps.state.currentConversationId = 'conv-with-note';

--- a/tests/unit/features/chat/controllers/StreamController.test.ts
+++ b/tests/unit/features/chat/controllers/StreamController.test.ts
@@ -1496,6 +1496,39 @@ describe('StreamController - Text Content', () => {
       expect(deps.state.usage).toEqual(usage);
     });
 
+    it('applies a custom context limit to live usage chunks', async () => {
+      const msg = createTestMessage();
+      const model = 'opencode:kimi-for-coding/k3';
+      Object.assign(deps.plugin.settings, {
+        customContextLimits: { [model]: 1_048_576 },
+      });
+      deps.state.currentConversationId = 'opencode-conv';
+      deps.plugin.getConversationSync = jest.fn().mockReturnValue({
+        id: 'opencode-conv',
+        messages: [],
+        providerId: 'opencode',
+        selectedModel: model,
+        sessionId: 'session-1',
+      });
+      deps.getProviderId = () => 'opencode';
+      const usage = createMockUsage({
+        model,
+        contextWindow: 200_000,
+        contextWindowIsAuthoritative: true,
+        contextTokens: 195_654,
+        percentage: 98,
+      });
+
+      await controller.handleStreamChunk({ type: 'usage', usage, sessionId: 'session-1' }, msg);
+
+      expect(deps.state.usage).toMatchObject({
+        model,
+        contextWindow: 1_048_576,
+        contextWindowIsAuthoritative: false,
+        percentage: 19,
+      });
+    });
+
     it('should not update usage when ignoreUsageUpdates is true', async () => {
       const msg = createTestMessage();
       deps.state.ignoreUsageUpdates = true;

--- a/tests/unit/features/chat/utils/usageInfo.test.ts
+++ b/tests/unit/features/chat/utils/usageInfo.test.ts
@@ -53,5 +53,30 @@ describe('usageInfo', () => {
         percentage: 50,
       });
     });
+
+    it('lets an explicit custom limit override an authoritative runtime window', () => {
+      const usage = {
+        model: 'opencode:kimi-for-coding/k3',
+        inputTokens: 0,
+        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: 0,
+        contextWindow: 200_000,
+        contextWindowIsAuthoritative: true,
+        contextTokens: 195_654,
+        percentage: 98,
+      };
+
+      expect(recalculateUsageForModel(
+        usage,
+        'opencode:kimi-for-coding/k3',
+        1_048_576,
+        1_048_576,
+      )).toEqual({
+        ...usage,
+        contextWindow: 1_048_576,
+        contextWindowIsAuthoritative: false,
+        percentage: 19,
+      });
+    });
   });
 });

--- a/tests/unit/features/settings/ClaudianSettings.display.test.ts
+++ b/tests/unit/features/settings/ClaudianSettings.display.test.ts
@@ -149,6 +149,7 @@ function createTab(enableDualPane: boolean): {
       mutation(settings);
     }),
     getAllViews: jest.fn(() => [{ refreshDualPaneLayout: jest.fn() }]),
+    notifyProviderChatOptionsChanged: jest.fn(),
     notifyAgentSkillsChanged: jest.fn(),
     checkCollabGitInstallation: jest.fn().mockResolvedValue('available'),
     setCollabEnabled: jest.fn(async (enabled: boolean) => {
@@ -294,6 +295,27 @@ describe('ClaudianSettingTab display settings', () => {
     expect(container.empty).toHaveBeenCalledTimes(1);
     expect(container.addClass).toHaveBeenCalledWith('claudian-settings');
     expect(findContainer(container, t('settings.tabs.general'))).not.toBeNull();
+  });
+
+  it('flushes a pending custom context limit refresh when settings cleanup runs', async () => {
+    jest.useFakeTimers();
+    try {
+      const { tab, plugin } = createTab(true);
+      const cleanup = (tab as any).renderSettings(createContainer()) as () => void;
+
+      await (tab as any).updateCustomContextLimit(
+        'codex',
+        'my-custom-model',
+        1_000_000,
+      );
+      cleanup();
+
+      expect(plugin.notifyProviderChatOptionsChanged).toHaveBeenCalledWith('codex');
+      jest.advanceTimersByTime(150);
+      expect(plugin.notifyProviderChatOptionsChanged).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('renders the dual-pane position only while dual-pane mode is enabled', () => {

--- a/tests/unit/features/settings/ClaudianSettings.test.ts
+++ b/tests/unit/features/settings/ClaudianSettings.test.ts
@@ -46,4 +46,31 @@ describe('ClaudianSettingTab model option updates', () => {
       expect.any(Function),
     );
   });
+
+  it('refreshes open provider views after a custom context limit changes', async () => {
+    jest.useFakeTimers();
+    const settings = { customContextLimits: {} as Record<string, number> };
+    const notifyProviderChatOptionsChanged = jest.fn();
+    const plugin = {
+      getAllViews: jest.fn(() => []),
+      notifyProviderChatOptionsChanged,
+      notifyAgentSkillsChanged: jest.fn(),
+      mutateSettings: jest.fn(async (mutation: (value: typeof settings) => void) => {
+        mutation(settings);
+      }),
+      settings,
+      storage: {
+        getAdapter: jest.fn(() => ({})),
+      },
+    };
+    const tab = new ClaudianSettingTab({} as any, plugin as any);
+
+    await (tab as any).updateCustomContextLimit('codex', 'my-custom-model', 1_000_000);
+
+    expect(settings.customContextLimits['my-custom-model']).toBe(1_000_000);
+    expect(notifyProviderChatOptionsChanged).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(150);
+    expect(notifyProviderChatOptionsChanged).toHaveBeenCalledWith('codex');
+    jest.useRealTimers();
+  });
 });

--- a/tests/unit/providers/codex/ui/CodexChatUIConfig.test.ts
+++ b/tests/unit/providers/codex/ui/CodexChatUIConfig.test.ts
@@ -514,6 +514,18 @@ describe('CodexChatUIConfig', () => {
     it('should return 200000 for all models', () => {
       expect(codexChatUIConfig.getContextWindowSize(TEST_CODEX_MODEL)).toBe(200_000);
     });
+
+    it('uses the configured context limit for the selected model', () => {
+      expect(codexChatUIConfig.getContextWindowSize(TEST_CODEX_MODEL, {
+        [TEST_CODEX_MODEL]: 1_050_000,
+      })).toBe(1_050_000);
+    });
+
+    it('uses a raw-keyed context limit for a namespaced custom model', () => {
+      expect(codexChatUIConfig.getContextWindowSize('openai-codex/my-custom-model', {
+        'my-custom-model': 1_000_000,
+      })).toBe(1_000_000);
+    });
   });
 
   describe('applyModelDefaults', () => {


### PR DESCRIPTION
## Why

Claudian can show every Codex/OpenCode conversation as a 200K context window even when a per-model custom limit is configured. Codex UI ignored custom limits, provider runtime 200K usage could override them, and restored/live views did not consistently reapply them. This makes the context meter report false saturation (for example, 196K / 200K instead of 196K / 1,048,576).

No issue is linked because existing issue and PR searches did not find this exact cross-provider override bug.

## What Changed

- Make Codex UI honor custom context limits.
- Resolve raw and namespaced model IDs through a shared provider model helper.
- Let explicit custom limits override runtime-reported values for restored conversations, live usage, settings refresh, and model switches.
- Debounce provider UI refresh after editing a custom context limit, while flushing pending refreshes when settings close.
- Add regressions for precedence, Codex ID normalization, restore/live paths, settings refresh, and cleanup before debounce expiry.

## Why This Approach

Explicit user overrides represent endpoint capabilities that a provider runtime may not know. The shared resolver keeps provider namespaces out of feature controllers, while authoritative runtime windows remain preserved whenever no explicit override exists.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test -- --runInBand` — 607 suites passed, 2 skipped; 8,916 tests passed, 2 skipped
- `npm run build`
- Manual Obsidian 1.13.7 cold reload on macOS: Kimi K3 context meter changed from `196k / 200k` (98%) to `196k / 1049k` (19%), and persisted after disabling and re-enabling Claudian

## Impact and Follow-ups

No storage migration or production dependency is added. Existing authoritative runtime windows are unchanged unless an explicit per-model custom limit exists. Custom limits still need to be configured for runtimes that do not expose correct context metadata.

## Checklist

- [x] This pull request addresses one focused problem.
- [x] I linked a relevant issue or explained why no issue is linked.
- [x] I added or updated tests for the changed behavior.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] User-facing documentation is unchanged because this corrects existing custom-limit behavior without adding a new setting or workflow.
