### PR TITLE
fix(codex): detect Codex in the unified ChatGPT app

### DIFF
--- a/src/providers/codex/runtime/CodexBinaryLocator.ts
+++ b/src/providers/codex/runtime/CodexBinaryLocator.ts
@@ -75,6 +75,8 @@ function getPreferredCodexBinaryDirs(platform: NodeJS.Platform): string[] {
       path.join(home, 'Applications', 'Codex.app', 'Contents', 'MacOS'),
       '/Applications/Codex.app/Contents/MacOS',
       path.join(home, '.local', 'bin'),
+      path.join(home, 'Applications', 'ChatGPT.app', 'Contents', 'Resources'),
+      '/Applications/ChatGPT.app/Contents/Resources',
     ];
   }
 

--- a/tests/unit/providers/codex/runtime/CodexBinaryLocator.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexBinaryLocator.test.ts
@@ -43,14 +43,46 @@ describe('CodexBinaryLocator', () => {
     expect(findCodexBinaryPath(pathDir, 'win32')).toBe(pathBinary);
   });
 
-  it('prefers the macOS Codex app bundle over generic PATH auto-detection', () => {
+  it('prefers the macOS Codex app bundle over the ChatGPT app fallback', () => {
     process.env.HOME = tempDir;
     const appDir = path.join(tempDir, 'Applications', 'Codex.app', 'Contents', 'Resources');
+    const appBinary = path.join(appDir, 'codex');
+    const chatGptAppDir = path.join(
+      tempDir,
+      'Applications',
+      'ChatGPT.app',
+      'Contents',
+      'Resources',
+    );
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.mkdirSync(chatGptAppDir, { recursive: true });
+    fs.writeFileSync(appBinary, '');
+    fs.writeFileSync(path.join(chatGptAppDir, 'codex'), '');
+
+    expect(findCodexBinaryPath('', 'darwin')).toBe(appBinary);
+  });
+
+  it('falls back to the unified macOS ChatGPT app bundle', () => {
+    process.env.HOME = tempDir;
+    const appDir = path.join(tempDir, 'Applications', 'ChatGPT.app', 'Contents', 'Resources');
     const appBinary = path.join(appDir, 'codex');
     fs.mkdirSync(appDir, { recursive: true });
     fs.writeFileSync(appBinary, '');
 
     expect(findCodexBinaryPath('', 'darwin')).toBe(appBinary);
+  });
+
+  it('prefers a user-local Codex binary over the ChatGPT app fallback', () => {
+    process.env.HOME = tempDir;
+    const localDir = path.join(tempDir, '.local', 'bin');
+    const localBinary = path.join(localDir, 'codex');
+    const appDir = path.join(tempDir, 'Applications', 'ChatGPT.app', 'Contents', 'Resources');
+    fs.mkdirSync(localDir, { recursive: true });
+    fs.mkdirSync(appDir, { recursive: true });
+    fs.writeFileSync(localBinary, '');
+    fs.writeFileSync(path.join(appDir, 'codex'), '');
+
+    expect(findCodexBinaryPath('', 'darwin')).toBe(localBinary);
   });
 
   it('honors an explicit runtime PATH before preferred macOS Codex locations', () => {


### PR DESCRIPTION
## Why

Fresh macOS installs can expose Codex only inside ChatGPT.app, so automatic model discovery fails when no standalone CLI is available.

## What

- Add user and system ChatGPT.app resource paths as fallbacks.
- Keep Codex.app and user-local CLI precedence unchanged.
- Cover fallback and precedence with unit tests.

## Why this approach

It extends the existing macOS locator without changing current resolution behavior.

## Validation

- Focused locator suite: 17 passed
- Typecheck, lint, production build: passed
- Architecture/config checks: 53 passed
- Full Jest: 8908 passed; one unrelated Collab LAN rebind test failed locally

## Impact

macOS-only fallback with no change for existing configured, Codex.app, or standalone CLI paths.

Closes #1243