### PR TITLE
test: pin LAN clock and diagnose Windows Pi launch timeouts

### DIFF
--- a/tests/integration/app/collab/lan/LanHostCoordinator.test.ts
+++ b/tests/integration/app/collab/lan/LanHostCoordinator.test.ts
@@ -1356,6 +1356,7 @@ describe('LanHostCoordinator production transport', () => {
   });
 
   it('replaces ordinary authority-transfer routes with a restart-safe terminal responder', async () => {
+    authorityTransferNow = new Date('2026-08-08T00:00:10.000Z');
     const running = await coordinator.startProject(PROJECT_ID);
     const membership = await localProjects.loadMembership(PROJECT_ID);
     if (!membership || !isCollabLocalLanMembership(membership)) {

--- a/tests/integration/providers/pi/PiSubprocess.windows.test.ts
+++ b/tests/integration/providers/pi/PiSubprocess.windows.test.ts
@@ -3,6 +3,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { PiSubprocess } from '@/providers/pi/runtime/PiSubprocess';
+import { findNodeExecutable, getEnhancedPath } from '@/utils/env';
 
 const describeOnWindows = process.platform === 'win32' ? describe : describe.skip;
 
@@ -47,7 +48,11 @@ describeOnWindows('PiSubprocess Windows argv integration', () => {
       });
       subprocess.start();
 
-      await expect(readFirstLine(subprocess)).resolves.toEqual(expectedArgs);
+      await expect(readFirstLine(subprocess, {
+        fixture: cliPath,
+        node: findNodeExecutable(getEnhancedPath(process.env.PATH, commandPath)),
+        runner: process.execPath,
+      })).resolves.toEqual(expectedArgs);
     } finally {
       await subprocess?.shutdown();
       await fs.rm(npmPrefix, { force: true, recursive: true });
@@ -78,12 +83,17 @@ function createWindowsCommandShim(commandPath: string, targetPath: string): stri
   ].join('\r\n');
 }
 
-function readFirstLine(subprocess: PiSubprocess): Promise<unknown> {
+function readFirstLine(subprocess: PiSubprocess, launch: Record<string, unknown>): Promise<unknown> {
   return new Promise((resolve, reject) => {
     let buffered = '';
     const timeout = window.setTimeout(() => {
       cleanup();
-      reject(new Error('Timed out waiting for the Pi argv fixture'));
+      reject(new Error(`Timed out waiting for the Pi argv fixture: ${JSON.stringify({
+        ...launch,
+        alive: subprocess.isAlive(),
+        stdout: buffered,
+        stderr: subprocess.getStderrSnapshot(),
+      })}`));
     }, 10_000);
     const onData = (chunk: Buffer | string): void => {
       buffered += chunk.toString();


### PR DESCRIPTION
The terminal authority-transfer responder test began failing after its fixture expired on September 7, 2026. Pin its existing injected clock to the fixture timeline so the test verifies route replacement without racing automatic expiry. Existing expiry tests still exercise route removal.

Windows CI also hit an intermittent Pi argv-fixture timeout. Include the selected Node executable, test runner, process liveness, stdout, and stderr in timeout failures so future failures provide launch evidence. The Windows rerun passed without changing the launcher or increasing the timeout.

Validation: `npm run typecheck`, `npm run lint`, `npm run test -- --runInBand` (8,938 passed, two skipped), and `npm run build`; GitHub's Windows and macOS smoke jobs also passed.
