### PR TITLE
Fix Cloud Member Leave binding privacy

### DIFF
--- a/src/app/collab/exit/PendingLeaveAuthorityService.ts
+++ b/src/app/collab/exit/PendingLeaveAuthorityService.ts
@@ -30,6 +30,10 @@ import { CollabError } from '@/core/collab/ClaudianCollabError';
 
 const CONTROL_TIMEOUT_MS = 10_000;
 
+function expectedSelfBindingState(role: 'manager' | 'member'): 'bound' | 'hidden' {
+  return role === 'manager' ? 'bound' : 'hidden';
+}
+
 export interface PendingLeaveAuthorityClientPort {
   leaveProject(input: LeaveProjectInput): Promise<MembershipTerminationResponse>;
   readSnapshot(
@@ -174,7 +178,7 @@ export class PendingLeaveAuthorityService {
         : [];
       if (
         matching.length !== 1
-        || matching[0]?.bindingState !== 'bound'
+        || matching[0]?.bindingState !== expectedSelfBindingState(snapshot.currentMember.role)
         || matching[0].role !== snapshot.currentMember.role
       ) {
         throw integrityError('cloud-pending-leave-recovery-member-mismatch');
@@ -278,7 +282,7 @@ export class PendingLeaveAuthorityService {
       const matching = listed.members.filter(member => member.memberId === pending.memberId);
       if (
         matching.length !== 1
-        || matching[0]?.bindingState !== 'bound'
+        || matching[0]?.bindingState !== expectedSelfBindingState(snapshot.currentMember.role)
         || matching[0].role !== snapshot.currentMember.role
       ) {
         throw integrityError('cloud-pending-leave-member-identity-mismatch');

--- a/tests/unit/app/collab/exit/PendingLeaveAuthorityService.test.ts
+++ b/tests/unit/app/collab/exit/PendingLeaveAuthorityService.test.ts
@@ -185,6 +185,17 @@ describe('PendingLeaveAuthorityService', () => {
     expect(client.dispose).toHaveBeenCalledTimes(1);
   });
 
+  it('accepts the protocol-hidden self binding when recovering a rejected Cloud Member Leave', async () => {
+    const client = cloudClientPort();
+    const service = new PendingLeaveAuthorityService({
+      createCloudClient: async () => client,
+    });
+
+    await expect(service.recoverRejected({
+      pending: submittedCloudRecord(),
+    })).resolves.toEqual({ memberRole: 'member' });
+  });
+
   it('replays a submitted Cloud Leave without active snapshot, member list, or Git', async () => {
     const client = cloudClientPort();
     client.readSnapshot.mockRejectedValue(new Error('membership is already gone'));
@@ -468,7 +479,7 @@ function cloudClientPort(
   role: 'manager' | 'member' = 'member',
 ): jest.Mocked<CloudPendingLeaveAuthorityClientPort & { dispose(): void }> {
   const member = {
-    bindingState: 'bound' as const,
+    bindingState: role === 'manager' ? 'bound' as const : 'hidden' as const,
     displayName: 'Alice',
     importedClaimGeneration: null,
     importedClaimState: 'not-applicable' as const,


### PR DESCRIPTION
## Summary
- accept the protocol-defined hidden binding projection when the current Cloud caller is a Member
- continue requiring an explicit bound projection for Managers
- cover fresh Leave preparation and rejected-request recovery

## Verification
- `npm test` — 621 suites passed, 9,473 tests passed, 2 skipped
- focused Leave unit/integration suites — 20 passed
- `npm run typecheck`
- `npm run lint`
- `npm run check:diff`
- `npm run build`
- `npm run check:performance`
- fresh read-only review: no P0–P2 findings
- installed-UI reproduction: a current-format two-Member Cloud Project failed before the fix with `cloud-pending-leave-member-identity-mismatch`

## Boundaries
- targets `codex/cloud-integration`, not `main`
- exact `@claudian-collab/protocol@4.1.4` remains unchanged
- no legacy Cloud migration, server/authentication change, main merge, or release