### PR TITLE
fix(collab): close Step 13 recovery gaps

### DIFF
--- a/src/app/collab/ClaudianCollabService.ts
+++ b/src/app/collab/ClaudianCollabService.ts
@@ -120,7 +120,11 @@ import {
 import { RetirementTerminalService } from '@/app/collab/retirement/RetirementTerminalService';
 import { RetirementTombstoneRepository } from '@/app/collab/retirement/RetirementTombstoneRepository';
 import { SerialTaskQueue } from '@/app/collab/SerialTaskQueue';
-import type { CollabRetirementResult, CollabRetireProjectRequest } from '@/core/collab';
+import type {
+  CollabOperationOptions,
+  CollabRetirementResult,
+  CollabRetireProjectRequest,
+} from '@/core/collab';
 import { CollabError } from '@/core/collab/ClaudianCollabError';
 import type { InstallationKey } from '@/core/device/InstallationKey';
 
@@ -201,6 +205,10 @@ function collabServiceError(
         : [],
     safeContext: { reason, ...safeContext },
   });
+}
+
+function throwIfCancelled(signal?: AbortSignal): void {
+  if (signal?.aborted) throw new CollabError({ code: 'cancelled' });
 }
 
 function environmentPath(environment: NodeJS.ProcessEnv): string | undefined {
@@ -433,12 +441,15 @@ export class ClaudianCollabService {
   async activateAuthorityTransferSourceRoute(
     projectId: CollabProjectId,
     expectedEndpoint?: string,
+    options: CollabOperationOptions = {},
   ): Promise<() => Promise<void>> {
     this.#assertOpen();
+    throwIfCancelled(options.signal);
     if (this.lanHost.isProjectRunning(projectId)) {
       return async () => undefined;
     }
     const authority = await this.inspectAuthority(projectId);
+    throwIfCancelled(options.signal);
     if (!authority) {
       throw collabServiceError(
         'not-initialized',
@@ -446,6 +457,7 @@ export class ClaudianCollabService {
       );
     }
     const project = await authority.database.read(connection => authority.projects.get(connection));
+    throwIfCancelled(options.signal);
     if (!project || project.projectId !== projectId) {
       throw collabServiceError(
         'not-initialized',
@@ -473,7 +485,7 @@ export class ClaudianCollabService {
       projectId,
       service,
       state: 'source-active',
-    });
+    }, options);
     return () => this.lanHost.stopAuthorityTransferRoute(projectId, 'source-active');
   }
 

--- a/src/app/collab/CollabFeatureService.ts
+++ b/src/app/collab/CollabFeatureService.ts
@@ -398,6 +398,7 @@ export interface CollabAuthorityTransferEntryPort {
     input: CollabBeginCloudToLanTransferRequest & Readonly<{ readonly operationIntentId: string }>,
     options?: CollabOperationOptions,
   ): Promise<CollabCloudToLanTransferHandle>;
+  beginClose(): void;
   close(): Promise<void>;
   cancelCloudToLanTransfer(
     handle: CollabCloudToLanTransferHandle,
@@ -2024,23 +2025,24 @@ class CollabFeatureServiceCore {
     if (this.#closePromise) return this.#closePromise;
     this.#closing = true;
     this.operationAdmission.beginClose();
+    this.options.authorityTransfer.beginClose();
     this.#activeOperationController?.abort();
     this.#lifecycleRecoveryController?.abort();
     const lifecycleRecoveryDrain = this.#lifecycleRecoveryPromise?.catch(() => undefined)
       ?? Promise.resolve();
-    let lifecycleRecoveryClose: Promise<void>;
-    try {
-      lifecycleRecoveryClose = Promise.resolve(this.options.lifecycleRecovery.close())
-        .catch(() => undefined);
-    } catch {
-      lifecycleRecoveryClose = Promise.resolve();
-    }
     const close = (async () => {
       await this.options.cloudEntry.close();
       await this.operationAdmission.drain();
       await lifecycleRecoveryDrain;
-      await lifecycleRecoveryClose;
-      await this.options.authorityTransfer.close();
+      await Promise.resolve()
+        .then(() => this.options.lifecycleRecovery.close())
+        .catch(() => undefined);
+      const closeErrors: unknown[] = [];
+      try {
+        await this.options.authorityTransfer.close();
+      } catch (error) {
+        closeErrors.push(error);
+      }
       await Promise.resolve()
         .then(() => this.options.retirement.close())
         .catch(() => undefined);
@@ -2048,12 +2050,19 @@ class CollabFeatureServiceCore {
         .then(() => this.options.hostTransfer.close())
         .catch(() => undefined);
       this.disposed = true;
-      this.#publicationSubscription.dispose();
+      try {
+        this.#publicationSubscription.dispose();
+      } catch (error) {
+        closeErrors.push(error);
+      }
       try {
         await this.options.publication.close();
+      } catch (error) {
+        closeErrors.push(error);
       } finally {
         this.listeners.clear();
       }
+      if (closeErrors.length > 0) throw closeErrors[0];
     })();
     this.#closePromise = close;
     return close;

--- a/src/app/collab/CollabFeatureSubcomposition.ts
+++ b/src/app/collab/CollabFeatureSubcomposition.ts
@@ -59,6 +59,7 @@ import {
   createCollabProjectLifecycleDurableOwners,
 } from '@/app/collab/lifecycle/CollabProjectLifecycleOwners';
 import { CollabProjectLifecycleSubsystem } from '@/app/collab/lifecycle/CollabProjectLifecycleSubsystem';
+import { decodeCloudManagementIntent } from '@/app/collab/membership/CloudManagementIntent';
 import { CollabMembershipService } from '@/app/collab/membership/CollabMembershipService';
 import {
   ManagerResponsibilityOperationCoordinator,
@@ -424,9 +425,8 @@ export function createCollabFeatureSubcomposition(
       reconcileSnapshot: (snapshot, assertCurrent) => {
         void requireFeature().runProjectLifecycleTransition(
           snapshot.project.id,
-          () => requireLifecycle().runExclusive(
+          () => requireLifecycle().runManagerResponsibility(
             snapshot.project.id,
-            'manager-responsibility',
             'continuation',
             async () => {
               assertCurrent();
@@ -453,10 +453,15 @@ export function createCollabFeatureSubcomposition(
     },
     {},
     {
-      managerResponsibilityAdmission: (projectId, operation) => (
-        requireLifecycle().runExclusive(
+      cloudManagementAdmission: (projectId, operation) => (
+        requireLifecycle().runCloudManagement(
           projectId,
-          'manager-responsibility',
+          operation,
+        )
+      ),
+      managerResponsibilityAdmission: (projectId, operation) => (
+        requireLifecycle().runManagerResponsibility(
+          projectId,
           'operation',
           operation,
         )
@@ -608,6 +613,13 @@ export function createCollabFeatureSubcomposition(
     closeRecovery: () => acknowledgementWorker.close(),
     durableOwners: createCollabProjectLifecycleDurableOwners(
       {
+        cloudManagementIntents: {
+          load: projectId => foundation.local.projects.loadProjectDocument(
+            projectId,
+            'cloud-management-intent',
+            decodeCloudManagementIntent,
+          ),
+        },
         cloudRetirementIntents: retirementIntents,
         hostTransferRecovery: foundation.local.projects.hostTransferRecovery,
         localCleanup: foundation.local.projects.localCleanup,
@@ -791,8 +803,12 @@ export function createCollabFeatureSubcomposition(
     loadMembership: projectId => foundation.local.projects.loadMembership(projectId),
   });
   const authorityTransfer = new AuthorityTransferModule({
-    activateLanToCloudSourceRoute: (projectId, expectedEndpoint) => (
-      foundation.activateAuthorityTransferSourceRoute(projectId, expectedEndpoint)
+    activateLanToCloudSourceRoute: (projectId, expectedEndpoint, operationOptions) => (
+      foundation.activateAuthorityTransferSourceRoute(
+        projectId,
+        expectedEndpoint,
+        operationOptions,
+      )
     ),
     assertLanToCloudSourceOwner: (projectId, expectedAuthorityGeneration) => (
       foundation.assertLanToCloudSourceOwner(projectId, expectedAuthorityGeneration)

--- a/src/app/collab/authority-transfer/AuthorityTransferEntryService.ts
+++ b/src/app/collab/authority-transfer/AuthorityTransferEntryService.ts
@@ -89,6 +89,7 @@ export class AuthorityTransferEntryService {
   readonly #createLanClient: NonNullable<AuthorityTransferEntryServiceOptions['createLanClient']>;
   readonly #loadMembership: AuthorityTransferEntryServiceOptions['loadMembership'];
   readonly #module: AuthorityTransferModule;
+  readonly #sharedAcceptController = new AbortController();
   readonly #pendingAccepts = new Map<CollabProjectId, PendingLanToCloudAcceptance>();
   readonly #pendingSources = new Map<
     CollabProjectId,
@@ -182,9 +183,11 @@ export class AuthorityTransferEntryService {
       if (pending.transferId !== request.transferId) {
         throw entryError('authority-transfer-source-proposal-stale');
       }
-      return this.#waitForAcceptance(pending.promise, options.signal);
+      return this.#waitForSharedAcceptance(pending.promise, options.signal);
     }
-    const promise = this.#acceptLanToCloudTransfer(request, {});
+    const promise = this.#acceptLanToCloudTransfer(request, {
+      signal: this.#sharedAcceptController.signal,
+    });
     const acceptance = { promise, transferId: request.transferId };
     this.#pendingAccepts.set(request.projectId, acceptance);
     const clear = () => {
@@ -193,7 +196,7 @@ export class AuthorityTransferEntryService {
       }
     };
     void promise.then(clear, clear);
-    return this.#waitForAcceptance(promise, options.signal);
+    return this.#waitForSharedAcceptance(promise, options.signal);
   }
 
   async #acceptLanToCloudTransfer(
@@ -205,6 +208,7 @@ export class AuthorityTransferEntryService {
       this.#requireLanMembership(request.projectId, true),
       this.#requireProposal(request.projectId),
     ]);
+    throwIfCancelled(options.signal);
     if (proposal.status.transferId !== request.transferId) {
       throw entryError('authority-transfer-source-proposal-stale');
     }
@@ -232,7 +236,7 @@ export class AuthorityTransferEntryService {
       expectedSourceEndpoint: membership.authority.endpoint!,
       expectedTargetUrl: proposal.request.targetUrl,
       projectId: request.projectId,
-    });
+    }, options);
     if (isTerminal(result)) await this.#releaseSource(request.projectId, runtime);
     return result;
   }
@@ -321,8 +325,13 @@ export class AuthorityTransferEntryService {
     return this.#module.redeemManagerReissuedClaim(invitation, options);
   }
 
-  async close(): Promise<void> {
+  beginClose(): void {
     this.#closed = true;
+    this.#sharedAcceptController.abort();
+  }
+
+  async close(): Promise<void> {
+    this.beginClose();
     await Promise.allSettled([...this.#pendingAccepts.values()].map(({ promise }) => promise));
     try {
       await this.#module.close();
@@ -422,16 +431,31 @@ export class AuthorityTransferEntryService {
   #waitForAcceptance(
     promise: Promise<CollabAuthorityTransferStatus>,
     signal?: AbortSignal,
+    abortError = new CollabError({ code: 'cancelled' }),
   ): Promise<CollabAuthorityTransferStatus> {
     if (!signal) return promise;
     throwIfCancelled(signal);
     return new Promise<CollabAuthorityTransferStatus>((resolve, reject) => {
-      const onAbort = () => reject(new CollabError({ code: 'cancelled' }));
+      const onAbort = () => reject(abortError);
       signal.addEventListener('abort', onAbort, { once: true });
       void promise.then(resolve, reject).finally(() => {
         signal.removeEventListener('abort', onAbort);
       });
     });
+  }
+
+  #waitForSharedAcceptance(
+    promise: Promise<CollabAuthorityTransferStatus>,
+    callerSignal?: AbortSignal,
+  ): Promise<CollabAuthorityTransferStatus> {
+    return this.#waitForAcceptance(
+      this.#waitForAcceptance(
+        promise,
+        this.#sharedAcceptController.signal,
+        entryError('authority-transfer-entry-service-closed'),
+      ),
+      callerSignal,
+    );
   }
 
   async #releaseSource(

--- a/src/app/collab/authority-transfer/AuthorityTransferModule.ts
+++ b/src/app/collab/authority-transfer/AuthorityTransferModule.ts
@@ -138,7 +138,8 @@ export interface AuthorityTransferModuleOptions {
   ) => Pick<ProjectControlClient, 'readSnapshot'>;
   readonly activateLanToCloudSourceRoute?: (
     projectId: CollabProjectId,
-    expectedEndpoint?: string,
+    expectedEndpoint: string | undefined,
+    options: CollabOperationOptions,
   ) => Promise<() => Promise<void>>;
   readonly lifecycle: CollabProjectLifecycleSubsystem;
   readonly loadClaimantMembership?: (
@@ -340,6 +341,10 @@ function moduleError(reason: string): CollabError {
   });
 }
 
+function throwIfCancelled(signal?: AbortSignal): void {
+  if (signal?.aborted) throw new CollabError({ code: 'cancelled' });
+}
+
 function durableOutcome(operationId: string, reason: string): CollabAuthorityTransferOutcomeError {
   return new CollabAuthorityTransferOutcomeError({
     durablePhase: 'committed',
@@ -437,10 +442,14 @@ export class AuthorityTransferModule {
 
   async bindLanToCloudSource(
     input: BindLanToCloudSourceInput,
+    options: CollabOperationOptions = {},
   ): Promise<AuthorityTransferDirectionBinding<LanToCloudSourceCoordinator>> {
+    throwIfCancelled(options.signal);
     this.assertCloudSession(input.projectId, input.cloudSession);
     const sourceEntry = await this.options.persistence.loadSourceEntry(input.projectId);
+    throwIfCancelled(options.signal);
     const record = sourceEntry ? null : await this.options.persistence.load(input.projectId);
+    throwIfCancelled(options.signal);
     const expectedAuthorityGeneration = sourceEntry?.request.expectedAuthorityGeneration
       ?? (record?.localRole === 'source'
         ? record.status.sourceAuthority.generation
@@ -452,6 +461,7 @@ export class AuthorityTransferModule {
       input.projectId,
       expectedAuthorityGeneration,
     );
+    throwIfCancelled(options.signal);
     const persistedTargetUrl = sourceEntry?.request.targetUrl
       ?? (record?.localRole === 'source' ? record.status.targetUrl : undefined);
     if (
@@ -484,16 +494,21 @@ export class AuthorityTransferModule {
       cleanupRoute = await this.options.activateLanToCloudSourceRoute?.(
         input.projectId,
         input.expectedSourceEndpoint,
+        options,
       ) ?? (async () => undefined);
-      return Object.freeze({
-        coordinator,
-        dispose: () => this.disposeLanToCloudSourceBinding(input.projectId, binding),
-      });
     } catch (error) {
       this.sourceBindings.delete(input.projectId);
       unregister();
       throw error;
     }
+    if (options.signal?.aborted) {
+      await this.disposeLanToCloudSourceBinding(input.projectId, binding);
+      throwIfCancelled(options.signal);
+    }
+    return Object.freeze({
+      coordinator,
+      dispose: () => this.disposeLanToCloudSourceBinding(input.projectId, binding),
+    });
   }
 
   createLanToCloudRequester(
@@ -618,29 +633,33 @@ export class AuthorityTransferModule {
   acceptLanToCloudTransferTarget(
     request: AcceptLanToCloudTransferTargetRequest,
     sourceInput?: BindLanToCloudSourceInput,
+    options: CollabOperationOptions = {},
   ): Promise<CollabAuthorityTransferStatus> {
     return this.options.lifecycle.runExclusive(
       request.projectId,
       'authority-transfer',
       'continuation',
       async () => {
+        throwIfCancelled(options.signal);
         await this.assertLanToCloudSourceOwner(
           request.projectId,
           request.expectedAuthorityGeneration,
         );
+        throwIfCancelled(options.signal);
         let binding = this.sourceBindings.get(request.projectId);
         if (!binding && sourceInput) {
           if (sourceInput.projectId !== request.projectId) {
             throw moduleError('authority-transfer-source-runtime-mismatch');
           }
-          await this.bindLanToCloudSource(sourceInput);
+          await this.bindLanToCloudSource(sourceInput, options);
           binding = this.sourceBindings.get(request.projectId);
         }
+        throwIfCancelled(options.signal);
         if (!binding) throw moduleError('authority-transfer-source-runtime-unavailable');
         if (binding.targetUrl !== request.targetUrl) {
           throw moduleError('authority-transfer-cloud-target-mismatch');
         }
-        const status = await binding.coordinator.acceptAndTransfer(request);
+        const status = await binding.coordinator.acceptAndTransfer(request, options);
         if (status.state === 'cancelled' || status.state === 'completed') {
           await this.disposeLanToCloudSourceBinding(request.projectId, binding);
         }
@@ -1703,7 +1722,7 @@ export class AuthorityTransferModule {
     this.targetBindings.clear();
     this.targetPreparations.clear();
     this.recoveredCloudSessions.clear();
-    await Promise.all([
+    const results = await Promise.allSettled([
       ...sourceBindings.map(([projectId, binding]) => (
         this.disposeLanToCloudSourceBinding(projectId, binding)
       )),
@@ -1714,6 +1733,10 @@ export class AuthorityTransferModule {
       )),
       ...recoveredCloudSessions.map(async session => { session.dispose(); }),
     ]);
+    const failure = results.find(
+      (result): result is PromiseRejectedResult => result.status === 'rejected',
+    );
+    if (failure) throw failure.reason;
   }
 
   bindLanToCloudClaimant(

--- a/src/app/collab/authority-transfer/lan-to-cloud/LanToCloudSourceCoordinator.ts
+++ b/src/app/collab/authority-transfer/lan-to-cloud/LanToCloudSourceCoordinator.ts
@@ -98,6 +98,10 @@ function transferError(reason: string): CollabError {
   });
 }
 
+function throwIfCancelled(signal?: AbortSignal): void {
+  if (signal?.aborted) throw new CollabError({ code: 'cancelled' });
+}
+
 function stagingDirectory(transferId: string): string {
   return `.claudian-authority-transfer-${transferId}`;
 }
@@ -115,6 +119,7 @@ export class LanToCloudSourceCoordinator {
     request: AcceptLanToCloudTransferTargetRequest,
     options: CollabOperationOptions = {},
   ): Promise<CollabAuthorityTransferStatus> {
+    throwIfCancelled(options.signal);
     const entry = await this.options.persistence.loadSourceEntry(request.projectId);
     if (
       !entry

--- a/src/app/collab/lan/LanHostCoordinator.ts
+++ b/src/app/collab/lan/LanHostCoordinator.ts
@@ -107,6 +107,10 @@ const ACTIVE_HOST_LOCK_NONCES = (() => {
   return created;
 })();
 
+function throwIfCancelled(signal?: AbortSignal): void {
+  if (signal?.aborted) throw new CollabError({ code: 'cancelled' });
+}
+
 export interface LanHostGitProxy {
   close(): Promise<void>;
   enable(): Promise<void>;
@@ -662,19 +666,28 @@ export class LanHostCoordinator {
 
   startAuthorityTransferRoute(
     registration: LanAuthorityTransferRouteRegistration,
+    options: Readonly<{ readonly signal?: AbortSignal }> = {},
   ): Promise<LanHostAuthorityTransferSession> {
     return this.#operationQueue.run(async () => {
+      throwIfCancelled(options.signal);
       this.#assertOpen();
       const firstListenerOwner = !this.listener
         && this.#hostedProjects.size === 0
         && this.terminalProjects.size === 0
         && this.provisionalTransfers.size === 0
         && this.#authorityTransferRoutes.size === 0;
-      if (firstListenerOwner) await this.#acquireHostLock();
+      let routeInstalled = false;
       try {
+        if (firstListenerOwner) {
+          await this.#acquireHostLock();
+          throwIfCancelled(options.signal);
+        }
         const expectedEndpoint = registration.expectedEndpoint
           ?? (registration.state === 'source-active' ? null : (this.listener?.endpoint ?? null));
-        if (!this.listener) this.listener = await this.#startListener(expectedEndpoint);
+        if (!this.listener) {
+          this.listener = await this.#startListener(expectedEndpoint);
+          throwIfCancelled(options.signal);
+        }
         this.#assertOpen();
         if (expectedEndpoint !== null && this.listener.endpoint !== expectedEndpoint) {
           throw hostError(
@@ -695,6 +708,7 @@ export class LanHostCoordinator {
             && current.transferId === registration.transferId
           )
         ) {
+          throwIfCancelled(options.signal);
           return {
             caCertificatePem: this.listener.caCertificatePem,
             caFingerprint: this.listener.caFingerprint,
@@ -702,7 +716,10 @@ export class LanHostCoordinator {
             projectId: registration.projectId,
           };
         }
+        throwIfCancelled(options.signal);
         await this.#authorityTransferRoutes.install(registration);
+        routeInstalled = true;
+        throwIfCancelled(options.signal);
         this.#scheduleAuthorityTransferExpiry(registration);
         this.#startAddressMonitor();
         return {
@@ -712,6 +729,13 @@ export class LanHostCoordinator {
           projectId: registration.projectId,
         };
       } catch (error) {
+        if (routeInstalled) {
+          const removed = await this.#authorityTransferRoutes.remove(
+            registration.projectId,
+            registration.state,
+          );
+          if (removed) this.#clearAuthorityTransferExpiry(registration.projectId);
+        }
         if (firstListenerOwner) await this.#closeUnusedListener().catch(() => undefined);
         throw error;
       }

--- a/src/app/collab/lifecycle/AGENTS.md
+++ b/src/app/collab/lifecycle/AGENTS.md
@@ -2,10 +2,11 @@
 
 ## Ownership
 
-- `CollabProjectLifecycleSubsystem` is the single app-owned assembly, recovery registration, and per-Project arbitration boundary for Leave, Retire, physical Host transfer, production authority transfer, private bootstrap transition, responsibility handoff, retirement acknowledgement, and local cleanup.
+- `CollabProjectLifecycleSubsystem` is the single app-owned assembly, recovery registration, and per-Project arbitration boundary for Leave, Retire, physical Host transfer, production authority transfer, private bootstrap transition, Cloud management intent, responsibility handoff, retirement acknowledgement, and local cleanup.
 - Each lifecycle module retains its own authorization, phases, persistence, physical effects, and recovery policy. The subsystem owns only mutually exclusive transition admission, stable owner dispatch, startup ordering, and common close/drain; it never interprets another owner's journal or becomes a generic phase engine.
 - Register Project-local recovery through `CollabLocalProjectRepository` and the existing subsystem enumeration. Vault-wide pending-Leave and applied-Retired-cleanup journals remain with `CollabLifecycleJournalStore`. Do not add a second Project catalog or infer pending work from the Project index.
 - A pending Cloud entry is a nonterminal durable owner, including after local finalization while activation or pending removal remains incomplete. Resume resolves the Project from the stored operation and reacquires this same arbiter before replay or working-copy effects; it cannot pass another nonterminal owner. New native Create allocates a fresh Project identity before admission, rather than taking over an existing Project lifecycle.
+- A Cloud management intent is nonterminal in every persisted phase until the exact retained result is explicitly completed. Retire, authority movement, and other lifecycle owners must block rather than adopt or remove that intent; completed rejections and actor-only authority reads are not operation-specific proof that it can be discarded. The independent Manager-responsibility receipt lane is the sole dual-owner exception: automatic responsibility reconciliation may begin beside Cloud management, and either owner may continue only when that exact pair already exists. A Manager-responsibility record alone still blocks a new Cloud management mutation.
 
 ## Arbitration
 

--- a/src/app/collab/lifecycle/CollabProjectLifecycleOwners.ts
+++ b/src/app/collab/lifecycle/CollabProjectLifecycleOwners.ts
@@ -10,11 +10,15 @@ import type { HostTransferRecoveryRecord } from '@/app/collab/host-transfer/Host
 import type {
   CollabProjectLifecycleDurableOwner,
 } from '@/app/collab/lifecycle/CollabProjectLifecycleSubsystem';
+import type { CloudManagementIntent } from '@/app/collab/membership/CloudManagementIntent';
 import type { CloudRetirementIntent } from '@/app/collab/retirement/CloudRetirementIntent';
 import type { RetirementRecord } from '@/app/collab/retirement/RetirementRecord';
 import type { RetirementTombstoneRecord } from '@/app/collab/retirement/RetirementTombstoneRecord';
 
 export interface CollabProjectLifecycleOwnerStores {
+  readonly cloudManagementIntents: {
+    load(projectId: CollabProjectId): Promise<CloudManagementIntent | null>;
+  };
   readonly cloudRetirementIntents: {
     load(projectId: CollabProjectId): Promise<CloudRetirementIntent | null>;
   };
@@ -71,6 +75,14 @@ export function createCollabProjectLifecycleDurableOwners(
           : 'absent' as const;
       },
       name: 'host-transfer',
+    }),
+    Object.freeze({
+      inspect: async (projectId: CollabProjectId) => (
+        await stores.cloudManagementIntents.load(projectId)
+          ? 'nonterminal' as const
+          : 'absent' as const
+      ),
+      name: 'cloud-management',
     }),
     Object.freeze({
       inspect: async (projectId: CollabProjectId) => {

--- a/src/app/collab/lifecycle/CollabProjectLifecycleSubsystem.ts
+++ b/src/app/collab/lifecycle/CollabProjectLifecycleSubsystem.ts
@@ -179,6 +179,33 @@ export class CollabProjectLifecycleSubsystem {
     );
   }
 
+  runCloudManagement<T>(
+    projectId: CollabProjectId,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    return this.runExclusiveWithPredecessor(
+      projectId,
+      'cloud-management',
+      ['manager-responsibility'],
+      'continuation',
+      operation,
+    );
+  }
+
+  runManagerResponsibility<T>(
+    projectId: CollabProjectId,
+    mode: CollabProjectLifecycleAdmissionMode,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    return this.runExclusiveWithPredecessor(
+      projectId,
+      'manager-responsibility',
+      ['cloud-management'],
+      mode,
+      operation,
+    );
+  }
+
   runRetirementAdoption<T>(
     projectId: CollabProjectId,
     operation: () => Promise<T>,
@@ -233,18 +260,41 @@ export class CollabProjectLifecycleSubsystem {
         }
         if (state === 'nonterminal') pendingOwners.push(owner.name);
       }
-      if (pendingOwners.length > 1) {
+      const isCloudManagementResponsibilityPair = pendingOwners.length === 2
+        && pendingOwners.includes('cloud-management')
+        && pendingOwners.includes('manager-responsibility');
+      const permitsCloudManagementResponsibilityPair = isCloudManagementResponsibilityPair
+        && predecessorOwnerNames.length === 1
+        && (
+          (ownerName === 'manager-responsibility'
+            && predecessorOwnerNames[0] === 'cloud-management')
+          || (ownerName === 'cloud-management'
+            && mode === 'continuation'
+            && predecessorOwnerNames[0] === 'manager-responsibility')
+        );
+      if (pendingOwners.length > 1 && !permitsCloudManagementResponsibilityPair) {
         throw new CollabError({
           code: 'durable-progress-recovery-required',
           recoveryActions: ['resume'],
           safeContext: { reason: 'lifecycle-owner-ambiguous' },
         });
       }
-      const pendingOwner = pendingOwners[0];
+      const unexpectedOwner = pendingOwners.find(name => (
+        name !== ownerName && !predecessorOwnerNames.includes(name)
+      ));
+      if (unexpectedOwner !== undefined) {
+        throw new CollabError({
+          code: 'durable-progress-recovery-required',
+          recoveryActions: ['resume'],
+          safeContext: { reason: 'lifecycle-owner-pending' },
+        });
+      }
       if (
-        pendingOwner !== undefined
-        && pendingOwner !== ownerName
-        && !predecessorOwnerNames.includes(pendingOwner)
+        ownerName === 'cloud-management'
+        && predecessorOwnerNames.length === 1
+        && predecessorOwnerNames[0] === 'manager-responsibility'
+        && pendingOwners.includes('manager-responsibility')
+        && !pendingOwners.includes(ownerName)
       ) {
         throw new CollabError({
           code: 'durable-progress-recovery-required',
@@ -252,7 +302,7 @@ export class CollabProjectLifecycleSubsystem {
           safeContext: { reason: 'lifecycle-owner-pending' },
         });
       }
-      if (pendingOwner === ownerName && mode === 'operation') {
+      if (pendingOwners.includes(ownerName) && mode === 'operation') {
         throw new CollabError({
           code: 'durable-progress-recovery-required',
           recoveryActions: ['resume'],
@@ -284,18 +334,16 @@ export class CollabProjectLifecycleSubsystem {
       readManagementOperation: (...args) => membership.readManagementOperation(...args),
       resumeManagementOperation: (...args) => membership.resumeManagementOperation(...args),
       completeManagementOperation: (...args) => membership.completeManagementOperation(...args),
-      cancelManagerResponsibilityOffer: (request, operationOptions) => this.runExclusive(
+      cancelManagerResponsibilityOffer: (request, operationOptions) => this.runManagerResponsibility(
         request.projectId,
-        'manager-responsibility',
         'operation',
         () => membership.cancelManagerResponsibilityOffer(request, operationOptions),
       ),
       createInvitation: (projectId, operationOptions) => (
         membership.createInvitation(projectId, operationOptions)
       ),
-      createManagerResponsibilityOffer: (request, operationOptions) => this.runExclusive(
+      createManagerResponsibilityOffer: (request, operationOptions) => this.runManagerResponsibility(
         request.projectId,
-        'manager-responsibility',
         'operation',
         () => membership.createManagerResponsibilityOffer(request, operationOptions),
       ),

--- a/src/app/collab/membership/CloudManagementIntent.ts
+++ b/src/app/collab/membership/CloudManagementIntent.ts
@@ -6,6 +6,7 @@ import type { CloudMembershipBinding } from '@/app/collab/remote-authority/Colla
 interface CloudManagementIntentBase extends CloudMembershipBinding {
   readonly schemaVersion: 1;
   readonly kind: 'cloud-management-intent';
+  readonly completionId: string;
   readonly phase: 'prepared' | 'submitted' | 'result-retained';
   readonly createdAt: string;
   readonly updatedAt: string;
@@ -22,7 +23,7 @@ export type CloudManagementIntent = {
 }[CloudManagementMutation];
 
 export function decodeCloudManagementIntent(value: unknown): CloudManagementIntent {
-  const keys = ['schemaVersion', 'kind', 'operation', 'phase', 'request', 'response', 'createdAt', 'updatedAt', 'projectId', 'serverUrl', 'memberId', 'authorityGeneration'];
+  const keys = ['schemaVersion', 'kind', 'completionId', 'operation', 'phase', 'request', 'response', 'createdAt', 'updatedAt', 'projectId', 'serverUrl', 'memberId', 'authorityGeneration'];
   if (!value || typeof value !== 'object' || Array.isArray(value)
     || Object.keys(value).length !== keys.length || Object.keys(value).some(key => !keys.includes(key))) {
     throw new TypeError('Invalid Cloud management intent');
@@ -30,6 +31,7 @@ export function decodeCloudManagementIntent(value: unknown): CloudManagementInte
   const input = value as Record<string, unknown>;
   if (input.schemaVersion !== 1 || input.kind !== 'cloud-management-intent'
     || !MUTATIONS.some(operation => operation === input.operation)
+    || typeof input.completionId !== 'string' || !/^[A-Za-z0-9-]{1,128}$/u.test(input.completionId)
     || !isCollabProjectId(input.projectId) || !isCollabMemberId(input.memberId)
     || typeof input.authorityGeneration !== 'number' || !Number.isSafeInteger(input.authorityGeneration) || input.authorityGeneration < 1
     || typeof input.serverUrl !== 'string'
@@ -85,7 +87,7 @@ export function decodeCloudManagementIntent(value: unknown): CloudManagementInte
   const updatedAt = timestamp(input.updatedAt);
   if (updatedAt < createdAt) throw new TypeError('Invalid Cloud management time');
   return {
-    authorityGeneration: input.authorityGeneration, createdAt, kind: input.kind, memberId: input.memberId,
+    authorityGeneration: input.authorityGeneration, completionId: input.completionId, createdAt, kind: input.kind, memberId: input.memberId,
     operation: input.operation, phase: input.phase, projectId: input.projectId, request: request.value,
     response, schemaVersion: 1, serverUrl: validateCloudServerUrl(input.serverUrl, 'serverUrl'), updatedAt,
   } as CloudManagementIntent;

--- a/src/app/collab/membership/CollabMembershipService.ts
+++ b/src/app/collab/membership/CollabMembershipService.ts
@@ -5,6 +5,7 @@ import { type CollabManagerResponsibilityOffer, type CollabMemberId, type Collab
 import { type CollabLocalProjectRepository, isCollabLocalCloudMembership } from '@/app/collab/CollabLocalProjectRepository';
 import type {
   CollabProjectLifecycleAdmission,
+  CollabProjectLifecycleAuthorityAdmission,
 } from '@/app/collab/lifecycle/CollabProjectLifecycleAdmission';
 import { type CloudManagementIntent, type CloudManagementMutation, decodeCloudManagementIntent } from '@/app/collab/membership/CloudManagementIntent';
 import type {
@@ -53,6 +54,7 @@ export interface CollabMembershipServiceOptions {
 }
 
 export interface CollabMembershipSafetyContext {
+  readonly cloudManagementAdmission: CollabProjectLifecycleAuthorityAdmission;
   readonly projects: CollabLocalProjectRepository;
   readonly managerResponsibilityAdmission: CollabProjectLifecycleAdmission;
   readonly managerResponsibilityOperations: ManagerResponsibilityOperationCoordinator;
@@ -86,7 +88,11 @@ export class CollabMembershipService {
   ): Promise<CollabInvitationView> {
     const membership = await this.safety.projects.loadMembership(projectId);
     if (membership && isCollabLocalCloudMembership(membership)) {
-      return this.runCloudMutation(projectId, options, () => this.createCloudInvitation(projectId, options));
+      return this.runCloudManagementMutation(
+        projectId,
+        options,
+        () => this.createCloudInvitation(projectId, options),
+      );
     }
     if (options.signal?.aborted) throw new CollabError({ code: 'cancelled' });
     return this.control.membership('createInvitation', {
@@ -110,7 +116,11 @@ export class CollabMembershipService {
     }
     await this.executeCloudIntent(intent, options);
     intent = await this.loadCloudIntent(projectId);
-    if (intent?.operation !== 'createProjectInvitation' || !intent.response) throw new CollabError({ code: 'invitation-expired' });
+    if (
+      intent?.operation !== 'createProjectInvitation'
+      || !intent.response
+      || retainedSecretExpired(intent.response)
+    ) throw new CollabError({ code: 'invitation-expired' });
     return { encodedInvitation: encodeCloudProjectInvitation({ invitation: intent.response, serverUrl: intent.serverUrl }), expiresAt: intent.response.expiresAt };
   }
 
@@ -125,8 +135,8 @@ export class CollabMembershipService {
         if (error instanceof CloudAuthorityRejection) {
           // A completed rejection cannot prove whether the exact idempotent
           // mutation committed. Keep the frozen request until replay recovers
-          // its result. These authenticated reads only classify a synchronized
-          // stale outcome; they never release the intent.
+          // its result. These authenticated reads classify a synchronized
+          // stale outcome but are not operation-specific negative proof.
           await this.readCloudBinding(intent.projectId, options);
           const members = await this.control.cloudMembership('listProjectMembers', { projectId: intent.projectId }, intent, options);
           if (members.projectId !== intent.projectId || !members.members.some(member => member.memberId === intent.memberId)) {
@@ -148,7 +158,7 @@ export class CollabMembershipService {
   }
 
   reissueMemberClaim(request: CollabImportedMemberClaimRequest, options: CollabOperationOptions = {}): Promise<CollabInvitationView> {
-    return this.runCloudMutation(request.projectId, options, async () => {
+    return this.runCloudManagementMutation(request.projectId, options, async () => {
       let intent = await this.loadCloudIntent(request.projectId);
       if (intent && (intent.operation !== 'reissueTransferredMembershipClaim' || intent.request.memberId !== request.memberId)) throw managementPending();
       if (!intent) {
@@ -156,13 +166,17 @@ export class CollabMembershipService {
       }
       await this.executeCloudIntent(intent, options);
       intent = await this.loadCloudIntent(request.projectId);
-      if (intent?.operation !== 'reissueTransferredMembershipClaim' || !intent.response) throw new CollabError({ code: 'invitation-expired' });
+      if (
+        intent?.operation !== 'reissueTransferredMembershipClaim'
+        || !intent.response
+        || retainedSecretExpired(intent.response)
+      ) throw new CollabError({ code: 'invitation-expired' });
       return { encodedInvitation: encodeCloudMembershipClaimInvitation({ claim: intent.response, serverUrl: intent.serverUrl }), expiresAt: intent.response.expiresAt };
     });
   }
 
   revokeMemberClaim(request: CollabImportedMemberClaimRequest, options: CollabOperationOptions = {}): Promise<void> {
-    return this.runCloudMutation(request.projectId, options, async () => {
+    return this.runCloudManagementMutation(request.projectId, options, async () => {
       let intent = await this.loadCloudIntent(request.projectId);
       if (intent && (intent.operation !== 'revokeTransferredMembershipClaim' || intent.request.memberId !== request.memberId)) throw managementPending();
       if (!intent) intent = await this.prepareCloudMemberClaim('revokeTransferredMembershipClaim', request, options);
@@ -250,7 +264,7 @@ export class CollabMembershipService {
   ): Promise<CloudManagementIntent> {
     const now = new Date().toISOString();
     const intent = decodeCloudManagementIntent({
-      ...binding, createdAt: now, updatedAt: now, kind: 'cloud-management-intent', operation,
+      ...binding, completionId: randomUUID(), createdAt: now, updatedAt: now, kind: 'cloud-management-intent', operation,
       phase: 'prepared', request, response: null, schemaVersion: 1,
     });
     await this.saveCloudIntent(intent);
@@ -276,10 +290,6 @@ export class CollabMembershipService {
       || intent.authorityGeneration !== membership.authority.authorityGeneration) {
       throw new CollabError({ code: 'authority-integrity-error', safeContext: { reason: 'cloud-management-binding-mismatch' } });
     }
-    if ((intent.operation === 'createProjectInvitation' || intent.operation === 'reissueTransferredMembershipClaim') && intent.response && Date.now() >= Math.min(Date.parse(intent.response.expiresAt), Date.parse(intent.response.secretReplayExpiresAt))) {
-      await this.safety.projects.removeProjectDocument(projectId, 'cloud-management-intent');
-      return null;
-    }
     return intent;
   }
 
@@ -296,7 +306,7 @@ export class CollabMembershipService {
     projectId: CollabProjectId,
     options: CollabOperationOptions = {},
   ): Promise<CollabManagementOperationView> {
-    return this.runCloudMutation(projectId, options, async () => {
+    return this.runCloudManagementMutation(projectId, options, async () => {
       let intent = await this.loadCloudIntent(projectId);
       if (!intent) throw new CollabError({ code: 'project-not-found' });
       await this.executeCloudIntent(intent, options);
@@ -312,21 +322,31 @@ export class CollabMembershipService {
     });
   }
 
-  completeManagementOperation(request: CollabCompleteManagementOperationRequest, options: CollabOperationOptions = {}): Promise<void> {
-    return this.runManagement(request.projectId, async () => {
-      const membership = await this.safety.projects.loadMembership(request.projectId);
-      if (!membership || !isCollabLocalCloudMembership(membership)) {
+  async completeManagementOperation(request: CollabCompleteManagementOperationRequest, options: CollabOperationOptions = {}): Promise<void> {
+    const membership = await this.safety.projects.loadMembership(request.projectId);
+    if (!membership || !isCollabLocalCloudMembership(membership)) {
+      return this.runManagement(request.projectId, async () => {
         this.lanManagementIntents.delete(request.projectId);
-        return;
-      }
-      const intent = await this.loadCloudIntent(request.projectId);
-      if (options.signal?.aborted) throw new CollabError({ code: 'cancelled' });
-      if (!intent) return;
-      if (intent.phase !== 'result-retained') {
-        throw new CollabError({ code: 'operation-failed', safeContext: { reason: 'cloud-management-result-not-settled' } });
-      }
-      await this.safety.projects.removeProjectDocument(request.projectId, 'cloud-management-intent');
-    });
+      });
+    }
+    return this.safety.cloudManagementAdmission(
+      request.projectId,
+      () => this.runManagement(request.projectId, async () => {
+        const intent = await this.loadCloudIntent(request.projectId);
+        if (options.signal?.aborted) throw new CollabError({ code: 'cancelled' });
+        if (!intent) return;
+        if (request.completionId !== intent.completionId) {
+          throw new CollabError({
+            code: 'operation-failed',
+            safeContext: { reason: 'cloud-management-completion-mismatch' },
+          });
+        }
+        if (intent.phase !== 'result-retained') {
+          throw new CollabError({ code: 'operation-failed', safeContext: { reason: 'cloud-management-result-not-settled' } });
+        }
+        await this.safety.projects.removeProjectDocument(request.projectId, 'cloud-management-intent');
+      }),
+    );
   }
 
   private runManagement<T>(projectId: CollabProjectId, operation: () => Promise<T>): Promise<T> {
@@ -362,6 +382,17 @@ export class CollabMembershipService {
     });
   }
 
+  private runCloudManagementMutation<T>(
+    projectId: CollabProjectId,
+    options: CollabOperationOptions,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    return this.safety.cloudManagementAdmission(
+      projectId,
+      () => this.runCloudMutation(projectId, options, operation),
+    );
+  }
+
   private runLanManagement<T>(
     projectId: CollabProjectId,
     identity: string,
@@ -393,7 +424,7 @@ export class CollabMembershipService {
     const membership = await this.safety.projects.loadMembership(projectId);
     if (membership && isCollabLocalCloudMembership(membership)) {
       if (typeof request === 'string') throw new CollabError({ code: 'invitation-invalid' });
-      return this.runCloudMutation(projectId, options, async () => {
+      return this.runCloudManagementMutation(projectId, options, async () => {
         let intent = await this.loadCloudIntent(projectId);
         if (intent && (intent.operation !== 'revokeProjectInvitation' || intent.request.invitationId !== request.invitationId)) throw managementPending();
         if (!intent) {
@@ -490,7 +521,7 @@ export class CollabMembershipService {
   }
 
   private async changeCloudMember(operation: 'demoteManager' | 'removeMember', projectId: CollabProjectId, targetMemberId: CollabMemberId, options: CollabOperationOptions): Promise<void> {
-      await this.runCloudMutation(projectId, options, async () => {
+      await this.runCloudManagementMutation(projectId, options, async () => {
         let intent = await this.loadCloudIntent(projectId);
         if (intent && (intent.operation !== operation || intent.request.targetMemberId !== targetMemberId)) throw managementPending();
         if (!intent) {
@@ -639,11 +670,40 @@ function cloudManagerOfferSummary(offer: CollabManagerResponsibilityOffer): Coll
 
 function retainedInvitation(intent: CloudManagementIntent): CollabInvitationView | null {
   if (intent.operation === 'createProjectInvitation' && intent.response) {
+    if (retainedSecretExpired(intent.response)) return null;
     return { encodedInvitation: encodeCloudProjectInvitation({ invitation: intent.response, serverUrl: intent.serverUrl }), expiresAt: intent.response.expiresAt };
   }
   if (intent.operation === 'reissueTransferredMembershipClaim' && intent.response) {
+    if (retainedSecretExpired(intent.response)) return null;
     return { encodedInvitation: encodeCloudMembershipClaimInvitation({ claim: intent.response, serverUrl: intent.serverUrl }), expiresAt: intent.response.expiresAt };
   }
+  return null;
+}
+
+function retainedSecretExpired(response: {
+  readonly expiresAt: string;
+  readonly secretReplayExpiresAt: string;
+}): boolean {
+  return Date.now() >= Date.parse(retainedSecretAvailableUntil(response));
+}
+
+function retainedSecretAvailableUntil(response: {
+  readonly expiresAt: string;
+  readonly secretReplayExpiresAt: string;
+}): string {
+  return Date.parse(response.expiresAt) <= Date.parse(response.secretReplayExpiresAt)
+    ? response.expiresAt
+    : response.secretReplayExpiresAt;
+}
+
+function managementSecretAvailableUntil(
+  intent: CloudManagementIntent,
+): string | null {
+  if (
+    (intent.operation === 'createProjectInvitation'
+      || intent.operation === 'reissueTransferredMembershipClaim')
+    && intent.response
+  ) return retainedSecretAvailableUntil(intent.response);
   return null;
 }
 
@@ -662,7 +722,9 @@ function managementOperationView(
       reissueTransferredMembershipClaim: 'reissue-member-claim',
       revokeTransferredMembershipClaim: 'revoke-member-claim',
     } as const)[intent.operation],
+    completionId: intent.completionId,
     invitation: retainedInvitation(intent),
+    secretAvailableUntil: managementSecretAvailableUntil(intent),
     status: intent.phase === 'result-retained' ? 'result-retained' : 'pending',
   };
 }

--- a/src/app/collab/remote-authority/CloudAuthorityAdapter.ts
+++ b/src/app/collab/remote-authority/CloudAuthorityAdapter.ts
@@ -242,6 +242,12 @@ function controlIntegrityError(reason: string): CollabError {
   });
 }
 
+function assertResponseRequestId(actual: string, expected: string): void {
+  if (actual !== expected) {
+    throw controlIntegrityError('cloud-control-response-request-id-mismatch');
+  }
+}
+
 function assertJsonResponse(response: CloudAuthorityHttpResponse): void {
   if (
     response.contentType === null
@@ -432,11 +438,12 @@ class CloudAuthorityControl implements CollabAuthorityControlPort, CollabAuthori
     const route = collabCloudProjectOperationRoute(projectId, 'getProjectSnapshot');
     const decoded = COLLAB_CLOUD_PROJECT_SNAPSHOT_CODEC.decodeRequest({ projectId });
     if (decoded.status !== 'ok') throw decoded.error;
+    const requestId = this.requestId();
     const response = await this.request({
       body: {
         data: decoded.value,
         protocolVersion: COLLAB_PROTOCOL_VERSION,
-        requestId: this.requestId(),
+        requestId,
       },
       headers: {},
       method: route.method,
@@ -446,9 +453,11 @@ class CloudAuthorityControl implements CollabAuthorityControlPort, CollabAuthori
     assertJsonResponse(response);
     if (response.status < 200 || response.status >= 300) {
       const envelope = decodeCollabCloudErrorEnvelope(response.body);
+      assertResponseRequestId(envelope.requestId, requestId);
       throw new CollabError(envelope.error);
     }
     const envelope = decodeCollabCloudSuccessEnvelope(response.body);
+    assertResponseRequestId(envelope.requestId, requestId);
     const snapshot = decodeCloudAuthorityProjectSnapshot(envelope.data);
     if (
       snapshot.project.id !== projectId
@@ -724,11 +733,12 @@ class CloudAuthorityControl implements CollabAuthorityControlPort, CollabAuthori
     const decoded = codec.decodeRequest(input);
     if (decoded.status !== 'ok') throw decoded.error;
     const route = collabCloudProjectOperationRoute(input.projectId, operation);
+    const requestId = this.requestId();
     const response = await this.request({
       body: {
         data: decoded.value,
         protocolVersion: COLLAB_PROTOCOL_VERSION,
-        requestId: this.requestId(),
+        requestId,
       },
       headers: {},
       method: route.method,
@@ -738,9 +748,11 @@ class CloudAuthorityControl implements CollabAuthorityControlPort, CollabAuthori
     assertJsonResponse(response);
     if (response.status < 200 || response.status >= 300) {
       const envelope = decodeCollabCloudErrorEnvelope(response.body);
+      assertResponseRequestId(envelope.requestId, requestId);
       throw new CloudAuthorityRejection(envelope.error);
     }
     const envelope = decodeCollabCloudSuccessEnvelope(response.body);
+    assertResponseRequestId(envelope.requestId, requestId);
     return codec.decodeResponse(envelope.data);
   }
 
@@ -1062,6 +1074,12 @@ export class CloudAuthorityAdapter implements CollabAuthorityAdapter {
       this.request,
       this.requestId,
     );
+    try {
+      await control.readSnapshot(projectId, options);
+    } catch (error) {
+      control.dispose();
+      throw error;
+    }
     let eventConnection: { dispose(): void } | null = null;
     return {
       authorityKind: 'cloud',

--- a/src/core/collab/CollabFeaturePort.ts
+++ b/src/core/collab/CollabFeaturePort.ts
@@ -288,8 +288,12 @@ export interface CollabMemberSummaryView {
 
 export interface CollabManagementOperationView {
   readonly action: 'create-invitation' | 'revoke-invitation' | 'demote-manager' | 'remove-member' | 'create-manager-offer' | 'cancel-manager-offer' | 'promote-manager' | 'reissue-member-claim' | 'revoke-member-claim';
-  readonly status: 'pending' | 'result-retained';
+  /** Opaque local result identity; it is never the authority idempotency key. */
+  readonly completionId: string;
   readonly invitation: CollabInvitationView | null;
+  /** Last instant at which a retained invitation or claim secret may be presented. */
+  readonly secretAvailableUntil: CollabIsoTimestamp | null;
+  readonly status: 'pending' | 'result-retained';
 }
 
 /** LAN revokes its singleton invitation; Cloud requires the selected invitation identity. */
@@ -300,6 +304,8 @@ export type CollabRevokeInvitationRequest = CollabProjectId | {
 
 export interface CollabCompleteManagementOperationRequest {
   readonly projectId: CollabProjectId;
+  /** Required for Cloud compare-and-remove; omitted for transient LAN abandonment. */
+  readonly completionId?: string;
 }
 
 export interface CollabImportedMemberClaimRequest {

--- a/src/features/collab/modals/project/ProjectInvitationModal.ts
+++ b/src/features/collab/modals/project/ProjectInvitationModal.ts
@@ -6,8 +6,11 @@ import type {
   CollabFeaturePort,
   CollabInvitationSummaryView,
   CollabInvitationView,
+  CollabManagementOperationView,
 } from '@/core/collab';
 import { t } from '@/i18n/i18n';
+
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 export type ProjectInvitationModalPort = Pick<
   CollabFeaturePort,
@@ -35,11 +38,13 @@ export class ProjectInvitationModal extends Modal {
   #invitation: CollabInvitationView | null = null;
   #invitations: readonly CollabInvitationSummaryView[] = [];
   #managementReadFailed = false;
+  #managementSlotOccupied = false;
   #opened = false;
   #operationGeneration = 0;
   #operationPending = false;
   #pendingCreation = false;
-  #retainedResult = false;
+  #retainedCompletionId: string | null = null;
+  #secretExpiryTimer: number | null = null;
   #status: InvitationStatus = null;
   readonly #port: ProjectInvitationModalPort;
   readonly #options: ProjectInvitationModalOptions;
@@ -55,15 +60,17 @@ export class ProjectInvitationModal extends Modal {
   }
 
   onOpen(): void {
+    this.#clearSecretExpiryTimer();
     this.#abortController = new AbortController();
     this.#invitation = null;
     this.#invitations = [];
     this.#managementReadFailed = false;
+    this.#managementSlotOccupied = false;
     this.#opened = true;
     this.#operationGeneration += 1;
     this.#operationPending = false;
     this.#pendingCreation = false;
-    this.#retainedResult = false;
+    this.#retainedCompletionId = null;
     this.#status = null;
     this.setTitle(t('collab.access.invitations'));
     this.modalEl.classList.add('claudian-collab-project-invitation-modal');
@@ -79,6 +86,7 @@ export class ProjectInvitationModal extends Modal {
     this.#opened = false;
     this.#operationGeneration += 1;
     this.#abortController.abort();
+    this.#clearSecretExpiryTimer();
     this.contentEl.replaceChildren();
     this.#options.onClosed?.();
   }
@@ -146,7 +154,7 @@ export class ProjectInvitationModal extends Modal {
   }
 
   async #createInvitation(): Promise<void> {
-    if (this.#operationPending) return;
+    if (this.#operationPending || this.#managementSlotOccupied) return;
     this.#operationPending = true;
     const generation = ++this.#operationGeneration;
     this.#status = null;
@@ -158,34 +166,79 @@ export class ProjectInvitationModal extends Modal {
         : []),
     );
     if (!this.#isCurrent(generation)) return;
-    this.#operationPending = false;
-    if (result.status === 'success') {
+    if (result.status === 'success' && this.#options.authorityKind === 'cloud') {
+      const retained = await this.#port.readManagementOperation(
+        this.#options.projectId,
+        { signal: this.#abortController.signal },
+      );
+      if (!this.#isCurrent(generation)) return;
+      if (
+        retained.status === 'success'
+        && retained.value?.action === 'create-invitation'
+        && retained.value.status === 'result-retained'
+        && retained.value.invitation?.encodedInvitation === result.value.encodedInvitation
+        && retained.value.invitation.expiresAt === result.value.expiresAt
+      ) {
+        this.#applyManagementOperation(retained.value);
+      } else {
+        this.#status = { kind: 'error', text: t('collab.access.invitationFailed') };
+      }
+    } else if (result.status === 'success') {
       this.#invitation = result.value;
-      this.#retainedResult = this.#options.authorityKind === 'cloud';
     } else {
       this.#status = { kind: 'error', text: t('collab.access.invitationFailed') };
     }
+    this.#operationPending = false;
     this.#render();
   }
 
   async #copyInvitation(): Promise<void> {
     if (!this.#invitation || !this.#options.copyText || this.#operationPending) return;
+    const invitation = this.#invitation;
+    const completionId = this.#retainedCompletionId;
     this.#operationPending = true;
     this.#status = null;
     this.#render();
     try {
-      await this.#options.copyText(this.#invitation.encodedInvitation);
+      if (this.#options.authorityKind === 'cloud' && completionId) {
+        const retained = await this.#port.readManagementOperation(
+          this.#options.projectId,
+          { signal: this.#abortController.signal },
+        );
+        if (!this.#opened || this.#abortController.signal.aborted) return;
+        if (retained.status !== 'success') {
+          this.#clearSecretExpiryTimer();
+          this.#invitation = null;
+          this.#status = { kind: 'error', text: t('collab.access.invitationFailed') };
+          return;
+        }
+        this.#applyManagementOperation(retained.value);
+        if (
+          retained.value?.action !== 'create-invitation'
+          || retained.value.status !== 'result-retained'
+          || retained.value.completionId !== completionId
+          || this.#invitation?.encodedInvitation !== invitation.encodedInvitation
+          || this.#invitation.expiresAt !== invitation.expiresAt
+        ) {
+          this.#status = { kind: 'error', text: t('collab.access.invitationFailed') };
+          return;
+        }
+      }
+      await this.#options.copyText(invitation.encodedInvitation);
       if (!this.#opened || this.#abortController.signal.aborted) return;
-      if (this.#retainedResult) {
+      if (completionId) {
         const completed = await this.#port.completeManagementOperation(
-          { projectId: this.#options.projectId },
+          {
+            completionId,
+            projectId: this.#options.projectId,
+          },
         );
         if (!this.#opened || this.#abortController.signal.aborted) return;
         if (completed.status !== 'success') {
           this.#status = { kind: 'error', text: t('collab.access.invitationFailed') };
           return;
         }
-        this.#retainedResult = false;
+        this.#applyManagementOperation(null);
       }
       this.#status = { kind: 'success', text: t('collab.access.invitationCopied') };
     } catch {
@@ -202,6 +255,7 @@ export class ProjectInvitationModal extends Modal {
   async #revokeInvitation(invitationId?: string): Promise<void> {
     if (
       this.#operationPending
+      || this.#managementSlotOccupied
       || (this.#options.authorityKind === 'lan' && !this.#invitation)
       || (this.#options.authorityKind === 'cloud' && !invitationId)
     ) return;
@@ -252,17 +306,7 @@ export class ProjectInvitationModal extends Modal {
     }
     this.#managementReadFailed = false;
     const retained = operation.value;
-    if (retained?.action === 'create-invitation') {
-      this.#pendingCreation = retained.status === 'pending';
-    }
-    if (
-      retained?.action === 'create-invitation'
-      && retained.status === 'result-retained'
-      && retained.invitation
-    ) {
-      this.#invitation = retained.invitation;
-      this.#retainedResult = true;
-    }
+    this.#applyManagementOperation(retained);
     const listed = await this.#port.listInvitations(
       this.#options.projectId,
       { signal: this.#abortController.signal },
@@ -293,7 +337,7 @@ export class ProjectInvitationModal extends Modal {
         attr: { 'data-action': 'create-invitation', type: 'button' },
         text: t('collab.access.createInvitation'),
       });
-      create.disabled = this.#operationPending || this.#pendingCreation;
+      create.disabled = this.#operationPending || this.#managementSlotOccupied;
       create.addEventListener('click', () => void this.#createInvitation());
     }
     if (this.#pendingCreation) {
@@ -303,6 +347,14 @@ export class ProjectInvitationModal extends Modal {
       });
       resume.disabled = this.#operationPending;
       resume.addEventListener('click', () => void this.#resumeInvitationCreation());
+    }
+    if (this.#retainedCompletionId && !this.#invitation) {
+      const complete = this.contentEl.createEl('button', {
+        attr: { 'data-action': 'complete-invitation', type: 'button' },
+        text: t('collab.access.finishOperation'),
+      });
+      complete.disabled = this.#operationPending;
+      complete.addEventListener('click', () => void this.#completeRetainedInvitation());
     }
     if (this.#invitations.length === 0) {
       heading.insertAdjacentElement('afterend', this.contentEl.createDiv({
@@ -330,7 +382,7 @@ export class ProjectInvitationModal extends Modal {
         });
         revoke.disabled = this.#operationPending
           || this.#managementReadFailed
-          || this.#pendingCreation
+          || this.#managementSlotOccupied
           || invitation.state !== 'active';
         revoke.addEventListener('click', () => void this.#revokeInvitation(
           invitation.invitationId,
@@ -361,12 +413,82 @@ export class ProjectInvitationModal extends Modal {
       this.#render();
       return;
     }
-    this.#pendingCreation = result.value.status === 'pending';
-    if (result.value.status === 'result-retained' && result.value.invitation) {
-      this.#invitation = result.value.invitation;
-      this.#retainedResult = true;
-    }
+    this.#applyManagementOperation(result.value);
     this.#render();
+  }
+
+  async #completeRetainedInvitation(): Promise<void> {
+    const completionId = this.#retainedCompletionId;
+    if (!completionId || this.#invitation || this.#operationPending) return;
+    const generation = ++this.#operationGeneration;
+    this.#operationPending = true;
+    this.#render();
+    const result = await this.#port.completeManagementOperation({
+      completionId,
+      projectId: this.#options.projectId,
+    });
+    if (!this.#isCurrent(generation)) return;
+    this.#operationPending = false;
+    if (result.status !== 'success') {
+      this.#status = { kind: 'error', text: t('collab.access.invitationFailed') };
+      this.#render();
+      return;
+    }
+    this.#applyManagementOperation(null);
+    this.#status = null;
+    await this.#loadCloudInvitations();
+  }
+
+  #applyManagementOperation(
+    operation: CollabManagementOperationView | null,
+  ): void {
+    this.#clearSecretExpiryTimer();
+    this.#invitation = null;
+    this.#pendingCreation = operation?.action === 'create-invitation'
+      && operation.status === 'pending';
+    this.#managementSlotOccupied = operation !== null;
+    this.#retainedCompletionId = null;
+    if (
+      operation?.action !== 'create-invitation'
+      || operation.status !== 'result-retained'
+    ) return;
+    this.#retainedCompletionId = operation.completionId;
+    if (!operation.invitation || !operation.secretAvailableUntil) return;
+    this.#invitation = operation.invitation;
+    this.#scheduleSecretExpiry(
+      operation.completionId,
+      operation.secretAvailableUntil,
+    );
+  }
+
+  #scheduleSecretExpiry(completionId: string, deadline: string): void {
+    const expiresAt = Date.parse(deadline);
+    const remaining = expiresAt - Date.now();
+    if (!Number.isFinite(expiresAt) || remaining <= 0) {
+      this.#redactRetainedInvitation(completionId);
+      return;
+    }
+    this.#secretExpiryTimer = window.setTimeout(() => {
+      this.#secretExpiryTimer = null;
+      if (!this.#opened || this.#retainedCompletionId !== completionId) return;
+      if (Date.now() < expiresAt) {
+        this.#scheduleSecretExpiry(completionId, deadline);
+        return;
+      }
+      this.#redactRetainedInvitation(completionId);
+    }, Math.min(remaining, MAX_TIMER_DELAY_MS));
+  }
+
+  #redactRetainedInvitation(completionId: string): void {
+    if (this.#retainedCompletionId !== completionId) return;
+    this.#invitation = null;
+    this.#render();
+  }
+
+  #clearSecretExpiryTimer(): void {
+    if (this.#secretExpiryTimer === null) return;
+    window.clearTimeout(this.#secretExpiryTimer);
+    this.#secretExpiryTimer = null;
   }
 
   #isCurrent(generation: number): boolean {

--- a/src/features/collab/modals/project/ProjectManagementModal.ts
+++ b/src/features/collab/modals/project/ProjectManagementModal.ts
@@ -37,6 +37,8 @@ import {
 } from '@/shared/async/LatestTaskScope';
 import { confirm } from '@/shared/modals/ConfirmModal';
 
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
 export type ProjectManagementModalPort = Pick<
   CollabFeaturePort,
   | 'acceptHostTransfer'
@@ -140,6 +142,7 @@ export class ProjectManagementModal extends Modal {
   #operationPending = false;
   readonly #readTasks = new LatestTaskScope();
   #retainedInvitation: CollabInvitationView | null = null;
+  #secretExpiryTimer: number | null = null;
   #snapshot: CollabProjectSnapshot | null = null;
   #status: AccessStatus | null = null;
   readonly #port: ProjectManagementModalPort;
@@ -158,6 +161,7 @@ export class ProjectManagementModal extends Modal {
   }
 
   onOpen(): void {
+    this.#clearSecretExpiryTimer();
     this.#abortController = new AbortController();
     this.#confirmation = null;
     this.#capabilities = null;
@@ -214,6 +218,7 @@ export class ProjectManagementModal extends Modal {
   onClose(): void {
     this.#opened = false;
     this.#abortController.abort();
+    this.#clearSecretExpiryTimer();
     this.#featureSubscription?.dispose();
     this.#featureSubscription = null;
     this.#readTasks.cancel();
@@ -441,11 +446,54 @@ export class ProjectManagementModal extends Modal {
   }
 
   #applyManagementOperation(operation: CollabManagementOperationView | null): void {
+    this.#clearSecretExpiryTimer();
     this.#managementOperation = operation;
-    this.#retainedInvitation = operation?.action === 'reissue-member-claim'
-      && operation.status === 'result-retained'
-      ? operation.invitation
-      : null;
+    this.#retainedInvitation = null;
+    if (
+      operation?.action !== 'reissue-member-claim'
+      || operation.status !== 'result-retained'
+    ) return;
+    if (!operation.invitation || !operation.secretAvailableUntil) {
+      this.#managementOperation = { ...operation, invitation: null };
+      return;
+    }
+    this.#retainedInvitation = operation.invitation;
+    this.#scheduleSecretExpiry(
+      operation.completionId,
+      operation.secretAvailableUntil,
+    );
+  }
+
+  #scheduleSecretExpiry(completionId: string, deadline: string): void {
+    const expiresAt = Date.parse(deadline);
+    const remaining = expiresAt - Date.now();
+    if (!Number.isFinite(expiresAt) || remaining <= 0) {
+      this.#redactRetainedInvitation(completionId);
+      return;
+    }
+    this.#secretExpiryTimer = window.setTimeout(() => {
+      this.#secretExpiryTimer = null;
+      if (!this.#opened || this.#managementOperation?.completionId !== completionId) return;
+      if (Date.now() < expiresAt) {
+        this.#scheduleSecretExpiry(completionId, deadline);
+        return;
+      }
+      this.#redactRetainedInvitation(completionId);
+    }, Math.min(remaining, MAX_TIMER_DELAY_MS));
+  }
+
+  #redactRetainedInvitation(completionId: string): void {
+    const operation = this.#managementOperation;
+    if (operation?.completionId !== completionId) return;
+    this.#retainedInvitation = null;
+    this.#managementOperation = { ...operation, invitation: null };
+    if (this.#snapshot) this.#render();
+  }
+
+  #clearSecretExpiryTimer(): void {
+    if (this.#secretExpiryTimer === null) return;
+    window.clearTimeout(this.#secretExpiryTimer);
+    this.#secretExpiryTimer = null;
   }
 
   #render(): void {
@@ -1584,15 +1632,16 @@ export class ProjectManagementModal extends Modal {
       );
       return;
     }
-    if (operation.action !== 'reissue-member-claim') {
+    if (operation.action !== 'reissue-member-claim' || operation.invitation === null) {
       this.#createLifecycleButton(
         this.#requireAccessContent(),
         'complete-management-operation',
         t('collab.access.finishOperation'),
         () => this.#port.completeManagementOperation({
+          completionId: operation.completionId,
           projectId: this.#options.project.id,
         }),
-        () => { this.#managementOperation = null; },
+        () => { this.#applyManagementOperation(null); },
         true,
       );
     }
@@ -1603,11 +1652,7 @@ export class ProjectManagementModal extends Modal {
       this.#options.project.id,
     );
     if (result.status !== 'success') return result;
-    this.#managementOperation = result.value;
-    this.#retainedInvitation = result.value.action === 'reissue-member-claim'
-      && result.value.status === 'result-retained'
-      ? result.value.invitation
-      : null;
+    this.#applyManagementOperation(result.value);
     return result;
   }
 
@@ -1628,7 +1673,12 @@ export class ProjectManagementModal extends Modal {
       attr: { 'data-action': 'copy-member-claim', type: 'button' },
       text: t('collab.access.copyMemberClaim'),
     });
-    copy.disabled = this.#operationPending || !this.#options.copyText;
+    copy.disabled = this.#operationPending
+      || !this.#options.copyText
+      || this.#managementOperation?.action !== 'reissue-member-claim'
+      || this.#managementOperation.status !== 'result-retained'
+      || this.#managementOperation.invitation?.encodedInvitation
+        !== this.#retainedInvitation.encodedInvitation;
     copy.addEventListener('click', () => void this.#copyRetainedInvitation());
   }
 
@@ -1642,32 +1692,84 @@ export class ProjectManagementModal extends Modal {
       projectId: this.#options.project.id,
     });
     if (!this.#opened || this.#abortController.signal.aborted) return;
-    this.#operationPending = false;
     if (result.status === 'success') {
-      this.#retainedInvitation = result.value;
-      this.#status = { kind: 'success', text: t('collab.access.memberClaimReady') };
+      const retained = await this.#port.readManagementOperation(
+        this.#options.project.id,
+        { signal: this.#abortController.signal },
+      );
+      if (!this.#opened || this.#abortController.signal.aborted) return;
+      if (
+        retained.status === 'success'
+        && retained.value?.action === 'reissue-member-claim'
+        && retained.value.status === 'result-retained'
+        && retained.value.invitation?.encodedInvitation === result.value.encodedInvitation
+        && retained.value.invitation.expiresAt === result.value.expiresAt
+      ) {
+        this.#applyManagementOperation(retained.value);
+        this.#status = { kind: 'success', text: t('collab.access.memberClaimReady') };
+      } else {
+        this.#status = { kind: 'error', text: t('collab.access.actionFailed') };
+      }
     } else {
       this.#status = { kind: 'error', text: t('collab.access.actionFailed') };
     }
+    this.#operationPending = false;
     this.#render();
   }
 
   async #copyRetainedInvitation(): Promise<void> {
-    if (!this.#retainedInvitation || !this.#options.copyText || this.#operationPending) return;
+    const operation = this.#managementOperation;
+    const invitation = this.#retainedInvitation;
+    if (
+      !invitation
+      || !this.#options.copyText
+      || this.#operationPending
+      || operation?.action !== 'reissue-member-claim'
+      || operation.status !== 'result-retained'
+      || operation.invitation?.encodedInvitation !== invitation.encodedInvitation
+    ) return;
     this.#operationPending = true;
     this.#render();
     try {
-      await this.#options.copyText(this.#retainedInvitation.encodedInvitation);
+      const retained = await this.#port.readManagementOperation(
+        this.#options.project.id,
+        { signal: this.#abortController.signal },
+      );
+      if (!this.#opened || this.#abortController.signal.aborted) return;
+      if (retained.status !== 'success') {
+        this.#clearSecretExpiryTimer();
+        this.#retainedInvitation = null;
+        this.#managementOperation = { ...operation, invitation: null };
+        this.#status = { kind: 'error', text: t('collab.access.actionFailed') };
+        return;
+      }
+      this.#applyManagementOperation(retained.value);
+      const validatedInvitation = this.#retainedInvitation;
+      if (
+        retained.value?.action !== 'reissue-member-claim'
+        || retained.value.status !== 'result-retained'
+        || retained.value.completionId !== operation.completionId
+        || !validatedInvitation
+        || validatedInvitation.encodedInvitation !== invitation.encodedInvitation
+        || validatedInvitation.expiresAt !== invitation.expiresAt
+      ) {
+        this.#status = { kind: 'error', text: t('collab.access.actionFailed') };
+        return;
+      }
+      await this.#options.copyText(validatedInvitation.encodedInvitation);
       if (!this.#opened || this.#abortController.signal.aborted) return;
       const completed = await this.#port.completeManagementOperation(
-        { projectId: this.#options.project.id },
+        {
+          completionId: operation.completionId,
+          projectId: this.#options.project.id,
+        },
       );
       if (!this.#opened || this.#abortController.signal.aborted) return;
       if (completed.status !== 'success') {
         this.#status = { kind: 'error', text: t('collab.access.actionFailed') };
         return;
       }
-      this.#retainedInvitation = null;
+      this.#applyManagementOperation(null);
       this.#status = { kind: 'success', text: t('collab.access.memberClaimCopied') };
     } catch {
       if (this.#opened && !this.#abortController.signal.aborted) {

--- a/src/features/collab/sidebar/CollabPanel.ts
+++ b/src/features/collab/sidebar/CollabPanel.ts
@@ -79,7 +79,10 @@ export interface CollabPanelOptions {
   readonly projectSetup: CollabPanelProjectSetupPort;
   readonly resolveGit: (rescan: boolean) => Promise<GitSetupResolution>;
   readonly ticketFocus?: TicketFocusPort;
-  readonly transientSurfaces?: Pick<CollabTransientSurfaceRegistry, 'open'>;
+  readonly transientSurfaces?: Pick<
+    CollabTransientSurfaceRegistry,
+    'closeAll' | 'open'
+  >;
 }
 
 interface CollabPanelViewState {
@@ -420,6 +423,7 @@ export class CollabPanel implements CollabSidebarSurfaceController {
       projectId,
     };
     this.fallbackProjectSelection = selection;
+    this.options.transientSurfaces?.closeAll();
     void this.options.port.selectProject(projectId).then(result => {
       if (this.destroyed || this.fallbackProjectSelection !== selection) return;
       selection.pending = false;
@@ -462,6 +466,7 @@ export class CollabPanel implements CollabSidebarSurfaceController {
         .setChecked(project.id === selectedProjectId)
         .onClick(() => {
           if (this.destroyed || project.id === selectedProjectId) return;
+          this.options.transientSurfaces?.closeAll();
           void this.options.port.selectProject(project.id).then(() => {
             if (this.active) this.render();
           });

--- a/tests/helpers/collab/CollabFeatureTestHarness.ts
+++ b/tests/helpers/collab/CollabFeatureTestHarness.ts
@@ -130,6 +130,7 @@ function defaultAuthorityTransfer(): CollabAuthorityTransferEntryPort {
     acceptLanToCloudTransfer: () => unexpected('acceptLanToCloudTransfer'),
     acceptCloudToLanTransfer: () => unexpected('acceptCloudToLanTransfer'),
     beginCloudToLanTransfer: () => unexpected('beginCloudToLanTransfer'),
+    beginClose: () => undefined,
     cancelCloudToLanTransfer: () => unexpected('cancelCloudToLanTransfer'),
     cancelLanToCloudTransfer: () => unexpected('cancelLanToCloudTransfer'),
     close: () => Promise.resolve(),

--- a/tests/integration/app/collab/gates/CloudPublishGate.test.ts
+++ b/tests/integration/app/collab/gates/CloudPublishGate.test.ts
@@ -127,6 +127,34 @@ function capabilityLimits() {
   };
 }
 
+function projectSnapshot(actor: typeof ACTORS[number], mainOid: string) {
+  const currentMember = {
+    activatedAt: CREATED_AT,
+    createdAt: CREATED_AT,
+    displayName: actor,
+    id: actor,
+    personalRef: collabMemberRef(actor),
+    role: actor === ACTORS[0] ? 'manager' as const : 'member' as const,
+    status: 'active' as const,
+  };
+  return {
+    currentMember,
+    eventSequence: 0,
+    members: [currentMember],
+    openRequests: [],
+    openTicketCount: 0,
+    project: {
+      authorityGeneration: 1,
+      createdAt: CREATED_AT,
+      expectedMainOid: mainOid,
+      id: PROJECT_ID,
+      mainRef: COLLAB_MAIN_REF,
+      name: 'Cloud Publish Gate',
+    },
+    ticketHighlights: [],
+  };
+}
+
 async function startGateServer(repository: RepositoryFixture): Promise<GateServer> {
   const attempts = new Map<string, string[]>();
   const errors: string[] = [];
@@ -145,6 +173,7 @@ async function startGateServer(repository: RepositoryFixture): Promise<GateServe
         writeJson(response, 200, collabCloudCapabilityDocument([
           'git-receive-pack-personal-ref',
           'git-upload-pack',
+          'project-snapshot',
           'requests',
         ], capabilityLimits()));
         return;
@@ -173,6 +202,17 @@ async function startGateServer(repository: RepositoryFixture): Promise<GateServe
           { ...repository, executablePath: GIT_EXECUTABLE, remoteUser: actor },
           pathname.slice(prefix.length),
         );
+        return;
+      }
+      if (match.kind === 'project-operation' && match.operation === 'getProjectSnapshot') {
+        const envelope = decodeCollabProtocolEnvelope(
+          JSON.parse((await readBody(request)).toString('utf8')) as unknown,
+        );
+        if (envelope.status !== 'ok') throw new Error('snapshot-envelope-invalid');
+        writeJson(response, 200, collabCloudSuccessEnvelope(
+          envelope.value.requestId,
+          projectSnapshot(actor as typeof ACTORS[number], repository.mainOid),
+        ));
         return;
       }
       if (match.kind === 'project-operation' && match.operation === 'ensureMyRequest') {

--- a/tests/integration/app/collab/lan/LanHostCoordinator.test.ts
+++ b/tests/integration/app/collab/lan/LanHostCoordinator.test.ts
@@ -222,6 +222,7 @@ async function membershipAccess(
       projection.readSnapshot(projectId, options)
     ),
   }, {}, {
+    cloudManagementAdmission: async (_projectId, operation) => operation(),
     projects,
     managerResponsibilityAdmission: async (_projectId, operation) => operation(),
     managerReceipts: {

--- a/tests/integration/app/collab/membership/CloudMembershipManagement.test.ts
+++ b/tests/integration/app/collab/membership/CloudMembershipManagement.test.ts
@@ -54,9 +54,9 @@ describe('Cloud membership management', () => {
       await fixture.seed(client.foundation);
       const at = fixture.invitation.createdAt;
       await client.foundation.local.projects.saveProjectDocument(PROJECT_ID, 'cloud-management-intent', {
-        schemaVersion: 1, kind: 'cloud-management-intent', projectId: PROJECT_ID, memberId: MEMBER_ID,
+        schemaVersion: 1, kind: 'cloud-management-intent', completionId: 'completion-prior-user-invitation', projectId: PROJECT_ID, memberId: MEMBER_ID,
         authorityGeneration: 7, serverUrl: fixture.serverUrl, phase: 'submitted', operation: 'createProjectInvitation',
-        request: { projectId: PROJECT_ID, idempotencyKey: 'prior-user-invitation', expectedManagerSetGeneration: 8 }, response: null, createdAt: at, updatedAt: at,
+        request: { projectId: PROJECT_ID, idempotencyKey: 'prior-user-invitation', expectedManagerSetGeneration: 9 }, response: null, createdAt: at, updatedAt: at,
       });
       const userIntent = await readFile(fixture.intentPath, 'utf8');
       await client.feature.readSnapshot(PROJECT_ID);
@@ -73,6 +73,27 @@ describe('Cloud membership management', () => {
       expect(fixture.acknowledgements).toEqual([receipt.request, receipt.request]);
       expect(JSON.parse(await readFile(fixture.receiptPath, 'utf8'))).toMatchObject({ phase: 'settled', offer: { state: 'acknowledged', revision: 2 } });
       expect(await readFile(fixture.intentPath, 'utf8')).toBe(userIntent);
+      const firstResume = await client.feature.resumeManagementOperation(PROJECT_ID);
+      expect(firstResume).toMatchObject({ status: 'recovery-required' });
+      expect(fixture.requests).toHaveLength(1);
+      const resumed = await client.feature.resumeManagementOperation(PROJECT_ID);
+      expect(resumed).toMatchObject({
+        status: 'success',
+        value: {
+          action: 'create-invitation',
+          status: 'result-retained',
+        },
+      });
+      if (resumed.status !== 'success') throw new Error('Expected retained management result');
+      await expect(client.feature.completeManagementOperation({
+        completionId: resumed.value.completionId,
+        projectId: PROJECT_ID,
+      })).resolves.toMatchObject({ status: 'success' });
+      await expect(access(fixture.intentPath)).rejects.toMatchObject({ code: 'ENOENT' });
+      expect(JSON.parse(await readFile(fixture.receiptPath, 'utf8'))).toMatchObject({
+        phase: 'settled',
+        offer: { state: 'acknowledged', revision: 2 },
+      });
       expect(fixture.failures).toEqual([]);
     } finally { await client.close(); await fixture.close(); }
   });
@@ -131,7 +152,9 @@ describe('Cloud membership management', () => {
       if (state === 'retained') await client.feature.reissueMemberClaim(request);
       const clock = jest.spyOn(Date, 'now').mockReturnValue(Date.parse(fixture.claim.expiresAt) + 1);
       try {
-        const expectedValue = state === 'retained' ? null : { status: 'pending', invitation: null };
+        const expectedValue = state === 'retained'
+          ? { status: 'result-retained', invitation: null }
+          : { status: 'pending', invitation: null };
         await expect(client.feature.readManagementOperation(PROJECT_ID)).resolves.toMatchObject({
           status: 'success', value: expectedValue,
         });
@@ -521,7 +544,8 @@ describe('Cloud membership management', () => {
       await client.close();
       client = fixture.client();
 
-      await expect(client.feature.resumeManagementOperation(PROJECT_ID)).resolves.toEqual({
+      const resumed = await client.feature.resumeManagementOperation(PROJECT_ID);
+      expect(resumed).toMatchObject({
         status: 'success',
         value: {
           action: 'revoke-invitation',
@@ -529,13 +553,17 @@ describe('Cloud membership management', () => {
           status: 'result-retained',
         },
       });
+      if (resumed.status !== 'success') throw new Error('Expected retained management result');
       expect(fixture.revocations).toEqual([submitted.request, submitted.request]);
       await expect(client.feature.readManagementOperation(PROJECT_ID)).resolves.toMatchObject({
         status: 'success',
         value: { action: 'revoke-invitation', status: 'result-retained' },
       });
       await expect(access(fixture.intentPath)).resolves.toBeUndefined();
-      await expect(client.feature.completeManagementOperation({ projectId: PROJECT_ID }))
+      await expect(client.feature.completeManagementOperation({
+        completionId: resumed.value.completionId,
+        projectId: PROJECT_ID,
+      }))
         .resolves.toMatchObject({ status: 'success' });
       await expect(access(fixture.intentPath)).rejects.toMatchObject({ code: 'ENOENT' });
     } finally { await client.close(); await fixture.close(); }
@@ -590,14 +618,15 @@ describe('Cloud membership management', () => {
       try {
         const result = await client.feature.readManagementOperation(PROJECT_ID);
         const expectedPending = expect.objectContaining({ status: 'pending', invitation: null });
-        expect(result).toEqual({ status: 'success', value: state === 'retained' ? null : expectedPending });
+        const expectedRetained = expect.objectContaining({ status: 'result-retained', invitation: null });
+        expect(result).toEqual({ status: 'success', value: state === 'retained' ? expectedRetained : expectedPending });
       } finally { clock.mockRestore(); }
       expect(fixture.requests).toHaveLength(state === 'retained' ? 2 : 1);
       const present = await access(fixture.intentPath).then(() => true, error => {
         if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
         throw error;
       });
-      expect(present).toBe(state === 'pending');
+      expect(present).toBe(true);
     } finally { await client.close(); await fixture.close(); }
   });
 
@@ -616,7 +645,10 @@ describe('Cloud membership management', () => {
       expect(state.value).toMatchObject({ action: 'create-invitation', status: 'result-retained', invitation: { expiresAt: fixture.invitation.expiresAt } });
       expect(state.value).not.toHaveProperty('operationId');
       await expect(access(fixture.intentPath)).resolves.toBeUndefined();
-      await expect(client.feature.completeManagementOperation({ projectId: PROJECT_ID }))
+      await expect(client.feature.completeManagementOperation({
+        completionId: state.value.completionId,
+        projectId: PROJECT_ID,
+      }))
         .resolves.toMatchObject({ status: 'success' });
       await expect(access(fixture.intentPath)).rejects.toMatchObject({ code: 'ENOENT' });
       expect(fixture.requests).toHaveLength(2);
@@ -736,8 +768,13 @@ async function createFixture(options: { onInvitationRequest?: () => void; onInvi
         })));
         return;
       }
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) chunks.push(Buffer.from(chunk));
+      const envelope = decodeCollabProtocolEnvelope(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+      assert.equal(envelope.status, 'ok');
+      if (envelope.status !== 'ok') throw new Error('Invalid fixture request');
       if (target === collabCloudProjectOperationRoute(PROJECT_ID, 'getProjectSnapshot').target) {
-        response.end(JSON.stringify(collabCloudSuccessEnvelope('snapshot', {
+        response.end(JSON.stringify(collabCloudSuccessEnvelope(envelope.value.requestId, {
           ...snapshot,
           currentMember: { ...snapshot.currentMember, role: currentRole },
           members: snapshot.members.map(snapshotMember => snapshotMember.id === MEMBER_ID
@@ -748,7 +785,7 @@ async function createFixture(options: { onInvitationRequest?: () => void; onInvi
       }
       if (target === collabCloudProjectOperationRoute(PROJECT_ID, 'listProjectMembers').target) {
         if (managerSetGeneration === 10 && options.blockBarrier) { request.socket.destroy(); return; }
-        response.end(JSON.stringify(collabCloudSuccessEnvelope('members', {
+        response.end(JSON.stringify(collabCloudSuccessEnvelope(envelope.value.requestId, {
           managerSetGeneration, projectId: PROJECT_ID,
           members: [{ bindingState: 'bound', displayName: 'Alice', importedClaimGeneration: null,
             importedClaimState: 'not-applicable', memberId: MEMBER_ID, membershipRevision: 4, role: currentRole },
@@ -762,17 +799,12 @@ async function createFixture(options: { onInvitationRequest?: () => void; onInvi
         return;
       }
       if (target === collabCloudProjectOperationRoute(PROJECT_ID, 'listProjectInvitations').target) {
-        response.end(JSON.stringify(collabCloudSuccessEnvelope('invitations', {
+        response.end(JSON.stringify(collabCloudSuccessEnvelope(envelope.value.requestId, {
           managerSetGeneration: 9, projectId: PROJECT_ID,
           invitations: [{ createdAt, expiresAt: invitation.expiresAt, invitationId: 'invitation-existing', revision: 5, state: 'active', terminalAt: null }],
         })));
         return;
       }
-      const chunks: Buffer[] = [];
-      for await (const chunk of request) chunks.push(Buffer.from(chunk));
-      const envelope = decodeCollabProtocolEnvelope(JSON.parse(Buffer.concat(chunks).toString('utf8')));
-      assert.equal(envelope.status, 'ok');
-      if (envelope.status !== 'ok') throw new Error('Invalid fixture request');
       if (target === collabCloudProjectOperationRoute(PROJECT_ID, 'acknowledgeManagerResponsibility').target) {
         const decoded = collabControlOperationCodec('acknowledgeManagerResponsibility').decodeRequest(envelope.value.data);
         if (decoded.status !== 'ok') throw decoded.error;

--- a/tests/integration/app/collab/project/CloudProjectEntryCoordinator.test.ts
+++ b/tests/integration/app/collab/project/CloudProjectEntryCoordinator.test.ts
@@ -951,25 +951,25 @@ async function createFixture(options: {
         })));
         return;
       }
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) chunks.push(Buffer.from(chunk));
+      const envelope = decodeCollabProtocolEnvelope(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+      if (envelope.status !== 'ok') throw envelope.error;
       if (routeTarget === collabCloudProjectOperationRoute(projectId, 'getProjectSnapshot').target) {
         await onSnapshot(projectId);
         if (options.snapshotFailure === 'transport') { request.socket.destroy(); return; }
         if (options.snapshotFailure === 'malformed') { response.end('{"invalid":true}'); return; }
         if (options.snapshotFailure === 'authorization') {
-          response.writeHead(403).end(JSON.stringify(collabCloudErrorEnvelope('snapshot-entry', new CollabError({ code: 'authorization-denied' }))));
+          response.writeHead(403).end(JSON.stringify(collabCloudErrorEnvelope(envelope.value.requestId, new CollabError({ code: 'authorization-denied' }))));
           return;
         }
         if (!bound) {
-          response.writeHead(404).end(JSON.stringify(collabCloudErrorEnvelope('snapshot-entry', new CollabError({ code: 'project-not-found' }))));
+          response.writeHead(404).end(JSON.stringify(collabCloudErrorEnvelope(envelope.value.requestId, new CollabError({ code: 'project-not-found' }))));
           return;
         }
-        response.end(JSON.stringify(collabCloudSuccessEnvelope('snapshot-entry', snapshot)));
+        response.end(JSON.stringify(collabCloudSuccessEnvelope(envelope.value.requestId, snapshot)));
         return;
       }
-      const chunks: Buffer[] = [];
-      for await (const chunk of request) chunks.push(Buffer.from(chunk));
-      const envelope = decodeCollabProtocolEnvelope(JSON.parse(Buffer.concat(chunks).toString('utf8')));
-      if (envelope.status !== 'ok') throw envelope.error;
       if (routeTarget === collabCloudProjectOperationRoute(projectId, 'joinCloudProject').target) {
         const decoded = collabControlOperationCodec('joinCloudProject').decodeRequest(envelope.value.data);
         if (decoded.status !== 'ok') throw decoded.error;

--- a/tests/integration/app/collab/publish/CloudPublishRecovery.test.ts
+++ b/tests/integration/app/collab/publish/CloudPublishRecovery.test.ts
@@ -173,7 +173,10 @@ class LostResponseCloudTransport {
   async request(input: CloudAuthorityHttpRequest): Promise<CloudAuthorityHttpResponse> {
     if (input.method === 'GET') {
       return {
-        body: collabCloudCapabilityDocument(['requests'], capabilityLimits()),
+        body: collabCloudCapabilityDocument([
+          'project-snapshot',
+          'requests',
+        ], capabilityLimits()),
         contentType: 'application/json',
         status: 200,
       };
@@ -182,6 +185,13 @@ class LostResponseCloudTransport {
       readonly data: Readonly<Record<string, unknown>>;
       readonly requestId: string;
     };
+    if (input.url.endsWith('/getProjectSnapshot')) {
+      return {
+        body: collabCloudSuccessEnvelope(envelope.requestId, cloudSnapshot(this.mainOid)),
+        contentType: 'application/json',
+        status: 200,
+      };
+    }
     const intent = String(envelope.data.idempotencyKey);
     this.requestIntents.push(intent);
     if (!this.requestRecord) {
@@ -213,6 +223,34 @@ class LostResponseCloudTransport {
       status: 200,
     };
   }
+}
+
+function cloudSnapshot(mainOid: string) {
+  const currentMember = {
+    activatedAt: CREATED_AT,
+    createdAt: CREATED_AT,
+    displayName: 'Alice',
+    id: ACTOR_ID,
+    personalRef: PERSONAL_REF,
+    role: 'member' as const,
+    status: 'active' as const,
+  };
+  return {
+    currentMember,
+    eventSequence: 0,
+    members: [currentMember],
+    openRequests: [],
+    openTicketCount: 0,
+    project: {
+      authorityGeneration: 1,
+      createdAt: CREATED_AT,
+      expectedMainOid: mainOid,
+      id: PROJECT_ID,
+      mainRef: 'refs/heads/main',
+      name: 'Cloud Project',
+    },
+    ticketHighlights: [],
+  };
 }
 
 class DirectNetwork implements PublishGitNetworkPort {

--- a/tests/unit/app/collab/ClaudianCollabService.test.ts
+++ b/tests/unit/app/collab/ClaudianCollabService.test.ts
@@ -24,6 +24,69 @@ async function admitProjectRecovery(
   await operation();
 }
 
+describe('ClaudianCollabService authority transfer routing', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('forwards cancellation through source route activation', async () => {
+    const service = new ClaudianCollabService({
+      getConfiguredGitPath: () => '',
+      installationKey: TEST_INSTALLATION_A,
+      obsidianConfigDirectory: '.obsidian',
+      vaultRoot: '/tmp/claudian-authority-transfer-route-cancellation',
+    });
+    const projectId = 'project-source-route-cancellation';
+    service.bindAuthorityTransferModule({
+      sourceActiveService: jest.fn(() => ({ kind: 'source-active-service' })),
+    } as never);
+    jest.spyOn(service, 'inspectAuthority').mockResolvedValue({
+      database: {
+        read: async (operation: (connection: unknown) => Promise<unknown>) => operation({}),
+      },
+      projects: {
+        get: async () => ({
+          authorityGeneration: 1,
+          hostMemberId: 'member-host',
+          projectId,
+        }),
+      },
+    } as never);
+    jest.spyOn(service.lanHost, 'isProjectRunning').mockReturnValue(false);
+    let releaseRoute!: () => void;
+    let enteredRoute!: () => void;
+    const routeGate = new Promise<void>(resolve => { releaseRoute = resolve; });
+    const routeStarted = new Promise<void>(resolve => { enteredRoute = resolve; });
+    let routeSignal: AbortSignal | undefined;
+    jest.spyOn(service.lanHost, 'startAuthorityTransferRoute').mockImplementation(async (
+      _registration,
+      options = {},
+    ) => {
+      routeSignal = options.signal;
+      enteredRoute();
+      await routeGate;
+      if (options.signal?.aborted) throw new CollabError({ code: 'cancelled' });
+      return {} as never;
+    });
+    const stopRoute = jest.spyOn(service.lanHost, 'stopAuthorityTransferRoute')
+      .mockResolvedValue(undefined);
+    const controller = new AbortController();
+    const activation = service.activateAuthorityTransferSourceRoute(
+      projectId,
+      'https://192.168.1.10:54545',
+      { signal: controller.signal },
+    );
+    await routeStarted;
+
+    controller.abort();
+    releaseRoute();
+
+    await expect(activation).rejects.toMatchObject({ code: 'cancelled' });
+    expect(routeSignal).toBe(controller.signal);
+    expect(stopRoute).not.toHaveBeenCalled();
+  });
+});
+
 describe('ClaudianCollabService retirement recovery', () => {
   afterEach(() => {
     jest.restoreAllMocks();

--- a/tests/unit/app/collab/CollabFeatureService.test.ts
+++ b/tests/unit/app/collab/CollabFeatureService.test.ts
@@ -13,6 +13,7 @@ import {
 } from '@test/helpers/collab/CollabFeatureTestHarness';
 
 import { CollabProjectWorkSessionRegistry } from '@/app/collab/activity/CollabProjectWorkSession';
+import { AuthorityTransferEntryService } from '@/app/collab/authority-transfer/AuthorityTransferEntryService';
 import {
   CollabAuthorityTransferOutcomeError,
 } from '@/app/collab/authority-transfer/CollabAuthorityTransferOutcomeError';
@@ -228,6 +229,7 @@ function membershipControl(): jest.Mocked<CollabMembershipPort> {
     readManagementOperation: jest.fn().mockResolvedValue(null),
     resumeManagementOperation: jest.fn().mockResolvedValue({
       action: 'remove-member',
+      completionId: 'completion-remove-member',
       invitation: null,
       status: 'result-retained',
     }),
@@ -749,7 +751,9 @@ describe('CollabFeatureService', () => {
     const membership = membershipControl();
     const operation = {
       action: 'remove-member' as const,
+      completionId: 'completion-remove-member',
       invitation: null,
+      secretAvailableUntil: null,
       status: 'result-retained' as const,
     };
     membership.readManagementOperation.mockResolvedValue(operation);
@@ -758,7 +762,10 @@ describe('CollabFeatureService', () => {
 
     await expect(service.readManagementOperation('project-alpha'))
       .resolves.toEqual({ status: 'success', value: operation });
-    await expect(service.completeManagementOperation({ projectId: 'project-alpha' }))
+    await expect(service.completeManagementOperation({
+      completionId: operation.completionId,
+      projectId: 'project-alpha',
+    }))
       .resolves.toEqual({ status: 'success', value: undefined });
 
     expect(service.resumeProjectAdmission(suspension)).toBe(true);
@@ -2043,6 +2050,7 @@ describe('CollabFeatureService', () => {
   it('closes required owners in the feature lifecycle order', async () => {
     const hostStarted = deferred<void>();
     const releaseHost = deferred<void>();
+    const recoveryCloseStarted = deferred<void>();
     const releaseRecoveryClose = deferred<void>();
     const order: string[] = [];
     const publish = publication();
@@ -2074,6 +2082,7 @@ describe('CollabFeatureService', () => {
       lifecycleRecovery: {
         close: jest.fn(() => {
           order.push('recovery-close-started');
+          recoveryCloseStarted.resolve();
           return releaseRecoveryClose.promise.then(() => {
             order.push('recovery-close-finished');
           });
@@ -2091,17 +2100,17 @@ describe('CollabFeatureService', () => {
     await hostStarted.promise;
     const closing = service.close();
 
-    expect(order).toEqual(['recovery-close-started']);
+    expect(order).toEqual([]);
     releaseHost.resolve();
     await restoring;
-    await Promise.resolve();
-    expect(order).toEqual(['recovery-close-started', 'admitted-operation']);
+    await recoveryCloseStarted.promise;
+    expect(order).toEqual(['admitted-operation', 'recovery-close-started']);
 
     releaseRecoveryClose.resolve();
     await expect(closing).resolves.toBeUndefined();
     expect(order).toEqual([
-      'recovery-close-started',
       'admitted-operation',
+      'recovery-close-started',
       'recovery-close-finished',
       'authority-transfer',
       'retirement',
@@ -2110,6 +2119,126 @@ describe('CollabFeatureService', () => {
       'publication',
     ]);
     expect(service).not.toHaveProperty('dispose');
+  });
+
+  it('drains a same-turn admitted lifecycle transition before closing its arbiter', async () => {
+    const order: string[] = [];
+    const hostTransfer = {
+      acceptHostTransfer: jest.fn(),
+      cancelHostTransfer: jest.fn(),
+      close: jest.fn(async () => undefined),
+      createHostTransfer: jest.fn(async () => {
+        order.push('transition');
+      }),
+      declineHostTransfer: jest.fn(),
+    };
+    const lifecycle = new CollabProjectLifecycleSubsystem({
+      closeRecovery: () => {
+        order.push('arbiter-close');
+      },
+      durableOwners: [],
+      hostTransfer,
+      localExit: {} as never,
+      recoveryStages: [],
+      retirement: {} as never,
+    });
+    const service = createService({
+      hostTransfer: lifecycle.hostTransfer,
+      lifecycleRecovery: lifecycle.lifecycleRecovery,
+    });
+
+    const transition = service.createHostTransfer({
+      projectId: 'project-alpha',
+      targetMemberId: 'member-a',
+    });
+    const closing = service.close();
+
+    await expect(transition).resolves.toMatchObject({ status: 'success' });
+    await expect(closing).resolves.toBeUndefined();
+    expect(order).toEqual(['transition', 'arbiter-close']);
+  });
+
+  it('aborts and quiesces a stalled LAN-to-Cloud acceptance before closing its resources', async () => {
+    const cleanupGate = deferred<void>();
+    const underlyingStarted = deferred<AbortSignal>();
+    const module = {
+      acceptLanToCloudTransferTarget: jest.fn((
+        _request,
+        _sourceInput,
+        options: { readonly signal?: AbortSignal } = {},
+      ) => {
+        const signal = options.signal;
+        if (!signal) throw new Error('Missing service-owned acceptance signal');
+        underlyingStarted.resolve(signal);
+        return new Promise((_, reject) => {
+          signal.addEventListener('abort', () => {
+            void cleanupGate.promise.then(() => reject(new CollabError({ code: 'cancelled' })));
+          }, { once: true });
+        });
+      }),
+      assertLanToCloudSourceInstallationOwner: jest.fn(async () => undefined),
+      close: jest.fn(async () => undefined),
+      readLanToCloudSourceProposal: jest.fn(async () => ({
+        proposedByMemberId: 'member-host',
+        request: {
+          expectedAuthorityGeneration: 1,
+          idempotencyKey: 'intent-feature-close',
+          projectId: 'project-alpha',
+          targetUrl: 'https://cloud.example.test/',
+        },
+        status: {
+          phase: 'collecting-readiness',
+          projectId: 'project-alpha',
+          state: 'active',
+          transferId: 'transfer-feature-close',
+        },
+      })),
+    };
+    const localMembership = membership();
+    const entry = new AuthorityTransferEntryService({
+      connectCloud: async () => ({
+        dispose: jest.fn(),
+        projectId: 'project-alpha',
+        serverUrl: 'https://cloud.example.test/',
+        supports: () => true,
+      }) as never,
+      loadMembership: async () => ({
+        ...localMembership,
+        authority: {
+          ...localMembership.authority,
+          endpoint: 'https://192.168.1.10:54545',
+          gitRemoteUrl: 'https://192.168.1.10:54545/v1/git/project-alpha/repository.git',
+          hostCaCertificatePem: 'test-ca',
+          hostCaFingerprint: 'a'.repeat(64),
+        },
+      }),
+      module: module as never,
+    });
+    const service = createService({
+      authorityTransfer: {
+        acceptLanToCloudTransfer: (...args) => entry.acceptLanToCloudTransfer(...args),
+        beginClose: () => entry.beginClose(),
+        close: () => entry.close(),
+      },
+    });
+
+    const accepting = service.acceptLanToCloudTransfer({
+      projectId: 'project-alpha',
+      transferId: 'transfer-feature-close',
+    });
+    const serviceSignal = await underlyingStarted.promise;
+    let closed = false;
+    const closing = service.close().then(() => { closed = true; });
+
+    expect(serviceSignal.aborted).toBe(true);
+    await expect(accepting).resolves.toMatchObject({ status: 'failure' });
+    await Promise.resolve();
+    expect(closed).toBe(false);
+    expect(module.close).not.toHaveBeenCalled();
+
+    cleanupGate.resolve();
+    await expect(closing).resolves.toBeUndefined();
+    expect(module.close).toHaveBeenCalledTimes(1);
   });
 
   it('continues feature close when best-effort owners throw synchronously', async () => {
@@ -2135,6 +2264,42 @@ describe('CollabFeatureService', () => {
 
     await expect(service.close()).resolves.toBeUndefined();
     expect(publish.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('settles remaining teardown after authority transfer close fails and reports it', async () => {
+    const closeError = new Error('authority-transfer-close-failed');
+    const publish = publication();
+    const subscription = { dispose: jest.fn() };
+    publish.subscribeCoordination.mockReturnValue(subscription);
+    const retirement = {
+      close: jest.fn(async () => undefined),
+    };
+    const transfer = {
+      close: jest.fn(async () => {
+        throw closeError;
+      }),
+    };
+    const host = {
+      close: jest.fn(async () => undefined),
+    };
+    const service = createService({
+      authorityTransfer: transfer as never,
+      hostTransfer: host,
+      publication: publish,
+      retirement,
+    });
+    service.subscribe(jest.fn());
+
+    await expect(service.close()).rejects.toBe(closeError);
+
+    expect(retirement.close).toHaveBeenCalledTimes(1);
+    expect(host.close).toHaveBeenCalledTimes(1);
+    expect(subscription.dispose).toHaveBeenCalledTimes(1);
+    expect(publish.close).toHaveBeenCalledTimes(1);
+    const core = service as unknown as {
+      readonly core: { readonly listeners: ReadonlySet<unknown> };
+    };
+    expect(core.core.listeners.size).toBe(0);
   });
 
   it('clears feature listeners when publication close fails', async () => {

--- a/tests/unit/app/collab/authority-transfer/AuthorityTransferEntryService.test.ts
+++ b/tests/unit/app/collab/authority-transfer/AuthorityTransferEntryService.test.ts
@@ -54,7 +54,9 @@ function lanMembership() {
   };
 }
 
-function createSubject() {
+function createSubject(options: Readonly<{
+  loadMembership?: () => Promise<ReturnType<typeof lanMembership>>;
+}> = {}) {
   const requester = {
     propose: jest.fn(async () => status()),
     resumeMatching: jest.fn(async () => null),
@@ -109,12 +111,15 @@ function createSubject() {
     supports: jest.fn(() => true),
   };
   const createLanClient = jest.fn(() => ({ kind: 'lan-client' }));
-  const connectCloud = jest.fn(async () => connection);
+  const connectCloud = jest.fn(async (
+    _input?: unknown,
+    _options?: { readonly signal?: AbortSignal },
+  ) => connection);
   const service = new AuthorityTransferEntryService({
     connectCloud: connectCloud as never,
     createIdempotencyKey: () => 'intent-new',
     createLanClient: createLanClient as never,
-    loadMembership: async () => lanMembership(),
+    loadMembership: options.loadMembership ?? (async () => lanMembership()),
     module: module as never,
   });
   return {
@@ -242,6 +247,7 @@ describe('AuthorityTransferEntryService', () => {
         expectedTargetUrl: SERVER_URL,
         projectId: PROJECT_ID,
       },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
     expect(subject.sourceBinding.dispose).not.toHaveBeenCalled();
     expect(subject.connection.dispose).toHaveBeenCalledTimes(1);
@@ -316,6 +322,80 @@ describe('AuthorityTransferEntryService', () => {
     release();
     await expect(first).resolves.toEqual(status());
     expect(subject.module.acceptLanToCloudTransferTarget).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts the shared acceptance lifetime on close without borrowing caller cancellation', async () => {
+    const subject = createSubject();
+    let entered!: () => void;
+    const enteredAcceptance = new Promise<void>(resolve => { entered = resolve; });
+    let releaseCleanup!: () => void;
+    const cleanupGate = new Promise<void>(resolve => { releaseCleanup = resolve; });
+    let underlyingQuiesced = false;
+    subject.module.acceptLanToCloudTransferTarget.mockImplementation((...args: readonly unknown[]) => {
+      const options = args[2] as { readonly signal?: AbortSignal } | undefined;
+      entered();
+      return new Promise<CollabAuthorityTransferStatus>((_resolve, reject) => {
+        options?.signal?.addEventListener('abort', () => {
+          void cleanupGate.then(() => {
+            underlyingQuiesced = true;
+            reject(new CollabError({ code: 'cancelled' }));
+          });
+        }, { once: true });
+      });
+    });
+    const controller = new AbortController();
+    const accepting = subject.service.acceptLanToCloudTransfer(
+      { projectId: PROJECT_ID, transferId: 'transfer-entry-service' },
+      { signal: controller.signal },
+    );
+    await enteredAcceptance;
+
+    const serviceSignal = subject.connectCloud.mock.calls[0]?.[1]?.signal;
+    expect(serviceSignal).toBeDefined();
+    expect(serviceSignal).not.toBe(controller.signal);
+    controller.abort();
+    await expect(accepting).rejects.toMatchObject({ code: 'cancelled' });
+    expect(serviceSignal?.aborted).toBe(false);
+
+    const closing = subject.service.close();
+    expect(serviceSignal?.aborted).toBe(true);
+    await Promise.resolve();
+    expect(subject.module.close).not.toHaveBeenCalled();
+    releaseCleanup();
+    await expect(closing).resolves.toBeUndefined();
+    expect(underlyingQuiesced).toBe(true);
+    expect(subject.module.close).toHaveBeenCalledTimes(1);
+    expect(subject.connection.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cross the preflight read fence after close begins', async () => {
+    let releaseMembership!: () => void;
+    let enteredMembership!: () => void;
+    const membershipGate = new Promise<void>(resolve => { releaseMembership = resolve; });
+    const membershipStarted = new Promise<void>(resolve => { enteredMembership = resolve; });
+    const subject = createSubject({
+      loadMembership: async () => {
+        enteredMembership();
+        await membershipGate;
+        return lanMembership();
+      },
+    });
+    const accepting = subject.service.acceptLanToCloudTransfer({
+      projectId: PROJECT_ID,
+      transferId: 'transfer-entry-service',
+    });
+    await membershipStarted;
+
+    const closing = subject.service.close();
+    releaseMembership();
+
+    await expect(accepting).rejects.toMatchObject({
+      safeContext: { reason: 'authority-transfer-entry-service-closed' },
+    });
+    await expect(closing).resolves.toBeUndefined();
+    expect(subject.module.assertLanToCloudSourceInstallationOwner).not.toHaveBeenCalled();
+    expect(subject.connectCloud).not.toHaveBeenCalled();
+    expect(subject.module.acceptLanToCloudTransferTarget).not.toHaveBeenCalled();
   });
 
   it('closes a source session that finishes connecting during shutdown', async () => {

--- a/tests/unit/app/collab/authority-transfer/AuthorityTransferModule.test.ts
+++ b/tests/unit/app/collab/authority-transfer/AuthorityTransferModule.test.ts
@@ -707,6 +707,16 @@ describe('AuthorityTransferModule', () => {
       );
       await service.close();
       expect(capture).toHaveBeenCalledTimes(2);
+      expect(capture).toHaveBeenNthCalledWith(
+        1,
+        expect.anything(),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+      expect(capture).toHaveBeenNthCalledWith(
+        2,
+        expect.anything(),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
       expect(reopenAfterCancellation).toHaveBeenCalledTimes(1);
       expect(cleanupSourceRoute).toHaveBeenCalledTimes(2);
     } finally {
@@ -999,6 +1009,165 @@ describe('AuthorityTransferModule', () => {
       projectId: PROJECT_ID,
     })).rejects.toBeDefined();
     expect(routeActivationOwnership).toEqual([false, true]);
+  });
+
+  it('removes a source route when acceptance is cancelled during route activation', async () => {
+    const request = {
+      expectedAuthorityGeneration: 1,
+      idempotencyKey: 'intent-route-cancellation',
+      projectId: PROJECT_ID,
+      targetUrl: 'https://cloud.example.test/',
+    };
+    const sourceEntry = createAuthorityTransferEntryRecord({
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      proposedByMemberId: 'member-host',
+      request,
+      status: proposal(),
+    });
+    let releaseRoute!: () => void;
+    let enteredRoute!: () => void;
+    const routeGate = new Promise<void>(resolve => { releaseRoute = resolve; });
+    const routeStarted = new Promise<void>(resolve => { enteredRoute = resolve; });
+    const cleanupRoute = jest.fn(async () => undefined);
+    let routeSignal: AbortSignal | undefined;
+    const capture = jest.fn();
+    const module = new AuthorityTransferModule({
+      activateLanToCloudSourceRoute: async (_projectId, _endpoint, options) => {
+        routeSignal = options.signal;
+        enteredRoute();
+        await routeGate;
+        return cleanupRoute;
+      },
+      assertLanToCloudSourceOwner: () => undefined,
+      assertRecoveryOwner: () => undefined,
+      claimantStore: {
+        listProjectIds: () => Promise.resolve([]),
+        load: () => Promise.resolve(null),
+        remove: () => Promise.resolve(false),
+        save: () => Promise.resolve(),
+      },
+      convergence: {} as never,
+      createLanToCloudSource: () => ({
+        activateTerminal: jest.fn(),
+        capture,
+        commitRelinquishmentFence: jest.fn(),
+        reopenAfterCancellation: jest.fn(),
+      }),
+      installationKey: TEST_INSTALLATION_A,
+      lifecycle: {
+        registerDurableOwner: jest.fn(),
+        registerRecoveryStage: jest.fn(),
+        runExclusive: jest.fn(async (_projectId, _owner, _mode, operation) => operation()),
+      } as unknown as CollabProjectLifecycleSubsystem,
+      persistence: {
+        loadSourceEntry: jest.fn(async () => sourceEntry),
+      } as unknown as AuthorityTransferPersistence,
+    });
+    const cloudSession = {
+      dispose: jest.fn(),
+      lifecycle: {},
+      projectId: PROJECT_ID,
+      serverUrl: request.targetUrl,
+      supports: () => true,
+    } as unknown as CloudAuthorityConnection;
+    const controller = new AbortController();
+    const accepting = module.acceptLanToCloudTransferTarget({
+      expectedAuthorityGeneration: 1,
+      idempotencyKey: 'unused-after-route-cancellation',
+      projectId: PROJECT_ID,
+      targetUrl: request.targetUrl,
+      transferId: TRANSFER_ID,
+    }, {
+      cloudSession,
+      expectedSourceEndpoint: 'https://192.168.1.10:54545',
+      expectedTargetUrl: request.targetUrl,
+      projectId: PROJECT_ID,
+    }, { signal: controller.signal });
+    await routeStarted;
+
+    controller.abort();
+    releaseRoute();
+
+    await expect(accepting).rejects.toMatchObject({ code: 'cancelled' });
+    expect(routeSignal).toBe(controller.signal);
+    expect(cleanupRoute).toHaveBeenCalledTimes(1);
+    expect(capture).not.toHaveBeenCalled();
+    await expect(module.close()).resolves.toBeUndefined();
+    expect(cleanupRoute).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for every owned disposer before reporting the first close failure', async () => {
+    const secondProjectId = 'project-authority-transfer-module-second';
+    const sourceEntry = (projectId: string) => createAuthorityTransferEntryRecord({
+      ownerInstallationKey: TEST_INSTALLATION_A,
+      proposedByMemberId: 'member-host',
+      request: {
+        expectedAuthorityGeneration: 1,
+        idempotencyKey: `intent-close-${projectId}`,
+        projectId,
+        targetUrl: 'https://cloud.example.test/',
+      },
+      status: proposal({ projectId }),
+    });
+    const firstFailure = new Error('first-source-dispose-failed');
+    const firstCleanup = jest.fn(async () => { throw firstFailure; });
+    let releaseSecond!: () => void;
+    const secondGate = new Promise<void>(resolve => { releaseSecond = resolve; });
+    const secondCleanup = jest.fn(async () => secondGate);
+    const module = new AuthorityTransferModule({
+      activateLanToCloudSourceRoute: async projectId => (
+        projectId === PROJECT_ID ? firstCleanup : secondCleanup
+      ),
+      assertLanToCloudSourceOwner: () => undefined,
+      assertRecoveryOwner: () => undefined,
+      claimantStore: {
+        listProjectIds: () => Promise.resolve([]),
+        load: () => Promise.resolve(null),
+        remove: () => Promise.resolve(false),
+        save: () => Promise.resolve(),
+      },
+      convergence: {} as never,
+      createLanToCloudSource: () => ({
+        activateTerminal: jest.fn(),
+        capture: jest.fn(),
+        commitRelinquishmentFence: jest.fn(),
+        reopenAfterCancellation: jest.fn(),
+      }),
+      installationKey: TEST_INSTALLATION_A,
+      lifecycle: {
+        registerDurableOwner: jest.fn(),
+        registerRecoveryStage: jest.fn(),
+      } as unknown as CollabProjectLifecycleSubsystem,
+      persistence: {
+        loadSourceEntry: jest.fn(async projectId => sourceEntry(projectId)),
+      } as unknown as AuthorityTransferPersistence,
+    });
+    const cloudSession = (projectId: string) => ({
+      dispose: jest.fn(),
+      lifecycle: {},
+      projectId,
+      serverUrl: 'https://cloud.example.test/',
+      supports: () => true,
+    }) as unknown as CloudAuthorityConnection;
+    await module.bindLanToCloudSource({
+      cloudSession: cloudSession(PROJECT_ID),
+      projectId: PROJECT_ID,
+    });
+    await module.bindLanToCloudSource({
+      cloudSession: cloudSession(secondProjectId),
+      projectId: secondProjectId,
+    });
+
+    let closeSettled = false;
+    const closing = module.close().finally(() => { closeSettled = true; });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(firstCleanup).toHaveBeenCalledTimes(1);
+    expect(secondCleanup).toHaveBeenCalledTimes(1);
+    expect(closeSettled).toBe(false);
+    releaseSecond();
+    await expect(closing).rejects.toBe(firstFailure);
   });
 
   it('prepares a product-owned Cloud-to-LAN target without exposing raw effects', async () => {

--- a/tests/unit/app/collab/bootstrap/LocalCloudBootstrapBindingEffects.test.ts
+++ b/tests/unit/app/collab/bootstrap/LocalCloudBootstrapBindingEffects.test.ts
@@ -153,7 +153,7 @@ describe('LocalCloudBootstrapBindingEffects', () => {
             maxJsonPayloadUtf8Bytes: COLLAB_LIMITS.maxJsonPayloadUtf8Bytes,
             maxRepositoryBytes: 1_024,
           })
-          : collabCloudSuccessEnvelope('bootstrap-snapshot', {
+          : collabCloudSuccessEnvelope((input.body as { readonly requestId: string }).requestId, {
             ...snapshot,
             members: [snapshot.currentMember],
             project: {

--- a/tests/unit/app/collab/client/CollabClientProjection.test.ts
+++ b/tests/unit/app/collab/client/CollabClientProjection.test.ts
@@ -1,4 +1,10 @@
-import { COLLAB_CHECKPOINT_ARTIFACT_LIMITS, COLLAB_LIMITS, collabCloudCapabilityDocument, type CollabTicketDetail } from '@claudian-collab/protocol';
+import {
+  COLLAB_CHECKPOINT_ARTIFACT_LIMITS,
+  COLLAB_LIMITS,
+  collabCloudCapabilityDocument,
+  collabCloudSuccessEnvelope,
+  type CollabTicketDetail,
+} from '@claudian-collab/protocol';
 
 import { CollabProjectWorkSessionRegistry } from '@/app/collab/activity/CollabProjectWorkSession';
 import {
@@ -20,7 +26,7 @@ import {
   CollabAuthoritySessionFactory,
 } from '@/app/collab/remote-authority/CollabAuthoritySessionFactory';
 import { LanAuthorityAdapter } from '@/app/collab/remote-authority/LanAuthorityAdapter';
-import type { CloudAuthorityHttpResponse, CloudAuthorityHttpTransport } from '@/app/collab/remote-authority/NodeCloudAuthorityHttpTransport';
+import type { CloudAuthorityHttpRequest, CloudAuthorityHttpResponse, CloudAuthorityHttpTransport } from '@/app/collab/remote-authority/NodeCloudAuthorityHttpTransport';
 import { type CollabCloudProjectSnapshot, type CollabLanProjectSnapshot, type CollabProjectSnapshot, isCollabLanProjectSnapshot } from '@/core/collab';
 import { CollabError } from '@/core/collab/ClaudianCollabError';
 
@@ -702,9 +708,11 @@ describe('CollabClientProjection', () => {
     const requested = deferred<void>();
     const response = deferred<CloudAuthorityHttpResponse>();
     const createSocket = jest.fn(() => new FakeEventSocket());
+    let requestCount = 0;
     const projection = new CollabClientProjection(store, controlPort(), {
       ...projectionOptions(),
-      authoritySessions: cloudEventSessions(createSocket, async () => {
+      authoritySessions: cloudEventSessions(createSocket, async input => {
+        if (requestCount++ > 0) return cloudSnapshotResponse(input);
         requested.resolve();
         return response.promise;
       }),
@@ -937,7 +945,9 @@ function lanEventSessions(createSocket: ProjectEventClientSocketFactory): Collab
 
 function cloudEventSessions(
   createSocket: NonNullable<CloudProjectEventClientOptions['createSocket']>,
-  request: CloudAuthorityHttpTransport = async () => cloudCapabilities(),
+  request: CloudAuthorityHttpTransport = async input => (
+    input.method === 'GET' ? cloudCapabilities() : cloudSnapshotResponse(input)
+  ),
 ): CollabAuthoritySessionFactory {
   return new CollabAuthoritySessionFactory([new CloudAuthorityAdapter({
     createEventClient: (input, onInvalidation) => new CloudProjectEventClient(input, onInvalidation, { createSocket }),
@@ -947,7 +957,7 @@ function cloudEventSessions(
 
 function cloudCapabilities(): CloudAuthorityHttpResponse {
   return {
-    body: collabCloudCapabilityDocument(['project-events'], {
+    body: collabCloudCapabilityDocument(['project-events', 'project-snapshot'], {
       maxCheckpointCoordinationBytes: COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxCoordinationBytes,
       maxCheckpointManifestUtf8Bytes: COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxManifestBytes,
       maxCheckpointRepositoryBundleBytes: COLLAB_CHECKPOINT_ARTIFACT_LIMITS.maxRepositoryBundleBytes,
@@ -960,6 +970,22 @@ function cloudCapabilities(): CloudAuthorityHttpResponse {
       maxJsonPayloadUtf8Bytes: COLLAB_LIMITS.maxJsonPayloadUtf8Bytes,
       maxRepositoryBytes: 1_024,
     }),
+    contentType: 'application/json',
+    status: 200,
+  };
+}
+
+function cloudSnapshotResponse(input: CloudAuthorityHttpRequest): CloudAuthorityHttpResponse {
+  const snapshot = cloudSnapshot();
+  const { authorityKind: _authorityKind, mainOid, ...project } = snapshot.project;
+  return {
+    body: collabCloudSuccessEnvelope(
+      (input.body as { readonly requestId: string }).requestId,
+      {
+        ...snapshot,
+        project: { ...project, authorityGeneration: 1, expectedMainOid: mainOid },
+      },
+    ),
     contentType: 'application/json',
     status: 200,
   };

--- a/tests/unit/app/collab/lifecycle/CollabProjectLifecycleOwners.test.ts
+++ b/tests/unit/app/collab/lifecycle/CollabProjectLifecycleOwners.test.ts
@@ -6,9 +6,12 @@ import {
 import {
   createCollabProjectLifecycleDurableOwners,
 } from '@/app/collab/lifecycle/CollabProjectLifecycleOwners';
+import { CollabProjectLifecycleSubsystem } from '@/app/collab/lifecycle/CollabProjectLifecycleSubsystem';
+import { decodeCloudManagementIntent } from '@/app/collab/membership/CloudManagementIntent';
 
 function stores() {
   return {
+    cloudManagementIntents: { load: jest.fn().mockResolvedValue(null) },
     cloudRetirementIntents: { load: jest.fn().mockResolvedValue(null) },
     hostTransferRecovery: { load: jest.fn().mockResolvedValue(null) },
     localCleanup: { load: jest.fn().mockResolvedValue(null) },
@@ -36,6 +39,7 @@ describe('CollabProjectLifecycleOwners', () => {
       state: await owner.inspect('project-alpha'),
     })))).resolves.toEqual([
       { name: 'host-transfer', state: 'nonterminal' },
+      { name: 'cloud-management', state: 'absent' },
       { name: 'manager-responsibility', state: 'terminal' },
       { name: 'local-exit', state: 'terminal' },
       { name: 'retirement', state: 'nonterminal' },
@@ -51,11 +55,68 @@ describe('CollabProjectLifecycleOwners', () => {
       state: await owner.inspect('project-alpha'),
     })))).resolves.toEqual([
       { name: 'host-transfer', state: 'absent' },
+      { name: 'cloud-management', state: 'absent' },
       { name: 'manager-responsibility', state: 'absent' },
       { name: 'local-exit', state: 'absent' },
       { name: 'retirement', state: 'absent' },
     ]);
   });
+
+  it.each(['prepared', 'submitted', 'result-retained'] as const)(
+    'blocks lifecycle transitions while a Cloud management intent is %s',
+    async phase => {
+      const backing = stores();
+      backing.cloudManagementIntents.load.mockResolvedValue(decodeCloudManagementIntent({
+        authorityGeneration: 7,
+        completionId: 'completion-management',
+        createdAt: '2026-09-02T00:00:00.000Z',
+        kind: 'cloud-management-intent',
+        memberId: 'member-manager',
+        operation: 'demoteManager',
+        phase,
+        projectId: 'project-alpha',
+        request: {
+          expectedManagerSetGeneration: 4,
+          expectedTargetMembershipRevision: 2,
+          idempotencyKey: 'private-management-key',
+          projectId: 'project-alpha',
+          targetMemberId: 'member-target',
+        },
+        response: phase === 'result-retained' ? {
+          demotedMemberId: 'member-target',
+          managerSetGeneration: 5,
+          membershipRevision: 3,
+          projectId: 'project-alpha',
+        } : null,
+        schemaVersion: 1,
+        serverUrl: 'https://cloud.example',
+        updatedAt: '2026-09-02T00:00:00.000Z',
+      }));
+      const owners = createCollabProjectLifecycleDurableOwners(backing, () => true);
+      const cloudManagement = owners.find(owner => owner.name === 'cloud-management')!;
+      await expect(cloudManagement.inspect('project-alpha')).resolves.toBe('nonterminal');
+
+      const retirement = jest.fn().mockResolvedValue(undefined);
+      const subsystem = new CollabProjectLifecycleSubsystem({
+        closeRecovery: jest.fn(),
+        durableOwners: owners,
+        hostTransfer: {} as never,
+        localExit: {} as never,
+        recoveryStages: [],
+        retirement: {} as never,
+      });
+      await expect(subsystem.runExclusive(
+        'project-alpha',
+        'retirement',
+        'operation',
+        retirement,
+      )).rejects.toMatchObject({
+        code: 'durable-progress-recovery-required',
+        safeContext: { reason: 'lifecycle-owner-pending' },
+      });
+      expect(retirement).not.toHaveBeenCalled();
+    },
+  );
 
   it('classifies a reversible Manager offer as a proposal until the target acknowledges it', async () => {
     const backing = stores();

--- a/tests/unit/app/collab/lifecycle/CollabProjectLifecycleSubsystem.test.ts
+++ b/tests/unit/app/collab/lifecycle/CollabProjectLifecycleSubsystem.test.ts
@@ -315,6 +315,91 @@ describe('CollabProjectLifecycleSubsystem', () => {
     expect(blockedRetirement).not.toHaveBeenCalled();
   });
 
+  it('keeps Manager responsibility independent from Cloud management without opening other lifecycle lanes', async () => {
+    let responsibilityPending = false;
+    const subsystem = new CollabProjectLifecycleSubsystem({
+      ...ports(),
+      durableOwners: [
+        { inspect: async () => 'nonterminal', name: 'cloud-management' },
+        {
+          inspect: async () => responsibilityPending ? 'nonterminal' : 'absent',
+          name: 'manager-responsibility',
+        },
+      ],
+      recoveryStages: [],
+    });
+    await expect(subsystem.runManagerResponsibility(
+      'project-alpha',
+      'operation',
+      async () => 'started',
+    )).resolves.toBe('started');
+
+    responsibilityPending = true;
+    const reconcileResponsibility = jest.fn().mockResolvedValue('reconciled');
+
+    await expect(subsystem.runManagerResponsibility(
+      'project-alpha',
+      'continuation',
+      reconcileResponsibility,
+    )).resolves.toBe('reconciled');
+    expect(reconcileResponsibility).toHaveBeenCalledTimes(1);
+
+    await expect(subsystem.runManagerResponsibility(
+      'project-alpha',
+      'operation',
+      async () => 'must-not-start',
+    )).rejects.toMatchObject({
+      code: 'durable-progress-recovery-required',
+      safeContext: { reason: 'lifecycle-owner-recovery-required' },
+    });
+
+    responsibilityPending = false;
+    const retire = jest.fn().mockResolvedValue('retired');
+    await expect(subsystem.runExclusive(
+      'project-alpha',
+      'retirement',
+      'operation',
+      retire,
+    )).rejects.toMatchObject({
+      code: 'durable-progress-recovery-required',
+      safeContext: { reason: 'lifecycle-owner-pending' },
+    });
+    expect(retire).not.toHaveBeenCalled();
+  });
+
+  it('continues an existing Cloud management intent beside responsibility without starting behind responsibility alone', async () => {
+    let cloudManagementPending = true;
+    const subsystem = new CollabProjectLifecycleSubsystem({
+      ...ports(),
+      durableOwners: [
+        {
+          inspect: async () => cloudManagementPending ? 'nonterminal' : 'absent',
+          name: 'cloud-management',
+        },
+        { inspect: async () => 'nonterminal', name: 'manager-responsibility' },
+      ],
+      recoveryStages: [],
+    });
+    const continueCloudManagement = jest.fn().mockResolvedValue('continued');
+
+    await expect(subsystem.runCloudManagement(
+      'project-alpha',
+      continueCloudManagement,
+    )).resolves.toBe('continued');
+    expect(continueCloudManagement).toHaveBeenCalledTimes(1);
+
+    cloudManagementPending = false;
+    const startCloudManagement = jest.fn().mockResolvedValue('started');
+    await expect(subsystem.runCloudManagement(
+      'project-alpha',
+      startCloudManagement,
+    )).rejects.toMatchObject({
+      code: 'durable-progress-recovery-required',
+      safeContext: { reason: 'lifecycle-owner-pending' },
+    });
+    expect(startCloudManagement).not.toHaveBeenCalled();
+  });
+
   it('routes every locally stateful lifecycle mutation through the Project arbiter', async () => {
     const hostTransfer = {
       acceptHostTransfer: jest.fn().mockResolvedValue(undefined),

--- a/tests/unit/app/collab/membership/CollabMembershipService.test.ts
+++ b/tests/unit/app/collab/membership/CollabMembershipService.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import { CollabLocalProjectRepository } from '@/app/collab/CollabLocalProjectRepository';
+import { decodeCloudManagementIntent } from '@/app/collab/membership/CloudManagementIntent';
 import {
   type CollabMembershipSafetyContext,
   CollabMembershipService,
@@ -11,6 +12,7 @@ import {
 import {
   ManagerResponsibilityOperationCoordinator,
 } from '@/app/collab/membership/ManagerResponsibilityOperationCoordinator';
+import { CloudAuthorityRejection } from '@/app/collab/remote-authority/CloudAuthorityError';
 import type {
   CollabAuthorityMembershipOperation,
   CollabAuthorityMembershipRouterPort,
@@ -126,6 +128,7 @@ function safetyContext(
   overrides: Partial<CollabMembershipSafetyContext> = {},
 ): CollabMembershipSafetyContext {
   return {
+    cloudManagementAdmission: async (_projectId, operation) => operation(),
     projects,
     managerResponsibilityAdmission: async (_projectId, operation) => operation(),
     managerReceipts: {
@@ -149,6 +152,485 @@ beforeEach(async () => {
 afterEach(async () => { await rm(vaultRoot, { recursive: true, force: true }); });
 
 describe('CollabMembershipService', () => {
+  it('admits Cloud management creation, recovery, and completion through the Project lifecycle', async () => {
+    await projects.saveMembership({
+      authority: {
+        authorityGeneration: 7,
+        bindingVersion: 3,
+        gitRemoteUrl: 'https://cloud.example/v3/projects/project-alpha/repository.git',
+        kind: 'cloud',
+        serverUrl: 'https://cloud.example',
+        wireVersion: 7,
+      },
+      createdAt: CREATED_AT,
+      lastEventSequence: 7,
+      lifecycle: 'active',
+      member: {
+        displayName: 'Manager',
+        id: 'member-manager',
+        personalRef: 'refs/heads/members/member-manager',
+        role: 'manager',
+      },
+      project: {
+        id: 'project-alpha',
+        name: 'Alpha',
+        workspacePath: 'Projects/alpha',
+      },
+      schemaVersion: 3,
+      updatedAt: CREATED_AT,
+    });
+    const lifecycleError = new CollabError({
+      code: 'durable-progress-recovery-required',
+      recoveryActions: ['resume'],
+      safeContext: { reason: 'lifecycle-owner-pending' },
+    });
+    const cloudManagementAdmission = jest.fn().mockRejectedValue(lifecycleError);
+    const context = {
+      ...safetyContext(),
+      cloudManagementAdmission,
+    };
+    const control = client();
+    const service = new CollabMembershipService(
+      control,
+      lanSnapshotPort(),
+      {},
+      context,
+    );
+
+    await expect(service.createInvitation('project-alpha')).rejects.toBe(lifecycleError);
+
+    await projects.saveProjectDocument(
+      'project-alpha',
+      'cloud-management-intent',
+      decodeCloudManagementIntent({
+        authorityGeneration: 7,
+        completionId: 'completion-pending',
+        createdAt: CREATED_AT,
+        kind: 'cloud-management-intent',
+        memberId: 'member-manager',
+        operation: 'demoteManager',
+        phase: 'submitted',
+        projectId: 'project-alpha',
+        request: {
+          expectedManagerSetGeneration: 4,
+          expectedTargetMembershipRevision: 2,
+          idempotencyKey: 'demote-private',
+          projectId: 'project-alpha',
+          targetMemberId: 'member-target',
+        },
+        response: null,
+        schemaVersion: 1,
+        serverUrl: 'https://cloud.example',
+        updatedAt: CREATED_AT,
+      }),
+    );
+    await expect(service.resumeManagementOperation('project-alpha')).rejects.toBe(lifecycleError);
+
+    await projects.saveProjectDocument(
+      'project-alpha',
+      'cloud-management-intent',
+      decodeCloudManagementIntent({
+        authorityGeneration: 7,
+        completionId: 'completion-retained',
+        createdAt: CREATED_AT,
+        kind: 'cloud-management-intent',
+        memberId: 'member-manager',
+        operation: 'demoteManager',
+        phase: 'result-retained',
+        projectId: 'project-alpha',
+        request: {
+          expectedManagerSetGeneration: 4,
+          expectedTargetMembershipRevision: 2,
+          idempotencyKey: 'demote-private',
+          projectId: 'project-alpha',
+          targetMemberId: 'member-target',
+        },
+        response: {
+          demotedMemberId: 'member-target',
+          managerSetGeneration: 5,
+          membershipRevision: 3,
+          projectId: 'project-alpha',
+        },
+        schemaVersion: 1,
+        serverUrl: 'https://cloud.example',
+        updatedAt: CREATED_AT,
+      }),
+    );
+    await expect(service.completeManagementOperation({
+      completionId: 'completion-retained',
+      projectId: 'project-alpha',
+    })).rejects.toBe(lifecycleError);
+
+    expect(cloudManagementAdmission.mock.calls.map(([projectId]) => projectId))
+      .toEqual(['project-alpha', 'project-alpha', 'project-alpha']);
+    expect(control.cloudMembership).not.toHaveBeenCalled();
+    await expect(service.readManagementOperation('project-alpha')).resolves.toMatchObject({
+      completionId: 'completion-retained',
+    });
+  });
+
+  it('retains the same frozen Cloud mutation after repeated synchronized stale rejections', async () => {
+    await projects.saveMembership({
+      authority: {
+        authorityGeneration: 7,
+        bindingVersion: 3,
+        gitRemoteUrl: 'https://cloud.example/v3/projects/project-alpha/repository.git',
+        kind: 'cloud',
+        serverUrl: 'https://cloud.example',
+        wireVersion: 7,
+      },
+      createdAt: CREATED_AT,
+      lastEventSequence: 7,
+      lifecycle: 'active',
+      member: {
+        displayName: 'Manager',
+        id: 'member-manager',
+        personalRef: 'refs/heads/members/member-manager',
+        role: 'manager',
+      },
+      project: {
+        id: 'project-alpha',
+        name: 'Alpha',
+        workspacePath: 'Projects/alpha',
+      },
+      schemaVersion: 3,
+      updatedAt: CREATED_AT,
+    });
+    const currentMember = {
+      activatedAt: CREATED_AT,
+      createdAt: CREATED_AT,
+      displayName: 'Manager',
+      id: 'member-manager',
+      personalRef: 'refs/heads/members/member-manager',
+      role: 'manager' as const,
+      status: 'active' as const,
+    };
+    const cloudProjection: CollabCoordinationSnapshot = {
+      snapshot: {
+        currentMember,
+        eventSequence: 7,
+        members: [currentMember],
+        openRequests: [],
+        openTicketCount: 0,
+        project: {
+          authorityGeneration: 7,
+          authorityKind: 'cloud',
+          createdAt: CREATED_AT,
+          id: 'project-alpha',
+          mainOid: 'a'.repeat(40),
+          mainRef: 'refs/heads/main',
+          name: 'Alpha',
+        },
+        ticketHighlights: [],
+      },
+      source: 'online',
+      stale: false,
+      syncState: {
+        eventSequence: 7,
+        generation: 1,
+        projectId: 'project-alpha',
+        status: 'synchronized',
+      },
+    };
+    const members = {
+      managerSetGeneration: 4,
+      members: [{
+        bindingState: 'bound',
+        displayName: 'Manager',
+        importedClaimGeneration: null,
+        importedClaimState: 'not-applicable',
+        memberId: 'member-manager',
+        membershipRevision: 3,
+        role: 'manager',
+      }, {
+        bindingState: 'bound',
+        displayName: 'Target',
+        importedClaimGeneration: null,
+        importedClaimState: 'not-applicable',
+        memberId: 'member-target',
+        membershipRevision: 5,
+        role: 'manager',
+      }],
+      projectId: 'project-alpha',
+    };
+    const submittedKeys: string[] = [];
+    const control = client();
+    (control.cloudMembership as jest.Mock).mockImplementation(async (operation, request) => {
+      if (operation === 'listProjectMembers') return members;
+      if (operation !== 'demoteManager') throw new Error(`Unexpected ${String(operation)}`);
+      submittedKeys.push(request.idempotencyKey);
+      throw new CloudAuthorityRejection({ code: 'authority-not-synchronized' });
+    });
+    let keySequence = 0;
+    const snapshots: jest.Mocked<CollabMembershipSnapshotPort> = {
+      readAuthoritySnapshot: jest.fn().mockResolvedValue(cloudProjection),
+      readCoordinationSnapshot: jest.fn().mockResolvedValue(cloudProjection),
+    };
+    const service = new CollabMembershipService(control, snapshots, {
+      createIdempotencyKey: kind => `${kind}-${++keySequence}`,
+    }, safetyContext());
+    const request = {
+      projectId: 'project-alpha',
+      targetMemberId: 'member-target',
+    } as const;
+
+    await expect(service.demoteManager(request)).rejects.toMatchObject({
+      result: { status: 'recovery-required' },
+    });
+    const resumedError = await service.resumeManagementOperation('project-alpha')
+      .catch(error => error);
+    expect(resumedError).toBeInstanceOf(Error);
+    expect(resumedError).toHaveProperty('result', expect.objectContaining({
+      durableProgress: true,
+      status: 'recovery-required',
+    }));
+    await expect(service.readManagementOperation('project-alpha')).resolves.toMatchObject({
+      action: 'demote-manager',
+      status: 'pending',
+    });
+    await expect(service.demoteManager(request)).rejects.toMatchObject({
+      result: { status: 'recovery-required' },
+    });
+    expect(submittedKeys).toEqual([
+      'demote-manager-1',
+      'demote-manager-1',
+      'demote-manager-1',
+    ]);
+    expect(keySequence).toBe(1);
+  });
+
+  it('compare-and-removes only the exact retained Cloud management result', async () => {
+    await projects.saveMembership({
+      authority: {
+        authorityGeneration: 7,
+        bindingVersion: 3,
+        gitRemoteUrl: 'https://cloud.example/v3/projects/project-alpha/repository.git',
+        kind: 'cloud',
+        serverUrl: 'https://cloud.example',
+        wireVersion: 7,
+      },
+      createdAt: CREATED_AT,
+      lastEventSequence: 7,
+      lifecycle: 'active',
+      member: {
+        displayName: 'Manager',
+        id: 'member-manager',
+        personalRef: 'refs/heads/members/member-manager',
+        role: 'manager',
+      },
+      project: {
+        id: 'project-alpha',
+        name: 'Alpha',
+        workspacePath: 'Projects/alpha',
+      },
+      schemaVersion: 3,
+      updatedAt: CREATED_AT,
+    });
+    const retained = (completionId: string, invitationId: string) => (
+      decodeCloudManagementIntent({
+        authorityGeneration: 7,
+        completionId,
+        createdAt: '2099-09-02T00:00:00.000Z',
+        kind: 'cloud-management-intent',
+        memberId: 'member-manager',
+        operation: 'createProjectInvitation',
+        phase: 'result-retained',
+        projectId: 'project-alpha',
+        request: {
+          expectedManagerSetGeneration: 4,
+          idempotencyKey: `private-${invitationId}`,
+          projectId: 'project-alpha',
+        },
+        response: {
+          createdAt: '2099-09-02T00:00:00.000Z',
+          expiresAt: '2099-09-03T00:00:00.000Z',
+          invitationId,
+          issuedState: 'active',
+          projectId: 'project-alpha',
+          secret: 'A'.repeat(43),
+          secretReplayExpiresAt: '2099-10-02T00:00:00.000Z',
+        },
+        schemaVersion: 1,
+        serverUrl: 'https://cloud.example',
+        updatedAt: '2099-09-02T00:00:00.000Z',
+      })
+    );
+    const service = new CollabMembershipService(
+      client(),
+      lanSnapshotPort(),
+      {},
+      safetyContext(),
+    );
+    await projects.saveProjectDocument(
+      'project-alpha',
+      'cloud-management-intent',
+      retained('completion-old', 'invitation-old'),
+    );
+    const oldView = await service.readManagementOperation('project-alpha');
+    expect(oldView).toMatchObject({
+      completionId: 'completion-old',
+      secretAvailableUntil: '2099-09-03T00:00:00.000Z',
+    });
+
+    await projects.saveProjectDocument(
+      'project-alpha',
+      'cloud-management-intent',
+      retained('completion-new', 'invitation-new'),
+    );
+    await expect(service.completeManagementOperation({
+      completionId: oldView!.completionId,
+      projectId: 'project-alpha',
+    })).rejects.toMatchObject({
+      code: 'operation-failed',
+      safeContext: { reason: 'cloud-management-completion-mismatch' },
+    });
+    await expect(service.readManagementOperation('project-alpha')).resolves.toMatchObject({
+      completionId: 'completion-new',
+      status: 'result-retained',
+    });
+
+    await service.completeManagementOperation({
+      completionId: 'completion-new',
+      projectId: 'project-alpha',
+    });
+    await expect(service.readManagementOperation('project-alpha')).resolves.toBeNull();
+  });
+
+  it.each([
+    {
+      completionId: 'completion-expired-invitation',
+      operation: 'createProjectInvitation' as const,
+      request: {
+        expectedManagerSetGeneration: 4,
+        idempotencyKey: 'private-expired-invitation',
+        projectId: 'project-alpha',
+      },
+      response: {
+        createdAt: '2020-09-02T00:00:00.000Z',
+        expiresAt: '2020-09-03T00:00:00.000Z',
+        invitationId: 'invitation-expired',
+        issuedState: 'active' as const,
+        projectId: 'project-alpha',
+        secret: 'A'.repeat(43),
+        secretReplayExpiresAt: '2020-10-02T00:00:00.000Z',
+      },
+      secretAvailableUntil: '2020-09-03T00:00:00.000Z',
+    },
+    {
+      completionId: 'completion-expired-claim',
+      operation: 'reissueTransferredMembershipClaim' as const,
+      request: {
+        expectedClaimGeneration: 3,
+        expectedManagerSetGeneration: 4,
+        expectedMembershipRevision: 2,
+        idempotencyKey: 'private-expired-claim',
+        memberId: 'member-imported',
+        projectId: 'project-alpha',
+      },
+      response: {
+        claim: `${'B'.repeat(42)}A`,
+        claimGeneration: 4,
+        createdAt: '2020-09-02T00:00:00.000Z',
+        expiresAt: '2020-10-02T00:00:00.000Z',
+        memberId: 'member-imported',
+        projectId: 'project-alpha',
+        secretReplayExpiresAt: '2020-10-02T00:00:00.000Z',
+        targetAuthorityGeneration: 7,
+        transferId: 'transfer-imported',
+      },
+      secretAvailableUntil: '2020-10-02T00:00:00.000Z',
+    },
+  ])('retains an expired $operation result until exact completion', async fixture => {
+    await projects.saveMembership({
+      authority: {
+        authorityGeneration: 7,
+        bindingVersion: 3,
+        gitRemoteUrl: 'https://cloud.example/v3/projects/project-alpha/repository.git',
+        kind: 'cloud',
+        serverUrl: 'https://cloud.example',
+        wireVersion: 7,
+      },
+      createdAt: CREATED_AT,
+      lastEventSequence: 7,
+      lifecycle: 'active',
+      member: {
+        displayName: 'Manager',
+        id: 'member-manager',
+        personalRef: 'refs/heads/members/member-manager',
+        role: 'manager',
+      },
+      project: {
+        id: 'project-alpha',
+        name: 'Alpha',
+        workspacePath: 'Projects/alpha',
+      },
+      schemaVersion: 3,
+      updatedAt: CREATED_AT,
+    });
+    const retained = decodeCloudManagementIntent({
+      authorityGeneration: 7,
+      completionId: fixture.completionId,
+      createdAt: '2020-09-02T00:00:00.000Z',
+      kind: 'cloud-management-intent',
+      memberId: 'member-manager',
+      operation: fixture.operation,
+      phase: 'result-retained',
+      projectId: 'project-alpha',
+      request: fixture.request,
+      response: fixture.response,
+      schemaVersion: 1,
+      serverUrl: 'https://cloud.example',
+      updatedAt: '2020-09-02T00:00:00.000Z',
+    });
+    await projects.saveProjectDocument(
+      'project-alpha',
+      'cloud-management-intent',
+      retained,
+    );
+    const service = new CollabMembershipService(
+      client(),
+      lanSnapshotPort(),
+      {},
+      safetyContext(),
+    );
+
+    await expect(service.readManagementOperation('project-alpha')).resolves.toMatchObject({
+      completionId: fixture.completionId,
+      invitation: null,
+      secretAvailableUntil: fixture.secretAvailableUntil,
+      status: 'result-retained',
+    });
+    const replay = fixture.operation === 'createProjectInvitation'
+      ? service.createInvitation('project-alpha')
+      : service.reissueMemberClaim({
+        memberId: 'member-imported',
+        projectId: 'project-alpha',
+      });
+    await expect(replay).rejects.toMatchObject({
+      result: {
+        error: { code: 'invitation-expired' },
+        status: 'recovery-required',
+      },
+    });
+    await expect(service.completeManagementOperation({
+      completionId: 'completion-stale',
+      projectId: 'project-alpha',
+    })).rejects.toMatchObject({
+      safeContext: { reason: 'cloud-management-completion-mismatch' },
+    });
+    await expect(service.readManagementOperation('project-alpha')).resolves.toMatchObject({
+      completionId: fixture.completionId,
+      invitation: null,
+      status: 'result-retained',
+    });
+
+    await service.completeManagementOperation({
+      completionId: fixture.completionId,
+      projectId: 'project-alpha',
+    });
+    await expect(service.readManagementOperation('project-alpha')).resolves.toBeNull();
+  });
+
   it('declines a Cloud responsibility against a pending Leave and replays the exact submitted request', async () => {
     await projects.saveMembership({
       schemaVersion: 3,

--- a/tests/unit/app/collab/publish/CollabPublicationService.test.ts
+++ b/tests/unit/app/collab/publish/CollabPublicationService.test.ts
@@ -440,6 +440,7 @@ describe('CollabPublicationService reconnect', () => {
         ...input,
         headers: { ...input.headers, 'x-test-ingress': 'private-fixture' },
       }),
+      requestIdFactory: () => 'response-snapshot',
     });
     const projects = {
       loadMembership: jest.fn().mockResolvedValue(membership),
@@ -486,6 +487,7 @@ describe('CollabPublicationService reconnect', () => {
         '/collab/capabilities',
         `/v3/projects/${CLOUD_PROJECT_ID}/operations/getProjectSnapshot`,
         '/collab/capabilities',
+        `/v3/projects/${CLOUD_PROJECT_ID}/operations/getProjectSnapshot`,
         `/v3/projects/${CLOUD_PROJECT_ID}/operations/getProjectSnapshot`,
       ]);
     } finally {

--- a/tests/unit/app/collab/remote-authority/CloudAuthorityAdapter.test.ts
+++ b/tests/unit/app/collab/remote-authority/CloudAuthorityAdapter.test.ts
@@ -13,7 +13,9 @@ import {
   type CollabAuthorityTransferStatus,
   type CollabCloudCapability,
   collabCloudCapabilityDocument,
+  collabCloudErrorEnvelope,
   collabCloudSuccessEnvelope,
+  CollabError as ProtocolError,
 } from '@claudian-collab/protocol';
 import { TEST_INSTALLATION_A } from '@test/helpers/installations';
 import { WebSocketServer } from 'ws';
@@ -26,6 +28,7 @@ import {
   CloudProjectEventClient,
   type CloudProjectEventSocket,
 } from '@/app/collab/remote-authority/CloudAuthorityAdapter';
+import { CloudAuthorityRejection } from '@/app/collab/remote-authority/CloudAuthorityError';
 import { NodeCloudAuthorityArtifactTransport } from '@/app/collab/remote-authority/NodeCloudAuthorityArtifactTransport';
 import {
   type CloudAuthorityHttpRequest,
@@ -172,6 +175,27 @@ function cloudSnapshot() {
   });
 }
 
+function boundCapabilityDocument(
+  capabilities: readonly CollabCloudCapability[],
+) {
+  return collabCloudCapabilityDocument([
+    ...new Set<CollabCloudCapability>(['project-snapshot', ...capabilities]),
+  ], limits);
+}
+
+function envelopeRequestId(input: CloudAuthorityHttpRequest | string): string {
+  if (typeof input === 'string') return input;
+  return (input.body as { readonly requestId: string }).requestId;
+}
+
+function cloudSnapshotResponse(input: CloudAuthorityHttpRequest | string) {
+  return {
+    body: collabCloudSuccessEnvelope(envelopeRequestId(input), cloudSnapshot()),
+    contentType: 'application/json',
+    status: 200,
+  } as const;
+}
+
 describe('CloudAuthorityAdapter', () => {
   jest.setTimeout(30_000);
 
@@ -212,7 +236,9 @@ describe('CloudAuthorityAdapter', () => {
       // Install only this fixture CA in the test process; production TLS options remain untouched.
       setDefaultCACertificates([...trustedCa, identity.caCertificatePem]);
       const bound = membership();
-      const session = await new CloudAuthorityAdapter().create({
+      const session = await new CloudAuthorityAdapter({
+        requestIdFactory: () => 'tls-snapshot',
+      }).create({
         ...bound,
         authority: {
           ...bound.authority,
@@ -221,9 +247,6 @@ describe('CloudAuthorityAdapter', () => {
         },
       });
       try {
-        await expect(session.control.readSnapshot(PROJECT_ID)).resolves.toMatchObject({
-          currentMember: { id: 'member-alice' }, project: { authorityGeneration: 1 },
-        });
         const artifact = await session.lifecycle!.downloadAuthorityTransferArtifact({
           artifact: 'checkpoint.json', projectId: PROJECT_ID, transferId: 'transfer-one',
         });
@@ -266,7 +289,7 @@ describe('CloudAuthorityAdapter', () => {
         return {
           body: input.method === 'GET'
             ? collabCloudCapabilityDocument(['project-snapshot'], limits)
-            : collabCloudSuccessEnvelope('response-snapshot', cloudSnapshot()),
+            : collabCloudSuccessEnvelope(envelopeRequestId(input), cloudSnapshot()),
           contentType: 'application/json',
           status: 200,
         };
@@ -322,10 +345,13 @@ describe('CloudAuthorityAdapter', () => {
   it.each(['dispose', 'caller'] as const)('fences a late snapshot completion after %s cancellation', async cancellation => {
     let release!: (response: Awaited<ReturnType<NodeCloudAuthorityHttpTransport['request']>>) => void;
     const response = new Promise<Awaited<ReturnType<NodeCloudAuthorityHttpTransport['request']>>>(resolve => { release = resolve; });
+    let snapshotReads = 0;
     const session = await new CloudAuthorityAdapter({
       request: async input => input.method === 'GET'
-        ? { body: collabCloudCapabilityDocument(['project-snapshot'], limits), contentType: 'application/json', status: 200 }
-        : response,
+        ? { body: boundCapabilityDocument([]), contentType: 'application/json', status: 200 }
+        : snapshotReads++ === 0
+          ? cloudSnapshotResponse(input)
+          : response,
     }).create(membership());
     const controller = new AbortController();
     try {
@@ -340,9 +366,11 @@ describe('CloudAuthorityAdapter', () => {
   });
 
   it('owns and closes its prefixed WebSocket without a development assertion', async () => {
-    const server = createServer((_request, response) => {
+    const server = createServer((request, response) => {
       response.setHeader('content-type', 'application/json');
-      response.end(JSON.stringify(collabCloudCapabilityDocument(['project-events'], limits)));
+      response.end(JSON.stringify(request.method === 'GET'
+        ? boundCapabilityDocument(['project-events'])
+        : collabCloudSuccessEnvelope('response-bound-snapshot', cloudSnapshot())));
     });
     const sockets = new WebSocketServer({ noServer: true });
     let connected!: () => void;
@@ -362,7 +390,9 @@ describe('CloudAuthorityAdapter', () => {
     if (!address || typeof address === 'string') throw new Error('Missing test listener');
     const serverUrl = `http://127.0.0.1:${address.port}/operator/cloud`;
     const bound = membership();
-    const session = await new CloudAuthorityAdapter().create({
+    const session = await new CloudAuthorityAdapter({
+      requestIdFactory: () => 'response-bound-snapshot',
+    }).create({
       ...bound,
       authority: {
         ...bound.authority,
@@ -443,10 +473,17 @@ describe('CloudAuthorityAdapter', () => {
   it.each(['bound', 'unbound'] as const)('disposes %s connections by aborting in-flight reads and closing further admission', async kind => {
     let reading!: () => void;
     const started = new Promise<void>(resolve => { reading = resolve; });
+    let snapshotReads = 0;
     const server = createServer((request, response) => {
       if (request.method === 'GET') {
         response.setHeader('content-type', 'application/json');
-        response.end(JSON.stringify(collabCloudCapabilityDocument(['project-snapshot'], limits)));
+        response.end(JSON.stringify(boundCapabilityDocument([])));
+      } else if (kind === 'bound' && snapshotReads++ === 0) {
+        response.setHeader('content-type', 'application/json');
+        response.end(JSON.stringify(collabCloudSuccessEnvelope(
+          'response-bound-snapshot',
+          cloudSnapshot(),
+        )));
       } else {
         reading();
       }
@@ -455,7 +492,10 @@ describe('CloudAuthorityAdapter', () => {
     const address = server.address();
     if (!address || typeof address === 'string') throw new Error('Missing test listener');
     const serverUrl = `http://127.0.0.1:${address.port}`;
-    const adapter = new CloudAuthorityAdapter({ request: new NodeCloudAuthorityHttpTransport(200).request });
+    const adapter = new CloudAuthorityAdapter({
+      request: new NodeCloudAuthorityHttpTransport(200).request,
+      requestIdFactory: () => 'response-bound-snapshot',
+    });
     const bound = membership();
     const connection = kind === 'bound'
       ? await adapter.create({
@@ -532,17 +572,13 @@ describe('CloudAuthorityAdapter', () => {
     const serverUrl = `HTTP://127.0.0.1:${address.port}/operator/cloud`;
     const gitRemoteUrl = `http://127.0.0.1:${address.port}/operator/cloud/v3/projects/project-cloud/repository.git`;
     const bound = membership();
-    const adapter = new CloudAuthorityAdapter();
+    const adapter = new CloudAuthorityAdapter({ requestIdFactory: () => 'prefixed-snapshot' });
     try {
       const session = await adapter.create({
         ...bound,
         authority: { ...bound.authority, authorityGeneration: 7, gitRemoteUrl, serverUrl },
       });
       try {
-        await expect(session.control.readSnapshot(PROJECT_ID)).resolves.toMatchObject({
-          currentMember: { id: 'member-alice', personalRef: 'refs/heads/members/member-alice' },
-          project: { authorityGeneration: 7, id: 'project-cloud' },
-        });
         expect(session.git).toEqual({ headers: [], remoteUrl: gitRemoteUrl });
         expect(observed).toEqual([
           { actor: undefined, path: '/operator/cloud/collab/capabilities' },
@@ -557,14 +593,13 @@ describe('CloudAuthorityAdapter', () => {
   });
 
   it('exposes only the implemented Step 13 membership-management capabilities', async () => {
-    const request = jest.fn(async () => ({
-      body: collabCloudCapabilityDocument(
-        STEP_12_CLOUD_MANAGEMENT_CAPABILITIES,
-        limits,
-      ),
-      contentType: 'application/json',
-      status: 200,
-    }));
+    const request = jest.fn(async (input: CloudAuthorityHttpRequest) => input.method === 'GET'
+      ? {
+        body: boundCapabilityDocument(STEP_12_CLOUD_MANAGEMENT_CAPABILITIES),
+        contentType: 'application/json',
+        status: 200,
+      }
+      : cloudSnapshotResponse(input));
     const adapter = new CloudAuthorityAdapter({ request });
     const [session, lifecycle] = await Promise.all([
       adapter.create(membership()),
@@ -631,7 +666,7 @@ describe('CloudAuthorityAdapter', () => {
             status: 'left',
           };
       return {
-        body: collabCloudSuccessEnvelope(`response-${String(operation)}`, data),
+        body: collabCloudSuccessEnvelope(envelopeRequestId(input), data),
         contentType: 'application/json',
         status: 200,
       };
@@ -712,7 +747,7 @@ describe('CloudAuthorityAdapter', () => {
             terminalExpiresAt: '2026-09-26T00:00:00.000Z',
           };
       return {
-        body: collabCloudSuccessEnvelope(`response-${String(operation)}`, data),
+        body: collabCloudSuccessEnvelope(envelopeRequestId(input), data),
         contentType: 'application/json',
         status: 200,
       };
@@ -744,7 +779,7 @@ describe('CloudAuthorityAdapter', () => {
     const request = jest.fn(async (input: CloudAuthorityHttpRequest) => ({
       body: input.method === 'GET'
         ? collabCloudCapabilityDocument(['project-snapshot'], limits)
-        : collabCloudSuccessEnvelope('response-lifecycle-snapshot', cloudSnapshot()),
+        : collabCloudSuccessEnvelope(envelopeRequestId(input), cloudSnapshot()),
       contentType: 'application/json',
       status: 200,
     }));
@@ -763,28 +798,104 @@ describe('CloudAuthorityAdapter', () => {
     lifecycle.dispose();
   });
 
-  it('rejects a snapshot from a different authority generation', async () => {
-    const request = jest.fn(async (input: CloudAuthorityHttpRequest) => ({
-      body: input.method === 'GET'
-        ? collabCloudCapabilityDocument(['project-snapshot'], limits)
-        : collabCloudSuccessEnvelope('response-snapshot', cloudSnapshot()),
-      contentType: 'application/json',
-      status: 200,
-    }));
+  it('rejects a bound session before exposing mutation ports when its authenticated snapshot has another authority generation', async () => {
+    const requests: CloudAuthorityHttpRequest[] = [];
+    const request = jest.fn(async (input: CloudAuthorityHttpRequest) => {
+      requests.push(input);
+      return {
+        body: input.method === 'GET'
+          ? collabCloudCapabilityDocument([
+            'cloud-project-membership',
+            'project-snapshot',
+          ], limits)
+          : collabCloudSuccessEnvelope(envelopeRequestId(input), cloudSnapshot()),
+        contentType: 'application/json',
+        status: 200,
+      };
+    });
     const bound = membership();
-    const session = await new CloudAuthorityAdapter({ request }).create({
+    const pending = new CloudAuthorityAdapter({ request }).create({
       ...bound,
       authority: { ...bound.authority, authorityGeneration: 7 },
     });
-    try {
-      await expect(session.control.readSnapshot(PROJECT_ID)).rejects.toMatchObject({
-        code: 'authority-integrity-error',
-        safeContext: { reason: 'cloud-control-snapshot-response-mismatch' },
-      });
-    } finally {
-      session.dispose();
-    }
+
+    await expect(pending).rejects.toMatchObject({
+      code: 'authority-integrity-error',
+      safeContext: { reason: 'cloud-control-snapshot-response-mismatch' },
+    });
+    expect(requests.map(input => input.url)).toEqual([
+      'https://cloud.example.test/collab/capabilities',
+      `https://cloud.example.test/v3/projects/${PROJECT_ID}/operations/getProjectSnapshot`,
+    ]);
   });
+
+  it('rejects an authenticated snapshot success envelope correlated to another request', async () => {
+    const request = jest.fn(async (input: CloudAuthorityHttpRequest) => ({
+      body: input.method === 'GET'
+        ? boundCapabilityDocument([])
+        : collabCloudSuccessEnvelope('response-for-another-request', cloudSnapshot()),
+      contentType: 'application/json',
+      status: 200,
+    }));
+
+    await expect(new CloudAuthorityAdapter({
+      request,
+      requestIdFactory: () => 'snapshot-request',
+    }).create(membership())).rejects.toMatchObject({
+      code: 'authority-integrity-error',
+      safeContext: { reason: 'cloud-control-response-request-id-mismatch' },
+    });
+  });
+
+  it.each(['success', 'rejection'] as const)(
+    'rejects an operation %s envelope correlated to another request without completed-rejection provenance',
+    async outcome => {
+      const request = jest.fn(async (input: CloudAuthorityHttpRequest) => {
+        if (input.method === 'GET') {
+          return {
+            body: boundCapabilityDocument(['requests']),
+            contentType: 'application/json',
+            status: 200,
+          };
+        }
+        if (input.url.endsWith('/getProjectSnapshot')) {
+          return cloudSnapshotResponse('operation-request');
+        }
+        return {
+          body: outcome === 'success'
+            ? collabCloudSuccessEnvelope('response-for-another-request', {
+              mainOid: MAIN_OID,
+              request: changeRequest(),
+            })
+            : collabCloudErrorEnvelope(
+              'response-for-another-request',
+              new ProtocolError({ code: 'authorization-denied' }),
+            ),
+          contentType: 'application/json',
+          status: outcome === 'success' ? 200 : 403,
+        };
+      });
+      const session = await new CloudAuthorityAdapter({
+        request,
+        requestIdFactory: () => 'operation-request',
+      }).create(membership());
+
+      const operation = session.control.ensure({
+        description: 'Published change',
+        expectedMainOid: MAIN_OID,
+        headOid: HEAD_OID,
+        idempotencyKey: 'publish-head',
+        projectId: PROJECT_ID,
+      });
+      const rejection: unknown = await operation.catch((error: unknown) => error);
+      expect(rejection).toMatchObject({
+        code: 'authority-integrity-error',
+        safeContext: { reason: 'cloud-control-response-request-id-mismatch' },
+      });
+      expect(rejection).not.toBeInstanceOf(CloudAuthorityRejection);
+      session.dispose();
+    },
+  );
 
   it('admits a Project through a short-lived connection without a fabricated membership', async () => {
     const received: unknown[] = [];
@@ -802,7 +913,7 @@ describe('CloudAuthorityAdapter', () => {
         body: JSON.parse(Buffer.concat(chunks).toString('utf8')),
         path: request.url,
       });
-      response.end(JSON.stringify(collabCloudSuccessEnvelope('created-project', {
+      response.end(JSON.stringify(collabCloudSuccessEnvelope('request-entry', {
         createdAt: CREATED_AT,
         mainOid: MAIN_OID,
         managerSetGeneration: 1,
@@ -902,13 +1013,18 @@ describe('CloudAuthorityAdapter', () => {
             body: collabCloudCapabilityDocument([
               'authority-transfer',
               'project-retirement',
+              'project-snapshot',
             ], limits),
             contentType: 'application/json',
             status: 200,
           };
         }
+        const operation = input.url.split('/').at(-1);
         return {
-          body: collabCloudSuccessEnvelope('request-lifecycle', transferStatus),
+          body: collabCloudSuccessEnvelope(
+            envelopeRequestId(input),
+            operation === 'getProjectSnapshot' ? cloudSnapshot() : transferStatus,
+          ),
           contentType: 'application/json',
           status: 200,
         };
@@ -936,7 +1052,7 @@ describe('CloudAuthorityAdapter', () => {
     const downloaded: Buffer[] = [];
     for await (const chunk of download.body) downloaded.push(Buffer.from(chunk));
 
-    expect(jsonRequests[1]?.url).toBe(
+    expect(jsonRequests[2]?.url).toBe(
       `https://cloud.example.test/v3/projects/${PROJECT_ID}`
         + '/operations/getProjectAuthorityTransfer',
     );
@@ -983,11 +1099,13 @@ describe('CloudAuthorityAdapter', () => {
   });
 
   it('keeps lifecycle calls capability-gated and rejects legacy binding documents', async () => {
-    const request = jest.fn(async () => ({
-      body: collabCloudCapabilityDocument([], limits),
-      contentType: 'application/json',
-      status: 200,
-    }));
+    const request = jest.fn(async (input: CloudAuthorityHttpRequest) => input.method === 'GET'
+      ? {
+        body: boundCapabilityDocument([]),
+        contentType: 'application/json',
+        status: 200,
+      }
+      : cloudSnapshotResponse(input));
     const session = await new CloudAuthorityAdapter({ request }).create(membership());
     await expect(session.lifecycle!.authorityTransfer(
       'getProjectAuthorityTransfer',
@@ -1047,11 +1165,9 @@ describe('CloudAuthorityAdapter', () => {
     } satisfies CollabLocalCloudMembershipRecord;
 
     try {
-      const session = await new CloudAuthorityAdapter().create(localMembership);
-      await expect(session.control.readSnapshot(PROJECT_ID)).resolves.toMatchObject({
-        currentMember: { id: ACTOR_ID },
-        project: { authorityKind: 'cloud', id: PROJECT_ID },
-      });
+      const session = await new CloudAuthorityAdapter({
+        requestIdFactory: () => 'request-snapshot',
+      }).create(localMembership);
       expect(requests).toEqual([
         { actor: undefined, url: '/collab/capabilities' },
         {
@@ -1059,6 +1175,7 @@ describe('CloudAuthorityAdapter', () => {
           url: `/v3/projects/${PROJECT_ID}/operations/getProjectSnapshot`,
         },
       ]);
+      session.dispose();
     } finally {
       fetchMock.mockRestore();
       await new Promise<void>((resolve, reject) => server.close(error => {
@@ -1092,22 +1209,12 @@ describe('CloudAuthorityAdapter', () => {
         };
       }
       return {
-        body: collabCloudSuccessEnvelope('request-snapshot', cloudSnapshot()),
+        body: collabCloudSuccessEnvelope(envelopeRequestId(input), cloudSnapshot()),
         contentType: 'application/json; charset=utf-8',
         status: 200,
       };
     });
     const session = await new CloudAuthorityAdapter({ request }).create(membership());
-
-    await expect(session.control.readSnapshot(PROJECT_ID)).resolves.toMatchObject({
-      currentMember: { id: ACTOR_ID },
-      eventSequence: 7,
-      project: {
-        authorityKind: 'cloud',
-        id: PROJECT_ID,
-        mainOid: 'a'.repeat(40),
-      },
-    });
     expect(session.supports('project-snapshot')).toBe(true);
     expect(session.supports('requests')).toBe(false);
     expect(session.git).toEqual({
@@ -1135,13 +1242,14 @@ describe('CloudAuthorityAdapter', () => {
       requests.push(input);
       if (input.method === 'GET') {
         return {
-          body: collabCloudCapabilityDocument(['requests'], limits),
+          body: boundCapabilityDocument(['requests']),
           contentType: 'application/json; charset=utf-8',
           status: 200,
         };
       }
+      if (input.url.endsWith('/getProjectSnapshot')) return cloudSnapshotResponse(input);
       return {
-        body: collabCloudSuccessEnvelope('response-ensure', {
+        body: collabCloudSuccessEnvelope(envelopeRequestId(input), {
           mainOid: MAIN_OID,
           request: changeRequest(),
         }),
@@ -1163,7 +1271,7 @@ describe('CloudAuthorityAdapter', () => {
       projectId: PROJECT_ID,
       signal: controller.signal,
     })).resolves.toMatchObject({ id: 'request-one', latestHeadOid: HEAD_OID });
-    expect(requests[1]).toEqual({
+    expect(requests[2]).toEqual({
       body: {
         data: {
           description: 'Published change',
@@ -1185,24 +1293,26 @@ describe('CloudAuthorityAdapter', () => {
   it('routes Accept through the canonical Cloud operation with its exact authority tuple', async () => {
     const request = jest.fn(async (input: CloudAuthorityHttpRequest) => input.method === 'GET'
       ? {
-        body: collabCloudCapabilityDocument(['accept'], limits),
+        body: boundCapabilityDocument(['accept']),
         contentType: 'application/json',
         status: 200,
       }
-      : {
-        body: collabCloudSuccessEnvelope('response-accept', {
-          mainOid: MERGED_OID,
-          mergeCommitOid: MERGED_OID,
-          request: changeRequest({
-            latestHeadOid: HEAD_OID,
-            mergedOid: MERGED_OID,
-            revision: 1,
-            status: 'merged',
+      : input.url.endsWith('/getProjectSnapshot')
+        ? cloudSnapshotResponse(input)
+        : {
+          body: collabCloudSuccessEnvelope(envelopeRequestId(input), {
+            mainOid: MERGED_OID,
+            mergeCommitOid: MERGED_OID,
+            request: changeRequest({
+              latestHeadOid: HEAD_OID,
+              mergedOid: MERGED_OID,
+              revision: 1,
+              status: 'merged',
+            }),
           }),
-        }),
-        contentType: 'application/json; charset=utf-8',
-        status: 200,
-      });
+          contentType: 'application/json; charset=utf-8',
+          status: 200,
+        });
     const control = (await new CloudAuthorityAdapter({ request }).create(membership())).control;
     const controller = new AbortController();
 
@@ -1219,7 +1329,7 @@ describe('CloudAuthorityAdapter', () => {
       mainOid: MERGED_OID,
       request: { id: 'request-one', mergedOid: MERGED_OID, status: 'merged' },
     });
-    expect(request.mock.calls[1]?.[0]).toEqual({
+    expect(request.mock.calls[2]?.[0]).toEqual({
       body: {
         data: {
           expectedHeadOid: HEAD_OID,
@@ -1243,16 +1353,18 @@ describe('CloudAuthorityAdapter', () => {
   it('rejects an Accept response for a different reviewed Request tuple', async () => {
     const request = jest.fn(async (input: CloudAuthorityHttpRequest) => ({
       body: input.method === 'GET'
-        ? collabCloudCapabilityDocument(['accept'], limits)
-        : collabCloudSuccessEnvelope('response-accept', {
-          mainOid: MERGED_OID,
-          mergeCommitOid: MERGED_OID,
-          request: changeRequest({
-            id: 'request-other',
-            mergedOid: MERGED_OID,
-            status: 'merged',
+        ? boundCapabilityDocument(['accept'])
+        : input.url.endsWith('/getProjectSnapshot')
+          ? cloudSnapshotResponse(input).body
+          : collabCloudSuccessEnvelope(envelopeRequestId(input), {
+            mainOid: MERGED_OID,
+            mergeCommitOid: MERGED_OID,
+            request: changeRequest({
+              id: 'request-other',
+              mergedOid: MERGED_OID,
+              status: 'merged',
+            }),
           }),
-        }),
       contentType: 'application/json',
       status: 200,
     }));
@@ -1277,12 +1389,13 @@ describe('CloudAuthorityAdapter', () => {
     const request = jest.fn(async (input: CloudAuthorityHttpRequest) => {
       if (input.method === 'GET') {
         return {
-          body: collabCloudCapabilityDocument(['requests'], limits),
+          body: boundCapabilityDocument(['requests']),
           contentType: 'application/json',
           status: 200,
         };
       }
       const operation = input.url.split('/').at(-1)!;
+      if (operation === 'getProjectSnapshot') return cloudSnapshotResponse(input);
       operations.push(operation);
       const data = operation === 'getRequest'
         ? {
@@ -1307,7 +1420,7 @@ describe('CloudAuthorityAdapter', () => {
             }
             : { request: changeRequest({ description: 'Updated description', revision: 2 }) };
       return {
-        body: collabCloudSuccessEnvelope(`response-${operation}`, data),
+        body: collabCloudSuccessEnvelope(envelopeRequestId(input), data),
         contentType: 'application/json',
         status: 200,
       };
@@ -1360,12 +1473,13 @@ describe('CloudAuthorityAdapter', () => {
       requests.push(input);
       if (input.method === 'GET') {
         return {
-          body: collabCloudCapabilityDocument(['tickets'], limits),
+          body: boundCapabilityDocument(['tickets']),
           contentType: 'application/json',
           status: 200,
         };
       }
       const operation = input.url.split('/').at(-1)!;
+      if (operation === 'getProjectSnapshot') return cloudSnapshotResponse(input);
       const data = operation === 'listTickets'
         ? { tickets: [ticketSummary()] }
         : operation === 'getTicket'
@@ -1389,7 +1503,7 @@ describe('CloudAuthorityAdapter', () => {
                   }
                   : { ticket: ticketSummary({ revision: 2 }) };
       return {
-        body: collabCloudSuccessEnvelope(`response-${operation}`, data),
+        body: collabCloudSuccessEnvelope(envelopeRequestId(input), data),
         contentType: 'application/json',
         status: 200,
       };
@@ -1439,7 +1553,7 @@ describe('CloudAuthorityAdapter', () => {
       ticketId: 'ticket-one',
     }, 'reopen-ticket')).resolves.toMatchObject({ id: 'ticket-one' });
 
-    expect(requests.slice(1).map(input => input.url.split('/').at(-1))).toEqual([
+    expect(requests.slice(2).map(input => input.url.split('/').at(-1))).toEqual([
       'listTickets',
       'getTicket',
       'getTicket',
@@ -1451,7 +1565,7 @@ describe('CloudAuthorityAdapter', () => {
       'closeTicket',
       'reopenTicket',
     ]);
-    for (const input of requests.slice(6)) {
+    for (const input of requests.slice(7)) {
       expect(input.body).toEqual(expect.objectContaining({
         data: expect.not.objectContaining({ intentId: expect.anything() }),
       }));
@@ -1484,12 +1598,13 @@ describe('CloudAuthorityAdapter', () => {
     const request = jest.fn(async (input: CloudAuthorityHttpRequest) => {
       if (input.method === 'GET') {
         return {
-          body: collabCloudCapabilityDocument(['requests', 'tickets'], limits),
+          body: boundCapabilityDocument(['requests', 'tickets']),
           contentType: 'application/json',
           status: 200,
         };
       }
       const operation = input.url.split('/').at(-1)!;
+      if (operation === 'getProjectSnapshot') return cloudSnapshotResponse(input);
       const body = input.body as { readonly data: Readonly<Record<string, unknown>> };
       const data = operation === 'getRequest'
         ? {
@@ -1511,7 +1626,7 @@ describe('CloudAuthorityAdapter', () => {
               ? { comments: [ticketComment(`ticket-${String(body.data.cursor)}`)] }
               : { acceptedRelations: [acceptedRelation] };
       return {
-        body: collabCloudSuccessEnvelope(`response-${operation}`, data),
+        body: collabCloudSuccessEnvelope(envelopeRequestId(input), data),
         contentType: 'application/json',
         status: 200,
       };
@@ -1522,7 +1637,7 @@ describe('CloudAuthorityAdapter', () => {
       comments: { comments: [{ id: 'request-comment-one' }], nextCursor: 'request-next' },
     });
     expect(request.mock.calls.map(([input]) => input.url.split('/').at(-1))).toEqual([
-      'capabilities', 'getRequest',
+      'capabilities', 'getProjectSnapshot', 'getRequest',
     ]);
     await expect(control.readRequest(PROJECT_ID, 'request-one')).resolves.toMatchObject({
       comments: { comments: [{ id: 'request-comment-one' }, { id: 'request-comment-two' }] },
@@ -1540,25 +1655,30 @@ describe('CloudAuthorityAdapter', () => {
   });
 
   it('rejects a Ticket cursor reused across complete comment and relation collections', async () => {
-    const request = jest.fn()
-      .mockResolvedValueOnce({
-        body: collabCloudCapabilityDocument(['tickets'], limits),
+    const request = jest.fn(async (input: CloudAuthorityHttpRequest) => {
+      if (input.method === 'GET') {
+        return {
+          body: boundCapabilityDocument(['tickets']),
+          contentType: 'application/json',
+          status: 200,
+        };
+      }
+      const operation = input.url.split('/').at(-1);
+      if (operation === 'getProjectSnapshot') return cloudSnapshotResponse(input);
+      return {
+        body: collabCloudSuccessEnvelope(
+          envelopeRequestId(input),
+          operation === 'getTicket'
+            ? ticketDetail({
+              acceptedRelations: { acceptedRelations: [], nextCursor: 'same-cursor' },
+              comments: { comments: [], nextCursor: 'same-cursor' },
+            })
+            : { comments: [] },
+        ),
         contentType: 'application/json',
         status: 200,
-      })
-      .mockResolvedValueOnce({
-        body: collabCloudSuccessEnvelope('response-detail', ticketDetail({
-          acceptedRelations: { acceptedRelations: [], nextCursor: 'same-cursor' },
-          comments: { comments: [], nextCursor: 'same-cursor' },
-        })),
-        contentType: 'application/json',
-        status: 200,
-      })
-      .mockResolvedValueOnce({
-        body: collabCloudSuccessEnvelope('response-comments', { comments: [] }),
-        contentType: 'application/json',
-        status: 200,
-      });
+      };
+    });
     const control = (await new CloudAuthorityAdapter({ request }).create(membership())).control;
 
     await expect(control.readTicket(PROJECT_ID, 'ticket-one')).rejects.toMatchObject({
@@ -1572,12 +1692,13 @@ describe('CloudAuthorityAdapter', () => {
     const request = jest.fn(async (input: CloudAuthorityHttpRequest) => {
       if (input.method === 'GET') {
         return {
-          body: collabCloudCapabilityDocument(['requests', 'tickets'], limits),
+          body: boundCapabilityDocument(['requests', 'tickets']),
           contentType: 'application/json',
           status: 200,
         };
       }
       const operation = input.url.split('/').at(-1)!;
+      if (operation === 'getProjectSnapshot') return cloudSnapshotResponse(input);
       const comment = {
         authorMemberId: ACTOR_ID,
         body: 'Wrong owner',
@@ -1588,7 +1709,7 @@ describe('CloudAuthorityAdapter', () => {
           : { ticketId: 'ticket-other' }),
       };
       return {
-        body: collabCloudSuccessEnvelope(`response-${operation}`, { comments: [comment] }),
+        body: collabCloudSuccessEnvelope(envelopeRequestId(input), { comments: [comment] }),
         contentType: 'application/json',
         status: 200,
       };
@@ -1616,20 +1737,19 @@ describe('CloudAuthorityAdapter', () => {
     });
   });
 
-  it('rejects a Cloud snapshot bound to a different Project', async () => {
+  it('rejects a bound session whose authenticated snapshot belongs to a different Project', async () => {
     const request = jest.fn(async (input: CloudAuthorityHttpRequest) => ({
       body: input.method === 'GET'
         ? collabCloudCapabilityDocument(['project-snapshot'], limits)
-        : collabCloudSuccessEnvelope('response-snapshot', {
+        : collabCloudSuccessEnvelope(envelopeRequestId(input), {
           ...cloudSnapshot(),
           project: { ...cloudSnapshot().project, id: 'project-other' },
         }),
       contentType: 'application/json',
       status: 200,
     }));
-    const control = (await new CloudAuthorityAdapter({ request }).create(membership())).control;
-
-    await expect(control.readSnapshot(PROJECT_ID)).rejects.toMatchObject({
+    await expect(new CloudAuthorityAdapter({ request }).create(membership())).rejects
+      .toMatchObject({
       code: 'authority-integrity-error',
       safeContext: { reason: 'cloud-control-snapshot-response-mismatch' },
     });

--- a/tests/unit/features/collab/modals/project/ProjectInvitationModal.test.ts
+++ b/tests/unit/features/collab/modals/project/ProjectInvitationModal.test.ts
@@ -120,7 +120,19 @@ describe('ProjectInvitationModal', () => {
         invitationId: 'invitation-existing',
         state: 'active',
       }])),
-      readManagementOperation: jest.fn().mockResolvedValue(success(null)),
+      readManagementOperation: jest.fn()
+        .mockResolvedValueOnce(success(null))
+        .mockResolvedValueOnce(success({
+          action: 'create-invitation',
+          completionId: 'completion-created',
+          invitation: {
+            encodedInvitation: 'claudian-cloud:v1:secret',
+            expiresAt: '2026-09-10T00:00:00.000Z',
+          },
+          secretAvailableUntil: '2026-09-10T00:00:00.000Z',
+          status: 'result-retained',
+        }))
+        .mockResolvedValue(success(null)),
       resumeManagementOperation: jest.fn(),
       revokeInvitation: jest.fn().mockResolvedValue(success(undefined)),
     } as unknown as jest.Mocked<ProjectInvitationModalPort>;
@@ -159,10 +171,12 @@ describe('ProjectInvitationModal', () => {
   it('retains a Cloud invitation result across close and completes it only after copy', async () => {
     const retained = {
       action: 'create-invitation' as const,
+      completionId: 'completion-retained',
       invitation: {
         encodedInvitation: 'claudian-cloud:v1:retained-secret',
         expiresAt: '2026-09-10T00:00:00.000Z',
       },
+      secretAvailableUntil: '2026-09-10T00:00:00.000Z',
       status: 'result-retained' as const,
     };
     const port: jest.Mocked<ProjectInvitationModalPort> = {
@@ -193,18 +207,205 @@ describe('ProjectInvitationModal', () => {
     await flush();
     expect(copyText).toHaveBeenCalledWith('claudian-cloud:v1:retained-secret');
     expect(port.completeManagementOperation).toHaveBeenCalledWith(
-      { projectId: 'project-alpha' },
+      { completionId: 'completion-retained', projectId: 'project-alpha' },
     );
+  });
+
+  it('finishes an expired retained Cloud invitation without exposing its secret', async () => {
+    const port = {
+      completeManagementOperation: jest.fn().mockResolvedValue(success(undefined)),
+      createInvitation: jest.fn(),
+      listInvitations: jest.fn().mockResolvedValue(success([])),
+      readManagementOperation: jest.fn()
+        .mockResolvedValueOnce(success({
+          action: 'create-invitation',
+          completionId: 'completion-expired',
+          invitation: null,
+          secretAvailableUntil: '2026-09-01T00:00:00.000Z',
+          status: 'result-retained',
+        }))
+        .mockResolvedValue(success(null)),
+      resumeManagementOperation: jest.fn(),
+      revokeInvitation: jest.fn(),
+    } as unknown as jest.Mocked<ProjectInvitationModalPort>;
+    const modal = new ProjectInvitationModal({} as never, port, {
+      authorityKind: 'cloud',
+      projectId: 'project-alpha',
+    });
+
+    modal.onOpen();
+    await flush();
+
+    expect(modal.contentEl.querySelector('[aria-label="Project invitation"]')).toBeNull();
+    expect(modal.contentEl.querySelector<HTMLButtonElement>(
+      '[data-action="create-invitation"]',
+    )?.disabled).toBe(true);
+    modal.contentEl.querySelector<HTMLButtonElement>(
+      '[data-action="complete-invitation"]',
+    )?.click();
+    await flush();
+
+    expect(port.completeManagementOperation).toHaveBeenCalledWith({
+      completionId: 'completion-expired',
+      projectId: 'project-alpha',
+    });
+  });
+
+  it('redacts a retained Cloud invitation when its secret availability expires', async () => {
+    jest.useFakeTimers();
+    try {
+      jest.setSystemTime(new Date('2026-09-02T00:00:00.000Z'));
+      const port = {
+        completeManagementOperation: jest.fn().mockResolvedValue(success(undefined)),
+        createInvitation: jest.fn(),
+        listInvitations: jest.fn().mockResolvedValue(success([])),
+        readManagementOperation: jest.fn().mockResolvedValue(success({
+          action: 'create-invitation',
+          completionId: 'completion-expiring',
+          invitation: {
+            encodedInvitation: 'claudian-cloud:v1:expiring-secret',
+            expiresAt: '2026-09-10T00:00:00.000Z',
+          },
+          secretAvailableUntil: '2026-09-02T00:00:01.000Z',
+          status: 'result-retained',
+        })),
+        resumeManagementOperation: jest.fn(),
+        revokeInvitation: jest.fn(),
+      } as unknown as jest.Mocked<ProjectInvitationModalPort>;
+      const modal = new ProjectInvitationModal({} as never, port, {
+        authorityKind: 'cloud',
+        projectId: 'project-alpha',
+      });
+
+      modal.onOpen();
+      await flush();
+      expect(modal.contentEl.textContent).toContain('claudian-cloud:v1:expiring-secret');
+
+      jest.advanceTimersByTime(1_000);
+
+      expect(modal.contentEl.textContent).not.toContain('claudian-cloud:v1:expiring-secret');
+      expect(modal.contentEl.querySelector('[data-action="copy-invitation"]')).toBeNull();
+      expect(modal.contentEl.querySelector('[data-action="complete-invitation"]')).not.toBeNull();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('revalidates a retained Cloud invitation immediately before copying it', async () => {
+    jest.useFakeTimers();
+    try {
+      jest.setSystemTime(new Date('2026-09-02T00:00:00.000Z'));
+      const retained = {
+        action: 'create-invitation' as const,
+        completionId: 'completion-copy-revalidation',
+        invitation: {
+          encodedInvitation: 'claudian-cloud:v1:stale-secret',
+          expiresAt: '2026-09-10T00:00:00.000Z',
+        },
+        secretAvailableUntil: '2026-09-02T00:00:01.000Z',
+        status: 'result-retained' as const,
+      };
+      const port = {
+        completeManagementOperation: jest.fn(),
+        createInvitation: jest.fn(),
+        listInvitations: jest.fn().mockResolvedValue(success([])),
+        readManagementOperation: jest.fn()
+          .mockResolvedValueOnce(success(retained))
+          .mockResolvedValueOnce(success({
+            ...retained,
+            invitation: null,
+          })),
+        resumeManagementOperation: jest.fn(),
+        revokeInvitation: jest.fn(),
+      } as unknown as jest.Mocked<ProjectInvitationModalPort>;
+      const copyText = jest.fn().mockResolvedValue(undefined);
+      const modal = new ProjectInvitationModal({} as never, port, {
+        authorityKind: 'cloud',
+        copyText,
+        projectId: 'project-alpha',
+      });
+
+      modal.onOpen();
+      await flush();
+      jest.setSystemTime(new Date('2026-09-02T00:00:01.000Z'));
+      modal.contentEl.querySelector<HTMLButtonElement>(
+        '[data-action="copy-invitation"]',
+      )?.click();
+      await flush();
+
+      expect(port.readManagementOperation).toHaveBeenCalledTimes(2);
+      expect(copyText).not.toHaveBeenCalled();
+      expect(modal.contentEl.textContent).not.toContain('claudian-cloud:v1:stale-secret');
+      expect(modal.contentEl.querySelector('[data-action="complete-invitation"]')).not.toBeNull();
+      expect(port.completeManagementOperation).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('cannot complete a newer retained result from a stale invitation modal', async () => {
+    let releaseCopy!: () => void;
+    const copying = new Promise<void>(resolve => { releaseCopy = resolve; });
+    let retainedCompletionId = 'completion-old';
+    const port = {
+      completeManagementOperation: jest.fn().mockImplementation(async request => (
+        request.completionId === retainedCompletionId
+          ? success(undefined)
+          : { status: 'error' as const }
+      )),
+      createInvitation: jest.fn(),
+      listInvitations: jest.fn().mockResolvedValue(success([])),
+      readManagementOperation: jest.fn().mockResolvedValue(success({
+        action: 'create-invitation',
+        completionId: 'completion-old',
+        invitation: {
+          encodedInvitation: 'claudian-cloud:v1:old-secret',
+          expiresAt: '2026-09-10T00:00:00.000Z',
+        },
+        secretAvailableUntil: '2026-09-10T00:00:00.000Z',
+        status: 'result-retained',
+      })),
+      resumeManagementOperation: jest.fn(),
+      revokeInvitation: jest.fn(),
+    } as unknown as jest.Mocked<ProjectInvitationModalPort>;
+    const modal = new ProjectInvitationModal({} as never, port, {
+      authorityKind: 'cloud',
+      copyText: () => copying,
+      projectId: 'project-alpha',
+    });
+
+    modal.onOpen();
+    await flush();
+    modal.contentEl.querySelector<HTMLButtonElement>(
+      '[data-action="copy-invitation"]',
+    )?.click();
+    retainedCompletionId = 'completion-new';
+    releaseCopy();
+    await flush();
+
+    expect(port.completeManagementOperation).toHaveBeenCalledWith({
+      completionId: 'completion-old',
+      projectId: 'project-alpha',
+    });
+    expect(retainedCompletionId).toBe('completion-new');
+    expect(modal.contentEl.querySelector('[role="alert"]')).not.toBeNull();
   });
 
   it('does not replay or reveal a management operation owned by another surface', async () => {
     const port = {
       completeManagementOperation: jest.fn(),
       createInvitation: jest.fn(),
-      listInvitations: jest.fn().mockResolvedValue(success([])),
+      listInvitations: jest.fn().mockResolvedValue(success([{
+        createdAt: '2026-09-02T00:00:00.000Z',
+        expiresAt: '2026-09-10T00:00:00.000Z',
+        invitationId: 'invitation-existing',
+        state: 'active',
+      }])),
       readManagementOperation: jest.fn().mockResolvedValue(success({
         action: 'remove-member',
+        completionId: 'completion-other',
         invitation: null,
+        secretAvailableUntil: null,
         status: 'pending',
       })),
       resumeManagementOperation: jest.fn(),
@@ -221,6 +422,12 @@ describe('ProjectInvitationModal', () => {
     expect(port.resumeManagementOperation).not.toHaveBeenCalled();
     expect(modal.contentEl.querySelector('[data-action="resume-invitation"]')).toBeNull();
     expect(modal.contentEl.querySelector('[aria-label="Project invitation"]')).toBeNull();
+    expect(modal.contentEl.querySelector<HTMLButtonElement>(
+      '[data-action="create-invitation"]',
+    )?.disabled).toBe(true);
+    expect(modal.contentEl.querySelector<HTMLButtonElement>(
+      '[data-action="revoke-invitation"]',
+    )?.disabled).toBe(true);
   });
 
   it('offers only a durable-slot read retry when Cloud recovery inspection fails', async () => {
@@ -261,10 +468,12 @@ describe('ProjectInvitationModal', () => {
   it('offers an explicit resume only for a pending invitation creation', async () => {
     const retained = {
       action: 'create-invitation' as const,
+      completionId: 'completion-resumed',
       invitation: {
         encodedInvitation: 'claudian-cloud:v1:resumed-secret',
         expiresAt: '2026-09-10T00:00:00.000Z',
       },
+      secretAvailableUntil: '2026-09-10T00:00:00.000Z',
       status: 'result-retained' as const,
     };
     const port = {
@@ -273,7 +482,9 @@ describe('ProjectInvitationModal', () => {
       listInvitations: jest.fn().mockResolvedValue(success([])),
       readManagementOperation: jest.fn().mockResolvedValue(success({
         action: 'create-invitation',
+        completionId: 'completion-pending',
         invitation: null,
+        secretAvailableUntil: null,
         status: 'pending',
       })),
       resumeManagementOperation: jest.fn().mockResolvedValue(success(retained)),
@@ -298,6 +509,54 @@ describe('ProjectInvitationModal', () => {
 
     expect(port.resumeManagementOperation).toHaveBeenCalledTimes(1);
     expect(modal.contentEl.textContent).toContain('claudian-cloud:v1:resumed-secret');
+  });
+
+  it('keeps exact completion reachable when resumed invitation creation is already expired', async () => {
+    const port = {
+      completeManagementOperation: jest.fn().mockResolvedValue(success(undefined)),
+      createInvitation: jest.fn(),
+      listInvitations: jest.fn().mockResolvedValue(success([])),
+      readManagementOperation: jest.fn().mockResolvedValue(success({
+        action: 'create-invitation',
+        completionId: 'completion-pending-expired',
+        invitation: null,
+        secretAvailableUntil: null,
+        status: 'pending',
+      })),
+      resumeManagementOperation: jest.fn().mockResolvedValue(success({
+        action: 'create-invitation',
+        completionId: 'completion-resumed-expired',
+        invitation: null,
+        secretAvailableUntil: '2026-09-01T00:00:00.000Z',
+        status: 'result-retained',
+      })),
+      revokeInvitation: jest.fn(),
+    } as unknown as jest.Mocked<ProjectInvitationModalPort>;
+    const modal = new ProjectInvitationModal({} as never, port, {
+      authorityKind: 'cloud',
+      projectId: 'project-alpha',
+    });
+
+    modal.onOpen();
+    await flush();
+    modal.contentEl.querySelector<HTMLButtonElement>(
+      '[data-action="resume-invitation"]',
+    )?.click();
+    await flush();
+
+    expect(modal.contentEl.querySelector<HTMLButtonElement>(
+      '[data-action="create-invitation"]',
+    )?.disabled).toBe(true);
+    const finish = modal.contentEl.querySelector<HTMLButtonElement>(
+      '[data-action="complete-invitation"]',
+    );
+    expect(finish).not.toBeNull();
+    finish?.click();
+    await flush();
+    expect(port.completeManagementOperation).toHaveBeenCalledWith({
+      completionId: 'completion-resumed-expired',
+      projectId: 'project-alpha',
+    });
   });
 
   it('has no detectable accessibility violations in the Cloud list state', async () => {

--- a/tests/unit/features/collab/modals/project/ProjectInvitationModal.test.ts
+++ b/tests/unit/features/collab/modals/project/ProjectInvitationModal.test.ts
@@ -254,7 +254,7 @@ describe('ProjectInvitationModal', () => {
   it('redacts a retained Cloud invitation when its secret availability expires', async () => {
     jest.useFakeTimers();
     try {
-      jest.setSystemTime(new Date('2026-09-02T00:00:00.000Z'));
+      jest.setSystemTime(Date.parse('2026-09-02T00:00:00.000Z'));
       const port = {
         completeManagementOperation: jest.fn().mockResolvedValue(success(undefined)),
         createInvitation: jest.fn(),
@@ -294,7 +294,7 @@ describe('ProjectInvitationModal', () => {
   it('revalidates a retained Cloud invitation immediately before copying it', async () => {
     jest.useFakeTimers();
     try {
-      jest.setSystemTime(new Date('2026-09-02T00:00:00.000Z'));
+      jest.setSystemTime(Date.parse('2026-09-02T00:00:00.000Z'));
       const retained = {
         action: 'create-invitation' as const,
         completionId: 'completion-copy-revalidation',
@@ -327,7 +327,7 @@ describe('ProjectInvitationModal', () => {
 
       modal.onOpen();
       await flush();
-      jest.setSystemTime(new Date('2026-09-02T00:00:01.000Z'));
+      jest.setSystemTime(Date.parse('2026-09-02T00:00:01.000Z'));
       modal.contentEl.querySelector<HTMLButtonElement>(
         '[data-action="copy-invitation"]',
       )?.click();

--- a/tests/unit/features/collab/modals/project/ProjectManagementModal.test.ts
+++ b/tests/unit/features/collab/modals/project/ProjectManagementModal.test.ts
@@ -296,6 +296,18 @@ describe('ProjectManagementModal', () => {
         encodedInvitation: 'claudian-cloud-claim:v1:replacement',
         expiresAt: '2026-09-10T00:00:00.000Z',
       })),
+      readManagementOperation: jest.fn()
+        .mockResolvedValueOnce(success(null))
+        .mockResolvedValue(success({
+          action: 'reissue-member-claim',
+          completionId: 'completion-reissued-claim',
+          invitation: {
+            encodedInvitation: 'claudian-cloud-claim:v1:replacement',
+            expiresAt: '2026-09-10T00:00:00.000Z',
+          },
+          secretAvailableUntil: '2026-09-10T00:00:00.000Z',
+          status: 'result-retained',
+        })),
     });
     const copyText = jest.fn().mockResolvedValue(undefined);
     const modal = new ProjectManagementModal({} as never, port, {
@@ -342,8 +354,121 @@ describe('ProjectManagementModal', () => {
     await flush();
     expect(copyText).toHaveBeenCalledWith('claudian-cloud-claim:v1:replacement');
     expect(port.completeManagementOperation).toHaveBeenCalledWith({
+      completionId: 'completion-reissued-claim',
       projectId: 'project-alpha',
     });
+  });
+
+  it('redacts a retained member claim when its secret availability expires', async () => {
+    jest.useFakeTimers();
+    try {
+      jest.setSystemTime(new Date('2026-09-02T00:00:00.000Z'));
+      const members = [member('member-manager', 'Alice', { role: 'manager' })];
+      const port = createPort(members, {
+        readManagementOperation: jest.fn().mockResolvedValue(success({
+          action: 'reissue-member-claim',
+          completionId: 'completion-expiring-claim',
+          invitation: {
+            encodedInvitation: 'claudian-cloud-claim:v1:expiring-secret',
+            expiresAt: '2026-09-10T00:00:00.000Z',
+          },
+          secretAvailableUntil: '2026-09-02T00:00:01.000Z',
+          status: 'result-retained',
+        })),
+        readProjectCapabilities: jest.fn().mockResolvedValue(success({
+          authorityKind: 'cloud', authorityTransfer: false, importedMemberClaims: true,
+          invitations: true, leave: true, managerResponsibility: true,
+          membershipManagement: true, retirement: true,
+        })),
+        readSnapshot: jest.fn().mockResolvedValue(success({
+          snapshot: {
+            currentMember: members[0], members,
+            project: { authorityGeneration: 4, authorityKind: 'cloud' },
+          },
+          source: 'online', stale: false, syncState: { status: 'synchronized' },
+        } as never)),
+      } as never);
+      const modal = new ProjectManagementModal({} as never, port, {
+        project: project({ authorityKind: 'cloud', connectionStatus: 'connected' }),
+      });
+
+      modal.onOpen();
+      await flush();
+      await flush();
+      expect(modal.contentEl.textContent)
+        .toContain('claudian-cloud-claim:v1:expiring-secret');
+
+      jest.advanceTimersByTime(1_000);
+
+      expect(modal.contentEl.textContent)
+        .not.toContain('claudian-cloud-claim:v1:expiring-secret');
+      expect(modal.contentEl.querySelector('[data-action="copy-member-claim"]')).toBeNull();
+      expect(modal.contentEl.querySelector(
+        '[data-action="complete-management-operation"]',
+      )).not.toBeNull();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('revalidates a retained member claim immediately before copying it', async () => {
+    jest.useFakeTimers();
+    try {
+      jest.setSystemTime(new Date('2026-09-02T00:00:00.000Z'));
+      const members = [member('member-manager', 'Alice', { role: 'manager' })];
+      const retained = {
+        action: 'reissue-member-claim' as const,
+        completionId: 'completion-claim-revalidation',
+        invitation: {
+          encodedInvitation: 'claudian-cloud-claim:v1:stale-secret',
+          expiresAt: '2026-09-10T00:00:00.000Z',
+        },
+        secretAvailableUntil: '2026-09-02T00:00:01.000Z',
+        status: 'result-retained' as const,
+      };
+      const port = createPort(members, {
+        readManagementOperation: jest.fn()
+          .mockResolvedValueOnce(success(retained))
+          .mockResolvedValueOnce(success({ ...retained, invitation: null })),
+        readProjectCapabilities: jest.fn().mockResolvedValue(success({
+          authorityKind: 'cloud', authorityTransfer: false, importedMemberClaims: true,
+          invitations: true, leave: true, managerResponsibility: true,
+          membershipManagement: true, retirement: true,
+        })),
+        readSnapshot: jest.fn().mockResolvedValue(success({
+          snapshot: {
+            currentMember: members[0], members,
+            project: { authorityGeneration: 4, authorityKind: 'cloud' },
+          },
+          source: 'online', stale: false, syncState: { status: 'synchronized' },
+        } as never)),
+      } as never);
+      const copyText = jest.fn().mockResolvedValue(undefined);
+      const modal = new ProjectManagementModal({} as never, port, {
+        copyText,
+        project: project({ authorityKind: 'cloud', connectionStatus: 'connected' }),
+      });
+
+      modal.onOpen();
+      await flush();
+      await flush();
+      jest.setSystemTime(new Date('2026-09-02T00:00:01.000Z'));
+      modal.contentEl.querySelector<HTMLButtonElement>(
+        '[data-action="copy-member-claim"]',
+      )?.click();
+      await flush();
+
+      expect(port.readManagementOperation).toHaveBeenCalledTimes(2);
+      expect(copyText).not.toHaveBeenCalled();
+      expect(modal.contentEl.textContent)
+        .not.toContain('claudian-cloud-claim:v1:stale-secret');
+      expect(modal.contentEl.querySelector(
+        '[data-action="complete-management-operation"]',
+      )).not.toBeNull();
+      expect(port.completeManagementOperation).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('hides imported-claim actions for an already bound Member', async () => {
@@ -458,7 +583,9 @@ describe('ProjectManagementModal', () => {
       })))),
       readManagementOperation: jest.fn().mockResolvedValue(success({
         action: 'remove-member',
+        completionId: 'completion-pending',
         invitation: null,
+        secretAvailableUntil: null,
         status: 'pending',
       })),
       readProjectCapabilities: jest.fn().mockResolvedValue(success({
@@ -475,7 +602,9 @@ describe('ProjectManagementModal', () => {
       } as never)),
       resumeManagementOperation: jest.fn().mockResolvedValue(success({
         action: 'remove-member',
+        completionId: 'completion-retained',
         invitation: null,
+        secretAvailableUntil: null,
         status: 'result-retained',
       })),
     });
@@ -499,7 +628,9 @@ describe('ProjectManagementModal', () => {
     const port = createPort([], {
       readManagementOperation: jest.fn().mockResolvedValue(success({
         action: 'remove-member',
+        completionId: 'completion-offline',
         invitation: null,
+        secretAvailableUntil: null,
         status: 'result-retained',
       })),
       readProjectCapabilities: jest.fn().mockResolvedValue({
@@ -751,7 +882,9 @@ describe('ProjectManagementModal', () => {
     const port = createPort(members, {
       readManagementOperation: jest.fn().mockResolvedValue(success({
         action: 'remove-member',
+        completionId: 'completion-lock',
         invitation: null,
+        secretAvailableUntil: null,
         status: 'pending',
       })),
       readProjectCapabilities: jest.fn().mockResolvedValue(success({
@@ -915,7 +1048,9 @@ describe('ProjectManagementModal', () => {
     const port = createPort(members, {
       readManagementOperation: jest.fn().mockResolvedValue(success({
         action: 'create-invitation',
+        completionId: 'completion-invitation',
         invitation: null,
+        secretAvailableUntil: null,
         status: 'pending',
       })),
       readProjectCapabilities: jest.fn().mockResolvedValue(success({
@@ -1320,6 +1455,7 @@ describe('ProjectManagementModal', () => {
     'create-manager-offer',
     'cancel-manager-offer',
     'promote-manager',
+    'reissue-member-claim',
     'revoke-member-claim',
   ] as const)('finishes a retained %s result explicitly', async action => {
     const members = [member('member-manager', 'Alice', { role: 'manager' })];
@@ -1330,7 +1466,13 @@ describe('ProjectManagementModal', () => {
         return success(undefined);
       }),
       readManagementOperation: jest.fn().mockImplementation(async () => success(retained
-        ? { action, invitation: null, status: 'result-retained' as const }
+        ? {
+          action,
+          completionId: `completion-${action}`,
+          invitation: null,
+          secretAvailableUntil: null,
+          status: 'result-retained' as const,
+        }
         : null)),
       readProjectCapabilities: jest.fn().mockResolvedValue(success({
         authorityKind: 'cloud', authorityTransfer: false, importedMemberClaims: true,
@@ -1360,6 +1502,7 @@ describe('ProjectManagementModal', () => {
     await flush();
 
     expect(port.completeManagementOperation).toHaveBeenCalledWith({
+      completionId: `completion-${action}`,
       projectId: 'project-alpha',
     });
   });

--- a/tests/unit/features/collab/modals/project/ProjectManagementModal.test.ts
+++ b/tests/unit/features/collab/modals/project/ProjectManagementModal.test.ts
@@ -362,7 +362,7 @@ describe('ProjectManagementModal', () => {
   it('redacts a retained member claim when its secret availability expires', async () => {
     jest.useFakeTimers();
     try {
-      jest.setSystemTime(new Date('2026-09-02T00:00:00.000Z'));
+      jest.setSystemTime(Date.parse('2026-09-02T00:00:00.000Z'));
       const members = [member('member-manager', 'Alice', { role: 'manager' })];
       const port = createPort(members, {
         readManagementOperation: jest.fn().mockResolvedValue(success({
@@ -414,7 +414,7 @@ describe('ProjectManagementModal', () => {
   it('revalidates a retained member claim immediately before copying it', async () => {
     jest.useFakeTimers();
     try {
-      jest.setSystemTime(new Date('2026-09-02T00:00:00.000Z'));
+      jest.setSystemTime(Date.parse('2026-09-02T00:00:00.000Z'));
       const members = [member('member-manager', 'Alice', { role: 'manager' })];
       const retained = {
         action: 'reissue-member-claim' as const,
@@ -452,7 +452,7 @@ describe('ProjectManagementModal', () => {
       modal.onOpen();
       await flush();
       await flush();
-      jest.setSystemTime(new Date('2026-09-02T00:00:01.000Z'));
+      jest.setSystemTime(Date.parse('2026-09-02T00:00:01.000Z'));
       modal.contentEl.querySelector<HTMLButtonElement>(
         '[data-action="copy-member-claim"]',
       )?.click();

--- a/tests/unit/features/collab/sidebar/CollabPanel.test.ts
+++ b/tests/unit/features/collab/sidebar/CollabPanel.test.ts
@@ -1,15 +1,19 @@
 /** @jest-environment jsdom */
 
+import { getByRole } from '@testing-library/dom';
 import { type App, Menu } from 'obsidian';
 
 import { type CollabFeatureState, type CollabLocalProjectSummary } from '@/core/collab';
 import { CollabError } from '@/core/collab/ClaudianCollabError';
+import { CollabTransientSurfaceRegistry } from '@/features/collab/modals/CollabTransientSurfaceRegistry';
 
 const mockOpenCreate = jest.fn();
 const mockOpenJoin = jest.fn();
 const mockOpenManagement = jest.fn();
 const mockOpenReconnect = jest.fn();
 const mockCreateManagement = jest.fn();
+let mockManagementAction: HTMLButtonElement | null = null;
+let mockManagementMutation: jest.Mock | null = null;
 
 jest.mock('@/features/collab/modals/project/CreateProjectModal', () => ({
   CreateProjectModal: class MockCreateProjectModal {
@@ -34,8 +38,44 @@ jest.mock('@/features/collab/modals/project/ReconnectProjectModal', () => ({
 
 jest.mock('@/features/collab/modals/project/ProjectManagementModal', () => ({
   ProjectManagementModal: class MockProjectManagementModal {
-    constructor(...args: unknown[]) { mockCreateManagement(...args); }
-    open(): void { mockOpenManagement(); }
+    readonly #action: HTMLButtonElement | null;
+    #closed = false;
+    readonly #onClosed: (() => void) | undefined;
+
+    constructor(...args: unknown[]) {
+      mockCreateManagement(...args);
+      const options = args[2] as {
+        onClosed?: () => void;
+        project: CollabLocalProjectSummary;
+      };
+      this.#onClosed = options.onClosed;
+      this.#action = mockManagementMutation ? document.createElement('button') : null;
+      if (this.#action) {
+        this.#action.type = 'button';
+        this.#action.setAttribute('aria-label', `Start ${options.project.name} Host`);
+        this.#action.addEventListener('click', () => {
+          if (!this.#closed) mockManagementMutation?.(options.project.id);
+        });
+      }
+    }
+
+    close(): void {
+      if (this.#closed) return;
+      this.#closed = true;
+      if (this.#action) {
+        this.#action.disabled = true;
+        this.#action.remove();
+      }
+      this.#onClosed?.();
+    }
+
+    open(): void {
+      mockOpenManagement();
+      if (this.#action) {
+        document.body.appendChild(this.#action);
+        mockManagementAction = this.#action;
+      }
+    }
   },
 }));
 
@@ -369,6 +409,9 @@ describe('CollabPanel', () => {
     mockOpenCreate.mockClear();
     mockOpenJoin.mockClear();
     mockOpenReconnect.mockClear();
+    mockManagementAction?.remove();
+    mockManagementAction = null;
+    mockManagementMutation = null;
   });
 
   afterEach(() => {
@@ -821,6 +864,56 @@ describe('CollabPanel', () => {
     expect(port.selectProject).toHaveBeenCalledWith('project-beta');
     menu.items[2]?.clickHandler?.();
     expect(mockOpenReconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes old Project management before a delayed Project selection publishes', async () => {
+    const container = document.body.createDiv();
+    const port = createPort({
+      lifecycle: 'ready',
+      projects: [
+        project(),
+        project({
+          id: 'project-beta',
+          name: 'Beta',
+          workspacePath: 'workspace/beta',
+        }),
+      ],
+      selectedProjectId: 'project-alpha',
+    });
+    let finishSelection!: () => void;
+    port.selectProject.mockImplementationOnce(() => new Promise(resolve => {
+      finishSelection = () => resolve({ status: 'cancelled' });
+    }));
+    const transientSurfaces = new CollabTransientSurfaceRegistry();
+    mockManagementMutation = jest.fn();
+    const panel = new CollabPanel(container, {} as never, {
+      app: createApp(),
+      configuredGitPath: () => '',
+      onSaveConfiguredGitPath: jest.fn(),
+      port,
+      projectSetup: { getPendingSetupOperationId: jest.fn() },
+      resolveGit: jest.fn().mockResolvedValue(AVAILABLE),
+      transientSurfaces,
+    });
+
+    panel.setActive(true);
+    await flush();
+    getByRole(container, 'button', { name: 'Project management' }).click();
+    const oldProjectAction = getByRole(document.body, 'button', {
+      name: 'Start Alpha Host',
+    }) as HTMLButtonElement;
+
+    getByRole(container, 'button', { name: 'Select project' }).click();
+    MockMenu.instances.at(-1)?.items[1]?.clickHandler?.();
+
+    expect(port.state.selectedProjectId).toBe('project-alpha');
+    expect(oldProjectAction.disabled).toBe(true);
+    expect(oldProjectAction.isConnected).toBe(false);
+    oldProjectAction.click();
+    expect(mockManagementMutation).not.toHaveBeenCalled();
+
+    finishSelection();
+    await flush();
   });
 
   it('mounts the shared personal Publish surface for a healthy Project', async () => {


### PR DESCRIPTION
Summary
- make Cloud management intents exact-completion durable lifecycle owners while preserving the narrow Manager-responsibility lane
- harden authority-transfer cancellation, route rollback, shutdown draining, and authenticated session preflight
- retain and safely redact secret-bearing results, prevent stale completion, and block competing UI mutations
- add focused lost-reply, restart, close, ABA, expiry, and cross-owner regression coverage

Verification
- 620 suites / 9415 tests, plus 53 script checks
- open-handle PASS
- cross-platform Collab 29 suites / 376 tests
- typecheck, lint, architecture 41/41, lockfile, safe build and performance gate
- real Cloud two-client milestone 1/1 with zero skips
- final three-reviewer Step 13 review-fix loop