### PR TITLE
perf: defer collapsed stored tool output until expansion

### DIFF
--- a/src/features/chat/rendering/ToolCallRenderer.ts
+++ b/src/features/chat/rendering/ToolCallRenderer.ts
@@ -1135,13 +1135,24 @@ export function renderStoredToolCall(
     setGenericToolHeaderRight(statusEl, toolCall);
   }
 
-  renderToolContent(content, toolCall);
+  let contentRendered = false;
+  const renderContentOnce = () => {
+    if (contentRendered) return;
+    renderToolContent(content, toolCall);
+    contentRendered = true;
+  };
+  const deferContent = toolCall.status !== 'running'
+    && toolCall.name !== TOOL_ASK_USER_QUESTION
+    && toolCall.name !== TOOL_TODO_WRITE;
+  if (!deferContent || options.initiallyExpanded) renderContentOnce();
 
   const state = { isExpanded: false };
   const todoStatusEl = toolCall.name === TOOL_TODO_WRITE ? statusEl : null;
   setupCollapsible(toolEl, header, content, state, {
     initiallyExpanded: options.initiallyExpanded ?? false,
-    onToggle: createTodoToggleHandler(currentTaskEl, todoStatusEl),
+    onToggle: createTodoToggleHandler(currentTaskEl, todoStatusEl, (expanded) => {
+      if (expanded) renderContentOnce();
+    }),
     baseAriaLabel: getToolLabel(toolCall.name, toolCall.input)
   });
 

--- a/src/features/chat/rendering/WriteEditRenderer.ts
+++ b/src/features/chat/rendering/WriteEditRenderer.ts
@@ -207,24 +207,32 @@ export function renderStoredWriteEdit(
   // Content
   const contentEl = wrapperEl.createDiv({ cls: 'claudian-write-edit-content' });
 
-  // Render diff if available
-  const row = contentEl.createDiv({ cls: 'claudian-write-edit-diff-row' });
+  let contentRendered = false;
+  const renderContentOnce = () => {
+    if (contentRendered) return;
+    const row = contentEl.createDiv({ cls: 'claudian-write-edit-diff-row' });
 
-  if (toolCall.diffData && toolCall.diffData.diffLines.length > 0) {
-    const diffEl = row.createDiv({ cls: 'claudian-write-edit-diff' });
-    renderDiffContent(diffEl, toolCall.diffData.diffLines);
-  } else if (isError && toolCall.result) {
-    const errorEl = row.createDiv({ cls: 'claudian-write-edit-error' });
-    errorEl.setText(toolCall.result);
-  } else {
-    const doneEl = row.createDiv({ cls: 'claudian-write-edit-done-text' });
-    doneEl.setText(isError ? 'ERROR' : 'DONE');
-  }
+    if (toolCall.diffData && toolCall.diffData.diffLines.length > 0) {
+      const diffEl = row.createDiv({ cls: 'claudian-write-edit-diff' });
+      renderDiffContent(diffEl, toolCall.diffData.diffLines);
+    } else if (isError && toolCall.result) {
+      const errorEl = row.createDiv({ cls: 'claudian-write-edit-error' });
+      errorEl.setText(toolCall.result);
+    } else {
+      const doneEl = row.createDiv({ cls: 'claudian-write-edit-done-text' });
+      doneEl.setText(isError ? 'ERROR' : 'DONE');
+    }
+    contentRendered = true;
+  };
+  if (toolCall.status === 'running' || options.initiallyExpanded) renderContentOnce();
 
   // Setup collapsible behavior (handles click, keyboard, ARIA, CSS)
   const state = { isExpanded: false };
   setupCollapsible(wrapperEl, headerEl, contentEl, state, {
     initiallyExpanded: options.initiallyExpanded ?? false,
+    onToggle: (expanded) => {
+      if (expanded) renderContentOnce();
+    },
     baseAriaLabel,
   });
 

--- a/tests/unit/features/chat/rendering/StoredToolContent.dom.test.ts
+++ b/tests/unit/features/chat/rendering/StoredToolContent.dom.test.ts
@@ -1,0 +1,198 @@
+/** @jest-environment jsdom */
+
+import { fireEvent, within } from '@testing-library/dom';
+import { axe } from 'jest-axe';
+
+import type { ToolCallInfo } from '@/core/types';
+import {
+  renderStoredToolCall,
+  renderToolCall,
+  updateToolCallResult,
+} from '@/features/chat/rendering/ToolCallRenderer';
+import { renderStoredWriteEdit } from '@/features/chat/rendering/WriteEditRenderer';
+
+HTMLElement.prototype.empty = function () { this.replaceChildren(); };
+HTMLElement.prototype.addClass = function (...classes) { this.classList.add(...classes); };
+HTMLElement.prototype.removeClass = function (...classes) { this.classList.remove(...classes); };
+HTMLElement.prototype.toggleClass = function (classes, enabled) {
+  for (const cls of typeof classes === 'string' ? [classes] : classes) {
+    this.classList.toggle(cls, enabled);
+  }
+};
+
+beforeEach(() => {
+  document.body.replaceChildren();
+});
+
+it('restores a completed Bash result without mounting its collapsed body until expansion', () => {
+  const tool: ToolCallInfo = {
+    id: 'stored-bash',
+    name: 'Bash',
+    input: { command: 'printf fixture' },
+    status: 'completed',
+    result: 'first fixture line\nlast fixture line',
+  };
+  const parent = document.body.createDiv();
+  const block = renderStoredToolCall(parent, tool);
+  const content = block.querySelector<HTMLElement>('.claudian-tool-content')!;
+  const header = within(block).getByRole('button', { name: /Bash: printf fixture/ });
+
+  expect(header.getAttribute('aria-expanded')).toBe('false');
+  expect(content.childElementCount).toBe(0);
+
+  fireEvent.click(header);
+  expect(header.getAttribute('aria-expanded')).toBe('true');
+  expect(content.textContent).toContain('first fixture line');
+  expect(content.textContent).toContain('last fixture line');
+  const rendered = Array.from(content.children);
+
+  fireEvent.click(header);
+  fireEvent.keyDown(header, { key: 'Enter' });
+  expect(content.firstElementChild).toBe(rendered[0]);
+  expect(tool.result).toBe('first fixture line\nlast fixture line');
+});
+
+it('restores an Edit summary without mounting diff rows until keyboard expansion', () => {
+  const tool: ToolCallInfo = {
+    id: 'stored-edit',
+    name: 'Edit',
+    input: { file_path: 'fixture.md' },
+    status: 'completed',
+    diffData: {
+      filePath: 'fixture.md',
+      diffLines: [
+        { type: 'delete', text: 'old fixture', oldLineNum: 1 },
+        { type: 'insert', text: 'new fixture', newLineNum: 1 },
+      ],
+      stats: { added: 1, removed: 1 },
+    },
+  };
+  const block = renderStoredWriteEdit(document.body.createDiv(), tool);
+  const content = block.querySelector<HTMLElement>('.claudian-write-edit-content')!;
+  const header = within(block).getByRole('button', { name: /Edit: fixture.md/ });
+
+  expect(header.textContent).toContain('+1');
+  expect(header.textContent).toContain('-1');
+  expect(content.childElementCount).toBe(0);
+
+  fireEvent.keyDown(header, { key: ' ' });
+  expect(header.getAttribute('aria-expanded')).toBe('true');
+  expect(Array.from(content.querySelectorAll('.claudian-diff-text'), el => el.textContent))
+    .toEqual(['old fixture', 'new fixture']);
+  const firstRow = content.firstElementChild;
+
+  fireEvent.keyDown(header, { key: 'Enter' });
+  fireEvent.click(header);
+  expect(content.firstElementChild).toBe(firstRow);
+});
+
+describe.each(['completed', 'error', 'blocked'] as const)('stored %s output', (status) => {
+  it('honors initiallyExpanded and retains the output through repeated toggles', () => {
+    const tool: ToolCallInfo = {
+      id: 'terminal-tool',
+      name: 'Read',
+      input: { file_path: 'fixture.md' },
+      status,
+      result: 'fixture output',
+    };
+    const original = JSON.stringify(tool);
+    const block = renderStoredToolCall(document.body.createDiv(), tool, { initiallyExpanded: true });
+    const content = block.querySelector<HTMLElement>('.claudian-tool-content')!;
+    const header = within(block).getByRole('button', { name: /Read: fixture.md/ });
+
+    expect(header.getAttribute('aria-expanded')).toBe('true');
+    expect(content.textContent).toContain('fixture output');
+    const children = Array.from(content.children);
+    fireEvent.click(header);
+    fireEvent.click(header);
+    expect(content.firstElementChild).toBe(children[0]);
+    expect(JSON.stringify(tool)).toBe(original);
+  });
+
+  it('preserves stored Edit status and materializes fallback output on demand', () => {
+    const tool: ToolCallInfo = {
+      id: 'terminal-edit',
+      name: 'Edit',
+      input: { file_path: 'fixture.md' },
+      status,
+      result: 'fixture failure',
+    };
+    const original = JSON.stringify(tool);
+    const block = renderStoredWriteEdit(document.body.createDiv(), tool);
+    const content = block.querySelector<HTMLElement>('.claudian-write-edit-content')!;
+    const header = within(block).getByRole('button', { name: /Edit: fixture.md/ });
+
+    expect(content.childElementCount).toBe(0);
+    expect(block.classList.contains(status === 'completed' ? 'done' : 'error')).toBe(true);
+    fireEvent.click(header);
+    expect(content.textContent).toBe(status === 'completed' ? 'DONE' : 'fixture failure');
+    expect(JSON.stringify(tool)).toBe(original);
+  });
+});
+
+it('keeps running stored tools and live result updates eager', () => {
+  const tool: ToolCallInfo = {
+    id: 'running-bash',
+    name: 'Bash',
+    input: { command: 'printf fixture' },
+    status: 'running',
+    result: 'partial output',
+  };
+  const parent = document.body.createDiv();
+  const stored = renderStoredToolCall(parent, tool);
+  expect(stored.querySelector('.claudian-tool-content')?.textContent).toContain('partial output');
+
+  const runningEdit = renderStoredWriteEdit(parent, {
+    ...tool, name: 'Edit', input: { file_path: 'fixture.md' },
+  });
+  expect(runningEdit.querySelector('.claudian-write-edit-content')?.childElementCount).toBeGreaterThan(0);
+
+  const liveElements = new Map<string, HTMLElement>();
+  const live = renderToolCall(parent, tool, liveElements);
+  tool.status = 'completed';
+  tool.result = 'finished output';
+  updateToolCallResult(tool.id, tool, liveElements);
+  expect(live.querySelector('.claudian-tool-content')?.textContent).toContain('finished output');
+});
+
+it('keeps default-expanded Edit diffs available immediately', async () => {
+  const block = renderStoredWriteEdit(document.body.createDiv(), {
+    id: 'expanded-edit',
+    name: 'Edit',
+    status: 'completed',
+    input: { file_path: 'fixture.md' },
+    diffData: {
+      filePath: 'fixture.md',
+      diffLines: [
+        { type: 'delete', text: 'before', oldLineNum: 1 },
+        { type: 'insert', text: 'after', newLineNum: 1 },
+      ],
+      stats: { added: 1, removed: 1 },
+    },
+  }, { initiallyExpanded: true });
+  expect(within(block).getByRole('button', { name: /Edit: fixture.md/ }).getAttribute('aria-expanded'))
+    .toBe('true');
+  expect(Array.from(block.querySelectorAll('.claudian-diff-text'), el => el.textContent))
+    .toEqual(['before', 'after']);
+  expect((await axe(block)).violations).toEqual([]);
+});
+
+it('keeps restored apply_patch statistics available before rendering its diff', () => {
+  const block = renderStoredToolCall(document.body.createDiv(), {
+    id: 'patch',
+    name: 'apply_patch',
+    status: 'completed',
+    input: {
+      patch: '*** Begin Patch\n*** Update File: fixture.md\n@@\n-old\n+new\n*** End Patch',
+    },
+    result: 'Applied patch',
+  });
+  const header = within(block).getByRole('button', { name: /apply_patch/ });
+  const content = block.querySelector<HTMLElement>('.claudian-tool-content')!;
+  expect(header.textContent).toContain('+1');
+  expect(header.textContent).toContain('-1');
+  expect(content.childElementCount).toBe(0);
+  fireEvent.keyDown(header, { key: ' ' });
+  expect(Array.from(content.querySelectorAll('.claudian-diff-text'), el => el.textContent))
+    .toEqual(['old', 'new']);
+});

--- a/tests/unit/features/chat/rendering/ToolCallRenderer.test.ts
+++ b/tests/unit/features/chat/rendering/ToolCallRenderer.test.ts
@@ -601,6 +601,7 @@ describe('ToolCallRenderer', () => {
       });
 
       const toolEl = renderStoredToolCall(parentEl, toolCall);
+      (toolEl.querySelector('.claudian-tool-header') as HTMLElement).click();
       const lines = Array.from(toolEl.querySelectorAll('.claudian-tool-line')).map(line => line.textContent);
 
       expect(lines).toContain('Query: obsidian plugin API');
@@ -621,6 +622,7 @@ describe('ToolCallRenderer', () => {
       });
 
       const toolEl = renderStoredToolCall(parentEl, toolCall);
+      (toolEl.querySelector('.claudian-tool-header') as HTMLElement).click();
       const links = toolEl.querySelectorAll('.claudian-tool-link');
       const lines = Array.from(toolEl.querySelectorAll('.claudian-tool-line')).map(line => line.textContent);
 
@@ -651,6 +653,7 @@ describe('ToolCallRenderer', () => {
       });
 
       const toolEl = renderStoredToolCall(parentEl, toolCall);
+      (toolEl.querySelector('.claudian-tool-header') as HTMLElement).click();
       const headers = Array.from(toolEl.querySelectorAll('.claudian-tool-patch-header')).map(el => el.textContent);
       const statusEl = toolEl.querySelector('.claudian-tool-status');
       const diffTexts = Array.from(toolEl.querySelectorAll('.claudian-diff-text')).map(el => el.textContent);
@@ -737,6 +740,7 @@ describe('ToolCallRenderer', () => {
       });
 
       const toolEl = renderStoredToolCall(parentEl, toolCall);
+      (toolEl.querySelector('.claudian-tool-header') as HTMLElement).click();
       const headers = Array.from(toolEl.querySelectorAll('.claudian-tool-patch-header')).map(el => el.textContent);
       const statusEl = toolEl.querySelector('.claudian-tool-status');
       const diffTexts = Array.from(toolEl.querySelectorAll('.claudian-diff-text')).map(el => el.textContent);
@@ -855,6 +859,7 @@ describe('ToolCallRenderer', () => {
       });
 
       const toolEl = renderStoredToolCall(parentEl, toolCall);
+      (toolEl.querySelector('.claudian-tool-header') as HTMLElement).click();
       const lines = Array.from(toolEl.querySelectorAll('.claudian-tool-line')).map(el => el.textContent);
 
       expect(lines).toContain('src/main.ts');


### PR DESCRIPTION
## Why

Fixes #1303.

Restoring terminal tool calls eagerly builds result/diff subtrees even when their cards start collapsed. In the reported Obsidian 1.13.7 / Claudian 2.2.6 session, 190 collapsed tool cards retained 8,993 descendant elements. Offscreen layout isolation and completed-work grouping retain those elements.

## What changed

- Defer body creation for default-collapsed terminal stored tool calls and stored Edit/Write diffs until the first expansion.
- Keep headers, status, filenames and diff counts available immediately.
- Honor `initiallyExpanded` and retain the materialized subtree on subsequent collapse/expand.
- Keep running restored tools, live updates, AskUserQuestion and TodoWrite content eager. Thinking rendering/finalization is unchanged.

The production change is confined to `renderStoredToolCall()` and `renderStoredWriteEdit()`. Five existing expanded-content tests now expand the card before checking the same output; new real-DOM tests cover first expansion, keyboard activation, node identity reuse, explicit initial expansion, errors/blocked results, live updates, source-data preservation and an accessibility check.

## Why this approach

This addresses the costly hidden bodies without introducing message-list virtualization, a new setting/dependency, or changes to provider/session/history ownership. It is independent of the live-render scheduling in #989 and preserves #1272's reuse of completed work elements.

First expansion now pays body construction when needed. Expanded bodies remain cached in their existing card; this is intentionally not a general fold-time eviction mechanism.

## Validation

On upstream base `af3d765b287c0aa582695fceb2633f777418ee68`, Node 24.16.0:

- Existing renderer baseline: 124 tests passed.
- Red: both new deferred-body tests failed on unchanged production code (collapsed Bash body had 2 children; stored Edit body had 1).
- Green: focused renderer suites, 135 tests passed. The 11 new DOM tests were re-run after strengthening node-identity assertions.
- `npm run typecheck`: passed.
- `npm run lint`: passed; the final DOM-test edit also passed ESLint.
- `npm run test -- --runInBand`: 603 suites / 8,754 tests passed; 2 suites / 2 tests skipped by the existing suite; 53 architecture/policy tests passed.
- `npm run build` and `git diff --check`: passed.

### Synthetic Obsidian comparison

I ran the actual two renderer modules from the base and patched source inside Obsidian's Electron 39.8.3 / Chromium 142.0.7444.265, using only synthetic data. Both variants stubbed `setIcon` identically; no provider request, transcript mutation or plugin replacement was involved.

Fixture: 60 alternating cards: 30 completed Bash results with 40 synthetic output lines, and 30 completed Edits with 40 delete/insert pairs. Three interleaved baseline/patched pairs gave:

| Check at initial collapsed render | Base | Patched |
| --- | ---: | ---: |
| Descendant elements | 8,520 | 540 |
| Hidden body descendants | 7,980 | 0 |
| Synchronous construction median | 13.7 ms | 1.8 ms |

In all six runs, expanding an Edit produced the exact 80 expected diff lines, and collapse followed by Enter reused the existing content node. Patched first-expansion-to-two-animation-frames measurements were 33.1 / 33.2 / 33.3 ms.

Element counts are the repeatable result; timings are illustrative samples on a loaded machine, not end-to-end latency or memory-savings claims. The temporary fixture was removed afterward. The user's normal plugin installation remains unchanged. No screenshot is attached because the resulting visible card layout is unchanged.

## Impact and limits

- No persisted data, model context, native transcript, provider execution or settings migration.
- Existing output preview limits remain in force.
- apply_patch header statistics still parse the patch eagerly; this does not remove all hydration/parse costs.
- This does not virtualize message history, unload already-expanded bodies, or eliminate eager thinking-history rendering.
- Native Windows/Linux runtime validation was not performed; the DOM behavior is covered by tests without platform-specific code.

## Checklist

- [x] One focused problem with a linked issue.
- [x] Failing behavior tests before implementation.
- [x] Typecheck, lint, tests and production build completed.
- [x] Tradeoffs and unverified platform behavior stated.
- [x] No user-facing configuration or storage changes requiring migration documentation.
