### PR TITLE
chore: remove orphaned plugin settings error and preview styles

### DIFF
--- a/src/style/settings/plugin-settings.css
+++ b/src/style/settings/plugin-settings.css
@@ -62,10 +62,6 @@
   opacity: 0.6;
 }
 
-.claudian-plugin-item-error {
-  opacity: 0.8;
-}
-
 .claudian-plugin-status {
   width: 8px;
   height: 8px;
@@ -82,10 +78,6 @@
   background: var(--text-muted);
 }
 
-.claudian-plugin-status-error {
-  background: var(--text-error);
-}
-
 .claudian-plugin-info {
   flex: 1;
   min-width: 0;
@@ -100,36 +92,6 @@
 
 .claudian-plugin-name {
   font-weight: 600;
-}
-
-.claudian-plugin-version-badge {
-  font-size: 10px;
-  padding: 2px 6px;
-  background: var(--background-modifier-border);
-  border-radius: 4px;
-  color: var(--text-muted);
-}
-
-.claudian-plugin-error-badge {
-  font-size: 10px;
-  padding: 2px 6px;
-  background: var(--text-error);
-  color: var(--text-on-accent);
-  border-radius: 4px;
-  text-transform: uppercase;
-}
-
-.claudian-plugin-preview {
-  font-size: 12px;
-  color: var(--text-muted);
-  margin-top: 4px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.claudian-plugin-preview-error {
-  color: var(--text-error);
 }
 
 .claudian-plugin-actions {

--- a/tests/unit/style/settings/plugin-settings.test.ts
+++ b/tests/unit/style/settings/plugin-settings.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+describe('Plugin settings styles', () => {
+  it('removes only the verified static orphans and retains the colliding item and status selectors', () => {
+    const css = readFileSync(path.resolve('src/style/settings/plugin-settings.css'), 'utf8');
+
+    for (const orphan of [
+      'claudian-plugin-error-badge',
+      'claudian-plugin-item-error',
+      'claudian-plugin-preview',
+      'claudian-plugin-preview-error',
+      'claudian-plugin-status-error',
+      'claudian-plugin-version-badge',
+    ]) {
+      expect(css).not.toContain(orphan);
+    }
+
+    expect(css).toContain('.claudian-plugin-item {');
+    expect(css).toContain('.claudian-plugin-item-disabled {');
+    expect(css).toContain('.claudian-plugin-status {');
+    expect(css).toContain('.claudian-plugin-status-enabled {');
+    expect(css).toContain('.claudian-plugin-status-disabled {');
+  });
+});


### PR DESCRIPTION
Six rules in `src/style/settings/plugin-settings.css` have no producer.

`2258a200` (#198) simplified plugin discovery and removed five class applications. The file lived at `src/features/settings/ui/PluginSettingsManager.ts` at that commit and has since moved, so the citation needs the historical path:

```
git show 2258a200 -- src/features/settings/ui/PluginSettingsManager.ts
```

That deleted the producers of `claudian-plugin-item-error`, `claudian-plugin-status-error`, `claudian-plugin-error-badge`, `claudian-plugin-preview`, and `claudian-plugin-preview-error`.

`claudian-plugin-version-badge` is a separate case: `fc853160` added it to CSS and it was never applied by TypeScript at all — `git log --all -S claudian-plugin-version-badge -- '*.ts'` returns no commits.

### The panel itself is still live

Only the error-state and preview surfaces were dropped upstream. `PluginSettingsManager` still emits the header, label, empty, list, section-header, item, item-disabled, status, status-enabled, status-disabled, info, name-row, name, actions, and action-btn classes, and every one of those rules is retained.

### Why this one adds a test

Every removed name is a strict superset of a surviving one — `-item-error` over `-item`, `-status-error` over `-status` — so a substring-driven deletion could silently remove shipping UI. The new test pins that retention boundary, following the paired absence-and-retention pattern in `tests/unit/style/features/collab-files.test.ts`.

The retention assertions include the trailing brace: without it, `expect(css).toContain('.claudian-plugin-item')` is satisfied by `.claudian-plugin-item-disabled` and the assertion stops discriminating. Verified by mutation — deleting only the `.claudian-plugin-item` block makes the braced form fail and the bare form pass.

### Validation

The new test is RED with the six rules restored (failing on the absence assertions) and GREEN with them removed. `npx jest tests/unit/style` is 12 suites / 41 tests. `npm run typecheck`, `npm run lint`, `npm run build`, `npm run lint:css`, `npm run build:css` all exit 0; `git diff --check` clean. In the built `styles.css` all six removed classes are absent and all fifteen survivors are present.

`.claudian-plugin-name-row` and `.claudian-plugin-info { min-width: 0 }` are arguably vestigial now that the badges and preview are gone, but both are still applied by live TypeScript, so they are left alone.