### PR TITLE
chore: remove the never-applied Codex settings placeholder rule

### DIFF
--- a/src/style/settings/base.css
+++ b/src/style/settings/base.css
@@ -76,14 +76,6 @@
   display: block;
 }
 
-/* Codex placeholder */
-.claudian-settings-codex-placeholder {
-  padding: 40px 20px;
-  text-align: center;
-  color: var(--text-muted);
-  font-size: var(--font-ui-small);
-}
-
 /* Settings page - remove separator lines from setting items */
 .setting-item.claudian-settings {
   display: block;


### PR DESCRIPTION
chore: remove the never-applied Codex settings placeholder rule

fc6405bd added `.claudian-settings-codex-placeholder` to
`src/style/settings/base.css`. No TypeScript has ever applied it.

    git log --all -S'claudian-settings-codex-placeholder'           # fc6405bd
    git log --all -S'claudian-settings-codex-placeholder' -- '*.ts' # empty

One commit ever touched the string, and it is not a removal: `git blame -L
79,85` still attributes all seven lines to fc6405bd. So this is not a selector
orphaned by a later removal -- it was born unused, the case #1294 recorded for
`claudian-plugin-version-badge`.

The `/* Codex placeholder */` comment goes with the rule. It labels that one
rule and describes a surface that was never built. Codex settings are rendered
in full by `src/providers/codex/ui/CodexSettingsTab.ts`, which has no
placeholder state; the sections it composes use the shared
`claudian-sp-empty-state` for their empty states. The settings shell's own
fallback for a provider with no renderer is an unclassed div in
`src/features/settings/ClaudianSettings.ts`, provider-neutral by construction
and not a candidate for a `-codex-` name.

`claudian-settings-codex-placeholder` is the only `claudian-settings-*` base
name in the stylesheet with no TypeScript counterpart; the other ten are all
emitted. It appears nowhere else in the tree. Nothing constructs it
dynamically: no interpolation anywhere in `src/` can assemble this name, and
every interpolated `claudian-settings-*` string carries a fixed prefix that
diverges from it.

No test is added. `.claudian-settings` is live -- `ClaudianSettings.ts:172`
applies it -- and `claudian-settings-codex-placeholder` is a strict superset of
it, which is the condition #1294 cited. The hazard that condition proxies for is
absent here. #1294's own note names it as lexical: a substring deletion could
take out shipping UI, and its retention assertions needed trailing braces
because `.claudian-plugin-item` would otherwise be satisfied by
`.claudian-plugin-item-disabled`. Here `.claudian-settings` has no standalone
rule block anywhere in `src/style/`; every bare use is a compound or descendant
selector, so there is no block a prefix-matched deletion could confuse with the
target. `claudian-settings-codex` exists nowhere, and the only other selector
sharing the prefix `.claudian-settings-c` is `.claudian-settings-cli-path-input`,
which diverges at the next character.

    grep -rnE "^\.claudian-settings[[:space:]]*\{" src/style/    # empty
    grep -rnoE "claudian-settings-c[a-z0-9-]*" src/ | sort -u    # two names

#1294 removed six rules across three hunks, interleaved with prefix-dense
survivors, and needed a retention boundary the diff could not show. This removes
one self-contained rule block in one hunk, with the neighbouring survivors
visible as context lines. Since the class was never applied there is no
replacement behavior to cover, and retention assertions over static selector
strings already shown in the diff would be exactly the negative and static-value
tests the TDD rules exclude.

