### PR TITLE
fix: restore Linked content scrolling in the session metadata popover

### DIFF
--- a/src/features/chat/controllers/ConversationController.ts
+++ b/src/features/chat/controllers/ConversationController.ts
@@ -1733,9 +1733,13 @@ export class ConversationController {
     const closeForViewportChange = (): void => {
       if (this.metadataPopoverEl === hoverEl) this.closeSessionMetadataPopover();
     };
+    const closeForExternalScroll = (event: Event): void => {
+      if (event.composedPath().includes(hoverEl)) return;
+      closeForViewportChange();
+    };
     hoverEl.addEventListener('mouseenter', cancelClose);
     hoverEl.addEventListener('mouseleave', scheduleClose);
-    document.addEventListener('scroll', closeForViewportChange, true);
+    document.addEventListener('scroll', closeForExternalScroll, true);
     document.defaultView?.addEventListener('resize', closeForViewportChange);
 
     const signal = options.signal;
@@ -1748,7 +1752,7 @@ export class ConversationController {
     this.metadataPopoverCleanup = () => {
       hoverEl.removeEventListener('mouseenter', cancelClose);
       hoverEl.removeEventListener('mouseleave', scheduleClose);
-      document.removeEventListener('scroll', closeForViewportChange, true);
+      document.removeEventListener('scroll', closeForExternalScroll, true);
       document.defaultView?.removeEventListener('resize', closeForViewportChange);
       signal?.removeEventListener('abort', closeOnAbort);
       if (descriptionTarget.getAttribute('aria-describedby') === popoverId) {

--- a/src/style/components/history.css
+++ b/src/style/components/history.css
@@ -634,14 +634,14 @@ body.theme-dark .claudian-session-metadata-popover {
   white-space: nowrap;
 }
 
-.claudian-session-metadata-value--note {
+.claudian-session-metadata-value--content {
   overflow-x: auto;
   overflow-y: hidden;
   text-overflow: clip;
   scrollbar-width: none;
 }
 
-.claudian-session-metadata-value--note::-webkit-scrollbar {
+.claudian-session-metadata-value--content::-webkit-scrollbar {
   display: none;
 }
 

--- a/tests/unit/features/chat/controllers/ConversationController.metadataPopover.dom.test.ts
+++ b/tests/unit/features/chat/controllers/ConversationController.metadataPopover.dom.test.ts
@@ -1,0 +1,75 @@
+/** @jest-environment jsdom */
+
+import { ConversationController, type ConversationControllerDeps } from '@/features/chat/controllers/ConversationController';
+import { ChatState } from '@/features/chat/state/ChatState';
+
+HTMLElement.prototype.empty = function () { this.replaceChildren(); };
+HTMLElement.prototype.addClass = function (...classes) { this.classList.add(...classes); };
+HTMLElement.prototype.removeClass = function (...classes) { this.classList.remove(...classes); };
+HTMLElement.prototype.hasClass = function (className) { return this.classList.contains(className); };
+
+function createController(): ConversationController {
+  const state = new ChatState();
+  const inputEl = document.createElement('textarea');
+  const messagesEl = document.createElement('div');
+
+  return new ConversationController({
+    plugin: {
+      getConversationList: jest.fn().mockReturnValue([{
+        id: 'session-1',
+        providerId: 'codex',
+        title: 'Review architecture',
+        createdAt: 1_000,
+        lastActivityAt: 2_000,
+        linkedContentPath: 'Projects/A linked content title that overflows the popover.md',
+      }]),
+      settings: {},
+    },
+    state,
+    renderer: {},
+    subagentManager: {},
+    getHistoryDropdown: () => null,
+    getWelcomeEl: () => null,
+    setWelcomeEl: jest.fn(),
+    getMessagesEl: () => messagesEl,
+    getInputEl: () => inputEl,
+    getLinkedContentController: () => ({}),
+    getImageContextManager: () => ({}),
+    clearQueuedMessage: jest.fn(),
+    getTitleGenerationService: () => null,
+    getStatusPanel: () => ({}),
+    getExecutionCoordinator: () => null,
+  } as unknown as ConversationControllerDeps);
+}
+
+describe('ConversationController session metadata popover', () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('stays open for its own content scroll and closes for an external scroll', () => {
+    const controller = createController();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    controller.renderHistoryDropdown(container, {
+      onSelectConversation: jest.fn().mockResolvedValue(undefined),
+      showMetadataPopover: true,
+    });
+
+    const item = container.querySelector<HTMLElement>('.claudian-history-item')!;
+    item.dispatchEvent(new MouseEvent('mouseenter'));
+
+    const popover = document.body.querySelector<HTMLElement>(
+      '.claudian-session-metadata-popover',
+    )!;
+    const linkedContent = popover.querySelector<HTMLElement>(
+      '.claudian-session-metadata-value--content',
+    )!;
+
+    linkedContent.dispatchEvent(new Event('scroll'));
+    expect(popover.isConnected).toBe(true);
+
+    container.dispatchEvent(new Event('scroll'));
+    expect(popover.isConnected).toBe(false);
+  });
+});

--- a/tests/unit/style/components/history.test.ts
+++ b/tests/unit/style/components/history.test.ts
@@ -54,3 +54,24 @@ describe('Single-pane history action styles', () => {
     );
   });
 });
+
+describe('Session metadata popover styles', () => {
+  it('scrolls a long Linked content title instead of clipping it to an ellipsis', () => {
+    const css = readFileSync(path.resolve('src/style/components/history.css'), 'utf8');
+
+    expect(css).toMatch(
+      /\.claudian-session-metadata-value--content\s*\{[^}]*overflow-x:\s*auto;[^}]*overflow-y:\s*hidden;[^}]*text-overflow:\s*clip;[^}]*scrollbar-width:\s*none;/,
+    );
+    expect(css).toMatch(
+      /\.claudian-session-metadata-value--content::-webkit-scrollbar\s*\{[^}]*display:\s*none;/,
+    );
+  });
+
+  it('keeps the Linked content override after the shared value rule so it still wins the cascade', () => {
+    const css = readFileSync(path.resolve('src/style/components/history.css'), 'utf8');
+
+    expect(css).toMatch(
+      /\.claudian-session-metadata-value\s*\{[^}]*overflow:\s*hidden;[^}]*text-overflow:\s*ellipsis;[\s\S]*?\.claudian-session-metadata-value--content\s*\{[^}]*overflow-x:\s*auto;/,
+    );
+  });
+});


### PR DESCRIPTION
### What

The Linked content row in the session metadata popover lost its inline horizontal scrolling. A long note title is clipped to an ellipsis instead of scrolling when you drag across it. This renames the two stale CSS selectors that cause it.

### Why this is a regression, not orphaned CSS

`a385665c` (#1050) introduced `.claudian-session-metadata-value--note` in CSS, TypeScript, and its test in one commit. The modifier exists specifically to override the shared `.claudian-session-metadata-value` base rule's `overflow: hidden` / `text-overflow: ellipsis` for the one row that holds unbounded user content, and to hide the resulting scrollbar.

`9c4d92f6` (#1117) renamed `--note` → `--content` in `ConversationController.ts` and its test. It touched `src/style/components/history.css` in the same commit, but the selector rename was missed. At `a7a33821`:

```
$ git log --oneline -S "session-metadata-value--note"
9c4d92f6 feat: add Claudian Collab mode (#1117)
a385665c feat: add dual-pane session management (#1050)

$ git log --oneline -S "session-metadata-value--content"
9c4d92f6 feat: add Claudian Collab mode (#1117)
```

`--note` was introduced by #1050 and removed from TypeScript by #1117, but never from CSS. Since #1117 the live `--content` class has matched no rule, while the element still carries the base class — so the base rule's clipping has gone unopposed.

### Why not simply delete the two `--note` blocks

This looks like the orphaned-CSS removals in #1289 / #1292 / #1294 / #1295 and reaches the opposite conclusion, so the distinction is worth stating plainly.

In those PRs no producer emitted the class at all. Here the producer is live and simply emits a different name — the caller passes the modifier and `renderSessionMetadataRow` joins it onto the base class:

```ts
// caller
{ className: 'claudian-session-metadata-value--content', title: linkedContentPath }

// renderSessionMetadataRow
cls: ['claudian-session-metadata-value', options.className ?? ''].filter(Boolean).join(' ')
```

So the base rule these blocks were written to override is still being applied to a real element. Deleting them would be a behavior change, not cleanup.

The consistent alternative would be to delete both CSS blocks *and* the TypeScript `className`, leaving the row plain like `--provider`. I'd prefer restoring: the scrolling behavior shipped deliberately in #1050 and was lost accidentally in an incomplete rename 15 days later, not removed on purpose. Happy to switch if you'd rather drop the behavior.

### Scope

The visible text is `getLinkedContentTitle(linkedContentPath)` — the basename with `.md` stripped, so a note *title*, not the full path. The row also sets `title={linkedContentPath}`, so the full path stays available through the native tooltip. What was lost is inline scrolling of a long title in the ~240px value column. A genuine regression, but a cosmetic one, and the fix is correspondingly small.

### Not in scope

A grep will show `.claudian-session-metadata-value--provider` is also unstyled. That one has been unstyled since `a385665c` (#1050) introduced it — never a regression, no prior behavior to restore — so it is deliberately left alone rather than overlooked.

### Test

`tests/unit/style/components/history.test.ts` gains two cases at the file's existing CSS-text seam. Both fail on `a7a33821` and pass after the change (verified by reverting only the CSS file and keeping the tests: `2 failed, 4 passed` → `6 passed`).

The second case asserts **block order**, not just presence. The base rule and the modifier are both single-class selectors at specificity `(0,1,0)`, and the base uses the shorthand `overflow: hidden` — which expands to both longhands — while the modifier uses the longhand `overflow-x: auto`. The override therefore resolves purely by source order: hoisting the modifier above the base would reproduce this exact bug with both rules present and both names correct. Confirmed by mutation — reordering the blocks fails that case alone (`1 failed, 5 passed`) while the presence-only case stays green. `no-descending-specificity` is not enabled in `stylelint.config.mjs`, and it would not catch an equal-specificity reorder anyway, so nothing else guards this. That said, the ordering invariant was never actually broken, so drop this case if you'd rather.

### Notes

- `styles.css` is generated output and gitignored, so it is not in the diff. `npm run build:css` reproduces it; both rules live in the same module and the build splices each file's contents verbatim, so their relative order survives into `styles.css`.
- No TypeScript change. `ConversationController` already emits the correct class pair; only the stylesheet was wrong. The existing DOM assertions in `ConversationController.test.ts` are unaffected.
- Verified: `npm run typecheck`, `npm run lint` (`lint:css` runs stylelint over `src/style/**`), `npm run test`, and `npm run build` all pass.
- The `::-webkit-scrollbar` block is renamed alongside its base. On current Electron `scrollbar-width: none` already does the work, so it may well be inert — but `history.css` pairs the two everywhere it uses them, and leaving `--note::-webkit-scrollbar` behind would create a fresh orphan of exactly the kind #1292 and #1294 removed.
- Not verifiable in CI, since no browser runs there: if you want visual confirmation, hover a session whose Linked content note title overflows the value column and check that the text scrolls horizontally with no visible scrollbar.
