### PR TITLE
fix: preserve image embeds in code

### DIFF
--- a/src/utils/imageEmbed.ts
+++ b/src/utils/imageEmbed.ts
@@ -10,6 +10,7 @@
 import type { App, TFile } from 'obsidian';
 
 import { escapeHtml } from './html';
+import { transformMarkdownSegments } from './markdownSegments';
 import { getVaultFileByPath } from './obsidianCompat';
 
 const IMAGE_EXTENSIONS = new Set([
@@ -117,23 +118,31 @@ export function replaceImageEmbedsWithHtml(
   // Reset lastIndex to avoid issues with global regex
   IMAGE_EMBED_PATTERN.lastIndex = 0;
 
-  return markdown.replace(
-    IMAGE_EMBED_PATTERN,
-    (match, imagePath: string, altText: string | undefined) => {
-      try {
-        if (!isImagePath(imagePath)) {
-          return match;
-        }
-
-        const file = resolveImageFile(app, imagePath, normalizedOptions);
-        if (!file) {
-          return createFallbackHtml(match);
-        }
-
-        return createImageHtml(app, file, altText);
-      } catch {
-        return createFallbackHtml(match);
+  return transformMarkdownSegments(markdown, {
+    wikilink: (wikilink, { embedded }) => {
+      if (!embedded) {
+        return wikilink;
       }
-    }
-  );
+
+      return wikilink.replace(
+        IMAGE_EMBED_PATTERN,
+        (match, imagePath: string, altText: string | undefined) => {
+          try {
+            if (!isImagePath(imagePath)) {
+              return match;
+            }
+
+            const file = resolveImageFile(app, imagePath, normalizedOptions);
+            if (!file) {
+              return createFallbackHtml(match);
+            }
+
+            return createImageHtml(app, file, altText);
+          } catch {
+            return createFallbackHtml(match);
+          }
+        }
+      );
+    },
+  });
 }

--- a/src/utils/markdownSegments.ts
+++ b/src/utils/markdownSegments.ts
@@ -33,11 +33,16 @@ interface MarkdownSegment {
   fence?: MarkdownFenceOpening;
   rawHtml?: boolean;
   sealed?: boolean;
+  wikilink?: MarkdownWikilink;
 }
 
 export interface MarkdownFenceOpening {
   info: string;
   infoStart: number;
+}
+
+export interface MarkdownWikilink {
+  embedded: boolean;
 }
 
 interface InlineContinuation {
@@ -262,6 +267,18 @@ function appendFenceOpeningSegment(
       infoStart,
     },
     sealed: true,
+  });
+}
+
+function appendWikilinkSegment(
+  segments: MarkdownSegment[],
+  text: string,
+  embedded: boolean,
+): void {
+  segments.push({
+    text,
+    transformable: false,
+    wikilink: { embedded },
   });
 }
 
@@ -554,14 +571,20 @@ function splitInlineMarkdown(
       continue;
     }
 
-    if (char === '[') {
-      const wikilinkEnd = findWikilinkEnd(line, index);
+    const embeddedWikilink = char === '!' && line.startsWith('![[', index);
+    if (embeddedWikilink || char === '[') {
+      const wikilinkStart = embeddedWikilink ? index + 1 : index;
+      const wikilinkEnd = findWikilinkEnd(line, wikilinkStart);
       if (wikilinkEnd !== null) {
         appendSegment(segments, line.slice(segmentStart, index), true);
-        appendSegment(segments, line.slice(index, wikilinkEnd + 1), false);
+        appendWikilinkSegment(
+          segments,
+          line.slice(index, wikilinkEnd + 1),
+          embeddedWikilink,
+        );
         segmentStart = wikilinkEnd + 1;
         index = wikilinkEnd;
-      } else if (!isBackslashEscaped(line, index)) {
+      } else if (char === '[' && !isBackslashEscaped(line, index)) {
         bracketDepth += 1;
       }
       continue;
@@ -836,6 +859,7 @@ interface MarkdownTransforms {
   fence?: (opener: string, fence: MarkdownFenceOpening) => string;
   text?: (text: string) => string;
   rawHtml?: (text: string) => string;
+  wikilink?: (wikilink: string, metadata: MarkdownWikilink) => string;
 }
 
 /** Applies targeted transforms while preserving protected Markdown syntax. */
@@ -847,6 +871,9 @@ export function transformMarkdownSegments(
     .map(segment => {
       if (segment.fence) {
         return transforms.fence?.(segment.text, segment.fence) ?? segment.text;
+      }
+      if (segment.wikilink) {
+        return transforms.wikilink?.(segment.text, segment.wikilink) ?? segment.text;
       }
       if (segment.rawHtml) {
         return transforms.rawHtml?.(segment.text) ?? segment.text;

--- a/tests/unit/utils/imageEmbed.test.ts
+++ b/tests/unit/utils/imageEmbed.test.ts
@@ -68,6 +68,67 @@ describe('replaceImageEmbedsWithHtml', () => {
       expect(result).toContain('image');
       expect(result).toContain('<img');
     });
+
+    it('replaces image embeds in text but preserves image embed syntax in inline code', () => {
+      const app = createMockApp(new Map([
+        ['visible.png', 'app://local/visible.png'],
+        ['literal.png', 'app://local/literal.png'],
+      ]));
+
+      const result = replaceImageEmbedsWithHtml(
+        'Visible ![[visible.png]] and `literal ![[literal.png]]`',
+        app
+      );
+
+      expect(result).toBe(
+        'Visible <span class="claudian-embedded-image"><img src="app://local/visible.png" alt="visible" loading="lazy"></span> and `literal ![[literal.png]]`'
+      );
+    });
+  });
+
+  describe('code syntax', () => {
+    it('preserves image embed syntax in backtick and tilde fences', () => {
+      const app = createMockApp(new Map([
+        ['visible.png', 'app://local/visible.png'],
+        ['backtick.png', 'app://local/backtick.png'],
+        ['tilde.png', 'app://local/tilde.png'],
+      ]));
+      const markdown = [
+        '![[visible.png]]',
+        '',
+        '```md',
+        '![[backtick.png]]',
+        '```',
+        '',
+        '~~~md',
+        '![[tilde.png]]',
+        '~~~',
+      ].join('\n');
+
+      const result = replaceImageEmbedsWithHtml(markdown, app);
+
+      expect(result).toContain('src="app://local/visible.png"');
+      expect(result).toContain('```md\n![[backtick.png]]\n```');
+      expect(result).toContain('~~~md\n![[tilde.png]]\n~~~');
+      expect(result).not.toContain('src="app://local/backtick.png"');
+      expect(result).not.toContain('src="app://local/tilde.png"');
+    });
+
+    it('preserves image embed syntax in indented code', () => {
+      const app = createMockApp(new Map([
+        ['visible.png', 'app://local/visible.png'],
+        ['literal.png', 'app://local/literal.png'],
+      ]));
+
+      const result = replaceImageEmbedsWithHtml(
+        '![[visible.png]]\n\n    ![[literal.png]]',
+        app
+      );
+
+      expect(result).toContain('src="app://local/visible.png"');
+      expect(result).toContain('\n\n    ![[literal.png]]');
+      expect(result).not.toContain('src="app://local/literal.png"');
+    });
   });
 
   describe('alt text and dimensions', () => {


### PR DESCRIPTION
## Why

Claudian converts Obsidian image embeds to trusted HTML before Markdown rendering. Because the conversion previously scanned the complete Markdown source, an embed shown as literal inline, fenced, or indented code was converted too, leaving raw generated HTML inside the rendered code example.

Fixes #1245.

## What Changed

- Preserve complete regular and embedded wikilinks as explicit segments in the shared Markdown boundary.
- Let image-embed conversion opt into embedded wikilink segments outside protected code contexts.
- Add regression coverage for mixed visible/inline-code embeds, backtick and tilde fences, and indented code.

## Why This Approach

The existing Markdown segmenter already owns protected syntax boundaries for code and other Markdown constructs. Extending its internal transform contract avoids introducing a second parser in the image utility. The new callback is optional, so existing HTML, math, and display-only-fence consumers continue to preserve wikilinks unchanged.

Image resolution, media-folder handling, alt text and dimensions, fallback markup, and HTML escaping remain owned by the existing image utility.

## Validation

- Focused utility and rendering tests: 6 suites, 166 tests passed.
- `npm run typecheck`
- `npm run lint`
- `npm run test:architecture` — 41/41 passed.
- `npm run test` — 607 suites and 8,913 tests passed; 2 suites and 2 tests skipped; script tests 53/53 passed.
- `npm run build`
- `git diff --check`

## Impact and Follow-ups

No settings, storage, provider, dependency, or rendering-order changes. Image embeds outside code continue to render as images; inline, fenced, and indented code now retain their literal source.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
