### PR TITLE
docs: correct the Collab ticket mention trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Open the chat sidebar from the ribbon icon or command palette. Select text and u
 
 **Slash Commands & Skills** — Type `/` or `$` for reusable prompt templates or Skills from user- and vault-level scopes.
 
-**`@mention`** — Type `@` to reference vault files, folders, and Collab member changes or tickets.
+**`@mention`** — Type `@` to reference vault files, folders, and Collab member changes. Type `#` to reference Collab tickets.
 
 
 **Instruction Mode (`/instruction`)** — Refined custom instructions added from the chat input.


### PR DESCRIPTION
## Summary

`README.md` tells users to type `@` for Collab tickets. Tickets are on `#`, so following the README never opens the ticket picker.

## Evidence

Tickets and mentions are two separate sources registered on the same controller, not one source with several kinds:

```ts
// src/features/chat/composer/MainChatComposerDropdown.ts
this.mentionSource.setExtensionFoldersLoader(signal => memberChanges.getRootItems(signal));
...
this.controller = new ComposerDropdownController(containerEl, inputEl,
  [this.slashSource, this.mentionSource, ...(this.ticketSource ? [this.ticketSource] : [])]);
```

- `src/features/chat/composer/CollabTicketReferenceSource.ts` matches on `before.lastIndexOf('#')`, returns `trigger: '#'`, and inserts `` `#${ticket.number} ` ``.
- `src/shared/composer-dropdown/MentionSource.ts` returns `trigger: '@'` and yields vault files, vault folders, and whatever `extensionFoldersLoader` supplies.
- `CollabMemberChangesFolder` is installed as a mention extension folder, so Collab member changes really are on `@`. Only the ticket half of the sentence was wrong.

The behaviour is already covered by `tests/unit/features/chat/composer/CollabComposerSources.test.ts`, in `matches Ticket references only at a token boundary and inserts #number text`, which asserts `replacement: '#12 '`. No new test is added here.

## Origin

The line was introduced by `9aabd893` (#1286) in its `docs: clarify supported mention references` sub-commit:

```
-**`@mention`** - Type `@` to mention anything you want the agent to work with, including vault files, folders, and subagents.
+**`@mention`** — Type `@` to reference vault files, folders, and Collab member changes or tickets.
```

That edit correctly dropped the stale `subagents` reference and introduced the ticket error in the same line.

## Scope

One line. The double blank line below it comes from `1f885558` removing the Plan Mode bullet and is left alone to keep this a pure factual correction.

Refs #1286
