### PR TITLE
Balance locked Linked-content chip padding

### DIFF
--- a/src/style/components/context-tray.css
+++ b/src/style/components/context-tray.css
@@ -41,6 +41,10 @@
   border-color: var(--background-modifier-border-hover);
 }
 
+.claudian-context-chip--content:not(:has(.claudian-context-chip-remove)) {
+  padding-right: 10px;
+}
+
 .claudian-context-chip--missing {
   border-color: var(--text-error);
 }

--- a/tests/unit/style/components/linked-content.test.ts
+++ b/tests/unit/style/components/linked-content.test.ts
@@ -65,6 +65,10 @@ describe('Linked content styles', () => {
     expect(contextTrayCss).toMatch(/\.claudian-context-chip--missing\s*{/);
   });
 
+  it('balances locked Linked content when the remove control is absent', () => {
+    expect(contextTrayCss).toMatch(/\.claudian-context-chip--content:not\(:has\(\.claudian-context-chip-remove\)\)\s*{[^}]*padding-right:\s*10px;/);
+  });
+
   it('keeps context removal controls muted and chromeless until interaction', () => {
     expect(contextTrayCss).toMatch(/\.claudian-context-chip-remove\s*{[^}]*background:\s*transparent;[^}]*color:\s*var\(--text-muted\);/);
     expect(contextTrayCss).toMatch(/\.claudian-context-chip\s*>\s*button\.claudian-context-chip-remove,[\s\S]*?\.claudian-context-chip\s*>\s*button\.claudian-context-chip-remove:active\s*{[^}]*background:\s*transparent;[^}]*color:\s*var\(--text-muted\);/);


### PR DESCRIPTION
## Why

Locked Linked-content chips lose their remove control after a conversation starts, leaving the right edge visually tight. No issue is needed for this focused visual correction.

## What Changed

- Adds 4px of right padding only when the Linked-content remove control is absent.
- Covers the locked-chip selector with a style regression test.

## Why This Approach

The selector reuses the existing absence of the remove control, avoiding additional TypeScript state or markup.

## Validation

- `npm run typecheck && npm run lint && npm run test && npm run build`
- 8,907 tests passed; 2 skipped.

## Impact and Follow-ups

None.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
