### PR TITLE
chore: remove write-edit binary selector orphaned by 675fee22

### DIFF
--- a/src/style/features/diff.css
+++ b/src/style/features/diff.css
@@ -119,7 +119,6 @@
 }
 
 .claudian-write-edit-loading,
-.claudian-write-edit-binary,
 .claudian-write-edit-error,
 .claudian-write-edit-done-text {
   font-family: var(--font-monospace);


### PR DESCRIPTION
`8984f8ab` added `claudian-write-edit-binary` together with five producers in `src/ui/WriteEditRenderer.ts`. Only one of them, `binaryEl`, rendered an actual binary placeholder — the other four were `skipEl` calls that used the same class to style `Diff skipped: file too large` and `Diff unavailable`. `84935ea0` later moved the rule out of root `styles.css` into `src/style/features/diff.css`.

`8d6d273b` (`refactor: remove binary content check and update duration format`) removed the binary check completely: `isBinaryContent`, its import and call site, the `binaryEl` producer, and the tests. The heuristic false-positived on text files containing stray null bytes, including Chinese Markdown. The class was overloaded from the start, so the selector survived that commit: the four unrelated `skipEl` placeholders were still using it for muted monospace styling.

`675fee22` (#182, `refactor: replace custom diff system with SDK-native toolUseResult`) removed those four. That is the commit that orphaned the rule, and it touched no CSS.

```
git grep "claudian-write-edit-binary" 8d6d273b -- '*.ts'   # four hits
git grep "claudian-write-edit-binary" 675fee22 -- '*.ts'   # none
```

So the class outlived its feature by a week through name reuse, not through an incomplete removal.

### Scope

The write/edit diff surface is still live. Only the binary-file placeholder was dropped.

The class is removed as a single selector line from a four-member grouped rule, not as a rule block. `claudian-write-edit-loading`, `claudian-write-edit-error`, and `claudian-write-edit-done-text` are all still emitted by `WriteEditRenderer` and keep the shared `font-family`, `font-size`, and `color`.

`claudian-write-edit-binary` is the only one of the fourteen `claudian-write-edit*` tokens in the stylesheet with no TypeScript counterpart. It appears nowhere else in the tree — no docs, no i18n key, no test, no other CSS.

Some class names in this codebase *are* built by template interpolation (`claudian-context-chip--${item.kind}`, `claudian-collab-git-path-status--${status}`, and others), so "no dynamic construction" needs to be checked rather than assumed. No `claudian-write-edit` name is among them: `grep -rnE "claudian-write-edit[a-z-]*\$\{" src/` is empty, and every write-edit class is a plain string literal.

The two `"Binary file"` strings in `src/i18n/locales/en.json` are `collab.review.binary` and `collab.conflict.kind.binary`, consumed by the live Collab review and conflict surfaces. The removed label was a hardcoded pre-i18n `setText('Binary file')` and never had a key.

### One thing worth your call

Binary detection went because the *heuristic* was wrong, not because the placeholder was unwanted. The repo now carries a reliable `file.binary` flag from git in the Collab review repositories, so a binary placeholder in the write/edit diff is plausible to want back.

I'd still remove the rule. Collab's own binary review surface renders entirely through `claudian-collab-review-*` and `claudian-collab-*` conflict classes (`ReviewDiffSession.ts:600-624`), so nothing there would reuse this selector. And restoring a placeholder in the chat write-edit renderer means adding one name back to a grouped rule whose three siblings already carry the exact three declarations the deleted line inherited. Happy to drop this PR if you'd rather hold the CSS.

### No test

Unlike #1294, no removed name here is a superset of a surviving one — `claudian-write-edit-binary` is neither a prefix nor a substring of any retained selector, and there is no standalone `.claudian-write-edit` — so there is no retention boundary to pin. An absence assertion would be the negative test AGENTS.md prohibits for deleted logic, and a retention assertion would be a static-value test that is green both before and after. This follows #1292, which removed selector lines from grouped rules with live remaining members and added none.

### Verification

`npm run typecheck`, `npm run lint` (`lint:css` runs stylelint over `src/style/**`), and `npm run build` all pass. Built `styles.css` confirms the token is gone and the three siblings remain; it is generated and gitignored, so it is not part of this change.

`npm run test` is non-deterministic in my local environment: the failing set differs from run to run across the Collab LAN and authority-transfer integration suites, and each one passes in isolation. No test reads `diff.css`, so this deletion cannot reach them.
