### PR TITLE
fix: distinguish inline code in chat messages

### DIFF
--- a/src/style/components/code.css
+++ b/src/style/components/code.css
@@ -37,6 +37,15 @@ body.theme-light .claudian-message-content pre {
   font-size: 13px;
 }
 
+.claudian-container .claudian-message-content :not(pre) > code {
+  background-color: var(--code-background, var(--background-secondary));
+  color: var(--code-normal, var(--text-normal));
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+}
+
 /* Clickable language label - positioned outside scroll area */
 .claudian-code-wrapper .claudian-code-lang-label {
   position: absolute;

--- a/tests/unit/style/components/code.test.ts
+++ b/tests/unit/style/components/code.test.ts
@@ -1,0 +1,86 @@
+/** @jest-environment jsdom */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+describe('Chat code styles', () => {
+  const css = readFileSync(path.resolve('src/style/components/code.css'), 'utf8');
+
+  afterEach(() => {
+    document.head.querySelector('[data-testid="code-styles"]')?.remove();
+    document.body.replaceChildren();
+    document.body.removeAttribute('class');
+  });
+
+  function renderCodeSamples(): {
+    blockCode: HTMLElement;
+    inlineCode: HTMLElement;
+    pre: HTMLPreElement;
+  } {
+    const style = document.createElement('style');
+    style.dataset.testid = 'code-styles';
+    style.textContent = css;
+    document.head.appendChild(style);
+
+    document.body.innerHTML = `
+      <div class="claudian-container">
+        <div class="claudian-message-content">
+          <p>Use <code data-testid="inline-code">test</code></p>
+          <pre><code data-testid="block-code">block</code></pre>
+        </div>
+      </div>
+    `;
+
+    return {
+      blockCode: document.querySelector('[data-testid="block-code"]') as HTMLElement,
+      inlineCode: document.querySelector('[data-testid="inline-code"]') as HTMLElement,
+      pre: document.querySelector('pre') as HTMLPreElement,
+    };
+  }
+
+  it('gives inline code a readable surface inside chat messages', () => {
+    const { inlineCode } = renderCodeSamples();
+    const inlineStyle = window.getComputedStyle(inlineCode);
+
+    expect({
+      backgroundColor: inlineStyle.backgroundColor,
+      borderRadius: inlineStyle.borderRadius,
+      boxDecorationBreak: inlineStyle.getPropertyValue('box-decoration-break'),
+      color: inlineStyle.color,
+      padding: inlineStyle.padding,
+    }).toEqual({
+      backgroundColor: 'var(--code-background, var(--background-secondary))',
+      borderRadius: '4px',
+      boxDecorationBreak: 'clone',
+      color: 'var(--code-normal, var(--text-normal))',
+      padding: '0.1em 0.35em',
+    });
+  });
+
+  it('keeps the existing code block surface on pre instead of its code child', () => {
+    const { blockCode, pre } = renderCodeSamples();
+    const blockCodeStyle = window.getComputedStyle(blockCode);
+    const preStyle = window.getComputedStyle(pre);
+
+    expect({
+      backgroundColor: preStyle.backgroundColor,
+      borderRadius: preStyle.borderRadius,
+      padding: preStyle.padding,
+    }).toEqual({
+      backgroundColor: 'rgba(0, 0, 0, 0.2)',
+      borderRadius: '6px',
+      padding: '8px 12px',
+    });
+    expect({
+      backgroundColor: blockCodeStyle.backgroundColor,
+      borderRadius: blockCodeStyle.borderRadius,
+      boxDecorationBreak: blockCodeStyle.getPropertyValue('box-decoration-break'),
+      padding: blockCodeStyle.padding,
+    }).toEqual({
+      backgroundColor: 'rgba(0, 0, 0, 0)',
+      borderRadius: '',
+      boxDecorationBreak: '',
+      padding: '',
+    });
+  });
+});


### PR DESCRIPTION
## Why

Inline code in Claudian chat currently has only a monospace font and fixed size. With themes or font configurations where surrounding text is also monospace, commands, paths, identifiers, and Markdown examples can become visually indistinguishable from ordinary prose. The behavior reported in #1246 is still present on current `main`: inline `<code>` computes to a transparent background with no padding or radius.

Fixes #1246

## What Changed

- Give inline code inside Claudian chat messages a theme-aware background and text color, compact padding, rounded corners, and cloned decoration when a token wraps.
- Scope the rule to non-`pre` code inside `.claudian-container .claudian-message-content`.
- Add computed-style coverage for both inline code and the existing code-block surface.

## Why This Approach

The rule uses Obsidian's semantic `--code-background` and `--code-normal` variables, with standard Obsidian surface/text fallbacks, so themes retain control of the actual colors. The Claudian container scope is specific enough to win over the reported theme rules without using `!important` or adding a theme-specific selector.

The `:not(pre) > code` boundary keeps fenced code unchanged: its surface remains owned by the existing `pre` rule, including the current background, spacing, overflow, language label, and copy behavior. No Markdown rendering or provider code changes are needed.

## Validation

- Red: before the new rule, the inline sample computed to a transparent background with empty padding, radius, and box-decoration values.
- Green: inline code now computes the theme-variable surface, `0.1em 0.35em` padding, `4px` radius, and cloned box decoration; `pre > code` remains unstyled while the `pre` retains its existing block surface.
- `npm run test:unit -- --runTestsByPath tests/unit/style/components/code.test.ts --runInBand`
- `npm run build:css`
- `npm run typecheck`
- `npm run lint`
- `npm run test:architecture` (41/41)
- `npm run test` (608 suites / 8,918 tests passed; 2 tests skipped by the repository suite)
- `npm run build`
- `git diff --check`

## Impact and Follow-ups

The change is limited to inline code in Claudian chat messages. Code blocks, Mermaid rendering, Inline Edit, settings, Collab surfaces, persistence, and providers are unchanged. No dependency or public API changes.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed (not needed for this scoped visual fix).