### PR TITLE
test: isolate Codex launch spec tests from host WSL discovery

### DIFF
--- a/tests/unit/providers/codex/runtime/CodexLaunchSpecBuilder.test.ts
+++ b/tests/unit/providers/codex/runtime/CodexLaunchSpecBuilder.test.ts
@@ -1,6 +1,22 @@
+import type * as ChildProcess from 'child_process';
+
 import { buildCodexLaunchSpec } from '@/providers/codex/runtime/CodexLaunchSpecBuilder';
 
+const childProcess = jest.requireActual<typeof ChildProcess>('child_process');
+
 describe('buildCodexLaunchSpec', () => {
+  let execFileSyncSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    execFileSyncSpy = jest.spyOn(childProcess, 'execFileSync').mockImplementation(() => {
+      throw Object.assign(new Error('spawnSync wsl.exe ENOENT'), { code: 'ENOENT' });
+    });
+  });
+
+  afterEach(() => {
+    execFileSyncSpy.mockRestore();
+  });
+
   it('builds a native Windows launch spec with a direct codex executable', () => {
     const spec = buildCodexLaunchSpec({
       settings: {
@@ -92,6 +108,71 @@ describe('buildCodexLaunchSpec', () => {
     expect(spec.target.distroName).toBe('Ubuntu');
     expect(spec.pathMapper.toHostPath('/home/user/.codex/sessions')).toBe(
       '\\\\wsl$\\Ubuntu\\home\\user\\.codex\\sessions',
+    );
+  });
+
+  it('uses the native WSL default when the injected resolver returns no distro', () => {
+    execFileSyncSpy.mockReturnValue(Buffer.from(
+      '  NAME              STATE           VERSION\r\n'
+      + '* Ubuntu-24.04      Running         2\r\n'
+      + '  Debian            Stopped         2\r\n',
+      'utf16le',
+    ));
+
+    const spec = buildCodexLaunchSpec({
+      settings: {
+        providerConfigs: {
+          codex: {
+            installationMethod: 'wsl',
+          },
+        },
+      },
+      resolvedCliCommand: 'codex',
+      hostVaultPath: 'C:\\repo',
+      env: {},
+      hostPlatform: 'win32',
+      resolveDefaultWslDistro: () => undefined,
+    });
+
+    expect(spec.command).toBe('wsl.exe');
+    expect(spec.args).toEqual([
+      '--distribution',
+      'Ubuntu-24.04',
+      '--cd',
+      '/mnt/c/repo',
+      'codex',
+      'app-server',
+      '--listen',
+      'stdio://',
+    ]);
+    expect(spec.target.distroName).toBe('Ubuntu-24.04');
+    expect(spec.pathMapper.toHostPath('/home/user/.codex/sessions')).toBe(
+      '\\\\wsl$\\Ubuntu-24.04\\home\\user\\.codex\\sessions',
+    );
+  });
+
+  it('fails fast when the native WSL list has no default distro', () => {
+    execFileSyncSpy.mockReturnValue(Buffer.from(
+      '  NAME              STATE           VERSION\r\n'
+      + '  Ubuntu-24.04      Running         2\r\n'
+      + '  Debian            Stopped         2\r\n',
+      'utf16le',
+    ));
+
+    expect(() => buildCodexLaunchSpec({
+      settings: {
+        providerConfigs: {
+          codex: {
+            installationMethod: 'wsl',
+          },
+        },
+      },
+      resolvedCliCommand: 'codex',
+      hostVaultPath: 'C:\\repo',
+      env: {},
+      hostPlatform: 'win32',
+    })).toThrow(
+      'Unable to determine the WSL distro. Set WSL distro override or configure a default WSL distro.',
     );
   });
 


### PR DESCRIPTION
## Why

Fixes #1266.

The missing-WSL-distro launch-spec test depends on whether the host can run `wsl.exe`. Returning `undefined` from the injected resolver still allows the real system fallback to discover a distro, so the expected error disappears on WSL-capable machines.

## What Changed

- Stub only `child_process.execFileSync` within the launch-spec suite and restore it after each test, making the missing-distro premise deterministic.
- Cover successful UTF-16LE system discovery when the injected resolver returns no distro, including launch arguments and transcript path mapping.
- Cover a successful system probe whose output has no default distro, preserving the existing missing-distro error.

## Why This Approach

The process call is the external boundary. The resolver, parser, launch builder, and path mapper remain real. Production fallback behavior does not change, and no new dependency-injection API is needed. The asynchronous `execFile` function remains untouched.

## Validation

- Node 24.15.0 with a clean `npm ci` installation.
- Before the fix, an executable UTF-16LE WSL fixture on PATH reproduced the original suite's failure: 5 passed, 1 failed (`Received function did not throw`). After the fix, the same environment passes all 8 tests; normal-PATH launch-builder and target-resolver suites pass 16 tests.
- `npm run typecheck`, `npm run lint`, `npm run build`, and `git diff --check`: passed.
- `npm run test -- --runInBand`: 608 suites / 8,922 tests passed, with 2 existing suites/tests skipped; all 53 script checks passed.
- `npm run test:architecture`: 41 checks passed.

The default parallel run hit timeouts in unchanged LAN integration tests and was stopped. The LAN-rebind test also timed out on its first isolated retry, then passed unchanged on a warm isolated rerun and in the final full serial run. No timeout or LAN behavior was changed, and this does not establish the cause of #1267.

## Impact and Follow-ups

Test-only change in one file; no runtime, settings, or public-contract changes. The host-dependent failure was reproduced on macOS by placing an executable `wsl.exe` fixture on PATH, not by running on a real Windows host. This does not claim a runtime fix for #895 or cover the separate LAN integration report #1267.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed. Not applicable: test-only change.
