### PR TITLE
fix: remove queued message action button backgrounds

### DIFF
--- a/src/style/components/input.css
+++ b/src/style/components/input.css
@@ -208,52 +208,49 @@ button.claudian-input-nav-btn[aria-disabled='true'] {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 8px;
 }
 
-.claudian-queue-indicator-action {
+.claudian-queue-indicator-actions button.claudian-queue-indicator-action,
+.claudian-queue-indicator-actions button.claudian-queue-indicator-icon-action {
   flex: 0 0 auto;
-  padding: 1px 8px;
+  height: auto;
+  padding: 0;
   border: 0;
   background: transparent;
-  color: var(--interactive-accent);
+  box-shadow: none;
+  color: var(--text-muted);
   font: inherit;
   cursor: pointer;
 }
 
-.claudian-queue-indicator-action:hover {
-  text-decoration: underline;
-}
-
-.claudian-queue-indicator-action[disabled] {
-  color: var(--text-faint);
-  cursor: default;
-  text-decoration: none;
-}
-
-.claudian-queue-indicator-icon-action {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex: 0 0 auto;
-  width: 22px;
-  height: 22px;
-  padding: 0;
+.claudian-queue-indicator-actions button.claudian-queue-indicator-action:is(:hover, :focus-visible, :active),
+.claudian-queue-indicator-actions button.claudian-queue-indicator-icon-action:is(:hover, :focus-visible, :active) {
   border: 0;
-  border-radius: 4px;
   background: transparent;
-  color: var(--text-muted);
-  cursor: pointer;
-}
-
-.claudian-queue-indicator-icon-action:hover {
-  background: var(--background-modifier-hover);
+  box-shadow: none;
   color: var(--text-normal);
 }
 
-.claudian-queue-indicator-icon-action svg {
+.claudian-queue-indicator-actions button.claudian-queue-indicator-action[disabled],
+.claudian-queue-indicator-actions button.claudian-queue-indicator-icon-action[disabled] {
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--text-faint);
+  cursor: default;
+}
+
+.claudian-queue-indicator-actions button.claudian-queue-indicator-icon-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.claudian-queue-indicator-actions button.claudian-queue-indicator-icon-action svg {
   width: 14px;
   height: 14px;
+  color: currentColor;
 }
 
 /* Light blue border when instruction mode is active */


### PR DESCRIPTION
## Why

Queued-message actions retained button backgrounds and normal text color at rest; this focused visual fix was requested directly, so no separate issue is needed.

## What Changed

Remove backgrounds, shadows, padding, and fixed icon-button dimensions from Steer Now, edit, and discard; use muted colors at rest and normal colors on hover/focus, preserving faint disabled states and spacing between actions.

## Why This Approach

Selectors scoped to the queue action container override Obsidian button styling without affecting other controls.

## Validation

- Passed: CSS build, CSS lint, and `git diff --check`
- Reviewed: user-provided screenshot of the original defect
- Not performed: live Obsidian visual verification
- Typecheck and behavior tests omitted: CSS-only presentation change

## Impact and Follow-ups

No data or provider behavior changes; live Obsidian appearance still needs verification.

## Checklist

- [x] One focused problem, with rationale
- [x] No separate issue needed: direct user request
- [x] Tests not applicable: CSS-only presentation change
- [x] Relevant CSS lint and build checks passed
- [x] No user-facing documentation changes needed
