### PR TITLE
fix: drop dead context_files instruction from main chat prompt

### DIFF
--- a/src/core/prompt/mainAgent.ts
+++ b/src/core/prompt/mainAgent.ts
@@ -41,7 +41,6 @@ The user's query comes first, followed by optional Claudian XML context tags. Tr
 - \`<editor_cursor path="path/to/note.md" line="8">\`: Text around the editor cursor.
 - \`<browser_selection source="browser:https://example.com" title="Example" url="https://example.com">\`: Selected browser-view text.
 - \`<canvas_selection path="boards/project.canvas">\`: Selected Canvas node IDs.
-- \`<context_files><context_file path="/absolute/context" /></context_files>\`: Additional file or directory references.
 - \`[[vault-relative-path|display-name]]\`: A Vault file reference. The text before \`|\` is the file path relative to the Vault root; the text after \`|\` is only a display label. Use the path, not the label, to identify the file.`;
 }
 

--- a/tests/unit/providers/claude/prompt/systemPrompt.test.ts
+++ b/tests/unit/providers/claude/prompt/systemPrompt.test.ts
@@ -91,10 +91,10 @@ describe('systemPrompt', () => {
       expect(prompt).toContain('<linked_content path="path/to/content" />');
       expect(prompt).toContain('<editor_cursor path="path/to/note.md" line="8">');
       expect(prompt).toContain('<canvas_selection path="boards/project.canvas">');
-      expect(prompt).toContain('<context_file path="/absolute/context" />');
       expect(prompt).not.toContain('Legacy messages may');
       expect(prompt).not.toContain('<linked_note>');
       expect(prompt).not.toContain('<current_note>');
+      expect(prompt).not.toContain('<context_file');
       expect(prompt).toContain('file, Note, or directory');
       expect(prompt).toContain('Inspect only the files needed');
       expect(prompt).toContain('not an instruction to recursively read');


### PR DESCRIPTION
## Summary

`3145e468` (#1283) removed external context in favor of provider-native access, deleting the chat-side producer of the `<context_files>` tag. The main-chat system prompt still documents that tag to the model, so every chat request carries an instruction describing a shape the chat runtime can no longer emit.

This removes that one bullet and restores the existing `should document only current live context shapes` invariant, which #1283 walked past.

## Evidence

The tag has exactly one producer, `appendContextFiles` (`src/utils/context.ts:139`). On `main` it has two callers, both inline-edit:

- `src/core/prompt/inlineEdit.ts:55`
- `src/core/auxiliary/InlineEditService.ts:68`

The consumer chain is closed: `InlineEditService` is constructed only by `ProviderRegistry.createInlineEditService` (`src/core/providers/ProviderRegistry.ts:109`), whose only caller is `src/features/inline-edit/ui/InlineEditModal.ts:404`. `contextFiles` originates solely at `InlineEditModal.resolveContextFilesFromMessage`.

The deleted chat-side producer was a single line:

```
git grep "appendContextFiles" 3145e468^ -- src/
src/providers/pi/execution/PiExecutionSession.ts:1575:
    text = appendContextFiles(text, [...context.externalContextPaths]);
```

`git grep "context_file" 3145e468^ -- src/` confirms `appendContextFiles` was the only producer even before that removal, so no differently-shaped chat emitter exists.

History replay does not reintroduce it: `buildContextFromHistory` reconstructs context only through `formatContextLine`, which emits `linked_content`.

## Why the test changed rather than gained a new case

`tests/unit/providers/claude/prompt/systemPrompt.test.ts` already owns this contract in `should document only current live context shapes`, mixing positives for live shapes with negatives for retired ones (`<linked_note>`, `<current_note>`). Those retired tags are still stripped by `src/utils/context.ts` yet deliberately undocumented — the same situation as `<context_file` now.

Adding a separate assertion elsewhere would have split one contract across two owners, so the existing positive assertion became a negative in place, next to the other retired shapes. `AGENTS.md` also rules out a freestanding test that merely proves a removed line is gone.

`#1283` did edit this file, but only removed `not.toContain('External context paths')` from the path-conventions test; the `<context_file path="/absolute/context" />` positive in the next block was left in place. `git show --stat 3145e468 | grep -c "core/prompt/mainAgent"` returns 0.

The assertion uses the unclosed prefix `'<context_file'` because the shape has two forms — the `<context_files>` wrapper and the `<context_file path=` entry — and neither closed literal covers both.

## Deliberately unchanged

- `src/core/prompt/inlineEdit.ts:77` documents the same tag and is still correct: inline edit really does emit it.
- `src/utils/context.ts` keeps `XML_CONTEXT_PATTERN` and the `<context_files>` stripping, which historical conversation messages still depend on.
- `systemPrompt.test.ts` tests a `core/` module from under `tests/unit/providers/claude/`. That predates this change and relocating it here would obscure a one-line diff.

## Verification

`npm run typecheck`, `npm run lint`, `npm run build`, and `git diff --check` all pass. Focused suites (`tests/unit/core/prompt/`, `systemPrompt.test.ts`, `tests/unit/utils/context.test.ts`, `tests/unit/core/auxiliary/InlineEditService.test.ts`) pass 103 tests across 6 suites. All three importers of `core/prompt/mainAgent` in `tests/` were run, including `tests/unit/providers/grok/runtime/GrokSessionMeta.test.ts`.

Red/green was taken at the changed assertion: with the prompt bullet restored, `not.toContain('<context_file')` fails 1 of 24 in `systemPrompt.test.ts`; with the bullet removed it passes 24 of 24.

Local full-suite runs on this machine show intermittent pre-existing failures in `tests/integration/app/collab/` LAN/TLS integration gates (`LocalProjectMilestoneGate`, `LanAuthorityTransferClient`, `ReconciliationConflictMilestoneGate`), which vary run to run and also occur on unmodified `main`. They are socket/timeout bound, import no prompt code, and are unrelated to this change.

Refs #1283
