### PR TITLE
fix: restore OpenCode SQLite history loading in Obsidian

### DIFF
--- a/src/providers/opencode/history/OpencodeConversationHistoryService.ts
+++ b/src/providers/opencode/history/OpencodeConversationHistoryService.ts
@@ -33,7 +33,7 @@ export class OpencodeConversationHistoryService implements ProviderConversationH
     const state = getOpencodeState(conversation.providerState);
     const databasePath = resolveOpencodeDatabasePathHint(state.databasePath, pathContext);
     if (!databasePath) return null;
-    return loadOpencodeSessionModel(conversation.sessionId, { databasePath });
+    return loadOpencodeSessionModel(conversation.sessionId, { databasePath }, pathContext?.environment);
   }
 
   async hydrateConversationHistory(
@@ -69,7 +69,11 @@ export class OpencodeConversationHistoryService implements ProviderConversationH
       return;
     }
 
-    const messages = await loadOpencodeSessionMessages(sessionId, { databasePath: databasePath ?? undefined });
+    const messages = await loadOpencodeSessionMessages(
+      sessionId,
+      { databasePath: databasePath ?? undefined },
+      pathContext?.environment,
+    );
     if (messages.length === 0) {
       this.hydratedKeys.delete(conversation.id);
       return;

--- a/src/providers/opencode/history/OpencodeHistoryStore.ts
+++ b/src/providers/opencode/history/OpencodeHistoryStore.ts
@@ -20,6 +20,7 @@ import type { OpencodeProviderState } from '../types';
 import {
   loadOpencodeSessionRows,
   type StoredRow,
+  type StoredSessionRows,
 } from './OpencodeSqliteReader';
 
 export { OPENCODE_MESSAGE_ROW_SQL } from './OpencodeSqliteReader';
@@ -39,17 +40,20 @@ const OPENCODE_HYDRATION_DIAGNOSTIC_ID_PREFIX = 'opencode-hydration-error';
 export async function loadOpencodeSessionMessages(
   sessionId: string,
   providerState?: OpencodeProviderState,
+  environment: NodeJS.ProcessEnv = process.env,
 ): Promise<ChatMessage[]> {
-  const databasePath = resolveExistingOpencodeDatabasePath(providerState?.databasePath);
+  const databasePath = resolveExistingOpencodeDatabasePath(providerState?.databasePath, environment);
   if (!databasePath || databasePath === ':memory:' || !fs.existsSync(databasePath)) {
     return [];
   }
 
-  const rows = await loadOpencodeSessionRows(databasePath, sessionId);
-  if (!rows) {
+  let rows: StoredSessionRows;
+  try {
+    rows = await loadOpencodeSessionRows(databasePath, sessionId, { environment });
+  } catch (error) {
     return [createOpencodeHydrationDiagnosticMessage({
       databasePath,
-      reason: 'Could not read OpenCode session rows from SQLite.',
+      reason: formatUnknownError(error),
       sessionId,
     })];
   }
@@ -63,13 +67,14 @@ export async function loadOpencodeSessionMessages(
 export async function loadOpencodeSessionModel(
   sessionId: string,
   providerState?: OpencodeProviderState,
+  environment: NodeJS.ProcessEnv = process.env,
 ): Promise<string | null> {
-  const databasePath = resolveExistingOpencodeDatabasePath(providerState?.databasePath);
+  const databasePath = resolveExistingOpencodeDatabasePath(providerState?.databasePath, environment);
   if (!databasePath || databasePath === ':memory:' || !fs.existsSync(databasePath)) {
     return null;
   }
 
-  const rows = await loadOpencodeSessionRows(databasePath, sessionId);
+  const rows = await loadOpencodeSessionRows(databasePath, sessionId, { environment }).catch(() => null);
   let rawModelId: string | null = null;
   for (const row of rows?.messageRows ?? []) {
     const data = parseJsonObject(row.data);
@@ -299,7 +304,10 @@ function createOpencodeHydrationDiagnosticMessage(params: {
     ...(params.messageId ? [`messageId: ${params.messageId}`] : []),
     `reason: ${params.reason}`,
   ];
-  const content = detailLines.join('\n');
+  const details = detailLines.join('\n');
+  const fenceLength = (details.match(/`+/g) ?? []).reduce((length, run) => Math.max(length, run.length + 1), 3);
+  const fence = '`'.repeat(fenceLength);
+  const content = `${fence}text\n${details}\n${fence}`;
 
   return {
     assistantMessageId: undefined,

--- a/src/providers/opencode/history/OpencodeSqliteReader.ts
+++ b/src/providers/opencode/history/OpencodeSqliteReader.ts
@@ -116,10 +116,9 @@ export async function loadOpencodeSessionRows(
 }
 
 function requireSqliteModule(): SqliteModule | null {
-  if (typeof module === 'undefined' || typeof module.require !== 'function') {
-    return null;
-  }
-  const sqlite = module.require('node:sqlite') as unknown;
+  // Obsidian supplies require separately from its plain { exports } module object.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- Load optional SQLite lazily through Obsidian's injected require.
+  const sqlite = require('node:sqlite') as unknown;
   return isPlainObject(sqlite) && typeof sqlite.DatabaseSync === 'function'
     ? sqlite as unknown as SqliteModule
     : null;

--- a/src/providers/opencode/history/OpencodeSqliteReader.ts
+++ b/src/providers/opencode/history/OpencodeSqliteReader.ts
@@ -1,6 +1,6 @@
-import { spawn as defaultSpawn } from 'node:child_process';
+import { type ChildProcess, spawn as defaultSpawn, type SpawnOptions } from 'node:child_process';
 
-import { findNodeExecutable } from '../../../utils/env';
+import { findNodeExecutables } from '../../../utils/env';
 
 export type StoredRow = Record<string, unknown>;
 
@@ -10,7 +10,7 @@ export interface StoredSessionRows {
 }
 
 interface SqliteModule {
-  DatabaseSync: new (location: string, options?: Record<string, unknown>) => {
+  DatabaseSync: new (location: string, options: { readOnly: boolean }) => {
     close(): void;
     prepare(sql: string): {
       all(...params: unknown[]): StoredRow[];
@@ -18,10 +18,13 @@ interface SqliteModule {
   };
 }
 
+type SpawnSqliteProcess = (command: string, args: string[], options: SpawnOptions) => ChildProcess;
+
 export interface OpencodeSqliteReaderDependencies {
-  findNodeExecutable?: () => string | null;
+  environment?: NodeJS.ProcessEnv;
+  findNodeExecutables?: () => string[];
   requireSqliteModule?: () => SqliteModule | null;
-  spawn?: typeof defaultSpawn;
+  spawn?: SpawnSqliteProcess;
 }
 
 export const OPENCODE_SQLITE_QUERY_MAX_BUFFER = 100 * 1024 * 1024;
@@ -33,7 +36,7 @@ const { DatabaseSync } = require('node:sqlite');
 const [databasePath, sessionId, messageSql, partSql] = process.argv.slice(1);
 let db;
 try {
-  db = new DatabaseSync(databasePath, { readonly: true });
+  db = new DatabaseSync(databasePath, { readOnly: true });
   const messageRows = db.prepare(messageSql).all(sessionId);
   const partRows = db.prepare(partSql).all(sessionId);
   process.stdout.write(JSON.stringify({ messageRows, partRows }));
@@ -46,177 +49,122 @@ export async function loadOpencodeSessionRows(
   databasePath: string,
   sessionId: string,
   dependencies: OpencodeSqliteReaderDependencies = {},
-): Promise<StoredSessionRows | null> {
-  const resolvedDependencies = resolveDependencies(dependencies);
-
-  const viaCurrentProcess = loadSessionRowsWithCurrentProcessSqlite(
-    databasePath,
-    sessionId,
-    resolvedDependencies.requireSqliteModule,
-  );
-  if (viaCurrentProcess) {
-    return viaCurrentProcess;
+): Promise<StoredSessionRows> {
+  const spawn = dependencies.spawn ?? defaultSpawn;
+  const environment = dependencies.environment ?? process.env;
+  const errors: string[] = [];
+  try {
+    const sqlite = (dependencies.requireSqliteModule ?? requireSqliteModule)();
+    if (!sqlite) throw new Error('node:sqlite is unavailable.');
+    const db = new sqlite.DatabaseSync(databasePath, { readOnly: true });
+    try {
+      return {
+        messageRows: db.prepare(OPENCODE_MESSAGE_ROW_SQL).all(sessionId),
+        partRows: db.prepare(OPENCODE_PART_ROW_SQL).all(sessionId),
+      };
+    } finally {
+      db.close();
+    }
+  } catch (error) {
+    errors.push(`Obsidian SQLite: ${formatError(error)}`);
   }
 
-  const viaNodeProcess = await loadSessionRowsWithNodeProcess(
-    databasePath,
-    sessionId,
-    resolvedDependencies.findNodeExecutable,
-    resolvedDependencies.spawn,
-  );
-  if (viaNodeProcess) {
-    return viaNodeProcess;
+  const nodePaths = dependencies.findNodeExecutables?.() ?? findNodeExecutables(environment.PATH);
+  if (nodePaths.length === 0) errors.push('Node.js: no executable found.');
+  for (const nodePath of nodePaths) {
+    try {
+      const stdout = await runBufferedChild(nodePath, [
+        '-e',
+        OPENCODE_SQLITE_CHILD_SCRIPT,
+        databasePath,
+        sessionId,
+        OPENCODE_MESSAGE_ROW_SQL,
+        OPENCODE_PART_ROW_SQL,
+      ], spawn, environment);
+      const rows = parseStoredSessionRows(stdout);
+      if (!rows) throw new Error('Invalid SQLite query output.');
+      return rows;
+    } catch (error) {
+      errors.push(`Node.js (${nodePath}): ${formatError(error)}`);
+    }
   }
 
-  return loadSessionRowsWithSqliteCli(
-    databasePath,
-    sessionId,
-    resolvedDependencies.spawn,
-  );
-}
+  try {
+    const escapedSessionId = escapeSqlLiteral(sessionId);
+    const messageRows = await runSqlite3JsonQuery(
+      databasePath,
+      buildOpencodeMessageRowsSql(`'${escapedSessionId}'`),
+      spawn,
+      environment,
+    );
+    const partRows = await runSqlite3JsonQuery(
+      databasePath,
+      buildOpencodePartRowsSql(`'${escapedSessionId}'`),
+      spawn,
+      environment,
+    );
+    return { messageRows, partRows };
+  } catch (error) {
+    errors.push(`sqlite3: ${formatError(error)}`);
+  }
 
-function resolveDependencies(
-  dependencies: OpencodeSqliteReaderDependencies,
-): Required<OpencodeSqliteReaderDependencies> {
-  return {
-    findNodeExecutable,
-    requireSqliteModule,
-    spawn: defaultSpawn,
-    ...dependencies,
-  };
+  throw new Error([
+    'Could not read OpenCode session rows from SQLite.',
+    ...errors,
+    'History requires working SQLite support in Obsidian, Node.js 22.13+ (or a newer supported release), or sqlite3.',
+  ].join('\n'));
 }
 
 function requireSqliteModule(): SqliteModule | null {
-  try {
-    if (typeof module === 'undefined' || typeof module.require !== 'function') {
-      return null;
-    }
-
-    const sqlite = module.require('node:sqlite') as unknown;
-    return isSqliteModule(sqlite) ? sqlite : null;
-  } catch {
+  if (typeof module === 'undefined' || typeof module.require !== 'function') {
     return null;
   }
-}
-
-function isSqliteModule(value: unknown): value is SqliteModule {
-  return (
-    isPlainObject(value)
-    && typeof value.DatabaseSync === 'function'
-  );
-}
-
-function loadSessionRowsWithCurrentProcessSqlite(
-  databasePath: string,
-  sessionId: string,
-  requireSqlite: () => SqliteModule | null,
-): StoredSessionRows | null {
-  const sqlite = requireSqlite();
-  if (!sqlite) {
-    return null;
-  }
-
-  let db: InstanceType<SqliteModule['DatabaseSync']> | null = null;
-  try {
-    db = new sqlite.DatabaseSync(databasePath, { readonly: true });
-    const messageRows = db.prepare(OPENCODE_MESSAGE_ROW_SQL).all(sessionId);
-    const partRows = db.prepare(OPENCODE_PART_ROW_SQL).all(sessionId);
-    return { messageRows, partRows };
-  } catch {
-    return null;
-  } finally {
-    db?.close();
-  }
-}
-
-async function loadSessionRowsWithNodeProcess(
-  databasePath: string,
-  sessionId: string,
-  findNode: () => string | null,
-  spawn: typeof defaultSpawn,
-): Promise<StoredSessionRows | null> {
-  const nodePath = findNode();
-  if (!nodePath) {
-    return null;
-  }
-
-  const stdout = await runBufferedChild(
-    nodePath,
-    [
-      '-e',
-      OPENCODE_SQLITE_CHILD_SCRIPT,
-      databasePath,
-      sessionId,
-      OPENCODE_MESSAGE_ROW_SQL,
-      OPENCODE_PART_ROW_SQL,
-    ],
-    spawn,
-  );
-  return stdout === null ? null : parseStoredSessionRows(stdout);
-}
-
-async function loadSessionRowsWithSqliteCli(
-  databasePath: string,
-  sessionId: string,
-  spawn: typeof defaultSpawn,
-): Promise<StoredSessionRows | null> {
-  const escapedSessionId = escapeSqlLiteral(sessionId);
-  const messageRows = await runSqlite3JsonQuery(
-    databasePath,
-    buildOpencodeMessageRowsSql(`'${escapedSessionId}'`),
-    spawn,
-  );
-  const partRows = await runSqlite3JsonQuery(
-    databasePath,
-    buildOpencodePartRowsSql(`'${escapedSessionId}'`),
-    spawn,
-  );
-
-  if (!messageRows || !partRows) {
-    return null;
-  }
-
-  return { messageRows, partRows };
+  const sqlite = module.require('node:sqlite') as unknown;
+  return isPlainObject(sqlite) && typeof sqlite.DatabaseSync === 'function'
+    ? sqlite as unknown as SqliteModule
+    : null;
 }
 
 async function runSqlite3JsonQuery(
   databasePath: string,
   sql: string,
-  spawn: typeof defaultSpawn,
-): Promise<StoredRow[] | null> {
+  spawn: SpawnSqliteProcess,
+  environment: NodeJS.ProcessEnv,
+): Promise<StoredRow[]> {
   const stdout = await runBufferedChild(
     'sqlite3',
-    ['-json', databasePath, sql],
+    ['-readonly', '-json', databasePath, sql],
     spawn,
+    environment,
   );
-  return stdout === null ? null : parseStoredRows(stdout);
+  const rows = parseStoredRows(stdout);
+  if (!rows) throw new Error('Invalid SQLite query output.');
+  return rows;
 }
 
 function runBufferedChild(
   command: string,
   args: string[],
-  spawn: typeof defaultSpawn,
-): Promise<string | null> {
-  return new Promise((resolve) => {
+  spawn: SpawnSqliteProcess,
+  environment: NodeJS.ProcessEnv,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
     let settled = false;
     let size = 0;
     let timer: number | null = null;
     const chunks: Buffer[] = [];
-    let child: ReturnType<typeof defaultSpawn>;
-    try {
-      child = spawn(command, args, {
-        stdio: ['ignore', 'pipe', 'ignore'],
-        windowsHide: true,
-      });
-    } catch {
-      resolve(null);
-      return;
-    }
-    const finish = (value: string | null): void => {
+    let stderr = '';
+    const child = spawn(command, args, {
+      env: environment,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    const finish = (error?: Error): void => {
       if (settled) return;
       settled = true;
       if (timer !== null) window.clearTimeout(timer);
-      resolve(value);
+      if (error) reject(error);
+      else resolve(Buffer.concat(chunks).toString('utf8'));
     };
 
     child.stdout?.on('data', (chunk: Buffer | string) => {
@@ -224,20 +172,27 @@ function runBufferedChild(
       size += buffer.length;
       if (size > OPENCODE_SQLITE_QUERY_MAX_BUFFER) {
         child.kill('SIGKILL');
-        finish(null);
+        finish(new Error('SQLite query output exceeded the size limit.'));
         return;
       }
       chunks.push(buffer);
     });
-    child.once('error', () => finish(null));
+    child.stderr?.on('data', (chunk: Buffer | string) => {
+      stderr = (stderr + chunk.toString()).slice(0, 2_000);
+    });
+    child.once('error', (error) => finish(error));
     child.once('close', (code) => {
-      finish(code === 0 ? Buffer.concat(chunks).toString('utf8') : null);
+      finish(code === 0 ? undefined : new Error(stderr.trim() || `Process exited with code ${code}.`));
     });
     timer = window.setTimeout(() => {
       child.kill('SIGKILL');
-      finish(null);
+      finish(new Error('SQLite query timed out after 10 seconds.'));
     }, 10_000);
   });
+}
+
+function formatError(error: unknown): string {
+  return (error instanceof Error ? error.message : String(error)).slice(0, 2_000);
 }
 
 function parseStoredSessionRows(value: string): StoredSessionRows | null {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -190,7 +190,8 @@ function getExtraBinaryPaths(): string[] {
   }
 }
 
-export function findNodeDirectory(additionalPaths?: string): string | null {
+function* findNodeDirectories(additionalPaths?: string): Generator<string, undefined> {
+  const executables = new Set<string>();
   const searchPaths = getExtraBinaryPaths();
 
   const currentPath = process.env.PATH || '';
@@ -204,24 +205,28 @@ export function findNodeDirectory(additionalPaths?: string): string | null {
       const nodePath = path.join(dir, NODE_EXECUTABLE);
       if (fs.existsSync(nodePath)) {
         const stat = fs.statSync(nodePath);
-        if (stat.isFile()) {
-          return dir;
+        if (stat.isFile() && !executables.has(nodePath)) {
+          executables.add(nodePath);
+          yield dir;
         }
       }
     } catch {
       // Inaccessible directory
     }
   }
+}
 
-  return null;
+export function findNodeExecutables(additionalPaths?: string): string[] {
+  return [...findNodeDirectories(additionalPaths)].map(dir => path.join(dir, NODE_EXECUTABLE));
+}
+
+export function findNodeDirectory(additionalPaths?: string): string | null {
+  return findNodeDirectories(additionalPaths).next().value ?? null;
 }
 
 export function findNodeExecutable(additionalPaths?: string): string | null {
   const nodeDir = findNodeDirectory(additionalPaths);
-  if (nodeDir) {
-    return path.join(nodeDir, NODE_EXECUTABLE);
-  }
-  return null;
+  return nodeDir ? path.join(nodeDir, NODE_EXECUTABLE) : null;
 }
 
 export function cliPathRequiresNode(cliPath: string): boolean {

--- a/tests/integration/providers/opencode/OpencodeSqliteReader.test.ts
+++ b/tests/integration/providers/opencode/OpencodeSqliteReader.test.ts
@@ -1,0 +1,59 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import { build } from 'esbuild';
+
+import type * as reader from '../../../../src/providers/opencode/history/OpencodeSqliteReader';
+
+it('reads history with the require function supplied by the Obsidian plugin loader', async () => {
+  const tmpRoot = mkdtempSync(path.join(os.tmpdir(), 'claudian-opencode-loader-'));
+  try {
+    const databasePath = path.join(tmpRoot, 'opencode.db');
+    const db = new DatabaseSync(databasePath);
+    try {
+      db.exec(`
+        CREATE TABLE message(id TEXT, session_id TEXT, time_created INTEGER, data TEXT);
+        CREATE TABLE part(id TEXT, session_id TEXT, message_id TEXT, data TEXT);
+        INSERT INTO message VALUES('msg-1', 'ses-1', 1000, '{"role":"user"}');
+        INSERT INTO part VALUES('part-1', 'ses-1', 'msg-1', '{"type":"text","text":"Hello"}');
+      `);
+    } finally {
+      db.close();
+    }
+
+    const bundle = await build({
+      entryPoints: [path.resolve(__dirname, '../../../../src/providers/opencode/history/OpencodeSqliteReader.ts')],
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      write: false,
+    });
+    // Obsidian supplies require separately and gives plugins only { exports } as module.
+    const pluginModule = { exports: {} as typeof reader };
+    Function('require', 'module', 'exports', bundle.outputFiles[0].text)(
+      createRequire(__filename), pluginModule, pluginModule.exports,
+    );
+
+    await expect(pluginModule.exports.loadOpencodeSessionRows(databasePath, 'ses-1', {
+      findNodeExecutables: () => [],
+      spawn: () => { throw new Error('No external SQLite reader installed.'); },
+    })).resolves.toEqual({
+      messageRows: [{
+        id: 'msg-1',
+        time_created: 1000,
+        data_valid: 1,
+        role: 'user',
+        provider_id: null,
+        model_id: null,
+        data_time_created: null,
+        data_time_completed: null,
+      }],
+      partRows: [{ id: 'part-1', message_id: 'msg-1', data: '{"type":"text","text":"Hello"}' }],
+    });
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/providers/opencode/OpencodeConversationHistoryService.test.ts
+++ b/tests/unit/providers/opencode/OpencodeConversationHistoryService.test.ts
@@ -1,3 +1,4 @@
+import type * as childProcessType from 'node:child_process';
 import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -17,6 +18,40 @@ describe('OpencodeConversationHistoryService', () => {
   afterEach(() => {
     Object.defineProperty(process, 'platform', { value: originalPlatform });
     rmSync(tmpRoot, { force: true, recursive: true });
+  });
+
+  it('passes the configured environment to the external history reader', async () => {
+    const dbPath = path.join(tmpRoot, 'opencode.db');
+    seedDatabase(dbPath, 'session-env', 'Configured history');
+    const conversation = createConversation('session-env', dbPath);
+    const childProcess = jest.requireActual<typeof childProcessType>('node:child_process');
+    const realSpawn = childProcess.spawn;
+    const environmentMarkers: Array<string | undefined> = [];
+    jest.spyOn(childProcess, 'spawn').mockImplementation((command, args, options) => {
+      environmentMarkers.push(options?.env?.CLAUDIAN_HISTORY_TEST);
+      return realSpawn(command, args, options!);
+    });
+    jest.doMock('node:sqlite', () => ({}));
+    try {
+      await jest.isolateModulesAsync(async () => {
+        const { OpencodeConversationHistoryService: HistoryService } = await import(
+          '../../../../src/providers/opencode/history/OpencodeConversationHistoryService'
+        );
+        await new HistoryService().hydrateConversationHistory(conversation, null, {
+          environment: {
+            ...process.env,
+            OPENCODE_DB: dbPath,
+            CLAUDIAN_HISTORY_TEST: 'configured',
+            PATH: path.dirname(process.execPath),
+          },
+        });
+      });
+      expect(conversation.messages.map(message => message.content)).toEqual(['Configured history']);
+      expect(environmentMarkers).toContain('configured');
+    } finally {
+      jest.dontMock('node:sqlite');
+      jest.restoreAllMocks();
+    }
   });
 
   it('retries after a session-level hydration diagnostic', async () => {

--- a/tests/unit/providers/opencode/OpencodeHistoryStore.test.ts
+++ b/tests/unit/providers/opencode/OpencodeHistoryStore.test.ts
@@ -5,11 +5,27 @@ import { DatabaseSync } from 'node:sqlite';
 
 import {
   loadOpencodeSessionMessages,
+  loadOpencodeSessionModel,
   mapOpencodeMessages,
   OPENCODE_MESSAGE_ROW_SQL,
 } from '../../../../src/providers/opencode/history/OpencodeHistoryStore';
 
 describe('mapOpencodeMessages', () => {
+  it('preserves Windows paths as literal code in hydration diagnostics', () => {
+    const [message] = mapOpencodeMessages([
+      { info: { id: 'msg-bad', data_valid: 0 }, parts: [] },
+    ], { databasePath: String.raw`C:\Users\cylix\.local\share\opencode\opencode.db` });
+    expect(message.content).toBe([
+      '```text',
+      'Failed to hydrate OpenCode session.',
+      'provider: OpenCode',
+      String.raw`databasePath: C:\Users\cylix\.local\share\opencode\opencode.db`,
+      'messageId: msg-bad',
+      'reason: OpenCode message metadata is not valid JSON.',
+      '```',
+    ].join('\n'));
+  });
+
   it('maps stored OpenCode messages into Claudian chat messages', () => {
     const messages = mapOpencodeMessages([
       {
@@ -378,10 +394,12 @@ describe('mapOpencodeMessages', () => {
     expect(messages).toEqual([
       expect.objectContaining({
         content: [
+          '```text',
           'Failed to hydrate OpenCode session.',
           'provider: OpenCode',
           'messageId: msg-bad',
           'reason: OpenCode message metadata is not valid JSON.',
+          '```',
         ].join('\n'),
         id: 'opencode-hydration-error-message-msg-bad',
         role: 'assistant',
@@ -409,6 +427,17 @@ describe('loadOpencodeSessionMessages', () => {
 
   afterEach(() => {
     rmSync(tmpRoot, { force: true, recursive: true });
+  });
+
+  it('shows the underlying SQLite failure as a history diagnostic', async () => {
+    const dbPath = path.join(tmpRoot, 'empty.db');
+    new DatabaseSync(dbPath).close();
+    const messages = await loadOpencodeSessionMessages('ses-empty', { databasePath: dbPath });
+    expect(messages).toEqual([expect.objectContaining({
+      id: 'opencode-hydration-error-session-ses-empty',
+      content: expect.stringContaining('no such table: message'),
+    })]);
+    await expect(loadOpencodeSessionModel('ses-empty', { databasePath: dbPath })).resolves.toBeNull();
   });
 
   it('loads conversation content without selecting raw message metadata', async () => {

--- a/tests/unit/providers/opencode/OpencodeSqliteReader.test.ts
+++ b/tests/unit/providers/opencode/OpencodeSqliteReader.test.ts
@@ -1,6 +1,6 @@
-import type { spawn as nodeSpawn } from 'node:child_process';
+import { spawn as nodeSpawn } from 'node:child_process';
 import { EventEmitter } from 'node:events';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
@@ -9,9 +9,10 @@ import { PassThrough } from 'node:stream';
 import {
   loadOpencodeSessionRows,
   OPENCODE_MESSAGE_ROW_SQL,
+  type OpencodeSqliteReaderDependencies,
 } from '../../../../src/providers/opencode/history/OpencodeSqliteReader';
 
-type Spawn = typeof nodeSpawn;
+type Spawn = NonNullable<OpencodeSqliteReaderDependencies['spawn']>;
 
 describe('loadOpencodeSessionRows', () => {
   let tmpRoot: string;
@@ -25,11 +26,66 @@ describe('loadOpencodeSessionRows', () => {
     jest.restoreAllMocks();
   });
 
+  it('never creates a missing history database through in-process SQLite', async () => {
+    const dbPath = path.join(tmpRoot, 'missing.db');
+    await loadOpencodeSessionRows(dbPath, 'ses-missing', {
+      requireSqliteModule: () => ({ DatabaseSync }),
+      findNodeExecutables: () => [],
+      spawn: createSpawnMock([]),
+    }).catch(() => undefined);
+    expect(existsSync(dbPath)).toBe(false);
+  });
+
+  it('tries a compatible Node after an installed Node fails', async () => {
+    const dbPath = createFixtureDatabase(tmpRoot);
+    const nodeWithoutSqlite = path.join(tmpRoot, 'old-node');
+    const spawn: Spawn = (command, args, options) => nodeSpawn(
+      process.execPath,
+      command === process.execPath ? args : ['--no-experimental-sqlite', ...args],
+      options,
+    );
+    await expect(loadOpencodeSessionRows(dbPath, 'ses-child', {
+      requireSqliteModule: () => null,
+      findNodeExecutables: () => [nodeWithoutSqlite, process.execPath],
+      spawn,
+    })).resolves.toMatchObject({ partRows: [{ id: 'part-user' }] });
+  });
+
+  it('reports backend errors when SQLite cannot read the database', async () => {
+    const dbPath = path.join(tmpRoot, 'empty.db');
+    new DatabaseSync(dbPath).close();
+    const spawn: Spawn = (command, args, options) => nodeSpawn(
+      command === 'sqlite3' ? path.join(tmpRoot, 'missing-sqlite3') : command,
+      args,
+      options,
+    );
+    await expect(loadOpencodeSessionRows(dbPath, 'ses-missing', {
+      requireSqliteModule: () => null,
+      findNodeExecutables: () => [process.execPath],
+      spawn,
+    })).rejects.toThrow('no such table: message');
+  });
+
+  it('uses the supplied environment for external SQLite readers', async () => {
+    const dbPath = createFixtureDatabase(tmpRoot);
+    const spawn: Spawn = (command, args, options) => nodeSpawn(
+      command === 'sqlite3' ? path.join(tmpRoot, 'missing-sqlite3') : command,
+      args,
+      options,
+    );
+    await expect(loadOpencodeSessionRows(dbPath, 'ses-child', {
+      environment: { ...process.env, NODE_OPTIONS: '--no-experimental-sqlite' },
+      requireSqliteModule: () => null,
+      findNodeExecutables: () => [process.execPath],
+      spawn,
+    })).rejects.toThrow('No such built-in module: node:sqlite');
+  });
+
   it('loads rows through a Node child process when in-process SQLite is unavailable', async () => {
     const dbPath = createFixtureDatabase(tmpRoot);
 
     await expect(loadOpencodeSessionRows(dbPath, 'ses-child', {
-      findNodeExecutable: () => process.execPath,
+      findNodeExecutables: () => [process.execPath],
       requireSqliteModule: () => null,
     })).resolves.toEqual({
       messageRows: [{
@@ -60,7 +116,7 @@ describe('loadOpencodeSessionRows', () => {
     }]);
 
     await expect(loadOpencodeSessionRows('/tmp/opencode.db', 'ses-node', {
-      findNodeExecutable: () => '/usr/local/bin/node',
+      findNodeExecutables: () => ['/usr/local/bin/node'],
       requireSqliteModule: () => null,
       spawn,
     })).resolves.toEqual({
@@ -80,7 +136,7 @@ describe('loadOpencodeSessionRows', () => {
         expect.stringContaining('from part'),
       ],
       expect.objectContaining({
-        stdio: ['ignore', 'pipe', 'ignore'],
+        stdio: ['ignore', 'pipe', 'pipe'],
         windowsHide: true,
       }),
     );
@@ -99,7 +155,7 @@ describe('loadOpencodeSessionRows', () => {
     ]);
 
     await expect(loadOpencodeSessionRows('/tmp/opencode.db', 'ses-with-quote\'s', {
-      findNodeExecutable: () => null,
+      findNodeExecutables: () => [],
       requireSqliteModule: () => null,
       spawn,
     })).resolves.toEqual({
@@ -112,12 +168,13 @@ describe('loadOpencodeSessionRows', () => {
       1,
       'sqlite3',
       [
+        '-readonly',
         '-json',
         '/tmp/opencode.db',
         expect.stringContaining("where session_id = 'ses-with-quote''s'"),
       ],
       expect.objectContaining({
-        stdio: ['ignore', 'pipe', 'ignore'],
+        stdio: ['ignore', 'pipe', 'pipe'],
         windowsHide: true,
       }),
     );
@@ -125,12 +182,13 @@ describe('loadOpencodeSessionRows', () => {
       2,
       'sqlite3',
       [
+        '-readonly',
         '-json',
         '/tmp/opencode.db',
         expect.stringContaining("where session_id = 'ses-with-quote''s'"),
       ],
       expect.objectContaining({
-        stdio: ['ignore', 'pipe', 'ignore'],
+        stdio: ['ignore', 'pipe', 'pipe'],
         windowsHide: true,
       }),
     );


### PR DESCRIPTION
## Why

OpenCode history fails to use Obsidian's embedded SQLite because the plugin loader supplies `require` separately and a plain `{ exports: {} }` module object. Checking `module.require` incorrectly marks SQLite unavailable. External fallback can also fail when the first Node installation is incompatible or the configured environment is ignored. Related to #738.

## What Changed

- Load optional in-process SQLite through Obsidian's injected `require`, retaining external fallbacks if the runtime does not support SQLite.
- Try each discovered Node executable and pass the configured environment, including PATH, to external readers. Preserve early exit for shared single-Node discovery callers.
- Open Node SQLite databases with `readOnly: true` and use `sqlite3 -readonly`.
- Include backend failures in hydration diagnostics and render diagnostics as literal code so Windows paths retain their backslashes.
- Preserve best-effort model recovery when SQLite reading fails.

## Why This Approach

The change stays within the existing provider-owned history reader and reuses its SQLite fallbacks without adding a runtime dependency. OpenCode's database CLI is unsuitable for reading the source database because initialization can run migrations.

## Validation

- Regression tests established failures before implementation for the Obsidian loader shape, read-only access, incompatible-first-Node fallback, environment forwarding, and diagnostics. The loader test executes the bundled reader with a plain module object and no external SQLite readers.
- `npm run typecheck` and `npm run lint` passed.
- `npm run test` passed: 8,762 tests, 2 skipped, plus 53 repository checks.
- `npm run build` and `git diff --check` passed.
- Windows and live Obsidian history behavior were not manually verified. The installed Obsidian loader was inspected to establish its require/module contract.

## Impact and Follow-ups

The loader bug was reproduced locally; verification on the reporter's Windows runtime is pending. A machine with no compatible SQLite backend still needs working SQLite support in Obsidian, Node.js, or sqlite3; diagnostics now identify the failed readers. No user-facing documentation changes are needed for this fix.

## Checklist

- [x] This pull request addresses one focused problem, and I have explained why this change is necessary.
- [x] I linked the relevant issue, or explained why no issue is needed.
- [x] I added or updated tests for behavior changes, or explained why tests are not applicable.
- [x] I ran the relevant typecheck, lint, test, and build commands.
- [x] I updated user-facing documentation when needed.
