### PR TITLE
fix: disable assistant layout isolation on Windows

### DIFF
--- a/src/style/components/messages.css
+++ b/src/style/components/messages.css
@@ -319,6 +319,11 @@
   text-align: start;
 }
 
+body.mod-windows .claudian-message-assistant {
+  content-visibility: visible;
+  contain-intrinsic-size: none;
+}
+
 .claudian-message-content {
   line-height: 1.5;
   user-select: text;

--- a/tests/unit/style/components/messages.test.ts
+++ b/tests/unit/style/components/messages.test.ts
@@ -1,20 +1,55 @@
+/** @jest-environment jsdom */
+
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
 describe('Long conversation message styles', () => {
   const css = readFileSync(path.resolve('src/style/components/messages.css'), 'utf8');
 
-  it('isolates assistant layout without containing user message actions', () => {
-    const messageRule = css.match(/\.claudian-message\s*{[^}]*}/)?.[0];
-    expect(messageRule).not.toContain('content-visibility: auto;');
+  afterEach(() => {
+    document.head.querySelector('[data-testid="messages-styles"]')?.remove();
+    document.body.replaceChildren();
+    document.body.removeAttribute('class');
+  });
 
-    const userRule = css.match(/\.claudian-message-user\s*{[^}]*}/)?.[0];
-    expect(userRule).not.toContain('content-visibility: auto;');
-    expect(userRule).not.toContain('contain-intrinsic-size:');
+  function getAssistantStyle(platformClass: string): CSSStyleDeclaration {
+    const style = document.createElement('style');
+    style.dataset.testid = 'messages-styles';
+    style.textContent = css;
+    document.head.appendChild(style);
 
-    const assistantRule = css.match(/\.claudian-message-assistant\s*{[^}]*}/)?.[0];
-    expect(assistantRule).toContain('flex-shrink: 0;');
-    expect(assistantRule).toContain('content-visibility: auto;');
-    expect(assistantRule).toContain('contain-intrinsic-size: auto 23.5rem;');
+    document.body.classList.add(platformClass);
+    const assistantMessage = document.createElement('div');
+    assistantMessage.className = 'claudian-message-assistant';
+    document.body.appendChild(assistantMessage);
+
+    return window.getComputedStyle(assistantMessage);
+  }
+
+  it('disables assistant layout isolation on Windows', () => {
+    const assistantStyle = getAssistantStyle('mod-windows');
+
+    expect({
+      contentVisibility: assistantStyle.getPropertyValue('content-visibility'),
+      containIntrinsicSize: assistantStyle.getPropertyValue('contain-intrinsic-size'),
+    }).toEqual({
+      contentVisibility: 'visible',
+      containIntrinsicSize: 'none',
+    });
+  });
+
+  it.each([
+    ['macOS', 'mod-macos'],
+    ['Linux', 'mod-linux'],
+  ])('keeps assistant layout isolation on %s', (_platform, platformClass) => {
+    const assistantStyle = getAssistantStyle(platformClass);
+
+    expect({
+      contentVisibility: assistantStyle.getPropertyValue('content-visibility'),
+      containIntrinsicSize: assistantStyle.getPropertyValue('contain-intrinsic-size'),
+    }).toEqual({
+      contentVisibility: 'auto',
+      containIntrinsicSize: 'auto 23.5rem',
+    });
   });
 });


### PR DESCRIPTION
## Why

Issue #1256 reports a Claudian 2.2.5 regression on two Windows 11 machines: fast upward scrolling through long, image-heavy conversations can leave the Obsidian renderer solid black or white until restart. Disabling hardware acceleration and updating the graphics driver did not change the failure. The reporter isolated the regression to the assistant-message layout isolation added in #1155; overriding it to `content-visibility: visible` and `contain-intrinsic-size: none` prevented the crash across three repeated stress scrolls on the laptop.

Refs #1256

## What Changed

- Disable assistant-message layout isolation only under Obsidian's official `body.mod-windows` platform class.
- Preserve the existing offscreen optimization on macOS and Linux, along with `flex-shrink: 0` and all existing message behavior.
- Replace static CSS-source assertions with computed-style tests that exercise the actual platform selector and cascade.

## Why This Approach

All confirmed crash evidence is Windows-specific, so a platform-scoped override matches the observed boundary without globally removing #1155's measured long-transcript performance improvement. Obsidian has exposed `.mod-windows`, `.mod-macos`, and `.mod-linux` on `<body>` since v0.9.0, so the fix does not require a new runtime platform class or TypeScript lifecycle change.

The Windows selector is more specific than the base assistant rule, so no `!important` is needed. A global rollback was considered, but it would also remove the optimization from platforms with no reported crash.

## Validation

- Red: before the CSS override, the Windows computed-style test received `auto` / `auto 23.5rem` instead of the reporter-validated `visible` / `none` behavior.
- Green: Windows now computes `visible` / `none`; macOS and Linux remain `auto` / `auto 23.5rem`.
- `npm run test:unit -- --runTestsByPath tests/unit/style/components/messages.test.ts --runInBand`
- `npm run build:css`
- `npm run typecheck`
- `npm run lint`
- `npm run test:architecture` (41/41)
- `npm run test` (607 suites / 8,918 tests passed; 2 tests skipped by the repository suite)
- `npm run build`
- `git diff --check`

The automated test verifies the platform route and final CSS cascade. It does not simulate Electron/GPU renderer failure; validation on the reporter's two Windows systems is still requested before treating the issue as closed.

## Impact and Follow-ups

Windows no longer receives the assistant-message offscreen layout optimization from #1155, trading that performance improvement for the reporter-validated stable rendering behavior. macOS and Linux retain the optimization. There are no message lifecycle, persistence, provider, image-rendering, or public API changes.

A future rendering optimization for Windows should include stress validation with long, image-heavy conversations before restoring containment there.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed (not needed for this platform-specific regression fix).