### PR TITLE
test: drop dead tool-content arm from StatusPanel mock

### DIFF
--- a/tests/unit/features/chat/ui/StatusPanel.test.ts
+++ b/tests/unit/features/chat/ui/StatusPanel.test.ts
@@ -185,7 +185,6 @@ class MockElement {
     if (
       this.classList.has('claudian-status-panel-todos')
       || this.classList.has('claudian-status-panel-content')
-      || this.classList.has('claudian-tool-content')
     ) {
       this.style.display = 'block';
       return;


### PR DESCRIPTION
The `claudian-tool-content` arm of the file-local `MockElement.syncDisplay()` in `tests/unit/features/chat/ui/StatusPanel.test.ts` cannot be reached.

`7be42151` introduced it for bash entries, so `entry.querySelector('.claudian-tool-content').style.display` would read `block` in the bash expand/collapse assertions. `26c9c8b5` removed bash mode: it deleted `StatusPanel.addBashOutput` — the sole producer of that element — dropped the whole `bash outputs` describe block, removed the two adjacent arms from this same condition, and removed three parallel entries from the shared `tests/helpers/MockElement.ts` display map. This one arm was left behind.

```diff
       this.classList.has('claudian-status-panel-todos')
       || this.classList.has('claudian-status-panel-content')
-      || this.classList.has('claudian-status-panel-bash')
-      || this.classList.has('claudian-status-panel-bash-content')
       || this.classList.has('claudian-tool-content')
```
<sub>(the hunk from `26c9c8b5`)</sub>

`StatusPanel` now emits only `claudian-status-panel*`, `claudian-hidden`, and, via `renderTodoItems`, `claudian-todo-*`. After this change the file-local mock's block-display set matches the shared helper's, which never contained `claudian-tool-content`.

`claudian-tool-content` is still live in `ToolCallRenderer`; that test uses the shared `createMockEl` helper, not this mock, so it is unaffected.

### What this does and does not do

It fixes no bug and prevents no false pass — the branch simply cannot be taken. The value is that the mock's display contract now describes only classes the component under test can produce.

The rest of `26c9c8b5`'s residue was audited in the class-name dimension; this was the last one.

### Validation

`tests/unit/features/chat/ui/StatusPanel.test.ts` stays 32/32, `ToolCallRenderer.test.ts` 93/93, and `--findRelatedTests` on this file resolves to this suite alone (the mock is a file-private class with no importers). `npm run typecheck`, `npm run lint`, `npm run build` exit 0.

Neutralising either surviving arm makes the suite fail (1 and 4 tests respectively), so the remaining logic is asserted. No test is added: an assertion that an unreachable branch is gone would be the negative test AGENTS.md prohibits.

`StatusPanel.test.ts` also carries a ~240-line file-local `MockElement` that duplicates much of `tests/helpers/MockElement.ts`. Reconciling them is a real cleanup but a materially larger one; kept out of scope here deliberately.