### PR TITLE
feat: guide vault operations through Obsidian in shared prompt

### DIFF
--- a/src/core/prompt/mainAgent.ts
+++ b/src/core/prompt/mainAgent.ts
@@ -52,7 +52,22 @@ function getPathConventions(): string {
 - Do not rely on the current working directory when constructing an operation path.
 - Resolve Vault-relative context paths against the Vault absolute path before using them.
 - If a supplied context path is already absolute, use it directly.
+- Obsidian CLI and API parameters are an exception: use exact Vault-relative paths for them, and explicitly target the current Vault.
 - This path rule does not expand the directories available under the active sandbox or permission policy.`;
+}
+
+function getFileOperations(): string {
+  return `## File Operations
+
+- Use built-in filesystem tools for ordinary reads, edits, file creation, directory creation, listing, and text search.
+- Use the Obsidian CLI for resolved link and backlink queries, indexed tags and tasks, and live app state that filesystem tools cannot reliably provide.
+- For targeted frontmatter property updates, prefer the Obsidian CLI's \`property:set\` and \`property:remove\` commands so Obsidian handles YAML serialization.
+- Move or rename Vault notes, attachments, and folders through the running Obsidian app so Obsidian can update links according to the user's link-update settings. Do not use shell \`mv\`, filesystem rename APIs, or copy-and-delete followed by manual link replacements.
+- Use the Obsidian CLI for file moves and renames: \`obsidian vault="Vault Name" move path="folder/old.md" to="folder/new.md"\`. Supply the actual current Vault name and exact Vault-relative source and destination paths, including the file extension; do not rely on the active note or a fuzzy \`file=\` match.
+- For folder moves and renames, use \`obsidian vault="Vault Name" eval code="..."\` to resolve the source with \`app.vault.getAbstractFileByPath(sourcePath)\` and await \`app.fileManager.renameFile(folder, destinationPath)\`. Use Vault-relative paths, confirm the source is a folder, and check that the destination does not already exist. Do not use \`app.vault.rename\`, which bypasses FileManager's link updates.
+- Quote shell arguments and safely encode paths embedded in JavaScript. For multiple moves, await each operation and verify the resulting paths and affected links before reporting success.
+- The CLI requires a running Obsidian instance and an available \`obsidian\` executable. If a command's syntax is uncertain, run bare \`obsidian\` to inspect the installed command catalog. If link-aware moves are unavailable, report the blocker instead of silently falling back to filesystem moves.
+- For requested deletions, prefer Obsidian's trash behavior: \`obsidian vault="Vault Name" delete path="folder/note.md"\`. Permanent deletion must be explicitly requested.`;
 }
 
 function getReferenceConventions(): string {
@@ -101,6 +116,7 @@ export function buildSystemPrompt(
     getRuntimeContext(settings.vaultPath, settings.userName),
     getUserMessageContext(),
     getPathConventions(),
+    getFileOperations(),
     getReferenceConventions(),
     getVaultMediaContext(settings.mediaFolder || ''),
     getDynamicSections(options.dynamicSections),


### PR DESCRIPTION
## Why

Agents need file-operation guidance in the shared prompt to use Obsidian's link-aware moves and renames without loading a separate skill. This directly requested improvement does not need a separate issue.

linked to #1277

## What Changed

Added a File Operations section covering file and folder moves/renames, trash-based deletion, indexed/live queries, and targeted frontmatter updates. Clarified that Obsidian CLI/API parameters use exact vault-relative paths while filesystem operations use absolute paths.

## Why This Approach

Keeps guidance in the existing provider-neutral prompt builder and follows its section-helper pattern. Ordinary content operations still use filesystem tools; moves and renames use Obsidian's FileManager so link updates follow the user's settings.

## Validation

- 35 existing prompt-related tests passed across three suites.
- Typecheck, targeted ESLint, and production build passed; the two subsequent instruction-only additions also passed the prompt suites and targeted ESLint.
- `git diff --check` passed.
- No new tests added for static instruction text. Live vault mutations were not exercised.

## Impact and Follow-ups

Applies to all providers using the shared main-agent prompt. CLI operations require an available executable and a running Obsidian instance. No runtime API or persistence changes. The build copied artifacts to the configured local Obsidian plugin folder.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
