### PR TITLE
refactor: remove built-in command argument plumbing left by /add-dir removal

### DIFF
--- a/src/core/commands/builtInCommands.ts
+++ b/src/core/commands/builtInCommands.ts
@@ -28,8 +28,6 @@ export interface BuiltInCommand {
   aliases?: string[];
   description: string;
   action: BuiltInCommandAction;
-  /** Whether this command accepts arguments. */
-  hasArgs?: boolean;
   /** Hint for arguments shown in dropdown (e.g., "path"). */
   argumentHint?: string;
   /** When set, provider capabilities must expose this feature. */

--- a/src/features/chat/controllers/InputController.ts
+++ b/src/features/chat/controllers/InputController.ts
@@ -325,7 +325,7 @@ export class InputController {
       if (shouldUseInput) {
         inputEl.value = '';
       }
-      await this.executeBuiltInCommand(builtInCmd.command, builtInCmd.args);
+      await this.executeBuiltInCommand(builtInCmd.command);
       return;
     }
 
@@ -1980,7 +1980,7 @@ export class InputController {
   // Built-in Commands
   // ============================================
 
-  private async executeBuiltInCommand(command: BuiltInCommand, args: string): Promise<void> {
+  private async executeBuiltInCommand(command: BuiltInCommand): Promise<void> {
     const { conversationController } = this.deps;
     const capabilities = this.getActiveCapabilities();
 

--- a/tests/unit/core/commands/builtInCommands.test.ts
+++ b/tests/unit/core/commands/builtInCommands.test.ts
@@ -150,11 +150,10 @@ describe('builtInCommands', () => {
       expect(resumeCmd?.description).toBe('Resume a previous conversation');
     });
 
-    it('has fork command without args', () => {
+    it('has fork command', () => {
       const forkCmd = BUILT_IN_COMMANDS.find((c) => c.name === 'fork');
       expect(forkCmd).toBeDefined();
       expect(forkCmd?.action).toBe('fork');
-      expect(forkCmd?.hasArgs).toBeUndefined();
     });
 
     it('has a Codex-only fast command', () => {


### PR DESCRIPTION
## Summary

`/add-dir` was the only argument-taking built-in command. #1283 removed it, and the argument plumbing it needed was left behind: `BuiltInCommand.hasArgs` has no writer or reader anywhere in the tree, and `executeBuiltInCommand`'s `args` parameter is ignored by all five surviving commands. This removes both.

## Evidence

`hasArgs` was never read by production code at any point in its history:

```
git log -S ".hasArgs" -- src   # no commits
```

It arrived with `/add-dir` in #146 as write-only metadata, and since #1283 deleted that command nothing even writes it. None of `clear`, `resume`, `fork`, `fast`, `instruction` sets it. `BUILT_IN_COMMANDS` is the only construction site of `BuiltInCommand` in the tree, so removing an optional field cannot break an excess-property check or a structural assignment elsewhere.

`executeBuiltInCommand` is private with a single call site, and `args` appears only in its signature — never in any of the five `case` arms or the `default` arm. Neither `tsc` nor ESLint reports it: `tsconfig.json` does not enable `noUnusedParameters`, and `eslint.config.mjs` sets `'@typescript-eslint/no-unused-vars': ['error', { args: 'none', ... }]`. This class of residue accumulates silently.

The test change is compiler-forced rather than editorial. `tsconfig.json` includes `tests/**/*.ts`, so once `hasArgs` leaves the interface, `expect(forkCmd?.hasArgs).toBeUndefined()` is a TS2339 error. That assertion was in any case a static-value assertion on a key omitted from an object literal eight lines above it, with no runtime behaviour behind it. The test title was renamed because "without args" would otherwise describe a contract the case no longer checks, and a stale title invites someone to restore the assertion to make the name true again.

## Deliberately kept

- **`BuiltInCommand.argumentHint`** — unlike `hasArgs` it has a live read path of its own: declared, mapped into the DTO by `getBuiltInCommandsForDropdown`, and read by `SlashCommandSource` for the dropdown detail line. The provider-entry branch beside it is also live.
- **`BuiltInCommandResult.args` and the parse in `detectBuiltInCommand`** — the parse cannot go. `args` is what powers `if (command.exact && args.length > 0) return null;`, which is how `/instruction remember this` falls through to a normal turn. The field has no production reader after this change, but it is the natural output of a parse function, and collapsing the result type to `BuiltInCommand | null` would be a design change rather than dead-code removal.

## Behaviour

Unchanged for every input. `/clear some text` still parses to `{ command: clear, args: 'some text' }` and still clears; `/instruction remember this` still returns `null` through the untouched `exact` guard; an unknown `/foo` still misses the command map. Interface members erase at compile time, so the emitted `BUILT_IN_COMMANDS` value is identical.

## Verification

`npm run typecheck`, `npm run lint`, `npm run build`, and `npm run test` all pass; the full suite is 602 suites / 8796 tests with no failures.

The affected test set was derived as a reverse-import closure from both changed modules rather than by directory: 14 test files counting value imports only, 27 including `import type` edges that erase at runtime. The 14 match `npx jest --listTests --findRelatedTests` file for file. All 27 were run and pass.

Refs #1283
