### PR TITLE
feat: add inline file and folder chips to the chat composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Open the chat sidebar from the ribbon icon or command palette. Select text and u
 
 **Slash Commands & Skills** — Type `/` or `$` for reusable prompt templates or Skills from user- and vault-level scopes.
 
-**`@mention`** - Type `@` to mention anything you want the agent to work with, including vault files, subagents, and files in external directories.
+**`@mention`** - Type `@` to mention anything you want the agent to work with, including vault files, folders, subagents, and files in external directories. Selecting a file or vault folder creates a removable inline chip while you compose. Click its label to open the referenced vault note or reveal the folder in the file explorer, or use the × to remove it. Missing targets are marked in the draft. Chips retain ordinary `@path` text (including the trailing `/` for folders) when copied or sent, and sent messages keep their existing reference rendering.
 
 **Plan Mode** — Toggle via `Shift+Tab`. The agent explores and designs before implementing, then presents a plan for approval.
 

--- a/src/features/chat/ClaudianView.ts
+++ b/src/features/chat/ClaudianView.ts
@@ -2824,7 +2824,8 @@ export class ClaudianView extends ItemView {
 
     const currentValue = inputEl.value;
     const separator = currentValue && !/\s$/.test(currentValue) ? ' ' : '';
-    inputEl.value = `${currentValue}${separator}${text}`;
+    if (inputEl.replaceText) inputEl.replaceText(currentValue.length, currentValue.length, `${separator}${text}`);
+    else inputEl.value = `${currentValue}${separator}${text}`;
 
     const cursorPosition = inputEl.value.length;
     inputEl.selectionStart = cursorPosition;

--- a/src/features/chat/composer/ComposerEditor.ts
+++ b/src/features/chat/composer/ComposerEditor.ts
@@ -1,0 +1,255 @@
+import { defaultKeymap, history, historyKeymap, insertNewline, invertedEffects } from '@codemirror/commands';
+import { Annotation, Compartment, EditorSelection, EditorState, StateEffect, StateField, Transaction } from '@codemirror/state';
+import { Decoration, type DecorationSet, EditorView, keymap, placeholder, WidgetType } from '@codemirror/view';
+
+import type { ComposerFileMention, ComposerInputElement } from '@/shared/composer-dropdown/types';
+
+const setMentions = StateEffect.define<readonly ComposerFileMention[]>();
+const refreshMentions = StateEffect.define<null>();
+const programmatic = Annotation.define<boolean>();
+
+const mentionsField = StateField.define<readonly ComposerFileMention[]>({
+  create: () => [],
+  update(mentions, transaction) {
+    let next = mentions.map(mention => ({
+      ...mention,
+      from: transaction.changes.mapPos(mention.from, 1),
+      to: transaction.changes.mapPos(mention.to, -1),
+    })).filter((mention, index) => mention.from < mention.to
+      && transaction.newDoc.sliceString(mention.from, mention.to)
+        === transaction.startState.doc.sliceString(mentions[index].from, mentions[index].to));
+    for (const effect of transaction.effects) {
+      if (effect.is(setMentions)) next = effect.value.map(mention => ({ ...mention }));
+    }
+    return next.filter(mention => mention.from >= 0 && mention.to <= transaction.newDoc.length
+      && mention.from < mention.to && transaction.newDoc.sliceString(mention.from, mention.from + 1) === '@');
+  },
+});
+
+class MentionWidget extends WidgetType {
+  constructor(
+    private readonly mention: ComposerFileMention,
+    private readonly missing: boolean,
+    private readonly remove: (mention: ComposerFileMention) => void,
+    private readonly openFile?: (path: string) => void,
+  ) { super(); }
+
+  eq(other: MentionWidget): boolean {
+    return this.mention.from === other.mention.from && this.mention.to === other.mention.to
+      && this.mention.path === other.mention.path && this.missing === other.missing;
+  }
+
+  toDOM(view: EditorView): HTMLElement {
+    const ownerWindow = view.dom.ownerDocument.win as Window & { createSpan: typeof createSpan };
+    const chip = ownerWindow.createSpan();
+    chip.className = `claudian-mention-chip${this.missing ? ' is-missing' : ''}`;
+    chip.contentEditable = 'false';
+    chip.title = this.mention.path;
+    const label = this.openFile ? chip.createEl('button') : chip.createSpan();
+    if (this.openFile) {
+      label.setAttribute('type', 'button');
+      label.className = 'claudian-mention-open';
+      label.setAttribute('aria-label', `Open ${this.mention.path}${this.missing ? ' (Missing)' : ''}`);
+      label.addEventListener('click', event => {
+        event.preventDefault();
+        this.openFile?.(this.mention.path);
+      });
+    }
+    const isFolder = this.mention.path.endsWith('/');
+    const basename = this.mention.path.replace(/\/$/, '').split(/[\\/]/).pop() ?? this.mention.path;
+    const name = isFolder ? `${basename}/` : basename.replace(/\.md$/i, '');
+    label.textContent = `${name}${this.missing ? ' · Missing' : ''}`;
+    const button = chip.createEl('button');
+    button.type = 'button';
+    button.className = 'claudian-mention-remove';
+    button.setAttribute('aria-label', `Remove ${this.mention.path}`);
+    button.textContent = '×';
+    button.addEventListener('click', event => {
+      event.preventDefault();
+      this.remove(this.mention);
+    });
+    return chip;
+  }
+}
+
+export interface ComposerEditorOptions {
+  readonly isFileAvailable?: (path: string) => boolean;
+  readonly onOpenFile?: (path: string) => void;
+}
+
+/** Owns the editable document and selected file/folder tokens; serialization stays plain text. */
+export class ComposerEditor {
+  readonly element: ComposerInputElement;
+  private state: EditorState;
+  private view: EditorView | null = null;
+  private readonly historyConfig = new Compartment();
+  private readonly placeholderConfig = new Compartment();
+  private placeholderText = 'Ask to make changes, @mention files, run /commands';
+  private destroyed = false;
+  private ariaObserver: MutationObserver | null = null;
+  private inputPending = false;
+  private readonly isFileAvailable: (path: string) => boolean;
+  private readonly onOpenFile?: (path: string) => void;
+
+  constructor(parent: HTMLElement, options: ComposerEditorOptions = {}) {
+    this.isFileAvailable = options.isFileAvailable ?? (() => true);
+    this.onOpenFile = options.onOpenFile;
+    const host = parent.createDiv({
+      cls: 'claudian-input claudian-composer-editor',
+      attr: { role: 'textbox', 'aria-label': 'Message', 'aria-multiline': 'true', tabindex: '0', dir: 'auto' },
+    });
+    this.element = host as unknown as ComposerInputElement;
+    const decorations = StateField.define<DecorationSet>({
+      create: state => this.decorate(state),
+      update: (_value, transaction) => this.decorate(transaction.state),
+      provide: field => [
+        EditorView.decorations.from(field),
+        EditorView.atomicRanges.of(view => view.state.field(field)),
+      ],
+    });
+    this.state = EditorState.create({
+      extensions: [
+        mentionsField, decorations, this.historyConfig.of(history()),
+        invertedEffects.of(transaction => transaction.docChanged || transaction.effects.some(effect => effect.is(setMentions))
+          ? [setMentions.of(transaction.startState.field(mentionsField))] : []),
+        keymap.of([
+          { key: 'Enter', run: insertNewline, shift: insertNewline },
+          ...historyKeymap, ...defaultKeymap,
+        ]),
+        EditorView.lineWrapping,
+        this.placeholderConfig.of(placeholder(this.placeholderText)),
+        EditorView.contentAttributes.of({ 'aria-label': 'Message', 'aria-multiline': 'true', role: 'textbox' }),
+        EditorView.domEventHandlers({ input: event => { event.stopPropagation(); return false; } }),
+        EditorView.updateListener.of(update => {
+          this.state = update.state;
+          if (update.docChanged && !update.transactions.every(transaction => transaction.annotation(programmatic))) {
+            this.scheduleInput();
+          }
+        }),
+      ],
+    });
+    Object.defineProperties(host, {
+      value: {
+        get: () => this.state.doc.toString(),
+        set: (value: string) => {
+          // A replacement starts a new draft; old undo effects must not overwrite its chips.
+          this.apply(this.state.update({
+            changes: { from: 0, to: this.state.doc.length, insert: value },
+            selection: { anchor: value.length },
+            effects: [setMentions.of([]), this.historyConfig.reconfigure([])],
+            annotations: [programmatic.of(true), Transaction.addToHistory.of(false)],
+          }));
+          this.apply(this.state.update({ effects: this.historyConfig.reconfigure(history()) }));
+        },
+      },
+      selectionStart: {
+        get: () => this.state.selection.main.from,
+        set: (value: number) => this.setSelection(value, Math.max(value, this.state.selection.main.to)),
+      },
+      selectionEnd: {
+        get: () => this.state.selection.main.to,
+        set: (value: number) => this.setSelection(Math.min(value, this.state.selection.main.from), value),
+      },
+      placeholder: {
+        get: () => this.placeholderText,
+        set: (value: string) => {
+          this.placeholderText = value;
+          this.element.setAttribute('data-placeholder', value);
+          this.apply(this.state.update({ effects: this.placeholderConfig.reconfigure(placeholder(value)) }));
+        },
+      },
+    });
+    this.element.replaceText = (from, to, text, filePath) => {
+      const change = this.state.changes({ from, to, insert: text });
+      const mapped = this.state.field(mentionsField).filter(mention => mention.to <= from || mention.from >= to)
+        .map(mention => ({ ...mention, from: change.mapPos(mention.from, 1), to: change.mapPos(mention.to, -1) }));
+      if (filePath) mapped.push({ from, to: from + text.trimEnd().length, path: filePath });
+      this.apply(this.state.update({
+        changes: change,
+        selection: { anchor: from + text.length },
+        effects: setMentions.of(mapped.sort((a, b) => a.from - b.from)),
+        annotations: programmatic.of(true),
+        userEvent: 'input.complete',
+      }));
+    };
+    this.element.getFileMentions = () => this.state.field(mentionsField).map(mention => ({ ...mention }));
+    this.element.setFileMentions = mentions => this.apply(this.state.update({
+      effects: setMentions.of(mentions), annotations: Transaction.addToHistory.of(false),
+    }));
+    host.setAttribute('data-placeholder', this.placeholderText);
+    host.addEventListener('focus', this.onFocus);
+  }
+
+  refreshMentions(): void {
+    if (!this.destroyed) this.apply(this.state.update({ effects: refreshMentions.of(null) }));
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+    this.element.removeEventListener('focus', this.onFocus);
+    this.ariaObserver?.disconnect();
+    this.view?.destroy();
+    this.view = null;
+  }
+
+  private readonly onFocus = (): void => {
+    if (this.destroyed) return;
+    if (!this.view) {
+      this.element.replaceChildren();
+      this.element.removeAttribute('role');
+      this.element.setAttribute('tabindex', '-1');
+      this.view = new EditorView({ state: this.state, parent: this.element });
+      const attributes = ['aria-autocomplete', 'aria-expanded', 'aria-activedescendant', 'aria-controls', 'aria-haspopup'];
+      const syncAria = () => {
+        for (const attribute of attributes) {
+          const value = this.element.getAttribute(attribute);
+          if (value === null) this.view?.contentDOM.removeAttribute(attribute);
+          else this.view?.contentDOM.setAttribute(attribute, value);
+        }
+      };
+      syncAria();
+      this.ariaObserver = new this.element.ownerDocument.defaultView!.MutationObserver(syncAria);
+      this.ariaObserver.observe(this.element, { attributes: true, attributeFilter: attributes });
+    }
+    this.view.focus();
+  };
+
+  private decorate(state: EditorState): DecorationSet {
+    return Decoration.set(state.field(mentionsField).map(mention => Decoration.replace({
+      widget: new MentionWidget(mention, !this.isFileAvailable(mention.path), token => {
+        this.element.replaceText!(token.from, token.to, '');
+        this.view?.focus();
+        this.emitInput();
+      }, this.onOpenFile),
+    }).range(mention.from, mention.to)), true);
+  }
+
+  private setSelection(from: number, to: number): void {
+    const clamp = (position: number) => Math.max(0, Math.min(position, this.state.doc.length));
+    this.apply(this.state.update({ selection: EditorSelection.single(clamp(from), clamp(to)) }));
+  }
+
+  private apply(transaction: Transaction): void {
+    if (this.destroyed) return;
+    if (this.view) this.view.dispatch(transaction);
+    else {
+      this.state = transaction.state;
+      this.element.textContent = this.state.doc.toString();
+    }
+  }
+
+  private scheduleInput(): void {
+    if (this.inputPending) return;
+    this.inputPending = true;
+    // Mode and completion listeners may dispatch editor changes of their own.
+    queueMicrotask(() => {
+      this.inputPending = false;
+      if (!this.destroyed) this.emitInput();
+    });
+  }
+
+  private emitInput(): void {
+    const EventConstructor = this.element.ownerDocument.defaultView!.Event;
+    this.element.dispatchEvent(new EventConstructor('input', { bubbles: true }));
+  }
+}

--- a/src/features/chat/composer/MainChatComposerDropdown.ts
+++ b/src/features/chat/composer/MainChatComposerDropdown.ts
@@ -11,6 +11,7 @@ import {
   ComposerDropdownController,
   SlashCommandSource,
 } from '@/shared/composer-dropdown';
+import type { ComposerInputElement } from '@/shared/composer-dropdown/types';
 
 import type { FileContextManager } from '../ui/FileContext';
 import { CollabMemberChangesFolder } from './CollabMemberChangesFolder';
@@ -34,7 +35,7 @@ export class MainChatComposerDropdown {
 
   constructor(
     containerEl: HTMLElement,
-    inputEl: HTMLTextAreaElement,
+    inputEl: ComposerInputElement,
     fileContextManager: FileContextManager,
     options: MainChatComposerDropdownOptions,
   ) {

--- a/src/features/chat/composer/OpenComposerPath.ts
+++ b/src/features/chat/composer/OpenComposerPath.ts
@@ -1,0 +1,50 @@
+import { existsSync } from 'fs';
+import { type App, Notice, TFile, TFolder } from 'obsidian';
+import { isAbsolute, win32 } from 'path';
+
+export function isComposerPathAvailable(app: App, path: string): boolean {
+  if (isAbsolute(path) || win32.isAbsolute(path)) return existsSync(path);
+  const isFolder = path.endsWith('/');
+  const target = app.vault.getAbstractFileByPath(isFolder ? path.slice(0, -1) : path);
+  return isFolder ? target instanceof TFolder : target instanceof TFile;
+}
+
+export async function openComposerPath(app: App, path: string): Promise<void> {
+  if (path.endsWith('/')) {
+    const folder = app.vault.getAbstractFileByPath(path.slice(0, -1));
+    if (!(folder instanceof TFolder)) {
+      new Notice(`Folder not found in this vault: ${path}`);
+      return;
+    }
+    try {
+      const workspace = app.workspace;
+      let leaf = workspace.getLeavesOfType('file-explorer')[0];
+      if (!leaf) {
+        leaf = workspace.getLeftLeaf(false) ?? workspace.getLeaf('tab');
+        await leaf.setViewState({ type: 'file-explorer', active: true });
+      }
+      await workspace.revealLeaf(leaf);
+      // The core Files view exposes these methods outside Obsidian's public typings.
+      const view = leaf.view as unknown as {
+        revealInFolder?: (target: TFolder) => Promise<void> | void;
+        revealFile?: (target: TFolder) => Promise<void> | void;
+      };
+      const reveal = view.revealInFolder ?? view.revealFile;
+      if (!reveal) throw new Error('File explorer cannot reveal folders');
+      await reveal.call(view, folder);
+    } catch {
+      new Notice(`Could not reveal folder: ${path}`);
+    }
+    return;
+  }
+  const file = app.vault.getAbstractFileByPath(path);
+  if (!(file instanceof TFile)) {
+    new Notice(`Note not found in this vault: ${path}`);
+    return;
+  }
+  try {
+    await app.workspace.getLeaf('tab').openFile(file);
+  } catch {
+    new Notice(`Could not open note: ${path}`);
+  }
+}

--- a/src/features/chat/controllers/BrowserSelectionController.ts
+++ b/src/features/chat/controllers/BrowserSelectionController.ts
@@ -236,7 +236,7 @@ export class BrowserSelectionController {
   }
 
   private clearWhenInputIsNotFocused(): void {
-    if (this.inputEl.ownerDocument.activeElement === this.inputEl) return;
+    if (this.inputEl.contains(this.inputEl.ownerDocument.activeElement)) return;
     if (this.storedSelection) {
       this.storedSelection = null;
       this.updateIndicator();

--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -1,5 +1,7 @@
 import { Menu, Notice, setIcon } from 'obsidian';
 
+import type { ComposerInputElement } from '@/shared/composer-dropdown/types';
+
 import type {
   ChatRewindConflict,
   ChatRewindMode,
@@ -75,7 +77,7 @@ export interface ConversationControllerDeps {
   getWelcomeEl: () => HTMLElement | null;
   setWelcomeEl: (el: HTMLElement | null) => void;
   getMessagesEl: () => HTMLElement;
-  getInputEl: () => HTMLTextAreaElement;
+  getInputEl: () => ComposerInputElement;
   restoreMessageToComposer?: (message: Pick<ChatMessage, 'content' | 'images'>) => void;
   getFileContextManager: () => FileContextManager | null;
   getLinkedContentController: () => LinkedContentController;

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -1,5 +1,7 @@
 import { Notice, setIcon } from 'obsidian';
 
+import type { ComposerFileMention, ComposerInputElement } from '@/shared/composer-dropdown/types';
+
 import {
   type BuiltInCommand,
   detectBuiltInCommand,
@@ -107,7 +109,7 @@ export interface InputControllerDeps {
   browserSelectionController?: BrowserSelectionController;
   canvasSelectionController: CanvasSelectionController;
   conversationController: ConversationController;
-  getInputEl: () => HTMLTextAreaElement;
+  getInputEl: () => ComposerInputElement;
   getWelcomeEl: () => HTMLElement | null;
   getMessagesEl: () => HTMLElement;
   getFileContextManager: () => FileContextManager | null;
@@ -314,7 +316,11 @@ export class InputController {
 
     const contentOverride = options?.content;
     const shouldUseInput = contentOverride === undefined;
-    const content = (contentOverride ?? inputEl.value).trim();
+    const rawContent = contentOverride ?? inputEl.value;
+    const content = rawContent.trim();
+    const fileMentions = shouldUseInput
+      ? trimFileMentions(rawContent, inputEl.getFileMentions?.() ?? [])
+      : [];
     const imageOverride = options?.images;
     const hasImages = imageOverride !== undefined
       ? imageOverride.length > 0
@@ -355,6 +361,7 @@ export class InputController {
       const canvasContext = canvasSelectionController.getContext();
       const { displayContent, turnRequest } = this.buildTurnSubmission({
         content,
+        fileMentions,
         images,
         editorContextOverride: editorContext,
         browserContextOverride: browserContext,
@@ -419,6 +426,7 @@ export class InputController {
       }
       : this.buildTurnSubmission({
         content,
+        fileMentions,
         images: imagesForMessage,
         editorContextOverride: options?.editorContextOverride,
         browserContextOverride: options?.browserContextOverride,
@@ -887,9 +895,15 @@ export class InputController {
     const { content, images } = message;
     const inputEl = this.deps.getInputEl();
     const currentContent = options.mergeWithComposer ? inputEl.value.trim() : '';
-    inputEl.value = currentContent
-      ? appendMarkdownSnippet(content, currentContent)
-      : content;
+    const currentMentions = options.mergeWithComposer
+      ? trimFileMentions(inputEl.value, inputEl.getFileMentions?.() ?? []) : [];
+    const restoredContent = currentContent ? appendMarkdownSnippet(content, currentContent) : content;
+    inputEl.value = restoredContent;
+    const offset = restoredContent.length - currentContent.length;
+    inputEl.setFileMentions?.([
+      ...(message.turnRequest?.fileMentions ?? []),
+      ...shiftFileMentions(currentMentions, offset),
+    ]);
 
     const imageContextManager = this.deps.getImageContextManager();
     const currentImages = options.mergeWithComposer
@@ -912,6 +926,7 @@ export class InputController {
 
     return this.createQueuedMessage(content, {
       text: content,
+      fileMentions: this.deps.getInputEl().getFileMentions?.(),
       images,
     });
   }
@@ -1001,6 +1016,7 @@ export class InputController {
 
   private buildTurnSubmission(options: {
     content: string;
+    fileMentions?: readonly ComposerFileMention[];
     images?: ChatMessage['images'];
     editorContextOverride?: EditorSelectionContext | null;
     browserContextOverride?: BrowserSelectionContext | null;
@@ -1042,6 +1058,7 @@ export class InputController {
       displayContent: options.content,
       turnRequest: {
         text: transformedText,
+        fileMentions: options.fileMentions,
         images: options.images,
         linkedContentPath,
         editorSelection: editorContext,
@@ -2345,6 +2362,7 @@ export class InputController {
 function cloneChatTurnRequest(request: ChatTurnRequest): ChatTurnRequest {
   return {
     ...request,
+    fileMentions: request.fileMentions?.map(mention => ({ ...mention })),
     externalContextPaths: request.externalContextPaths
       ? [...request.externalContextPaths]
       : undefined,
@@ -2367,10 +2385,18 @@ function mergeQueuedChatTurns(
     ...(existing.request.images ?? []),
     ...(incoming.request.images ?? []),
   ];
+  const existingLength = existing.displayContent.trim().length;
   return {
     displayContent: mergeText(existing.displayContent, incoming.displayContent),
     request: {
       ...cloneChatTurnRequest(incoming.request),
+      fileMentions: [
+        ...trimFileMentions(existing.displayContent, existing.request.fileMentions ?? []),
+        ...shiftFileMentions(
+          trimFileMentions(incoming.displayContent, incoming.request.fileMentions ?? []),
+          existingLength ? existingLength + 2 : 0,
+        ),
+      ],
       linkedContentPath:
         incoming.request.linkedContentPath ?? existing.request.linkedContentPath,
       externalContextPaths:
@@ -2379,4 +2405,15 @@ function mergeQueuedChatTurns(
       text: mergeText(existing.request.text, incoming.request.text),
     },
   };
+}
+
+function trimFileMentions(text: string, mentions: readonly ComposerFileMention[]): ComposerFileMention[] {
+  const offset = text.length - text.trimStart().length;
+  const length = text.trim().length;
+  return shiftFileMentions(mentions, -offset)
+    .filter(mention => mention.from >= 0 && mention.to <= length);
+}
+
+function shiftFileMentions(mentions: readonly ComposerFileMention[], offset: number): ComposerFileMention[] {
+  return mentions.map(mention => ({ ...mention, from: mention.from + offset, to: mention.to + offset }));
 }

--- a/src/features/chat/controllers/NavigationController.ts
+++ b/src/features/chat/controllers/NavigationController.ts
@@ -1,3 +1,5 @@
+import type { ComposerInputElement } from '@/shared/composer-dropdown/types';
+
 import type { KeyboardNavigationSettings } from '../../../core/types';
 import {
   cancelScheduledAnimationFrame,
@@ -10,7 +12,7 @@ const SCROLL_SPEED = 8;
 
 export interface NavigationControllerDeps {
   getMessagesEl: () => HTMLElement;
-  getInputEl: () => HTMLTextAreaElement;
+  getInputEl: () => ComposerInputElement;
   getSettings: () => KeyboardNavigationSettings;
   isStreaming: () => boolean;
   /** Returns true if a UI component (dropdown, modal, mode) should handle Escape instead. */

--- a/src/features/chat/state/types.ts
+++ b/src/features/chat/state/types.ts
@@ -1,5 +1,7 @@
 import type { EditorView } from '@codemirror/view';
 
+import type { ComposerFileMention } from '@/shared/composer-dropdown/types';
+
 import type { TodoItem } from '../../../core/tools/todo';
 import type {
   ChatMessage,
@@ -16,6 +18,7 @@ import type { WriteEditState } from '../rendering/WriteEditRenderer';
 
 export interface ChatTurnRequest {
   text: string;
+  fileMentions?: readonly ComposerFileMention[];
   images?: ImageAttachment[];
   linkedContentPath?: string;
   editorSelection?: EditorSelectionContext | null;

--- a/src/features/chat/tabs/TabInputEvents.ts
+++ b/src/features/chat/tabs/TabInputEvents.ts
@@ -35,7 +35,7 @@ function shouldSendMessageFromEnterKey(
 }
 
 function isTabInputFocused(tab: AssembledTabRuntime): boolean {
-  return tab.dom.inputEl.ownerDocument.activeElement === tab.dom.inputEl;
+  return tab.dom.inputEl.contains(tab.dom.inputEl.ownerDocument.activeElement);
 }
 
 function sendTabInputMessage(

--- a/src/features/chat/tabs/runtime/TabRuntimeInputBindings.ts
+++ b/src/features/chat/tabs/runtime/TabRuntimeInputBindings.ts
@@ -30,6 +30,7 @@ export function buildTabRuntimeInputBindings(
   };
 
   const keydownHandler = (event: KeyboardEvent) => {
+    if ((event.target as HTMLElement | null)?.closest?.('button')) return;
     const tab = runtimeRef.requirePublished();
     if (ui.bangBashModeManager?.isActive()) {
       ui.bangBashModeManager.handleKeydown(event);
@@ -69,10 +70,10 @@ export function buildTabRuntimeInputBindings(
       return;
     }
   };
-  dom.inputEl.addEventListener('keydown', keydownHandler);
+  dom.inputEl.addEventListener('keydown', keydownHandler, true);
   options.registerCleanup(
     'tab input keydown binding',
-    () => dom.inputEl.removeEventListener('keydown', keydownHandler),
+    () => dom.inputEl.removeEventListener('keydown', keydownHandler, true),
   );
 
   const inputHandler = () => {

--- a/src/features/chat/tabs/runtime/TabRuntimeShell.ts
+++ b/src/features/chat/tabs/runtime/TabRuntimeShell.ts
@@ -6,6 +6,8 @@ import { getEnabledProviderForModel } from '../../../../core/providers/modelRout
 import { ProviderRegistry } from '../../../../core/providers/ProviderRegistry';
 import { DEFAULT_CHAT_PROVIDER_ID } from '../../../../core/providers/types';
 import { getVaultPath } from '../../../../utils/path';
+import { ComposerEditor } from '../../composer/ComposerEditor';
+import { isComposerPathAvailable, openComposerPath } from '../../composer/OpenComposerPath';
 import { ChatExecutionCoordinator } from '../../execution/ChatExecutionCoordinator';
 import { cleanupThinkingBlock } from '../../rendering/ThinkingBlockRenderer';
 import { createWelcomeElement } from '../../rendering/WelcomeRenderer';
@@ -35,7 +37,7 @@ export function buildTabRuntimeShell(
   });
   options.registerCleanup('tab DOM root', () => contentEl.remove());
 
-  const dom = buildTabDOM(contentEl);
+  const dom = buildTabDOM(contentEl, options);
   const state = new ChatState({
     onStreamingStateChanged: isStreaming => {
       options.onStreamingChanged?.(runtimeRef.requirePublished(), isStreaming);
@@ -155,7 +157,7 @@ export function buildTabRuntimeShell(
   };
 }
 
-function buildTabDOM(contentEl: HTMLElement): TabDOMElements {
+function buildTabDOM(contentEl: HTMLElement, options: TabRuntimeConstructionContext): TabDOMElements {
   const messagesWrapperEl = contentEl.createDiv({ cls: 'claudian-messages-wrapper' });
   const messagesEl = messagesWrapperEl.createDiv({ cls: 'claudian-messages' });
   const welcomeEl = createWelcomeElement(messagesEl);
@@ -166,14 +168,22 @@ function buildTabDOM(contentEl: HTMLElement): TabDOMElements {
   const navRowEl = inputContainerEl.createDiv({ cls: 'claudian-input-nav-row' });
   const inputWrapper = inputContainerEl.createDiv({ cls: 'claudian-input-wrapper' });
   const contextRowEl = inputWrapper.createDiv({ cls: 'claudian-context-row' });
-  const inputEl = inputWrapper.createEl('textarea', {
-    cls: 'claudian-input',
-    attr: {
-      placeholder: 'Ask to make changes, @mention files, run /commands',
-      rows: '3',
-      dir: 'auto',
-    },
+  const composerEditor = new ComposerEditor(inputWrapper, {
+    onOpenFile: path => { void openComposerPath(options.plugin.app, path); },
+    isFileAvailable: path => isComposerPathAvailable(options.plugin.app, path),
   });
+  options.registerCleanup('tab composer editor', () => composerEditor.destroy());
+  const vault = options.plugin.app.vault;
+  const refresh = () => composerEditor.refreshMentions();
+  for (const subscribe of [
+    () => vault.on('create', refresh),
+    () => vault.on('delete', refresh),
+    () => vault.on('rename', refresh),
+  ]) {
+    const ref = subscribe();
+    options.registerCleanup('composer vault listener', () => vault.offref(ref));
+  }
+  const inputEl = composerEditor.element;
 
   return {
     contentEl,

--- a/src/features/chat/tabs/types.ts
+++ b/src/features/chat/tabs/types.ts
@@ -1,5 +1,7 @@
 import type { Component, WorkspaceLeaf } from 'obsidian';
 
+import type { ComposerInputElement } from '@/shared/composer-dropdown/types';
+
 import type { ProviderCommandDropdownConfig } from '../../../core/providers/commands/ProviderCommandCatalog';
 import type { ProviderCommandDiscoveryController } from '../../../core/providers/commands/ProviderCommandDiscoveryStore';
 import type { ProviderCommandEntry } from '../../../core/providers/commands/ProviderCommandEntry';
@@ -153,7 +155,7 @@ export interface TabDOMElements {
   readonly inputContainerEl: HTMLElement;
   readonly queueIndicatorEl: HTMLElement;
   readonly inputWrapper: HTMLElement;
-  readonly inputEl: HTMLTextAreaElement;
+  readonly inputEl: ComposerInputElement;
 
   /** Nav row for tab badges and header icons (above input wrapper). */
   readonly navRowEl: HTMLElement;

--- a/src/features/chat/ui/BangBashModeManager.ts
+++ b/src/features/chat/ui/BangBashModeManager.ts
@@ -1,5 +1,7 @@
 import { Notice } from 'obsidian';
 
+import type { ComposerInputElement } from '@/shared/composer-dropdown/types';
+
 import { t } from '../../../i18n/i18n';
 
 export interface BangBashModeCallbacks {
@@ -13,14 +15,14 @@ export interface BangBashModeState {
 }
 
 export class BangBashModeManager {
-  private inputEl: HTMLTextAreaElement;
+  private inputEl: ComposerInputElement;
   private callbacks: BangBashModeCallbacks;
   private state: BangBashModeState = { active: false, rawCommand: '' };
   private isSubmitting = false;
   private originalPlaceholder: string = '';
 
   constructor(
-    inputEl: HTMLTextAreaElement,
+    inputEl: ComposerInputElement,
     callbacks: BangBashModeCallbacks
   ) {
     this.inputEl = inputEl;

--- a/src/features/chat/ui/ImageContext.ts
+++ b/src/features/chat/ui/ImageContext.ts
@@ -1,6 +1,8 @@
 import { Notice } from 'obsidian';
 import * as path from 'path';
 
+import type { ComposerInputElement } from '@/shared/composer-dropdown/types';
+
 import type { ImageAttachment, ImageMediaType } from '../../../core/types';
 import { ComposerContextTray } from './ComposerContextTray';
 import { ImagePreviewModal } from './ImagePreviewModal';
@@ -25,7 +27,7 @@ export class ImageContextManager {
   private containerEl: HTMLElement;
   private contextTray: ComposerContextTray;
   private ownedContextTray: ComposerContextTray | null = null;
-  private inputEl: HTMLTextAreaElement;
+  private inputEl: ComposerInputElement;
   private dropOverlay: HTMLElement | null = null;
   private dropZoneEl: HTMLElement | null = null;
   private attachedImages: Map<string, ImageAttachment> = new Map();
@@ -44,7 +46,7 @@ export class ImageContextManager {
 
   constructor(
     containerEl: HTMLElement,
-    inputEl: HTMLTextAreaElement,
+    inputEl: ComposerInputElement,
     callbacks: ImageContextCallbacks,
     previewContainerEl?: HTMLElement,
     contextTray?: ComposerContextTray,
@@ -103,7 +105,7 @@ export class ImageContextManager {
   destroy(): void {
     if (this.destroyed) return;
     this.destroyed = true;
-    this.inputEl.removeEventListener('paste', this.pasteHandler);
+    this.inputEl.removeEventListener('paste', this.pasteHandler, true);
     if (this.dropZoneEl) {
       this.dropZoneEl.removeEventListener('dragenter', this.dragEnterHandler);
       this.dropZoneEl.removeEventListener('dragover', this.dragOverHandler);
@@ -207,7 +209,7 @@ export class ImageContextManager {
   }
 
   private setupPasteHandler() {
-    this.inputEl.addEventListener('paste', this.pasteHandler);
+    this.inputEl.addEventListener('paste', this.pasteHandler, true);
   }
 
   private async handlePaste(e: ClipboardEvent): Promise<void> {

--- a/src/features/chat/ui/InstructionModeManager.ts
+++ b/src/features/chat/ui/InstructionModeManager.ts
@@ -1,3 +1,4 @@
+import type { ComposerInputElement } from '@/shared/composer-dropdown/types';
 export interface InstructionModeCallbacks {
   onSubmit: (rawInstruction: string) => Promise<void>;
   getInputWrapper: () => HTMLElement | null;
@@ -12,14 +13,14 @@ export interface InstructionModeState {
 const INSTRUCTION_MODE_PLACEHOLDER = 'Save in custom system prompt';
 
 export class InstructionModeManager {
-  private inputEl: HTMLTextAreaElement;
+  private inputEl: ComposerInputElement;
   private callbacks: InstructionModeCallbacks;
   private state: InstructionModeState = { active: false, rawInstruction: '' };
   private isSubmitting = false;
   private originalPlaceholder: string = '';
 
   constructor(
-    inputEl: HTMLTextAreaElement,
+    inputEl: ComposerInputElement,
     callbacks: InstructionModeCallbacks
   ) {
     this.inputEl = inputEl;

--- a/src/features/chat/ui/textareaSizing.ts
+++ b/src/features/chat/ui/textareaSizing.ts
@@ -5,7 +5,7 @@ export function calculateTextareaMaxHeight(viewHeight: number): number {
   return Math.max(TEXTAREA_MIN_MAX_HEIGHT, viewHeight * TEXTAREA_MAX_HEIGHT_PERCENT);
 }
 
-export function installTextareaSizing(textarea: HTMLTextAreaElement): () => void {
+export function installTextareaSizing(textarea: HTMLElement): () => void {
   const container = textarea.closest<HTMLElement>('.claudian-container');
   const ownerWindow = textarea.ownerDocument.defaultView;
   let currentMaxHeight = '';

--- a/src/shared/components/ResumeSessionDropdown.ts
+++ b/src/shared/components/ResumeSessionDropdown.ts
@@ -4,8 +4,9 @@
  * Dropup UI for selecting a previous conversation to resume.
  * Shown when the /resume built-in command is executed.
  */
-
 import { setIcon } from 'obsidian';
+
+import type { ComposerInputElement } from '@/shared/composer-dropdown/types';
 
 import type { ConversationMeta } from '../../core/types';
 
@@ -25,7 +26,7 @@ let nextListboxId = 0;
 
 export class ResumeSessionDropdown {
   private containerEl: HTMLElement;
-  private inputEl: HTMLTextAreaElement;
+  private inputEl: ComposerInputElement;
   private dropdownEl: HTMLElement;
   private callbacks: ResumeSessionDropdownCallbacks;
   private conversations: ConversationMeta[];
@@ -37,7 +38,7 @@ export class ResumeSessionDropdown {
 
   constructor(
     containerEl: HTMLElement,
-    inputEl: HTMLTextAreaElement,
+    inputEl: ComposerInputElement,
     conversations: ConversationMeta[],
     currentConversationId: string | null,
     callbacks: ResumeSessionDropdownCallbacks

--- a/src/shared/composer-dropdown/ComposerDropdownController.ts
+++ b/src/shared/composer-dropdown/ComposerDropdownController.ts
@@ -85,14 +85,21 @@ export class ComposerDropdownController {
         }
       }
     }
-    if (!sourceMatch?.match) {
+    if (!sourceMatch) {
+      this.hide();
+      return;
+    }
+    const { match, source } = sourceMatch;
+    // Selected chips are completed references, even though their @path stays in the document.
+    if (this.inputEl.getFileMentions?.().some(mention =>
+      match.start < mention.to && match.end > mention.from)) {
       this.hide();
       return;
     }
 
-    if (this.activeSource?.id !== sourceMatch.source.id) this.activeFolder = null;
-    this.activeSource = sourceMatch.source;
-    this.activeMatch = sourceMatch.match;
+    if (this.activeSource?.id !== source.id) this.activeFolder = null;
+    this.activeSource = source;
+    this.activeMatch = match;
     this.requestActiveLoad(inputDriven);
   }
 
@@ -307,18 +314,22 @@ export class ComposerDropdownController {
       return;
     }
     if (action.kind === 'replace') {
-      this.replaceRange(match, action.text);
+      this.replaceRange(match, action.text, action.filePath);
       this.hide();
       action.onApplied?.();
       this.inputEl.focus();
     }
   }
 
-  private replaceRange(match: ComposerTriggerMatch, replacement: string): void {
-    let after = this.inputEl.value.slice(match.end);
-    if (/\s$/.test(replacement) && /^\s/.test(after)) after = after.slice(1);
+  private replaceRange(match: ComposerTriggerMatch, replacement: string, filePath?: string): void {
+    const duplicateSpace = /\s$/.test(replacement) && /^\s/.test(this.inputEl.value.slice(match.end));
+    const end = match.end + (duplicateSpace ? 1 : 0);
+    if (this.inputEl.replaceText) {
+      this.inputEl.replaceText(match.start, end, replacement, filePath);
+      return;
+    }
     const before = this.inputEl.value.slice(0, match.start);
-    this.inputEl.value = before + replacement + after;
+    this.inputEl.value = before + replacement + this.inputEl.value.slice(end);
     const cursor = before.length + replacement.length;
     this.inputEl.selectionStart = cursor;
     this.inputEl.selectionEnd = cursor;

--- a/src/shared/composer-dropdown/ComposerDropdownView.ts
+++ b/src/shared/composer-dropdown/ComposerDropdownView.ts
@@ -1,10 +1,10 @@
 import { setIcon } from 'obsidian';
 
-import type { ComposerDropdownItem } from './types';
+import type { ComposerDropdownItem, ComposerInputElement } from './types';
 
 export interface ComposerDropdownViewOptions {
   readonly fixed?: boolean;
-  readonly inputEl: HTMLInputElement | HTMLTextAreaElement;
+  readonly inputEl: ComposerInputElement;
   readonly onHover: (index: number) => void;
   readonly onSelect: (index: number) => void;
 }

--- a/src/shared/composer-dropdown/MentionSource.ts
+++ b/src/shared/composer-dropdown/MentionSource.ts
@@ -18,7 +18,7 @@ import type {
 type MentionValue =
   | { readonly kind: 'agent'; readonly agentId: string }
   | { readonly kind: 'context-file'; readonly absolutePath: string }
-  | { readonly kind: 'vault-file'; readonly path: string };
+  | { readonly kind: 'vault-file' | 'vault-folder'; readonly path: string };
 
 export interface MentionSourceCallbacks {
   readonly getCachedVaultFiles: () => readonly TFile[];
@@ -144,6 +144,8 @@ export class MentionSource implements ComposerDropdownSource {
     return {
       kind: 'replace',
       text: item.replacement,
+      ...(value?.kind === 'vault-file' || value?.kind === 'vault-folder' ? { filePath: value.path } : {}),
+      ...(value?.kind === 'context-file' ? { filePath: value.absolutePath } : {}),
       onApplied: () => {
         if (!value) return;
         if (value.kind === 'agent') this.callbacks.onAgentMentionSelect?.(value.agentId);
@@ -311,6 +313,7 @@ export class MentionSource implements ComposerDropdownSource {
             kind: 'value',
             label: `@${folder.path}/`,
             replacement: `@${normalized}/ `,
+            value: { kind: 'vault-folder', path: `${normalized}/` } satisfies MentionValue,
           },
           mtime: folderMtimes.get(folder.path) ?? 0,
           name: folder.name,

--- a/src/shared/composer-dropdown/types.ts
+++ b/src/shared/composer-dropdown/types.ts
@@ -1,4 +1,20 @@
-export type ComposerInputElement = HTMLInputElement | HTMLTextAreaElement;
+export interface ComposerFileMention {
+  readonly from: number;
+  readonly to: number;
+  /** Folder references retain their trailing slash, including while missing. */
+  readonly path: string;
+}
+
+/** Text/caret contract shared by native inputs and the Main Chat rich editor. */
+export interface ComposerInputElement extends HTMLElement {
+  value: string;
+  selectionStart: number | null;
+  selectionEnd: number | null;
+  placeholder: string;
+  replaceText?: (from: number, to: number, text: string, filePath?: string) => void;
+  getFileMentions?: () => readonly ComposerFileMention[];
+  setFileMentions?: (mentions: readonly ComposerFileMention[]) => void;
+}
 
 export interface ComposerTriggerMatch {
   readonly atInputStart: boolean;
@@ -58,6 +74,7 @@ export type ComposerSelectionAction =
   | {
     readonly kind: 'replace';
     readonly text: string;
+    readonly filePath?: string;
     readonly onApplied?: () => void;
   };
 

--- a/src/style/components/composer-editor.css
+++ b/src/style/components/composer-editor.css
@@ -1,0 +1,128 @@
+/* The wrapper owns composer chrome; CodeMirror owns document layout and scrolling. */
+.claudian-input-wrapper .claudian-composer-editor {
+  width: 100%;
+  min-width: 0;
+  min-height: 60px;
+  flex: 1 1 auto;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--text-normal);
+  font-family: inherit;
+  font-size: 14px;
+  line-height: 1.6;
+  cursor: text;
+  white-space: pre-wrap;
+}
+
+.claudian-composer-editor:focus,
+.claudian-composer-editor .cm-editor.cm-focused {
+  outline: none;
+}
+
+.claudian-composer-editor:empty::before {
+  display: block;
+  padding: 8px 10px 10px;
+  content: attr(data-placeholder);
+  color: var(--text-muted);
+}
+
+.claudian-composer-editor .cm-editor {
+  background: transparent;
+}
+
+.claudian-composer-editor .cm-scroller {
+  max-height: var(--claudian-textarea-max-height, none);
+  overflow: auto;
+  font-family: inherit;
+}
+
+.claudian-composer-editor .cm-content {
+  padding: 8px 0 10px;
+  min-height: 60px;
+  caret-color: var(--text-normal);
+}
+
+.claudian-composer-editor .cm-line {
+  padding: 0 10px;
+}
+
+.claudian-composer-editor .cm-placeholder {
+  color: var(--text-muted);
+}
+
+.claudian-composer-editor .cm-cursor {
+  border-left-color: var(--text-normal);
+}
+
+.claudian-mention-chip {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 3px;
+  max-width: 100%;
+  padding: 0 4px 0 6px;
+  border-radius: 4px;
+  background: var(--background-modifier-hover);
+  color: var(--text-normal);
+  font-size: 0.92em;
+  vertical-align: baseline;
+  white-space: nowrap;
+}
+
+.claudian-mention-chip > span,
+button.claudian-mention-open {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.claudian-mention-chip.is-missing {
+  outline: 1px dashed var(--text-faint);
+  color: var(--text-muted);
+}
+
+button.claudian-mention-open,
+button.claudian-mention-remove {
+  height: auto;
+  min-height: 0;
+  padding: 0 3px;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+button.claudian-mention-open:hover,
+button.claudian-mention-open:focus-visible,
+button.claudian-mention-open:active,
+button.claudian-mention-remove:hover,
+button.claudian-mention-remove:focus-visible,
+button.claudian-mention-remove:active {
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--text-normal);
+}
+
+button.claudian-mention-open:focus-visible,
+button.claudian-mention-remove:focus-visible {
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: 1px;
+}
+
+button.claudian-mention-open:disabled,
+button.claudian-mention-remove:disabled {
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--text-faint);
+  cursor: default;
+}
+
+button.claudian-mention-open {
+  padding: 0;
+  font: inherit;
+  text-align: start;
+  white-space: nowrap;
+}

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -18,6 +18,7 @@
 @import "./components/status-panel.css";
 @import "./components/subagent.css";
 @import "./components/input.css";
+@import "./components/composer-editor.css";
 @import "./components/context-tray.css";
 @import "./components/context-footer.css";
 @import "./components/composer-dropdown.css";

--- a/tests/unit/features/chat/composer/ComposerEditor.dom.test.ts
+++ b/tests/unit/features/chat/composer/ComposerEditor.dom.test.ts
@@ -1,0 +1,352 @@
+/** @jest-environment jsdom */
+
+import { fireEvent, waitFor, within } from '@testing-library/dom';
+import { axe } from 'jest-axe';
+import { type App, Platform, TFile, TFolder } from 'obsidian';
+
+import { ComposerEditor } from '@/features/chat/composer/ComposerEditor';
+import { isComposerPathAvailable } from '@/features/chat/composer/OpenComposerPath';
+import { sendTabInputMessageFromExplicitEnterShortcut } from '@/features/chat/tabs/TabInputEvents';
+import { ImageContextManager } from '@/features/chat/ui/ImageContext';
+import { ComposerDropdownController } from '@/shared/composer-dropdown/ComposerDropdownController';
+import { MentionSource } from '@/shared/composer-dropdown/MentionSource';
+
+beforeEach(() => {
+  HTMLElement.prototype.empty = function () { this.replaceChildren(); };
+  HTMLElement.prototype.addClass = function (...names) { this.classList.add(...names); };
+  HTMLElement.prototype.removeClass = function (...names) { this.classList.remove(...names); };
+  HTMLElement.prototype.hasClass = function (name) { return this.classList.contains(name); };
+  HTMLElement.prototype.toggleClass = function (name, enabled) { for (const cls of Array.isArray(name) ? name : [name]) this.classList.toggle(cls, enabled); };
+  HTMLElement.prototype.scrollIntoView = jest.fn();
+});
+
+it('edits selected mentions as inline chips while retaining plain text, undo, and draft restoration', async () => {
+  const parent = document.body.createDiv();
+  let available = true;
+  const editor = new ComposerEditor(parent, { isFileAvailable: () => available });
+  const input = editor.element;
+  input.value = 'Compare @A with B';
+  input.focus();
+  input.replaceText!(8, 10, '@Notes/A.md ', 'Notes/A.md');
+  expect(input.value).toBe('Compare @Notes/A.md  with B');
+  const mentions = input.getFileMentions!();
+  expect(mentions).toEqual([{ from: 8, to: 19, path: 'Notes/A.md' }]);
+  const chip = within(parent).getByRole('button', { name: 'Remove Notes/A.md' });
+  expect(chip.getAttribute('type')).toBe('button');
+  expect((await axe(chip.parentElement!)).violations).toEqual([]);
+  available = false;
+  editor.refreshMentions();
+  expect(within(parent).getByText('A · Missing')).toBeTruthy();
+  fireEvent.click(within(parent).getByRole('button', { name: 'Remove Notes/A.md' }));
+  expect(input.value).toBe('Compare   with B');
+  fireEvent.keyDown(parent.querySelector('[contenteditable]')!, { key: 'z', code: 'KeyZ', ctrlKey: true });
+  expect(input.value).toBe('Compare @Notes/A.md  with B');
+  expect(input.getFileMentions!()).toEqual(mentions);
+  const draft = input.value;
+  input.value = '';
+  expect(input.getFileMentions!()).toEqual([]);
+  input.value = draft;
+  input.setFileMentions!(mentions);
+  expect(within(parent).getByRole('button', { name: 'Remove Notes/A.md' })).toBeTruthy();
+  editor.destroy();
+  parent.remove();
+});
+
+it('exposes missing-file feedback in the chip action name and keeps it removable', async () => {
+  const parent = document.body.createDiv();
+  let available = true;
+  const onOpenFile = jest.fn();
+  const editor = new ComposerEditor(parent, { isFileAvailable: () => available, onOpenFile });
+  try {
+    editor.element.focus();
+    editor.element.replaceText!(0, 0, '@Notes/A.md ', 'Notes/A.md');
+    available = false;
+    editor.refreshMentions();
+    const open = within(parent).getByRole('button', { name: 'Open Notes/A.md (Missing)' });
+    expect((await axe(open.parentElement!)).violations).toEqual([]);
+    fireEvent.click(open);
+    expect(onOpenFile).toHaveBeenCalledWith('Notes/A.md');
+    expect(editor.element.value).toBe('@Notes/A.md ');
+    fireEvent.click(within(parent).getByRole('button', { name: 'Remove Notes/A.md' }));
+    expect(editor.element.value).toBe(' ');
+  } finally {
+    editor.destroy();
+    parent.remove();
+  }
+});
+
+it('copies paths as text and supports atomic keyboard deletion, undo, redo, and plain-text paste', () => {
+  const parent = document.body.createDiv();
+  const editor = new ComposerEditor(parent);
+  const input = editor.element;
+  input.focus();
+  input.replaceText!(0, 0, '@A.md ', 'A.md');
+  const content = parent.querySelector('[contenteditable]')!;
+  input.selectionStart = 0;
+  input.selectionEnd = 5;
+  const clipboardData = { clearData: jest.fn(), setData: jest.fn(), getData: () => '@B.md', files: [] };
+  fireEvent.copy(content, { clipboardData });
+  expect(clipboardData.setData).toHaveBeenCalledWith('text/plain', '@A.md');
+  input.selectionStart = 5;
+  input.selectionEnd = 5;
+  fireEvent.keyDown(content, { key: 'Backspace', code: 'Backspace' });
+  expect(input.value).toBe(' ');
+  fireEvent.keyDown(content, { key: 'z', code: 'KeyZ', ctrlKey: true });
+  expect(input.getFileMentions!()).toEqual([{ from: 0, to: 5, path: 'A.md' }]);
+  fireEvent.keyDown(content, { key: 'y', code: 'KeyY', ctrlKey: true });
+  expect(input.value).toBe(' ');
+  input.value = '';
+  fireEvent.paste(content, { clipboardData });
+  expect(input.value).toBe('@B.md');
+  expect(input.getFileMentions!()).toEqual([]);
+  input.value = '';
+  fireEvent.keyDown(content, { key: 'z', code: 'KeyZ', ctrlKey: true });
+  expect(input.value).toBe('');
+  editor.destroy();
+  parent.remove();
+});
+
+it('keeps a restored draft separate from the previous draft undo history', () => {
+  const parent = document.body.createDiv();
+  const editor = new ComposerEditor(parent, { onOpenFile: jest.fn() });
+  const input = editor.element;
+  try {
+    input.focus();
+    input.replaceText!(0, 0, '@A.md ', 'A.md');
+    const content = within(parent).getByRole('textbox', { name: 'Message' });
+    fireEvent.keyDown(content, { key: 'Backspace', code: 'Backspace' });
+    expect(input.value).toBe('@A.md');
+
+    input.value = '@B.md';
+    input.setFileMentions!([{ from: 0, to: 5, path: 'B.md' }]);
+    fireEvent.keyDown(content, { key: 'z', code: 'KeyZ', ctrlKey: true });
+    expect(input.value).toBe('@B.md');
+    expect(input.getFileMentions!()).toEqual([{ from: 0, to: 5, path: 'B.md' }]);
+    expect(within(parent).getByRole('button', { name: 'Open B.md' })).toBeTruthy();
+  } finally {
+    editor.destroy();
+    parent.remove();
+  }
+});
+
+it.each([false, true])('inserts a plain newline without rewriting draft whitespace (shift=%s)', shiftKey => {
+  const parent = document.body.createDiv();
+  const editor = new ComposerEditor(parent);
+  try {
+    editor.element.value = '  Keep these spaces  ';
+    editor.element.focus();
+    fireEvent.keyDown(within(parent).getByRole('textbox', { name: 'Message' }), {
+      key: 'Enter', code: 'Enter', shiftKey,
+    });
+    expect(editor.element.value).toBe('  Keep these spaces  \n');
+  } finally {
+    editor.destroy();
+    parent.remove();
+  }
+});
+
+it('allows input listeners to update composer modes and forwards dropdown accessibility to the focused textbox', async () => {
+  const parent = document.body.createDiv();
+  const editor = new ComposerEditor(parent);
+  const input = editor.element;
+  input.focus();
+  input.value = 'x';
+  input.addEventListener('input', () => { input.placeholder = 'Save instructions'; });
+  const content = within(parent).getByRole('textbox', { name: 'Message' });
+  fireEvent.keyDown(content, { key: 'Backspace', code: 'Backspace' });
+  await Promise.resolve();
+  expect(within(parent).getByText('Save instructions')).toBeTruthy();
+  input.setAttribute('aria-autocomplete', 'list');
+  input.setAttribute('aria-activedescendant', 'option-1');
+  await Promise.resolve();
+  expect(content.getAttribute('aria-autocomplete')).toBe('list');
+  expect(content.getAttribute('aria-activedescendant')).toBe('option-1');
+  editor.destroy();
+  parent.remove();
+});
+
+it('keeps the explicit send shortcut focused inside the editor', () => {
+  const parent = document.body.createDiv();
+  const editor = new ComposerEditor(parent);
+  editor.element.focus();
+  const sendMessage = jest.fn().mockResolvedValue(undefined);
+  const tab = { dom: { inputEl: editor.element }, controllers: { inputController: { sendMessage } } };
+  const event = new KeyboardEvent('keydown', { key: 'Enter', ctrlKey: !Platform.isMacOS, metaKey: Platform.isMacOS, cancelable: true });
+  expect(sendTabInputMessageFromExplicitEnterShortcut(tab as never, event, { requireInputFocus: true })).toBe(true);
+  expect(sendMessage).toHaveBeenCalled();
+  editor.destroy();
+  parent.remove();
+});
+
+describe.each([
+  {
+    kind: 'file', path: 'Notes/A note.md', label: 'A note', option: 'Notes/A note.md',
+    inputText: 'Read @A today', cursor: 7, expectedText: 'Read @Notes/A note.md today', end: 21,
+  },
+  {
+    kind: 'folder', path: 'Journals/Pages/Travel/', label: 'Travel/', option: '@Journals/Pages/Travel/',
+    inputText: 'Read @Travel today', cursor: 12, expectedText: 'Read @Journals/Pages/Travel/ today', end: 28,
+  },
+])('$kind completion', fixture => {
+  it.each(['click', 'Enter', 'Tab'])('selects an openable, removable chip using %s', async method => {
+    const parent = document.body.createDiv();
+    const onOpenFile = jest.fn();
+    const editor = new ComposerEditor(parent, { onOpenFile });
+    const file = Object.assign(new TFile(), { path: 'Notes/A note.md', name: 'A note.md', stat: { mtime: 0 } });
+    const source = new MentionSource({
+      getCachedVaultFiles: () => [file],
+      getCachedVaultFolders: () => [{ name: 'Travel', path: 'Journals/Pages/Travel' }],
+      getExternalContexts: () => [],
+      normalizePathForVault: path => path ?? null,
+      onAttachFile: () => {},
+    });
+    const dropdown = new ComposerDropdownController(parent, editor.element, [source]);
+    try {
+      editor.element.value = fixture.inputText;
+      editor.element.selectionStart = editor.element.selectionEnd = fixture.cursor;
+      editor.element.focus();
+      dropdown.handleInputChange();
+      const option = await waitFor(() => within(parent).getByRole('option', { name: fixture.option }));
+      if (method === 'click') fireEvent.click(option);
+      else dropdown.handleKeydown(new KeyboardEvent('keydown', { key: method }));
+
+      const open = within(parent).getByRole('button', { name: `Open ${fixture.path}` });
+      expect(open.textContent).toBe(fixture.label);
+      expect(open.getAttribute('type')).toBe('button');
+      expect((await axe(open.parentElement!)).violations).toEqual([]);
+      fireEvent.click(open);
+      expect(onOpenFile).toHaveBeenCalledWith(fixture.path);
+      expect(editor.element.value).toBe(fixture.expectedText);
+      expect(editor.element.getFileMentions!()).toEqual([
+        { from: 5, to: fixture.end, path: fixture.path },
+      ]);
+      onOpenFile.mockClear();
+      fireEvent.click(within(parent).getByRole('button', { name: `Remove ${fixture.path}` }));
+      expect(editor.element.value).toBe('Read  today');
+      expect(onOpenFile).not.toHaveBeenCalled();
+    } finally {
+      dropdown.destroy();
+      source.destroy();
+      editor.destroy();
+      parent.remove();
+    }
+  });
+});
+
+it.each(['Journals/Pages/Travel/', 'Journals/Pages/Travel plan.md'])(
+  'ends matching after selecting %s and allows a new mention after the chip',
+  async path => {
+    const parent = document.body.createDiv();
+    const editor = new ComposerEditor(parent);
+    const file = Object.assign(new TFile(), {
+      path: 'Journals/Pages/Travel plan.md', name: 'Travel plan.md', stat: { mtime: 0 },
+    });
+    const source = new MentionSource({
+      getCachedVaultFiles: () => [file],
+      getCachedVaultFolders: () => [{ name: 'Travel', path: 'Journals/Pages/Travel' }],
+      getExternalContexts: () => [],
+      normalizePathForVault: value => value ?? null,
+      onAttachFile: () => {},
+    });
+    const input = editor.element;
+    const dropdown = new ComposerDropdownController(parent, input, [source]);
+    input.addEventListener('input', () => dropdown.handleInputChange());
+    try {
+      input.value = '@Travel';
+      input.focus();
+      fireEvent.input(input);
+      const optionName = path.endsWith('/') ? `@${path}` : path;
+      fireEvent.click(await waitFor(() => within(parent).getByRole('option', { name: optionName })));
+      expect(within(parent).getByRole('button', { name: `Remove ${path}` })).toBeTruthy();
+      expect(dropdown.isVisible()).toBe(false);
+
+      // An input notification after completion must not restart its finished search.
+      fireEvent.input(input);
+      expect(dropdown.isVisible()).toBe(false);
+
+      const content = within(parent).getByRole('textbox', { name: 'Message' });
+      fireEvent.paste(content, { clipboardData: { getData: () => 'Plan a trip ', files: [] } });
+      await Promise.resolve();
+      expect(input.value).toBe(`@${path} Plan a trip `);
+      expect(dropdown.isVisible()).toBe(false);
+      expect(input.getAttribute('aria-expanded')).toBe('false');
+
+      fireEvent.paste(content, { clipboardData: { getData: () => '@Travel', files: [] } });
+      await Promise.resolve();
+      fireEvent.click(await waitFor(() => within(parent).getByRole('option', { name: '@Journals/Pages/Travel/' })));
+      expect(input.value).toBe(`@${path} Plan a trip @Journals/Pages/Travel/ `);
+      expect(input.getFileMentions!()).toHaveLength(2);
+      expect(dropdown.isVisible()).toBe(false);
+    } finally {
+      dropdown.destroy();
+      source.destroy();
+      editor.destroy();
+      parent.remove();
+    }
+  },
+);
+
+it('keeps folder identity and missing feedback through removal, undo, and draft restoration', () => {
+  const parent = document.body.createDiv();
+  const folder = Object.assign(new TFolder(), { path: 'Journals/Travel.md' });
+  let target: TFolder | TFile | null = folder;
+  const app = {
+    vault: { getAbstractFileByPath: (path: string) => path === 'Journals/Travel.md' ? target : null },
+  } as unknown as App;
+  const editor = new ComposerEditor(parent, {
+    isFileAvailable: path => isComposerPathAvailable(app, path),
+    onOpenFile: () => {},
+  });
+  const input = editor.element;
+  try {
+    input.focus();
+    input.replaceText!(0, 0, '@Journals/Travel.md/ ', 'Journals/Travel.md/');
+    expect(within(parent).getByRole('button', { name: 'Open Journals/Travel.md/' }).textContent).toBe('Travel.md/');
+    input.selectionStart = 0;
+    input.selectionEnd = 20;
+    const clipboardData = { clearData: jest.fn(), setData: jest.fn() };
+    fireEvent.copy(within(parent).getByRole('textbox', { name: 'Message' }), { clipboardData });
+    expect(clipboardData.setData).toHaveBeenCalledWith('text/plain', '@Journals/Travel.md/');
+    target = null;
+    editor.refreshMentions();
+    expect(within(parent).getByRole('button', { name: 'Open Journals/Travel.md/ (Missing)' }).textContent).toBe('Travel.md/ · Missing');
+    fireEvent.click(within(parent).getByRole('button', { name: 'Remove Journals/Travel.md/' }));
+    expect(input.value).toBe(' ');
+    fireEvent.keyDown(within(parent).getByRole('textbox', { name: 'Message' }), {
+      key: 'z', code: 'KeyZ', ctrlKey: true,
+    });
+    expect(input.value).toBe('@Journals/Travel.md/ ');
+    const mentions = input.getFileMentions!();
+    expect(mentions).toEqual([{ from: 0, to: 20, path: 'Journals/Travel.md/' }]);
+    input.value = '';
+    input.value = '@Journals/Travel.md/ ';
+    input.setFileMentions!(mentions);
+    expect(within(parent).getByRole('button', { name: 'Open Journals/Travel.md/ (Missing)' })).toBeTruthy();
+
+    target = new TFile();
+    editor.refreshMentions();
+    expect(within(parent).getByRole('button', { name: 'Open Journals/Travel.md/ (Missing)' })).toBeTruthy();
+    target = folder;
+    editor.refreshMentions();
+    expect(within(parent).getByRole('button', { name: 'Open Journals/Travel.md/' }).textContent).toBe('Travel.md/');
+  } finally {
+    editor.destroy();
+    parent.remove();
+  }
+});
+
+it('lets image attachment handling consume image paste before the rich editor inserts fallback text', () => {
+  const parent = document.body.createDiv({ cls: 'claudian-input-wrapper' });
+  const editor = new ComposerEditor(parent);
+  const images = new ImageContextManager(parent, editor.element, {});
+  editor.element.value = 'Keep this';
+  editor.element.focus();
+  const clipboardData = {
+    items: [{ type: 'image/png', getAsFile: () => null }], files: [], getData: () => 'image fallback',
+  };
+  fireEvent.paste(within(parent).getByRole('textbox', { name: 'Message' }), { clipboardData });
+  expect(editor.element.value).toBe('Keep this');
+  images.destroy();
+  editor.destroy();
+  parent.remove();
+});

--- a/tests/unit/features/chat/composer/OpenComposerPath.test.ts
+++ b/tests/unit/features/chat/composer/OpenComposerPath.test.ts
@@ -1,0 +1,92 @@
+import { type App, Notice, TFile, TFolder } from 'obsidian';
+
+import { openComposerPath } from '@/features/chat/composer/OpenComposerPath';
+
+it.each([true, false])('reveals the selected folder in the file explorer (already open=%s)', async alreadyOpen => {
+  const folder = Object.assign(new TFolder(), { path: 'Journals/Pages/Travel' });
+  const revealInFolder = jest.fn().mockResolvedValue(undefined);
+  const leaf = {
+    view: { revealInFolder: alreadyOpen ? revealInFolder : undefined },
+    setViewState: async (state: { type: string; active: boolean }) => {
+      expect(state).toEqual({ type: 'file-explorer', active: true });
+      leaf.view.revealInFolder = revealInFolder;
+    },
+  };
+  const getAbstractFileByPath = jest.fn().mockReturnValue(folder);
+  const revealLeaf = jest.fn().mockResolvedValue(undefined);
+  const app = {
+    vault: { getAbstractFileByPath },
+    workspace: {
+      getLeavesOfType: () => alreadyOpen ? [leaf] : [],
+      getLeftLeaf: () => leaf,
+      revealLeaf,
+    },
+  } as unknown as App;
+
+  await openComposerPath(app, 'Journals/Pages/Travel/');
+
+  expect(getAbstractFileByPath).toHaveBeenCalledWith('Journals/Pages/Travel');
+  expect(revealLeaf).toHaveBeenCalledWith(leaf);
+  expect(revealInFolder).toHaveBeenCalledWith(folder);
+});
+
+it('opens the exact referenced vault file in a note tab and rechecks deleted references', async () => {
+  const file = Object.assign(new TFile(), { path: 'Notes/A #1.md' });
+  const openFile = jest.fn().mockResolvedValue(undefined);
+  const getLeaf = jest.fn().mockReturnValue({ openFile });
+  const getAbstractFileByPath = jest.fn().mockReturnValue(file);
+  const app = { vault: { getAbstractFileByPath }, workspace: { getLeaf } } as unknown as App;
+
+  await openComposerPath(app, file.path);
+  expect(getAbstractFileByPath).toHaveBeenCalledWith('Notes/A #1.md');
+  expect(getLeaf).toHaveBeenCalledWith('tab');
+  expect(openFile).toHaveBeenCalledWith(file);
+
+  getLeaf.mockClear();
+  openFile.mockClear();
+  getAbstractFileByPath.mockReturnValue(null);
+  await openComposerPath(app, file.path);
+  expect(Notice).toHaveBeenCalledWith('Note not found in this vault: Notes/A #1.md');
+  expect(getLeaf).not.toHaveBeenCalled();
+  expect(openFile).not.toHaveBeenCalled();
+});
+
+it.each([null, new TFile()])('reports the folder path when its target is unavailable (%s)', async target => {
+  const app = {
+    vault: { getAbstractFileByPath: () => target },
+  } as unknown as App;
+
+  await openComposerPath(app, 'Journals/Pages/Travel/');
+
+  expect(Notice).toHaveBeenCalledWith('Folder not found in this vault: Journals/Pages/Travel/');
+});
+
+it('reports a failed folder reveal without opening a note', async () => {
+  const folder = Object.assign(new TFolder(), { path: 'Journals/Pages/Travel' });
+  const app = {
+    vault: { getAbstractFileByPath: () => folder },
+    workspace: {
+      getLeavesOfType: () => [{ view: { revealInFolder: () => { throw new Error('Unavailable'); } } }],
+      revealLeaf: jest.fn().mockResolvedValue(undefined),
+    },
+  } as unknown as App;
+
+  await openComposerPath(app, 'Journals/Pages/Travel/');
+
+  expect(Notice).toHaveBeenCalledWith('Could not reveal folder: Journals/Pages/Travel/');
+});
+
+it('reports folders and failures to open a note', async () => {
+  const openFile = jest.fn().mockRejectedValue(new Error('View unavailable'));
+  const getAbstractFileByPath = jest.fn().mockReturnValue(new TFolder());
+  const app = {
+    vault: { getAbstractFileByPath }, workspace: { getLeaf: () => ({ openFile }) },
+  } as unknown as App;
+
+  await openComposerPath(app, 'Notes');
+  expect(Notice).toHaveBeenCalledWith('Note not found in this vault: Notes');
+  expect(openFile).not.toHaveBeenCalled();
+  getAbstractFileByPath.mockReturnValue(new TFile());
+  await openComposerPath(app, 'Notes/A.md');
+  expect(Notice).toHaveBeenCalledWith('Could not open note: Notes/A.md');
+});

--- a/tests/unit/features/chat/controllers/InputController.test.ts
+++ b/tests/unit/features/chat/controllers/InputController.test.ts
@@ -14,6 +14,7 @@ import {
   type ChatTurnSubmission,
 } from '@/features/chat/execution/ChatExecutionCoordinator';
 import { ChatState } from '@/features/chat/state/ChatState';
+import type { ComposerInputElement } from '@/shared/composer-dropdown/types';
 
 jest.mock('@/core/providers/ProviderRegistry', () => ({
   ProviderRegistry: {
@@ -38,12 +39,12 @@ jest.mock('@/core/providers/ProviderSettingsCoordinator', () => ({
   },
 }));
 
-function createInput(): HTMLTextAreaElement {
+function createInput(): ComposerInputElement {
   return {
     dispatchEvent: jest.fn().mockReturnValue(true),
     focus: jest.fn(),
     value: '',
-  } as unknown as HTMLTextAreaElement;
+  } as unknown as ComposerInputElement;
 }
 
 function deferred<T>(): {
@@ -223,6 +224,38 @@ function createFixture(overrides: Record<string, unknown> = {}) {
     state,
   };
 }
+
+describe('inline file chips', () => {
+  it('restores selected chips after a definite failure before provider handoff', async () => {
+    const fixture = createFixture();
+    fixture.input.value = '@A.md';
+    fixture.input.getFileMentions = () => [{ from: 0, to: 5, path: 'A.md' }];
+    fixture.input.setFileMentions = jest.fn();
+    fixture.coordinator.execute.mockRejectedValue(new ChatExecutionPreHandoffError('ledger unavailable'));
+    await fixture.controller.sendMessage();
+    expect(fixture.input.value).toBe('@A.md');
+    expect(fixture.input.setFileMentions).toHaveBeenCalledWith([{ from: 0, to: 5, path: 'A.md' }]);
+    expect(fixture.state.messages).toEqual([]);
+  });
+
+  it('preserves chips when queued messages are merged and returned to the draft', async () => {
+    const fixture = createFixture();
+    fixture.state.isStreaming = true;
+    fixture.input.value = '  @A.md  ';
+    fixture.input.getFileMentions = () => [{ from: 2, to: 7, path: 'A.md' }];
+    await fixture.controller.sendMessage();
+    fixture.input.value = '@B.md';
+    fixture.input.getFileMentions = () => [{ from: 0, to: 5, path: 'B.md' }];
+    await fixture.controller.sendMessage();
+    fixture.input.getFileMentions = () => [];
+    fixture.input.setFileMentions = jest.fn();
+    fixture.controller.withdrawQueuedMessageToComposer();
+    expect(fixture.input.value).toBe('@A.md\n\n@B.md');
+    expect(fixture.input.setFileMentions).toHaveBeenCalledWith([
+      { from: 0, to: 5, path: 'A.md' }, { from: 7, to: 12, path: 'B.md' },
+    ]);
+  });
+});
 
 describe('InputController approval details', () => {
   it('makes long approval details a named keyboard-scrollable region', () => {


### PR DESCRIPTION
## Why

Long `@path` references make drafts harder to scan and selected references difficult to distinguish from unfinished mentions. Inline chips give users a clear, removable reference at the point where it appears in their message.

Related to #1277; implements the [inline-chip scope welcomed by the maintainer](https://github.com/YishenTu/claudian/issues/1277#issuecomment-5578784523).

## What Changed

- Selecting a file or vault folder from `@` completion creates an inline chip. Folder labels retain `/` to distinguish them from files.
- Chip labels open the referenced vault note or reveal the folder in the file explorer. Separate remove buttons and visible missing-target feedback support correction before sending.
- Preserve selected references through editing, undo/redo, draft restoration, queued-message merging and withdrawal, and failures before provider handoff.
- End completion matching at selected chips so typing after a folder selection does not leave the matching menu open. Fresh `@` mentions still trigger completion.
- Document the composer behavior in the README and add regression coverage at the editor, completion, open/reveal, and input-controller seams.

## Why This Approach

The composer uses the existing CodeMirror dependencies for atomic inline widgets and undoable text edits. A native textarea cannot contain interactive inline controls. The shared composer input contract keeps existing completion and input orchestration in place, with native-input compatibility for other consumers.

The editor owns draft text and selected ranges; InputController owns queue snapshots and restoration. Serialization remains ordinary `@path` text, so the UI can preserve chip identity without extending provider contracts or conversation storage.

## Validation

- `npm run typecheck`, `npm run lint`, and `npm run build` passed on Node 24.19.0.
- All 53 repository checks passed, including 41 architecture checks.
- Focused regression run: 7 suites, 139 tests passed, including real-DOM control semantics and targeted accessibility checks.
- Full test run: 611 suites passed, 1 failed, 2 skipped; 8,999 tests passed, 2 failed, 2 skipped. Both failures are existing `CodexBinaryLocator` fixture tests, independently reproduced on unchanged upstream: the installed macOS Codex.app binary takes precedence over the fixture binary.
- Browser checks covered mouse/Enter/Tab completion, native Enter/Space chip activation, removal, undo, plain-text copying, typing after selected chips, and fresh mention matching. The build was also installed in Obsidian for local testing.

## Impact and Follow-ups

Persistent linked-note behavior, provider context, and sent-message rendering retain their existing behavior. No dependencies or storage migrations are added. Chip metadata stays in transient composer and queue state; manually typed or pasted references remain plain text until selected from completion. Missing paths remain ordinary text when sent.

This PR covers inline composer chips; the broader message-attachment redesign proposed in #1277 is outside this change.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
