### PR TITLE
fix(collab): retain authority transfer cleanup ownership

### DIFF
--- a/src/app/collab/authority-transfer/AuthorityTransferModule.ts
+++ b/src/app/collab/authority-transfer/AuthorityTransferModule.ts
@@ -299,10 +299,16 @@ interface SourceBinding {
 interface TargetBinding {
   readonly coordinator: CloudToLanTargetCoordinator;
   dispose(): Promise<void>;
+  readonly terminalCleanup?: {
+    readonly handle: CloudToLanTransferHandle;
+    readonly status: CollabAuthorityTransferStatus;
+    targetDisposed: boolean;
+  };
   readonly unregister: () => void;
 }
 
 interface TargetPreparationBinding {
+  readonly cleanupOperationIntentId?: string;
   readonly connection: CloudToLanEntryConnection;
   readonly target: CloudToLanTargetCoordinatorOptions['target'];
 }
@@ -614,8 +620,10 @@ export class AuthorityTransferModule {
         coordinator,
         dispose: async () => {
           if (this.targetBindings.get(input.projectId) !== binding) return;
-          this.targetBindings.delete(input.projectId);
           await binding.dispose();
+          if (this.targetBindings.get(input.projectId) === binding) {
+            this.targetBindings.delete(input.projectId);
+          }
         },
         targetUrl: input.expectedTargetUrl,
       });
@@ -643,6 +651,22 @@ export class AuthorityTransferModule {
     input: PrepareCloudToLanTargetInput,
     options: CollabOperationOptions,
   ): Promise<CloudToLanTargetPreparationDescriptor> {
+    const retainedBinding = this.targetBindings.get(input.projectId);
+    if (retainedBinding?.terminalCleanup) {
+      throw durableOutcome(
+        retainedBinding.terminalCleanup.handle.operationIntentId,
+        'authority-transfer-target-cancellation-cleanup-incomplete',
+      );
+    }
+    const retainedCleanup = this.targetPreparations.get(input.projectId);
+    if (retainedCleanup?.cleanupOperationIntentId) {
+      if (!(await this.disposeCloudToLanTargetRuntime(input.projectId))) {
+        throw durableOutcome(
+          retainedCleanup.cleanupOperationIntentId,
+          'authority-transfer-target-preparation-incomplete',
+        );
+      }
+    }
     const createConnection = this.options.createCloudToLanConnection;
     const createTarget = this.options.createCloudToLanTarget;
     let existing = await this.options.persistence.loadCloudToLanTargetEntry(
@@ -657,6 +681,15 @@ export class AuthorityTransferModule {
       && existing.operationIntentId !== input.operationIntentId
       && existing.phase === 'withdrawn'
     ) {
+      if (
+        this.targetBindings.has(input.projectId)
+        || this.targetPreparations.has(input.projectId)
+      ) {
+        throw durableOutcome(
+          existing.operationIntentId,
+          'authority-transfer-target-withdrawal-cleanup-incomplete',
+        );
+      }
       existing = null;
     }
     const retainedPreparation = this.targetPreparations.get(input.projectId);
@@ -742,9 +775,20 @@ export class AuthorityTransferModule {
       throw error;
     } finally {
       if (!keepConnection) {
-        await Promise.allSettled([
+        const [cleanup] = await Promise.allSettled([
           disposeCloudToLanTargetPreparation(connection, createdTarget),
         ]);
+        if (
+          cleanup?.status === 'rejected'
+          && createdTarget
+          && durableOperationId !== null
+        ) {
+          this.targetPreparations.set(input.projectId, {
+            cleanupOperationIntentId: durableOperationId,
+            connection,
+            target: createdTarget,
+          });
+        }
       }
     }
   }
@@ -884,6 +928,14 @@ export class AuthorityTransferModule {
       'authority-transfer',
       'continuation',
       async () => {
+        let binding = this.targetBindings.get(handle.projectId);
+        const retainedCleanup = binding?.terminalCleanup;
+        if (binding && retainedCleanup) {
+          if (!sameCloudToLanTransferHandle(retainedCleanup.handle, handle)) {
+            throw moduleError('authority-transfer-target-handle-mismatch');
+          }
+          return this.completeCancelledCloudToLanTarget(binding, retainedCleanup);
+        }
         const entry = await this.options.persistence.loadCloudToLanTargetEntry(
           handle.projectId,
         );
@@ -898,7 +950,6 @@ export class AuthorityTransferModule {
         } catch {
           throw moduleError('authority-transfer-target-handle-mismatch');
         }
-        let binding = this.targetBindings.get(handle.projectId);
         if (!binding) {
           const createConnection = this.options.createCloudToLanConnection;
           const createTarget = this.options.createCloudToLanTarget;
@@ -961,33 +1012,68 @@ export class AuthorityTransferModule {
           );
           throw error;
         }
-        let managerSettlementFailed = false;
+        if (status.state === 'cancelled') {
+          const terminalCleanup = {
+            handle,
+            status,
+            targetDisposed: false,
+          };
+          const terminalBinding: TargetBinding = {
+            ...binding,
+            terminalCleanup,
+          };
+          if (this.targetBindings.get(handle.projectId) === binding) {
+            this.targetBindings.set(handle.projectId, terminalBinding);
+          }
+          return this.completeCancelledCloudToLanTarget(
+            terminalBinding,
+            terminalCleanup,
+          );
+        }
         try {
           await this.settleMatchingCloudToLanManager(handle, status);
         } catch {
-          managerSettlementFailed = true;
-        }
-        let targetCleanupFailed = false;
-        if (status.state === 'cancelled') {
-          if (this.targetBindings.get(handle.projectId) === binding) {
-            this.targetBindings.delete(handle.projectId);
-            try {
-              await binding.dispose();
-            } catch {
-              targetCleanupFailed = true;
-            }
-          }
-        }
-        if (managerSettlementFailed || targetCleanupFailed) {
           throw durableOutcome(
             handle.operationIntentId,
-            targetCleanupFailed
-              ? 'authority-transfer-target-cancellation-cleanup-incomplete'
-              : 'authority-transfer-manager-status-incomplete',
+            'authority-transfer-manager-status-incomplete',
           );
         }
         return status;
       },
+    );
+  }
+
+  private async completeCancelledCloudToLanTarget(
+    binding: TargetBinding,
+    cleanup: NonNullable<TargetBinding['terminalCleanup']>,
+  ): Promise<CollabAuthorityTransferStatus> {
+    const { handle, status } = cleanup;
+    let managerSettlementFailed = false;
+    try {
+      await this.settleMatchingCloudToLanManager(handle, status);
+    } catch {
+      managerSettlementFailed = true;
+    }
+    let targetCleanupFailed = false;
+    if (!cleanup.targetDisposed) {
+      try {
+        await binding.dispose();
+        cleanup.targetDisposed = true;
+      } catch {
+        targetCleanupFailed = true;
+      }
+    }
+    if (!managerSettlementFailed && !targetCleanupFailed) {
+      if (this.targetBindings.get(handle.projectId) === binding) {
+        this.targetBindings.delete(handle.projectId);
+      }
+      return status;
+    }
+    throw durableOutcome(
+      handle.operationIntentId,
+      targetCleanupFailed
+        ? 'authority-transfer-target-cancellation-cleanup-incomplete'
+        : 'authority-transfer-manager-status-incomplete',
     );
   }
 
@@ -1014,21 +1100,36 @@ export class AuthorityTransferModule {
         }
         const binding = this.targetBindings.get(input.projectId);
         const preparation = this.targetPreparations.get(input.projectId);
-        this.targetBindings.delete(input.projectId);
-        this.targetPreparations.delete(input.projectId);
-        const cleanup = await Promise.allSettled([
-          ...(binding ? [binding.dispose()] : []),
-          ...(preparation ? [disposeCloudToLanTargetPreparation(
-            preparation.connection,
-            preparation.target,
-          )] : []),
-        ]);
-        const failed = cleanup.find(
-          (result): result is PromiseRejectedResult => result.status === 'rejected',
-        );
-        if (failed) throw failed.reason;
+        if (!binding && !preparation) return;
+        if (!(await this.disposeCloudToLanTargetRuntime(input.projectId))) {
+          throw durableOutcome(
+            entry.operationIntentId,
+            'authority-transfer-target-withdrawal-cleanup-incomplete',
+          );
+        }
       },
     );
+  }
+
+  private async disposeCloudToLanTargetRuntime(projectId: CollabProjectId): Promise<boolean> {
+    const binding = this.targetBindings.get(projectId);
+    const preparation = this.targetPreparations.get(projectId);
+    const [bindingResult, preparationResult] = await Promise.allSettled([
+      binding?.dispose() ?? Promise.resolve(),
+      preparation
+        ? disposeCloudToLanTargetPreparation(preparation.connection, preparation.target)
+        : Promise.resolve(),
+    ]);
+    if (bindingResult.status === 'fulfilled' && this.targetBindings.get(projectId) === binding) {
+      this.targetBindings.delete(projectId);
+    }
+    if (
+      preparationResult.status === 'fulfilled'
+      && this.targetPreparations.get(projectId) === preparation
+    ) {
+      this.targetPreparations.delete(projectId);
+    }
+    return bindingResult.status === 'fulfilled' && preparationResult.status === 'fulfilled';
   }
 
   async observeCloudToLanTransfer(
@@ -1465,7 +1566,10 @@ export class AuthorityTransferModule {
           await input.lanClient.requestWithMember(
             'acknowledgeTransferredMembershipClaimRedemption',
             {
-              idempotencyKey: `${record.operationIntentId}-source-ack`,
+              idempotencyKey: authorityTransferChildIdempotencyKey(
+                record.operationIntentId,
+                'source-ack',
+              ),
               projectId: record.projectId,
               receipt: record.redemptionReceipt,
               transferId: record.transferId,
@@ -1647,7 +1751,10 @@ export class AuthorityTransferModule {
           await input.cloudSession.lifecycle.authorityTransfer(
             'acknowledgeTransferredMembershipClaimRedemption',
             {
-              idempotencyKey: `${record.operationIntentId}-source-ack`,
+              idempotencyKey: authorityTransferChildIdempotencyKey(
+                record.operationIntentId,
+                'source-ack',
+              ),
               projectId: record.projectId,
               receipt: record.redemptionReceipt,
               transferId: record.transferId,

--- a/src/app/collab/authority-transfer/AuthorityTransferOperationIdentity.ts
+++ b/src/app/collab/authority-transfer/AuthorityTransferOperationIdentity.ts
@@ -8,6 +8,7 @@ export type AuthorityTransferChildOperation =
   | 'claims'
   | 'custody'
   | 'relinquish'
+  | 'source-ack'
   | 'stage';
 
 export function authorityTransferChildIdempotencyKey(

--- a/src/app/collab/authority-transfer/cloud-to-lan/ProductionCloudToLanTargetEffects.ts
+++ b/src/app/collab/authority-transfer/cloud-to-lan/ProductionCloudToLanTargetEffects.ts
@@ -445,8 +445,9 @@ export class ProductionCloudToLanTargetEffects implements CloudToLanTargetEffect
 
   async dispose(): Promise<void> {
     const preparation = this.#preparation;
-    this.#preparation = null;
-    await preparation?.dispose();
+    if (!preparation) return;
+    await preparation.dispose();
+    if (this.#preparation === preparation) this.#preparation = null;
   }
 
   async prepareTarget(expectedEndpoint?: string): Promise<Readonly<{
@@ -685,8 +686,8 @@ export class ProductionCloudToLanTargetEffects implements CloudToLanTargetEffect
     );
     this.#stagedRegistration = null;
     const preparation = this.#preparation;
-    this.#preparation = null;
     await preparation?.dispose();
+    if (this.#preparation === preparation) this.#preparation = null;
     await this.options.foundation.discardAuthorityTransferTarget(
       record.projectId,
       record.ownerInstallationKey,

--- a/src/app/collab/lan/LanHostCoordinator.ts
+++ b/src/app/collab/lan/LanHostCoordinator.ts
@@ -471,6 +471,7 @@ export class LanHostCoordinator {
   );
    readonly #clearAuthorityTransferExpiryTimeout: (handle: number) => void;
   private hostLock: HeldHostLock | null = null;
+  private hostLockRelease: Promise<void> | null = null;
    readonly #hostLockPath: string;
   private listener: RunningListener | null = null;
    #listenerFailure: CollabError | null = null;
@@ -1819,23 +1820,45 @@ export class LanHostCoordinator {
   }
 
    async #releaseHostLock(): Promise<void> {
+    if (this.hostLockRelease) return this.hostLockRelease;
     const lock = this.hostLock;
     if (!lock) return;
-    this.hostLock = null;
+    const release = this.#releaseOwnedHostLock(lock);
+    this.hostLockRelease = release;
     try {
-      await lock.handle.close().catch(() => undefined);
-      const contents = await readFile(lock.path, 'utf8').catch(() => null);
-      if (contents === null) return;
-      const current = parseHostLock(contents);
-      if (current.nonce !== lock.nonce || current.pid !== lock.pid) {
-        throw hostError('authorization-denied', 'vault-host-lock-replaced');
-      }
-      await unlink(lock.path).catch(() => {
-        throw hostError('operation-failed', 'vault-host-lock-release-failed');
-      });
+      await release;
     } finally {
-      ACTIVE_HOST_LOCK_NONCES.delete(lock.nonce);
+      if (this.hostLockRelease === release) this.hostLockRelease = null;
     }
+  }
+
+   async #releaseOwnedHostLock(lock: HeldHostLock): Promise<void> {
+    await lock.handle.close().catch(() => undefined);
+    let contents: string | null;
+    try {
+      contents = await readFile(lock.path, 'utf8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw hostError('operation-failed', 'vault-host-lock-read-failed');
+      }
+      contents = null;
+    }
+    if (contents === null) {
+      if (this.hostLock === lock) this.hostLock = null;
+      ACTIVE_HOST_LOCK_NONCES.delete(lock.nonce);
+      return;
+    }
+    const current = parseHostLock(contents);
+    if (current.nonce !== lock.nonce || current.pid !== lock.pid) {
+      if (this.hostLock === lock) this.hostLock = null;
+      ACTIVE_HOST_LOCK_NONCES.delete(lock.nonce);
+      throw hostError('authorization-denied', 'vault-host-lock-replaced');
+    }
+    await unlink(lock.path).catch(() => {
+      throw hostError('operation-failed', 'vault-host-lock-release-failed');
+    });
+    if (this.hostLock === lock) this.hostLock = null;
+    ACTIVE_HOST_LOCK_NONCES.delete(lock.nonce);
   }
 
    async #closeListenerAndLock(): Promise<void> {
@@ -2144,7 +2167,12 @@ export class LanHostCoordinator {
    #releaseAuthorityTransferPreparation(token: symbol): Promise<void> {
     return this.#operationQueue.run(async () => {
       if (!this.#authorityTransferPreparations.delete(token)) return;
-      await this.#closeUnusedListener();
+      try {
+        await this.#closeUnusedListener();
+      } catch (error) {
+        this.#authorityTransferPreparations.add(token);
+        throw error;
+      }
     });
   }
 

--- a/tests/integration/app/collab/authority-transfer/ProductionAuthorityTransferEffects.test.ts
+++ b/tests/integration/app/collab/authority-transfer/ProductionAuthorityTransferEffects.test.ts
@@ -152,6 +152,89 @@ describe('production authority-transfer effects', () => {
     expect(unpinAuthorityTransferSourceEndpoint).toHaveBeenCalledWith(PROJECT_ID, endpoint);
   });
 
+  it('retains a Cloud-to-LAN target preparation until disposal succeeds', async () => {
+    const dispose = jest.fn()
+      .mockRejectedValueOnce(new Error('simulated target cleanup failure'))
+      .mockResolvedValue(undefined);
+    const effects = new ProductionCloudToLanTargetEffects({
+      cloudSession: {} as CloudAuthorityConnection,
+      convergence: {} as AuthorityTransferLocalConvergence,
+      foundation: {
+        lanHost: {
+          prepareAuthorityTransferTarget: jest.fn(async () => ({
+            caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+            caFingerprint: 'c'.repeat(64),
+            dispose,
+            endpoint: 'https://127.0.0.1:54545',
+          })),
+        },
+      } as never,
+      persistence: {} as never,
+      projectId: PROJECT_ID,
+    });
+
+    await effects.prepareTarget();
+    await expect(effects.dispose()).rejects.toThrow('simulated target cleanup failure');
+    await expect(effects.dispose()).resolves.toBeUndefined();
+
+    expect(dispose).toHaveBeenCalledTimes(2);
+  });
+
+  it('retains a cancelled Cloud-to-LAN target preparation until disposal succeeds', async () => {
+    const dispose = jest.fn()
+      .mockRejectedValueOnce(new Error('simulated target cancellation cleanup failure'))
+      .mockResolvedValue(undefined);
+    const discardAuthorityTransferTarget = jest.fn(async () => undefined);
+    const removeReservedProjectsFolderChild = jest.fn(async () => true);
+    const effects = new ProductionCloudToLanTargetEffects({
+      cloudSession: {} as CloudAuthorityConnection,
+      convergence: {} as AuthorityTransferLocalConvergence,
+      foundation: {
+        discardAuthorityTransferTarget,
+        lanHost: {
+          prepareAuthorityTransferTarget: jest.fn(async () => ({
+            caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+            caFingerprint: 'c'.repeat(64),
+            dispose,
+            endpoint: 'https://127.0.0.1:54545',
+          })),
+          stopAuthorityTransferRoute: jest.fn(async () => undefined),
+        },
+        local: {
+          projects: {
+            loadMembership: jest.fn(async () => ({
+              project: { workspacePath: '/vault/Projects/Portable' },
+            })),
+          },
+          workspace: { removeReservedProjectsFolderChild },
+        },
+      } as never,
+      persistence: {} as never,
+      projectId: PROJECT_ID,
+    });
+    const record = createAuthorityTransferRecord({
+      lifecycleOwnership: 'owned',
+      localRole: 'target',
+      operationIntentId: OPERATION_ID,
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
+      status: {
+        ...status('cloud-to-lan', 'cancelled', 'https://127.0.0.1:54545'),
+        state: 'cancelled',
+      },
+    });
+
+    await effects.prepareTarget();
+    await expect(effects.cancelStaging(record)).rejects.toThrow(
+      'simulated target cancellation cleanup failure',
+    );
+    await expect(effects.cancelStaging(record)).resolves.toBeUndefined();
+
+    expect(dispose).toHaveBeenCalledTimes(2);
+    expect(discardAuthorityTransferTarget).toHaveBeenCalledTimes(1);
+    expect(removeReservedProjectsFolderChild).toHaveBeenCalledTimes(1);
+  });
+
   it('uses ordinary guarded Host start for an open-fence cancelled record', async () => {
     const startProject = jest.fn(async () => ({
       endpoint: 'https://127.0.0.1:54545',

--- a/tests/integration/app/collab/gates/LocalProjectMilestoneGate.test.ts
+++ b/tests/integration/app/collab/gates/LocalProjectMilestoneGate.test.ts
@@ -86,6 +86,7 @@ describe('G3 local Project milestone gate', () => {
       ),
       getConfiguredGitPath: () => configuredGitPath,
       installationKey: TEST_INSTALLATION_A,
+      lanHost: { portCandidates: [0] },
       obsidianConfigDirectory: '.obsidian',
       vaultRoot,
     });
@@ -464,7 +465,9 @@ describe('G3 local Project milestone gate', () => {
       'startAuthorityTransferRoute',
     );
     readSnapshot.mockRejectedValueOnce(new Error('simulated Cloud snapshot outage'));
-    await expect(reopened.feature.restoreLifecycle()).rejects.toThrow();
+    await expect(reopened.feature.restoreLifecycle()).rejects.toThrow(
+      'simulated Cloud snapshot outage',
+    );
     expect(restoreTerminalRoute).toHaveBeenCalledTimes(1);
     await expect(reopened.feature.restoreLifecycle()).resolves.toBeUndefined();
     const convergedMembership = await reopenedFoundation.local.projects.loadMembership(PROJECT_ID);

--- a/tests/integration/app/collab/join/JoinProjectCoordinator.test.ts
+++ b/tests/integration/app/collab/join/JoinProjectCoordinator.test.ts
@@ -40,6 +40,8 @@ const OID = 'a'.repeat(40);
 const CA_FINGERPRINT = 'ab'.repeat(32);
 const CA_PEM = '-----BEGIN CERTIFICATE-----\nTEST CA\n-----END CERTIFICATE-----\n';
 
+jest.setTimeout(30_000);
+
 interface TestHarness {
   readonly cloneInputs: unknown[];
   readonly controlPaths: string[];

--- a/tests/integration/app/collab/lan/LanHostCoordinator.test.ts
+++ b/tests/integration/app/collab/lan/LanHostCoordinator.test.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import {
   access,
+  chmod,
   mkdir,
   mkdtemp,
   readFile,
@@ -1375,6 +1376,36 @@ describe('LanHostCoordinator production transport', () => {
       projectId: PROJECT_ID,
       transferId: 'transfer-prepared-target',
     }, HOST_CREDENTIAL)).rejects.toMatchObject({ code: 'endpoint-unreachable' });
+  });
+
+  it('retains Cloud-to-LAN listener-lock ownership until cleanup can be retried', async () => {
+    if (process.platform === 'win32') return;
+    const preparation = await coordinator.prepareAuthorityTransferTarget();
+    const lockPath = hostLockPath(root);
+    const lockDirectory = path.dirname(hostLockPath(root));
+
+    await chmod(lockPath, 0o000);
+    try {
+      await expect(preparation.dispose()).rejects.toMatchObject({
+        safeContext: { reason: 'vault-host-lock-read-failed' },
+      });
+    } finally {
+      await chmod(lockPath, 0o600);
+    }
+    expect(await readFile(lockPath, 'utf8')).toContain(`"pid":${process.pid}`);
+
+    await chmod(lockDirectory, 0o500);
+    try {
+      await expect(preparation.dispose()).rejects.toMatchObject({
+        safeContext: { reason: 'vault-host-lock-release-failed' },
+      });
+    } finally {
+      await chmod(lockDirectory, 0o700);
+    }
+    expect(await readFile(lockPath, 'utf8')).toContain(`"pid":${process.pid}`);
+
+    await expect(preparation.dispose()).resolves.toBeUndefined();
+    await expect(access(lockPath)).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
   it('replaces ordinary authority-transfer routes with a restart-safe terminal responder', async () => {

--- a/tests/integration/app/collab/membership/CloudMembershipManagement.test.ts
+++ b/tests/integration/app/collab/membership/CloudMembershipManagement.test.ts
@@ -31,6 +31,8 @@ const PROJECT_ID = 'project-cloud-management';
 const MEMBER_ID = 'member-manager';
 const MAIN_OID = 'a'.repeat(40);
 
+jest.setTimeout(30_000);
+
 describe('Cloud membership management', () => {
   it('does not create a receipt when the authority returns multiple active responsibility offers', async () => {
     const fixture = await createFixture({ receiptTarget: true, multipleReceiptOffers: true });
@@ -989,9 +991,10 @@ async function createFixture(options: { onInvitationRequest?: () => void; onInvi
 }
 
 async function waitUntil(predicate: () => boolean): Promise<void> {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
     if (predicate()) return;
-    await new Promise<void>(resolve => setTimeout(resolve, 5));
+    await new Promise<void>(resolve => setTimeout(resolve, 10));
   }
   throw new Error('Timed out waiting for fixture state');
 }
@@ -1000,14 +1003,15 @@ async function waitForDocument(
   documentPath: string,
   predicate: (value: Record<string, unknown>) => boolean,
 ): Promise<void> {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
     try {
       const value = JSON.parse(await readFile(documentPath, 'utf8')) as Record<string, unknown>;
       if (predicate(value)) return;
     } catch {
       // The lifecycle transition may not have created its document yet.
     }
-    await new Promise<void>(resolve => setTimeout(resolve, 5));
+    await new Promise<void>(resolve => setTimeout(resolve, 10));
   }
   throw new Error('Timed out waiting for fixture document');
 }

--- a/tests/unit/app/collab/authority-transfer/AuthorityTransferModule.test.ts
+++ b/tests/unit/app/collab/authority-transfer/AuthorityTransferModule.test.ts
@@ -91,6 +91,7 @@ class AuthorityTransferModule extends ProductionAuthorityTransferModule {
 function recoverableClaimantRecord(input: Readonly<{
   direction?: 'cloud-to-lan' | 'lan-to-cloud';
   expiresAt?: string;
+  operationIntentId?: string;
   phase?: SourceIssuedAuthorityTransferClaimantPhase;
 }> = {}): SourceIssuedAuthorityTransferClaimantRecord {
   const direction = input.direction ?? 'lan-to-cloud';
@@ -170,7 +171,7 @@ function recoverableClaimantRecord(input: Readonly<{
         }
       : null,
     memberId: 'member-host',
-    operationIntentId: 'intent-claimant-recovery',
+    operationIntentId: input.operationIntentId ?? 'intent-claimant-recovery',
     phase,
     projectId: PROJECT_ID,
     redemptionReceipt: phaseIndex >= 3
@@ -178,7 +179,7 @@ function recoverableClaimantRecord(input: Readonly<{
           checkpointSha256,
           claimSha256: createHash('sha256').update(claimValue, 'utf8').digest('hex'),
           memberId: 'member-host',
-          operationIntentId: 'intent-claimant-recovery',
+          operationIntentId: input.operationIntentId ?? 'intent-claimant-recovery',
           projectId: PROJECT_ID,
           receiptId: 'receipt-claimant-recovery',
           receiptKeyId: 'receipt-key-recovery',
@@ -809,7 +810,9 @@ describe('AuthorityTransferModule', () => {
   });
 
   it('prepares a product-owned Cloud-to-LAN target without exposing raw effects', async () => {
-    const dispose = jest.fn();
+    const dispose = jest.fn()
+      .mockRejectedValueOnce(new Error('simulated target cleanup failure'))
+      .mockResolvedValue(undefined);
     const prepareTarget = jest.fn(async () => ({
       targetUrl: 'https://192.168.1.20:54545',
     }));
@@ -855,8 +858,9 @@ describe('AuthorityTransferModule', () => {
 
     expect(binding.targetUrl).toBe('https://192.168.1.20:54545');
     expect(prepareTarget).toHaveBeenCalledWith('https://192.168.1.20:54545');
-    binding.dispose();
-    expect(dispose).toHaveBeenCalledTimes(1);
+    await expect(binding.dispose()).rejects.toThrow('simulated target cleanup failure');
+    await expect(binding.dispose()).resolves.toBeUndefined();
+    expect(dispose).toHaveBeenCalledTimes(2);
   });
 
   it('persists a selected non-Manager target before listener effects and freezes Manager begin before send', async () => {
@@ -1614,7 +1618,106 @@ describe('AuthorityTransferModule', () => {
     });
   });
 
-  it('releases a withdrawn preparation even when listener disposal fails', async () => {
+  it('releases failed pre-publication target cleanup before rebuilding the preparation', async () => {
+    let targetEntry: CloudToLanTargetEntryRecord | null = null;
+    const persistence = {
+      loadCloudToLanTargetEntry: jest.fn(async () => targetEntry),
+      prepareCloudToLanTargetEntry: jest.fn(async (entry: CloudToLanTargetEntryRecord) => {
+        targetEntry = entry;
+        return entry;
+      }),
+      publishCloudToLanTargetEntry: jest.fn()
+        .mockRejectedValueOnce(new Error('simulated descriptor persistence failure'))
+        .mockImplementation(async (
+          entry: CloudToLanTargetEntryRecord,
+          descriptor: Parameters<typeof publishCloudToLanTargetEntry>[1],
+        ) => {
+          targetEntry = publishCloudToLanTargetEntry(entry, descriptor);
+          return targetEntry;
+        }),
+    } as unknown as AuthorityTransferPersistence;
+    const connections = [0, 1].map(() => ({
+      authorityGeneration: 1,
+      dispose: jest.fn(),
+      lifecycle: { authorityTransfer: jest.fn() },
+      listProjectMembers: jest.fn(),
+      memberId: 'member-target',
+      personalRef: 'refs/heads/members/member-target',
+      projectId: PROJECT_ID,
+      readSnapshot: jest.fn(async () => ({
+        currentMember: {
+          displayName: 'Target',
+          id: 'member-target',
+          personalRef: 'refs/heads/members/member-target',
+          role: 'member',
+        },
+        project: { authorityGeneration: 1, id: PROJECT_ID },
+      })),
+      serverUrl: 'https://cloud.example.test/',
+    }));
+    const firstDispose = jest.fn()
+      .mockRejectedValueOnce(new Error('simulated listener cleanup failure'))
+      .mockResolvedValue(undefined);
+    const targetDisposals = [firstDispose, jest.fn(async () => undefined)];
+    let connectionIndex = 0;
+    let targetIndex = 0;
+    const module = new AuthorityTransferModule({
+      assertLanToCloudSourceOwner: () => undefined,
+      assertRecoveryOwner: () => undefined,
+      claimantStore: {
+        listProjectIds: () => Promise.resolve([]),
+        load: () => Promise.resolve(null),
+        remove: () => Promise.resolve(false),
+        save: () => Promise.resolve(),
+      },
+      convergence: {} as never,
+      createCloudToLanConnection: async () => connections[connectionIndex++] as never,
+      createCloudToLanTarget: () => ({
+        acceptanceRequest: jest.fn(),
+        activate: jest.fn(),
+        cancelStaging: jest.fn(),
+        dispose: targetDisposals[targetIndex++],
+        prepareTarget: jest.fn(async () => ({
+          caCertificatePem: '-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----',
+          caFingerprint: 'c'.repeat(64),
+          targetUrl: 'https://192.168.1.20:54545',
+        })),
+        stage: jest.fn(),
+      }),
+      createLanToCloudSource: jest.fn() as never,
+      installationKey: TEST_INSTALLATION_A,
+      lifecycle: {
+        registerDurableOwner: jest.fn(),
+        registerRecoveryStage: jest.fn(),
+        runExclusive: jest.fn(async (_projectId, _owner, _mode, operation) => operation()),
+      } as unknown as CollabProjectLifecycleSubsystem,
+      now: () => new Date('2026-08-27T00:00:00.000Z'),
+      persistence,
+    });
+
+    await expect(module.prepareCloudToLanTarget({
+      operationIntentId: 'intent-failed-target-publication',
+      projectId: PROJECT_ID,
+    })).rejects.toMatchObject({
+      result: {
+        durableProgress: true,
+        operationId: 'intent-failed-target-publication',
+        status: 'recovery-required',
+      },
+    });
+    await expect(module.prepareCloudToLanTarget({
+      operationIntentId: 'intent-failed-target-publication',
+      projectId: PROJECT_ID,
+    })).resolves.toMatchObject({
+      preparationId: 'intent-failed-target-publication',
+    });
+
+    expect(firstDispose).toHaveBeenCalledTimes(2);
+    expect(connections[0].dispose).toHaveBeenCalledTimes(2);
+    expect(connections[1].dispose).not.toHaveBeenCalled();
+  });
+
+  it('retains a withdrawn preparation until listener disposal can be retried', async () => {
     let targetEntry: CloudToLanTargetEntryRecord | null = null;
     const persistence = {
       loadCloudToLanTargetEntry: jest.fn(async () => targetEntry),
@@ -1707,15 +1810,35 @@ describe('AuthorityTransferModule', () => {
       preparationId: 'intent-first-target-preparation',
       projectId: PROJECT_ID,
     }))
-      .rejects.toThrow('listener-dispose-failed');
-    await module.prepareCloudToLanTarget({
+      .rejects.toMatchObject({
+        result: {
+          durableProgress: true,
+          operationId: 'intent-first-target-preparation',
+          status: 'recovery-required',
+        },
+      });
+    await expect(module.prepareCloudToLanTarget({
       operationIntentId: 'intent-replacement-target-preparation',
       projectId: PROJECT_ID,
+    })).rejects.toMatchObject({
+      result: {
+        durableProgress: true,
+        operationId: 'intent-first-target-preparation',
+        status: 'recovery-required',
+      },
     });
+    await expect(module.withdrawCloudToLanTarget({
+      preparationId: 'intent-first-target-preparation',
+      projectId: PROJECT_ID,
+    })).resolves.toBeUndefined();
+    await expect(module.prepareCloudToLanTarget({
+      operationIntentId: 'intent-replacement-target-preparation',
+      projectId: PROJECT_ID,
+    })).resolves.toBeDefined();
     await module.close();
 
-    expect(firstDispose).toHaveBeenCalledTimes(1);
-    expect(connections[0].dispose).toHaveBeenCalledTimes(1);
+    expect(firstDispose).toHaveBeenCalledTimes(2);
+    expect(connections[0].dispose).toHaveBeenCalledTimes(2);
     expect(connections[1].dispose).toHaveBeenCalledTimes(1);
   });
 
@@ -1769,9 +1892,9 @@ describe('AuthorityTransferModule', () => {
       })),
       serverUrl: 'https://cloud.example.test/',
     };
-    const disposeTarget = jest.fn(async () => {
-      throw new Error('listener-dispose-failed');
-    });
+    const disposeTarget = jest.fn()
+      .mockRejectedValueOnce(new Error('listener-dispose-failed'))
+      .mockResolvedValue(undefined);
     const module = new AuthorityTransferModule({
       assertLanToCloudSourceOwner: () => undefined,
       assertRecoveryOwner: () => undefined,
@@ -1827,13 +1950,23 @@ describe('AuthorityTransferModule', () => {
     await expect(module.withdrawCloudToLanTarget({
       preparationId: descriptor.preparationId,
       projectId: PROJECT_ID,
-    })).rejects.toThrow('listener-dispose-failed');
+    })).rejects.toMatchObject({
+      result: {
+        durableProgress: true,
+        operationId: descriptor.preparationId,
+        status: 'recovery-required',
+      },
+    });
+    await expect(module.withdrawCloudToLanTarget({
+      preparationId: descriptor.preparationId,
+      projectId: PROJECT_ID,
+    })).resolves.toBeUndefined();
 
     expect(targetEntry).toMatchObject({ phase: 'withdrawn' });
-    expect(disposeTarget).toHaveBeenCalledTimes(1);
-    expect(connection.dispose).toHaveBeenCalledTimes(1);
+    expect(disposeTarget).toHaveBeenCalledTimes(2);
+    expect(connection.dispose).toHaveBeenCalledTimes(2);
     await module.close();
-    expect(disposeTarget).toHaveBeenCalledTimes(1);
+    expect(disposeTarget).toHaveBeenCalledTimes(2);
   });
 
   it('classifies an existing target binding retry failure after durable progress', async () => {
@@ -1873,7 +2006,10 @@ describe('AuthorityTransferModule', () => {
       stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
       status: completedStatus,
     });
-    const targetEntry = handoffCloudToLanTargetEntry(published, physical);
+    const targetEntry = handoffCloudToLanTargetEntry(
+      published,
+      physical,
+    );
     let managerEntry: CloudToLanManagerEntryRecord | null = recordCloudToLanManagerStatus(
       markCloudToLanManagerBeginPossiblySent(createCloudToLanManagerEntry({
         createdAt: collectingStatus.createdAt,
@@ -1961,7 +2097,7 @@ describe('AuthorityTransferModule', () => {
     expect(createCloudToLanConnection).toHaveBeenCalledTimes(1);
   });
 
-  it('releases the target listener and Cloud session when Manager cancellation settlement fails', async () => {
+  it('retries retained target cleanup when cancelled acceptance settlement fails', async () => {
     const collectingStatus = proposal({
       direction: 'cloud-to-lan',
       sourceAuthority: { generation: 1, kind: 'cloud' },
@@ -1999,7 +2135,10 @@ describe('AuthorityTransferModule', () => {
       stagingDirectoryName: `.claudian-authority-transfer-${TRANSFER_ID}`,
       status: cancelledStatus,
     });
-    const targetEntry = handoffCloudToLanTargetEntry(published, physical);
+    let targetEntry: CloudToLanTargetEntryRecord | null = handoffCloudToLanTargetEntry(
+      published,
+      physical,
+    );
     let managerEntry: CloudToLanManagerEntryRecord | null = recordCloudToLanManagerStatus(
       markCloudToLanManagerBeginPossiblySent(createCloudToLanManagerEntry({
         createdAt: collectingStatus.createdAt,
@@ -2011,7 +2150,9 @@ describe('AuthorityTransferModule', () => {
       })),
       collectingStatus,
     );
-    const completeTerminalCleanup = jest.fn(async () => undefined);
+    const completeTerminalCleanup = jest.fn(async () => {
+      targetEntry = null;
+    });
     const persistence = {
       completeTerminalCleanup,
       load: jest.fn(async () => physical),
@@ -2023,7 +2164,9 @@ describe('AuthorityTransferModule', () => {
       settleCloudToLanManagerEntry: jest.fn(async () => { managerEntry = null; }),
     } as unknown as AuthorityTransferPersistence;
     const cancelStaging = jest.fn(async () => undefined);
-    const disposeTarget = jest.fn(async () => undefined);
+    const disposeTarget = jest.fn()
+      .mockRejectedValueOnce(new Error('simulated target cleanup failure'))
+      .mockResolvedValue(undefined);
     const connection = {
       authorityGeneration: 1,
       dispose: jest.fn(),
@@ -2035,6 +2178,7 @@ describe('AuthorityTransferModule', () => {
       readSnapshot: jest.fn(),
       serverUrl: 'https://cloud.example.test/',
     };
+    const createCloudToLanConnection = jest.fn(async () => connection as never);
     const module = new AuthorityTransferModule({
       assertLanToCloudSourceOwner: () => undefined,
       assertRecoveryOwner: () => undefined,
@@ -2045,7 +2189,7 @@ describe('AuthorityTransferModule', () => {
         save: () => Promise.resolve(),
       },
       convergence: {} as never,
-      createCloudToLanConnection: async () => connection as never,
+      createCloudToLanConnection,
       createCloudToLanTarget: () => ({
         acceptanceRequest: jest.fn(),
         activate: jest.fn(),
@@ -2080,11 +2224,41 @@ describe('AuthorityTransferModule', () => {
         status: 'recovery-required',
       },
     });
+    await expect(module.prepareCloudToLanTarget({
+      operationIntentId: 'intent-replacement-after-disposed-cancelled-target',
+      projectId: PROJECT_ID,
+    })).rejects.toMatchObject({
+      result: {
+        durableProgress: true,
+        operationId: physical.operationIntentId,
+        status: 'recovery-required',
+      },
+    });
+    await expect(module.acceptCloudToLanTransfer({
+      handle: cloudToLanTransferHandle(managerEntry!),
+    })).rejects.toMatchObject({
+      result: {
+        durableProgress: true,
+        operationId: physical.operationIntentId,
+        status: 'recovery-required',
+      },
+    });
+    await expect(module.prepareCloudToLanTarget({
+      operationIntentId: 'intent-replacement-after-cancelled-cleanup',
+      projectId: PROJECT_ID,
+    })).rejects.toMatchObject({
+      result: {
+        durableProgress: true,
+        operationId: physical.operationIntentId,
+        status: 'recovery-required',
+      },
+    });
 
     expect(cancelStaging).toHaveBeenCalledTimes(1);
     expect(completeTerminalCleanup).toHaveBeenCalledTimes(1);
-    expect(disposeTarget).toHaveBeenCalledTimes(1);
-    expect(connection.dispose).toHaveBeenCalledTimes(2);
+    expect(disposeTarget).toHaveBeenCalledTimes(2);
+    expect(createCloudToLanConnection).toHaveBeenCalledTimes(2);
+    expect(connection.dispose).toHaveBeenCalledTimes(3);
     expect(managerEntry).toMatchObject({ phase: 'observing' });
   });
 
@@ -2955,6 +3129,100 @@ describe('AuthorityTransferModule', () => {
     expect(record).toBeNull();
     expect(cloudSession.dispose).toHaveBeenCalledTimes(1);
   });
+
+  it.each(['lan-to-cloud', 'cloud-to-lan'] as const)(
+    'derives a bounded source ACK key for a maximum-length %s claimant intent',
+    async (direction) => {
+      const operationIntentId = 'x'.repeat(128);
+      let record: AuthorityTransferClaimantRecord | null = recoverableClaimantRecord({
+        direction,
+        operationIntentId,
+        phase: 'target-claimed',
+      });
+      const sourceAck = { idempotencyKey: null as string | null };
+      const lanRequest = jest.fn(async (
+        _operation: string,
+        request: Readonly<{ readonly idempotencyKey: string }>,
+      ) => {
+        sourceAck.idempotencyKey = request.idempotencyKey;
+      });
+      const cloudRequest = jest.fn(async (
+        _operation: string,
+        request: Readonly<{ readonly idempotencyKey: string }>,
+      ) => {
+        sourceAck.idempotencyKey = request.idempotencyKey;
+      });
+      const cloudSession = {
+        dispose: jest.fn(),
+        lifecycle: { authorityTransfer: cloudRequest },
+        projectId: PROJECT_ID,
+        readSnapshot: jest.fn(async () => ({
+          currentMember: { id: 'member-host' },
+          eventSequence: 1,
+          project: { id: PROJECT_ID },
+        })),
+        serverUrl: 'https://cloud.example.test/',
+        supports: () => true,
+      } as unknown as CloudAuthorityConnection;
+      const module = new AuthorityTransferModule({
+        assertLanToCloudSourceOwner: () => undefined,
+        assertRecoveryOwner: () => undefined,
+        claimantStore: {
+          listProjectIds: async () => record ? [PROJECT_ID] : [],
+          load: async () => record,
+          remove: async () => {
+            const existed = record !== null;
+            record = null;
+            return existed;
+          },
+          save: async current => { record = current; },
+        },
+        convergence: {
+          cloudToLanMember: jest.fn(async () => undefined),
+          lanToCloudMember: jest.fn(async () => undefined),
+        } as never,
+        createLanTargetSnapshotReader: () => ({
+          readSnapshot: jest.fn(async () => ({
+            currentMember: { id: 'member-host' },
+            eventSequence: 1,
+            project: { id: PROJECT_ID },
+          } as never)),
+        }),
+        createLanToCloudSource: jest.fn() as never,
+        installationKey: TEST_INSTALLATION_A,
+        lifecycle: {
+          registerDurableOwner: jest.fn(),
+          registerRecoveryStage: jest.fn(),
+        } as unknown as CollabProjectLifecycleSubsystem,
+        persistence: {} as AuthorityTransferPersistence,
+      });
+      const lanClient = {
+        claimTransferredMembership: jest.fn(),
+        requestWithMember: lanRequest,
+      } as unknown as LanAuthorityTransferClient;
+      const binding = direction === 'lan-to-cloud'
+        ? module.bindLanToCloudClaimant({
+            cloudSession,
+            lanClient,
+            memberCredential: Buffer.alloc(32, 1).toString('base64url'),
+            projectId: PROJECT_ID,
+          })
+        : module.bindCloudToLanClaimant({
+            cloudSession,
+            lanClient,
+            projectId: PROJECT_ID,
+            targetHost: record!.lanTarget!,
+          });
+
+      await binding.coordinator.resume(PROJECT_ID);
+
+      if (sourceAck.idempotencyKey === null) throw new Error('Missing source ACK key');
+      expect(sourceAck.idempotencyKey).toMatch(/^[A-Za-z0-9._:-]+$/);
+      expect(sourceAck.idempotencyKey.length).toBeLessThanOrEqual(128);
+      expect(sourceAck.idempotencyKey).not.toContain(operationIntentId);
+      expect(record).toBeNull();
+    },
+  );
 
   it('redeems a Manager-reissued claim through exact Cloud status and snapshot confirmation', async () => {
     let record: AuthorityTransferClaimantRecord | null = null;

--- a/tests/unit/app/collab/authority-transfer/ProductionAuthorityTransferCoordinators.test.ts
+++ b/tests/unit/app/collab/authority-transfer/ProductionAuthorityTransferCoordinators.test.ts
@@ -359,6 +359,7 @@ describe('production authority-transfer direction coordinators', () => {
       'claims',
       'custody',
       'relinquish',
+      'source-ack',
       'stage',
     ] as const).map(operation => authorityTransferChildIdempotencyKey(
       operationIntentId,

--- a/tests/unit/app/collab/remote-authority/CloudAuthorityAdapter.test.ts
+++ b/tests/unit/app/collab/remote-authority/CloudAuthorityAdapter.test.ts
@@ -173,6 +173,8 @@ function cloudSnapshot() {
 }
 
 describe('CloudAuthorityAdapter', () => {
+  jest.setTimeout(30_000);
+
   it('preserves the HTTPS prefix with native certificate verification for JSON, artifacts, and WebSockets', async () => {
     const root = await mkdtemp(path.join(tmpdir(), 'claudian-cloud-tls-'));
     const identity = await new LanTlsIdentity(root, { installationKey: TEST_INSTALLATION_A })
@@ -232,7 +234,7 @@ describe('CloudAuthorityAdapter', () => {
         await Promise.race([
           opened,
           new Promise<never>((_resolve, reject) => {
-            eventDeadline = setTimeout(() => reject(new Error('TLS event connection did not open')), 500);
+            eventDeadline = setTimeout(() => reject(new Error('TLS event connection did not open')), 5_000);
           }),
         ]);
         expect(observed).toEqual([


### PR DESCRIPTION
## Summary
- retain Cloud-to-LAN target cleanup ownership across preparation, withdrawal, cancellation, terminal handoff, and Host-lock failures
- derive bounded source acknowledgement idempotency keys for maximum-length transfer intents
- isolate the completed LAN-to-Cloud recovery fixture from parallel listener-port contention

## Verification
- full Jest: 619 suites passed, 9298 tests passed, 2 existing descriptor-gated skips
- Jest open-handle check: PASS with the same 619 suites / 9298 tests
- cross-platform Collab: 29 suites / 373 tests
- typecheck, lint, architecture (40), lockfile, safe production build, performance check
- five fresh GT review passes; final pass reported no material findings

Targets only codex/cloud-integration. No UI, Protocol, Cloud Server, Gomami, installed Vault, or Step 14 changes.