### PR TITLE
chore: remove approved-actions CSS selectors missed by 7f83bab9

### DIFF
--- a/src/style/accessibility.css
+++ b/src/style/accessibility.css
@@ -20,7 +20,6 @@
 .claudian-context-chip-remove:focus-visible,
 .claudian-context-more:focus-visible,
 .claudian-image-modal-close:focus-visible,
-.claudian-approved-remove-btn:focus-visible,
 .claudian-save-env-btn:focus-visible,
 .claudian-restore-snippet-btn:focus-visible,
 .claudian-edit-snippet-btn:focus-visible,

--- a/src/style/settings/base.css
+++ b/src/style/settings/base.css
@@ -168,8 +168,7 @@
 /* Custom section descriptions - align with items */
 .claudian-sp-settings-desc,
 .claudian-mcp-settings-desc,
-.claudian-plugin-settings-desc,
-.claudian-approved-desc {
+.claudian-plugin-settings-desc {
   padding: 0 12px;
 }
 


### PR DESCRIPTION
`0436940a` removed the TypeScript that applied `claudian-approved-desc` and `claudian-approved-remove-btn`. Eight minutes later `7f83bab9` deleted `src/style/settings/approved-actions.css`, dropped its `index.css` import, and stripped the `approvedActions` keys from all ten locales and from `src/i18n/types.ts`.

These two selectors lived outside that file and survived it. `settings/base.css` also carried a second, duplicate declaration of `claudian-approved-desc`, added later by `f14f2596`.

```
git grep -n "claudian-approved-desc\|claudian-approved-remove-btn"   # only the two lines removed here
```

### Both are single selector lines inside grouped rules

Not rule blocks — the surrounding members are live and stay:

- `settings/base.css`: `claudian-sp-settings-desc`, `claudian-mcp-settings-desc`, and `claudian-plugin-settings-desc` are emitted by the Claude, Codex, and OpenCode settings tabs. The trailing comma moves onto the last surviving selector.
- `accessibility.css`: thirteen `:focus-visible` selectors remain, including `claudian-cancel-btn` and `claudian-save-btn`.

Class names in this codebase are only ever built as template literals with fixed prefixes — there is no `+` concatenation of `claudian-` names anywhere — so no dynamic construction reaches either class.

### Validation

`npm run lint:css`, `npm run build:css`, `npm run typecheck`, `npm run lint`, `npm run build` all exit 0; `git diff --check` clean. In the built `styles.css` both removed classes are absent and every neighbour listed above is present.

No test is added. This repo does have CSS-source tests under `tests/unit/style/`, and `tests/unit/style/features/collab-files.test.ts` pairs orphan-absence assertions with retention assertions — but that pattern earns its keep where a removed name is a substring of a surviving one and a substring deletion could take out live styling. `claudian-approved-*` shares no stem with either survivor, so absence assertions alone would be the negative test AGENTS.md prohibits.