### PR TITLE
feat(collab): add Cloud to LAN authority transfer

### DIFF
--- a/src/app/collab/CollabFeatureService.ts
+++ b/src/app/collab/CollabFeatureService.ts
@@ -2,9 +2,10 @@ import { randomUUID } from 'node:crypto';
 import { lstat } from 'node:fs/promises';
 import path from 'node:path';
 
-import { type CollabChangeRequest, type CollabComment, type CollabCommentPage, type CollabGitOid, type CollabOperationId, type CollabProjectId, type CollabRequestId, type CollabTicketAcceptedRelationPage, type CollabTicketComment, type CollabTicketCommentPage, type CollabTicketDetail, type CollabTicketSummary } from '@claudian-collab/protocol';
+import { type CollabAuthorityTransferStatus, type CollabChangeRequest, type CollabComment, type CollabCommentPage, type CollabGitOid, type CollabOperationId, type CollabProjectId, type CollabRequestId, type CollabTicketAcceptedRelationPage, type CollabTicketComment, type CollabTicketCommentPage, type CollabTicketDetail, type CollabTicketSummary } from '@claudian-collab/protocol';
 
 import type { CollabProjectInspectionLease } from '@/app/collab/activity/CollabProjectWorkSession';
+import { CollabAuthorityTransferOutcomeError } from '@/app/collab/authority-transfer/CollabAuthorityTransferOutcomeError';
 import type {
   StartCloudBootstrapServiceInput,
   SubmitCloudBootstrapServiceParticipantInput,
@@ -39,6 +40,13 @@ import {
 import type { CollabCompleteManagementOperationRequest, CollabImportedMemberClaimRequest, CollabInvitationSummaryView, CollabManagementOperationView, CollabManagerResponsibilityOfferSummary, CollabMemberSummaryView, CollabRevokeInvitationRequest } from '@/core/collab';
 import { type CollabAcceptOutcome, type CollabAcceptRequest, type CollabAddCommentRequest, type CollabAddTicketCommentRequest, type CollabBoundedQueryPort, type CollabCancelManagerResponsibilityOfferRequest, type CollabChangeTicketStatusRequest, type CollabConfirmPublishRequest, type CollabConflictFileContent, type CollabConflictFileRequest, type CollabConflictSession, type CollabCoordinationSnapshot, type CollabCreateHostTransferRequest, type CollabCreateManagerResponsibilityOfferRequest, type CollabCreateProjectRequest, type CollabCreateTicketRequest, type CollabDemoteManagerRequest, type CollabFeaturePort, type CollabFeatureState, type CollabFeatureStateListener, type CollabFeatureSubscription, type CollabFinalizeRetiredProjectRequest, type CollabGitStatus, type CollabHostSession, type CollabHostStatus, type CollabHostTransferIntentRequest, type CollabInvitationView, type CollabJoinProjectRequest, type CollabLeaveProjectRequest, type CollabListTicketsRequest, type CollabLocalProjectSummary, type CollabOperationOptions, type CollabPersonalChangesInspection, type CollabProjectInspection, type CollabProjectSelectionProjection, type CollabPromoteManagerRequest, type CollabPublicationReview, type CollabPublicationReviewFileRequest, type CollabPublishOutcome, type CollabPublishRequest, type CollabReconciliationOutcome, type CollabReconnectProjectRequest, type CollabRemoveMemberRequest, type CollabRequestReview, type CollabResult, type CollabResumeSetupRequest, type CollabRetireProjectRequest, type CollabReviewFileContent, type CollabReviewFileRequest, type CollabTicketDetailProjection, type CollabTicketPageProjection, type CollabUpdateRequestMetadataRequest, type CollabUpdateTicketContentRequest, type CollabWorkingTreeReview, type CollabWorkingTreeReviewFileRequest, resolveEffectiveCollabProjectId } from '@/core/collab';
 import { CollabError } from '@/core/collab/ClaudianCollabError';
+import type {
+  CollabBeginCloudToLanTransferRequest,
+  CollabCloudToLanTargetPreparationDescriptor,
+  CollabCloudToLanTransferHandle,
+  CollabPrepareCloudToLanTargetRequest,
+  CollabWithdrawCloudToLanTargetRequest,
+} from '@/core/collab/CollabFeaturePort';
 
 export interface CollabFeatureFoundationPort {
   readonly local: {
@@ -345,6 +353,7 @@ export interface CollabCloudProjectEntryPort {
 }
 
 export interface CollabFeatureServiceOptions {
+  readonly authorityTransfer: CollabAuthorityTransferEntryPort;
   readonly cloudEntry: CollabCloudProjectEntryPort;
   readonly cloudBootstrap: CollabCloudBootstrapPort;
   readonly hostTransfer: CollabHostTransferPort;
@@ -364,6 +373,34 @@ export interface CollabFeatureServiceOptions {
   readonly publication: CollabPublicationPort;
   readonly retirement: CollabRetirementPort;
   readonly vaultRoot: string;
+}
+
+export interface CollabAuthorityTransferEntryPort {
+  acceptCloudToLanTransfer(
+    input: Readonly<{ readonly handle: CollabCloudToLanTransferHandle }>,
+    options?: CollabOperationOptions,
+  ): Promise<CollabAuthorityTransferStatus>;
+  beginCloudToLanTransfer(
+    input: CollabBeginCloudToLanTransferRequest & Readonly<{ readonly operationIntentId: string }>,
+    options?: CollabOperationOptions,
+  ): Promise<CollabCloudToLanTransferHandle>;
+  close(): Promise<void>;
+  cancelCloudToLanTransfer(
+    handle: CollabCloudToLanTransferHandle,
+    options?: CollabOperationOptions,
+  ): Promise<CollabAuthorityTransferStatus>;
+  observeCloudToLanTransfer(
+    projectId: CollabProjectId,
+    options?: CollabOperationOptions,
+  ): Promise<CollabAuthorityTransferStatus>;
+  prepareCloudToLanTarget(
+    input: CollabPrepareCloudToLanTargetRequest & Readonly<{ readonly operationIntentId: string }>,
+    options?: CollabOperationOptions,
+  ): Promise<CollabCloudToLanTargetPreparationDescriptor>;
+  withdrawCloudToLanTarget(
+    input: CollabWithdrawCloudToLanTargetRequest,
+    options?: CollabOperationOptions,
+  ): Promise<void>;
 }
 
 export interface CollabCloudBootstrapPort {
@@ -488,6 +525,66 @@ class CollabFeatureServiceCore {
 
   get state(): CollabFeatureState {
     return this.#stateValue;
+  }
+
+  prepareCloudToLanTarget(
+    request: CollabPrepareCloudToLanTargetRequest,
+    options: CollabOperationOptions = {},
+  ): Promise<CollabResult<CollabCloudToLanTargetPreparationDescriptor>> {
+    return this.#runAuthorityTransfer(options, port => port.prepareCloudToLanTarget({
+      ...request,
+      operationIntentId: `cloud-to-lan-target-${randomUUID().replaceAll('-', '')}`,
+    }, options));
+  }
+
+  beginCloudToLanTransfer(
+    request: CollabBeginCloudToLanTransferRequest,
+    options: CollabOperationOptions = {},
+  ): Promise<CollabResult<CollabCloudToLanTransferHandle>> {
+    return this.#runAuthorityTransfer(options, port => port.beginCloudToLanTransfer({
+      ...request,
+      operationIntentId: `cloud-to-lan-manager-${randomUUID().replaceAll('-', '')}`,
+    }, options));
+  }
+
+  acceptCloudToLanTransfer(
+    handle: CollabCloudToLanTransferHandle,
+    options: CollabOperationOptions = {},
+  ): Promise<CollabResult<CollabAuthorityTransferStatus>> {
+    return this.#runAuthorityTransfer(
+      options,
+      port => port.acceptCloudToLanTransfer({ handle }, options),
+    );
+  }
+
+  withdrawCloudToLanTarget(
+    request: CollabWithdrawCloudToLanTargetRequest,
+    options: CollabOperationOptions = {},
+  ): Promise<CollabResult<void>> {
+    return this.#runAuthorityTransfer(options, async port => {
+      await port.withdrawCloudToLanTarget(request, options);
+      return undefined;
+    });
+  }
+
+  observeCloudToLanTransfer(
+    projectId: CollabProjectId,
+    options: CollabOperationOptions = {},
+  ): Promise<CollabResult<CollabAuthorityTransferStatus>> {
+    return this.#runAuthorityTransfer(
+      options,
+      port => port.observeCloudToLanTransfer(projectId, options),
+    );
+  }
+
+  cancelCloudToLanTransfer(
+    handle: CollabCloudToLanTransferHandle,
+    options: CollabOperationOptions = {},
+  ): Promise<CollabResult<CollabAuthorityTransferStatus>> {
+    return this.#runAuthorityTransfer(
+      options,
+      port => port.cancelCloudToLanTransfer(handle, options),
+    );
   }
 
   initialize(
@@ -1782,6 +1879,7 @@ class CollabFeatureServiceCore {
       await lifecycleRecoveryDrain;
       await this.options.cloudBootstrap.close();
       await lifecycleRecoveryClose;
+      await this.options.authorityTransfer.close();
       await Promise.resolve()
         .then(() => this.options.retirement.close())
         .catch(() => undefined);
@@ -2118,12 +2216,27 @@ class CollabFeatureServiceCore {
 
    #failureResult<T>(error: unknown): CollabResult<T> {
     if (error instanceof CollabMembershipOutcomeError) return error.result;
+    if (error instanceof CollabAuthorityTransferOutcomeError) return error.result;
     const collabError = error instanceof CollabError
       ? error
       : operationError('collab-operation-failed');
     return collabError.code === 'cancelled'
       ? { durableProgress: false, status: 'cancelled' }
       : { error: collabError, status: 'failure' };
+  }
+
+  async #runAuthorityTransfer<T>(
+    options: CollabOperationOptions,
+    operation: (port: CollabAuthorityTransferEntryPort) => Promise<T>,
+  ): Promise<CollabResult<T>> {
+    try {
+      this.#throwIfDisposed();
+      throwIfCancelled(options.signal);
+      const value = await operation(this.options.authorityTransfer);
+      return { status: 'success', value };
+    } catch (error) {
+      return this.#failureResult(error);
+    }
   }
 
    #publishState(state: CollabFeatureState): void {
@@ -2152,14 +2265,16 @@ class CollabFeatureServiceCore {
 export class CollabFeatureService implements CollabFeaturePort {
   readonly boundedQueries: CollabBoundedQueryPort;
   private readonly cloudBootstrap: CollabCloudBootstrapPort;
-   readonly #operationAdmission = new ProjectOperationAdmission();
+   readonly #operationAdmission: ProjectOperationAdmission;
   private readonly core: CollabFeatureServiceCore;
 
   constructor(
     private readonly foundation: CollabFeatureFoundationPort,
     projectSetup: CollabProjectSetupPort,
     options: CollabFeatureServiceOptions,
+    operationAdmission: ProjectOperationAdmission = new ProjectOperationAdmission(),
   ) {
+    this.#operationAdmission = operationAdmission;
     this.cloudBootstrap = options.cloudBootstrap;
     this.core = new CollabFeatureServiceCore(
       foundation,
@@ -2424,6 +2539,27 @@ export class CollabFeatureService implements CollabFeaturePort {
       'retired-local',
       () => this.core.retryProjectCleanup(...args),
     )
+  );
+  prepareCloudToLanTarget: CollabFeaturePort['prepareCloudToLanTarget'] = (...args) => (
+    this.projectTransition(() => args[0].projectId, () => this.core.prepareCloudToLanTarget(...args))
+  );
+  beginCloudToLanTransfer: CollabFeaturePort['beginCloudToLanTransfer'] = (...args) => (
+    this.projectTransition(
+      () => args[0].descriptor.projectId,
+      () => this.core.beginCloudToLanTransfer(...args),
+    )
+  );
+  acceptCloudToLanTransfer: CollabFeaturePort['acceptCloudToLanTransfer'] = (...args) => (
+    this.projectTransition(() => args[0].projectId, () => this.core.acceptCloudToLanTransfer(...args))
+  );
+  withdrawCloudToLanTarget: CollabFeaturePort['withdrawCloudToLanTarget'] = (...args) => (
+    this.projectTransition(() => args[0].projectId, () => this.core.withdrawCloudToLanTarget(...args))
+  );
+  observeCloudToLanTransfer: CollabFeaturePort['observeCloudToLanTransfer'] = (...args) => (
+    this.project(() => args[0], 'active', () => this.core.observeCloudToLanTransfer(...args))
+  );
+  cancelCloudToLanTransfer: CollabFeaturePort['cancelCloudToLanTransfer'] = (...args) => (
+    this.project(() => args[0].projectId, 'active', () => this.core.cancelCloudToLanTransfer(...args))
   );
   subscribe: CollabFeaturePort['subscribe'] = (...args) => this.core.subscribe(...args);
 

--- a/src/app/collab/CollabFeatureSubcomposition.ts
+++ b/src/app/collab/CollabFeatureSubcomposition.ts
@@ -89,12 +89,18 @@ import {
 import { decodeCollabPendingProjectOperation } from '@/app/collab/PendingProjectOperation';
 import { CloudProjectEntryCoordinator } from '@/app/collab/project/CloudProjectEntryCoordinator';
 import type { CollabProjectSetupService } from '@/app/collab/project/CollabProjectSetupService';
-import type { ProjectOperationSuspension } from '@/app/collab/ProjectOperationAdmission';
+import {
+  ProjectOperationAdmission,
+  type ProjectOperationSuspension,
+} from '@/app/collab/ProjectOperationAdmission';
 import { CollabPublicationService } from '@/app/collab/publish/CollabPublicationService';
 import { CloudAuthorityAdapter } from '@/app/collab/remote-authority/CloudAuthorityAdapter';
 import {
   CollabAuthorityGitNetworkEnvironment,
 } from '@/app/collab/remote-authority/CollabAuthorityGitNetworkEnvironment';
+import type {
+  CloudAuthorityMembershipControlPort,
+} from '@/app/collab/remote-authority/CollabAuthorityMembershipControlPort';
 import { CloudRetirementClient } from '@/app/collab/retirement/CloudRetirementClient';
 import { decodeCloudRetirementIntent } from '@/app/collab/retirement/CloudRetirementIntent';
 import { RetirementAcknowledgementWorker } from '@/app/collab/retirement/RetirementAcknowledgementWorker';
@@ -141,6 +147,7 @@ export function createCollabFeatureSubcomposition(
   const journals = new CollabLifecycleJournalStore(vaultRoot);
   const transitions = foundation.cloudBootstrapTransitions;
   const pendingLeaves = journals.pendingLeaves;
+  const operationAdmission = new ProjectOperationAdmission();
   const cloudAuthority = options.cloudAuthority ?? new CloudAuthorityAdapter();
   const connectPendingLeave = cloudAuthority.connectPendingLeave?.bind(cloudAuthority);
   const pendingLeaveAuthority = new PendingLeaveAuthorityService({
@@ -939,42 +946,11 @@ export function createCollabFeatureSubcomposition(
       return pending?.kind === 'cloud-entry' ? 'nonterminal' : 'absent';
     },
   });
-  feature = new CollabFeatureService(foundation, projectSetup, {
-    cloudEntry: {
-      close: () => cloudEntry.close(),
-      createProject: (request, operationOptions) => cloudEntry.createProject(request, operationOptions),
-      joinProject: (request, operationOptions) => requireLifecycle().runExclusive(
-        'projectId' in request ? request.projectId : request.invitation.invitation.projectId,
-        'cloud-project-entry', 'operation', () => cloudEntry.joinProject(request, operationOptions),
-      ),
-      resumeSetup: (request, operationOptions) => requireLifecycle().runExclusive(
-        request.projectId, 'cloud-project-entry', 'recovery', () => cloudEntry.resumeSetup(request, operationOptions),
-      ),
-    },
-    cloudBootstrap: lifecycleCloudBootstrap,
-    hostTransfer: lifecycle.hostTransfer,
-    hostInstallation: foundation.hostInstallations,
-    join: foundation.join,
-    lanHost: foundation.lanHost,
-    lifecycleRecovery: lifecycle.lifecycleRecovery,
-    localExit: lifecycle.localExit,
-    membership: lifecycleMembership,
-    cloudRetirementIntents: retirementIntents,
-    pendingLeaves,
-    publication,
-    retirement: lifecycle.retirement,
-    vaultRoot,
-  });
-  lifecycle.bindProjection({
-    closeProjectAdmission: projectId => requireFeature().closeProjectAdmission(projectId),
-    refreshLifecycleProjection: () => requireFeature().refreshLifecycleProjection(),
-  });
-
   const authorityTransferLocalFence = new AuthorityTransferLocalFence({
     admission: {
-      drainAdmittedOperations: projectId => requireFeature().drainAdmittedOperations(projectId),
-      resumeProjectAdmission: suspension => requireFeature().resumeProjectAdmission(suspension),
-      suspendProjectAdmission: projectId => requireFeature().suspendProjectAdmission(projectId),
+      drainAdmittedOperations: projectId => operationAdmission.drainAdmittedOperations(projectId),
+      resumeProjectAdmission: suspension => operationAdmission.resumeProject(suspension),
+      suspendProjectAdmission: projectId => operationAdmission.suspendProject(projectId),
     },
     workSessions: {
       resumeProject: suspension => requirePublication().resumeProject(suspension),
@@ -1022,6 +998,56 @@ export function createCollabFeatureSubcomposition(
     ),
     claimantStore: foundation.local.projects.authorityTransferClaimants,
     convergence: authorityTransferConvergence,
+    createCloudToLanConnection: async projectId => {
+      const membership = await foundation.local.projects.loadMembership(projectId);
+      if (!membership || !isCollabLocalCloudMembership(membership)) {
+        throw bootstrapCompositionError('authority-transfer-target-membership-invalid');
+      }
+      const session = await cloudAuthority.create(membership);
+      const lifecyclePort = session.lifecycle;
+      const membershipPort = session.membership as CloudAuthorityMembershipControlPort | undefined;
+      if (
+        session.authorityKind !== 'cloud'
+        || !lifecyclePort
+        || membershipPort?.authorityKind !== 'cloud'
+      ) {
+        session.dispose();
+        throw bootstrapCompositionError('authority-transfer-cloud-session-incomplete');
+      }
+      const binding = {
+        authorityGeneration: membership.authority.authorityGeneration,
+        memberId: membership.member.id,
+        projectId,
+        serverUrl: membership.authority.serverUrl,
+      };
+      return {
+        authorityGeneration: binding.authorityGeneration,
+        dispose: () => session.dispose(),
+        lifecycle: lifecyclePort,
+        listProjectMembers: (request, operationOptions = {}) => (
+          membershipPort.cloudMembership(
+            'listProjectMembers',
+            request,
+            binding,
+            operationOptions,
+          )
+        ),
+        memberId: membership.member.id,
+        personalRef: membership.member.personalRef,
+        projectId,
+        readSnapshot: async (requestedProjectId, operationOptions) => {
+          const snapshot = await session.control.readSnapshot(
+            requestedProjectId,
+            operationOptions,
+          );
+          if (!isCollabCloudProjectSnapshot(snapshot)) {
+            throw bootstrapCompositionError('authority-transfer-cloud-snapshot-invalid');
+          }
+          return snapshot;
+        },
+        serverUrl: membership.authority.serverUrl,
+      };
+    },
     createCloudToLanTarget: (projectId, cloudSession) => (
       new ProductionCloudToLanTargetEffects({
         cloudSession,
@@ -1125,6 +1151,29 @@ export function createCollabFeatureSubcomposition(
         if (
           record.localRole === 'target'
           && record.status.direction === 'cloud-to-lan'
+          && record.status.state === 'cancelled'
+        ) {
+          return {
+            resume: async () => {
+              await new ProductionCloudToLanTargetEffects({
+                cloudSession: null,
+                convergence: authorityTransferConvergence,
+                foundation,
+                persistence: foundation.authorityTransfers,
+                projectId: record.projectId,
+              }).cancelStaging(record);
+              await foundation.authorityTransfers.completeTerminalCleanup({
+                operationIntentId: record.operationIntentId,
+                projectId: record.projectId,
+                stagingDirectoryName: record.stagingDirectoryName,
+                transferId: record.transferId,
+              });
+            },
+          };
+        }
+        if (
+          record.localRole === 'target'
+          && record.status.direction === 'cloud-to-lan'
           && record.status.state === 'completed'
           && record.status.relinquishmentProof !== null
         ) {
@@ -1183,6 +1232,37 @@ export function createCollabFeatureSubcomposition(
     },
   });
   foundation.bindAuthorityTransferModule(authorityTransfer);
+  feature = new CollabFeatureService(foundation, projectSetup, {
+    authorityTransfer,
+    cloudEntry: {
+      close: () => cloudEntry.close(),
+      createProject: (request, operationOptions) => cloudEntry.createProject(request, operationOptions),
+      joinProject: (request, operationOptions) => requireLifecycle().runExclusive(
+        'projectId' in request ? request.projectId : request.invitation.invitation.projectId,
+        'cloud-project-entry', 'operation', () => cloudEntry.joinProject(request, operationOptions),
+      ),
+      resumeSetup: (request, operationOptions) => requireLifecycle().runExclusive(
+        request.projectId, 'cloud-project-entry', 'recovery', () => cloudEntry.resumeSetup(request, operationOptions),
+      ),
+    },
+    cloudBootstrap: lifecycleCloudBootstrap,
+    hostTransfer: lifecycle.hostTransfer,
+    hostInstallation: foundation.hostInstallations,
+    join: foundation.join,
+    lanHost: foundation.lanHost,
+    lifecycleRecovery: lifecycle.lifecycleRecovery,
+    localExit: lifecycle.localExit,
+    membership: lifecycleMembership,
+    cloudRetirementIntents: retirementIntents,
+    pendingLeaves,
+    publication,
+    retirement: lifecycle.retirement,
+    vaultRoot,
+  }, operationAdmission);
+  lifecycle.bindProjection({
+    closeProjectAdmission: projectId => requireFeature().closeProjectAdmission(projectId),
+    refreshLifecycleProjection: () => requireFeature().refreshLifecycleProjection(),
+  });
 
   return Object.freeze({
     authorityTransfer,

--- a/src/app/collab/CollabLocalProjectRepository.ts
+++ b/src/app/collab/CollabLocalProjectRepository.ts
@@ -20,6 +20,10 @@ import {
   type AuthorityTransferClaimantStore,
   decodeAuthorityTransferClaimantRecord,
 } from '@/app/collab/authority-transfer/claim/AuthorityTransferClaimantRecord';
+import type {
+  CloudToLanManagerEntryRecord,
+  CloudToLanTargetEntryRecord,
+} from '@/app/collab/authority-transfer/cloud-to-lan/CloudToLanTransferEntryRecord';
 import {
   decodeAuthorityTransferClaimBatchCommitmentRecord,
 } from '@/app/collab/authority-transfer/persistence/AuthorityTransferClaimBatchCommitmentRecord';
@@ -772,10 +776,14 @@ export class CollabLocalProjectRepository {
     this.#onDiagnostic = options.onDiagnostic;
     const authorityTransferEntries: AuthorityTransferEntryStorePort = {
       load: projectId => this.#loadAuthorityTransferEntry(projectId),
+      removeManager: record => this.#removeCloudToLanManagerEntry(record),
       removeRequester: record => this.#removeAuthorityTransferRequester(record),
       removeSource: record => this.#removeAuthorityTransferSource(record),
+      removeTarget: record => this.#removeCloudToLanTargetEntry(record),
+      saveManager: record => this.#saveCloudToLanManagerEntry(record),
       saveRequester: record => this.#saveAuthorityTransferRequester(record),
       saveSource: record => this.#saveAuthorityTransferSource(record),
+      saveTarget: record => this.#saveCloudToLanTargetEntry(record),
     };
     this.authorityTransferEntries = Object.freeze(authorityTransferEntries);
     const authorityTransferRecords: AuthorityTransferRecordStorePort = {
@@ -1545,10 +1553,27 @@ export class CollabLocalProjectRepository {
     });
     if (entries.some(entry => (
       entry.isSymbolicLink()
-      || (entry.name !== 'source.json' && entry.name !== 'requesters')
-      || (entry.name === 'source.json' ? !entry.isFile() : !entry.isDirectory())
+      || (
+        entry.name !== 'manager.json'
+        && entry.name !== 'requesters'
+        && entry.name !== 'source.json'
+        && entry.name !== 'target.json'
+      )
+      || (entry.name === 'requesters' ? !entry.isDirectory() : !entry.isFile())
     ))) {
       throw localRecordError('local-record-corrupt', 'authority-transfer-entry', projectId);
+    }
+    let manager: CloudToLanManagerEntryRecord | null = null;
+    if (entries.some(entry => entry.name === 'manager.json')) {
+      const decoded = decodeLocalAuthorityTransferEntryComponent(await this.#readJson(
+        `${entryDirectory}/manager.json`,
+        'authority-transfer-entry',
+        projectId,
+      ), projectId);
+      if (decoded.entryRole !== 'cloud-to-lan-manager') {
+        throw localRecordError('local-record-corrupt', 'authority-transfer-entry', projectId);
+      }
+      manager = decoded;
     }
     let source: AuthorityTransferSourceEntryRecord | null = null;
     if (entries.some(entry => entry.name === 'source.json')) {
@@ -1561,6 +1586,18 @@ export class CollabLocalProjectRepository {
         throw localRecordError('local-record-corrupt', 'authority-transfer-entry', projectId);
       }
       source = decoded;
+    }
+    let target: CloudToLanTargetEntryRecord | null = null;
+    if (entries.some(entry => entry.name === 'target.json')) {
+      const decoded = decodeLocalAuthorityTransferEntryComponent(await this.#readJson(
+        `${entryDirectory}/target.json`,
+        'authority-transfer-entry',
+        projectId,
+      ), projectId);
+      if (decoded.entryRole !== 'cloud-to-lan-target') {
+        throw localRecordError('local-record-corrupt', 'authority-transfer-entry', projectId);
+      }
+      target = decoded;
     }
     const requesters: Record<string, AuthorityTransferRequesterEntryRecord> = {};
     if (entries.some(entry => entry.name === 'requesters')) {
@@ -1596,8 +1633,43 @@ export class CollabLocalProjectRepository {
         requesters[installationKey] = decoded;
       }
     }
-    if (!source && Object.keys(requesters).length === 0) return null;
-    return createAuthorityTransferEntryDocument({ projectId, requesters, source });
+    if (!manager && !source && !target && Object.keys(requesters).length === 0) return null;
+    return createAuthorityTransferEntryDocument({ manager, projectId, requesters, source, target });
+  }
+
+  #saveCloudToLanManagerEntry(record: CloudToLanManagerEntryRecord): Promise<void> {
+    return this.#saveAuthorityTransferSingleton(record, 'cloud-to-lan-manager', 'manager.json');
+  }
+
+  #saveCloudToLanTargetEntry(record: CloudToLanTargetEntryRecord): Promise<void> {
+    return this.#saveAuthorityTransferSingleton(record, 'cloud-to-lan-target', 'target.json');
+  }
+
+  #saveAuthorityTransferSingleton(
+    record: CloudToLanManagerEntryRecord | CloudToLanTargetEntryRecord,
+    expectedRole: 'cloud-to-lan-manager' | 'cloud-to-lan-target',
+    fileName: 'manager.json' | 'target.json',
+  ): Promise<void> {
+    this.#requireProjectId(record.projectId);
+    return this.#operationQueue.run(async () => {
+      const decoded = decodeLocalAuthorityTransferEntryComponent(record, record.projectId);
+      if (decoded.entryRole !== expectedRole) {
+        throw localRecordError('local-record-corrupt', 'authority-transfer-entry', record.projectId);
+      }
+      const entryDirectory = this.getProjectPaths(record.projectId).authorityTransferEntry;
+      await this.#ensurePrivateProjectDirectory(record.projectId, true);
+      await ensureCollabVaultDirectory(this.vaultRoot, entryDirectory, {
+        durable: true,
+        mode: 0o700,
+        onDiagnostic: this.#onDiagnostic,
+      });
+      await writeCollabFileAtomically(
+        this.vaultRoot,
+        `${entryDirectory}/${fileName}`,
+        serializeJson(decoded),
+        { mode: 0o600, onDiagnostic: this.#onDiagnostic },
+      );
+    });
   }
 
   #saveAuthorityTransferRequester(
@@ -1716,6 +1788,38 @@ export class CollabLocalProjectRepository {
       `${this.getProjectPaths(projectId).authorityTransferEntry}/source.json`,
       this.#onDiagnostic,
     );
+  }
+
+  #removeCloudToLanManagerEntry(record: CloudToLanManagerEntryRecord): Promise<boolean> {
+    return this.#removeAuthorityTransferSingleton(record, 'cloud-to-lan-manager', 'manager.json');
+  }
+
+  #removeCloudToLanTargetEntry(record: CloudToLanTargetEntryRecord): Promise<boolean> {
+    return this.#removeAuthorityTransferSingleton(record, 'cloud-to-lan-target', 'target.json');
+  }
+
+  #removeAuthorityTransferSingleton(
+    record: CloudToLanManagerEntryRecord | CloudToLanTargetEntryRecord,
+    expectedRole: 'cloud-to-lan-manager' | 'cloud-to-lan-target',
+    fileName: 'manager.json' | 'target.json',
+  ): Promise<boolean> {
+    this.#requireProjectId(record.projectId);
+    return this.#operationQueue.run(async () => {
+      const entryPath = `${this.getProjectPaths(record.projectId).authorityTransferEntry}`
+        + `/${fileName}`;
+      const current = await this.#readJson(
+        entryPath,
+        'authority-transfer-entry',
+        record.projectId,
+      );
+      if (current === null) return false;
+      const decoded = decodeLocalAuthorityTransferEntryComponent(current, record.projectId);
+      if (
+        decoded.entryRole !== expectedRole
+        || serializeJson(decoded) !== serializeJson(record)
+      ) return false;
+      return removeCollabFileDurably(this.vaultRoot, entryPath, this.#onDiagnostic);
+    });
   }
 
   listPendingOperationProjectIds(): Promise<readonly CollabProjectId[]> {

--- a/src/app/collab/authority-transfer/AuthorityTransferEntryRecord.ts
+++ b/src/app/collab/authority-transfer/AuthorityTransferEntryRecord.ts
@@ -12,6 +12,12 @@ import {
 
 import type { AuthorityTransferRecord } from '@/app/collab/authority-transfer/AuthorityTransferRecord';
 import {
+  type CloudToLanManagerEntryRecord,
+  type CloudToLanTargetEntryRecord,
+  decodeCloudToLanManagerEntryRecord,
+  decodeCloudToLanTargetEntryRecord,
+} from '@/app/collab/authority-transfer/cloud-to-lan/CloudToLanTransferEntryRecord';
+import {
   type InstallationKey,
   parseInstallationKey,
 } from '@/core/device/InstallationKey';
@@ -63,23 +69,29 @@ export interface AuthorityTransferSourceEntryRecord extends AuthorityTransferEnt
 }
 
 export type AuthorityTransferEntryComponent =
+  | CloudToLanManagerEntryRecord
   | AuthorityTransferRequesterEntryRecord
-  | AuthorityTransferSourceEntryRecord;
+  | AuthorityTransferSourceEntryRecord
+  | CloudToLanTargetEntryRecord;
 
 export interface AuthorityTransferEntryRecord {
   readonly kind: 'authority-transfer-entry';
+  readonly manager: CloudToLanManagerEntryRecord | null;
   readonly projectId: CollabProjectId;
   readonly requesters: Readonly<Record<string, AuthorityTransferRequesterEntryRecord>>;
   readonly schemaVersion: typeof AUTHORITY_TRANSFER_ENTRY_SCHEMA_VERSION;
   readonly source: AuthorityTransferSourceEntryRecord | null;
+  readonly target: CloudToLanTargetEntryRecord | null;
 }
 
 const DOCUMENT_KEYS = new Set([
   'kind',
+  'manager',
   'projectId',
   'requesters',
   'schemaVersion',
   'source',
+  'target',
 ]);
 const COMPONENT_KEYS = [
   'expiresAt',
@@ -231,6 +243,12 @@ function assertCancelledEntryStatus(status: CollabAuthorityTransferStatus): void
 export function decodeAuthorityTransferEntryComponent(
   value: unknown,
 ): AuthorityTransferEntryComponent {
+  if (isRecord(value) && value.entryRole === 'cloud-to-lan-manager') {
+    return decodeCloudToLanManagerEntryRecord(value);
+  }
+  if (isRecord(value) && value.entryRole === 'cloud-to-lan-target') {
+    return decodeCloudToLanTargetEntryRecord(value);
+  }
   if (
     !isRecord(value)
     || (value.entryRole !== 'requester' && value.entryRole !== 'source')
@@ -352,32 +370,52 @@ export function decodeAuthorityTransferEntryRecord(
   const source = value.source === null
     ? null
     : decodeAuthorityTransferEntryComponent(value.source);
+  const manager = value.manager === null
+    ? null
+    : decodeAuthorityTransferEntryComponent(value.manager);
+  const target = value.target === null
+    ? null
+    : decodeAuthorityTransferEntryComponent(value.target);
   if (
     (source !== null && source.entryRole !== 'source')
-    || (Object.keys(requesters).length === 0 && source === null)
+    || (manager !== null && manager.entryRole !== 'cloud-to-lan-manager')
+    || (target !== null && target.entryRole !== 'cloud-to-lan-target')
+    || (source !== null && (manager !== null || target !== null))
+    || (Object.keys(requesters).length === 0
+      && source === null
+      && manager === null
+      && target === null)
     || Object.values(requesters).some(requester => requester.projectId !== value.projectId)
     || (source !== null && source.projectId !== value.projectId)
+    || (manager !== null && manager.projectId !== value.projectId)
+    || (target !== null && target.projectId !== value.projectId)
   ) throw new TypeError('Invalid authority transfer entry document components');
   return {
     kind: 'authority-transfer-entry',
-    projectId: (Object.values(requesters)[0] ?? source).projectId,
+    manager: manager,
+    projectId: (Object.values(requesters)[0] ?? source ?? manager ?? target).projectId,
     requesters: Object.freeze(requesters),
     schemaVersion: AUTHORITY_TRANSFER_ENTRY_SCHEMA_VERSION,
     source,
+    target: target,
   };
 }
 
 export function createAuthorityTransferEntryDocument(input: Readonly<{
+  readonly manager?: CloudToLanManagerEntryRecord | null;
   readonly projectId: CollabProjectId;
   readonly requesters?: Readonly<Record<string, AuthorityTransferRequesterEntryRecord>>;
   readonly source?: AuthorityTransferSourceEntryRecord | null;
+  readonly target?: CloudToLanTargetEntryRecord | null;
 }>): AuthorityTransferEntryRecord {
   return decodeAuthorityTransferEntryRecord({
     kind: 'authority-transfer-entry',
+    manager: input.manager ?? null,
     projectId: input.projectId,
     requesters: input.requesters ?? {},
     schemaVersion: AUTHORITY_TRANSFER_ENTRY_SCHEMA_VERSION,
     source: input.source ?? null,
+    target: input.target ?? null,
   });
 }
 

--- a/src/app/collab/authority-transfer/AuthorityTransferImportedTargetIdentity.ts
+++ b/src/app/collab/authority-transfer/AuthorityTransferImportedTargetIdentity.ts
@@ -1,0 +1,79 @@
+import {
+  type CollabMemberId,
+  collabMemberRef,
+  type CollabProjectId,
+  type CollabRole,
+  isCollabMemberId,
+  isCollabProjectId,
+} from '@claudian-collab/protocol';
+
+export interface AuthorityTransferImportedTargetIdentity {
+  readonly authorityGeneration: number;
+  readonly currentMember: Readonly<{
+    readonly displayName: string;
+    readonly id: CollabMemberId;
+    readonly personalRef: string;
+    readonly role: CollabRole;
+  }>;
+  readonly eventSequence: number;
+  readonly project: Readonly<{
+    readonly id: CollabProjectId;
+    readonly name: string;
+  }>;
+}
+
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function exactKeys(value: UnknownRecord, keys: readonly string[]): boolean {
+  const actual = Object.keys(value);
+  return actual.length === keys.length && actual.every(key => keys.includes(key));
+}
+
+export function decodeAuthorityTransferImportedTargetIdentity(
+  value: unknown,
+): AuthorityTransferImportedTargetIdentity {
+  if (
+    !isRecord(value)
+    || !exactKeys(value, [
+      'authorityGeneration',
+      'currentMember',
+      'eventSequence',
+      'project',
+    ])
+    || !Number.isSafeInteger(value.authorityGeneration)
+    || (value.authorityGeneration as number) < 1
+    || !Number.isSafeInteger(value.eventSequence)
+    || (value.eventSequence as number) < 0
+    || !isRecord(value.currentMember)
+    || !exactKeys(value.currentMember, ['displayName', 'id', 'personalRef', 'role'])
+    || !isCollabMemberId(value.currentMember.id)
+    || typeof value.currentMember.displayName !== 'string'
+    || Buffer.byteLength(value.currentMember.displayName, 'utf8') > 128
+    || typeof value.currentMember.personalRef !== 'string'
+    || value.currentMember.personalRef !== collabMemberRef(value.currentMember.id)
+    || (value.currentMember.role !== 'manager' && value.currentMember.role !== 'member')
+    || !isRecord(value.project)
+    || !exactKeys(value.project, ['id', 'name'])
+    || !isCollabProjectId(value.project.id)
+    || typeof value.project.name !== 'string'
+    || Buffer.byteLength(value.project.name, 'utf8') > 256
+  ) throw new TypeError('Invalid imported authority-transfer target identity');
+  return Object.freeze({
+    authorityGeneration: value.authorityGeneration as number,
+    currentMember: Object.freeze({
+      displayName: value.currentMember.displayName,
+      id: value.currentMember.id,
+      personalRef: value.currentMember.personalRef,
+      role: value.currentMember.role,
+    }),
+    eventSequence: value.eventSequence as number,
+    project: Object.freeze({
+      id: value.project.id,
+      name: value.project.name,
+    }),
+  });
+}

--- a/src/app/collab/authority-transfer/AuthorityTransferLocalConvergence.ts
+++ b/src/app/collab/authority-transfer/AuthorityTransferLocalConvergence.ts
@@ -6,6 +6,9 @@ import {
 } from '@claudian-collab/protocol';
 
 import type {
+  AuthorityTransferImportedTargetIdentity,
+} from '@/app/collab/authority-transfer/AuthorityTransferImportedTargetIdentity';
+import type {
   AuthorityTransferClaimantRecord,
 } from '@/app/collab/authority-transfer/claim/AuthorityTransferClaimantRecord';
 import type {
@@ -73,8 +76,8 @@ export interface CloudToLanHostConvergenceInput {
   readonly endpoint: string;
   readonly hostCaCertificatePem: string;
   readonly hostCaFingerprint: string;
+  readonly identity: AuthorityTransferImportedTargetIdentity;
   readonly memberCredential: string;
-  readonly snapshot: CollabProjectSnapshot;
   readonly status: CollabAuthorityTransferStatus;
 }
 
@@ -322,7 +325,14 @@ export class AuthorityTransferLocalConvergence {
     targetOwnsAuthority: boolean,
   ): Promise<void> {
     const membership = await this.requireMembership(input.status.projectId);
-    assertSnapshot(membership, input.snapshot);
+    const identity = input.identity;
+    if (
+      identity.project.id !== membership.project.id
+      || identity.project.name !== membership.project.name
+      || identity.currentMember.id !== membership.member.id
+      || identity.currentMember.personalRef !== membership.member.personalRef
+      || identity.authorityGeneration !== input.status.targetAuthority.generation
+    ) throw convergenceError('authority-transfer-convergence-target-identity-mismatch');
     const newRemoteUrl = lanRemoteUrl(input.endpoint, input.status.projectId);
     if (isCollabLocalCloudMembership(membership)) {
       await this.rotate(membership, membership.authority.gitRemoteUrl, newRemoteUrl, null);
@@ -339,14 +349,14 @@ export class AuthorityTransferLocalConvergence {
           autoStart: targetOwnsAuthority,
           ownsAuthority: targetOwnsAuthority,
         },
-        lastEventSequence: input.snapshot.eventSequence,
+        lastEventSequence: identity.eventSequence,
         ...(membership.lifecycle === undefined ? {} : { lifecycle: membership.lifecycle }),
         member: {
           credential: input.memberCredential,
-          displayName: input.snapshot.currentMember.displayName,
-          id: input.snapshot.currentMember.id,
-          personalRef: input.snapshot.currentMember.personalRef,
-          role: input.snapshot.currentMember.role,
+          displayName: identity.currentMember.displayName,
+          id: identity.currentMember.id,
+          personalRef: identity.currentMember.personalRef,
+          role: identity.currentMember.role,
         },
         project: membership.project,
         schemaVersion: membership.schemaVersion,

--- a/src/app/collab/authority-transfer/AuthorityTransferModule.ts
+++ b/src/app/collab/authority-transfer/AuthorityTransferModule.ts
@@ -2,12 +2,22 @@ import type {
   AcceptLanToCloudTransferTargetRequest,
   CollabAuthorityTransferStatus,
   CollabProjectId,
+  CollabProjectMembershipOperationMap,
   RequestLanToCloudTransferRequest,
 } from '@claudian-collab/protocol';
+import {
+  COLLAB_AUTHORITY_TRANSFER_CANCELLABLE_PHASES,
+} from '@claudian-collab/protocol';
 
+import {
+  authorityTransferEntryExpiresAt,
+} from '@/app/collab/authority-transfer/AuthorityTransferEntryRecord';
 import type {
   AuthorityTransferLocalConvergence,
 } from '@/app/collab/authority-transfer/AuthorityTransferLocalConvergence';
+import {
+  authorityTransferChildIdempotencyKey,
+} from '@/app/collab/authority-transfer/AuthorityTransferOperationIdentity';
 import type {
   AuthorityTransferRecord,
 } from '@/app/collab/authority-transfer/AuthorityTransferRecord';
@@ -32,6 +42,18 @@ import {
   CloudToLanTargetCoordinator,
   type CloudToLanTargetCoordinatorOptions,
 } from '@/app/collab/authority-transfer/cloud-to-lan/CloudToLanTargetCoordinator';
+import {
+  assertCloudToLanTargetHandle,
+  type CloudToLanManagerEntryRecord,
+  type CloudToLanTargetPreparationDescriptor,
+  type CloudToLanTransferHandle,
+  cloudToLanTransferHandle,
+  createCloudToLanManagerEntry,
+  createCloudToLanTargetEntry,
+  decodeCloudToLanTargetPreparationDescriptor,
+  decodeCloudToLanTransferHandle,
+} from '@/app/collab/authority-transfer/cloud-to-lan/CloudToLanTransferEntryRecord';
+import { CollabAuthorityTransferOutcomeError } from '@/app/collab/authority-transfer/CollabAuthorityTransferOutcomeError';
 import {
   LanToCloudRequesterCoordinator,
 } from '@/app/collab/authority-transfer/lan-to-cloud/LanToCloudRequesterCoordinator';
@@ -60,6 +82,8 @@ import { ProjectControlClient } from '@/app/collab/publish/ProjectControlClient'
 import type {
   CloudAuthorityConnection,
 } from '@/app/collab/remote-authority/CloudAuthorityAdapter';
+import { CloudAuthorityRejection } from '@/app/collab/remote-authority/CloudAuthorityError';
+import type { CollabOperationOptions } from '@/core/collab';
 import { CollabError } from '@/core/collab/ClaudianCollabError';
 import type { InstallationKey } from '@/core/device/InstallationKey';
 
@@ -83,10 +107,13 @@ export interface AuthorityTransferModuleOptions {
   ) => Promise<void> | void;
   readonly claimantStore: AuthorityTransferClaimantCoordinatorOptions['store'];
   readonly convergence: AuthorityTransferLocalConvergence;
-  readonly createCloudToLanTarget?: (
+  readonly createCloudToLanTarget: (
     projectId: CollabProjectId,
-    session: CloudAuthorityConnection,
+    session: Readonly<{ readonly serverUrl: string }>,
   ) => CloudToLanTargetCoordinatorOptions['target'];
+  readonly createCloudToLanConnection: (
+    projectId: CollabProjectId,
+  ) => Promise<CloudToLanEntryConnection>;
   readonly createLanToCloudSource: (
     projectId: CollabProjectId,
     session: CloudAuthorityConnection,
@@ -101,6 +128,7 @@ export interface AuthorityTransferModuleOptions {
   ) => Promise<() => Promise<void>>;
   readonly lifecycle: CollabProjectLifecycleSubsystem;
   readonly installationKey: InstallationKey;
+  readonly now?: () => Date;
   readonly persistence: AuthorityTransferPersistence;
   readonly recoverCloudSession?: (
     record: AuthorityTransferRecord,
@@ -109,6 +137,21 @@ export interface AuthorityTransferModuleOptions {
     record: AuthorityTransferClaimantRecord,
   ) => Promise<RecoveredAuthorityTransferClaimantBinding>;
   readonly terminalResolver?: AuthorityTransferRuntimeResolver;
+}
+
+export interface CloudToLanEntryConnection {
+  readonly authorityGeneration: number;
+  dispose(): void;
+  readonly lifecycle: CloudAuthorityConnection['lifecycle'];
+  listProjectMembers(
+    request: CollabProjectMembershipOperationMap['listProjectMembers']['request'],
+    options?: { readonly signal?: AbortSignal },
+  ): Promise<CollabProjectMembershipOperationMap['listProjectMembers']['response']>;
+  readonly memberId: string;
+  readonly personalRef: string;
+  readonly projectId: CollabProjectId;
+  readSnapshot: CloudAuthorityConnection['readSnapshot'];
+  readonly serverUrl: string;
 }
 
 export interface BindLanToCloudSourceInput {
@@ -134,6 +177,25 @@ export interface LanToCloudSourceProposalView {
 export interface BindCloudToLanTargetInput {
   readonly cloudSession: CloudAuthorityConnection;
   readonly expectedTargetUrl?: string;
+  readonly projectId: CollabProjectId;
+}
+
+export interface PrepareCloudToLanTargetInput {
+  readonly operationIntentId: string;
+  readonly projectId: CollabProjectId;
+}
+
+export interface BeginCloudToLanTransferInput {
+  readonly descriptor: CloudToLanTargetPreparationDescriptor;
+  readonly operationIntentId: string;
+}
+
+export interface AcceptPreparedCloudToLanTransferInput {
+  readonly handle: CloudToLanTransferHandle;
+}
+
+export interface WithdrawPreparedCloudToLanTargetInput {
+  readonly preparationId: string;
   readonly projectId: CollabProjectId;
 }
 
@@ -209,7 +271,24 @@ interface SourceBinding {
 
 interface TargetBinding {
   readonly coordinator: CloudToLanTargetCoordinator;
+  dispose(): Promise<void>;
   readonly unregister: () => void;
+}
+
+interface TargetPreparationBinding {
+  readonly connection: CloudToLanEntryConnection;
+  readonly target: CloudToLanTargetCoordinatorOptions['target'];
+}
+
+async function disposeCloudToLanTargetPreparation(
+  connection: CloudToLanEntryConnection,
+  target: CloudToLanTargetCoordinatorOptions['target'] | null,
+): Promise<void> {
+  try {
+    await target?.dispose?.();
+  } finally {
+    connection.dispose();
+  }
 }
 
 function moduleError(reason: string): CollabError {
@@ -218,6 +297,40 @@ function moduleError(reason: string): CollabError {
     recoveryActions: ['resume', 'open-diagnostics'],
     safeContext: { reason },
   });
+}
+
+function durableOutcome(operationId: string, reason: string): CollabAuthorityTransferOutcomeError {
+  return new CollabAuthorityTransferOutcomeError({
+    durablePhase: 'committed',
+    durableProgress: true,
+    error: moduleError(reason),
+    operationId,
+    status: 'recovery-required',
+  });
+}
+
+function isDefinitiveCloudToLanBeginRejection(
+  error: CloudAuthorityRejection,
+  wasPossiblySent: boolean,
+): boolean {
+  return !wasPossiblySent && (
+    error.code === 'authorization-denied' || error.code === 'authority-transfer-stale'
+  );
+}
+
+function sameCloudToLanTransferHandle(
+  left: CloudToLanTransferHandle,
+  right: CloudToLanTransferHandle,
+): boolean {
+  return left.operationIntentId === right.operationIntentId
+    && left.preparationId === right.preparationId
+    && left.projectId === right.projectId
+    && left.schemaVersion === right.schemaVersion
+    && left.selectedTargetMemberId === right.selectedTargetMemberId
+    && left.sourceAuthorityGeneration === right.sourceAuthorityGeneration
+    && left.sourceCloudUrl === right.sourceCloudUrl
+    && left.targetUrl === right.targetUrl
+    && left.transferId === right.transferId;
 }
 
 /**
@@ -230,12 +343,16 @@ export class AuthorityTransferModule {
   readonly convergence: AuthorityTransferLocalConvergence;
   readonly runtimes: AuthorityTransferRuntimeRegistry;
   private readonly claimantRecovery: AuthorityTransferClaimantRecovery;
+  private readonly recoveredCloudSessions = new Map<CollabProjectId, CloudAuthorityConnection>();
   private readonly sourceProposals: LanToCloudSourceProposalCoordinator;
   private readonly sourceBindings = new Map<CollabProjectId, SourceBinding>();
   private readonly targetBindings = new Map<CollabProjectId, TargetBinding>();
+  private readonly targetPreparations = new Map<CollabProjectId, TargetPreparationBinding>();
   private readonly transferRecovery: AuthorityTransferRecovery;
+  private readonly now: () => Date;
 
   constructor(private readonly options: AuthorityTransferModuleOptions) {
+    this.now = options.now ?? (() => new Date());
     this.convergence = options.convergence;
     this.runtimes = new AuthorityTransferRuntimeRegistry({
       resolve: record => this.resolveRuntime(record),
@@ -249,12 +366,29 @@ export class AuthorityTransferModule {
     });
     this.transferRecovery = new AuthorityTransferRecovery(
       options.persistence,
-      this.runtimes,
+      {
+        prepare: record => this.runtimes.prepare(record),
+        resume: (record, recoveryOptions) => (
+          this.resumeAuthorityTransferRecord(record, recoveryOptions)
+        ),
+        resumeManager: (projectId, recoveryOptions) => (
+          this.resumeCloudToLanManagerEntry(projectId, recoveryOptions)
+        ),
+        resumeTargetPreparation: (entry, recoveryOptions) => (
+          this.prepareCloudToLanTargetOwned({
+            operationIntentId: entry.operationIntentId,
+            projectId: entry.projectId,
+          }, recoveryOptions).then(() => undefined)
+        ),
+      },
       options.assertRecoveryOwner,
     );
     this.claimantRecovery = new AuthorityTransferClaimantRecovery(
       options.claimantStore,
-      this.claimants,
+      {
+        beforeProject: projectId => this.assertCloudToLanManagerSettled(projectId),
+        resume: (record, recoveryOptions) => this.claimants.resume(record, recoveryOptions),
+      },
     );
     this.transferRecovery.register(options.lifecycle);
     this.claimantRecovery.register(options.lifecycle);
@@ -411,7 +545,6 @@ export class AuthorityTransferModule {
   ): Promise<CloudToLanAuthorityTransferBinding> {
     this.assertCloudSession(input.projectId, input.cloudSession);
     const createTarget = this.options.createCloudToLanTarget;
-    if (!createTarget) throw moduleError('authority-transfer-target-runtime-unavailable');
     if (this.sourceBindings.has(input.projectId) || this.targetBindings.has(input.projectId)) {
       throw moduleError('authority-transfer-direction-runtime-conflict');
     }
@@ -422,6 +555,17 @@ export class AuthorityTransferModule {
     if (!input.expectedTargetUrl) {
       throw moduleError('authority-transfer-target-url-required');
     }
+    let prepared: Awaited<ReturnType<NonNullable<typeof target.prepareTarget>>>;
+    try {
+      prepared = await target.prepareTarget(input.expectedTargetUrl);
+    } catch (error) {
+      await target.dispose?.();
+      throw error;
+    }
+    if (prepared.targetUrl !== input.expectedTargetUrl) {
+      await target.dispose?.();
+      throw moduleError('authority-transfer-target-url-mismatch');
+    }
     const coordinator = new CloudToLanTargetCoordinator({
       cloud: input.cloudSession.lifecycle,
       installationKey: this.options.installationKey,
@@ -429,25 +573,842 @@ export class AuthorityTransferModule {
       target,
     });
     const unregister = this.runtimes.register(input.projectId, 'target', coordinator);
-    const binding = Object.freeze({ coordinator, unregister });
+    const binding: TargetBinding = Object.freeze({
+      coordinator,
+      dispose: async () => {
+        unregister();
+        await target.dispose?.();
+      },
+      unregister,
+    });
     this.targetBindings.set(input.projectId, binding);
     try {
       return Object.freeze({
         coordinator,
-        dispose: () => {
+        dispose: async () => {
           if (this.targetBindings.get(input.projectId) !== binding) return;
           this.targetBindings.delete(input.projectId);
-          unregister();
-          target.dispose?.();
+          await binding.dispose();
         },
         targetUrl: input.expectedTargetUrl,
       });
     } catch (error) {
       this.targetBindings.delete(input.projectId);
       unregister();
-      target.dispose?.();
+      await target.dispose?.();
       throw error;
     }
+  }
+
+  async prepareCloudToLanTarget(
+    input: PrepareCloudToLanTargetInput,
+    options: CollabOperationOptions = {},
+  ): Promise<CloudToLanTargetPreparationDescriptor> {
+    return this.options.lifecycle.runExclusive(
+      input.projectId,
+      'authority-transfer',
+      'continuation',
+      () => this.prepareCloudToLanTargetOwned(input, options),
+    );
+  }
+
+  private async prepareCloudToLanTargetOwned(
+    input: PrepareCloudToLanTargetInput,
+    options: CollabOperationOptions,
+  ): Promise<CloudToLanTargetPreparationDescriptor> {
+    const createConnection = this.options.createCloudToLanConnection;
+    const createTarget = this.options.createCloudToLanTarget;
+    let existing = await this.options.persistence.loadCloudToLanTargetEntry(
+      input.projectId,
+    );
+    if (existing?.ownerInstallationKey !== undefined
+      && existing.ownerInstallationKey !== this.options.installationKey) {
+      throw moduleError('host-installation-recovery-owner-mismatch');
+    }
+    if (
+      existing
+      && existing.operationIntentId !== input.operationIntentId
+      && existing.phase === 'withdrawn'
+    ) {
+      existing = null;
+    }
+    const retainedPreparation = this.targetPreparations.get(input.projectId);
+    if (existing?.phase === 'published' && existing.descriptor && retainedPreparation) {
+      return existing.descriptor;
+    }
+    const connection = await createConnection(input.projectId);
+    let durableOperationId = existing?.operationIntentId ?? null;
+    let keepConnection = false;
+    let createdTarget: CloudToLanTargetCoordinatorOptions['target'] | null = null;
+    try {
+      let entry = existing;
+      if (!entry) {
+        const snapshot = await connection.readSnapshot(input.projectId, options);
+        this.assertCloudToLanConnectionIdentity(connection, snapshot);
+        const createdAt = this.now().toISOString();
+        entry = await this.options.persistence.prepareCloudToLanTargetEntry(
+          createCloudToLanTargetEntry({
+            createdAt,
+            expiresAt: authorityTransferEntryExpiresAt(createdAt),
+            operationIntentId: input.operationIntentId,
+            ownerInstallationKey: this.options.installationKey,
+            projectId: input.projectId,
+            selectedTargetMemberId: snapshot.currentMember.id,
+            selectedTargetPersonalRef: snapshot.currentMember.personalRef,
+            sourceAuthorityGeneration: snapshot.project.authorityGeneration,
+            sourceCloudUrl: connection.serverUrl,
+          }),
+        );
+        durableOperationId = entry.operationIntentId;
+      } else {
+        this.assertCloudToLanTargetConnection(entry, connection);
+      }
+      if (entry.descriptor) {
+        if (entry.phase !== 'published') {
+          throw moduleError('authority-transfer-target-preparation-withdrawn');
+        }
+        const target = createTarget(input.projectId, connection);
+        createdTarget = target;
+        const prepared = await target.prepareTarget?.(entry.descriptor.targetUrl);
+        if (!prepared || prepared.targetUrl !== entry.descriptor.targetUrl) {
+          throw moduleError('authority-transfer-target-url-mismatch');
+        }
+        this.targetPreparations.set(input.projectId, { connection, target });
+        keepConnection = true;
+        return entry.descriptor;
+      }
+      const target = createTarget(input.projectId, connection);
+      createdTarget = target;
+      if (!target.prepareTarget) {
+        throw moduleError('authority-transfer-target-preparation-unavailable');
+      }
+      const prepared = await target.prepareTarget();
+      if (
+        !('caCertificatePem' in prepared)
+        || !('caFingerprint' in prepared)
+        || typeof prepared.caCertificatePem !== 'string'
+        || typeof prepared.caFingerprint !== 'string'
+      ) throw moduleError('authority-transfer-target-trust-unavailable');
+      const publishedAt = this.now().toISOString();
+      const published = await this.options.persistence.publishCloudToLanTargetEntry(
+        entry,
+        {
+          caCertificatePem: prepared.caCertificatePem,
+          caFingerprint: prepared.caFingerprint,
+          publishedAt,
+          targetUrl: prepared.targetUrl,
+        },
+      );
+      if (!published.descriptor) {
+        throw moduleError('authority-transfer-target-descriptor-missing');
+      }
+      this.targetPreparations.set(input.projectId, { connection, target });
+      keepConnection = true;
+      return published.descriptor;
+    } catch (error) {
+      if (durableOperationId !== null) {
+        throw durableOutcome(
+          durableOperationId,
+          'authority-transfer-target-preparation-incomplete',
+        );
+      }
+      throw error;
+    } finally {
+      if (!keepConnection) {
+        await Promise.allSettled([
+          disposeCloudToLanTargetPreparation(connection, createdTarget),
+        ]);
+      }
+    }
+  }
+
+  async beginCloudToLanTransfer(
+    input: BeginCloudToLanTransferInput,
+    options: CollabOperationOptions = {},
+  ): Promise<CloudToLanTransferHandle> {
+    const descriptor = decodeCloudToLanTargetPreparationDescriptor(input.descriptor);
+    return this.options.lifecycle.runExclusive(
+      descriptor.projectId,
+      'authority-transfer',
+      'continuation',
+      () => this.beginCloudToLanTransferOwned(
+        descriptor,
+        input.operationIntentId,
+        options,
+      ),
+    );
+  }
+
+  private async beginCloudToLanTransferOwned(
+    descriptor: CloudToLanTargetPreparationDescriptor,
+    operationIntentId: string,
+    options: CollabOperationOptions,
+  ): Promise<CloudToLanTransferHandle> {
+    const createConnection = this.options.createCloudToLanConnection;
+    let entry = await this.options.persistence.loadCloudToLanManagerEntry(
+      descriptor.projectId,
+    );
+    const existingDescriptorMatches = entry !== null
+      && JSON.stringify(entry.descriptor) === JSON.stringify(descriptor);
+    if (entry?.phase === 'settled') {
+      if (existingDescriptorMatches && entry.status) {
+        return cloudToLanTransferHandle(entry);
+      }
+      entry = null;
+    } else if (entry?.phase === 'rejected') {
+      await this.options.persistence.settleCloudToLanManagerEntry(entry);
+      entry = null;
+    }
+    if (entry && !existingDescriptorMatches) {
+      throw moduleError('authority-transfer-manager-entry-conflict');
+    }
+    if (entry?.status) return cloudToLanTransferHandle(entry);
+    const connection = await createConnection(descriptor.projectId);
+    try {
+      if (!entry) {
+        const [snapshot, listed] = await Promise.all([
+          connection.readSnapshot(descriptor.projectId, options),
+          connection.listProjectMembers({ projectId: descriptor.projectId }, options),
+        ]);
+        this.assertCloudToLanConnectionIdentity(connection, snapshot);
+        const targetMembers = listed.projectId === descriptor.projectId
+          ? listed.members.filter(member => member.memberId === descriptor.selectedTargetMemberId)
+          : [];
+        if (
+          snapshot.currentMember.role !== 'manager'
+          || descriptor.sourceCloudUrl !== connection.serverUrl
+          || descriptor.sourceAuthorityGeneration !== connection.authorityGeneration
+          || targetMembers.length !== 1
+          || targetMembers[0]?.bindingState !== 'bound'
+        ) throw moduleError('authority-transfer-manager-selection-stale');
+        const createdAt = this.now().toISOString();
+        entry = await this.options.persistence.prepareCloudToLanManagerEntry(
+          createCloudToLanManagerEntry({
+            createdAt,
+            descriptor,
+            expiresAt: authorityTransferEntryExpiresAt(createdAt),
+            initiatingMemberId: snapshot.currentMember.id,
+            initiatingPersonalRef: snapshot.currentMember.personalRef,
+            operationIntentId,
+          }),
+        );
+      }
+      if (
+        JSON.stringify(entry.descriptor) !== JSON.stringify(descriptor)
+      ) throw moduleError('authority-transfer-manager-entry-conflict');
+      this.assertCloudToLanManagerConnection(entry, connection);
+      const wasPossiblySent = entry.phase === 'submitted';
+      try {
+        entry = await this.options.persistence.markCloudToLanManagerBeginPossiblySent(entry);
+      } catch {
+        throw durableOutcome(
+          entry.operationIntentId,
+          'authority-transfer-manager-begin-incomplete',
+        );
+      }
+      let status: CollabAuthorityTransferStatus;
+      try {
+        status = await connection.lifecycle.authorityTransfer(
+          'beginCloudToLanTransfer',
+          entry.request,
+          options,
+        );
+      } catch (error) {
+        if (
+          error instanceof CloudAuthorityRejection
+          && isDefinitiveCloudToLanBeginRejection(error, wasPossiblySent)
+        ) {
+          try {
+            await this.settleRejectedCloudToLanManagerEntry(entry, connection, options);
+          } catch {
+            throw durableOutcome(
+              entry.operationIntentId,
+              'authority-transfer-manager-rejection-settlement-incomplete',
+            );
+          }
+          throw error;
+        }
+        throw durableOutcome(
+          entry.operationIntentId,
+          'authority-transfer-manager-begin-ambiguous',
+        );
+      }
+      try {
+        entry = await this.options.persistence.recordCloudToLanManagerStatus(entry, status);
+      } catch {
+        throw durableOutcome(
+          entry.operationIntentId,
+          'authority-transfer-manager-status-incomplete',
+        );
+      }
+      return cloudToLanTransferHandle(entry);
+    } finally {
+      connection.dispose();
+    }
+  }
+
+  async acceptCloudToLanTransfer(
+    input: AcceptPreparedCloudToLanTransferInput,
+    options: CollabOperationOptions = {},
+  ): Promise<CollabAuthorityTransferStatus> {
+    const handle = decodeCloudToLanTransferHandle(input.handle);
+    return this.options.lifecycle.runExclusive(
+      handle.projectId,
+      'authority-transfer',
+      'continuation',
+      async () => {
+        const entry = await this.options.persistence.loadCloudToLanTargetEntry(
+          handle.projectId,
+        );
+        if (!entry || entry.ownerInstallationKey !== this.options.installationKey) {
+          throw moduleError('host-installation-recovery-owner-mismatch');
+        }
+        if (entry.phase !== 'published' && entry.phase !== 'handed-off') {
+          throw moduleError('authority-transfer-target-handle-mismatch');
+        }
+        try {
+          assertCloudToLanTargetHandle(entry, handle);
+        } catch {
+          throw moduleError('authority-transfer-target-handle-mismatch');
+        }
+        let binding = this.targetBindings.get(handle.projectId);
+        if (!binding) {
+          const createConnection = this.options.createCloudToLanConnection;
+          const createTarget = this.options.createCloudToLanTarget;
+          let preparation = this.targetPreparations.get(handle.projectId);
+          if (!preparation) {
+            const connection = await createConnection(handle.projectId);
+            try {
+              this.assertCloudToLanTargetConnection(entry, connection);
+              preparation = {
+                connection,
+                target: createTarget(
+                  handle.projectId,
+                  connection,
+                ),
+              };
+            } catch (error) {
+              connection.dispose();
+              throw error;
+            }
+            this.targetPreparations.set(handle.projectId, preparation);
+          }
+          if (this.sourceBindings.has(handle.projectId)) {
+            throw moduleError('authority-transfer-direction-runtime-conflict');
+          }
+          const coordinator = new CloudToLanTargetCoordinator({
+            cloud: preparation.connection.lifecycle,
+            installationKey: this.options.installationKey,
+            persistence: this.options.persistence,
+            target: preparation.target,
+          });
+          const unregister = this.runtimes.register(handle.projectId, 'target', coordinator);
+          binding = {
+            coordinator,
+            dispose: async () => {
+              unregister();
+              await disposeCloudToLanTargetPreparation(
+                preparation.connection,
+                preparation.target,
+              );
+            },
+            unregister,
+          };
+          this.targetBindings.set(handle.projectId, binding);
+          this.targetPreparations.delete(handle.projectId);
+        }
+        let status: CollabAuthorityTransferStatus;
+        try {
+          status = await binding.coordinator.acceptPreparedTransfer(handle, options);
+        } catch (error) {
+          const physical = await this.options.persistence.load(handle.projectId);
+          if (
+            physical
+            && physical.localRole === 'target'
+            && physical.status.direction === 'cloud-to-lan'
+            && physical.operationIntentId === handle.operationIntentId
+            && physical.transferId === handle.transferId
+          ) throw durableOutcome(
+            handle.operationIntentId,
+            'authority-transfer-target-acceptance-incomplete',
+          );
+          throw error;
+        }
+        let managerSettlementFailed = false;
+        try {
+          await this.settleMatchingCloudToLanManager(handle, status);
+        } catch {
+          managerSettlementFailed = true;
+        }
+        let targetCleanupFailed = false;
+        if (status.state === 'cancelled') {
+          if (this.targetBindings.get(handle.projectId) === binding) {
+            this.targetBindings.delete(handle.projectId);
+            try {
+              await binding.dispose();
+            } catch {
+              targetCleanupFailed = true;
+            }
+          }
+        }
+        if (managerSettlementFailed || targetCleanupFailed) {
+          throw durableOutcome(
+            handle.operationIntentId,
+            targetCleanupFailed
+              ? 'authority-transfer-target-cancellation-cleanup-incomplete'
+              : 'authority-transfer-manager-status-incomplete',
+          );
+        }
+        return status;
+      },
+    );
+  }
+
+  async withdrawCloudToLanTarget(
+    input: WithdrawPreparedCloudToLanTargetInput,
+    options: CollabOperationOptions = {},
+  ): Promise<void> {
+    return this.options.lifecycle.runExclusive(
+      input.projectId,
+      'authority-transfer',
+      'continuation',
+      async () => {
+        if (options.signal?.aborted) throw new CollabError({ code: 'cancelled' });
+        const entry = await this.options.persistence.loadCloudToLanTargetEntry(input.projectId);
+        if (
+          !entry
+          || entry.ownerInstallationKey !== this.options.installationKey
+        ) throw moduleError('host-installation-recovery-owner-mismatch');
+        if (entry.operationIntentId !== input.preparationId) {
+          throw moduleError('authority-transfer-target-preparation-mismatch');
+        }
+        if (entry.phase !== 'withdrawn') {
+          await this.options.persistence.withdrawCloudToLanTargetEntry(entry);
+        }
+        const binding = this.targetBindings.get(input.projectId);
+        const preparation = this.targetPreparations.get(input.projectId);
+        this.targetBindings.delete(input.projectId);
+        this.targetPreparations.delete(input.projectId);
+        const cleanup = await Promise.allSettled([
+          ...(binding ? [binding.dispose()] : []),
+          ...(preparation ? [disposeCloudToLanTargetPreparation(
+            preparation.connection,
+            preparation.target,
+          )] : []),
+        ]);
+        const failed = cleanup.find(
+          (result): result is PromiseRejectedResult => result.status === 'rejected',
+        );
+        if (failed) throw failed.reason;
+      },
+    );
+  }
+
+  async observeCloudToLanTransfer(
+    projectId: CollabProjectId,
+    options: CollabOperationOptions = {},
+  ): Promise<CollabAuthorityTransferStatus> {
+    const entry = await this.requireCloudToLanManagerStatus(projectId);
+    const connection = await this.requireCloudToLanManagerConnection(entry);
+    try {
+      const status = await connection.lifecycle.authorityTransfer(
+        'getProjectAuthorityTransfer',
+        { projectId, transferId: entry.status!.transferId },
+        options,
+      );
+      const observed = await this.options.persistence.recordCloudToLanManagerStatus(entry, status);
+      if (observed.phase === 'settled') {
+        await this.options.persistence.settleCloudToLanManagerEntry(observed);
+      }
+      return status;
+    } finally {
+      connection.dispose();
+    }
+  }
+
+  async cancelCloudToLanTransfer(
+    input: CloudToLanTransferHandle,
+    options: CollabOperationOptions = {},
+  ): Promise<CollabAuthorityTransferStatus> {
+    const handle = decodeCloudToLanTransferHandle(input);
+    const projectId = handle.projectId;
+    let entry = await this.requireCloudToLanManagerStatus(projectId);
+    if (!sameCloudToLanTransferHandle(cloudToLanTransferHandle(entry), handle)) {
+      throw moduleError('authority-transfer-manager-handle-mismatch');
+    }
+    const connection = await this.requireCloudToLanManagerConnection(entry);
+    try {
+      if (entry.cancellation === null) {
+        const current = await connection.lifecycle.authorityTransfer(
+          'getProjectAuthorityTransfer',
+          { projectId, transferId: entry.status!.transferId },
+          options,
+        );
+        entry = await this.options.persistence.recordCloudToLanManagerStatus(entry, current);
+        if (entry.phase === 'settled') {
+          await this.options.persistence.settleCloudToLanManagerEntry(entry);
+          return current;
+        }
+        if (!COLLAB_AUTHORITY_TRANSFER_CANCELLABLE_PHASES.includes(current.phase as never)) {
+          throw new CollabError({ code: 'authority-transfer-cancellation-forbidden' });
+        }
+        entry = await this.options.persistence.prepareCloudToLanManagerCancellation(entry, {
+          expectedPhase: current.phase as typeof COLLAB_AUTHORITY_TRANSFER_CANCELLABLE_PHASES[number],
+          idempotencyKey: authorityTransferChildIdempotencyKey(
+            entry.operationIntentId,
+            'cancel',
+          ),
+          projectId,
+          transferId: current.transferId,
+        });
+      }
+      try {
+        entry = await this.options.persistence
+          .markCloudToLanManagerCancellationPossiblySent(entry);
+      } catch {
+        throw durableOutcome(
+          entry.operationIntentId,
+          'authority-transfer-manager-cancellation-incomplete',
+        );
+      }
+      try {
+        const cancelled = await connection.lifecycle.authorityTransfer(
+          'cancelProjectAuthorityTransfer',
+          entry.cancellation!.request,
+          options,
+        );
+        let observed: CloudToLanManagerEntryRecord;
+        try {
+          observed = await this.options.persistence.recordCloudToLanManagerStatus(
+            entry,
+            cancelled,
+          );
+        } catch {
+          throw durableOutcome(
+            entry.operationIntentId,
+            'authority-transfer-manager-cancellation-status-incomplete',
+          );
+        }
+        if (observed.phase === 'settled') {
+          await this.options.persistence.settleCloudToLanManagerEntry(observed);
+        }
+        return cancelled;
+      } catch (error) {
+        if (error instanceof CollabAuthorityTransferOutcomeError) throw error;
+        if (!(error instanceof CloudAuthorityRejection)) {
+          throw durableOutcome(
+            entry.operationIntentId,
+            'authority-transfer-manager-cancellation-ambiguous',
+          );
+        }
+        let observed: CollabAuthorityTransferStatus;
+        try {
+          observed = await connection.lifecycle.authorityTransfer(
+            'getProjectAuthorityTransfer',
+            { projectId, transferId: entry.status!.transferId },
+            options,
+          );
+        } catch {
+          throw durableOutcome(
+            entry.operationIntentId,
+            'authority-transfer-manager-cancellation-observation-incomplete',
+          );
+        }
+        if (observed.phase === entry.status!.phase) throw error;
+        let advanced: CloudToLanManagerEntryRecord;
+        try {
+          advanced = await this.options.persistence.recordCloudToLanManagerStatus(
+            entry,
+            observed,
+          );
+        } catch {
+          throw durableOutcome(
+            entry.operationIntentId,
+            'authority-transfer-manager-cancellation-status-incomplete',
+          );
+        }
+        if (advanced.phase === 'settled') {
+          await this.options.persistence.settleCloudToLanManagerEntry(advanced);
+        }
+        return observed;
+      }
+    } finally {
+      connection.dispose();
+    }
+  }
+
+  private async resumeCloudToLanManagerEntry(
+    projectId: CollabProjectId,
+    options: CollabOperationOptions,
+  ): Promise<void> {
+    let entry = await this.options.persistence.loadCloudToLanManagerEntry(projectId);
+    if (!entry) return;
+    if (entry.phase === 'settled' || entry.phase === 'rejected') {
+      await this.options.persistence.settleCloudToLanManagerEntry(entry);
+      return;
+    }
+    const physical = await this.options.persistence.load(projectId);
+    if (physical && physical.ownerInstallationKey === undefined) {
+      throw moduleError('host-installation-recovery-owner-mismatch');
+    }
+    if (physical?.ownerInstallationKey === this.options.installationKey) {
+      if (!this.cloudToLanManagerMatchesPhysical(entry, physical)) {
+        throw moduleError('authority-transfer-manager-physical-mismatch');
+      }
+      return;
+    }
+    const connection = await this.requireCloudToLanManagerConnection(entry);
+    try {
+      let status: CollabAuthorityTransferStatus;
+      if (!entry.status) {
+        const wasPossiblySent = entry.phase === 'submitted';
+        entry = await this.options.persistence.markCloudToLanManagerBeginPossiblySent(entry);
+        try {
+          status = await connection.lifecycle.authorityTransfer(
+            'beginCloudToLanTransfer',
+            entry.request,
+            options,
+          );
+        } catch (error) {
+          if (
+            !(error instanceof CloudAuthorityRejection)
+            || !isDefinitiveCloudToLanBeginRejection(error, wasPossiblySent)
+          ) throw error;
+          await this.settleRejectedCloudToLanManagerEntry(entry, connection, options);
+          return;
+        }
+      } else if (entry.cancellation) {
+        const priorStatus = entry.status;
+        entry = await this.options.persistence
+          .markCloudToLanManagerCancellationPossiblySent(entry);
+        try {
+          status = await connection.lifecycle.authorityTransfer(
+            'cancelProjectAuthorityTransfer',
+            entry.cancellation!.request,
+            options,
+          );
+        } catch (error) {
+          if (!(error instanceof CloudAuthorityRejection)) throw error;
+          status = await connection.lifecycle.authorityTransfer(
+            'getProjectAuthorityTransfer',
+            { projectId, transferId: priorStatus.transferId },
+            options,
+          );
+          if (status.phase === priorStatus.phase) throw error;
+        }
+      } else {
+        status = await connection.lifecycle.authorityTransfer(
+          'getProjectAuthorityTransfer',
+          { projectId, transferId: entry.status.transferId },
+          options,
+        );
+      }
+      const observed = await this.options.persistence.recordCloudToLanManagerStatus(entry, status);
+      if (observed.phase === 'settled') {
+        await this.options.persistence.settleCloudToLanManagerEntry(observed);
+      }
+    } finally {
+      connection.dispose();
+    }
+  }
+
+  private async resumeAuthorityTransferRecord(
+    record: AuthorityTransferRecord,
+    options: CollabOperationOptions,
+  ): Promise<void> {
+    if (record.terminalCleanupCompleted) {
+      await this.options.persistence.completeTerminalCleanup({
+        operationIntentId: record.operationIntentId,
+        projectId: record.projectId,
+        stagingDirectoryName: record.stagingDirectoryName,
+        transferId: record.transferId,
+      });
+    } else {
+      await this.runtimes.resume(record, options);
+    }
+    const current = await this.options.persistence.load(record.projectId);
+    if (
+      current
+      && current.localRole === 'target'
+      && current.status.direction === 'cloud-to-lan'
+      && (current.status.state === 'cancelled' || current.status.state === 'completed')
+    ) await this.settleRecoveredCloudToLanManager(current);
+  }
+
+  private async settleRecoveredCloudToLanManager(
+    record: AuthorityTransferRecord,
+  ): Promise<void> {
+    const entry = await this.options.persistence.loadCloudToLanManagerEntry(record.projectId);
+    if (!entry?.status) return;
+    if (!this.cloudToLanManagerMatchesPhysical(entry, record)) {
+      throw moduleError('authority-transfer-manager-physical-mismatch');
+    }
+    await this.settleMatchingCloudToLanManager(
+      cloudToLanTransferHandle(entry),
+      record.status,
+    );
+  }
+
+  private cloudToLanManagerMatchesPhysical(
+    entry: CloudToLanManagerEntryRecord,
+    record: AuthorityTransferRecord,
+  ): boolean {
+    return entry.status !== null
+      && record.localRole === 'target'
+      && record.status.direction === 'cloud-to-lan'
+      && entry.operationIntentId === record.operationIntentId
+      && entry.projectId === record.projectId
+      && entry.status.transferId === record.transferId
+      && entry.status.createdAt === record.status.createdAt
+      && entry.status.expiresAt === record.status.expiresAt
+      && entry.descriptor.sourceAuthorityGeneration
+        === record.status.sourceAuthority.generation
+      && entry.descriptor.targetUrl === record.status.targetUrl;
+  }
+
+  private async assertCloudToLanManagerSettled(projectId: CollabProjectId): Promise<void> {
+    const entry = await this.options.persistence.loadCloudToLanManagerEntry(projectId);
+    if (entry && entry.phase !== 'settled') {
+      throw moduleError('authority-transfer-manager-observer-pending');
+    }
+  }
+
+  private async settleMatchingCloudToLanManager(
+    handle: CloudToLanTransferHandle,
+    status: CollabAuthorityTransferStatus,
+  ): Promise<void> {
+    const entry = await this.options.persistence.loadCloudToLanManagerEntry(
+      handle.projectId,
+    );
+    if (
+      !entry?.status
+      || !sameCloudToLanTransferHandle(cloudToLanTransferHandle(entry), handle)
+    ) return;
+    if (entry.phase === 'settled') {
+      await this.options.persistence.settleCloudToLanManagerEntry(entry);
+      return;
+    }
+    if (entry.phase !== 'submitted' && entry.phase !== 'observing') return;
+    const observed = await this.options.persistence.recordCloudToLanManagerStatus(entry, status);
+    if (observed.phase === 'settled') {
+      await this.options.persistence.settleCloudToLanManagerEntry(observed);
+    }
+  }
+
+  private async requireCloudToLanManagerConnection(
+    entry: NonNullable<Awaited<ReturnType<AuthorityTransferPersistence['loadCloudToLanManagerEntry']>>>,
+  ): Promise<CloudToLanEntryConnection> {
+    const createConnection = this.options.createCloudToLanConnection;
+    const connection = await createConnection(entry.projectId);
+    try {
+      this.assertCloudToLanManagerConnection(entry, connection);
+      return connection;
+    } catch (error) {
+      connection.dispose();
+      throw error;
+    }
+  }
+
+  private async settleRejectedCloudToLanManagerEntry(
+    entry: CloudToLanManagerEntryRecord,
+    connection: CloudToLanEntryConnection,
+    options: CollabOperationOptions,
+  ): Promise<void> {
+    const [snapshot, listed] = await Promise.all([
+      connection.readSnapshot(entry.projectId, options),
+      connection.listProjectMembers({ projectId: entry.projectId }, options),
+    ]);
+    this.assertCloudToLanConnectionIdentity(connection, snapshot);
+    const initiatingMembers = listed.projectId === entry.projectId
+      ? listed.members.filter(member => member.memberId === entry.initiatingMemberId)
+      : [];
+    if (
+      snapshot.project.authorityGeneration !== entry.descriptor.sourceAuthorityGeneration
+      || snapshot.currentMember.id !== entry.initiatingMemberId
+      || snapshot.currentMember.personalRef !== entry.initiatingPersonalRef
+      || initiatingMembers.length !== 1
+      || initiatingMembers[0]?.bindingState !== (
+        snapshot.currentMember.role === 'manager' ? 'bound' : 'hidden'
+      )
+      || initiatingMembers[0].role !== snapshot.currentMember.role
+    ) throw moduleError('authority-transfer-manager-rejection-barrier-mismatch');
+    const rejected = await this.options.persistence.rejectCloudToLanManagerEntry(entry);
+    await this.options.persistence.settleCloudToLanManagerEntry(rejected);
+  }
+
+  private assertCloudToLanManagerConnection(
+    entry: NonNullable<Awaited<ReturnType<AuthorityTransferPersistence['loadCloudToLanManagerEntry']>>>,
+    connection: CloudToLanEntryConnection,
+  ): void {
+    if (
+      connection.projectId !== entry.projectId
+      || connection.memberId !== entry.initiatingMemberId
+      || connection.personalRef !== entry.initiatingPersonalRef
+      || connection.serverUrl !== entry.descriptor.sourceCloudUrl
+      || connection.authorityGeneration !== entry.descriptor.sourceAuthorityGeneration
+    ) {
+      throw moduleError('authority-transfer-cloud-binding-mismatch');
+    }
+  }
+
+  private assertCloudToLanTargetConnection(
+    entry: NonNullable<Awaited<ReturnType<AuthorityTransferPersistence['loadCloudToLanTargetEntry']>>>,
+    connection: CloudToLanEntryConnection,
+  ): void {
+    if (
+      connection.projectId !== entry.projectId
+      || connection.memberId !== entry.selectedTargetMemberId
+      || connection.personalRef !== entry.selectedTargetPersonalRef
+      || connection.serverUrl !== entry.sourceCloudUrl
+      || connection.authorityGeneration !== entry.sourceAuthorityGeneration
+    ) {
+      throw moduleError('authority-transfer-cloud-binding-mismatch');
+    }
+  }
+
+  private async requireCloudToLanManagerStatus(
+    projectId: CollabProjectId,
+  ) {
+    const entry = await this.options.persistence.loadCloudToLanManagerEntry(projectId);
+    if (!entry?.status || entry.phase === 'settled') {
+      throw moduleError('authority-transfer-manager-status-missing');
+    }
+    return entry;
+  }
+
+  private assertCloudToLanConnectionIdentity(
+    connection: CloudToLanEntryConnection,
+    snapshot: Awaited<ReturnType<CloudToLanEntryConnection['readSnapshot']>>,
+  ): void {
+    if (
+      connection.projectId !== snapshot.project.id
+      || connection.authorityGeneration !== snapshot.project.authorityGeneration
+      || connection.memberId !== snapshot.currentMember.id
+      || connection.personalRef !== snapshot.currentMember.personalRef
+    ) throw moduleError('authority-transfer-cloud-binding-mismatch');
+  }
+
+  async close(): Promise<void> {
+    const sourceBindings = [...this.sourceBindings.values()];
+    const targetBindings = [...this.targetBindings.values()];
+    const targetPreparations = [...this.targetPreparations.values()];
+    const recoveredCloudSessions = [...this.recoveredCloudSessions.values()];
+    this.sourceBindings.clear();
+    this.targetBindings.clear();
+    this.targetPreparations.clear();
+    this.recoveredCloudSessions.clear();
+    await Promise.all([
+      ...sourceBindings.map(async binding => {
+        binding.unregister();
+        await binding.cleanupRoute();
+      }),
+      ...targetBindings.map(binding => binding.dispose()),
+      ...targetPreparations.map(preparation => disposeCloudToLanTargetPreparation(
+        preparation.connection,
+        preparation.target,
+      )),
+      ...recoveredCloudSessions.map(async session => { session.dispose(); }),
+    ]);
   }
 
   bindLanToCloudClaimant(
@@ -523,8 +1484,13 @@ export class AuthorityTransferModule {
             endpoint: input.targetHost.endpoint,
             hostCaCertificatePem: input.targetHost.caCertificatePem,
             hostCaFingerprint: input.targetHost.caFingerprint,
+            identity: {
+              authorityGeneration: record.status.targetAuthority.generation,
+              currentMember: snapshot.currentMember,
+              eventSequence: snapshot.eventSequence,
+              project: snapshot.project,
+            },
             memberCredential: targetCredential,
-            snapshot,
             status: record.status,
           });
         },
@@ -615,8 +1581,13 @@ export class AuthorityTransferModule {
             endpoint: input.targetHost.endpoint,
             hostCaCertificatePem: input.targetHost.caCertificatePem,
             hostCaFingerprint: input.targetHost.caFingerprint,
+            identity: {
+              authorityGeneration: record.status.targetAuthority.generation,
+              currentMember: snapshot.currentMember,
+              eventSequence: snapshot.eventSequence,
+              project: snapshot.project,
+            },
             memberCredential: targetCredential,
-            snapshot,
             status: record.status,
           });
         },
@@ -848,17 +1819,20 @@ export class AuthorityTransferModule {
         });
         try {
           await binding.coordinator.restoreSourceEndpoint(record);
+          this.recoveredCloudSessions.set(record.projectId, session);
           return binding.coordinator;
         } catch (error) {
           await binding.dispose();
           throw error;
         }
       }
-      return (await this.bindCloudToLanTarget({
+      const coordinator = (await this.bindCloudToLanTarget({
         cloudSession: session,
         expectedTargetUrl: record.status.targetUrl,
         projectId: record.projectId,
       })).coordinator;
+      this.recoveredCloudSessions.set(record.projectId, session);
+      return coordinator;
     } catch (error) {
       session.dispose();
       throw error;

--- a/src/app/collab/authority-transfer/AuthorityTransferObservedStatus.ts
+++ b/src/app/collab/authority-transfer/AuthorityTransferObservedStatus.ts
@@ -74,19 +74,64 @@ function intermediateStatus(
 }
 
 function sameIdentity(
-  record: AuthorityTransferRecord,
+  current: CollabAuthorityTransferStatus,
   observed: CollabAuthorityTransferStatus,
 ): boolean {
-  return record.projectId === observed.projectId
-    && record.transferId === observed.transferId
-    && record.status.direction === observed.direction
-    && record.status.sourceAuthority.kind === observed.sourceAuthority.kind
-    && record.status.sourceAuthority.generation === observed.sourceAuthority.generation
-    && record.status.targetAuthority.kind === observed.targetAuthority.kind
-    && record.status.targetAuthority.generation === observed.targetAuthority.generation
-    && record.status.targetUrl === observed.targetUrl
-    && record.status.createdAt === observed.createdAt
-    && record.status.expiresAt === observed.expiresAt;
+  return current.projectId === observed.projectId
+    && current.transferId === observed.transferId
+    && current.direction === observed.direction
+    && current.sourceAuthority.kind === observed.sourceAuthority.kind
+    && current.sourceAuthority.generation === observed.sourceAuthority.generation
+    && current.targetAuthority.kind === observed.targetAuthority.kind
+    && current.targetAuthority.generation === observed.targetAuthority.generation
+    && current.targetUrl === observed.targetUrl
+    && current.createdAt === observed.createdAt
+    && current.expiresAt === observed.expiresAt;
+}
+
+export function assertAuthorityTransferStatusObservation(
+  current: CollabAuthorityTransferStatus,
+  observedValue: CollabAuthorityTransferStatus,
+): CollabAuthorityTransferStatus {
+  const observed = decodeCollabAuthorityTransferStatus(observedValue);
+  if (!sameIdentity(current, observed)) {
+    throw statusError('authority-transfer-observed-identity-mismatch');
+  }
+  if (Date.parse(observed.updatedAt) < Date.parse(current.updatedAt)) {
+    throw statusError('authority-transfer-observed-time-regressed');
+  }
+  const path = phases(observed);
+  const currentIndex = path.indexOf(current.phase);
+  const observedIndex = path.indexOf(observed.phase);
+  const crossingIntoCancellation = observedIndex >= 0
+    && currentIndex < 0
+    && current.relinquishmentProof === null;
+  if ((!crossingIntoCancellation && currentIndex < 0) || observedIndex < 0) {
+    throw statusError('authority-transfer-observed-phase-family-mismatch');
+  }
+  if (!crossingIntoCancellation && observedIndex < currentIndex) {
+    throw statusError('authority-transfer-observed-phase-regressed');
+  }
+  if (
+    current.checkpointSha256 !== null
+    && current.checkpointSha256 !== observed.checkpointSha256
+  ) throw statusError('authority-transfer-observed-checkpoint-mismatch');
+  if (current.batchRevision !== null && (
+    current.batchRevision !== observed.batchRevision
+    || current.batchSha256 !== observed.batchSha256
+  )) throw statusError('authority-transfer-observed-batch-mismatch');
+  if (
+    current.relinquishmentProof !== null
+    && JSON.stringify(current.relinquishmentProof)
+      !== JSON.stringify(observed.relinquishmentProof)
+  ) throw statusError('authority-transfer-observed-relinquishment-mismatch');
+  if (current.phase === observed.phase) {
+    if (JSON.stringify(current) !== JSON.stringify(observed)) {
+      throw statusError('authority-transfer-observed-phase-conflict');
+    }
+    return observed;
+  }
+  return observed;
 }
 
 function canAdoptLanToCloudCanonicalIdentity(
@@ -124,16 +169,11 @@ export async function advanceThroughObservedAuthorityStatus(
   observedValue: CollabAuthorityTransferStatus,
 ): Promise<AuthorityTransferRecord> {
   const observed = decodeCollabAuthorityTransferStatus(observedValue);
-  const adoptingCanonicalIdentity = !sameIdentity(initial, observed)
+  const adoptingCanonicalIdentity = !sameIdentity(initial.status, observed)
     && canAdoptLanToCloudCanonicalIdentity(initial, observed);
-  if (!sameIdentity(initial, observed) && !adoptingCanonicalIdentity) {
-    throw statusError('authority-transfer-observed-identity-mismatch');
-  }
-  if (initial.status.phase === observed.phase) {
-    if (JSON.stringify(initial.status) !== JSON.stringify(observed)) {
-      throw statusError('authority-transfer-observed-phase-conflict');
-    }
-    return initial;
+  if (!adoptingCanonicalIdentity) {
+    assertAuthorityTransferStatusObservation(initial.status, observed);
+    if (initial.status.phase === observed.phase) return initial;
   }
   const path = phases(observed);
   const currentIndex = path.indexOf(initial.status.phase);

--- a/src/app/collab/authority-transfer/AuthorityTransferOperationIdentity.ts
+++ b/src/app/collab/authority-transfer/AuthorityTransferOperationIdentity.ts
@@ -2,10 +2,13 @@ import { createHash } from 'node:crypto';
 
 export type AuthorityTransferChildOperation =
   | 'accept'
+  | 'activate'
   | 'begin'
+  | 'cancel'
   | 'claims'
   | 'custody'
-  | 'relinquish';
+  | 'relinquish'
+  | 'stage';
 
 export function authorityTransferChildIdempotencyKey(
   operationIntentId: string,

--- a/src/app/collab/authority-transfer/AuthorityTransferRecord.ts
+++ b/src/app/collab/authority-transfer/AuthorityTransferRecord.ts
@@ -241,7 +241,10 @@ export function decodeAuthorityTransferRecord(value: unknown): AuthorityTransfer
     throw new TypeError('Invalid authority transfer ownership');
   }
   if (relinquishmentProof !== null && (
-    relinquishmentProof.operationIntentId !== operationIntentId
+    (
+      status.direction === 'lan-to-cloud'
+      && relinquishmentProof.operationIntentId !== operationIntentId
+    )
     || relinquishmentProof.committedAt < status.createdAt
     || relinquishmentProof.committedAt > status.updatedAt
     || relinquishmentProof.committedAt >= status.expiresAt

--- a/src/app/collab/authority-transfer/AuthorityTransferRuntimeRegistry.ts
+++ b/src/app/collab/authority-transfer/AuthorityTransferRuntimeRegistry.ts
@@ -1,7 +1,6 @@
 import { type CollabProjectId } from '@claudian-collab/protocol';
 
 import type { AuthorityTransferRecord } from '@/app/collab/authority-transfer/AuthorityTransferRecord';
-import type { AuthorityTransferRecoveryHandler } from '@/app/collab/authority-transfer/recovery/AuthorityTransferRecovery';
 import type { CollabOperationOptions } from '@/core/collab';
 import { CollabError } from '@/core/collab/ClaudianCollabError';
 
@@ -35,7 +34,7 @@ function runtimeError(reason: string): CollabError {
  * Holds only live operation adapters. Durable ownership remains in the
  * Project-local transfer record and the existing lifecycle recovery catalog.
  */
-export class AuthorityTransferRuntimeRegistry implements AuthorityTransferRecoveryHandler {
+export class AuthorityTransferRuntimeRegistry {
   private readonly runtimes = new Map<CollabProjectId, RegisteredRuntime>();
 
   constructor(private readonly resolver?: AuthorityTransferRuntimeResolver) {}

--- a/src/app/collab/authority-transfer/CollabAuthorityTransferOutcomeError.ts
+++ b/src/app/collab/authority-transfer/CollabAuthorityTransferOutcomeError.ts
@@ -1,0 +1,8 @@
+import type { CollabResult } from '@/core/collab';
+
+/** Carries one durable transfer operation's safe recovery identity across the feature seam. */
+export class CollabAuthorityTransferOutcomeError extends Error {
+  constructor(readonly result: Extract<CollabResult<never>, { status: 'recovery-required' }>) {
+    super('Authority transfer did not complete');
+  }
+}

--- a/src/app/collab/authority-transfer/DurablePrivateFile.ts
+++ b/src/app/collab/authority-transfer/DurablePrivateFile.ts
@@ -37,3 +37,17 @@ export async function writeDurablePrivateFile(
     throw errors.writeFailed();
   }
 }
+
+export async function removeDurablePrivateFile(
+  filePath: string,
+  removeFailed: () => Error,
+): Promise<void> {
+  try {
+    await rm(filePath, { force: true });
+  } catch {
+    throw removeFailed();
+  }
+  const directory = await open(path.dirname(filePath), 'r').catch(() => null);
+  await directory?.sync().catch(() => undefined);
+  await directory?.close().catch(() => undefined);
+}

--- a/src/app/collab/authority-transfer/checkpoint/AuthorityTransferCheckpointRepository.ts
+++ b/src/app/collab/authority-transfer/checkpoint/AuthorityTransferCheckpointRepository.ts
@@ -16,6 +16,10 @@ import type {
   AuthoritySqlRow,
   AuthoritySqlValue,
 } from '@/app/collab/authority/SqlJsProjectDatabase';
+import {
+  type AuthorityTransferImportedTargetIdentity,
+  decodeAuthorityTransferImportedTargetIdentity,
+} from '@/app/collab/authority-transfer/AuthorityTransferImportedTargetIdentity';
 import { verifyAuthorityTransferCheckpointManifest } from '@/app/collab/authority-transfer/checkpoint/AuthorityTransferCheckpointManifest';
 import { CollabError } from '@/core/collab/ClaudianCollabError';
 
@@ -336,6 +340,47 @@ function requireEmptyAuthority(connection: AuthorityDatabaseConnection): void {
   }
 }
 
+function importedTargetIdentity(
+  connection: AuthorityDatabaseConnection,
+  targetHostMemberId: CollabMemberId,
+): AuthorityTransferImportedTargetIdentity {
+  const project = connection.get(`
+    SELECT project_id, name
+    FROM project
+    WHERE singleton = 1
+  `);
+  const member = connection.get(`
+    SELECT member_id, display_name, personal_ref, role, status, access_state
+    FROM members
+    WHERE member_id = ?
+  `, [targetHostMemberId]);
+  const sequence = connection.get(`
+    SELECT COALESCE(MAX(sequence), 0) AS event_sequence
+    FROM events
+  `);
+  if (
+    !project
+    || !member
+    || status(member.status) !== 'active'
+    || text(member, 'access_state') !== 'bound'
+    || !sequence
+  ) throw checkpointError('checkpoint-imported-target-identity-invalid');
+  return decodeAuthorityTransferImportedTargetIdentity({
+    authorityGeneration: new AuthorityMetadataRepository().getGeneration(connection),
+    currentMember: {
+      displayName: text(member, 'display_name'),
+      id: text(member, 'member_id'),
+      personalRef: text(member, 'personal_ref'),
+      role: role(member.role),
+    },
+    eventSequence: integer(sequence, 'event_sequence'),
+    project: {
+      id: text(project, 'project_id'),
+      name: text(project, 'name'),
+    },
+  });
+}
+
 export class AuthorityTransferCheckpointRepository {
   activateImportedAuthority(
     connection: AuthorityDatabaseConnection,
@@ -383,7 +428,7 @@ export class AuthorityTransferCheckpointRepository {
   importCoordination(
     connection: AuthorityDatabaseConnection,
     input: ImportAuthorityTransferCoordinationInput,
-  ): void {
+  ): AuthorityTransferImportedTargetIdentity {
     if (input.targetHostCredentialHash.byteLength !== 32) {
       throw checkpointError('checkpoint-target-credential-invalid');
     }
@@ -566,5 +611,6 @@ export class AuthorityTransferCheckpointRepository {
           break;
       }
     }
+    return importedTargetIdentity(connection, input.targetHostMemberId);
   }
 }

--- a/src/app/collab/authority-transfer/claim/AuthorityTransferClaimantRecovery.ts
+++ b/src/app/collab/authority-transfer/claim/AuthorityTransferClaimantRecovery.ts
@@ -13,6 +13,10 @@ import type { CollabOperationOptions } from '@/core/collab';
 import { CollabError } from '@/core/collab/ClaudianCollabError';
 
 export interface AuthorityTransferClaimantRecoveryHandler {
+  beforeProject(
+    projectId: CollabProjectId,
+    options: CollabOperationOptions,
+  ): Promise<void>;
   resume(
     record: AuthorityTransferClaimantRecord,
     options: CollabOperationOptions,
@@ -81,6 +85,7 @@ implements CollabProjectLifecycleRecoveryStage {
         this.durableOwner.name,
         'recovery',
         async () => {
+          await this.handler.beforeProject(projectId, options);
           const record = await this.store.load(projectId);
           if (!record) return;
           if (requiresNoRuntime(record, this.now())) {

--- a/src/app/collab/authority-transfer/cloud-to-lan/CloudToLanTargetCoordinator.ts
+++ b/src/app/collab/authority-transfer/cloud-to-lan/CloudToLanTargetCoordinator.ts
@@ -2,11 +2,9 @@ import type { Readable } from 'node:stream';
 
 import {
   type AcceptCloudToLanTransferTargetRequest,
-  COLLAB_AUTHORITY_TRANSFER_CANCELLABLE_PHASES,
   COLLAB_AUTHORITY_TRANSFER_CANCELLATION_PHASES,
   COLLAB_PROJECT_CHECKPOINT_ARTIFACTS,
   type CollabAuthorityRelinquishmentProof,
-  type CollabAuthorityTransferCancellablePhase,
   type CollabAuthorityTransferStatus,
   type CollabCheckpointAuthority,
   type CollabCloudAuthorityTransferArtifact,
@@ -21,9 +19,18 @@ import {
   advanceThroughObservedAuthorityStatus,
 } from '@/app/collab/authority-transfer/AuthorityTransferObservedStatus';
 import {
+  authorityTransferChildIdempotencyKey,
+} from '@/app/collab/authority-transfer/AuthorityTransferOperationIdentity';
+import {
   type AuthorityTransferRecord,
   createAuthorityTransferRecord,
 } from '@/app/collab/authority-transfer/AuthorityTransferRecord';
+import {
+  assertCloudToLanTargetHandle,
+  type CloudToLanTargetEntryRecord,
+  type CloudToLanTransferHandle,
+  decodeCloudToLanTransferHandle,
+} from '@/app/collab/authority-transfer/cloud-to-lan/CloudToLanTransferEntryRecord';
 import type {
   AuthorityTransferPersistence,
 } from '@/app/collab/authority-transfer/persistence/AuthorityTransferPersistence';
@@ -45,12 +52,17 @@ export interface CloudToLanTargetStageResult {
   readonly checkpointSha256: string;
   readonly stageSha256: string;
   readonly targetAuthority: CollabCheckpointAuthority & { readonly kind: 'lan' };
+  readonly targetHostMemberId: string;
   readonly targetProof: string;
 }
 
 export interface CloudToLanTargetEffects {
-  dispose?(): void;
-  prepareTarget?(expectedEndpoint?: string): Promise<Readonly<{ readonly targetUrl: string }>>;
+  dispose?(): Promise<void> | void;
+  prepareTarget?(expectedEndpoint?: string): Promise<Readonly<{
+    readonly caCertificatePem?: string;
+    readonly caFingerprint?: string;
+    readonly targetUrl: string;
+  }>>;
   acceptanceRequest(
     record: AuthorityTransferRecord,
     options?: CollabOperationOptions,
@@ -100,15 +112,6 @@ function assertTargetStatus(
   }
 }
 
-function cancellablePhase(
-  phase: CollabAuthorityTransferStatus['phase'],
-): CollabAuthorityTransferCancellablePhase {
-  if (!COLLAB_AUTHORITY_TRANSFER_CANCELLABLE_PHASES.includes(phase as never)) {
-    throw new CollabError({ code: 'authority-transfer-cancellation-forbidden' });
-  }
-  return phase as CollabAuthorityTransferCancellablePhase;
-}
-
 export class CloudToLanTargetCoordinator {
   constructor(private readonly options: CloudToLanTargetCoordinatorOptions) {}
 
@@ -118,34 +121,58 @@ export class CloudToLanTargetCoordinator {
     }
   }
 
-  async acceptAndTransfer(
-    request: AcceptCloudToLanTransferTargetRequest,
-    operationIntentId: string,
+  async acceptPreparedTransfer(
+    input: CloudToLanTransferHandle,
     options: CollabOperationOptions = {},
   ): Promise<CollabAuthorityTransferStatus> {
+    const handle = decodeCloudToLanTransferHandle(input);
+    const entry = await this.options.persistence.loadCloudToLanTargetEntry(handle.projectId);
+    this.assertPreparedHandle(entry, handle);
+    if (entry.phase === 'handed-off') {
+      const record = await this.options.persistence.load(handle.projectId);
+      if (
+        !record
+        || record.localRole !== 'target'
+        || record.ownerInstallationKey !== this.options.installationKey
+        || record.operationIntentId !== handle.operationIntentId
+        || record.transferId !== handle.transferId
+      ) throw targetError('cloud-to-lan-target-successor-mismatch');
+      return this.resumeRecord(record, options, entry.selectedTargetMemberId);
+    }
     const proposed = await this.options.cloud.authorityTransfer(
       'getProjectAuthorityTransfer',
-      { projectId: request.projectId, transferId: request.transferId },
+      { projectId: handle.projectId, transferId: handle.transferId },
       options,
     );
-    assertTargetStatus(proposed, request.projectId);
-    if (proposed.phase !== 'collecting-readiness') {
-      throw targetError('cloud-to-lan-proposal-phase-invalid');
+    assertTargetStatus(proposed, handle.projectId);
+    if (
+      proposed.transferId !== handle.transferId
+      || proposed.sourceAuthority.kind !== 'cloud'
+      || proposed.sourceAuthority.generation !== handle.sourceAuthorityGeneration
+      || proposed.targetAuthority.kind !== 'lan'
+      || proposed.targetAuthority.generation !== handle.sourceAuthorityGeneration + 1
+      || proposed.targetUrl !== handle.targetUrl
+    ) throw targetError('cloud-to-lan-prepared-status-mismatch');
+    if (proposed.state === 'cancelled' && proposed.phase === 'cancelled') {
+      await this.options.persistence.withdrawCloudToLanTargetEntry(entry);
+      return proposed;
+    }
+    if (proposed.state !== 'active' || proposed.phase !== 'collecting-readiness') {
+      throw targetError('cloud-to-lan-prepared-status-mismatch');
     }
     const record = createAuthorityTransferRecord({
       lifecycleOwnership: 'owned',
       localRole: 'target',
-      operationIntentId,
+      operationIntentId: handle.operationIntentId,
       ownerInstallationKey: this.options.installationKey,
       stagingDirectoryName: `.claudian-authority-transfer-${proposed.transferId}`,
       status: proposed,
     });
-    await this.options.persistence.create(record);
-    const recoverableRequest = await this.options.target.acceptanceRequest(record, options);
-    if (JSON.stringify(recoverableRequest) !== JSON.stringify(request)) {
-      throw targetError('cloud-to-lan-target-acceptance-mismatch');
-    }
-    return this.resumeRecord(record, options);
+    const persisted = await this.options.persistence.handoffCloudToLanTargetEntry(
+      entry,
+      record,
+    );
+    return this.resumeRecord(persisted, options, handle.selectedTargetMemberId);
   }
 
   async resume(
@@ -157,49 +184,28 @@ export class CloudToLanTargetCoordinator {
       throw targetError('cloud-to-lan-record-missing');
     }
     this.assertOwnedRecord(record);
-    return this.resumeRecord(record, options);
-  }
-
-  async cancel(
-    projectId: CollabProjectId,
-    options: CollabOperationOptions = {},
-  ): Promise<CollabAuthorityTransferStatus> {
-    const record = await this.options.persistence.load(projectId);
-    if (!record || record.localRole !== 'target') {
-      throw targetError('cloud-to-lan-record-missing');
-    }
-    this.assertOwnedRecord(record);
-    if (record.status.relinquishmentProof !== null) {
-      throw new CollabError({ code: 'authority-transfer-cancellation-forbidden' });
-    }
-    const cancelled = await this.options.cloud.authorityTransfer(
-      'cancelProjectAuthorityTransfer',
-      {
-        expectedPhase: cancellablePhase(record.status.phase),
-        idempotencyKey: `${record.operationIntentId}-cancel`,
-        projectId: record.projectId,
-        transferId: record.transferId,
-      },
-      options,
-    );
-    const cancelling = await advanceThroughObservedAuthorityStatus(
-      this.options.persistence,
-      record,
-      cancelled,
-    );
-    return this.resumeRecord(cancelling, options);
+    const targetEntry = await this.options.persistence.loadCloudToLanTargetEntry(projectId);
+    if (
+      !targetEntry
+      || targetEntry.phase !== 'handed-off'
+      || targetEntry.ownerInstallationKey !== this.options.installationKey
+      || targetEntry.successor?.operationIntentId !== record.operationIntentId
+      || targetEntry.successor.ownerInstallationKey !== record.ownerInstallationKey
+      || targetEntry.successor.transferId !== record.transferId
+    ) throw targetError('cloud-to-lan-target-successor-mismatch');
+    return this.resumeRecord(record, options, targetEntry.selectedTargetMemberId);
   }
 
   private async resumeRecord(
     initial: AuthorityTransferRecord,
     options: CollabOperationOptions,
+    selectedTargetMemberId?: string,
   ): Promise<CollabAuthorityTransferStatus> {
     let record = initial;
     let activatedThisRun = false;
     for (let step = 0; step < 16; step += 1) {
       if (record.status.state === 'cancelled') {
-        await this.options.target.cancelStaging(record, options);
-        return record.status;
+        return this.completeCancellation(record, options);
       }
       if (record.status.state === 'completed') {
         const proof = record.status.relinquishmentProof;
@@ -216,21 +222,42 @@ export class CloudToLanTargetCoordinator {
       )) {
         await this.options.target.cancelStaging(record, options);
         record = await this.readAndAdvance(record, options);
-        if (record.status.state === 'cancelled') return record.status;
+        if (record.status.state === 'cancelled') {
+          await this.options.persistence.completeTerminalCleanup({
+            operationIntentId: record.operationIntentId,
+            projectId: record.projectId,
+            stagingDirectoryName: record.stagingDirectoryName,
+            transferId: record.transferId,
+          });
+          return record.status;
+        }
         continue;
       }
       if (record.status.phase === 'collecting-readiness') {
-      const accepted = await this.options.cloud.authorityTransfer(
-        'acceptCloudToLanTransferTarget',
-        await this.options.target.acceptanceRequest(record, options),
-        options,
-      );
-      assertTargetStatus(accepted, record.projectId);
-      record = await advanceThroughObservedAuthorityStatus(
-        this.options.persistence,
-        record,
-        accepted,
-      );
+        const acceptance = await this.options.target.acceptanceRequest(record, options);
+        if (
+          acceptance.idempotencyKey !== authorityTransferChildIdempotencyKey(
+            record.operationIntentId,
+            'accept',
+          )
+          || acceptance.projectId !== record.projectId
+          || acceptance.transferId !== record.transferId
+          || (
+            selectedTargetMemberId !== undefined
+            && acceptance.targetHostMemberId !== selectedTargetMemberId
+          )
+        ) throw targetError('cloud-to-lan-target-acceptance-mismatch');
+        const accepted = await this.options.cloud.authorityTransfer(
+          'acceptCloudToLanTransferTarget',
+          acceptance,
+          options,
+        );
+        assertTargetStatus(accepted, record.projectId);
+        record = await advanceThroughObservedAuthorityStatus(
+          this.options.persistence,
+          record,
+          accepted,
+        );
         continue;
       }
       if (record.status.phase === 'cloud-quiesced') {
@@ -238,43 +265,51 @@ export class CloudToLanTargetCoordinator {
         continue;
       }
       if (record.status.phase === 'checkpoint-captured') {
-      const artifacts: CloudToLanDownloadedArtifact[] = [];
-      let staged: CloudToLanTargetStageResult;
-      try {
-        for (const artifact of COLLAB_PROJECT_CHECKPOINT_ARTIFACTS) {
-          artifacts.push({
-            artifact,
-            ...await this.options.cloud.downloadAuthorityTransferArtifact({
+        const artifacts: CloudToLanDownloadedArtifact[] = [];
+        const stageOperationIntentId = authorityTransferChildIdempotencyKey(
+          record.operationIntentId,
+          'stage',
+        );
+        let staged: CloudToLanTargetStageResult;
+        try {
+          for (const artifact of COLLAB_PROJECT_CHECKPOINT_ARTIFACTS) {
+            artifacts.push({
               artifact,
-              projectId: record.projectId,
-              transferId: record.transferId,
-            }, options),
-          });
+              ...await this.options.cloud.downloadAuthorityTransferArtifact({
+                artifact,
+                projectId: record.projectId,
+                transferId: record.transferId,
+              }, options),
+            });
+          }
+          staged = await this.options.target.stage(record, artifacts, options);
+        } finally {
+          destroyAuthorityTransferArtifactBodies(artifacts);
         }
-        staged = await this.options.target.stage(record, artifacts, options);
-      } finally {
-        destroyAuthorityTransferArtifactBodies(artifacts);
-      }
-      await this.options.persistence.retainClaimBatch({
-        batch: staged.claimBatch,
-        operationIntentId: record.operationIntentId,
-        purpose: 'target-delivery',
-      });
-      const receipt = await this.options.cloud.authorityTransfer(
-        'reportCloudToLanTargetStaged',
-        {
-          checkpointSha256: staged.checkpointSha256,
-          claimBatch: staged.claimBatch,
-          idempotencyKey: `${record.operationIntentId}-stage`,
-          projectId: record.projectId,
-          stageSha256: staged.stageSha256,
-          targetAuthority: staged.targetAuthority,
-          targetProof: staged.targetProof,
-          transferId: record.transferId,
-        },
-        options,
-      );
-      await this.options.persistence.acknowledgeClaimBatch(receipt);
+        if (
+          selectedTargetMemberId === undefined
+          || staged.targetHostMemberId !== selectedTargetMemberId
+        ) throw targetError('cloud-to-lan-target-stage-member-mismatch');
+        await this.options.persistence.retainClaimBatch({
+          batch: staged.claimBatch,
+          operationIntentId: stageOperationIntentId,
+          purpose: 'target-delivery',
+        });
+        const receipt = await this.options.cloud.authorityTransfer(
+          'reportCloudToLanTargetStaged',
+          {
+            checkpointSha256: staged.checkpointSha256,
+            claimBatch: staged.claimBatch,
+            idempotencyKey: stageOperationIntentId,
+            projectId: record.projectId,
+            stageSha256: staged.stageSha256,
+            targetAuthority: staged.targetAuthority,
+            targetProof: staged.targetProof,
+            transferId: record.transferId,
+          },
+          options,
+        );
+        await this.options.persistence.acknowledgeClaimBatch(receipt);
         record = await this.readAndAdvance(record, options);
         continue;
       }
@@ -283,26 +318,29 @@ export class CloudToLanTargetCoordinator {
         continue;
       }
       if (record.status.phase === 'cloud-relinquished') {
-      const proof = record.status.relinquishmentProof;
-      if (!proof) throw targetError('cloud-to-lan-relinquishment-proof-missing');
-      const targetActivationProof = await this.options.target.activate(record, proof, options);
-      activatedThisRun = true;
-      const completed = await this.options.cloud.authorityTransfer(
-        'confirmCloudToLanTargetActive',
-        {
-          idempotencyKey: `${record.operationIntentId}-activate`,
-          projectId: record.projectId,
-          relinquishmentProof: proof,
-          targetActivationProof,
-          transferId: record.transferId,
-        },
-        options,
-      );
-      record = await advanceThroughObservedAuthorityStatus(
-        this.options.persistence,
-        record,
-        completed,
-      );
+        const proof = record.status.relinquishmentProof;
+        if (!proof) throw targetError('cloud-to-lan-relinquishment-proof-missing');
+        const targetActivationProof = await this.options.target.activate(record, proof, options);
+        activatedThisRun = true;
+        const completed = await this.options.cloud.authorityTransfer(
+          'confirmCloudToLanTargetActive',
+          {
+            idempotencyKey: authorityTransferChildIdempotencyKey(
+              record.operationIntentId,
+              'activate',
+            ),
+            projectId: record.projectId,
+            relinquishmentProof: proof,
+            targetActivationProof,
+            transferId: record.transferId,
+          },
+          options,
+        );
+        record = await advanceThroughObservedAuthorityStatus(
+          this.options.persistence,
+          record,
+          completed,
+        );
         continue;
       }
       if (record.status.phase === 'lan-activated') {
@@ -316,6 +354,35 @@ export class CloudToLanTargetCoordinator {
       throw targetError('cloud-to-lan-phase-unhandled');
     }
     throw targetError('cloud-to-lan-recovery-did-not-converge');
+  }
+
+  private assertPreparedHandle(
+    entry: CloudToLanTargetEntryRecord | null,
+    handle: CloudToLanTransferHandle,
+  ): asserts entry is CloudToLanTargetEntryRecord {
+    if (
+      !entry
+      || entry.ownerInstallationKey !== this.options.installationKey
+    ) throw targetError('cloud-to-lan-target-handle-mismatch');
+    try {
+      assertCloudToLanTargetHandle(entry, handle);
+    } catch {
+      throw targetError('cloud-to-lan-target-handle-mismatch');
+    }
+  }
+
+  private async completeCancellation(
+    record: AuthorityTransferRecord,
+    options: CollabOperationOptions,
+  ): Promise<CollabAuthorityTransferStatus> {
+    await this.options.target.cancelStaging(record, options);
+    await this.options.persistence.completeTerminalCleanup({
+      operationIntentId: record.operationIntentId,
+      projectId: record.projectId,
+      stagingDirectoryName: record.stagingDirectoryName,
+      transferId: record.transferId,
+    });
+    return record.status;
   }
 
   private readStatus(

--- a/src/app/collab/authority-transfer/cloud-to-lan/CloudToLanTransferEntryRecord.ts
+++ b/src/app/collab/authority-transfer/cloud-to-lan/CloudToLanTransferEntryRecord.ts
@@ -1,0 +1,673 @@
+import {
+  type BeginCloudToLanTransferRequest,
+  type CancelProjectAuthorityTransferRequest,
+  type CollabAuthorityTransferStatus,
+  type CollabIsoTimestamp,
+  type CollabMemberId,
+  type CollabProjectId,
+  decodeCollabAuthorityTransferOperationRequest,
+  decodeCollabAuthorityTransferStatus,
+  isCollabMemberId,
+  isCollabOpaqueId,
+  isCollabProjectId,
+} from '@claudian-collab/protocol';
+
+import type { AuthorityTransferEntrySuccessor } from '@/app/collab/authority-transfer/AuthorityTransferEntryRecord';
+import {
+  assertAuthorityTransferStatusObservation,
+} from '@/app/collab/authority-transfer/AuthorityTransferObservedStatus';
+import type { AuthorityTransferRecord } from '@/app/collab/authority-transfer/AuthorityTransferRecord';
+import { validateCloudServerUrl } from '@/app/collab/remote-authority/CloudAuthorityUrls';
+import type {
+  CollabCloudToLanTargetPreparationDescriptor,
+  CollabCloudToLanTransferHandle,
+} from '@/core/collab/CollabFeaturePort';
+import {
+  type InstallationKey,
+  parseInstallationKey,
+} from '@/core/device/InstallationKey';
+
+export const CLOUD_TO_LAN_ENTRY_SCHEMA_VERSION = 1 as const;
+
+export type CloudToLanTargetPreparationDescriptor =
+  CollabCloudToLanTargetPreparationDescriptor;
+
+export type CloudToLanTransferHandle = CollabCloudToLanTransferHandle;
+
+export interface CloudToLanTargetEntryRecord {
+  readonly createdAt: CollabIsoTimestamp;
+  readonly descriptor: CloudToLanTargetPreparationDescriptor | null;
+  readonly entryRole: 'cloud-to-lan-target';
+  readonly expiresAt: CollabIsoTimestamp;
+  readonly operationIntentId: string;
+  readonly ownerInstallationKey: InstallationKey;
+  readonly phase: 'handed-off' | 'preparing' | 'published' | 'withdrawn';
+  readonly projectId: CollabProjectId;
+  readonly selectedTargetMemberId: CollabMemberId;
+  readonly selectedTargetPersonalRef: string;
+  readonly sourceAuthorityGeneration: number;
+  readonly sourceCloudUrl: string;
+  readonly successor: AuthorityTransferEntrySuccessor | null;
+  readonly withdrawnAt: CollabIsoTimestamp | null;
+}
+
+export interface CloudToLanManagerEntryRecord {
+  readonly cancellation: Readonly<{
+    readonly request: CancelProjectAuthorityTransferRequest;
+    readonly submission: 'not-sent' | 'possibly-sent';
+  }> | null;
+  readonly createdAt: CollabIsoTimestamp;
+  readonly descriptor: CloudToLanTargetPreparationDescriptor;
+  readonly entryRole: 'cloud-to-lan-manager';
+  readonly expiresAt: CollabIsoTimestamp;
+  readonly initiatingMemberId: CollabMemberId;
+  readonly initiatingPersonalRef: string;
+  readonly operationIntentId: string;
+  readonly phase: 'observing' | 'prepared' | 'rejected' | 'settled' | 'submitted';
+  readonly projectId: CollabProjectId;
+  readonly request: BeginCloudToLanTransferRequest;
+  readonly status: CollabAuthorityTransferStatus | null;
+}
+
+type UnknownRecord = Record<string, unknown>;
+
+const TARGET_KEYS = new Set([
+  'createdAt',
+  'descriptor',
+  'entryRole',
+  'expiresAt',
+  'operationIntentId',
+  'ownerInstallationKey',
+  'phase',
+  'projectId',
+  'selectedTargetMemberId',
+  'selectedTargetPersonalRef',
+  'sourceAuthorityGeneration',
+  'sourceCloudUrl',
+  'successor',
+  'withdrawnAt',
+]);
+const MANAGER_KEYS = new Set([
+  'cancellation',
+  'createdAt',
+  'descriptor',
+  'entryRole',
+  'expiresAt',
+  'initiatingMemberId',
+  'initiatingPersonalRef',
+  'operationIntentId',
+  'phase',
+  'projectId',
+  'request',
+  'status',
+]);
+const DESCRIPTOR_KEYS = new Set([
+  'caCertificatePem',
+  'caFingerprint',
+  'preparationId',
+  'projectId',
+  'publishedAt',
+  'schemaVersion',
+  'selectedTargetMemberId',
+  'sourceAuthorityGeneration',
+  'sourceCloudUrl',
+  'targetUrl',
+]);
+const SUCCESSOR_KEYS = new Set([
+  'operationIntentId',
+  'ownerInstallationKey',
+  'transferId',
+]);
+const FINGERPRINT_PATTERN = /^[0-9a-f]{64}$/;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasExactKeys(value: UnknownRecord, keys: ReadonlySet<string>): boolean {
+  const actual = Object.keys(value);
+  return actual.length === keys.size && actual.every(key => keys.has(key));
+}
+
+function timestamp(value: unknown): CollabIsoTimestamp {
+  if (
+    typeof value !== 'string'
+    || !Number.isFinite(Date.parse(value))
+    || new Date(value).toISOString() !== value
+  ) throw new TypeError('Invalid Cloud-to-LAN entry timestamp');
+  return value;
+}
+
+function generation(value: unknown): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 1) {
+    throw new TypeError('Invalid Cloud-to-LAN authority generation');
+  }
+  return value as number;
+}
+
+function cloudUrl(value: unknown): string {
+  if (
+    typeof value !== 'string'
+    || Buffer.byteLength(value, 'utf8') > 4096
+  ) throw new TypeError('Invalid Cloud-to-LAN source URL');
+  try {
+    return validateCloudServerUrl(value, 'Cloud-to-LAN source URL');
+  } catch {
+    throw new TypeError('Invalid Cloud-to-LAN source URL');
+  }
+}
+
+function lanUrl(value: unknown): string {
+  if (typeof value !== 'string') throw new TypeError('Invalid Cloud-to-LAN target URL');
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new TypeError('Invalid Cloud-to-LAN target URL');
+  }
+  if (
+    parsed.protocol !== 'https:'
+    || parsed.origin !== value
+    || parsed.username !== ''
+    || parsed.password !== ''
+    || parsed.port === ''
+  ) throw new TypeError('Invalid Cloud-to-LAN target URL');
+  return value;
+}
+
+function successor(value: unknown): AuthorityTransferEntrySuccessor | null {
+  if (value === null) return null;
+  if (!isRecord(value) || !hasExactKeys(value, SUCCESSOR_KEYS)) {
+    throw new TypeError('Invalid Cloud-to-LAN entry successor');
+  }
+  if (
+    typeof value.operationIntentId !== 'string'
+    || !isCollabOpaqueId(value.operationIntentId)
+    || typeof value.transferId !== 'string'
+    || !isCollabOpaqueId(value.transferId)
+    || typeof value.ownerInstallationKey !== 'string'
+  ) throw new TypeError('Invalid Cloud-to-LAN entry successor');
+  return {
+    operationIntentId: value.operationIntentId,
+    ownerInstallationKey: parseInstallationKey(value.ownerInstallationKey),
+    transferId: value.transferId,
+  };
+}
+
+export function decodeCloudToLanTargetPreparationDescriptor(
+  value: unknown,
+): CloudToLanTargetPreparationDescriptor {
+  if (
+    !isRecord(value)
+    || !hasExactKeys(value, DESCRIPTOR_KEYS)
+    || value.schemaVersion !== CLOUD_TO_LAN_ENTRY_SCHEMA_VERSION
+    || !isCollabProjectId(value.projectId)
+    || !isCollabMemberId(value.selectedTargetMemberId)
+    || typeof value.preparationId !== 'string'
+    || !isCollabOpaqueId(value.preparationId)
+    || typeof value.caCertificatePem !== 'string'
+    || value.caCertificatePem.length > 64 * 1024
+    || !value.caCertificatePem.startsWith('-----BEGIN CERTIFICATE-----\n')
+    || (
+      !value.caCertificatePem.endsWith('\n-----END CERTIFICATE-----')
+      && !value.caCertificatePem.endsWith('\n-----END CERTIFICATE-----\n')
+    )
+    || typeof value.caFingerprint !== 'string'
+    || !FINGERPRINT_PATTERN.test(value.caFingerprint)
+  ) throw new TypeError('Invalid Cloud-to-LAN target descriptor');
+  return Object.freeze({
+    caCertificatePem: value.caCertificatePem,
+    caFingerprint: value.caFingerprint,
+    preparationId: value.preparationId,
+    projectId: value.projectId,
+    publishedAt: timestamp(value.publishedAt),
+    schemaVersion: CLOUD_TO_LAN_ENTRY_SCHEMA_VERSION,
+    selectedTargetMemberId: value.selectedTargetMemberId,
+    sourceAuthorityGeneration: generation(value.sourceAuthorityGeneration),
+    sourceCloudUrl: cloudUrl(value.sourceCloudUrl),
+    targetUrl: lanUrl(value.targetUrl),
+  });
+}
+
+export function decodeCloudToLanTransferHandle(value: unknown): CloudToLanTransferHandle {
+  if (!isRecord(value)) throw new TypeError('Invalid Cloud-to-LAN transfer handle');
+  const keys = new Set([
+    'operationIntentId',
+    'preparationId',
+    'projectId',
+    'schemaVersion',
+    'selectedTargetMemberId',
+    'sourceAuthorityGeneration',
+    'sourceCloudUrl',
+    'targetUrl',
+    'transferId',
+  ]);
+  if (
+    !hasExactKeys(value, keys)
+    || value.schemaVersion !== CLOUD_TO_LAN_ENTRY_SCHEMA_VERSION
+    || !isCollabProjectId(value.projectId)
+    || !isCollabMemberId(value.selectedTargetMemberId)
+    || typeof value.operationIntentId !== 'string'
+    || !isCollabOpaqueId(value.operationIntentId)
+    || typeof value.preparationId !== 'string'
+    || !isCollabOpaqueId(value.preparationId)
+    || typeof value.transferId !== 'string'
+    || !isCollabOpaqueId(value.transferId)
+  ) throw new TypeError('Invalid Cloud-to-LAN transfer handle');
+  return Object.freeze({
+    operationIntentId: value.operationIntentId,
+    preparationId: value.preparationId,
+    projectId: value.projectId,
+    schemaVersion: CLOUD_TO_LAN_ENTRY_SCHEMA_VERSION,
+    selectedTargetMemberId: value.selectedTargetMemberId,
+    sourceAuthorityGeneration: generation(value.sourceAuthorityGeneration),
+    sourceCloudUrl: cloudUrl(value.sourceCloudUrl),
+    targetUrl: lanUrl(value.targetUrl),
+    transferId: value.transferId,
+  });
+}
+
+export function assertCloudToLanTargetHandle(
+  entry: CloudToLanTargetEntryRecord,
+  handle: CloudToLanTransferHandle,
+): void {
+  if (
+    (entry.phase !== 'published' && entry.phase !== 'handed-off')
+    || !entry.descriptor
+    || entry.operationIntentId !== handle.preparationId
+    || entry.projectId !== handle.projectId
+    || entry.selectedTargetMemberId !== handle.selectedTargetMemberId
+    || entry.sourceAuthorityGeneration !== handle.sourceAuthorityGeneration
+    || entry.sourceCloudUrl !== handle.sourceCloudUrl
+    || entry.descriptor.targetUrl !== handle.targetUrl
+    || (
+      entry.successor !== null
+      && (
+        entry.successor.operationIntentId !== handle.operationIntentId
+        || entry.successor.transferId !== handle.transferId
+      )
+    )
+  ) throw new TypeError('Cloud-to-LAN target handle mismatch');
+}
+
+export function decodeCloudToLanTargetEntryRecord(
+  value: unknown,
+): CloudToLanTargetEntryRecord {
+  if (
+    !isRecord(value)
+    || !hasExactKeys(value, TARGET_KEYS)
+    || value.entryRole !== 'cloud-to-lan-target'
+    || !isCollabProjectId(value.projectId)
+    || !isCollabMemberId(value.selectedTargetMemberId)
+    || typeof value.operationIntentId !== 'string'
+    || !isCollabOpaqueId(value.operationIntentId)
+    || typeof value.ownerInstallationKey !== 'string'
+    || typeof value.selectedTargetPersonalRef !== 'string'
+    || (
+      value.phase !== 'preparing'
+      && value.phase !== 'published'
+      && value.phase !== 'handed-off'
+      && value.phase !== 'withdrawn'
+    )
+  ) throw new TypeError('Invalid Cloud-to-LAN target entry');
+  const createdAt = timestamp(value.createdAt);
+  const expiresAt = timestamp(value.expiresAt);
+  const decodedDescriptor = value.descriptor === null
+    ? null
+    : decodeCloudToLanTargetPreparationDescriptor(value.descriptor);
+  const decodedSuccessor = successor(value.successor);
+  const withdrawnAt = value.withdrawnAt === null ? null : timestamp(value.withdrawnAt);
+  if (
+    Date.parse(expiresAt) <= Date.parse(createdAt)
+    || (value.phase === 'preparing' && decodedDescriptor !== null)
+    || (
+      (value.phase === 'published' || value.phase === 'handed-off')
+      && decodedDescriptor === null
+    )
+    || (value.phase === 'handed-off') !== (decodedSuccessor !== null)
+    || (value.phase === 'withdrawn') !== (withdrawnAt !== null)
+    || (withdrawnAt !== null && withdrawnAt < createdAt)
+    || (decodedDescriptor !== null && (
+      decodedDescriptor.preparationId !== value.operationIntentId
+      || decodedDescriptor.projectId !== value.projectId
+      || decodedDescriptor.publishedAt < createdAt
+      || decodedDescriptor.selectedTargetMemberId !== value.selectedTargetMemberId
+      || decodedDescriptor.sourceAuthorityGeneration !== value.sourceAuthorityGeneration
+      || decodedDescriptor.sourceCloudUrl !== value.sourceCloudUrl
+    ))
+  ) throw new TypeError('Invalid Cloud-to-LAN target entry binding');
+  return {
+    createdAt,
+    descriptor: decodedDescriptor,
+    entryRole: 'cloud-to-lan-target',
+    expiresAt,
+    operationIntentId: value.operationIntentId,
+    ownerInstallationKey: parseInstallationKey(value.ownerInstallationKey),
+    phase: value.phase,
+    projectId: value.projectId,
+    selectedTargetMemberId: value.selectedTargetMemberId,
+    selectedTargetPersonalRef: value.selectedTargetPersonalRef,
+    sourceAuthorityGeneration: generation(value.sourceAuthorityGeneration),
+    sourceCloudUrl: cloudUrl(value.sourceCloudUrl),
+    successor: decodedSuccessor,
+    withdrawnAt,
+  };
+}
+
+export function decodeCloudToLanManagerEntryRecord(
+  value: unknown,
+): CloudToLanManagerEntryRecord {
+  if (
+    !isRecord(value)
+    || !hasExactKeys(value, MANAGER_KEYS)
+    || value.entryRole !== 'cloud-to-lan-manager'
+    || !isCollabProjectId(value.projectId)
+    || !isCollabMemberId(value.initiatingMemberId)
+    || typeof value.initiatingPersonalRef !== 'string'
+    || typeof value.operationIntentId !== 'string'
+    || !isCollabOpaqueId(value.operationIntentId)
+    || (
+      value.phase !== 'prepared'
+      && value.phase !== 'submitted'
+      && value.phase !== 'observing'
+      && value.phase !== 'rejected'
+      && value.phase !== 'settled'
+    )
+  ) throw new TypeError('Invalid Cloud-to-LAN Manager entry');
+  const descriptor = decodeCloudToLanTargetPreparationDescriptor(value.descriptor);
+  const request = decodeCollabAuthorityTransferOperationRequest(
+    'beginCloudToLanTransfer',
+    value.request,
+  );
+  const status = value.status === null ? null : decodeCollabAuthorityTransferStatus(value.status);
+  const cancellation = value.cancellation === null
+    ? null
+    : (() => {
+        if (!isRecord(value.cancellation) || !hasExactKeys(
+          value.cancellation,
+          new Set(['request', 'submission']),
+        )) throw new TypeError('Invalid Cloud-to-LAN Manager cancellation');
+        const cancellationRequest = decodeCollabAuthorityTransferOperationRequest(
+          'cancelProjectAuthorityTransfer',
+          value.cancellation.request,
+        );
+        if (
+          value.cancellation.submission !== 'not-sent'
+          && value.cancellation.submission !== 'possibly-sent'
+        ) throw new TypeError('Invalid Cloud-to-LAN Manager cancellation');
+        return {
+          request: cancellationRequest,
+          submission: value.cancellation.submission,
+        } as const;
+      })();
+  const createdAt = timestamp(value.createdAt);
+  const expiresAt = timestamp(value.expiresAt);
+  if (
+    Date.parse(expiresAt) <= Date.parse(createdAt)
+    || request.projectId !== value.projectId
+    || request.idempotencyKey !== value.operationIntentId
+    || request.expectedAuthorityGeneration !== descriptor.sourceAuthorityGeneration
+    || request.targetHostMemberId !== descriptor.selectedTargetMemberId
+    || request.targetUrl !== descriptor.targetUrl
+    || descriptor.projectId !== value.projectId
+    || ((value.phase === 'observing' || value.phase === 'settled') !== (status !== null))
+    || (value.phase === 'rejected' && (status !== null || cancellation !== null))
+    || (value.phase === 'observing' && status?.state !== 'active')
+    || (
+      value.phase === 'settled'
+      && status?.state !== 'completed'
+      && status?.state !== 'cancelled'
+    )
+    || (status !== null && (
+      status.direction !== 'cloud-to-lan'
+      || status.projectId !== value.projectId
+      || status.sourceAuthority.kind !== 'cloud'
+      || status.sourceAuthority.generation !== request.expectedAuthorityGeneration
+      || status.targetAuthority.kind !== 'lan'
+      || status.targetAuthority.generation !== request.expectedAuthorityGeneration + 1
+      || status.targetUrl !== request.targetUrl
+      || status.expiresAt !== expiresAt
+    ))
+    || (cancellation !== null && (
+      status === null
+      || status.state !== 'active'
+      || status.relinquishmentProof !== null
+      || cancellation.request.projectId !== value.projectId
+      || cancellation.request.transferId !== status.transferId
+      || cancellation.request.expectedPhase !== status.phase
+    ))
+  ) throw new TypeError('Invalid Cloud-to-LAN Manager entry binding');
+  return {
+    cancellation,
+    createdAt,
+    descriptor,
+    entryRole: 'cloud-to-lan-manager',
+    expiresAt,
+    initiatingMemberId: value.initiatingMemberId,
+    initiatingPersonalRef: value.initiatingPersonalRef,
+    operationIntentId: value.operationIntentId,
+    phase: value.phase,
+    projectId: value.projectId,
+    request,
+    status,
+  };
+}
+
+export function createCloudToLanTargetEntry(input: Readonly<{
+  readonly createdAt: CollabIsoTimestamp;
+  readonly expiresAt: CollabIsoTimestamp;
+  readonly operationIntentId: string;
+  readonly ownerInstallationKey: InstallationKey;
+  readonly projectId: CollabProjectId;
+  readonly selectedTargetMemberId: CollabMemberId;
+  readonly selectedTargetPersonalRef: string;
+  readonly sourceAuthorityGeneration: number;
+  readonly sourceCloudUrl: string;
+}>): CloudToLanTargetEntryRecord {
+  return decodeCloudToLanTargetEntryRecord({
+    ...input,
+    descriptor: null,
+    entryRole: 'cloud-to-lan-target',
+    phase: 'preparing',
+    successor: null,
+    withdrawnAt: null,
+  });
+}
+
+export function publishCloudToLanTargetEntry(
+  entry: CloudToLanTargetEntryRecord,
+  input: Readonly<{
+    readonly caCertificatePem: string;
+    readonly caFingerprint: string;
+    readonly publishedAt: CollabIsoTimestamp;
+    readonly targetUrl: string;
+  }>,
+): CloudToLanTargetEntryRecord {
+  if (entry.phase !== 'preparing') throw new TypeError('Cloud-to-LAN target is already published');
+  return decodeCloudToLanTargetEntryRecord({
+    ...entry,
+    descriptor: {
+      ...input,
+      preparationId: entry.operationIntentId,
+      projectId: entry.projectId,
+      schemaVersion: CLOUD_TO_LAN_ENTRY_SCHEMA_VERSION,
+      selectedTargetMemberId: entry.selectedTargetMemberId,
+      sourceAuthorityGeneration: entry.sourceAuthorityGeneration,
+      sourceCloudUrl: entry.sourceCloudUrl,
+    },
+    phase: 'published',
+  });
+}
+
+export function handoffCloudToLanTargetEntry(
+  entry: CloudToLanTargetEntryRecord,
+  record: AuthorityTransferRecord,
+): CloudToLanTargetEntryRecord {
+  if (
+    (entry.phase !== 'published' && entry.phase !== 'handed-off')
+    || !entry.descriptor
+    || record.localRole !== 'target'
+    || record.lifecycleOwnership !== 'owned'
+    || record.ownerInstallationKey !== entry.ownerInstallationKey
+    || record.projectId !== entry.projectId
+    || record.status.direction !== 'cloud-to-lan'
+    || record.status.sourceAuthority.kind !== 'cloud'
+    || record.status.sourceAuthority.generation !== entry.sourceAuthorityGeneration
+    || record.status.targetAuthority.kind !== 'lan'
+    || record.status.targetAuthority.generation !== entry.sourceAuthorityGeneration + 1
+    || record.status.targetUrl !== entry.descriptor.targetUrl
+  ) throw new TypeError('Invalid Cloud-to-LAN target handoff');
+  const handedOff = decodeCloudToLanTargetEntryRecord({
+    ...entry,
+    phase: 'handed-off',
+    successor: {
+      operationIntentId: record.operationIntentId,
+      ownerInstallationKey: record.ownerInstallationKey,
+      transferId: record.transferId,
+    },
+  });
+  if (
+    entry.phase === 'handed-off'
+    && JSON.stringify(entry) !== JSON.stringify(handedOff)
+  ) throw new TypeError('Invalid Cloud-to-LAN target handoff');
+  return handedOff;
+}
+
+export function withdrawCloudToLanTargetEntry(
+  entry: CloudToLanTargetEntryRecord,
+  withdrawnAt: CollabIsoTimestamp,
+): CloudToLanTargetEntryRecord {
+  if (
+    (entry.phase !== 'preparing' && entry.phase !== 'published')
+    || entry.successor !== null
+  ) throw new TypeError('Cloud-to-LAN target is not withdrawable');
+  return decodeCloudToLanTargetEntryRecord({
+    ...entry,
+    phase: 'withdrawn',
+    withdrawnAt,
+  });
+}
+
+export function createCloudToLanManagerEntry(input: Readonly<{
+  readonly createdAt: CollabIsoTimestamp;
+  readonly descriptor: CloudToLanTargetPreparationDescriptor;
+  readonly expiresAt: CollabIsoTimestamp;
+  readonly initiatingMemberId: CollabMemberId;
+  readonly initiatingPersonalRef: string;
+  readonly operationIntentId: string;
+}>): CloudToLanManagerEntryRecord {
+  return decodeCloudToLanManagerEntryRecord({
+    cancellation: null,
+    createdAt: input.createdAt,
+    descriptor: input.descriptor,
+    entryRole: 'cloud-to-lan-manager',
+    expiresAt: input.expiresAt,
+    initiatingMemberId: input.initiatingMemberId,
+    initiatingPersonalRef: input.initiatingPersonalRef,
+    operationIntentId: input.operationIntentId,
+    phase: 'prepared',
+    projectId: input.descriptor.projectId,
+    request: {
+      expectedAuthorityGeneration: input.descriptor.sourceAuthorityGeneration,
+      idempotencyKey: input.operationIntentId,
+      projectId: input.descriptor.projectId,
+      targetHostMemberId: input.descriptor.selectedTargetMemberId,
+      targetUrl: input.descriptor.targetUrl,
+    },
+    status: null,
+  });
+}
+
+export function markCloudToLanManagerBeginPossiblySent(
+  entry: CloudToLanManagerEntryRecord,
+): CloudToLanManagerEntryRecord {
+  if (entry.phase !== 'prepared' && entry.phase !== 'submitted') {
+    throw new TypeError('Cloud-to-LAN Manager begin is not submittable');
+  }
+  if (entry.phase === 'submitted') return entry;
+  return decodeCloudToLanManagerEntryRecord({
+    ...entry,
+    phase: 'submitted',
+  });
+}
+
+export function recordCloudToLanManagerStatus(
+  entry: CloudToLanManagerEntryRecord,
+  status: CollabAuthorityTransferStatus,
+): CloudToLanManagerEntryRecord {
+  if (entry.phase !== 'submitted' && entry.phase !== 'observing') {
+    throw new TypeError('Cloud-to-LAN Manager status is not recordable');
+  }
+  if (entry.status) {
+    assertAuthorityTransferStatusObservation(entry.status, status);
+  }
+  return decodeCloudToLanManagerEntryRecord({
+    ...entry,
+    cancellation: null,
+    expiresAt: status.expiresAt,
+    phase: status.state === 'completed' || status.state === 'cancelled'
+      ? 'settled'
+      : 'observing',
+    status,
+  });
+}
+
+export function rejectCloudToLanManagerEntry(
+  entry: CloudToLanManagerEntryRecord,
+): CloudToLanManagerEntryRecord {
+  if (entry.phase !== 'submitted' || entry.status !== null) {
+    throw new TypeError('Cloud-to-LAN Manager begin is not rejectable');
+  }
+  return decodeCloudToLanManagerEntryRecord({
+    ...entry,
+    cancellation: null,
+    phase: 'rejected',
+  });
+}
+
+export function prepareCloudToLanManagerCancellation(
+  entry: CloudToLanManagerEntryRecord,
+  request: CancelProjectAuthorityTransferRequest,
+): CloudToLanManagerEntryRecord {
+  if (
+    entry.phase !== 'observing'
+    || !entry.status
+    || entry.status.state !== 'active'
+    || entry.status.relinquishmentProof !== null
+    || entry.cancellation !== null
+  ) throw new TypeError('Cloud-to-LAN Manager cancellation is not preparable');
+  return decodeCloudToLanManagerEntryRecord({
+    ...entry,
+    cancellation: { request, submission: 'not-sent' },
+  });
+}
+
+export function markCloudToLanManagerCancellationPossiblySent(
+  entry: CloudToLanManagerEntryRecord,
+): CloudToLanManagerEntryRecord {
+  if (!entry.cancellation) {
+    throw new TypeError('Cloud-to-LAN Manager cancellation is missing');
+  }
+  if (entry.cancellation.submission === 'possibly-sent') return entry;
+  return decodeCloudToLanManagerEntryRecord({
+    ...entry,
+    cancellation: { ...entry.cancellation, submission: 'possibly-sent' },
+  });
+}
+
+export function cloudToLanTransferHandle(
+  entry: CloudToLanManagerEntryRecord,
+): CloudToLanTransferHandle {
+  if (!entry.status) throw new TypeError('Cloud-to-LAN Manager status is missing');
+  return decodeCloudToLanTransferHandle({
+    operationIntentId: entry.operationIntentId,
+    preparationId: entry.descriptor.preparationId,
+    projectId: entry.projectId,
+    schemaVersion: CLOUD_TO_LAN_ENTRY_SCHEMA_VERSION,
+    selectedTargetMemberId: entry.descriptor.selectedTargetMemberId,
+    sourceAuthorityGeneration: entry.descriptor.sourceAuthorityGeneration,
+    sourceCloudUrl: entry.descriptor.sourceCloudUrl,
+    targetUrl: entry.descriptor.targetUrl,
+    transferId: entry.status.transferId,
+  });
+}

--- a/src/app/collab/authority-transfer/cloud-to-lan/ProductionCloudToLanTargetEffects.ts
+++ b/src/app/collab/authority-transfer/cloud-to-lan/ProductionCloudToLanTargetEffects.ts
@@ -39,7 +39,14 @@ import {
 } from '@claudian-collab/protocol';
 
 import { PendingMembershipRepository } from '@/app/collab/authority/PendingMembershipRepository';
+import {
+  type AuthorityTransferImportedTargetIdentity,
+  decodeAuthorityTransferImportedTargetIdentity,
+} from '@/app/collab/authority-transfer/AuthorityTransferImportedTargetIdentity';
 import type { AuthorityTransferLocalConvergence } from '@/app/collab/authority-transfer/AuthorityTransferLocalConvergence';
+import {
+  authorityTransferChildIdempotencyKey,
+} from '@/app/collab/authority-transfer/AuthorityTransferOperationIdentity';
 import type { AuthorityTransferRecord } from '@/app/collab/authority-transfer/AuthorityTransferRecord';
 import { AuthorityTransferCheckpointGit } from '@/app/collab/authority-transfer/checkpoint/AuthorityTransferCheckpointGit';
 import { verifyAuthorityTransferCheckpointManifest } from '@/app/collab/authority-transfer/checkpoint/AuthorityTransferCheckpointManifest';
@@ -49,7 +56,10 @@ import type {
   CloudToLanTargetEffects,
   CloudToLanTargetStageResult,
 } from '@/app/collab/authority-transfer/cloud-to-lan/CloudToLanTargetCoordinator';
-import { writeDurablePrivateFile } from '@/app/collab/authority-transfer/DurablePrivateFile';
+import {
+  removeDurablePrivateFile,
+  writeDurablePrivateFile,
+} from '@/app/collab/authority-transfer/DurablePrivateFile';
 import type { AuthorityTransferPersistence } from '@/app/collab/authority-transfer/persistence/AuthorityTransferPersistence';
 import type {
   ClaudianCollabService,
@@ -66,9 +76,8 @@ import type {
 import { PersistentLanAuthorityTransferTargetActiveService } from '@/app/collab/lan/authority-transfer/PersistentLanAuthorityTransferServices';
 import type { LanHostAuthorityTransferPreparation } from '@/app/collab/lan/LanHostCoordinator';
 import { fingerprintCertificatePem } from '@/app/collab/lan/LanTlsIdentity';
-import type { CloudAuthorityConnection } from '@/app/collab/remote-authority/CloudAuthorityAdapter';
 import { SerialTaskQueue } from '@/app/collab/SerialTaskQueue';
-import type { CollabCloudProjectSnapshot, CollabOperationOptions } from '@/core/collab';
+import type { CollabOperationOptions } from '@/core/collab';
 import { CollabError } from '@/core/collab/ClaudianCollabError';
 
 const MANIFEST_FILE = 'checkpoint.json';
@@ -86,14 +95,26 @@ interface TargetReceiptKey {
 interface TargetPrivateState {
   readonly claimBatch: CollabTransferredMembershipClaimBatch | null;
   readonly hostCredential: string;
+  readonly importedIdentity: AuthorityTransferImportedTargetIdentity | null;
   readonly receiptKey: TargetReceiptKey;
   readonly receipts: Readonly<Record<string, CollabTransferredMembershipRedemptionReceipt>>;
   readonly schemaVersion: 1;
-  readonly snapshot: CollabCloudProjectSnapshot | null;
   readonly targetProof: string | null;
   readonly transferCredential: string;
   readonly transferId: string | null;
 }
+
+const TARGET_PRIVATE_STATE_KEYS = [
+  'claimBatch',
+  'hostCredential',
+  'importedIdentity',
+  'receiptKey',
+  'receipts',
+  'schemaVersion',
+  'targetProof',
+  'transferCredential',
+  'transferId',
+] as const;
 
 interface TargetProofEnvelope {
   readonly caCertificatePem: string;
@@ -199,7 +220,7 @@ function decodeTargetProof(value: string): TargetProofEnvelope {
 }
 
 export interface ProductionCloudToLanTargetEffectsOptions {
-  readonly cloudSession: CloudAuthorityConnection | null;
+  readonly cloudSession: Readonly<{ readonly serverUrl: string }> | null;
   readonly convergence: AuthorityTransferLocalConvergence;
   readonly foundation: ClaudianCollabService;
   readonly now?: () => Date;
@@ -249,10 +270,10 @@ function initialState(): TargetPrivateState {
   return {
     claimBatch: null,
     hostCredential: credential(),
+    importedIdentity: null,
     receiptKey: receiptKey(),
     receipts: {},
     schemaVersion: 1,
-    snapshot: null,
     targetProof: null,
     transferCredential: credential(),
     transferId: null,
@@ -265,6 +286,8 @@ function assertState(value: unknown): TargetPrivateState {
   }
   const state = value as Partial<TargetPrivateState>;
   if (
+    !hasExactKeys(value as Record<string, unknown>, TARGET_PRIVATE_STATE_KEYS)
+    ||
     state.schemaVersion !== 1
     || typeof state.hostCredential !== 'string'
     || Buffer.from(state.hostCredential, 'base64url').byteLength !== 32
@@ -280,7 +303,15 @@ function assertState(value: unknown): TargetPrivateState {
     || (state.transferId !== null && typeof state.transferId !== 'string')
     || (state.targetProof !== null && typeof state.targetProof !== 'string')
   ) throw targetError('authority-transfer-target-state-invalid');
-  return state as TargetPrivateState;
+  let importedIdentity: AuthorityTransferImportedTargetIdentity | null;
+  try {
+    importedIdentity = state.importedIdentity === null
+      ? null
+      : decodeAuthorityTransferImportedTargetIdentity(state.importedIdentity);
+  } catch {
+    throw targetError('authority-transfer-target-state-invalid');
+  }
+  return { ...(state as TargetPrivateState), importedIdentity };
 }
 
 async function readState(filePath: string): Promise<TargetPrivateState | null> {
@@ -412,13 +443,17 @@ export class ProductionCloudToLanTargetEffects implements CloudToLanTargetEffect
     this.now = options.now ?? (() => new Date());
   }
 
-  dispose(): void {
+  async dispose(): Promise<void> {
     const preparation = this.#preparation;
     this.#preparation = null;
-    void preparation?.dispose().catch(() => undefined);
+    await preparation?.dispose();
   }
 
-  async prepareTarget(expectedEndpoint?: string): Promise<Readonly<{ readonly targetUrl: string }>> {
+  async prepareTarget(expectedEndpoint?: string): Promise<Readonly<{
+    readonly caCertificatePem: string;
+    readonly caFingerprint: string;
+    readonly targetUrl: string;
+  }>> {
     if (!this.#preparation) {
       this.#preparation = await this.options.foundation.lanHost.prepareAuthorityTransferTarget(
         expectedEndpoint ?? null,
@@ -427,7 +462,11 @@ export class ProductionCloudToLanTargetEffects implements CloudToLanTargetEffect
     if (expectedEndpoint && this.#preparation.endpoint !== expectedEndpoint) {
       throw targetError('authority-transfer-target-url-mismatch');
     }
-    return { targetUrl: this.#preparation.endpoint };
+    return {
+      caCertificatePem: this.#preparation.caCertificatePem,
+      caFingerprint: this.#preparation.caFingerprint,
+      targetUrl: this.#preparation.endpoint,
+    };
   }
 
   async acceptanceRequest(
@@ -475,7 +514,10 @@ export class ProductionCloudToLanTargetEffects implements CloudToLanTargetEffect
       }
       await this.#ensureStagedRoute(record, state);
       return {
-        idempotencyKey: `${record.operationIntentId}-accept`,
+        idempotencyKey: authorityTransferChildIdempotencyKey(
+          record.operationIntentId,
+          'accept',
+        ),
         projectId: record.projectId,
         targetHostMemberId: memberId,
         targetProof: state.targetProof,
@@ -510,12 +552,11 @@ export class ProductionCloudToLanTargetEffects implements CloudToLanTargetEffect
       assertArtifact(manifest, COORDINATION_FILE, coordinationBytes);
       await assertArtifactFile(manifest, BUNDLE_FILE, path.join(stagingPath, BUNDLE_FILE));
       let state = (await readState(path.join(stagingPath, TARGET_STATE_FILE)))!;
+      const targetProof = await this.#validatePreparedStateBindings(record, state);
+      if (targetProof.payload.targetHostMemberId !== memberId) {
+        throw targetError('authority-transfer-target-imported-identity-mismatch');
+      }
       if (state.claimBatch === null) {
-        const cloudSession = this.#requireCloudSession();
-        const snapshot = await cloudSession.readSnapshot(record.projectId, options);
-        if (snapshot.currentMember.id !== memberId) {
-          throw targetError('authority-transfer-target-host-snapshot-mismatch');
-        }
         await this.options.foundation.discardAuthorityTransferTarget(
           record.projectId,
           record.ownerInstallationKey,
@@ -526,15 +567,16 @@ export class ProductionCloudToLanTargetEffects implements CloudToLanTargetEffect
         );
         const git = await this.options.foundation.requireGitFoundation();
         const checkpoint = new AuthorityTransferCheckpointRepository();
+        let importedIdentity: AuthorityTransferImportedTargetIdentity;
         try {
-          await authority.database.mutate(connection => checkpoint.importCoordination(connection, {
+          importedIdentity = (await authority.database.mutate(connection => checkpoint.importCoordination(connection, {
             coordinationNdjson: coordinationBytes.toString('utf8'),
             manifest,
             targetHostCredentialHash: createHash('sha256')
               .update(Buffer.from(state.hostCredential, 'base64url'))
               .digest(),
             targetHostMemberId: memberId,
-          }));
+          }))).value;
           await new AuthorityTransferCheckpointGit(git.runner).importIntoEmptyBareRepository({
             bundlePath: path.join(stagingPath, BUNDLE_FILE),
             manifest,
@@ -544,6 +586,11 @@ export class ProductionCloudToLanTargetEffects implements CloudToLanTargetEffect
         } finally {
           await authority.database.close();
         }
+        if (
+          importedIdentity.project.id !== record.projectId
+          || importedIdentity.authorityGeneration !== record.status.targetAuthority.generation
+          || importedIdentity.currentMember.id !== memberId
+        ) throw targetError('authority-transfer-target-imported-identity-mismatch');
         state = {
           ...state,
           claimBatch: claimBatch(
@@ -552,11 +599,11 @@ export class ProductionCloudToLanTargetEffects implements CloudToLanTargetEffect
             coordinationBytes.toString('utf8'),
             memberId,
           ),
-          snapshot,
+          importedIdentity,
         };
         await writeState(path.join(stagingPath, TARGET_STATE_FILE), state);
       }
-      if (!state.claimBatch || !state.snapshot || !state.targetProof) {
+      if (!state.claimBatch || !state.importedIdentity || !state.targetProof) {
         throw targetError('authority-transfer-target-stage-incomplete');
       }
       return {
@@ -571,6 +618,7 @@ export class ProductionCloudToLanTargetEffects implements CloudToLanTargetEffect
           generation: record.status.targetAuthority.generation,
           kind: 'lan',
         },
+        targetHostMemberId: state.importedIdentity.currentMember.id,
         targetProof: state.targetProof,
       };
     });
@@ -611,15 +659,14 @@ export class ProductionCloudToLanTargetEffects implements CloudToLanTargetEffect
         path.join(authority.authorityDirectory, AUTHORITY_TARGET_STATE_FILE),
       );
       if (!state) {
-        if (
-          expired
-          && isCollabLocalLanMembership(membership)
-          && membership.authority.endpoint === new URL(record.status.targetUrl).origin
-          && membership.hostOwnership.autoStart
-          && membership.hostOwnership.ownsAuthority
-        ) {
+        if (expired) {
+          await this.#assertExpiredRecordCurrent(record);
+          await this.#assertCompletedTargetConvergence(record, authority, null, null, false);
           await this.options.foundation.lanHost.startProject(record.projectId);
-          await this.#expireActiveRouteUnlocked(record);
+          if (!this.options.foundation.lanHost.isProjectRunning(record.projectId)) {
+            throw targetError('authority-transfer-target-convergence-incomplete');
+          }
+          await this.#completeExpiredTargetCleanup(record, authority);
           return;
         }
         throw targetError('authority-transfer-target-state-owner-mismatch');
@@ -689,6 +736,27 @@ export class ProductionCloudToLanTargetEffects implements CloudToLanTargetEffect
   }
 
    async #expireActiveRouteUnlocked(record: AuthorityTransferRecord): Promise<void> {
+    await this.#assertExpiredRecordCurrent(record);
+    const proof = record.status.relinquishmentProof;
+    if (!proof) throw targetError('authority-transfer-target-completion-missing');
+    const authority = await this.options.foundation.inspectAuthority(record.projectId);
+    if (!authority) throw targetError('authority-transfer-target-authority-missing');
+    const state = await readState(
+      path.join(authority.authorityDirectory, AUTHORITY_TARGET_STATE_FILE),
+    );
+    if (!state) throw targetError('authority-transfer-target-state-owner-mismatch');
+    const targetProof = await this.#assertActiveState(record, proof, state, authority);
+    await this.#assertCompletedTargetConvergence(
+      record,
+      authority,
+      state,
+      targetProof,
+      true,
+    );
+    await this.#completeExpiredTargetCleanup(record, authority);
+  }
+
+   async #assertExpiredRecordCurrent(record: AuthorityTransferRecord): Promise<void> {
     if (this.now().getTime() < Date.parse(record.status.expiresAt)) {
       throw targetError('authority-transfer-target-expiry-early');
     }
@@ -699,12 +767,68 @@ export class ProductionCloudToLanTargetEffects implements CloudToLanTargetEffect
       || current.localRole !== 'target'
       || current.status.state !== 'completed'
     ) throw targetError('authority-transfer-target-expiry-owner-mismatch');
+  }
+
+   async #assertCompletedTargetConvergence(
+    record: AuthorityTransferRecord,
+    authority: CollabAuthorityFoundation,
+    state: TargetPrivateState | null,
+    targetProof: TargetProofEnvelope | null,
+    requireRunningHost: boolean,
+  ): Promise<void> {
+    const [membership, index, project, signer] = await Promise.all([
+      this.options.foundation.local.projects.loadMembership(record.projectId),
+      this.options.foundation.local.projects.loadIndex(),
+      authority.database.read(connection => authority.projects.get(connection)),
+      this.options.foundation.lanHost.hostCaSigner(),
+    ]);
+    const indexed = index.projects.find(candidate => candidate.id === record.projectId);
+    const targetEndpoint = new URL(record.status.targetUrl).origin;
+    if (
+      !membership
+      || !isCollabLocalLanMembership(membership)
+      || membership.project.id !== record.projectId
+      || membership.authority.endpoint !== targetEndpoint
+      || membership.authority.gitRemoteUrl
+        !== `${targetEndpoint}/v1/git/${record.projectId}/repository.git`
+      || membership.authority.hostCaCertificatePem !== signer.caCertificatePem
+      || membership.authority.hostCaFingerprint !== signer.caFingerprint
+      || membership.hostOwnership.autoStart !== true
+      || membership.hostOwnership.ownsAuthority !== true
+      || !project
+      || project.authorityGeneration !== record.status.targetAuthority.generation
+      || project.hostMemberId !== membership.member.id
+      || !indexed
+      || indexed.authorityKind !== 'lan'
+      || indexed.name !== membership.project.name
+      || indexed.workspacePath !== membership.project.workspacePath
+      || (
+        requireRunningHost
+        && !this.options.foundation.lanHost.isProjectRunning(record.projectId)
+      )
+      || (state === null) !== (targetProof === null)
+      || (state !== null && (
+        !state.importedIdentity
+        || state.hostCredential !== membership.member.credential
+        || state.importedIdentity.project.id !== membership.project.id
+        || state.importedIdentity.currentMember.id !== membership.member.id
+        || state.importedIdentity.currentMember.personalRef !== membership.member.personalRef
+        || state.importedIdentity.eventSequence > membership.lastEventSequence
+        || targetProof!.caCertificatePem !== membership.authority.hostCaCertificatePem
+        || targetProof!.caFingerprint !== membership.authority.hostCaFingerprint
+      ))
+    ) throw targetError('authority-transfer-target-convergence-incomplete');
+  }
+
+   async #completeExpiredTargetCleanup(
+    record: AuthorityTransferRecord,
+    authority: CollabAuthorityFoundation,
+  ): Promise<void> {
     await this.options.persistence.expireClaims(record.projectId, record.transferId);
-    const authority = await this.options.foundation.inspectAuthority(record.projectId);
-    if (!authority) throw targetError('authority-transfer-target-authority-missing');
-    await rm(path.join(authority.authorityDirectory, AUTHORITY_TARGET_STATE_FILE), {
-      force: true,
-    });
+    await removeDurablePrivateFile(
+      path.join(authority.authorityDirectory, AUTHORITY_TARGET_STATE_FILE),
+      () => targetError('authority-transfer-target-state-remove-failed'),
+    );
     await this.options.persistence.completeTerminalCleanup({
       operationIntentId: record.operationIntentId,
       projectId: record.projectId,
@@ -745,29 +869,34 @@ export class ProductionCloudToLanTargetEffects implements CloudToLanTargetEffect
     ) throw targetError('authority-transfer-target-relinquishment-mismatch');
     const { stagingPath } = await this.#prepareState(record);
     let state = await this.#loadTargetState(record, stagingPath);
-    if (!state.claimBatch || !state.snapshot) {
+    if (!state.claimBatch || !state.importedIdentity) {
       throw targetError('authority-transfer-target-stage-incomplete');
     }
-    const authority = await this.options.foundation.activateAuthorityTransferTarget(
-      record.projectId,
-      record.ownerInstallationKey,
-    );
+    const stagedTargetProof = await this.#validateStateBindings(record, proof, state);
+    let authority = await this.options.foundation.inspectAuthority(record.projectId);
+    if (!authority) {
+      const provisional = await this.options.foundation.openAuthorityTransferTarget(
+        record.projectId,
+        record.ownerInstallationKey,
+      );
+      try {
+        await this.#assertStagedAuthorityBindings(state, stagedTargetProof, provisional);
+      } finally {
+        await provisional.database.close();
+      }
+      authority = await this.options.foundation.activateAuthorityTransferTarget(
+        record.projectId,
+        record.ownerInstallationKey,
+      );
+    }
     const authorityStatePath = path.join(authority.authorityDirectory, AUTHORITY_TARGET_STATE_FILE);
     const persistedAuthorityState = await readState(authorityStatePath);
     if (persistedAuthorityState) state = persistedAuthorityState;
     else await writeState(authorityStatePath, state);
-    if (!state.claimBatch || !state.snapshot) {
+    if (!state.claimBatch || !state.importedIdentity) {
       throw targetError('authority-transfer-target-stage-incomplete');
     }
-    const targetProof = await this.#validateProof(state);
-    const checkpoint = new AuthorityTransferCheckpointRepository();
-    await authority.database.mutate(connection => checkpoint.activateImportedAuthority(
-      connection,
-      {
-        projectId: record.projectId,
-        targetAuthorityGeneration: record.status.targetAuthority.generation,
-      },
-    ));
+    const targetProof = await this.#assertActiveState(record, proof, state, authority);
     await this.#activateRoute(record, proof, state);
     return { state, targetProof };
   }
@@ -778,7 +907,35 @@ export class ProductionCloudToLanTargetEffects implements CloudToLanTargetEffect
     state: TargetPrivateState,
     authority: CollabAuthorityFoundation,
   ): Promise<TargetProofEnvelope> {
-    const targetProof = await this.#validateProof(state);
+    const targetProof = await this.#validateStateBindings(record, proof, state);
+    const project = await authority.database.read(connection => authority.projects.get(connection));
+    if (!project || project.hostMemberId !== targetProof.payload.targetHostMemberId) {
+      throw targetError('authority-transfer-target-host-mismatch');
+    }
+    await authority.database.mutate(connection => (
+      new AuthorityTransferCheckpointRepository().activateImportedAuthority(connection, {
+        projectId: record.projectId,
+        targetAuthorityGeneration: record.status.targetAuthority.generation,
+      })
+    ));
+    return targetProof;
+  }
+
+   async #validateStateBindings(
+    record: AuthorityTransferRecord,
+    proof: CollabAuthorityRelinquishmentProof,
+    state: TargetPrivateState,
+  ): Promise<TargetProofEnvelope> {
+    const targetProof = await this.#validatePreparedStateBindings(record, state);
+    let claimBatch: CollabTransferredMembershipClaimBatch;
+    try {
+      claimBatch = decodeCollabTransferredMembershipClaimBatch(state.claimBatch);
+    } catch {
+      throw targetError('authority-transfer-target-state-owner-mismatch');
+    }
+    const batchSha256 = sha256(
+      encodeCollabTransferredMembershipClaimBatchDigestInput(claimBatch),
+    );
     if (
       proof.projectId !== record.projectId
       || proof.transferId !== record.transferId
@@ -786,22 +943,18 @@ export class ProductionCloudToLanTargetEffects implements CloudToLanTargetEffect
       || proof.targetAuthority.kind !== 'lan'
       || state.transferId !== record.transferId
       || !state.claimBatch
-      || !state.snapshot
+      || !state.importedIdentity
+      || claimBatch.batchRevision !== record.status.batchRevision
+      || claimBatch.batchSha256 !== record.status.batchSha256
+      || claimBatch.batchSha256 !== batchSha256
       || state.claimBatch.projectId !== record.projectId
       || state.claimBatch.transferId !== record.transferId
       || state.claimBatch.targetAuthorityGeneration
         !== record.status.targetAuthority.generation
       || state.claimBatch.checkpointSha256 !== record.status.checkpointSha256
-      || state.snapshot.project.id !== record.projectId
-      || state.snapshot.currentMember.id !== targetProof.payload.targetHostMemberId
-      || targetProof.payload.projectId !== record.projectId
-      || targetProof.payload.transferId !== record.transferId
-      || targetProof.payload.targetAuthorityGeneration
-        !== record.status.targetAuthority.generation
-      || targetProof.payload.targetUrl !== record.status.targetUrl
-      || targetProof.payload.receiptKeyId !== state.receiptKey.receiptKeyId
-      || targetProof.payload.receiptPublicKey !== state.receiptKey.publicKey
-      || targetProof.payload.transferCredential !== state.transferCredential
+      || state.importedIdentity.project.id !== record.projectId
+      || state.importedIdentity.authorityGeneration !== record.status.targetAuthority.generation
+      || state.importedIdentity.currentMember.id !== targetProof.payload.targetHostMemberId
     ) throw targetError('authority-transfer-target-state-owner-mismatch');
     let receiptPublicKey: string | undefined;
     try {
@@ -817,16 +970,55 @@ export class ProductionCloudToLanTargetEffects implements CloudToLanTargetEffect
       receiptPublicKey !== state.receiptKey.publicKey
       || state.receiptKey.receiptKeyId !== `lan-${sha256(receiptPublicKey).slice(0, 32)}`
     ) throw targetError('authority-transfer-target-state-owner-mismatch');
-    const project = await authority.database.read(connection => authority.projects.get(connection));
-    if (!project || project.hostMemberId !== targetProof.payload.targetHostMemberId) {
-      throw targetError('authority-transfer-target-host-mismatch');
-    }
-    await authority.database.mutate(connection => (
-      new AuthorityTransferCheckpointRepository().activateImportedAuthority(connection, {
-        projectId: record.projectId,
-        targetAuthorityGeneration: record.status.targetAuthority.generation,
-      })
-    ));
+    return targetProof;
+  }
+
+   async #assertStagedAuthorityBindings(
+    state: TargetPrivateState,
+    targetProof: TargetProofEnvelope,
+    authority: CollabAuthorityFoundation,
+  ): Promise<void> {
+    const facts = await authority.database.read(connection => ({
+      members: new PendingMembershipRepository().listCredentialRecords(
+        connection,
+        ['active'],
+      ),
+      project: authority.projects.get(connection),
+    }));
+    const targetMembers = facts.members.filter(
+      candidate => candidate.member.id === targetProof.payload.targetHostMemberId,
+    );
+    const expectedCredentialHash = createHash('sha256')
+      .update(Buffer.from(state.hostCredential, 'base64url'))
+      .digest();
+    const actualCredentialHash = targetMembers[0]?.credentialHash;
+    if (
+      !facts.project
+      || facts.project.hostMemberId !== targetProof.payload.targetHostMemberId
+      || targetMembers.length !== 1
+      || targetMembers[0]?.accessState !== 'bound'
+      || !actualCredentialHash
+      || actualCredentialHash.byteLength !== expectedCredentialHash.byteLength
+      || !timingSafeEqual(actualCredentialHash, expectedCredentialHash)
+    ) throw targetError('authority-transfer-target-state-owner-mismatch');
+  }
+
+   async #validatePreparedStateBindings(
+    record: AuthorityTransferRecord,
+    state: TargetPrivateState,
+  ): Promise<TargetProofEnvelope> {
+    const targetProof = await this.#validateProof(state);
+    if (
+      state.transferId !== record.transferId
+      || targetProof.payload.projectId !== record.projectId
+      || targetProof.payload.transferId !== record.transferId
+      || targetProof.payload.targetAuthorityGeneration
+        !== record.status.targetAuthority.generation
+      || targetProof.payload.targetUrl !== record.status.targetUrl
+      || targetProof.payload.receiptKeyId !== state.receiptKey.receiptKeyId
+      || targetProof.payload.receiptPublicKey !== state.receiptKey.publicKey
+      || targetProof.payload.transferCredential !== state.transferCredential
+    ) throw targetError('authority-transfer-target-state-owner-mismatch');
     return targetProof;
   }
 
@@ -1067,7 +1259,7 @@ export class ProductionCloudToLanTargetEffects implements CloudToLanTargetEffect
     );
   }
 
-   #requireCloudSession(): CloudAuthorityConnection {
+   #requireCloudSession(): Readonly<{ readonly serverUrl: string }> {
     if (!this.options.cloudSession) {
       throw targetError('authority-transfer-cloud-session-missing');
     }
@@ -1087,7 +1279,7 @@ export class ProductionCloudToLanTargetEffects implements CloudToLanTargetEffect
     state: TargetPrivateState,
     targetProof: TargetProofEnvelope,
   ): Promise<void> {
-    if (!state.snapshot) throw targetError('authority-transfer-target-stage-incomplete');
+    if (!state.importedIdentity) throw targetError('authority-transfer-target-stage-incomplete');
     const preparation = this.#preparation;
     this.#preparation = null;
     await preparation?.dispose();
@@ -1096,7 +1288,7 @@ export class ProductionCloudToLanTargetEffects implements CloudToLanTargetEffect
       hostCaCertificatePem: targetProof.caCertificatePem,
       hostCaFingerprint: targetProof.caFingerprint,
       memberCredential: state.hostCredential,
-      snapshot: state.snapshot,
+      identity: state.importedIdentity,
       status: record.status,
     });
     await this.options.foundation.lanHost.startProject(record.projectId);

--- a/src/app/collab/authority-transfer/persistence/AuthorityTransferPersistence.ts
+++ b/src/app/collab/authority-transfer/persistence/AuthorityTransferPersistence.ts
@@ -36,6 +36,9 @@ import {
   settleAuthorityTransferSourceCancellation,
 } from '@/app/collab/authority-transfer/AuthorityTransferEntryRecord';
 import {
+  authorityTransferChildIdempotencyKey,
+} from '@/app/collab/authority-transfer/AuthorityTransferOperationIdentity';
+import {
   assertAuthorityTransferTransition,
   type AuthorityTransferRecord,
   bindLegacyAuthorityTransferSourceOwner,
@@ -47,6 +50,21 @@ import {
   markAuthorityTransferTerminalCleanupCompleted,
   pinAuthorityTransferReceiptVerifier,
 } from '@/app/collab/authority-transfer/AuthorityTransferRecord';
+import {
+  type CloudToLanManagerEntryRecord,
+  type CloudToLanTargetEntryRecord,
+  type CloudToLanTargetPreparationDescriptor,
+  decodeCloudToLanManagerEntryRecord,
+  decodeCloudToLanTargetEntryRecord,
+  handoffCloudToLanTargetEntry,
+  markCloudToLanManagerBeginPossiblySent,
+  markCloudToLanManagerCancellationPossiblySent,
+  prepareCloudToLanManagerCancellation,
+  publishCloudToLanTargetEntry,
+  recordCloudToLanManagerStatus,
+  rejectCloudToLanManagerEntry,
+  withdrawCloudToLanTargetEntry,
+} from '@/app/collab/authority-transfer/cloud-to-lan/CloudToLanTransferEntryRecord';
 import {
   type AuthorityTransferClaimBatchCommitmentRecord,
   createAuthorityTransferClaimBatchCommitmentRecord,
@@ -211,8 +229,15 @@ export class AuthorityTransferPersistence {
       ]);
       const entry = await this.#removeExpiredEntry(loadedEntry, record);
       const source = entry?.source ?? null;
+      const target = entry?.target ?? null;
+      const manager = entry?.manager ?? null;
       const localSource = source !== null && this.#isLocalSourceEntry(source);
+      const localTarget = target !== null && this.#isLocalTargetEntry(target);
       const foreignPhysical = record !== null && this.#isForeignPhysical(record);
+      const managerMatchesLocalPhysical = manager !== null
+        && record !== null
+        && !foreignPhysical
+        && this.#managerMatchesPhysical(manager, record);
       if (localSource && source.phase === 'handed-off' && foreignPhysical) {
         throw transferError(
           'durable-progress-recovery-required',
@@ -227,8 +252,24 @@ export class AuthorityTransferPersistence {
       ) {
         await this.#reconcileEntrySuccessor(source, record);
       }
+      if (localTarget && target.phase === 'handed-off' && foreignPhysical) {
+        throw transferError(
+          'durable-progress-recovery-required',
+          'authority-transfer-target-entry-successor-owner-mismatch',
+        );
+      }
+      if (localTarget && record && !foreignPhysical && target.phase !== 'withdrawn') {
+        await this.#reconcileTargetEntrySuccessor(target, record);
+      }
       if (!record) {
         if (custody || commitment) return 'nonterminal';
+        if (localTarget && target.phase === 'handed-off') {
+          throw transferError(
+            'durable-progress-recovery-required',
+            'authority-transfer-target-entry-successor-missing',
+          );
+        }
+        if (localTarget && target.phase !== 'withdrawn') return 'nonterminal';
         if (!localSource || source.phase === 'cancelled') return 'absent';
         return source.phase === 'proposed' ? 'proposal' : 'nonterminal';
       }
@@ -240,6 +281,8 @@ export class AuthorityTransferPersistence {
       return isAuthorityTransferTerminal(record)
         && record.terminalCleanupCompleted
         && (!localSource || source.phase === 'cancelled')
+        && !localTarget
+        && !managerMatchesLocalPhysical
         ? 'terminal'
         : 'nonterminal';
     });
@@ -254,6 +297,7 @@ export class AuthorityTransferPersistence {
         this.stores.authorityTransferRecords.load(projectId),
       ]);
       const source = entry?.source;
+      const target = entry?.target;
       if (
         !record
         && source?.phase === 'handed-off'
@@ -263,6 +307,19 @@ export class AuthorityTransferPersistence {
           'durable-progress-recovery-required',
           'authority-transfer-entry-successor-missing',
         );
+      }
+      if (
+        !record
+        && target?.phase === 'handed-off'
+        && this.#isLocalTargetEntry(target)
+      ) {
+        throw transferError(
+          'durable-progress-recovery-required',
+          'authority-transfer-target-entry-successor-missing',
+        );
+      }
+      if (record && target && this.#isLocalTargetEntry(target)) {
+        await this.#reconcileTargetEntrySuccessor(target, record);
       }
       return record;
     });
@@ -312,6 +369,355 @@ export class AuthorityTransferPersistence {
         this.stores.authorityTransferRecords.load(projectId),
       ]);
       return (await this.#removeExpiredEntry(loadedEntry, record))?.source ?? null;
+    });
+  }
+
+  loadCloudToLanTargetEntry(
+    projectId: CollabProjectId,
+  ): Promise<CloudToLanTargetEntryRecord | null> {
+    return this.runProject(projectId, async () => {
+      const [loadedEntry, record] = await Promise.all([
+        this.stores.authorityTransferEntries.load(projectId),
+        this.stores.authorityTransferRecords.load(projectId),
+      ]);
+      const entry = await this.#removeExpiredEntry(loadedEntry, record);
+      const target = entry?.target ?? null;
+      if (target && record && this.#isLocalTargetEntry(target)) {
+        await this.#reconcileTargetEntrySuccessor(target, record);
+      }
+      return target;
+    });
+  }
+
+  loadCloudToLanManagerEntry(
+    projectId: CollabProjectId,
+  ): Promise<CloudToLanManagerEntryRecord | null> {
+    return this.runProject(projectId, async () => {
+      const [loadedEntry, record] = await Promise.all([
+        this.stores.authorityTransferEntries.load(projectId),
+        this.stores.authorityTransferRecords.load(projectId),
+      ]);
+      return (await this.#removeExpiredEntry(loadedEntry, record))?.manager ?? null;
+    });
+  }
+
+  prepareCloudToLanTargetEntry(
+    entry: CloudToLanTargetEntryRecord,
+  ): Promise<CloudToLanTargetEntryRecord> {
+    let decoded: CloudToLanTargetEntryRecord;
+    try {
+      decoded = decodeCloudToLanTargetEntryRecord(entry);
+    } catch {
+      throw transferError(
+        'durable-progress-recovery-required',
+        'authority-transfer-target-entry-invalid',
+      );
+    }
+    if (!this.#isRecoveryOwner(decoded.ownerInstallationKey)) {
+      throw transferError(
+        'durable-progress-recovery-required',
+        'authority-transfer-target-entry-owner-mismatch',
+      );
+    }
+    return this.runProject(decoded.projectId, async () => {
+      const [loadedEntry, loadedRecord] = await Promise.all([
+        this.stores.authorityTransferEntries.load(decoded.projectId),
+        this.stores.authorityTransferRecords.load(decoded.projectId),
+      ]);
+      let record = loadedRecord;
+      const document = await this.#removeExpiredEntry(loadedEntry, record);
+      if (
+        record
+        && !this.#isForeignPhysical(record)
+        && record.localRole === 'target'
+        && record.status.direction === 'cloud-to-lan'
+        && record.status.state === 'cancelled'
+        && record.terminalCleanupCompleted
+      ) {
+        if (!await this.stores.authorityTransferRecords.removeExact(record)) {
+          throw transferError(
+            'durable-progress-recovery-required',
+            'authority-transfer-physical-record-stale',
+          );
+        }
+        record = null;
+      }
+      const existing = document?.target;
+      const managerIsUnresolved = document?.manager !== null
+        && document?.manager !== undefined
+        && document.manager.phase !== 'settled';
+      if (existing) {
+        if (sameValue(existing, decoded)) return existing;
+        if (
+          existing.phase === 'withdrawn'
+          && record === null
+          && !managerIsUnresolved
+        ) {
+          await this.stores.authorityTransferEntries.saveTarget(decoded);
+          return decoded;
+        }
+        throw transferError(
+          'durable-progress-recovery-required',
+          'authority-transfer-target-entry-conflict',
+        );
+      }
+      if (
+        record
+        || managerIsUnresolved
+        || (document?.source !== null && document?.source !== undefined)
+      ) throw transferError(
+        'durable-progress-recovery-required',
+        'authority-transfer-target-entry-conflict',
+      );
+      await this.stores.authorityTransferEntries.saveTarget(decoded);
+      return decoded;
+    });
+  }
+
+  publishCloudToLanTargetEntry(
+    entry: CloudToLanTargetEntryRecord,
+    descriptor: Pick<
+      CloudToLanTargetPreparationDescriptor,
+      'caCertificatePem' | 'caFingerprint' | 'publishedAt' | 'targetUrl'
+    >,
+  ): Promise<CloudToLanTargetEntryRecord> {
+    let decoded: CloudToLanTargetEntryRecord;
+    let published: CloudToLanTargetEntryRecord;
+    try {
+      decoded = decodeCloudToLanTargetEntryRecord(entry);
+      published = publishCloudToLanTargetEntry(decoded, descriptor);
+    } catch {
+      throw transferError(
+        'durable-progress-recovery-required',
+        'authority-transfer-target-entry-publish-invalid',
+      );
+    }
+    return this.runProject(decoded.projectId, async () => {
+      const current = (await this.stores.authorityTransferEntries.load(decoded.projectId))?.target;
+      if (!current || !sameValue(current, decoded)) {
+        if (current && sameValue(current, published)) return current;
+        throw transferError(
+          'durable-progress-recovery-required',
+          'authority-transfer-target-entry-stale',
+        );
+      }
+      await this.stores.authorityTransferEntries.saveTarget(published);
+      return published;
+    });
+  }
+
+  withdrawCloudToLanTargetEntry(
+    entry: CloudToLanTargetEntryRecord,
+  ): Promise<CloudToLanTargetEntryRecord> {
+    let decoded: CloudToLanTargetEntryRecord;
+    let withdrawn: CloudToLanTargetEntryRecord;
+    try {
+      decoded = decodeCloudToLanTargetEntryRecord(entry);
+      withdrawn = withdrawCloudToLanTargetEntry(decoded, this.now().toISOString());
+    } catch {
+      throw transferError(
+        'authority-transfer-stale',
+        'authority-transfer-target-withdrawal-invalid',
+      );
+    }
+    return this.runProject(decoded.projectId, async () => {
+      const [document, record] = await Promise.all([
+        this.stores.authorityTransferEntries.load(decoded.projectId),
+        this.stores.authorityTransferRecords.load(decoded.projectId),
+      ]);
+      const current = document?.target;
+      if (current && sameValue(current, withdrawn)) return current;
+      if (!current || !sameValue(current, decoded) || record !== null) {
+        throw transferError(
+          'authority-transfer-cancellation-forbidden',
+          'authority-transfer-target-withdrawal-stale',
+        );
+      }
+      await this.stores.authorityTransferEntries.saveTarget(withdrawn);
+      return withdrawn;
+    });
+  }
+
+  handoffCloudToLanTargetEntry(
+    entry: CloudToLanTargetEntryRecord,
+    record: AuthorityTransferRecord,
+  ): Promise<AuthorityTransferRecord> {
+    let decodedEntry: CloudToLanTargetEntryRecord;
+    let decodedRecord: AuthorityTransferRecord;
+    let handedOff: CloudToLanTargetEntryRecord;
+    try {
+      decodedEntry = decodeCloudToLanTargetEntryRecord(entry);
+      decodedRecord = decodeAuthorityTransferRecord(record);
+      handedOff = handoffCloudToLanTargetEntry(decodedEntry, decodedRecord);
+    } catch {
+      throw transferError(
+        'durable-progress-recovery-required',
+        'authority-transfer-target-entry-handoff-invalid',
+      );
+    }
+    return this.runProject(decodedEntry.projectId, async () => {
+      const [document, physical] = await Promise.all([
+        this.stores.authorityTransferEntries.load(decodedEntry.projectId),
+        this.stores.authorityTransferRecords.load(decodedEntry.projectId),
+      ]);
+      const current = document?.target;
+      if (!current) throw transferError(
+        'durable-progress-recovery-required',
+        'authority-transfer-target-entry-handoff-missing',
+      );
+      if (physical) {
+        if (!sameValue(physical, decodedRecord)) throw transferError(
+          'durable-progress-recovery-required',
+          'authority-transfer-target-entry-successor-conflict',
+        );
+      } else {
+        // The canonical physical record becomes durable before the logical
+        // preparation records its successor. A crash between these writes is
+        // recovered only by the exact entry/record linkage below.
+        await this.stores.authorityTransferRecords.save(decodedRecord);
+      }
+      if (sameValue(current, handedOff)) return decodedRecord;
+      if (!sameValue(current, decodedEntry)) throw transferError(
+        'durable-progress-recovery-required',
+        'authority-transfer-target-entry-handoff-stale',
+      );
+      await this.stores.authorityTransferEntries.saveTarget(handedOff);
+      return decodedRecord;
+    });
+  }
+
+  prepareCloudToLanManagerEntry(
+    entry: CloudToLanManagerEntryRecord,
+  ): Promise<CloudToLanManagerEntryRecord> {
+    let decoded: CloudToLanManagerEntryRecord;
+    try {
+      decoded = decodeCloudToLanManagerEntryRecord(entry);
+    } catch {
+      throw transferError(
+        'durable-progress-recovery-required',
+        'authority-transfer-manager-entry-invalid',
+      );
+    }
+    return this.runProject(decoded.projectId, async () => {
+      const [document, record] = await Promise.all([
+        this.stores.authorityTransferEntries.load(decoded.projectId),
+        this.stores.authorityTransferRecords.load(decoded.projectId),
+      ]);
+      const existing = document?.manager;
+      if (existing) {
+        if (sameValue(existing, decoded)) return existing;
+        if (
+          existing.phase === 'settled'
+          && record === null
+        ) {
+          await this.stores.authorityTransferEntries.saveManager(decoded);
+          return decoded;
+        }
+        throw transferError(
+          'durable-progress-recovery-required',
+          'authority-transfer-manager-entry-conflict',
+        );
+      }
+      const target = document?.target;
+      const compatibleSameDeviceTarget = target === undefined || target === null
+        || (
+          target.phase === 'published'
+          && target.descriptor !== null
+          && sameValue(target.descriptor, decoded.descriptor)
+        );
+      if (record || document?.source || !compatibleSameDeviceTarget) throw transferError(
+        'durable-progress-recovery-required',
+        'authority-transfer-manager-entry-conflict',
+      );
+      await this.stores.authorityTransferEntries.saveManager(decoded);
+      return decoded;
+    });
+  }
+
+  markCloudToLanManagerBeginPossiblySent(
+    entry: CloudToLanManagerEntryRecord,
+  ): Promise<CloudToLanManagerEntryRecord> {
+    return this.#updateCloudToLanManagerEntry(
+      entry,
+      markCloudToLanManagerBeginPossiblySent(entry),
+    );
+  }
+
+  recordCloudToLanManagerStatus(
+    entry: CloudToLanManagerEntryRecord,
+    status: CollabAuthorityTransferStatus,
+  ): Promise<CloudToLanManagerEntryRecord> {
+    return this.#updateCloudToLanManagerEntry(
+      entry,
+      recordCloudToLanManagerStatus(entry, status),
+    );
+  }
+
+  prepareCloudToLanManagerCancellation(
+    entry: CloudToLanManagerEntryRecord,
+    request: Parameters<typeof prepareCloudToLanManagerCancellation>[1],
+  ): Promise<CloudToLanManagerEntryRecord> {
+    return this.#updateCloudToLanManagerEntry(
+      entry,
+      prepareCloudToLanManagerCancellation(entry, request),
+    );
+  }
+
+  markCloudToLanManagerCancellationPossiblySent(
+    entry: CloudToLanManagerEntryRecord,
+  ): Promise<CloudToLanManagerEntryRecord> {
+    return this.#updateCloudToLanManagerEntry(
+      entry,
+      markCloudToLanManagerCancellationPossiblySent(entry),
+    );
+  }
+
+  rejectCloudToLanManagerEntry(
+    entry: CloudToLanManagerEntryRecord,
+  ): Promise<CloudToLanManagerEntryRecord> {
+    return this.#updateCloudToLanManagerEntry(
+      entry,
+      rejectCloudToLanManagerEntry(entry),
+    );
+  }
+
+  settleCloudToLanManagerEntry(
+    entry: CloudToLanManagerEntryRecord,
+  ): Promise<void> {
+    if (entry.phase !== 'settled' && entry.phase !== 'rejected') {
+      throw transferError(
+        'authority-transfer-stale',
+        'authority-transfer-manager-entry-not-settled',
+      );
+    }
+    return this.runProject(entry.projectId, async () => {
+      if (!await this.stores.authorityTransferEntries.removeManager(entry)) {
+        const current = (await this.stores.authorityTransferEntries.load(entry.projectId))?.manager;
+        if (current !== null && current !== undefined) {
+          throw transferError(
+            'durable-progress-recovery-required',
+            'authority-transfer-manager-entry-stale',
+          );
+        }
+      }
+    });
+  }
+
+  #updateCloudToLanManagerEntry(
+    expected: CloudToLanManagerEntryRecord,
+    next: CloudToLanManagerEntryRecord,
+  ): Promise<CloudToLanManagerEntryRecord> {
+    return this.runProject(expected.projectId, async () => {
+      const current = (await this.stores.authorityTransferEntries.load(expected.projectId))?.manager;
+      if (!current || !sameValue(current, expected)) {
+        if (current && sameValue(current, next)) return current;
+        throw transferError(
+          'durable-progress-recovery-required',
+          'authority-transfer-manager-entry-stale',
+        );
+      }
+      await this.stores.authorityTransferEntries.saveManager(next);
+      return next;
     });
   }
 
@@ -997,12 +1403,20 @@ export class AuthorityTransferPersistence {
           'authority-transfer-terminal-cleanup-owner-stale',
         );
       }
-      const source = entry?.source;
+      let source = entry?.source;
+      let target = entry?.target;
       if (
         source
         && this.#isLocalSourceEntry(source)
         && source.phase !== 'cancelled'
-      ) await this.#reconcileEntrySuccessor(source, record);
+      ) {
+        await this.#reconcileEntrySuccessor(source, record);
+        source = (await this.stores.authorityTransferEntries.load(input.projectId))?.source;
+      }
+      if (target && this.#isLocalTargetEntry(target)) {
+        await this.#reconcileTargetEntrySuccessor(target, record);
+        target = (await this.stores.authorityTransferEntries.load(input.projectId))?.target;
+      }
       if (
         record.terminalResponder?.state === 'active'
         || record.terminalResponder?.state === 'pending'
@@ -1037,6 +1451,14 @@ export class AuthorityTransferPersistence {
           );
         }
       }
+      if (target && this.#isLocalTargetEntry(target)) {
+        if (!await this.stores.authorityTransferEntries.removeTarget(target)) {
+          throw transferError(
+            'durable-progress-recovery-required',
+            'authority-transfer-entry-target-stale',
+          );
+        }
+      }
     });
   }
 
@@ -1065,6 +1487,7 @@ export class AuthorityTransferPersistence {
         await this.#assertClaimBatchOwner(custody, record);
       }
       const source = entry?.source;
+      const target = entry?.target;
       if (
         source
         && this.#isLocalSourceEntry(source)
@@ -1073,6 +1496,9 @@ export class AuthorityTransferPersistence {
         && source.phase !== 'cancelled'
       ) {
         await this.#reconcileEntrySuccessor(source, record);
+      }
+      if (target && record && this.#isLocalTargetEntry(target)) {
+        await this.#reconcileTargetEntrySuccessor(target, record);
       }
       return record;
     });
@@ -1619,9 +2045,13 @@ export class AuthorityTransferPersistence {
     ]);
     const entry = await this.#removeExpiredEntry(loadedEntry, record);
     const source = entry?.source;
+    const target = entry?.target;
     const localSource = source !== null
       && source !== undefined
       && this.#isLocalSourceEntry(source);
+    const localTarget = target !== null
+      && target !== undefined
+      && this.#isLocalTargetEntry(target);
     if (
       localSource
       && source.phase === 'handed-off'
@@ -1636,6 +2066,9 @@ export class AuthorityTransferPersistence {
     if (record && this.#isForeignPhysical(record)) return;
     if (localSource && record && source.phase !== 'cancelled') {
       await this.#reconcileEntrySuccessor(source, record);
+    }
+    if (localTarget && record && target.phase !== 'withdrawn') {
+      await this.#reconcileTargetEntrySuccessor(target, record);
     }
     if (record && record.ownerInstallationKey === undefined) {
       throw transferError(
@@ -1654,6 +2087,12 @@ export class AuthorityTransferPersistence {
       throw transferError(
         'durable-progress-recovery-required',
         'authority-transfer-entry-successor-missing',
+      );
+    }
+    if (!record && localTarget && target.phase === 'handed-off') {
+      throw transferError(
+        'durable-progress-recovery-required',
+        'authority-transfer-target-entry-successor-missing',
       );
     }
     if (commitment && !custody) {
@@ -1766,15 +2205,29 @@ export class AuthorityTransferPersistence {
       )
       ? entry.source
       : null;
+    const managerIsRemovable = entry.manager !== null
+      && (entry.manager.phase === 'settled' || entry.manager.phase === 'rejected')
+      && now >= Date.parse(entry.manager.expiresAt);
+    const targetIsRemovable = entry.target !== null
+      && entry.target.phase === 'withdrawn'
+      && now >= Date.parse(entry.target.expiresAt);
     if (
       source === entry.source
       && expiredRequesters.length === 0
+      && !managerIsRemovable
+      && !targetIsRemovable
     ) return entry;
     for (const requester of expiredRequesters) {
       await this.stores.authorityTransferEntries.removeRequester(requester);
     }
     if (entry.source && source === null) {
       await this.stores.authorityTransferEntries.removeSource(entry.source);
+    }
+    if (managerIsRemovable && entry.manager) {
+      await this.stores.authorityTransferEntries.removeManager(entry.manager);
+    }
+    if (targetIsRemovable && entry.target) {
+      await this.stores.authorityTransferEntries.removeTarget(entry.target);
     }
     return this.stores.authorityTransferEntries.load(entry.projectId);
   }
@@ -1784,7 +2237,28 @@ export class AuthorityTransferPersistence {
       && !this.#isRecoveryOwner(record.ownerInstallationKey);
   }
 
+  #managerMatchesPhysical(
+    manager: CloudToLanManagerEntryRecord,
+    record: AuthorityTransferRecord,
+  ): boolean {
+    return manager.status !== null
+      && record.localRole === 'target'
+      && record.status.direction === 'cloud-to-lan'
+      && manager.operationIntentId === record.operationIntentId
+      && manager.projectId === record.projectId
+      && manager.status.transferId === record.transferId
+      && manager.status.createdAt === record.status.createdAt
+      && manager.status.expiresAt === record.status.expiresAt
+      && manager.descriptor.sourceAuthorityGeneration
+        === record.status.sourceAuthority.generation
+      && manager.descriptor.targetUrl === record.status.targetUrl;
+  }
+
   #isLocalSourceEntry(entry: AuthorityTransferSourceEntryRecord): boolean {
+    return this.#isRecoveryOwner(entry.ownerInstallationKey);
+  }
+
+  #isLocalTargetEntry(entry: CloudToLanTargetEntryRecord): boolean {
     return this.#isRecoveryOwner(entry.ownerInstallationKey);
   }
 
@@ -1809,6 +2283,31 @@ export class AuthorityTransferPersistence {
       throw transferError(
         'durable-progress-recovery-required',
         'authority-transfer-entry-successor-mismatch',
+      );
+    }
+  }
+
+  async #reconcileTargetEntrySuccessor(
+    entry: CloudToLanTargetEntryRecord,
+    record: AuthorityTransferRecord,
+  ): Promise<void> {
+    let expected: CloudToLanTargetEntryRecord;
+    try {
+      expected = handoffCloudToLanTargetEntry(entry, record);
+    } catch {
+      throw transferError(
+        'durable-progress-recovery-required',
+        'authority-transfer-target-entry-successor-mismatch',
+      );
+    }
+    if (entry.phase === 'published') {
+      await this.stores.authorityTransferEntries.saveTarget(expected);
+      return;
+    }
+    if (!sameValue(entry, expected)) {
+      throw transferError(
+        'durable-progress-recovery-required',
+        'authority-transfer-target-entry-successor-mismatch',
       );
     }
   }
@@ -1926,10 +2425,13 @@ export class AuthorityTransferPersistence {
       ?? await this.stores.authorityTransferRecords.load(custody.projectId);
     const checkpointMatches = record?.status.checkpointSha256 === null
       || record?.status.checkpointSha256 === custody.checkpointSha256;
+    const expectedOperationIntentId = record?.localRole === 'target'
+      ? authorityTransferChildIdempotencyKey(record.operationIntentId, 'stage')
+      : record?.operationIntentId;
     if (
       !record
       || record.transferId !== custody.transferId
-      || record.operationIntentId !== custody.operationIntentId
+      || expectedOperationIntentId !== custody.operationIntentId
       || !checkpointMatches
       || record.status.targetAuthority.generation !== custody.targetAuthorityGeneration
       || record.status.expiresAt !== custody.expiresAt
@@ -1974,7 +2476,11 @@ export class AuthorityTransferPersistence {
     if (
       commitment.projectId !== record.projectId
       || commitment.transferId !== record.transferId
-      || commitment.operationIntentId !== record.operationIntentId
+      || commitment.operationIntentId !== (
+        record.localRole === 'target'
+          ? authorityTransferChildIdempotencyKey(record.operationIntentId, 'stage')
+          : record.operationIntentId
+      )
     ) {
       throw transferError('authority-transfer-stale', 'authority-transfer-claim-owner-stale');
     }

--- a/src/app/collab/authority-transfer/persistence/AuthorityTransferPersistenceStores.ts
+++ b/src/app/collab/authority-transfer/persistence/AuthorityTransferPersistenceStores.ts
@@ -7,6 +7,10 @@ import type {
 } from '@/app/collab/authority-transfer/AuthorityTransferEntryRecord';
 import { type AuthorityTransferRecord } from '@/app/collab/authority-transfer/AuthorityTransferRecord';
 import type {
+  CloudToLanManagerEntryRecord,
+  CloudToLanTargetEntryRecord,
+} from '@/app/collab/authority-transfer/cloud-to-lan/CloudToLanTransferEntryRecord';
+import type {
   AuthorityTransferClaimBatchCommitmentRecord,
 } from '@/app/collab/authority-transfer/persistence/AuthorityTransferClaimBatchCommitmentRecord';
 import {
@@ -24,10 +28,14 @@ export interface AuthorityTransferRecordStorePort {
 
 export interface AuthorityTransferEntryStorePort {
   load(projectId: CollabProjectId): Promise<AuthorityTransferEntryRecord | null>;
+  removeManager(record: CloudToLanManagerEntryRecord): Promise<boolean>;
   removeRequester(record: AuthorityTransferRequesterEntryRecord): Promise<boolean>;
   removeSource(record: AuthorityTransferSourceEntryRecord): Promise<boolean>;
+  removeTarget(record: CloudToLanTargetEntryRecord): Promise<boolean>;
+  saveManager(record: CloudToLanManagerEntryRecord): Promise<void>;
   saveRequester(record: AuthorityTransferRequesterEntryRecord): Promise<void>;
   saveSource(record: AuthorityTransferSourceEntryRecord): Promise<void>;
+  saveTarget(record: CloudToLanTargetEntryRecord): Promise<void>;
 }
 
 export interface AuthorityTransferProjectCatalog {

--- a/src/app/collab/authority-transfer/recovery/AuthorityTransferRecovery.ts
+++ b/src/app/collab/authority-transfer/recovery/AuthorityTransferRecovery.ts
@@ -3,6 +3,9 @@ import { type CollabProjectId } from '@claudian-collab/protocol';
 import {
   type AuthorityTransferRecord,
 } from '@/app/collab/authority-transfer/AuthorityTransferRecord';
+import type {
+  CloudToLanTargetEntryRecord,
+} from '@/app/collab/authority-transfer/cloud-to-lan/CloudToLanTransferEntryRecord';
 import {
   type AuthorityTransferPersistence,
 } from '@/app/collab/authority-transfer/persistence/AuthorityTransferPersistence';
@@ -17,6 +20,11 @@ import { CollabError } from '@/core/collab/ClaudianCollabError';
 export interface AuthorityTransferRecoveryHandler {
   prepare?(record: AuthorityTransferRecord): Promise<void>;
   resume(record: AuthorityTransferRecord, options: CollabOperationOptions): Promise<void>;
+  resumeManager(projectId: CollabProjectId, options: CollabOperationOptions): Promise<void>;
+  resumeTargetPreparation(
+    entry: CloudToLanTargetEntryRecord,
+    options: CollabOperationOptions,
+  ): Promise<void>;
 }
 
 function throwIfCancelled(signal?: AbortSignal): void {
@@ -62,15 +70,23 @@ export class AuthorityTransferRecovery implements CollabProjectLifecycleRecovery
       : undefined;
     for (const projectId of catalog.projectIds) {
       throwIfCancelled(options.signal);
-      await this.lifecycle.runExclusive(
+      await this.lifecycle.runAuthorityTransferRecovery(
         projectId,
-        this.durableOwner.name,
-        'recovery',
         async () => {
+          await this.handler.resumeManager(projectId, options);
           let ownerState = await this.persistence.inspectLifecycleOwner(projectId);
           if (ownerState === 'absent' || ownerState === 'terminal') return;
           const ownerRecord = await this.persistence.loadRecoveryOwnerRecord(projectId);
-          if (!ownerRecord) return;
+          if (!ownerRecord) {
+            const targetEntry = await this.persistence.loadCloudToLanTargetEntry(projectId);
+            if (
+              !targetEntry
+              || (targetEntry.phase !== 'preparing' && targetEntry.phase !== 'published')
+            ) return;
+            await this.assertRecoveryOwner(targetEntry.ownerInstallationKey, projectId);
+            await this.handler.resumeTargetPreparation(targetEntry, options);
+            return;
+          }
           await this.assertRecoveryOwner(ownerRecord.ownerInstallationKey, projectId);
           await this.persistence.recoverInterruptedClaimCommitment(projectId);
           ownerState = await this.persistence.inspectLifecycleOwner(projectId);

--- a/src/app/collab/lan/LanHostCoordinator.ts
+++ b/src/app/collab/lan/LanHostCoordinator.ts
@@ -1378,13 +1378,7 @@ export class LanHostCoordinator {
             'authority-transfer-route-host-mismatch',
           );
         }
-        if (existingAuthorityTransferRoute?.state !== 'source-active') {
-          if (existingAuthorityTransferRoute) {
-            throw hostError(
-              'operation-failed',
-              'authority-transfer-route-conflict',
-            );
-          }
+        if (!existingAuthorityTransferRoute) {
           await this.#authorityTransferRoutes.install({
             hostMemberId: hostedMembership.member.id,
             projectId,
@@ -1392,6 +1386,14 @@ export class LanHostCoordinator {
             state: 'source-active',
           });
           authorityTransferRouteRegistered = true;
+        } else if (
+          existingAuthorityTransferRoute.state !== 'source-active'
+          && existingAuthorityTransferRoute.state !== 'target-active'
+        ) {
+            throw hostError(
+              'operation-failed',
+              'authority-transfer-route-conflict',
+            );
         }
       }
       advertisement = await this.options.discovery?.advertiseProject({

--- a/src/app/collab/lifecycle/CollabProjectLifecycleSubsystem.ts
+++ b/src/app/collab/lifecycle/CollabProjectLifecycleSubsystem.ts
@@ -162,6 +162,19 @@ export class CollabProjectLifecycleSubsystem {
     );
   }
 
+  runAuthorityTransferRecovery<T>(
+    projectId: CollabProjectId,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    return this.runExclusiveWithPredecessor(
+      projectId,
+      'authority-transfer',
+      ['authority-transfer-claimant'],
+      'recovery',
+      operation,
+    );
+  }
+
   runRetirementAdoption<T>(
     projectId: CollabProjectId,
     operation: () => Promise<T>,

--- a/src/core/collab/CollabFeaturePort.ts
+++ b/src/core/collab/CollabFeaturePort.ts
@@ -1,4 +1,4 @@
-import type { CollabChangeRequest, CollabComment, CollabCommentPage, CollabGitOid, CollabIsoTimestamp, CollabMemberId, CollabOperationId, CollabProjectId, CollabRelativePath, CollabRequestId, CollabResolvingTicketExpectation, CollabTicketAcceptedRelationPage, CollabTicketComment, CollabTicketCommentPage, CollabTicketDetail, CollabTicketId, CollabTicketPage, CollabTicketStatus, CollabTicketSummary } from '@claudian-collab/protocol';
+import type { CollabAuthorityTransferStatus, CollabChangeRequest, CollabComment, CollabCommentPage, CollabGitOid, CollabIsoTimestamp, CollabMemberId, CollabOperationId, CollabProjectId, CollabRelativePath, CollabRequestId, CollabResolvingTicketExpectation, CollabTicketAcceptedRelationPage, CollabTicketComment, CollabTicketCommentPage, CollabTicketDetail, CollabTicketId, CollabTicketPage, CollabTicketStatus, CollabTicketSummary } from '@claudian-collab/protocol';
 import type { CollabImportedClaimState, CollabProjectInvitationState, CollabProjectMemberBindingState, CollabRole } from '@claudian-collab/protocol';
 
 import type { CollabError } from '@/core/collab/ClaudianCollabError';
@@ -421,6 +421,44 @@ export interface CollabFinalizeRetiredProjectRequest {
   cleanupChoice: CollabLocalCleanupChoice;
 }
 
+export interface CollabCloudToLanTargetPreparationDescriptor {
+  readonly caCertificatePem: string;
+  readonly caFingerprint: string;
+  readonly preparationId: string;
+  readonly projectId: CollabProjectId;
+  readonly publishedAt: CollabIsoTimestamp;
+  readonly schemaVersion: 1;
+  readonly selectedTargetMemberId: CollabMemberId;
+  readonly sourceAuthorityGeneration: number;
+  readonly sourceCloudUrl: string;
+  readonly targetUrl: string;
+}
+
+export interface CollabCloudToLanTransferHandle {
+  readonly operationIntentId: string;
+  readonly preparationId: string;
+  readonly projectId: CollabProjectId;
+  readonly schemaVersion: 1;
+  readonly selectedTargetMemberId: CollabMemberId;
+  readonly sourceAuthorityGeneration: number;
+  readonly sourceCloudUrl: string;
+  readonly targetUrl: string;
+  readonly transferId: string;
+}
+
+export interface CollabPrepareCloudToLanTargetRequest {
+  readonly projectId: CollabProjectId;
+}
+
+export interface CollabBeginCloudToLanTransferRequest {
+  readonly descriptor: CollabCloudToLanTargetPreparationDescriptor;
+}
+
+export interface CollabWithdrawCloudToLanTargetRequest {
+  readonly preparationId: string;
+  readonly projectId: CollabProjectId;
+}
+
 export interface CollabRemoveMemberRequest {
   projectId: CollabProjectId;
   memberId: CollabMemberId;
@@ -484,6 +522,12 @@ export interface CollabFeaturePort {
   retireProject(request: CollabRetireProjectRequest, options?: CollabOperationOptions): Promise<CollabResult<void>>;
   finalizeRetiredProject(request: CollabFinalizeRetiredProjectRequest, options?: CollabOperationOptions): Promise<CollabResult<void>>;
   retryProjectCleanup(projectId: CollabProjectId, options?: CollabOperationOptions): Promise<CollabResult<void>>;
+  prepareCloudToLanTarget(request: CollabPrepareCloudToLanTargetRequest, options?: CollabOperationOptions): Promise<CollabResult<CollabCloudToLanTargetPreparationDescriptor>>;
+  beginCloudToLanTransfer(request: CollabBeginCloudToLanTransferRequest, options?: CollabOperationOptions): Promise<CollabResult<CollabCloudToLanTransferHandle>>;
+  acceptCloudToLanTransfer(handle: CollabCloudToLanTransferHandle, options?: CollabOperationOptions): Promise<CollabResult<CollabAuthorityTransferStatus>>;
+  withdrawCloudToLanTarget(request: CollabWithdrawCloudToLanTargetRequest, options?: CollabOperationOptions): Promise<CollabResult<void>>;
+  observeCloudToLanTransfer(projectId: CollabProjectId, options?: CollabOperationOptions): Promise<CollabResult<CollabAuthorityTransferStatus>>;
+  cancelCloudToLanTransfer(handle: CollabCloudToLanTransferHandle, options?: CollabOperationOptions): Promise<CollabResult<CollabAuthorityTransferStatus>>;
   subscribe(listener: CollabFeatureStateListener): CollabFeatureSubscription;
 }
 

--- a/tests/helpers/collab/CollabFeatureTestHarness.ts
+++ b/tests/helpers/collab/CollabFeatureTestHarness.ts
@@ -1,4 +1,5 @@
 import type {
+  CollabAuthorityTransferEntryPort,
   CollabCloudBootstrapPort,
   CollabFeatureServiceOptions,
   CollabHostTransferPort,
@@ -81,6 +82,12 @@ export const TEST_COLLAB_FEATURE_PORT_METHODS = [
   'retireProject',
   'finalizeRetiredProject',
   'retryProjectCleanup',
+  'prepareCloudToLanTarget',
+  'beginCloudToLanTransfer',
+  'acceptCloudToLanTransfer',
+  'withdrawCloudToLanTarget',
+  'observeCloudToLanTransfer',
+  'cancelCloudToLanTransfer',
   'subscribe',
 ] as const satisfies readonly (keyof CollabFeaturePort)[];
 
@@ -94,6 +101,7 @@ export const TEST_COLLAB_RESULT_STATUSES = [
 ] as const satisfies readonly CollabResult<unknown>['status'][];
 
 type FeatureOptionsOverrides = {
+  readonly authorityTransfer?: Partial<CollabAuthorityTransferEntryPort>;
   readonly cloudEntry?: Partial<CollabFeatureServiceOptions['cloudEntry']>;
   readonly cloudBootstrap?: Partial<CollabCloudBootstrapPort>;
   readonly cloudRetirementIntents?: CollabFeatureServiceOptions['cloudRetirementIntents'];
@@ -118,6 +126,18 @@ function defaultCloudBootstrap(): CollabCloudBootstrapPort {
     recoverPending: () => Promise.resolve(),
     startFormerHost: () => unexpected('startCloudBootstrapFormerHost'),
     submitParticipant: () => unexpected('submitCloudBootstrapParticipant'),
+  };
+}
+
+function defaultAuthorityTransfer(): CollabAuthorityTransferEntryPort {
+  return {
+    acceptCloudToLanTransfer: () => unexpected('acceptCloudToLanTransfer'),
+    beginCloudToLanTransfer: () => unexpected('beginCloudToLanTransfer'),
+    cancelCloudToLanTransfer: () => unexpected('cancelCloudToLanTransfer'),
+    close: () => Promise.resolve(),
+    observeCloudToLanTransfer: () => unexpected('observeCloudToLanTransfer'),
+    prepareCloudToLanTarget: () => unexpected('prepareCloudToLanTarget'),
+    withdrawCloudToLanTarget: () => unexpected('withdrawCloudToLanTarget'),
   };
 }
 
@@ -329,6 +349,10 @@ export function completeCollabFeatureOptions(
   overrides: FeatureOptionsOverrides,
 ): CollabFeatureServiceOptions {
   return {
+    authorityTransfer: {
+      ...defaultAuthorityTransfer(),
+      ...overrides.authorityTransfer,
+    },
     cloudBootstrap: { ...defaultCloudBootstrap(), ...overrides.cloudBootstrap },
     cloudRetirementIntents: overrides.cloudRetirementIntents ?? {
       listProjectIds: () => Promise.resolve([]),

--- a/tests/integration/app/collab/authority-transfer/AuthorityTransferPersistence.test.ts
+++ b/tests/integration/app/collab/authority-transfer/AuthorityTransferPersistence.test.ts
@@ -22,11 +22,23 @@ import {
   prepareAuthorityTransferSourceCancellation,
 } from '@/app/collab/authority-transfer/AuthorityTransferEntryRecord';
 import {
+  authorityTransferChildIdempotencyKey,
+} from '@/app/collab/authority-transfer/AuthorityTransferOperationIdentity';
+import {
   assertAuthorityTransferTransition,
   createAuthorityTransferRecord,
   decodeAuthorityTransferRecord,
   expireAuthorityTransferTerminalResponder,
 } from '@/app/collab/authority-transfer/AuthorityTransferRecord';
+import {
+  createCloudToLanManagerEntry,
+  createCloudToLanTargetEntry,
+  decodeCloudToLanManagerEntryRecord,
+  markCloudToLanManagerBeginPossiblySent,
+  publishCloudToLanTargetEntry,
+  recordCloudToLanManagerStatus,
+  rejectCloudToLanManagerEntry,
+} from '@/app/collab/authority-transfer/cloud-to-lan/CloudToLanTransferEntryRecord';
 import {
   createAuthorityTransferClaimBatchCommitmentRecord,
 } from '@/app/collab/authority-transfer/persistence/AuthorityTransferClaimBatchCommitmentRecord';
@@ -41,6 +53,7 @@ import { CollabLocalProjectRepository } from '@/app/collab/CollabLocalProjectRep
 const PROJECT_ID = 'project-alpha';
 const TRANSFER_ID = 'transfer-one';
 const OPERATION_INTENT_ID = 'intent-one';
+const CLOUD_RELINQUISHMENT_INTENT_ID = 'intent-cloud-relinquishment';
 const CHECKPOINT_SHA256 = 'a'.repeat(64);
 const MEMBER_ALICE = 'member-alice';
 const MEMBER_BOB = 'member-bob';
@@ -200,7 +213,7 @@ function cloudToLanStatus(
           certificateAlgorithm: 'ed25519',
           checkpointSha256: CHECKPOINT_SHA256,
           committedAt: '2026-08-26T00:04:30.000Z',
-          operationIntentId: OPERATION_INTENT_ID,
+          operationIntentId: CLOUD_RELINQUISHMENT_INTENT_ID,
           projectId: PROJECT_ID,
           sourceAuthority: { generation: 1, kind: 'cloud' },
           sourceHostMemberId: null,
@@ -292,6 +305,561 @@ describe('AuthorityTransferPersistence', () => {
       },
     });
     await expect(persistence.inspectLifecycleOwner(PROJECT_ID)).resolves.toBe('nonterminal');
+  });
+
+  it('persists coexisting target and Manager entries and recovers a physical-first target handoff', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository, {
+      isRecoveryOwner: owner => owner === TEST_INSTALLATION_A,
+    });
+    const target = createCloudToLanTargetEntry({
+      createdAt: '2026-08-26T00:00:00.000Z',
+      expiresAt: ENTRY_EXPIRES_AT,
+      operationIntentId: 'intent-target-preparation',
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      projectId: PROJECT_ID,
+      selectedTargetMemberId: MEMBER_BOB,
+      selectedTargetPersonalRef: `refs/heads/members/${MEMBER_BOB}`,
+      sourceAuthorityGeneration: 1,
+      sourceCloudUrl: 'https://cloud.example.test/',
+    });
+    const published = publishCloudToLanTargetEntry(target, {
+      caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+      caFingerprint: 'c'.repeat(64),
+      publishedAt: '2026-08-26T00:00:30.000Z',
+      targetUrl: 'https://192.168.1.20:27001',
+    });
+    await persistence.prepareCloudToLanTargetEntry(target);
+    await persistence.publishCloudToLanTargetEntry(target, published.descriptor!);
+    const manager = createCloudToLanManagerEntry({
+      createdAt: '2026-08-26T00:00:45.000Z',
+      descriptor: published.descriptor!,
+      expiresAt: ENTRY_EXPIRES_AT,
+      initiatingMemberId: MEMBER_ALICE,
+      initiatingPersonalRef: `refs/heads/members/${MEMBER_ALICE}`,
+      operationIntentId: OPERATION_INTENT_ID,
+    });
+    await persistence.prepareCloudToLanManagerEntry(manager);
+    await expect(repository.authorityTransferEntries.load(PROJECT_ID)).resolves.toMatchObject({
+      manager: { operationIntentId: OPERATION_INTENT_ID, phase: 'prepared' },
+      target: { operationIntentId: 'intent-target-preparation', phase: 'published' },
+    });
+
+    const physical = createAuthorityTransferRecord({
+      lifecycleOwnership: 'owned',
+      localRole: 'target',
+      operationIntentId: OPERATION_INTENT_ID,
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: {
+        ...cloudToLanStatus('collecting-readiness'),
+        targetUrl: published.descriptor!.targetUrl,
+      },
+    });
+    let injectSplit = true;
+    const splitEntryStore = {
+      ...repository.authorityTransferEntries,
+      saveTarget: async (record: typeof published) => {
+        if (record.phase === 'handed-off' && injectSplit) {
+          injectSplit = false;
+          throw new Error('injected-target-handoff-split');
+        }
+        await repository.authorityTransferEntries.saveTarget(record);
+      },
+    };
+    const splitPersistence = new AuthorityTransferPersistence({
+      authorityTransferClaimCommitments: repository.authorityTransferClaimCommitments,
+      authorityTransferClaims: repository.authorityTransferClaims,
+      authorityTransferEntries: splitEntryStore,
+      authorityTransferRecords: repository.authorityTransferRecords,
+    }, { isRecoveryOwner: owner => owner === TEST_INSTALLATION_A });
+    await expect(splitPersistence.handoffCloudToLanTargetEntry(published, physical))
+      .rejects.toThrow('injected-target-handoff-split');
+    await expect(repository.authorityTransferRecords.load(PROJECT_ID)).resolves.toEqual(physical);
+    await expect(repository.authorityTransferEntries.load(PROJECT_ID)).resolves.toMatchObject({
+      target: { phase: 'published', successor: null },
+    });
+
+    const recovered = new AuthorityTransferPersistence(repository, {
+      isRecoveryOwner: owner => owner === TEST_INSTALLATION_A,
+    });
+    await expect(recovered.load(PROJECT_ID)).resolves.toEqual(physical);
+    await expect(repository.authorityTransferEntries.load(PROJECT_ID)).resolves.toMatchObject({
+      manager: { phase: 'prepared' },
+      target: {
+        phase: 'handed-off',
+        successor: {
+          operationIntentId: OPERATION_INTENT_ID,
+          ownerInstallationKey: TEST_INSTALLATION_A,
+          transferId: TRANSFER_ID,
+        },
+      },
+    });
+    await expect(recovered.inspectLifecycleOwner(PROJECT_ID)).resolves.toBe('nonterminal');
+  });
+
+  it('rejects a Manager begin while an unrelated local target preparation exists', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository, {
+      isRecoveryOwner: owner => owner === TEST_INSTALLATION_A,
+    });
+    const target = createCloudToLanTargetEntry({
+      createdAt: '2026-08-26T00:00:00.000Z',
+      expiresAt: ENTRY_EXPIRES_AT,
+      operationIntentId: 'intent-unrelated-target-preparation',
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      projectId: PROJECT_ID,
+      selectedTargetMemberId: MEMBER_BOB,
+      selectedTargetPersonalRef: `refs/heads/members/${MEMBER_BOB}`,
+      sourceAuthorityGeneration: 1,
+      sourceCloudUrl: 'https://cloud.example.test/',
+    });
+    const published = publishCloudToLanTargetEntry(target, {
+      caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+      caFingerprint: 'c'.repeat(64),
+      publishedAt: '2026-08-26T00:00:30.000Z',
+      targetUrl: 'https://192.168.1.20:27001',
+    });
+    await persistence.prepareCloudToLanTargetEntry(target);
+    await persistence.publishCloudToLanTargetEntry(target, published.descriptor!);
+    const unrelatedDescriptor = {
+      ...published.descriptor!,
+      targetUrl: 'https://192.168.1.99:27001',
+    };
+
+    await expect(persistence.prepareCloudToLanManagerEntry(
+      createCloudToLanManagerEntry({
+        createdAt: '2026-08-26T00:00:45.000Z',
+        descriptor: unrelatedDescriptor,
+        expiresAt: ENTRY_EXPIRES_AT,
+        initiatingMemberId: MEMBER_ALICE,
+        initiatingPersonalRef: `refs/heads/members/${MEMBER_ALICE}`,
+        operationIntentId: OPERATION_INTENT_ID,
+      }),
+    )).rejects.toMatchObject({
+      safeContext: { reason: 'authority-transfer-manager-entry-conflict' },
+    });
+    await expect(repository.authorityTransferEntries.load(PROJECT_ID)).resolves.toMatchObject({
+      manager: null,
+      target: { operationIntentId: 'intent-unrelated-target-preparation' },
+    });
+  });
+
+  it('withdraws a preparing target before descriptor publication', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository, {
+      isRecoveryOwner: owner => owner === TEST_INSTALLATION_A,
+      now: () => new Date('2026-08-26T00:00:30.000Z'),
+    });
+    const preparing = await persistence.prepareCloudToLanTargetEntry(
+      createCloudToLanTargetEntry({
+        createdAt: '2026-08-26T00:00:00.000Z',
+        expiresAt: ENTRY_EXPIRES_AT,
+        operationIntentId: 'intent-unpublished-target',
+        ownerInstallationKey: TEST_INSTALLATION_A,
+        projectId: PROJECT_ID,
+        selectedTargetMemberId: MEMBER_BOB,
+        selectedTargetPersonalRef: `refs/heads/members/${MEMBER_BOB}`,
+        sourceAuthorityGeneration: 1,
+        sourceCloudUrl: 'https://cloud.example.test/',
+      }),
+    );
+
+    await expect(persistence.withdrawCloudToLanTargetEntry(preparing)).resolves.toMatchObject({
+      descriptor: null,
+      phase: 'withdrawn',
+      withdrawnAt: '2026-08-26T00:00:30.000Z',
+    });
+    await expect(persistence.inspectLifecycleOwner(PROJECT_ID)).resolves.toBe('absent');
+  });
+
+  it('withdraws only the same-device target while its Manager begin remains unresolved', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository, {
+      isRecoveryOwner: owner => owner === TEST_INSTALLATION_A,
+    });
+    const preparing = createCloudToLanTargetEntry({
+      createdAt: '2026-08-26T00:00:00.000Z',
+      expiresAt: ENTRY_EXPIRES_AT,
+      operationIntentId: 'intent-original-target',
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      projectId: PROJECT_ID,
+      selectedTargetMemberId: MEMBER_ALICE,
+      selectedTargetPersonalRef: `refs/heads/members/${MEMBER_ALICE}`,
+      sourceAuthorityGeneration: 1,
+      sourceCloudUrl: 'https://cloud.example.test/',
+    });
+    const published = publishCloudToLanTargetEntry(preparing, {
+      caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+      caFingerprint: 'c'.repeat(64),
+      publishedAt: '2026-08-26T00:00:30.000Z',
+      targetUrl: 'https://192.168.1.20:27001',
+    });
+    await persistence.prepareCloudToLanTargetEntry(preparing);
+    await persistence.publishCloudToLanTargetEntry(preparing, published.descriptor!);
+    await persistence.prepareCloudToLanManagerEntry(createCloudToLanManagerEntry({
+      createdAt: '2026-08-26T00:00:45.000Z',
+      descriptor: published.descriptor!,
+      expiresAt: ENTRY_EXPIRES_AT,
+      initiatingMemberId: MEMBER_ALICE,
+      initiatingPersonalRef: `refs/heads/members/${MEMBER_ALICE}`,
+      operationIntentId: OPERATION_INTENT_ID,
+    }));
+    await expect(persistence.withdrawCloudToLanTargetEntry(published)).resolves.toMatchObject({
+      phase: 'withdrawn',
+    });
+    await expect(repository.authorityTransferEntries.load(PROJECT_ID)).resolves.toMatchObject({
+      manager: { operationIntentId: OPERATION_INTENT_ID, phase: 'prepared' },
+      target: { operationIntentId: 'intent-original-target', phase: 'withdrawn' },
+    });
+    const replacement = createCloudToLanTargetEntry({
+      ...preparing,
+      operationIntentId: 'intent-replacement-target',
+    });
+
+    await expect(persistence.prepareCloudToLanTargetEntry(replacement)).rejects.toMatchObject({
+      safeContext: { reason: 'authority-transfer-target-entry-conflict' },
+    });
+  });
+
+  it('observes an exact published foreign target while preparing its Manager entry', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository, {
+      isRecoveryOwner: owner => owner === TEST_INSTALLATION_A,
+    });
+    const foreignTarget = createCloudToLanTargetEntry({
+      createdAt: '2026-08-26T00:00:00.000Z',
+      expiresAt: ENTRY_EXPIRES_AT,
+      operationIntentId: 'intent-foreign-target',
+      ownerInstallationKey: TEST_INSTALLATION_B,
+      projectId: PROJECT_ID,
+      selectedTargetMemberId: MEMBER_BOB,
+      selectedTargetPersonalRef: `refs/heads/members/${MEMBER_BOB}`,
+      sourceAuthorityGeneration: 1,
+      sourceCloudUrl: 'https://cloud.example.test/',
+    });
+    const published = publishCloudToLanTargetEntry(foreignTarget, {
+      caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+      caFingerprint: 'c'.repeat(64),
+      publishedAt: '2026-08-26T00:00:30.000Z',
+      targetUrl: 'https://192.168.1.20:27001',
+    });
+    await repository.authorityTransferEntries.saveTarget(published);
+
+    await expect(persistence.prepareCloudToLanManagerEntry(createCloudToLanManagerEntry({
+      createdAt: '2026-08-26T00:00:45.000Z',
+      descriptor: published.descriptor!,
+      expiresAt: ENTRY_EXPIRES_AT,
+      initiatingMemberId: MEMBER_ALICE,
+      initiatingPersonalRef: `refs/heads/members/${MEMBER_ALICE}`,
+      operationIntentId: OPERATION_INTENT_ID,
+    }))).resolves.toMatchObject({ phase: 'prepared' });
+  });
+
+  it('rejects a Manager phase that disagrees with its observed status state', () => {
+    const prepared = createCloudToLanManagerEntry({
+      createdAt: '2026-08-26T00:00:45.000Z',
+      descriptor: publishCloudToLanTargetEntry(createCloudToLanTargetEntry({
+        createdAt: '2026-08-26T00:00:00.000Z',
+        expiresAt: ENTRY_EXPIRES_AT,
+        operationIntentId: 'intent-decoder-target',
+        ownerInstallationKey: TEST_INSTALLATION_A,
+        projectId: PROJECT_ID,
+        selectedTargetMemberId: MEMBER_BOB,
+        selectedTargetPersonalRef: `refs/heads/members/${MEMBER_BOB}`,
+        sourceAuthorityGeneration: 1,
+        sourceCloudUrl: 'https://cloud.example.test/',
+      }), {
+        caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+        caFingerprint: 'c'.repeat(64),
+        publishedAt: '2026-08-26T00:00:30.000Z',
+        targetUrl: 'https://192.168.1.20:27001',
+      }).descriptor!,
+      expiresAt: ENTRY_EXPIRES_AT,
+      initiatingMemberId: MEMBER_ALICE,
+      initiatingPersonalRef: `refs/heads/members/${MEMBER_ALICE}`,
+      operationIntentId: OPERATION_INTENT_ID,
+    });
+    const observing = recordCloudToLanManagerStatus(
+      markCloudToLanManagerBeginPossiblySent(prepared),
+      { ...cloudToLanStatus('collecting-readiness'), targetUrl: prepared.descriptor.targetUrl },
+    );
+    const completed = recordCloudToLanManagerStatus(observing, {
+      ...cloudToLanStatus('completed'),
+      targetUrl: prepared.descriptor.targetUrl,
+    });
+
+    expect(() => decodeCloudToLanManagerEntryRecord({
+      ...observing,
+      phase: 'settled',
+    })).toThrow('Invalid Cloud-to-LAN Manager entry binding');
+    expect(() => decodeCloudToLanManagerEntryRecord({
+      ...completed,
+      phase: 'observing',
+    })).toThrow('Invalid Cloud-to-LAN Manager entry binding');
+    const rejected = rejectCloudToLanManagerEntry(
+      markCloudToLanManagerBeginPossiblySent(prepared),
+    );
+    expect(rejected).toMatchObject({ phase: 'rejected', status: null });
+    expect(() => decodeCloudToLanManagerEntryRecord({
+      ...rejected,
+      status: cloudToLanStatus('collecting-readiness'),
+    })).toThrow('Invalid Cloud-to-LAN Manager entry binding');
+  });
+
+  it('recovers a crash after the definitive Manager rejection write without removing the target', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository, {
+      isRecoveryOwner: owner => owner === TEST_INSTALLATION_A,
+    });
+    const target = publishCloudToLanTargetEntry(createCloudToLanTargetEntry({
+      createdAt: '2026-08-26T00:00:00.000Z',
+      expiresAt: ENTRY_EXPIRES_AT,
+      operationIntentId: 'intent-rejected-target-preparation',
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      projectId: PROJECT_ID,
+      selectedTargetMemberId: MEMBER_ALICE,
+      selectedTargetPersonalRef: `refs/heads/members/${MEMBER_ALICE}`,
+      sourceAuthorityGeneration: 1,
+      sourceCloudUrl: 'https://cloud.example.test/',
+    }), {
+      caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+      caFingerprint: 'c'.repeat(64),
+      publishedAt: '2026-08-26T00:00:30.000Z',
+      targetUrl: 'https://192.168.1.20:27001',
+    });
+    await repository.authorityTransferEntries.saveTarget(target);
+    const prepared = await persistence.prepareCloudToLanManagerEntry(
+      createCloudToLanManagerEntry({
+        createdAt: '2026-08-26T00:00:45.000Z',
+        descriptor: target.descriptor!,
+        expiresAt: ENTRY_EXPIRES_AT,
+        initiatingMemberId: MEMBER_ALICE,
+        initiatingPersonalRef: `refs/heads/members/${MEMBER_ALICE}`,
+        operationIntentId: OPERATION_INTENT_ID,
+      }),
+    );
+    const submitted = await persistence.markCloudToLanManagerBeginPossiblySent(prepared);
+    const rejected = await persistence.rejectCloudToLanManagerEntry(submitted);
+
+    await expect(repository.authorityTransferEntries.load(PROJECT_ID)).resolves.toMatchObject({
+      manager: { operationIntentId: OPERATION_INTENT_ID, phase: 'rejected' },
+      target: { operationIntentId: 'intent-rejected-target-preparation', phase: 'published' },
+    });
+
+    const restarted = new AuthorityTransferPersistence(repository, {
+      isRecoveryOwner: owner => owner === TEST_INSTALLATION_A,
+    });
+    await restarted.settleCloudToLanManagerEntry(rejected);
+    await expect(repository.authorityTransferEntries.load(PROJECT_ID)).resolves.toMatchObject({
+      manager: null,
+      target: { operationIntentId: 'intent-rejected-target-preparation', phase: 'published' },
+    });
+  });
+
+  it('removes the handed-off target entry only after physical terminal cleanup is durable', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository, {
+      isRecoveryOwner: owner => owner === TEST_INSTALLATION_A,
+    });
+    const preparing = createCloudToLanTargetEntry({
+      createdAt: '2026-08-26T00:00:00.000Z',
+      expiresAt: ENTRY_EXPIRES_AT,
+      operationIntentId: 'intent-terminal-target-preparation',
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      projectId: PROJECT_ID,
+      selectedTargetMemberId: MEMBER_BOB,
+      selectedTargetPersonalRef: `refs/heads/members/${MEMBER_BOB}`,
+      sourceAuthorityGeneration: 1,
+      sourceCloudUrl: 'https://cloud.example.test/',
+    });
+    const published = publishCloudToLanTargetEntry(preparing, {
+      caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+      caFingerprint: 'c'.repeat(64),
+      publishedAt: '2026-08-26T00:00:30.000Z',
+      targetUrl: 'https://192.168.1.20:27001',
+    });
+    await persistence.prepareCloudToLanTargetEntry(preparing);
+    await persistence.publishCloudToLanTargetEntry(preparing, published.descriptor!);
+    const physical = createAuthorityTransferRecord({
+      lifecycleOwnership: 'owned',
+      localRole: 'target',
+      operationIntentId: OPERATION_INTENT_ID,
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: {
+        ...cloudToLanStatus('completed'),
+        targetUrl: published.descriptor!.targetUrl,
+      },
+    });
+    await persistence.handoffCloudToLanTargetEntry(published, physical);
+
+    await persistence.completeTerminalCleanup({
+      operationIntentId: OPERATION_INTENT_ID,
+      projectId: PROJECT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      transferId: TRANSFER_ID,
+    });
+
+    await expect(repository.authorityTransferEntries.load(PROJECT_ID)).resolves.toBeNull();
+    await expect(repository.authorityTransferRecords.load(PROJECT_ID)).resolves.toMatchObject({
+      terminalCleanupCompleted: true,
+      transferId: TRANSFER_ID,
+    });
+    await expect(persistence.inspectLifecycleOwner(PROJECT_ID)).resolves.toBe('terminal');
+  });
+
+  it('recovers a crash between the terminal marker and target-entry removal', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const preparing = createCloudToLanTargetEntry({
+      createdAt: '2026-08-26T00:00:00.000Z',
+      expiresAt: ENTRY_EXPIRES_AT,
+      operationIntentId: 'intent-split-target-preparation',
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      projectId: PROJECT_ID,
+      selectedTargetMemberId: MEMBER_BOB,
+      selectedTargetPersonalRef: `refs/heads/members/${MEMBER_BOB}`,
+      sourceAuthorityGeneration: 1,
+      sourceCloudUrl: 'https://cloud.example.test/',
+    });
+    const published = publishCloudToLanTargetEntry(preparing, {
+      caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+      caFingerprint: 'c'.repeat(64),
+      publishedAt: '2026-08-26T00:00:30.000Z',
+      targetUrl: 'https://192.168.1.20:27001',
+    });
+    const physical = createAuthorityTransferRecord({
+      lifecycleOwnership: 'owned',
+      localRole: 'target',
+      operationIntentId: OPERATION_INTENT_ID,
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: {
+        ...cloudToLanStatus('completed'),
+        targetUrl: published.descriptor!.targetUrl,
+      },
+    });
+    await repository.authorityTransferEntries.saveTarget(
+      publishCloudToLanTargetEntry(preparing, published.descriptor!),
+    );
+    await repository.authorityTransferRecords.save(physical);
+    const removeTarget = jest.fn()
+      .mockResolvedValueOnce(false)
+      .mockImplementation(record => repository.authorityTransferEntries.removeTarget(record));
+    const persistence = new AuthorityTransferPersistence({
+      authorityTransferClaimCommitments: repository.authorityTransferClaimCommitments,
+      authorityTransferClaims: repository.authorityTransferClaims,
+      authorityTransferEntries: {
+        ...repository.authorityTransferEntries,
+        removeTarget,
+      },
+      authorityTransferRecords: repository.authorityTransferRecords,
+    }, {
+      isRecoveryOwner: owner => owner === TEST_INSTALLATION_A,
+    });
+    await persistence.handoffCloudToLanTargetEntry(
+      publishCloudToLanTargetEntry(preparing, published.descriptor!),
+      physical,
+    );
+    const cleanup = {
+      operationIntentId: OPERATION_INTENT_ID,
+      projectId: PROJECT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      transferId: TRANSFER_ID,
+    };
+
+    await expect(persistence.completeTerminalCleanup(cleanup)).rejects.toMatchObject({
+      safeContext: { reason: 'authority-transfer-entry-target-stale' },
+    });
+    await expect(repository.authorityTransferRecords.load(PROJECT_ID)).resolves.toMatchObject({
+      terminalCleanupCompleted: true,
+    });
+    await expect(persistence.inspectLifecycleOwner(PROJECT_ID)).resolves.toBe('nonterminal');
+
+    await expect(persistence.completeTerminalCleanup(cleanup)).resolves.toBeUndefined();
+    await expect(persistence.inspectLifecycleOwner(PROJECT_ID)).resolves.toBe('terminal');
+    expect(removeTarget).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps a remote-only Manager observer out of lifecycle ownership and settles it exactly', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository, {
+      isRecoveryOwner: owner => owner === TEST_INSTALLATION_A,
+    });
+    const descriptor = publishCloudToLanTargetEntry(createCloudToLanTargetEntry({
+      createdAt: '2026-08-26T00:00:00.000Z',
+      expiresAt: ENTRY_EXPIRES_AT,
+      operationIntentId: 'intent-remote-target-preparation',
+      ownerInstallationKey: TEST_INSTALLATION_B,
+      projectId: PROJECT_ID,
+      selectedTargetMemberId: MEMBER_BOB,
+      selectedTargetPersonalRef: `refs/heads/members/${MEMBER_BOB}`,
+      sourceAuthorityGeneration: 1,
+      sourceCloudUrl: 'https://cloud.example.test/',
+    }), {
+      caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+      caFingerprint: 'c'.repeat(64),
+      publishedAt: '2026-08-26T00:00:30.000Z',
+      targetUrl: 'https://192.168.1.20:27001',
+    }).descriptor!;
+    let manager = await persistence.prepareCloudToLanManagerEntry(
+      createCloudToLanManagerEntry({
+        createdAt: '2026-08-26T00:00:45.000Z',
+        descriptor,
+        expiresAt: ENTRY_EXPIRES_AT,
+        initiatingMemberId: MEMBER_ALICE,
+        initiatingPersonalRef: `refs/heads/members/${MEMBER_ALICE}`,
+        operationIntentId: OPERATION_INTENT_ID,
+      }),
+    );
+    manager = await persistence.markCloudToLanManagerBeginPossiblySent(manager);
+    manager = await persistence.recordCloudToLanManagerStatus(manager, {
+      ...cloudToLanStatus('collecting-readiness'),
+      targetUrl: descriptor.targetUrl,
+    });
+    await expect(persistence.inspectLifecycleOwner(PROJECT_ID)).resolves.toBe('absent');
+
+    await expect(Promise.resolve().then(() => persistence.recordCloudToLanManagerStatus(manager, {
+      ...cloudToLanStatus('cloud-quiesced'),
+      targetUrl: descriptor.targetUrl,
+      updatedAt: '2026-08-26T00:03:00.000Z',
+      transferId: 'transfer-other',
+    }))).rejects.toMatchObject({
+      safeContext: { reason: 'authority-transfer-observed-identity-mismatch' },
+    });
+    manager = await persistence.recordCloudToLanManagerStatus(manager, {
+      ...cloudToLanStatus('checkpoint-captured'),
+      targetUrl: descriptor.targetUrl,
+    });
+    await expect(Promise.resolve().then(() => persistence.recordCloudToLanManagerStatus(manager, {
+      ...cloudToLanStatus('cloud-quiesced'),
+      targetUrl: descriptor.targetUrl,
+      updatedAt: '2026-08-26T00:03:00.000Z',
+    }))).rejects.toMatchObject({
+      safeContext: { reason: 'authority-transfer-observed-phase-regressed' },
+    });
+
+    manager = await persistence.recordCloudToLanManagerStatus(manager, {
+      ...cloudToLanStatus('completed'),
+      targetUrl: descriptor.targetUrl,
+    });
+    expect(manager.phase).toBe('settled');
+    await persistence.settleCloudToLanManagerEntry(manager);
+    await expect(repository.authorityTransferEntries.load(PROJECT_ID)).resolves.toBeNull();
+  });
+
+  it('preserves a bounded raw HTTP Cloud endpoint in target preparation', () => {
+    expect(createCloudToLanTargetEntry({
+      createdAt: '2026-08-26T00:00:00.000Z',
+      expiresAt: ENTRY_EXPIRES_AT,
+      operationIntentId: 'intent-raw-http-target',
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      projectId: PROJECT_ID,
+      selectedTargetMemberId: MEMBER_BOB,
+      selectedTargetPersonalRef: `refs/heads/members/${MEMBER_BOB}`,
+      sourceAuthorityGeneration: 1,
+      sourceCloudUrl: 'http://127.0.0.1:8787',
+    }).sourceCloudUrl).toBe('http://127.0.0.1:8787');
   });
 
   it('adopts the Cloud lifecycle timestamps only at the first physical source phase', async () => {
@@ -1643,10 +2211,14 @@ describe('AuthorityTransferPersistence', () => {
       authorityTransferClaims: emptyStore,
       authorityTransferEntries: {
         ...emptyStore,
+        removeManager: jest.fn().mockResolvedValue(false),
         removeRequester: jest.fn().mockResolvedValue(false),
         removeSource: jest.fn().mockResolvedValue(false),
+        removeTarget: jest.fn().mockResolvedValue(false),
+        saveManager: jest.fn().mockResolvedValue(undefined),
         saveRequester: jest.fn().mockResolvedValue(undefined),
         saveSource: jest.fn().mockResolvedValue(undefined),
+        saveTarget: jest.fn().mockResolvedValue(undefined),
       },
       authorityTransferRecords: {
         ...emptyStore,
@@ -1992,9 +2564,13 @@ describe('AuthorityTransferPersistence', () => {
     for (const phase of CLOUD_TO_LAN_PHASES.slice(1)) {
       if (phase === 'claims-retained') {
         const batch = claimBatch();
+        const stageOperationIntentId = authorityTransferChildIdempotencyKey(
+          OPERATION_INTENT_ID,
+          'stage',
+        );
         await persistence.retainClaimBatch({
           batch,
-          operationIntentId: OPERATION_INTENT_ID,
+          operationIntentId: stageOperationIntentId,
           purpose: 'target-delivery',
         });
         await persistence.acknowledgeClaimBatch({
@@ -2003,7 +2579,7 @@ describe('AuthorityTransferPersistence', () => {
           checkpointSha256: batch.checkpointSha256,
           committedAt: '2026-08-26T00:03:30.000Z',
           custodyAuthority: { generation: 1, kind: 'cloud' },
-          operationIntentId: OPERATION_INTENT_ID,
+          operationIntentId: stageOperationIntentId,
           projectId: PROJECT_ID,
           receiptId: 'target-custody-receipt',
           submittedByMemberId: MEMBER_ALICE,
@@ -2152,6 +2728,47 @@ describe('AuthorityTransferPersistence', () => {
 
     await expect(persistence.create(replacement)).resolves.toBeUndefined();
     await expect(persistence.load(PROJECT_ID)).resolves.toEqual(replacement);
+  });
+
+  it('replaces a fully cleaned target cancellation with a fresh target preparation', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository, { isRecoveryOwner: () => true });
+    const cancelled = createAuthorityTransferRecord({
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      lifecycleOwnership: 'owned',
+      localRole: 'target',
+      operationIntentId: OPERATION_INTENT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: {
+        ...cloudToLanStatus('cloud-quiesced'),
+        phase: 'cancelled',
+        state: 'cancelled',
+        updatedAt: '2026-08-26T00:08:00.000Z',
+      },
+    });
+    await repository.authorityTransferRecords.save(cancelled);
+    await persistence.completeTerminalCleanup({
+      operationIntentId: OPERATION_INTENT_ID,
+      projectId: PROJECT_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      transferId: TRANSFER_ID,
+    });
+    const replacement = createCloudToLanTargetEntry({
+      createdAt: '2026-08-26T00:09:00.000Z',
+      expiresAt: ENTRY_EXPIRES_AT,
+      operationIntentId: 'intent-replacement-target',
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      projectId: PROJECT_ID,
+      selectedTargetMemberId: MEMBER_BOB,
+      selectedTargetPersonalRef: `refs/heads/members/${MEMBER_BOB}`,
+      sourceAuthorityGeneration: 2,
+      sourceCloudUrl: 'http://127.0.0.1:8787',
+    });
+
+    await expect(persistence.prepareCloudToLanTargetEntry(replacement)).resolves.toEqual(
+      replacement,
+    );
+    await expect(repository.authorityTransferRecords.load(PROJECT_ID)).resolves.toBeNull();
   });
 
   it('refuses terminal cleanup when claim custody belongs to a different durable owner', async () => {

--- a/tests/integration/app/collab/authority-transfer/ProductionAuthorityTransferEffects.test.ts
+++ b/tests/integration/app/collab/authority-transfer/ProductionAuthorityTransferEffects.test.ts
@@ -39,13 +39,15 @@ import { createAuthorityTransferRecord } from '@/app/collab/authority-transfer/A
 import { createAuthorityTransferCheckpointManifest } from '@/app/collab/authority-transfer/checkpoint/AuthorityTransferCheckpointManifest';
 import { ProductionCloudToLanTargetEffects } from '@/app/collab/authority-transfer/cloud-to-lan/ProductionCloudToLanTargetEffects';
 import { ProductionLanToCloudSourceEffects } from '@/app/collab/authority-transfer/lan-to-cloud/ProductionLanToCloudSourceEffects';
-import type { CollabLocalLanMembershipRecord } from '@/app/collab/CollabLocalProjectRepository';
+import {
+  type CollabLocalLanMembershipRecord,
+  isCollabLocalCloudMembership,
+} from '@/app/collab/CollabLocalProjectRepository';
 import { rotateAuthorityTransferOrigin } from '@/app/collab/git/CollabGitOriginPolicy';
 import { LanAuthorityTransferClient } from '@/app/collab/lan/authority-transfer/LanAuthorityTransferClient';
 import { ProjectOperationAdmission } from '@/app/collab/ProjectOperationAdmission';
 import type { CloudAuthorityConnection } from '@/app/collab/remote-authority/CloudAuthorityAdapter';
 import { cloudProjectGitRemoteUrl } from '@/app/collab/remote-authority/CloudAuthorityUrls';
-import type { CollabCloudProjectSnapshot } from '@/core/collab';
 
 const PROJECT_ID = 'project-production-effects';
 const MEMBER_ID = 'member-production-host';
@@ -658,6 +660,119 @@ describe('production authority-transfer effects', () => {
     }
   });
 
+  it('cleans a cancelled Cloud-to-LAN target after restart without reconnecting Cloud', async () => {
+    const initialFoundation = foundation(sourceRoot);
+    const initialComposition = createCollabFeatureSubcomposition({
+      foundation: initialFoundation,
+      projectSetup: new CollabProjectSetupService(initialFoundation, {
+        installationKey: TEST_INSTALLATION_A,
+        createCredential: () => HOST_CREDENTIAL,
+        createId: kind => {
+          if (kind === 'member') return MEMBER_ID;
+          if (kind === 'operation') return 'create-cancelled-target-effects';
+          return PROJECT_ID;
+        },
+        now: () => new Date('2026-08-08T00:00:00.000Z'),
+        vaultRoot: sourceRoot,
+      }),
+      vaultRoot: sourceRoot,
+    });
+    await initialComposition.feature.initialize();
+    await initialComposition.feature.createProject({
+      memberDisplayName: 'Alice',
+      name: 'Portable',
+    });
+    const membership = await initialFoundation.local.projects.loadMembership(PROJECT_ID);
+    if (!membership || membership.authority.kind !== 'lan') {
+      throw new Error('Missing initial LAN membership');
+    }
+    await initialComposition.feature.close();
+    await initialFoundation.close();
+
+    const seededFoundation = foundation(targetRoot);
+    await seededFoundation.local.workspace.claimProjectsFolder('workspace');
+    await mkdir(path.join(targetRoot, 'workspace', 'portable'), {
+      mode: 0o700,
+      recursive: true,
+    });
+    const cloudServerUrl = 'https://cloud.example.test/';
+    await seededFoundation.local.projects.saveMembership({
+      authority: {
+        authorityGeneration: 2,
+        bindingVersion: COLLAB_CLOUD_BINDING_VERSION,
+        gitRemoteUrl: cloudProjectGitRemoteUrl(cloudServerUrl, PROJECT_ID),
+        kind: 'cloud',
+        serverUrl: cloudServerUrl,
+        wireVersion: COLLAB_PROTOCOL_VERSION,
+      },
+      createdAt: membership.createdAt,
+      lastEventSequence: 0,
+      member: {
+        displayName: membership.member.displayName,
+        id: membership.member.id,
+        personalRef: membership.member.personalRef,
+        role: membership.member.role,
+      },
+      project: membership.project,
+      schemaVersion: membership.schemaVersion,
+      updatedAt: membership.updatedAt,
+    });
+    const cancelledRecord = createAuthorityTransferRecord({
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      lifecycleOwnership: 'owned',
+      localRole: 'target',
+      operationIntentId: OPERATION_ID,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: {
+        ...status('cloud-to-lan', 'cancelled', 'https://127.0.0.1:54545'),
+        state: 'cancelled',
+      },
+    });
+    await seededFoundation.local.projects.authorityTransferRecords.save(cancelledRecord);
+    const staging = await seededFoundation.local.workspace.reserveProjectsFolderChild(
+      'workspace',
+      {
+        childName: cancelledRecord.stagingDirectoryName,
+        operationId: cancelledRecord.transferId,
+        projectId: cancelledRecord.projectId,
+        purpose: 'authority-transfer-staging',
+      },
+    );
+    await mkdir(staging.absolutePath, { mode: 0o700 });
+    await seededFoundation.close();
+
+    const connect = jest.fn(async () => {
+      throw new Error('cancelled target recovery must not reconnect Cloud');
+    });
+    const create = jest.fn(async () => {
+      throw new Error('cancelled target recovery must not create a Cloud session');
+    });
+    const reopenedFoundation = foundation(targetRoot);
+    const reopenedComposition = createCollabFeatureSubcomposition({
+      cloudAuthority: { authorityKind: 'cloud', connect, create } as never,
+      foundation: reopenedFoundation,
+      projectSetup: new CollabProjectSetupService(reopenedFoundation, {
+        installationKey: TEST_INSTALLATION_A,
+        vaultRoot: targetRoot,
+      }),
+      vaultRoot: targetRoot,
+    });
+    try {
+      await reopenedComposition.feature.initialize();
+      await reopenedComposition.feature.restoreLifecycle();
+      expect(connect).not.toHaveBeenCalled();
+      expect(create).not.toHaveBeenCalled();
+      await expect(access(staging.absolutePath)).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(reopenedFoundation.authorityTransfers.load(PROJECT_ID)).resolves.toMatchObject({
+        status: { phase: 'cancelled', state: 'cancelled' },
+        terminalCleanupCompleted: true,
+      });
+    } finally {
+      await reopenedComposition.feature.close();
+      await reopenedFoundation.close();
+    }
+  });
+
   async function captureSource() {
     const sourceFoundation = foundation(sourceRoot);
     const sourceSetup = new CollabProjectSetupService(sourceFoundation, {
@@ -1014,54 +1129,31 @@ describe('production authority-transfer effects', () => {
       createdAt: sourceMembership.createdAt,
       lastEventSequence: 0,
       member: {
-        displayName: sourceMembership.member.displayName,
-        id: MEMBER_ID,
-        personalRef: sourceMembership.member.personalRef,
-        role: sourceMembership.member.role,
+        displayName: 'Bob',
+        id: 'member-production-peer',
+        personalRef: 'refs/heads/members/member-production-peer',
+        role: 'member',
       },
       project: sourceMembership.project,
       schemaVersion: sourceMembership.schemaVersion,
       updatedAt: sourceMembership.updatedAt,
     });
-    const snapshot: CollabCloudProjectSnapshot = {
-      currentMember: {
-        activatedAt: '2026-08-08T00:00:00.000Z',
-        createdAt: '2026-08-08T00:00:00.000Z',
-        displayName: sourceMembership.member.displayName,
-        id: MEMBER_ID,
-        personalRef: sourceMembership.member.personalRef,
-        role: sourceMembership.member.role,
-        status: 'active',
-      },
-      eventSequence: 3,
-      members: [],
-      openRequests: [],
-      openTicketCount: 0,
-      project: {
-        authorityGeneration: 2,
-        authorityKind: 'cloud',
-        createdAt: sourceMembership.createdAt,
-        id: PROJECT_ID,
-        mainOid: git(path.join(sourceRoot, 'workspace', 'portable'), ['rev-parse', 'HEAD']),
-        mainRef: 'refs/heads/main',
-        name: sourceMembership.project.name,
-      },
-      ticketHighlights: [],
-    };
     const cloudSession = {
       dispose: jest.fn(),
       projectId: PROJECT_ID,
-      readSnapshot: jest.fn(async () => snapshot),
+      readSnapshot: jest.fn(async () => {
+        throw new Error('post-begin ordinary Cloud snapshot must stay closed');
+      }),
       serverUrl: cloudServerUrl,
     } as unknown as CloudAuthorityConnection;
     const gitFoundation = await targetFoundation.requireGitFoundation();
     await gitFoundation.repositories.configureLocalRepository(
       path.join(targetRoot, 'workspace', 'portable'),
       {
-        memberId: MEMBER_ID,
-        personalRef: sourceMembership.member.personalRef,
+        memberId: 'member-production-peer',
+        personalRef: 'refs/heads/members/member-production-peer',
         projectId: PROJECT_ID,
-        userDisplayName: sourceMembership.member.displayName,
+        userDisplayName: 'Bob',
       },
     );
     const convergence = new AuthorityTransferLocalConvergence({
@@ -1078,10 +1170,16 @@ describe('production authority-transfer effects', () => {
       projects: targetFoundation.local.projects,
       workspace: targetFoundation.local.workspace,
     });
+    let targetNow = new Date('2026-08-28T00:03:00.000Z');
+    const activeRouteTransition = jest.spyOn(
+      targetFoundation.lanHost,
+      'transitionAuthorityTransferRoute',
+    );
     const targetEffects = new ProductionCloudToLanTargetEffects({
       cloudSession,
       convergence,
       foundation: targetFoundation,
+      now: () => targetNow,
       persistence: targetFoundation.authorityTransfers,
       projectId: PROJECT_ID,
     });
@@ -1110,7 +1208,7 @@ describe('production authority-transfer effects', () => {
     await mkdir(targetStaging.absolutePath, { mode: 0o700 });
     await writeFile(interruptedTargetState, '{"truncated":', { mode: 0o600 });
     const acceptance = await targetEffects.acceptanceRequest(proposed);
-    expect(acceptance.targetHostMemberId).toBe(MEMBER_ID);
+    expect(acceptance.targetHostMemberId).toBe('member-production-peer');
     await expect(access(interruptedTargetState)).rejects.toMatchObject({ code: 'ENOENT' });
     const stagedRecord = createAuthorityTransferRecord({
       ownerInstallationKey: TEST_INSTALLATION_A,
@@ -1125,7 +1223,7 @@ describe('production authority-transfer effects', () => {
         targetManifest.manifestSha256,
       ),
     });
-    const staged = await targetEffects.stage(stagedRecord, [
+    const stageArtifacts = () => [
       'checkpoint.json',
       'coordination.ndjson',
       'repository.bundle',
@@ -1134,12 +1232,54 @@ describe('production authority-transfer effects', () => {
       const bytes = artifactBytes.get(typed);
       if (!bytes) throw new Error(`Missing ${artifact}`);
       return { artifact: typed, body: Readable.from([bytes]), byteCount: bytes.byteLength };
-    }));
+    });
+    const exactPreparedMembership = await targetFoundation.local.projects.loadMembership(
+      PROJECT_ID,
+    );
+    if (!exactPreparedMembership || !isCollabLocalCloudMembership(exactPreparedMembership)) {
+      throw new Error('Missing prepared target Cloud membership');
+    }
+    await targetFoundation.local.projects.saveMembership({
+      ...exactPreparedMembership,
+      member: {
+        ...exactPreparedMembership.member,
+        id: 'member-mutated-after-acceptance',
+        personalRef: 'refs/heads/members/member-mutated-after-acceptance',
+      },
+    });
+    await expect(targetEffects.stage(stagedRecord, stageArtifacts())).rejects.toMatchObject({
+      safeContext: { reason: 'authority-transfer-target-imported-identity-mismatch' },
+    });
+    await targetFoundation.local.projects.saveMembership(exactPreparedMembership);
+    const staged = await targetEffects.stage(stagedRecord, stageArtifacts());
 
     expect(staged.checkpointSha256).toBe(targetManifest.manifestSha256);
     expect(staged.claimBatch.claims).toEqual([
-      expect.objectContaining({ memberId: 'member-production-peer' }),
+      expect.objectContaining({ memberId: MEMBER_ID }),
     ]);
+    await targetFoundation.local.projects.authorityTransferRecords.save(stagedRecord);
+    const targetStageOperationIntentId = authorityTransferChildIdempotencyKey(
+      OPERATION_ID,
+      'stage',
+    );
+    const retainedTargetClaims = await targetFoundation.authorityTransfers.retainClaimBatch({
+      batch: staged.claimBatch,
+      operationIntentId: targetStageOperationIntentId,
+      purpose: 'target-delivery',
+    });
+    await targetFoundation.authorityTransfers.acknowledgeClaimBatch({
+      batchRevision: staged.claimBatch.batchRevision,
+      batchSha256: staged.claimBatch.batchSha256,
+      checkpointSha256: staged.claimBatch.checkpointSha256,
+      committedAt: retainedTargetClaims.createdAt,
+      custodyAuthority: { generation: 2, kind: 'cloud' },
+      operationIntentId: targetStageOperationIntentId,
+      projectId: PROJECT_ID,
+      receiptId: 'custody-receipt-production-target',
+      submittedByMemberId: 'member-production-peer',
+      targetAuthorityGeneration: 3,
+      transferId: TRANSFER_ID,
+    });
     let targetAuthority = await targetFoundation.inspectAuthority(PROJECT_ID);
     expect(targetAuthority).toBeNull();
     await expect(access(path.join(
@@ -1157,7 +1297,7 @@ describe('production authority-transfer effects', () => {
       certificateAlgorithm: 'ed25519' as const,
       checkpointSha256: staged.checkpointSha256,
       committedAt: '2026-08-28T00:02:00.000Z',
-      operationIntentId: OPERATION_ID,
+      operationIntentId: 'intent-cloud-relinquishment',
       projectId: PROJECT_ID,
       sourceAuthority: { generation: 2, kind: 'cloud' as const },
       sourceHostMemberId: null,
@@ -1187,6 +1327,67 @@ describe('production authority-transfer effects', () => {
       status: completedStatus,
     });
     await targetFoundation.local.projects.authorityTransferRecords.save(completedRecord);
+    const stagedTargetStatePath = path.join(targetStaging.absolutePath, 'target-private.json');
+    const exactStagedTargetState = await readFile(stagedTargetStatePath, 'utf8');
+    const invalidClaimState = JSON.parse(exactStagedTargetState) as {
+      claimBatch: { claims: Array<{ claim: string }> };
+    };
+    if (!invalidClaimState.claimBatch.claims[0]) {
+      throw new Error('Missing staged imported claim');
+    }
+    invalidClaimState.claimBatch.claims[0].claim = Buffer.alloc(32, 8).toString('base64url');
+    await writeFile(stagedTargetStatePath, `${JSON.stringify(invalidClaimState)}\n`);
+    await expect(targetEffects.activate(completedRecord, relinquishmentProof)).rejects.toMatchObject({
+      safeContext: { reason: 'authority-transfer-target-state-owner-mismatch' },
+    });
+    await expect(access(path.join(
+      targetRoot,
+      '.claudian',
+      'collab',
+      'authorities',
+      PROJECT_ID,
+      '.claudian-authority.json',
+    ))).rejects.toMatchObject({ code: 'ENOENT' });
+    const invalidCredentialState = JSON.parse(exactStagedTargetState) as {
+      hostCredential: string;
+    };
+    invalidCredentialState.hostCredential = Buffer.alloc(32, 8).toString('base64url');
+    await writeFile(stagedTargetStatePath, `${JSON.stringify(invalidCredentialState)}\n`);
+    await expect(targetEffects.activate(completedRecord, relinquishmentProof)).rejects.toMatchObject({
+      safeContext: { reason: 'authority-transfer-target-state-owner-mismatch' },
+    });
+    await expect(access(path.join(
+      targetRoot,
+      '.claudian',
+      'collab',
+      'authorities',
+      PROJECT_ID,
+      '.claudian-authority.json',
+    ))).rejects.toMatchObject({ code: 'ENOENT' });
+    const invalidStagedTargetState = JSON.parse(exactStagedTargetState) as {
+      targetProof: string;
+    };
+    const invalidStagedTargetProof = JSON.parse(
+      Buffer.from(invalidStagedTargetState.targetProof, 'base64url').toString('utf8'),
+    ) as { payload: { receiptKeyId: string } };
+    invalidStagedTargetProof.payload.receiptKeyId = 'tampered-before-binding';
+    invalidStagedTargetState.targetProof = Buffer.from(
+      JSON.stringify(invalidStagedTargetProof),
+      'utf8',
+    ).toString('base64url');
+    await writeFile(stagedTargetStatePath, `${JSON.stringify(invalidStagedTargetState)}\n`);
+    await expect(targetEffects.activate(completedRecord, relinquishmentProof)).rejects.toMatchObject({
+      safeContext: { reason: 'authority-transfer-target-proof-invalid' },
+    });
+    await expect(access(path.join(
+      targetRoot,
+      '.claudian',
+      'collab',
+      'authorities',
+      PROJECT_ID,
+      '.claudian-authority.json',
+    ))).rejects.toMatchObject({ code: 'ENOENT' });
+    await writeFile(stagedTargetStatePath, exactStagedTargetState);
     await targetEffects.activate(completedRecord, relinquishmentProof);
     targetAuthority = await targetFoundation.inspectAuthority(PROJECT_ID);
     expect(JSON.parse(await readFile(path.join(
@@ -1205,6 +1406,7 @@ describe('production authority-transfer effects', () => {
       cloudSession: null,
       convergence,
       foundation: targetFoundation,
+      now: () => targetNow,
       persistence: targetFoundation.authorityTransfers,
       projectId: PROJECT_ID,
     });
@@ -1214,6 +1416,31 @@ describe('production authority-transfer effects', () => {
       'authority-transfer-target.json',
     );
     const exactTargetState = await readFile(targetStatePath, 'utf8');
+    const activeRegistration = activeRouteTransition.mock.calls[0]?.[0].next;
+    if (activeRegistration?.state !== 'target-active') {
+      throw new Error('Missing active Cloud-to-LAN target route');
+    }
+    const expireClaims = jest.spyOn(
+      targetFoundation.authorityTransfers,
+      'expireClaims',
+    ).mockResolvedValueOnce();
+    targetNow = new Date('2026-10-01T00:00:00.000Z');
+
+    await expect(activeRegistration.service.expire())
+      .rejects.toMatchObject({
+        safeContext: { reason: 'authority-transfer-target-convergence-incomplete' },
+      });
+    await expect(readFile(targetStatePath, 'utf8')).resolves.toBe(exactTargetState);
+    await expect(targetFoundation.local.projects.loadMembership(PROJECT_ID))
+      .resolves.toMatchObject({ authority: { kind: 'cloud' } });
+    await expect(targetFoundation.authorityTransfers.load(PROJECT_ID)).resolves.toMatchObject({
+      status: { phase: 'completed', state: 'completed' },
+      terminalCleanupCompleted: false,
+    });
+    expect(expireClaims).not.toHaveBeenCalled();
+    expireClaims.mockRestore();
+    targetNow = new Date('2026-08-28T00:03:00.000Z');
+
     const tamperedTargetState = JSON.parse(exactTargetState) as {
       targetProof: string;
     };
@@ -1267,6 +1494,7 @@ describe('production authority-transfer effects', () => {
     await expect(targetFoundation.local.projects.loadMembership(PROJECT_ID)).resolves.toMatchObject({
       authority: { kind: 'lan' },
       hostOwnership: { autoStart: true, ownsAuthority: true },
+      member: { id: 'member-production-peer', role: 'member' },
     });
     expect(await targetAuthority?.database.read(connection => connection.get(
       'SELECT state FROM project WHERE singleton = 1',
@@ -1289,27 +1517,404 @@ describe('production authority-transfer effects', () => {
       credentialHash: createHash('sha256')
         .update(Buffer.from(claimantCredential, 'base64url'))
         .digest('hex'),
-      idempotencyKey: 'claim-production-peer',
+      idempotencyKey: 'claim-production-manager',
       projectId: PROJECT_ID,
       transferId: TRANSFER_ID,
     };
     const firstReceipt = await claimClient.claimTransferredMembership(claimRequest);
     const replayedReceipt = await claimClient.claimTransferredMembership(claimRequest);
     expect(replayedReceipt).toEqual(firstReceipt);
-    expect(firstReceipt.memberId).toBe('member-production-peer');
+    expect(firstReceipt.memberId).toBe(MEMBER_ID);
     expect(await targetAuthority?.database.read(connection => connection.get(`
       SELECT access_state, credential_hash
       FROM members
-      WHERE member_id = 'member-production-peer'
+      WHERE member_id = '${MEMBER_ID}'
     `))).toEqual({
       access_state: 'bound',
       credential_hash: createHash('sha256')
         .update(Buffer.from(claimantCredential, 'base64url'))
         .digest(),
     });
+    await targetFoundation.local.projects.saveMembership({
+      ...targetMembership,
+      lastEventSequence: targetMembership.lastEventSequence + 1,
+      updatedAt: '2026-08-28T00:04:00.000Z',
+    });
+    jest.spyOn(targetFoundation.authorityTransfers, 'expireClaims').mockResolvedValue();
+    const completeTerminalCleanup = jest.spyOn(
+      targetFoundation.authorityTransfers,
+      'completeTerminalCleanup',
+    ).mockRejectedValueOnce(new Error('simulated crash after target-private unlink'));
+    targetNow = new Date('2026-10-01T00:00:00.000Z');
+
+    await expect(activeRegistration.service.expire())
+      .rejects.toThrow('simulated crash after target-private unlink');
+    await expect(access(targetStatePath)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(targetFoundation.authorityTransfers.load(PROJECT_ID)).resolves.toMatchObject({
+      terminalCleanupCompleted: false,
+    });
+    await expect(recoveringEffects().restoreCompleted(completedRecord)).resolves.toBeUndefined();
+    expect(completeTerminalCleanup).toHaveBeenCalledTimes(2);
+    await expect(targetFoundation.authorityTransfers.load(PROJECT_ID)).resolves.toMatchObject({
+      terminalCleanupCompleted: true,
+    });
+    await expect(access(path.join(
+      targetRoot,
+      '.claudian',
+      'collab',
+      'projects',
+      PROJECT_ID,
+      'authority-transfer-claims.json',
+    ))).rejects.toMatchObject({ code: 'ENOENT' });
     await sourceFeature.close();
     await sourceFoundation.close();
     await targetFoundation.close();
+  });
+
+  it('moves Manager Alice Cloud authority to Member Bob through the composed feature facade', async () => {
+    const {
+      artifactBytes,
+      repositoryBytes,
+      sourceCoordinationBytes,
+      sourceFeature,
+      sourceFoundation,
+      sourceManifestBytes,
+      sourceMembership,
+    } = await captureSource();
+    const managerRoot = await mkdtemp(path.join(tmpdir(), 'claudian-transfer-manager-'));
+    const cloudServerUrl = 'https://cloud.example.test/';
+    const sourceManifest = decodeCollabProjectCheckpointManifest(
+      JSON.parse(sourceManifestBytes.toString('utf8')),
+    );
+    const records = sourceCoordinationBytes.toString('utf8').trimEnd().split('\n')
+      .map(line => JSON.parse(line) as Record<string, unknown>);
+    const project = records[0] as { value: Record<string, unknown> };
+    project.value.authorityGeneration = 2;
+    const coordinationBytes = Buffer.from(
+      `${records.map(record => JSON.stringify(record)).join('\n')}\n`,
+      'utf8',
+    );
+    const manifest = createAuthorityTransferCheckpointManifest({
+      artifacts: [
+        {
+          byteCount: coordinationBytes.byteLength,
+          name: 'coordination.ndjson',
+          sha256: createHash('sha256').update(coordinationBytes).digest('hex'),
+        },
+        {
+          byteCount: repositoryBytes.byteLength,
+          name: 'repository.bundle',
+          sha256: createHash('sha256').update(repositoryBytes).digest('hex'),
+        },
+      ],
+      createdAt: sourceManifest.createdAt,
+      expectedMainOid: sourceManifest.expectedMainOid,
+      gitObjectFormat: sourceManifest.gitObjectFormat,
+      operationId: TRANSFER_ID,
+      projectId: PROJECT_ID,
+      refs: sourceManifest.refs,
+      sourceAuthority: { generation: 2, kind: 'cloud' },
+      targetAuthority: { generation: 3, kind: 'lan' },
+    });
+    artifactBytes.set('coordination.ndjson', coordinationBytes);
+    artifactBytes.set(
+      'checkpoint.json',
+      Buffer.from(encodeCollabProjectCheckpointManifestCanonicalJson(manifest), 'utf8'),
+    );
+
+    let begun = false;
+    let transferStatus: CollabAuthorityTransferStatus | null = null;
+    const members = [
+      {
+        bindingState: 'bound' as const,
+        displayName: 'Alice',
+        importedClaimGeneration: null,
+        importedClaimState: 'not-applicable' as const,
+        memberId: MEMBER_ID,
+        membershipRevision: 1,
+        role: 'manager' as const,
+      },
+      {
+        bindingState: 'bound' as const,
+        displayName: 'Bob',
+        importedClaimGeneration: null,
+        importedClaimState: 'not-applicable' as const,
+        memberId: 'member-production-peer',
+        membershipRevision: 1,
+        role: 'member' as const,
+      },
+    ];
+    const transferLifecycle = {
+      authorityTransfer: jest.fn(async (operation: string, request: never) => {
+        const input = request as Record<string, unknown>;
+        if (operation === 'beginCloudToLanTransfer') {
+          begun = true;
+          transferStatus = status(
+            'cloud-to-lan',
+            'collecting-readiness',
+            input.targetUrl as string,
+          );
+          return transferStatus;
+        }
+        if (!transferStatus) throw new Error('Transfer has not begun');
+        if (operation === 'getProjectAuthorityTransfer') {
+          if (transferStatus.phase === 'cloud-quiesced') {
+            transferStatus = {
+              ...transferStatus,
+              checkpointSha256: manifest.manifestSha256,
+              phase: 'checkpoint-captured',
+              updatedAt: '2026-08-28T00:02:00.000Z',
+            };
+          }
+          return transferStatus;
+        }
+        if (operation === 'acceptCloudToLanTransferTarget') {
+          transferStatus = {
+            ...transferStatus,
+            phase: 'cloud-quiesced',
+            updatedAt: '2026-08-28T00:01:00.000Z',
+          };
+          return transferStatus;
+        }
+        if (operation === 'reportCloudToLanTargetStaged') {
+          const staged = input as unknown as {
+            readonly checkpointSha256: string;
+            readonly claimBatch: CollabTransferredMembershipClaimBatch;
+            readonly idempotencyKey: string;
+          };
+          const proof = {
+            batchRevision: staged.claimBatch.batchRevision,
+            batchSha256: staged.claimBatch.batchSha256,
+            certificate: Buffer.alloc(64, 4).toString('base64url'),
+            certificateAlgorithm: 'ed25519' as const,
+            checkpointSha256: staged.checkpointSha256,
+            committedAt: '2026-08-28T00:03:00.000Z',
+            operationIntentId: 'intent-cloud-relinquishment',
+            projectId: PROJECT_ID,
+            sourceAuthority: { generation: 2, kind: 'cloud' as const },
+            sourceHostMemberId: null,
+            targetAuthority: { generation: 3, kind: 'lan' as const },
+            transferId: TRANSFER_ID,
+          };
+          transferStatus = {
+            ...transferStatus,
+            batchRevision: staged.claimBatch.batchRevision,
+            batchSha256: staged.claimBatch.batchSha256,
+            checkpointSha256: staged.checkpointSha256,
+            phase: 'cloud-relinquished',
+            relinquishmentProof: proof,
+            updatedAt: '2026-08-28T00:03:00.000Z',
+          };
+          return {
+            batchRevision: staged.claimBatch.batchRevision,
+            batchSha256: staged.claimBatch.batchSha256,
+            checkpointSha256: staged.checkpointSha256,
+            committedAt: new Date(Date.now() + 60_000).toISOString(),
+            custodyAuthority: { generation: 2, kind: 'cloud' as const },
+            operationIntentId: staged.idempotencyKey,
+            projectId: PROJECT_ID,
+            receiptId: 'receipt-composed-cloud-to-lan',
+            submittedByMemberId: 'member-production-peer',
+            targetAuthorityGeneration: 3,
+            transferId: TRANSFER_ID,
+          };
+        }
+        if (operation === 'confirmCloudToLanTargetActive') {
+          transferStatus = {
+            ...transferStatus,
+            phase: 'completed',
+            state: 'completed',
+            updatedAt: '2026-08-28T00:04:00.000Z',
+          };
+          return transferStatus;
+        }
+        throw new Error(`Unexpected Cloud operation ${operation}`);
+      }),
+      downloadAuthorityTransferArtifact: jest.fn(async (
+        input: { readonly artifact: CollabCloudAuthorityTransferArtifact },
+      ) => {
+        const bytes = artifactBytes.get(input.artifact);
+        if (!bytes) throw new Error(`Missing ${input.artifact}`);
+        return { body: Readable.from([bytes]), byteCount: bytes.byteLength };
+      }),
+      retirement: jest.fn(),
+      uploadAuthorityTransferArtifact: jest.fn(),
+    };
+    const snapshot = (memberId: string) => {
+      if (begun) throw new Error('post-begin ordinary Cloud snapshot must stay closed');
+      const listed = members.find(member => member.memberId === memberId);
+      if (!listed) throw new Error('Unknown composed Cloud Member');
+      return {
+        currentMember: {
+          activatedAt: sourceMembership.createdAt,
+          createdAt: sourceMembership.createdAt,
+          displayName: listed.displayName,
+          id: listed.memberId,
+          personalRef: `refs/heads/members/${listed.memberId}`,
+          role: listed.role,
+          status: 'active' as const,
+        },
+        eventSequence: 3,
+        members: [],
+        openRequests: [],
+        openTicketCount: 0,
+        project: {
+          authorityGeneration: 2,
+          authorityKind: 'cloud' as const,
+          createdAt: sourceMembership.createdAt,
+          id: PROJECT_ID,
+          mainOid: sourceManifest.expectedMainOid,
+          mainRef: 'refs/heads/main' as const,
+          name: sourceMembership.project.name,
+        },
+        ticketHighlights: [],
+      };
+    };
+    const cloudAuthority = {
+      authorityKind: 'cloud' as const,
+      connect: jest.fn(async () => {
+        throw new Error('Fresh composed flow must use its bound membership');
+      }),
+      create: jest.fn(async (membership: { readonly member: { readonly id: string } }) => {
+        const memberId = membership.member.id;
+        return {
+          authorityKind: 'cloud' as const,
+          control: { readSnapshot: jest.fn(async () => snapshot(memberId)) },
+          dispose: jest.fn(),
+          lifecycle: transferLifecycle,
+          membership: {
+            authorityKind: 'cloud' as const,
+            cloudMembership: jest.fn(async (operation: string) => {
+              if (operation !== 'listProjectMembers' || begun) {
+                throw new Error('Unexpected or post-begin membership read');
+              }
+              return {
+                authorityGeneration: 2,
+                managerSetGeneration: 1,
+                members,
+                projectId: PROJECT_ID,
+              };
+            }),
+          },
+        };
+      }),
+    };
+
+    const seed = async (
+      root: string,
+      installationKey: typeof TEST_INSTALLATION_A | typeof TEST_INSTALLATION_B,
+      member: typeof members[number],
+    ) => {
+      const seeded = foundation(root, installationKey);
+      await seeded.local.workspace.claimProjectsFolder('workspace');
+      git(root, [
+        'clone',
+        '--quiet',
+        path.join(sourceRoot, 'workspace', 'portable'),
+        path.join(root, 'workspace', 'portable'),
+      ]);
+      git(path.join(root, 'workspace', 'portable'), [
+        'remote',
+        'set-url',
+        'origin',
+        cloudProjectGitRemoteUrl(cloudServerUrl, PROJECT_ID),
+      ]);
+      await seeded.local.projects.saveMembership({
+        authority: {
+          authorityGeneration: 2,
+          bindingVersion: COLLAB_CLOUD_BINDING_VERSION,
+          gitRemoteUrl: cloudProjectGitRemoteUrl(cloudServerUrl, PROJECT_ID),
+          kind: 'cloud',
+          serverUrl: cloudServerUrl,
+          wireVersion: COLLAB_PROTOCOL_VERSION,
+        },
+        createdAt: sourceMembership.createdAt,
+        lastEventSequence: 0,
+        member: {
+          displayName: member.displayName,
+          id: member.memberId,
+          personalRef: `refs/heads/members/${member.memberId}`,
+          role: member.role,
+        },
+        project: sourceMembership.project,
+        schemaVersion: sourceMembership.schemaVersion,
+        updatedAt: sourceMembership.updatedAt,
+      });
+      await seeded.local.projects.repairIndexFromMemberships();
+      const repositories = (await seeded.requireGitFoundation()).repositories;
+      await repositories.configureLocalRepository(path.join(root, 'workspace', 'portable'), {
+        memberId: member.memberId,
+        personalRef: `refs/heads/members/${member.memberId}`,
+        projectId: PROJECT_ID,
+        userDisplayName: member.displayName,
+      });
+      const composition = createCollabFeatureSubcomposition({
+        cloudAuthority: cloudAuthority as never,
+        foundation: seeded,
+        projectSetup: new CollabProjectSetupService(seeded, {
+          installationKey,
+          vaultRoot: root,
+        }),
+        vaultRoot: root,
+      });
+      await expect(composition.feature.initialize()).resolves.toMatchObject({
+        status: 'success',
+      });
+      return { composition, foundation: seeded };
+    };
+
+    const manager = await seed(managerRoot, TEST_INSTALLATION_A, members[0]);
+    const target = await seed(targetRoot, TEST_INSTALLATION_B, members[1]);
+    try {
+      const prepared = await target.composition.feature.prepareCloudToLanTarget({
+        projectId: PROJECT_ID,
+      });
+      if (prepared.status !== 'success') {
+        if ('error' in prepared) throw prepared.error;
+        throw new Error(`Target preparation returned ${prepared.status}`);
+      }
+      expect(prepared).toMatchObject({
+        status: 'success',
+        value: { selectedTargetMemberId: 'member-production-peer' },
+      });
+      const begunResult = await manager.composition.feature.beginCloudToLanTransfer({
+        descriptor: prepared.value,
+      });
+      expect(begunResult).toMatchObject({
+        status: 'success',
+        value: { selectedTargetMemberId: 'member-production-peer' },
+      });
+      if (begunResult.status !== 'success') throw new Error('Manager begin failed');
+      const accepted = await target.composition.feature
+        .acceptCloudToLanTransfer(begunResult.value);
+      if (accepted.status !== 'success') {
+        if ('error' in accepted) throw accepted.error;
+        throw new Error(`Target acceptance returned ${accepted.status}`);
+      }
+      expect(accepted.value).toMatchObject({ state: 'completed' });
+      await expect(manager.composition.feature.observeCloudToLanTransfer(PROJECT_ID))
+        .resolves.toMatchObject({ status: 'success', value: { state: 'completed' } });
+      await expect(target.foundation.local.projects.loadMembership(PROJECT_ID))
+        .resolves.toMatchObject({
+          authority: { kind: 'lan' },
+          hostOwnership: { autoStart: true, ownsAuthority: true },
+          member: { id: 'member-production-peer', role: 'member' },
+        });
+      await expect(manager.foundation.authorityTransfers.loadCloudToLanManagerEntry(PROJECT_ID))
+        .resolves.toBeNull();
+    } finally {
+      await Promise.all([
+        manager.composition.feature.close(),
+        target.composition.feature.close(),
+      ]);
+      await Promise.all([
+        manager.foundation.close(),
+        target.foundation.close(),
+        sourceFeature.close(),
+      ]);
+      await sourceFoundation.close();
+      await rm(managerRoot, { force: true, recursive: true });
+    }
   });
 
   function foundation(

--- a/tests/integration/app/collab/lan/LanHostCoordinator.test.ts
+++ b/tests/integration/app/collab/lan/LanHostCoordinator.test.ts
@@ -1469,6 +1469,12 @@ describe('LanHostCoordinator production transport', () => {
       assertRecoveryOwner: () => undefined,
       claimantStore: localProjects.authorityTransferClaimants,
       convergence: {} as never,
+      createCloudToLanConnection: async () => {
+        throw new Error('Unexpected Cloud-to-LAN connection');
+      },
+      createCloudToLanTarget: () => {
+        throw new Error('Unexpected Cloud-to-LAN target');
+      },
       createLanToCloudSource,
       installationKey: INSTALLATION_A,
       lifecycle: {

--- a/tests/unit/app/collab/CollabFeatureService.test.ts
+++ b/tests/unit/app/collab/CollabFeatureService.test.ts
@@ -14,6 +14,9 @@ import {
 
 import { CollabProjectWorkSessionRegistry } from '@/app/collab/activity/CollabProjectWorkSession';
 import {
+  CollabAuthorityTransferOutcomeError,
+} from '@/app/collab/authority-transfer/CollabAuthorityTransferOutcomeError';
+import {
   type CollabFeatureFoundationPort,
   CollabFeatureService,
   type CollabHostTransferPort,
@@ -24,6 +27,7 @@ import {
 } from '@/app/collab/CollabFeatureService';
 import type { CollabLocalProjectIndex } from '@/app/collab/CollabLocalProjectRepository';
 import { COLLAB_LOCAL_PROJECT_SCHEMA_VERSION } from '@/app/collab/CollabSchemaVersions';
+import { CollabProjectLifecycleSubsystem } from '@/app/collab/lifecycle/CollabProjectLifecycleSubsystem';
 import type { CollabLanProjectSnapshot } from '@/core/collab';
 import { type CollabPublishOutcome, type CollabResult } from '@/core/collab';
 import { CollabError } from '@/core/collab/ClaudianCollabError';
@@ -504,6 +508,298 @@ describe('CollabFeatureService', () => {
     });
     expect(foundation.requireGitFoundation).toHaveBeenCalledTimes(1);
     expect(states).toEqual(['uninitialized', 'initializing', 'initializing', 'ready']);
+  });
+
+  it('exposes the selected-target Cloud-to-LAN handshake through the ordinary feature facade', async () => {
+    const descriptor = {
+      caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+      caFingerprint: 'c'.repeat(64),
+      preparationId: 'intent-target-preparation',
+      projectId: 'project-alpha',
+      publishedAt: CREATED_AT,
+      schemaVersion: 1 as const,
+      selectedTargetMemberId: 'member-target',
+      sourceAuthorityGeneration: 1,
+      sourceCloudUrl: 'https://cloud.example.test/',
+      targetUrl: 'https://192.168.1.20:54545',
+    };
+    const handle = {
+      operationIntentId: 'intent-manager-begin',
+      preparationId: descriptor.preparationId,
+      projectId: descriptor.projectId,
+      schemaVersion: 1 as const,
+      selectedTargetMemberId: descriptor.selectedTargetMemberId,
+      sourceAuthorityGeneration: descriptor.sourceAuthorityGeneration,
+      sourceCloudUrl: descriptor.sourceCloudUrl,
+      targetUrl: descriptor.targetUrl,
+      transferId: 'transfer-cloud-to-lan',
+    };
+    const status = { projectId: 'project-alpha', transferId: handle.transferId } as never;
+    const authorityTransfer = {
+      acceptCloudToLanTransfer: jest.fn(async () => status),
+      beginCloudToLanTransfer: jest.fn(async () => handle),
+      cancelCloudToLanTransfer: jest.fn(async () => status),
+      observeCloudToLanTransfer: jest.fn(async () => status),
+      prepareCloudToLanTarget: jest.fn(async () => descriptor),
+      withdrawCloudToLanTarget: jest.fn(async () => undefined),
+    };
+    const service = createService({ authorityTransfer });
+
+    await expect(service.prepareCloudToLanTarget({
+      projectId: descriptor.projectId,
+    })).resolves.toEqual({ status: 'success', value: descriptor });
+    await expect(service.beginCloudToLanTransfer({
+      descriptor,
+    })).resolves.toEqual({ status: 'success', value: handle });
+    await expect(service.acceptCloudToLanTransfer(handle))
+      .resolves.toEqual({ status: 'success', value: status });
+    await expect(service.observeCloudToLanTransfer(descriptor.projectId))
+      .resolves.toEqual({ status: 'success', value: status });
+    await expect(service.cancelCloudToLanTransfer(handle))
+      .resolves.toEqual({ status: 'success', value: status });
+    await expect(service.withdrawCloudToLanTarget({
+      preparationId: descriptor.preparationId,
+      projectId: descriptor.projectId,
+    })).resolves.toEqual({ status: 'success', value: undefined });
+
+    expect(authorityTransfer.acceptCloudToLanTransfer).toHaveBeenCalledWith({ handle }, {});
+    expect(authorityTransfer.prepareCloudToLanTarget).toHaveBeenCalledWith(
+      {
+        operationIntentId: expect.stringMatching(/^cloud-to-lan-target-[a-f0-9]{32}$/),
+        projectId: descriptor.projectId,
+      },
+      {},
+    );
+    expect(authorityTransfer.beginCloudToLanTransfer).toHaveBeenCalledWith(
+      {
+        descriptor,
+        operationIntentId: expect.stringMatching(/^cloud-to-lan-manager-[a-f0-9]{32}$/),
+      },
+      {},
+    );
+    expect(authorityTransfer.observeCloudToLanTransfer).toHaveBeenCalledWith(
+      descriptor.projectId,
+      {},
+    );
+    expect(authorityTransfer.cancelCloudToLanTransfer).toHaveBeenCalledWith(
+      handle,
+      {},
+    );
+    expect(authorityTransfer.withdrawCloudToLanTarget).toHaveBeenCalledWith(
+      { preparationId: descriptor.preparationId, projectId: descriptor.projectId },
+      {},
+    );
+  });
+
+  it('preserves a durable authority-transfer recovery outcome across the feature facade', async () => {
+    const operationId = 'intent-manager-durable-begin';
+    const error = new CollabError({
+      code: 'durable-progress-recovery-required',
+      recoveryActions: ['resume'],
+      safeContext: { reason: 'authority-transfer-manager-begin-ambiguous' },
+    });
+    const authorityTransfer = {
+      acceptCloudToLanTransfer: jest.fn(),
+      beginCloudToLanTransfer: jest.fn(async () => {
+        throw new CollabAuthorityTransferOutcomeError({
+          durablePhase: 'committed',
+          durableProgress: true,
+          error,
+          operationId,
+          status: 'recovery-required',
+        });
+      }),
+      cancelCloudToLanTransfer: jest.fn(),
+      observeCloudToLanTransfer: jest.fn(),
+      prepareCloudToLanTarget: jest.fn(),
+      withdrawCloudToLanTarget: jest.fn(),
+    };
+    const service = createService({ authorityTransfer });
+
+    await expect(service.beginCloudToLanTransfer({
+      descriptor: {
+        caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+        caFingerprint: 'c'.repeat(64),
+        preparationId: 'intent-target-preparation',
+        projectId: 'project-alpha',
+        publishedAt: CREATED_AT,
+        schemaVersion: 1,
+        selectedTargetMemberId: 'member-target',
+        sourceAuthorityGeneration: 1,
+        sourceCloudUrl: 'https://cloud.example.test/',
+        targetUrl: 'https://192.168.1.20:54545',
+      },
+    })).resolves.toEqual({
+      durablePhase: 'committed',
+      durableProgress: true,
+      error,
+      operationId,
+      status: 'recovery-required',
+    });
+  });
+
+  it('does not replace a completed authority transfer with a late cancellation', async () => {
+    const controller = new AbortController();
+    const status = { projectId: 'project-alpha' } as never;
+    const authorityTransfer = {
+      acceptCloudToLanTransfer: jest.fn(),
+      beginCloudToLanTransfer: jest.fn(),
+      cancelCloudToLanTransfer: jest.fn(async () => {
+        controller.abort();
+        return status;
+      }),
+      observeCloudToLanTransfer: jest.fn(),
+      prepareCloudToLanTarget: jest.fn(),
+      withdrawCloudToLanTarget: jest.fn(),
+    };
+    const service = createService({ authorityTransfer });
+
+    await expect(service.cancelCloudToLanTransfer({
+      operationIntentId: 'intent-manager-begin',
+      preparationId: 'intent-target-preparation',
+      projectId: 'project-alpha',
+      schemaVersion: 1,
+      selectedTargetMemberId: 'member-target',
+      sourceAuthorityGeneration: 1,
+      sourceCloudUrl: 'https://cloud.example.test/',
+      targetUrl: 'https://192.168.1.20:54545',
+      transferId: 'transfer-cloud-to-lan',
+    }, {
+      signal: controller.signal,
+    })).resolves.toEqual({ status: 'success', value: status });
+  });
+
+  it('keeps target-side Cloud-to-LAN work outside the ordinary Project drain', async () => {
+    const acceptingStarted = deferred<void>();
+    const acceptingReleased = deferred<void>();
+    const authorityTransfer = {
+      acceptCloudToLanTransfer: jest.fn(async () => {
+        acceptingStarted.resolve();
+        await acceptingReleased.promise;
+        return { projectId: 'project-alpha' } as never;
+      }),
+      beginCloudToLanTransfer: jest.fn(),
+      cancelCloudToLanTransfer: jest.fn(),
+      close: jest.fn(async () => undefined),
+      observeCloudToLanTransfer: jest.fn(),
+      prepareCloudToLanTarget: jest.fn(),
+      withdrawCloudToLanTarget: jest.fn(),
+    };
+    const service = createService({ authorityTransfer });
+    const accepting = service.acceptCloudToLanTransfer({
+      operationIntentId: 'intent-manager-begin',
+      preparationId: 'intent-target-preparation',
+      projectId: 'project-alpha',
+      schemaVersion: 1,
+      selectedTargetMemberId: 'member-target',
+      sourceAuthorityGeneration: 1,
+      sourceCloudUrl: 'https://cloud.example.test/',
+      targetUrl: 'https://192.168.1.20:54545',
+      transferId: 'transfer-cloud-to-lan',
+    });
+    await acceptingStarted.promise;
+
+    const suspension = service.suspendProjectAdmission('project-alpha');
+    let drained = false;
+    await service.drainAdmittedOperations('project-alpha').then(() => {
+      drained = true;
+    });
+    expect(drained).toBe(true);
+
+    let closed = false;
+    const closing = service.close().then(() => { closed = true; });
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(closed).toBe(false);
+    expect(authorityTransfer.close).not.toHaveBeenCalled();
+
+    acceptingReleased.resolve();
+    await expect(accepting).resolves.toMatchObject({ status: 'success' });
+    await closing;
+    expect(authorityTransfer.close).toHaveBeenCalledTimes(1);
+    expect(service.resumeProjectAdmission(suspension)).toBe(false);
+  });
+
+  it('keeps a lifecycle-queued Manager begin outside the lane holder ordinary drain', async () => {
+    const projectId = 'project-alpha';
+    const descriptor = {
+      caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+      caFingerprint: 'c'.repeat(64),
+      preparationId: 'intent-target-preparation',
+      projectId,
+      publishedAt: CREATED_AT,
+      schemaVersion: 1 as const,
+      selectedTargetMemberId: 'member-target',
+      sourceAuthorityGeneration: 1,
+      sourceCloudUrl: 'https://cloud.example.test/',
+      targetUrl: 'https://192.168.1.20:54545',
+    };
+    const handle = {
+      operationIntentId: 'intent-manager-begin',
+      preparationId: descriptor.preparationId,
+      projectId,
+      schemaVersion: 1 as const,
+      selectedTargetMemberId: descriptor.selectedTargetMemberId,
+      sourceAuthorityGeneration: descriptor.sourceAuthorityGeneration,
+      sourceCloudUrl: descriptor.sourceCloudUrl,
+      targetUrl: descriptor.targetUrl,
+      transferId: 'transfer-cloud-to-lan',
+    };
+    const laneAcquired = deferred<void>();
+    const beginQueued = deferred<void>();
+    const startDrain = deferred<void>();
+    const releaseDrain = deferred<void>();
+    const lifecycle = new CollabProjectLifecycleSubsystem({
+      closeRecovery: jest.fn(),
+      durableOwners: [],
+      hostTransfer: {} as never,
+      localExit: {} as never,
+      recoveryStages: [],
+      retirement: {} as never,
+    });
+    let drainCompleted = false;
+    const authorityTransfer = {
+      acceptCloudToLanTransfer: jest.fn(() => lifecycle.runExclusive(
+        projectId,
+        'authority-transfer',
+        'continuation',
+        async () => {
+          laneAcquired.resolve();
+          await startDrain.promise;
+          const drain = service.drainAdmittedOperations(projectId).then(() => {
+            drainCompleted = true;
+          });
+          await Promise.race([drain, releaseDrain.promise]);
+          return { projectId } as never;
+        },
+      )),
+      beginCloudToLanTransfer: jest.fn(() => {
+        beginQueued.resolve();
+        return lifecycle.runExclusive(
+          projectId,
+          'authority-transfer',
+          'continuation',
+          async () => handle,
+        );
+      }),
+      cancelCloudToLanTransfer: jest.fn(),
+      close: jest.fn(async () => undefined),
+      observeCloudToLanTransfer: jest.fn(),
+      prepareCloudToLanTarget: jest.fn(),
+      withdrawCloudToLanTarget: jest.fn(),
+    };
+    const service = createService({ authorityTransfer });
+
+    const accepting = service.acceptCloudToLanTransfer(handle);
+    await laneAcquired.promise;
+    const beginning = service.beginCloudToLanTransfer({ descriptor });
+    await beginQueued.promise;
+    startDrain.resolve();
+    await new Promise<void>(resolve => setImmediate(resolve));
+    const drainedBeforeRelease = drainCompleted;
+    releaseDrain.resolve();
+    await Promise.all([accepting, beginning]);
+
+    expect(drainedBeforeRelease).toBe(true);
   });
 
   it('projects a Vault pending Cloud Leave after the Project index was removed', async () => {
@@ -1423,6 +1719,11 @@ describe('CollabFeatureService', () => {
       order.push('publication');
     });
     const service = createService({
+      authorityTransfer: {
+        close: jest.fn(async () => {
+          order.push('authority-transfer');
+        }),
+      } as never,
       hostTransfer: {
         close: jest.fn(async () => {
           order.push('host-transfer');
@@ -1468,6 +1769,7 @@ describe('CollabFeatureService', () => {
       'recovery-close-started',
       'admitted-operation',
       'recovery-close-finished',
+      'authority-transfer',
       'retirement',
       'host-transfer',
       'publication-subscription',

--- a/tests/unit/app/collab/authority-transfer/AuthorityTransferLocalConvergence.test.ts
+++ b/tests/unit/app/collab/authority-transfer/AuthorityTransferLocalConvergence.test.ts
@@ -306,8 +306,13 @@ describe('AuthorityTransferLocalConvergence', () => {
       endpoint: 'https://192.168.1.20:54545',
       hostCaCertificatePem: '-----BEGIN CERTIFICATE-----\nTEST\n-----END CERTIFICATE-----\n',
       hostCaFingerprint: 'e'.repeat(64),
+      identity: {
+        authorityGeneration: 2,
+        currentMember: snapshot('lan').currentMember,
+        eventSequence: snapshot('lan').eventSequence,
+        project: snapshot('lan').project,
+      },
       memberCredential,
-      snapshot: snapshot('lan'),
       status: completed('cloud-to-lan'),
     });
 
@@ -397,8 +402,13 @@ describe('AuthorityTransferLocalConvergence', () => {
       endpoint: 'https://192.168.1.20:54545',
       hostCaCertificatePem: '-----BEGIN CERTIFICATE-----\nTEST\n-----END CERTIFICATE-----\n',
       hostCaFingerprint: 'e'.repeat(64),
+      identity: {
+        authorityGeneration: 2,
+        currentMember: snapshot('lan').currentMember,
+        eventSequence: snapshot('lan').eventSequence,
+        project: snapshot('lan').project,
+      },
       memberCredential: credential,
-      snapshot: snapshot('lan'),
       status: completed('cloud-to-lan'),
     });
     await convergence.recoverConvertedClaimant({

--- a/tests/unit/app/collab/authority-transfer/AuthorityTransferModule.test.ts
+++ b/tests/unit/app/collab/authority-transfer/AuthorityTransferModule.test.ts
@@ -11,7 +11,8 @@ import {
   createAuthorityTransferRequesterEntry,
 } from '@/app/collab/authority-transfer/AuthorityTransferEntryRecord';
 import {
-  AuthorityTransferModule,
+  AuthorityTransferModule as ProductionAuthorityTransferModule,
+  type AuthorityTransferModuleOptions,
 } from '@/app/collab/authority-transfer/AuthorityTransferModule';
 import type {
   AuthorityTransferRecord} from '@/app/collab/authority-transfer/AuthorityTransferRecord';
@@ -30,6 +31,19 @@ import type {
   AuthorityTransferClaimantRecovery,
 } from '@/app/collab/authority-transfer/claim/AuthorityTransferClaimantRecovery';
 import {
+  type CloudToLanManagerEntryRecord,
+  type CloudToLanTargetEntryRecord,
+  cloudToLanTransferHandle,
+  createCloudToLanManagerEntry,
+  createCloudToLanTargetEntry,
+  handoffCloudToLanTargetEntry,
+  markCloudToLanManagerBeginPossiblySent,
+  publishCloudToLanTargetEntry,
+  recordCloudToLanManagerStatus,
+  rejectCloudToLanManagerEntry,
+  withdrawCloudToLanTargetEntry,
+} from '@/app/collab/authority-transfer/cloud-to-lan/CloudToLanTransferEntryRecord';
+import {
   LanToCloudRequesterCoordinator,
 } from '@/app/collab/authority-transfer/lan-to-cloud/LanToCloudRequesterCoordinator';
 import type {
@@ -38,15 +52,38 @@ import type {
 import type {
   LanAuthorityTransferClient,
 } from '@/app/collab/lan/authority-transfer/LanAuthorityTransferClient';
-import type {
+import {
   CollabProjectLifecycleSubsystem,
 } from '@/app/collab/lifecycle/CollabProjectLifecycleSubsystem';
 import type {
   CloudAuthorityConnection,
 } from '@/app/collab/remote-authority/CloudAuthorityAdapter';
+import { CloudAuthorityRejection } from '@/app/collab/remote-authority/CloudAuthorityError';
 
 const PROJECT_ID = 'project-authority-transfer-module';
 const TRANSFER_ID = 'transfer-authority-transfer-module';
+
+type TestAuthorityTransferModuleOptions = Omit<
+  AuthorityTransferModuleOptions,
+  'createCloudToLanConnection' | 'createCloudToLanTarget'
+> & Partial<Pick<
+  AuthorityTransferModuleOptions,
+  'createCloudToLanConnection' | 'createCloudToLanTarget'
+>>;
+
+class AuthorityTransferModule extends ProductionAuthorityTransferModule {
+  constructor(options: TestAuthorityTransferModuleOptions) {
+    super({
+      createCloudToLanConnection: async () => {
+        throw new Error('Unexpected Cloud-to-LAN connection');
+      },
+      createCloudToLanTarget: () => {
+        throw new Error('Unexpected Cloud-to-LAN target');
+      },
+      ...options,
+    });
+  }
+}
 
 function recoverableClaimantRecord(input: Readonly<{
   direction?: 'cloud-to-lan' | 'lan-to-cloud';
@@ -235,6 +272,7 @@ describe('AuthorityTransferModule', () => {
       lifecycle: {
         registerDurableOwner: jest.fn(),
         registerRecoveryStage: jest.fn(),
+        runExclusive: jest.fn(async (_projectId, _owner, _mode, operation) => operation()),
       } as unknown as CollabProjectLifecycleSubsystem,
       persistence,
     });
@@ -699,9 +737,1758 @@ describe('AuthorityTransferModule', () => {
     });
 
     expect(binding.targetUrl).toBe('https://192.168.1.20:54545');
-    expect(prepareTarget).not.toHaveBeenCalled();
+    expect(prepareTarget).toHaveBeenCalledWith('https://192.168.1.20:54545');
     binding.dispose();
     expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists a selected non-Manager target before listener effects and freezes Manager begin before send', async () => {
+    const order: string[] = [];
+    let targetEntry: Readonly<Record<string, unknown>> | null = null;
+    let managerEntry: Readonly<Record<string, unknown>> | null = null;
+    const targetUrl = 'https://192.168.1.20:54545';
+    const sourceUrl = 'https://cloud.example.test/';
+    const targetDispose = jest.fn(() => { order.push('listener-released'); });
+    const begun = {
+      ...proposal(),
+      direction: 'cloud-to-lan' as const,
+      sourceAuthority: { generation: 1, kind: 'cloud' as const },
+      targetAuthority: { generation: 2, kind: 'lan' as const },
+      targetUrl,
+    };
+    const persistence = {
+      loadCloudToLanManagerEntry: jest.fn(async () => managerEntry),
+      loadCloudToLanTargetEntry: jest.fn(async () => targetEntry),
+      markCloudToLanManagerBeginPossiblySent: jest.fn(async (entry: never) => {
+        order.push('begin-frozen');
+        managerEntry = { ...(entry as object), phase: 'submitted' };
+        return managerEntry;
+      }),
+      markCloudToLanManagerCancellationPossiblySent: jest.fn(async (entry: never) => {
+        order.push('cancel-marked');
+        const current = entry as unknown as Readonly<Record<string, unknown>>;
+        managerEntry = {
+          ...current,
+          cancellation: {
+            ...current.cancellation as object,
+            submission: 'possibly-sent',
+          },
+        };
+        return managerEntry;
+      }),
+      prepareCloudToLanManagerCancellation: jest.fn(async (entry: never, request: never) => {
+        order.push('cancel-frozen');
+        managerEntry = {
+          ...(entry as object),
+          cancellation: { request, submission: 'not-sent' },
+        };
+        return managerEntry;
+      }),
+      prepareCloudToLanManagerEntry: jest.fn(async (entry: never) => {
+        managerEntry = entry;
+        return entry;
+      }),
+      prepareCloudToLanTargetEntry: jest.fn(async (entry: never) => {
+        order.push('target-persisted');
+        targetEntry = entry;
+        return entry;
+      }),
+      publishCloudToLanTargetEntry: jest.fn(async (_entry: never, descriptor: never) => {
+        order.push('descriptor-persisted');
+        const entry = _entry as unknown as Readonly<Record<string, unknown>>;
+        targetEntry = {
+          ...entry,
+          descriptor: {
+            ...(descriptor as object),
+            preparationId: entry.operationIntentId,
+            projectId: entry.projectId,
+            schemaVersion: 1,
+            selectedTargetMemberId: entry.selectedTargetMemberId,
+            sourceAuthorityGeneration: entry.sourceAuthorityGeneration,
+            sourceCloudUrl: entry.sourceCloudUrl,
+          },
+          phase: 'published',
+        };
+        return targetEntry;
+      }),
+      recordCloudToLanManagerStatus: jest.fn(async (_entry: never, status: never) => {
+        order.push('status-persisted');
+        const statusRecord = status as unknown as CollabAuthorityTransferStatus;
+        managerEntry = {
+          ...(_entry as object),
+          cancellation: null,
+          phase: statusRecord.state === 'cancelled' || statusRecord.state === 'completed'
+            ? 'settled'
+            : 'observing',
+          status,
+        };
+        return managerEntry;
+      }),
+      settleCloudToLanManagerEntry: jest.fn(async () => {
+        order.push('observer-settled');
+        managerEntry = null;
+      }),
+      withdrawCloudToLanTargetEntry: jest.fn(async (entry: never) => {
+        order.push('withdrawal-persisted');
+        targetEntry = {
+          ...(entry as object),
+          phase: 'withdrawn',
+          withdrawnAt: '2026-08-27T00:05:00.000Z',
+        };
+        return targetEntry;
+      }),
+    } as unknown as AuthorityTransferPersistence;
+    const lifecycle = {
+      registerDurableOwner: jest.fn(),
+      registerRecoveryStage: jest.fn(),
+      runExclusive: jest.fn(async (_projectId, _owner, _mode, operation) => operation()),
+    } as unknown as CollabProjectLifecycleSubsystem;
+    const targetCloud = {
+      authorityGeneration: 1,
+      dispose: jest.fn(),
+      lifecycle: { authorityTransfer: jest.fn() },
+      listProjectMembers: jest.fn(async () => ({
+        authorityGeneration: 1,
+        managerSetGeneration: 1,
+        members: [{
+          bindingState: 'bound',
+          displayName: 'Target',
+          importedClaimGeneration: null,
+          importedClaimState: 'not-applicable',
+          memberId: 'member-target',
+          membershipRevision: 1,
+          role: 'member',
+        }],
+        projectId: PROJECT_ID,
+      })),
+      memberId: 'member-target',
+      personalRef: 'refs/heads/members/member-target',
+      projectId: PROJECT_ID,
+      readSnapshot: jest.fn(async () => ({
+        currentMember: {
+          activatedAt: '2026-08-27T00:00:00.000Z',
+          createdAt: '2026-08-27T00:00:00.000Z',
+          displayName: 'Target',
+          id: 'member-target',
+          personalRef: 'refs/heads/members/member-target',
+          role: 'member',
+          status: 'active',
+        },
+        eventSequence: 3,
+        members: [],
+        openRequests: [],
+        openTicketCount: 0,
+        project: {
+          authorityGeneration: 1,
+          createdAt: '2026-08-27T00:00:00.000Z',
+          expectedMainOid: 'a'.repeat(40),
+          id: PROJECT_ID,
+          mainRef: 'refs/heads/main',
+          name: 'Transfer Project',
+        },
+        ticketHighlights: [],
+      })),
+      serverUrl: sourceUrl,
+    };
+    const managerCloud = {
+      ...targetCloud,
+      dispose: jest.fn(),
+      lifecycle: {
+        authorityTransfer: jest.fn(async (operation: string) => {
+          if (operation === 'beginCloudToLanTransfer') {
+            order.push('begin-sent');
+            return begun;
+          }
+          if (operation === 'getProjectAuthorityTransfer') {
+            order.push('status-read');
+            return begun;
+          }
+          if (operation === 'cancelProjectAuthorityTransfer') {
+            order.push('cancel-sent');
+            return {
+              ...begun,
+              phase: 'cancelled',
+              state: 'cancelled',
+              updatedAt: '2026-08-27T00:05:00.000Z',
+            };
+          }
+          throw new Error(`unexpected ${operation}`);
+        }),
+      },
+      listProjectMembers: jest.fn(async () => ({
+        authorityGeneration: 1,
+        managerSetGeneration: 1,
+        members: [
+          {
+            bindingState: 'bound',
+            displayName: 'Manager',
+            importedClaimGeneration: null,
+            importedClaimState: 'not-applicable',
+            memberId: 'member-manager',
+            membershipRevision: 1,
+            role: 'manager',
+          },
+          {
+            bindingState: 'bound',
+            displayName: 'Target',
+            importedClaimGeneration: null,
+            importedClaimState: 'not-applicable',
+            memberId: 'member-target',
+            membershipRevision: 1,
+            role: 'member',
+          },
+        ],
+        projectId: PROJECT_ID,
+      })),
+      memberId: 'member-manager',
+      personalRef: 'refs/heads/members/member-manager',
+      readSnapshot: jest.fn(async () => ({
+        ...(await targetCloud.readSnapshot()),
+        currentMember: {
+          activatedAt: '2026-08-27T00:00:00.000Z',
+          createdAt: '2026-08-27T00:00:00.000Z',
+          displayName: 'Manager',
+          id: 'member-manager',
+          personalRef: 'refs/heads/members/member-manager',
+          role: 'manager',
+          status: 'active',
+        },
+      })),
+    };
+    const createManagerConnection = jest.fn(async () => managerCloud as never);
+    const targetModule = new AuthorityTransferModule({
+      assertLanToCloudSourceOwner: () => undefined,
+      assertRecoveryOwner: () => undefined,
+      claimantStore: {
+        listProjectIds: () => Promise.resolve([]),
+        load: () => Promise.resolve(null),
+        remove: () => Promise.resolve(false),
+        save: () => Promise.resolve(),
+      },
+      convergence: {} as never,
+      createCloudToLanConnection: async () => targetCloud as never,
+      createCloudToLanTarget: () => ({
+        acceptanceRequest: jest.fn(),
+        activate: jest.fn(),
+        cancelStaging: jest.fn(),
+        dispose: targetDispose,
+        prepareTarget: jest.fn(async () => {
+          order.push('listener-prepared');
+          return {
+            caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+            caFingerprint: 'c'.repeat(64),
+            targetUrl,
+          };
+        }),
+        stage: jest.fn(),
+      }),
+      createLanToCloudSource: jest.fn() as never,
+      installationKey: TEST_INSTALLATION_B,
+      lifecycle,
+      persistence,
+    });
+    const managerModule = new AuthorityTransferModule({
+      assertLanToCloudSourceOwner: () => undefined,
+      assertRecoveryOwner: () => undefined,
+      claimantStore: {
+        listProjectIds: () => Promise.resolve([]),
+        load: () => Promise.resolve(null),
+        remove: () => Promise.resolve(false),
+        save: () => Promise.resolve(),
+      },
+      convergence: {} as never,
+      createCloudToLanConnection: createManagerConnection,
+      createCloudToLanTarget: jest.fn() as never,
+      createLanToCloudSource: jest.fn() as never,
+      installationKey: TEST_INSTALLATION_A,
+      lifecycle,
+      persistence,
+    });
+
+    const descriptor = await targetModule.prepareCloudToLanTarget({
+      operationIntentId: 'intent-target-preparation',
+      projectId: PROJECT_ID,
+    });
+    await expect(targetModule.prepareCloudToLanTarget({
+      operationIntentId: 'intent-new-facade-preparation-retry',
+      projectId: PROJECT_ID,
+    })).resolves.toEqual(descriptor);
+    const handle = await managerModule.beginCloudToLanTransfer({
+      descriptor,
+      operationIntentId: 'intent-manager-begin',
+    });
+
+    expect(descriptor).toMatchObject({
+      projectId: PROJECT_ID,
+      selectedTargetMemberId: 'member-target',
+      sourceAuthorityGeneration: 1,
+      sourceCloudUrl: sourceUrl,
+      targetUrl,
+    });
+    expect(handle).toMatchObject({
+      operationIntentId: 'intent-manager-begin',
+      preparationId: 'intent-target-preparation',
+      projectId: PROJECT_ID,
+      transferId: TRANSFER_ID,
+    });
+    expect(order).toEqual([
+      'target-persisted',
+      'listener-prepared',
+      'descriptor-persisted',
+      'begin-frozen',
+      'begin-sent',
+      'status-persisted',
+    ]);
+    await expect(targetModule.acceptCloudToLanTransfer({
+      handle: { ...handle, sourceAuthorityGeneration: 2 },
+    })).rejects.toMatchObject({
+      safeContext: { reason: 'authority-transfer-target-handle-mismatch' },
+    });
+    expect(targetCloud.lifecycle.authorityTransfer).not.toHaveBeenCalled();
+
+    await expect(targetModule.withdrawCloudToLanTarget({
+      preparationId: 'intent-stale-target-preparation',
+      projectId: PROJECT_ID,
+    } as never)).rejects.toMatchObject({
+      safeContext: { reason: 'authority-transfer-target-preparation-mismatch' },
+    });
+    expect(order).not.toContain('withdrawal-persisted');
+    expect(targetDispose).not.toHaveBeenCalled();
+    await targetModule.withdrawCloudToLanTarget({
+      preparationId: descriptor.preparationId,
+      projectId: PROJECT_ID,
+    } as never);
+    expect(order.slice(-2)).toEqual(['withdrawal-persisted', 'listener-released']);
+    await expect(targetModule.acceptCloudToLanTransfer({ handle })).rejects.toMatchObject({
+      safeContext: { reason: 'authority-transfer-target-handle-mismatch' },
+    });
+    expect(targetCloud.lifecycle.authorityTransfer).not.toHaveBeenCalled();
+    await expect(managerModule.prepareCloudToLanTarget({
+      operationIntentId: descriptor.preparationId,
+      projectId: PROJECT_ID,
+    })).rejects.toMatchObject({
+      safeContext: { reason: 'host-installation-recovery-owner-mismatch' },
+    });
+    expect(createManagerConnection).toHaveBeenCalledTimes(1);
+
+    await expect(targetModule.cancelCloudToLanTransfer(handle as never)).rejects.toMatchObject({
+      safeContext: { reason: 'authority-transfer-cloud-binding-mismatch' },
+    });
+    const authorityTransferCallCount = managerCloud.lifecycle.authorityTransfer.mock.calls.length;
+    await expect(managerModule.cancelCloudToLanTransfer({
+      ...handle,
+      operationIntentId: 'intent-stale-manager-begin',
+    } as never)).rejects.toMatchObject({
+      safeContext: { reason: 'authority-transfer-manager-handle-mismatch' },
+    });
+    expect(managerCloud.lifecycle.authorityTransfer).toHaveBeenCalledTimes(
+      authorityTransferCallCount,
+    );
+    (managerCloud.lifecycle.authorityTransfer as jest.Mock)
+      .mockImplementationOnce(async () => {
+        order.push('status-read');
+        return begun;
+      })
+      .mockImplementationOnce(async () => {
+        order.push('cancel-sent');
+        throw new Error('ambiguous-cancel-network-loss');
+      });
+    await expect(managerModule.cancelCloudToLanTransfer(handle as never)).rejects.toMatchObject({
+      result: {
+        durablePhase: 'committed',
+        durableProgress: true,
+        operationId: 'intent-manager-begin',
+        status: 'recovery-required',
+      },
+    });
+    await expect(managerModule.cancelCloudToLanTransfer(handle as never)).resolves.toMatchObject({
+      state: 'cancelled',
+    });
+    expect(order.slice(-9)).toEqual([
+      'status-read',
+      'status-persisted',
+      'cancel-frozen',
+      'cancel-marked',
+      'cancel-sent',
+      'cancel-marked',
+      'cancel-sent',
+      'status-persisted',
+      'observer-settled',
+    ]);
+  });
+
+  it('releases the Cloud session and preserves the durable outcome when preparation cleanup fails', async () => {
+    const connection = {
+      authorityGeneration: 1,
+      dispose: jest.fn(),
+      lifecycle: { authorityTransfer: jest.fn() },
+      listProjectMembers: jest.fn(),
+      memberId: 'member-target',
+      personalRef: 'refs/heads/members/member-target',
+      projectId: PROJECT_ID,
+      readSnapshot: jest.fn(async () => ({
+        currentMember: {
+          id: 'member-target',
+          personalRef: 'refs/heads/members/member-target',
+          role: 'member',
+        },
+        project: { authorityGeneration: 1, id: PROJECT_ID },
+      })),
+      serverUrl: 'https://cloud.example.test/',
+    };
+    const disposeTarget = jest.fn(async () => {
+      throw new Error('listener-dispose-failed');
+    });
+    const persistence = {
+      loadCloudToLanTargetEntry: jest.fn(async () => null),
+      prepareCloudToLanTargetEntry: jest.fn(async (entry: CloudToLanTargetEntryRecord) => entry),
+      publishCloudToLanTargetEntry: jest.fn(async () => {
+        throw new Error('simulated descriptor persistence failure');
+      }),
+    } as unknown as AuthorityTransferPersistence;
+    const module = new AuthorityTransferModule({
+      assertLanToCloudSourceOwner: () => undefined,
+      assertRecoveryOwner: () => undefined,
+      claimantStore: {
+        listProjectIds: () => Promise.resolve([]),
+        load: () => Promise.resolve(null),
+        remove: () => Promise.resolve(false),
+        save: () => Promise.resolve(),
+      },
+      convergence: {} as never,
+      createCloudToLanConnection: async () => connection as never,
+      createCloudToLanTarget: () => ({
+        acceptanceRequest: jest.fn(),
+        activate: jest.fn(),
+        cancelStaging: jest.fn(),
+        dispose: disposeTarget,
+        prepareTarget: jest.fn(async () => ({
+          caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+          caFingerprint: 'c'.repeat(64),
+          targetUrl: 'https://192.168.1.20:54545',
+        })),
+        stage: jest.fn(),
+      }),
+      createLanToCloudSource: jest.fn() as never,
+      installationKey: TEST_INSTALLATION_A,
+      lifecycle: {
+        registerDurableOwner: jest.fn(),
+        registerRecoveryStage: jest.fn(),
+        runExclusive: jest.fn(async (_projectId, _owner, _mode, operation) => operation()),
+      } as unknown as CollabProjectLifecycleSubsystem,
+      now: () => new Date('2026-08-27T00:00:00.000Z'),
+      persistence,
+    });
+
+    await expect(module.prepareCloudToLanTarget({
+      operationIntentId: 'intent-failed-target-preparation',
+      projectId: PROJECT_ID,
+    })).rejects.toMatchObject({
+      result: {
+        durableProgress: true,
+        operationId: 'intent-failed-target-preparation',
+        status: 'recovery-required',
+      },
+    });
+
+    expect(disposeTarget).toHaveBeenCalledTimes(1);
+    expect(connection.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('settles a definitive pre-ID begin rejection only after the bound recovery barrier', async () => {
+    let managerEntry: CloudToLanManagerEntryRecord | null = null;
+    const persistence = {
+      loadCloudToLanManagerEntry: jest.fn(async () => managerEntry),
+      markCloudToLanManagerBeginPossiblySent: jest.fn(async (
+        entry: CloudToLanManagerEntryRecord,
+      ) => {
+        managerEntry = markCloudToLanManagerBeginPossiblySent(entry);
+        return managerEntry;
+      }),
+      prepareCloudToLanManagerEntry: jest.fn(async (
+        entry: CloudToLanManagerEntryRecord,
+      ) => {
+        managerEntry = entry;
+        return entry;
+      }),
+      rejectCloudToLanManagerEntry: jest.fn(async (
+        entry: CloudToLanManagerEntryRecord,
+      ) => {
+        managerEntry = rejectCloudToLanManagerEntry(entry);
+        return managerEntry;
+      }),
+      settleCloudToLanManagerEntry: jest.fn(async (entry: CloudToLanManagerEntryRecord) => {
+        expect(entry.phase).toBe('rejected');
+        managerEntry = null;
+      }),
+    } as unknown as AuthorityTransferPersistence;
+    const snapshot = (role: 'manager' | 'member') => ({
+      currentMember: {
+        activatedAt: '2026-08-27T00:00:00.000Z',
+        createdAt: '2026-08-27T00:00:00.000Z',
+        displayName: 'Manager',
+        id: 'member-manager',
+        personalRef: 'refs/heads/members/member-manager',
+        role,
+        status: 'active',
+      },
+      eventSequence: 3,
+      members: [],
+      openRequests: [],
+      openTicketCount: 0,
+      project: {
+        authorityGeneration: 1,
+        createdAt: '2026-08-27T00:00:00.000Z',
+        expectedMainOid: 'a'.repeat(40),
+        id: PROJECT_ID,
+        mainRef: 'refs/heads/main',
+        name: 'Transfer Project',
+      },
+      ticketHighlights: [],
+    });
+    const readSnapshot = jest.fn()
+      .mockResolvedValueOnce(snapshot('manager'))
+      .mockResolvedValueOnce(snapshot('member'));
+    const listProjectMembers = jest.fn()
+      .mockResolvedValueOnce({
+        authorityGeneration: 1,
+        managerSetGeneration: 1,
+        members: [{
+          bindingState: 'bound',
+          displayName: 'Target',
+          importedClaimGeneration: null,
+          importedClaimState: 'not-applicable',
+          memberId: 'member-target',
+          membershipRevision: 1,
+          role: 'member',
+        }],
+        projectId: PROJECT_ID,
+      })
+      .mockResolvedValueOnce({
+        authorityGeneration: 1,
+        managerSetGeneration: 2,
+        members: [{
+          bindingState: 'hidden',
+          displayName: 'Manager',
+          importedClaimGeneration: null,
+          importedClaimState: 'hidden',
+          memberId: 'member-manager',
+          membershipRevision: 2,
+          role: 'member',
+        }],
+        projectId: PROJECT_ID,
+      });
+    const rejection = new CloudAuthorityRejection({ code: 'authorization-denied' });
+    const authorityTransfer = jest.fn().mockRejectedValueOnce(rejection);
+    const connection = {
+      authorityGeneration: 1,
+      dispose: jest.fn(),
+      lifecycle: { authorityTransfer },
+      listProjectMembers,
+      memberId: 'member-manager',
+      personalRef: 'refs/heads/members/member-manager',
+      projectId: PROJECT_ID,
+      readSnapshot,
+      serverUrl: 'https://cloud.example.test/',
+    };
+    const options = {
+      assertLanToCloudSourceOwner: () => undefined,
+      assertRecoveryOwner: () => undefined,
+      claimantStore: {
+        listProjectIds: () => Promise.resolve([]),
+        load: () => Promise.resolve(null),
+        remove: () => Promise.resolve(false),
+        save: () => Promise.resolve(),
+      },
+      convergence: {} as never,
+      createCloudToLanConnection: async () => connection as never,
+      createCloudToLanTarget: jest.fn() as never,
+      createLanToCloudSource: jest.fn() as never,
+      installationKey: TEST_INSTALLATION_A,
+      lifecycle: {
+        registerDurableOwner: jest.fn(),
+        registerRecoveryStage: jest.fn(),
+        runExclusive: jest.fn(async (_projectId, _owner, _mode, operation) => operation()),
+      } as unknown as CollabProjectLifecycleSubsystem,
+      now: () => new Date('2026-08-27T00:00:00.000Z'),
+      persistence,
+    };
+    const input = {
+      descriptor: {
+        caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+        caFingerprint: 'c'.repeat(64),
+        preparationId: 'intent-target-preparation',
+        projectId: PROJECT_ID,
+        publishedAt: '2026-08-27T00:00:00.000Z',
+        schemaVersion: 1 as const,
+        selectedTargetMemberId: 'member-target',
+        sourceAuthorityGeneration: 1,
+        sourceCloudUrl: 'https://cloud.example.test/',
+        targetUrl: 'https://192.168.1.20:54545',
+      },
+      operationIntentId: 'intent-manager-rejected',
+    };
+
+    await expect(new AuthorityTransferModule(options).beginCloudToLanTransfer(input))
+      .rejects.toBe(rejection);
+    expect(managerEntry).toBeNull();
+    expect(readSnapshot).toHaveBeenCalledTimes(2);
+    expect(listProjectMembers).toHaveBeenCalledTimes(2);
+    expect(persistence.rejectCloudToLanManagerEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ phase: 'submitted', status: null }),
+    );
+    expect(persistence.settleCloudToLanManagerEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ phase: 'rejected', status: null }),
+    );
+    expect(authorityTransfer).toHaveBeenCalledTimes(1);
+  });
+
+  it('coexists as the selected target and initiating Manager on one installation', async () => {
+    const targetUrl = 'https://192.168.1.20:54545';
+    const sourceUrl = 'https://cloud.example.test/';
+    let targetEntry: CloudToLanTargetEntryRecord | null = null;
+    let managerEntry: CloudToLanManagerEntryRecord | null = null;
+    const persistence = {
+      loadCloudToLanManagerEntry: jest.fn(async () => managerEntry),
+      loadCloudToLanTargetEntry: jest.fn(async () => targetEntry),
+      markCloudToLanManagerBeginPossiblySent: jest.fn(async (
+        entry: CloudToLanManagerEntryRecord,
+      ) => {
+        managerEntry = markCloudToLanManagerBeginPossiblySent(entry);
+        return managerEntry;
+      }),
+      prepareCloudToLanManagerEntry: jest.fn(async (
+        entry: CloudToLanManagerEntryRecord,
+      ) => {
+        managerEntry = entry;
+        return entry;
+      }),
+      prepareCloudToLanTargetEntry: jest.fn(async (
+        entry: CloudToLanTargetEntryRecord,
+      ) => {
+        targetEntry = entry;
+        return entry;
+      }),
+      publishCloudToLanTargetEntry: jest.fn(async (
+        entry: CloudToLanTargetEntryRecord,
+        descriptor: Parameters<typeof publishCloudToLanTargetEntry>[1],
+      ) => {
+        targetEntry = publishCloudToLanTargetEntry(entry, descriptor);
+        return targetEntry;
+      }),
+      recordCloudToLanManagerStatus: jest.fn(async (
+        entry: CloudToLanManagerEntryRecord,
+        transferStatus: CollabAuthorityTransferStatus,
+      ) => {
+        managerEntry = recordCloudToLanManagerStatus(entry, transferStatus);
+        return managerEntry;
+      }),
+    } as unknown as AuthorityTransferPersistence;
+    const cloudSnapshot = {
+      currentMember: {
+        activatedAt: '2026-08-27T00:00:00.000Z',
+        createdAt: '2026-08-27T00:00:00.000Z',
+        displayName: 'Self Manager',
+        id: 'member-self-manager',
+        personalRef: 'refs/heads/members/member-self-manager',
+        role: 'manager' as const,
+        status: 'active' as const,
+      },
+      eventSequence: 3,
+      members: [],
+      openRequests: [],
+      openTicketCount: 0,
+      project: {
+        authorityGeneration: 1,
+        createdAt: '2026-08-27T00:00:00.000Z',
+        expectedMainOid: 'a'.repeat(40),
+        id: PROJECT_ID,
+        mainRef: 'refs/heads/main',
+        name: 'Transfer Project',
+      },
+      ticketHighlights: [],
+    };
+    const begun: CollabAuthorityTransferStatus = {
+      ...proposal(),
+      direction: 'cloud-to-lan',
+      sourceAuthority: { generation: 1, kind: 'cloud' },
+      targetAuthority: { generation: 2, kind: 'lan' },
+      targetUrl,
+    };
+    const connection = {
+      authorityGeneration: 1,
+      dispose: jest.fn(),
+      lifecycle: { authorityTransfer: jest.fn(async () => begun) },
+      listProjectMembers: jest.fn(async () => ({
+        authorityGeneration: 1,
+        managerSetGeneration: 1,
+        members: [{
+          bindingState: 'bound',
+          displayName: 'Self Manager',
+          importedClaimGeneration: null,
+          importedClaimState: 'not-applicable',
+          memberId: 'member-self-manager',
+          membershipRevision: 1,
+          role: 'manager',
+        }],
+        projectId: PROJECT_ID,
+      })),
+      memberId: 'member-self-manager',
+      personalRef: 'refs/heads/members/member-self-manager',
+      projectId: PROJECT_ID,
+      readSnapshot: jest.fn(async () => cloudSnapshot),
+      serverUrl: sourceUrl,
+    };
+    const module = new AuthorityTransferModule({
+      assertLanToCloudSourceOwner: () => undefined,
+      assertRecoveryOwner: () => undefined,
+      claimantStore: {
+        listProjectIds: () => Promise.resolve([]),
+        load: () => Promise.resolve(null),
+        remove: () => Promise.resolve(false),
+        save: () => Promise.resolve(),
+      },
+      convergence: {} as never,
+      createCloudToLanConnection: async () => connection as never,
+      createCloudToLanTarget: () => ({
+        acceptanceRequest: jest.fn(),
+        activate: jest.fn(),
+        cancelStaging: jest.fn(),
+        prepareTarget: jest.fn(async () => ({
+          caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+          caFingerprint: 'c'.repeat(64),
+          targetUrl,
+        })),
+        stage: jest.fn(),
+      }),
+      createLanToCloudSource: jest.fn() as never,
+      installationKey: TEST_INSTALLATION_A,
+      lifecycle: {
+        registerDurableOwner: jest.fn(),
+        registerRecoveryStage: jest.fn(),
+        runExclusive: jest.fn(async (_projectId, _owner, _mode, operation) => operation()),
+      } as unknown as CollabProjectLifecycleSubsystem,
+      now: () => new Date('2026-08-27T00:00:00.000Z'),
+      persistence,
+    });
+
+    const descriptor = await module.prepareCloudToLanTarget({
+      operationIntentId: 'intent-self-preparation',
+      projectId: PROJECT_ID,
+    });
+    const handle = await module.beginCloudToLanTransfer({
+      descriptor,
+      operationIntentId: 'intent-self-manager-begin',
+    });
+
+    expect(targetEntry).toMatchObject({
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      phase: 'published',
+      selectedTargetMemberId: 'member-self-manager',
+    });
+    expect(managerEntry).toMatchObject({
+      initiatingMemberId: 'member-self-manager',
+      phase: 'observing',
+    });
+    expect(handle).toMatchObject({
+      preparationId: 'intent-self-preparation',
+      selectedTargetMemberId: 'member-self-manager',
+      transferId: TRANSFER_ID,
+    });
+  });
+
+  it('releases a withdrawn preparation even when listener disposal fails', async () => {
+    let targetEntry: CloudToLanTargetEntryRecord | null = null;
+    const persistence = {
+      loadCloudToLanTargetEntry: jest.fn(async () => targetEntry),
+      prepareCloudToLanTargetEntry: jest.fn(async (entry: CloudToLanTargetEntryRecord) => {
+        targetEntry = entry;
+        return entry;
+      }),
+      publishCloudToLanTargetEntry: jest.fn(async (
+        entry: CloudToLanTargetEntryRecord,
+        descriptor: Parameters<typeof publishCloudToLanTargetEntry>[1],
+      ) => {
+        targetEntry = publishCloudToLanTargetEntry(entry, descriptor);
+        return targetEntry;
+      }),
+      withdrawCloudToLanTargetEntry: jest.fn(async (entry: CloudToLanTargetEntryRecord) => {
+        targetEntry = withdrawCloudToLanTargetEntry(
+          entry,
+          '2026-08-27T00:01:00.000Z',
+        );
+        return targetEntry;
+      }),
+    } as unknown as AuthorityTransferPersistence;
+    const connections = [0, 1].map(() => ({
+      authorityGeneration: 1,
+      dispose: jest.fn(),
+      lifecycle: { authorityTransfer: jest.fn() },
+      listProjectMembers: jest.fn(),
+      memberId: 'member-target',
+      personalRef: 'refs/heads/members/member-target',
+      projectId: PROJECT_ID,
+      readSnapshot: jest.fn(async () => ({
+        currentMember: {
+          displayName: 'Target',
+          id: 'member-target',
+          personalRef: 'refs/heads/members/member-target',
+          role: 'member',
+        },
+        project: { authorityGeneration: 1, id: PROJECT_ID },
+      })),
+      serverUrl: 'https://cloud.example.test/',
+    }));
+    const firstDispose = jest.fn()
+      .mockRejectedValueOnce(new Error('listener-dispose-failed'))
+      .mockResolvedValue(undefined);
+    const targetDisposals = [firstDispose, jest.fn(async () => undefined)];
+    let connectionIndex = 0;
+    let targetIndex = 0;
+    const module = new AuthorityTransferModule({
+      assertLanToCloudSourceOwner: () => undefined,
+      assertRecoveryOwner: () => undefined,
+      claimantStore: {
+        listProjectIds: () => Promise.resolve([]),
+        load: () => Promise.resolve(null),
+        remove: () => Promise.resolve(false),
+        save: () => Promise.resolve(),
+      },
+      convergence: {} as never,
+      createCloudToLanConnection: async () => connections[connectionIndex++] as never,
+      createCloudToLanTarget: () => {
+        const dispose = targetDisposals[targetIndex++];
+        return {
+          acceptanceRequest: jest.fn(),
+          activate: jest.fn(),
+          cancelStaging: jest.fn(),
+          dispose,
+          prepareTarget: jest.fn(async () => ({
+            caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+            caFingerprint: 'c'.repeat(64),
+            targetUrl: 'https://192.168.1.20:54545',
+          })),
+          stage: jest.fn(),
+        };
+      },
+      createLanToCloudSource: jest.fn() as never,
+      installationKey: TEST_INSTALLATION_A,
+      lifecycle: {
+        registerDurableOwner: jest.fn(),
+        registerRecoveryStage: jest.fn(),
+        runExclusive: jest.fn(async (_projectId, _owner, _mode, operation) => operation()),
+      } as unknown as CollabProjectLifecycleSubsystem,
+      now: () => new Date('2026-08-27T00:00:00.000Z'),
+      persistence,
+    });
+
+    await module.prepareCloudToLanTarget({
+      operationIntentId: 'intent-first-target-preparation',
+      projectId: PROJECT_ID,
+    });
+    await expect(module.withdrawCloudToLanTarget({
+      preparationId: 'intent-first-target-preparation',
+      projectId: PROJECT_ID,
+    }))
+      .rejects.toThrow('listener-dispose-failed');
+    await module.prepareCloudToLanTarget({
+      operationIntentId: 'intent-replacement-target-preparation',
+      projectId: PROJECT_ID,
+    });
+    await module.close();
+
+    expect(firstDispose).toHaveBeenCalledTimes(1);
+    expect(connections[0].dispose).toHaveBeenCalledTimes(1);
+    expect(connections[1].dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases a failed pre-handoff acceptance binding when the target withdraws', async () => {
+    let targetEntry: CloudToLanTargetEntryRecord | null = null;
+    const persistence = {
+      load: jest.fn(async () => null),
+      loadCloudToLanTargetEntry: jest.fn(async () => targetEntry),
+      prepareCloudToLanTargetEntry: jest.fn(async (entry: CloudToLanTargetEntryRecord) => {
+        targetEntry = entry;
+        return entry;
+      }),
+      publishCloudToLanTargetEntry: jest.fn(async (
+        entry: CloudToLanTargetEntryRecord,
+        descriptor: Parameters<typeof publishCloudToLanTargetEntry>[1],
+      ) => {
+        targetEntry = publishCloudToLanTargetEntry(entry, descriptor);
+        return targetEntry;
+      }),
+      withdrawCloudToLanTargetEntry: jest.fn(async (entry: CloudToLanTargetEntryRecord) => {
+        targetEntry = withdrawCloudToLanTargetEntry(entry, '2026-08-27T00:01:00.000Z');
+        return targetEntry;
+      }),
+    } as unknown as AuthorityTransferPersistence;
+    const targetUrl = 'https://192.168.1.20:54545';
+    const connection = {
+      authorityGeneration: 1,
+      dispose: jest.fn(),
+      lifecycle: {
+        authorityTransfer: jest.fn(async () => ({
+          ...proposal(),
+          direction: 'cloud-to-lan' as const,
+          phase: 'cloud-quiesced' as const,
+          sourceAuthority: { generation: 1, kind: 'cloud' as const },
+          targetAuthority: { generation: 2, kind: 'lan' as const },
+          targetUrl,
+        })),
+      },
+      listProjectMembers: jest.fn(),
+      memberId: 'member-target',
+      personalRef: 'refs/heads/members/member-target',
+      projectId: PROJECT_ID,
+      readSnapshot: jest.fn(async () => ({
+        currentMember: {
+          displayName: 'Target',
+          id: 'member-target',
+          personalRef: 'refs/heads/members/member-target',
+          role: 'member',
+        },
+        project: { authorityGeneration: 1, id: PROJECT_ID },
+      })),
+      serverUrl: 'https://cloud.example.test/',
+    };
+    const disposeTarget = jest.fn(async () => {
+      throw new Error('listener-dispose-failed');
+    });
+    const module = new AuthorityTransferModule({
+      assertLanToCloudSourceOwner: () => undefined,
+      assertRecoveryOwner: () => undefined,
+      claimantStore: {
+        listProjectIds: () => Promise.resolve([]),
+        load: () => Promise.resolve(null),
+        remove: () => Promise.resolve(false),
+        save: () => Promise.resolve(),
+      },
+      convergence: {} as never,
+      createCloudToLanConnection: async () => connection as never,
+      createCloudToLanTarget: () => ({
+        acceptanceRequest: jest.fn(),
+        activate: jest.fn(),
+        cancelStaging: jest.fn(),
+        dispose: disposeTarget,
+        prepareTarget: jest.fn(async () => ({
+          caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+          caFingerprint: 'c'.repeat(64),
+          targetUrl,
+        })),
+        stage: jest.fn(),
+      }),
+      createLanToCloudSource: jest.fn() as never,
+      installationKey: TEST_INSTALLATION_A,
+      lifecycle: {
+        registerDurableOwner: jest.fn(),
+        registerRecoveryStage: jest.fn(),
+        runExclusive: jest.fn(async (_projectId, _owner, _mode, operation) => operation()),
+      } as unknown as CollabProjectLifecycleSubsystem,
+      now: () => new Date('2026-08-27T00:00:00.000Z'),
+      persistence,
+    });
+    const descriptor = await module.prepareCloudToLanTarget({
+      operationIntentId: 'intent-failed-accept-preparation',
+      projectId: PROJECT_ID,
+    });
+    const handle = {
+      operationIntentId: 'intent-failed-accept-manager',
+      preparationId: descriptor.preparationId,
+      projectId: PROJECT_ID,
+      schemaVersion: 1 as const,
+      selectedTargetMemberId: descriptor.selectedTargetMemberId,
+      sourceAuthorityGeneration: descriptor.sourceAuthorityGeneration,
+      sourceCloudUrl: descriptor.sourceCloudUrl,
+      targetUrl: descriptor.targetUrl,
+      transferId: TRANSFER_ID,
+    };
+
+    await expect(module.acceptCloudToLanTransfer({ handle })).rejects.toMatchObject({
+      safeContext: { reason: 'cloud-to-lan-prepared-status-mismatch' },
+    });
+    await expect(module.withdrawCloudToLanTarget({
+      preparationId: descriptor.preparationId,
+      projectId: PROJECT_ID,
+    })).rejects.toThrow('listener-dispose-failed');
+
+    expect(targetEntry).toMatchObject({ phase: 'withdrawn' });
+    expect(disposeTarget).toHaveBeenCalledTimes(1);
+    expect(connection.dispose).toHaveBeenCalledTimes(1);
+    await module.close();
+    expect(disposeTarget).toHaveBeenCalledTimes(1);
+  });
+
+  it('classifies an existing target binding retry failure after durable progress', async () => {
+    const completedStatus = recoverableClaimantRecord({ direction: 'cloud-to-lan' }).status;
+    const collectingStatus: CollabAuthorityTransferStatus = {
+      ...completedStatus,
+      batchRevision: null,
+      batchSha256: null,
+      checkpointSha256: null,
+      phase: 'collecting-readiness',
+      relinquishmentProof: null,
+      state: 'active',
+      updatedAt: completedStatus.createdAt,
+    };
+    const preparing = createCloudToLanTargetEntry({
+      createdAt: completedStatus.createdAt,
+      expiresAt: completedStatus.expiresAt,
+      operationIntentId: 'intent-self-target-preparation',
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      projectId: PROJECT_ID,
+      selectedTargetMemberId: 'member-host',
+      selectedTargetPersonalRef: 'refs/heads/members/member-host',
+      sourceAuthorityGeneration: 1,
+      sourceCloudUrl: 'https://cloud.example.test/',
+    });
+    const published = publishCloudToLanTargetEntry(preparing, {
+      caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+      caFingerprint: 'c'.repeat(64),
+      publishedAt: completedStatus.createdAt,
+      targetUrl: completedStatus.targetUrl,
+    });
+    const physical = createAuthorityTransferRecord({
+      lifecycleOwnership: 'owned',
+      localRole: 'target',
+      operationIntentId: completedStatus.relinquishmentProof!.operationIntentId,
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: completedStatus,
+    });
+    const targetEntry = handoffCloudToLanTargetEntry(published, physical);
+    let managerEntry: CloudToLanManagerEntryRecord | null = recordCloudToLanManagerStatus(
+      markCloudToLanManagerBeginPossiblySent(createCloudToLanManagerEntry({
+        createdAt: collectingStatus.createdAt,
+        descriptor: published.descriptor!,
+        expiresAt: collectingStatus.expiresAt,
+        initiatingMemberId: 'member-host',
+        initiatingPersonalRef: 'refs/heads/members/member-host',
+        operationIntentId: physical.operationIntentId,
+      })),
+      collectingStatus,
+    );
+    const handle = cloudToLanTransferHandle(managerEntry);
+    const settleCloudToLanManagerEntry = jest.fn(async () => {
+      managerEntry = null;
+    });
+    const persistence = {
+      load: jest.fn(async () => physical),
+      loadCloudToLanManagerEntry: jest.fn(async () => managerEntry),
+      loadCloudToLanTargetEntry: jest.fn(async () => targetEntry),
+      recordCloudToLanManagerStatus: jest.fn(async (
+        entry: CloudToLanManagerEntryRecord,
+        transferStatus: CollabAuthorityTransferStatus,
+      ) => {
+        const recorded = recordCloudToLanManagerStatus(entry, transferStatus);
+        managerEntry = recorded;
+        return recorded;
+      }),
+      settleCloudToLanManagerEntry,
+    } as unknown as AuthorityTransferPersistence;
+    const connection = {
+      authorityGeneration: 1,
+      dispose: jest.fn(),
+      lifecycle: { authorityTransfer: jest.fn() },
+      listProjectMembers: jest.fn(),
+      memberId: 'member-host',
+      personalRef: 'refs/heads/members/member-host',
+      projectId: PROJECT_ID,
+      readSnapshot: jest.fn(),
+      serverUrl: 'https://cloud.example.test/',
+    };
+    const createCloudToLanConnection = jest.fn(async () => connection as never);
+    const activate = jest.fn()
+      .mockResolvedValueOnce('activation-proof')
+      .mockRejectedValueOnce(new Error('simulated retry convergence failure'));
+    const module = new AuthorityTransferModule({
+      assertLanToCloudSourceOwner: () => undefined,
+      assertRecoveryOwner: () => undefined,
+      claimantStore: {
+        listProjectIds: () => Promise.resolve([]),
+        load: () => Promise.resolve(null),
+        remove: () => Promise.resolve(false),
+        save: () => Promise.resolve(),
+      },
+      convergence: {} as never,
+      createCloudToLanConnection,
+      createCloudToLanTarget: () => ({
+        acceptanceRequest: jest.fn(),
+        activate,
+        cancelStaging: jest.fn(),
+        stage: jest.fn(),
+      }),
+      createLanToCloudSource: jest.fn() as never,
+      installationKey: TEST_INSTALLATION_A,
+      lifecycle: {
+        registerDurableOwner: jest.fn(),
+        registerRecoveryStage: jest.fn(),
+        runExclusive: jest.fn(async (_projectId, _owner, _mode, operation) => operation()),
+      } as unknown as CollabProjectLifecycleSubsystem,
+      persistence,
+    });
+
+    await expect(module.acceptCloudToLanTransfer({ handle })).resolves.toMatchObject({
+      state: 'completed',
+    });
+    await expect(module.acceptCloudToLanTransfer({ handle })).rejects.toMatchObject({
+      result: {
+        durableProgress: true,
+        operationId: physical.operationIntentId,
+        status: 'recovery-required',
+      },
+    });
+
+    expect(settleCloudToLanManagerEntry).toHaveBeenCalledTimes(1);
+    expect(managerEntry).toBeNull();
+    expect(createCloudToLanConnection).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the target listener and Cloud session when Manager cancellation settlement fails', async () => {
+    const collectingStatus = proposal({
+      direction: 'cloud-to-lan',
+      sourceAuthority: { generation: 1, kind: 'cloud' },
+      targetAuthority: { generation: 2, kind: 'lan' },
+      targetUrl: 'https://192.168.1.20:54545',
+    });
+    const cancelledStatus: CollabAuthorityTransferStatus = {
+      ...collectingStatus,
+      phase: 'cancelled',
+      state: 'cancelled',
+      updatedAt: '2026-08-27T00:01:00.000Z',
+    };
+    const preparing = createCloudToLanTargetEntry({
+      createdAt: collectingStatus.createdAt,
+      expiresAt: collectingStatus.expiresAt,
+      operationIntentId: 'intent-cancelled-target-preparation',
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      projectId: PROJECT_ID,
+      selectedTargetMemberId: 'member-host',
+      selectedTargetPersonalRef: 'refs/heads/members/member-host',
+      sourceAuthorityGeneration: 1,
+      sourceCloudUrl: 'https://cloud.example.test/',
+    });
+    const published = publishCloudToLanTargetEntry(preparing, {
+      caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+      caFingerprint: 'c'.repeat(64),
+      publishedAt: collectingStatus.createdAt,
+      targetUrl: collectingStatus.targetUrl,
+    });
+    const physical = createAuthorityTransferRecord({
+      lifecycleOwnership: 'owned',
+      localRole: 'target',
+      operationIntentId: 'intent-cancelled-manager-begin',
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: cancelledStatus,
+    });
+    const targetEntry = handoffCloudToLanTargetEntry(published, physical);
+    let managerEntry: CloudToLanManagerEntryRecord | null = recordCloudToLanManagerStatus(
+      markCloudToLanManagerBeginPossiblySent(createCloudToLanManagerEntry({
+        createdAt: collectingStatus.createdAt,
+        descriptor: published.descriptor!,
+        expiresAt: collectingStatus.expiresAt,
+        initiatingMemberId: 'member-host',
+        initiatingPersonalRef: 'refs/heads/members/member-host',
+        operationIntentId: physical.operationIntentId,
+      })),
+      collectingStatus,
+    );
+    const completeTerminalCleanup = jest.fn(async () => undefined);
+    const persistence = {
+      completeTerminalCleanup,
+      load: jest.fn(async () => physical),
+      loadCloudToLanManagerEntry: jest.fn(async () => managerEntry),
+      loadCloudToLanTargetEntry: jest.fn(async () => targetEntry),
+      recordCloudToLanManagerStatus: jest.fn(async () => {
+        throw new Error('simulated Manager status persistence failure');
+      }),
+      settleCloudToLanManagerEntry: jest.fn(async () => { managerEntry = null; }),
+    } as unknown as AuthorityTransferPersistence;
+    const cancelStaging = jest.fn(async () => undefined);
+    const disposeTarget = jest.fn(async () => undefined);
+    const connection = {
+      authorityGeneration: 1,
+      dispose: jest.fn(),
+      lifecycle: { authorityTransfer: jest.fn() },
+      listProjectMembers: jest.fn(),
+      memberId: 'member-host',
+      personalRef: 'refs/heads/members/member-host',
+      projectId: PROJECT_ID,
+      readSnapshot: jest.fn(),
+      serverUrl: 'https://cloud.example.test/',
+    };
+    const module = new AuthorityTransferModule({
+      assertLanToCloudSourceOwner: () => undefined,
+      assertRecoveryOwner: () => undefined,
+      claimantStore: {
+        listProjectIds: () => Promise.resolve([]),
+        load: () => Promise.resolve(null),
+        remove: () => Promise.resolve(false),
+        save: () => Promise.resolve(),
+      },
+      convergence: {} as never,
+      createCloudToLanConnection: async () => connection as never,
+      createCloudToLanTarget: () => ({
+        acceptanceRequest: jest.fn(),
+        activate: jest.fn(),
+        cancelStaging,
+        dispose: disposeTarget,
+        stage: jest.fn(),
+      }),
+      createLanToCloudSource: jest.fn() as never,
+      installationKey: TEST_INSTALLATION_A,
+      lifecycle: {
+        registerDurableOwner: jest.fn(),
+        registerRecoveryStage: jest.fn(),
+        runExclusive: jest.fn(async (_projectId, _owner, _mode, operation) => operation()),
+      } as unknown as CollabProjectLifecycleSubsystem,
+      persistence,
+    });
+
+    connection.memberId = 'member-relocated';
+    await expect(module.acceptCloudToLanTransfer({
+      handle: cloudToLanTransferHandle(managerEntry!),
+    })).rejects.toMatchObject({
+      safeContext: { reason: 'authority-transfer-cloud-binding-mismatch' },
+    });
+    connection.memberId = 'member-host';
+
+    await expect(module.acceptCloudToLanTransfer({
+      handle: cloudToLanTransferHandle(managerEntry!),
+    })).rejects.toMatchObject({
+      result: {
+        durableProgress: true,
+        operationId: physical.operationIntentId,
+        status: 'recovery-required',
+      },
+    });
+
+    expect(cancelStaging).toHaveBeenCalledTimes(1);
+    expect(completeTerminalCleanup).toHaveBeenCalledTimes(1);
+    expect(disposeTarget).toHaveBeenCalledTimes(1);
+    expect(connection.dispose).toHaveBeenCalledTimes(2);
+    expect(managerEntry).toMatchObject({ phase: 'observing' });
+  });
+
+  it('replays one frozen Manager begin after an ambiguous result without another snapshot', async () => {
+    let managerEntry: CloudToLanManagerEntryRecord | null = null;
+    const persistence = {
+      loadCloudToLanManagerEntry: jest.fn(async () => managerEntry),
+      markCloudToLanManagerBeginPossiblySent: jest.fn(async (
+        entry: CloudToLanManagerEntryRecord,
+      ) => {
+        managerEntry = markCloudToLanManagerBeginPossiblySent(entry);
+        return managerEntry;
+      }),
+      prepareCloudToLanManagerEntry: jest.fn(async (
+        entry: CloudToLanManagerEntryRecord,
+      ) => {
+        managerEntry = entry;
+        return entry;
+      }),
+      recordCloudToLanManagerStatus: jest.fn(async (
+        entry: CloudToLanManagerEntryRecord,
+        transferStatus: CollabAuthorityTransferStatus,
+      ) => {
+        managerEntry = recordCloudToLanManagerStatus(entry, transferStatus);
+        return managerEntry;
+      }),
+      rejectCloudToLanManagerEntry: jest.fn(async (
+        entry: CloudToLanManagerEntryRecord,
+      ) => {
+        managerEntry = rejectCloudToLanManagerEntry(entry);
+        return managerEntry;
+      }),
+      settleCloudToLanManagerEntry: jest.fn(async () => {
+        managerEntry = null;
+      }),
+    } as unknown as AuthorityTransferPersistence;
+    const targetUrl = 'https://192.168.1.20:54545';
+    const begun: CollabAuthorityTransferStatus = {
+      ...proposal(),
+      direction: 'cloud-to-lan',
+      sourceAuthority: { generation: 1, kind: 'cloud' },
+      targetAuthority: { generation: 2, kind: 'lan' },
+      targetUrl,
+    };
+    const authorityTransfer = jest.fn()
+      .mockRejectedValueOnce(new Error('ambiguous-network-loss'))
+      .mockRejectedValueOnce(new CloudAuthorityRejection({ code: 'authorization-denied' }))
+      .mockResolvedValueOnce(begun);
+    const readSnapshot = jest.fn(async () => ({
+      currentMember: {
+        activatedAt: '2026-08-27T00:00:00.000Z',
+        createdAt: '2026-08-27T00:00:00.000Z',
+        displayName: 'Manager',
+        id: 'member-manager',
+        personalRef: 'refs/heads/members/member-manager',
+        role: 'manager',
+        status: 'active',
+      },
+      eventSequence: 3,
+      members: [],
+      openRequests: [],
+      openTicketCount: 0,
+      project: {
+        authorityGeneration: 1,
+        createdAt: '2026-08-27T00:00:00.000Z',
+        expectedMainOid: 'a'.repeat(40),
+        id: PROJECT_ID,
+        mainRef: 'refs/heads/main',
+        name: 'Transfer Project',
+      },
+      ticketHighlights: [],
+    }));
+    const listProjectMembers = jest.fn(async () => ({
+      authorityGeneration: 1,
+      managerSetGeneration: 1,
+      members: [{
+        bindingState: 'bound',
+        displayName: 'Target',
+        importedClaimGeneration: null,
+        importedClaimState: 'not-applicable',
+        memberId: 'member-target',
+        membershipRevision: 1,
+        role: 'member',
+      }],
+      projectId: PROJECT_ID,
+    }));
+    const connection = {
+      authorityGeneration: 1,
+      dispose: jest.fn(),
+      lifecycle: { authorityTransfer },
+      listProjectMembers,
+      memberId: 'member-manager',
+      personalRef: 'refs/heads/members/member-manager',
+      projectId: PROJECT_ID,
+      readSnapshot,
+      serverUrl: 'https://cloud.example.test/',
+    };
+    const module = new AuthorityTransferModule({
+      assertLanToCloudSourceOwner: () => undefined,
+      assertRecoveryOwner: () => undefined,
+      claimantStore: {
+        listProjectIds: () => Promise.resolve([]),
+        load: () => Promise.resolve(null),
+        remove: () => Promise.resolve(false),
+        save: () => Promise.resolve(),
+      },
+      convergence: {} as never,
+      createCloudToLanConnection: async () => connection as never,
+      createCloudToLanTarget: jest.fn() as never,
+      createLanToCloudSource: jest.fn() as never,
+      installationKey: TEST_INSTALLATION_A,
+      lifecycle: {
+        registerDurableOwner: jest.fn(),
+        registerRecoveryStage: jest.fn(),
+        runExclusive: jest.fn(async (_projectId, _owner, _mode, operation) => operation()),
+      } as unknown as CollabProjectLifecycleSubsystem,
+      now: () => new Date('2026-08-27T00:00:00.000Z'),
+      persistence,
+    });
+    const input = {
+      descriptor: {
+        caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+        caFingerprint: 'c'.repeat(64),
+        preparationId: 'intent-target-preparation',
+        projectId: PROJECT_ID,
+        publishedAt: '2026-08-27T00:00:00.000Z',
+        schemaVersion: 1 as const,
+        selectedTargetMemberId: 'member-target',
+        sourceAuthorityGeneration: 1,
+        sourceCloudUrl: 'https://cloud.example.test/',
+        targetUrl,
+      },
+      operationIntentId: 'intent-ambiguous-manager-begin',
+    };
+
+    await expect(module.beginCloudToLanTransfer(input)).rejects.toMatchObject({
+      result: {
+        durablePhase: 'committed',
+        durableProgress: true,
+        operationId: 'intent-ambiguous-manager-begin',
+        status: 'recovery-required',
+      },
+    });
+    expect(managerEntry).toMatchObject({ phase: 'submitted', status: null });
+    connection.serverUrl = 'https://relocated.example.test/';
+    await expect(module.beginCloudToLanTransfer({
+      ...input,
+      operationIntentId: 'intent-relocated-facade-retry',
+    })).rejects.toMatchObject({
+      safeContext: { reason: 'authority-transfer-cloud-binding-mismatch' },
+    });
+    expect(authorityTransfer).toHaveBeenCalledTimes(1);
+    connection.serverUrl = 'https://cloud.example.test/';
+    await expect(module.beginCloudToLanTransfer({
+      ...input,
+      operationIntentId: 'intent-new-facade-ambiguous-retry',
+    })).rejects.toMatchObject({
+      result: {
+        durablePhase: 'committed',
+        durableProgress: true,
+        operationId: 'intent-ambiguous-manager-begin',
+        status: 'recovery-required',
+      },
+    });
+    expect(managerEntry).toMatchObject({ phase: 'submitted', status: null });
+    expect(readSnapshot).toHaveBeenCalledTimes(1);
+    expect(listProjectMembers).toHaveBeenCalledTimes(1);
+    await expect(module.beginCloudToLanTransfer({
+      ...input,
+      operationIntentId: 'intent-final-facade-ambiguous-retry',
+    })).resolves.toMatchObject({
+      operationIntentId: 'intent-ambiguous-manager-begin',
+      transferId: TRANSFER_ID,
+    });
+    expect(readSnapshot).toHaveBeenCalledTimes(1);
+    expect(listProjectMembers).toHaveBeenCalledTimes(1);
+    expect(authorityTransfer.mock.calls[0]?.[1]).toEqual(authorityTransfer.mock.calls[1]?.[1]);
+    expect(authorityTransfer.mock.calls[1]?.[1]).toEqual(authorityTransfer.mock.calls[2]?.[1]);
+  });
+
+  it('serializes concurrent Manager begins before deciding whether a rejection is definitive', async () => {
+    const descriptor = {
+      caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+      caFingerprint: 'c'.repeat(64),
+      preparationId: 'intent-concurrent-target-preparation',
+      projectId: PROJECT_ID,
+      publishedAt: '2026-08-27T00:00:00.000Z',
+      schemaVersion: 1 as const,
+      selectedTargetMemberId: 'member-target',
+      sourceAuthorityGeneration: 1,
+      sourceCloudUrl: 'https://cloud.example.test/',
+      targetUrl: 'https://192.168.1.20:54545',
+    };
+    let managerEntry: CloudToLanManagerEntryRecord | null = createCloudToLanManagerEntry({
+      createdAt: '2026-08-27T00:00:00.000Z',
+      descriptor,
+      expiresAt: '2026-09-26T00:00:00.000Z',
+      initiatingMemberId: 'member-manager',
+      initiatingPersonalRef: 'refs/heads/members/member-manager',
+      operationIntentId: 'intent-concurrent-manager-begin',
+    });
+    const persistence = {
+      inspectLifecycleOwner: jest.fn(async () => managerEntry ? 'nonterminal' : 'absent'),
+      loadCloudToLanManagerEntry: jest.fn(async () => managerEntry),
+      markCloudToLanManagerBeginPossiblySent: jest.fn(async (
+        entry: CloudToLanManagerEntryRecord,
+      ) => {
+        managerEntry = markCloudToLanManagerBeginPossiblySent(entry);
+        return managerEntry;
+      }),
+      rejectCloudToLanManagerEntry: jest.fn(async (
+        entry: CloudToLanManagerEntryRecord,
+      ) => {
+        managerEntry = rejectCloudToLanManagerEntry(entry);
+        return managerEntry;
+      }),
+      settleCloudToLanManagerEntry: jest.fn(async () => {
+        managerEntry = null;
+      }),
+    } as unknown as AuthorityTransferPersistence;
+    const authorityTransfer = jest.fn()
+      .mockRejectedValueOnce(new Error('ambiguous-network-loss-after-commit'))
+      .mockRejectedValueOnce(new CloudAuthorityRejection({ code: 'authorization-denied' }));
+    const readSnapshot = jest.fn(async () => ({
+      currentMember: {
+        id: 'member-manager',
+        personalRef: 'refs/heads/members/member-manager',
+        role: 'manager',
+      },
+      project: { authorityGeneration: 1, id: PROJECT_ID },
+    }));
+    const connection = {
+      authorityGeneration: 1,
+      dispose: jest.fn(),
+      lifecycle: { authorityTransfer },
+      listProjectMembers: jest.fn(async () => ({
+        members: [{
+          bindingState: 'bound',
+          memberId: 'member-manager',
+          role: 'manager',
+        }],
+        projectId: PROJECT_ID,
+      })),
+      memberId: 'member-manager',
+      personalRef: 'refs/heads/members/member-manager',
+      projectId: PROJECT_ID,
+      readSnapshot,
+      serverUrl: 'https://cloud.example.test/',
+    };
+    const lifecycle = new CollabProjectLifecycleSubsystem({
+      closeRecovery: jest.fn(),
+      durableOwners: [],
+      hostTransfer: {} as never,
+      localExit: {} as never,
+      recoveryStages: [],
+      retirement: {} as never,
+    });
+    const module = new AuthorityTransferModule({
+      assertLanToCloudSourceOwner: () => undefined,
+      assertRecoveryOwner: () => undefined,
+      claimantStore: {
+        listProjectIds: () => Promise.resolve([]),
+        load: () => Promise.resolve(null),
+        remove: () => Promise.resolve(false),
+        save: () => Promise.resolve(),
+      },
+      convergence: {} as never,
+      createCloudToLanConnection: async () => connection as never,
+      createCloudToLanTarget: jest.fn() as never,
+      createLanToCloudSource: jest.fn() as never,
+      installationKey: TEST_INSTALLATION_A,
+      lifecycle,
+      persistence,
+    });
+    const input = {
+      descriptor,
+      operationIntentId: 'intent-ignored-concurrent-retry',
+    };
+
+    const results = await Promise.allSettled([
+      module.beginCloudToLanTransfer(input),
+      module.beginCloudToLanTransfer(input),
+    ]);
+
+    expect(results).toHaveLength(2);
+    for (const result of results) {
+      expect(result).toMatchObject({
+        reason: {
+          result: {
+            durableProgress: true,
+            operationId: 'intent-concurrent-manager-begin',
+            status: 'recovery-required',
+          },
+        },
+        status: 'rejected',
+      });
+    }
+    expect(managerEntry).toMatchObject({ phase: 'submitted', status: null });
+    expect(readSnapshot).not.toHaveBeenCalled();
+    expect(persistence.rejectCloudToLanManagerEntry).not.toHaveBeenCalled();
+  });
+
+  it('replays a submitted Manager journal during startup recovery', async () => {
+    const descriptor = {
+      caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+      caFingerprint: 'c'.repeat(64),
+      preparationId: 'intent-recovery-target-preparation',
+      projectId: PROJECT_ID,
+      publishedAt: '2026-08-27T00:00:00.000Z',
+      schemaVersion: 1 as const,
+      selectedTargetMemberId: 'member-target',
+      sourceAuthorityGeneration: 1,
+      sourceCloudUrl: 'https://cloud.example.test/',
+      targetUrl: 'https://192.168.1.20:54545',
+    };
+    let managerEntry: CloudToLanManagerEntryRecord | null =
+      markCloudToLanManagerBeginPossiblySent(createCloudToLanManagerEntry({
+        createdAt: '2026-08-27T00:00:00.000Z',
+        descriptor,
+        expiresAt: '2026-09-26T00:00:00.000Z',
+        initiatingMemberId: 'member-manager',
+        initiatingPersonalRef: 'refs/heads/members/member-manager',
+        operationIntentId: 'intent-recovery-manager-begin',
+      }));
+    const frozenRequest = managerEntry.request;
+    const begun = proposal({
+      direction: 'cloud-to-lan',
+      sourceAuthority: { generation: 1, kind: 'cloud' },
+      targetAuthority: { generation: 2, kind: 'lan' },
+      targetUrl: descriptor.targetUrl,
+    });
+    let physicalRecord: AuthorityTransferRecord | null = null;
+    const persistence = {
+      inspectLifecycleOwner: jest.fn(async () => 'absent'),
+      load: jest.fn(async () => physicalRecord),
+      loadCloudToLanManagerEntry: jest.fn(async () => managerEntry),
+      markCloudToLanManagerBeginPossiblySent: jest.fn(async (
+        entry: CloudToLanManagerEntryRecord,
+      ) => entry),
+      recordCloudToLanManagerStatus: jest.fn(async (
+        entry: CloudToLanManagerEntryRecord,
+        status: CollabAuthorityTransferStatus,
+      ) => {
+        managerEntry = recordCloudToLanManagerStatus(entry, status);
+        return managerEntry;
+      }),
+      scanProjectCatalog: jest.fn(async () => ({
+        invalidEntryCount: 0,
+        projectIds: [PROJECT_ID],
+      })),
+      settleCloudToLanManagerEntry: jest.fn(async () => { managerEntry = null; }),
+    } as unknown as AuthorityTransferPersistence;
+    const completed = recoverableClaimantRecord({ direction: 'cloud-to-lan' }).status;
+    const authorityTransfer = jest.fn()
+      .mockResolvedValueOnce(begun)
+      .mockResolvedValueOnce(completed);
+    const connection = {
+      authorityGeneration: 1,
+      dispose: jest.fn(),
+      lifecycle: { authorityTransfer },
+      listProjectMembers: jest.fn(),
+      memberId: 'member-manager',
+      personalRef: 'refs/heads/members/member-manager',
+      projectId: PROJECT_ID,
+      readSnapshot: jest.fn(),
+      serverUrl: descriptor.sourceCloudUrl,
+    };
+    const lifecycle = new CollabProjectLifecycleSubsystem({
+      closeRecovery: jest.fn(),
+      durableOwners: [],
+      hostTransfer: {} as never,
+      localExit: {} as never,
+      recoveryStages: [],
+      retirement: {} as never,
+    });
+    new AuthorityTransferModule({
+      assertLanToCloudSourceOwner: () => undefined,
+      assertRecoveryOwner: () => undefined,
+      claimantStore: {
+        listProjectIds: () => Promise.resolve([]),
+        load: () => Promise.resolve(null),
+        remove: () => Promise.resolve(false),
+        save: () => Promise.resolve(),
+      },
+      convergence: {} as never,
+      createCloudToLanConnection: async () => connection as never,
+      createLanToCloudSource: jest.fn() as never,
+      installationKey: TEST_INSTALLATION_A,
+      lifecycle,
+      persistence,
+    });
+
+    await expect(lifecycle.lifecycleRecovery.resume()).resolves.toBeUndefined();
+
+    expect(authorityTransfer).toHaveBeenCalledWith(
+      'beginCloudToLanTransfer',
+      frozenRequest,
+      {},
+    );
+    expect(managerEntry).toMatchObject({ phase: 'observing', status: begun });
+    expect(connection.dispose).toHaveBeenCalledTimes(1);
+
+    physicalRecord = createAuthorityTransferRecord({
+      lifecycleOwnership: 'owned',
+      localRole: 'target',
+      operationIntentId: 'intent-recovery-manager-begin',
+      ownerInstallationKey: TEST_INSTALLATION_B,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: begun,
+    });
+
+    await expect(lifecycle.lifecycleRecovery.resume()).resolves.toBeUndefined();
+
+    expect(authorityTransfer).toHaveBeenLastCalledWith(
+      'getProjectAuthorityTransfer',
+      { projectId: PROJECT_ID, transferId: TRANSFER_ID },
+      {},
+    );
+    expect(managerEntry).toBeNull();
+    expect(connection.dispose).toHaveBeenCalledTimes(2);
+  });
+
+  it('settles a same-device Manager only after its target physical recovery', async () => {
+    const completedStatus = recoverableClaimantRecord({ direction: 'cloud-to-lan' }).status;
+    const collectingStatus: CollabAuthorityTransferStatus = {
+      ...completedStatus,
+      batchRevision: null,
+      batchSha256: null,
+      checkpointSha256: null,
+      phase: 'collecting-readiness',
+      relinquishmentProof: null,
+      state: 'active',
+      updatedAt: completedStatus.createdAt,
+    };
+    const descriptor = {
+      caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+      caFingerprint: 'c'.repeat(64),
+      preparationId: 'intent-same-device-target-preparation',
+      projectId: PROJECT_ID,
+      publishedAt: completedStatus.createdAt,
+      schemaVersion: 1 as const,
+      selectedTargetMemberId: 'member-host',
+      sourceAuthorityGeneration: 1,
+      sourceCloudUrl: 'https://cloud.example.test/',
+      targetUrl: completedStatus.targetUrl,
+    };
+    let managerEntry: CloudToLanManagerEntryRecord | null = recordCloudToLanManagerStatus(
+      markCloudToLanManagerBeginPossiblySent(createCloudToLanManagerEntry({
+        createdAt: collectingStatus.createdAt,
+        descriptor,
+        expiresAt: collectingStatus.expiresAt,
+        initiatingMemberId: 'member-host',
+        initiatingPersonalRef: 'refs/heads/members/member-host',
+        operationIntentId: completedStatus.relinquishmentProof!.operationIntentId,
+      })),
+      collectingStatus,
+    );
+    const physical = createAuthorityTransferRecord({
+      lifecycleOwnership: 'owned',
+      localRole: 'target',
+      operationIntentId: managerEntry.operationIntentId,
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: completedStatus,
+    });
+    const settleCloudToLanManagerEntry = jest.fn(async () => { managerEntry = null; });
+    const persistence = {
+      inspectLifecycleOwner: jest.fn(async () => 'nonterminal'),
+      load: jest.fn(async () => physical),
+      loadCloudToLanManagerEntry: jest.fn(async () => managerEntry),
+      loadRecoveryOwnerRecord: jest.fn(async () => physical),
+      recordCloudToLanManagerStatus: jest.fn(async (
+        entry: CloudToLanManagerEntryRecord,
+        status: CollabAuthorityTransferStatus,
+      ) => {
+        managerEntry = recordCloudToLanManagerStatus(entry, status);
+        return managerEntry;
+      }),
+      recoverInterruptedClaimCommitment: jest.fn(async () => undefined),
+      scanProjectCatalog: jest.fn(async () => ({
+        invalidEntryCount: 0,
+        projectIds: [PROJECT_ID],
+      })),
+      settleCloudToLanManagerEntry,
+    } as unknown as AuthorityTransferPersistence;
+    const resume = jest.fn(async () => undefined);
+    const createCloudToLanConnection = jest.fn(async () => {
+      throw new Error('same-device recovery must not reconnect Cloud');
+    });
+    const lifecycle = new CollabProjectLifecycleSubsystem({
+      closeRecovery: jest.fn(),
+      durableOwners: [],
+      hostTransfer: {} as never,
+      localExit: {} as never,
+      recoveryStages: [],
+      retirement: {} as never,
+    });
+    new AuthorityTransferModule({
+      assertLanToCloudSourceOwner: () => undefined,
+      assertRecoveryOwner: () => undefined,
+      claimantStore: {
+        listProjectIds: () => Promise.resolve([]),
+        load: () => Promise.resolve(null),
+        remove: () => Promise.resolve(false),
+        save: () => Promise.resolve(),
+      },
+      convergence: {} as never,
+      createCloudToLanConnection,
+      createLanToCloudSource: jest.fn() as never,
+      installationKey: TEST_INSTALLATION_A,
+      lifecycle,
+      persistence,
+      terminalResolver: { resolve: jest.fn(async () => ({ resume })) },
+    });
+
+    await expect(lifecycle.lifecycleRecovery.resume()).resolves.toBeUndefined();
+
+    expect(createCloudToLanConnection).not.toHaveBeenCalled();
+    expect(resume).toHaveBeenCalledWith(PROJECT_ID, {});
+    expect(settleCloudToLanManagerEntry).toHaveBeenCalledTimes(1);
+    expect(managerEntry).toBeNull();
   });
 
   it('reconstructs a Cloud-to-LAN target on its durable endpoint', async () => {
@@ -763,7 +2550,100 @@ describe('AuthorityTransferModule', () => {
 
     await module.runtimes.prepare(record);
 
-    expect(prepareTarget).not.toHaveBeenCalled();
+    expect(prepareTarget).toHaveBeenCalledWith(targetUrl);
+  });
+
+  it('rebinds a published target entry to its exact listener endpoint during startup recovery', async () => {
+    const targetUrl = 'https://192.168.1.20:54545';
+    const preparing = createCloudToLanTargetEntry({
+      createdAt: '2026-08-27T00:00:00.000Z',
+      expiresAt: '2026-09-26T00:00:00.000Z',
+      operationIntentId: 'intent-recovered-preparation',
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      projectId: PROJECT_ID,
+      selectedTargetMemberId: 'member-target',
+      selectedTargetPersonalRef: 'refs/heads/members/member-target',
+      sourceAuthorityGeneration: 1,
+      sourceCloudUrl: 'https://cloud.example.test/',
+    });
+    const published = publishCloudToLanTargetEntry(preparing, {
+      caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+      caFingerprint: 'c'.repeat(64),
+      publishedAt: '2026-08-27T00:01:00.000Z',
+      targetUrl,
+    });
+    const persistence = {
+      inspectLifecycleOwner: jest.fn(async () => 'nonterminal'),
+      loadCloudToLanManagerEntry: jest.fn(async () => null),
+      loadCloudToLanTargetEntry: jest.fn(async () => published),
+      loadRecoveryOwnerRecord: jest.fn(async () => null),
+      scanProjectCatalog: jest.fn(async () => ({
+        invalidEntryCount: 0,
+        projectIds: [PROJECT_ID],
+      })),
+    } as unknown as AuthorityTransferPersistence;
+    const readSnapshot = jest.fn(() => {
+      throw new Error('published preparation recovery must not read a new snapshot');
+    });
+    const connection = {
+      authorityGeneration: 1,
+      dispose: jest.fn(),
+      lifecycle: { authorityTransfer: jest.fn() },
+      listProjectMembers: jest.fn(),
+      memberId: 'member-target',
+      personalRef: 'refs/heads/members/member-target',
+      projectId: PROJECT_ID,
+      readSnapshot,
+      serverUrl: 'https://cloud.example.test/',
+    };
+    const disposeTarget = jest.fn(async () => {
+      throw new Error('listener-dispose-failed');
+    });
+    const prepareTarget = jest.fn(async (expectedTargetUrl?: string) => ({
+      targetUrl: expectedTargetUrl ?? targetUrl,
+    }));
+    const lifecycle = new CollabProjectLifecycleSubsystem({
+      closeRecovery: jest.fn(),
+      durableOwners: [],
+      hostTransfer: {} as never,
+      localExit: {} as never,
+      recoveryStages: [],
+      retirement: {} as never,
+    });
+    const module = new AuthorityTransferModule({
+      assertLanToCloudSourceOwner: () => undefined,
+      assertRecoveryOwner: ownerInstallationKey => {
+        if (ownerInstallationKey !== TEST_INSTALLATION_A) throw new Error('foreign owner');
+      },
+      claimantStore: {
+        listProjectIds: () => Promise.resolve([]),
+        load: () => Promise.resolve(null),
+        remove: () => Promise.resolve(false),
+        save: () => Promise.resolve(),
+      },
+      convergence: {} as never,
+      createCloudToLanConnection: async () => connection as never,
+      createCloudToLanTarget: () => ({
+        acceptanceRequest: jest.fn(),
+        activate: jest.fn(),
+        cancelStaging: jest.fn(),
+        dispose: disposeTarget,
+        prepareTarget,
+        stage: jest.fn(),
+      }),
+      createLanToCloudSource: jest.fn() as never,
+      installationKey: TEST_INSTALLATION_A,
+      lifecycle,
+      persistence,
+    });
+
+    await expect(lifecycle.lifecycleRecovery.resume()).resolves.toBeUndefined();
+
+    expect(prepareTarget).toHaveBeenCalledWith(targetUrl);
+    expect(readSnapshot).not.toHaveBeenCalled();
+    await expect(module.close()).rejects.toThrow('listener-dispose-failed');
+    expect(disposeTarget).toHaveBeenCalledTimes(1);
+    expect(connection.dispose).toHaveBeenCalledTimes(1);
   });
 
   it('reconstructs an accepted source runtime behind the existing LAN Host route', async () => {
@@ -856,7 +2736,9 @@ describe('AuthorityTransferModule', () => {
         registerDurableOwner: jest.fn(),
         registerRecoveryStage: jest.fn(),
       } as unknown as CollabProjectLifecycleSubsystem,
-      persistence: {} as AuthorityTransferPersistence,
+      persistence: {
+        loadCloudToLanManagerEntry: jest.fn(async () => null),
+      } as unknown as AuthorityTransferPersistence,
       recoverCloudSession,
       terminalResolver: {
         resolve: jest.fn(async () => ({ resume })),
@@ -934,7 +2816,9 @@ describe('AuthorityTransferModule', () => {
           operation: () => Promise<Result>,
         ) => operation(),
       } as unknown as CollabProjectLifecycleSubsystem,
-      persistence: {} as AuthorityTransferPersistence,
+      persistence: {
+        loadCloudToLanManagerEntry: jest.fn(async () => null),
+      } as unknown as AuthorityTransferPersistence,
       recoverClaimant,
     });
 
@@ -947,6 +2831,46 @@ describe('AuthorityTransferModule', () => {
     expect(convergence.lanToCloudMember).toHaveBeenCalledTimes(1);
     expect(record).toBeNull();
     expect(cloudSession.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not recover a claimant while its same-Project Manager observer is unresolved', async () => {
+    const record = recoverableClaimantRecord();
+    let claimantRecovery: AuthorityTransferClaimantRecovery | null = null;
+    const recoverClaimant = jest.fn();
+    new AuthorityTransferModule({
+      assertLanToCloudSourceOwner: () => undefined,
+      assertRecoveryOwner: () => undefined,
+      installationKey: TEST_INSTALLATION_A,
+      claimantStore: {
+        listProjectIds: async () => [PROJECT_ID],
+        load: async () => record,
+        remove: async () => false,
+        save: async () => undefined,
+      },
+      convergence: {} as never,
+      createLanToCloudSource: jest.fn() as never,
+      lifecycle: {
+        registerDurableOwner: jest.fn(),
+        registerRecoveryStage: (stage: AuthorityTransferClaimantRecovery) => {
+          if (stage.name === 'authority-transfer-claimants') claimantRecovery = stage;
+        },
+        runExclusive: async <Result>(
+          _projectId: string,
+          _owner: string,
+          _mode: string,
+          operation: () => Promise<Result>,
+        ) => operation(),
+      } as unknown as CollabProjectLifecycleSubsystem,
+      persistence: {
+        loadCloudToLanManagerEntry: jest.fn(async () => ({ phase: 'observing' })),
+      } as unknown as AuthorityTransferPersistence,
+      recoverClaimant,
+    });
+
+    await expect(claimantRecovery!.run()).rejects.toMatchObject({
+      safeContext: { reason: 'authority-transfer-manager-observer-pending' },
+    });
+    expect(recoverClaimant).not.toHaveBeenCalled();
   });
 
   it.each(['lan-to-cloud', 'cloud-to-lan'] as const)(
@@ -990,7 +2914,9 @@ describe('AuthorityTransferModule', () => {
             operation: () => Promise<Result>,
           ) => operation(),
         } as unknown as CollabProjectLifecycleSubsystem,
-        persistence: {} as AuthorityTransferPersistence,
+        persistence: {
+          loadCloudToLanManagerEntry: jest.fn(async () => null),
+        } as unknown as AuthorityTransferPersistence,
         recoverClaimant,
       });
 
@@ -1049,7 +2975,9 @@ describe('AuthorityTransferModule', () => {
           operation: () => Promise<Result>,
         ) => operation(),
       } as unknown as CollabProjectLifecycleSubsystem,
-      persistence: {} as AuthorityTransferPersistence,
+      persistence: {
+        loadCloudToLanManagerEntry: jest.fn(async () => null),
+      } as unknown as AuthorityTransferPersistence,
       recoverClaimant,
     });
 
@@ -1104,7 +3032,9 @@ describe('AuthorityTransferModule', () => {
             operation: () => Promise<Result>,
           ) => operation(),
         } as unknown as CollabProjectLifecycleSubsystem,
-        persistence: {} as AuthorityTransferPersistence,
+        persistence: {
+          loadCloudToLanManagerEntry: jest.fn(async () => null),
+        } as unknown as AuthorityTransferPersistence,
         recoverClaimant,
       });
 
@@ -1152,7 +3082,9 @@ describe('AuthorityTransferModule', () => {
           operation: () => Promise<Result>,
         ) => operation(),
       } as unknown as CollabProjectLifecycleSubsystem,
-      persistence: {} as AuthorityTransferPersistence,
+      persistence: {
+        loadCloudToLanManagerEntry: jest.fn(async () => null),
+      } as unknown as AuthorityTransferPersistence,
       recoverClaimant,
     });
 

--- a/tests/unit/app/collab/authority-transfer/ProductionAuthorityTransferCoordinators.test.ts
+++ b/tests/unit/app/collab/authority-transfer/ProductionAuthorityTransferCoordinators.test.ts
@@ -26,6 +26,12 @@ import {
   CloudToLanTargetCoordinator,
 } from '@/app/collab/authority-transfer/cloud-to-lan/CloudToLanTargetCoordinator';
 import {
+  type CloudToLanTargetEntryRecord,
+  createCloudToLanTargetEntry,
+  publishCloudToLanTargetEntry,
+  withdrawCloudToLanTargetEntry,
+} from '@/app/collab/authority-transfer/cloud-to-lan/CloudToLanTransferEntryRecord';
+import {
   LanToCloudSourceCoordinator,
 } from '@/app/collab/authority-transfer/lan-to-cloud/LanToCloudSourceCoordinator';
 import type {
@@ -146,7 +152,9 @@ function relinquishmentProof(
     certificateAlgorithm: 'ed25519',
     checkpointSha256: CHECKPOINT_SHA256,
     committedAt: '2026-08-27T00:00:09.000Z',
-    operationIntentId: 'intent-production-transfer',
+    operationIntentId: direction === 'cloud-to-lan'
+      ? 'intent-cloud-relinquishment'
+      : 'intent-production-transfer',
     projectId: PROJECT_ID,
     sourceAuthority: {
       generation: 1,
@@ -188,6 +196,7 @@ function claimBatch(
 class MemoryPersistence {
   batch: CollabTransferredMembershipClaimBatch | null = null;
   entry: AuthorityTransferSourceEntryRecord | null = null;
+  targetEntry: CloudToLanTargetEntryRecord | null = null;
   record: AuthorityTransferRecord | null = null;
   readonly phases: string[] = [];
   readonly completeTerminalCleanup = jest.fn(async () => undefined);
@@ -228,6 +237,33 @@ class MemoryPersistence {
     this.phases.push(record.status.phase);
     return record;
   };
+  handoffCloudToLanTargetEntry = async (
+    entry: CloudToLanTargetEntryRecord,
+    record: AuthorityTransferRecord,
+  ): Promise<AuthorityTransferRecord> => {
+    this.record = record;
+    this.targetEntry = {
+      ...entry,
+      phase: 'handed-off',
+      successor: {
+        operationIntentId: record.operationIntentId,
+        ownerInstallationKey: TEST_INSTALLATION_A,
+        transferId: record.transferId,
+      },
+    };
+    this.phases.push(record.status.phase);
+    return record;
+  };
+  loadCloudToLanTargetEntry = async (): Promise<CloudToLanTargetEntryRecord | null> => (
+    this.targetEntry
+  );
+  withdrawCloudToLanTargetEntry = async (
+    entry: CloudToLanTargetEntryRecord,
+  ): Promise<CloudToLanTargetEntryRecord> => {
+    const withdrawn = withdrawCloudToLanTargetEntry(entry, '2026-08-27T00:00:11.000Z');
+    this.targetEntry = withdrawn;
+    return withdrawn;
+  };
   pinReceiptVerifier = async (
     _projectId: string,
     _transferId: string,
@@ -254,6 +290,41 @@ class MemoryPersistence {
   asPort(): AuthorityTransferPersistence {
     return this as unknown as AuthorityTransferPersistence;
   }
+
+  setTargetRecord(record: AuthorityTransferRecord): void {
+    if (record.localRole !== 'target' || record.status.direction !== 'cloud-to-lan') {
+      throw new TypeError('Expected a Cloud-to-LAN target record');
+    }
+    this.record = record;
+    const published = publishCloudToLanTargetEntry(
+      createCloudToLanTargetEntry({
+        createdAt: CREATED_AT,
+        expiresAt: EXPIRES_AT,
+        operationIntentId: 'intent-target-preparation',
+        ownerInstallationKey: TEST_INSTALLATION_A,
+        projectId: record.projectId,
+        selectedTargetMemberId: HOST_MEMBER_ID,
+        selectedTargetPersonalRef: `refs/heads/members/${HOST_MEMBER_ID}`,
+        sourceAuthorityGeneration: record.status.sourceAuthority.generation,
+        sourceCloudUrl: 'https://cloud.example.test/',
+      }),
+      {
+        caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+        caFingerprint: 'c'.repeat(64),
+        publishedAt: CREATED_AT,
+        targetUrl: record.status.targetUrl,
+      },
+    );
+    this.targetEntry = {
+      ...published,
+      phase: 'handed-off',
+      successor: {
+        operationIntentId: record.operationIntentId,
+        ownerInstallationKey: record.ownerInstallationKey!,
+        transferId: record.transferId,
+      },
+    };
+  }
 }
 
 function custodyReceipt(direction: 'cloud-to-lan' | 'lan-to-cloud', batchSha256: string) {
@@ -266,7 +337,9 @@ function custodyReceipt(direction: 'cloud-to-lan' | 'lan-to-cloud', batchSha256:
       generation: 1,
       kind: direction === 'lan-to-cloud' ? 'lan' : 'cloud',
     },
-    operationIntentId: 'intent-production-transfer',
+    operationIntentId: direction === 'cloud-to-lan'
+      ? authorityTransferChildIdempotencyKey('intent-production-transfer', 'stage')
+      : 'intent-production-transfer',
     projectId: PROJECT_ID,
     receiptId: 'receipt-production-transfer',
     submittedByMemberId: HOST_MEMBER_ID,
@@ -280,10 +353,13 @@ describe('production authority-transfer direction coordinators', () => {
     const operationIntentId = 'x'.repeat(128);
     const keys = ([
       'accept',
+      'activate',
       'begin',
+      'cancel',
       'claims',
       'custody',
       'relinquish',
+      'stage',
     ] as const).map(operation => authorityTransferChildIdempotencyKey(
       operationIntentId,
       operation,
@@ -291,6 +367,173 @@ describe('production authority-transfer direction coordinators', () => {
 
     expect(new Set(keys).size).toBe(keys.length);
     expect(keys.every(key => key.length <= 128 && isCollabOpaqueId(key))).toBe(true);
+  });
+
+  it('builds target acceptance internally only after the exact preparation hands off', async () => {
+    const persistence = new MemoryPersistence();
+    persistence.targetEntry = publishCloudToLanTargetEntry(
+      createCloudToLanTargetEntry({
+        createdAt: CREATED_AT,
+        expiresAt: EXPIRES_AT,
+        operationIntentId: 'intent-target-preparation',
+        ownerInstallationKey: TEST_INSTALLATION_A,
+        projectId: PROJECT_ID,
+        selectedTargetMemberId: HOST_MEMBER_ID,
+        selectedTargetPersonalRef: `refs/heads/members/${HOST_MEMBER_ID}`,
+        sourceAuthorityGeneration: 1,
+        sourceCloudUrl: 'https://cloud.example.test/',
+      }),
+      {
+        caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+        caFingerprint: 'c'.repeat(64),
+        publishedAt: CREATED_AT,
+        targetUrl: 'https://192.168.1.10:43123',
+      },
+    );
+    const acceptanceRequest = jest.fn(async (record: AuthorityTransferRecord) => {
+      expect(persistence.targetEntry).toMatchObject({
+        phase: 'handed-off',
+        successor: {
+          operationIntentId: 'intent-production-transfer',
+          transferId: TRANSFER_ID,
+        },
+      });
+      return {
+        idempotencyKey: authorityTransferChildIdempotencyKey(
+          record.operationIntentId,
+          'accept',
+        ),
+        projectId: PROJECT_ID,
+        targetHostMemberId: HOST_MEMBER_ID,
+        targetProof: Buffer.alloc(64, 2).toString('base64url'),
+        transferId: TRANSFER_ID,
+      };
+    });
+    const cloud = {
+      authorityTransfer: jest.fn(async (operation: string) => {
+        if (operation === 'getProjectAuthorityTransfer') {
+          return status('cloud-to-lan', 'collecting-readiness');
+        }
+        if (operation === 'acceptCloudToLanTransferTarget') {
+          return status('cloud-to-lan', 'cancelled');
+        }
+        throw new Error(`unexpected ${operation}`);
+      }),
+    } as unknown as CollabAuthorityLifecyclePort;
+    const coordinator = new CloudToLanTargetCoordinator({
+      cloud,
+      installationKey: TEST_INSTALLATION_A,
+      persistence: persistence.asPort(),
+      target: {
+        acceptanceRequest,
+        activate: jest.fn(),
+        cancelStaging: jest.fn(),
+        stage: jest.fn(),
+      },
+    });
+
+    const handle = {
+      operationIntentId: 'intent-production-transfer',
+      preparationId: 'intent-target-preparation',
+      projectId: PROJECT_ID,
+      schemaVersion: 1,
+      selectedTargetMemberId: HOST_MEMBER_ID,
+      sourceAuthorityGeneration: 1,
+      sourceCloudUrl: 'https://cloud.example.test/',
+      targetUrl: 'https://192.168.1.10:43123',
+      transferId: TRANSFER_ID,
+    } as const;
+    await expect(coordinator.acceptPreparedTransfer(handle))
+      .resolves.toMatchObject({ state: 'cancelled' });
+    await expect(coordinator.acceptPreparedTransfer(handle))
+      .resolves.toMatchObject({ state: 'cancelled' });
+    expect(acceptanceRequest).toHaveBeenCalledTimes(1);
+    expect((cloud.authorityTransfer as jest.Mock).mock.calls.filter(
+      ([operation]) => operation === 'getProjectAuthorityTransfer',
+    )).toHaveLength(1);
+  });
+
+  it('withdraws an exact prepared target when Cloud already cancelled the transfer', async () => {
+    const persistence = new MemoryPersistence();
+    persistence.targetEntry = publishCloudToLanTargetEntry(
+      createCloudToLanTargetEntry({
+        createdAt: CREATED_AT,
+        expiresAt: EXPIRES_AT,
+        operationIntentId: 'intent-target-preparation',
+        ownerInstallationKey: TEST_INSTALLATION_A,
+        projectId: PROJECT_ID,
+        selectedTargetMemberId: HOST_MEMBER_ID,
+        selectedTargetPersonalRef: `refs/heads/members/${HOST_MEMBER_ID}`,
+        sourceAuthorityGeneration: 1,
+        sourceCloudUrl: 'https://cloud.example.test/',
+      }),
+      {
+        caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+        caFingerprint: 'c'.repeat(64),
+        publishedAt: CREATED_AT,
+        targetUrl: 'https://192.168.1.10:43123',
+      },
+    );
+    const acceptanceRequest = jest.fn();
+    const cloud = {
+      authorityTransfer: jest.fn(async () => status('cloud-to-lan', 'cancelled')),
+    } as unknown as CollabAuthorityLifecyclePort;
+    const coordinator = new CloudToLanTargetCoordinator({
+      cloud,
+      installationKey: TEST_INSTALLATION_A,
+      persistence: persistence.asPort(),
+      target: {
+        acceptanceRequest,
+        activate: jest.fn(),
+        cancelStaging: jest.fn(),
+        stage: jest.fn(),
+      },
+    });
+
+    await expect(coordinator.acceptPreparedTransfer({
+      operationIntentId: 'intent-production-transfer',
+      preparationId: 'intent-target-preparation',
+      projectId: PROJECT_ID,
+      schemaVersion: 1,
+      selectedTargetMemberId: HOST_MEMBER_ID,
+      sourceAuthorityGeneration: 1,
+      sourceCloudUrl: 'https://cloud.example.test/',
+      targetUrl: 'https://192.168.1.10:43123',
+      transferId: TRANSFER_ID,
+    })).resolves.toMatchObject({ phase: 'cancelled', state: 'cancelled' });
+    expect(persistence.targetEntry).toMatchObject({ phase: 'withdrawn' });
+    expect(acceptanceRequest).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when target recovery has no exact handed-off preparation entry', async () => {
+    const persistence = new MemoryPersistence();
+    persistence.record = createAuthorityTransferRecord({
+      lifecycleOwnership: 'owned',
+      localRole: 'target',
+      operationIntentId: 'intent-production-transfer',
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: status('cloud-to-lan', 'collecting-readiness'),
+    });
+    const authorityTransfer = jest.fn();
+    const acceptanceRequest = jest.fn();
+    const coordinator = new CloudToLanTargetCoordinator({
+      cloud: { authorityTransfer } as unknown as CollabAuthorityLifecyclePort,
+      installationKey: TEST_INSTALLATION_A,
+      persistence: persistence.asPort(),
+      target: {
+        acceptanceRequest,
+        activate: jest.fn(),
+        cancelStaging: jest.fn(),
+        stage: jest.fn(),
+      },
+    });
+
+    await expect(coordinator.resume(PROJECT_ID)).rejects.toMatchObject({
+      safeContext: { reason: 'cloud-to-lan-target-successor-mismatch' },
+    });
+    expect(acceptanceRequest).not.toHaveBeenCalled();
+    expect(authorityTransfer).not.toHaveBeenCalled();
   });
 
   it('locally cancels an accepted pre-begin source after exact Cloud not-found proof', async () => {
@@ -751,14 +994,14 @@ describe('production authority-transfer direction coordinators', () => {
 
   it('destroys downloaded bodies when a later Cloud-to-LAN download fails', async () => {
     const persistence = new MemoryPersistence();
-    persistence.record = createAuthorityTransferRecord({
+    persistence.setTargetRecord(createAuthorityTransferRecord({
       ownerInstallationKey: TEST_INSTALLATION_A,
       lifecycleOwnership: 'owned',
       localRole: 'target',
       operationIntentId: 'intent-production-transfer',
       stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
       status: status('cloud-to-lan', 'checkpoint-captured'),
-    });
+    }));
     const first = new Readable({ read() {} });
     let downloads = 0;
     const cloud = {
@@ -789,14 +1032,14 @@ describe('production authority-transfer direction coordinators', () => {
 
   it('destroys every downloaded body when Cloud-to-LAN staging fails', async () => {
     const persistence = new MemoryPersistence();
-    persistence.record = createAuthorityTransferRecord({
+    persistence.setTargetRecord(createAuthorityTransferRecord({
       ownerInstallationKey: TEST_INSTALLATION_A,
       lifecycleOwnership: 'owned',
       localRole: 'target',
       operationIntentId: 'intent-production-transfer',
       stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
       status: status('cloud-to-lan', 'checkpoint-captured'),
-    });
+    }));
     const bodies: Readable[] = [];
     const cloud = {
       authorityTransfer: jest.fn(),
@@ -955,7 +1198,7 @@ describe('production authority-transfer direction coordinators', () => {
           : {}),
       },
     );
-    persistence.record = createAuthorityTransferRecord({
+    persistence.setTargetRecord(createAuthorityTransferRecord({
       ownerInstallationKey: TEST_INSTALLATION_A,
       lifecycleOwnership: 'owned',
       localRole: 'target',
@@ -968,7 +1211,7 @@ describe('production authority-transfer direction coordinators', () => {
         || phase === 'completed'
         ? withBatch(phase)
         : status('cloud-to-lan', phase),
-    });
+    }));
     const cloud = {
       authorityTransfer: jest.fn(async (operation: string) => {
         if (operation === 'getAuthorityTransferReceiptVerifier') return RECEIPT_VERIFIER;
@@ -1005,7 +1248,10 @@ describe('production authority-transfer direction coordinators', () => {
       persistence: persistence.asPort(),
       target: {
         acceptanceRequest: jest.fn(async () => ({
-          idempotencyKey: 'intent-target-acceptance',
+          idempotencyKey: authorityTransferChildIdempotencyKey(
+            'intent-production-transfer',
+            'accept',
+          ),
           projectId: PROJECT_ID,
           targetHostMemberId: HOST_MEMBER_ID,
           targetProof: Buffer.alloc(64, 2).toString('base64url'),
@@ -1018,6 +1264,7 @@ describe('production authority-transfer direction coordinators', () => {
           claimBatch: batch,
           stageSha256: 'c'.repeat(64),
           targetAuthority: { generation: 2, kind: 'lan' as const },
+          targetHostMemberId: HOST_MEMBER_ID,
           targetProof: Buffer.alloc(64, 5).toString('base64url'),
         })),
       },
@@ -1028,6 +1275,55 @@ describe('production authority-transfer direction coordinators', () => {
       state: 'completed',
     });
     expect(activate).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a staged checkpoint imported for a different target Member before reporting it', async () => {
+    const persistence = new MemoryPersistence();
+    const batch = claimBatch('cloud-to-lan');
+    persistence.setTargetRecord(createAuthorityTransferRecord({
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      lifecycleOwnership: 'owned',
+      localRole: 'target',
+      operationIntentId: 'intent-production-transfer',
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: status('cloud-to-lan', 'checkpoint-captured'),
+    }));
+    const authorityTransfer = jest.fn();
+    const retainClaimBatch = persistence.retainClaimBatch;
+    const coordinator = new CloudToLanTargetCoordinator({
+      installationKey: TEST_INSTALLATION_A,
+      cloud: {
+        authorityTransfer,
+        downloadAuthorityTransferArtifact: jest.fn(async ({ artifact }) => ({
+          body: Readable.from([artifact]),
+          byteCount: Buffer.byteLength(artifact),
+        })),
+      } as unknown as CollabAuthorityLifecyclePort,
+      persistence: persistence.asPort(),
+      target: {
+        acceptanceRequest: jest.fn(),
+        activate: jest.fn(),
+        cancelStaging: jest.fn(),
+        stage: jest.fn(async () => ({
+          checkpointSha256: CHECKPOINT_SHA256,
+          claimBatch: batch,
+          stageSha256: 'c'.repeat(64),
+          targetAuthority: { generation: 2, kind: 'lan' as const },
+          targetHostMemberId: 'member-different-target',
+          targetProof: Buffer.alloc(64, 5).toString('base64url'),
+        })),
+      },
+    });
+
+    await expect(coordinator.resume(PROJECT_ID)).rejects.toMatchObject({
+      safeContext: { reason: 'cloud-to-lan-target-stage-member-mismatch' },
+    });
+    expect(retainClaimBatch).not.toHaveBeenCalled();
+    expect(authorityTransfer).not.toHaveBeenCalledWith(
+      'reportCloudToLanTargetStaged',
+      expect.anything(),
+      expect.anything(),
+    );
   });
 
   it.each([
@@ -1047,14 +1343,14 @@ describe('production authority-transfer direction coordinators', () => {
       status: status('lan-to-cloud', phase),
     });
     const targetPersistence = new MemoryPersistence();
-    targetPersistence.record = createAuthorityTransferRecord({
+    targetPersistence.setTargetRecord(createAuthorityTransferRecord({
       ownerInstallationKey: TEST_INSTALLATION_A,
       lifecycleOwnership: 'owned',
       localRole: 'target',
       operationIntentId: 'intent-production-transfer',
       stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
       status: status('cloud-to-lan', phase),
-    });
+    }));
     const lifecycle = (direction: 'cloud-to-lan' | 'lan-to-cloud') => ({
       authorityTransfer: jest.fn(async () => status(direction, 'cancelled')),
       downloadAuthorityTransferArtifact: jest.fn(),
@@ -1090,6 +1386,7 @@ describe('production authority-transfer direction coordinators', () => {
     expect(reopenAfterCancellation).toHaveBeenCalledTimes(1);
     expect(sourcePersistence.completeTerminalCleanup).toHaveBeenCalledTimes(1);
     expect(cancelStaging).toHaveBeenCalled();
+    expect(targetPersistence.completeTerminalCleanup).toHaveBeenCalledTimes(1);
   });
 
   it('resumes LAN-to-Cloud from a persisted checkpoint intermediate and restores terminal service', async () => {
@@ -1249,14 +1546,14 @@ describe('production authority-transfer direction coordinators', () => {
     }).resume(PROJECT_ID);
 
     const targetPersistence = new MemoryPersistence();
-    targetPersistence.record = createAuthorityTransferRecord({
+    targetPersistence.setTargetRecord(createAuthorityTransferRecord({
       ownerInstallationKey: TEST_INSTALLATION_A,
       lifecycleOwnership: 'owned',
       localRole: 'target',
       operationIntentId: 'intent-production-transfer',
       stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
       status: status('cloud-to-lan', 'completed'),
-    });
+    }));
     const activate = jest.fn(async () => 'target-activation-proof');
     await new CloudToLanTargetCoordinator({
       installationKey: TEST_INSTALLATION_A,
@@ -1425,7 +1722,10 @@ describe('production authority-transfer direction coordinators', () => {
           schemaVersion: 2,
         });
         return {
-          idempotencyKey: 'intent-target-acceptance',
+          idempotencyKey: authorityTransferChildIdempotencyKey(
+            'intent-production-transfer',
+            'accept',
+          ),
           projectId: PROJECT_ID,
           targetHostMemberId: HOST_MEMBER_ID,
           targetProof: Buffer.alloc(64, 2).toString('base64url'),
@@ -1439,6 +1739,7 @@ describe('production authority-transfer direction coordinators', () => {
         claimBatch: batch,
         stageSha256: 'c'.repeat(64),
         targetAuthority: { generation: 2, kind: 'lan' as const },
+        targetHostMemberId: HOST_MEMBER_ID,
         targetProof: Buffer.alloc(64, 5).toString('base64url'),
       })),
     };
@@ -1448,13 +1749,36 @@ describe('production authority-transfer direction coordinators', () => {
       persistence: persistence.asPort(),
       target,
     });
-    const completed = await coordinator.acceptAndTransfer({
-      idempotencyKey: 'intent-target-acceptance',
+    persistence.targetEntry = publishCloudToLanTargetEntry(
+      createCloudToLanTargetEntry({
+        createdAt: CREATED_AT,
+        expiresAt: EXPIRES_AT,
+        operationIntentId: 'intent-target-preparation',
+        ownerInstallationKey: TEST_INSTALLATION_A,
+        projectId: PROJECT_ID,
+        selectedTargetMemberId: HOST_MEMBER_ID,
+        selectedTargetPersonalRef: `refs/heads/members/${HOST_MEMBER_ID}`,
+        sourceAuthorityGeneration: 1,
+        sourceCloudUrl: 'https://cloud.example.test/',
+      }),
+      {
+        caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+        caFingerprint: 'c'.repeat(64),
+        publishedAt: CREATED_AT,
+        targetUrl: 'https://192.168.1.10:43123',
+      },
+    );
+    const completed = await coordinator.acceptPreparedTransfer({
+      operationIntentId: 'intent-production-transfer',
+      preparationId: 'intent-target-preparation',
       projectId: PROJECT_ID,
-      targetHostMemberId: HOST_MEMBER_ID,
-      targetProof: Buffer.alloc(64, 2).toString('base64url'),
+      schemaVersion: 1,
+      selectedTargetMemberId: HOST_MEMBER_ID,
+      sourceAuthorityGeneration: 1,
+      sourceCloudUrl: 'https://cloud.example.test/',
+      targetUrl: 'https://192.168.1.10:43123',
       transferId: TRANSFER_ID,
-    }, 'intent-production-transfer');
+    });
 
     expect(completed.state).toBe('completed');
     expect(target.stage).toHaveBeenCalledTimes(1);

--- a/tests/unit/app/collab/authority-transfer/recovery/AuthorityTransferRecovery.test.ts
+++ b/tests/unit/app/collab/authority-transfer/recovery/AuthorityTransferRecovery.test.ts
@@ -22,6 +22,10 @@ import {
   decodeAuthorityTransferRecord,
 } from '@/app/collab/authority-transfer/AuthorityTransferRecord';
 import {
+  createCloudToLanTargetEntry,
+  publishCloudToLanTargetEntry,
+} from '@/app/collab/authority-transfer/cloud-to-lan/CloudToLanTransferEntryRecord';
+import {
   createAuthorityTransferClaimBatchCommitmentRecord,
 } from '@/app/collab/authority-transfer/persistence/AuthorityTransferClaimBatchCommitmentRecord';
 import {
@@ -32,6 +36,7 @@ import {
 } from '@/app/collab/authority-transfer/persistence/AuthorityTransferPersistence';
 import {
   AuthorityTransferRecovery,
+  type AuthorityTransferRecoveryHandler,
 } from '@/app/collab/authority-transfer/recovery/AuthorityTransferRecovery';
 import { CollabLocalProjectRepository } from '@/app/collab/CollabLocalProjectRepository';
 import {
@@ -118,6 +123,17 @@ function lifecycle() {
   });
 }
 
+function recoveryHandler(
+  overrides: Partial<AuthorityTransferRecoveryHandler> = {},
+): AuthorityTransferRecoveryHandler {
+  return {
+    resume: jest.fn(async () => undefined),
+    resumeManager: jest.fn(async () => undefined),
+    resumeTargetPreparation: jest.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
 describe('AuthorityTransferRecovery', () => {
   let vaultRoot: string;
 
@@ -141,7 +157,11 @@ describe('AuthorityTransferRecovery', () => {
       status: status('collecting-readiness'),
     }));
     const resume = jest.fn().mockResolvedValue(undefined);
-    const recovery = new AuthorityTransferRecovery(persistence, { resume }, () => undefined);
+    const recovery = new AuthorityTransferRecovery(
+      persistence,
+      recoveryHandler({ resume }),
+      () => undefined,
+    );
     const subsystem = lifecycle();
     recovery.register(subsystem);
 
@@ -151,6 +171,32 @@ describe('AuthorityTransferRecovery', () => {
       expect.objectContaining({ projectId: PROJECT_ID, transferId: 'transfer-one' }),
       {},
     );
+  });
+
+  it('recovers the transfer predecessor while a same-Project claimant is pending', async () => {
+    const persistence = {
+      inspectLifecycleOwner: jest.fn(async () => 'absent'),
+      scanProjectCatalog: jest.fn(async () => ({
+        invalidEntryCount: 0,
+        projectIds: [PROJECT_ID],
+      })),
+    } as unknown as AuthorityTransferPersistence;
+    const resumeManager = jest.fn(async () => undefined);
+    const recovery = new AuthorityTransferRecovery(
+      persistence,
+      recoveryHandler({ resumeManager }),
+      () => undefined,
+    );
+    const subsystem = lifecycle();
+    subsystem.registerDurableOwner({
+      inspect: async projectId => projectId === PROJECT_ID ? 'nonterminal' : 'absent',
+      name: 'authority-transfer-claimant',
+    });
+    recovery.register(subsystem);
+
+    await expect(subsystem.lifecycleRecovery.resume()).resolves.toBeUndefined();
+
+    expect(resumeManager).toHaveBeenCalledWith(PROJECT_ID, {});
   });
 
   it('rejects a foreign installation owner before commitment repair or runtime effects', async () => {
@@ -171,7 +217,7 @@ describe('AuthorityTransferRecovery', () => {
     });
     const recovery = new AuthorityTransferRecovery(
       persistence,
-      { resume },
+      recoveryHandler({ resume }),
       assertRecoveryOwner,
     );
     const subsystem = lifecycle();
@@ -199,7 +245,7 @@ describe('AuthorityTransferRecovery', () => {
     }));
     const repair = jest.spyOn(persistence, 'recoverInterruptedClaimCommitment');
     const resume = jest.fn().mockResolvedValue(undefined);
-    const recovery = new AuthorityTransferRecovery(persistence, { resume }, () => {
+    const recovery = new AuthorityTransferRecovery(persistence, recoveryHandler({ resume }), () => {
       throw new CollabError({
         code: 'durable-progress-recovery-required',
         safeContext: { reason: 'host-installation-recovery-owner-mismatch' },
@@ -233,14 +279,18 @@ describe('AuthorityTransferRecovery', () => {
       isRecoveryOwner: ownerInstallationKey => ownerInstallationKey === TEST_INSTALLATION_A,
     });
     const resume = jest.fn().mockResolvedValue(undefined);
-    const recovery = new AuthorityTransferRecovery(persistence, { resume }, ownerInstallationKey => {
+    const recovery = new AuthorityTransferRecovery(
+      persistence,
+      recoveryHandler({ resume }),
+      ownerInstallationKey => {
       if (ownerInstallationKey === undefined) {
         throw new CollabError({
           code: 'durable-progress-recovery-required',
           safeContext: { reason: 'host-installation-recovery-owner-mismatch' },
         });
       }
-    });
+      },
+    );
     const subsystem = lifecycle();
     recovery.register(subsystem);
 
@@ -264,7 +314,11 @@ describe('AuthorityTransferRecovery', () => {
     }));
     const prepare = jest.fn().mockResolvedValue(undefined);
     const resume = jest.fn().mockResolvedValue(undefined);
-    const recovery = new AuthorityTransferRecovery(persistence, { prepare, resume }, () => undefined);
+    const recovery = new AuthorityTransferRecovery(
+      persistence,
+      recoveryHandler({ prepare, resume }),
+      () => undefined,
+    );
     const subsystem = lifecycle();
     recovery.register(subsystem);
 
@@ -301,9 +355,13 @@ describe('AuthorityTransferRecovery', () => {
     const inspect = jest.spyOn(persistence, 'inspectLifecycleOwner');
     const prepare = jest.fn().mockResolvedValue(undefined);
     const resume = jest.fn().mockResolvedValue(undefined);
-    const recovery = new AuthorityTransferRecovery(persistence, { prepare, resume }, () => {
+    const recovery = new AuthorityTransferRecovery(
+      persistence,
+      recoveryHandler({ prepare, resume }),
+      () => {
       throw new Error('A nonphysical proposal has no installation recovery owner');
-    });
+      },
+    );
     const subsystem = lifecycle();
     recovery.register(subsystem);
 
@@ -313,6 +371,45 @@ describe('AuthorityTransferRecovery', () => {
     expect(prepare).not.toHaveBeenCalled();
     expect(resume).not.toHaveBeenCalled();
     await expect(persistence.inspectLifecycleOwner(PROJECT_ID)).resolves.toBe('proposal');
+  });
+
+  it('rebinds an entry-only Cloud-to-LAN target preparation during startup recovery', async () => {
+    const repository = new CollabLocalProjectRepository(vaultRoot);
+    const persistence = new AuthorityTransferPersistence(repository, {
+      isRecoveryOwner: ownerInstallationKey => ownerInstallationKey === TEST_INSTALLATION_A,
+    });
+    const preparing = createCloudToLanTargetEntry({
+      createdAt: '2026-08-27T00:00:00.000Z',
+      expiresAt: '2026-09-26T00:00:00.000Z',
+      operationIntentId: 'intent-target-preparation',
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      projectId: PROJECT_ID,
+      selectedTargetMemberId: 'member-target',
+      selectedTargetPersonalRef: 'refs/heads/members/member-target',
+      sourceAuthorityGeneration: 1,
+      sourceCloudUrl: 'https://cloud.example.test/',
+    });
+    const published = publishCloudToLanTargetEntry(preparing, {
+      caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+      caFingerprint: 'c'.repeat(64),
+      publishedAt: '2026-08-27T00:01:00.000Z',
+      targetUrl: 'https://192.168.1.20:54545',
+    });
+    await repository.authorityTransferEntries.saveTarget(published);
+    const resumeTargetPreparation = jest.fn().mockResolvedValue(undefined);
+    const assertRecoveryOwner = jest.fn();
+    const recovery = new AuthorityTransferRecovery(
+      persistence,
+      recoveryHandler({ resumeTargetPreparation }),
+      assertRecoveryOwner,
+    );
+    const subsystem = lifecycle();
+    recovery.register(subsystem);
+
+    await expect(subsystem.lifecycleRecovery.resume()).resolves.toBeUndefined();
+
+    expect(assertRecoveryOwner).toHaveBeenCalledWith(TEST_INSTALLATION_A, PROJECT_ID);
+    expect(resumeTargetPreparation).toHaveBeenCalledWith(published, {});
   });
 
   it('expires an entry-only proposal during startup enumeration', async () => {
@@ -337,7 +434,11 @@ describe('AuthorityTransferRecovery', () => {
       now: () => new Date('2026-09-25T00:00:00.000Z'),
     });
     const resume = jest.fn().mockResolvedValue(undefined);
-    const recovery = new AuthorityTransferRecovery(persistence, { resume }, () => undefined);
+    const recovery = new AuthorityTransferRecovery(
+      persistence,
+      recoveryHandler({ resume }),
+      () => undefined,
+    );
     const subsystem = lifecycle();
     recovery.register(subsystem);
 
@@ -365,7 +466,11 @@ describe('AuthorityTransferRecovery', () => {
       purpose: 'source-terminal',
     }));
     const resume = jest.fn().mockResolvedValue(undefined);
-    const recovery = new AuthorityTransferRecovery(persistence, { resume }, () => undefined);
+    const recovery = new AuthorityTransferRecovery(
+      persistence,
+      recoveryHandler({ resume }),
+      () => undefined,
+    );
     const subsystem = lifecycle();
     recovery.register(subsystem);
 
@@ -393,7 +498,11 @@ describe('AuthorityTransferRecovery', () => {
       stagingDirectoryName: record.stagingDirectoryName,
       transferId: record.transferId,
     }));
-    const recovery = new AuthorityTransferRecovery(persistence, { resume }, () => undefined);
+    const recovery = new AuthorityTransferRecovery(
+      persistence,
+      recoveryHandler({ resume }),
+      () => undefined,
+    );
     const subsystem = lifecycle();
     recovery.register(subsystem);
 
@@ -460,7 +569,11 @@ describe('AuthorityTransferRecovery', () => {
       stagingDirectoryName: record.stagingDirectoryName,
       transferId: record.transferId,
     }));
-    const recovery = new AuthorityTransferRecovery(persistence, { resume }, () => undefined);
+    const recovery = new AuthorityTransferRecovery(
+      persistence,
+      recoveryHandler({ resume }),
+      () => undefined,
+    );
     const subsystem = lifecycle();
     recovery.register(subsystem);
 
@@ -506,7 +619,11 @@ describe('AuthorityTransferRecovery', () => {
       stagingDirectoryName: record.stagingDirectoryName,
       transferId: record.transferId,
     }));
-    const recovery = new AuthorityTransferRecovery(persistence, { resume }, () => undefined);
+    const recovery = new AuthorityTransferRecovery(
+      persistence,
+      recoveryHandler({ resume }),
+      () => undefined,
+    );
     const subsystem = lifecycle();
     recovery.register(subsystem);
 
@@ -528,9 +645,9 @@ describe('AuthorityTransferRecovery', () => {
       stagingDirectoryName: '.claudian-authority-transfer-transfer-one',
       status: status('source-quiesced'),
     }));
-    const recovery = new AuthorityTransferRecovery(persistence, {
+    const recovery = new AuthorityTransferRecovery(persistence, recoveryHandler({
       resume: jest.fn().mockResolvedValue(undefined),
-    }, () => undefined);
+    }), () => undefined);
     const subsystem = lifecycle();
     recovery.register(subsystem);
 
@@ -576,9 +693,9 @@ describe('AuthorityTransferRecovery', () => {
         return record ? 'nonterminal' : 'absent';
       },
     };
-    const recovery = new AuthorityTransferRecovery(persistence, {
+    const recovery = new AuthorityTransferRecovery(persistence, recoveryHandler({
       resume: jest.fn().mockResolvedValue(undefined),
-    }, () => undefined);
+    }), () => undefined);
     const subsystem = lifecycle();
     subsystem.registerDurableOwner(hostTransferOwner);
     recovery.register(subsystem);
@@ -599,9 +716,9 @@ describe('AuthorityTransferRecovery', () => {
       stagingDirectoryName: '.claudian-authority-transfer-transfer-one',
       status: status('collecting-readiness'),
     }));
-    const recovery = new AuthorityTransferRecovery(persistence, {
+    const recovery = new AuthorityTransferRecovery(persistence, recoveryHandler({
       resume: jest.fn().mockResolvedValue(undefined),
-    }, () => undefined);
+    }), () => undefined);
     const subsystem = lifecycle();
     recovery.register(subsystem);
     const operation = jest.fn().mockResolvedValue('admitted');
@@ -633,12 +750,12 @@ describe('AuthorityTransferRecovery', () => {
     }
     const firstError = new Error('alpha recovery unavailable');
     const resumed: string[] = [];
-    const recovery = new AuthorityTransferRecovery(persistence, {
+    const recovery = new AuthorityTransferRecovery(persistence, recoveryHandler({
       resume: jest.fn(async record => {
         resumed.push(record.projectId);
         if (record.projectId === 'project-alpha') throw firstError;
       }),
-    }, () => undefined);
+    }), () => undefined);
     const subsystem = lifecycle();
     recovery.register(subsystem);
 
@@ -661,9 +778,9 @@ describe('AuthorityTransferRecovery', () => {
     await mkdir(path.dirname(corruptPath), { recursive: true });
     await writeFile(corruptPath, '{', { mode: 0o600 });
     const resumed: string[] = [];
-    const recovery = new AuthorityTransferRecovery(persistence, {
+    const recovery = new AuthorityTransferRecovery(persistence, recoveryHandler({
       resume: jest.fn(async record => { resumed.push(record.projectId); }),
-    }, () => undefined);
+    }), () => undefined);
     const subsystem = lifecycle();
     recovery.register(subsystem);
 
@@ -689,9 +806,9 @@ describe('AuthorityTransferRecovery', () => {
       recursive: true,
     });
     const resumed: string[] = [];
-    const recovery = new AuthorityTransferRecovery(persistence, {
+    const recovery = new AuthorityTransferRecovery(persistence, recoveryHandler({
       resume: jest.fn(async record => { resumed.push(record.projectId); }),
-    }, () => undefined);
+    }), () => undefined);
     const subsystem = lifecycle();
     recovery.register(subsystem);
 
@@ -714,7 +831,11 @@ describe('AuthorityTransferRecovery', () => {
       status: status('collecting-readiness'),
     }));
     const resume = jest.fn().mockResolvedValue(undefined);
-    const recovery = new AuthorityTransferRecovery(persistence, { resume }, () => undefined);
+    const recovery = new AuthorityTransferRecovery(
+      persistence,
+      recoveryHandler({ resume }),
+      () => undefined,
+    );
     const subsystem = lifecycle();
     recovery.register(subsystem);
     let releaseBlocker!: () => void;

--- a/tests/unit/core/collab/CollabFeaturePort.test.ts
+++ b/tests/unit/core/collab/CollabFeaturePort.test.ts
@@ -70,6 +70,12 @@ describe('CollabFeaturePort', () => {
       retireProject: true,
       finalizeRetiredProject: true,
       retryProjectCleanup: true,
+      prepareCloudToLanTarget: true,
+      beginCloudToLanTransfer: true,
+      acceptCloudToLanTransfer: true,
+      withdrawCloudToLanTarget: true,
+      observeCloudToLanTransfer: true,
+      cancelCloudToLanTransfer: true,
       subscribe: true,
     } satisfies Record<keyof CollabFeaturePort, true>;
 


### PR DESCRIPTION
## Summary

- add the selected-target Cloud-to-LAN prepare, begin, accept, observe, cancel, and withdraw facade without exposing UI
- persist independent Manager and target journals with exact replay, recovery, cleanup, and same-device handling
- stage and activate the LAN authority with canonical Cloud checkpoint, repository, membership, credential, and relinquishment-proof validation
- serialize Manager begin through transition admission and the Project lifecycle lane to prevent duplicate sends and drain lock inversion

## Verification

- full Jest: 619 suites passed, 2 skipped; 9273 tests passed, 2 skipped
- focused T2/admission suites: 243 tests passed
- cross-platform Collab: 373 tests passed
- TypeScript typecheck and lint
- frozen lockfile and production build
- startup performance check
- Jest open-handle check: PASS
- three final read-only review passes: no material findings

## Scope

- targets codex/cloud-integration
- exact @claudian-collab/protocol 4.0.0 unchanged
- no UI, T3/S14, Protocol, Cloud Server, or Gomami changes