### PR TITLE
style: remove orphaned tool label rule and its false comment

### DIFF
--- a/src/style/components/toolcalls.css
+++ b/src/style/components/toolcalls.css
@@ -65,17 +65,6 @@
   padding: 2px 0 4px;
 }
 
-/* Legacy: StatusPanel bash entries still use claudian-tool-label */
-.claudian-tool-label {
-  font-family: var(--font-monospace);
-  font-size: 13px;
-  font-weight: 400;
-  color: var(--text-normal);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 .claudian-tool-current {
   font-family: var(--font-monospace);
   font-size: 13px;


### PR DESCRIPTION
## Summary

`src/style/components/toolcalls.css` carries a comment that states, in the present tense, that `StatusPanel` bash entries still use `.claudian-tool-label`. #1284 deleted those entries, so the comment is false and the rule it justifies is orphaned.

```css
/* Legacy: StatusPanel bash entries still use claudian-tool-label */
.claudian-tool-label { ... }
```

The misleading comment is the reason to fix this: anyone auditing that file is told a component depends on the rule, and goes looking for bash entries that no longer exist.

## Evidence

Both producers were removed by `26c9c8b5` (#1284, remove Claude bash mode). `git show 26c9c8b5 -- src/features/chat/ui/StatusPanel.ts` shows them as deleted lines:

- `StatusPanel.renderBashOutputs` — `bashHeaderEl.createSpan({ cls: 'claudian-tool-label' })`
- `StatusPanel.renderBashEntry` — `cls: 'claudian-tool-label'`

The same commit also removed the four `.claudian-tool-label` querySelector assertions from `StatusPanel.test.ts`, so the test side was already cleaned up; only the stylesheet was left behind.

On current `main`, `claudian-tool-label` appears nowhere in `src/` or `tests/` except the two lines removed here. There is no dynamic construction: no template literal or concatenation produces a `claudian-tool-*` class name for this family.

After this deletion the `claudian-tool*` token sets in `src/**/*.ts` and `src/**/*.css` match exactly, 27 each. Before it, `claudian-tool-label` was the only CSS-only member.

The comment was accurate when written in `cb959ae9` (2026-02-08) and became false at `26c9c8b5`.

## Scope

Only the orphaned block. Every sibling in that file is still live and untouched — `claudian-tool-call`, `-header`, `-icon`, `-name`, `-summary`, `-status`, `-content`, `-result-row`, `-result-text`, `-bash-command`, `-current` all still have producers in `ToolCallRenderer`.

`claudian-tool-bash-command` in particular is kept: it is still produced by `ToolCallRenderer` for Bash tool calls, which is unrelated to the removed bash input mode.

No test is added. This is a non-behavioural deletion of a rule no element can match, so the computed cascade is unchanged for every rendered node, and an assertion that the class is absent would be the kind of negative test `AGENTS.md` rules out.

Refs #1284
