### PR TITLE
fix: consume protocol backup continuity correction

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "claudian",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.226",
-        "@claudian-collab/protocol": "4.1.3",
+        "@claudian-collab/protocol": "4.1.4",
         "@codemirror/commands": "6.10.0",
         "@codemirror/lang-markdown": "^6.5.2",
         "@codemirror/language": "^6.12.4",
@@ -165,7 +165,7 @@
 
     "@cacheable/utils": ["@cacheable/utils@2.5.0", "", { "dependencies": { "hashery": "^1.5.1", "keyv": "^5.6.0" } }, "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA=="],
 
-    "@claudian-collab/protocol": ["@claudian-collab/protocol@4.1.3", "", { "dependencies": { "@lezer/markdown": "1.7.2" } }, "sha512-WU1Z8GXd5B6wLmZxHnl3MqI6DCkNF+5QTDzIT/pOGy0xoyQwHc2UP6V9MzlZPZ66k+85ppZcmUjb9kfYQHw0mg=="],
+    "@claudian-collab/protocol": ["@claudian-collab/protocol@4.1.4", "", { "dependencies": { "@lezer/markdown": "1.7.2" } }, "sha512-bf9fBnScpuWEbRism3ng6FUP35TRnCJfAQOgooQxQr1aOGZU2MTYzq6ISDoLkDUmQynQJBxgH8p8svgRo7HV9g=="],
 
     "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.226",
-        "@claudian-collab/protocol": "4.1.3",
+        "@claudian-collab/protocol": "4.1.4",
         "@codemirror/commands": "6.10.0",
         "@codemirror/lang-markdown": "^6.5.2",
         "@codemirror/language": "^6.12.4",
@@ -831,9 +831,9 @@
       }
     },
     "node_modules/@claudian-collab/protocol": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@claudian-collab/protocol/-/protocol-4.1.3.tgz",
-      "integrity": "sha512-WU1Z8GXd5B6wLmZxHnl3MqI6DCkNF+5QTDzIT/pOGy0xoyQwHc2UP6V9MzlZPZ66k+85ppZcmUjb9kfYQHw0mg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@claudian-collab/protocol/-/protocol-4.1.4.tgz",
+      "integrity": "sha512-bf9fBnScpuWEbRism3ng6FUP35TRnCJfAQOgooQxQr1aOGZU2MTYzq6ISDoLkDUmQynQJBxgH8p8svgRo7HV9g==",
       "license": "MIT",
       "dependencies": {
         "@lezer/markdown": "1.7.2"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.226",
-    "@claudian-collab/protocol": "4.1.3",
+    "@claudian-collab/protocol": "4.1.4",
     "@codemirror/commands": "6.10.0",
     "@codemirror/lang-markdown": "^6.5.2",
     "@codemirror/language": "^6.12.4",

--- a/scripts/check-architecture-boundaries.test.mjs
+++ b/scripts/check-architecture-boundaries.test.mjs
@@ -682,21 +682,21 @@ test('Claudian consumes the standalone Collab protocol only from the exact regis
 
   const protocol = await import(protocolPackageName);
 
-  assert.equal(manifest.dependencies?.[protocolPackageName], '4.1.3');
+  assert.equal(manifest.dependencies?.[protocolPackageName], '4.1.4');
   assert.equal(manifest.dependencies?.['@lezer/markdown'], '1.7.2');
   assert.equal(protocolManifest.dependencies?.['@lezer/markdown'], '1.7.2');
   assert.equal(manifest.dependencies?.['@claudian/collab-protocol'], undefined);
   assert.equal(manifest.workspaces, undefined);
-  assert.equal(lockfile.packages?.['']?.dependencies?.[protocolPackageName], '4.1.3');
-  assert.equal(lockfile.packages?.[protocolInstallPath]?.version, '4.1.3');
+  assert.equal(lockfile.packages?.['']?.dependencies?.[protocolPackageName], '4.1.4');
+  assert.equal(lockfile.packages?.[protocolInstallPath]?.version, '4.1.4');
   assert.equal(
     lockfile.packages?.[protocolInstallPath]?.integrity,
-    'sha512-WU1Z8GXd5B6wLmZxHnl3MqI6DCkNF+5QTDzIT/pOGy0xoyQwHc2UP6V9MzlZPZ66k+85ppZcmUjb9kfYQHw0mg==',
+    'sha512-bf9fBnScpuWEbRism3ng6FUP35TRnCJfAQOgooQxQr1aOGZU2MTYzq6ISDoLkDUmQynQJBxgH8p8svgRo7HV9g==',
   );
   assert.equal(lockfile.packages?.['node_modules/@lezer/markdown']?.version, '1.7.2');
   assert.match(
     lockfile.packages?.[protocolInstallPath]?.resolved ?? '',
-    /^https:\/\/registry\.npmjs\.org\/@claudian-collab\/protocol\/-\/protocol-4\.1\.3\.tgz$/u,
+    /^https:\/\/registry\.npmjs\.org\/@claudian-collab\/protocol\/-\/protocol-4\.1\.4\.tgz$/u,
   );
   assert.equal(protocol.COLLAB_PROTOCOL_VERSION, 8);
   assert.equal(protocol.COLLAB_CLOUD_BINDING_VERSION, 4);


### PR DESCRIPTION
## Why

Step 14 restart acceptance exposed a Protocol backup-v3 continuity decoder defect after a LAN-to-Cloud transfer gained a later Cloud member. Claudian must consume the corrected exact registry release before the physical two-Mac restart matrix resumes. No issue is needed because this is tracked by the Step 14 acceptance gate.

## What Changed

- Pin @claudian-collab/protocol exactly to 4.1.4 in the npm and Bun manifests and lockfiles.
- Update the architecture contract test to lock the exact version, registry URL, integrity, wire 8, Cloud binding 4, and backup format 3.

## Why This Approach

The standalone Protocol package remains the only wire and backup contract owner. Claudian receives the producer correction without duplicating decoder policy or adding compatibility paths.

## Validation

- fnm exec --using=24.16.0 npm run typecheck
- fnm exec --using=24.16.0 npm run lint
- fnm exec --using=24.16.0 npm test (621 suites / 9,432 tests passed; 2 existing skips)
- fnm exec --using=24.16.0 npm run build
- node --test scripts/check-architecture-boundaries.test.mjs (42/42)
- Fresh adversarial review: no P0-P2 findings

## Impact and Follow-ups

No wire, Cloud binding, backup format, UI, or LAN migration change. Physical two-Mac Step 14 acceptance continues after the matching Cloud Server deployment.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.