### PR TITLE
chore: remove the dead settings.codexSkills locale namespace

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -750,30 +750,6 @@
       "modal": { "titleEdit": "Edit Shared Skill", "titleAdd": "Add Shared Skill", "name": "Skill name", "nameDesc": "Lowercase letters and numbers separated by single hyphens", "namePlaceholder": "code-reviewer", "description": "Description", "descriptionDesc": "Required portable description used by providers to select the skill", "descriptionPlaceholder": "Reviews code for correctness and maintainability", "instructions": "Instructions", "instructionsDesc": "Required SKILL.md instructions", "instructionsPlaceholder": "Review the supplied code and report actionable findings..." },
       "delete": { "title": "Delete Shared Skill", "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.", "confirm": "Move to trash" }
     },
-    "codexSkills": {
-      "modal": {
-        "titleEdit": "Codex-Fähigkeit bearbeiten",
-        "titleAdd": "Codex-Fähigkeit hinzufügen",
-        "directory": "Verzeichnis",
-        "directoryDesc": "Speicherort der Fähigkeit",
-        "skillName": "Name der Fähigkeit",
-        "skillNameDesc": "Der Name nach $ (z. B. \"analyze\" für $analyze)",
-        "description": "Beschreibung",
-        "descriptionDesc": "Optionale Beschreibung im Dropdown",
-        "instructions": "Anweisungen",
-        "instructionsDesc": "Anweisungen der Fähigkeit (SKILL.md-Inhalt)",
-        "instructionsPlaceholder": "Analyze the code for..."
-      },
-      "instructionsRequired": "Anweisungen sind erforderlich",
-      "saveFailed": "Codex-Fähigkeit konnte nicht gespeichert werden",
-      "header": "Codex-Fähigkeiten",
-      "noSkills": "Keine Codex-Fähigkeiten im Vault. Klicke auf +, um eine zu erstellen.",
-      "skillBadge": "Fähigkeit",
-      "deleted": "Codex-Fähigkeit \"{name}\" gelöscht",
-      "deleteFailed": "Codex-Fähigkeit konnte nicht gelöscht werden",
-      "created": "Codex-Fähigkeit \"{name}\" erstellt",
-      "updated": "Codex-Fähigkeit \"{name}\" aktualisiert"
-    },
     "codexSubagents": {
       "modal": {
         "titleEdit": "Codex-Sub-Agent bearbeiten",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -781,30 +781,6 @@
         "confirm": "Move to trash"
       }
     },
-    "codexSkills": {
-      "modal": {
-        "titleEdit": "Edit Codex Skill",
-        "titleAdd": "Add Codex Skill",
-        "directory": "Directory",
-        "directoryDesc": "Where to store the skill",
-        "skillName": "Skill name",
-        "skillNameDesc": "The name used after $ (e.g., \"analyze\" for $analyze)",
-        "description": "Description",
-        "descriptionDesc": "Optional description shown in dropdown",
-        "instructions": "Instructions",
-        "instructionsDesc": "The skill instructions (SKILL.md content)",
-        "instructionsPlaceholder": "Analyze the code for..."
-      },
-      "instructionsRequired": "Instructions are required",
-      "saveFailed": "Failed to save Codex skill",
-      "header": "Codex Skills",
-      "noSkills": "No Codex skills in vault. Click + to create one.",
-      "skillBadge": "skill",
-      "deleted": "Codex skill \"{name}\" deleted",
-      "deleteFailed": "Failed to delete Codex skill",
-      "created": "Codex skill \"{name}\" created",
-      "updated": "Codex skill \"{name}\" updated"
-    },
     "codexSubagents": {
       "modal": {
         "titleEdit": "Edit Codex Subagent",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -750,30 +750,6 @@
       "modal": { "titleEdit": "Edit Shared Skill", "titleAdd": "Add Shared Skill", "name": "Skill name", "nameDesc": "Lowercase letters and numbers separated by single hyphens", "namePlaceholder": "code-reviewer", "description": "Description", "descriptionDesc": "Required portable description used by providers to select the skill", "descriptionPlaceholder": "Reviews code for correctness and maintainability", "instructions": "Instructions", "instructionsDesc": "Required SKILL.md instructions", "instructionsPlaceholder": "Review the supplied code and report actionable findings..." },
       "delete": { "title": "Delete Shared Skill", "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.", "confirm": "Move to trash" }
     },
-    "codexSkills": {
-      "modal": {
-        "titleEdit": "Editar habilidad de Codex",
-        "titleAdd": "Añadir habilidad de Codex",
-        "directory": "Directorio",
-        "directoryDesc": "Dónde guardar la habilidad",
-        "skillName": "Nombre de habilidad",
-        "skillNameDesc": "El nombre usado después de $ (por ejemplo, \"analyze\" para $analyze)",
-        "description": "Descripción",
-        "descriptionDesc": "Descripción opcional mostrada en el desplegable",
-        "instructions": "Instrucciones",
-        "instructionsDesc": "Instrucciones de la habilidad (contenido de SKILL.md)",
-        "instructionsPlaceholder": "Analyze the code for..."
-      },
-      "instructionsRequired": "Las instrucciones son obligatorias",
-      "saveFailed": "No se pudo guardar la habilidad de Codex",
-      "header": "Habilidades de Codex",
-      "noSkills": "No hay habilidades Codex en el vault. Haz clic en + para crear una.",
-      "skillBadge": "habilidad",
-      "deleted": "Habilidad de Codex \"{name}\" eliminada",
-      "deleteFailed": "No se pudo eliminar la habilidad de Codex",
-      "created": "Habilidad de Codex \"{name}\" creada",
-      "updated": "Habilidad de Codex \"{name}\" actualizada"
-    },
     "codexSubagents": {
       "modal": {
         "titleEdit": "Editar subagente de Codex",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -750,30 +750,6 @@
       "modal": { "titleEdit": "Edit Shared Skill", "titleAdd": "Add Shared Skill", "name": "Skill name", "nameDesc": "Lowercase letters and numbers separated by single hyphens", "namePlaceholder": "code-reviewer", "description": "Description", "descriptionDesc": "Required portable description used by providers to select the skill", "descriptionPlaceholder": "Reviews code for correctness and maintainability", "instructions": "Instructions", "instructionsDesc": "Required SKILL.md instructions", "instructionsPlaceholder": "Review the supplied code and report actionable findings..." },
       "delete": { "title": "Delete Shared Skill", "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.", "confirm": "Move to trash" }
     },
-    "codexSkills": {
-      "modal": {
-        "titleEdit": "Modifier la compétence Codex",
-        "titleAdd": "Ajouter une compétence Codex",
-        "directory": "Répertoire",
-        "directoryDesc": "Où stocker la compétence",
-        "skillName": "Nom de la compétence",
-        "skillNameDesc": "Le nom utilisé après $ (par ex. \"analyze\" pour $analyze)",
-        "description": "Description",
-        "descriptionDesc": "Description facultative affichée dans le menu déroulant",
-        "instructions": "Instructions",
-        "instructionsDesc": "Instructions de la compétence (contenu de SKILL.md)",
-        "instructionsPlaceholder": "Analyze the code for..."
-      },
-      "instructionsRequired": "Les instructions sont obligatoires",
-      "saveFailed": "Échec de l’enregistrement de la compétence Codex",
-      "header": "Compétences Codex",
-      "noSkills": "Aucune compétence Codex dans le vault. Cliquez sur + pour en créer une.",
-      "skillBadge": "compétence",
-      "deleted": "Compétence Codex \"{name}\" supprimée",
-      "deleteFailed": "Échec de la suppression de la compétence Codex",
-      "created": "Compétence Codex \"{name}\" créée",
-      "updated": "Compétence Codex \"{name}\" mise à jour"
-    },
     "codexSubagents": {
       "modal": {
         "titleEdit": "Modifier le sous-agent Codex",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -750,30 +750,6 @@
       "modal": { "titleEdit": "Edit Shared Skill", "titleAdd": "Add Shared Skill", "name": "Skill name", "nameDesc": "Lowercase letters and numbers separated by single hyphens", "namePlaceholder": "code-reviewer", "description": "Description", "descriptionDesc": "Required portable description used by providers to select the skill", "descriptionPlaceholder": "Reviews code for correctness and maintainability", "instructions": "Instructions", "instructionsDesc": "Required SKILL.md instructions", "instructionsPlaceholder": "Review the supplied code and report actionable findings..." },
       "delete": { "title": "Delete Shared Skill", "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.", "confirm": "Move to trash" }
     },
-    "codexSkills": {
-      "modal": {
-        "titleEdit": "Codex スキルを編集",
-        "titleAdd": "Codex スキルを追加",
-        "directory": "ディレクトリ",
-        "directoryDesc": "スキルの保存先",
-        "skillName": "スキル名",
-        "skillNameDesc": "$ の後に使う名前（例: $analyze の場合は \"analyze\"）",
-        "description": "説明",
-        "descriptionDesc": "ドロップダウンに表示される任意の説明",
-        "instructions": "指示",
-        "instructionsDesc": "スキルの指示（SKILL.md の内容）",
-        "instructionsPlaceholder": "Analyze the code for..."
-      },
-      "instructionsRequired": "指示は必須です",
-      "saveFailed": "Codex スキルの保存に失敗しました",
-      "header": "Codex スキル",
-      "noSkills": "Vault に Codex スキルがありません。+ をクリックして作成してください。",
-      "skillBadge": "スキル",
-      "deleted": "Codex スキル「{name}」を削除しました",
-      "deleteFailed": "Codex スキルの削除に失敗しました",
-      "created": "Codex スキル「{name}」を作成しました",
-      "updated": "Codex スキル「{name}」を更新しました"
-    },
     "codexSubagents": {
       "modal": {
         "titleEdit": "Codex サブエージェントを編集",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -750,30 +750,6 @@
       "modal": { "titleEdit": "Edit Shared Skill", "titleAdd": "Add Shared Skill", "name": "Skill name", "nameDesc": "Lowercase letters and numbers separated by single hyphens", "namePlaceholder": "code-reviewer", "description": "Description", "descriptionDesc": "Required portable description used by providers to select the skill", "descriptionPlaceholder": "Reviews code for correctness and maintainability", "instructions": "Instructions", "instructionsDesc": "Required SKILL.md instructions", "instructionsPlaceholder": "Review the supplied code and report actionable findings..." },
       "delete": { "title": "Delete Shared Skill", "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.", "confirm": "Move to trash" }
     },
-    "codexSkills": {
-      "modal": {
-        "titleEdit": "Codex 스킬 편집",
-        "titleAdd": "Codex 스킬 추가",
-        "directory": "디렉터리",
-        "directoryDesc": "스킬을 저장할 위치",
-        "skillName": "스킬 이름",
-        "skillNameDesc": "$ 뒤에 사용할 이름입니다(예: $analyze의 경우 \"analyze\")",
-        "description": "설명",
-        "descriptionDesc": "드롭다운에 표시할 선택적 설명",
-        "instructions": "지침",
-        "instructionsDesc": "스킬 지침(SKILL.md 내용)",
-        "instructionsPlaceholder": "Analyze the code for..."
-      },
-      "instructionsRequired": "지침은 필수입니다",
-      "saveFailed": "Codex 스킬 저장 실패",
-      "header": "Codex 스킬",
-      "noSkills": "Vault에 Codex 스킬이 없습니다. +를 클릭해 만드세요.",
-      "skillBadge": "스킬",
-      "deleted": "Codex 스킬 \"{name}\" 삭제됨",
-      "deleteFailed": "Codex 스킬 삭제 실패",
-      "created": "Codex 스킬 \"{name}\" 생성됨",
-      "updated": "Codex 스킬 \"{name}\" 업데이트됨"
-    },
     "codexSubagents": {
       "modal": {
         "titleEdit": "Codex 하위 에이전트 편집",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -750,30 +750,6 @@
       "modal": { "titleEdit": "Edit Shared Skill", "titleAdd": "Add Shared Skill", "name": "Skill name", "nameDesc": "Lowercase letters and numbers separated by single hyphens", "namePlaceholder": "code-reviewer", "description": "Description", "descriptionDesc": "Required portable description used by providers to select the skill", "descriptionPlaceholder": "Reviews code for correctness and maintainability", "instructions": "Instructions", "instructionsDesc": "Required SKILL.md instructions", "instructionsPlaceholder": "Review the supplied code and report actionable findings..." },
       "delete": { "title": "Delete Shared Skill", "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.", "confirm": "Move to trash" }
     },
-    "codexSkills": {
-      "modal": {
-        "titleEdit": "Editar habilidade Codex",
-        "titleAdd": "Adicionar habilidade Codex",
-        "directory": "Diretório",
-        "directoryDesc": "Onde armazenar a habilidade",
-        "skillName": "Nome da habilidade",
-        "skillNameDesc": "O nome usado após $ (ex.: \"analyze\" para $analyze)",
-        "description": "Descrição",
-        "descriptionDesc": "Descrição opcional exibida no menu",
-        "instructions": "Instruções",
-        "instructionsDesc": "Instruções da habilidade (conteúdo de SKILL.md)",
-        "instructionsPlaceholder": "Analyze the code for..."
-      },
-      "instructionsRequired": "Instruções são obrigatórias",
-      "saveFailed": "Falha ao salvar habilidade Codex",
-      "header": "Habilidades Codex",
-      "noSkills": "Não há habilidades Codex no vault. Clique em + para criar uma.",
-      "skillBadge": "habilidade",
-      "deleted": "Habilidade Codex \"{name}\" excluída",
-      "deleteFailed": "Falha ao excluir habilidade Codex",
-      "created": "Habilidade Codex \"{name}\" criada",
-      "updated": "Habilidade Codex \"{name}\" atualizada"
-    },
     "codexSubagents": {
       "modal": {
         "titleEdit": "Editar subagente Codex",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -750,30 +750,6 @@
       "modal": { "titleEdit": "Edit Shared Skill", "titleAdd": "Add Shared Skill", "name": "Skill name", "nameDesc": "Lowercase letters and numbers separated by single hyphens", "namePlaceholder": "code-reviewer", "description": "Description", "descriptionDesc": "Required portable description used by providers to select the skill", "descriptionPlaceholder": "Reviews code for correctness and maintainability", "instructions": "Instructions", "instructionsDesc": "Required SKILL.md instructions", "instructionsPlaceholder": "Review the supplied code and report actionable findings..." },
       "delete": { "title": "Delete Shared Skill", "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.", "confirm": "Move to trash" }
     },
-    "codexSkills": {
-      "modal": {
-        "titleEdit": "Редактировать навык Codex",
-        "titleAdd": "Добавить навык Codex",
-        "directory": "Каталог",
-        "directoryDesc": "Где хранить навык",
-        "skillName": "Имя навыка",
-        "skillNameDesc": "Имя, используемое после $ (например, \"analyze\" для $analyze)",
-        "description": "Описание",
-        "descriptionDesc": "Необязательное описание, отображаемое в списке",
-        "instructions": "Инструкции",
-        "instructionsDesc": "Инструкции навыка (содержимое SKILL.md)",
-        "instructionsPlaceholder": "Analyze the code for..."
-      },
-      "instructionsRequired": "Инструкции обязательны",
-      "saveFailed": "Не удалось сохранить навык Codex",
-      "header": "Навыки Codex",
-      "noSkills": "В vault нет навыков Codex. Нажмите +, чтобы создать навык.",
-      "skillBadge": "навык",
-      "deleted": "Навык Codex \"{name}\" удален",
-      "deleteFailed": "Не удалось удалить навык Codex",
-      "created": "Навык Codex \"{name}\" создан",
-      "updated": "Навык Codex \"{name}\" обновлен"
-    },
     "codexSubagents": {
       "modal": {
         "titleEdit": "Редактировать субагента Codex",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -750,30 +750,6 @@
       "modal": { "titleEdit": "Edit Shared Skill", "titleAdd": "Add Shared Skill", "name": "Skill name", "nameDesc": "Lowercase letters and numbers separated by single hyphens", "namePlaceholder": "code-reviewer", "description": "Description", "descriptionDesc": "Required portable description used by providers to select the skill", "descriptionPlaceholder": "Reviews code for correctness and maintainability", "instructions": "Instructions", "instructionsDesc": "Required SKILL.md instructions", "instructionsPlaceholder": "Review the supplied code and report actionable findings..." },
       "delete": { "title": "Delete Shared Skill", "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.", "confirm": "Move to trash" }
     },
-    "codexSkills": {
-      "modal": {
-        "titleEdit": "编辑 Codex 技能",
-        "titleAdd": "添加 Codex 技能",
-        "directory": "目录",
-        "directoryDesc": "技能的存储位置",
-        "skillName": "技能名称",
-        "skillNameDesc": "在 $ 后使用的名称（例如 $analyze 的名称为 “analyze”）",
-        "description": "描述",
-        "descriptionDesc": "下拉菜单中显示的可选描述",
-        "instructions": "指令",
-        "instructionsDesc": "技能指令（SKILL.md 内容）",
-        "instructionsPlaceholder": "Analyze the code for..."
-      },
-      "instructionsRequired": "指令为必填项",
-      "saveFailed": "保存 Codex 技能失败",
-      "header": "Codex 技能",
-      "noSkills": "Vault 中没有 Codex 技能。点击 + 创建一个。",
-      "skillBadge": "技能",
-      "deleted": "已删除 Codex 技能“{name}”",
-      "deleteFailed": "删除 Codex 技能失败",
-      "created": "已创建 Codex 技能“{name}”",
-      "updated": "已更新 Codex 技能“{name}”"
-    },
     "codexSubagents": {
       "modal": {
         "titleEdit": "编辑 Codex 子代理",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -750,30 +750,6 @@
       "modal": { "titleEdit": "Edit Shared Skill", "titleAdd": "Add Shared Skill", "name": "Skill name", "nameDesc": "Lowercase letters and numbers separated by single hyphens", "namePlaceholder": "code-reviewer", "description": "Description", "descriptionDesc": "Required portable description used by providers to select the skill", "descriptionPlaceholder": "Reviews code for correctness and maintainability", "instructions": "Instructions", "instructionsDesc": "Required SKILL.md instructions", "instructionsPlaceholder": "Review the supplied code and report actionable findings..." },
       "delete": { "title": "Delete Shared Skill", "description": "The entire skill folder, including scripts, references, and assets, will be moved to trash.", "confirm": "Move to trash" }
     },
-    "codexSkills": {
-      "modal": {
-        "titleEdit": "編輯 Codex 技能",
-        "titleAdd": "新增 Codex 技能",
-        "directory": "目錄",
-        "directoryDesc": "技能的儲存位置",
-        "skillName": "技能名稱",
-        "skillNameDesc": "在 $ 後使用的名稱（例如 $analyze 的名稱為「analyze」）",
-        "description": "描述",
-        "descriptionDesc": "下拉選單中顯示的可選描述",
-        "instructions": "指令",
-        "instructionsDesc": "技能指令（SKILL.md 內容）",
-        "instructionsPlaceholder": "Analyze the code for..."
-      },
-      "instructionsRequired": "指令為必填項",
-      "saveFailed": "儲存 Codex 技能失敗",
-      "header": "Codex 技能",
-      "noSkills": "Vault 中沒有 Codex 技能。點擊 + 建立一個。",
-      "skillBadge": "技能",
-      "deleted": "已刪除 Codex 技能「{name}」",
-      "deleteFailed": "刪除 Codex 技能失敗",
-      "created": "已建立 Codex 技能「{name}」",
-      "updated": "已更新 Codex 技能「{name}」"
-    },
     "codexSubagents": {
       "modal": {
         "titleEdit": "編輯 Codex 子代理",

--- a/tests/unit/i18n/locales.test.ts
+++ b/tests/unit/i18n/locales.test.ts
@@ -80,7 +80,6 @@ const localizedKeys = [
   'settings.codex.skills.name',
   'settings.codex.subagents.name',
   'settings.codex.environment.name',
-  'settings.codexSkills.noSkills',
   'settings.codexSubagents.noAgents',
   'collab.access.managerCount',
   'collab.access.makeManager',


### PR DESCRIPTION
chore: remove the dead settings.codexSkills locale namespace

8a9a2ce8 (#966) replaced the Codex-only skills UI with the shared
agent-skill settings. That squash is the large Grok Build provider
integration; the relevant sub-commit in its body is "feat: add shared
agent skills across providers", and it deleted
src/providers/codex/ui/CodexSkillSettings.ts and
src/providers/codex/storage/CodexSkillStorage.ts. CodexSettingsTab now
renders the shared surface through settings.agentSkills.*.

The settings.codexSkills block survived in all ten locale files. Before
this change the literal codexSkills appeared in exactly eleven tracked
files: those ten locale JSON files, and one stale entry in the
localizedKeys fixture in tests/unit/i18n/locales.test.ts. No TypeScript
file under src/ contained it.

Remove all twenty leaves from every locale and drop that fixture entry.
Every locale goes from 647 leaves to 627, and each one loses the same
twenty keys.

No key in this namespace is reachable through a computed translation
key. TranslationKey is declared as LeafKeys<typeof en> in
src/i18n/types.ts, so typecheck already rejects any uncast
string-literal t() call that names a deleted key. In src/ the single
cast escaping that bound is t(`${translationPrefix}.name` as
TranslationKey) in ClaudianSettings.ts, whose five call sites all pass
settings.*Hotkey literals. The other eighteen as TranslationKey casts
are all in tests/unit/i18n/i18n.test.ts, and none of them names a
settings.codexSkills key. The only other template-literal t() call
sites build settings.tabs.* and settings.collabGitStatus.*, and neither
fixed prefix can produce settings.codexSkills.

This does not touch settings.codex.skills, which is a different and
still-live namespace rendered by CodexSettingsTab.


## Verification

- `npm run typecheck`, `npm run lint`, `npm run build` all exit 0 (Node 24; `.node-version` pins 24.16.0).
- `npx jest tests/unit/i18n tests/integration/build/collab-dependency-envelope.test.ts` — 4 suites, 69 tests, all passing. That set is the complete importer list derived from `grep -rln "i18n/locales" tests/ src/` plus the relative-path importers in `src/i18n/`.
- Full suite: no new failures. One pre-existing flake, `tests/integration/app/collab/lan/authority-transfer/LanAuthorityTransferClient.test.ts`, times out under parallel load and passes in isolation; it has no i18n dependency and is untouched here.
- The existing `keeps every locale structurally aligned with English` assertion in `tests/unit/i18n/locales.test.ts` is the regression guard for this change, and it fires in both directions: leaving the key in one locale fails, and removing it from English alone fails.
