### PR TITLE
feat: recover Manager-reissued Cloud claims

### DIFF
--- a/src/app/collab/CollabFeatureService.ts
+++ b/src/app/collab/CollabFeatureService.ts
@@ -30,7 +30,11 @@ import {
   decodeCollabPendingProjectOperation,
 } from '@/app/collab/PendingProjectOperation';
 import type { CloudProjectEntryCoordinator } from '@/app/collab/project/CloudProjectEntryCoordinator';
-import { decodeCloudProjectInvitation } from '@/app/collab/project/CloudProjectInvitation';
+import {
+  type CloudMembershipClaimInvitation,
+  decodeCloudMembershipClaimInvitation,
+  decodeCloudProjectInvitation,
+} from '@/app/collab/project/CloudProjectInvitation';
 import type { CollabProjectSetupService } from '@/app/collab/project/CollabProjectSetupService';
 import {
   ProjectOperationAdmission,
@@ -397,6 +401,10 @@ export interface CollabAuthorityTransferEntryPort {
     input: CollabPrepareCloudToLanTargetRequest & Readonly<{ readonly operationIntentId: string }>,
     options?: CollabOperationOptions,
   ): Promise<CollabCloudToLanTargetPreparationDescriptor>;
+  redeemManagerReissuedClaim(
+    invitation: CloudMembershipClaimInvitation,
+    options?: CollabOperationOptions,
+  ): Promise<void>;
   withdrawCloudToLanTarget(
     input: CollabWithdrawCloudToLanTargetRequest,
     options?: CollabOperationOptions,
@@ -948,9 +956,12 @@ class CollabFeatureServiceCore {
     });
     try {
       throwIfCancelled(controller.signal);
-      const result = await this.options.publication.reconnectProject(request, {
-        signal: controller.signal,
-      });
+      const result = 'encodedInvitation' in request
+        && request.encodedInvitation.startsWith('claudian-cloud-claim:')
+        ? await this.reconnectManagerReissuedClaim(request, { signal: controller.signal })
+        : await this.options.publication.reconnectProject(request, {
+            signal: controller.signal,
+          });
       await this.#refreshAfterMutation(result);
       return result;
     } catch (error) {
@@ -964,6 +975,20 @@ class CollabFeatureServiceCore {
         this.#publishState(state);
       }
     }
+  }
+
+  private async reconnectManagerReissuedClaim(
+    request: Extract<CollabReconnectProjectRequest, { encodedInvitation: string }>,
+    options: CollabOperationOptions,
+  ): Promise<CollabResult<CollabLocalProjectSummary>> {
+    const invitation = decodeCloudMembershipClaimInvitation(request.encodedInvitation.trim());
+    if (invitation.claim.projectId !== request.projectId) {
+      throw operationError('authority-transfer-claimant-project-mismatch');
+    }
+    await this.options.authorityTransfer.redeemManagerReissuedClaim(invitation, options);
+    const project = (await this.#refreshProjects()).find(item => item.id === request.projectId);
+    if (!project) throw operationError('authority-transfer-claimant-project-missing');
+    return { status: 'success', value: project };
   }
 
   async readSnapshot(

--- a/src/app/collab/CollabFeatureSubcomposition.ts
+++ b/src/app/collab/CollabFeatureSubcomposition.ts
@@ -997,6 +997,9 @@ export function createCollabFeatureSubcomposition(
       )
     ),
     claimantStore: foundation.local.projects.authorityTransferClaimants,
+    createManagerReissuedClaimConnection: (binding, operationOptions) => (
+      cloudAuthority.connect(binding, operationOptions)
+    ),
     convergence: authorityTransferConvergence,
     createCloudToLanConnection: async projectId => {
       const membership = await foundation.local.projects.loadMembership(projectId);
@@ -1067,6 +1070,7 @@ export function createCollabFeatureSubcomposition(
       })
     ),
     lifecycle,
+    loadClaimantMembership: projectId => foundation.local.projects.loadMembership(projectId),
     installationKey: foundation.installationKey,
     persistence: foundation.authorityTransfers,
     recoverCloudSession: async record => {

--- a/src/app/collab/authority-transfer/AuthorityTransferLocalConvergence.ts
+++ b/src/app/collab/authority-transfer/AuthorityTransferLocalConvergence.ts
@@ -11,6 +11,9 @@ import type {
 import type {
   AuthorityTransferClaimantRecord,
 } from '@/app/collab/authority-transfer/claim/AuthorityTransferClaimantRecord';
+import {
+  authorityTransferClaimantStatus,
+} from '@/app/collab/authority-transfer/claim/AuthorityTransferClaimantRecord';
 import type {
   AuthorityProjectionTransitionPort,
 } from '@/app/collab/AuthorityProjectionTransitionCoordinator';
@@ -197,27 +200,32 @@ export class AuthorityTransferLocalConvergence {
   }
 
   async recoverConvertedClaimant(record: AuthorityTransferClaimantRecord): Promise<void> {
-    assertCompleted(record.status, record.status.direction);
+    const status = authorityTransferClaimantStatus(record);
+    if (!status) throw convergenceError('authority-transfer-claimant-status-missing');
+    assertCompleted(status, status.direction);
     return this.transitionProject(record.projectId, async () => {
       const membership = await this.requireMembership(record.projectId);
       if (membership.member.id !== record.memberId) {
         throw convergenceError('authority-transfer-claimant-member-conflict');
       }
-      if (record.status.direction === 'lan-to-cloud') {
+      if (status.direction === 'lan-to-cloud') {
         const serverUrl = validateCloudServerUrl(
-          record.status.targetUrl,
+          status.targetUrl,
           'authorityTransferTargetUrl',
         );
         if (
           !isCollabLocalCloudMembership(membership)
           || membership.authority.authorityGeneration
-            !== record.status.targetAuthority.generation
+            !== status.targetAuthority.generation
           || membership.authority.serverUrl !== serverUrl
           || membership.authority.gitRemoteUrl
-            !== cloudRemoteUrl(record.status.targetUrl, record.projectId)
+            !== cloudRemoteUrl(status.targetUrl, record.projectId)
         ) throw convergenceError('authority-transfer-cloud-membership-conflict');
         await this.finish(record.projectId, 'cloud');
         return;
+      }
+      if (record.variant !== 'source-issued') {
+        throw convergenceError('authority-transfer-claimant-direction-invalid');
       }
       const lanTarget = record.lanTarget;
       const targetCredential = record.targetCredential;

--- a/src/app/collab/authority-transfer/AuthorityTransferModule.ts
+++ b/src/app/collab/authority-transfer/AuthorityTransferModule.ts
@@ -30,7 +30,10 @@ import {
   AuthorityTransferClaimantCoordinator,
   type AuthorityTransferClaimantCoordinatorOptions,
 } from '@/app/collab/authority-transfer/claim/AuthorityTransferClaimantCoordinator';
-import type { AuthorityTransferClaimantRecord } from '@/app/collab/authority-transfer/claim/AuthorityTransferClaimantRecord';
+import {
+  type AuthorityTransferClaimantRecord,
+  type ManagerReissuedAuthorityTransferClaimantRecord,
+} from '@/app/collab/authority-transfer/claim/AuthorityTransferClaimantRecord';
 import {
   AuthorityTransferClaimantRecovery,
 } from '@/app/collab/authority-transfer/claim/AuthorityTransferClaimantRecovery';
@@ -69,6 +72,10 @@ import type {
 import {
   AuthorityTransferRecovery,
 } from '@/app/collab/authority-transfer/recovery/AuthorityTransferRecovery';
+import {
+  type CollabLocalMembershipRecord,
+  isCollabLocalLanMembership,
+} from '@/app/collab/CollabLocalProjectRepository';
 import type { LanAuthorityTransferClient } from '@/app/collab/lan/authority-transfer/LanAuthorityTransferClient';
 import type {
   LanAuthorityTransferActor,
@@ -78,6 +85,9 @@ import { PinnedCollabHttpClient } from '@/app/collab/lan/CollabHttpClient';
 import type {
   CollabProjectLifecycleSubsystem,
 } from '@/app/collab/lifecycle/CollabProjectLifecycleSubsystem';
+import type {
+  CloudMembershipClaimInvitation,
+} from '@/app/collab/project/CloudProjectInvitation';
 import { ProjectControlClient } from '@/app/collab/publish/ProjectControlClient';
 import type {
   CloudAuthorityConnection,
@@ -106,6 +116,10 @@ export interface AuthorityTransferModuleOptions {
     projectId: CollabProjectId,
   ) => Promise<void> | void;
   readonly claimantStore: AuthorityTransferClaimantCoordinatorOptions['store'];
+  readonly createManagerReissuedClaimConnection?: (
+    input: Readonly<{ readonly projectId: CollabProjectId; readonly serverUrl: string }>,
+    options: CollabOperationOptions,
+  ) => Promise<CloudAuthorityConnection>;
   readonly convergence: AuthorityTransferLocalConvergence;
   readonly createCloudToLanTarget: (
     projectId: CollabProjectId,
@@ -127,6 +141,9 @@ export interface AuthorityTransferModuleOptions {
     expectedEndpoint?: string,
   ) => Promise<() => Promise<void>>;
   readonly lifecycle: CollabProjectLifecycleSubsystem;
+  readonly loadClaimantMembership?: (
+    projectId: CollabProjectId,
+  ) => Promise<CollabLocalMembershipRecord | null>;
   readonly installationKey: InstallationKey;
   readonly now?: () => Date;
   readonly persistence: AuthorityTransferPersistence;
@@ -222,6 +239,11 @@ export interface BindCloudToLanClaimantInput {
   }>;
 }
 
+export interface BindManagerReissuedClaimantInput {
+  readonly cloudSession: CloudAuthorityConnection;
+  readonly projectId: CollabProjectId;
+}
+
 export type RecoveredAuthorityTransferClaimantBinding =
   | Readonly<{
       readonly cloudSession: CloudAuthorityConnection;
@@ -236,6 +258,11 @@ export type RecoveredAuthorityTransferClaimantBinding =
       readonly lanClient: LanAuthorityTransferClient;
       readonly mode: 'full';
       readonly targetHost: BindCloudToLanClaimantInput['targetHost'];
+    }>
+  | Readonly<{
+      readonly cloudSession: CloudAuthorityConnection;
+      readonly direction: 'lan-to-cloud';
+      readonly mode: 'manager-reissued';
     }>
   | Readonly<{
       readonly cloudSession: CloudAuthorityConnection;
@@ -1418,6 +1445,9 @@ export class AuthorityTransferModule {
     return this.bindClaimant({
       convergence: {
         converge: async (record, options) => {
+          if (record.variant !== 'source-issued') {
+            throw moduleError('authority-transfer-claimant-variant-invalid');
+          }
           const snapshot = await input.cloudSession.readSnapshot(record.projectId, options);
           await this.convergence.lanToCloudMember({
             snapshot,
@@ -1466,6 +1496,115 @@ export class AuthorityTransferModule {
     });
   }
 
+  bindManagerReissuedClaimant(
+    input: BindManagerReissuedClaimantInput,
+  ): AuthorityTransferDirectionBinding<AuthorityTransferClaimantCoordinator> {
+    this.assertCloudSession(input.projectId, input.cloudSession);
+    return this.bindClaimant({
+      convergence: {
+        converge: async (record, options) => {
+          if (record.variant !== 'manager-reissued' || !record.targetStatus) {
+            throw moduleError('authority-transfer-claimant-variant-invalid');
+          }
+          if (record.serverUrl !== input.cloudSession.serverUrl) {
+            throw moduleError('authority-transfer-cloud-binding-mismatch');
+          }
+          const snapshot = await input.cloudSession.readSnapshot(record.projectId, options);
+          this.assertManagerReissuedTarget(record, record.targetStatus, snapshot);
+          await this.convergence.lanToCloudMember({
+            snapshot,
+            status: record.targetStatus,
+          });
+        },
+      },
+      projectId: input.projectId,
+      lanTarget: null,
+      target: {
+        claimTransferredMembership: (record, request, options) => {
+          if (record.variant !== 'manager-reissued') {
+            throw moduleError('authority-transfer-claimant-variant-invalid');
+          }
+          if (record.serverUrl !== input.cloudSession.serverUrl) {
+            throw moduleError('authority-transfer-cloud-binding-mismatch');
+          }
+          if ('credentialHash' in request && request.credentialHash !== undefined) {
+            throw moduleError('authority-transfer-cloud-claim-credential-unexpected');
+          }
+          return input.cloudSession.lifecycle.authorityTransfer(
+            'claimTransferredMembership',
+            request,
+            options,
+          );
+        },
+        confirmTargetBinding: async (record, _proof, options) => {
+          if (record.serverUrl !== input.cloudSession.serverUrl) {
+            throw moduleError('authority-transfer-cloud-binding-mismatch');
+          }
+          const status = await input.cloudSession.lifecycle.authorityTransfer(
+            'getProjectAuthorityTransfer',
+            { projectId: record.projectId, transferId: record.transferId },
+            options,
+          );
+          const snapshot = await input.cloudSession.readSnapshot(record.projectId, options);
+          this.assertManagerReissuedTarget(record, status, snapshot);
+          return status;
+        },
+      },
+    });
+  }
+
+  redeemManagerReissuedClaim(
+    invitation: CloudMembershipClaimInvitation,
+    options: CollabOperationOptions = {},
+  ): Promise<void> {
+    return this.options.lifecycle.runExclusive(
+      invitation.claim.projectId,
+      this.claimantRecovery.durableOwner.name,
+      'continuation',
+      () => this.redeemManagerReissuedClaimOwned(invitation, options),
+    );
+  }
+
+  private async redeemManagerReissuedClaimOwned(
+    invitation: CloudMembershipClaimInvitation,
+    options: CollabOperationOptions,
+  ): Promise<void> {
+    const loadMembership = this.options.loadClaimantMembership;
+    const createConnection = this.options.createManagerReissuedClaimConnection;
+    if (!loadMembership || !createConnection) {
+      throw moduleError('authority-transfer-claimant-entry-unavailable');
+    }
+    const membership = await loadMembership(invitation.claim.projectId);
+    if (
+      !membership
+      || !isCollabLocalLanMembership(membership)
+      || membership.hostOwnership.ownsAuthority
+      || membership.member.id !== invitation.claim.memberId
+    ) throw moduleError('authority-transfer-claimant-membership-invalid');
+    const cloudSession = await createConnection({
+      projectId: invitation.claim.projectId,
+      serverUrl: invitation.serverUrl,
+    }, options);
+    try {
+      await this.assertCloudToLanManagerSettled(invitation.claim.projectId);
+      const binding = this.bindManagerReissuedClaimant({
+        cloudSession,
+        projectId: invitation.claim.projectId,
+      });
+      try {
+        await binding.coordinator.startManagerReissued({
+          descriptor: invitation.claim,
+          memberPersonalRef: membership.member.personalRef,
+          serverUrl: invitation.serverUrl,
+        }, options);
+      } finally {
+        await binding.dispose();
+      }
+    } finally {
+      cloudSession.dispose();
+    }
+  }
+
   bindCloudToLanClaimant(
     input: BindCloudToLanClaimantInput,
   ): AuthorityTransferDirectionBinding<AuthorityTransferClaimantCoordinator> {
@@ -1474,6 +1613,9 @@ export class AuthorityTransferModule {
     return this.bindClaimant({
       convergence: {
         converge: async (record, options) => {
+          if (record.variant !== 'source-issued') {
+            throw moduleError('authority-transfer-claimant-variant-invalid');
+          }
           const targetCredential = this.requireTargetCredential(record);
           const snapshot = await control.readSnapshot(
             record.projectId,
@@ -1538,6 +1680,9 @@ export class AuthorityTransferModule {
     return this.bindClaimant({
       convergence: {
         converge: async (record, options) => {
+          if (record.variant !== 'source-issued') {
+            throw moduleError('authority-transfer-claimant-variant-invalid');
+          }
           const snapshot = await input.cloudSession.readSnapshot(record.projectId, options);
           await this.convergence.lanToCloudMember({
             snapshot,
@@ -1571,6 +1716,9 @@ export class AuthorityTransferModule {
     return this.bindClaimant({
       convergence: {
         converge: async (record, options) => {
+          if (record.variant !== 'source-issued') {
+            throw moduleError('authority-transfer-claimant-variant-invalid');
+          }
           const targetCredential = this.requireTargetCredential(record);
           const snapshot = await control.readSnapshot(
             record.projectId,
@@ -1618,7 +1766,7 @@ export class AuthorityTransferModule {
         converge: current => this.convergence.recoverConvertedClaimant(current),
       },
       projectId: record.projectId,
-      lanTarget: record.lanTarget,
+      lanTarget: record.variant === 'source-issued' ? record.lanTarget : null,
       source: {
         acknowledgeRedemption: () => {
           throw moduleError('authority-transfer-claimant-source-unavailable');
@@ -1642,8 +1790,8 @@ export class AuthorityTransferModule {
       convergence: input.convergence,
       ...(input.createCredential ? { createCredential: input.createCredential } : {}),
       ...(input.lanTarget !== undefined ? { lanTarget: input.lanTarget } : {}),
-      ...(input.now ? { now: input.now } : {}),
-      source: input.source,
+      now: input.now ?? this.now,
+      ...(input.source ? { source: input.source } : {}),
       store: this.options.claimantStore,
       target: input.target,
     });
@@ -1652,10 +1800,34 @@ export class AuthorityTransferModule {
   }
 
   private requireTargetCredential(record: AuthorityTransferClaimantRecord): string {
-    if (!record.targetCredential) {
+    if (record.variant !== 'source-issued' || !record.targetCredential) {
       throw moduleError('authority-transfer-claimant-target-credential-missing');
     }
     return record.targetCredential;
+  }
+
+  private assertManagerReissuedTarget(
+    record: ManagerReissuedAuthorityTransferClaimantRecord,
+    status: CollabAuthorityTransferStatus,
+    snapshot: Awaited<ReturnType<CloudAuthorityConnection['readSnapshot']>>,
+  ): void {
+    if (
+      status.direction !== 'lan-to-cloud'
+      || status.state !== 'completed'
+      || status.phase !== 'completed'
+      || status.relinquishmentProof === null
+      || status.checkpointSha256 === null
+      || status.projectId !== record.projectId
+      || status.transferId !== record.transferId
+      || status.targetAuthority.kind !== 'cloud'
+      || status.targetAuthority.generation !== record.descriptor.targetAuthorityGeneration
+      || status.targetUrl !== record.serverUrl
+      || snapshot.project.id !== record.projectId
+      || snapshot.project.authorityKind !== 'cloud'
+      || snapshot.project.authorityGeneration !== record.descriptor.targetAuthorityGeneration
+      || snapshot.currentMember.id !== record.memberId
+      || snapshot.currentMember.personalRef !== record.memberPersonalRef
+    ) throw moduleError('authority-transfer-claimant-target-binding-invalid');
   }
 
   private lanTargetSnapshotReader(
@@ -1678,13 +1850,21 @@ export class AuthorityTransferModule {
     const disposeCloudSession = (): void => {
       if ('cloudSession' in recovered) recovered.cloudSession.dispose();
     };
-    if (recovered.direction !== record.status.direction) {
+    const direction = record.variant === 'source-issued'
+      ? record.status.direction
+      : 'lan-to-cloud';
+    if (recovered.direction !== direction) {
       disposeCloudSession();
       throw moduleError('authority-transfer-claimant-direction-mismatch');
     }
     try {
       const binding = recovered.mode === 'local-only'
         ? this.bindLocalOnlyClaimant(record)
+        : recovered.mode === 'manager-reissued'
+          ? this.bindManagerReissuedClaimant({
+              cloudSession: recovered.cloudSession,
+              projectId: record.projectId,
+            })
         : recovered.direction === 'lan-to-cloud' && recovered.mode === 'full'
           ? this.bindLanToCloudClaimant({
             cloudSession: recovered.cloudSession,

--- a/src/app/collab/authority-transfer/claim/AuthorityTransferClaimantBindingResolver.ts
+++ b/src/app/collab/authority-transfer/claim/AuthorityTransferClaimantBindingResolver.ts
@@ -64,6 +64,35 @@ export class AuthorityTransferClaimantBindingResolver {
     if (!membership || membership.member.id !== record.memberId) {
       throw resolutionError('authority-transfer-claimant-membership-invalid');
     }
+    if (record.variant === 'manager-reissued') {
+      if (membership.member.personalRef !== record.memberPersonalRef) {
+        throw resolutionError('authority-transfer-claimant-membership-invalid');
+      }
+      if (isCollabLocalCloudMembership(membership)) {
+        if (
+          record.phase !== 'target-confirmed'
+          && record.phase !== 'membership-converged'
+          && record.phase !== 'completed'
+        ) throw resolutionError('authority-transfer-claimant-phase-invalid');
+        if (
+          membership.authority.authorityGeneration
+            !== record.descriptor.targetAuthorityGeneration
+          || membership.authority.serverUrl !== record.serverUrl
+        ) throw resolutionError('authority-transfer-claimant-target-invalid');
+        return { direction: 'lan-to-cloud', mode: 'local-only' };
+      }
+      if (!isCollabLocalLanMembership(membership) || membership.hostOwnership.ownsAuthority) {
+        throw resolutionError('authority-transfer-claimant-source-invalid');
+      }
+      return {
+        cloudSession: await this.options.createCloudConnection({
+          projectId: record.projectId,
+          serverUrl: record.serverUrl,
+        }),
+        direction: 'lan-to-cloud',
+        mode: 'manager-reissued',
+      };
+    }
     const requiresSource = authorityTransferClaimantRequiresSource(record, this.now());
     if (record.status.direction === 'lan-to-cloud') {
       if (isCollabLocalCloudMembership(membership)) {

--- a/src/app/collab/authority-transfer/claim/AuthorityTransferClaimantCoordinator.ts
+++ b/src/app/collab/authority-transfer/claim/AuthorityTransferClaimantCoordinator.ts
@@ -7,6 +7,7 @@ import type {
   CollabProjectId,
   CollabTransferredMembershipClaim,
   CollabTransferredMembershipRedemptionReceipt,
+  ReissueTransferredMembershipClaimResponse,
 } from '@claudian-collab/protocol';
 
 import {
@@ -15,17 +16,20 @@ import {
   type AuthorityTransferClaimantRecord,
   type AuthorityTransferClaimantStore,
   createAuthorityTransferClaimantRecord,
+  createManagerReissuedAuthorityTransferClaimantRecord,
+  type ManagerReissuedAuthorityTransferClaimantRecord,
+  type SourceIssuedAuthorityTransferClaimantRecord,
 } from '@/app/collab/authority-transfer/claim/AuthorityTransferClaimantRecord';
 import type { CollabOperationOptions } from '@/core/collab';
 import { CollabError } from '@/core/collab/ClaudianCollabError';
 
 export interface AuthorityTransferClaimantSource {
   getClaim(
-    record: AuthorityTransferClaimantRecord,
+    record: SourceIssuedAuthorityTransferClaimantRecord,
     options: CollabOperationOptions,
   ): Promise<CollabTransferredMembershipClaim>;
   acknowledgeRedemption(
-    record: AuthorityTransferClaimantRecord,
+    record: SourceIssuedAuthorityTransferClaimantRecord,
     options: CollabOperationOptions,
   ): Promise<void>;
 }
@@ -36,6 +40,11 @@ export interface AuthorityTransferClaimantTarget {
     request: ClaimTransferredMembershipRequest,
     options: CollabOperationOptions,
   ): Promise<CollabTransferredMembershipRedemptionReceipt>;
+  confirmTargetBinding?(
+    record: ManagerReissuedAuthorityTransferClaimantRecord,
+    proof: 'receipt' | 'existing-binding',
+    options: CollabOperationOptions,
+  ): Promise<CollabAuthorityTransferStatus>;
 }
 
 export interface AuthorityTransferClaimantConvergence {
@@ -50,7 +59,7 @@ export interface AuthorityTransferClaimantCoordinatorOptions {
   readonly createCredential?: () => string;
   readonly lanTarget?: AuthorityTransferClaimantLanTarget | null;
   readonly now?: () => Date;
-  readonly source: AuthorityTransferClaimantSource;
+  readonly source?: AuthorityTransferClaimantSource;
   readonly store: AuthorityTransferClaimantStore;
   readonly target: AuthorityTransferClaimantTarget;
 }
@@ -59,6 +68,13 @@ export interface StartAuthorityTransferClaimantInput {
   readonly memberId: CollabMemberId;
   readonly operationIntentId: string;
   readonly status: CollabAuthorityTransferStatus;
+}
+
+export interface StartManagerReissuedAuthorityTransferClaimantInput {
+  readonly descriptor: ReissueTransferredMembershipClaimResponse;
+  readonly memberPersonalRef: string;
+  readonly operationIntentId?: string;
+  readonly serverUrl: string;
 }
 
 function claimantError(reason: string): CollabError {
@@ -73,12 +89,13 @@ function assertNotCancelled(options: CollabOperationOptions): void {
   if (options.signal?.aborted) throw new CollabError({ code: 'cancelled' });
 }
 
-function sameAttempt(
+function sameSourceIssuedAttempt(
   record: AuthorityTransferClaimantRecord,
   input: StartAuthorityTransferClaimantInput,
   lanTarget: AuthorityTransferClaimantLanTarget | null,
 ): boolean {
-  return record.projectId === input.status.projectId
+  return record.variant === 'source-issued'
+    && record.projectId === input.status.projectId
     && record.transferId === input.status.transferId
     && record.memberId === input.memberId
     && record.operationIntentId === input.operationIntentId
@@ -97,11 +114,28 @@ function sameAttempt(
     );
 }
 
-/**
- * Owns an offline Member's restart-safe claim retrieval and target binding.
- * The source and target remain authoritative for claim and receipt validity;
- * this record only makes the claimant-side sequence durable.
- */
+function sameManagerReissuedAttempt(
+  record: AuthorityTransferClaimantRecord,
+  input: StartManagerReissuedAuthorityTransferClaimantInput,
+): boolean {
+  const descriptor = record.variant === 'manager-reissued'
+    ? record.descriptor
+    : null;
+  return record.variant === 'manager-reissued'
+    && record.memberPersonalRef === input.memberPersonalRef
+    && record.serverUrl === input.serverUrl
+    && descriptor?.claim === input.descriptor.claim
+    && descriptor.claimGeneration === input.descriptor.claimGeneration
+    && descriptor.createdAt === input.descriptor.createdAt
+    && descriptor.expiresAt === input.descriptor.expiresAt
+    && descriptor.memberId === input.descriptor.memberId
+    && descriptor.projectId === input.descriptor.projectId
+    && descriptor.secretReplayExpiresAt === input.descriptor.secretReplayExpiresAt
+    && descriptor.targetAuthorityGeneration === input.descriptor.targetAuthorityGeneration
+    && descriptor.transferId === input.descriptor.transferId;
+}
+
+/** Owns both bounded claimant variants without treating a reissue as source custody. */
 export class AuthorityTransferClaimantCoordinator {
   private readonly createCredential: () => string;
   private readonly now: () => Date;
@@ -120,7 +154,7 @@ export class AuthorityTransferClaimantCoordinator {
     const existing = await this.options.store.load(input.status.projectId);
     const lanTarget = this.options.lanTarget ?? null;
     if (existing) {
-      if (!sameAttempt(existing, input, lanTarget)) {
+      if (!sameSourceIssuedAttempt(existing, input, lanTarget)) {
         throw claimantError('authority-transfer-claimant-attempt-conflict');
       }
     } else {
@@ -135,12 +169,47 @@ export class AuthorityTransferClaimantCoordinator {
     await this.resume(input.status.projectId, options);
   }
 
+  async startManagerReissued(
+    input: StartManagerReissuedAuthorityTransferClaimantInput,
+    options: CollabOperationOptions = {},
+  ): Promise<void> {
+    assertNotCancelled(options);
+    const existing = await this.options.store.load(input.descriptor.projectId);
+    if (existing) {
+      if (!sameManagerReissuedAttempt(existing, input)) {
+        throw claimantError('authority-transfer-claimant-attempt-conflict');
+      }
+    } else {
+      const candidate = createManagerReissuedAuthorityTransferClaimantRecord({
+        ...input,
+        operationIntentId: input.operationIntentId
+          ?? `manager-reissued-${randomBytes(16).toString('hex')}`,
+      });
+      await this.options.store.save(candidate);
+    }
+    await this.resume(input.descriptor.projectId, options);
+  }
+
   async resume(
     projectId: CollabProjectId,
     options: CollabOperationOptions = {},
   ): Promise<void> {
-    let record = await this.options.store.load(projectId);
+    const record = await this.options.store.load(projectId);
     if (!record) throw claimantError('authority-transfer-claimant-record-missing');
+    if (record.variant === 'manager-reissued') {
+      await this.resumeManagerReissued(record, options);
+      return;
+    }
+    await this.resumeSourceIssued(record, options);
+  }
+
+  private async resumeSourceIssued(
+    initial: SourceIssuedAuthorityTransferClaimantRecord,
+    options: CollabOperationOptions,
+  ): Promise<void> {
+    const source = this.options.source;
+    if (!source) throw claimantError('authority-transfer-claimant-source-unavailable');
+    let record = initial;
     while (record.phase !== 'completed') {
       assertNotCancelled(options);
       if (this.now().getTime() >= Date.parse(record.status.expiresAt)) {
@@ -148,10 +217,10 @@ export class AuthorityTransferClaimantCoordinator {
           case 'prepared':
           case 'claim-retained':
           case 'credential-persisted':
-            await this.options.store.remove(projectId);
+            await this.options.store.remove(record.projectId);
             return;
           case 'target-claimed':
-            record = await this.advance(record, 'source-acknowledged');
+            record = await this.advanceSource(record, 'source-acknowledged');
             continue;
           case 'source-acknowledged':
           case 'membership-converged':
@@ -160,15 +229,15 @@ export class AuthorityTransferClaimantCoordinator {
       }
       switch (record.phase) {
         case 'prepared': {
-          const claim = await this.options.source.getClaim(record, options);
-          record = await this.advance(record, 'claim-retained', { claim });
+          const claim = await source.getClaim(record, options);
+          record = await this.advanceSource(record, 'claim-retained', { claim });
           break;
         }
         case 'claim-retained': {
           const targetCredential = record.status.targetAuthority.kind === 'lan'
             ? this.createCredential()
             : null;
-          record = await this.advance(record, 'credential-persisted', {
+          record = await this.advanceSource(record, 'credential-persisted', {
             targetCredential,
           });
           break;
@@ -196,39 +265,136 @@ export class AuthorityTransferClaimantCoordinator {
             request,
             options,
           );
-          record = await this.advance(record, 'target-claimed', { redemptionReceipt });
+          record = await this.advanceSource(record, 'target-claimed', { redemptionReceipt });
           break;
         }
         case 'target-claimed':
-          await this.options.source.acknowledgeRedemption(record, options);
-          record = await this.advance(record, 'source-acknowledged');
+          await source.acknowledgeRedemption(record, options);
+          record = await this.advanceSource(record, 'source-acknowledged');
           break;
         case 'source-acknowledged':
           await this.options.convergence.converge(record, options);
-          record = await this.advance(record, 'membership-converged');
+          record = await this.advanceSource(record, 'membership-converged');
           break;
         case 'membership-converged':
-          record = await this.advance(record, 'completed');
+          record = await this.advanceSource(record, 'completed');
           break;
       }
     }
-    await this.options.store.remove(projectId);
+    await this.options.store.remove(record.projectId);
   }
 
-  private async advance(
-    previous: AuthorityTransferClaimantRecord,
-    phase: AuthorityTransferClaimantRecord['phase'],
-    update: Partial<Pick<
-      AuthorityTransferClaimantRecord,
-      'claim' | 'redemptionReceipt' | 'targetCredential'
-    >> = {},
-  ): Promise<AuthorityTransferClaimantRecord> {
+  private async resumeManagerReissued(
+    initial: ManagerReissuedAuthorityTransferClaimantRecord,
+    options: CollabOperationOptions,
+  ): Promise<void> {
+    let record = initial;
+    while (record.phase !== 'completed') {
+      assertNotCancelled(options);
+      switch (record.phase) {
+        case 'redemption-prepared': {
+          if (this.now().getTime() >= Date.parse(record.descriptor.expiresAt)) {
+            const targetStatus = await this.confirmManagerTargetBinding(
+              record,
+              'existing-binding',
+              options,
+            );
+            record = await this.advanceManager(record, 'target-confirmed', {
+              convergenceProof: 'existing-binding',
+              targetStatus,
+            });
+            break;
+          }
+          const redemptionReceipt = await this.options.target.claimTransferredMembership(
+            record,
+            record.redemptionRequest,
+            options,
+          );
+          record = await this.advanceManager(record, 'target-claimed', {
+            redemptionReceipt,
+          });
+          break;
+        }
+        case 'target-claimed': {
+          const targetStatus = await this.confirmManagerTargetBinding(
+            record,
+            'receipt',
+            options,
+          );
+          record = await this.advanceManager(record, 'target-confirmed', {
+            convergenceProof: 'receipt',
+            targetStatus,
+          });
+          break;
+        }
+        case 'target-confirmed':
+          await this.options.convergence.converge(record, options);
+          record = await this.advanceManager(record, 'membership-converged');
+          break;
+        case 'membership-converged':
+          record = await this.advanceManager(record, 'completed');
+          break;
+      }
+    }
+    await this.options.store.remove(record.projectId);
+  }
+
+  private confirmManagerTargetBinding(
+    record: ManagerReissuedAuthorityTransferClaimantRecord,
+    proof: 'receipt' | 'existing-binding',
+    options: CollabOperationOptions,
+  ): Promise<CollabAuthorityTransferStatus> {
+    const confirm = this.options.target.confirmTargetBinding?.bind(this.options.target);
+    if (!confirm) {
+      throw claimantError('authority-transfer-claimant-target-confirmation-unavailable');
+    }
+    return confirm(record, proof, options);
+  }
+
+  private async advanceSource(
+    previous: SourceIssuedAuthorityTransferClaimantRecord,
+    phase: SourceIssuedAuthorityTransferClaimantRecord['phase'],
+    update: Readonly<{
+      claim?: CollabTransferredMembershipClaim;
+      redemptionReceipt?: CollabTransferredMembershipRedemptionReceipt;
+      targetCredential?: string | null;
+    }> = {},
+  ): Promise<SourceIssuedAuthorityTransferClaimantRecord> {
     const record = advanceAuthorityTransferClaimantRecord(previous, {
       ...update,
       phase,
-      updatedAt: this.now().toISOString(),
+      updatedAt: this.monotonicTimestamp(previous.updatedAt),
     });
     await this.options.store.save(record);
+    if (record.variant !== 'source-issued') {
+      throw claimantError('authority-transfer-claimant-variant-invalid');
+    }
     return record;
+  }
+
+  private async advanceManager(
+    previous: ManagerReissuedAuthorityTransferClaimantRecord,
+    phase: ManagerReissuedAuthorityTransferClaimantRecord['phase'],
+    update: Readonly<{
+      convergenceProof?: 'receipt' | 'existing-binding';
+      redemptionReceipt?: CollabTransferredMembershipRedemptionReceipt;
+      targetStatus?: CollabAuthorityTransferStatus;
+    }> = {},
+  ): Promise<ManagerReissuedAuthorityTransferClaimantRecord> {
+    const record = advanceAuthorityTransferClaimantRecord(previous, {
+      ...update,
+      phase,
+      updatedAt: this.monotonicTimestamp(previous.updatedAt),
+    });
+    await this.options.store.save(record);
+    if (record.variant !== 'manager-reissued') {
+      throw claimantError('authority-transfer-claimant-variant-invalid');
+    }
+    return record;
+  }
+
+  private monotonicTimestamp(previous: string): string {
+    const current = this.now();
+    return current.getTime() < Date.parse(previous) ? previous : current.toISOString();
   }
 }

--- a/src/app/collab/authority-transfer/claim/AuthorityTransferClaimantRecord.ts
+++ b/src/app/collab/authority-transfer/claim/AuthorityTransferClaimantRecord.ts
@@ -1,23 +1,29 @@
 import { createHash } from 'node:crypto';
 
 import {
+  type ClaimTransferredMembershipRequest,
   type CollabAuthorityTransferStatus,
+  collabControlOperationCodec,
   type CollabIsoTimestamp,
   type CollabMemberId,
   type CollabProjectId,
   type CollabTransferredMembershipClaim,
   type CollabTransferredMembershipRedemptionReceipt,
+  decodeCollabAuthorityTransferOperationRequest,
   decodeCollabAuthorityTransferStatus,
   decodeCollabTransferredMembershipClaim,
   decodeCollabTransferredMembershipRedemptionReceipt,
   isCollabMemberId,
   isCollabOpaqueId,
   isCollabProjectId,
+  type ReissueTransferredMembershipClaimResponse,
 } from '@claudian-collab/protocol';
+
+import { validateCloudServerUrl } from '@/app/collab/remote-authority/CloudAuthorityUrls';
 
 export const AUTHORITY_TRANSFER_CLAIMANT_RECORD_SCHEMA_VERSION = 1 as const;
 
-export const AUTHORITY_TRANSFER_CLAIMANT_PHASES = [
+export const SOURCE_ISSUED_AUTHORITY_TRANSFER_CLAIMANT_PHASES = [
   'prepared',
   'claim-retained',
   'credential-persisted',
@@ -27,8 +33,21 @@ export const AUTHORITY_TRANSFER_CLAIMANT_PHASES = [
   'completed',
 ] as const;
 
+export const MANAGER_REISSUED_AUTHORITY_TRANSFER_CLAIMANT_PHASES = [
+  'redemption-prepared',
+  'target-claimed',
+  'target-confirmed',
+  'membership-converged',
+  'completed',
+] as const;
+
+export type SourceIssuedAuthorityTransferClaimantPhase =
+  typeof SOURCE_ISSUED_AUTHORITY_TRANSFER_CLAIMANT_PHASES[number];
+export type ManagerReissuedAuthorityTransferClaimantPhase =
+  typeof MANAGER_REISSUED_AUTHORITY_TRANSFER_CLAIMANT_PHASES[number];
 export type AuthorityTransferClaimantPhase =
-  typeof AUTHORITY_TRANSFER_CLAIMANT_PHASES[number];
+  | SourceIssuedAuthorityTransferClaimantPhase
+  | ManagerReissuedAuthorityTransferClaimantPhase;
 
 export interface AuthorityTransferClaimantLanTarget {
   readonly caCertificatePem: string;
@@ -36,38 +55,55 @@ export interface AuthorityTransferClaimantLanTarget {
   readonly endpoint: string;
 }
 
-export interface AuthorityTransferClaimantRecord {
-  readonly claim: CollabTransferredMembershipClaim | null;
+interface AuthorityTransferClaimantRecordBase {
   readonly createdAt: CollabIsoTimestamp;
   readonly kind: 'authority-transfer-claimant';
-  readonly lanTarget: AuthorityTransferClaimantLanTarget | null;
   readonly memberId: CollabMemberId;
   readonly operationIntentId: string;
-  readonly phase: AuthorityTransferClaimantPhase;
   readonly projectId: CollabProjectId;
-  readonly redemptionReceipt: CollabTransferredMembershipRedemptionReceipt | null;
   readonly schemaVersion: typeof AUTHORITY_TRANSFER_CLAIMANT_RECORD_SCHEMA_VERSION;
-  readonly status: CollabAuthorityTransferStatus;
-  readonly targetCredential: string | null;
   readonly transferId: string;
   readonly updatedAt: CollabIsoTimestamp;
 }
 
-const KEYS = new Set([
-  'claim',
-  'createdAt',
-  'kind',
-  'lanTarget',
-  'memberId',
-  'operationIntentId',
-  'phase',
-  'projectId',
-  'redemptionReceipt',
-  'schemaVersion',
-  'status',
-  'targetCredential',
-  'transferId',
-  'updatedAt',
+export interface SourceIssuedAuthorityTransferClaimantRecord
+  extends AuthorityTransferClaimantRecordBase {
+  readonly claim: CollabTransferredMembershipClaim | null;
+  readonly lanTarget: AuthorityTransferClaimantLanTarget | null;
+  readonly phase: SourceIssuedAuthorityTransferClaimantPhase;
+  readonly redemptionReceipt: CollabTransferredMembershipRedemptionReceipt | null;
+  readonly status: CollabAuthorityTransferStatus;
+  readonly targetCredential: string | null;
+  readonly variant: 'source-issued';
+}
+
+export interface ManagerReissuedAuthorityTransferClaimantRecord
+  extends AuthorityTransferClaimantRecordBase {
+  readonly convergenceProof: 'receipt' | 'existing-binding' | null;
+  readonly descriptor: ReissueTransferredMembershipClaimResponse;
+  readonly memberPersonalRef: string;
+  readonly phase: ManagerReissuedAuthorityTransferClaimantPhase;
+  readonly redemptionReceipt: CollabTransferredMembershipRedemptionReceipt | null;
+  readonly redemptionRequest: ClaimTransferredMembershipRequest;
+  readonly serverUrl: string;
+  readonly targetStatus: CollabAuthorityTransferStatus | null;
+  readonly variant: 'manager-reissued';
+}
+
+export type AuthorityTransferClaimantRecord =
+  | SourceIssuedAuthorityTransferClaimantRecord
+  | ManagerReissuedAuthorityTransferClaimantRecord;
+
+const SOURCE_KEYS = new Set([
+  'claim', 'createdAt', 'kind', 'lanTarget', 'memberId', 'operationIntentId', 'phase',
+  'projectId', 'redemptionReceipt', 'schemaVersion', 'status', 'targetCredential',
+  'transferId', 'updatedAt', 'variant',
+]);
+const MANAGER_KEYS = new Set([
+  'convergenceProof', 'createdAt', 'descriptor', 'kind', 'memberId',
+  'memberPersonalRef', 'operationIntentId', 'phase', 'projectId', 'redemptionReceipt',
+  'redemptionRequest', 'schemaVersion', 'serverUrl', 'targetStatus', 'transferId',
+  'updatedAt', 'variant',
 ]);
 const CREDENTIAL_PATTERN = /^[A-Za-z0-9_-]{43}$/;
 const FINGERPRINT_PATTERN = /^(?:[A-Fa-f0-9]{64}|(?:[A-Fa-f0-9]{2}:){31}[A-Fa-f0-9]{2})$/;
@@ -86,25 +122,17 @@ function timestamp(value: unknown): value is CollabIsoTimestamp {
     && new Date(value).toISOString() === value;
 }
 
-function phaseIndex(phase: AuthorityTransferClaimantPhase): number {
-  return AUTHORITY_TRANSFER_CLAIMANT_PHASES.indexOf(phase);
+function assertKeys(source: Readonly<Record<string, unknown>>, keys: ReadonlySet<string>): void {
+  if (
+    Object.keys(source).length !== keys.size
+    || Object.keys(source).some(key => !keys.has(key))
+  ) throw new TypeError('Invalid authority-transfer claimant record');
 }
 
-export function decodeAuthorityTransferClaimantRecord(
-  value: unknown,
-): AuthorityTransferClaimantRecord {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new TypeError('Invalid authority-transfer claimant record');
-  }
-  const source = value as Readonly<Record<string, unknown>>;
-  const phase = source.phase;
+function assertBase(source: Readonly<Record<string, unknown>>): void {
   if (
-    Object.keys(source).length !== KEYS.size
-    || Object.keys(source).some(key => !KEYS.has(key))
-    || source.schemaVersion !== AUTHORITY_TRANSFER_CLAIMANT_RECORD_SCHEMA_VERSION
+    source.schemaVersion !== AUTHORITY_TRANSFER_CLAIMANT_RECORD_SCHEMA_VERSION
     || source.kind !== 'authority-transfer-claimant'
-    || typeof phase !== 'string'
-    || !AUTHORITY_TRANSFER_CLAIMANT_PHASES.includes(phase as never)
     || !isCollabProjectId(source.projectId)
     || !isCollabMemberId(source.memberId)
     || typeof source.operationIntentId !== 'string'
@@ -115,6 +143,71 @@ export function decodeAuthorityTransferClaimantRecord(
     || !timestamp(source.updatedAt)
     || Date.parse(source.updatedAt) < Date.parse(source.createdAt)
   ) throw new TypeError('Invalid authority-transfer claimant identity');
+}
+
+function decodeLanTarget(
+  value: unknown,
+  status: CollabAuthorityTransferStatus,
+): AuthorityTransferClaimantLanTarget | null {
+  if (value === null) return null;
+  if (
+    !value || typeof value !== 'object' || Array.isArray(value)
+    || Object.keys(value).length !== LAN_TARGET_KEYS.size
+    || Object.keys(value).some(key => !LAN_TARGET_KEYS.has(key))
+  ) throw new TypeError('Invalid authority-transfer claimant LAN target');
+  const candidate = value as Readonly<Record<string, unknown>>;
+  if (
+    typeof candidate.caCertificatePem !== 'string'
+    || candidate.caCertificatePem.length > 64 * 1024
+    || !candidate.caCertificatePem.includes('-----BEGIN CERTIFICATE-----')
+    || !candidate.caCertificatePem.includes('-----END CERTIFICATE-----')
+    || candidate.caCertificatePem.includes('PRIVATE KEY')
+    || typeof candidate.caFingerprint !== 'string'
+    || !FINGERPRINT_PATTERN.test(candidate.caFingerprint)
+    || typeof candidate.endpoint !== 'string'
+    || candidate.endpoint !== status.targetUrl
+  ) throw new TypeError('Invalid authority-transfer claimant LAN target');
+  return Object.freeze({
+    caCertificatePem: candidate.caCertificatePem,
+    caFingerprint: candidate.caFingerprint.replaceAll(':', '').toLocaleLowerCase('en-US'),
+    endpoint: candidate.endpoint,
+  });
+}
+
+function decodeCredential(value: unknown): string | null {
+  if (value === null) return null;
+  if (
+    typeof value !== 'string'
+    || !CREDENTIAL_PATTERN.test(value)
+    || Buffer.from(value, 'base64url').byteLength !== 32
+    || Buffer.from(value, 'base64url').toString('base64url') !== value
+  ) throw new TypeError('Invalid authority-transfer claimant credential');
+  return value;
+}
+
+function decodeReceipt(value: unknown): CollabTransferredMembershipRedemptionReceipt | null {
+  return value === null
+    ? null
+    : decodeCollabTransferredMembershipRedemptionReceipt(value);
+}
+
+function decodeConvergenceProof(
+  value: unknown,
+): ManagerReissuedAuthorityTransferClaimantRecord['convergenceProof'] {
+  if (value === null || value === 'receipt' || value === 'existing-binding') return value;
+  throw new TypeError('Invalid Manager-reissued authority-transfer claimant proof');
+}
+
+function decodeSourceIssuedRecord(
+  source: Readonly<Record<string, unknown>>,
+): SourceIssuedAuthorityTransferClaimantRecord {
+  assertKeys(source, SOURCE_KEYS);
+  assertBase(source);
+  const phase = source.phase;
+  if (
+    typeof phase !== 'string'
+    || !SOURCE_ISSUED_AUTHORITY_TRANSFER_CLAIMANT_PHASES.includes(phase as never)
+  ) throw new TypeError('Invalid authority-transfer claimant phase');
   const status = decodeCollabAuthorityTransferStatus(source.status);
   if (
     status.projectId !== source.projectId
@@ -123,56 +216,16 @@ export function decodeAuthorityTransferClaimantRecord(
     || status.phase !== 'completed'
     || status.relinquishmentProof === null
   ) throw new TypeError('Invalid authority-transfer claimant status');
-  const lanTargetValue = source.lanTarget;
-  let lanTarget: AuthorityTransferClaimantLanTarget | null = null;
-  if (lanTargetValue !== null) {
-    if (
-      !lanTargetValue
-      || typeof lanTargetValue !== 'object'
-      || Array.isArray(lanTargetValue)
-      || Object.keys(lanTargetValue).length !== LAN_TARGET_KEYS.size
-      || Object.keys(lanTargetValue).some(key => !LAN_TARGET_KEYS.has(key))
-    ) throw new TypeError('Invalid authority-transfer claimant LAN target');
-    const candidate = lanTargetValue as Readonly<Record<string, unknown>>;
-    if (
-      typeof candidate.caCertificatePem !== 'string'
-      || candidate.caCertificatePem.length > 64 * 1024
-      || !candidate.caCertificatePem.includes('-----BEGIN CERTIFICATE-----')
-      || !candidate.caCertificatePem.includes('-----END CERTIFICATE-----')
-      || candidate.caCertificatePem.includes('PRIVATE KEY')
-      || typeof candidate.caFingerprint !== 'string'
-      || !FINGERPRINT_PATTERN.test(candidate.caFingerprint)
-      || typeof candidate.endpoint !== 'string'
-      || candidate.endpoint !== status.targetUrl
-    ) throw new TypeError('Invalid authority-transfer claimant LAN target');
-    lanTarget = Object.freeze({
-      caCertificatePem: candidate.caCertificatePem,
-      caFingerprint: candidate.caFingerprint.replaceAll(':', '').toLocaleLowerCase('en-US'),
-      endpoint: candidate.endpoint,
-    });
-  }
+  const lanTarget = decodeLanTarget(source.lanTarget, status);
   if ((status.direction === 'cloud-to-lan') !== (lanTarget !== null)) {
     throw new TypeError('Invalid authority-transfer claimant LAN target direction');
   }
   const claim = source.claim === null
     ? null
     : decodeCollabTransferredMembershipClaim(source.claim);
-  const credential = source.targetCredential;
-  const targetCredential = credential === null
-    ? null
-    : typeof credential === 'string'
-      && CREDENTIAL_PATTERN.test(credential)
-      && Buffer.from(credential, 'base64url').byteLength === 32
-      && Buffer.from(credential, 'base64url').toString('base64url') === credential
-      ? credential
-      : undefined;
-  if (targetCredential === undefined) {
-    throw new TypeError('Invalid authority-transfer claimant credential');
-  }
-  const redemptionReceipt = source.redemptionReceipt === null
-    ? null
-    : decodeCollabTransferredMembershipRedemptionReceipt(source.redemptionReceipt);
-  const index = phaseIndex(phase as AuthorityTransferClaimantPhase);
+  const targetCredential = decodeCredential(source.targetCredential);
+  const redemptionReceipt = decodeReceipt(source.redemptionReceipt);
+  const index = SOURCE_ISSUED_AUTHORITY_TRANSFER_CLAIMANT_PHASES.indexOf(phase as never);
   if (
     (index >= 1) !== (claim !== null)
     || (status.targetAuthority.kind === 'lan' && index >= 2) !== (targetCredential !== null)
@@ -202,20 +255,128 @@ export function decodeAuthorityTransferClaimantRecord(
   ) throw new TypeError('Invalid authority-transfer claimant progress');
   return Object.freeze({
     claim,
-    createdAt: source.createdAt,
+    createdAt: source.createdAt as CollabIsoTimestamp,
     kind: 'authority-transfer-claimant',
     lanTarget,
-    memberId: source.memberId,
-    operationIntentId: source.operationIntentId,
-    phase: phase as AuthorityTransferClaimantPhase,
+    memberId: source.memberId as CollabMemberId,
+    operationIntentId: source.operationIntentId as string,
+    phase: phase as SourceIssuedAuthorityTransferClaimantPhase,
     projectId: source.projectId,
     redemptionReceipt,
     schemaVersion: AUTHORITY_TRANSFER_CLAIMANT_RECORD_SCHEMA_VERSION,
     status,
     targetCredential,
     transferId: source.transferId,
-    updatedAt: source.updatedAt,
+    updatedAt: source.updatedAt as CollabIsoTimestamp,
+    variant: 'source-issued',
   });
+}
+
+function decodeManagerReissuedRecord(
+  source: Readonly<Record<string, unknown>>,
+): ManagerReissuedAuthorityTransferClaimantRecord {
+  assertKeys(source, MANAGER_KEYS);
+  assertBase(source);
+  const phase = source.phase;
+  if (
+    typeof phase !== 'string'
+    || !MANAGER_REISSUED_AUTHORITY_TRANSFER_CLAIMANT_PHASES.includes(phase as never)
+  ) throw new TypeError('Invalid authority-transfer claimant phase');
+  const descriptor = collabControlOperationCodec(
+    'reissueTransferredMembershipClaim',
+  ).decodeResponse(source.descriptor);
+  const redemptionRequest = decodeCollabAuthorityTransferOperationRequest(
+    'claimTransferredMembership',
+    source.redemptionRequest,
+  );
+  if (typeof source.serverUrl !== 'string') {
+    throw new TypeError('Invalid Manager-reissued authority-transfer claimant endpoint');
+  }
+  const serverUrl = validateCloudServerUrl(source.serverUrl, 'serverUrl');
+  const targetStatus = source.targetStatus === null
+    ? null
+    : decodeCollabAuthorityTransferStatus(source.targetStatus);
+  const redemptionReceipt = decodeReceipt(source.redemptionReceipt);
+  const convergenceProof = decodeConvergenceProof(source.convergenceProof);
+  const index = MANAGER_REISSUED_AUTHORITY_TRANSFER_CLAIMANT_PHASES.indexOf(phase as never);
+  if (
+    typeof source.memberPersonalRef !== 'string'
+    || source.memberPersonalRef.length === 0
+    || Buffer.byteLength(source.memberPersonalRef, 'utf8') > 1024
+    || descriptor.createdAt !== source.createdAt
+    || descriptor.projectId !== source.projectId
+    || descriptor.memberId !== source.memberId
+    || descriptor.transferId !== source.transferId
+    || Date.parse(descriptor.expiresAt) <= Date.parse(descriptor.createdAt)
+    || Date.parse(descriptor.secretReplayExpiresAt) < Date.parse(descriptor.expiresAt)
+    || redemptionRequest.projectId !== descriptor.projectId
+    || redemptionRequest.transferId !== descriptor.transferId
+    || redemptionRequest.idempotencyKey !== source.operationIntentId
+    || redemptionRequest.claim !== descriptor.claim
+    || ('credentialHash' in redemptionRequest && redemptionRequest.credentialHash !== undefined)
+    || (index === 0 && (redemptionReceipt !== null || targetStatus !== null || convergenceProof !== null))
+    || (index === 1 && (redemptionReceipt === null || targetStatus !== null || convergenceProof !== null))
+    || (index >= 2 && targetStatus === null)
+    || (index >= 2 && convergenceProof !== 'receipt' && convergenceProof !== 'existing-binding')
+    || (convergenceProof === 'receipt' && redemptionReceipt === null)
+    || (convergenceProof === 'existing-binding' && redemptionReceipt !== null)
+    || (redemptionReceipt !== null && (
+      redemptionReceipt.memberId !== descriptor.memberId
+      || redemptionReceipt.projectId !== descriptor.projectId
+      || redemptionReceipt.transferId !== descriptor.transferId
+      || redemptionReceipt.targetAuthorityGeneration !== descriptor.targetAuthorityGeneration
+      || redemptionReceipt.operationIntentId !== source.operationIntentId
+      || Date.parse(redemptionReceipt.redeemedAt) < Date.parse(descriptor.createdAt)
+      || Date.parse(redemptionReceipt.redeemedAt) >= Date.parse(descriptor.expiresAt)
+      || redemptionReceipt.claimSha256 !== createHash('sha256')
+        .update(descriptor.claim, 'utf8')
+        .digest('hex')
+    ))
+    || (targetStatus !== null && (
+      targetStatus.direction !== 'lan-to-cloud'
+      || targetStatus.phase !== 'completed'
+      || targetStatus.state !== 'completed'
+      || targetStatus.relinquishmentProof === null
+      || targetStatus.projectId !== descriptor.projectId
+      || targetStatus.transferId !== descriptor.transferId
+      || targetStatus.targetAuthority.kind !== 'cloud'
+      || targetStatus.targetAuthority.generation !== descriptor.targetAuthorityGeneration
+      || validateCloudServerUrl(targetStatus.targetUrl, 'targetUrl') !== serverUrl
+      || (redemptionReceipt !== null
+        && redemptionReceipt.checkpointSha256 !== targetStatus.checkpointSha256)
+    ))
+  ) throw new TypeError('Invalid Manager-reissued authority-transfer claimant progress');
+  return Object.freeze({
+    convergenceProof,
+    createdAt: source.createdAt,
+    descriptor,
+    kind: 'authority-transfer-claimant',
+    memberId: source.memberId,
+    memberPersonalRef: source.memberPersonalRef,
+    operationIntentId: source.operationIntentId,
+    phase: phase as ManagerReissuedAuthorityTransferClaimantPhase,
+    projectId: source.projectId,
+    redemptionReceipt,
+    redemptionRequest,
+    schemaVersion: AUTHORITY_TRANSFER_CLAIMANT_RECORD_SCHEMA_VERSION,
+    serverUrl,
+    targetStatus,
+    transferId: source.transferId,
+    updatedAt: source.updatedAt as CollabIsoTimestamp,
+    variant: 'manager-reissued',
+  });
+}
+
+export function decodeAuthorityTransferClaimantRecord(
+  value: unknown,
+): AuthorityTransferClaimantRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError('Invalid authority-transfer claimant record');
+  }
+  const source = value as Readonly<Record<string, unknown>>;
+  if (source.variant === 'source-issued') return decodeSourceIssuedRecord(source);
+  if (source.variant === 'manager-reissued') return decodeManagerReissuedRecord(source);
+  throw new TypeError('Invalid authority-transfer claimant variant');
 }
 
 export function createAuthorityTransferClaimantRecord(input: {
@@ -224,7 +385,7 @@ export function createAuthorityTransferClaimantRecord(input: {
   readonly memberId: CollabMemberId;
   readonly operationIntentId: string;
   readonly status: CollabAuthorityTransferStatus;
-}): AuthorityTransferClaimantRecord {
+}): SourceIssuedAuthorityTransferClaimantRecord {
   return decodeAuthorityTransferClaimantRecord({
     claim: null,
     createdAt: input.createdAt,
@@ -240,21 +401,84 @@ export function createAuthorityTransferClaimantRecord(input: {
     targetCredential: null,
     transferId: input.status.transferId,
     updatedAt: input.createdAt,
-  });
+    variant: 'source-issued',
+  }) as SourceIssuedAuthorityTransferClaimantRecord;
+}
+
+export function createManagerReissuedAuthorityTransferClaimantRecord(input: {
+  readonly descriptor: ReissueTransferredMembershipClaimResponse;
+  readonly memberPersonalRef: string;
+  readonly operationIntentId: string;
+  readonly serverUrl: string;
+}): ManagerReissuedAuthorityTransferClaimantRecord {
+  return decodeAuthorityTransferClaimantRecord({
+    convergenceProof: null,
+    createdAt: input.descriptor.createdAt,
+    descriptor: input.descriptor,
+    kind: 'authority-transfer-claimant',
+    memberId: input.descriptor.memberId,
+    memberPersonalRef: input.memberPersonalRef,
+    operationIntentId: input.operationIntentId,
+    phase: 'redemption-prepared',
+    projectId: input.descriptor.projectId,
+    redemptionReceipt: null,
+    redemptionRequest: {
+      claim: input.descriptor.claim,
+      idempotencyKey: input.operationIntentId,
+      projectId: input.descriptor.projectId,
+      transferId: input.descriptor.transferId,
+    },
+    schemaVersion: AUTHORITY_TRANSFER_CLAIMANT_RECORD_SCHEMA_VERSION,
+    serverUrl: input.serverUrl,
+    targetStatus: null,
+    transferId: input.descriptor.transferId,
+    updatedAt: input.descriptor.createdAt,
+    variant: 'manager-reissued',
+  }) as ManagerReissuedAuthorityTransferClaimantRecord;
 }
 
 export function advanceAuthorityTransferClaimantRecord(
+  previous: SourceIssuedAuthorityTransferClaimantRecord,
+  update: AuthorityTransferClaimantRecordUpdate,
+): SourceIssuedAuthorityTransferClaimantRecord;
+export function advanceAuthorityTransferClaimantRecord(
+  previous: ManagerReissuedAuthorityTransferClaimantRecord,
+  update: AuthorityTransferClaimantRecordUpdate,
+): ManagerReissuedAuthorityTransferClaimantRecord;
+export function advanceAuthorityTransferClaimantRecord(
   previous: AuthorityTransferClaimantRecord,
-  update: Partial<Pick<
-    AuthorityTransferClaimantRecord,
-    'claim' | 'redemptionReceipt' | 'targetCredential'
-  >> & {
-    readonly phase: AuthorityTransferClaimantPhase;
-    readonly updatedAt: CollabIsoTimestamp;
-  },
+  update: AuthorityTransferClaimantRecordUpdate,
 ): AuthorityTransferClaimantRecord {
-  if (phaseIndex(update.phase) !== phaseIndex(previous.phase) + 1) {
+  const phases: readonly AuthorityTransferClaimantPhase[] = previous.variant === 'source-issued'
+    ? SOURCE_ISSUED_AUTHORITY_TRANSFER_CLAIMANT_PHASES
+    : MANAGER_REISSUED_AUTHORITY_TRANSFER_CLAIMANT_PHASES;
+  const isExistingBindingRecovery = previous.variant === 'manager-reissued'
+    && previous.phase === 'redemption-prepared'
+    && update.phase === 'target-confirmed'
+    && update.convergenceProof === 'existing-binding'
+    && update.targetStatus !== null
+    && update.targetStatus !== undefined;
+  if (
+    !isExistingBindingRecovery
+    && phases.indexOf(update.phase) !== phases.indexOf(previous.phase) + 1
+  ) {
     throw new TypeError('Authority-transfer claimant phase is stale');
   }
   return decodeAuthorityTransferClaimantRecord({ ...previous, ...update });
+}
+
+interface AuthorityTransferClaimantRecordUpdate {
+  readonly claim?: CollabTransferredMembershipClaim | null;
+  readonly convergenceProof?: 'receipt' | 'existing-binding' | null;
+  readonly phase: AuthorityTransferClaimantPhase;
+  readonly redemptionReceipt?: CollabTransferredMembershipRedemptionReceipt | null;
+  readonly targetCredential?: string | null;
+  readonly targetStatus?: CollabAuthorityTransferStatus | null;
+  readonly updatedAt: CollabIsoTimestamp;
+}
+
+export function authorityTransferClaimantStatus(
+  record: AuthorityTransferClaimantRecord,
+): CollabAuthorityTransferStatus | null {
+  return record.variant === 'source-issued' ? record.status : record.targetStatus;
 }

--- a/src/app/collab/authority-transfer/claim/AuthorityTransferClaimantRecovery.ts
+++ b/src/app/collab/authority-transfer/claim/AuthorityTransferClaimantRecovery.ts
@@ -31,6 +31,7 @@ export function authorityTransferClaimantRequiresSource(
   record: AuthorityTransferClaimantRecord,
   now: Date,
 ): boolean {
+  if (record.variant === 'manager-reissued') return false;
   if (
     record.phase === 'prepared'
     || record.phase === 'claim-retained'
@@ -45,6 +46,7 @@ function requiresNoRuntime(
   now: Date,
 ): boolean {
   if (record.phase === 'completed' || record.phase === 'membership-converged') return true;
+  if (record.variant === 'manager-reissued') return false;
   if (now.getTime() < Date.parse(record.status.expiresAt)) return false;
   return record.phase === 'prepared'
     || record.phase === 'claim-retained'

--- a/tests/helpers/collab/CollabFeatureTestHarness.ts
+++ b/tests/helpers/collab/CollabFeatureTestHarness.ts
@@ -137,6 +137,7 @@ function defaultAuthorityTransfer(): CollabAuthorityTransferEntryPort {
     close: () => Promise.resolve(),
     observeCloudToLanTransfer: () => unexpected('observeCloudToLanTransfer'),
     prepareCloudToLanTarget: () => unexpected('prepareCloudToLanTarget'),
+    redeemManagerReissuedClaim: () => unexpected('redeemManagerReissuedClaim'),
     withdrawCloudToLanTarget: () => unexpected('withdrawCloudToLanTarget'),
   };
 }

--- a/tests/integration/app/collab/gates/LocalProjectMilestoneGate.test.ts
+++ b/tests/integration/app/collab/gates/LocalProjectMilestoneGate.test.ts
@@ -42,6 +42,9 @@ import {
 } from '@/app/collab/authority-transfer/persistence/AuthorityTransferClaimCustodyRecord';
 import { InvitationCodec } from '@/app/collab/lan/InvitationCodec';
 import { listPrivateIpv4Addresses } from '@/app/collab/lan/LanHostCoordinator';
+import {
+  encodeCloudMembershipClaimInvitation,
+} from '@/app/collab/project/CloudProjectInvitation';
 import type {
   CloudAuthorityConnection,
 } from '@/app/collab/remote-authority/CloudAuthorityAdapter';
@@ -661,6 +664,185 @@ describe('G3 local Project milestone gate', () => {
       await reopenedFoundation.close();
     },
   );
+
+  it('redeems a Manager-reissued claim after original source expiry through the real local transition lane', async () => {
+    const foundation = createFoundation();
+    const setup = new CollabProjectSetupService(foundation, {
+      installationKey: TEST_INSTALLATION_A,
+      createCredential: () => CREDENTIAL,
+      createId: kind => {
+        if (kind === 'member') return MEMBER_ID;
+        if (kind === 'operation') return OPERATION_ID;
+        return PROJECT_ID;
+      },
+      now: () => new Date('2026-08-08T00:00:00.000Z'),
+      vaultRoot,
+    });
+    const transferId = 'transfer-manager-reissued-gate';
+    const checkpointSha256 = 'e'.repeat(64);
+    const claimValue = Buffer.alloc(32, 6).toString('base64url');
+    const status: CollabAuthorityTransferStatus = {
+      batchRevision: 1,
+      batchSha256: 'b'.repeat(64),
+      checkpointSha256,
+      createdAt: '2026-08-01T00:00:00.000Z',
+      direction: 'lan-to-cloud',
+      expiresAt: '2026-08-31T00:00:00.000Z',
+      phase: 'completed',
+      projectId: PROJECT_ID,
+      relinquishmentProof: {
+        batchRevision: 1,
+        batchSha256: 'b'.repeat(64),
+        certificate: Buffer.alloc(64, 2).toString('base64url'),
+        certificateAlgorithm: 'ed25519',
+        checkpointSha256,
+        committedAt: '2026-08-01T00:00:08.000Z',
+        operationIntentId: 'intent-manager-reissued-source',
+        projectId: PROJECT_ID,
+        sourceAuthority: { generation: 1, kind: 'lan' },
+        sourceHostMemberId: MEMBER_ID,
+        targetAuthority: { generation: 2, kind: 'cloud' },
+        transferId,
+      },
+      sourceAuthority: { generation: 1, kind: 'lan' },
+      state: 'completed',
+      targetAuthority: { generation: 2, kind: 'cloud' },
+      targetUrl: 'https://cloud.example.test/',
+      transferId,
+      updatedAt: '2026-08-01T00:00:10.000Z',
+    };
+    const descriptor = {
+      claim: claimValue,
+      claimGeneration: 4,
+      createdAt: '2026-09-01T00:00:00.000Z',
+      expiresAt: '2026-10-01T00:00:00.000Z',
+      memberId: MEMBER_ID,
+      projectId: PROJECT_ID,
+      secretReplayExpiresAt: '2026-10-01T00:00:00.000Z',
+      targetAuthorityGeneration: 2,
+      transferId,
+    };
+    let repositoryHead = '';
+    const readSnapshot = jest.fn(async (): Promise<CollabCloudProjectSnapshot> => ({
+      currentMember: {
+        activatedAt: '2026-08-01T00:00:00.000Z',
+        createdAt: '2026-08-01T00:00:00.000Z',
+        displayName: 'Alice',
+        id: MEMBER_ID,
+        personalRef: `refs/heads/members/${MEMBER_ID}`,
+        role: 'manager',
+        status: 'active',
+      },
+      eventSequence: 11,
+      members: [],
+      openRequests: [],
+      openTicketCount: 0,
+      project: {
+        authorityGeneration: 2,
+        authorityKind: 'cloud',
+        createdAt: '2026-08-08T00:00:00.000Z',
+        id: PROJECT_ID,
+        mainOid: repositoryHead,
+        mainRef: 'refs/heads/main',
+        name: 'M2 Notes',
+      },
+      ticketHighlights: [],
+    }));
+    const authorityTransfer = jest.fn(async (
+      operation: string,
+      request: Readonly<{ readonly idempotencyKey?: string }>,
+    ) => operation === 'claimTransferredMembership'
+      ? {
+          checkpointSha256,
+          claimSha256: createHash('sha256').update(claimValue, 'utf8').digest('hex'),
+          memberId: MEMBER_ID,
+          operationIntentId: request.idempotencyKey!,
+          projectId: PROJECT_ID,
+          receiptId: 'receipt-manager-reissued-gate',
+          receiptKeyId: 'receipt-key-manager-reissued-gate',
+          redeemedAt: '2026-09-02T00:00:00.000Z',
+          signature: Buffer.alloc(64, 3).toString('base64url'),
+          signatureAlgorithm: 'ed25519',
+          targetAuthorityGeneration: 2,
+          transferId,
+        }
+      : status);
+    const cloudSession = {
+      dispose: jest.fn(),
+      lifecycle: { authorityTransfer },
+      projectId: PROJECT_ID,
+      readSnapshot,
+      serverUrl: 'https://cloud.example.test/',
+      supports: (capability: string) => (
+        capability === 'authority-transfer' || capability === 'project-snapshot'
+      ),
+    } as unknown as CloudAuthorityConnection;
+    const subcomposition = createCollabFeatureSubcomposition({
+      cloudAuthority: {
+        authorityKind: 'cloud',
+        create: jest.fn() as never,
+        connect: jest.fn(async () => cloudSession),
+      },
+      foundation,
+      projectSetup: setup,
+      vaultRoot,
+    });
+    try {
+      await expect(subcomposition.feature.initialize()).resolves.toMatchObject({
+        status: 'success',
+      });
+      await expect(subcomposition.feature.createProject({
+        memberDisplayName: 'Alice',
+        name: 'M2 Notes',
+      })).resolves.toMatchObject({ status: 'success' });
+      await foundation.lanHost.stopProject(PROJECT_ID);
+      const membership = await foundation.local.projects.loadMembership(PROJECT_ID);
+      if (!membership || membership.authority.kind !== 'lan') {
+        throw new Error('Expected initial LAN membership');
+      }
+      await foundation.local.projects.saveMembership({
+        ...membership,
+        hostOwnership: { ownsAuthority: false },
+      });
+      const repositoryPath = path.join(vaultRoot, 'workspace', 'm2-notes');
+      repositoryHead = git(repositoryPath, ['rev-parse', 'HEAD']);
+
+      await expect(subcomposition.feature.reconnectProject({
+        encodedInvitation: encodeCloudMembershipClaimInvitation({
+          claim: descriptor,
+          serverUrl: 'https://cloud.example.test/',
+        }),
+        projectId: PROJECT_ID,
+      })).resolves.toMatchObject({
+        status: 'success',
+        value: { authorityKind: 'cloud', id: PROJECT_ID },
+      });
+
+      await expect(foundation.local.projects.loadMembership(PROJECT_ID)).resolves.toMatchObject({
+        authority: {
+          authorityGeneration: 2,
+          kind: 'cloud',
+          serverUrl: 'https://cloud.example.test/',
+        },
+        member: { id: MEMBER_ID, personalRef: `refs/heads/members/${MEMBER_ID}` },
+      });
+      expect(git(repositoryPath, ['remote', 'get-url', 'origin'])).toBe(
+        `https://cloud.example.test/v3/projects/${PROJECT_ID}/repository.git`,
+      );
+      await expect(
+        foundation.local.projects.authorityTransferClaimants.load(PROJECT_ID),
+      ).resolves.toBeNull();
+      expect(authorityTransfer.mock.calls.map(([operation]) => operation)).toEqual([
+        'claimTransferredMembership',
+        'getProjectAuthorityTransfer',
+      ]);
+      expect(readSnapshot).toHaveBeenCalledTimes(2);
+      expect(cloudSession.dispose).toHaveBeenCalledTimes(1);
+    } finally {
+      await subcomposition.feature.close();
+      await foundation.close();
+    }
+  });
 
   it('finishes expired terminal-source staging cleanup after restart', async () => {
     const foundation = createFoundation();

--- a/tests/unit/app/collab/CollabFeatureService.test.ts
+++ b/tests/unit/app/collab/CollabFeatureService.test.ts
@@ -28,6 +28,9 @@ import {
 import type { CollabLocalProjectIndex } from '@/app/collab/CollabLocalProjectRepository';
 import { COLLAB_LOCAL_PROJECT_SCHEMA_VERSION } from '@/app/collab/CollabSchemaVersions';
 import { CollabProjectLifecycleSubsystem } from '@/app/collab/lifecycle/CollabProjectLifecycleSubsystem';
+import {
+  encodeCloudMembershipClaimInvitation,
+} from '@/app/collab/project/CloudProjectInvitation';
 import type { CollabLanProjectSnapshot } from '@/core/collab';
 import { type CollabPublishOutcome, type CollabResult } from '@/core/collab';
 import { CollabError } from '@/core/collab/ClaudianCollabError';
@@ -1459,6 +1462,48 @@ describe('CollabFeatureService', () => {
     expect(publish.reconnectProject).toHaveBeenCalledWith(request, {
       signal: expect.any(AbortSignal),
     });
+    expect(service.state.activeOperation).toBeUndefined();
+  });
+
+  it('routes an imported Cloud claim through claimant convergence instead of ordinary reconnect or Join', async () => {
+    const publish = publication();
+    const claim = {
+      claim: Buffer.alloc(32, 4).toString('base64url'),
+      claimGeneration: 4,
+      createdAt: '2026-10-01T00:00:00.000Z',
+      expiresAt: '2026-10-31T00:00:00.000Z',
+      memberId: 'member-host',
+      projectId: 'project-alpha',
+      secretReplayExpiresAt: '2026-10-31T00:00:00.000Z',
+      targetAuthorityGeneration: 2,
+      transferId: 'transfer-manager-reissued',
+    };
+    const invitation = {
+      claim,
+      kind: 'cloud-membership-claim' as const,
+      serverUrl: 'https://cloud.example.test/',
+    };
+    const authorityTransfer = {
+      redeemManagerReissuedClaim: jest.fn(async () => undefined),
+    };
+    const service = createService({ authorityTransfer, publication: publish });
+
+    await expect(service.reconnectProject({
+      encodedInvitation: encodeCloudMembershipClaimInvitation({
+        claim: invitation.claim,
+        serverUrl: invitation.serverUrl,
+      }),
+      projectId: 'project-alpha',
+    })).resolves.toMatchObject({
+      status: 'success',
+      value: { id: 'project-alpha' },
+    });
+
+    expect(authorityTransfer.redeemManagerReissuedClaim).toHaveBeenCalledWith(
+      invitation,
+      { signal: expect.any(AbortSignal) },
+    );
+    expect(publish.reconnectProject).not.toHaveBeenCalled();
     expect(service.state.activeOperation).toBeUndefined();
   });
 

--- a/tests/unit/app/collab/authority-transfer/AuthorityTransferClaimantCoordinator.test.ts
+++ b/tests/unit/app/collab/authority-transfer/AuthorityTransferClaimantCoordinator.test.ts
@@ -5,6 +5,7 @@ import type {
   CollabAuthorityTransferStatus,
   CollabTransferredMembershipClaim,
   CollabTransferredMembershipRedemptionReceipt,
+  ReissueTransferredMembershipClaimResponse,
 } from '@claudian-collab/protocol';
 
 import {
@@ -17,8 +18,10 @@ import type {
 import {
   advanceAuthorityTransferClaimantRecord,
   createAuthorityTransferClaimantRecord,
+  createManagerReissuedAuthorityTransferClaimantRecord,
   decodeAuthorityTransferClaimantRecord,
 } from '@/app/collab/authority-transfer/claim/AuthorityTransferClaimantRecord';
+import { CollabError } from '@/core/collab/ClaudianCollabError';
 
 const PROJECT_ID = 'project-claimant';
 const TRANSFER_ID = 'transfer-claimant';
@@ -82,6 +85,16 @@ function claim(): CollabTransferredMembershipClaim {
   };
 }
 
+function reissuedClaim(): ReissueTransferredMembershipClaimResponse {
+  return {
+    ...claim(),
+    claimGeneration: 4,
+    createdAt: '2026-10-01T00:00:00.000Z',
+    expiresAt: '2026-10-31T00:00:00.000Z',
+    secretReplayExpiresAt: '2026-10-31T00:00:00.000Z',
+  };
+}
+
 function receipt(): CollabTransferredMembershipRedemptionReceipt {
   return {
     checkpointSha256: CHECKPOINT_SHA256,
@@ -127,6 +140,364 @@ class MemoryStore implements AuthorityTransferClaimantStore {
 }
 
 describe('AuthorityTransferClaimantCoordinator', () => {
+  it('persists a Manager-reissued descriptor and exact request before target redemption without resolving the source', async () => {
+    const store = new MemoryStore();
+    const source = {
+      acknowledgeRedemption: jest.fn(),
+      getClaim: jest.fn(),
+    };
+    const targetStatus = completed('lan-to-cloud');
+    const claimTarget = jest.fn(async (
+      record: AuthorityTransferClaimantRecord,
+      request: ClaimTransferredMembershipRequest,
+    ) => {
+      expect(store.record).toEqual(record);
+      expect(record).toMatchObject({
+        descriptor: reissuedClaim(),
+        phase: 'redemption-prepared',
+        redemptionRequest: request,
+        variant: 'manager-reissued',
+      });
+      return {
+        ...receipt(),
+        redeemedAt: '2026-10-01T00:01:00.000Z',
+      };
+    });
+    const confirmTargetBinding = jest.fn(async (
+      record: AuthorityTransferClaimantRecord,
+      proof: 'receipt' | 'existing-binding',
+    ) => {
+      expect(proof).toBe('receipt');
+      expect(store.record).toEqual(record);
+      expect(record).toMatchObject({
+        phase: 'target-claimed',
+        redemptionReceipt: { receiptId: 'receipt-claimant' },
+      });
+      return targetStatus;
+    });
+    const converge = jest.fn(async (record: AuthorityTransferClaimantRecord) => {
+      expect(store.record).toEqual(record);
+      expect(record).toMatchObject({
+        convergenceProof: 'receipt',
+        phase: 'target-confirmed',
+        targetStatus,
+      });
+    });
+    const coordinator = new AuthorityTransferClaimantCoordinator({
+      convergence: { converge },
+      now: () => new Date('2026-10-01T00:00:10.000Z'),
+      source,
+      store,
+      target: { claimTransferredMembership: claimTarget, confirmTargetBinding },
+    });
+
+    await coordinator.startManagerReissued({
+      descriptor: reissuedClaim(),
+      memberPersonalRef: 'refs/heads/members/member-offline',
+      operationIntentId: INTENT_ID,
+      serverUrl: 'https://cloud.example.test/',
+    });
+
+    expect(store.phases).toEqual([
+      'redemption-prepared',
+      'target-claimed',
+      'target-confirmed',
+      'membership-converged',
+      'completed',
+    ]);
+    expect(store.record).toBeNull();
+    expect(source.getClaim).not.toHaveBeenCalled();
+    expect(source.acknowledgeRedemption).not.toHaveBeenCalled();
+    expect(claimTarget).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: 'manager-reissued' }),
+      {
+        claim: CLAIM_VALUE,
+        idempotencyKey: INTENT_ID,
+        projectId: PROJECT_ID,
+        transferId: TRANSFER_ID,
+      },
+      expect.any(Object),
+    );
+  });
+
+  it('persists Manager-reissued progress when the client clock lags the Cloud descriptor', async () => {
+    const store = new MemoryStore();
+    const coordinator = new AuthorityTransferClaimantCoordinator({
+      convergence: { converge: jest.fn(async () => undefined) },
+      now: () => new Date('2026-09-30T23:59:00.000Z'),
+      store,
+      target: {
+        claimTransferredMembership: jest.fn(async () => ({
+          ...receipt(),
+          redeemedAt: '2026-10-01T00:01:00.000Z',
+        })),
+        confirmTargetBinding: jest.fn(async () => completed('lan-to-cloud')),
+      },
+    });
+
+    await coordinator.startManagerReissued({
+      descriptor: reissuedClaim(),
+      memberPersonalRef: 'refs/heads/members/member-offline',
+      operationIntentId: INTENT_ID,
+      serverUrl: 'https://cloud.example.test/',
+    });
+
+    expect(store.phases).toEqual([
+      'redemption-prepared',
+      'target-claimed',
+      'target-confirmed',
+      'membership-converged',
+      'completed',
+    ]);
+    expect(store.record).toBeNull();
+  });
+
+  it('uses only authenticated existing-binding confirmation after a Manager reissue expires', async () => {
+    const store = new MemoryStore();
+    const claimTarget = jest.fn();
+    const confirmTargetBinding = jest.fn(async (
+      record: AuthorityTransferClaimantRecord,
+      proof: 'receipt' | 'existing-binding',
+    ) => {
+      expect(proof).toBe('existing-binding');
+      expect(record).toMatchObject({
+        phase: 'redemption-prepared',
+        redemptionReceipt: null,
+        variant: 'manager-reissued',
+      });
+      return completed('lan-to-cloud');
+    });
+    const converge = jest.fn(async (record: AuthorityTransferClaimantRecord) => {
+      expect(record).toMatchObject({
+        convergenceProof: 'existing-binding',
+        phase: 'target-confirmed',
+        redemptionReceipt: null,
+      });
+    });
+    const coordinator = new AuthorityTransferClaimantCoordinator({
+      convergence: { converge },
+      now: () => new Date(reissuedClaim().expiresAt),
+      store,
+      target: { claimTransferredMembership: claimTarget, confirmTargetBinding },
+    });
+
+    await coordinator.startManagerReissued({
+      descriptor: reissuedClaim(),
+      memberPersonalRef: 'refs/heads/members/member-offline',
+      operationIntentId: INTENT_ID,
+      serverUrl: 'https://cloud.example.test/',
+    });
+
+    expect(claimTarget).not.toHaveBeenCalled();
+    expect(confirmTargetBinding).toHaveBeenCalledTimes(1);
+    expect(converge).toHaveBeenCalledTimes(1);
+    expect(store.record).toBeNull();
+  });
+
+  it('finishes a target-confirmed Manager reissue locally without a target confirmation port', async () => {
+    const store = new MemoryStore();
+    const prepared = createManagerReissuedAuthorityTransferClaimantRecord({
+      descriptor: reissuedClaim(),
+      memberPersonalRef: 'refs/heads/members/member-offline',
+      operationIntentId: INTENT_ID,
+      serverUrl: 'https://cloud.example.test/',
+    });
+    const claimed = advanceAuthorityTransferClaimantRecord(prepared, {
+      phase: 'target-claimed',
+      redemptionReceipt: {
+        ...receipt(),
+        redeemedAt: '2026-10-01T00:01:00.000Z',
+      },
+      updatedAt: '2026-10-01T00:01:00.000Z',
+    });
+    store.record = advanceAuthorityTransferClaimantRecord(claimed, {
+      convergenceProof: 'receipt',
+      phase: 'target-confirmed',
+      targetStatus: completed('lan-to-cloud'),
+      updatedAt: '2026-10-01T00:02:00.000Z',
+    });
+    const converge = jest.fn(async () => undefined);
+    const coordinator = new AuthorityTransferClaimantCoordinator({
+      convergence: { converge },
+      now: () => new Date('2026-10-01T00:03:00.000Z'),
+      store,
+      target: { claimTransferredMembership: jest.fn() },
+    });
+
+    await coordinator.resume(PROJECT_ID);
+
+    expect(converge).toHaveBeenCalledWith(
+      expect.objectContaining({ phase: 'target-confirmed', variant: 'manager-reissued' }),
+      {},
+    );
+    expect(store.record).toBeNull();
+  });
+
+  it('keeps an expired ambiguous Manager reissue visibly recoverable when exact binding cannot be proved', async () => {
+    const store = new MemoryStore();
+    const coordinator = new AuthorityTransferClaimantCoordinator({
+      convergence: { converge: jest.fn() },
+      now: () => new Date(reissuedClaim().expiresAt),
+      store,
+      target: {
+        claimTransferredMembership: jest.fn(),
+        confirmTargetBinding: async () => {
+          throw new CollabError({
+            code: 'durable-progress-recovery-required',
+            safeContext: { reason: 'target-binding-not-proved' },
+          });
+        },
+      },
+    });
+
+    await expect(coordinator.startManagerReissued({
+      descriptor: reissuedClaim(),
+      memberPersonalRef: 'refs/heads/members/member-offline',
+      operationIntentId: INTENT_ID,
+      serverUrl: 'https://cloud.example.test/',
+    })).rejects.toMatchObject({ code: 'durable-progress-recovery-required' });
+
+    expect(store.record).toMatchObject({
+      convergenceProof: null,
+      phase: 'redemption-prepared',
+      redemptionReceipt: null,
+      variant: 'manager-reissued',
+    });
+  });
+
+  it('recovers a persisted Manager-reissued receipt forward after its own expiry', async () => {
+    const store = new MemoryStore();
+    const beforeExpiry = new AuthorityTransferClaimantCoordinator({
+      convergence: { converge: jest.fn() },
+      now: () => new Date('2026-10-01T00:00:10.000Z'),
+      store,
+      target: {
+        claimTransferredMembership: async () => ({
+          ...receipt(),
+          redeemedAt: '2026-10-01T00:01:00.000Z',
+        }),
+        confirmTargetBinding: async () => {
+          throw new Error('simulated local death after receipt persistence');
+        },
+      },
+    });
+    await expect(beforeExpiry.startManagerReissued({
+      descriptor: reissuedClaim(),
+      memberPersonalRef: 'refs/heads/members/member-offline',
+      operationIntentId: INTENT_ID,
+      serverUrl: 'https://cloud.example.test/',
+    })).rejects.toThrow('simulated local death after receipt persistence');
+    expect(store.record).toMatchObject({ phase: 'target-claimed' });
+
+    const converge = jest.fn(async () => undefined);
+    const afterExpiry = new AuthorityTransferClaimantCoordinator({
+      convergence: { converge },
+      now: () => new Date(reissuedClaim().expiresAt),
+      store,
+      target: {
+        claimTransferredMembership: jest.fn(),
+        confirmTargetBinding: async (_record, proof) => {
+          expect(proof).toBe('receipt');
+          return completed('lan-to-cloud');
+        },
+      },
+    });
+
+    await afterExpiry.resume(PROJECT_ID);
+
+    expect(converge).toHaveBeenCalledTimes(1);
+    expect(store.record).toBeNull();
+  });
+
+  it('replays the same private request after a lost Manager-reissued response', async () => {
+    const store = new MemoryStore();
+    const requests: ClaimTransferredMembershipRequest[] = [];
+    const descriptor = reissuedClaim();
+    const input = {
+      descriptor,
+      memberPersonalRef: 'refs/heads/members/member-offline',
+      serverUrl: 'https://cloud.example.test/',
+    };
+    const first = new AuthorityTransferClaimantCoordinator({
+      convergence: { converge: jest.fn() },
+      now: () => new Date('2026-10-01T00:00:10.000Z'),
+      store,
+      target: {
+        claimTransferredMembership: async (_record, request) => {
+          requests.push(request);
+          throw new Error('simulated lost response');
+        },
+        confirmTargetBinding: jest.fn(),
+      },
+    });
+    await expect(first.startManagerReissued(input)).rejects.toThrow('simulated lost response');
+    const frozenIntentId = store.record?.operationIntentId;
+    expect(frozenIntentId).toMatch(/^manager-reissued-[a-f0-9]{32}$/);
+
+    const second = new AuthorityTransferClaimantCoordinator({
+      convergence: { converge: async () => undefined },
+      now: () => new Date('2026-10-01T00:00:20.000Z'),
+      store,
+      target: {
+        claimTransferredMembership: async (_record, request) => {
+          requests.push(request);
+          return {
+            ...receipt(),
+            operationIntentId: request.idempotencyKey,
+            redeemedAt: '2026-10-01T00:01:00.000Z',
+          };
+        },
+        confirmTargetBinding: async () => completed('lan-to-cloud'),
+      },
+    });
+
+    await second.startManagerReissued(input);
+
+    expect(requests).toEqual([
+      {
+        claim: descriptor.claim,
+        idempotencyKey: frozenIntentId,
+        projectId: PROJECT_ID,
+        transferId: TRANSFER_ID,
+      },
+      {
+        claim: descriptor.claim,
+        idempotencyKey: frozenIntentId,
+        projectId: PROJECT_ID,
+        transferId: TRANSFER_ID,
+      },
+    ]);
+    expect(store.record).toBeNull();
+  });
+
+  it('retains a revoked Manager reissue without attempting existing-binding recovery before expiry', async () => {
+    const store = new MemoryStore();
+    const confirmTargetBinding = jest.fn();
+    const coordinator = new AuthorityTransferClaimantCoordinator({
+      convergence: { converge: jest.fn() },
+      now: () => new Date('2026-10-01T00:00:10.000Z'),
+      store,
+      target: {
+        claimTransferredMembership: async () => {
+          throw new CollabError({ code: 'invitation-revoked' });
+        },
+        confirmTargetBinding,
+      },
+    });
+
+    await expect(coordinator.startManagerReissued({
+      descriptor: reissuedClaim(),
+      memberPersonalRef: 'refs/heads/members/member-offline',
+      serverUrl: 'https://cloud.example.test/',
+    })).rejects.toMatchObject({ code: 'invitation-revoked' });
+
+    expect(store.record).toMatchObject({
+      phase: 'redemption-prepared',
+      variant: 'manager-reissued',
+    });
+    expect(confirmTargetBinding).not.toHaveBeenCalled();
+  });
+
   it('rejects a claim or redemption outside the exact transfer lifetime', () => {
     const value = {
       claim: claim(),
@@ -143,6 +514,7 @@ describe('AuthorityTransferClaimantCoordinator', () => {
       targetCredential: null,
       transferId: TRANSFER_ID,
       updatedAt: '2026-08-27T00:02:00.000Z',
+      variant: 'source-issued',
     };
 
     expect(() => decodeAuthorityTransferClaimantRecord({

--- a/tests/unit/app/collab/authority-transfer/AuthorityTransferLocalConvergence.test.ts
+++ b/tests/unit/app/collab/authority-transfer/AuthorityTransferLocalConvergence.test.ts
@@ -200,6 +200,7 @@ describe('AuthorityTransferLocalConvergence', () => {
       projectId: PROJECT_ID,
       status: input.status,
       targetCredential: null,
+      variant: 'source-issued',
     } as AuthorityTransferClaimantRecord);
 
     expect(membership).toMatchObject({
@@ -421,6 +422,7 @@ describe('AuthorityTransferLocalConvergence', () => {
       projectId: PROJECT_ID,
       status: completed('cloud-to-lan'),
       targetCredential: credential,
+      variant: 'source-issued',
     } as AuthorityTransferClaimantRecord);
 
     expect(membership).toMatchObject({

--- a/tests/unit/app/collab/authority-transfer/AuthorityTransferModule.test.ts
+++ b/tests/unit/app/collab/authority-transfer/AuthorityTransferModule.test.ts
@@ -23,9 +23,12 @@ import {
   AuthorityTransferClaimantBindingResolver,
 } from '@/app/collab/authority-transfer/claim/AuthorityTransferClaimantBindingResolver';
 import {
-  type AuthorityTransferClaimantPhase,
+  advanceAuthorityTransferClaimantRecord,
   type AuthorityTransferClaimantRecord,
+  createManagerReissuedAuthorityTransferClaimantRecord,
   decodeAuthorityTransferClaimantRecord,
+  type SourceIssuedAuthorityTransferClaimantPhase,
+  type SourceIssuedAuthorityTransferClaimantRecord,
 } from '@/app/collab/authority-transfer/claim/AuthorityTransferClaimantRecord';
 import type {
   AuthorityTransferClaimantRecovery,
@@ -88,8 +91,8 @@ class AuthorityTransferModule extends ProductionAuthorityTransferModule {
 function recoverableClaimantRecord(input: Readonly<{
   direction?: 'cloud-to-lan' | 'lan-to-cloud';
   expiresAt?: string;
-  phase?: AuthorityTransferClaimantPhase;
-}> = {}): AuthorityTransferClaimantRecord {
+  phase?: SourceIssuedAuthorityTransferClaimantPhase;
+}> = {}): SourceIssuedAuthorityTransferClaimantRecord {
   const direction = input.direction ?? 'lan-to-cloud';
   const phase = input.phase ?? 'source-acknowledged';
   const phaseIndex = [
@@ -193,7 +196,8 @@ function recoverableClaimantRecord(input: Readonly<{
       : null,
     transferId: TRANSFER_ID,
     updatedAt: '2026-08-27T00:01:01.000Z',
-  });
+    variant: 'source-issued',
+  }) as SourceIssuedAuthorityTransferClaimantRecord;
 }
 
 function proposal(
@@ -216,6 +220,64 @@ function proposal(
     transferId: TRANSFER_ID,
     updatedAt: '2026-08-27T00:00:00.000Z',
     ...overrides,
+  };
+}
+
+function managerReissuedDescriptor() {
+  return {
+    claim: Buffer.alloc(32, 4).toString('base64url'),
+    claimGeneration: 4,
+    createdAt: '2026-10-01T00:00:00.000Z',
+    expiresAt: '2026-10-31T00:00:00.000Z',
+    memberId: 'member-host',
+    projectId: PROJECT_ID,
+    secretReplayExpiresAt: '2026-10-31T00:00:00.000Z',
+    targetAuthorityGeneration: 2,
+    transferId: TRANSFER_ID,
+  };
+}
+
+function managerClaimantMembership() {
+  return {
+    authority: {
+      authorityGeneration: 1,
+      endpoint: 'https://192.168.1.10:54545',
+      gitRemoteUrl: `https://192.168.1.10:54545/v1/git/${PROJECT_ID}/repository.git`,
+      hostCaCertificatePem: '-----BEGIN CERTIFICATE-----\nsource\n-----END CERTIFICATE-----\n',
+      hostCaFingerprint: 'a'.repeat(64),
+      kind: 'lan' as const,
+    },
+    createdAt: '2026-08-27T00:00:00.000Z',
+    hostOwnership: { ownsAuthority: false },
+    lastEventSequence: 1,
+    member: {
+      credential: Buffer.alloc(32, 1).toString('base64url'),
+      displayName: 'Host',
+      id: 'member-host',
+      personalRef: 'refs/heads/members/member-host',
+      role: 'manager' as const,
+    },
+    project: { id: PROJECT_ID, name: 'Recovery', workspacePath: 'workspace/recovery' },
+    schemaVersion: 3 as const,
+    updatedAt: '2026-08-27T00:00:00.000Z',
+  };
+}
+
+function managerClaimantSnapshot() {
+  return {
+    currentMember: {
+      displayName: 'Host',
+      id: 'member-host',
+      personalRef: 'refs/heads/members/member-host',
+      role: 'manager' as const,
+    },
+    eventSequence: 9,
+    project: {
+      authorityGeneration: 2,
+      authorityKind: 'cloud' as const,
+      id: PROJECT_ID,
+      name: 'Recovery',
+    },
   };
 }
 
@@ -533,6 +595,61 @@ describe('AuthorityTransferModule', () => {
       targetHost: record.lanTarget,
     });
     expect(createCloudConnection).not.toHaveBeenCalled();
+  });
+
+  it('reconstructs a Manager-reissued claimant with only its frozen Cloud target', async () => {
+    const descriptor = managerReissuedDescriptor();
+    const record = createManagerReissuedAuthorityTransferClaimantRecord({
+      descriptor,
+      memberPersonalRef: 'refs/heads/members/member-host',
+      operationIntentId: 'intent-manager-reissued',
+      serverUrl: 'https://cloud.example.test/',
+    });
+    const cloudSession = { projectId: PROJECT_ID } as CloudAuthorityConnection;
+    const createCloudConnection = jest.fn(async () => cloudSession);
+    const createLanClient = jest.fn();
+    const resolver = new AuthorityTransferClaimantBindingResolver({
+      createCloudConnection,
+      createLanClient,
+      loadMembership: async () => ({
+        authority: {
+          authorityGeneration: 1,
+          endpoint: 'https://192.168.1.10:54545',
+          gitRemoteUrl: `https://192.168.1.10:54545/v1/git/${PROJECT_ID}/repository.git`,
+          hostCaCertificatePem: '-----BEGIN CERTIFICATE-----\nsource\n-----END CERTIFICATE-----\n',
+          hostCaFingerprint: 'a'.repeat(64),
+          kind: 'lan',
+        },
+        createdAt: '2026-08-27T00:00:00.000Z',
+        hostOwnership: { ownsAuthority: false },
+        lastEventSequence: 1,
+        member: {
+          credential: Buffer.alloc(32, 1).toString('base64url'),
+          displayName: 'Host',
+          id: 'member-host',
+          personalRef: 'refs/heads/members/member-host',
+          role: 'manager',
+        },
+        project: {
+          id: PROJECT_ID,
+          name: 'Recovery',
+          workspacePath: 'workspace/recovery',
+        },
+        schemaVersion: 3,
+        updatedAt: '2026-08-27T00:00:00.000Z',
+      }),
+    });
+
+    await expect(resolver.resolve(record)).resolves.toEqual({
+      cloudSession,
+      direction: 'lan-to-cloud',
+      mode: 'manager-reissued',
+    });
+    expect(createCloudConnection).toHaveBeenCalledWith({
+      projectId: PROJECT_ID,
+      serverUrl: 'https://cloud.example.test/',
+    });
+    expect(createLanClient).not.toHaveBeenCalled();
   });
 
   it('registers both durable recovery owners and installs a bound LAN source service', async () => {
@@ -2529,6 +2646,12 @@ describe('AuthorityTransferModule', () => {
       lifecycle: {
         registerDurableOwner: jest.fn(),
         registerRecoveryStage: jest.fn(),
+        runExclusive: async <Result>(
+          _projectId: string,
+          _owner: string,
+          _mode: string,
+          operation: () => Promise<Result>,
+        ) => operation(),
       } as unknown as CollabProjectLifecycleSubsystem,
       persistence: {} as AuthorityTransferPersistence,
       recoverCloudSession: jest.fn(async () => cloudSession),
@@ -2833,6 +2956,423 @@ describe('AuthorityTransferModule', () => {
     expect(cloudSession.dispose).toHaveBeenCalledTimes(1);
   });
 
+  it('redeems a Manager-reissued claim through exact Cloud status and snapshot confirmation', async () => {
+    let record: AuthorityTransferClaimantRecord | null = null;
+    const phases: string[] = [];
+    const status = recoverableClaimantRecord().status;
+    const descriptor = managerReissuedDescriptor();
+    const receipt = {
+      checkpointSha256: status.checkpointSha256!,
+      claimSha256: createHash('sha256').update(descriptor.claim, 'utf8').digest('hex'),
+      memberId: descriptor.memberId,
+      projectId: PROJECT_ID,
+      receiptId: 'receipt-manager-reissued',
+      receiptKeyId: 'receipt-key-manager-reissued',
+      redeemedAt: '2026-10-01T00:01:00.000Z',
+      signature: Buffer.alloc(64, 3).toString('base64url'),
+      signatureAlgorithm: 'ed25519' as const,
+      targetAuthorityGeneration: 2,
+      transferId: TRANSFER_ID,
+    };
+    const authorityTransfer = jest.fn(async (
+      operation: string,
+      request: Readonly<{ readonly idempotencyKey?: string }>,
+    ) => operation === 'claimTransferredMembership'
+      ? { ...receipt, operationIntentId: request.idempotencyKey! }
+      : status);
+    const snapshot = {
+      currentMember: {
+        displayName: 'Host',
+        id: 'member-host',
+        personalRef: 'refs/heads/members/member-host',
+        role: 'manager' as const,
+      },
+      eventSequence: 9,
+      project: {
+        authorityGeneration: 2,
+        authorityKind: 'cloud' as const,
+        id: PROJECT_ID,
+        name: 'Recovery',
+      },
+    };
+    const readSnapshot = jest.fn(async () => snapshot);
+    const cloudSession = {
+      dispose: jest.fn(),
+      lifecycle: { authorityTransfer },
+      projectId: PROJECT_ID,
+      readSnapshot,
+      serverUrl: 'https://cloud.example.test/',
+      supports: (capability: CollabCloudCapability) => (
+        capability === 'authority-transfer' || capability === 'project-snapshot'
+      ),
+    } as unknown as CloudAuthorityConnection;
+    const lanToCloudMember = jest.fn(async () => undefined);
+    const createManagerReissuedClaimConnection = jest.fn(async () => cloudSession);
+    const module = new AuthorityTransferModule({
+      assertLanToCloudSourceOwner: () => undefined,
+      assertRecoveryOwner: () => undefined,
+      claimantStore: {
+        listProjectIds: async () => record ? [PROJECT_ID] : [],
+        load: async () => record,
+        remove: async () => {
+          const existed = record !== null;
+          record = null;
+          return existed;
+        },
+        save: async current => {
+          record = current;
+          phases.push(current.phase);
+        },
+      },
+      convergence: { lanToCloudMember } as never,
+      createManagerReissuedClaimConnection,
+      createLanToCloudSource: jest.fn() as never,
+      installationKey: TEST_INSTALLATION_A,
+      lifecycle: {
+        registerDurableOwner: jest.fn(),
+        registerRecoveryStage: jest.fn(),
+        runExclusive: async <Result>(
+          _projectId: string,
+          _owner: string,
+          _mode: string,
+          operation: () => Promise<Result>,
+        ) => operation(),
+      } as unknown as CollabProjectLifecycleSubsystem,
+      loadClaimantMembership: async () => ({
+        authority: {
+          authorityGeneration: 1,
+          endpoint: 'https://192.168.1.10:54545',
+          gitRemoteUrl: `https://192.168.1.10:54545/v1/git/${PROJECT_ID}/repository.git`,
+          hostCaCertificatePem: '-----BEGIN CERTIFICATE-----\nsource\n-----END CERTIFICATE-----\n',
+          hostCaFingerprint: 'a'.repeat(64),
+          kind: 'lan',
+        },
+        createdAt: '2026-08-27T00:00:00.000Z',
+        hostOwnership: { ownsAuthority: false },
+        lastEventSequence: 1,
+        member: {
+          credential: Buffer.alloc(32, 1).toString('base64url'),
+          displayName: 'Host',
+          id: 'member-host',
+          personalRef: 'refs/heads/members/member-host',
+          role: 'manager',
+        },
+        project: { id: PROJECT_ID, name: 'Recovery', workspacePath: 'workspace/recovery' },
+        schemaVersion: 3,
+        updatedAt: '2026-08-27T00:00:00.000Z',
+      }),
+      now: () => new Date('2026-10-01T00:00:10.000Z'),
+      persistence: {
+        loadCloudToLanManagerEntry: jest.fn(async () => null),
+      } as unknown as AuthorityTransferPersistence,
+    });
+    const controller = new AbortController();
+    await module.redeemManagerReissuedClaim({
+      claim: descriptor,
+      kind: 'cloud-membership-claim',
+      serverUrl: 'https://cloud.example.test/',
+    }, {
+      signal: controller.signal,
+    });
+
+    expect(phases).toEqual([
+      'redemption-prepared',
+      'target-claimed',
+      'target-confirmed',
+      'membership-converged',
+      'completed',
+    ]);
+    expect(authorityTransfer.mock.calls.map(([operation]) => operation)).toEqual([
+      'claimTransferredMembership',
+      'getProjectAuthorityTransfer',
+    ]);
+    expect(readSnapshot).toHaveBeenCalledTimes(2);
+    expect(lanToCloudMember).toHaveBeenCalledWith({ snapshot, status });
+    expect(createManagerReissuedClaimConnection).toHaveBeenCalledWith({
+      projectId: PROJECT_ID,
+      serverUrl: 'https://cloud.example.test/',
+    }, { signal: controller.signal });
+    expect(record).toBeNull();
+    expect(cloudSession.dispose).toHaveBeenCalledTimes(1);
+    await module.close();
+  });
+
+  it('rejects Manager-reissued redemption before local or remote work when another lifecycle owner is pending', async () => {
+    const loadClaimantMembership = jest.fn(async () => managerClaimantMembership());
+    const createManagerReissuedClaimConnection = jest.fn(async () => {
+      throw new Error('claim connection must not open');
+    });
+    const lifecycle = new CollabProjectLifecycleSubsystem({
+      closeRecovery: jest.fn(),
+      durableOwners: [{
+        inspect: async () => 'nonterminal',
+        name: 'local-exit',
+      }],
+      hostTransfer: {} as never,
+      localExit: {} as never,
+      recoveryStages: [],
+      retirement: {} as never,
+    });
+    const module = new AuthorityTransferModule({
+      assertLanToCloudSourceOwner: () => undefined,
+      assertRecoveryOwner: () => undefined,
+      claimantStore: {
+        listProjectIds: async () => [],
+        load: async () => null,
+        remove: async () => false,
+        save: jest.fn(async () => undefined),
+      },
+      convergence: {} as never,
+      createLanToCloudSource: jest.fn() as never,
+      createManagerReissuedClaimConnection,
+      installationKey: TEST_INSTALLATION_A,
+      lifecycle,
+      loadClaimantMembership,
+      persistence: {
+        inspectLifecycleOwner: jest.fn(async () => 'absent'),
+        loadCloudToLanManagerEntry: jest.fn(async () => null),
+      } as unknown as AuthorityTransferPersistence,
+    });
+
+    await expect(module.redeemManagerReissuedClaim({
+      claim: managerReissuedDescriptor(),
+      kind: 'cloud-membership-claim',
+      serverUrl: 'https://cloud.example.test/',
+    })).rejects.toMatchObject({
+      safeContext: { reason: 'lifecycle-owner-pending' },
+    });
+
+    expect(loadClaimantMembership).not.toHaveBeenCalled();
+    expect(createManagerReissuedClaimConnection).not.toHaveBeenCalled();
+  });
+
+  it('queues the complete Manager-reissued entry before claimant persistence', async () => {
+    let releaseOwner!: () => void;
+    let ownerEntered!: () => void;
+    const ownerGate = new Promise<void>(resolve => { releaseOwner = resolve; });
+    const entered = new Promise<void>(resolve => { ownerEntered = resolve; });
+    const lifecycle = new CollabProjectLifecycleSubsystem({
+      closeRecovery: jest.fn(),
+      durableOwners: [],
+      hostTransfer: {} as never,
+      localExit: {} as never,
+      recoveryStages: [],
+      retirement: {} as never,
+    });
+    const saved: AuthorityTransferClaimantRecord[] = [];
+    const loadClaimantMembership = jest.fn(async () => managerClaimantMembership());
+    const cloudSession = {
+      dispose: jest.fn(),
+      lifecycle: {
+        authorityTransfer: jest.fn(async () => {
+          throw new Error('simulated remote stop');
+        }),
+      },
+      projectId: PROJECT_ID,
+      readSnapshot: jest.fn(),
+      serverUrl: 'https://cloud.example.test/',
+      supports: () => true,
+    } as unknown as CloudAuthorityConnection;
+    const module = new AuthorityTransferModule({
+      assertLanToCloudSourceOwner: () => undefined,
+      assertRecoveryOwner: () => undefined,
+      claimantStore: {
+        listProjectIds: async () => saved.length > 0 ? [PROJECT_ID] : [],
+        load: async () => saved.at(-1) ?? null,
+        remove: async () => false,
+        save: async record => { saved.push(record); },
+      },
+      convergence: {} as never,
+      createLanToCloudSource: jest.fn() as never,
+      createManagerReissuedClaimConnection: async () => cloudSession,
+      installationKey: TEST_INSTALLATION_A,
+      lifecycle,
+      loadClaimantMembership,
+      persistence: {
+        inspectLifecycleOwner: jest.fn(async () => 'absent'),
+        loadCloudToLanManagerEntry: jest.fn(async () => null),
+      } as unknown as AuthorityTransferPersistence,
+    });
+    const competingOwner = lifecycle.runExclusive(
+      PROJECT_ID,
+      'local-exit',
+      'operation',
+      async () => {
+        ownerEntered();
+        await ownerGate;
+      },
+    );
+    await entered;
+
+    const redemption = module.redeemManagerReissuedClaim({
+      claim: managerReissuedDescriptor(),
+      kind: 'cloud-membership-claim',
+      serverUrl: 'https://cloud.example.test/',
+    }).catch(error => error as Error);
+    await new Promise(resolve => setImmediate(resolve));
+    const membershipLoadedBeforeRelease = loadClaimantMembership.mock.calls.length > 0;
+    const savedBeforeRelease = saved.length > 0;
+
+    releaseOwner();
+    await competingOwner;
+    await expect(redemption).resolves.toMatchObject({ message: 'simulated remote stop' });
+    expect(membershipLoadedBeforeRelease).toBe(false);
+    expect(savedBeforeRelease).toBe(false);
+    expect(loadClaimantMembership).toHaveBeenCalledTimes(1);
+    expect(saved).toEqual([
+      expect.objectContaining({ phase: 'redemption-prepared', variant: 'manager-reissued' }),
+    ]);
+    expect(cloudSession.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('recovers an expired ambiguous Manager reissue only from exact authenticated target binding', async () => {
+    const descriptor = managerReissuedDescriptor();
+    let record: AuthorityTransferClaimantRecord | null =
+      createManagerReissuedAuthorityTransferClaimantRecord({
+        descriptor,
+        memberPersonalRef: 'refs/heads/members/member-host',
+        operationIntentId: 'intent-manager-reissued-expired',
+        serverUrl: 'https://cloud.example.test/',
+      });
+    const status = recoverableClaimantRecord().status;
+    const authorityTransfer = jest.fn(async () => status);
+    const readSnapshot = jest.fn(async () => managerClaimantSnapshot());
+    const cloudSession = {
+      dispose: jest.fn(),
+      lifecycle: { authorityTransfer },
+      projectId: PROJECT_ID,
+      readSnapshot,
+      serverUrl: 'https://cloud.example.test/',
+      supports: (capability: CollabCloudCapability) => (
+        capability === 'authority-transfer' || capability === 'project-snapshot'
+      ),
+    } as unknown as CloudAuthorityConnection;
+    const lanToCloudMember = jest.fn(async () => undefined);
+    const module = new AuthorityTransferModule({
+      assertLanToCloudSourceOwner: () => undefined,
+      assertRecoveryOwner: () => undefined,
+      claimantStore: {
+        listProjectIds: async () => record ? [PROJECT_ID] : [],
+        load: async () => record,
+        remove: async () => {
+          const existed = record !== null;
+          record = null;
+          return existed;
+        },
+        save: async current => { record = current; },
+      },
+      convergence: { lanToCloudMember } as never,
+      createLanToCloudSource: jest.fn() as never,
+      createManagerReissuedClaimConnection: async () => cloudSession,
+      installationKey: TEST_INSTALLATION_A,
+      lifecycle: {
+        registerDurableOwner: jest.fn(),
+        registerRecoveryStage: jest.fn(),
+        runExclusive: async <Result>(
+          _projectId: string,
+          _owner: string,
+          _mode: string,
+          operation: () => Promise<Result>,
+        ) => operation(),
+      } as unknown as CollabProjectLifecycleSubsystem,
+      loadClaimantMembership: async () => managerClaimantMembership(),
+      now: () => new Date(descriptor.expiresAt),
+      persistence: {
+        loadCloudToLanManagerEntry: jest.fn(async () => null),
+      } as unknown as AuthorityTransferPersistence,
+    });
+
+    await module.redeemManagerReissuedClaim({
+      claim: descriptor,
+      kind: 'cloud-membership-claim',
+      serverUrl: 'https://cloud.example.test/',
+    });
+
+    expect(authorityTransfer).toHaveBeenCalledWith(
+      'getProjectAuthorityTransfer',
+      { projectId: PROJECT_ID, transferId: TRANSFER_ID },
+      {},
+    );
+    expect(authorityTransfer).toHaveBeenCalledTimes(1);
+    expect(readSnapshot).toHaveBeenCalledTimes(2);
+    expect(lanToCloudMember).toHaveBeenCalledTimes(1);
+    expect(record).toBeNull();
+    expect(cloudSession.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['Member', { currentMember: { ...managerClaimantSnapshot().currentMember, id: 'member-other' } }],
+    ['personal ref', { currentMember: { ...managerClaimantSnapshot().currentMember, personalRef: 'refs/heads/members/other' } }],
+    ['generation', { project: { ...managerClaimantSnapshot().project, authorityGeneration: 3 } }],
+  ] as const)(
+    'keeps an expired Manager reissue blocked when target %s does not match',
+    async (_label, override) => {
+      const descriptor = managerReissuedDescriptor();
+      let record: AuthorityTransferClaimantRecord | null =
+        createManagerReissuedAuthorityTransferClaimantRecord({
+          descriptor,
+          memberPersonalRef: 'refs/heads/members/member-host',
+          operationIntentId: 'intent-manager-reissued-expired',
+          serverUrl: 'https://cloud.example.test/',
+        });
+      const status = recoverableClaimantRecord().status;
+      const snapshot = managerClaimantSnapshot();
+      const cloudSession = {
+        dispose: jest.fn(),
+        lifecycle: { authorityTransfer: jest.fn(async () => status) },
+        projectId: PROJECT_ID,
+        readSnapshot: jest.fn(async () => ({ ...snapshot, ...override })),
+        serverUrl: 'https://cloud.example.test/',
+        supports: () => true,
+      } as unknown as CloudAuthorityConnection;
+      const lanToCloudMember = jest.fn();
+      const module = new AuthorityTransferModule({
+        assertLanToCloudSourceOwner: () => undefined,
+        assertRecoveryOwner: () => undefined,
+        claimantStore: {
+          listProjectIds: async () => [PROJECT_ID],
+          load: async () => record,
+          remove: async () => false,
+          save: async current => { record = current; },
+        },
+        convergence: { lanToCloudMember } as never,
+        createLanToCloudSource: jest.fn() as never,
+        createManagerReissuedClaimConnection: async () => cloudSession,
+        installationKey: TEST_INSTALLATION_A,
+        lifecycle: {
+          registerDurableOwner: jest.fn(),
+          registerRecoveryStage: jest.fn(),
+          runExclusive: async <Result>(
+            _projectId: string,
+            _owner: string,
+            _mode: string,
+            operation: () => Promise<Result>,
+          ) => operation(),
+        } as unknown as CollabProjectLifecycleSubsystem,
+        loadClaimantMembership: async () => managerClaimantMembership(),
+        now: () => new Date(descriptor.expiresAt),
+        persistence: {
+          loadCloudToLanManagerEntry: jest.fn(async () => null),
+        } as unknown as AuthorityTransferPersistence,
+      });
+
+      await expect(module.redeemManagerReissuedClaim({
+        claim: descriptor,
+        kind: 'cloud-membership-claim',
+        serverUrl: 'https://cloud.example.test/',
+      })).rejects.toMatchObject({
+        safeContext: { reason: 'authority-transfer-claimant-target-binding-invalid' },
+      });
+
+      expect(record).toMatchObject({
+        phase: 'redemption-prepared',
+        variant: 'manager-reissued',
+      });
+      expect(lanToCloudMember).not.toHaveBeenCalled();
+      expect(cloudSession.dispose).toHaveBeenCalledTimes(1);
+    },
+  );
+
   it('does not recover a claimant while its same-Project Manager observer is unresolved', async () => {
     const record = recoverableClaimantRecord();
     let claimantRecovery: AuthorityTransferClaimantRecovery | null = null;
@@ -2930,6 +3470,91 @@ describe('AuthorityTransferModule', () => {
       expect(record).toBeNull();
     },
   );
+
+  it('finishes a target-confirmed Manager-reissued claimant locally without Cloud or LAN transport', async () => {
+    const descriptor = managerReissuedDescriptor();
+    const status = recoverableClaimantRecord().status;
+    const prepared = createManagerReissuedAuthorityTransferClaimantRecord({
+      descriptor,
+      memberPersonalRef: 'refs/heads/members/member-host',
+      operationIntentId: 'intent-manager-local-only',
+      serverUrl: 'https://cloud.example.test/',
+    });
+    const claimed = advanceAuthorityTransferClaimantRecord(prepared, {
+      phase: 'target-claimed',
+      redemptionReceipt: {
+        checkpointSha256: status.checkpointSha256!,
+        claimSha256: createHash('sha256').update(descriptor.claim, 'utf8').digest('hex'),
+        memberId: descriptor.memberId,
+        operationIntentId: prepared.operationIntentId,
+        projectId: descriptor.projectId,
+        receiptId: 'receipt-manager-local-only',
+        receiptKeyId: 'receipt-key-manager-local-only',
+        redeemedAt: '2026-10-01T00:01:00.000Z',
+        signature: Buffer.alloc(64, 3).toString('base64url'),
+        signatureAlgorithm: 'ed25519',
+        targetAuthorityGeneration: descriptor.targetAuthorityGeneration,
+        transferId: descriptor.transferId,
+      },
+      updatedAt: '2026-10-01T00:01:00.000Z',
+    });
+    let record: AuthorityTransferClaimantRecord | null =
+      advanceAuthorityTransferClaimantRecord(claimed, {
+        convergenceProof: 'receipt',
+        phase: 'target-confirmed',
+        targetStatus: status,
+        updatedAt: '2026-10-01T00:02:00.000Z',
+      });
+    let claimantRecovery: AuthorityTransferClaimantRecovery | null = null;
+    const recoverConvertedClaimant = jest.fn(async () => undefined);
+    const recoverClaimant = jest.fn(async () => ({
+      direction: 'lan-to-cloud' as const,
+      mode: 'local-only' as const,
+    }));
+    new AuthorityTransferModule({
+      assertLanToCloudSourceOwner: () => undefined,
+      assertRecoveryOwner: () => undefined,
+      claimantStore: {
+        listProjectIds: async () => record ? [PROJECT_ID] : [],
+        load: async () => record,
+        remove: async () => {
+          const existed = record !== null;
+          record = null;
+          return existed;
+        },
+        save: async current => { record = current; },
+      },
+      convergence: { recoverConvertedClaimant } as never,
+      createLanToCloudSource: jest.fn() as never,
+      installationKey: TEST_INSTALLATION_A,
+      lifecycle: {
+        registerDurableOwner: jest.fn(),
+        registerRecoveryStage: (stage: AuthorityTransferClaimantRecovery) => {
+          if (stage.name === 'authority-transfer-claimants') claimantRecovery = stage;
+        },
+        runExclusive: async <Result>(
+          _projectId: string,
+          _owner: string,
+          _mode: string,
+          operation: () => Promise<Result>,
+        ) => operation(),
+      } as unknown as CollabProjectLifecycleSubsystem,
+      now: () => new Date('2026-10-01T00:03:00.000Z'),
+      persistence: {
+        loadCloudToLanManagerEntry: jest.fn(async () => null),
+      } as unknown as AuthorityTransferPersistence,
+      recoverClaimant,
+    });
+
+    await claimantRecovery!.run();
+
+    expect(recoverClaimant).toHaveBeenCalledWith(expect.objectContaining({
+      phase: 'target-confirmed',
+      variant: 'manager-reissued',
+    }));
+    expect(recoverConvertedClaimant).toHaveBeenCalledTimes(1);
+    expect(record).toBeNull();
+  });
 
   it('recovers an expired Cloud-to-LAN redemption from the LAN target only', async () => {
     let record: AuthorityTransferClaimantRecord | null = recoverableClaimantRecord({


### PR DESCRIPTION
## Summary

- extend the existing claimant aggregate with explicit source-issued and Manager-reissued variants
- persist and exactly replay Manager reissue redemption, confirm authenticated target binding, and converge through the existing local transition owner
- serialize the complete claim entry through the claimant lifecycle lane and preserve cancellation, clock-skew, expiry, target-only, and local-only recovery
- route imported claim reconnects through the application facade without exposing UI

## Scope

Step 13 T3 only. This PR targets `codex/cloud-integration`; it does not change Protocol, Cloud Server, Gomami, UI, installed Vault state, legacy compatibility, or S14. Exact installed Protocol remains `@claudian-collab/protocol@4.0.0`.

## Verification

- TDD red/green coverage for exact request replay, expiry, revocation, identity/generation mismatch, client clock skew, lifecycle concurrency, cancellation forwarding, receipt durability, and local-only recovery
- three-pass fresh-context review-fix loop; final pass found no material issue
- full test: 619 suites passed, 2 skipped; 9,292 tests passed, 2 skipped
- open handles: PASS
- cross-platform Collab: 29 suites / 373 tests passed
- lint, typecheck, architecture/policy checks, frozen lockfile, diff hygiene, and production build passed
- bundle: 5,162,267 bytes (under 5,170,000-byte S13 ceiling)
- cold evaluation: 64.7 ms; existing non-blocking 50 ms warning remains visible
