### PR TITLE
refactor: simplify LAN collaboration routing and transport

### DIFF
--- a/src/app/collab/lan/CollabControlOperationBindings.ts
+++ b/src/app/collab/lan/CollabControlOperationBindings.ts
@@ -72,12 +72,14 @@ export const COLLAB_CONTROL_OPERATION_BINDINGS = {
 
 function binding<
   Method extends CollabControlOperationBinding['method'],
+  Authentication extends CollabControlAuthentication,
+  Admission extends CollabControlAdmission,
 >(
   method: Method,
   route: string,
   family: CollabControlOperationBinding['family'],
-  authentication: CollabControlOperationBinding['authentication'],
-  admission: CollabControlOperationBinding['admission'],
+  authentication: Authentication,
+  admission: Admission,
   requestSource: CollabControlOperationBinding['requestSource'],
   successStatus: 200 | 201,
 ) {

--- a/src/app/collab/lan/CollabControlRouter.ts
+++ b/src/app/collab/lan/CollabControlRouter.ts
@@ -20,10 +20,7 @@ import {
   TerminalLifecycleGateway,
 } from '@/app/collab/lan/lifecycle/LifecycleGateway';
 import { handleJoinRoute } from '@/app/collab/lan/routes/JoinRoutes';
-import {
-  handleLifecycleRoute,
-  isLifecycleControlRoute,
-} from '@/app/collab/lan/routes/LifecycleRoutes';
+import { handleLifecycleRoute } from '@/app/collab/lan/routes/LifecycleRoutes';
 import { handleMembershipRoute } from '@/app/collab/lan/routes/MembershipRoutes';
 import { handleProjectRoute } from '@/app/collab/lan/routes/ProjectRoutes';
 import { handleRequestRoute } from '@/app/collab/lan/routes/RequestRoutes';
@@ -417,12 +414,10 @@ export class CollabControlRouter {
           authorization: singleHeader(request.headers, 'authorization'),
           body,
           idempotencyKey: singleHeader(request.headers, 'idempotency-key'),
-          method: request.method ?? '',
-          ...(operationMatch ? { operationMatch } : {}),
+          operationMatch,
           projectId: route.projectId,
           query: route.query,
           remoteAddress: normalizeRemoteAddress(request.socket.remoteAddress),
-          segments: route.segments,
           lifecycle: terminal.lifecycle,
         }, terminal.service);
         invokeAfterResponseFlush(response, result.afterResponseFlushed);
@@ -434,23 +429,18 @@ export class CollabControlRouter {
         });
         return;
       }
-      const routeRequest: CollabControlRouteRequest = {
+      const dispatch = () => operationMatch ? this.dispatch({
         authorization: singleHeader(request.headers, 'authorization'),
         body,
         idempotencyKey: singleHeader(request.headers, 'idempotency-key'),
         lifecycle: registered.routing.lifecycle,
-        method: request.method ?? '',
-        ...(operationMatch ? { operationMatch } : {}),
+        operationMatch,
         projectId: route.projectId,
         query: route.query,
         remoteAddress: normalizeRemoteAddress(request.socket.remoteAddress),
-        segments: route.segments,
         service: registered.service,
-      };
-      const dispatch = () => this.dispatch(routeRequest);
-      const lifecycleRoute = operationBinding
-        ? operationBinding.family === 'lifecycle'
-        : isLifecycleControlRoute(request.method, route.segments);
+      }) : Promise.resolve(null);
+      const lifecycleRoute = operationBinding?.family === 'lifecycle';
       const requiresOuterAdmission = operationBinding
         ? operationBinding.admission === 'active' && !lifecycleRoute
         : !lifecycleRoute;
@@ -522,9 +512,7 @@ export class CollabControlRouter {
   private async dispatch(
     request: CollabControlRouteRequest,
   ): Promise<CollabControlRouteResult | null> {
-    const match = request.operationMatch
-      ?? matchCollabControlOperation(request.method, request.segments);
-    if (!match) return null;
+    const match = request.operationMatch;
     switch (COLLAB_CONTROL_OPERATION_BINDINGS[match.operation].family) {
       case 'join': return handleJoinRoute(request);
       case 'request': return handleRequestRoute(request);
@@ -539,11 +527,12 @@ export class CollabControlRouter {
     request: CollabTerminalControlRouteRequest,
     terminal: CollabTerminalProjectService,
   ): Promise<CollabControlRouteResult> {
-    const operation = request.operationMatch?.operation;
+    const match = request.operationMatch;
+    const operation = match?.operation;
     const isAcknowledgement = operation === 'acknowledgeRetirement';
     const isHostTransitions = operation === 'getHostTransitions';
-    if (isAcknowledgement || isHostTransitions) {
-      const result = await handleLifecycleRoute(request);
+    if (match && (isAcknowledgement || isHostTransitions)) {
+      const result = await handleLifecycleRoute({ ...request, operationMatch: match });
       if (result) return result;
     }
     if (!request.authorization?.startsWith('Bearer ')) {

--- a/src/app/collab/lan/CollabHttpClient.ts
+++ b/src/app/collab/lan/CollabHttpClient.ts
@@ -1,5 +1,4 @@
 import { randomUUID, X509Certificate } from 'node:crypto';
-import { request as httpsRequest } from 'node:https';
 import { connect as connectTls, type DetailedPeerCertificate } from 'node:tls';
 
 import { isCollabOpaqueId, isCollabProjectId } from '@claudian-collab/protocol';
@@ -9,6 +8,7 @@ import {
   type CollabControlOperationBinding,
   matchCollabControlOperation,
 } from '@/app/collab/lan/CollabControlOperationBindings';
+import { HttpsRequestError, isTlsValidationError, requestHttpsBytes } from '@/app/collab/lan/httpsRequest';
 import {
   InvitationCodec,
   type LanCollabInvitation,
@@ -152,16 +152,6 @@ function readPresentedRoot(peer: DetailedPeerCertificate): Buffer {
     throw transportError('tls-untrusted', 'tls-presented-root-invalid');
   }
   return Buffer.from(current.raw);
-}
-
-function isTlsValidationError(error: unknown): boolean {
-  const code = (error as NodeJS.ErrnoException)?.code ?? '';
-  return code.includes('CERT')
-    || code.includes('TLS')
-    || code === 'DEPTH_ZERO_SELF_SIGNED_CERT'
-    || code === 'SELF_SIGNED_CERT_IN_CHAIN'
-    || code === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'
-    || code === 'ERR_TLS_CERT_ALTNAME_INVALID';
 }
 
 function validateTimeout(timeoutMs: number): number {
@@ -458,111 +448,60 @@ export class PinnedCollabHttpClient {
       throw transportError('protocol-payload-invalid', 'control-request-too-large');
     }
     const endpoint = new URL(this.trust.endpoint);
-    const responseValue = await new Promise<unknown>((resolve, reject) => {
-      let settled = false;
-      const finish = (operation: () => void) => {
-        if (settled) return;
-        settled = true;
-        window.clearTimeout(timer);
-        options.signal?.removeEventListener('abort', onAbort);
-        operation();
-      };
-      const nodeRequest = httpsRequest({
-        ca: this.trust.caCertificatePem,
-        headers: {
-          accept: 'application/json',
-          ...(authorization ? { authorization } : {}),
-          ...(body ? {
-            'content-length': String(body.length),
-            'content-type': 'application/json',
-          } : {}),
-          ...(request.idempotencyKey
-            ? { 'idempotency-key': request.idempotencyKey }
-            : {}),
-          'x-request-id': randomUUID(),
-        },
-        hostname: endpoint.hostname,
-        method: request.method,
-        minVersion: 'TLSv1.2',
-        path: request.path,
-        port: Number(endpoint.port),
-        rejectUnauthorized: true,
-      }, response => {
-        const chunks: Buffer[] = [];
-        let bytes = 0;
-        response.on('data', (chunk: Buffer | string) => {
-          const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-          bytes += buffer.length;
-          if (bytes > COLLAB_CONTROL_MAX_BODY_BYTES) {
-            response.destroy();
-            finish(() => reject(transportError(
-              'protocol-payload-invalid',
-              'control-response-too-large',
-            )));
-            return;
-          }
-          chunks.push(buffer);
-        });
-        response.once('error', () => {
-          finish(() => reject(transportError(
-            'endpoint-unreachable',
-            'control-response-failed',
-          )));
-        });
-        response.once('end', () => {
-          if (settled) return;
-          const statusCode = response.statusCode ?? 0;
-          try {
-            const contents = Buffer.concat(chunks).toString('utf8');
-            const parsed: unknown = contents.length === 0
-              ? null
-              : JSON.parse(contents) as unknown;
-            if (statusCode < 200 || statusCode >= 300) {
-              const stateError = statusCode === 409 || statusCode === 410
-                ? protocolStructuredError(parsed)
-                : null;
-              finish(() => reject(
-                stateError ?? responseStatusError(statusCode, authenticationKind),
-              ));
-              return;
-            }
-            finish(() => resolve(parsed));
-          } catch {
-            finish(() => reject(
-              statusCode < 200 || statusCode >= 300
-                ? responseStatusError(statusCode, authenticationKind)
-                : transportError(
-                  'protocol-payload-invalid',
-                  'control-response-json-invalid',
-                ),
-            ));
-          }
-        });
-      });
-      const onAbort = () => {
-        finish(() => {
-          nodeRequest.destroy();
-          reject(transportError('cancelled', 'transport-aborted'));
-        });
-      };
-      const timer = window.setTimeout(() => {
-        finish(() => {
-          nodeRequest.destroy();
-          reject(transportError('operation-timeout', 'control-request-timeout'));
-        });
-      }, timeoutMs);
-      options.signal?.addEventListener('abort', onAbort, { once: true });
-      nodeRequest.once('error', error => {
-        finish(() => reject(transportError(
-          isTlsValidationError(error) ? 'tls-untrusted' : 'endpoint-unreachable',
-          isTlsValidationError(error)
-            ? 'control-tls-validation-failed'
-            : 'control-connection-failed',
-        )));
-      });
-      if (body) nodeRequest.write(body);
-      nodeRequest.end();
+    const response = await requestHttpsBytes({
+      ca: this.trust.caCertificatePem,
+      headers: {
+        accept: 'application/json',
+        ...(authorization ? { authorization } : {}),
+        ...(body ? {
+          'content-length': String(body.length),
+          'content-type': 'application/json',
+        } : {}),
+        ...(request.idempotencyKey
+          ? { 'idempotency-key': request.idempotencyKey }
+          : {}),
+        'x-request-id': randomUUID(),
+      },
+      hostname: endpoint.hostname,
+      method: request.method,
+      path: request.path,
+      port: Number(endpoint.port),
+    }, {
+      body,
+      maxResponseBytes: COLLAB_CONTROL_MAX_BODY_BYTES,
+      signal: options.signal,
+      timeoutMs,
+    }).catch((error: unknown) => {
+      if (!(error instanceof HttpsRequestError)) throw error;
+      switch (error.reason) {
+        case 'cancelled': throw transportError('cancelled', 'transport-aborted');
+        case 'timeout': throw transportError('operation-timeout', 'control-request-timeout');
+        case 'response-too-large':
+          throw transportError('protocol-payload-invalid', 'control-response-too-large');
+        case 'response-failed':
+          throw transportError('endpoint-unreachable', 'control-response-failed');
+        case 'tls-untrusted':
+          throw transportError('tls-untrusted', 'control-tls-validation-failed');
+        case 'connection-failed':
+          throw transportError('endpoint-unreachable', 'control-connection-failed');
+      }
     });
+    const { statusCode } = response;
+    let responseValue: unknown;
+    try {
+      const contents = response.body.toString('utf8');
+      responseValue = contents.length === 0 ? null : JSON.parse(contents) as unknown;
+    } catch {
+      throw statusCode < 200 || statusCode >= 300
+        ? responseStatusError(statusCode, authenticationKind)
+        : transportError('protocol-payload-invalid', 'control-response-json-invalid');
+    }
+    if (statusCode < 200 || statusCode >= 300) {
+      const stateError = statusCode === 409 || statusCode === 410
+        ? protocolStructuredError(responseValue)
+        : null;
+      throw stateError ?? responseStatusError(statusCode, authenticationKind);
+    }
     try {
       return request.decode(responseValue);
     } catch {

--- a/src/app/collab/lan/authority-transfer/LanAuthorityTransferClient.ts
+++ b/src/app/collab/lan/authority-transfer/LanAuthorityTransferClient.ts
@@ -1,5 +1,4 @@
 import { randomUUID, X509Certificate } from 'node:crypto';
-import { request as httpsRequest } from 'node:https';
 
 import {
   type ClaimTransferredMembershipRequest,
@@ -20,6 +19,7 @@ import {
   COLLAB_LAN_AUTHORITY_TRANSFER_BINDING_VERSION,
   collabLanAuthorityTransferOperationPath,
 } from '@/app/collab/lan/authority-transfer/LanAuthorityTransferBinding';
+import { HttpsRequestError, requestHttpsBytes } from '@/app/collab/lan/httpsRequest';
 import { fingerprintCertificatePem } from '@/app/collab/lan/LanTlsIdentity';
 import { CollabError } from '@/core/collab/ClaudianCollabError';
 
@@ -165,16 +165,6 @@ function validateTrust(trust: LanAuthorityTransferTrustedHost): ValidatedTrust {
     throw clientError('operation-failed', 'authority-transfer-endpoint-invalid');
   }
   return { caCertificatePem, endpoint };
-}
-
-function isTlsValidationError(error: unknown): boolean {
-  const code = (error as NodeJS.ErrnoException)?.code ?? '';
-  return code.includes('CERT')
-    || code.includes('TLS')
-    || code === 'DEPTH_ZERO_SELF_SIGNED_CERT'
-    || code === 'SELF_SIGNED_CERT_IN_CHAIN'
-    || code === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'
-    || code === 'ERR_TLS_CERT_ALTNAME_INVALID';
 }
 
 function record(value: unknown): Readonly<Record<string, unknown>> | null {
@@ -360,108 +350,60 @@ export class LanAuthorityTransferClient {
       this.trust.projectId,
       operation,
     );
-    const responseValue = await new Promise<unknown>((resolve, reject) => {
-      let settled = false;
-      const finish = (action: () => void) => {
-        if (settled) return;
-        settled = true;
-        window.clearTimeout(timer);
-        options.signal?.removeEventListener('abort', onAbort);
-        action();
-      };
-      const outgoing = httpsRequest({
-        ca: this.caCertificatePem,
-        headers: {
-          accept: 'application/json',
-          authorization: authentication.authorization,
-          'content-length': String(body.byteLength),
-          'content-type': 'application/json',
-          'x-request-id': requestId,
-        },
-        hostname: this.endpoint.hostname,
-        method: 'POST',
-        minVersion: 'TLSv1.2',
-        path,
-        port: Number(this.endpoint.port),
-        rejectUnauthorized: true,
-      }, incoming => {
-        const chunks: Buffer[] = [];
-        let observed = 0;
-        incoming.on('data', chunk => {
-          const bytes = Buffer.from(chunk as Uint8Array);
-          observed += bytes.byteLength;
-          if (observed > COLLAB_LIMITS.maxJsonPayloadUtf8Bytes) {
-            incoming.destroy();
-            finish(() => reject(clientError(
-              'protocol-payload-invalid',
-              'authority-transfer-response-too-large',
-            )));
-            return;
-          }
-          chunks.push(bytes);
-        });
-        incoming.once('error', () => finish(() => reject(clientError(
-          'endpoint-unreachable',
-          'authority-transfer-response-failed',
-        ))));
-        incoming.once('end', () => {
-          if (settled) return;
-          const statusCode = incoming.statusCode ?? 0;
-          const contentType = incoming.headers['content-type'];
-          if (
-            typeof contentType !== 'string'
-            || !/^application\/json(?:\s*;|$)/i.test(contentType)
-          ) {
-            finish(() => reject(clientError(
-              'protocol-payload-invalid',
-              'authority-transfer-response-content-type-invalid',
-            )));
-            return;
-          }
-          try {
-            const value = JSON.parse(
-              Buffer.concat(chunks).toString('utf8'),
-            ) as unknown;
-            if (statusCode !== 200) {
-              finish(() => reject(
-                decodeErrorEnvelope(value, requestId) ?? statusError(statusCode),
-              ));
-              return;
-            }
-            finish(() => resolve(value));
-          } catch {
-            finish(() => reject(
-              statusCode === 200
-                ? clientError(
-                  'protocol-payload-invalid',
-                  'authority-transfer-response-json-invalid',
-                )
-                : statusError(statusCode),
-            ));
-          }
-        });
-      });
-      const onAbort = () => finish(() => {
-        outgoing.destroy();
-        reject(clientError('cancelled', 'authority-transfer-request-cancelled'));
-      });
-      const timer = window.setTimeout(() => finish(() => {
-        outgoing.destroy();
-        reject(clientError('operation-timeout', 'authority-transfer-request-timeout'));
-      }), timeoutMs);
-      options.signal?.addEventListener('abort', onAbort, { once: true });
-      outgoing.once('error', error => finish(() => reject(clientError(
-        isTlsValidationError(error) ? 'tls-untrusted' : 'endpoint-unreachable',
-        isTlsValidationError(error)
-          ? 'authority-transfer-tls-validation-failed'
-          : 'authority-transfer-connection-failed',
-      ))));
-      if (options.signal?.aborted) {
-        onAbort();
-        return;
+    const response = await requestHttpsBytes({
+      ca: this.caCertificatePem,
+      headers: {
+        accept: 'application/json',
+        authorization: authentication.authorization,
+        'content-length': String(body.byteLength),
+        'content-type': 'application/json',
+        'x-request-id': requestId,
+      },
+      hostname: this.endpoint.hostname,
+      method: 'POST',
+      path,
+      port: Number(this.endpoint.port),
+    }, {
+      body,
+      maxResponseBytes: COLLAB_LIMITS.maxJsonPayloadUtf8Bytes,
+      signal: options.signal,
+      timeoutMs,
+    }).catch((error: unknown) => {
+      if (!(error instanceof HttpsRequestError)) throw error;
+      switch (error.reason) {
+        case 'cancelled':
+          throw clientError('cancelled', 'authority-transfer-request-cancelled');
+        case 'timeout':
+          throw clientError('operation-timeout', 'authority-transfer-request-timeout');
+        case 'response-too-large':
+          throw clientError('protocol-payload-invalid', 'authority-transfer-response-too-large');
+        case 'response-failed':
+          throw clientError('endpoint-unreachable', 'authority-transfer-response-failed');
+        case 'tls-untrusted':
+          throw clientError('tls-untrusted', 'authority-transfer-tls-validation-failed');
+        case 'connection-failed':
+          throw clientError('endpoint-unreachable', 'authority-transfer-connection-failed');
       }
-      outgoing.end(body);
     });
+    const { statusCode } = response;
+    const contentType = response.headers['content-type'];
+    if (
+      typeof contentType !== 'string'
+      || !/^application\/json(?:\s*;|$)/i.test(contentType)
+    ) {
+      throw clientError('protocol-payload-invalid', 'authority-transfer-response-content-type-invalid');
+    }
+    let responseValue: unknown;
+    try {
+      responseValue = JSON.parse(response.body.toString('utf8')) as unknown;
+    } catch {
+      throw statusCode === 200
+        ? clientError('protocol-payload-invalid', 'authority-transfer-response-json-invalid')
+        : statusError(statusCode);
+    }
+    if (statusCode !== 200) {
+      throw decodeErrorEnvelope(responseValue, requestId) ?? statusError(statusCode);
+    }
     const envelope = record(responseValue);
     if (!envelope) {
       throw clientError('protocol-payload-invalid', 'authority-transfer-response-invalid');

--- a/src/app/collab/lan/httpsRequest.ts
+++ b/src/app/collab/lan/httpsRequest.ts
@@ -1,0 +1,94 @@
+import type { IncomingHttpHeaders } from 'node:http';
+import { request as httpsRequest, type RequestOptions } from 'node:https';
+
+type HttpsRequestFailure =
+  | 'cancelled'
+  | 'connection-failed'
+  | 'response-failed'
+  | 'response-too-large'
+  | 'timeout'
+  | 'tls-untrusted';
+
+export class HttpsRequestError extends Error {
+  constructor(readonly reason: HttpsRequestFailure) {
+    super(reason);
+  }
+}
+
+interface HttpsResponseBytes {
+  readonly body: Buffer;
+  readonly headers: IncomingHttpHeaders;
+  readonly statusCode: number;
+}
+
+export function isTlsValidationError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException)?.code ?? '';
+  return code.includes('CERT')
+    || code.includes('TLS')
+    || code === 'DEPTH_ZERO_SELF_SIGNED_CERT'
+    || code === 'SELF_SIGNED_CERT_IN_CHAIN'
+    || code === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'
+    || code === 'ERR_TLS_CERT_ALTNAME_INVALID';
+}
+
+/** Owns one verified HTTPS request; callers own authentication and wire policy. */
+export async function requestHttpsBytes(
+  requestOptions: Pick<RequestOptions, 'ca' | 'headers' | 'hostname' | 'method' | 'path' | 'port'>,
+  options: {
+    readonly body: Buffer | null;
+    readonly maxResponseBytes: number;
+    readonly signal?: AbortSignal;
+    readonly timeoutMs: number;
+  },
+): Promise<HttpsResponseBytes> {
+  if (options.signal?.aborted) throw new HttpsRequestError('cancelled');
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (action: () => void) => {
+      if (settled) return;
+      settled = true;
+      window.clearTimeout(timer);
+      options.signal?.removeEventListener('abort', onAbort);
+      action();
+    };
+    const fail = (reason: HttpsRequestFailure) => finish(() => {
+      outgoing.destroy();
+      reject(new HttpsRequestError(reason));
+    });
+    const outgoing = httpsRequest({
+      ...requestOptions,
+      minVersion: 'TLSv1.2',
+      rejectUnauthorized: true,
+    }, incoming => {
+      const chunks: Buffer[] = [];
+      let observed = 0;
+      incoming.on('data', (chunk: Buffer | string) => {
+        if (settled) return;
+        const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        observed += bytes.byteLength;
+        if (observed > options.maxResponseBytes) {
+          fail('response-too-large');
+          return;
+        }
+        chunks.push(bytes);
+      });
+      incoming.once('error', () => fail('response-failed'));
+      incoming.once('end', () => finish(() => resolve({
+        body: Buffer.concat(chunks),
+        headers: incoming.headers,
+        statusCode: incoming.statusCode ?? 0,
+      })));
+    });
+    const onAbort = () => fail('cancelled');
+    const timer = window.setTimeout(() => fail('timeout'), options.timeoutMs);
+    options.signal?.addEventListener('abort', onAbort, { once: true });
+    outgoing.once('error', error => fail(
+      isTlsValidationError(error) ? 'tls-untrusted' : 'connection-failed',
+    ));
+    if (options.signal?.aborted) {
+      onAbort();
+      return;
+    }
+    outgoing.end(options.body ?? undefined);
+  });
+}

--- a/src/app/collab/lan/lifecycle/LifecycleGateway.ts
+++ b/src/app/collab/lan/lifecycle/LifecycleGateway.ts
@@ -2,7 +2,6 @@ import { type CollabMemberStatus } from '@claudian-collab/protocol';
 
 import {
   COLLAB_CONTROL_OPERATION_BINDINGS,
-  type CollabControlAdmission,
   type CollabControlAuthentication,
 } from '@/app/collab/lan/CollabControlOperationBindings';
 import type {
@@ -13,7 +12,6 @@ import type {
   HostedMembershipAdminPort,
 } from '@/app/collab/lan/HostedProjectControlService';
 import {
-  LAN_COLLAB_LIFECYCLE_CONTROL_OPERATIONS as COLLAB_LIFECYCLE_CONTROL_OPERATIONS,
   type LanCollabControlOperationMap as CollabControlOperationMap,
   type LanCollabLifecycleControlOperation as CollabLifecycleControlOperation,
 } from '@/app/collab/lan/LanCollabControlOperations';
@@ -48,33 +46,14 @@ export interface LifecycleGatewayPort {
 }
 
 type LifecycleAuthentication = Exclude<CollabControlAuthentication, 'invitation'>;
-type LifecycleAdmission = CollabControlAdmission;
-
-interface LifecycleOperationPolicy {
-  readonly admission: LifecycleAdmission;
-  readonly authentication: LifecycleAuthentication;
-}
-
-export const LIFECYCLE_OPERATION_POLICIES: Readonly<
-  Record<CollabLifecycleControlOperation, LifecycleOperationPolicy>
-> = Object.freeze(Object.fromEntries(
-  COLLAB_LIFECYCLE_CONTROL_OPERATIONS.map(operation => {
-    const binding = COLLAB_CONTROL_OPERATION_BINDINGS[operation];
-    return [operation, {
-      admission: binding.admission,
-      authentication: binding.authentication,
-    }];
-  }),
-) as Record<CollabLifecycleControlOperation, LifecycleOperationPolicy>);
-
 export interface ActiveLifecycleGatewayOptions {
   readonly admission?: CollabControlAdmissionPort;
-  readonly administration?: HostedMembershipAdminPort;
+  readonly administration: HostedMembershipAdminPort;
   readonly authenticateMemberCredential: (
     credential: string,
     statuses: readonly CollabMemberStatus[],
   ) => Promise<{ readonly member: { readonly id: string } }>;
-  readonly lifecycle?: HostedLifecycleControlPort;
+  readonly lifecycle: HostedLifecycleControlPort;
 }
 
 function gatewayError(reason: string): CollabError {
@@ -121,7 +100,7 @@ export class ActiveLifecycleGateway implements LifecycleGatewayPort {
   }
 
   private executeKnown(input: LifecycleGatewayInputUnion): Promise<CollabControlRouteResult> {
-    const policy = LIFECYCLE_OPERATION_POLICIES[input.operation];
+    const policy = COLLAB_CONTROL_OPERATION_BINDINGS[input.operation];
     if (policy.admission === 'terminal') {
       return Promise.reject(gatewayError('lifecycle-service-unavailable'));
     }
@@ -139,7 +118,7 @@ export class ActiveLifecycleGateway implements LifecycleGatewayPort {
     const actorMemberId = await this.authenticate(authentication, input.credential);
     if (actorMemberId === null) {
       if (input.operation === 'getHostTransitions') {
-        return { data: await this.requireLifecycle().getHostTransitions(input.request) };
+        return { data: await this.options.lifecycle.getHostTransitions(input.request) };
       }
       throw gatewayError('lifecycle-policy-operation-mismatch');
     }
@@ -150,78 +129,78 @@ export class ActiveLifecycleGateway implements LifecycleGatewayPort {
     switch (input.operation) {
       case 'leaveProject':
         return {
-          data: await this.requireAdministration().leaveProject(actorMemberId, input.request),
+          data: await this.options.administration.leaveProject(actorMemberId, input.request),
         };
       case 'promoteManager':
         return {
-          data: await this.requireAdministration().promoteManager(actorMemberId, input.request),
+          data: await this.options.administration.promoteManager(actorMemberId, input.request),
         };
       case 'demoteManager':
         return {
-          data: await this.requireAdministration().demoteManager(actorMemberId, input.request),
+          data: await this.options.administration.demoteManager(actorMemberId, input.request),
         };
       case 'createManagerResponsibilityOffer':
         return {
-          data: await this.requireLifecycle().createManagerResponsibilityOffer(
+          data: await this.options.lifecycle.createManagerResponsibilityOffer(
             actorMemberId,
             input.request,
           ),
         };
       case 'getCurrentManagerResponsibilityOffer':
         return {
-          data: await this.requireLifecycle().getCurrentManagerResponsibilityOffer(
+          data: await this.options.lifecycle.getCurrentManagerResponsibilityOffer(
             actorMemberId,
             input.request,
           ),
         };
       case 'getManagerResponsibilityOffer':
         return {
-          data: await this.requireLifecycle().getManagerResponsibilityOffer(
+          data: await this.options.lifecycle.getManagerResponsibilityOffer(
             actorMemberId,
             input.request,
           ),
         };
       case 'acknowledgeManagerResponsibility':
         return {
-          data: await this.requireLifecycle().acknowledgeManagerResponsibility(
+          data: await this.options.lifecycle.acknowledgeManagerResponsibility(
             actorMemberId,
             input.request,
           ),
         };
       case 'declineManagerResponsibility':
         return {
-          data: await this.requireLifecycle().declineManagerResponsibility(
+          data: await this.options.lifecycle.declineManagerResponsibility(
             actorMemberId,
             input.request,
           ),
         };
       case 'cancelManagerResponsibilityOffer':
         return {
-          data: await this.requireLifecycle().cancelManagerResponsibilityOffer(
+          data: await this.options.lifecycle.cancelManagerResponsibilityOffer(
             actorMemberId,
             input.request,
           ),
         };
       case 'createHostTransfer':
         return {
-          data: await this.requireLifecycle().createHostTransfer(actorMemberId, input.request),
+          data: await this.options.lifecycle.createHostTransfer(actorMemberId, input.request),
         };
       case 'acceptHostTransfer':
-        return normalizeDeferred(await this.requireLifecycle().acceptHostTransfer(
+        return normalizeDeferred(await this.options.lifecycle.acceptHostTransfer(
           actorMemberId,
           input.request,
         ));
       case 'declineHostTransfer':
         return {
-          data: await this.requireLifecycle().declineHostTransfer(actorMemberId, input.request),
+          data: await this.options.lifecycle.declineHostTransfer(actorMemberId, input.request),
         };
       case 'cancelHostTransfer':
         return {
-          data: await this.requireLifecycle().cancelHostTransfer(actorMemberId, input.request),
+          data: await this.options.lifecycle.cancelHostTransfer(actorMemberId, input.request),
         };
       case 'retireProject':
         return {
-          data: await this.requireLifecycle().retireProject(actorMemberId, input.request),
+          data: await this.options.lifecycle.retireProject(actorMemberId, input.request),
         };
     }
     throw gatewayError('lifecycle-policy-operation-mismatch');
@@ -249,16 +228,6 @@ export class ActiveLifecycleGateway implements LifecycleGatewayPort {
       }
     }
   }
-
-  private requireAdministration(): HostedMembershipAdminPort {
-    if (this.options.administration) return this.options.administration;
-    throw gatewayError('membership-admin-service-unavailable');
-  }
-
-  private requireLifecycle(): HostedLifecycleControlPort {
-    if (this.options.lifecycle) return this.options.lifecycle;
-    throw gatewayError('lifecycle-service-unavailable');
-  }
 }
 
 export class TerminalLifecycleGateway implements LifecycleGatewayPort {
@@ -273,7 +242,7 @@ export class TerminalLifecycleGateway implements LifecycleGatewayPort {
   private async executeKnown(
     input: LifecycleGatewayInputUnion,
   ): Promise<CollabControlRouteResult> {
-    const policy = LIFECYCLE_OPERATION_POLICIES[input.operation];
+    const policy = COLLAB_CONTROL_OPERATION_BINDINGS[input.operation];
     if (policy.authentication === 'public' && input.operation === 'getHostTransitions') {
       return { data: await this.terminal.getHostTransitions(input.request) };
     }

--- a/src/app/collab/lan/routes/JoinRoutes.ts
+++ b/src/app/collab/lan/routes/JoinRoutes.ts
@@ -1,7 +1,4 @@
-import {
-  COLLAB_CONTROL_OPERATION_BINDINGS,
-  matchCollabControlOperation,
-} from '@/app/collab/lan/CollabControlOperationBindings';
+import { COLLAB_CONTROL_OPERATION_BINDINGS } from '@/app/collab/lan/CollabControlOperationBindings';
 import { lanCollabControlOperationCodec } from '@/app/collab/lan/LanCollabControlOperationCodecs';
 import { requireOperationCredential } from '@/app/collab/lan/routes/RouteAuthentication';
 import type {
@@ -41,11 +38,9 @@ function parseActivationRequest(request: CollabControlRouteRequest, pathId: stri
 }
 
 export const handleJoinRoute: CollabControlRouteHandler = async request => {
-  const match = request.operationMatch
-    ?? matchCollabControlOperation(request.method, request.segments);
+  const match = request.operationMatch;
   if (
-    !match
-    || COLLAB_CONTROL_OPERATION_BINDINGS[match.operation].family !== 'join'
+    COLLAB_CONTROL_OPERATION_BINDINGS[match.operation].family !== 'join'
   ) return null;
 
   if (match.operation === 'createJoinAttempt') {

--- a/src/app/collab/lan/routes/LifecycleRoutes.ts
+++ b/src/app/collab/lan/routes/LifecycleRoutes.ts
@@ -1,7 +1,4 @@
-import {
-  COLLAB_CONTROL_OPERATION_BINDINGS,
-  matchCollabControlOperation,
-} from '@/app/collab/lan/CollabControlOperationBindings';
+import { COLLAB_CONTROL_OPERATION_BINDINGS } from '@/app/collab/lan/CollabControlOperationBindings';
 import { lanCollabControlOperationCodec } from '@/app/collab/lan/LanCollabControlOperationCodecs';
 import type {
   LanCollabLifecycleControlOperation as CollabLifecycleControlOperation,
@@ -12,37 +9,6 @@ import type {
   CollabLifecycleRouteRequest,
 } from '@/app/collab/lan/routes/RouteTypes';
 import { CollabError } from '@/core/collab/ClaudianCollabError';
-
-interface LifecycleRouteMatch {
-  readonly memberId?: string;
-  readonly offerId?: string;
-  readonly operation: CollabLifecycleControlOperation;
-  readonly transferId?: string;
-}
-
-function matchLifecycleControlRoute(
-  method: string,
-  segments: readonly string[],
-): LifecycleRouteMatch | null {
-  const match = matchCollabControlOperation(method, segments);
-  if (
-    !match
-    || COLLAB_CONTROL_OPERATION_BINDINGS[match.operation].family !== 'lifecycle'
-  ) return null;
-  return {
-    ...(match.parameters.memberId ? { memberId: match.parameters.memberId } : {}),
-    ...(match.parameters.offerId ? { offerId: match.parameters.offerId } : {}),
-    operation: match.operation as CollabLifecycleControlOperation,
-    ...(match.parameters.transferId ? { transferId: match.parameters.transferId } : {}),
-  };
-}
-
-export function isLifecycleControlRoute(
-  method: string | undefined,
-  segments: readonly string[],
-): boolean {
-  return matchLifecycleControlRoute(method ?? '', segments) !== null;
-}
 
 function routeError(reason: string): CollabError {
   return new CollabError({
@@ -91,85 +57,71 @@ function execute<Operation extends CollabLifecycleControlOperation>(
 export async function handleLifecycleRoute(
   request: CollabLifecycleRouteRequest,
 ): Promise<CollabControlRouteResult | null> {
-  const sharedMatch = request.operationMatch;
-  const match = sharedMatch
-    && COLLAB_CONTROL_OPERATION_BINDINGS[sharedMatch.operation].family === 'lifecycle'
-    ? {
-      ...(sharedMatch.parameters.memberId
-        ? { memberId: sharedMatch.parameters.memberId }
-        : {}),
-      ...(sharedMatch.parameters.offerId
-        ? { offerId: sharedMatch.parameters.offerId }
-        : {}),
-      operation: sharedMatch.operation as CollabLifecycleControlOperation,
-      ...(sharedMatch.parameters.transferId
-        ? { transferId: sharedMatch.parameters.transferId }
-        : {}),
-    }
-    : matchLifecycleControlRoute(request.method, request.segments);
-  if (!match) return null;
+  const { operationMatch: match } = request;
+  if (COLLAB_CONTROL_OPERATION_BINDINGS[match.operation].family !== 'lifecycle') return null;
+  const operation = match.operation as CollabLifecycleControlOperation;
 
-  if (match.operation === 'getHostTransitions') {
+  if (operation === 'getHostTransitions') {
     const input = decode('getHostTransitions', { projectId: request.projectId });
-    return execute(request, null, match.operation, input);
+    return execute(request, null, operation, input);
   }
 
-  const credential = requireOperationCredential(request.authorization, match.operation);
-  switch (match.operation) {
+  const credential = requireOperationCredential(request.authorization, operation);
+  switch (operation) {
     case 'getCurrentManagerResponsibilityOffer': {
-      const input = decode(match.operation, { projectId: request.projectId });
-      return execute(request, credential, match.operation, input);
+      const input = decode(operation, { projectId: request.projectId });
+      return execute(request, credential, operation, input);
     }
     case 'getManagerResponsibilityOffer': {
-      const input = decode(match.operation, {
-        offerId: match.offerId,
+      const input = decode(operation, {
+        offerId: match.parameters.offerId,
         projectId: request.projectId,
       });
-      return execute(request, credential, match.operation, input);
+      return execute(request, credential, operation, input);
     }
     case 'leaveProject': {
-      const input = decodeMutation(match.operation, request);
-      return execute(request, credential, match.operation, input);
+      const input = decodeMutation(operation, request);
+      return execute(request, credential, operation, input);
     }
     case 'createManagerResponsibilityOffer': {
-      const input = decodeMutation(match.operation, request);
-      return execute(request, credential, match.operation, input);
+      const input = decodeMutation(operation, request);
+      return execute(request, credential, operation, input);
     }
     case 'acknowledgeManagerResponsibility':
     case 'declineManagerResponsibility':
     case 'cancelManagerResponsibilityOffer': {
-      const input = decodeMutation(match.operation, request);
-      requirePathId(input.offerId, match.offerId ?? '', 'lifecycle-offer-path-mismatch');
-      return execute(request, credential, match.operation, input);
+      const input = decodeMutation(operation, request);
+      requirePathId(input.offerId, match.parameters.offerId ?? '', 'lifecycle-offer-path-mismatch');
+      return execute(request, credential, operation, input);
     }
     case 'promoteManager':
     case 'demoteManager': {
-      const input = decodeMutation(match.operation, request);
-      requirePathId(input.targetMemberId, match.memberId ?? '', 'lifecycle-member-path-mismatch');
-      return execute(request, credential, match.operation, input);
+      const input = decodeMutation(operation, request);
+      requirePathId(input.targetMemberId, match.parameters.memberId ?? '', 'lifecycle-member-path-mismatch');
+      return execute(request, credential, operation, input);
     }
     case 'createHostTransfer': {
-      const input = decodeMutation(match.operation, request);
-      return execute(request, credential, match.operation, input);
+      const input = decodeMutation(operation, request);
+      return execute(request, credential, operation, input);
     }
     case 'acceptHostTransfer': {
-      const input = decodeMutation(match.operation, request);
-      requirePathId(input.transferId, match.transferId ?? '', 'lifecycle-transfer-path-mismatch');
-      return execute(request, credential, match.operation, input);
+      const input = decodeMutation(operation, request);
+      requirePathId(input.transferId, match.parameters.transferId ?? '', 'lifecycle-transfer-path-mismatch');
+      return execute(request, credential, operation, input);
     }
     case 'declineHostTransfer':
     case 'cancelHostTransfer': {
-      const input = decodeMutation(match.operation, request);
-      requirePathId(input.transferId, match.transferId ?? '', 'lifecycle-transfer-path-mismatch');
-      return execute(request, credential, match.operation, input);
+      const input = decodeMutation(operation, request);
+      requirePathId(input.transferId, match.parameters.transferId ?? '', 'lifecycle-transfer-path-mismatch');
+      return execute(request, credential, operation, input);
     }
     case 'retireProject': {
-      const input = decodeMutation(match.operation, request);
-      return execute(request, credential, match.operation, input);
+      const input = decodeMutation(operation, request);
+      return execute(request, credential, operation, input);
     }
     case 'acknowledgeRetirement': {
-      const input = decodeMutation(match.operation, request);
-      return execute(request, credential, match.operation, input);
+      const input = decodeMutation(operation, request);
+      return execute(request, credential, operation, input);
     }
   }
 }

--- a/src/app/collab/lan/routes/MembershipRoutes.ts
+++ b/src/app/collab/lan/routes/MembershipRoutes.ts
@@ -1,9 +1,6 @@
 import { isCollabMemberId } from '@claudian-collab/protocol';
 
-import {
-  COLLAB_CONTROL_OPERATION_BINDINGS,
-  matchCollabControlOperation,
-} from '@/app/collab/lan/CollabControlOperationBindings';
+import { COLLAB_CONTROL_OPERATION_BINDINGS } from '@/app/collab/lan/CollabControlOperationBindings';
 import { lanCollabControlOperationCodec } from '@/app/collab/lan/LanCollabControlOperationCodecs';
 import { requireOperationCredential } from '@/app/collab/lan/routes/RouteAuthentication';
 import type {
@@ -34,11 +31,9 @@ function parseRemoval(request: CollabControlRouteRequest, memberId: string) {
 }
 
 export const handleMembershipRoute: CollabControlRouteHandler = async request => {
-  const match = request.operationMatch
-    ?? matchCollabControlOperation(request.method, request.segments);
+  const match = request.operationMatch;
   if (
-    match
-    && COLLAB_CONTROL_OPERATION_BINDINGS[match.operation].family === 'membership'
+    COLLAB_CONTROL_OPERATION_BINDINGS[match.operation].family === 'membership'
     && match.operation === 'removeMember'
   ) {
     const memberId = match.parameters.memberId ?? '';

--- a/src/app/collab/lan/routes/ProjectRoutes.ts
+++ b/src/app/collab/lan/routes/ProjectRoutes.ts
@@ -1,7 +1,4 @@
-import {
-  COLLAB_CONTROL_OPERATION_BINDINGS,
-  matchCollabControlOperation,
-} from '@/app/collab/lan/CollabControlOperationBindings';
+import { COLLAB_CONTROL_OPERATION_BINDINGS } from '@/app/collab/lan/CollabControlOperationBindings';
 import { lanCollabControlOperationCodec } from '@/app/collab/lan/LanCollabControlOperationCodecs';
 import { requireOperationCredential } from '@/app/collab/lan/routes/RouteAuthentication';
 import type {
@@ -44,11 +41,9 @@ function parseRefreshInvitation(request: CollabControlRouteRequest) {
 }
 
 export const handleProjectRoute: CollabControlRouteHandler = async request => {
-  const match = request.operationMatch
-    ?? matchCollabControlOperation(request.method, request.segments);
+  const match = request.operationMatch;
   if (
-    !match
-    || COLLAB_CONTROL_OPERATION_BINDINGS[match.operation].family !== 'project'
+    COLLAB_CONTROL_OPERATION_BINDINGS[match.operation].family !== 'project'
   ) return null;
 
   if (match.operation === 'getSnapshot') {

--- a/src/app/collab/lan/routes/RequestRoutes.ts
+++ b/src/app/collab/lan/routes/RequestRoutes.ts
@@ -1,9 +1,6 @@
 import { type CollabRequestTicketOperation } from '@claudian-collab/protocol';
 
-import {
-  COLLAB_CONTROL_OPERATION_BINDINGS,
-  matchCollabControlOperation,
-} from '@/app/collab/lan/CollabControlOperationBindings';
+import { COLLAB_CONTROL_OPERATION_BINDINGS } from '@/app/collab/lan/CollabControlOperationBindings';
 import { lanCollabControlOperationCodec } from '@/app/collab/lan/LanCollabControlOperationCodecs';
 import { requireOperationCredential } from '@/app/collab/lan/routes/RouteAuthentication';
 import { decodeRoutePageQuery } from '@/app/collab/lan/routes/RoutePageQuery';
@@ -85,11 +82,9 @@ function parseMetadataRequest(request: CollabControlRouteRequest, requestId: str
 }
 
 export const handleRequestRoute: CollabControlRouteHandler = async request => {
-  const match = request.operationMatch
-    ?? matchCollabControlOperation(request.method, request.segments);
+  const match = request.operationMatch;
   if (
-    !match
-    || COLLAB_CONTROL_OPERATION_BINDINGS[match.operation].family !== 'request'
+    COLLAB_CONTROL_OPERATION_BINDINGS[match.operation].family !== 'request'
   ) return null;
   const requestId = match.parameters.requestId;
 

--- a/src/app/collab/lan/routes/RouteTypes.ts
+++ b/src/app/collab/lan/routes/RouteTypes.ts
@@ -144,26 +144,24 @@ interface CollabControlRouteRequestBase {
   readonly authorization: string | null;
   readonly body: unknown;
   readonly idempotencyKey: string | null;
-  readonly method: string;
-  readonly operationMatch?: CollabControlOperationMatch;
   readonly projectId: string;
   readonly query: Readonly<Record<string, string>>;
   readonly remoteAddress: string;
-  readonly segments: readonly string[];
 }
 
-export interface CollabControlRouteRequest extends CollabControlRouteRequestBase {
+export interface CollabLifecycleRouteRequest extends CollabControlRouteRequestBase {
+  readonly operationMatch: CollabControlOperationMatch;
   readonly lifecycle: LifecycleGatewayPort;
+}
+
+export interface CollabControlRouteRequest extends CollabLifecycleRouteRequest {
   readonly service: CollabControlProjectService;
 }
 
 export interface CollabTerminalControlRouteRequest extends CollabControlRouteRequestBase {
+  readonly operationMatch: CollabControlOperationMatch | null;
   readonly lifecycle: LifecycleGatewayPort;
 }
-
-export type CollabLifecycleRouteRequest =
-  | CollabControlRouteRequest
-  | CollabTerminalControlRouteRequest;
 
 export interface CollabControlRouteResult {
   readonly afterResponseFlushed?: () => void;

--- a/src/app/collab/lan/routes/TicketRoutes.ts
+++ b/src/app/collab/lan/routes/TicketRoutes.ts
@@ -1,9 +1,6 @@
 import { type CollabRequestTicketOperation, type ListTicketsRequest } from '@claudian-collab/protocol';
 
-import {
-  COLLAB_CONTROL_OPERATION_BINDINGS,
-  matchCollabControlOperation,
-} from '@/app/collab/lan/CollabControlOperationBindings';
+import { COLLAB_CONTROL_OPERATION_BINDINGS } from '@/app/collab/lan/CollabControlOperationBindings';
 import { lanCollabControlOperationCodec } from '@/app/collab/lan/LanCollabControlOperationCodecs';
 import { requireOperationCredential } from '@/app/collab/lan/routes/RouteAuthentication';
 import { decodeRoutePageQuery } from '@/app/collab/lan/routes/RoutePageQuery';
@@ -77,11 +74,9 @@ function listRequest(request: CollabControlRouteRequest): ListTicketsRequest {
 }
 
 export const handleTicketRoute: CollabControlRouteHandler = async request => {
-  const match = request.operationMatch
-    ?? matchCollabControlOperation(request.method, request.segments);
+  const match = request.operationMatch;
   if (
-    !match
-    || COLLAB_CONTROL_OPERATION_BINDINGS[match.operation].family !== 'ticket'
+    COLLAB_CONTROL_OPERATION_BINDINGS[match.operation].family !== 'ticket'
   ) return null;
   const memberCredential = requireOperationCredential(request.authorization, match.operation);
   const ticketId = match.parameters.ticketId;

--- a/tests/integration/app/collab/lan/httpsRequest.test.ts
+++ b/tests/integration/app/collab/lan/httpsRequest.test.ts
@@ -1,0 +1,138 @@
+import { once } from 'node:events';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createServer, type Server } from 'node:https';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { TEST_INSTALLATION_A } from '@test/helpers/installations';
+
+import { requestHttpsBytes } from '@/app/collab/lan/httpsRequest';
+import { LanTlsIdentity, type LanTlsServerIdentity } from '@/app/collab/lan/LanTlsIdentity';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>(done => { resolve = done; });
+  return { promise, resolve };
+}
+
+describe('requestHttpsBytes', () => {
+  let directory: string;
+  let identity: LanTlsServerIdentity;
+  let server: Server;
+
+  beforeAll(async () => {
+    directory = await mkdtemp(path.join(tmpdir(), 'claudian-https-bytes-'));
+    identity = await new LanTlsIdentity(directory, {
+      installationKey: TEST_INSTALLATION_A,
+    }).issueServerIdentity('127.0.0.1');
+  });
+
+  afterEach(async () => {
+    if (server?.listening) {
+      await new Promise<void>(resolve => {
+        server.close(() => resolve());
+        server.closeAllConnections();
+      });
+    }
+  });
+
+  afterAll(async () => {
+    await rm(directory, { force: true, recursive: true });
+  });
+
+  async function listen(handler: Parameters<typeof createServer>[1]) {
+    server = createServer({
+      cert: identity.certificateChainPem,
+      key: identity.privateKeyPem,
+    }, handler);
+    server.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Missing server address');
+    return {
+      ca: identity.caCertificatePem,
+      hostname: '127.0.0.1',
+      method: 'POST',
+      path: '/bytes',
+      port: address.port,
+    };
+  }
+
+  it('preserves request and response bytes, status, and headers at the byte limit', async () => {
+    const request = await listen((incoming, response) => {
+      response.writeHead(201, { 'content-type': 'application/octet-stream' });
+      incoming.pipe(response);
+    });
+    const body = Buffer.from('é雪', 'utf8');
+    await expect(requestHttpsBytes(request, {
+      body, maxResponseBytes: 5, timeoutMs: 1_000,
+    })).resolves.toMatchObject({
+      body,
+      headers: { 'content-type': 'application/octet-stream' },
+      statusCode: 201,
+    });
+  });
+
+  it('rejects an untrusted server before transmitting HTTP credentials', async () => {
+    let authorization: string | undefined;
+    const request = await listen((incoming, response) => {
+      authorization = incoming.headers.authorization;
+      response.end();
+    });
+    await expect(requestHttpsBytes({
+      ...request,
+      ca: [],
+      headers: { authorization: 'Bearer private-credential' },
+    }, {
+      body: null, maxResponseBytes: 100, timeoutMs: 1_000,
+    })).rejects.toMatchObject({ reason: 'tls-untrusted' });
+    expect(authorization).toBeUndefined();
+  });
+
+  it('rejects an oversized chunked response without waiting for its end', async () => {
+    const closed = deferred();
+    const request = await listen((_incoming, response) => {
+      response.once('close', () => closed.resolve());
+      response.write('é');
+      response.write('雪');
+      response.write('!');
+    });
+    await expect(requestHttpsBytes(request, {
+      body: null, maxResponseBytes: 5, timeoutMs: 1_000,
+    })).rejects.toMatchObject({ reason: 'response-too-large' });
+    await closed.promise;
+  });
+
+  it.each(['cancelled', 'timeout'] as const)(
+    'closes a stalled response when %s', async reason => {
+      const received = deferred();
+      const closed = deferred();
+      const request = await listen((_incoming, response) => {
+        response.once('close', () => closed.resolve());
+        response.write('partial');
+        received.resolve();
+      });
+      const controller = new AbortController();
+      const result = requestHttpsBytes(request, {
+        body: null,
+        maxResponseBytes: 100,
+        signal: controller.signal,
+        timeoutMs: reason === 'timeout' ? 100 : 1_000,
+      }).catch((error: unknown) => error);
+      await received.promise;
+      if (reason === 'cancelled') controller.abort();
+      await expect(result).resolves.toMatchObject({ reason });
+      await closed.promise;
+    },
+  );
+
+  it('rejects a response that closes before its declared content length', async () => {
+    const request = await listen((_incoming, response) => {
+      response.writeHead(200, { 'content-length': '100' });
+      response.write('partial', () => response.destroy());
+    });
+    await expect(requestHttpsBytes(request, {
+      body: null, maxResponseBytes: 100, timeoutMs: 1_000,
+    })).rejects.toMatchObject({ reason: 'response-failed' });
+  });
+});

--- a/tests/unit/app/collab/lan/CollabControlOperationBindings.test.ts
+++ b/tests/unit/app/collab/lan/CollabControlOperationBindings.test.ts
@@ -7,7 +7,6 @@ import {
   LAN_COLLAB_CONTROL_OPERATION_CODECS,
   lanCollabControlOperationCodec,
 } from '@/app/collab/lan/LanCollabControlOperationCodecs';
-import { LAN_COLLAB_LIFECYCLE_CONTROL_OPERATIONS } from '@/app/collab/lan/LanCollabControlOperations';
 
 describe('CollabControlOperationBindings', () => {
   it('keeps the LAN codec authority immutable and rejects inherited keys', () => {
@@ -34,84 +33,61 @@ describe('CollabControlOperationBindings', () => {
     expect(COLLAB_CONTROL_OPERATION_BINDINGS).not.toHaveProperty('transferManager');
   });
 
-  it('preserves the exact executable tuple for every v9 JSON control operation', () => {
-    expect(Object.entries(COLLAB_CONTROL_OPERATION_BINDINGS).map(([
+  it('preserves the wire contract for every v9 JSON control operation', () => {
+    expect(new Map(Object.entries(COLLAB_CONTROL_OPERATION_BINDINGS).map(([
       operation,
       binding,
     ]) => [
       operation,
-      binding.method,
-      binding.route,
-      binding.family,
-      binding.authentication,
-      binding.admission,
-      binding.requestSource,
-      binding.successStatus,
-    ])).toEqual([
-      ['createJoinAttempt', 'POST', 'join-attempts', 'join', 'invitation', 'active', 'body', 201],
-      ['activateJoinAttempt', 'POST', 'join-attempts/:joinAttemptId/activate', 'join', 'active-member', 'active', 'path-and-body', 200],
-      ['getSnapshot', 'GET', 'snapshot', 'project', 'active-member', 'active', 'path', 200],
-      ['getRequest', 'GET', 'requests/:requestId', 'request', 'active-member', 'active', 'path', 200],
-      ['listRequestComments', 'GET', 'requests/:requestId/comments', 'request', 'active-member', 'active', 'path-and-query', 200],
-      ['ensureMyRequest', 'PUT', 'requests/mine', 'request', 'active-member', 'active', 'body', 200],
-      ['createComment', 'POST', 'requests/:requestId/comments', 'request', 'active-member', 'active', 'path-and-body', 201],
-      ['listTickets', 'GET', 'tickets', 'ticket', 'active-member', 'active', 'path-and-query', 200],
-      ['getTicket', 'GET', 'tickets/:ticketId', 'ticket', 'active-member', 'active', 'path', 200],
-      ['listTicketComments', 'GET', 'tickets/:ticketId/comments', 'ticket', 'active-member', 'active', 'path-and-query', 200],
-      ['listTicketAcceptedRelations', 'GET', 'tickets/:ticketId/relations', 'ticket', 'active-member', 'active', 'path-and-query', 200],
-      ['createTicket', 'POST', 'tickets', 'ticket', 'active-member', 'active', 'body', 201],
-      ['updateTicketContent', 'PUT', 'tickets/:ticketId/content', 'ticket', 'active-member', 'active', 'path-and-body', 200],
-      ['createTicketComment', 'POST', 'tickets/:ticketId/comments', 'ticket', 'active-member', 'active', 'path-and-body', 201],
-      ['closeTicket', 'POST', 'tickets/:ticketId/close', 'ticket', 'active-member', 'active', 'path-and-body', 200],
-      ['reopenTicket', 'POST', 'tickets/:ticketId/reopen', 'ticket', 'active-member', 'active', 'path-and-body', 200],
-      ['updateMyRequestMetadata', 'PUT', 'requests/:requestId/metadata', 'request', 'active-member', 'active', 'path-and-body', 200],
-      ['acceptRequest', 'POST', 'requests/:requestId/accept', 'request', 'active-member', 'active', 'path-and-body', 200],
-      ['createInvitation', 'POST', 'invitations', 'project', 'active-member', 'active', 'body', 201],
-      ['revokeInvitation', 'DELETE', 'invitations/current', 'project', 'active-member', 'active', 'body', 200],
-      ['createManagerResponsibilityOffer', 'POST', 'manager-responsibility-offers', 'lifecycle', 'active-member', 'active', 'body', 201],
-      ['getCurrentManagerResponsibilityOffer', 'GET', 'manager-responsibility-offers/current', 'lifecycle', 'active-member', 'active', 'path', 200],
-      ['getManagerResponsibilityOffer', 'GET', 'manager-responsibility-offers/:offerId', 'lifecycle', 'active-member', 'active', 'path', 200],
-      ['acknowledgeManagerResponsibility', 'POST', 'manager-responsibility-offers/:offerId/acknowledge', 'lifecycle', 'active-member', 'active', 'path-and-body', 200],
-      ['declineManagerResponsibility', 'POST', 'manager-responsibility-offers/:offerId/decline', 'lifecycle', 'active-member', 'active', 'path-and-body', 200],
-      ['cancelManagerResponsibilityOffer', 'DELETE', 'manager-responsibility-offers/:offerId', 'lifecycle', 'active-member', 'active', 'path-and-body', 200],
-      ['promoteManager', 'POST', 'managers/:memberId/promote', 'lifecycle', 'active-member', 'active', 'path-and-body', 200],
-      ['demoteManager', 'POST', 'managers/:memberId/demote', 'lifecycle', 'active-member', 'active', 'path-and-body', 200],
-      ['createHostTransfer', 'POST', 'host-transfers', 'lifecycle', 'active-member', 'active', 'body', 201],
-      ['acceptHostTransfer', 'POST', 'host-transfers/:transferId/accept', 'lifecycle', 'active-member', 'active', 'path-and-body', 200],
-      ['declineHostTransfer', 'POST', 'host-transfers/:transferId/decline', 'lifecycle', 'active-member', 'active', 'path-and-body', 200],
-      ['cancelHostTransfer', 'DELETE', 'host-transfers/:transferId', 'lifecycle', 'active-member', 'bypass', 'path-and-body', 200],
-      ['removeMember', 'DELETE', 'members/:memberId', 'membership', 'active-member', 'active', 'path-and-body', 200],
-      ['leaveProject', 'POST', 'leave', 'lifecycle', 'active-or-left', 'active', 'body', 200],
-      ['retireProject', 'POST', 'retire', 'lifecycle', 'active-member', 'bypass', 'body', 200],
-      ['acknowledgeRetirement', 'POST', 'retirement/acknowledgements/current', 'lifecycle', 'terminal-member', 'terminal', 'body', 200],
-      ['getHostTransitions', 'GET', 'host-transitions', 'lifecycle', 'public', 'bypass', 'path', 200],
-      ['refreshEndpoint', 'POST', 'endpoint-refresh', 'project', 'active-member', 'active', 'body', 200],
-      ['confirmEndpoint', 'GET', 'endpoint', 'project', 'active-member', 'active', 'path', 200],
-    ]);
-  });
-
-  it('binds every lifecycle operation to its exact v7 route tuple', () => {
-    expect(LAN_COLLAB_LIFECYCLE_CONTROL_OPERATIONS.map(operation => {
-      const binding = COLLAB_CONTROL_OPERATION_BINDINGS[operation];
-      return [operation, binding.method, `/v${binding.version}/projects/:projectId/${binding.route}`];
-    })).toEqual([
-      ['leaveProject', 'POST', '/v9/projects/:projectId/leave'],
-      ['createManagerResponsibilityOffer', 'POST', '/v9/projects/:projectId/manager-responsibility-offers'],
-      ['getCurrentManagerResponsibilityOffer', 'GET', '/v9/projects/:projectId/manager-responsibility-offers/current'],
-      ['getManagerResponsibilityOffer', 'GET', '/v9/projects/:projectId/manager-responsibility-offers/:offerId'],
-      ['acknowledgeManagerResponsibility', 'POST', '/v9/projects/:projectId/manager-responsibility-offers/:offerId/acknowledge'],
-      ['declineManagerResponsibility', 'POST', '/v9/projects/:projectId/manager-responsibility-offers/:offerId/decline'],
-      ['cancelManagerResponsibilityOffer', 'DELETE', '/v9/projects/:projectId/manager-responsibility-offers/:offerId'],
-      ['promoteManager', 'POST', '/v9/projects/:projectId/managers/:memberId/promote'],
-      ['demoteManager', 'POST', '/v9/projects/:projectId/managers/:memberId/demote'],
-      ['createHostTransfer', 'POST', '/v9/projects/:projectId/host-transfers'],
-      ['acceptHostTransfer', 'POST', '/v9/projects/:projectId/host-transfers/:transferId/accept'],
-      ['declineHostTransfer', 'POST', '/v9/projects/:projectId/host-transfers/:transferId/decline'],
-      ['cancelHostTransfer', 'DELETE', '/v9/projects/:projectId/host-transfers/:transferId'],
-      ['retireProject', 'POST', '/v9/projects/:projectId/retire'],
-      ['acknowledgeRetirement', 'POST', '/v9/projects/:projectId/retirement/acknowledgements/current'],
-      ['getHostTransitions', 'GET', '/v9/projects/:projectId/host-transitions'],
-    ]);
+      [
+        binding.method,
+        binding.route,
+        binding.authentication,
+        binding.admission,
+        binding.requestSource,
+        binding.successStatus,
+      ],
+    ]))).toEqual(new Map([
+      ['createJoinAttempt', ['POST', 'join-attempts', 'invitation', 'active', 'body', 201]],
+      ['activateJoinAttempt', ['POST', 'join-attempts/:joinAttemptId/activate', 'active-member', 'active', 'path-and-body', 200]],
+      ['getSnapshot', ['GET', 'snapshot', 'active-member', 'active', 'path', 200]],
+      ['getRequest', ['GET', 'requests/:requestId', 'active-member', 'active', 'path', 200]],
+      ['listRequestComments', ['GET', 'requests/:requestId/comments', 'active-member', 'active', 'path-and-query', 200]],
+      ['ensureMyRequest', ['PUT', 'requests/mine', 'active-member', 'active', 'body', 200]],
+      ['createComment', ['POST', 'requests/:requestId/comments', 'active-member', 'active', 'path-and-body', 201]],
+      ['listTickets', ['GET', 'tickets', 'active-member', 'active', 'path-and-query', 200]],
+      ['getTicket', ['GET', 'tickets/:ticketId', 'active-member', 'active', 'path', 200]],
+      ['listTicketComments', ['GET', 'tickets/:ticketId/comments', 'active-member', 'active', 'path-and-query', 200]],
+      ['listTicketAcceptedRelations', ['GET', 'tickets/:ticketId/relations', 'active-member', 'active', 'path-and-query', 200]],
+      ['createTicket', ['POST', 'tickets', 'active-member', 'active', 'body', 201]],
+      ['updateTicketContent', ['PUT', 'tickets/:ticketId/content', 'active-member', 'active', 'path-and-body', 200]],
+      ['createTicketComment', ['POST', 'tickets/:ticketId/comments', 'active-member', 'active', 'path-and-body', 201]],
+      ['closeTicket', ['POST', 'tickets/:ticketId/close', 'active-member', 'active', 'path-and-body', 200]],
+      ['reopenTicket', ['POST', 'tickets/:ticketId/reopen', 'active-member', 'active', 'path-and-body', 200]],
+      ['updateMyRequestMetadata', ['PUT', 'requests/:requestId/metadata', 'active-member', 'active', 'path-and-body', 200]],
+      ['acceptRequest', ['POST', 'requests/:requestId/accept', 'active-member', 'active', 'path-and-body', 200]],
+      ['createInvitation', ['POST', 'invitations', 'active-member', 'active', 'body', 201]],
+      ['revokeInvitation', ['DELETE', 'invitations/current', 'active-member', 'active', 'body', 200]],
+      ['createManagerResponsibilityOffer', ['POST', 'manager-responsibility-offers', 'active-member', 'active', 'body', 201]],
+      ['getCurrentManagerResponsibilityOffer', ['GET', 'manager-responsibility-offers/current', 'active-member', 'active', 'path', 200]],
+      ['getManagerResponsibilityOffer', ['GET', 'manager-responsibility-offers/:offerId', 'active-member', 'active', 'path', 200]],
+      ['acknowledgeManagerResponsibility', ['POST', 'manager-responsibility-offers/:offerId/acknowledge', 'active-member', 'active', 'path-and-body', 200]],
+      ['declineManagerResponsibility', ['POST', 'manager-responsibility-offers/:offerId/decline', 'active-member', 'active', 'path-and-body', 200]],
+      ['cancelManagerResponsibilityOffer', ['DELETE', 'manager-responsibility-offers/:offerId', 'active-member', 'active', 'path-and-body', 200]],
+      ['promoteManager', ['POST', 'managers/:memberId/promote', 'active-member', 'active', 'path-and-body', 200]],
+      ['demoteManager', ['POST', 'managers/:memberId/demote', 'active-member', 'active', 'path-and-body', 200]],
+      ['createHostTransfer', ['POST', 'host-transfers', 'active-member', 'active', 'body', 201]],
+      ['acceptHostTransfer', ['POST', 'host-transfers/:transferId/accept', 'active-member', 'active', 'path-and-body', 200]],
+      ['declineHostTransfer', ['POST', 'host-transfers/:transferId/decline', 'active-member', 'active', 'path-and-body', 200]],
+      ['cancelHostTransfer', ['DELETE', 'host-transfers/:transferId', 'active-member', 'bypass', 'path-and-body', 200]],
+      ['removeMember', ['DELETE', 'members/:memberId', 'active-member', 'active', 'path-and-body', 200]],
+      ['leaveProject', ['POST', 'leave', 'active-or-left', 'active', 'body', 200]],
+      ['retireProject', ['POST', 'retire', 'active-member', 'bypass', 'body', 200]],
+      ['acknowledgeRetirement', ['POST', 'retirement/acknowledgements/current', 'terminal-member', 'terminal', 'body', 200]],
+      ['getHostTransitions', ['GET', 'host-transitions', 'public', 'bypass', 'path', 200]],
+      ['refreshEndpoint', ['POST', 'endpoint-refresh', 'active-member', 'active', 'body', 200]],
+      ['confirmEndpoint', ['GET', 'endpoint', 'active-member', 'active', 'path', 200]],
+    ]));
   });
 
   it('builds parameterized paths from the authoritative binding', () => {

--- a/tests/unit/app/collab/lan/HostedProjectControlService.test.ts
+++ b/tests/unit/app/collab/lan/HostedProjectControlService.test.ts
@@ -1,5 +1,17 @@
-import type { AcceptRequest, CreateCommentRequest, EnsureMyRequestRequest } from '@claudian-collab/protocol';
+import { createHash } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 
+import type { AcceptRequest, CreateCommentRequest, EnsureMyRequestRequest } from '@claudian-collab/protocol';
+import initSqlJs from 'sql.js';
+
+import { AuthorityEventRepository } from '@/app/collab/authority/AuthorityEventRepository';
+import { AuthorityIdempotencyRepository } from '@/app/collab/authority/AuthorityIdempotencyRepository';
+import { HostTransferAuthorityService } from '@/app/collab/authority/HostTransferAuthorityService';
+import { ManagerResponsibilityService } from '@/app/collab/authority/ManagerResponsibilityService';
+import { ProjectAuthorityRepository } from '@/app/collab/authority/ProjectAuthorityRepository';
+import { SqlJsProjectDatabase } from '@/app/collab/authority/SqlJsProjectDatabase';
 import {
   type HostedLifecycleControlPort,
   type HostedMembershipAdminPort,
@@ -8,6 +20,8 @@ import {
   type HostedRequestControlPort,
   type HostedTicketControlPort,
 } from '@/app/collab/lan/HostedProjectControlService';
+import { InvitationCodec } from '@/app/collab/lan/InvitationCodec';
+import { PendingMembershipService } from '@/app/collab/lan/PendingMembershipService';
 
 function createHostedService(
   membership: HostedMembershipControlPort,
@@ -106,33 +120,92 @@ describe('HostedProjectControlService', () => {
     );
   });
 
-  it('retries when membership changes while lifecycle summaries are read', async () => {
-    const before = {
-      currentMember: { id: 'member-target', role: 'member' as const },
-      eventSequence: 4,
-      project: { id: 'project-a', managerSetGeneration: 0 },
-    };
-    const after = {
-      currentMember: { id: 'member-target', role: 'manager' as const },
-      eventSequence: 5,
-      project: { id: 'project-a', managerSetGeneration: 1 },
-    };
-    const membership = {
-      readSnapshot: jest.fn()
-        .mockResolvedValueOnce(before)
-        .mockResolvedValueOnce(after)
-        .mockResolvedValueOnce(after)
-        .mockResolvedValueOnce(after),
-    } as unknown as HostedMembershipControlPort;
-    const lifecycle = {
-      getCurrentHostTransfer: jest.fn().mockResolvedValue(null),
-      getCurrentManagerResponsibilityOffer: jest.fn().mockResolvedValue(null),
-    };
-    const service = createHostedService(membership, { lifecycle });
-
-    await expect(service.readSnapshot('credential')).resolves.toEqual(after);
-    expect(membership.readSnapshot).toHaveBeenCalledTimes(4);
-    expect(lifecycle.getCurrentManagerResponsibilityOffer).toHaveBeenCalledTimes(2);
+  it('returns current lifecycle data when an offer changes during a snapshot read', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'claudian-hosted-snapshot-'));
+    const database = new SqlJsProjectDatabase(root, { loadSqlJs: () => initSqlJs() });
+    try {
+      await database.open();
+      const credential = Buffer.alloc(32, 1).toString('base64url');
+      const projects = new ProjectAuthorityRepository();
+      const authority = {
+        database,
+        events: new AuthorityEventRepository(),
+        idempotency: new AuthorityIdempotencyRepository(),
+        projects,
+      };
+      const now = () => new Date('2026-08-08T00:00:00.000Z');
+      await database.mutate(connection => projects.initialize(connection, {
+        createdAt: now().toISOString(),
+        hostCredentialHash: createHash('sha256').update(credential).digest(),
+        hostDisplayName: 'Host',
+        hostMemberId: 'member-host',
+        name: 'Alpha',
+        projectId: 'project-a',
+      }));
+      let beforeGitRead = async () => {};
+      const membership = new PendingMembershipService(authority, {
+        invitationCodec: new InvitationCodec({ now }),
+        getHostEndpoint: () => ({
+          caFingerprint: 'ab'.repeat(32),
+          endpoint: 'https://192.168.1.20:54545',
+        }),
+        now,
+        readMainOid: async () => {
+          await beforeGitRead();
+          return 'a'.repeat(40);
+        },
+      });
+      const invitation = await membership.createInvitation(credential, {
+        idempotencyKey: 'invite', projectId: 'project-a',
+      });
+      const joined = await membership.createJoinAttempt(invitation.invitationSecret, {
+        displayName: 'Target', joinAttemptId: 'join-target', projectId: 'project-a',
+      }, { remoteAddress: '192.168.1.21' });
+      await membership.activateJoinAttempt(joined.memberCredential, {
+        idempotencyKey: 'activate', joinAttemptId: joined.id, projectId: 'project-a',
+      });
+      const responsibilities = new ManagerResponsibilityService({
+        ...authority,
+        presence: { hasAuthenticatedPresence: () => true },
+      }, { now });
+      const transfers = new HostTransferAuthorityService(authority, { now });
+      const offerRequest = {
+        projectId: 'project-a', purpose: 'manager-promotion' as const,
+        targetMemberId: joined.member.id,
+      };
+      const staleOffer = await responsibilities.create('member-host', {
+        ...offerRequest, idempotencyKey: 'offer-first',
+      });
+      // Replace the offer at the Git boundary of the second snapshot, after
+      // lifecycle summaries were collected against the first snapshot.
+      beforeGitRead = async () => {
+        beforeGitRead = async () => {
+          beforeGitRead = async () => {};
+          await responsibilities.cancel('member-host', {
+            idempotencyKey: 'cancel-first', offerId: staleOffer.offerId, projectId: 'project-a',
+          });
+          await responsibilities.create('member-host', {
+            ...offerRequest, idempotencyKey: 'offer-current',
+          });
+        };
+      };
+      const service = createHostedService(membership, {
+        lifecycle: {
+          getCurrentHostTransfer: (actor, projectId) => transfers.getCurrent(actor, projectId),
+          getCurrentManagerResponsibilityOffer: (actor, request) => (
+            responsibilities.getCurrent(actor, request.projectId)
+          ),
+        },
+      });
+      const snapshot = await service.readSnapshot(credential);
+      const currentOffer = await responsibilities.getCurrent('member-host', 'project-a');
+      expect(currentOffer).not.toBeNull();
+      expect(currentOffer?.offerId).not.toBe(staleOffer.offerId);
+      expect(snapshot.managerResponsibilityOffer).toEqual(currentOffer);
+    } finally {
+      await database.close();
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it('authenticates an active Member before request ensure', async () => {

--- a/tests/unit/app/collab/lan/LifecycleRoutes.test.ts
+++ b/tests/unit/app/collab/lan/LifecycleRoutes.test.ts
@@ -1,11 +1,9 @@
+import { matchCollabControlOperation } from '@/app/collab/lan/CollabControlOperationBindings';
 import {
   LAN_COLLAB_LIFECYCLE_CONTROL_OPERATIONS,
   type LanCollabLifecycleControlOperation as CollabLifecycleControlOperation,
 } from '@/app/collab/lan/LanCollabControlOperations';
-import {
-  handleLifecycleRoute,
-  isLifecycleControlRoute,
-} from '@/app/collab/lan/routes/LifecycleRoutes';
+import { handleLifecycleRoute } from '@/app/collab/lan/routes/LifecycleRoutes';
 import type {
   CollabControlRouteRequest,
 } from '@/app/collab/lan/routes/RouteTypes';
@@ -158,12 +156,12 @@ const cases: readonly RouteCase[] = [
 
 function route(
   testCase: RouteCase,
-  overrides: Partial<CollabControlRouteRequest> = {},
+  overrides: Partial<CollabControlRouteRequest> & { method?: string; segments?: readonly string[] } = {},
 ): CollabControlRouteRequest {
   const lifecycle = {
     execute: jest.fn().mockResolvedValue({ data: { operation: testCase.operation } }),
   };
-  return {
+  const { method, segments, ...request } = {
     authorization: `Bearer ${CREDENTIAL}`,
     body: testCase.body,
     idempotencyKey: testCase.method === 'GET' ? null : IDEMPOTENCY_KEY,
@@ -176,17 +174,20 @@ function route(
     service: {} as never,
     ...overrides,
   };
+  const operationMatch = matchCollabControlOperation(method, segments);
+  if (!operationMatch) throw new Error('Invalid route fixture');
+  return { ...request, operationMatch };
 }
 
 describe('handleLifecycleRoute', () => {
-  it('covers the complete v7 lifecycle operation inventory', () => {
+  it('covers the complete v9 lifecycle operation inventory', () => {
     expect([
       ...cases.map(testCase => testCase.operation),
       'getHostTransitions',
     ]).toEqual(LAN_COLLAB_LIFECYCLE_CONTROL_OPERATIONS);
   });
 
-  it.each(cases)('dispatches $operation with the exact v7 contract', async testCase => {
+  it.each(cases)('dispatches $operation with the exact v9 contract', async testCase => {
     const request = route(testCase);
 
     await expect(handleLifecycleRoute(request)).resolves.toEqual({
@@ -310,15 +311,5 @@ describe('handleLifecycleRoute', () => {
       code: 'protocol-payload-invalid',
     });
     expect(request.lifecycle?.execute).not.toHaveBeenCalled();
-  });
-
-  it('exposes exact lifecycle classification so the Router can reject old versions', () => {
-    for (const testCase of cases) {
-      expect(isLifecycleControlRoute(testCase.method, testCase.segments)).toBe(true);
-    }
-    expect(isLifecycleControlRoute('GET', ['host-transitions'])).toBe(true);
-    expect(isLifecycleControlRoute('POST', ['leave', 'extra'])).toBe(false);
-    expect(isLifecycleControlRoute('POST', ['manager-transfer'])).toBe(false);
-    expect(isLifecycleControlRoute('DELETE', ['retire'])).toBe(false);
   });
 });

--- a/tests/unit/app/collab/lan/MembershipRoutes.test.ts
+++ b/tests/unit/app/collab/lan/MembershipRoutes.test.ts
@@ -1,3 +1,4 @@
+import { matchCollabControlOperation } from '@/app/collab/lan/CollabControlOperationBindings';
 import { handleMembershipRoute } from '@/app/collab/lan/routes/MembershipRoutes';
 import type {
   CollabControlProjectService,
@@ -7,9 +8,9 @@ import type {
 const CREDENTIAL = 'A'.repeat(43);
 
 function route(
-  overrides: Partial<CollabControlRouteRequest> = {},
+  overrides: Partial<CollabControlRouteRequest> & { method?: string; segments?: readonly string[] } = {},
 ): CollabControlRouteRequest {
-  return {
+  const { method, segments, ...request } = {
     authorization: `Bearer ${CREDENTIAL}`,
     body: {
       idempotencyKey: 'promote-key',
@@ -27,6 +28,9 @@ function route(
     service: {} as CollabControlProjectService,
     ...overrides,
   };
+  const operationMatch = matchCollabControlOperation(method, segments);
+  if (!operationMatch) throw new Error('Invalid route fixture');
+  return { ...request, operationMatch };
 }
 
 describe('handleMembershipRoute', () => {
@@ -93,12 +97,5 @@ describe('handleMembershipRoute', () => {
       service: { removeMember: jest.fn() } as unknown as CollabControlProjectService,
       ...override,
     }))).rejects.toMatchObject({ code: 'protocol-payload-invalid' });
-  });
-
-  it('returns null outside membership administration endpoints', async () => {
-    await expect(handleMembershipRoute(route({
-      method: 'GET',
-      segments: ['members'],
-    }))).resolves.toBeNull();
   });
 });

--- a/tests/unit/app/collab/lan/RequestRoutes.test.ts
+++ b/tests/unit/app/collab/lan/RequestRoutes.test.ts
@@ -1,3 +1,4 @@
+import { matchCollabControlOperation } from '@/app/collab/lan/CollabControlOperationBindings';
 import { handleRequestRoute } from '@/app/collab/lan/routes/RequestRoutes';
 import type {
   CollabControlProjectService,
@@ -9,9 +10,9 @@ const HEAD = 'a'.repeat(40);
 const MAIN = 'b'.repeat(40);
 
 function route(
-  overrides: Partial<CollabControlRouteRequest> = {},
+  overrides: Partial<CollabControlRouteRequest> & { method?: string; segments?: readonly string[] } = {},
 ): CollabControlRouteRequest {
-  return {
+  const { method, segments, ...request } = {
     authorization: `Bearer ${CREDENTIAL}`,
     body: {
       description: 'Implements #12',
@@ -34,6 +35,9 @@ function route(
     } as unknown as CollabControlProjectService,
     ...overrides,
   };
+  const operationMatch = matchCollabControlOperation(method, segments);
+  if (!operationMatch) throw new Error('Invalid route fixture');
+  return { ...request, operationMatch };
 }
 
 describe('handleRequestRoute', () => {
@@ -227,12 +231,5 @@ describe('handleRequestRoute', () => {
     await expect(handleRequestRoute(route(override))).rejects.toMatchObject({
       code: expect.stringMatching(/^(authentication-failed|protocol-payload-invalid)$/),
     });
-  });
-
-  it('returns null for routes outside the request endpoints', async () => {
-    await expect(handleRequestRoute(route({
-      method: 'GET',
-      segments: ['requests'],
-    }))).resolves.toBeNull();
   });
 });

--- a/tests/unit/app/collab/lan/TicketRoutes.test.ts
+++ b/tests/unit/app/collab/lan/TicketRoutes.test.ts
@@ -1,3 +1,4 @@
+import { matchCollabControlOperation } from '@/app/collab/lan/CollabControlOperationBindings';
 import type {
   CollabControlProjectService,
   CollabControlRouteRequest,
@@ -7,9 +8,9 @@ import { handleTicketRoute } from '@/app/collab/lan/routes/TicketRoutes';
 const CREDENTIAL = 'A'.repeat(43);
 
 function route(
-  overrides: Partial<CollabControlRouteRequest> = {},
+  overrides: Partial<CollabControlRouteRequest> & { method?: string; segments?: readonly string[] } = {},
 ): CollabControlRouteRequest {
-  return {
+  const { method, segments, ...request } = {
     authorization: `Bearer ${CREDENTIAL}`,
     body: {},
     idempotencyKey: null,
@@ -22,6 +23,9 @@ function route(
     service: {} as CollabControlProjectService,
     ...overrides,
   };
+  const operationMatch = matchCollabControlOperation(method, segments);
+  if (!operationMatch) throw new Error('Invalid route fixture');
+  return { ...request, operationMatch };
 }
 
 describe('handleTicketRoute', () => {

--- a/tests/unit/app/collab/lan/lifecycle/LifecycleGateway.test.ts
+++ b/tests/unit/app/collab/lan/lifecycle/LifecycleGateway.test.ts
@@ -1,33 +1,11 @@
-import { COLLAB_CONTROL_OPERATION_BINDINGS } from '@/app/collab/lan/CollabControlOperationBindings';
-import { LAN_COLLAB_LIFECYCLE_CONTROL_OPERATIONS } from '@/app/collab/lan/LanCollabControlOperations';
 import {
   ActiveLifecycleGateway,
-  LIFECYCLE_OPERATION_POLICIES,
   TerminalLifecycleGateway,
 } from '@/app/collab/lan/lifecycle/LifecycleGateway';
 
 const CREDENTIAL = 'A'.repeat(43);
 
 describe('LifecycleGateway', () => {
-  it('declares one exhaustive security and admission policy for all operations', () => {
-    expect(Object.keys(LIFECYCLE_OPERATION_POLICIES)).toEqual(
-      LAN_COLLAB_LIFECYCLE_CONTROL_OPERATIONS,
-    );
-    expect(LIFECYCLE_OPERATION_POLICIES).toEqual(Object.fromEntries(
-      LAN_COLLAB_LIFECYCLE_CONTROL_OPERATIONS.map(operation => [operation, {
-        admission: COLLAB_CONTROL_OPERATION_BINDINGS[operation].admission,
-        authentication: COLLAB_CONTROL_OPERATION_BINDINGS[operation].authentication,
-      }]),
-    ));
-    expect(LIFECYCLE_OPERATION_POLICIES).toMatchObject({
-      acknowledgeRetirement: { admission: 'terminal', authentication: 'terminal-member' },
-      cancelHostTransfer: { admission: 'bypass', authentication: 'active-member' },
-      getHostTransitions: { admission: 'bypass', authentication: 'public' },
-      leaveProject: { admission: 'active', authentication: 'active-or-left' },
-      retireProject: { admission: 'bypass', authentication: 'active-member' },
-    });
-  });
-
   it.each([
     ['leaveProject', 'administration', 'leaveProject'],
     ['createManagerResponsibilityOffer', 'lifecycle', 'createManagerResponsibilityOffer'],
@@ -198,22 +176,5 @@ describe('LifecycleGateway', () => {
       CREDENTIAL,
       { projectId: 'project-a' },
     );
-  });
-
-  it('fails closed when an operation is unavailable in the selected binding', async () => {
-    const gateway = new ActiveLifecycleGateway({
-      authenticateMemberCredential: jest.fn().mockResolvedValue({
-        member: { id: 'member-a' },
-      }),
-    } as never);
-
-    await expect(gateway.execute({
-      credential: CREDENTIAL,
-      operation: 'createHostTransfer',
-      request: { projectId: 'project-a' },
-    } as never)).rejects.toMatchObject({
-      code: 'operation-failed',
-      safeContext: { reason: 'lifecycle-service-unavailable' },
-    });
   });
 });


### PR DESCRIPTION
## Why

The LAN audit found repeated route matching, unsupported partial lifecycle gateways, duplicated HTTPS request cleanup, and tests coupled to internal tables and call counts. This PR addresses that audit directly; no separate issue is needed.

## What Changed

- Resolve control routes once and pass the matched operation to route handlers, preserving active admission and terminal retirement fallback.
- Require complete lifecycle dependencies and read authentication/admission policy directly from the control bindings.
- Share verified HTTPS request settlement, cancellation, timeouts, and bounded response reads. Each client retains its own credentials, versions, envelope validation, and error mapping.
- Remove duplicate policy/route expectations. Replace the snapshot read-count test with a real authority race and add socket-level transport checks.

## Why This Approach

The shared transport is a function that returns bytes, status, and headers. It does not interpret protocol messages. Physical Host handoff keeps its separate streaming upload implementation. Route handlers receive resolved input instead of supporting a second parsing path for tests.

## Validation

- Node 24.16.0; `npm run typecheck` and `npm run lint` passed.
- `npm run test`: 609 suites / 9,373 tests passed, with 2 skipped tests; all 53 architecture/configuration checks passed.
- `npm run build` and `npm run check:performance` passed. The bundle is 4.93 MiB. Cold evaluation was 69.6 ms, above the 50 ms advisory indicator; the checker exited successfully.
- `npm run test:cross-platform-collab` on macOS: 29 suites / 379 tests passed.
- Temporarily removing snapshot retry made the new stale-summary test fail; restoring it passed.
- Verification overrode `OBSIDIAN_VAULT` to a nonexistent workspace path so builds did not copy into the configured live vault.

## Impact and Follow-ups

No wire version, persisted data, or user-facing behavior changes are intended. Windows verification remains covered by CI's affected-path Collab smoke job.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
