### PR TITLE
refactor: remove superseded provider-neutral subagent tool helpers

### DIFF
--- a/src/core/tools/toolNames.ts
+++ b/src/core/tools/toolNames.ts
@@ -46,21 +46,6 @@ export function isAgentLifecycleTool(name: string): boolean {
   return (AGENT_LIFECYCLE_TOOLS as readonly string[]).includes(name);
 }
 
-/** Tools that should be hidden from rendering when a provider subagent block is shown. */
-export const SUBAGENT_HIDDEN_TOOLS = [
-  TOOL_WAIT,
-  TOOL_WAIT_AGENT,
-  TOOL_CLOSE_AGENT,
-] as const;
-
-export function isSubagentSpawnTool(name: string): boolean {
-  return name === TOOL_SPAWN_AGENT;
-}
-
-export function isSubagentHiddenTool(name: string): boolean {
-  return (SUBAGENT_HIDDEN_TOOLS as readonly string[]).includes(name);
-}
-
 export const EDIT_TOOLS = [TOOL_WRITE, TOOL_EDIT, TOOL_NOTEBOOK_EDIT] as const;
 export type EditToolName = (typeof EDIT_TOOLS)[number];
 


### PR DESCRIPTION
`SUBAGENT_HIDDEN_TOOLS`, `isSubagentSpawnTool`, and `isSubagentHiddenTool` in `src/core/tools/toolNames.ts` have never had a consumer.

`fc6405bd` added all three, and in the same commit added `ProviderSubagentLifecycleAdapter` with `isHiddenTool` / `isSpawnTool` (`src/core/providers/types.ts`), which expresses the same distinctions as a provider capability. The adapter was wired up; these three were not — not in that commit, and not in the 385 commits since.

```
git log --all -S isSubagentSpawnTool --oneline     # exactly one commit: fc6405bd
git grep -n "SUBAGENT_HIDDEN_TOOLS\|isSubagentSpawnTool\|isSubagentHiddenTool"
```

### Why a shared constant is the wrong shape here

`isSubagentSpawnTool` hardcoded `name === 'spawn_agent'`. That matches only Codex:

| provider | `isSpawnTool` |
| --- | --- |
| Codex | `name === TOOL_SPAWN_AGENT` |
| Grok | `GROK_SUBAGENT_SPAWN_TOOLS.has(normalizedName(name))` |
| OpenCode | `name === TOOL_SUBAGENT` |
| Claude | `isClaudeSubagentToolName(name)` |

It was not merely unused — it would have been wrong for three of the four providers that register an adapter.

### Behaviour is unchanged

The live hide rules are `MessageRenderer.shouldRenderToolCall` and `StreamController`'s lifecycle branch. Both gate `adapter.isHiddenTool` on `isToolCallFullyOwned` ownership fencing that these name-only helpers never had, so wiring them up would have hidden unowned `wait` / `close_agent` calls that must stay visible.

No barrel reaches `toolNames.ts`: there is no `src/core/index.ts` and no `src/core/tools/index.ts`, and the only wildcard barrel under `core/` is `collab/index.ts`, which re-exports Collab files only.

### Validation

`--findRelatedTests src/core/tools/toolNames.ts` is 67 suites / 2330 tests — all passing. `npm run typecheck`, `npm run lint`, `npm run build` all exit 0. `tests/unit/core/tools/toolNames.test.ts` is untouched and does not reference any of the three symbols.

No test is added: there is no reachable behaviour to cover, and an assertion that the removed exports are gone would be the negative test AGENTS.md prohibits.