### PR TITLE
chore: remove model chevron rules orphaned by bab87d32

### DIFF
--- a/src/style/toolbar/model-selector.css
+++ b/src/style/toolbar/model-selector.css
@@ -18,16 +18,6 @@
   font-weight: 500;
 }
 
-.claudian-model-chevron {
-  display: flex;
-  align-items: center;
-}
-
-.claudian-model-chevron svg {
-  width: 12px;
-  height: 12px;
-}
-
 .claudian-model-dropdown {
   position: absolute;
   bottom: 100%;


### PR DESCRIPTION
`bab87d32` (`feat: add context paths for read-only access to external directories`) deleted the chevron span from the model selector button — `createSpan({ cls: 'claudian-model-chevron' })` and `setIcon(chevronEl, 'chevron-up')`. The file was `src/ui/InputToolbar.ts` at that commit; it is now `src/features/chat/ui/InputToolbar.ts`.

```
git grep "claudian-model-chevron" bab87d32^ -- '*.ts'   # one hit
git grep "claudian-model-chevron" bab87d32  -- '*.ts'   # none
```

Unlike #1299, there was no name reuse: the class had exactly one producer at every point in its life. `96a522d5` introduced it in `ClaudianView.ts`, `a4e46f65` moved it into `InputToolbar.ts`, `bab87d32` removed it. The rules survived only because `bab87d32` touched no CSS, and `84935ea0` then carried the already-dead declarations from root `styles.css` into `src/style/toolbar/model-selector.css` four days later. Four commits have touched that file since — `aeca7a37`, `a2ff0022`, `fc6405bd`, and `33ef0310` — and the two rules are byte-identical at every one of those snapshots.

### Scope

The model selector is live. `ModelSelector.updateDisplay()` emits an optional `claudian-model-provider-icon` SVG and a `claudian-model-label` span; the dropdown emits `claudian-model-dropdown`, `-group`, and `-option`. Every one of those rules is retained. `claudian-model-chevron` is the only `claudian-model-*` token in the stylesheet with no TypeScript counterpart.

Nothing renders a chevron on the button by another mechanism. The stylesheet has no `content:` declaration and no `::before`/`::after` on any `claudian-model-*` selector; the only other rule reaching the button is the `:focus-visible` outline in `accessibility.css`. The provider icon is sized inline (`createProviderIconSvg(icon, { width: 12, height: 12 })`), so the `svg { width: 12px; height: 12px }` rule was specific to the chevron and takes nothing with it.

Some class names in this codebase are built by template interpolation (`claudian-todo-${todo.status}`, `claudian-context-chip--${item.kind}`), so this needs checking rather than assuming. No `claudian-model` name is among them: `grep -rnE "claudian-model[a-z-]*\$\{" src/` is empty and all seven live names are plain string literals in `InputToolbar.ts`. The class appears nowhere else in the tree — no docs, no i18n key, no test, no other CSS.

`claudian-citations-chevron` (`c660b1e2`, a `›` text glyph in `CitationRenderer.ts`) and `claudian-provider-model-picker-catalog-caret` (`4601d0c4`, a `<details>` marker in `ProviderModelPicker.ts`) are unrelated: both entered the tree seven to eight months after this class was orphaned, on different surfaces. This is not half of an unfinished rename.

### One thing worth your call

The chevron removal was drive-by. `bab87d32` is about read-only context paths, and those two lines are the only unrelated deletion in it. The same commit added a fourth control to the same flat toolbar row (`ContextPathSelector`), which reads as a space rationale, and that row now carries seven controls — so the pressure against re-adding a chevron is higher today than it was in December, not lower.

Against that, the removal looks ratified rather than overlooked. You've touched `model-selector.css` four times since — including `33ef0310` (`feat: refine chat branding and model selector`, #965), a dedicated pass over this exact component that also changed `InputToolbar.ts` — and the chevron was not restored in any of them.

I'd still remove the rules. Unlike #1298, no live class is left unstyled here, so the deletion conceals no current bug: nothing renders an element carrying the class, and the rules contain no `content:`, so they have zero effect on rendered output in any state. Restoring the affordance would require a TypeScript change whether or not this CSS is present. But if you'd rather restore the chevron first, say so and I'll drop this PR.

### No test

Unlike #1294, no removed name here is a superset of a surviving one. `claudian-model-chevron` is neither a prefix, suffix, nor substring of any retained selector, and there is no standalone `.claudian-model` — so there is no retention boundary to pin. An absence assertion would be the negative test AGENTS.md prohibits for deleted logic, and a retention assertion would be a static-value test green both before and after. This follows #1292 and #1299, which removed selectors and added none.

### Verification

`npm run typecheck`, `npm run lint`, and `npm run build` pass, and the full jest run is green (603 suites, 8754 tests). `lint:css` runs stylelint over `src/style/**`, though the config enables only `declaration-no-important`, so it confirms parseability rather than coverage.

Built `styles.css` confirms the token is gone and the seven siblings remain; it is generated and gitignored, so it is not part of this change. No test reads `model-selector.css`, and `tests/unit/features/chat/ui/InputToolbar.test.ts` — which asserts on the button's live classes and never on the chevron — is unaffected.
