### PR TITLE
chore: remove orphaned env snippet button and preview rules

### DIFF
--- a/src/style/accessibility.css
+++ b/src/style/accessibility.css
@@ -20,10 +20,6 @@
 .claudian-context-chip-remove:focus-visible,
 .claudian-context-more:focus-visible,
 .claudian-image-modal-close:focus-visible,
-.claudian-save-env-btn:focus-visible,
-.claudian-restore-snippet-btn:focus-visible,
-.claudian-edit-snippet-btn:focus-visible,
-.claudian-delete-snippet-btn:focus-visible,
 .claudian-cancel-btn:focus-visible,
 .claudian-save-btn:focus-visible,
 .claudian-code-lang-label:focus-visible {

--- a/src/style/settings/env-snippets.css
+++ b/src/style/settings/env-snippets.css
@@ -123,21 +123,6 @@
   font-weight: var(--font-medium);
 }
 
-.claudian-save-env-btn {
-  padding: 6px 16px;
-  font-size: 13px;
-  background: var(--interactive-accent);
-  color: var(--text-on-accent);
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  transition: opacity 0.2s;
-}
-
-.claudian-save-env-btn:hover {
-  opacity: 0.9;
-}
-
 .claudian-snippet-empty {
   padding: 20px;
   text-align: center;
@@ -191,48 +176,6 @@
   flex-shrink: 0;
 }
 
-.claudian-restore-snippet-btn {
-  padding: 4px 12px;
-  font-size: 12px;
-  background: var(--interactive-accent);
-  color: var(--text-on-accent);
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-}
-
-.claudian-restore-snippet-btn:hover {
-  opacity: 0.9;
-}
-
-.claudian-edit-snippet-btn {
-  padding: 4px 12px;
-  font-size: 12px;
-  background: var(--background-modifier-border);
-  color: var(--text-normal);
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-}
-
-.claudian-edit-snippet-btn:hover {
-  background: var(--background-modifier-border-hover);
-}
-
-.claudian-delete-snippet-btn {
-  padding: 4px 12px;
-  font-size: 12px;
-  background: var(--background-modifier-error);
-  color: var(--text-on-accent);
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-}
-
-.claudian-delete-snippet-btn:hover {
-  opacity: 0.9;
-}
-
 /* Env Snippet Modal */
 .claudian-env-snippet-modal .modal-content {
   max-width: 550px;
@@ -274,28 +217,6 @@
   font-family: var(--font-monospace);
   font-size: 12px;
   resize: vertical;
-}
-
-.claudian-snippet-preview {
-  margin: 8px 0;
-  padding: 6px;
-  background: var(--background-secondary);
-  border-radius: 6px;
-}
-
-.claudian-env-preview {
-  background: var(--background-primary);
-  padding: 6px;
-  border-radius: 4px;
-  font-family: var(--font-monospace);
-  font-size: 11px;
-  line-height: 1.3;
-  white-space: pre-wrap;
-  word-break: break-all;
-  color: var(--text-muted);
-  max-height: 120px;
-  overflow-y: auto;
-  margin: 0;
 }
 
 .claudian-snippet-buttons {


### PR DESCRIPTION
## Problem

Six classes in `src/style/settings/env-snippets.css` have no TypeScript producer. They are residue from two separate changes to the env snippet UI, neither of which removed the styling it stranded.

**`f14f2596`** converted the four env snippet text buttons to shared icon buttons. `claudian-save-env-btn`, `claudian-restore-snippet-btn`, `claudian-edit-snippet-btn`, and `claudian-delete-snippet-btn` were each replaced by `claudian-settings-action-btn`, with the delete button also taking `claudian-settings-delete-btn`:

```
git show f14f2596 -- src/ui/settings/EnvSnippetManager.ts
```

The replacement styling landed in that same commit, in `settings/base.css`, which gained `.claudian-settings-action-btn`, its `:hover` and ` svg` rules, and `.claudian-settings-delete-btn:hover`. The commit did also touch `env-snippets.css`, but only a four-line layout change — padding on `.claudian-snippet-header`, `gap` and `flex-shrink` on `.claudian-snippet-actions`. It removed none of the eight selectors the four buttons owned in that file, a rule and a `:hover` each.

**`84b257fd`** dropped the read-only environment preview from the snippet modal, which now shows the saved variables in the editable textarea instead. That removed the only producers of `claudian-snippet-preview` and `claudian-env-preview`:

```
git grep -l claudian-env-preview 84b257fd^   # EnvSnippetManager.ts, styles.css
git grep -l claudian-env-preview 84b257fd    # styles.css only
```

That commit did edit the stylesheet — still root `styles.css` at the time — and left both preview rules in place.

## Change

`2 files changed, 0 insertions(+), 83 deletions(-)`.

- `src/style/settings/env-snippets.css`: the six rule blocks and their `:hover` companions (366 → 287 lines).
- `src/style/accessibility.css`: four selector lines removed from a grouped `:focus-visible` rule, **not** the rule block (52 → 48 lines). The rule survives with its remaining nine members, all of which are live — including `claudian-cancel-btn` and `claudian-save-btn`, which the snippet modal still emits.

The env snippet feature itself is unchanged and live. `EnvSnippetManager` still renders the header, list, items, and modal.

## Evidence

The strongest check is not per-class but exhaustive: **`env-snippets.css` defines 40 distinct `claudian-` classes; exactly six have no producer in `src/**/*.ts`, and they are exactly the six removed.** After this change the file has 34, all emitted, and zero orphans remain in either file.

Producers were pinned by **state at each commit**, not by `git log -S` ordering:

| class | orphaned by | producers at `sha^` | at `sha` |
| --- | --- | --- | --- |
| the four `*-btn` | `f14f2596` | `src/ui/settings/EnvSnippetManager.ts` | none |
| the two `*-preview` | `84b257fd` | `src/ui/EnvSnippetManager.ts` | none |

All six were introduced by `7e5a0131`, and nothing has reintroduced them since `f14f2596`. All three cited commits are ancestors of `main`.

Some class names in this codebase are built by template interpolation, so the absence of a literal is not sufficient on its own. None of the interpolated prefixes can produce these names, and the fragments `snippet-btn`, `save-env`, `env-preview`, and `snippet-preview` appear nowhere in `src/**/*.ts`.

## Verification

- **Generated output proves no rule boundary was miscut:** building `styles.css` before and after gives `8891 → 8808` lines with **83 removed and zero added**. Braces balance 1272/1272 on both sides.
- `npm run typecheck`, `npm run lint` (which includes `stylelint` via `lint:css`), `npm run test`, `npm run build` all exit 0.
- Full suite: 603 passed, 2 skipped of 605 suites; 8754 passed of 8756 tests; zero failures. The two skips are pre-existing environment gates.
- No test reads either file, and no test references any of the six names — checked by filename and by class name across `tests/`, since `.css` never enters the TypeScript module graph and `--findRelatedTests` cannot scope it.

## Scope

This does not add a `:focus-visible` rule for `claudian-settings-action-btn`. That class has no custom focus rule, so those buttons fall back to the browser default ring — as they already do on `main` — rather than the accent ring the old classes carried. No `outline: none` reset reaches them, so this is a styling gap rather than an accessibility break, and it predates this change by about nine months. Whether to restyle them is a separate question from removing selectors that match nothing; happy to follow up if you want it.
