### PR TITLE
test: allow slow Windows Pi fixture startup

### DIFF
--- a/tests/integration/providers/pi/PiSubprocess.windows.test.ts
+++ b/tests/integration/providers/pi/PiSubprocess.windows.test.ts
@@ -57,7 +57,7 @@ describeOnWindows('PiSubprocess Windows argv integration', () => {
       await subprocess?.shutdown();
       await fs.rm(npmPrefix, { force: true, recursive: true });
     }
-  }, 20_000);
+  }, 45_000);
 });
 
 function createWindowsCommandShim(commandPath: string, targetPath: string): string {
@@ -86,6 +86,7 @@ function createWindowsCommandShim(commandPath: string, targetPath: string): stri
 function readFirstLine(subprocess: PiSubprocess, launch: Record<string, unknown>): Promise<unknown> {
   return new Promise((resolve, reject) => {
     let buffered = '';
+    // Allow for slow Node startup on hosted Windows runners.
     const timeout = window.setTimeout(() => {
       cleanup();
       reject(new Error(`Timed out waiting for the Pi argv fixture: ${JSON.stringify({
@@ -94,7 +95,7 @@ function readFirstLine(subprocess: PiSubprocess, launch: Record<string, unknown>
         stdout: buffered,
         stderr: subprocess.getStderrSnapshot(),
       })}`));
-    }, 10_000);
+    }, 30_000);
     const onData = (chunk: Buffer | string): void => {
       buffered += chunk.toString();
       const newlineIndex = buffered.indexOf('\n');


### PR DESCRIPTION
The Windows Pi argv integration test timed out after ten seconds on main while its Node child was still alive with no stdout or stderr. The identical fixture passed in 2.39 seconds on the integration branch, consistent with intermittent runner startup latency.

Allow up to thirty seconds for the first output line and forty-five seconds for the test, including process cleanup. The exact opaque-argument assertion, early-exit failures, timeout diagnostics, and bounded cleanup remain in place.

Validation: TypeScript, targeted ESLint, and diff checks passed locally. Actual Windows launch behavior must pass the PR's Windows CI job; this change does not establish a production launch defect.
