### PR TITLE
fix: drop version number from Fable tier label

### DIFF
--- a/src/providers/claude/modelTiers.ts
+++ b/src/providers/claude/modelTiers.ts
@@ -51,7 +51,7 @@ export const CLAUDE_MODEL_TIER_DEFINITIONS = [
   },
   {
     id: 'fable',
-    label: 'Fable 5 ($$$)',
+    label: 'Fable ($$$)',
     agentLabel: 'Fable',
     description: "Anthropic's most capable model — premium pricing above Opus",
     environmentKey: 'ANTHROPIC_DEFAULT_FABLE_MODEL',


### PR DESCRIPTION
## Why

The Fable entry in the Claude model picker is labeled `Fable 5 ($$$)`, but its id is the family alias `fable`, not a pinned model id. The Claude Code CLI resolves that alias to the newest Fable model. Since CLI 2.1.258 that is `claude-fable-5-1`, so the label now names a model the entry no longer selects. It is also the only tier label carrying a version number: Opus, Sonnet and Haiku are plain family names. Every future Fable release would make the label wrong again.

No issue exists for this; the change is a one-line label fix.

## What Changed

`src/providers/claude/modelTiers.ts`: the Fable tier `label` changes from `Fable 5 ($$$)` to `Fable ($$$)`. Nothing else changes. The `agentLabel` was already `Fable`, and the `legacyAliases` entry `claude-fable-5` keeps existing saved settings working.

## Why This Approach

Dropping the version number makes the label match the other three tiers and stay correct across Fable releases, because the alias already tracks the newest model. Keeping `($$$)` preserves the only in-picker hint that this tier costs more than Opus. The alternative, bumping the label to `Fable 5.1`, would need a follow-up on every Fable release and would still be inconsistent with the sibling labels.

## Validation

- `npm run typecheck`: pass
- `npm run lint`: pass
- `npm run build`: pass
- `npm run test`: 127 failures in 30 suites on a Windows 11 checkout, all path/environment related (opencode, codex, collab, utils/path). I ran the failing suites against the unmodified base commit and they fail identically there, so they are pre-existing and unrelated to this change. `tests/unit/providers/claude` passes apart from two `AgentManager` cases that also fail on the base commit.
- No test asserts on the Fable label text, so no test update is needed.

## Impact and Follow-ups

None. Label text only; no behavior, storage or alias change.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
