### PR TITLE
fix: block native plan mode in OpenCode and Grok

### DIFF
--- a/src/providers/grok/AGENTS.md
+++ b/src/providers/grok/AGENTS.md
@@ -26,7 +26,8 @@
 - Use Grok's native history under `~/.grok/sessions/` read-only.
 - Send image attachments as ACP image content blocks and rehydrate their persisted native blocks. Use Grok's `_x.ai/interject` and `_x.ai/session/fork` extensions behind typed provider-owned boundaries for steering and forks.
 - Grok's `_x.ai/session/fork` request does not carry system-prompt metadata. After adopting the child, load that child with the current complete Grok/Claudian system-prompt replacement before its first prompt, and record the configuration as applied only after that load succeeds.
-- Keep Grok/xAI tools enabled and preserve unknown tool data losslessly. Adapt Grok task-family lifecycle calls into the shared subagent renderer while retaining their raw names and payloads.
+- Keep Grok/xAI tools enabled except native plan entry/exit, which Claudian blocks without replacing native or user agent profiles. Preserve unknown tool data losslessly. Adapt Grok task-family lifecycle calls into the shared subagent renderer while retaining their raw names and payloads.
+- Grok client-hook errors and timeouts fail open. Answer plan-hook callbacks with a native denial directly, including during cancellation; do not route them through user approval or throw on malformed callbacks.
 
 ## Models and Settings
 

--- a/src/providers/grok/execution/GrokExecutionNativeConnection.ts
+++ b/src/providers/grok/execution/GrokExecutionNativeConnection.ts
@@ -86,6 +86,14 @@ implements GrokExecutionNativeConnection {
         params => options.requestExtension(method, params),
       ));
     }
+    for (const method of ['x.ai/hooks/run', '_x.ai/hooks/run']) {
+      // This client registers only plan-mode hooks. Always return a denial:
+      // Grok fails open on callback errors, even during cancellation.
+      this.unsubscribers.push(this.transport.onRequest(method, () => ({
+        decision: 'deny',
+        systemMessage: 'Plan mode is unavailable in Claudian. Continue in normal mode.',
+      })));
+    }
     for (const method of GROK_EXTENSION_NOTIFICATION_METHODS) {
       this.unsubscribers.push(this.transport.onNotification(method, params => {
         if (!isRecord(params) || typeof params.yolo_mode !== 'boolean') return;
@@ -115,7 +123,18 @@ implements GrokExecutionNativeConnection {
   );
 
   async initialize(): Promise<void> {
-    await this.connection.initialize();
+    const response = await this.connection.initialize();
+    const meta = isRecord(response.agentCapabilities) ? response.agentCapabilities._meta : undefined;
+    const hooks = isRecord(meta) ? meta['x.ai/hooks'] : undefined;
+    if (
+      !isRecord(hooks)
+      || !Array.isArray(hooks.blockingEvents)
+      || !hooks.blockingEvents.includes('pre_tool_use')
+      || !Array.isArray(hooks.decisions)
+      || !hooks.decisions.includes('deny')
+    ) {
+      throw new Error('Grok does not support blocking tool hooks. Update Grok to the latest version.');
+    }
   }
 
   isAlive(): boolean {
@@ -130,7 +149,7 @@ implements GrokExecutionNativeConnection {
   }
 
   loadSession: GrokExecutionNativeConnection['loadSession'] = request => (
-    this.connection.loadSession(request)
+    this.connection.loadSession({ ...request, _meta: withPlanModeHooks(request._meta) })
   );
 
   async listCommands(
@@ -149,7 +168,7 @@ implements GrokExecutionNativeConnection {
   }
 
   newSession: GrokExecutionNativeConnection['newSession'] = request => (
-    this.connection.newSession(request)
+    this.connection.newSession({ ...request, _meta: withPlanModeHooks(request._meta) })
   );
 
   onNotification(
@@ -203,6 +222,18 @@ implements GrokExecutionNativeConnection {
   ): void {
     for (const listener of this.listeners) listener(notification, source);
   }
+}
+
+function withPlanModeHooks(meta: Record<string, unknown> | null | undefined): Record<string, unknown> {
+  return {
+    ...meta,
+    'x.ai/hooks': {
+      PreToolUse: [{
+        matcher: '^(enter_plan_mode|exit_plan_mode)$',
+        hookCallbackIds: ['claudian-block-plan'],
+      }],
+    },
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/providers/opencode/runtime/OpencodeLaunchArtifacts.ts
+++ b/src/providers/opencode/runtime/OpencodeLaunchArtifacts.ts
@@ -169,6 +169,10 @@ export function buildOpencodeManagedConfig(
     };
   }
 
+  nextAgents.plan = {
+    ...(isPlainObject(nextAgents.plan) ? nextAgents.plan : {}),
+    disable: true,
+  };
   config.agent = nextAgents;
   const trimmedDefaultAgentId = defaultAgentId?.trim();
   if (trimmedDefaultAgentId) {

--- a/tests/fixtures/providers/grok/extensions/plan-mode-hook.json
+++ b/tests/fixtures/providers/grok/extensions/plan-mode-hook.json
@@ -1,0 +1,40 @@
+{
+  "grokVersion": "1.0.13",
+  "evidence": "Real ACP runtime with deterministic localhost Responses API tool output; paths and session identifiers sanitized.",
+  "initializeResult": {
+    "protocolVersion": 1,
+    "agentCapabilities": {
+      "loadSession": true,
+      "_meta": {
+        "x.ai/hooks": {
+          "blockingEvents": ["pre_tool_use", "stop", "subagent_stop"],
+          "decisions": ["deny", "block"],
+          "stopSignals": ["continue", "stopReason", "additionalContext"]
+        }
+      }
+    }
+  },
+  "sessionMeta": {
+    "x.ai/hooks": {
+      "PreToolUse": [
+        {
+          "matcher": "^(enter_plan_mode|exit_plan_mode)$",
+          "hookCallbackIds": ["claudian-block-plan"]
+        }
+      ]
+    }
+  },
+  "request": {
+    "method": "_x.ai/hooks/run",
+    "params": {
+      "hookCallbackId": "claudian-block-plan",
+      "hookEventName": "pre_tool_use",
+      "sessionId": "session-native",
+      "permissionMode": "default",
+      "toolName": "enter_plan_mode",
+      "toolUseId": "call-plan",
+      "toolInput": {},
+      "toolInputTruncated": false
+    }
+  }
+}

--- a/tests/unit/providers/grok/execution/GrokExecutionNativeConnection.test.ts
+++ b/tests/unit/providers/grok/execution/GrokExecutionNativeConnection.test.ts
@@ -1,0 +1,147 @@
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+
+jest.mock('cross-spawn', () => jest.fn());
+
+import fixture from '@test/fixtures/providers/grok/extensions/plan-mode-hook.json';
+import spawn from 'cross-spawn';
+
+import { AcpJsonRpcTransport } from '@/providers/acp';
+import { GrokExecutionNativeConnectionImpl } from '@/providers/grok/execution/GrokExecutionNativeConnection';
+
+function createNativeProcess() {
+  const proc = Object.assign(new EventEmitter(), {
+    exitCode: null as number | null,
+    killed: false,
+    pid: 12345,
+    stderr: new PassThrough(),
+    stdin: new PassThrough(),
+    stdout: new PassThrough(),
+    kill: () => {
+      proc.exitCode = 0;
+      proc.killed = true;
+      proc.emit('exit', 0, null);
+      return true;
+    },
+  });
+  jest.mocked(spawn).mockReturnValue(proc as unknown as ChildProcessWithoutNullStreams);
+  return proc;
+}
+
+describe('GrokExecutionNativeConnection', () => {
+  let native: AcpJsonRpcTransport;
+  let connection: GrokExecutionNativeConnectionImpl;
+
+  beforeEach(() => {
+    const proc = createNativeProcess();
+    native = new AcpJsonRpcTransport({ input: proc.stdin, output: proc.stdout });
+    native.onRequest('initialize', () => fixture.initializeResult);
+    native.start();
+    connection = new GrokExecutionNativeConnectionImpl({
+      command: '/opt/grok',
+      cwd: '/vault',
+      env: {},
+      requestExtension: async () => { throw new Error('Unexpected UI extension'); },
+      requestPermission: async () => ({ outcome: { outcome: 'cancelled' } }),
+      version: 'test',
+    });
+  });
+
+  afterEach(async () => {
+    await connection.shutdown();
+    native.dispose();
+  });
+
+  it('registers native plan blocking without replacing session configuration', async () => {
+    let received: unknown;
+    native.onRequest('session/new', params => {
+      received = params;
+      return { sessionId: 'session-native' };
+    });
+    const request = {
+      _meta: {
+        modelId: 'grok-4.6',
+        systemPromptOverride: 'Keep these instructions.',
+        yoloMode: true,
+      },
+      cwd: '/vault',
+      mcpServers: [],
+    };
+
+    await connection.initialize();
+    await connection.newSession(request);
+
+    expect(received).toEqual({
+      ...request,
+      _meta: { ...request._meta, ...fixture.sessionMeta },
+    });
+    await expect(native.request(fixture.request.method, fixture.request.params)).resolves.toEqual({
+      decision: 'deny',
+      systemMessage: 'Plan mode is unavailable in Claudian. Continue in normal mode.',
+    });
+    expect(request._meta).toEqual({
+      modelId: 'grok-4.6',
+      systemPromptOverride: 'Keep these instructions.',
+      yoloMode: true,
+    });
+  });
+
+  it.each(['_x.ai/hooks/run', 'x.ai/hooks/run'])(
+    'rebinds hooks on load and denies late child callbacks through %s',
+    async method => {
+      let received: unknown;
+      native.onRequest('session/load', params => {
+        received = params;
+        return {};
+      });
+      const request = {
+        _meta: { systemPromptOverride: 'Resumed instructions.', yoloMode: true },
+        cwd: '/vault',
+        mcpServers: [],
+        sessionId: 'session-existing',
+      };
+
+      await connection.initialize();
+      await connection.loadSession(request);
+      connection.cancel(request.sessionId);
+
+      expect(received).toEqual({
+        ...request,
+        _meta: { ...request._meta, ...fixture.sessionMeta },
+      });
+      await expect(native.request(method, {
+        ...fixture.request.params,
+        permissionMode: 'bypassPermissions',
+        sessionId: 'session-child',
+        toolName: 'exit_plan_mode',
+      })).resolves.toEqual({
+        decision: 'deny',
+        systemMessage: 'Plan mode is unavailable in Claudian. Continue in normal mode.',
+      });
+    },
+  );
+
+  it('denies malformed hook callbacks instead of returning a fail-open protocol error', async () => {
+    await connection.initialize();
+
+    await expect(native.request('_x.ai/hooks/run', null)).resolves.toMatchObject({ decision: 'deny' });
+  });
+
+  it.each([
+    undefined,
+    { blockingEvents: ['pre_tool_use'], decisions: ['continue'] },
+    { blockingEvents: ['stop'], decisions: ['deny'] },
+    { blockingEvents: 'pre_tool_use', decisions: 'deny' },
+  ])('rejects runtimes without blocking pre-tool hooks', async hooks => {
+    native.onRequest('initialize', () => ({
+      protocolVersion: 1,
+      agentCapabilities: { _meta: { 'x.ai/hooks': hooks } },
+    }));
+
+    await expect(connection.initialize()).rejects.toThrow(
+      'Grok does not support blocking tool hooks. Update Grok to the latest version.',
+    );
+  });
+
+});

--- a/tests/unit/providers/opencode/OpencodeLaunchArtifacts.test.ts
+++ b/tests/unit/providers/opencode/OpencodeLaunchArtifacts.test.ts
@@ -16,6 +16,7 @@ describe('buildOpencodeManagedConfig', () => {
     expect(buildOpencodeManagedConfig({}, '/vault/.claudian/opencode/system.md', 'Yishen')).toEqual({
       $schema: 'https://opencode.ai/config.json',
       agent: {
+        plan: { disable: true },
         build: {
           prompt: '{file:/vault/.claudian/opencode/system.md}',
         },
@@ -61,6 +62,7 @@ describe('buildOpencodeManagedConfig', () => {
     )).toEqual({
       $schema: 'https://opencode.ai/config.json',
       agent: {
+        plan: { disable: true },
         'claudian-aux-readonly': {
           mode: 'primary',
           permission: {
@@ -72,6 +74,33 @@ describe('buildOpencodeManagedConfig', () => {
       },
       default_agent: 'claudian-aux-readonly',
     });
+  });
+
+  it.each([
+    undefined,
+    [{ id: 'claudian-aux-readonly', definition: { permission: { '*': 'deny' } } }],
+  ])('disables the native plan agent while preserving user agent configuration', (managedAgents) => {
+    const baseConfig = {
+      agent: {
+        plan: { disable: false, model: 'anthropic/claude-sonnet-4' },
+        reviewer: { description: 'Review changes', mode: 'subagent' },
+      },
+      command: { discuss: { agent: 'plan', template: 'Discuss the change' } },
+    };
+
+    const config = buildOpencodeManagedConfig(
+      baseConfig,
+      '/vault/.claudian/opencode/system.md',
+      undefined,
+      managedAgents,
+    );
+
+    expect(config.agent).toMatchObject({
+      plan: { disable: true, model: 'anthropic/claude-sonnet-4' },
+      reviewer: { description: 'Review changes', mode: 'subagent' },
+    });
+    expect(config.command).toEqual(baseConfig.command);
+    expect(baseConfig.agent.plan.disable).toBe(false);
   });
 
   it('merges the user config instead of replacing it', () => {
@@ -95,6 +124,7 @@ describe('buildOpencodeManagedConfig', () => {
     }, '/vault/.claudian/opencode/system.md')).toEqual({
       $schema: 'https://opencode.ai/config.json',
       agent: {
+        plan: { disable: true },
         build: {
           model: 'openai/gpt-5',
           permission: {


### PR DESCRIPTION
## Why

Follow-up to #1285: removing Claudian's plan controls still left native entry paths in OpenCode and Grok. An OpenCode command could target the built-in `plan` agent, and Grok could invoke its plan-entry tool during a turn. This implements the directly requested follow-up; no separate issue is needed.

## What Changed

- Disable OpenCode's native `plan` agent in managed launch configuration, including auxiliary launches, while preserving user configuration.
- Register Grok blocking hooks on new and loaded sessions and deny native plan-entry/exit calls directly, including late or malformed callbacks.
- Require Grok's blocking-hook capability at startup; unsupported runtimes receive an upgrade message with no legacy fallback.
- Add regression tests, a sanitized native Grok fixture, and provider guidance.

## Why This Approach

Keep enforcement in each provider's native connection or managed configuration. Grok hooks preserve native and user agent profiles; replacing the profile to remove tools would also change unrelated behavior. Existing default-mode selection handles resumed plan sessions.

## Validation

- Established failing tests before implementation.
- `npm run typecheck`
- `npm run lint`
- `npm run test -- --runInBand`: 605 suites and 8,810 tests passed; 2 suites and 2 tests skipped; all 53 script checks passed.
- `npm run build`
- `git diff --check`
- OpenCode 1.18.27 smoke: native `plan` unavailable despite project configuration enabling it; Safe, YOLO, and a custom agent still resolve.
- Grok 1.0.13 smoke: real CLI and implemented connection against a deterministic localhost API blocked entry in YOLO and after cold-loading a plan session and resetting its mode. No live model inference or manual UI check was needed.

## Impact and Follow-ups

Grok plan tools remain advertised to the model, but execution is denied. Grok's native hook timeouts and transport errors still fail open; this is not an unconditional security boundary. User configuration and existing provider histories are not rewritten.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
