### PR TITLE
chore(i18n): drop hotkey strings orphaned by the compact hotkey grid

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -463,39 +463,19 @@
     },
     "hotkeys": "Tastenkürzel",
     "inlineEditHotkey": {
-      "name": "Inline-Bearbeitung",
-      "descWithKey": "Aktuelles Tastenkürzel: {hotkey}",
-      "descNoKey": "Kein Tastenkürzel festgelegt",
-      "btnChange": "Ändern",
-      "btnSet": "Festlegen"
+      "name": "Inline-Bearbeitung"
     },
     "openChatHotkey": {
-      "name": "Chat öffnen",
-      "descWithKey": "Aktuelles Tastenkürzel: {hotkey}",
-      "descNoKey": "Kein Tastenkürzel festgelegt",
-      "btnChange": "Ändern",
-      "btnSet": "Festlegen"
+      "name": "Chat öffnen"
     },
     "newSessionHotkey": {
-      "name": "Aktuelle Unterhaltung ersetzen",
-      "descWithKey": "Aktuelles Tastenkürzel: {hotkey}",
-      "descNoKey": "Kein Tastenkürzel festgelegt",
-      "btnChange": "Ändern",
-      "btnSet": "Festlegen"
+      "name": "Aktuelle Unterhaltung ersetzen"
     },
     "newTabHotkey": {
-      "name": "Neu",
-      "descWithKey": "Aktuelles Tastenkürzel: {hotkey}",
-      "descNoKey": "Kein Tastenkürzel festgelegt",
-      "btnChange": "Ändern",
-      "btnSet": "Festlegen"
+      "name": "Neu"
     },
     "closeTabHotkey": {
-      "name": "Tab schließen",
-      "descWithKey": "Aktuelles Tastenkürzel: {hotkey}",
-      "descNoKey": "Kein Tastenkürzel festgelegt",
-      "btnChange": "Ändern",
-      "btnSet": "Festlegen"
+      "name": "Tab schließen"
     },
     "slashCommands": {
       "name": "Befehle und Fähigkeiten",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -463,39 +463,19 @@
     },
     "hotkeys": "Hotkeys",
     "inlineEditHotkey": {
-      "name": "Inline Edit",
-      "descWithKey": "Current hotkey: {hotkey}",
-      "descNoKey": "No hotkey set",
-      "btnChange": "Change",
-      "btnSet": "Set hotkey"
+      "name": "Inline Edit"
     },
     "openChatHotkey": {
-      "name": "Open Chat",
-      "descWithKey": "Current hotkey: {hotkey}",
-      "descNoKey": "No hotkey set",
-      "btnChange": "Change",
-      "btnSet": "Set hotkey"
+      "name": "Open Chat"
     },
     "newSessionHotkey": {
-      "name": "Replace Current Conversation",
-      "descWithKey": "Current hotkey: {hotkey}",
-      "descNoKey": "No hotkey set",
-      "btnChange": "Change",
-      "btnSet": "Set hotkey"
+      "name": "Replace Current Conversation"
     },
     "newTabHotkey": {
-      "name": "New",
-      "descWithKey": "Current hotkey: {hotkey}",
-      "descNoKey": "No hotkey set",
-      "btnChange": "Change",
-      "btnSet": "Set hotkey"
+      "name": "New"
     },
     "closeTabHotkey": {
-      "name": "Close Tab",
-      "descWithKey": "Current hotkey: {hotkey}",
-      "descNoKey": "No hotkey set",
-      "btnChange": "Change",
-      "btnSet": "Set hotkey"
+      "name": "Close Tab"
     },
     "slashCommands": {
       "name": "Commands and Skills",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -463,39 +463,19 @@
     },
     "hotkeys": "Atajos de teclado",
     "inlineEditHotkey": {
-      "name": "Edición en línea",
-      "descWithKey": "Atajo actual: {hotkey}",
-      "descNoKey": "Sin atajo configurado",
-      "btnChange": "Cambiar",
-      "btnSet": "Configurar"
+      "name": "Edición en línea"
     },
     "openChatHotkey": {
-      "name": "Abrir chat",
-      "descWithKey": "Atajo actual: {hotkey}",
-      "descNoKey": "Sin atajo configurado",
-      "btnChange": "Cambiar",
-      "btnSet": "Configurar"
+      "name": "Abrir chat"
     },
     "newSessionHotkey": {
-      "name": "Reemplazar conversación actual",
-      "descWithKey": "Atajo actual: {hotkey}",
-      "descNoKey": "Sin atajo configurado",
-      "btnChange": "Cambiar",
-      "btnSet": "Configurar"
+      "name": "Reemplazar conversación actual"
     },
     "newTabHotkey": {
-      "name": "Nuevo",
-      "descWithKey": "Atajo actual: {hotkey}",
-      "descNoKey": "Sin atajo configurado",
-      "btnChange": "Cambiar",
-      "btnSet": "Configurar"
+      "name": "Nuevo"
     },
     "closeTabHotkey": {
-      "name": "Cerrar pestaña",
-      "descWithKey": "Atajo actual: {hotkey}",
-      "descNoKey": "Sin atajo configurado",
-      "btnChange": "Cambiar",
-      "btnSet": "Configurar"
+      "name": "Cerrar pestaña"
     },
     "slashCommands": {
       "name": "Comandos y habilidades",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -463,39 +463,19 @@
     },
     "hotkeys": "Raccourcis clavier",
     "inlineEditHotkey": {
-      "name": "Édition en ligne",
-      "descWithKey": "Raccourci actuel : {hotkey}",
-      "descNoKey": "Aucun raccourci défini",
-      "btnChange": "Modifier",
-      "btnSet": "Définir"
+      "name": "Édition en ligne"
     },
     "openChatHotkey": {
-      "name": "Ouvrir le chat",
-      "descWithKey": "Raccourci actuel : {hotkey}",
-      "descNoKey": "Aucun raccourci défini",
-      "btnChange": "Modifier",
-      "btnSet": "Définir"
+      "name": "Ouvrir le chat"
     },
     "newSessionHotkey": {
-      "name": "Remplacer la conversation actuelle",
-      "descWithKey": "Raccourci actuel : {hotkey}",
-      "descNoKey": "Aucun raccourci défini",
-      "btnChange": "Modifier",
-      "btnSet": "Définir"
+      "name": "Remplacer la conversation actuelle"
     },
     "newTabHotkey": {
-      "name": "Nouveau",
-      "descWithKey": "Raccourci actuel : {hotkey}",
-      "descNoKey": "Aucun raccourci défini",
-      "btnChange": "Modifier",
-      "btnSet": "Définir"
+      "name": "Nouveau"
     },
     "closeTabHotkey": {
-      "name": "Fermer l'onglet",
-      "descWithKey": "Raccourci actuel : {hotkey}",
-      "descNoKey": "Aucun raccourci défini",
-      "btnChange": "Modifier",
-      "btnSet": "Définir"
+      "name": "Fermer l'onglet"
     },
     "slashCommands": {
       "name": "Commandes et compétences",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -463,39 +463,19 @@
     },
     "hotkeys": "ホットキー",
     "inlineEditHotkey": {
-      "name": "インライン編集",
-      "descWithKey": "現在のホットキー: {hotkey}",
-      "descNoKey": "ホットキー未設定",
-      "btnChange": "変更",
-      "btnSet": "設定"
+      "name": "インライン編集"
     },
     "openChatHotkey": {
-      "name": "チャットを開く",
-      "descWithKey": "現在のホットキー: {hotkey}",
-      "descNoKey": "ホットキー未設定",
-      "btnChange": "変更",
-      "btnSet": "設定"
+      "name": "チャットを開く"
     },
     "newSessionHotkey": {
-      "name": "現在の会話を置き換える",
-      "descWithKey": "現在のホットキー: {hotkey}",
-      "descNoKey": "ホットキー未設定",
-      "btnChange": "変更",
-      "btnSet": "設定"
+      "name": "現在の会話を置き換える"
     },
     "newTabHotkey": {
-      "name": "新規",
-      "descWithKey": "現在のホットキー: {hotkey}",
-      "descNoKey": "ホットキー未設定",
-      "btnChange": "変更",
-      "btnSet": "設定"
+      "name": "新規"
     },
     "closeTabHotkey": {
-      "name": "タブを閉じる",
-      "descWithKey": "現在のホットキー: {hotkey}",
-      "descNoKey": "ホットキー未設定",
-      "btnChange": "変更",
-      "btnSet": "設定"
+      "name": "タブを閉じる"
     },
     "slashCommands": {
       "name": "コマンドとスキル",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -463,39 +463,19 @@
     },
     "hotkeys": "단축키",
     "inlineEditHotkey": {
-      "name": "인라인 편집",
-      "descWithKey": "현재 단축키: {hotkey}",
-      "descNoKey": "단축키 미설정",
-      "btnChange": "변경",
-      "btnSet": "단축키 설정"
+      "name": "인라인 편집"
     },
     "openChatHotkey": {
-      "name": "채팅 열기",
-      "descWithKey": "현재 단축키: {hotkey}",
-      "descNoKey": "단축키 미설정",
-      "btnChange": "변경",
-      "btnSet": "단축키 설정"
+      "name": "채팅 열기"
     },
     "newSessionHotkey": {
-      "name": "현재 대화 바꾸기",
-      "descWithKey": "현재 단축키: {hotkey}",
-      "descNoKey": "단축키 미설정",
-      "btnChange": "변경",
-      "btnSet": "단축키 설정"
+      "name": "현재 대화 바꾸기"
     },
     "newTabHotkey": {
-      "name": "새로 만들기",
-      "descWithKey": "현재 단축키: {hotkey}",
-      "descNoKey": "단축키 미설정",
-      "btnChange": "변경",
-      "btnSet": "단축키 설정"
+      "name": "새로 만들기"
     },
     "closeTabHotkey": {
-      "name": "탭 닫기",
-      "descWithKey": "현재 단축키: {hotkey}",
-      "descNoKey": "단축키 미설정",
-      "btnChange": "변경",
-      "btnSet": "단축키 설정"
+      "name": "탭 닫기"
     },
     "slashCommands": {
       "name": "명령어와 스킬",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -463,39 +463,19 @@
     },
     "hotkeys": "Atalhos",
     "inlineEditHotkey": {
-      "name": "Edição em linha",
-      "descWithKey": "Atalho atual: {hotkey}",
-      "descNoKey": "Nenhum atalho definido",
-      "btnChange": "Alterar",
-      "btnSet": "Definir"
+      "name": "Edição em linha"
     },
     "openChatHotkey": {
-      "name": "Abrir chat",
-      "descWithKey": "Atalho atual: {hotkey}",
-      "descNoKey": "Nenhum atalho definido",
-      "btnChange": "Alterar",
-      "btnSet": "Definir"
+      "name": "Abrir chat"
     },
     "newSessionHotkey": {
-      "name": "Substituir conversa atual",
-      "descWithKey": "Atalho atual: {hotkey}",
-      "descNoKey": "Nenhum atalho definido",
-      "btnChange": "Alterar",
-      "btnSet": "Definir"
+      "name": "Substituir conversa atual"
     },
     "newTabHotkey": {
-      "name": "Novo",
-      "descWithKey": "Atalho atual: {hotkey}",
-      "descNoKey": "Nenhum atalho definido",
-      "btnChange": "Alterar",
-      "btnSet": "Definir"
+      "name": "Novo"
     },
     "closeTabHotkey": {
-      "name": "Fechar aba",
-      "descWithKey": "Atalho atual: {hotkey}",
-      "descNoKey": "Nenhum atalho definido",
-      "btnChange": "Alterar",
-      "btnSet": "Definir"
+      "name": "Fechar aba"
     },
     "slashCommands": {
       "name": "Comandos e habilidades",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -463,39 +463,19 @@
     },
     "hotkeys": "Горячие клавиши",
     "inlineEditHotkey": {
-      "name": "Инлайн-редактирование",
-      "descWithKey": "Текущая клавиша: {hotkey}",
-      "descNoKey": "Клавиша не назначена",
-      "btnChange": "Изменить",
-      "btnSet": "Назначить"
+      "name": "Инлайн-редактирование"
     },
     "openChatHotkey": {
-      "name": "Открыть чат",
-      "descWithKey": "Текущая клавиша: {hotkey}",
-      "descNoKey": "Клавиша не назначена",
-      "btnChange": "Изменить",
-      "btnSet": "Назначить"
+      "name": "Открыть чат"
     },
     "newSessionHotkey": {
-      "name": "Заменить текущий диалог",
-      "descWithKey": "Текущая клавиша: {hotkey}",
-      "descNoKey": "Клавиша не назначена",
-      "btnChange": "Изменить",
-      "btnSet": "Назначить"
+      "name": "Заменить текущий диалог"
     },
     "newTabHotkey": {
-      "name": "Новое",
-      "descWithKey": "Текущая клавиша: {hotkey}",
-      "descNoKey": "Клавиша не назначена",
-      "btnChange": "Изменить",
-      "btnSet": "Назначить"
+      "name": "Новое"
     },
     "closeTabHotkey": {
-      "name": "Закрыть вкладку",
-      "descWithKey": "Текущая клавиша: {hotkey}",
-      "descNoKey": "Клавиша не назначена",
-      "btnChange": "Изменить",
-      "btnSet": "Назначить"
+      "name": "Закрыть вкладку"
     },
     "slashCommands": {
       "name": "Команды и навыки",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -463,39 +463,19 @@
     },
     "hotkeys": "快捷键",
     "inlineEditHotkey": {
-      "name": "内联编辑",
-      "descWithKey": "当前快捷键：{hotkey}",
-      "descNoKey": "未设置快捷键",
-      "btnChange": "更改",
-      "btnSet": "设置快捷键"
+      "name": "内联编辑"
     },
     "openChatHotkey": {
-      "name": "打开聊天",
-      "descWithKey": "当前快捷键：{hotkey}",
-      "descNoKey": "未设置快捷键",
-      "btnChange": "更改",
-      "btnSet": "设置快捷键"
+      "name": "打开聊天"
     },
     "newSessionHotkey": {
-      "name": "替换当前会话",
-      "descWithKey": "当前快捷键：{hotkey}",
-      "descNoKey": "未设置快捷键",
-      "btnChange": "更改",
-      "btnSet": "设置快捷键"
+      "name": "替换当前会话"
     },
     "newTabHotkey": {
-      "name": "新建",
-      "descWithKey": "当前快捷键：{hotkey}",
-      "descNoKey": "未设置快捷键",
-      "btnChange": "更改",
-      "btnSet": "设置快捷键"
+      "name": "新建"
     },
     "closeTabHotkey": {
-      "name": "关闭标签页",
-      "descWithKey": "当前快捷键：{hotkey}",
-      "descNoKey": "未设置快捷键",
-      "btnChange": "更改",
-      "btnSet": "设置快捷键"
+      "name": "关闭标签页"
     },
     "slashCommands": {
       "name": "命令与技能",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -463,39 +463,19 @@
     },
     "hotkeys": "快捷鍵",
     "inlineEditHotkey": {
-      "name": "內嵌編輯",
-      "descWithKey": "目前快捷鍵：{hotkey}",
-      "descNoKey": "未設定快捷鍵",
-      "btnChange": "變更",
-      "btnSet": "設定快捷鍵"
+      "name": "內嵌編輯"
     },
     "openChatHotkey": {
-      "name": "開啟聊天",
-      "descWithKey": "目前快捷鍵：{hotkey}",
-      "descNoKey": "未設定快捷鍵",
-      "btnChange": "變更",
-      "btnSet": "設定快捷鍵"
+      "name": "開啟聊天"
     },
     "newSessionHotkey": {
-      "name": "取代目前對話",
-      "descWithKey": "目前快捷鍵：{hotkey}",
-      "descNoKey": "未設定快捷鍵",
-      "btnChange": "變更",
-      "btnSet": "設定快捷鍵"
+      "name": "取代目前對話"
     },
     "newTabHotkey": {
-      "name": "新增",
-      "descWithKey": "目前快捷鍵：{hotkey}",
-      "descNoKey": "未設定快捷鍵",
-      "btnChange": "變更",
-      "btnSet": "設定快捷鍵"
+      "name": "新增"
     },
     "closeTabHotkey": {
-      "name": "關閉分頁",
-      "descWithKey": "目前快捷鍵：{hotkey}",
-      "descNoKey": "未設定快捷鍵",
-      "btnChange": "變更",
-      "btnSet": "設定快捷鍵"
+      "name": "關閉分頁"
     },
     "slashCommands": {
       "name": "命令與技能",


### PR DESCRIPTION
`d0c7c9ff` replaced the verbose hotkey `Setting` rows with a compact name-and-badge grid:

```
git show d0c7c9ff -- src/features/settings/ClaudianSettings.ts
```

That removed every construction of `.descWithKey`, `.descNoKey`, `.btnChange`, and `.btnSet` for the five hotkey blocks, leaving twenty strings per locale with no consumer.

```
git grep -nE "descWithKey|descNoKey|btnChange|btnSet" -- ':!src/i18n/locales'   # nothing
```

### Scope: `.name` is deliberately kept

`.name` survives in all five blocks. It is the only sub-key still built, at `ClaudianSettings.ts:135`:

```ts
text: t(`${translationPrefix}.name` as TranslationKey),
```

Removing it would break the hotkey rows. Each block therefore keeps exactly one key, which is why the diff rewrites fifty `"name"` lines to drop a trailing comma.

This is scoped to the strings orphaned by `d0c7c9ff` — it is not a general sweep of the locale files.

### Why the deadness proof here is airtight

`t()` is typed `t(key: TranslationKey, ...)`, and `git grep "as TranslationKey" -- src/` returns exactly **one** hit in all of `src/` (the line above). There are three dynamic `t()` sites in total — `${translationPrefix}.name`, `settings.tabs.${id}`, `settings.collabGitStatus.${status}` — and no `TranslationKey`-typed variable, array, or map anywhere. So the dynamic-construction hole is closed by construction, not by inspection.

### Validation

All ten locales parse; each lost exactly 20 leaves (667 → 647) with no reordering and no key added. Every one of the fifty blocks now contains exactly `{ name }`. No top-level key was emptied, so the identifier check in `scripts/compressedStaticAssets.js` is unaffected, and the Brotli round-trip probes (`en.collab.commands.createProject`, `de.common.save`) are untouched.

`npm run typecheck` exits 0 — meaningful here, since `TranslationKey = LeafKeys<typeof en>` makes `en.json` a type source. `npx jest tests/unit/i18n tests/unit/features/settings` is 11 suites / 105 tests; `tests/integration/build` is 4 suites / 28 tests, run explicitly because `--findRelatedTests` does not select it (its locale imports sit inside an esbuild `stdin.contents` string). `npm run build` exits 0 and the four key names are absent from `main.js`.

No test is added. The locale-alignment test in `tests/unit/i18n/locales.test.ts` already guards the realistic failure mode for a ten-file edit — dropping a key from some files but not others — and none of the twenty appears in its `localizedKeys` list. Unlike the CSS orphan cases, no removed key is a prefix of a surviving one (JSON keys are addressed structurally, not matched as text), so there is no over-deletion hazard for a paired test to pin.